### PR TITLE
RF-16 — feat(catalog): introduce Contracts/Event with 5 integration events

### DIFF
--- a/apps/api/src/Catalog/Application/Subscriber/ObjectIndexedSubscriber.php
+++ b/apps/api/src/Catalog/Application/Subscriber/ObjectIndexedSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Subscriber;
+
+use App\Catalog\Contracts\Event\ObjectArchived;
+use App\Catalog\Contracts\Event\ObjectAttributesChanged;
+use App\Catalog\Contracts\Event\ObjectCreated;
+use App\Catalog\Contracts\Event\ObjectPublished;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Placeholder subscriber wired up for {@see \App\Catalog\Contracts\Event}
+ * domain events. Each #[AsMessageHandler] is a no-op today; the real work
+ * lands in:
+ *
+ *   - RF-19 — search index sync (Meilisearch incremental updates);
+ *   - epic 0.5 — bulk reindex worker.
+ *
+ * Wiring this stub now means RF-20's
+ * {@see \App\Shared\Infrastructure\Messenger\DomainEventToMessageMiddleware}
+ * has somewhere to route Catalog events as soon as it ships, without
+ * touching the entity again.
+ */
+final class ObjectIndexedSubscriber
+{
+    #[AsMessageHandler]
+    public function onObjectCreated(ObjectCreated $event): void
+    {
+        // TODO(RF-19/epic-0.5): index $event->objectId in Meilisearch.
+    }
+
+    #[AsMessageHandler]
+    public function onObjectPublished(ObjectPublished $event): void
+    {
+        // TODO(RF-19/epic-0.5): mark $event->objectId as published in the search index.
+    }
+
+    #[AsMessageHandler]
+    public function onObjectArchived(ObjectArchived $event): void
+    {
+        // TODO(RF-19/epic-0.5): drop $event->objectId from active search indices.
+    }
+
+    #[AsMessageHandler]
+    public function onObjectAttributesChanged(ObjectAttributesChanged $event): void
+    {
+        // TODO(RF-19/epic-0.5): partial reindex of $event->changedAttributeCodes for $event->objectId.
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectArchived.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectArchived.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when {@see \App\Catalog\Domain\Entity\CatalogObject} transitions
+ * to status=archived. Channel publishers depublish; search indexers drop
+ * the row from active indices.
+ */
+final readonly class ObjectArchived implements DomainEvent
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.archived';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectAttributesChanged.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectAttributesChanged.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted whenever the denormalized `attributes_indexed` cache on a
+ * CatalogObject changes — i.e. when ObjectValues are written and the
+ * sync listener (or the async rebuilder) has pushed the new shape onto
+ * the parent row.
+ *
+ * Search indexers consume this to reindex; channel publishers compare
+ * against last published payload.
+ */
+final readonly class ObjectAttributesChanged implements DomainEvent
+{
+    /**
+     * @param list<string> $changedAttributeCodes attribute codes whose values were affected
+     */
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public array $changedAttributeCodes = [],
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.attributes-changed';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectCreated.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectCreated.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted by {@see \App\Catalog\Domain\Entity\CatalogObject} once a new
+ * row is persisted. Cross-BC subscribers (search indexer in Faza 2,
+ * channel publishers, asset linker) react to creation via this event.
+ */
+final readonly class ObjectCreated implements DomainEvent
+{
+    public function __construct(
+        public Uuid $objectId,
+        public ObjectKind $kind,
+        public string $code,
+        public Uuid $tenantId,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.created';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectEnabledChanged.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectEnabledChanged.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when {@see \App\Catalog\Domain\Entity\CatalogObject} flips its
+ * `enabled` flag. Cheaper than republishing on every attribute write —
+ * channel adapters can short-circuit on `false`.
+ */
+final readonly class ObjectEnabledChanged implements DomainEvent
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public bool $enabled,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.enabled-changed';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Event/ObjectPublished.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectPublished.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when {@see \App\Catalog\Domain\Entity\CatalogObject} transitions
+ * to status=published. Triggers downstream publication (search index sync,
+ * channel push, etc.).
+ */
+final readonly class ObjectPublished implements DomainEvent
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.published';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -4,13 +4,21 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
+use App\Catalog\Contracts\Event\ObjectArchived;
+use App\Catalog\Contracts\Event\ObjectAttributesChanged;
+use App\Catalog\Contracts\Event\ObjectCreated;
+use App\Catalog\Contracts\Event\ObjectEnabledChanged;
+use App\Catalog\Contracts\Event\ObjectPublished;
 use App\Catalog\Domain\ObjectKind;
 use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
+
+use const ARRAY_FILTER_USE_BOTH;
 
 /**
  * Generic catalog object — polymorphic per `kind` (per ADR-009).
@@ -42,7 +50,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *   - `kind='product'` for variants (size/color of a parent SKU);
  *   - `kind='category'` for the tree (parent category in ltree).
  */
-class CatalogObject implements TenantScoped
+class CatalogObject extends AggregateRoot implements TenantScoped
 {
     public const string STATUS_DRAFT = 'draft';
     public const string STATUS_PUBLISHED = 'published';
@@ -116,6 +124,12 @@ class CatalogObject implements TenantScoped
         }
 
         $this->tenant = $tenant;
+        $this->recordThat(new ObjectCreated(
+            objectId: $this->id,
+            kind: $this->kind,
+            code: $this->code,
+            tenantId: $tenant->getId(),
+        ));
     }
 
     public function getObjectType(): ObjectType
@@ -151,8 +165,20 @@ class CatalogObject implements TenantScoped
 
     public function changeEnabled(bool $enabled): void
     {
+        if ($this->enabled === $enabled) {
+            return;
+        }
+
         $this->enabled = $enabled;
         $this->touch();
+
+        if (null !== $this->tenant) {
+            $this->recordThat(new ObjectEnabledChanged(
+                objectId: $this->id,
+                tenantId: $this->tenant->getId(),
+                enabled: $enabled,
+            ));
+        }
     }
 
     public function getStatus(): string
@@ -162,8 +188,30 @@ class CatalogObject implements TenantScoped
 
     public function transitionTo(string $status): void
     {
+        if ($this->status === $status) {
+            return;
+        }
+
+        $previous = $this->status;
         $this->status = $status;
         $this->touch();
+
+        if (null === $this->tenant) {
+            return;
+        }
+
+        if (self::STATUS_PUBLISHED === $status) {
+            $this->recordThat(new ObjectPublished(
+                objectId: $this->id,
+                tenantId: $this->tenant->getId(),
+            ));
+        } elseif (self::STATUS_ARCHIVED === $status) {
+            $this->recordThat(new ObjectArchived(
+                objectId: $this->id,
+                tenantId: $this->tenant->getId(),
+            ));
+        }
+        unset($previous);
     }
 
     /**
@@ -196,8 +244,33 @@ class CatalogObject implements TenantScoped
      */
     public function updateAttributeIndex(array $attributes): void
     {
+        $previous = $this->attributesIndexed;
         $this->attributesIndexed = $attributes;
         $this->touch();
+
+        if (null === $this->tenant) {
+            return;
+        }
+
+        $changedCodes = array_values(array_unique(array_merge(
+            array_keys(array_diff_key($attributes, $previous)),
+            array_keys(array_diff_key($previous, $attributes)),
+            array_keys(array_filter(
+                $attributes,
+                static fn ($value, string $key) => isset($previous[$key]) && $previous[$key] !== $value,
+                ARRAY_FILTER_USE_BOTH,
+            )),
+        )));
+
+        if ([] === $changedCodes) {
+            return;
+        }
+
+        $this->recordThat(new ObjectAttributesChanged(
+            objectId: $this->id,
+            tenantId: $this->tenant->getId(),
+            changedAttributeCodes: $changedCodes,
+        ));
     }
 
     public function getPath(): ?string

--- a/apps/api/src/Shared/Infrastructure/Doctrine/Orm/Mapping/AggregateRoot.orm.xml
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Orm/Mapping/AggregateRoot.orm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <!--
+        Mapped superclass with no persistent state. The `$pendingEvents`
+        buffer on AggregateRoot is intentionally transient; Doctrine ORM 3
+        with `report_fields_where_declared: true` would otherwise reject
+        the property as "unmapped on a mapped class". Declaring the
+        superclass here without any <field> entries makes the buffer
+        invisible to the persister.
+    -->
+    <mapped-superclass name="App\Shared\Domain\AggregateRoot"/>
+
+</doctrine-mapping>

--- a/apps/api/tests/Unit/Catalog/CatalogObjectEventsTest.php
+++ b/apps/api/tests/Unit/Catalog/CatalogObjectEventsTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Contracts\Event\ObjectArchived;
+use App\Catalog\Contracts\Event\ObjectAttributesChanged;
+use App\Catalog\Contracts\Event\ObjectCreated;
+use App\Catalog\Contracts\Event\ObjectEnabledChanged;
+use App\Catalog\Contracts\Event\ObjectPublished;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CatalogObjectEventsTest extends TestCase
+{
+    #[Test]
+    public function assignTenantRecordsObjectCreated(): void
+    {
+        $object = $this->newObject();
+
+        $tenant = new Tenant('demo', 'Demo');
+        $object->assignTenant($tenant);
+
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        $event = $events[0];
+        self::assertInstanceOf(ObjectCreated::class, $event);
+        self::assertSame($object->getId()->toRfc4122(), $event->aggregateId());
+        self::assertSame(ObjectKind::Product, $event->kind);
+        self::assertSame($tenant->getId(), $event->tenantId);
+    }
+
+    #[Test]
+    public function transitionToPublishedRecordsObjectPublished(): void
+    {
+        $object = $this->newObjectWithTenant();
+        $object->pullEvents();
+
+        $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ObjectPublished::class, $events[0]);
+    }
+
+    #[Test]
+    public function transitionToArchivedRecordsObjectArchived(): void
+    {
+        $object = $this->newObjectWithTenant();
+        $object->pullEvents();
+
+        $object->transitionTo(CatalogObject::STATUS_ARCHIVED);
+
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ObjectArchived::class, $events[0]);
+    }
+
+    #[Test]
+    public function transitionToSameStatusEmitsNothing(): void
+    {
+        $object = $this->newObjectWithTenant();
+        $object->pullEvents();
+
+        $object->transitionTo(CatalogObject::STATUS_DRAFT);
+
+        self::assertSame([], $object->pullEvents());
+    }
+
+    #[Test]
+    public function changeEnabledRecordsEvent(): void
+    {
+        $object = $this->newObjectWithTenant();
+        $object->pullEvents();
+
+        $object->changeEnabled(false);
+
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        $event = $events[0];
+        self::assertInstanceOf(ObjectEnabledChanged::class, $event);
+        self::assertFalse($event->enabled);
+    }
+
+    #[Test]
+    public function changeEnabledNoOpEmitsNothing(): void
+    {
+        $object = $this->newObjectWithTenant();
+        $object->pullEvents();
+
+        $object->changeEnabled(true); // already true on construction
+
+        self::assertSame([], $object->pullEvents());
+    }
+
+    #[Test]
+    public function updateAttributeIndexEmitsChangedCodes(): void
+    {
+        $object = $this->newObjectWithTenant();
+        $object->updateAttributeIndex(['sku' => 'A1', 'color' => 'red']);
+        $object->pullEvents();
+
+        $object->updateAttributeIndex(['sku' => 'A1', 'color' => 'blue', 'name' => ['pl' => 'X']]);
+
+        $events = $object->pullEvents();
+        self::assertCount(1, $events);
+        $event = $events[0];
+        self::assertInstanceOf(ObjectAttributesChanged::class, $event);
+        self::assertEqualsCanonicalizing(['color', 'name'], $event->changedAttributeCodes);
+    }
+
+    private function newObject(): CatalogObject
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+
+        return new CatalogObject($type, 'TEST-001');
+    }
+
+    private function newObjectWithTenant(): CatalogObject
+    {
+        $object = $this->newObject();
+        $object->assignTenant(new Tenant('demo', 'Demo'));
+
+        return $object;
+    }
+}


### PR DESCRIPTION
## Summary
Catalog now records domain change events through a `Contracts/Event/` surface other BCs can subscribe to. Five events ship:

- `ObjectCreated` — emitted on first persist (`assignTenant`)
- `ObjectPublished` — `transitionTo(STATUS_PUBLISHED)`
- `ObjectArchived` — `transitionTo(STATUS_ARCHIVED)`
- `ObjectEnabledChanged` — `changeEnabled()` with a different value
- `ObjectAttributesChanged` — `updateAttributeIndex()` with diff codes

`CatalogObject` extends `Shared\Domain\AggregateRoot`. `AggregateRoot` itself becomes a Doctrine mapped-superclass via a fresh XML mapping so the transient `pendingEvents` buffer survives `report_fields_where_declared: true` without any Doctrine annotations leaking into Domain.

`Catalog\Application\Subscriber\ObjectIndexedSubscriber` stub wires the four events to no-op handlers — wiring is intentionally boring; real reindex work lands in RF-19 / epic 0.5. The dispatcher (`DomainEventToMessageMiddleware`) ships in RF-20.

## Test plan
- [x] `bin/console doctrine:schema:validate` — mapping correct
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean
- [x] `php bin/phpunit tests/Unit` — 151/151 green (7 new in `CatalogObjectEventsTest`)
- [x] `bin/console doctrine:fixtures:load` — fixtures load
- [ ] CI: full quality stack green

Closes #166