### PR TITLE
RF-07 — refactor(channel): migrate 4 Domain entities to Doctrine XML mapping

### DIFF
--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -56,9 +56,9 @@ doctrine:
                 prefix: 'App\Catalog\Domain\Entity'
                 alias: Catalog
             Channel:
-                type: attribute
+                type: xml
                 is_bundle: false
-                dir: '%kernel.project_dir%/src/Channel/Domain/Entity'
+                dir: '%kernel.project_dir%/src/Channel/Infrastructure/Doctrine/Orm/Mapping'
                 prefix: 'App\Channel\Domain\Entity'
                 alias: Channel
             Asset:

--- a/apps/api/src/Channel/Domain/Entity/Channel.php
+++ b/apps/api/src/Channel/Domain/Entity/Channel.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace App\Channel\Domain\Entity;
 
 use App\Catalog\Domain\Entity\CatalogObject;
-use App\Channel\Infrastructure\Doctrine\Repository\ChannelRepository;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -36,21 +33,12 @@ use Symfony\Component\Validator\Constraints as Assert;
  * per `ObjectType` so a single channel can have different field shapes
  * for product vs. category exports.
  */
-#[ORM\Entity(repositoryClass: ChannelRepository::class)]
-#[ORM\Table(name: 'channels')]
-#[ORM\UniqueConstraint(name: 'channels_tenant_code_uniq', columns: ['tenant_id', 'code'])]
-#[ORM\Index(name: 'channels_tenant_idx', columns: ['tenant_id'])]
 class Channel implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
 
-    #[ORM\Column(type: 'string', length: 64)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 64)]
     private string $code;
@@ -58,30 +46,19 @@ class Channel implements TenantScoped
     /**
      * @var array<string, string>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
     #[Assert\Type('array')]
     private array $label;
 
     /**
      * @var Collection<int, Locale>
      */
-    #[ORM\ManyToMany(targetEntity: Locale::class)]
-    #[ORM\JoinTable(name: 'channel_locales')]
-    #[ORM\JoinColumn(name: 'channel_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    #[ORM\InverseJoinColumn(name: 'locale_id', referencedColumnName: 'id', onDelete: 'RESTRICT')]
     private Collection $locales;
 
     /**
      * @var Collection<int, Currency>
      */
-    #[ORM\ManyToMany(targetEntity: Currency::class)]
-    #[ORM\JoinTable(name: 'channel_currencies')]
-    #[ORM\JoinColumn(name: 'channel_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    #[ORM\InverseJoinColumn(name: 'currency_id', referencedColumnName: 'id', onDelete: 'RESTRICT')]
     private Collection $currencies;
 
-    #[ORM\ManyToOne(targetEntity: CatalogObject::class)]
-    #[ORM\JoinColumn(name: 'category_tree_root_object_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?CatalogObject $categoryTreeRoot = null;
 
     /**

--- a/apps/api/src/Channel/Domain/Entity/ChannelObjectTypeMapping.php
+++ b/apps/api/src/Channel/Domain/Entity/ChannelObjectTypeMapping.php
@@ -6,9 +6,6 @@ namespace App\Channel\Domain\Entity;
 
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\ObjectType;
-use App\Channel\Infrastructure\Doctrine\Repository\ChannelObjectTypeMappingRepository;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -33,35 +30,20 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Tenant scope is inherited via the parent Channel — no own `tenant_id`.
  * The table joins `INFRA_TABLES` allowlist in `pim:tenant:audit`.
  */
-#[ORM\Entity(repositoryClass: ChannelObjectTypeMappingRepository::class)]
-#[ORM\Table(name: 'channel_object_type_mappings')]
-#[ORM\UniqueConstraint(name: 'channel_object_type_mappings_triple_uniq', columns: ['channel_id', 'object_type_id', 'attribute_id'])]
-#[ORM\Index(name: 'channel_object_type_mappings_channel_idx', columns: ['channel_id'])]
-#[ORM\Index(name: 'channel_object_type_mappings_object_type_idx', columns: ['object_type_id'])]
 class ChannelObjectTypeMapping
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\ManyToOne(targetEntity: Channel::class)]
-    #[ORM\JoinColumn(name: 'channel_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private Channel $channel;
 
-    #[ORM\ManyToOne(targetEntity: ObjectType::class)]
-    #[ORM\JoinColumn(name: 'object_type_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ObjectType $objectType;
 
-    #[ORM\ManyToOne(targetEntity: Attribute::class)]
-    #[ORM\JoinColumn(name: 'attribute_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private Attribute $attribute;
 
-    #[ORM\Column(name: 'target_field', type: Types::STRING, length: 255)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 255)]
     private string $targetField;
 
-    #[ORM\Column(name: 'is_published', type: Types::BOOLEAN, options: ['default' => true])]
     private bool $isPublished = true;
 
     public function __construct(

--- a/apps/api/src/Channel/Domain/Entity/Currency.php
+++ b/apps/api/src/Channel/Domain/Entity/Currency.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace App\Channel\Domain\Entity;
 
-use App\Channel\Infrastructure\Doctrine\Repository\CurrencyRepository;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -15,24 +12,16 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * Mirrors {@see Locale}: global, opt-in via the Channel ↔ Currency M2M.
  */
-#[ORM\Entity(repositoryClass: CurrencyRepository::class)]
-#[ORM\Table(name: 'currencies')]
-#[ORM\UniqueConstraint(name: 'currencies_code_uniq', columns: ['code'])]
 class Currency
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\Column(type: 'string', length: 8)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 8)]
     private string $code;
 
-    #[ORM\Column(type: Types::STRING, length: 8)]
     private string $symbol;
 
-    #[ORM\Column(type: Types::STRING, length: 64)]
     private string $label;
 
     public function __construct(string $code, string $symbol, string $label, ?Uuid $id = null)

--- a/apps/api/src/Channel/Domain/Entity/Locale.php
+++ b/apps/api/src/Channel/Domain/Entity/Locale.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace App\Channel\Domain\Entity;
 
-use App\Channel\Infrastructure\Doctrine\Repository\LocaleRepository;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -21,21 +18,14 @@ use Symfony\Component\Validator\Constraints as Assert;
  * No TenantScoped: the table sits on the audit allowlist as global
  * infrastructure, like `permissions` and the global RBAC roles.
  */
-#[ORM\Entity(repositoryClass: LocaleRepository::class)]
-#[ORM\Table(name: 'locales')]
-#[ORM\UniqueConstraint(name: 'locales_code_uniq', columns: ['code'])]
 class Locale
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\Column(type: 'string', length: 16)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 16)]
     private string $code;
 
-    #[ORM\Column(type: Types::STRING, length: 64)]
     private string $label;
 
     public function __construct(string $code, string $label, ?Uuid $id = null)

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Channel\Domain\Entity\Channel"
+            table="channels"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\ChannelRepository">
+
+        <unique-constraints>
+            <unique-constraint name="channels_tenant_code_uniq" columns="tenant_id,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="channels_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="64"/>
+        <field name="label" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <many-to-many field="locales" target-entity="App\Channel\Domain\Entity\Locale">
+            <join-table name="channel_locales">
+                <join-columns>
+                    <join-column name="channel_id" referenced-column-name="id" on-delete="CASCADE"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="locale_id" referenced-column-name="id" on-delete="RESTRICT"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
+        <many-to-many field="currencies" target-entity="App\Channel\Domain\Entity\Currency">
+            <join-table name="channel_currencies">
+                <join-columns>
+                    <join-column name="channel_id" referenced-column-name="id" on-delete="CASCADE"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="currency_id" referenced-column-name="id" on-delete="RESTRICT"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
+        <many-to-one field="categoryTreeRoot" target-entity="App\Catalog\Domain\Entity\CatalogObject">
+            <join-column name="category_tree_root_object_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ChannelObjectTypeMapping.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ChannelObjectTypeMapping.orm.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Channel\Domain\Entity\ChannelObjectTypeMapping"
+            table="channel_object_type_mappings"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\ChannelObjectTypeMappingRepository">
+
+        <unique-constraints>
+            <unique-constraint name="channel_object_type_mappings_triple_uniq" columns="channel_id,object_type_id,attribute_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="channel_object_type_mappings_channel_idx" columns="channel_id"/>
+            <index name="channel_object_type_mappings_object_type_idx" columns="object_type_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="channel" target-entity="App\Channel\Domain\Entity\Channel">
+            <join-column name="channel_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="objectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
+            <join-column name="object_type_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="attribute" target-entity="App\Catalog\Domain\Entity\Attribute">
+            <join-column name="attribute_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="targetField" type="string" length="255" column="target_field"/>
+        <field name="isPublished" type="boolean" column="is_published">
+            <options>
+                <option name="default">true</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Currency.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Currency.orm.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Channel\Domain\Entity\Currency"
+            table="currencies"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\CurrencyRepository">
+
+        <unique-constraints>
+            <unique-constraint name="currencies_code_uniq" columns="code"/>
+        </unique-constraints>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="code" type="string" length="8"/>
+        <field name="symbol" type="string" length="8"/>
+        <field name="label" type="string" length="64"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Locale.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Locale.orm.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Channel\Domain\Entity\Locale"
+            table="locales"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\LocaleRepository">
+
+        <unique-constraints>
+            <unique-constraint name="locales_code_uniq" columns="code"/>
+        </unique-constraints>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="code" type="string" length="16"/>
+        <field name="label" type="string" length="64"/>
+
+    </entity>
+
+</doctrine-mapping>


### PR DESCRIPTION
## Summary
- 4 new XML mappings under `apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/` (Channel, Locale, Currency, ChannelObjectTypeMapping).
- 4 Channel Domain entities cleaned of every `#[ORM\*]` and Doctrine import.
- `doctrine.yaml`: Channel mapping switched to `type: xml`.

Cross-BC FKs (Channel.categoryTreeRoot → Catalog\CatalogObject; ChannelObjectTypeMapping → Catalog\ObjectType + Catalog\Attribute) are preserved in XML — RF-19 replaces them with `Uuid` columns + `Contracts/Query` lookup.

## Test plan
- [x] `bin/console doctrine:schema:validate` — mapping correct, dev DB in sync
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean
- [x] `php bin/phpunit tests/Unit` — 144/144 green
- [ ] CI: full quality stack green

Closes #157