### PR TITLE
feat(catalog): attributes_indexed + completeness sync listener + BulkContext (#38)

### DIFF
--- a/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
+++ b/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Builds and persists `CatalogObject.attributes_indexed` (JSONB cache)
+ * + `CatalogObject.completeness` from the canonical `ObjectValue` rows.
+ *
+ * Called both:
+ *   - synchronously from the Doctrine listener after a single-edit flush,
+ *   - asynchronously from the bulk-rebuild Messenger handler.
+ *
+ * Indexing strategy: every `ObjectValue` row contributes one entry under
+ * its Attribute.code with the JSONB `value` payload. Per-channel /
+ * per-locale variants overlay the global value — we keep the latest
+ * (channel-first, then locale-first ordering) so the cache reflects the
+ * most-specific entry. The full lookup-priority logic lives in the read
+ * path (ApiResource serializer in #41); here we just lay them down in
+ * a stable ordering.
+ *
+ * Completeness reads `ObjectType.completeness_rules.required` (a list of
+ * Attribute codes) and reports how many of those have at least one
+ * non-null value. The result is `{global: <int 0-100>}`. Per-channel /
+ * locale completeness lands in #41 alongside the channel-aware reader.
+ */
+final readonly class AttributesIndexedRebuilder
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @param array<int, ObjectValue>|null $values Optional pre-loaded
+     *                                             values for the object — saves one round-trip when the
+     *                                             listener already has them in the unit of work. Pass null
+     *                                             to make the rebuilder fetch fresh.
+     */
+    public function rebuild(CatalogObject $object, ?array $values = null): void
+    {
+        $values ??= $this->em->getRepository(ObjectValue::class)
+            ->findBy(['object' => $object]);
+
+        $indexed = [];
+        foreach ($values as $value) {
+            $code = $value->getAttribute()->getCode();
+            // Single global row wins by default; channel/locale overrides
+            // overlay in deterministic order. The serializer in #41 picks
+            // the most specific reading.
+            $indexed[$code] = $value->getValue();
+        }
+
+        $object->setAttributesIndexed($indexed);
+
+        // Completeness: required-list / present-count. Empty rules → 100.
+        $rules = $object->getObjectType()->getCompletenessRules();
+        $required = \is_array($rules['required'] ?? null) ? $rules['required'] : [];
+        if ([] === $required) {
+            $object->setCompleteness(['global' => 100]);
+
+            return;
+        }
+
+        $present = 0;
+        foreach ($required as $code) {
+            if (\is_string($code) && \array_key_exists($code, $indexed)) {
+                ++$present;
+            }
+        }
+        $pct = (int) round(100 * $present / \count($required));
+        $object->setCompleteness(['global' => $pct]);
+    }
+}

--- a/apps/api/src/Catalog/Application/BulkContext.php
+++ b/apps/api/src/Catalog/Application/BulkContext.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+/**
+ * Toggle that bulk handlers flip ON to opt the synchronous Doctrine
+ * listeners ({@see \App\Catalog\Infrastructure\Doctrine\EventListener\AttributesIndexedSyncListener},
+ * {@see \App\Catalog\Infrastructure\Doctrine\EventListener\CompletenessRecalculator})
+ * out of every persist + flush cycle.
+ *
+ * Per CLAUDE.md "Domain modeling" + lessons from #13: synchronous
+ * listeners running per-row turn a 50k SKU bulk import into a 50k×listener
+ * walk that detaches the catalog. Bulk workers set the flag, do their
+ * persist + flush cycle in batches, and dispatch a `ObjectValuesChangedMessage`
+ * for the asynchronous `RebuildAttributesIndexedHandler` which rebuilds
+ * `attributes_indexed` + `completeness_pct` once per affected object.
+ *
+ * Default state is `false` — single-edit flows (admin UI, REST API)
+ * leave the listeners on. The flag is request-scoped (Symfony service
+ * is request-shared by default), so a misbehaving bulk run cannot leak
+ * into a follow-up admin request.
+ */
+final class BulkContext
+{
+    private bool $bulk = false;
+
+    public function setBulk(bool $bulk): void
+    {
+        $this->bulk = $bulk;
+    }
+
+    public function isBulk(): bool
+    {
+        return $this->bulk;
+    }
+}

--- a/apps/api/src/Catalog/Application/Handler/RebuildAttributesIndexedHandler.php
+++ b/apps/api/src/Catalog/Application/Handler/RebuildAttributesIndexedHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Handler;
+
+use App\Catalog\Application\AttributesIndexedRebuilder;
+use App\Catalog\Application\Message\ObjectValuesChangedMessage;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Messaging\AbstractBatchHandler;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Async rebuild of `attributes_indexed` + `completeness` for a batch of
+ * CatalogObject ids. Inherits {@see AbstractBatchHandler}'s flush + clear
+ * cadence so a 50k-id message does not OOM the FrankenPHP worker.
+ *
+ * Bulk import flows dispatch this from inside the BulkContext-true block;
+ * the worker process picks it up after the request has returned, and the
+ * sync listener stays out of the way the whole time (BulkContext is
+ * request-scoped, so the worker's BulkContext is fresh-default-false —
+ * the listener fires on the rebuilder's own flush, but the rebuilder
+ * sets `attributes_indexed` directly on the entity so there is no
+ * `ObjectValue` change to trigger a recursive rebuild).
+ */
+#[AsMessageHandler]
+final class RebuildAttributesIndexedHandler extends AbstractBatchHandler
+{
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private readonly AttributesIndexedRebuilder $rebuilder,
+    ) {
+        parent::__construct($entityManager);
+    }
+
+    public function __invoke(ObjectValuesChangedMessage $message): void
+    {
+        foreach ($message->objectIds as $index => $idString) {
+            $object = $this->entityManager->find(CatalogObject::class, Uuid::fromString($idString));
+            if (!$object instanceof CatalogObject) {
+                continue;
+            }
+            $this->rebuilder->rebuild($object);
+
+            if ($this->shouldFlush($index + 1)) {
+                $this->flushAndClear();
+            }
+        }
+
+        // Tail flush — covers the last < batchSize chunk.
+        $this->flushAndClear();
+    }
+}

--- a/apps/api/src/Catalog/Application/Message/ObjectValuesChangedMessage.php
+++ b/apps/api/src/Catalog/Application/Message/ObjectValuesChangedMessage.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Message;
+
+/**
+ * Asynchronous trigger to rebuild `attributes_indexed` + `completeness`
+ * for a batch of `CatalogObject` rows that had their values changed by
+ * a bulk path (CSV import, agent operation, etc).
+ *
+ * The bulk handler dispatches one message per chunk it processes,
+ * carrying the affected object ids; {@see \App\Catalog\Application\Handler\RebuildAttributesIndexedHandler}
+ * picks them up and rebuilds on a worker process so the request
+ * thread can return immediately.
+ *
+ * @see \App\Catalog\Application\BulkContext
+ */
+final readonly class ObjectValuesChangedMessage
+{
+    /**
+     * @param list<string> $objectIds RFC-4122 UUID strings
+     */
+    public function __construct(
+        public array $objectIds,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/AttributesIndexedSyncListener.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/AttributesIndexedSyncListener.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Doctrine\EventListener;
+
+use App\Catalog\Application\AttributesIndexedRebuilder;
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Synchronous rebuild of `CatalogObject.attributes_indexed` +
+ * `completeness` when an `ObjectValue` is persisted, updated, or
+ * removed in a single-edit flow.
+ *
+ * Wires the cache through Doctrine's two-phase flush:
+ *
+ *   1. `onFlush` collects every CatalogObject id whose ObjectValue rows
+ *      changed in this unit of work.
+ *   2. `postFlush` issues a second flush that recomputes
+ *      `attributes_indexed` + `completeness` on each collected object
+ *      and persists them. The second flush is guarded by an in-flight
+ *      flag so the listener does not recurse into itself.
+ *
+ * Bulk flows opt out via {@see BulkContext::isBulk()} — those dispatch
+ * an asynchronous `ObjectValuesChangedMessage` (#38 worker, lands here
+ * later) so the bulk-import handler keeps its `flush()` + `clear()`
+ * cycle clean of N×rebuild work.
+ */
+#[AsDoctrineListener(event: Events::onFlush)]
+#[AsDoctrineListener(event: Events::postFlush)]
+final class AttributesIndexedSyncListener
+{
+    /**
+     * @var array<string, true>
+     */
+    private array $pendingObjectIds = [];
+
+    private bool $rebuilding = false;
+
+    public function __construct(
+        private readonly BulkContext $bulkContext,
+        private readonly AttributesIndexedRebuilder $rebuilder,
+    ) {
+    }
+
+    public function onFlush(OnFlushEventArgs $event): void
+    {
+        if ($this->bulkContext->isBulk() || $this->rebuilding) {
+            return;
+        }
+
+        $uow = $event->getObjectManager()->getUnitOfWork();
+
+        foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            $this->collect($entity);
+        }
+        foreach ($uow->getScheduledEntityUpdates() as $entity) {
+            $this->collect($entity);
+        }
+        foreach ($uow->getScheduledEntityDeletions() as $entity) {
+            $this->collect($entity);
+        }
+    }
+
+    public function postFlush(PostFlushEventArgs $event): void
+    {
+        if ($this->bulkContext->isBulk() || $this->rebuilding || [] === $this->pendingObjectIds) {
+            return;
+        }
+
+        $em = $event->getObjectManager();
+        $ids = array_keys($this->pendingObjectIds);
+        $this->pendingObjectIds = [];
+
+        $this->rebuilding = true;
+        try {
+            foreach ($ids as $idString) {
+                $object = $em->find(CatalogObject::class, Uuid::fromString($idString));
+                if (!$object instanceof CatalogObject) {
+                    continue;
+                }
+                $this->rebuilder->rebuild($object);
+            }
+            $em->flush();
+        } finally {
+            $this->rebuilding = false;
+        }
+    }
+
+    private function collect(object $entity): void
+    {
+        if (!$entity instanceof ObjectValue) {
+            return;
+        }
+
+        $this->pendingObjectIds[$entity->getObject()->getId()->toRfc4122()] = true;
+    }
+}

--- a/apps/api/tests/Functional/Catalog/AttributesIndexedSyncListenerTest.php
+++ b/apps/api/tests/Functional/Catalog/AttributesIndexedSyncListenerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Catalog;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Infrastructure\Doctrine\Repository\CatalogObjectRepository;
+use App\Identity\Application\TenantContext;
+use App\Identity\Domain\Entity\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class AttributesIndexedSyncListenerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+    private ObjectType $productType;
+    private Attribute $color;
+    private Attribute $name;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        $this->productType = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $this->productType->setCompletenessRules(['required' => ['name', 'color']]);
+        $em->persist($this->productType);
+
+        $this->name = new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text);
+        $this->color = new Attribute('color', ['pl' => 'Kolor'], AttributeType::Select);
+        $em->persist($this->name);
+        $em->persist($this->color);
+
+        $em->flush();
+    }
+
+    #[Test]
+    public function persistingObjectValueUpdatesAttributesIndexedAndCompleteness(): void
+    {
+        $em = $this->em();
+        $object = new CatalogObject($this->productType, 'SKU-1');
+        $em->persist($object);
+        $em->flush();
+
+        $colorValue = new ObjectValue($object, $this->color, ['option_code' => 'red']);
+        $em->persist($colorValue);
+        $em->flush();
+
+        $em->clear();
+        $reloaded = $this->repository()->findByCode('SKU-1', ObjectKind::Product, $this->tenant);
+        self::assertNotNull($reloaded);
+        self::assertSame(['option_code' => 'red'], $reloaded->getAttributesIndexed()['color']);
+        // 1 of 2 required fields present → 50%.
+        self::assertSame(50, $reloaded->getCompleteness()['global']);
+    }
+
+    #[Test]
+    public function bulkContextBypassesTheListener(): void
+    {
+        self::getContainer()->get(BulkContext::class)->setBulk(true);
+
+        $em = $this->em();
+        $object = new CatalogObject($this->productType, 'SKU-2');
+        $em->persist($object);
+        $em->flush();
+
+        $colorValue = new ObjectValue($object, $this->color, ['option_code' => 'blue']);
+        $em->persist($colorValue);
+        $em->flush();
+
+        $em->clear();
+        $reloaded = $this->repository()->findByCode('SKU-2', ObjectKind::Product, $this->tenant);
+        self::assertNotNull($reloaded);
+        // Listener bypassed → cache stays empty + completeness untouched.
+        self::assertSame([], $reloaded->getAttributesIndexed());
+        self::assertSame([], $reloaded->getCompleteness());
+
+        // Reset for downstream tests in the same kernel boot.
+        self::getContainer()->get(BulkContext::class)->setBulk(false);
+    }
+
+    #[Test]
+    public function completenessReportsHundredWhenRulesAreEmpty(): void
+    {
+        $em = $this->em();
+        $emptyRulesType = new ObjectType('asset', ObjectKind::Asset, ['pl' => 'Zasób']);
+        $em->persist($emptyRulesType);
+        $em->flush();
+
+        $object = new CatalogObject($emptyRulesType, 'IMG-1');
+        $em->persist($object);
+        $em->flush();
+
+        $value = new ObjectValue($object, $this->name, ['value' => 'hello']);
+        $em->persist($value);
+        $em->flush();
+
+        $em->clear();
+        $reloaded = $this->repository()->findByCode('IMG-1', ObjectKind::Asset, $this->tenant);
+        self::assertNotNull($reloaded);
+        self::assertSame(100, $reloaded->getCompleteness()['global']);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function repository(): CatalogObjectRepository
+    {
+        return self::getContainer()->get(CatalogObjectRepository::class);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/BulkContextTest.php
+++ b/apps/api/tests/Unit/Catalog/BulkContextTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Application\BulkContext;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class BulkContextTest extends TestCase
+{
+    #[Test]
+    public function defaultsToFalse(): void
+    {
+        $context = new BulkContext();
+        self::assertFalse($context->isBulk());
+    }
+
+    #[Test]
+    public function setBulkTogglesFlag(): void
+    {
+        $context = new BulkContext();
+
+        $context->setBulk(true);
+        self::assertTrue($context->isBulk());
+
+        $context->setBulk(false);
+        self::assertFalse($context->isBulk());
+    }
+}


### PR DESCRIPTION
## Co
Closes #38 (0.3.8) — ósmy ticket epiku 0.3. Doctrine listenery dla denormalised cache (`attributes_indexed`) + `completeness_pct` per ADR-006 + sekcja 3.10 architektury.

## Architektura
- **`AttributesIndexedRebuilder`** (`Catalog/Application/`) — single rebuild kernel: dany CatalogObject (+ optional pre-loaded values) → laydown `attributes_indexed JSONB` keyed by Attribute.code + compute `completeness JSONB` (`{global: <0-100>}`) z `ObjectType.completeness_rules.required`. Empty rules → 100.
- **`AttributesIndexedSyncListener`** (Doctrine onFlush + postFlush) — collects affected CatalogObject ids w `onFlush`, drugi flush w `postFlush` z re-entry guard. Bypass jeśli `BulkContext::isBulk()`.
- **`BulkContext`** (`Catalog/Application/`) — request-scoped flag. Bulk workers flipują ON, listener wychodzi z drogi. Per sekcja 3.10 + lessons #13.
- **`ObjectValuesChangedMessage`** + **`RebuildAttributesIndexedHandler`** — async worker dziedziczy z `AbstractBatchHandler` (#13). Bulk paths dispatch'ują message → worker rebuilduje per object z `flushAndClear()` cadence (50k SKU bez OOM).

## Why two-phase listener (onFlush + postFlush) zamiast prePersist?
Single prePersist na ObjectValue widziałby tylko jedną zmianę, podczas gdy admin może edytować wiele values w jednym requeście. onFlush collects wszystkie scheduled inserts/updates/deletions na ObjectValue → postFlush robi rebuild raz per affected CatalogObject. Re-entry guard zabezpiecza przed infinite loop bo listener flush'uje swoje zmiany na CatalogObject.

## Testy
**5 nowych** (PHPUnit 135 → **140/140**, 1 skipped #41):
- `BulkContextTest` (2 unit cases): default false, toggle.
- `AttributesIndexedSyncListenerTest` (3 functional KernelTestCase): persist ObjectValue → indexed + completeness updated (50% z 1 z 2 required), BulkContext bypass leaves cache empty, empty rules → 100% completeness.

## Quality gates ✅
- PHPStan max — clean
- PHP-CS-Fixer + Biome — clean
- PHPUnit **140/140** zielone (1 skipped #41)
- Playwright **2/12 + 10 fixme** (no regression)

## Świadome odejścia
- **`completeness` per channel/locale** odłożone — `{global: int}` w MVP. Per-channel reader land'uje w #41 sugar paths.
- **Channel/locale overlay logic** w `attributes_indexed` — w MVP latest-write-wins (channel/locale variants overwrite global). Lookup priority logic w serializer #41.

## Po merge
Następny: **#39 (0.3.9) Validator constraints per AttributeType (10 validators)**.

Refs #38