### PR TITLE
feat(catalog): kind-aware ApiResource hooks — szkielet pod #41 (#128)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -65,6 +65,20 @@ services:
         factory: ['App\Catalog\Application\Validation\AttributeValueValidator', 'default']
         arguments: []
 
+    # Kind-aware ApiResource hooks (#128). Built-in Product/Category/Asset
+    # ship via dedicated sugar paths in #41; this layer holds the metadata
+    # + decorator the AP4 declarations call into. Wired up now so #41 only
+    # has to drop the `#[ApiResource]` annotations + per-kind normalizers
+    # — no bootstrap chain change required.
+    App\Catalog\Infrastructure\ApiPlatform\CustomObjectTypeApiGuard:
+        arguments:
+            $enableCustomObjectTypes: '%pim.catalog.enable_custom_object_types%'
+
+    App\Catalog\Infrastructure\ApiPlatform\KindAwareSerializerContextBuilder:
+        decorates: 'api_platform.serializer.context_builder'
+        arguments:
+            $decorated: '@.inner'
+
     # Bind the named Flysystem storage for the Asset uploader. Without
     # this Symfony has multiple FilesystemOperator services (one per
     # named storage) and autowire can't pick. The named alias

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/CustomObjectTypeApiGuard.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/CustomObjectTypeApiGuard.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform;
+
+use App\Catalog\Domain\Exception\DisabledFeatureException;
+use App\Catalog\Domain\ObjectKind;
+
+/**
+ * API-layer counterpart to the service-layer feature flag enforcement in
+ * {@see \App\Catalog\Application\ObjectTypeService}.
+ *
+ * The DB CHECK constraint allows `kind='custom'` rows to exist (mitigation
+ * R-29 — schema is forward-compatible with phase 2/3 custom kinds), and
+ * the service layer guard rejects programmatic creation. This guard is
+ * the third layer: an explicit assertion the API denormalizers in #41
+ * call when accepting an inbound `ObjectType` payload, so a future
+ * regression in the service layer does not silently leak `custom` rows
+ * out via REST.
+ *
+ * Defensive triple-layering is intentional — the cost is one constructor
+ * + one `assertAllowed` call per write request.
+ */
+final readonly class CustomObjectTypeApiGuard
+{
+    public function __construct(
+        private bool $enableCustomObjectTypes,
+    ) {
+    }
+
+    /**
+     * Throws when the kind is `Custom` and the feature flag is off.
+     * Safe to call for every kind — built-in kinds short-circuit.
+     */
+    public function assertAllowed(ObjectKind $kind): void
+    {
+        if (ObjectKind::Custom !== $kind) {
+            return;
+        }
+        if (!$this->enableCustomObjectTypes) {
+            throw DisabledFeatureException::customObjectTypesDisabled();
+        }
+    }
+
+    public function isCustomKindEnabled(): bool
+    {
+        return $this->enableCustomObjectTypes;
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/KindAwareSerializerContextBuilder.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/KindAwareSerializerContextBuilder.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform;
+
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\State\SerializerContextBuilderInterface;
+use App\Catalog\Domain\ObjectKind;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Decorator on AP4's default serializer context builder that enriches the
+ * context with the current `ObjectKind` when the matched operation has
+ * `extraProperties.kind` set (the convention for the per-kind sugar paths
+ * landing in #41).
+ *
+ * Today the decorator is a near no-op — there are no `#[ApiResource]`
+ * declarations on `CatalogObject` yet (#41 ticket of epic 0.4 wires them
+ * in). Shipping the decorator now means #41 can drop the kind-aware
+ * normalizers + voters in without re-touching the bootstrap chain.
+ *
+ * Built-in kinds get their per-kind serializer groups merged in via
+ * {@see ObjectKindRouter::groupsFor}. Custom kinds (phase 2/3) get only
+ * the shared `object:read` group.
+ */
+final readonly class KindAwareSerializerContextBuilder implements SerializerContextBuilderInterface
+{
+    public function __construct(
+        private SerializerContextBuilderInterface $decorated,
+        private ObjectKindRouter $router,
+    ) {
+    }
+
+    public function createFromRequest(Request $request, bool $normalization, ?array $extractedAttributes = null): array
+    {
+        $context = $this->decorated->createFromRequest($request, $normalization, $extractedAttributes);
+
+        $operation = $context['operation'] ?? null;
+        if (!$operation instanceof HttpOperation) {
+            return $context;
+        }
+
+        $kindValue = $operation->getExtraProperties()['kind'] ?? null;
+        if (!\is_string($kindValue)) {
+            return $context;
+        }
+
+        $kind = ObjectKind::tryFrom($kindValue);
+        if (null === $kind) {
+            return $context;
+        }
+
+        $existing = $context['groups'] ?? [];
+        if (\is_string($existing)) {
+            $existing = [$existing];
+        }
+        if (!\is_array($existing)) {
+            $existing = [];
+        }
+
+        /** @var list<string> $existingStrings */
+        $existingStrings = array_values(array_filter($existing, 'is_string'));
+
+        $context['kind'] = $kind->value;
+        $context['groups'] = array_values(array_unique([...$existingStrings, ...$this->router->groupsFor($kind)]));
+
+        return $context;
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform;
+
+use App\Catalog\Domain\Exception\DisabledFeatureException;
+use App\Catalog\Domain\ObjectKind;
+
+/**
+ * Pure mapping table: `ObjectKind` → API surface metadata.
+ *
+ * Built-in kinds (Product, Category, Asset) ship with dedicated sugar paths
+ * (`/api/products`, `/api/categories`, `/api/assets`) and per-kind serializer
+ * groups so AP4 can branch context off the operation's `extraProperties.kind`
+ * (#41 wires the actual `#[ApiResource]` declarations). `Custom` is the
+ * escape hatch for tenant-defined kinds in phase 2/3 — until then it has
+ * no public API surface, so the lookup throws.
+ *
+ * The class is stateless + pure so callers (AP4 metadata layer, admin UI
+ * for navigation, agent tool in phase 2) can rely on the same answers
+ * without wiring an EntityManager. The custom-kind feature flag is checked
+ * by {@see CustomObjectTypeApiGuard}, not here — this file maps, the guard
+ * gates.
+ */
+final class ObjectKindRouter
+{
+    /**
+     * @var array<value-of<ObjectKind>, array{path: string, groups: list<string>}>
+     */
+    private const array BUILT_IN_ROUTES = [
+        'product' => [
+            'path' => '/api/products',
+            'groups' => ['object:read', 'object:read:product'],
+        ],
+        'category' => [
+            'path' => '/api/categories',
+            'groups' => ['object:read', 'object:read:category'],
+        ],
+        'asset' => [
+            'path' => '/api/assets',
+            'groups' => ['object:read', 'object:read:asset'],
+        ],
+    ];
+
+    /**
+     * Sugar path for a built-in kind. `Custom` raises — the API surface for
+     * custom kinds lives behind `/api/objects?kind=...` (phase 2) and the
+     * router will not pretend to know its path.
+     */
+    public function pathFor(ObjectKind $kind): string
+    {
+        if (ObjectKind::Custom === $kind) {
+            throw DisabledFeatureException::customObjectTypesDisabled();
+        }
+
+        return self::BUILT_IN_ROUTES[$kind->value]['path'];
+    }
+
+    /**
+     * Serializer groups to merge into the AP4 context for the given kind.
+     * Always includes the shared `object:read` group plus a kind-specific
+     * one so #41's normalizers can opt fields in/out per kind.
+     *
+     * @return list<string>
+     */
+    public function groupsFor(ObjectKind $kind): array
+    {
+        if (ObjectKind::Custom === $kind) {
+            // Custom kinds get only the shared group in MVP — phase 2's
+            // schema editor will register per-tenant groups dynamically.
+            return ['object:read'];
+        }
+
+        return self::BUILT_IN_ROUTES[$kind->value]['groups'];
+    }
+
+    /**
+     * Convenience for the AP4 metadata factory in #41: returns the list of
+     * built-in kinds so it can stamp one `#[ApiResource]` declaration per
+     * kind without hardcoding the list.
+     *
+     * @return list<ObjectKind>
+     */
+    public static function builtInKinds(): array
+    {
+        return [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset];
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/CustomObjectTypeApiGuardTest.php
+++ b/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/CustomObjectTypeApiGuardTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Infrastructure\ApiPlatform;
+
+use App\Catalog\Domain\Exception\DisabledFeatureException;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Infrastructure\ApiPlatform\CustomObjectTypeApiGuard;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CustomObjectTypeApiGuardTest extends TestCase
+{
+    #[Test]
+    public function builtInKindsAlwaysPass(): void
+    {
+        $guard = new CustomObjectTypeApiGuard(false);
+
+        $guard->assertAllowed(ObjectKind::Product);
+        $guard->assertAllowed(ObjectKind::Category);
+        $guard->assertAllowed(ObjectKind::Asset);
+
+        self::assertFalse($guard->isCustomKindEnabled());
+    }
+
+    #[Test]
+    public function customKindIsRejectedWhenFlagOff(): void
+    {
+        $guard = new CustomObjectTypeApiGuard(false);
+
+        $this->expectException(DisabledFeatureException::class);
+        $this->expectExceptionMessage('disabled in MVP');
+        $guard->assertAllowed(ObjectKind::Custom);
+    }
+
+    #[Test]
+    public function customKindPassesWhenFlagOn(): void
+    {
+        $guard = new CustomObjectTypeApiGuard(true);
+
+        $guard->assertAllowed(ObjectKind::Custom);
+
+        self::assertTrue($guard->isCustomKindEnabled());
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/KindAwareSerializerContextBuilderTest.php
+++ b/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/KindAwareSerializerContextBuilderTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Infrastructure\ApiPlatform;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\State\SerializerContextBuilderInterface;
+use App\Catalog\Infrastructure\ApiPlatform\KindAwareSerializerContextBuilder;
+use App\Catalog\Infrastructure\ApiPlatform\ObjectKindRouter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class KindAwareSerializerContextBuilderTest extends TestCase
+{
+    #[Test]
+    public function passesThroughWhenOperationHasNoKindExtraProperty(): void
+    {
+        $builder = $this->builderReturning(['groups' => ['object:read']]);
+
+        $context = $builder->createFromRequest(new Request(), true);
+
+        self::assertSame(['object:read'], $context['groups']);
+        self::assertArrayNotHasKey('kind', $context);
+    }
+
+    #[Test]
+    public function mergesPerKindGroupsAndStampsKindWhenOperationHasIt(): void
+    {
+        $operation = new Get()->withExtraProperties(['kind' => 'product']);
+        $builder = $this->builderReturning([
+            'groups' => ['object:read'],
+            'operation' => $operation,
+        ]);
+
+        $context = $builder->createFromRequest(new Request(), true);
+
+        self::assertSame('product', $context['kind']);
+        self::assertSame(['object:read', 'object:read:product'], $context['groups']);
+    }
+
+    #[Test]
+    public function unknownKindValueIsIgnoredAndContextLeftUntouched(): void
+    {
+        $operation = new Get()->withExtraProperties(['kind' => 'banana']);
+        $builder = $this->builderReturning([
+            'groups' => ['object:read'],
+            'operation' => $operation,
+        ]);
+
+        $context = $builder->createFromRequest(new Request(), true);
+
+        self::assertArrayNotHasKey('kind', $context);
+        self::assertSame(['object:read'], $context['groups']);
+    }
+
+    #[Test]
+    public function customKindFallsBackToSharedGroupAndStillStampsKindMarker(): void
+    {
+        $operation = new Get()->withExtraProperties(['kind' => 'custom']);
+        $builder = $this->builderReturning([
+            'groups' => ['object:read'],
+            'operation' => $operation,
+        ]);
+
+        $context = $builder->createFromRequest(new Request(), true);
+
+        self::assertSame('custom', $context['kind']);
+        self::assertSame(['object:read'], $context['groups']);
+    }
+
+    #[Test]
+    public function singleStringGroupIsPromotedToList(): void
+    {
+        $operation = new Get()->withExtraProperties(['kind' => 'category']);
+        $builder = $this->builderReturning([
+            'groups' => 'object:read',
+            'operation' => $operation,
+        ]);
+
+        $context = $builder->createFromRequest(new Request(), true);
+
+        self::assertSame(['object:read', 'object:read:category'], $context['groups']);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function builderReturning(array $context): KindAwareSerializerContextBuilder
+    {
+        $inner = new class($context) implements SerializerContextBuilderInterface {
+            /**
+             * @param array<string, mixed> $context
+             */
+            public function __construct(private readonly array $context)
+            {
+            }
+
+            public function createFromRequest(Request $request, bool $normalization, ?array $extractedAttributes = null): array
+            {
+                return $this->context;
+            }
+        };
+
+        return new KindAwareSerializerContextBuilder($inner, new ObjectKindRouter());
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/ObjectKindRouterTest.php
+++ b/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/ObjectKindRouterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Infrastructure\ApiPlatform;
+
+use App\Catalog\Domain\Exception\DisabledFeatureException;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Infrastructure\ApiPlatform\ObjectKindRouter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectKindRouterTest extends TestCase
+{
+    private ObjectKindRouter $router;
+
+    protected function setUp(): void
+    {
+        $this->router = new ObjectKindRouter();
+    }
+
+    #[Test]
+    public function pathForBuiltInKindsMatchesSugarConvention(): void
+    {
+        self::assertSame('/api/products', $this->router->pathFor(ObjectKind::Product));
+        self::assertSame('/api/categories', $this->router->pathFor(ObjectKind::Category));
+        self::assertSame('/api/assets', $this->router->pathFor(ObjectKind::Asset));
+    }
+
+    #[Test]
+    public function pathForCustomKindThrows(): void
+    {
+        $this->expectException(DisabledFeatureException::class);
+        $this->router->pathFor(ObjectKind::Custom);
+    }
+
+    #[Test]
+    public function groupsForBuiltInKindIncludesSharedAndPerKindGroup(): void
+    {
+        self::assertSame(['object:read', 'object:read:product'], $this->router->groupsFor(ObjectKind::Product));
+        self::assertSame(['object:read', 'object:read:category'], $this->router->groupsFor(ObjectKind::Category));
+        self::assertSame(['object:read', 'object:read:asset'], $this->router->groupsFor(ObjectKind::Asset));
+    }
+
+    #[Test]
+    public function groupsForCustomKindFallsBackToSharedGroupOnly(): void
+    {
+        self::assertSame(['object:read'], $this->router->groupsFor(ObjectKind::Custom));
+    }
+
+    #[Test]
+    public function builtInKindsListMatchesAdr009(): void
+    {
+        self::assertSame(
+            [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset],
+            ObjectKindRouter::builtInKinds(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Ostatni ticket epiku 0.3 — **#128 (0.3.11)**: szkielet hookow pod sugar paths per `kind` + feature flag dla `kind='custom'` na poziomie ApiResource. Pełna implementacja `#[ApiResource]` na encji `CatalogObject` przyjdzie w **#41** (epik 0.4); ten ticket dostarcza extension pointy które #41 pdpina bez touch'a w bootstrap chain.

Mitigacja R-29 (ADR-009): w MVP `kind='custom'` jest CHECK-allowed w bazie ale wyłączony przez feature flag w service'ach + (od dziś) na poziomie API. Triple-layering (DB CHECK → ObjectTypeService → CustomObjectTypeApiGuard) zapewnia że custom rows nie przeciekną przez REST nawet jeśli service-layer guard zostanie zregresowany.

## What's added

- **`App\Catalog\Infrastructure\ApiPlatform\ObjectKindRouter`** — pure mapping `ObjectKind → {sugar path, serializer groups}`. Built-in kindy (Product/Category/Asset) zwracają `/api/products` etc. + `['object:read', 'object:read:product']`. Custom kind rzuca `DisabledFeatureException` z `pathFor()` (nie ma sugar path) i fallback na `['object:read']` w `groupsFor()` (phase 2 zarejestruje per-tenant groups dynamicznie).
- **`App\Catalog\Infrastructure\ApiPlatform\CustomObjectTypeApiGuard`** — API-layer twin guard'a z #32. `assertAllowed(ObjectKind)` rzuca `DisabledFeatureException` dla `Custom` gdy parametr `pim.catalog.enable_custom_object_types=false`. Built-in kindy zawsze przechodzą.
- **`App\Catalog\Infrastructure\ApiPlatform\KindAwareSerializerContextBuilder`** — AP4 dekorator `SerializerContextBuilderInterface` (`api_platform.serializer.context_builder`) który czyta `operation.extraProperties.kind` i wzbogaca context o `kind` + per-kind groups z routera. No-op dopóki #41 nie wire'uje `#[ApiResource(extraProperties: ['kind' => 'product'])]` na `CatalogObject`.

## Out of scope (świadome odejścia)

- Faktyczne `#[ApiResource]` declarations na `CatalogObject` → **#41** (epik 0.4).
- Per-kind normalizers / denormalizers + Voters → **#41**.
- UI builder + runtime schema editor dla custom kindów → **Faza 2/3** wraz z agent toolem `create_object_type`.

## Test plan

- [x] PHPStan max — 0 errors
- [x] PHP-CS-Fixer dry-run — clean
- [x] PHPUnit — 195/195 (182 → 195, +13 testów)
- [x] Playwright admin — 2 passed + 10 fixme (no regression)
- [x] `composer audit` — 0 advisories
- [x] `bin/console debug:container KindAwareSerializerContextBuilder` — decorator zdiagnozowany jako wewnętrzny `api_platform.serializer.context_builder.filter.inner`

Closes #128