### PR TITLE
RF-12 — refactor(catalog): replace public setters with domain methods

### DIFF
--- a/apps/api/src/Benchmark/BulkImportBenchmarkCommand.php
+++ b/apps/api/src/Benchmark/BulkImportBenchmarkCommand.php
@@ -125,8 +125,8 @@ final class BulkImportBenchmarkCommand extends Command
         for ($i = 1; $i <= $count; ++$i) {
             $sku = \sprintf('%s%05d', $skuPrefix, $i);
             $object = new CatalogObject($productType, $sku);
-            $object->setStatus(CatalogObject::STATUS_PUBLISHED);
-            $object->setAttributesIndexed([
+            $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $object->updateAttributeIndex([
                 'sku' => $sku,
                 'name' => \sprintf('Benchmark product %05d', $i),
                 'brand' => 'Benchmark Co',

--- a/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
+++ b/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
@@ -56,13 +56,13 @@ final readonly class AttributesIndexedRebuilder
             $indexed[$code] = $value->getValue();
         }
 
-        $object->setAttributesIndexed($indexed);
+        $object->updateAttributeIndex($indexed);
 
         // Completeness: required-list / present-count. Empty rules → 100.
         $rules = $object->getObjectType()->getCompletenessRules();
         $required = \is_array($rules['required'] ?? null) ? $rules['required'] : [];
         if ([] === $required) {
-            $object->setCompleteness(['global' => 100]);
+            $object->recordCompleteness(['global' => 100]);
 
             return;
         }
@@ -74,6 +74,6 @@ final readonly class AttributesIndexedRebuilder
             }
         }
         $pct = (int) round(100 * $present / \count($required));
-        $object->setCompleteness(['global' => $pct]);
+        $object->recordCompleteness(['global' => $pct]);
     }
 }

--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -74,13 +74,13 @@ final readonly class DemoCatalogSeeder
 
             $attributes = $this->seedAttributes($tenant);
             $this->seedJunctions($productType, $categoryType, $assetType, $attributes);
-            $productType->setLabelAttribute($attributes['name']);
-            $productType->setImageAttribute($attributes['main_image']);
-            $productType->setCompletenessRules(['required' => ['sku', 'name', 'description', 'price']]);
-            $categoryType->setLabelAttribute($attributes['name']);
-            $categoryType->setImageAttribute($attributes['main_image']);
-            $categoryType->setCompletenessRules(['required' => ['name', 'seo_title']]);
-            $assetType->setLabelAttribute($attributes['name']);
+            $productType->assignLabelAttribute($attributes['name']);
+            $productType->assignImageAttribute($attributes['main_image']);
+            $productType->updateCompletenessRules(['required' => ['sku', 'name', 'description', 'price']]);
+            $categoryType->assignLabelAttribute($attributes['name']);
+            $categoryType->assignImageAttribute($attributes['main_image']);
+            $categoryType->updateCompletenessRules(['required' => ['name', 'seo_title']]);
+            $assetType->assignLabelAttribute($attributes['name']);
             $this->em->flush();
 
             $categories = $this->seedCategories($categoryType, $attributes);
@@ -116,10 +116,10 @@ final readonly class DemoCatalogSeeder
                 continue;
             }
             $attribute = new Attribute($code, $def['label'], $def['type']);
-            $attribute->setRequired($def['required'] ?? false);
-            $attribute->setLocalizable($def['localizable'] ?? false);
-            $attribute->setValidationRules($def['rules'] ?? []);
-            $attribute->setPosition($position++);
+            $attribute->changeRequired($def['required'] ?? false);
+            $attribute->changeLocalizable($def['localizable'] ?? false);
+            $attribute->updateValidationRules($def['rules'] ?? []);
+            $attribute->reorder($position++);
             $this->em->persist($attribute);
             $attributes[$code] = $attribute;
 
@@ -180,8 +180,8 @@ final readonly class DemoCatalogSeeder
         $categories = [];
         foreach ($defs as [$code, $path, $name, $description]) {
             $category = new CatalogObject($type, $code);
-            $category->setStatus(CatalogObject::STATUS_PUBLISHED);
-            $category->setPath($path);
+            $category->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $category->attachToPath($path);
 
             $values = [
                 ['name', ['value' => $name]],
@@ -195,8 +195,8 @@ final readonly class DemoCatalogSeeder
                 $this->em->persist($value);
                 $indexed[$attrCode] = $payload;
             }
-            $category->setAttributesIndexed($indexed);
-            $category->setCompleteness(['global' => 100]);
+            $category->updateAttributeIndex($indexed);
+            $category->recordCompleteness(['global' => 100]);
             $this->em->persist($category);
             $categories[] = $category;
         }
@@ -215,7 +215,7 @@ final readonly class DemoCatalogSeeder
         for ($i = 1; $i <= 10; ++$i) {
             $code = \sprintf('ASSET-%03d', $i);
             $catalogAsset = new CatalogObject($type, $code);
-            $catalogAsset->setStatus(CatalogObject::STATUS_PUBLISHED);
+            $catalogAsset->transitionTo(CatalogObject::STATUS_PUBLISHED);
 
             $name = \sprintf('Demo image %d', $i);
             $alt = \sprintf('Image alt text #%d', $i);
@@ -225,11 +225,11 @@ final readonly class DemoCatalogSeeder
             $valueAlt = new ObjectValue($catalogAsset, $attributes['alt_text'], ['value' => $alt], Provenance::Import);
             $this->em->persist($valueAlt);
 
-            $catalogAsset->setAttributesIndexed([
+            $catalogAsset->updateAttributeIndex([
                 'name' => ['value' => $name],
                 'alt_text' => ['value' => $alt],
             ]);
-            $catalogAsset->setCompleteness(['global' => 100]);
+            $catalogAsset->recordCompleteness(['global' => 100]);
             $this->em->persist($catalogAsset);
 
             $storagePath = \sprintf(
@@ -272,7 +272,7 @@ final readonly class DemoCatalogSeeder
         for ($i = 1; $i <= self::PRODUCT_COUNT; ++$i) {
             $sku = \sprintf('DEMO-%03d', $i);
             $product = new CatalogObject($type, $sku);
-            $product->setStatus(0 === $i % 11 ? CatalogObject::STATUS_DRAFT : CatalogObject::STATUS_PUBLISHED);
+            $product->transitionTo(0 === $i % 11 ? CatalogObject::STATUS_DRAFT : CatalogObject::STATUS_PUBLISHED);
 
             $brand = $brands[$i % \count($brands)];
             $color = $colors[$i % \count($colors)];
@@ -307,8 +307,8 @@ final readonly class DemoCatalogSeeder
                 $this->em->persist($value);
                 $indexed[$code] = $payload;
             }
-            $product->setAttributesIndexed($indexed);
-            $product->setCompleteness(['global' => 100]);
+            $product->updateAttributeIndex($indexed);
+            $product->recordCompleteness(['global' => 100]);
             $this->em->persist($product);
         }
     }

--- a/apps/api/src/Catalog/Application/ObjectTypeService.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeService.php
@@ -92,8 +92,8 @@ final readonly class ObjectTypeService
             $junction = new ObjectTypeAttribute($objectType, $attribute, $required, $sortOrder);
             $this->em->persist($junction);
         } else {
-            $junction->setRequiredForCompleteness($required);
-            $junction->setSortOrder($sortOrder);
+            $junction->changeRequiredForCompleteness($required);
+            $junction->reorder($sortOrder);
         }
 
         $this->em->flush();

--- a/apps/api/src/Catalog/Domain/Entity/Association.php
+++ b/apps/api/src/Catalog/Domain/Entity/Association.php
@@ -97,7 +97,7 @@ class Association implements TenantScoped
         return $this->position;
     }
 
-    public function setPosition(int $position): void
+    public function reorder(int $position): void
     {
         $this->position = $position;
     }

--- a/apps/api/src/Catalog/Domain/Entity/AssociationType.php
+++ b/apps/api/src/Catalog/Domain/Entity/AssociationType.php
@@ -94,7 +94,7 @@ class AssociationType implements TenantScoped
     /**
      * @param array<string, string> $label
      */
-    public function setLabel(array $label): void
+    public function rename(array $label): void
     {
         $this->label = $label;
     }
@@ -104,7 +104,7 @@ class AssociationType implements TenantScoped
         return $this->position;
     }
 
-    public function setPosition(int $position): void
+    public function reorder(int $position): void
     {
         $this->position = $position;
     }

--- a/apps/api/src/Catalog/Domain/Entity/Attribute.php
+++ b/apps/api/src/Catalog/Domain/Entity/Attribute.php
@@ -107,7 +107,7 @@ class Attribute implements TenantScoped
         return $this->group;
     }
 
-    public function setGroup(?AttributeGroup $group): void
+    public function assignToGroup(?AttributeGroup $group): void
     {
         $this->group = $group;
     }
@@ -128,7 +128,7 @@ class Attribute implements TenantScoped
     /**
      * @param array<string, string> $label
      */
-    public function setLabel(array $label): void
+    public function rename(array $label): void
     {
         $this->label = $label;
     }
@@ -144,7 +144,7 @@ class Attribute implements TenantScoped
     /**
      * @param array<string, string>|null $help
      */
-    public function setHelp(?array $help): void
+    public function updateHelp(?array $help): void
     {
         $this->help = $help;
     }
@@ -159,7 +159,7 @@ class Attribute implements TenantScoped
         return $this->isLocalizable;
     }
 
-    public function setLocalizable(bool $localizable): void
+    public function changeLocalizable(bool $localizable): void
     {
         $this->isLocalizable = $localizable;
     }
@@ -169,7 +169,7 @@ class Attribute implements TenantScoped
         return $this->isScopable;
     }
 
-    public function setScopable(bool $scopable): void
+    public function changeScopable(bool $scopable): void
     {
         $this->isScopable = $scopable;
     }
@@ -179,7 +179,7 @@ class Attribute implements TenantScoped
         return $this->isRequired;
     }
 
-    public function setRequired(bool $required): void
+    public function changeRequired(bool $required): void
     {
         $this->isRequired = $required;
     }
@@ -195,7 +195,7 @@ class Attribute implements TenantScoped
     /**
      * @param array<string, mixed> $rules
      */
-    public function setValidationRules(array $rules): void
+    public function updateValidationRules(array $rules): void
     {
         $this->validationRules = $rules;
     }
@@ -205,7 +205,7 @@ class Attribute implements TenantScoped
         return $this->position;
     }
 
-    public function setPosition(int $position): void
+    public function reorder(int $position): void
     {
         $this->position = $position;
     }

--- a/apps/api/src/Catalog/Domain/Entity/AttributeGroup.php
+++ b/apps/api/src/Catalog/Domain/Entity/AttributeGroup.php
@@ -94,7 +94,7 @@ class AttributeGroup implements TenantScoped
     /**
      * @param array<string, string> $label
      */
-    public function setLabel(array $label): void
+    public function rename(array $label): void
     {
         $this->label = $label;
     }
@@ -104,7 +104,7 @@ class AttributeGroup implements TenantScoped
         return $this->position;
     }
 
-    public function setPosition(int $position): void
+    public function reorder(int $position): void
     {
         $this->position = $position;
     }

--- a/apps/api/src/Catalog/Domain/Entity/AttributeOption.php
+++ b/apps/api/src/Catalog/Domain/Entity/AttributeOption.php
@@ -99,7 +99,7 @@ class AttributeOption implements TenantScoped
     /**
      * @param array<string, string> $label
      */
-    public function setLabel(array $label): void
+    public function rename(array $label): void
     {
         $this->label = $label;
     }
@@ -109,7 +109,7 @@ class AttributeOption implements TenantScoped
         return $this->position;
     }
 
-    public function setPosition(int $position): void
+    public function reorder(int $position): void
     {
         $this->position = $position;
     }

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -138,7 +138,7 @@ class CatalogObject implements TenantScoped
         return $this->parent;
     }
 
-    public function setParent(?self $parent): void
+    public function assignParent(?self $parent): void
     {
         $this->parent = $parent;
         $this->touch();
@@ -149,7 +149,7 @@ class CatalogObject implements TenantScoped
         return $this->enabled;
     }
 
-    public function setEnabled(bool $enabled): void
+    public function changeEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
         $this->touch();
@@ -160,7 +160,7 @@ class CatalogObject implements TenantScoped
         return $this->status;
     }
 
-    public function setStatus(string $status): void
+    public function transitionTo(string $status): void
     {
         $this->status = $status;
         $this->touch();
@@ -177,7 +177,7 @@ class CatalogObject implements TenantScoped
     /**
      * @param array<string, mixed> $completeness
      */
-    public function setCompleteness(array $completeness): void
+    public function recordCompleteness(array $completeness): void
     {
         $this->completeness = $completeness;
         $this->touch();
@@ -194,7 +194,7 @@ class CatalogObject implements TenantScoped
     /**
      * @param array<string, mixed> $attributes
      */
-    public function setAttributesIndexed(array $attributes): void
+    public function updateAttributeIndex(array $attributes): void
     {
         $this->attributesIndexed = $attributes;
         $this->touch();
@@ -205,7 +205,7 @@ class CatalogObject implements TenantScoped
         return $this->path;
     }
 
-    public function setPath(?string $path): void
+    public function attachToPath(?string $path): void
     {
         $this->path = $path;
         $this->touch();

--- a/apps/api/src/Catalog/Domain/Entity/ObjectType.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectType.php
@@ -135,7 +135,7 @@ class ObjectType implements TenantScoped
     /**
      * @param array<string, string> $label
      */
-    public function setLabel(array $label): void
+    public function rename(array $label): void
     {
         $this->label = $label;
         $this->touch();
@@ -152,7 +152,7 @@ class ObjectType implements TenantScoped
     /**
      * @param array<string, mixed> $rules
      */
-    public function setCompletenessRules(array $rules): void
+    public function updateCompletenessRules(array $rules): void
     {
         $this->completenessRules = $rules;
         $this->touch();
@@ -163,7 +163,7 @@ class ObjectType implements TenantScoped
         return $this->labelAttribute;
     }
 
-    public function setLabelAttribute(?Attribute $attribute): void
+    public function assignLabelAttribute(?Attribute $attribute): void
     {
         $this->labelAttribute = $attribute;
         $this->touch();
@@ -174,7 +174,7 @@ class ObjectType implements TenantScoped
         return $this->imageAttribute;
     }
 
-    public function setImageAttribute(?Attribute $attribute): void
+    public function assignImageAttribute(?Attribute $attribute): void
     {
         $this->imageAttribute = $attribute;
         $this->touch();

--- a/apps/api/src/Catalog/Domain/Entity/ObjectTypeAttribute.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectTypeAttribute.php
@@ -67,7 +67,7 @@ class ObjectTypeAttribute
         return $this->requiredForCompleteness;
     }
 
-    public function setRequiredForCompleteness(bool $required): void
+    public function changeRequiredForCompleteness(bool $required): void
     {
         $this->requiredForCompleteness = $required;
     }
@@ -77,7 +77,7 @@ class ObjectTypeAttribute
         return $this->sortOrder;
     }
 
-    public function setSortOrder(int $sortOrder): void
+    public function reorder(int $sortOrder): void
     {
         $this->sortOrder = $sortOrder;
     }
@@ -87,7 +87,7 @@ class ObjectTypeAttribute
         return $this->channelId;
     }
 
-    public function setChannelId(?Uuid $channelId): void
+    public function changeChannelId(?Uuid $channelId): void
     {
         $this->channelId = $channelId;
     }
@@ -97,7 +97,7 @@ class ObjectTypeAttribute
         return $this->locale;
     }
 
-    public function setLocale(?string $locale): void
+    public function changeLocale(?string $locale): void
     {
         $this->locale = $locale;
     }

--- a/apps/api/src/Catalog/Domain/Entity/ObjectValue.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectValue.php
@@ -120,7 +120,7 @@ class ObjectValue implements TenantScoped
         return $this->channelId;
     }
 
-    public function setChannelId(?Uuid $channelId): void
+    public function changeChannelId(?Uuid $channelId): void
     {
         $this->channelId = $channelId;
     }
@@ -130,7 +130,7 @@ class ObjectValue implements TenantScoped
         return $this->locale;
     }
 
-    public function setLocale(?string $locale): void
+    public function changeLocale(?string $locale): void
     {
         $this->locale = $locale;
     }
@@ -146,7 +146,7 @@ class ObjectValue implements TenantScoped
     /**
      * @param array<string, mixed> $value
      */
-    public function setValue(array $value): void
+    public function updateValue(array $value): void
     {
         $this->value = $value;
     }
@@ -156,7 +156,7 @@ class ObjectValue implements TenantScoped
         return $this->provenance;
     }
 
-    public function setProvenance(Provenance $provenance): void
+    public function changeProvenance(Provenance $provenance): void
     {
         $this->provenance = $provenance;
     }
@@ -172,7 +172,7 @@ class ObjectValue implements TenantScoped
     /**
      * @param array<string, mixed> $meta
      */
-    public function setProvenanceMeta(array $meta): void
+    public function updateProvenanceMeta(array $meta): void
     {
         $this->provenanceMeta = $meta;
     }

--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -112,8 +112,8 @@ class AppFixtures extends Fixture
             ['ACME-003', 'Acme Sprocket', 'Acme'],
         ] as [$sku, $name, $brand]) {
             $object = new CatalogObject($acmeProductType, $sku);
-            $object->setStatus(CatalogObject::STATUS_PUBLISHED);
-            $object->setAttributesIndexed([
+            $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+            $object->updateAttributeIndex([
                 'sku' => $sku,
                 'name' => $name,
                 'brand' => $brand,

--- a/apps/api/tests/Functional/Catalog/AttributesIndexedSyncListenerTest.php
+++ b/apps/api/tests/Functional/Catalog/AttributesIndexedSyncListenerTest.php
@@ -42,7 +42,7 @@ final class AttributesIndexedSyncListenerTest extends KernelTestCase
         $this->tenantContext()->set($this->tenant);
 
         $this->productType = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
-        $this->productType->setCompletenessRules(['required' => ['name', 'color']]);
+        $this->productType->updateCompletenessRules(['required' => ['name', 'color']]);
         $em->persist($this->productType);
 
         $this->name = new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text);

--- a/apps/api/tests/Unit/Catalog/CatalogObjectTest.php
+++ b/apps/api/tests/Unit/Catalog/CatalogObjectTest.php
@@ -50,7 +50,7 @@ final class CatalogObjectTest extends TestCase
         $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
         $object = new CatalogObject($type, 'SKU-002');
 
-        $object->setAttributesIndexed([
+        $object->updateAttributeIndex([
             'name' => ['pl' => 'Smartfon', 'en' => 'Smartphone'],
             'sku' => 'SKU-002',
             'color' => 'red',
@@ -71,7 +71,7 @@ final class CatalogObjectTest extends TestCase
         $categoryType = new ObjectType('category', ObjectKind::Category, ['pl' => 'Kategoria']);
         $object = new CatalogObject($categoryType, 'shoes');
 
-        $object->setPath('root.men.shoes');
+        $object->attachToPath('root.men.shoes');
 
         self::assertSame('root.men.shoes', $object->getPath());
         // The kind = 'category' OR path IS NULL invariant + ltree validation
@@ -85,7 +85,7 @@ final class CatalogObjectTest extends TestCase
         $parent = new CatalogObject($type, 'PARENT-SKU');
         $variant = new CatalogObject($type, 'VARIANT-SKU');
 
-        $variant->setParent($parent);
+        $variant->assignParent($parent);
 
         self::assertSame($parent, $variant->getParent());
     }
@@ -111,10 +111,10 @@ final class CatalogObjectTest extends TestCase
         $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
         $object = new CatalogObject($type, 'SKU-004');
 
-        $object->setStatus(CatalogObject::STATUS_PUBLISHED);
+        $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
         self::assertSame('published', $object->getStatus());
 
-        $object->setStatus(CatalogObject::STATUS_ARCHIVED);
+        $object->transitionTo(CatalogObject::STATUS_ARCHIVED);
         self::assertSame('archived', $object->getStatus());
     }
 }

--- a/apps/api/tests/Unit/Catalog/CategoryPathValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/CategoryPathValidatorTest.php
@@ -120,7 +120,7 @@ final class CategoryPathValidatorTest extends TestCase
     {
         $type = new ObjectType($kind->value, $kind, ['pl' => 'X']);
         $object = new CatalogObject($type, $code);
-        $object->setPath($path);
+        $object->attachToPath($path);
 
         return $object;
     }

--- a/apps/api/tests/Unit/Catalog/ObjectTypeTest.php
+++ b/apps/api/tests/Unit/Catalog/ObjectTypeTest.php
@@ -58,8 +58,8 @@ final class ObjectTypeTest extends TestCase
         $name = new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text);
         $image = new Attribute('main_image', ['pl' => 'Zdjęcie'], AttributeType::Asset);
 
-        $type->setLabelAttribute($name);
-        $type->setImageAttribute($image);
+        $type->assignLabelAttribute($name);
+        $type->assignImageAttribute($image);
 
         self::assertSame($name, $type->getLabelAttribute());
         self::assertSame($image, $type->getImageAttribute());
@@ -70,7 +70,7 @@ final class ObjectTypeTest extends TestCase
     {
         $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
 
-        $type->setCompletenessRules(['required' => ['sku', 'name'], 'weight' => ['sku' => 2]]);
+        $type->updateCompletenessRules(['required' => ['sku', 'name'], 'weight' => ['sku' => 2]]);
 
         self::assertSame(
             ['required' => ['sku', 'name'], 'weight' => ['sku' => 2]],

--- a/apps/api/tests/Unit/Catalog/ObjectValueTest.php
+++ b/apps/api/tests/Unit/Catalog/ObjectValueTest.php
@@ -88,7 +88,7 @@ final class ObjectValueTest extends TestCase
         [$object, $attribute] = $this->fixture();
 
         $value = new ObjectValue($object, $attribute, ['value' => 'x'], Provenance::Integration);
-        $value->setProvenanceMeta([
+        $value->updateProvenanceMeta([
             'integration' => 'shopify',
             'sync_job_id' => '019dd522-6ea8-7e9d-9e63-5a4a782152e6',
         ]);

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/DateValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/DateValidatorTest.php
@@ -45,7 +45,7 @@ final class DateValidatorTest extends TestCase
     #[Test]
     public function minMaxBoundsAreEnforced(): void
     {
-        $this->attribute->setValidationRules(['min' => '2026-01-01', 'max' => '2026-12-31']);
+        $this->attribute->updateValidationRules(['min' => '2026-01-01', 'max' => '2026-12-31']);
 
         $low = $this->validator->validate($this->attribute, ['value' => '2025-12-31']);
         $high = $this->validator->validate($this->attribute, ['value' => '2027-01-01']);

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/MetricValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/MetricValidatorTest.php
@@ -40,7 +40,7 @@ final class MetricValidatorTest extends TestCase
     #[Test]
     public function unitAllowlistIsEnforced(): void
     {
-        $this->attribute->setValidationRules(['units' => ['kg', 'g']]);
+        $this->attribute->updateValidationRules(['units' => ['kg', 'g']]);
 
         $errors = $this->validator->validate($this->attribute, ['value' => 1, 'unit' => 'lb']);
 
@@ -50,7 +50,7 @@ final class MetricValidatorTest extends TestCase
     #[Test]
     public function boundsAndPrecisionEnforced(): void
     {
-        $this->attribute->setValidationRules([
+        $this->attribute->updateValidationRules([
             'min' => 0,
             'max' => 100,
             'decimal_precision' => 1,

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/MultiselectValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/MultiselectValidatorTest.php
@@ -48,7 +48,7 @@ final class MultiselectValidatorTest extends TestCase
     #[Test]
     public function allowlistAndCountBoundsCombineErrors(): void
     {
-        $this->attribute->setValidationRules([
+        $this->attribute->updateValidationRules([
             'option_codes' => ['red', 'green'],
             'min_count' => 2,
             'max_count' => 3,

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/NumberValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/NumberValidatorTest.php
@@ -39,7 +39,7 @@ final class NumberValidatorTest extends TestCase
     #[Test]
     public function minAndMaxBoundsAreEnforced(): void
     {
-        $this->attribute->setValidationRules(['min' => 0, 'max' => 10]);
+        $this->attribute->updateValidationRules(['min' => 0, 'max' => 10]);
 
         $low = $this->validator->validate($this->attribute, ['value' => -1]);
         $high = $this->validator->validate($this->attribute, ['value' => 11]);
@@ -51,7 +51,7 @@ final class NumberValidatorTest extends TestCase
     #[Test]
     public function decimalPrecisionRejectsExtraDigits(): void
     {
-        $this->attribute->setValidationRules(['decimal_precision' => 2]);
+        $this->attribute->updateValidationRules(['decimal_precision' => 2]);
 
         $ok = $this->validator->validate($this->attribute, ['value' => 1.23]);
         $bad = $this->validator->validate($this->attribute, ['value' => 1.234]);

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/PriceValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/PriceValidatorTest.php
@@ -40,7 +40,7 @@ final class PriceValidatorTest extends TestCase
     #[Test]
     public function minAmountAndCurrencyAllowlistEnforced(): void
     {
-        $this->attribute->setValidationRules([
+        $this->attribute->updateValidationRules([
             'min_amount' => 10,
             'currencies' => ['PLN', 'EUR'],
         ]);

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/SelectValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/SelectValidatorTest.php
@@ -37,7 +37,7 @@ final class SelectValidatorTest extends TestCase
     #[Test]
     public function unknownOptionRejectedWhenAllowlistConfigured(): void
     {
-        $this->attribute->setValidationRules(['option_codes' => ['red', 'green', 'blue']]);
+        $this->attribute->updateValidationRules(['option_codes' => ['red', 'green', 'blue']]);
 
         $ok = $this->validator->validate($this->attribute, ['option_code' => 'red']);
         $bad = $this->validator->validate($this->attribute, ['option_code' => 'magenta']);

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/TextValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/TextValidatorTest.php
@@ -39,7 +39,7 @@ final class TextValidatorTest extends TestCase
     #[Test]
     public function maxLengthIsEnforcedInUtf8Characters(): void
     {
-        $this->attribute->setValidationRules(['max_length' => 3]);
+        $this->attribute->updateValidationRules(['max_length' => 3]);
 
         // 4 utf-8 characters (with polish diacritics).
         $errors = $this->validator->validate($this->attribute, ['value' => 'łóść']);
@@ -51,7 +51,7 @@ final class TextValidatorTest extends TestCase
     #[Test]
     public function minLengthIsEnforced(): void
     {
-        $this->attribute->setValidationRules(['min_length' => 5]);
+        $this->attribute->updateValidationRules(['min_length' => 5]);
 
         $errors = $this->validator->validate($this->attribute, ['value' => 'hi']);
 
@@ -61,7 +61,7 @@ final class TextValidatorTest extends TestCase
     #[Test]
     public function patternMustMatchTheWholeValue(): void
     {
-        $this->attribute->setValidationRules(['pattern' => '/^[A-Z]{3}$/']);
+        $this->attribute->updateValidationRules(['pattern' => '/^[A-Z]{3}$/']);
 
         $ok = $this->validator->validate($this->attribute, ['value' => 'ABC']);
         $bad = $this->validator->validate($this->attribute, ['value' => 'abc']);


### PR DESCRIPTION
## Summary
Encapsulate Catalog aggregate state behind intent-named operations. Every public `set<X>()` in `Catalog/Domain/Entity/` is renamed to a domain method that reflects the actual change.

Per-entity rename map (~25 setters across 8 entities) — see commit body for full table. Highlights:
- `setLabel` → `rename`
- `setPosition` / `setSortOrder` → `reorder`
- `setEnabled` → `changeEnabled`, `setStatus` → `transitionTo`
- `setAttributesIndexed` → `updateAttributeIndex`
- `setLabelAttribute`/`setImageAttribute` → `assign*`

17 consumer files in `src/Catalog`, `src/DataFixtures`, `src/Benchmark`, and `tests/{Unit,Functional}/Catalog` updated.

## Test plan
- [x] `composer phpstan` — 0 errors (no public setters left in Catalog Domain)
- [x] `composer cs-check` — clean
- [x] `php bin/phpunit tests/Unit/Catalog` — 119/119 green
- [x] `bin/console doctrine:fixtures:load` — fixtures load
- [ ] CI: full quality stack green

## Notes
- Doctrine ORM 3 hydration uses Reflection — no setters needed for entity rehydration.
- The rename is intentionally non-destructive: arguments + behaviour stay identical, only the method name changes.
- Channel/Asset/Identity follow in RF-13.

Closes #162