### PR TITLE
test(admin): Playwright E2E happy path (closes #10)

### DIFF
--- a/.github/workflows/quality-frontend.yml
+++ b/.github/workflows/quality-frontend.yml
@@ -167,7 +167,11 @@ jobs:
           docker compose exec -T api php bin/console doctrine:fixtures:load --no-interaction --env=dev
 
       - name: Start the rest of the stack and wait for healthy
-        run: docker compose up -d --wait
+        # Explicit service list excludes minio-init (a one-shot `restart: no`
+        # init container) and unused-for-E2E services (minio, meilisearch,
+        # mailpit). `--wait` would otherwise treat the init container's
+        # clean exit as a failure of the wait condition.
+        run: docker compose up -d --wait database redis api admin caddy mercure
         env:
           POSTGRES_USER: pim
           POSTGRES_PASSWORD: ChangeMeInDev

--- a/.github/workflows/quality-frontend.yml
+++ b/.github/workflows/quality-frontend.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     paths:
       - "apps/admin/**"
+      # Playwright runs the full stack — any backend / infra change can break the E2E happy path.
+      - "apps/api/**"
+      - "docker-compose.yml"
+      - "docker/**"
       - "packages/**"
       - "biome.json"
       - "package.json"
@@ -17,6 +21,9 @@ on:
     branches: [main]
     paths:
       - "apps/admin/**"
+      - "apps/api/**"
+      - "docker-compose.yml"
+      - "docker/**"
       - "packages/**"
       - "biome.json"
       - "package.json"
@@ -92,3 +99,99 @@ jobs:
 
       - name: Build
         run: pnpm --filter @pim/admin build
+
+  e2e:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Map pim.localhost to 127.0.0.1
+        run: echo "127.0.0.1 pim.localhost" | sudo tee -a /etc/hosts
+
+      - name: Read JWT passphrase from apps/api/.env
+        id: jwt
+        run: echo "passphrase=$(grep '^JWT_PASSPHRASE=' apps/api/.env | cut -d'=' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate JWT keypair (matching .env passphrase)
+        run: |
+          mkdir -p apps/api/config/jwt
+          openssl genpkey -algorithm RSA -out apps/api/config/jwt/private.pem -aes256 -pass pass:${{ steps.jwt.outputs.passphrase }} -pkeyopt rsa_keygen_bits:4096
+          openssl pkey -in apps/api/config/jwt/private.pem -passin pass:${{ steps.jwt.outputs.passphrase }} -pubout -out apps/api/config/jwt/public.pem
+
+      - name: Start docker-compose stack
+        run: docker compose up -d --wait
+        env:
+          POSTGRES_USER: pim
+          POSTGRES_PASSWORD: ChangeMeInDev
+          POSTGRES_DB: pim
+
+      - name: Wait for Caddy + Vite to be reachable
+        run: |
+          for i in {1..30}; do
+            if curl -ksSf -o /dev/null https://pim.localhost/api; then
+              echo "API reachable"
+              break
+            fi
+            echo "Waiting for stack... ($i/30)"
+            sleep 2
+          done
+          curl -ksSf https://pim.localhost/api > /dev/null
+
+      - name: Run migrations + load fixtures
+        run: |
+          docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction --env=dev
+          docker compose exec -T api php bin/console doctrine:fixtures:load --no-interaction --env=dev
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter @pim/admin exec playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: pnpm --filter @pim/admin e2e
+        env:
+          CI: "true"
+
+      - name: Upload Playwright HTML report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/admin/playwright-report
+          retention-days: 7
+
+      - name: Upload test-results (screenshots / traces) on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: apps/admin/test-results
+          retention-days: 7
+
+      - name: Dump docker-compose logs on failure
+        if: failure()
+        run: docker compose logs --no-color > docker-compose.log || true
+
+      - name: Upload docker-compose logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-compose-logs
+          path: docker-compose.log
+          retention-days: 7
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/quality-frontend.yml
+++ b/.github/workflows/quality-frontend.yml
@@ -132,29 +132,58 @@ jobs:
           openssl genpkey -algorithm RSA -out apps/api/config/jwt/private.pem -aes256 -pass pass:${{ steps.jwt.outputs.passphrase }} -pkeyopt rsa_keygen_bits:4096
           openssl pkey -in apps/api/config/jwt/private.pem -passin pass:${{ steps.jwt.outputs.passphrase }} -pubout -out apps/api/config/jwt/public.pem
 
-      - name: Start docker-compose stack
+      - name: Start database + redis (healthcheck deps for api)
+        run: docker compose up -d --wait database redis
+        env:
+          POSTGRES_USER: pim
+          POSTGRES_PASSWORD: ChangeMeInDev
+          POSTGRES_DB: pim
+
+      - name: Start api container (will be unhealthy until migrations)
+        run: docker compose up -d api
+        env:
+          POSTGRES_USER: pim
+          POSTGRES_PASSWORD: ChangeMeInDev
+          POSTGRES_DB: pim
+
+      - name: Wait for FrankenPHP worker to accept exec commands
+        run: |
+          for i in {1..30}; do
+            if docker compose exec -T api php -v >/dev/null 2>&1; then
+              echo "api container ready for exec"
+              break
+            fi
+            echo "Waiting for api to accept exec... ($i/30)"
+            sleep 2
+          done
+
+      - name: Run migrations + load fixtures
+        # The api healthcheck hits /api which triggers RequestTenantSubscriber and
+        # queries the `tenants` table — so migrations have to run before the rest
+        # of the stack waits for api healthy. Fixtures stay coupled to migrations
+        # because the admin user the E2E suite logs in as is seeded here.
+        run: |
+          docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction --env=dev
+          docker compose exec -T api php bin/console doctrine:fixtures:load --no-interaction --env=dev
+
+      - name: Start the rest of the stack and wait for healthy
         run: docker compose up -d --wait
         env:
           POSTGRES_USER: pim
           POSTGRES_PASSWORD: ChangeMeInDev
           POSTGRES_DB: pim
 
-      - name: Wait for Caddy + Vite to be reachable
+      - name: Wait for Caddy edge to serve /api
         run: |
           for i in {1..30}; do
             if curl -ksSf -o /dev/null https://pim.localhost/api; then
-              echo "API reachable"
+              echo "Caddy edge serving /api"
               break
             fi
-            echo "Waiting for stack... ($i/30)"
+            echo "Waiting for Caddy... ($i/30)"
             sleep 2
           done
           curl -ksSf https://pim.localhost/api > /dev/null
-
-      - name: Run migrations + load fixtures
-        run: |
-          docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction --env=dev
-          docker compose exec -T api php bin/console doctrine:fixtures:load --no-interaction --env=dev
 
       - name: Install Playwright Chromium
         run: pnpm --filter @pim/admin exec playwright install --with-deps chromium

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,9 @@ coverage/
 playwright-report/
 test-results/
 playwright/.cache/
+**/playwright-report/
+**/test-results/
+**/.playwright/
 
 # Docker
 docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -73,16 +73,36 @@ Caddy ma własny lokalny CA — przy pierwszym `pnpm dev` przeglądarka wymaga z
 pnpm typecheck    # tsc --noEmit dla apps/admin + packages/*
 pnpm build        # build production wszystkich workspace'ów
 
-# PHP gates (działają w kontenerze api po wejściu do shell'a)
-docker compose exec api composer test           # PHPUnit (po dodaniu w 0.0.11)
-docker compose exec api vendor/bin/phpstan      # PHPStan (po dodaniu w 0.0.11)
+# PHP gates (w kontenerze api)
+docker compose exec api composer phpstan        # PHPStan max
+docker compose exec api composer cs-check       # PHP-CS-Fixer (dry-run)
+docker compose exec -e APP_ENV=test api php bin/phpunit
 ```
 
-Pełen CI: GitHub Actions, ticket [#21 — 0.1.5](https://github.com/malipie/PIM/issues/21).
+CI: GitHub Actions na PR + push do main — `quality-php.yml`, `quality-frontend.yml` (Biome / typecheck / Vite build / **Playwright E2E**), `audit.yml` (composer + pnpm audit).
+
+## Running E2E tests (Playwright)
+
+E2E używa Chromium przeciwko full stackowi (`https://pim.localhost`). Przed pierwszym uruchomieniem:
+
+```bash
+pnpm stack:up                                       # Caddy + Postgres + API + admin Vite
+docker compose exec api php bin/console doctrine:fixtures:load --no-interaction --env=dev
+pnpm --filter @pim/admin exec playwright install chromium  # raz, host-side (Alpine container nie wspiera Playwright deps)
+```
+
+Następnie:
+
+```bash
+pnpm --filter @pim/admin e2e          # headless, pełna suite
+pnpm --filter @pim/admin e2e:ui       # tryb interaktywny (debug)
+```
+
+Artefakty failure (screenshot / video / trace) lądują w `apps/admin/test-results/`. Reportowy HTML w `apps/admin/playwright-report/`. CI uploads obie ścieżki przez `actions/upload-artifact` przy failure.
 
 ## Następny krok
 
-Sprint 0, ticket [#2 — 0.0.2](https://github.com/malipie/PIM/issues/2): encja `Product` minimalna + `tenant_id` + Doctrine `TenantFilter`.
+Sprint 0 — pozostałe tickety przed gate decision: [#13](https://github.com/malipie/PIM/issues/13), [#14](https://github.com/malipie/PIM/issues/14), [#15](https://github.com/malipie/PIM/issues/15), [#9](https://github.com/malipie/PIM/issues/9). Status: [`agent/current_status.md`](agent/current_status.md).
 
 ## Licencja
 

--- a/apps/admin/e2e/auth.spec.ts
+++ b/apps/admin/e2e/auth.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, loginAsAdmin } from './helpers/auth';
+
+test.describe('Authentication', () => {
+  test('user can log in and lands on the products list', async ({ page }) => {
+    await loginAsAdmin(page);
+    await expect(page.getByRole('heading', { name: /produkty|products/i })).toBeVisible();
+  });
+
+  test('wrong password surfaces an inline error and stays on /login', async ({ page }) => {
+    await page.goto('/login');
+    await page.getByLabel(/e-?mail/i).fill(ADMIN_EMAIL);
+    await page.getByLabel(/has[lł]o|password/i).fill('not-the-password');
+    await page.getByRole('button', { name: /zaloguj|sign in/i }).click();
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByRole('alert')).toBeVisible();
+  });
+
+  test('an unauthenticated visit to /products bounces to /login', async ({ page, context }) => {
+    // Ensure no token leaks in from a previous test in the same browser context.
+    await context.clearCookies();
+    await page.goto('/products');
+    await expect(page).toHaveURL(/\/login$/);
+  });
+
+  test('logout clears the session and redirects to /login', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.getByRole('button', { name: /wyloguj|sign out/i }).click();
+    await expect(page).toHaveURL(/\/login$/);
+  });
+
+  // Sanity check that the credentials we use everywhere actually match the
+  // fixtures the API ships with — if this fails, every other test is bogus.
+  test('seeded credentials match the fixtures', async ({ page }) => {
+    await loginAsAdmin(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await expect(page).toHaveURL(/\/products$/);
+  });
+});

--- a/apps/admin/e2e/helpers/auth.ts
+++ b/apps/admin/e2e/helpers/auth.ts
@@ -1,0 +1,33 @@
+import { expect, type Page } from '@playwright/test';
+
+export const ADMIN_EMAIL = 'admin@pim.localhost';
+export const ADMIN_PASSWORD = 'changeme';
+
+/**
+ * Log in through the actual /login form and wait for the products list to
+ * render. Single happy-path login helper used by every protected-route test.
+ */
+export async function loginAsAdmin(
+  page: Page,
+  email: string = ADMIN_EMAIL,
+  password: string = ADMIN_PASSWORD,
+): Promise<void> {
+  await page.goto('/login');
+  await page.getByLabel(/e-?mail/i).fill(email);
+  await page.getByLabel(/has[lł]o|password/i).fill(password);
+  await page.getByRole('button', { name: /zaloguj|sign in/i }).click();
+  await expect(page).toHaveURL(/\/products$/);
+}
+
+/**
+ * Random SKU — the API enforces a unique (tenant_id, sku) constraint and the
+ * dev DB is not reset between runs locally; suffix with timestamp + random
+ * so successive runs of the create-product test never collide.
+ */
+export function uniqueSku(prefix = 'E2E'): string {
+  const stamp = Date.now().toString(36).toUpperCase();
+  const random = Math.floor(Math.random() * 1000)
+    .toString()
+    .padStart(3, '0');
+  return `${prefix}-${stamp}-${random}`;
+}

--- a/apps/admin/e2e/products.spec.ts
+++ b/apps/admin/e2e/products.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+test.describe('Products CRUD', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('list shows seeded products for the current tenant', async ({ page }) => {
+    // Demo tenant fixtures persist DEMO-001..003 — list the page and assert
+    // at least one of them is rendered. Other tests may add E2E-* rows but
+    // those are filtered to the same tenant by Doctrine TenantFilter.
+    await expect(page.getByRole('cell', { name: /^DEMO-/ }).first()).toBeVisible();
+  });
+
+  test('creates a new product and surfaces it in the list', async ({ page }) => {
+    const sku = uniqueSku();
+    const name = `Playwright created ${sku}`;
+
+    await page.getByRole('link', { name: /dodaj produkt|add product/i }).click();
+    await expect(page).toHaveURL(/\/products\/new$/);
+
+    await page.getByLabel(/^SKU$/).fill(sku);
+    await page.getByLabel(/nazwa|name/i).fill(name);
+    await page.getByLabel(/marka|brand/i).fill('Playwright Inc.');
+    await page.getByLabel(/opis|description/i).fill('Created by E2E test.');
+
+    await page.getByRole('button', { name: /^zapisz$|^save$/i }).click();
+
+    // The form redirects to /products on success; the new row appears in the table.
+    await expect(page).toHaveURL(/\/products$/);
+    // `exact: true` because `name` happens to start with `sku`, so a non-exact
+    // match would resolve to two cells in strict mode.
+    await expect(page.getByRole('cell', { name: sku, exact: true })).toBeVisible();
+    await expect(page.getByRole('cell', { name, exact: true })).toBeVisible();
+  });
+
+  test('PATCH updates the name but leaves the SKU immutable on the form', async ({ page }) => {
+    const sku = uniqueSku('PATCH');
+    const initialName = `Initial ${sku}`;
+    const renamed = `Renamed ${sku}`;
+
+    // Seed via the UI — fewer moving parts than calling the API from Playwright.
+    await page.getByRole('link', { name: /dodaj produkt|add product/i }).click();
+    await page.getByLabel(/^SKU$/).fill(sku);
+    await page.getByLabel(/nazwa|name/i).fill(initialName);
+    await page.getByRole('button', { name: /^zapisz$|^save$/i }).click();
+    await expect(page).toHaveURL(/\/products$/);
+
+    // Click the edit button on the new row and rename it.
+    const row = page.getByRole('row').filter({ hasText: sku });
+    await row.getByRole('link').click();
+    await expect(page).toHaveURL(/\/products\/[0-9a-f-]{36}\/edit$/);
+
+    // SKU must stay locked — disabled per ticket #3 (product:patch group).
+    await expect(page.getByLabel(/^SKU$/)).toBeDisabled();
+
+    const nameField = page.getByLabel(/nazwa|name/i);
+    await nameField.fill(renamed);
+    await page.getByRole('button', { name: /^zapisz$|^save$/i }).click();
+
+    await expect(page).toHaveURL(/\/products$/);
+    const updatedRow = page.getByRole('row').filter({ hasText: sku });
+    await expect(updatedRow.getByRole('cell', { name: renamed, exact: true })).toBeVisible();
+  });
+
+  test('blank SKU + name on create surfaces a validation error and keeps user on the form', async ({
+    page,
+  }) => {
+    await page.getByRole('link', { name: /dodaj produkt|add product/i }).click();
+    await expect(page).toHaveURL(/\/products\/new$/);
+
+    // Leave both required fields empty and submit.
+    await page.getByRole('button', { name: /^zapisz$|^save$/i }).click();
+
+    // react-hook-form keeps us on the form; the SKU input is flagged invalid.
+    await expect(page).toHaveURL(/\/products\/new$/);
+    await expect(page.getByLabel(/^SKU$/)).toHaveAttribute('aria-invalid', 'true');
+  });
+});

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,11 +6,14 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5173",
     "build": "tsc -b && vite build",
-    "lint": "biome check src",
-    "lint:fix": "biome check --write src",
-    "format": "biome format --write src",
+    "lint": "biome check src e2e",
+    "lint:fix": "biome check --write src e2e",
+    "format": "biome format --write src e2e",
     "typecheck": "tsc -b --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -35,6 +38,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.4",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const ciMode = !!process.env.CI;
+
+/**
+ * Playwright config for the admin E2E suite.
+ *
+ * Tests target the same single-origin URL the browser uses
+ * (`https://pim.localhost`) — the Caddy proxy in front of the FrankenPHP
+ * worker and the Vite dev server lives on this hostname locally and in CI
+ * (CI maps `pim.localhost` to 127.0.0.1 via /etc/hosts before running).
+ * Self-signed cert from Caddy is accepted via `ignoreHTTPSErrors`.
+ *
+ * The stack is brought up by `docker compose up -d` outside Playwright —
+ * we don't use the `webServer` option because we need the full
+ * Postgres+API+Caddy combo, not just Vite. Locally, run `pnpm stack:up`
+ * before `pnpm e2e`.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: ciMode,
+  retries: ciMode ? 2 : 0,
+  workers: 1,
+  reporter: ciMode ? [['github'], ['html', { open: 'never' }]] : 'list',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'https://pim.localhost',
+    ignoreHTTPSErrors: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 10_000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,10 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost/api"]
+      # Caddy listens on :443 only (single-origin HTTPS); the healthcheck has
+      # to negotiate TLS to reach /api. Self-signed cert from the local CA is
+      # accepted with --no-check-certificate.
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "--no-check-certificate", "https://localhost/api"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.4.13
         version: 2.4.13
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)(yaml@2.8.3))
@@ -332,6 +335,11 @@ packages:
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -1176,6 +1184,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1490,6 +1503,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -2059,6 +2082,10 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.127.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -2766,6 +2793,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3030,6 +3060,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
## Cel

Zamknięcie ticketu **#10 (0.0.10)** — pierwszy Playwright E2E test od dnia 1, domykający **DoD Sprint 0** dla #5 i wszystkich UI ticketów MVP-Alpha. Scope zrewidowany zgodnie z #16: bez Shopify (→ Faza 1) i bez Cmd+K agent (→ Faza 2). Happy path: login → list → create → edit → logout + edge cases.

## Co zmienia

### `apps/admin/playwright.config.ts`
- Test dir `./e2e`, target `https://pim.localhost`, `ignoreHTTPSErrors: true` (self-signed cert)
- Trace `retain-on-failure`, screenshot/video on failure
- CI mode: 2 retries + GitHub reporter + HTML report
- Stack management OUTSIDE Playwright — używamy `docker compose up -d` (nie `webServer`) bo potrzebujemy pełnej combinacji Caddy + FrankenPHP + Postgres

### Specs (9 tests, 44s lokalnie)

**`e2e/auth.spec.ts`** (5 tests):
- Login success → redirect `/products`
- Wrong password → inline error + stays on `/login`
- Unauthenticated `/products` → bounce do `/login`
- Logout → token cleared + redirect `/login`
- Seeded credentials match fixtures (sanity check)

**`e2e/products.spec.ts`** (4 tests):
- List shows seeded `DEMO-*` products for current tenant
- Create new product → redirect + appears in list
- PATCH name; SKU disabled in form (immutable per #3 `product:patch` group)
- Blank SKU/name → `aria-invalid="true"` + stays on form

### Helpers
- `loginAsAdmin(page, email?, password?)` — single happy-path login helper
- `uniqueSku(prefix?)` — timestamp+random SKU bo dev DB nie jest reset między runami

### CI: `quality-frontend.yml` nowy job `e2e`
- Maps `pim.localhost` → 127.0.0.1 w `/etc/hosts`
- Czyta `JWT_PASSPHRASE` z `apps/api/.env`, generuje matching RSA keypair
- `docker compose up -d --wait` (Caddy + API + admin healthy)
- Polls `https://pim.localhost/api` przez 30 × 2s aż endpoint odpowie
- `doctrine:migrations:migrate` + `doctrine:fixtures:load`
- `playwright install --with-deps chromium` + `pnpm e2e`
- Failure → upload HTML report + test-results (screenshots/traces) + `docker-compose logs` jako artefakty
- `docker compose down -v` w `if: always()`

### Path triggery
Job triggeruje na zmiany w `apps/api/**`, `apps/admin/**`, `docker-compose.yml`, `docker/**` — bo full stack regression jest kandydatem na break w E2E.

### `package.json` apps/admin
- `e2e`, `e2e:ui`, `e2e:install` scripts
- `lint` / `lint:fix` rozszerzone na `e2e/` dir

### `README.md`
- Sekcja "Running E2E tests (Playwright)" — host-side install (Alpine admin container nie wspiera Playwright deps), kroki 3 polecenia

### `.gitignore`
- Dodano `**/playwright-report/`, `**/test-results/`, `**/.playwright/`

## Manual smoke (lokalnie, 44s)

```
✓ 1 [chromium] Authentication › user can log in and lands on the products list (10.6s)
✓ 2 [chromium] Authentication › wrong password surfaces an inline error (9.0s)
✓ 3 [chromium] Authentication › an unauthenticated visit to /products bounces to /login (1.3s)
✓ 4 [chromium] Authentication › logout clears the session and redirects to /login (2.0s)
✓ 5 [chromium] Authentication › seeded credentials match the fixtures (2.7s)
✓ 6 [chromium] Products CRUD › list shows seeded products for the current tenant (3.5s)
✓ 7 [chromium] Products CRUD › creates a new product and surfaces it in the list (3.8s)
✓ 8 [chromium] Products CRUD › PATCH updates the name but leaves the SKU immutable (2.5s)
✓ 9 [chromium] Products CRUD › blank SKU + name surfaces a validation error (1.8s)
9 passed (44.4s)
```

## Quality gates

- ✅ Biome strict (src + e2e) — green
- ✅ TypeScript noEmit — green
- ✅ Vite build — green
- ✅ Playwright lokalnie — 9/9 (CI ten PR potwierdzi)

## Świadome decyzje

- **Playwright host-side w dev** — `node:22-alpine` w admin container nie ma `apt-get`, Playwright nie instaluje deps Chromium. Dev runs `pnpm playwright install` raz na hoście. CI używa standardowego ubuntu z `--with-deps`.
- **`docker compose up` w CI zamiast Playwright `webServer` config** — bo testy potrzebują pełnego single-origin stack'u (Caddy + FrankenPHP + Postgres + Vite), nie tylko Vite preview. `webServer` wspiera tylko jeden command.
- **Random timestamped SKU** zamiast resetu DB między testami — testy robią mutacje (POST products) ale nie depenują od konkretnych ID/SKU innych niż własne. DB cleanup po CI run via teardown.
- **`workers: 1` + `fullyParallel: false`** — happy path w MVP nie wymaga paralelizmu; tests share container container state (auth + Doctrine filter). Po MVP-Alpha można odpalić wiele workerów z izolowanym tenantem per worker.
- **Brak Cmd+K / Shopify scenariusza** w przeciwieństwie do oryginalnego ticketu — zgodnie z rewizją zakresu w #16 (`Project Plan/06-sprint-0-findings.md` sekcja 2). Te ścieżki dochodzą w Fazie 2 (agent) i Fazie 1 (Shopify).
- **Brak `tsconfig.e2e.json`** — Playwright kompiluje TS na lotu via tsx, Biome lintuje, runtime wystarczy. Pełen typecheck e2e dochodzi w fazie 1 jeśli pojawi się więcej niż 20+ specs.

## Powiązania

- Closes #10
- Refs #5 (admin Refine), #4 (LexikJWT), #3 (ApiResource Product), #16 (rewizja zakresu)
- Plan: `Project Plan/02-plan-projektu-pim.md` ticket 0.0.10 + sekcja 2.2 (Definition of Done)
- Findings: `Project Plan/06-sprint-0-findings.md` sekcja 2 (rewizja zakresu — Cmd+K + Shopify out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)