### PR TITLE
fix(admin): vite ESM alias + redirect after login/logout

### DIFF
--- a/apps/admin/src/layout/AppLayout.tsx
+++ b/apps/admin/src/layout/AppLayout.tsx
@@ -1,7 +1,7 @@
 import { useGetIdentity, useLogout } from '@refinedev/core';
 import { Boxes, LogOut, Package } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { NavLink, Outlet } from 'react-router';
+import { NavLink, Outlet, useNavigate } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -12,8 +12,18 @@ interface Identity {
 
 export function AppLayout() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { mutate: logout, isPending: loggingOut } = useLogout();
   const { data: identity } = useGetIdentity<Identity>();
+
+  const handleLogout = () => {
+    logout(undefined, {
+      // Plain react-router-7 here — Refine's routerProvider would handle the
+      // redirect for us; we navigate manually so logout actually leaves the
+      // protected layout.
+      onSuccess: () => navigate('/login', { replace: true }),
+    });
+  };
 
   return (
     <div className="flex min-h-screen bg-muted/30">
@@ -46,7 +56,7 @@ export function AppLayout() {
             {identity?.name ? (
               <span className="text-sm text-muted-foreground">{identity.name}</span>
             ) : null}
-            <Button variant="ghost" size="sm" onClick={() => logout()} disabled={loggingOut}>
+            <Button variant="ghost" size="sm" onClick={handleLogout} disabled={loggingOut}>
               <LogOut className="size-4" />
               {t('app.logout')}
             </Button>

--- a/apps/admin/src/pages/login.tsx
+++ b/apps/admin/src/pages/login.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useLogin } from '@refinedev/core';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 import { z } from 'zod';
 
 import { Button } from '@/components/ui/button';
@@ -18,14 +19,38 @@ type LoginValues = z.infer<typeof loginSchema>;
 
 export function LoginPage() {
   const { t } = useTranslation();
-  const { mutate: login, isPending, error } = useLogin<LoginValues>();
+  const navigate = useNavigate();
+  const { mutate: login, isPending } = useLogin<LoginValues>();
   const {
     register,
     handleSubmit,
     formState: { errors },
+    setError,
   } = useForm<LoginValues>({ resolver: zodResolver(loginSchema) });
 
-  const apiErrorKey = (error as { message?: string } | null | undefined)?.message ?? null;
+  const submit = handleSubmit((values) => {
+    login(values, {
+      onSuccess: (response) => {
+        // Refine collapses both validation and HTTP failures into a successful
+        // mutation with `success: false`; the routerProvider would normally
+        // honor the redirect — we do it manually since the admin uses plain
+        // react-router-7 instead of @refinedev/react-router.
+        if (response?.success === false) {
+          const message =
+            (response.error as { message?: string } | undefined)?.message ?? 'auth.login_failed';
+          setError('root', { message });
+          return;
+        }
+        const target = response?.redirectTo ?? '/products';
+        navigate(typeof target === 'string' ? target : '/products', { replace: true });
+      },
+      onError: () => {
+        setError('root', { message: 'auth.login_failed' });
+      },
+    });
+  });
+
+  const rootErrorKey = errors.root?.message ?? null;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
@@ -35,7 +60,7 @@ export function LoginPage() {
           <CardDescription>{t('auth.login_subtitle')}</CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit((values) => login(values))} className="space-y-4" noValidate>
+          <form onSubmit={submit} className="space-y-4" noValidate>
             <div className="space-y-2">
               <Label htmlFor="email">{t('auth.email')}</Label>
               <Input
@@ -56,9 +81,9 @@ export function LoginPage() {
                 {...register('password')}
               />
             </div>
-            {apiErrorKey ? (
+            {rootErrorKey ? (
               <p className="text-sm text-destructive" role="alert">
-                {t(apiErrorKey)}
+                {t(rootErrorKey)}
               </p>
             ) : null}
             <Button type="submit" className="w-full" disabled={isPending}>

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,7 +1,13 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+
+// `__dirname` is not defined in ESM (`"type": "module"` in package.json) — derive it
+// from `import.meta.url` so the @/* alias resolves correctly under both Vite dev
+// and Vite build.
+const here = path.dirname(fileURLToPath(import.meta.url));
 
 // HMR through Caddy reverse proxy: WebSocket upgrades on the same single origin (pim.localhost).
 // The Vite dev server listens on 0.0.0.0:5173 inside the container; Caddy forwards / and the
@@ -10,7 +16,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(here, './src'),
     },
   },
   server: {


### PR DESCRIPTION
## Cel

Hotfix do PR #119 (#5 admin Refine + shadcn). **Dwa fixy:**

### 1. Vite alias `@/*` failuje w dev server (ESM `__dirname` undefined)
Po merge'u dev server admin'a fail'uje z `Failed to resolve import "@/locales/en.json"` (i innych `@/*`) bo `__dirname` jest **undefined w ESM** (`"type": "module"` w `apps/admin/package.json`).

**Fix:** `vite.config.ts` używa `fileURLToPath(import.meta.url)` zamiast `__dirname`. To kanoniczny ESM pattern — działa w dev (Vite serve) i build (esbuild config compile).

**Dlaczego nie wykryliśmy w PR #119:** `pnpm build` (część CI) i lokalny `pnpm typecheck` przechodziły zielono — esbuild kompiluje config przed uruchomieniem i `__dirname` ma fallback do project root, a runtime build resolution sięga po fallback. **Dev server** (Vite dev) parsuje import na żywo bez tego fallback'u → fail.

### 2. Login button "nic nie robi" — brak redirectu

User raportował: po kliknięciu Sign In nic się nie dzieje. Diagnoza: Refine v5 honoruje `redirectTo` z `authProvider.login` **tylko z routerProvider'em**. My używamy plain react-router-7 bez `@refinedev/react-router` adaptera, więc `mutate(values)` POST-uje login, token się zapisuje, ale ekran zostaje na `/login`.

**Fix:** ręczne `useNavigate` w `onSuccess` / `onError` callback'ach `mutate`. Symetrycznie w `AppLayout.handleLogout` żeby logout też trafiał do `/login`. Login dodatkowo `setError('root', ...)` żeby user widział "Invalid email or password" zamiast cichego buttona.

## Quality gates

- ✅ Biome — 0 issues
- ✅ TypeScript noEmit — green
- ✅ Vite build — 595 kB / 187 kB gzip

## Manual smoke

- ✅ `https://pim.localhost/login` → render Card login
- ✅ `admin@pim.localhost` / `changeme` → redirect na `/products`, lista 3 produktów
- ✅ Wrong password → "Nie udało się zalogować. Spróbuj ponownie." (PL) / "Sign-in failed..." (EN)
- ✅ Logout → redirect na `/login`

## Powiązania

- Refs #5
- Hotfix do `04bc2ad` (PR #119)
- Lessons: Refine v5 + plain react-router-7 wymaga manual navigate w onSuccess/onError mutacji (do `agent/lessons.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)