### PR TITLE
feat(catalog): expose Product as ApiResource with cursor pagination + ApiTestCase

### DIFF
--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -93,3 +93,58 @@ jobs:
 
       - name: PHP-CS-Fixer
         run: composer cs-check
+
+  phpunit:
+    name: PHPUnit
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: pim
+          POSTGRES_PASSWORD: ChangeMeInDev
+          POSTGRES_DB: pim
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U pim"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          extensions: ctype, iconv, intl, opcache, pcntl, pdo_pgsql, zip
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: |
+            apps/api/vendor
+            ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('apps/api/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run PHPUnit
+        run: php bin/phpunit
+        env:
+          APP_ENV: test
+          APP_DEBUG: "0"
+          # Foundry's ResetDatabase rebuilds the schema from entity metadata into the
+          # dbname_suffix-derived "pim_test" database — Postgres service is enough,
+          # no migrations step required for the Sprint-0 entity surface.
+          DATABASE_URL: postgresql://pim:ChangeMeInDev@127.0.0.1:5432/pim?serverVersion=16&charset=utf8
+          MESSENGER_TRANSPORT_DSN: in-memory://
+          MERCURE_URL: http://localhost/.well-known/mercure
+          MERCURE_PUBLIC_URL: http://localhost/.well-known/mercure
+          MERCURE_JWT_SECRET: ci
+          APP_DEFAULT_TENANT_CODE: demo

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -30,6 +30,7 @@
         "symfony/runtime": "7.4.*",
         "symfony/security-bundle": "7.4.*",
         "symfony/serializer": "7.4.*",
+        "symfony/twig-bundle": "7.4.*",
         "symfony/uid": "7.4.*",
         "symfony/validator": "7.4.*",
         "symfony/yaml": "7.4.*"
@@ -103,6 +104,7 @@
         "phpunit/phpunit": "^12",
         "symfony/browser-kit": "7.4.*",
         "symfony/css-selector": "7.4.*",
+        "symfony/http-client": "7.4.*",
         "zenstruck/foundry": "^2"
     }
 }

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32197e016dc3b05ca857a9d62dc51444",
+    "content-hash": "0d1fce749d33fc16b6a7f5858655eba2",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -6636,6 +6636,211 @@
             "time": "2025-07-15T13:41:35+00:00"
         },
         {
+            "name": "symfony/twig-bridge",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bridge.git",
+                "reference": "ac43e7e59298ed1ce98c8d228b651d46e907d02c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/ac43e7e59298ed1ce98c8d228b651d46e907d02c",
+                "reference": "ac43e7e59298ed1ce98c8d228b651d46e907d02c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/translation-contracts": "^2.5|^3",
+                "twig/twig": "^3.21"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/console": "<6.4",
+                "symfony/form": "<6.4.32|>7,<7.3.10|>7.4,<7.4.4|>8.0,<8.0.4",
+                "symfony/http-foundation": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/mime": "<6.4.36|>7,<7.4.8|>8.0,<8.0.8",
+                "symfony/serializer": "<6.4",
+                "symfony/translation": "<6.4",
+                "symfony/workflow": "<6.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/asset": "^6.4|^7.0|^8.0",
+                "symfony/asset-mapper": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/form": "^6.4.32|~7.3.10|^7.4.4|^8.0.4",
+                "symfony/html-sanitizer": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^7.3|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4.36|^7.4.8|^8.0.8",
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/security-acl": "^2.8|^3.0",
+                "symfony/security-core": "^6.4|^7.0|^8.0",
+                "symfony/security-csrf": "^6.4|^7.0|^8.0",
+                "symfony/security-http": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/web-link": "^6.4|^7.0|^8.0",
+                "symfony/workflow": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0",
+                "twig/cssinliner-extra": "^3",
+                "twig/inky-extra": "^3",
+                "twig/markdown-extra": "^3"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Twig\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides integration for Twig with various Symfony components",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bridge/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:17:09+00:00"
+        },
+        {
+            "name": "symfony/twig-bundle",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bundle.git",
+                "reference": "ba1e06d7ff1ebb1d1799b6608d925f4eaba88d95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/ba1e06d7ff1ebb1d1799b6608d925f4eaba88d95",
+                "reference": "ba1e06d7ff1ebb1d1799b6608d925f4eaba88d95",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "php": ">=8.2",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4.13|^7.1.6|^8.0",
+                "symfony/twig-bridge": "^7.3|^8.0",
+                "twig/twig": "^3.12"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<6.4",
+                "symfony/translation": "<6.4"
+            },
+            "require-dev": {
+                "symfony/asset": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/form": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4.13|^7.1.6|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/runtime": "^6.4.13|^7.1.6",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/web-link": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\TwigBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of Twig into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bundle/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
             "name": "symfony/type-info",
             "version": "v7.4.8",
             "source": {
@@ -7230,6 +7435,86 @@
                 }
             ],
             "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-17T21:31:11+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -10806,6 +11091,185 @@
             "time": "2026-03-24T13:12:05+00:00"
         },
         {
+            "name": "symfony/http-client",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "01933e626c3de76bea1e22641e205e78f6a34342"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/01933e626c3de76bea1e22641e205e78f6a34342",
+                "reference": "01933e626c3de76bea1e22641e205e78f6a34342",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/polyfill-php83": "^1.29",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "amphp/amp": "<2.5",
+                "amphp/socket": "<1.1",
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.4"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/http-client": "^4.2.1|^5.0",
+                "amphp/http-tunnel": "^1.0|^2.0",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/amphp-http-client-meta": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/rate-limiter": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T12:55:43+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-29T11:18:49+00:00"
+        },
+        {
             "name": "symfony/options-resolver",
             "version": "v7.4.8",
             "source": {
@@ -11181,7 +11645,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -11189,6 +11653,6 @@
         "ext-ctype": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.9.0"
 }

--- a/apps/api/config/bundles.php
+++ b/apps/api/config/bundles.php
@@ -8,4 +8,5 @@ return [
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     Zenstruck\Foundry\ZenstruckFoundryBundle::class => ['dev' => true, 'test' => true],
+    Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
 ];

--- a/apps/api/config/packages/twig.yaml
+++ b/apps/api/config/packages/twig.yaml
@@ -1,0 +1,6 @@
+twig:
+    file_name_pattern: '*.twig'
+
+when@test:
+    twig:
+        strict_variables: true

--- a/apps/api/config/reference.php
+++ b/apps/api/config/reference.php
@@ -716,9 +716,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     handle_symfony_errors?: bool|Param, // Allows to handle symfony exceptions. // Default: false
  *     enable_swagger?: bool|Param, // Enable the Swagger documentation and export. // Default: true
  *     enable_json_streamer?: bool|Param, // Enable json streamer. // Default: false
- *     enable_swagger_ui?: bool|Param, // Enable Swagger UI // Default: false
- *     enable_re_doc?: bool|Param, // Enable ReDoc // Default: false
- *     enable_scalar?: bool|Param, // Enable Scalar API Reference // Default: false
+ *     enable_swagger_ui?: bool|Param, // Enable Swagger UI // Default: true
+ *     enable_re_doc?: bool|Param, // Enable ReDoc // Default: true
+ *     enable_scalar?: bool|Param, // Enable Scalar API Reference // Default: true
  *     enable_entrypoint?: bool|Param, // Enable the entrypoint // Default: true
  *     enable_docs?: bool|Param, // Enable the docs // Default: true
  *     enable_profiler?: bool|Param, // Enable the data collector and the WebProfilerBundle integration. // Default: true
@@ -1594,6 +1594,39 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         default_namespace?: scalar|Param|null, // Default namespace where stories will be created by maker. // Default: "Story"
  *     },
  * }
+ * @psalm-type TwigConfig = array{
+ *     form_themes?: list<scalar|Param|null>,
+ *     globals?: array<string, array{ // Default: []
+ *         id?: scalar|Param|null,
+ *         type?: scalar|Param|null,
+ *         value?: mixed,
+ *     }>,
+ *     autoescape_service?: scalar|Param|null, // Default: null
+ *     autoescape_service_method?: scalar|Param|null, // Default: null
+ *     base_template_class?: scalar|Param|null, // Deprecated: The child node "base_template_class" at path "twig.base_template_class" is deprecated.
+ *     cache?: scalar|Param|null, // Default: true
+ *     charset?: scalar|Param|null, // Default: "%kernel.charset%"
+ *     debug?: bool|Param, // Default: "%kernel.debug%"
+ *     strict_variables?: bool|Param, // Default: "%kernel.debug%"
+ *     auto_reload?: scalar|Param|null,
+ *     optimizations?: int|Param,
+ *     default_path?: scalar|Param|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
+ *     file_name_pattern?: list<scalar|Param|null>,
+ *     paths?: array<string, mixed>,
+ *     date?: array{ // The default format options used by the date filter.
+ *         format?: scalar|Param|null, // Default: "F j, Y H:i"
+ *         interval_format?: scalar|Param|null, // Default: "%d days"
+ *         timezone?: scalar|Param|null, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
+ *     },
+ *     number_format?: array{ // The default format options for the number_format filter.
+ *         decimals?: int|Param, // Default: 0
+ *         decimal_point?: scalar|Param|null, // Default: "."
+ *         thousands_separator?: scalar|Param|null, // Default: ","
+ *     },
+ *     mailer?: array{
+ *         html_to_text_converter?: scalar|Param|null, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
+ *     },
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1603,6 +1636,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     doctrine?: DoctrineConfig,
  *     doctrine_migrations?: DoctrineMigrationsConfig,
  *     security?: SecurityConfig,
+ *     twig?: TwigConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1613,6 +1647,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         doctrine_migrations?: DoctrineMigrationsConfig,
  *         security?: SecurityConfig,
  *         zenstruck_foundry?: ZenstruckFoundryConfig,
+ *         twig?: TwigConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -1623,6 +1658,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         doctrine?: DoctrineConfig,
  *         doctrine_migrations?: DoctrineMigrationsConfig,
  *         security?: SecurityConfig,
+ *         twig?: TwigConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1634,6 +1670,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         doctrine_migrations?: DoctrineMigrationsConfig,
  *         security?: SecurityConfig,
  *         zenstruck_foundry?: ZenstruckFoundryConfig,
+ *         twig?: TwigConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/apps/api/src/Catalog/Domain/Entity/Product.php
+++ b/apps/api/src/Catalog/Domain/Entity/Product.php
@@ -4,21 +4,71 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
+use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
+use ApiPlatform\Doctrine\Orm\Filter\RangeFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
 use App\Catalog\Infrastructure\Doctrine\Repository\ProductRepository;
 use App\Identity\Domain\Entity\Tenant;
+use ArrayObject;
 use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use LogicException;
+use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity(repositoryClass: ProductRepository::class)]
 #[ORM\Table(name: 'products')]
 #[ORM\UniqueConstraint(name: 'products_tenant_sku_uniq', columns: ['tenant_id', 'sku'])]
 #[ORM\Index(name: 'products_tenant_idx', columns: ['tenant_id'])]
+#[ApiResource(
+    shortName: 'Product',
+    description: 'A SKU-keyed catalog item scoped to the caller\'s tenant.',
+    operations: [
+        new GetCollection(
+            paginationType: 'cursor',
+            paginationViaCursor: [
+                ['field' => 'id', 'direction' => 'DESC'],
+            ],
+            paginationItemsPerPage: 30,
+            paginationMaximumItemsPerPage: 100,
+        ),
+        new Get(),
+        new Post(
+            openapi: new \ApiPlatform\OpenApi\Model\Operation(
+                requestBody: new \ApiPlatform\OpenApi\Model\RequestBody(
+                    content: new ArrayObject([
+                        'application/ld+json' => [
+                            'example' => [
+                                'sku' => 'WIDGET-001',
+                                'name' => 'Stainless steel widget',
+                                'description' => '12mm diameter, food-grade.',
+                                'brand' => 'Acme',
+                            ],
+                        ],
+                    ]),
+                ),
+            ),
+        ),
+        new Patch(
+            denormalizationContext: ['groups' => ['product:patch']],
+        ),
+    ],
+    normalizationContext: ['groups' => ['product:read']],
+    denormalizationContext: ['groups' => ['product:write']],
+)]
+#[ApiFilter(OrderFilter::class, properties: ['id' => 'DESC'])]
+#[ApiFilter(RangeFilter::class, properties: ['id'])]
 class Product
 {
     #[ORM\Id]
     #[ORM\Column(type: 'uuid')]
+    #[Groups(['product:read'])]
     private Uuid $id;
 
     #[ORM\ManyToOne(targetEntity: Tenant::class)]
@@ -26,21 +76,33 @@ class Product
     private ?Tenant $tenant = null;
 
     #[ORM\Column(type: 'string', length: 64)]
+    #[Groups(['product:read', 'product:write'])]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 64)]
     private string $sku;
 
     #[ORM\Column(type: 'string', length: 255)]
+    #[Groups(['product:read', 'product:write', 'product:patch'])]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
     private string $name;
 
     #[ORM\Column(type: 'text', nullable: true)]
+    #[Groups(['product:read', 'product:write', 'product:patch'])]
+    #[Assert\Length(max: 4000)]
     private ?string $description = null;
 
     #[ORM\Column(type: 'string', length: 128, nullable: true)]
+    #[Groups(['product:read', 'product:write', 'product:patch'])]
+    #[Assert\Length(max: 128)]
     private ?string $brand = null;
 
     #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['product:read'])]
     private DateTimeImmutable $createdAt;
 
     #[ORM\Column(type: 'datetime_immutable')]
+    #[Groups(['product:read'])]
     private DateTimeImmutable $updatedAt;
 
     public function __construct(string $sku, string $name, ?Uuid $id = null)
@@ -89,7 +151,7 @@ class Product
         return $this->name;
     }
 
-    public function rename(string $name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
         $this->touch();

--- a/apps/api/symfony.lock
+++ b/apps/api/symfony.lock
@@ -192,6 +192,19 @@
             "config/routes/security.yaml"
         ]
     },
+    "symfony/twig-bundle": {
+        "version": "7.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.4",
+            "ref": "f250159ebe99153d0c640a3e7742876fc7453f2c"
+        },
+        "files": [
+            "config/packages/twig.yaml",
+            "templates/base.html.twig"
+        ]
+    },
     "symfony/uid": {
         "version": "7.4",
         "recipe": {

--- a/apps/api/templates/base.html.twig
+++ b/apps/api/templates/base.html.twig
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>{% block title %}Welcome!{% endblock %}</title>
+        <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⚫️</text><text y=%221.3em%22 x=%220.2em%22 font-size=%2276%22 fill=%22%23fff%22>sf</text></svg>">
+        {% block stylesheets %}
+        {% endblock %}
+
+        {% block javascripts %}
+        {% endblock %}
+
+        {% set frankenphpHotReload = app.request.server.get('FRANKENPHP_HOT_RELOAD') %}
+        {% if frankenphpHotReload %}
+        <meta name="frankenphp-hot-reload:url" content="{{ frankenphpHotReload }}">
+        <script src="https://cdn.jsdelivr.net/npm/idiomorph"></script>
+        <script src="https://cdn.jsdelivr.net/npm/frankenphp-hot-reload/+esm" type="module"></script>
+        {% endif %}
+    </head>
+    <body>
+        {% block body %}{% endblock %}
+    </body>
+</html>

--- a/apps/api/tests/Functional/Catalog/ProductApiTest.php
+++ b/apps/api/tests/Functional/Catalog/ProductApiTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Catalog;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Catalog\Domain\Entity\Product;
+use App\Identity\Application\TenantContext;
+use App\Identity\Domain\Entity\Tenant;
+use App\Identity\Infrastructure\Doctrine\Repository\TenantRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Functional API contract for /api/products.
+ *
+ * Each test runs against a fresh schema (Foundry ResetDatabase) and seeds a
+ * single "demo" Tenant matching APP_DEFAULT_TENANT_CODE so the request
+ * subscriber + Doctrine filter resolve a real tenant. Authentication wiring
+ * lands in #4 (0.0.4); for Sprint 0 the env-fallback path is exercised here.
+ */
+final class ProductApiTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    /**
+     * Required since api-platform/symfony 4.1: createClient() boots the kernel
+     * once and this opt-in keeps the deprecation quiet under failOnDeprecation.
+     */
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_CODE = 'demo';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $em = $this->em();
+        $em->persist(new Tenant(self::TENANT_CODE, 'Demo Tenant'));
+        $em->flush();
+    }
+
+    #[Test]
+    public function getCollectionReturnsHydraDocumentForCurrentTenant(): void
+    {
+        $this->seedProduct('SKU-LIST-001', 'Listed product');
+        $this->seedProduct('SKU-LIST-002', 'Another listed product');
+
+        static::createClient()->request('GET', '/api/products');
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        self::assertJsonContains([
+            '@context' => '/api/contexts/Product',
+            '@id' => '/api/products',
+            '@type' => 'Collection',
+            'totalItems' => 2,
+        ]);
+    }
+
+    #[Test]
+    public function postCreatesProductAndReturnsCreated(): void
+    {
+        $payload = [
+            'sku' => 'WIDGET-001',
+            'name' => 'Stainless steel widget',
+            'description' => '12mm diameter, food-grade.',
+            'brand' => 'Acme',
+        ];
+
+        $response = static::createClient()->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode($payload, JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertJsonContains([
+            '@type' => 'Product',
+            'sku' => 'WIDGET-001',
+            'name' => 'Stainless steel widget',
+            'description' => '12mm diameter, food-grade.',
+            'brand' => 'Acme',
+        ]);
+
+        $iri = $response->toArray()['@id'] ?? null;
+        \assert(\is_string($iri));
+        self::assertMatchesRegularExpression(
+            '#^/api/products/[0-9a-f-]{36}$#',
+            $iri,
+            'POST must return an IRI for the created Product.',
+        );
+    }
+
+    #[Test]
+    public function postRejectsBlankSkuAndName(): void
+    {
+        static::createClient()->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode(['sku' => '', 'name' => ''], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+        self::assertJsonContains([
+            '@type' => 'ConstraintViolation',
+            'status' => 422,
+        ]);
+    }
+
+    #[Test]
+    public function getReturnsSingleProduct(): void
+    {
+        $product = $this->seedProduct('SKU-GET-001', 'Single product');
+
+        static::createClient()->request('GET', '/api/products/'.$product->getId()->toRfc4122());
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains([
+            '@type' => 'Product',
+            'sku' => 'SKU-GET-001',
+            'name' => 'Single product',
+        ]);
+    }
+
+    #[Test]
+    public function patchUpdatesAllowedFieldsButLeavesSkuImmutable(): void
+    {
+        $product = $this->seedProduct('SKU-PATCH-001', 'Original name');
+
+        static::createClient()->request('PATCH', '/api/products/'.$product->getId()->toRfc4122(), [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode([
+                'sku' => 'SKU-HIJACKED',
+                'name' => 'Renamed product',
+                'description' => 'Filled in via PATCH',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertJsonContains([
+            'sku' => 'SKU-PATCH-001',
+            'name' => 'Renamed product',
+            'description' => 'Filled in via PATCH',
+        ]);
+    }
+
+    #[Test]
+    public function getCollectionExposesCursorViewLinks(): void
+    {
+        // Three products are enough to assert the next/prev IRIs are emitted;
+        // verifying the ordering math is the integration test job once we
+        // ramp the corpus during the load-test ticket (#13 / 0.0.13).
+        $this->seedProduct('SKU-CURSOR-001', 'A');
+        $this->seedProduct('SKU-CURSOR-002', 'B');
+        $this->seedProduct('SKU-CURSOR-003', 'C');
+
+        $response = static::createClient()->request('GET', '/api/products?id[lt]=ffffffff-ffff-ffff-ffff-ffffffffffff');
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertArrayHasKey('view', $body, 'Cursor pagination must emit a PartialCollectionView.');
+        $view = $body['view'];
+        \assert(\is_array($view));
+        self::assertSame('PartialCollectionView', $view['@type'] ?? null);
+        self::assertArrayHasKey('next', $view);
+    }
+
+    private function seedProduct(string $sku, string $name): Product
+    {
+        $container = self::getContainer();
+
+        $tenantRepository = $container->get(TenantRepository::class);
+        $tenant = $tenantRepository->findByCode(self::TENANT_CODE);
+        \assert($tenant instanceof Tenant, 'setUp must seed the demo tenant.');
+
+        $tenantContext = $container->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $em = $this->em();
+        $product = new Product($sku, $name);
+        $em->persist($product);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $product;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
## Cel

Zamknięcie ticketu #3 (0.0.3) — wystawienie `Product` jako `#[ApiResource]` z pełnym CRUD-em (GetCollection / Get / Post / Patch), kursorową paginacją, walidatorami i ApiTestCase.

## Co zmienia

### Resource API Platform na `Product`
- `#[ApiResource]` z `shortName: 'Product'` i `description` użytą również w OpenAPI tag
- Operacje: `GetCollection` (cursor pagination po `id` DESC, default 30, max 100), `Get`, `Post`, `Patch`
- Grupy serializacji:
  - `product:read` — wszystkie pola (id, sku, name, description, brand, createdAt, updatedAt)
  - `product:write` — `sku` + `name` + `description` + `brand` (POST tylko, SKU obowiązkowy)
  - `product:patch` — `name` + `description` + `brand` (SKU **immutable po POST** — PATCH ze SKU silently ignored bo brak grupy + brak setter'a)
- Walidatory: `NotBlank` na `sku`/`name`, `Length(max: 64/255/4000/128)` na każdym writable polu
- Cursor pagination via `paginationViaCursor` + `OrderFilter` + `RangeFilter` po `id` — `view.next` IRI generowane gdy `id[lt]=`/`id[gt]=` w query
- Custom OpenAPI request body example dla `Post` operation widoczny w `/api/docs`

### ApiTestCase (6 cases, all green)
- `getCollectionReturnsHydraDocumentForCurrentTenant` — GET /api/products zwraca Hydra Collection ograniczoną przez `TenantFilter`
- `postCreatesProductAndReturnsCreated` — POST 201 + IRI w response
- `postRejectsBlankSkuAndName` — POST z pustymi polami → 422 ConstraintViolation
- `getReturnsSingleProduct` — GET /api/products/{id}
- `patchUpdatesAllowedFieldsButLeavesSkuImmutable` — PATCH z `sku` w body **nie zmienia** SKU
- `getCollectionExposesCursorViewLinks` — `id[lt]=` zwraca PartialCollectionView z `next`

Trait `Foundry\Test\ResetDatabase` rebuilds schema z entity metadata przed każdym test'em (mode `SCHEMA`, nie `MIGRATE`). Test seeduje `demo` tenant zgodny z `APP_DEFAULT_TENANT_CODE` żeby `RequestTenantSubscriber` wstrzyknął kontekst przy HTTP request'ie.

### CI: PHPUnit job dodany do `quality-php.yml`
- Postgres 16 jako service container
- Schema rebuild przez Foundry, bez migrations step
- ENV: `APP_DEFAULT_TENANT_CODE=demo` żeby env-fallback w `CurrentTenantProvider` znalazł tenanta

### Pakiety
- `+symfony/http-client` (dev) — wymagane przez ApiTestCase BrowserKit
- `+symfony/twig-bundle` — żeby AP4 auto-enable Swagger UI (`enable_swagger_ui` defaultuje na `class_exists(TwigBundle::class)`)

## Manual smoke

- ✅ `curl -k https://pim.localhost/api/products` → `Collection` z 3 produktami `demo` tenanta
- ✅ `POST /api/products` z `{sku, name}` → 201 + IRI + obiekt
- ✅ `PATCH .../api/products/{id}` z `{sku: 'HACKED', name: 'X'}` → SKU **niezmieniony**, name zaktualizowany
- ✅ `POST` z `{sku: '', name: ''}` → 422 ConstraintViolation
- ✅ `GET /api/docs` (HTML) — Swagger UI renderuje się i pokazuje endpoint Product
- ✅ `id[lt]=...` query param zwraca `view.next` IRI

## Quality gates

- ✅ PHPStan max — green
- ✅ PHP-CS-Fixer — 0 issues
- ✅ PHPUnit — 10/10 tests, 21 assertions
- ✅ composer audit — 0 advisories

## Świadome odejścia (do `06-sprint-0-findings.md`)

- **`UniqueEntity['tenant', 'sku']` validator skipped** — listener stempluje `tenant` w PrePersist, validator widziałby zawsze `tenant=null`. Postgres unique index `products_tenant_sku_uniq` zachowuje invariant on DB level (HTTP 500 zamiast 422 dla duplikatu). Custom validator z dostępem do `TenantContext` dochodzi w epiku 0.4 (#41+).
- **Plain `application/json` jako format input/output nie aktywowany** — tylko `application/ld+json` + `application/merge-patch+json`. Plain JSON dochodzi w epiku 0.4 razem z decyzją o explicit DTO.
- **`Product` wystawiony bez DTO input/output** — entity bezpośrednio z grupami. W MVP-Alpha decyzja czy split na osobne DTO (epic 0.4 #41).
- **Twig zainstalowany jako `'all' => true`** — runtime overhead minimalny; dla prod docs można `enable_swagger_ui: false` env-aware w fazie 1.

## Powiązania

- Closes #3
- Architektura: `Project Plan/01-architektura-pim.md` sekcja 4.2 (API Platform), ADR-008
- Plan: `Project Plan/02-plan-projektu-pim.md` ticket 0.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)