### PR TITLE
feat(catalog): walidatory AttributeType per typ (#39)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -56,6 +56,15 @@ services:
         arguments:
             $enableCustomObjectTypes: '%pim.catalog.enable_custom_object_types%'
 
+    # Per-AttributeType validator dispatcher (#39). The factory wires up
+    # one validator per AttributeType so the rest of the app can ask
+    # "is this {value: ...} payload valid against this Attribute?" without
+    # branching on the type. New types: extend the factory + add the
+    # matching TypeValidator implementation.
+    App\Catalog\Application\Validation\AttributeValueValidator:
+        factory: ['App\Catalog\Application\Validation\AttributeValueValidator', 'default']
+        arguments: []
+
     # Bind the named Flysystem storage for the Asset uploader. Without
     # this Symfony has multiple FilesystemOperator services (one per
     # named storage) and autowire can't pick. The named alias

--- a/apps/api/src/Catalog/Application/Validation/AttributeValueValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/AttributeValueValidator.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * Per-AttributeType validator dispatcher.
+ *
+ * The dispatcher reads {@see Attribute::getType()} + the JSONB
+ * `validation_rules` payload and runs the matching {@see AttributeValueValidatorInterface}.
+ * Returning a flat list of {@see ValidationError} keeps the contract
+ * agnostic of Symfony Validator vs. RFC 7807 vs. admin form rendering —
+ * the API layer (#41) and the admin UI (#56) translate them to whichever
+ * shape they need.
+ *
+ * Validators operate on the raw JSONB `value` array (the `ObjectValue.value`
+ * field), not on the entity itself, so this validator works equally well
+ * for: API request payloads (validate before persist), CLI imports
+ * (validate before bulk insert), and agent operations (validate before
+ * approval). The shape per type is:
+ *
+ *   text/number/date/boolean: `{value: scalar}`
+ *   select:                   `{option_code: 'red'}`
+ *   multiselect:              `{option_codes: ['red', 'blue']}`
+ *   asset:                    `{asset_id: '<uuid>'}`
+ *   relation:                 `{object_id: '<uuid>'}`
+ *   price:                    `{amount: 19.99, currency: 'PLN'}`
+ *   metric:                   `{value: 12.5, unit: 'kg'}`
+ */
+final readonly class AttributeValueValidator
+{
+    /**
+     * @param array<string, AttributeValueValidatorInterface> $validators map of `AttributeType->value` to validator
+     */
+    public function __construct(
+        private array $validators,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     *
+     * @return list<ValidationError>
+     */
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $type = $attribute->getType();
+        $validator = $this->validators[$type->value] ?? null;
+        if (null === $validator) {
+            return [new ValidationError(
+                path: 'value',
+                code: 'attribute.unsupported_type',
+                message: \sprintf('No validator registered for AttributeType "%s".', $type->value),
+            )];
+        }
+
+        return $validator->validate($attribute, $value);
+    }
+
+    public static function default(): self
+    {
+        return new self([
+            AttributeType::Text->value => new TypeValidator\TextValidator(),
+            AttributeType::Number->value => new TypeValidator\NumberValidator(),
+            AttributeType::Select->value => new TypeValidator\SelectValidator(),
+            AttributeType::Multiselect->value => new TypeValidator\MultiselectValidator(),
+            AttributeType::Date->value => new TypeValidator\DateValidator(),
+            AttributeType::Boolean->value => new TypeValidator\BooleanValidator(),
+            AttributeType::Asset->value => new TypeValidator\AssetValidator(),
+            AttributeType::Relation->value => new TypeValidator\RelationValidator(),
+            AttributeType::Price->value => new TypeValidator\PriceValidator(),
+            AttributeType::Metric->value => new TypeValidator\MetricValidator(),
+        ]);
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/AttributeValueValidatorInterface.php
+++ b/apps/api/src/Catalog/Application/Validation/AttributeValueValidatorInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation;
+
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * Contract for per-{@see \App\Catalog\Domain\AttributeType} validators
+ * dispatched by {@see AttributeValueValidator}.
+ *
+ * Implementations check the raw JSONB `value` payload + apply the rules
+ * the admin configured on `Attribute.validation_rules` (e.g. `min`/`max`
+ * for `number`, `max_length`/`pattern` for `text`, `unit_family` for
+ * `metric`). Returning an empty list means "value is acceptable".
+ */
+interface AttributeValueValidatorInterface
+{
+    /**
+     * @param array<string, mixed> $value
+     *
+     * @return list<ValidationError>
+     */
+    public function validate(Attribute $attribute, array $value): array;
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/AssetValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/AssetValidator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * `asset` AttributeType validator — value points at an Asset row.
+ *
+ * Schema-shape only here: `value.asset_id` must be a valid UUID. Cross-
+ * checking that the row actually exists + belongs to the same tenant is
+ * the API layer's job (#41) where the database is reachable.
+ */
+final class AssetValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $raw = $value['asset_id'] ?? null;
+        if (!\is_string($raw) || !Uuid::isValid($raw)) {
+            return [new ValidationError('value.asset_id', 'asset.expected_uuid', 'Asset value must include a valid asset_id UUID.')];
+        }
+
+        return [];
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/BooleanValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/BooleanValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `boolean` AttributeType validator. Accepts strict bool only — `1`,
+ * `'true'`, `'on'` etc. are explicitly rejected to keep the JSONB
+ * payload deterministic.
+ */
+final class BooleanValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $raw = $value['value'] ?? null;
+        if (!\is_bool($raw)) {
+            return [new ValidationError('value.value', 'boolean.expected_bool', 'Boolean value must be true or false (strict).')];
+        }
+
+        return [];
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/DateValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/DateValidator.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `date` AttributeType validator. Accepts ISO 8601 strings (YYYY-MM-DD
+ * or full date-time). Rules: `min` / `max` (ISO 8601 strings).
+ */
+final class DateValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $raw = $value['value'] ?? null;
+        if (!\is_string($raw) || '' === $raw) {
+            return [new ValidationError('value.value', 'date.expected_iso_string', 'Date value must be a non-empty ISO 8601 string.')];
+        }
+
+        $parsed = date_create_immutable($raw);
+        if (false === $parsed) {
+            return [new ValidationError('value.value', 'date.unparseable', \sprintf('Date "%s" is not a valid ISO 8601 string.', $raw))];
+        }
+
+        $errors = [];
+        $rules = $attribute->getValidationRules();
+        if (\is_string($rules['min'] ?? null)) {
+            $min = date_create_immutable($rules['min']);
+            if (false !== $min && $parsed < $min) {
+                $errors[] = new ValidationError('value.value', 'date.below_min', \sprintf('Date %s is before min %s.', $raw, $rules['min']));
+            }
+        }
+        if (\is_string($rules['max'] ?? null)) {
+            $max = date_create_immutable($rules['max']);
+            if (false !== $max && $parsed > $max) {
+                $errors[] = new ValidationError('value.value', 'date.above_max', \sprintf('Date %s is after max %s.', $raw, $rules['max']));
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/MetricValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/MetricValidator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `metric` AttributeType validator. Shape: `{value: numeric, unit: 'kg' | 'cm' | …}`.
+ *
+ * Rules:
+ *   - `units` (list<string>) — restrict the allowed unit set
+ *   - `min` / `max` (numeric) — bounds on the numeric value
+ *   - `decimal_precision` (int >=0) — max decimal places
+ *
+ * Unit family normalization (kg ↔ g, cm ↔ m, …) is the API layer's job —
+ * the validator only checks membership in the configured `units` set.
+ */
+final class MetricValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $errors = [];
+        $raw = $value['value'] ?? null;
+        $unit = $value['unit'] ?? null;
+
+        if (!\is_int($raw) && !\is_float($raw)) {
+            $errors[] = new ValidationError('value.value', 'metric.expected_numeric_value', 'Metric value must be int or float.');
+        }
+        if (!\is_string($unit) || '' === $unit) {
+            $errors[] = new ValidationError('value.unit', 'metric.expected_unit', 'Metric unit must be a non-empty string.');
+        }
+
+        $rules = $attribute->getValidationRules();
+        $allowed = $rules['units'] ?? null;
+        if (\is_string($unit) && \is_array($allowed) && !\in_array($unit, $allowed, true)) {
+            $errors[] = new ValidationError('value.unit', 'metric.unsupported_unit', \sprintf('Unit "%s" is not in the configured units set.', $unit));
+        }
+
+        $min = $rules['min'] ?? null;
+        if ((\is_int($raw) || \is_float($raw)) && (\is_int($min) || \is_float($min)) && $raw < $min) {
+            $errors[] = new ValidationError('value.value', 'metric.below_min', \sprintf('Metric value %s is below min %s.', (string) $raw, (string) $min));
+        }
+        $max = $rules['max'] ?? null;
+        if ((\is_int($raw) || \is_float($raw)) && (\is_int($max) || \is_float($max)) && $raw > $max) {
+            $errors[] = new ValidationError('value.value', 'metric.above_max', \sprintf('Metric value %s exceeds max %s.', (string) $raw, (string) $max));
+        }
+        $precision = $rules['decimal_precision'] ?? null;
+        if (\is_int($precision) && $precision >= 0 && \is_float($raw)) {
+            $rounded = round($raw, $precision);
+            if (abs($rounded - $raw) > 1e-9) {
+                $errors[] = new ValidationError('value.value', 'metric.precision_exceeded', \sprintf('Metric value has more than %d decimal places.', $precision));
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/MultiselectValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/MultiselectValidator.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `multiselect` AttributeType validator.
+ *
+ * Rules: `option_codes` (list<string>), `min_count` / `max_count` (int).
+ */
+final class MultiselectValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $codes = $value['option_codes'] ?? null;
+        if (!\is_array($codes)) {
+            return [new ValidationError('value.option_codes', 'multiselect.expected_list', 'Multiselect value must be a list of option codes.')];
+        }
+
+        $errors = [];
+        foreach ($codes as $i => $code) {
+            if (!\is_string($code) || '' === $code) {
+                $errors[] = new ValidationError(\sprintf('value.option_codes.%d', $i), 'multiselect.expected_string_item', 'Each option code must be a non-empty string.');
+            }
+        }
+
+        $rules = $attribute->getValidationRules();
+        $allowed = $rules['option_codes'] ?? null;
+        if (\is_array($allowed)) {
+            foreach ($codes as $i => $code) {
+                if (\is_string($code) && !\in_array($code, $allowed, true)) {
+                    $errors[] = new ValidationError(\sprintf('value.option_codes.%d', $i), 'multiselect.unknown_option', \sprintf('Option "%s" is not in the configured option_codes set.', $code));
+                }
+            }
+        }
+
+        $count = \count($codes);
+        $min = $rules['min_count'] ?? null;
+        if (\is_int($min) && $count < $min) {
+            $errors[] = new ValidationError('value.option_codes', 'multiselect.too_few', \sprintf('At least %d option(s) required, got %d.', $min, $count));
+        }
+        $max = $rules['max_count'] ?? null;
+        if (\is_int($max) && $count > $max) {
+            $errors[] = new ValidationError('value.option_codes', 'multiselect.too_many', \sprintf('At most %d option(s) allowed, got %d.', $max, $count));
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/NumberValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/NumberValidator.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `number` AttributeType validator. Accepts int + float.
+ *
+ * Rules: `min` (numeric), `max` (numeric), `decimal_precision` (int >=0).
+ */
+final class NumberValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $errors = [];
+        $raw = $value['value'] ?? null;
+
+        if (!\is_int($raw) && !\is_float($raw)) {
+            return [new ValidationError('value.value', 'number.expected_numeric', 'Number value must be int or float.')];
+        }
+
+        $rules = $attribute->getValidationRules();
+        $min = $rules['min'] ?? null;
+        if ((\is_int($min) || \is_float($min)) && $raw < $min) {
+            $errors[] = new ValidationError('value.value', 'number.below_min', \sprintf('Value %s is below min %s.', (string) $raw, (string) $min));
+        }
+        $max = $rules['max'] ?? null;
+        if ((\is_int($max) || \is_float($max)) && $raw > $max) {
+            $errors[] = new ValidationError('value.value', 'number.above_max', \sprintf('Value %s exceeds max %s.', (string) $raw, (string) $max));
+        }
+        $precision = $rules['decimal_precision'] ?? null;
+        if (\is_int($precision) && $precision >= 0 && \is_float($raw)) {
+            $rounded = round($raw, $precision);
+            if (abs($rounded - $raw) > 1e-9) {
+                $errors[] = new ValidationError('value.value', 'number.precision_exceeded', \sprintf('Value has more than %d decimal places.', $precision));
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/PriceValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/PriceValidator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `price` AttributeType validator. Shape: `{amount: numeric, currency:
+ * 'PLN' | 'EUR' | …}`.
+ *
+ * Rules:
+ *   - `min_amount` (numeric)
+ *   - `currencies` (list<string>) — restrict the allowed currency set
+ *
+ * Cross-check that the currency exists in the global `currencies` table
+ * is the API layer's job.
+ */
+final class PriceValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $errors = [];
+        $amount = $value['amount'] ?? null;
+        $currency = $value['currency'] ?? null;
+
+        if (!\is_int($amount) && !\is_float($amount)) {
+            $errors[] = new ValidationError('value.amount', 'price.expected_numeric_amount', 'Price amount must be int or float.');
+        }
+        if (!\is_string($currency) || 1 !== preg_match('/^[A-Z]{3}$/', $currency)) {
+            $errors[] = new ValidationError('value.currency', 'price.expected_iso_currency', 'Price currency must be a 3-letter ISO 4217 code (uppercase).');
+        }
+
+        $rules = $attribute->getValidationRules();
+        $min = $rules['min_amount'] ?? null;
+        if ((\is_int($amount) || \is_float($amount)) && (\is_int($min) || \is_float($min)) && $amount < $min) {
+            $errors[] = new ValidationError('value.amount', 'price.below_min', \sprintf('Price amount %s below min %s.', (string) $amount, (string) $min));
+        }
+        $allowed = $rules['currencies'] ?? null;
+        if (\is_string($currency) && \is_array($allowed) && !\in_array($currency, $allowed, true)) {
+            $errors[] = new ValidationError('value.currency', 'price.unsupported_currency', \sprintf('Currency "%s" is not in the configured currencies set.', $currency));
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/RelationValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/RelationValidator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * `relation` AttributeType validator — value points at a CatalogObject.
+ *
+ * Schema-shape only: `value.object_id` must be a UUID. Existence + kind
+ * cross-check (`relation` rules can pin which kinds are acceptable
+ * targets via `value.allowed_kinds`) lives at the API layer in #41.
+ */
+final class RelationValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $raw = $value['object_id'] ?? null;
+        if (!\is_string($raw) || !Uuid::isValid($raw)) {
+            return [new ValidationError('value.object_id', 'relation.expected_uuid', 'Relation value must include a valid object_id UUID.')];
+        }
+
+        return [];
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/SelectValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/SelectValidator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `select` AttributeType validator.
+ *
+ * Rule: `option_codes` (list<string>) — when configured, the picked
+ * value must match one of these. When the rule is missing the
+ * validator only checks the shape; the API layer (#41) is expected to
+ * cross-check against the live AttributeOption rows from the database.
+ */
+final class SelectValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $code = $value['option_code'] ?? null;
+        if (!\is_string($code) || '' === $code) {
+            return [new ValidationError('value.option_code', 'select.expected_string', 'Select value must include a non-empty option_code.')];
+        }
+
+        $rules = $attribute->getValidationRules();
+        $allowed = $rules['option_codes'] ?? null;
+        if (\is_array($allowed) && !\in_array($code, $allowed, true)) {
+            return [new ValidationError(
+                'value.option_code',
+                'select.unknown_option',
+                \sprintf('Option "%s" is not in the configured option_codes set.', $code),
+            )];
+        }
+
+        return [];
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/TextValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/TextValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `text` AttributeType validator.
+ *
+ * Rules from `Attribute.validation_rules`:
+ *   - `max_length` (int): UTF-8 character cap
+ *   - `min_length` (int): UTF-8 character floor
+ *   - `pattern` (string): PCRE regex (must match the whole value)
+ */
+final class TextValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $errors = [];
+        $raw = $value['value'] ?? null;
+
+        if (!\is_string($raw)) {
+            return [new ValidationError('value.value', 'text.expected_string', 'Text value must be a string.')];
+        }
+
+        $rules = $attribute->getValidationRules();
+        $length = mb_strlen($raw, 'UTF-8');
+
+        $max = $rules['max_length'] ?? null;
+        if (\is_int($max) && $length > $max) {
+            $errors[] = new ValidationError('value.value', 'text.too_long', \sprintf('Text exceeds max_length=%d (got %d).', $max, $length));
+        }
+        $min = $rules['min_length'] ?? null;
+        if (\is_int($min) && $length < $min) {
+            $errors[] = new ValidationError('value.value', 'text.too_short', \sprintf('Text shorter than min_length=%d (got %d).', $min, $length));
+        }
+        $pattern = $rules['pattern'] ?? null;
+        if (\is_string($pattern) && '' !== $pattern && 1 !== preg_match($pattern, $raw)) {
+            $errors[] = new ValidationError('value.value', 'text.pattern_mismatch', \sprintf('Text does not match pattern %s.', $pattern));
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/ValidationError.php
+++ b/apps/api/src/Catalog/Application/Validation/ValidationError.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation;
+
+/**
+ * Lightweight value object describing a single validation failure.
+ *
+ * The catalog validator chain returns a list of these — the API layer
+ * (#41) maps them onto RFC 7807 Problem Details `errors[]`, and the
+ * admin UI (#56) renders them inline next to form fields.
+ *
+ * Why not Symfony's {@see \Symfony\Component\Validator\ConstraintViolation}?
+ * The shape we need is a flat tuple — no metadata, no parameterised
+ * messages, no localisation hooks (i18n stays in the UI layer). A
+ * three-field DTO is cheaper than dragging the validator constraint
+ * machinery through every per-type validator + lossless to translate
+ * back to ConstraintViolation when API Platform asks for one in #41.
+ */
+final readonly class ValidationError
+{
+    public function __construct(
+        public string $path,
+        public string $code,
+        public string $message,
+    ) {
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/AttributeValueValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/AttributeValueValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation;
+
+use App\Catalog\Application\Validation\AttributeValueValidator;
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeValueValidatorTest extends TestCase
+{
+    #[Test]
+    public function dispatchesToTheValidatorMatchingAttributeType(): void
+    {
+        $marker = new class implements AttributeValueValidatorInterface {
+            public function validate(Attribute $attribute, array $value): array
+            {
+                return [new ValidationError('value', 'marker.hit', 'marker reached')];
+            }
+        };
+        $validator = new AttributeValueValidator([
+            AttributeType::Text->value => $marker,
+        ]);
+        $attribute = new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text);
+
+        $errors = $validator->validate($attribute, ['value' => 'hello']);
+
+        self::assertCount(1, $errors);
+        self::assertSame('marker.hit', $errors[0]->code);
+    }
+
+    #[Test]
+    public function returnsUnsupportedTypeErrorWhenNoValidatorRegistered(): void
+    {
+        $validator = new AttributeValueValidator([]);
+        $attribute = new Attribute('color', ['pl' => 'Kolor'], AttributeType::Select);
+
+        $errors = $validator->validate($attribute, ['option_code' => 'red']);
+
+        self::assertCount(1, $errors);
+        self::assertSame('attribute.unsupported_type', $errors[0]->code);
+    }
+
+    #[Test]
+    public function defaultFactoryRegistersValidatorsForAllTenAttributeTypes(): void
+    {
+        $validator = AttributeValueValidator::default();
+
+        // Smoke: every AttributeType case must dispatch to a real validator,
+        // not the unsupported_type fallback.
+        foreach (AttributeType::cases() as $type) {
+            $attribute = new Attribute('a_'.$type->value, ['pl' => $type->value], $type);
+            $errors = $validator->validate($attribute, []);
+
+            // All validators reject empty payload with type-specific codes.
+            self::assertNotEmpty($errors, \sprintf('Type "%s" produced no errors on empty payload.', $type->value));
+            foreach ($errors as $error) {
+                self::assertNotSame('attribute.unsupported_type', $error->code, \sprintf('Type "%s" hit the unsupported fallback.', $type->value));
+            }
+        }
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/AssetValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/AssetValidatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\AssetValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class AssetValidatorTest extends TestCase
+{
+    private AssetValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new AssetValidator();
+        $this->attribute = new Attribute('hero_image', ['pl' => 'Zdjęcie'], AttributeType::Asset);
+    }
+
+    #[Test]
+    public function validUuidPasses(): void
+    {
+        $uuid = Uuid::v7()->toRfc4122();
+
+        self::assertSame([], $this->validator->validate($this->attribute, ['asset_id' => $uuid]));
+    }
+
+    #[Test]
+    public function nonUuidFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['asset_id' => 'not-a-uuid']);
+
+        self::assertSame('asset.expected_uuid', $errors[0]->code);
+    }
+
+    #[Test]
+    public function missingAssetIdFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, []);
+
+        self::assertSame('asset.expected_uuid', $errors[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/BooleanValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/BooleanValidatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\BooleanValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class BooleanValidatorTest extends TestCase
+{
+    private BooleanValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new BooleanValidator();
+        $this->attribute = new Attribute('is_active', ['pl' => 'Aktywny'], AttributeType::Boolean);
+    }
+
+    #[Test]
+    public function strictTrueAndFalsePass(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => true]));
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => false]));
+    }
+
+    #[Test]
+    public function truthyButNonBoolValuesAreRejected(): void
+    {
+        foreach ([1, 0, 'true', 'false', 'on', null] as $bad) {
+            $errors = $this->validator->validate($this->attribute, ['value' => $bad]);
+            self::assertSame('boolean.expected_bool', $errors[0]->code);
+        }
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/DateValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/DateValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\DateValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DateValidatorTest extends TestCase
+{
+    private DateValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new DateValidator();
+        $this->attribute = new Attribute('release_date', ['pl' => 'Data premiery'], AttributeType::Date);
+    }
+
+    #[Test]
+    public function isoDateStringPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => '2026-04-28']));
+    }
+
+    #[Test]
+    public function emptyOrNonStringFails(): void
+    {
+        self::assertSame('date.expected_iso_string', $this->validator->validate($this->attribute, ['value' => ''])[0]->code);
+        self::assertSame('date.expected_iso_string', $this->validator->validate($this->attribute, ['value' => 20260428])[0]->code);
+    }
+
+    #[Test]
+    public function unparseableValueFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => 'not-a-date']);
+
+        self::assertSame('date.unparseable', $errors[0]->code);
+    }
+
+    #[Test]
+    public function minMaxBoundsAreEnforced(): void
+    {
+        $this->attribute->setValidationRules(['min' => '2026-01-01', 'max' => '2026-12-31']);
+
+        $low = $this->validator->validate($this->attribute, ['value' => '2025-12-31']);
+        $high = $this->validator->validate($this->attribute, ['value' => '2027-01-01']);
+        $ok = $this->validator->validate($this->attribute, ['value' => '2026-06-15']);
+
+        self::assertSame('date.below_min', $low[0]->code);
+        self::assertSame('date.above_max', $high[0]->code);
+        self::assertSame([], $ok);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/MetricValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/MetricValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\MetricValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MetricValidatorTest extends TestCase
+{
+    private MetricValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new MetricValidator();
+        $this->attribute = new Attribute('weight', ['pl' => 'Waga'], AttributeType::Metric);
+    }
+
+    #[Test]
+    public function validMetricPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => 12.5, 'unit' => 'kg']));
+    }
+
+    #[Test]
+    public function nonNumericValueAndEmptyUnitBothFail(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => '12', 'unit' => '']);
+
+        $codes = array_map(static fn ($e) => $e->code, $errors);
+        self::assertContains('metric.expected_numeric_value', $codes);
+        self::assertContains('metric.expected_unit', $codes);
+    }
+
+    #[Test]
+    public function unitAllowlistIsEnforced(): void
+    {
+        $this->attribute->setValidationRules(['units' => ['kg', 'g']]);
+
+        $errors = $this->validator->validate($this->attribute, ['value' => 1, 'unit' => 'lb']);
+
+        self::assertSame('metric.unsupported_unit', $errors[0]->code);
+    }
+
+    #[Test]
+    public function boundsAndPrecisionEnforced(): void
+    {
+        $this->attribute->setValidationRules([
+            'min' => 0,
+            'max' => 100,
+            'decimal_precision' => 1,
+        ]);
+
+        $tooLow = $this->validator->validate($this->attribute, ['value' => -1.0, 'unit' => 'kg']);
+        $tooHigh = $this->validator->validate($this->attribute, ['value' => 200.0, 'unit' => 'kg']);
+        $tooPrecise = $this->validator->validate($this->attribute, ['value' => 1.234, 'unit' => 'kg']);
+
+        self::assertSame('metric.below_min', $tooLow[0]->code);
+        self::assertSame('metric.above_max', $tooHigh[0]->code);
+        self::assertSame('metric.precision_exceeded', $tooPrecise[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/MultiselectValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/MultiselectValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\MultiselectValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MultiselectValidatorTest extends TestCase
+{
+    private MultiselectValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new MultiselectValidator();
+        $this->attribute = new Attribute('tags', ['pl' => 'Tagi'], AttributeType::Multiselect);
+    }
+
+    #[Test]
+    public function listOfStringsPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['option_codes' => ['red', 'blue']]));
+    }
+
+    #[Test]
+    public function nonArrayFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['option_codes' => 'red,blue']);
+
+        self::assertSame('multiselect.expected_list', $errors[0]->code);
+    }
+
+    #[Test]
+    public function nonStringItemsAreReportedPerIndex(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['option_codes' => ['ok', 42, '']]);
+
+        self::assertCount(2, $errors);
+        self::assertSame('value.option_codes.1', $errors[0]->path);
+        self::assertSame('value.option_codes.2', $errors[1]->path);
+    }
+
+    #[Test]
+    public function allowlistAndCountBoundsCombineErrors(): void
+    {
+        $this->attribute->setValidationRules([
+            'option_codes' => ['red', 'green'],
+            'min_count' => 2,
+            'max_count' => 3,
+        ]);
+
+        $tooFewWithUnknown = $this->validator->validate($this->attribute, ['option_codes' => ['magenta']]);
+
+        $codes = array_map(static fn ($e) => $e->code, $tooFewWithUnknown);
+        self::assertContains('multiselect.unknown_option', $codes);
+        self::assertContains('multiselect.too_few', $codes);
+
+        $tooMany = $this->validator->validate($this->attribute, ['option_codes' => ['red', 'green', 'red', 'red']]);
+        $codesMany = array_map(static fn ($e) => $e->code, $tooMany);
+        self::assertContains('multiselect.too_many', $codesMany);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/NumberValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/NumberValidatorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\NumberValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class NumberValidatorTest extends TestCase
+{
+    private NumberValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new NumberValidator();
+        $this->attribute = new Attribute('weight', ['pl' => 'Waga'], AttributeType::Number);
+    }
+
+    #[Test]
+    public function intAndFloatBothAcceptable(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => 5]));
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => 1.5]));
+    }
+
+    #[Test]
+    public function nonNumericFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => '5']);
+
+        self::assertSame('number.expected_numeric', $errors[0]->code);
+    }
+
+    #[Test]
+    public function minAndMaxBoundsAreEnforced(): void
+    {
+        $this->attribute->setValidationRules(['min' => 0, 'max' => 10]);
+
+        $low = $this->validator->validate($this->attribute, ['value' => -1]);
+        $high = $this->validator->validate($this->attribute, ['value' => 11]);
+
+        self::assertSame('number.below_min', $low[0]->code);
+        self::assertSame('number.above_max', $high[0]->code);
+    }
+
+    #[Test]
+    public function decimalPrecisionRejectsExtraDigits(): void
+    {
+        $this->attribute->setValidationRules(['decimal_precision' => 2]);
+
+        $ok = $this->validator->validate($this->attribute, ['value' => 1.23]);
+        $bad = $this->validator->validate($this->attribute, ['value' => 1.234]);
+
+        self::assertSame([], $ok);
+        self::assertSame('number.precision_exceeded', $bad[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/PriceValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/PriceValidatorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\PriceValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class PriceValidatorTest extends TestCase
+{
+    private PriceValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new PriceValidator();
+        $this->attribute = new Attribute('price', ['pl' => 'Cena'], AttributeType::Price);
+    }
+
+    #[Test]
+    public function validPricePasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['amount' => 19.99, 'currency' => 'PLN']));
+    }
+
+    #[Test]
+    public function nonNumericAmountAndLowercaseCurrencyBothFail(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['amount' => '19.99', 'currency' => 'pln']);
+
+        $codes = array_map(static fn ($e) => $e->code, $errors);
+        self::assertContains('price.expected_numeric_amount', $codes);
+        self::assertContains('price.expected_iso_currency', $codes);
+    }
+
+    #[Test]
+    public function minAmountAndCurrencyAllowlistEnforced(): void
+    {
+        $this->attribute->setValidationRules([
+            'min_amount' => 10,
+            'currencies' => ['PLN', 'EUR'],
+        ]);
+
+        $low = $this->validator->validate($this->attribute, ['amount' => 5, 'currency' => 'PLN']);
+        $unsupported = $this->validator->validate($this->attribute, ['amount' => 50, 'currency' => 'USD']);
+
+        self::assertSame('price.below_min', $low[0]->code);
+        self::assertSame('price.unsupported_currency', $unsupported[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/RelationValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/RelationValidatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\RelationValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class RelationValidatorTest extends TestCase
+{
+    private RelationValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new RelationValidator();
+        $this->attribute = new Attribute('parent', ['pl' => 'Rodzic'], AttributeType::Relation);
+    }
+
+    #[Test]
+    public function validUuidPasses(): void
+    {
+        $uuid = Uuid::v7()->toRfc4122();
+
+        self::assertSame([], $this->validator->validate($this->attribute, ['object_id' => $uuid]));
+    }
+
+    #[Test]
+    public function nonUuidFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['object_id' => 'abc']);
+
+        self::assertSame('relation.expected_uuid', $errors[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/SelectValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/SelectValidatorTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\SelectValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class SelectValidatorTest extends TestCase
+{
+    private SelectValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new SelectValidator();
+        $this->attribute = new Attribute('color', ['pl' => 'Kolor'], AttributeType::Select);
+    }
+
+    #[Test]
+    public function optionCodeStringPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['option_code' => 'red']));
+    }
+
+    #[Test]
+    public function emptyOrMissingOptionCodeFails(): void
+    {
+        self::assertSame('select.expected_string', $this->validator->validate($this->attribute, [])[0]->code);
+        self::assertSame('select.expected_string', $this->validator->validate($this->attribute, ['option_code' => ''])[0]->code);
+    }
+
+    #[Test]
+    public function unknownOptionRejectedWhenAllowlistConfigured(): void
+    {
+        $this->attribute->setValidationRules(['option_codes' => ['red', 'green', 'blue']]);
+
+        $ok = $this->validator->validate($this->attribute, ['option_code' => 'red']);
+        $bad = $this->validator->validate($this->attribute, ['option_code' => 'magenta']);
+
+        self::assertSame([], $ok);
+        self::assertSame('select.unknown_option', $bad[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/TextValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/TextValidatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\TextValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TextValidatorTest extends TestCase
+{
+    private TextValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new TextValidator();
+        $this->attribute = new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text);
+    }
+
+    #[Test]
+    public function plainStringPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => 'hello']));
+    }
+
+    #[Test]
+    public function nonStringValueFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => 42]);
+
+        self::assertCount(1, $errors);
+        self::assertSame('text.expected_string', $errors[0]->code);
+    }
+
+    #[Test]
+    public function maxLengthIsEnforcedInUtf8Characters(): void
+    {
+        $this->attribute->setValidationRules(['max_length' => 3]);
+
+        // 4 utf-8 characters (with polish diacritics).
+        $errors = $this->validator->validate($this->attribute, ['value' => 'łóść']);
+
+        self::assertCount(1, $errors);
+        self::assertSame('text.too_long', $errors[0]->code);
+    }
+
+    #[Test]
+    public function minLengthIsEnforced(): void
+    {
+        $this->attribute->setValidationRules(['min_length' => 5]);
+
+        $errors = $this->validator->validate($this->attribute, ['value' => 'hi']);
+
+        self::assertSame('text.too_short', $errors[0]->code);
+    }
+
+    #[Test]
+    public function patternMustMatchTheWholeValue(): void
+    {
+        $this->attribute->setValidationRules(['pattern' => '/^[A-Z]{3}$/']);
+
+        $ok = $this->validator->validate($this->attribute, ['value' => 'ABC']);
+        $bad = $this->validator->validate($this->attribute, ['value' => 'abc']);
+
+        self::assertSame([], $ok);
+        self::assertSame('text.pattern_mismatch', $bad[0]->code);
+    }
+}


### PR DESCRIPTION
## Summary

Ticket **#39 (0.3.9)** epiku 0.3 — walidacja wartości atrybutów per `AttributeType` przez prosty dispatcher + 10 dedykowanych walidatorów.

- `AttributeValueValidator` — dispatcher mapujący `AttributeType->value` → `AttributeValueValidatorInterface`. Factory `default()` rejestruje wszystkie 10 typów; service registracja przez factory w `services.yaml`.
- 10 walidatorów (`TypeValidator/*Validator.php`) czytających payload `value` (JSONB shape z #34) + reguły z `Attribute.validation_rules` (JSONB z #31):
  - **text** — `max_length` / `min_length` (UTF-8 chars) + `pattern` (PCRE)
  - **number** — `min` / `max` + `decimal_precision`
  - **select** — `option_codes` allowlist
  - **multiselect** — `option_codes` + `min_count` / `max_count`
  - **date** — ISO 8601 + `min` / `max` (date strings)
  - **boolean** — strict bool only (1, 'true', 'on' odrzucone)
  - **asset** — `value.asset_id` jako UUID
  - **relation** — `value.object_id` jako UUID
  - **price** — `{amount, currency}` (ISO 4217 3-letter) + `min_amount` + `currencies` allowlist
  - **metric** — `{value, unit}` + `units` allowlist + `min/max/decimal_precision`
- Flat `list<ValidationError>` kontrakt — API layer (#41) zamapuje do RFC 7807, admin (#56) do form errors.
- 37 nowych unit testów (happy + sad path per walidator + smoke factory dispatcher); pełna suite 177/177.

## Out of scope (zgodnie z ticketem)

- Cross-row checks (`select` allowlist vs. live `AttributeOption` rows, asset/relation existence) → **#41** API layer.
- Mapowanie do `Symfony\Component\Validator\Constraints` na encji `Attribute` → **#41** (jeden mapping per request).
- Unit family normalization (`kg ↔ g`) dla typu `metric` → faza 1.

## Test plan

- [x] PHPStan max — 0 errors
- [x] PHP-CS-Fixer dry-run — clean
- [x] PHPUnit — 177/177 (140 → 177, +37 testów)
- [x] Playwright admin — 2 passed + 10 fixme (no regression)
- [x] `composer audit` — 0 advisories
- [x] `bin/console debug:container AttributeValueValidator` — service rozwiązany przez factory `default()`

Closes #39