### PR TITLE
RF-09 — refactor(identity): migrate 4 Domain entities to Doctrine XML mapping

### DIFF
--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -68,9 +68,9 @@ doctrine:
                 prefix: 'App\Asset\Domain\Entity'
                 alias: Asset
             Identity:
-                type: attribute
+                type: xml
                 is_bundle: false
-                dir: '%kernel.project_dir%/src/Identity/Domain/Entity'
+                dir: '%kernel.project_dir%/src/Identity/Infrastructure/Doctrine/Orm/Mapping'
                 prefix: 'App\Identity\Domain\Entity'
                 alias: Identity
         controller_resolver:

--- a/apps/api/src/Identity/Domain/Entity/Permission.php
+++ b/apps/api/src/Identity/Domain/Entity/Permission.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Identity\Domain\Entity;
 
-use App\Identity\Infrastructure\Doctrine\Repository\PermissionRepository;
 use DateTimeImmutable;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -16,10 +14,6 @@ use Symfony\Component\Uid\Uuid;
  * (e.g. `product.write`). Schema uniqueness is enforced on (resource, action)
  * because the matrix is the source of truth; `code` is a derived label.
  */
-#[ORM\Entity(repositoryClass: PermissionRepository::class)]
-#[ORM\Table(name: 'permissions')]
-#[ORM\UniqueConstraint(name: 'permissions_resource_action_uniq', columns: ['resource', 'action'])]
-#[ORM\UniqueConstraint(name: 'permissions_code_uniq', columns: ['code'])]
 class Permission
 {
     public const string ACTION_READ = 'read';
@@ -27,20 +21,14 @@ class Permission
     public const string ACTION_DELETE = 'delete';
     public const string ACTION_ADMIN = 'admin';
 
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\Column(type: 'string', length: 128)]
     private string $code;
 
-    #[ORM\Column(type: 'string', length: 64)]
     private string $resource;
 
-    #[ORM\Column(type: 'string', length: 32)]
     private string $action;
 
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $createdAt;
 
     public function __construct(

--- a/apps/api/src/Identity/Domain/Entity/RefreshToken.php
+++ b/apps/api/src/Identity/Domain/Entity/RefreshToken.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Identity\Domain\Entity;
 
-use App\Identity\Infrastructure\Doctrine\Repository\RefreshTokenRepository;
 use DateTimeImmutable;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -21,40 +19,24 @@ use Symfony\Component\Uid\Uuid;
  * lookups never join: the refresh path is hot and the only reads are by hash.
  * The schema-level FKs in the migration enforce referential integrity.
  */
-#[ORM\Entity(repositoryClass: RefreshTokenRepository::class)]
-#[ORM\Table(name: 'refresh_tokens')]
-#[ORM\Index(name: 'refresh_tokens_tenant_idx', columns: ['tenant_id'])]
-#[ORM\Index(name: 'refresh_tokens_user_idx', columns: ['user_id'])]
-#[ORM\Index(name: 'refresh_tokens_family_idx', columns: ['family_id'])]
-#[ORM\UniqueConstraint(name: 'refresh_tokens_token_hash_uniq', columns: ['token_hash'])]
 class RefreshToken
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\Column(name: 'tenant_id', type: 'uuid')]
     private Uuid $tenantId;
 
-    #[ORM\Column(name: 'user_id', type: 'uuid')]
     private Uuid $userId;
 
-    #[ORM\Column(name: 'family_id', type: 'uuid')]
     private Uuid $familyId;
 
-    #[ORM\Column(name: 'token_hash', type: 'string', length: 64)]
     private string $tokenHash;
 
-    #[ORM\Column(name: 'issued_at', type: 'datetime_immutable')]
     private DateTimeImmutable $issuedAt;
 
-    #[ORM\Column(name: 'expires_at', type: 'datetime_immutable')]
     private DateTimeImmutable $expiresAt;
 
-    #[ORM\Column(name: 'used_at', type: 'datetime_immutable', nullable: true)]
     private ?DateTimeImmutable $usedAt = null;
 
-    #[ORM\Column(name: 'revoked_at', type: 'datetime_immutable', nullable: true)]
     private ?DateTimeImmutable $revokedAt = null;
 
     public function __construct(

--- a/apps/api/src/Identity/Domain/Entity/Role.php
+++ b/apps/api/src/Identity/Domain/Entity/Role.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace App\Identity\Domain\Entity;
 
-use App\Identity\Infrastructure\Doctrine\Repository\RoleRepository;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -19,36 +17,21 @@ use Symfony\Component\Uid\Uuid;
  * super_admin / catalog_manager / integration_manager / viewer). Per-tenant
  * custom roles land in Faza 2+ once admin UI for role management arrives.
  */
-#[ORM\Entity(repositoryClass: RoleRepository::class)]
-#[ORM\Table(name: 'roles')]
-#[ORM\UniqueConstraint(name: 'roles_tenant_code_uniq', columns: ['tenant_id', 'code'])]
-#[ORM\Index(name: 'roles_tenant_idx', columns: ['tenant_id'])]
 class Role
 {
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     private ?Tenant $tenant;
 
-    #[ORM\Column(type: 'string', length: 64)]
     private string $code;
 
-    #[ORM\Column(type: 'string', length: 255)]
     private string $name;
 
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $createdAt;
 
     /**
      * @var Collection<int, Permission>
      */
-    #[ORM\ManyToMany(targetEntity: Permission::class)]
-    #[ORM\JoinTable(name: 'role_permissions')]
-    #[ORM\JoinColumn(name: 'role_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    #[ORM\InverseJoinColumn(name: 'permission_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     private Collection $permissions;
 
     public function __construct(

--- a/apps/api/src/Identity/Domain/Entity/User.php
+++ b/apps/api/src/Identity/Domain/Entity/User.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace App\Identity\Domain\Entity;
 
-use App\Identity\Infrastructure\Doctrine\Repository\UserRepository;
 use App\Shared\Application\TenantAware;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Uid\Uuid;
@@ -27,27 +25,17 @@ use Symfony\Component\Uid\Uuid;
  * The TenantAware interface lets CurrentTenantProvider read the tenant from
  * the security token's user without coupling Identity to Catalog.
  */
-#[ORM\Entity(repositoryClass: UserRepository::class)]
-#[ORM\Table(name: 'users')]
-#[ORM\UniqueConstraint(name: 'users_email_uniq', columns: ['email'])]
-#[ORM\Index(name: 'users_tenant_idx', columns: ['tenant_id'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface, TenantAware
 {
     public const string STATUS_ACTIVE = 'active';
     public const string STATUS_DISABLED = 'disabled';
 
-    #[ORM\Id]
-    #[ORM\Column(type: 'uuid')]
     private Uuid $id;
 
-    #[ORM\ManyToOne(targetEntity: Tenant::class)]
-    #[ORM\JoinColumn(name: 'tenant_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
     private Tenant $tenant;
 
-    #[ORM\Column(type: 'string', length: 255)]
     private string $email;
 
-    #[ORM\Column(type: 'string')]
     private string $password;
 
     /**
@@ -58,25 +46,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TenantA
      *
      * @var list<string>
      */
-    #[ORM\Column(type: 'json')]
     private array $roles;
 
     /**
      * @var Collection<int, Role>
      */
-    #[ORM\ManyToMany(targetEntity: Role::class)]
-    #[ORM\JoinTable(name: 'user_roles')]
-    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    #[ORM\InverseJoinColumn(name: 'role_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     private Collection $assignedRoles;
 
-    #[ORM\Column(type: 'string', length: 16, options: ['default' => self::STATUS_ACTIVE])]
     private string $status;
 
-    #[ORM\Column(name: 'last_login_at', type: 'datetime_immutable', nullable: true)]
     private ?DateTimeImmutable $lastLoginAt;
 
-    #[ORM\Column(type: 'datetime_immutable')]
     private DateTimeImmutable $createdAt;
 
     /**

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/Permission.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/Permission.orm.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Identity\Domain\Entity\Permission"
+            table="permissions"
+            repository-class="App\Identity\Infrastructure\Doctrine\Repository\PermissionRepository">
+
+        <unique-constraints>
+            <unique-constraint name="permissions_resource_action_uniq" columns="resource,action"/>
+            <unique-constraint name="permissions_code_uniq" columns="code"/>
+        </unique-constraints>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="code" type="string" length="128"/>
+        <field name="resource" type="string" length="64"/>
+        <field name="action" type="string" length="32"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/RefreshToken.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/RefreshToken.orm.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Identity\Domain\Entity\RefreshToken"
+            table="refresh_tokens"
+            repository-class="App\Identity\Infrastructure\Doctrine\Repository\RefreshTokenRepository">
+
+        <unique-constraints>
+            <unique-constraint name="refresh_tokens_token_hash_uniq" columns="token_hash"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="refresh_tokens_tenant_idx" columns="tenant_id"/>
+            <index name="refresh_tokens_user_idx" columns="user_id"/>
+            <index name="refresh_tokens_family_idx" columns="family_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="tenantId" type="uuid" column="tenant_id"/>
+        <field name="userId" type="uuid" column="user_id"/>
+        <field name="familyId" type="uuid" column="family_id"/>
+        <field name="tokenHash" type="string" length="64" column="token_hash"/>
+        <field name="issuedAt" type="datetime_immutable" column="issued_at"/>
+        <field name="expiresAt" type="datetime_immutable" column="expires_at"/>
+        <field name="usedAt" type="datetime_immutable" column="used_at" nullable="true"/>
+        <field name="revokedAt" type="datetime_immutable" column="revoked_at" nullable="true"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/Role.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/Role.orm.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Identity\Domain\Entity\Role"
+            table="roles"
+            repository-class="App\Identity\Infrastructure\Doctrine\Repository\RoleRepository">
+
+        <unique-constraints>
+            <unique-constraint name="roles_tenant_code_uniq" columns="tenant_id,code"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="roles_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="true" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="code" type="string" length="64"/>
+        <field name="name" type="string" length="255"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+        <many-to-many field="permissions" target-entity="App\Identity\Domain\Entity\Permission">
+            <join-table name="role_permissions">
+                <join-columns>
+                    <join-column name="role_id" referenced-column-name="id" on-delete="CASCADE"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="permission_id" referenced-column-name="id" on-delete="CASCADE"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/User.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/User.orm.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Identity\Domain\Entity\User"
+            table="users"
+            repository-class="App\Identity\Infrastructure\Doctrine\Repository\UserRepository">
+
+        <unique-constraints>
+            <unique-constraint name="users_email_uniq" columns="email"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="users_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="email" type="string" length="255"/>
+        <field name="password" type="string"/>
+        <field name="roles" type="json"/>
+
+        <many-to-many field="assignedRoles" target-entity="App\Identity\Domain\Entity\Role">
+            <join-table name="user_roles">
+                <join-columns>
+                    <join-column name="user_id" referenced-column-name="id" on-delete="CASCADE"/>
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="role_id" referenced-column-name="id" on-delete="CASCADE"/>
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
+
+        <field name="status" type="string" length="16">
+            <options>
+                <option name="default">active</option>
+            </options>
+        </field>
+        <field name="lastLoginAt" type="datetime_immutable" column="last_login_at" nullable="true"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>


### PR DESCRIPTION
## Summary
- 4 new XML mappings under `apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/` (User, Role, Permission, RefreshToken).
- 4 Identity Domain entities cleaned of every `#[ORM\*]` and Doctrine import.
- `doctrine.yaml`: Identity mapping switched to `type: xml`.

This closes the BC migration sweep started in RF-06: every BC's Domain folder is now framework-agnostic.

## Test plan
- [x] `bin/console doctrine:schema:validate` — mapping correct, dev DB in sync
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean
- [x] `php bin/phpunit tests/Unit` — 144/144 green
- [ ] CI: full quality stack green (PHPUnit Functional + Playwright validate the auth flow)

## Notes
- User → Tenant (NOT NULL), Role → Tenant (nullable for global roles), RefreshToken with denormalized `tenant_id` / `user_id` UUID columns preserved as before.
- M2M tables `user_roles` and `role_permissions` translated to `<many-to-many>` + `<join-table>` blocks.
- Branch from `main@<post RF-08>`.

Closes #159