### PR TITLE
RF-13 — refactor(channel,asset,identity,shared): replace public setters with domain methods

### DIFF
--- a/apps/api/src/Asset/Domain/Entity/Asset.php
+++ b/apps/api/src/Asset/Domain/Entity/Asset.php
@@ -118,7 +118,7 @@ class Asset implements TenantScoped
         return $this->object;
     }
 
-    public function setObject(?CatalogObject $object): void
+    public function linkToObject(?CatalogObject $object): void
     {
         $this->object = $object;
     }
@@ -149,7 +149,7 @@ class Asset implements TenantScoped
     /**
      * @param array<string, mixed> $metadata
      */
-    public function setMetadata(array $metadata): void
+    public function updateMetadata(array $metadata): void
     {
         $this->metadata = $metadata;
     }

--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -244,7 +244,7 @@ final readonly class DemoCatalogSeeder
                 size: 1024 * 12,
                 storagePath: $storagePath,
             );
-            $asset->setObject($catalogAsset);
+            $asset->linkToObject($catalogAsset);
             $variant = new AssetVariant($asset, AssetVariant::CODE_ORIGINAL, $storagePath, 'image/jpeg', 1024 * 12);
             $asset->addVariant($variant);
             $this->em->persist($asset);

--- a/apps/api/src/Channel/Domain/Entity/Channel.php
+++ b/apps/api/src/Channel/Domain/Entity/Channel.php
@@ -111,7 +111,7 @@ class Channel implements TenantScoped
     /**
      * @param array<string, string> $label
      */
-    public function setLabel(array $label): void
+    public function rename(array $label): void
     {
         $this->label = $label;
     }
@@ -161,7 +161,7 @@ class Channel implements TenantScoped
         return $this->categoryTreeRoot;
     }
 
-    public function setCategoryTreeRoot(?CatalogObject $root): void
+    public function attachCategoryTreeRoot(?CatalogObject $root): void
     {
         $this->categoryTreeRoot = $root;
     }

--- a/apps/api/src/Channel/Domain/Entity/ChannelObjectTypeMapping.php
+++ b/apps/api/src/Channel/Domain/Entity/ChannelObjectTypeMapping.php
@@ -87,7 +87,7 @@ class ChannelObjectTypeMapping
         return $this->targetField;
     }
 
-    public function setTargetField(string $targetField): void
+    public function mapToField(string $targetField): void
     {
         $this->targetField = $targetField;
     }
@@ -97,7 +97,7 @@ class ChannelObjectTypeMapping
         return $this->isPublished;
     }
 
-    public function setPublished(bool $published): void
+    public function changePublished(bool $published): void
     {
         $this->isPublished = $published;
     }

--- a/apps/api/src/Shared/Domain/Tenant.php
+++ b/apps/api/src/Shared/Domain/Tenant.php
@@ -76,7 +76,7 @@ class Tenant
         return $this->domain;
     }
 
-    public function setDomain(?string $domain): void
+    public function changeDomain(?string $domain): void
     {
         $this->domain = $domain;
     }

--- a/apps/api/tests/Unit/Asset/AssetTest.php
+++ b/apps/api/tests/Unit/Asset/AssetTest.php
@@ -37,7 +37,7 @@ final class AssetTest extends TestCase
     public function metadataRoundTripsJsonbPayload(): void
     {
         $asset = $this->makeAsset();
-        $asset->setMetadata([
+        $asset->updateMetadata([
             'width' => 1920,
             'height' => 1080,
             'exif' => ['camera' => 'Sony A7'],
@@ -55,7 +55,7 @@ final class AssetTest extends TestCase
         $object = new CatalogObject($type, 'hero-image');
         $asset = $this->makeAsset();
 
-        $asset->setObject($object);
+        $asset->linkToObject($object);
 
         self::assertSame($object, $asset->getObject());
     }

--- a/apps/api/tests/Unit/Channel/ChannelCategoryRootValidatorTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelCategoryRootValidatorTest.php
@@ -43,7 +43,7 @@ final class ChannelCategoryRootValidatorTest extends TestCase
         $channel = new Channel('shop', ['pl' => 'Sklep']);
         $type = new ObjectType('category', ObjectKind::Category, ['pl' => 'Kategoria']);
         $root = new CatalogObject($type, 'root');
-        $channel->setCategoryTreeRoot($root);
+        $channel->attachCategoryTreeRoot($root);
 
         $this->validator->prePersist(new PrePersistEventArgs($channel, $this->em));
 
@@ -56,7 +56,7 @@ final class ChannelCategoryRootValidatorTest extends TestCase
         $channel = new Channel('shop', ['pl' => 'Sklep']);
         $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
         $root = new CatalogObject($type, 'SKU-1');
-        $channel->setCategoryTreeRoot($root);
+        $channel->attachCategoryTreeRoot($root);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('kind=category');

--- a/apps/api/tests/Unit/Channel/ChannelTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelTest.php
@@ -60,7 +60,7 @@ final class ChannelTest extends TestCase
         $categoryType = new ObjectType('category', ObjectKind::Category, ['pl' => 'Kategoria']);
         $root = new CatalogObject($categoryType, 'root');
 
-        $channel->setCategoryTreeRoot($root);
+        $channel->attachCategoryTreeRoot($root);
 
         self::assertSame($root, $channel->getCategoryTreeRoot());
     }


### PR DESCRIPTION
## Summary
Same encapsulation pass as RF-12, applied to the rest of the domain:

- **Channel:** `setLabel` → `rename`, `setCategoryTreeRoot` → `attachCategoryTreeRoot`
- **ChannelObjectTypeMapping:** `setTargetField` → `mapToField`, `setPublished` → `changePublished`
- **Asset:** `setObject` → `linkToObject`, `setMetadata` → `updateMetadata`
- **Shared\\Tenant:** `setDomain` → `changeDomain`

Identity (User/Role) already exposed proper domain methods (`disable`, `enable`, `recordLogin`, `rename`, `grantPermission`, `revokePermission`). RefreshToken was always lifecycle-only.

**Public setter count in `src/{Catalog,Channel,Asset,Identity,Shared}/Domain/` is now zero** — DDD-004 closes for the whole codebase.

## Test plan
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean
- [x] `php bin/phpunit tests/Unit` — 144/144 green
- [ ] CI: full quality stack green

Closes #163