### PR TITLE
RF-06 — refactor(catalog): migrate 9 Domain entities from Doctrine attributes to XML mapping

### DIFF
--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -50,9 +50,9 @@ doctrine:
                 prefix: 'App\Shared\Domain'
                 alias: Shared
             Catalog:
-                type: attribute
+                type: xml
                 is_bundle: false
-                dir: '%kernel.project_dir%/src/Catalog/Domain/Entity'
+                dir: '%kernel.project_dir%/src/Catalog/Infrastructure/Doctrine/Orm/Mapping'
                 prefix: 'App\Catalog\Domain\Entity'
                 alias: Catalog
             Channel:

--- a/apps/api/src/Catalog/Domain/Entity/Association.php
+++ b/apps/api/src/Catalog/Domain/Entity/Association.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
-use App\Catalog\Infrastructure\Doctrine\Repository\AssociationRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 
@@ -30,35 +27,14 @@ use Symfony\Component\Uid\Uuid;
  * one-way leaves room for asymmetric semantics like "this product
  * replaces that one".
  */
-#[ORM\Entity(repositoryClass: AssociationRepository::class)]
-#[ORM\Table(name: 'object_associations')]
-#[ORM\UniqueConstraint(name: 'object_associations_triple_uniq', columns: ['source_object_id', 'target_object_id', 'type_id'])]
-#[ORM\Index(name: 'object_associations_tenant_idx', columns: ['tenant_id'])]
-#[ORM\Index(name: 'object_associations_source_type_idx', columns: ['source_object_id', 'type_id'])]
-#[ORM\Index(name: 'object_associations_target_idx', columns: ['target_object_id'])]
 class Association implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
-
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
-
-    #[ORM\ManyToOne(targetEntity: CatalogObject::class)]
-    #[ORM\JoinColumn(name: 'source_object_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private CatalogObject $source;
-
-    #[ORM\ManyToOne(targetEntity: CatalogObject::class)]
-    #[ORM\JoinColumn(name: 'target_object_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private CatalogObject $target;
-
-    #[ORM\ManyToOne(targetEntity: AssociationType::class)]
-    #[ORM\JoinColumn(name: 'type_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private AssociationType $type;
 
-    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
     private int $position;
 
     public function __construct(

--- a/apps/api/src/Catalog/Domain/Entity/AssociationType.php
+++ b/apps/api/src/Catalog/Domain/Entity/AssociationType.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
-use App\Catalog\Infrastructure\Doctrine\Repository\AssociationTypeRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -28,21 +25,10 @@ use Symfony\Component\Validator\Constraints as Assert;
  * (not just products) — products linking to categories, categories
  * linking to assets, etc.
  */
-#[ORM\Entity(repositoryClass: AssociationTypeRepository::class)]
-#[ORM\Table(name: 'association_types')]
-#[ORM\UniqueConstraint(name: 'association_types_tenant_code_uniq', columns: ['tenant_id', 'code'])]
-#[ORM\Index(name: 'association_types_tenant_position_idx', columns: ['tenant_id', 'position'])]
 class AssociationType implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
-
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
-
-    #[ORM\Column(type: 'string', length: 64)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 64)]
     private string $code;
@@ -50,11 +36,9 @@ class AssociationType implements TenantScoped
     /**
      * @var array<string, string>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
     #[Assert\Type('array')]
     private array $label;
 
-    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
     private int $position;
 
     /**

--- a/apps/api/src/Catalog/Domain/Entity/Attribute.php
+++ b/apps/api/src/Catalog/Domain/Entity/Attribute.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace App\Catalog\Domain\Entity;
 
 use App\Catalog\Domain\AttributeType;
-use App\Catalog\Infrastructure\Doctrine\Repository\AttributeRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -32,25 +29,11 @@ use Symfony\Component\Validator\Constraints as Assert;
  * `group_id` FK is nullable + ON DELETE SET NULL — removing an attribute
  * group leaves its members ungrouped rather than deleting them.
  */
-#[ORM\Entity(repositoryClass: AttributeRepository::class)]
-#[ORM\Table(name: 'attributes')]
-#[ORM\UniqueConstraint(name: 'attributes_tenant_code_uniq', columns: ['tenant_id', 'code'])]
-#[ORM\Index(name: 'attributes_tenant_group_position_idx', columns: ['tenant_id', 'group_id', 'position'])]
 class Attribute implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
-
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
-
-    #[ORM\ManyToOne(targetEntity: AttributeGroup::class)]
-    #[ORM\JoinColumn(name: 'group_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?AttributeGroup $group = null;
-
-    #[ORM\Column(type: 'string', length: 64)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 64)]
     private string $code;
@@ -58,38 +41,27 @@ class Attribute implements TenantScoped
     /**
      * @var array<string, string>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
     #[Assert\Type('array')]
     private array $label;
 
     /**
      * @var array<string, string>|null
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true], nullable: true)]
     private ?array $help = null;
-
-    #[ORM\Column(type: Types::STRING, length: 32, enumType: AttributeType::class)]
     private AttributeType $type;
 
-    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
     private bool $isLocalizable = false;
 
-    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
     private bool $isScopable = false;
 
-    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
     private bool $isRequired = false;
 
     /**
      * @var array<string, mixed>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true, 'default' => '{}'])]
     private array $validationRules = [];
 
-    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
     private int $position = 0;
-
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $createdAt;
 
     /**

--- a/apps/api/src/Catalog/Domain/Entity/AttributeGroup.php
+++ b/apps/api/src/Catalog/Domain/Entity/AttributeGroup.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
-use App\Catalog\Infrastructure\Doctrine\Repository\AttributeGroupRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -26,21 +23,10 @@ use Symfony\Component\Validator\Constraints as Assert;
  * `label` is JSONB `{pl: "...", en: "..."}` so the same row carries every
  * supported locale in MVP — no separate translations table.
  */
-#[ORM\Entity(repositoryClass: AttributeGroupRepository::class)]
-#[ORM\Table(name: 'attribute_groups')]
-#[ORM\UniqueConstraint(name: 'attribute_groups_tenant_code_uniq', columns: ['tenant_id', 'code'])]
-#[ORM\Index(name: 'attribute_groups_tenant_position_idx', columns: ['tenant_id', 'position'])]
 class AttributeGroup implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
-
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
-
-    #[ORM\Column(type: 'string', length: 64)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 64)]
     private string $code;
@@ -48,14 +34,10 @@ class AttributeGroup implements TenantScoped
     /**
      * @var array<string, string>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
     #[Assert\Type('array')]
     private array $label;
 
-    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
     private int $position;
-
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $createdAt;
 
     /**

--- a/apps/api/src/Catalog/Domain/Entity/AttributeOption.php
+++ b/apps/api/src/Catalog/Domain/Entity/AttributeOption.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
-use App\Catalog\Infrastructure\Doctrine\Repository\AttributeOptionRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -25,26 +22,11 @@ use Symfony\Component\Validator\Constraints as Assert;
  * without a JOIN, and so `pim:tenant:audit` sees the table as domain.
  * Cost: 16 extra bytes per row, plus listener stamping.
  */
-#[ORM\Entity(repositoryClass: AttributeOptionRepository::class)]
-#[ORM\Table(name: 'attribute_options')]
-#[ORM\UniqueConstraint(name: 'attribute_options_attribute_code_uniq', columns: ['attribute_id', 'code'])]
-#[ORM\Index(name: 'attribute_options_attribute_position_idx', columns: ['attribute_id', 'position'])]
-#[ORM\Index(name: 'attribute_options_tenant_idx', columns: ['tenant_id'])]
 class AttributeOption implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
-
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
-
-    #[ORM\ManyToOne(targetEntity: Attribute::class)]
-    #[ORM\JoinColumn(name: 'attribute_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private Attribute $attribute;
-
-    #[ORM\Column(type: 'string', length: 64)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 64)]
     private string $code;
@@ -52,11 +34,9 @@ class AttributeOption implements TenantScoped
     /**
      * @var array<string, string>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
     #[Assert\Type('array')]
     private array $label;
 
-    #[ORM\Column(type: Types::INTEGER, options: ['default' => 0])]
     private int $position;
 
     /**

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace App\Catalog\Domain\Entity;
 
 use App\Catalog\Domain\ObjectKind;
-use App\Catalog\Infrastructure\Doctrine\Repository\CatalogObjectRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -45,57 +42,32 @@ use Symfony\Component\Validator\Constraints as Assert;
  *   - `kind='product'` for variants (size/color of a parent SKU);
  *   - `kind='category'` for the tree (parent category in ltree).
  */
-#[ORM\Entity(repositoryClass: CatalogObjectRepository::class)]
-#[ORM\Table(name: 'objects')]
-#[ORM\UniqueConstraint(name: 'objects_tenant_kind_code_uniq', columns: ['tenant_id', 'kind', 'code'])]
-#[ORM\Index(name: 'objects_tenant_type_idx', columns: ['tenant_id', 'object_type_id'])]
-#[ORM\Index(name: 'objects_tenant_kind_idx', columns: ['tenant_id', 'kind'])]
 class CatalogObject implements TenantScoped
 {
     public const string STATUS_DRAFT = 'draft';
     public const string STATUS_PUBLISHED = 'published';
     public const string STATUS_ARCHIVED = 'archived';
-
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
-
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
-
-    #[ORM\ManyToOne(targetEntity: ObjectType::class)]
-    #[ORM\JoinColumn(name: 'object_type_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ObjectType $objectType;
-
-    #[ORM\Column(type: Types::STRING, length: 32, enumType: ObjectKind::class)]
     private ObjectKind $kind;
-
-    #[ORM\Column(type: 'string', length: 128)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 128)]
     private string $code;
-
-    #[ORM\ManyToOne(targetEntity: self::class)]
-    #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?self $parent = null;
 
-    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => true])]
     private bool $enabled = true;
 
-    #[ORM\Column(type: 'string', length: 16, options: ['default' => self::STATUS_DRAFT])]
     private string $status = self::STATUS_DRAFT;
 
     /**
      * @var array<string, mixed>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true, 'default' => '{}'])]
     private array $completeness = [];
 
     /**
      * @var array<string, mixed>
      */
-    #[ORM\Column(name: 'attributes_indexed', type: Types::JSON, options: ['jsonb' => true, 'default' => '{}'])]
     private array $attributesIndexed = [];
 
     /**
@@ -107,13 +79,8 @@ class CatalogObject implements TenantScoped
      * enforces the same invariant on writes with a friendlier error
      * message and validates ltree label format.
      */
-    #[ORM\Column(type: 'ltree', nullable: true)]
     private ?string $path = null;
-
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $createdAt;
-
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $updatedAt;
 
     public function __construct(

--- a/apps/api/src/Catalog/Domain/Entity/ObjectType.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectType.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace App\Catalog\Domain\Entity;
 
 use App\Catalog\Domain\ObjectKind;
-use App\Catalog\Infrastructure\Doctrine\Repository\ObjectTypeRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -39,59 +36,32 @@ use Symfony\Component\Validator\Constraints as Assert;
  * environments) — set on every save, bumped manually when a schema-
  * breaking change to `completeness_rules` ships.
  */
-#[ORM\Entity(repositoryClass: ObjectTypeRepository::class)]
-#[ORM\Table(name: 'object_types')]
-#[ORM\UniqueConstraint(name: 'object_types_tenant_code_uniq', columns: ['tenant_id', 'code'])]
-#[ORM\Index(name: 'object_types_tenant_kind_idx', columns: ['tenant_id', 'kind'])]
 class ObjectType implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
-
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
-
-    #[ORM\Column(type: 'string', length: 128)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 128)]
     private string $code;
-
-    #[ORM\Column(type: Types::STRING, length: 32, enumType: ObjectKind::class)]
     private ObjectKind $kind;
 
-    #[ORM\Column(name: 'is_built_in', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $isBuiltIn = false;
 
     /**
      * @var array<string, string>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
     #[Assert\Type('array')]
     private array $label;
 
     /**
      * @var array<string, mixed>
      */
-    #[ORM\Column(name: 'completeness_rules', type: Types::JSON, options: ['jsonb' => true, 'default' => '{}'])]
     private array $completenessRules = [];
-
-    #[ORM\ManyToOne(targetEntity: Attribute::class)]
-    #[ORM\JoinColumn(name: 'label_attribute_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?Attribute $labelAttribute = null;
-
-    #[ORM\ManyToOne(targetEntity: Attribute::class)]
-    #[ORM\JoinColumn(name: 'image_attribute_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?Attribute $imageAttribute = null;
 
-    #[ORM\Column(name: 'schema_version', type: Types::INTEGER, options: ['default' => 1])]
     private int $schemaVersion = 1;
-
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $createdAt;
-
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $updatedAt;
 
     /**

--- a/apps/api/src/Catalog/Domain/Entity/ObjectTypeAttribute.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectTypeAttribute.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
-use App\Catalog\Infrastructure\Doctrine\Repository\ObjectTypeAttributeRepository;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -32,31 +29,15 @@ use Symfony\Component\Uid\Uuid;
  * ObjectType. Listed in `TenantAuditCommand::INFRA_TABLES` allowlist so
  * the audit doesn't flag it as an unscoped domain table.
  */
-#[ORM\Entity(repositoryClass: ObjectTypeAttributeRepository::class)]
-#[ORM\Table(name: 'object_type_attributes')]
-#[ORM\Index(name: 'object_type_attributes_object_type_sort_idx', columns: ['object_type_id', 'sort_order'])]
 class ObjectTypeAttribute
 {
-    #[ORM\Id]
-    #[ORM\ManyToOne(targetEntity: ObjectType::class)]
-    #[ORM\JoinColumn(name: 'object_type_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ObjectType $objectType;
-
-    #[ORM\Id]
-    #[ORM\ManyToOne(targetEntity: Attribute::class)]
-    #[ORM\JoinColumn(name: 'attribute_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private Attribute $attribute;
 
-    #[ORM\Column(name: 'required_for_completeness', type: Types::BOOLEAN, options: ['default' => false])]
     private bool $requiredForCompleteness = false;
 
-    #[ORM\Column(name: 'sort_order', type: Types::INTEGER, options: ['default' => 0])]
     private int $sortOrder = 0;
-
-    #[ORM\Column(name: 'channel_id', type: 'uuid', nullable: true)]
     private ?Uuid $channelId = null;
-
-    #[ORM\Column(name: 'locale', type: Types::STRING, length: 8, nullable: true)]
     private ?string $locale = null;
 
     public function __construct(

--- a/apps/api/src/Catalog/Domain/Entity/ObjectValue.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectValue.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace App\Catalog\Domain\Entity;
 
 use App\Catalog\Domain\Provenance;
-use App\Catalog\Infrastructure\Doctrine\Repository\ObjectValueRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 
@@ -33,38 +30,13 @@ use Symfony\Component\Uid\Uuid;
  * (#61) reads them for the per-field badge ("manual" / "import" /
  * "integration"). Phase 2 adds the `agent` case to {@see Provenance}.
  */
-#[ORM\Entity(repositoryClass: ObjectValueRepository::class)]
-#[ORM\Table(name: 'object_values')]
-#[ORM\UniqueConstraint(
-    name: 'object_values_scope_uniq',
-    columns: ['object_id', 'attribute_id', 'channel_id', 'locale'],
-    options: ['nulls_not_distinct' => true],
-)]
-#[ORM\Index(name: 'object_values_tenant_idx', columns: ['tenant_id'])]
-#[ORM\Index(name: 'object_values_object_idx', columns: ['object_id'])]
-#[ORM\Index(name: 'object_values_attribute_idx', columns: ['attribute_id'])]
 class ObjectValue implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
-
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
-
-    #[ORM\ManyToOne(targetEntity: CatalogObject::class)]
-    #[ORM\JoinColumn(name: 'object_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private CatalogObject $object;
-
-    #[ORM\ManyToOne(targetEntity: Attribute::class)]
-    #[ORM\JoinColumn(name: 'attribute_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private Attribute $attribute;
-
-    #[ORM\Column(name: 'channel_id', type: 'uuid', nullable: true)]
     private ?Uuid $channelId = null;
-
-    #[ORM\Column(type: 'string', length: 8, nullable: true)]
     private ?string $locale = null;
 
     /**
@@ -81,16 +53,13 @@ class ObjectValue implements TenantScoped
      *
      * @var array<string, mixed>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
     private array $value;
 
-    #[ORM\Column(type: Types::STRING, length: 16, enumType: Provenance::class, options: ['default' => Provenance::Manual->value])]
     private Provenance $provenance = Provenance::Manual;
 
     /**
      * @var array<string, mixed>
      */
-    #[ORM\Column(name: 'provenance_meta', type: Types::JSON, options: ['jsonb' => true, 'default' => '{}'])]
     private array $provenanceMeta = [];
 
     /**

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/Association.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/Association.orm.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\Association"
+            table="object_associations"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\AssociationRepository">
+
+        <unique-constraints>
+            <unique-constraint name="object_associations_triple_uniq" columns="source_object_id,target_object_id,type_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="object_associations_tenant_idx" columns="tenant_id"/>
+            <index name="object_associations_source_type_idx" columns="source_object_id,type_id"/>
+            <index name="object_associations_target_idx" columns="target_object_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="source" target-entity="App\Catalog\Domain\Entity\CatalogObject">
+            <join-column name="source_object_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="target" target-entity="App\Catalog\Domain\Entity\CatalogObject">
+            <join-column name="target_object_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="type" target-entity="App\Catalog\Domain\Entity\AssociationType">
+            <join-column name="type_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AssociationType.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AssociationType.orm.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\AssociationType"
+            table="association_types"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\AssociationTypeRepository">
+
+        <unique-constraints>
+            <unique-constraint name="association_types_tenant_code_uniq" columns="tenant_id,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="association_types_tenant_position_idx" columns="tenant_id,position"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="64"/>
+        <field name="label" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/Attribute.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/Attribute.orm.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\Attribute"
+            table="attributes"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\AttributeRepository">
+
+        <unique-constraints>
+            <unique-constraint name="attributes_tenant_code_uniq" columns="tenant_id,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="attributes_tenant_group_position_idx" columns="tenant_id,group_id,position"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="group" target-entity="App\Catalog\Domain\Entity\AttributeGroup">
+            <join-column name="group_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="64"/>
+        <field name="label" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="help" type="json" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="type" type="string" length="32" enum-type="App\Catalog\Domain\AttributeType"/>
+        <field name="isLocalizable" type="boolean" column="is_localizable">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="isScopable" type="boolean" column="is_scopable">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="isRequired" type="boolean" column="is_required">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="validationRules" type="json" column="validation_rules">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeGroup.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeGroup.orm.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\AttributeGroup"
+            table="attribute_groups"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\AttributeGroupRepository">
+
+        <unique-constraints>
+            <unique-constraint name="attribute_groups_tenant_code_uniq" columns="tenant_id,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="attribute_groups_tenant_position_idx" columns="tenant_id,position"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="64"/>
+        <field name="label" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeOption.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeOption.orm.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\AttributeOption"
+            table="attribute_options"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\AttributeOptionRepository">
+
+        <unique-constraints>
+            <unique-constraint name="attribute_options_attribute_code_uniq" columns="attribute_id,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="attribute_options_attribute_position_idx" columns="attribute_id,position"/>
+            <index name="attribute_options_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="attribute" target-entity="App\Catalog\Domain\Entity\Attribute">
+            <join-column name="attribute_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="64"/>
+        <field name="label" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\CatalogObject"
+            table="objects"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\CatalogObjectRepository">
+
+        <unique-constraints>
+            <unique-constraint name="objects_tenant_kind_code_uniq" columns="tenant_id,kind,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="objects_tenant_type_idx" columns="tenant_id,object_type_id"/>
+            <index name="objects_tenant_kind_idx" columns="tenant_id,kind"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="objectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
+            <join-column name="object_type_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="kind" type="string" length="32" enum-type="App\Catalog\Domain\ObjectKind"/>
+        <field name="code" type="string" length="128"/>
+
+        <many-to-one field="parent" target-entity="App\Catalog\Domain\Entity\CatalogObject">
+            <join-column name="parent_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <field name="enabled" type="boolean">
+            <options>
+                <option name="default">true</option>
+            </options>
+        </field>
+        <field name="status" type="string" length="16">
+            <options>
+                <option name="default">draft</option>
+            </options>
+        </field>
+        <field name="completeness" type="json">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="attributesIndexed" type="json" column="attributes_indexed">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="path" type="ltree" nullable="true"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\ObjectType"
+            table="object_types"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\ObjectTypeRepository">
+
+        <unique-constraints>
+            <unique-constraint name="object_types_tenant_code_uniq" columns="tenant_id,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="object_types_tenant_kind_idx" columns="tenant_id,kind"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="128"/>
+        <field name="kind" type="string" length="32" enum-type="App\Catalog\Domain\ObjectKind"/>
+        <field name="isBuiltIn" type="boolean" column="is_built_in">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="label" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="completenessRules" type="json" column="completeness_rules">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+
+        <many-to-one field="labelAttribute" target-entity="App\Catalog\Domain\Entity\Attribute">
+            <join-column name="label_attribute_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <many-to-one field="imageAttribute" target-entity="App\Catalog\Domain\Entity\Attribute">
+            <join-column name="image_attribute_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <field name="schemaVersion" type="integer" column="schema_version">
+            <options>
+                <option name="default">1</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectTypeAttribute.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectTypeAttribute.orm.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\ObjectTypeAttribute"
+            table="object_type_attributes"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\ObjectTypeAttributeRepository">
+
+        <indexes>
+            <index name="object_type_attributes_object_type_sort_idx" columns="object_type_id,sort_order"/>
+        </indexes>
+
+        <id name="objectType" association-key="true"/>
+        <id name="attribute" association-key="true"/>
+
+        <many-to-one field="objectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
+            <join-column name="object_type_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="attribute" target-entity="App\Catalog\Domain\Entity\Attribute">
+            <join-column name="attribute_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="requiredForCompleteness" type="boolean" column="required_for_completeness">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="sortOrder" type="integer" column="sort_order">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="channelId" type="uuid" column="channel_id" nullable="true"/>
+        <field name="locale" type="string" length="8" nullable="true"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectValue.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectValue.orm.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\ObjectValue"
+            table="object_values"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\ObjectValueRepository">
+
+        <unique-constraints>
+            <unique-constraint name="object_values_scope_uniq" columns="object_id,attribute_id,channel_id,locale">
+                <options>
+                    <option name="nulls_not_distinct">true</option>
+                </options>
+            </unique-constraint>
+        </unique-constraints>
+
+        <indexes>
+            <index name="object_values_tenant_idx" columns="tenant_id"/>
+            <index name="object_values_object_idx" columns="object_id"/>
+            <index name="object_values_attribute_idx" columns="attribute_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="object" target-entity="App\Catalog\Domain\Entity\CatalogObject">
+            <join-column name="object_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="attribute" target-entity="App\Catalog\Domain\Entity\Attribute">
+            <join-column name="attribute_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="channelId" type="uuid" column="channel_id" nullable="true"/>
+        <field name="locale" type="string" length="8" nullable="true"/>
+        <field name="value" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="provenance" type="string" length="16" enum-type="App\Catalog\Domain\Provenance">
+            <options>
+                <option name="default">manual</option>
+            </options>
+        </field>
+        <field name="provenanceMeta" type="json" column="provenance_meta">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>


### PR DESCRIPTION
## Summary
- 9 new XML mappings under `apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/` (AttributeGroup, AttributeOption, Attribute, ObjectType, CatalogObject, ObjectValue, Association, AssociationType, ObjectTypeAttribute).
- 9 Domain entities cleaned of every `#[ORM\*]` attribute and Doctrine import — Catalog Domain is now framework-agnostic.
- `doctrine.yaml`: Catalog mapping switched to `type: xml`.

Schema validate is green; fixtures still load; PHPUnit + CS-Fixer pass.

## Test plan
- [x] `bin/console doctrine:schema:validate` — mapping correct, dev DB in sync
- [x] `bin/console doctrine:fixtures:load` — fixtures load
- [x] `composer phpstan` (level max) — 0 errors
- [x] `composer cs-check` — clean
- [x] `php bin/phpunit tests/Unit` — 144/144 green
- [ ] CI: full quality stack green

## Notes
- ltree DBAL type carried into XML via `<field type="ltree" .../>` on `CatalogObject.path`. Custom Doctrine `LtreeType` still wired up in `doctrine.yaml`.
- ObjectKind / AttributeType / Provenance backed enums preserved via `enum-type=` on fields.
- ObjectTypeAttribute (junction with composite PK) kept its dual `<id>` association-keys.
- `phpstan.dist.neon` `doctrine.associationType` ignoreErrors paths kept for Catalog — XML mappings still produce the same `?Tenant` vs `nullable=false` mismatch the attribute mappings did, because the column is NOT NULL at the schema level but the property holds null briefly between `new` and `prePersist`. Same caveat as before; Channel + Asset still on the list and follow in RF-07/08.
- Branch from `main@3dd6163` (post RF-05 merge).

Closes #156