### PR TITLE
RF-08 — refactor(asset): migrate 2 Domain entities to Doctrine XML mapping

### DIFF
--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -62,9 +62,9 @@ doctrine:
                 prefix: 'App\Channel\Domain\Entity'
                 alias: Channel
             Asset:
-                type: attribute
+                type: xml
                 is_bundle: false
-                dir: '%kernel.project_dir%/src/Asset/Domain/Entity'
+                dir: '%kernel.project_dir%/src/Asset/Infrastructure/Doctrine/Orm/Mapping'
                 prefix: 'App\Asset\Domain\Entity'
                 alias: Asset
             Identity:

--- a/apps/api/src/Asset/Domain/Entity/Asset.php
+++ b/apps/api/src/Asset/Domain/Entity/Asset.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace App\Asset\Domain\Entity;
 
-use App\Asset\Infrastructure\Doctrine\Repository\AssetRepository;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -37,57 +34,38 @@ use Symfony\Component\Validator\Constraints as Assert;
  * {@see AssetVariant} and are derived in phase 1 (transformations are
  * out of MVP scope — #37 only handles the original upload).
  */
-#[ORM\Entity(repositoryClass: AssetRepository::class)]
-#[ORM\Table(name: 'assets')]
-#[ORM\UniqueConstraint(name: 'assets_tenant_code_uniq', columns: ['tenant_id', 'code'])]
-#[ORM\UniqueConstraint(name: 'assets_object_id_uniq', columns: ['object_id'])]
-#[ORM\Index(name: 'assets_tenant_idx', columns: ['tenant_id'])]
 class Asset implements TenantScoped
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private ?Tenant $tenant = null;
 
-    #[ORM\Column(type: 'string', length: 128)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 128)]
     private string $code;
 
-    #[ORM\OneToOne(targetEntity: CatalogObject::class)]
-    #[ORM\JoinColumn(name: 'object_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?CatalogObject $object = null;
 
-    #[ORM\Column(name: 'original_filename', type: Types::STRING, length: 255)]
     #[Assert\NotBlank]
     private string $originalFilename;
 
-    #[ORM\Column(name: 'mime_type', type: Types::STRING, length: 128)]
     private string $mimeType;
 
-    #[ORM\Column(type: Types::BIGINT)]
     private int $size;
 
     /**
      * @var array<string, mixed>
      */
-    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true, 'default' => '{}'])]
     private array $metadata = [];
 
-    #[ORM\Column(name: 'storage_path', type: Types::STRING, length: 1024)]
     #[Assert\NotBlank]
     private string $storagePath;
 
-    #[ORM\Column(name: 'created_at', type: 'datetime_immutable')]
     private DateTimeImmutable $createdAt;
 
     /**
      * @var Collection<int, AssetVariant>
      */
-    #[ORM\OneToMany(targetEntity: AssetVariant::class, mappedBy: 'asset', cascade: ['persist'], orphanRemoval: true)]
     private Collection $variants;
 
     public function __construct(

--- a/apps/api/src/Asset/Domain/Entity/AssetVariant.php
+++ b/apps/api/src/Asset/Domain/Entity/AssetVariant.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace App\Asset\Domain\Entity;
 
-use App\Asset\Infrastructure\Doctrine\Repository\AssetVariantRepository;
-use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -22,35 +19,23 @@ use Symfony\Component\Validator\Constraints as Assert;
  * column. The table joins `INFRA_TABLES` allowlist in
  * `pim:tenant:audit`.
  */
-#[ORM\Entity(repositoryClass: AssetVariantRepository::class)]
-#[ORM\Table(name: 'asset_variants')]
-#[ORM\UniqueConstraint(name: 'asset_variants_asset_code_uniq', columns: ['asset_id', 'variant_code'])]
-#[ORM\Index(name: 'asset_variants_asset_idx', columns: ['asset_id'])]
 class AssetVariant
 {
     public const string CODE_ORIGINAL = 'original';
     public const string CODE_THUMB = 'thumb';
     public const string CODE_MEDIUM = 'medium';
 
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\ManyToOne(targetEntity: Asset::class, inversedBy: 'variants')]
-    #[ORM\JoinColumn(name: 'asset_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private Asset $asset;
 
-    #[ORM\Column(name: 'variant_code', type: Types::STRING, length: 32)]
     #[Assert\NotBlank]
     private string $variantCode;
 
-    #[ORM\Column(name: 'storage_path', type: Types::STRING, length: 1024)]
     private string $storagePath;
 
-    #[ORM\Column(name: 'mime_type', type: Types::STRING, length: 128)]
     private string $mimeType;
 
-    #[ORM\Column(type: Types::BIGINT)]
     private int $size;
 
     public function __construct(

--- a/apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/Asset.orm.xml
+++ b/apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/Asset.orm.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Asset\Domain\Entity\Asset"
+            table="assets"
+            repository-class="App\Asset\Infrastructure\Doctrine\Repository\AssetRepository">
+
+        <unique-constraints>
+            <unique-constraint name="assets_tenant_code_uniq" columns="tenant_id,code"/>
+            <unique-constraint name="assets_object_id_uniq" columns="object_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="assets_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="128"/>
+
+        <one-to-one field="object" target-entity="App\Catalog\Domain\Entity\CatalogObject">
+            <join-column name="object_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </one-to-one>
+
+        <field name="originalFilename" type="string" length="255" column="original_filename"/>
+        <field name="mimeType" type="string" length="128" column="mime_type"/>
+        <field name="size" type="bigint"/>
+        <field name="metadata" type="json">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="storagePath" type="string" length="1024" column="storage_path"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+        <one-to-many field="variants" target-entity="App\Asset\Domain\Entity\AssetVariant" mapped-by="asset" orphan-removal="true">
+            <cascade>
+                <cascade-persist/>
+            </cascade>
+        </one-to-many>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/AssetVariant.orm.xml
+++ b/apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/AssetVariant.orm.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Asset\Domain\Entity\AssetVariant"
+            table="asset_variants"
+            repository-class="App\Asset\Infrastructure\Doctrine\Repository\AssetVariantRepository">
+
+        <unique-constraints>
+            <unique-constraint name="asset_variants_asset_code_uniq" columns="asset_id,variant_code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="asset_variants_asset_idx" columns="asset_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="asset" target-entity="App\Asset\Domain\Entity\Asset" inversed-by="variants">
+            <join-column name="asset_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="variantCode" type="string" length="32" column="variant_code"/>
+        <field name="storagePath" type="string" length="1024" column="storage_path"/>
+        <field name="mimeType" type="string" length="128" column="mime_type"/>
+        <field name="size" type="bigint"/>
+
+    </entity>
+
+</doctrine-mapping>


### PR DESCRIPTION
## Summary
- 2 new XML mappings under `apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/` (Asset, AssetVariant).
- 2 Asset Domain entities cleaned of every `#[ORM\*]` and Doctrine import.
- `doctrine.yaml`: Asset mapping switched to `type: xml`.

Cross-BC FK Asset.object → CatalogObject preserved in XML; RF-19 will swap it for a Uuid column + Contracts/Query.

## Test plan
- [x] `bin/console doctrine:schema:validate` — mapping correct, DB in sync
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean
- [x] `php bin/phpunit tests/Unit` — 144/144 green
- [ ] CI: full quality stack green

Closes #158