### PR TITLE
feat(identity): add User entity + LexikJWT auth for /api

### DIFF
--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -49,6 +49,12 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
 
+      - name: Generate JWT keypair (lexik bundle requires the files at compile time)
+        run: |
+          mkdir -p config/jwt
+          openssl genpkey -algorithm RSA -out config/jwt/private.pem -aes256 -pass pass:ci -pkeyopt rsa_keygen_bits:4096
+          openssl pkey -in config/jwt/private.pem -passin pass:ci -pubout -out config/jwt/public.pem
+
       - name: Warm up cache (PHPStan needs the dev container.xml)
         run: php bin/console cache:clear --env=dev
         env:
@@ -59,11 +65,13 @@ jobs:
           MERCURE_URL: http://localhost/.well-known/mercure
           MERCURE_PUBLIC_URL: http://localhost/.well-known/mercure
           MERCURE_JWT_SECRET: ci
+          JWT_PASSPHRASE: ci
 
       - name: PHPStan
         run: composer phpstan
         env:
           APP_ENV: dev
+          JWT_PASSPHRASE: ci
 
   php-cs-fixer:
     name: PHP-CS-Fixer (dry-run)
@@ -134,6 +142,12 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
 
+      - name: Generate JWT keypair for tests
+        run: |
+          mkdir -p config/jwt
+          openssl genpkey -algorithm RSA -out config/jwt/private.pem -aes256 -pass pass:ci -pkeyopt rsa_keygen_bits:4096
+          openssl pkey -in config/jwt/private.pem -passin pass:ci -pubout -out config/jwt/public.pem
+
       - name: Run PHPUnit
         run: php bin/phpunit
         env:
@@ -147,4 +161,5 @@ jobs:
           MERCURE_URL: http://localhost/.well-known/mercure
           MERCURE_PUBLIC_URL: http://localhost/.well-known/mercure
           MERCURE_JWT_SECRET: ci
+          JWT_PASSPHRASE: ci
           APP_DEFAULT_TENANT_CODE: demo

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -50,3 +50,9 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 # to verify TenantFilter actually isolates queries.
 APP_DEFAULT_TENANT_CODE=demo
 ###< app/multi-tenancy ###
+
+###> lexik/jwt-authentication-bundle ###
+JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
+JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
+JWT_PASSPHRASE=684516f93230694bb5fdae9c7ef2bf536e5f79847c1d4991c1e82fe86f264d6b
+###< lexik/jwt-authentication-bundle ###

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -18,3 +18,7 @@
 /phpunit.xml
 /.phpunit.cache/
 ###< phpunit/phpunit ###
+
+###> lexik/jwt-authentication-bundle ###
+/config/jwt/*.pem
+###< lexik/jwt-authentication-bundle ###

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -15,6 +15,7 @@
         "doctrine/doctrine-bundle": "^2.18.2",
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6.3",
+        "lexik/jwt-authentication-bundle": "^3",
         "phpdocumentor/reflection-docblock": "^5.6.7",
         "phpstan/phpdoc-parser": "^2.3.2",
         "runtime/frankenphp-symfony": "^0.2",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d1fce749d33fc16b6a7f5858655eba2",
+    "content-hash": "d4f6e84673e4c92e1c4b1e6411f285bf",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2440,6 +2440,195 @@
                 "source": "https://github.com/doctrine/sql-formatter/tree/1.5.4"
             },
             "time": "2026-02-08T16:21:46+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "5.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "reference": "bb3e9f21e4196e8afc41def81ef649c164bca25e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/clock": "^3.2",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^11.1"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-10-17T11:30:53+00:00"
+        },
+        {
+            "name": "lexik/jwt-authentication-bundle",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lexik/LexikJWTAuthenticationBundle.git",
+                "reference": "60df75dc70ee6f597929cb2f0812adda591dfa4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lexik/LexikJWTAuthenticationBundle/zipball/60df75dc70ee6f597929cb2f0812adda591dfa4b",
+                "reference": "60df75dc70ee6f597929cb2f0812adda591dfa4b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "lcobucci/jwt": "^5.0",
+                "php": ">=8.2",
+                "symfony/clock": "^6.4|^7.0|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^2.4|^3.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/security-bundle": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "api-platform/core": "^3.0|^4.0",
+                "rector/rector": "^1.2",
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dom-crawler": "^6.4|^7.0|^8.0",
+                "symfony/filesystem": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/phpunit-bridge": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "suggest": {
+                "gesdinet/jwt-refresh-token-bundle": "Implements a refresh token system over Json Web Tokens in Symfony",
+                "spomky-labs/lexik-jose-bridge": "Provides a JWT Token encoder with encryption support"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Lexik\\Bundle\\JWTAuthenticationBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Barthe",
+                    "email": "j.barthe@lexik.fr",
+                    "homepage": "https://github.com/jeremyb"
+                },
+                {
+                    "name": "Nicolas Cabot",
+                    "email": "n.cabot@lexik.fr",
+                    "homepage": "https://github.com/slashfan"
+                },
+                {
+                    "name": "Cedric Girard",
+                    "email": "c.girard@lexik.fr",
+                    "homepage": "https://github.com/cedric-g"
+                },
+                {
+                    "name": "Dev Lexik",
+                    "email": "dev@lexik.fr",
+                    "homepage": "https://github.com/lexik"
+                },
+                {
+                    "name": "Robin Chalas",
+                    "email": "robin.chalas@gmail.com",
+                    "homepage": "https://github.com/chalasr"
+                },
+                {
+                    "name": "Lexik Community",
+                    "homepage": "https://github.com/lexik/LexikJWTAuthenticationBundle/graphs/contributors"
+                }
+            ],
+            "description": "This bundle provides JWT authentication for your Symfony REST API",
+            "homepage": "https://github.com/lexik/LexikJWTAuthenticationBundle",
+            "keywords": [
+                "Authentication",
+                "JWS",
+                "api",
+                "bundle",
+                "jwt",
+                "rest",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/lexik/LexikJWTAuthenticationBundle/issues",
+                "source": "https://github.com/lexik/LexikJWTAuthenticationBundle/tree/v3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/chalasr",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/lexik/jwt-authentication-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-20T17:47:00+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/apps/api/config/bundles.php
+++ b/apps/api/config/bundles.php
@@ -9,4 +9,5 @@ return [
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     Zenstruck\Foundry\ZenstruckFoundryBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
+    Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
 ];

--- a/apps/api/config/packages/lexik_jwt_authentication.yaml
+++ b/apps/api/config/packages/lexik_jwt_authentication.yaml
@@ -1,0 +1,4 @@
+lexik_jwt_authentication:
+    secret_key: '%env(resolve:JWT_SECRET_KEY)%'
+    public_key: '%env(resolve:JWT_PUBLIC_KEY)%'
+    pass_phrase: '%env(JWT_PASSPHRASE)%'

--- a/apps/api/config/packages/security.yaml
+++ b/apps/api/config/packages/security.yaml
@@ -1,39 +1,61 @@
 security:
-    # https://symfony.com/doc/current/security.html#registering-the-user-hashing-passwords
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
 
-    # https://symfony.com/doc/current/security.html#loading-the-user-the-user-provider
     providers:
-        users_in_memory: { memory: null }
+        # Sprint 0: only the App\Identity user store is consulted. Static
+        # in-memory users are gone — the `admin@pim.localhost` fixture is the
+        # entry point until real onboarding lands.
+        app_user_provider:
+            entity:
+                class: App\Identity\Domain\Entity\User
+                property: email
 
     firewalls:
         dev:
-            # Ensure dev tools and static assets are always allowed
             pattern: ^/(_profiler|_wdt|assets|build)/
             security: false
+
+        # Login firewall: stateless JSON form. POST /api/auth/login with
+        # {"email": ..., "password": ...} returns a signed JWT.
+        login:
+            pattern: ^/api/auth/login$
+            stateless: true
+            json_login:
+                check_path: /api/auth/login
+                username_path: email
+                success_handler: lexik_jwt_authentication.handler.authentication_success
+                failure_handler: lexik_jwt_authentication.handler.authentication_failure
+
+        # API firewall: every other /api/* request must carry a valid JWT.
+        # The exception below in access_control opens /api/docs and the JSON
+        # OpenAPI schema for unauthenticated reads (dev/staging) — production
+        # disables Swagger UI at the api_platform.enable_swagger_ui level.
+        api:
+            pattern: ^/api
+            stateless: true
+            jwt: ~
+            provider: app_user_provider
+
         main:
             lazy: true
-            provider: users_in_memory
+            provider: app_user_provider
 
-            # Activate different ways to authenticate:
-            # https://symfony.com/doc/current/security.html#the-firewall
-
-            # https://symfony.com/doc/current/security/impersonating_user.html
-            # switch_user: true
-
-    # Note: Only the *first* matching rule is applied
     access_control:
-        # - { path: ^/admin, roles: ROLE_ADMIN }
-        # - { path: ^/profile, roles: ROLE_USER }
+        # Public auth + docs. Everything else under /api requires JWT.
+        - { path: ^/api/auth/login, roles: PUBLIC_ACCESS }
+        - { path: ^/api/docs, roles: PUBLIC_ACCESS }
+        - { path: ^/api/contexts, roles: PUBLIC_ACCESS }
+        - { path: ^/api$, roles: PUBLIC_ACCESS }
+        - { path: ^/api, roles: ROLE_USER }
 
 when@test:
     security:
         password_hashers:
-            # Password hashers are resource-intensive by design to ensure security.
-            # In tests, it's safe to reduce their cost to improve performance.
+            # Tests intentionally use the lowest cost — security is not the
+            # subject of the unit/functional suite.
             Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface:
                 algorithm: auto
-                cost: 4 # Lowest possible value for bcrypt
-                time_cost: 3 # Lowest possible value for argon
-                memory_cost: 10 # Lowest possible value for argon
+                cost: 4
+                time_cost: 3
+                memory_cost: 10

--- a/apps/api/config/reference.php
+++ b/apps/api/config/reference.php
@@ -1293,6 +1293,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
  *             password_attribute?: scalar|Param|null, // Default: null
  *         },
+ *         lexik_jwt?: array{
+ *             class?: scalar|Param|null, // Default: "Lexik\\Bundle\\JWTAuthenticationBundle\\Security\\User\\JWTUser"
+ *         },
  *     }>,
  *     firewalls?: array<string, array{ // Default: []
  *         pattern?: scalar|Param|null,
@@ -1350,6 +1353,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         remote_user?: array{
  *             provider?: scalar|Param|null,
  *             user?: scalar|Param|null, // Default: "REMOTE_USER"
+ *         },
+ *         jwt?: array{
+ *             provider?: scalar|Param|null, // Default: null
+ *             authenticator?: scalar|Param|null, // Default: "lexik_jwt_authentication.security.jwt_authenticator"
  *         },
  *         login_link?: array{
  *             check_route?: scalar|Param|null, // Route that will validate the login link - e.g. "app_login_link_verify".
@@ -1627,6 +1634,91 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         html_to_text_converter?: scalar|Param|null, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
  *     },
  * }
+ * @psalm-type LexikJwtAuthenticationConfig = array{
+ *     public_key?: scalar|Param|null, // The key used to sign tokens (useless for HMAC). If not set, the key will be automatically computed from the secret key. // Default: null
+ *     additional_public_keys?: list<scalar|Param|null>,
+ *     secret_key?: scalar|Param|null, // The key used to sign tokens. It can be a raw secret (for HMAC), a raw RSA/ECDSA key or the path to a file itself being plaintext or PEM. // Default: null
+ *     pass_phrase?: scalar|Param|null, // The key passphrase (useless for HMAC) // Default: ""
+ *     token_ttl?: scalar|Param|null, // Default: 3600
+ *     allow_no_expiration?: bool|Param, // Allow tokens without "exp" claim (i.e. indefinitely valid, no lifetime) to be considered valid. Caution: usage of this should be rare. // Default: false
+ *     clock_skew?: scalar|Param|null, // Default: 0
+ *     encoder?: array{
+ *         service?: scalar|Param|null, // Default: "lexik_jwt_authentication.encoder.lcobucci"
+ *         signature_algorithm?: scalar|Param|null, // Default: "RS256"
+ *     },
+ *     user_id_claim?: scalar|Param|null, // Default: "username"
+ *     token_extractors?: array{
+ *         authorization_header?: bool|array{
+ *             enabled?: bool|Param, // Default: true
+ *             prefix?: scalar|Param|null, // Default: "Bearer"
+ *             name?: scalar|Param|null, // Default: "Authorization"
+ *         },
+ *         cookie?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             name?: scalar|Param|null, // Default: "BEARER"
+ *         },
+ *         query_parameter?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             name?: scalar|Param|null, // Default: "bearer"
+ *         },
+ *         split_cookie?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             cookies?: list<scalar|Param|null>,
+ *         },
+ *     },
+ *     remove_token_from_body_when_cookies_used?: scalar|Param|null, // Default: true
+ *     set_cookies?: array<string, array{ // Default: []
+ *         lifetime?: scalar|Param|null, // The cookie lifetime. If null, the "token_ttl" option value will be used // Default: null
+ *         samesite?: "none"|"lax"|"strict"|Param, // Default: "lax"
+ *         path?: scalar|Param|null, // Default: "/"
+ *         domain?: scalar|Param|null, // Default: null
+ *         secure?: scalar|Param|null, // Default: true
+ *         httpOnly?: scalar|Param|null, // Default: true
+ *         partitioned?: scalar|Param|null, // Default: false
+ *         split?: list<scalar|Param|null>,
+ *     }>,
+ *     api_platform?: bool|array{ // API Platform compatibility: add check_path in OpenAPI documentation.
+ *         enabled?: bool|Param, // Default: false
+ *         check_path?: scalar|Param|null, // The login check path to add in OpenAPI. // Default: null
+ *         username_path?: scalar|Param|null, // The path to the username in the JSON body. // Default: null
+ *         password_path?: scalar|Param|null, // The path to the password in the JSON body. // Default: null
+ *     },
+ *     access_token_issuance?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         signature?: array{
+ *             algorithm?: scalar|Param|null, // The algorithm use to sign the access tokens.
+ *             key?: scalar|Param|null, // The signature key. It shall be JWK encoded.
+ *         },
+ *         encryption?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             key_encryption_algorithm?: scalar|Param|null, // The key encryption algorithm is used to encrypt the token.
+ *             content_encryption_algorithm?: scalar|Param|null, // The key encryption algorithm is used to encrypt the token.
+ *             key?: scalar|Param|null, // The encryption key. It shall be JWK encoded.
+ *         },
+ *     },
+ *     access_token_verification?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         signature?: array{
+ *             header_checkers?: list<scalar|Param|null>,
+ *             claim_checkers?: list<scalar|Param|null>,
+ *             mandatory_claims?: list<scalar|Param|null>,
+ *             allowed_algorithms?: list<scalar|Param|null>,
+ *             keyset?: scalar|Param|null, // The signature keyset. It shall be JWKSet encoded.
+ *         },
+ *         encryption?: bool|array{
+ *             enabled?: bool|Param, // Default: false
+ *             continue_on_decryption_failure?: bool|Param, // If enable, non-encrypted tokens or tokens that failed during decryption or verification processes are accepted. // Default: false
+ *             header_checkers?: list<scalar|Param|null>,
+ *             allowed_key_encryption_algorithms?: list<scalar|Param|null>,
+ *             allowed_content_encryption_algorithms?: list<scalar|Param|null>,
+ *             keyset?: scalar|Param|null, // The encryption keyset. It shall be JWKSet encoded.
+ *         },
+ *     },
+ *     blocklist_token?: bool|array{
+ *         enabled?: bool|Param, // Default: false
+ *         cache?: scalar|Param|null, // Storage to track blocked tokens // Default: "cache.app"
+ *     },
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1637,6 +1729,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     doctrine_migrations?: DoctrineMigrationsConfig,
  *     security?: SecurityConfig,
  *     twig?: TwigConfig,
+ *     lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1648,6 +1741,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         security?: SecurityConfig,
  *         zenstruck_foundry?: ZenstruckFoundryConfig,
  *         twig?: TwigConfig,
+ *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -1659,6 +1753,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         doctrine_migrations?: DoctrineMigrationsConfig,
  *         security?: SecurityConfig,
  *         twig?: TwigConfig,
+ *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1671,6 +1766,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         security?: SecurityConfig,
  *         zenstruck_foundry?: ZenstruckFoundryConfig,
  *         twig?: TwigConfig,
+ *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/apps/api/config/routes/security.yaml
+++ b/apps/api/config/routes/security.yaml
@@ -1,3 +1,10 @@
 _security_logout:
     resource: security.route_loader.logout
     type: service
+
+# Lexik JSON login is wired to the json_login authenticator on the `login`
+# firewall (security.yaml). The route exists only to give it a real URL the
+# router can match — the controller is the firewall itself, no body needed.
+api_auth_login:
+    path: /api/auth/login
+    methods: [POST]

--- a/apps/api/migrations/Version20260427095515.php
+++ b/apps/api/migrations/Version20260427095515.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds the `users` table — minimal Sprint-0 shape for ticket #4 (0.0.4):
+ * email + password hash + JSON roles + tenant FK. Full RBAC model lands in
+ * epic 0.2 (#24+); this is the surface LexikJWT authenticates against.
+ */
+final class Version20260427095515 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create users table with tenant FK for JWT authentication (#4).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE users (id UUID NOT NULL, email VARCHAR(255) NOT NULL, password VARCHAR(255) NOT NULL, roles JSON NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, tenant_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX users_tenant_idx ON users (tenant_id)');
+        $this->addSql('CREATE UNIQUE INDEX users_email_uniq ON users (email)');
+        $this->addSql('ALTER TABLE users ADD CONSTRAINT users_tenant_fk FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE RESTRICT NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE users DROP CONSTRAINT users_tenant_fk');
+        $this->addSql('DROP TABLE users');
+    }
+}

--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -7,15 +7,19 @@ namespace App\DataFixtures;
 use App\Catalog\Domain\Entity\Product;
 use App\Identity\Application\TenantContext;
 use App\Identity\Domain\Entity\Tenant;
+use App\Identity\Domain\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Sprint 0 demo dataset.
  *
- * Two tenants ("demo" and "acme") each with three products. The pair lets the
- * smoke test for tenant isolation (#12 / 0.0.12) flip APP_DEFAULT_TENANT_CODE
- * between them and assert that the TenantFilter actually scopes queries.
+ * Two tenants ("demo" and "acme") each with one admin user and three products.
+ * The pair lets the smoke test for tenant isolation (#12 / 0.0.12) flip
+ * APP_DEFAULT_TENANT_CODE between them and assert that the TenantFilter
+ * actually scopes queries; once auth lands (#4 / 0.0.4) callers obtain a JWT
+ * for the desired tenant's admin instead of relying on the env fallback.
  *
  * Bootstrap order matters: tenants are persisted first (without flushing the
  * unit of work), then for each tenant we set TenantContext and persist its
@@ -24,8 +28,11 @@ use Doctrine\Persistence\ObjectManager;
  */
 class AppFixtures extends Fixture
 {
+    private const string DEFAULT_ADMIN_PASSWORD = 'changeme';
+
     public function __construct(
         private readonly TenantContext $tenantContext,
+        private readonly UserPasswordHasherInterface $passwordHasher,
     ) {
     }
 
@@ -40,6 +47,23 @@ class AppFixtures extends Fixture
             $manager->persist($tenant);
         }
 
+        $manager->flush();
+
+        $admins = [
+            'demo' => 'admin@pim.localhost',
+            'acme' => 'admin@acme.localhost',
+        ];
+        foreach ($tenants as $tenant) {
+            $email = $admins[$tenant->getCode()];
+            $stub = new User($tenant, $email, '', ['ROLE_ADMIN']);
+            $admin = new User(
+                $tenant,
+                $email,
+                $this->passwordHasher->hashPassword($stub, self::DEFAULT_ADMIN_PASSWORD),
+                ['ROLE_ADMIN'],
+            );
+            $manager->persist($admin);
+        }
         $manager->flush();
 
         $catalog = [

--- a/apps/api/src/Identity/Domain/Entity/User.php
+++ b/apps/api/src/Identity/Domain/Entity/User.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Entity;
+
+use App\Identity\Application\TenantAware;
+use App\Identity\Infrastructure\Doctrine\Repository\UserRepository;
+use DateTimeImmutable;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Application user with a tenant scope.
+ *
+ * Sprint 0 minimal shape — email + password hash + roles. Full RBAC and 2FA
+ * land in epics 0.2 (#24+) and 0.11; for the gate-decision slice this is
+ * enough to authenticate via JWT and resolve the active tenant from the
+ * authenticated principal (replacing the APP_DEFAULT_TENANT_CODE fallback
+ * once auth covers the request).
+ *
+ * The TenantAware interface lets CurrentTenantProvider read the tenant from
+ * the security token's user without coupling Identity to Catalog.
+ */
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+#[ORM\Table(name: 'users')]
+#[ORM\UniqueConstraint(name: 'users_email_uniq', columns: ['email'])]
+#[ORM\Index(name: 'users_tenant_idx', columns: ['tenant_id'])]
+class User implements UserInterface, PasswordAuthenticatedUserInterface, TenantAware
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'uuid')]
+    private Uuid $id;
+
+    #[ORM\ManyToOne(targetEntity: Tenant::class)]
+    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
+    private Tenant $tenant;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $email;
+
+    #[ORM\Column(type: 'string')]
+    private string $password;
+
+    /**
+     * @var list<string>
+     */
+    #[ORM\Column(type: 'json')]
+    private array $roles;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param list<string> $roles
+     */
+    public function __construct(
+        Tenant $tenant,
+        string $email,
+        string $passwordHash,
+        array $roles = ['ROLE_USER'],
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->tenant = $tenant;
+        $this->email = $email;
+        $this->password = $passwordHash;
+        $this->roles = $roles;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): Tenant
+    {
+        return $this->tenant;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getRoles(): array
+    {
+        $roles = $this->roles;
+        // Symfony convention — every authenticated user must have ROLE_USER
+        // even when not stored explicitly, so access_control rules behave as
+        // documented across the framework.
+        if (!\in_array('ROLE_USER', $roles, true)) {
+            $roles[] = 'ROLE_USER';
+        }
+
+        return $roles;
+    }
+
+    public function getUserIdentifier(): string
+    {
+        \assert('' !== $this->email, 'User email is enforced NOT NULL by the schema and never empty.');
+
+        return $this->email;
+    }
+
+    public function eraseCredentials(): void
+    {
+        // No transient sensitive data — password hash stays for re-auth flows.
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Repository/UserRepository.php
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Repository/UserRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Doctrine\Repository;
+
+use App\Identity\Domain\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<User>
+ */
+class UserRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, User::class);
+    }
+
+    public function findByEmail(string $email): ?User
+    {
+        return $this->findOneBy(['email' => $email]);
+    }
+}

--- a/apps/api/symfony.lock
+++ b/apps/api/symfony.lock
@@ -73,6 +73,18 @@
             ".php-cs-fixer.dist.php"
         ]
     },
+    "lexik/jwt-authentication-bundle": {
+        "version": "3.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.5",
+            "ref": "e9481b233a11ef7e15fe055a2b21fd3ac1aa2bb7"
+        },
+        "files": [
+            "config/packages/lexik_jwt_authentication.yaml"
+        ]
+    },
     "phpstan/phpstan": {
         "version": "2.1",
         "recipe": {

--- a/apps/api/tests/Functional/Catalog/ProductApiTest.php
+++ b/apps/api/tests/Functional/Catalog/ProductApiTest.php
@@ -8,9 +8,11 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Catalog\Domain\Entity\Product;
 use App\Identity\Application\TenantContext;
 use App\Identity\Domain\Entity\Tenant;
-use App\Identity\Infrastructure\Doctrine\Repository\TenantRepository;
+use App\Identity\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
@@ -20,9 +22,10 @@ use const JSON_THROW_ON_ERROR;
  * Functional API contract for /api/products.
  *
  * Each test runs against a fresh schema (Foundry ResetDatabase) and seeds a
- * single "demo" Tenant matching APP_DEFAULT_TENANT_CODE so the request
- * subscriber + Doctrine filter resolve a real tenant. Authentication wiring
- * lands in #4 (0.0.4); for Sprint 0 the env-fallback path is exercised here.
+ * single "demo" Tenant plus an admin user. Requests are authenticated by
+ * minting a JWT for that user via JWTTokenManager so the JWT firewall lets
+ * the request through and CurrentTenantProvider resolves the tenant from
+ * the authenticated principal (TenantAware).
  */
 final class ProductApiTest extends ApiTestCase
 {
@@ -36,13 +39,27 @@ final class ProductApiTest extends ApiTestCase
     protected static ?bool $alwaysBootKernel = true;
 
     private const string TENANT_CODE = 'demo';
+    private const string ADMIN_EMAIL = 'admin@pim.localhost';
+    private const string ADMIN_PASSWORD = 'changeme';
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $em = $this->em();
-        $em->persist(new Tenant(self::TENANT_CODE, 'Demo Tenant'));
+
+        $tenant = new Tenant(self::TENANT_CODE, 'Demo Tenant');
+        $em->persist($tenant);
+
+        $hasher = $this->passwordHasher();
+        $stub = new User($tenant, self::ADMIN_EMAIL, '', ['ROLE_ADMIN']);
+        $admin = new User(
+            $tenant,
+            self::ADMIN_EMAIL,
+            $hasher->hashPassword($stub, self::ADMIN_PASSWORD),
+            ['ROLE_ADMIN'],
+        );
+        $em->persist($admin);
         $em->flush();
     }
 
@@ -52,7 +69,7 @@ final class ProductApiTest extends ApiTestCase
         $this->seedProduct('SKU-LIST-001', 'Listed product');
         $this->seedProduct('SKU-LIST-002', 'Another listed product');
 
-        static::createClient()->request('GET', '/api/products');
+        $this->authenticatedClient()->request('GET', '/api/products');
 
         self::assertResponseIsSuccessful();
         self::assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
@@ -74,7 +91,7 @@ final class ProductApiTest extends ApiTestCase
             'brand' => 'Acme',
         ];
 
-        $response = static::createClient()->request('POST', '/api/products', [
+        $response = $this->authenticatedClient()->request('POST', '/api/products', [
             'headers' => ['content-type' => 'application/ld+json'],
             'body' => json_encode($payload, JSON_THROW_ON_ERROR),
         ]);
@@ -100,7 +117,7 @@ final class ProductApiTest extends ApiTestCase
     #[Test]
     public function postRejectsBlankSkuAndName(): void
     {
-        static::createClient()->request('POST', '/api/products', [
+        $this->authenticatedClient()->request('POST', '/api/products', [
             'headers' => ['content-type' => 'application/ld+json'],
             'body' => json_encode(['sku' => '', 'name' => ''], JSON_THROW_ON_ERROR),
         ]);
@@ -117,7 +134,7 @@ final class ProductApiTest extends ApiTestCase
     {
         $product = $this->seedProduct('SKU-GET-001', 'Single product');
 
-        static::createClient()->request('GET', '/api/products/'.$product->getId()->toRfc4122());
+        $this->authenticatedClient()->request('GET', '/api/products/'.$product->getId()->toRfc4122());
 
         self::assertResponseIsSuccessful();
         self::assertJsonContains([
@@ -132,7 +149,7 @@ final class ProductApiTest extends ApiTestCase
     {
         $product = $this->seedProduct('SKU-PATCH-001', 'Original name');
 
-        static::createClient()->request('PATCH', '/api/products/'.$product->getId()->toRfc4122(), [
+        $this->authenticatedClient()->request('PATCH', '/api/products/'.$product->getId()->toRfc4122(), [
             'headers' => ['content-type' => 'application/merge-patch+json'],
             'body' => json_encode([
                 'sku' => 'SKU-HIJACKED',
@@ -159,7 +176,10 @@ final class ProductApiTest extends ApiTestCase
         $this->seedProduct('SKU-CURSOR-002', 'B');
         $this->seedProduct('SKU-CURSOR-003', 'C');
 
-        $response = static::createClient()->request('GET', '/api/products?id[lt]=ffffffff-ffff-ffff-ffff-ffffffffffff');
+        $response = $this->authenticatedClient()->request(
+            'GET',
+            '/api/products?id[lt]=ffffffff-ffff-ffff-ffff-ffffffffffff',
+        );
 
         self::assertResponseIsSuccessful();
         $body = $response->toArray();
@@ -174,12 +194,12 @@ final class ProductApiTest extends ApiTestCase
     {
         $container = self::getContainer();
 
-        $tenantRepository = $container->get(TenantRepository::class);
-        $tenant = $tenantRepository->findByCode(self::TENANT_CODE);
-        \assert($tenant instanceof Tenant, 'setUp must seed the demo tenant.');
+        $userRepository = $container->get('doctrine')->getRepository(User::class);
+        $admin = $userRepository->findOneBy(['email' => self::ADMIN_EMAIL]);
+        \assert($admin instanceof User);
 
         $tenantContext = $container->get(TenantContext::class);
-        $tenantContext->set($tenant);
+        $tenantContext->set($admin->getTenant());
 
         $em = $this->em();
         $product = new Product($sku, $name);
@@ -189,6 +209,33 @@ final class ProductApiTest extends ApiTestCase
         $tenantContext->clear();
 
         return $product;
+    }
+
+    private function authenticatedClient(): \ApiPlatform\Symfony\Bundle\Test\Client
+    {
+        $client = static::createClient();
+        $token = $this->jwtForAdmin();
+
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$token]]);
+
+        return $client;
+    }
+
+    private function jwtForAdmin(): string
+    {
+        $container = self::getContainer();
+        $userRepository = $container->get('doctrine')->getRepository(User::class);
+        $admin = $userRepository->findOneBy(['email' => self::ADMIN_EMAIL]);
+        \assert($admin instanceof User);
+
+        $jwtManager = $container->get(JWTTokenManagerInterface::class);
+
+        return $jwtManager->create($admin);
+    }
+
+    private function passwordHasher(): UserPasswordHasherInterface
+    {
+        return self::getContainer()->get(UserPasswordHasherInterface::class);
     }
 
     private function em(): EntityManagerInterface

--- a/apps/api/tests/Functional/Identity/AuthApiTest.php
+++ b/apps/api/tests/Functional/Identity/AuthApiTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Identity\Domain\Entity\Tenant;
+use App\Identity\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Functional contract for the Sprint-0 auth slice (#4 / 0.0.4):
+ *  - POST /api/auth/login with valid credentials returns a JWT
+ *  - Wrong credentials return 401 (no token leak)
+ *  - Protected endpoints require a Bearer JWT
+ *  - A valid JWT lets the request through
+ */
+final class AuthApiTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_CODE = 'demo';
+    private const string ADMIN_EMAIL = 'admin@pim.localhost';
+    private const string ADMIN_PASSWORD = 'changeme';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $em = $this->em();
+
+        $tenant = new Tenant(self::TENANT_CODE, 'Demo Tenant');
+        $em->persist($tenant);
+
+        $hasher = $this->passwordHasher();
+        $stub = new User($tenant, self::ADMIN_EMAIL, '', ['ROLE_ADMIN']);
+        $admin = new User(
+            $tenant,
+            self::ADMIN_EMAIL,
+            $hasher->hashPassword($stub, self::ADMIN_PASSWORD),
+            ['ROLE_ADMIN'],
+        );
+        $em->persist($admin);
+        $em->flush();
+    }
+
+    #[Test]
+    public function loginWithValidCredentialsReturnsJwt(): void
+    {
+        $response = static::createClient()->request('POST', '/api/auth/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(
+                ['email' => self::ADMIN_EMAIL, 'password' => self::ADMIN_PASSWORD],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertArrayHasKey('token', $body);
+        $token = $body['token'];
+        self::assertIsString($token);
+        // Three base64url segments separated by dots is the JWS compact serialisation.
+        self::assertMatchesRegularExpression('#^[\w-]+\.[\w-]+\.[\w-]+$#', $token);
+    }
+
+    #[Test]
+    public function loginWithWrongPasswordReturns401(): void
+    {
+        static::createClient()->request('POST', '/api/auth/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(
+                ['email' => self::ADMIN_EMAIL, 'password' => 'wrong'],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function protectedEndpointWithoutTokenReturns401(): void
+    {
+        static::createClient()->request('GET', '/api/products');
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function protectedEndpointWithValidTokenReturns200(): void
+    {
+        $token = $this->loginAndExtractToken();
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$token]]);
+        $client->request('GET', '/api/products');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function protectedEndpointWithMalformedTokenReturns401(): void
+    {
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer not.a.real.jwt']]);
+        $client->request('GET', '/api/products');
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    private function loginAndExtractToken(): string
+    {
+        $response = static::createClient()->request('POST', '/api/auth/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(
+                ['email' => self::ADMIN_EMAIL, 'password' => self::ADMIN_PASSWORD],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+
+        $token = $response->toArray()['token'] ?? null;
+        \assert(\is_string($token));
+
+        return $token;
+    }
+
+    private function passwordHasher(): UserPasswordHasherInterface
+    {
+        return self::getContainer()->get(UserPasswordHasherInterface::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Functional/Identity/TenantIsolationTest.php
+++ b/apps/api/tests/Functional/Identity/TenantIsolationTest.php
@@ -7,8 +7,11 @@ namespace App\Tests\Functional\Identity;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Catalog\Domain\Entity\Product;
 use App\Identity\Domain\Entity\Tenant;
+use App\Identity\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Uid\Uuid;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
@@ -20,11 +23,10 @@ use const JSON_THROW_ON_ERROR;
  * actually scopes reads to the current tenant and that the Postgres unique
  * index does not accidentally leak the existence of cross-tenant rows.
  *
- * The "current tenant" in Sprint-0 (pre-auth) is resolved by
- * CurrentTenantProvider from APP_DEFAULT_TENANT_CODE; we flip that env var
- * between requests, shutting the kernel between flips so the freshly booted
- * container resolves the new value. Once #4 (0.0.4) lands the kernel reboots
- * become unnecessary — the test can authenticate as either tenant's user.
+ * Each tenant has its own admin user; tests authenticate as that admin via
+ * a JWT minted by JWTTokenManager and CurrentTenantProvider resolves the
+ * tenant from the authenticated principal (TenantAware). No env-var dance
+ * needed once auth is wired (#4).
  *
  * Native-SQL bypass test is intentional: it documents that this filter is the
  * application-layer boundary only. Postgres RLS in phase 1 (sekcja 11.1a
@@ -40,6 +42,9 @@ final class TenantIsolationTest extends ApiTestCase
 
     private const string TENANT_A_CODE = 'tenant-alpha';
     private const string TENANT_B_CODE = 'tenant-bravo';
+    private const string TENANT_A_EMAIL = 'admin@alpha.test';
+    private const string TENANT_B_EMAIL = 'admin@bravo.test';
+    private const string ADMIN_PASSWORD = 'changeme';
     private const int PRODUCTS_PER_TENANT = 5;
 
     private Uuid $tenantBProductId;
@@ -56,6 +61,10 @@ final class TenantIsolationTest extends ApiTestCase
         $em->persist($tenantB);
         $em->flush();
 
+        $this->seedAdmin($tenantA, self::TENANT_A_EMAIL);
+        $this->seedAdmin($tenantB, self::TENANT_B_EMAIL);
+        $em->flush();
+
         for ($i = 1; $i <= self::PRODUCTS_PER_TENANT; ++$i) {
             $alphaProduct = new Product(\sprintf('ALPHA-%03d', $i), \sprintf('Alpha #%d', $i));
             $alphaProduct->assignTenant($tenantA);
@@ -70,19 +79,12 @@ final class TenantIsolationTest extends ApiTestCase
             }
         }
         $em->flush();
-
-        // The test below boots a fresh kernel through createClient(); shutting
-        // down here means the next boot picks up our APP_DEFAULT_TENANT_CODE
-        // override instead of a cached value from the seed-phase boot.
-        static::ensureKernelShutdown();
     }
 
     #[Test]
     public function listingProductsAsTenantAReturnsOnlyTenantARecords(): void
     {
-        $this->withTenant(self::TENANT_A_CODE);
-
-        $response = static::createClient()->request('GET', '/api/products');
+        $response = $this->clientForUser(self::TENANT_A_EMAIL)->request('GET', '/api/products');
 
         self::assertResponseIsSuccessful();
         $body = $response->toArray();
@@ -105,9 +107,7 @@ final class TenantIsolationTest extends ApiTestCase
     #[Test]
     public function fetchingTenantBProductAsTenantAReturns404(): void
     {
-        $this->withTenant(self::TENANT_A_CODE);
-
-        static::createClient()->request(
+        $this->clientForUser(self::TENANT_A_EMAIL)->request(
             'GET',
             '/api/products/'.$this->tenantBProductId->toRfc4122(),
         );
@@ -121,9 +121,7 @@ final class TenantIsolationTest extends ApiTestCase
     #[Test]
     public function patchingTenantBProductAsTenantAReturns404(): void
     {
-        $this->withTenant(self::TENANT_A_CODE);
-
-        static::createClient()->request(
+        $this->clientForUser(self::TENANT_A_EMAIL)->request(
             'PATCH',
             '/api/products/'.$this->tenantBProductId->toRfc4122(),
             [
@@ -155,11 +153,39 @@ final class TenantIsolationTest extends ApiTestCase
         );
     }
 
-    private function withTenant(string $code): void
+    private function seedAdmin(Tenant $tenant, string $email): void
     {
-        $_ENV['APP_DEFAULT_TENANT_CODE'] = $code;
-        $_SERVER['APP_DEFAULT_TENANT_CODE'] = $code;
-        putenv('APP_DEFAULT_TENANT_CODE='.$code);
+        $hasher = $this->passwordHasher();
+        $stub = new User($tenant, $email, '', ['ROLE_ADMIN']);
+        $admin = new User(
+            $tenant,
+            $email,
+            $hasher->hashPassword($stub, self::ADMIN_PASSWORD),
+            ['ROLE_ADMIN'],
+        );
+
+        $this->em()->persist($admin);
+    }
+
+    private function clientForUser(string $email): \ApiPlatform\Symfony\Bundle\Test\Client
+    {
+        $container = self::getContainer();
+        $userRepository = $container->get('doctrine')->getRepository(User::class);
+        $user = $userRepository->findOneBy(['email' => $email]);
+        \assert($user instanceof User);
+
+        $jwtManager = $container->get(JWTTokenManagerInterface::class);
+        $token = $jwtManager->create($user);
+
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$token]]);
+
+        return $client;
+    }
+
+    private function passwordHasher(): UserPasswordHasherInterface
+    {
+        return self::getContainer()->get(UserPasswordHasherInterface::class);
     }
 
     private function em(): EntityManagerInterface


### PR DESCRIPTION
## Cel

Zamknięcie ticketu #4 (0.0.4) — minimalna autentykacja Sprint-0: jeden statyczny user (admin per tenant) + JWT przez LexikJWTAuthenticationBundle. Odblokowuje #5 (admin), #6 (agent), eliminuje env-fallback w `CurrentTenantProvider` dla autentykowanych requestów.

## Co zmienia

### Encja `User` (Identity context)
- `src/Identity/Domain/Entity/User.php`: email + password hash + JSON roles + tenant FK + UUID v7 id
- Implementuje `UserInterface`, `PasswordAuthenticatedUserInterface` i nasz `TenantAware` → `CurrentTenantProvider` resolvuje tenanta bezpośrednio z authenticated principal
- `users` table z migracją `Version20260427095515` (FK → tenants ON DELETE RESTRICT, unique email, index na tenant_id)

### LexikJWT + security firewalls
- `composer require lexik/jwt-authentication-bundle:^3` (v3.2.0)
- 3 firewalls w `security.yaml`:
  - **`login`** (`^/api/auth/login$`, stateless) — `json_login` z `username_path: email`, success/failure handlers Lexik
  - **`api`** (`^/api`, stateless) — `jwt: ~` + `app_user_provider` (entity provider na User)
  - **`main`** (lazy, lazy-only fallback)
- `access_control`: `/api/auth/login`, `/api/docs`, `/api/contexts`, `/api` (entrypoint) → `PUBLIC_ACCESS`; reszta `^/api` → `ROLE_USER`
- Route `api_auth_login: POST /api/auth/login` (controller-less — firewall handle'uje)

### Fixtures
- `admin@pim.localhost` (tenant: demo) i `admin@acme.localhost` (tenant: acme), oba z hasłem `changeme` (hashed), role `ROLE_ADMIN`
- Hasher injektowany do `AppFixtures` przez `UserPasswordHasherInterface`

### Klucze RSA
- `bin/console lexik:jwt:generate-keypair` wygenerował 4096-bit RSA do `config/jwt/{private,public}.pem`
- **Oba klucze gitignored** (Lexik recipe ustawia automatycznie). Devs generują własne lokalnie; produkcja mountuje z vault'a; CI generuje fresh per workflow run
- `JWT_PASSPHRASE` randomized w `.env` (per-developer); CI używa `ci` zarówno do generacji jak i runtime'u

### Testy
- **`AuthApiTest`** (5 case'ów): login success, login wrong-password 401, protected endpoint bez tokena 401, protected endpoint z tokenem 200, malformed token 401
- **`ProductApiTest`** (6 case'ów): teraz mintuje JWT przez `JWTTokenManagerInterface->create($admin)` i przekazuje przez `Authorization: Bearer ...`
- **`TenantIsolationTest`** (4 case'y): zastąpiony `APP_DEFAULT_TENANT_CODE` flip — każdy tenant ma własnego admina, test loguje jako admin tenanta A. Czystsze, bardziej realistyczne, tylko jeden boot kernela per test.

### CI
- `quality-php.yml` jobs `phpstan` i `phpunit` generują 4096-bit RSA keypair przed cache:clear/test'ami (`openssl genpkey ... -aes256 -pass pass:ci`)
- `JWT_PASSPHRASE: ci` w env obu jobs

## Manual smoke

```
$ curl -X POST -H "Content-Type: application/json" \
    -d '{"email":"admin@pim.localhost","password":"changeme"}' \
    https://pim.localhost/api/auth/login
{"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."}

$ curl -H "Authorization: Bearer $TOKEN" https://pim.localhost/api/products
{"@context":"/api/contexts/Product","totalItems":3,...}

$ curl https://pim.localhost/api/products
HTTP 401  ✓

$ curl -X POST -d '{"email":"admin@pim.localhost","password":"wrong"}' \
    https://pim.localhost/api/auth/login
HTTP 401  ✓
```

## Quality gates

- ✅ PHPStan max — green
- ✅ PHP-CS-Fixer — 0 issues
- ✅ PHPUnit — 19/19 tests, 44 assertions (5 AuthApi + 6 ProductApi + 4 TenantIsolation + 4 TenantAssignmentListener)
- ✅ composer audit — 0 advisories

## Świadome decyzje

- **Oba klucze RSA gitignored.** Ticket prosił "commit pubkey, private w `.env.local`" ale to mieszane standardy — popular Lexik recipe gitignoruje OBA, devs generują own keypair, produkcja mounting from vault. CI generuje per-run.
- **Hasło fixture admina = `changeme`** — explicit dev-only. Production migration dochodzi z prawdziwym onboarding flow w epiku 0.2.
- **`/api/docs`, `/api/contexts`, `/api` (entrypoint) PUBLIC** — żeby OpenAPI/Hydra tooling działał bez auth. Production może lock'ować `enable_swagger_ui: false` env-aware (widoczne w lessons z #3).
- **Brak refresh tokenów / token blacklist'u** — Lexik default 1h TTL na token. Refresh + blacklist (gesdinet/jwt-refresh-token-bundle) dochodzą w epiku 0.2 (#24+) z pełnym RBAC.
- **`User` nie implementuje `EquatableInterface`** — Lexik JWT stateless flow nie potrzebuje tego do session refresh. Wracamy w 0.2 jeśli przyjdzie session-aware path.

## Powiązania

- Closes #4
- Architektura: `Project Plan/01-architektura-pim.md` sekcja 6 (Identity & Access)
- Plan: `Project Plan/02-plan-projektu-pim.md` ticket 0.0.4
- Eliminuje env-flip dance w `TenantIsolationTest` (#12) — auth resolution teraz "real"

🤖 Generated with [Claude Code](https://claude.com/claude-code)