### PR TITLE
RF-17 — feat(asset,channel,identity): Contracts/Event for remaining BCs

### DIFF
--- a/apps/api/src/Asset/Contracts/Event/AssetUploaded.php
+++ b/apps/api/src/Asset/Contracts/Event/AssetUploaded.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when {@see \App\Asset\Domain\Entity\Asset} finishes initial
+ * persistence — i.e. the original file has landed in object storage and
+ * the Doctrine row is in the database. Channel publishers and the search
+ * indexer subscribe to this for `media` blocks; Catalog can pick it up
+ * to denormalize media URLs into `attributes_indexed`.
+ */
+final readonly class AssetUploaded implements DomainEvent
+{
+    public function __construct(
+        public Uuid $assetId,
+        public Uuid $tenantId,
+        public string $code,
+        public string $mimeType,
+        public ?Uuid $linkedObjectId = null,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'asset.uploaded';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->assetId->toRfc4122();
+    }
+}

--- a/apps/api/src/Asset/Contracts/Event/AssetVariantCreated.php
+++ b/apps/api/src/Asset/Contracts/Event/AssetVariantCreated.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when a derivative {@see \App\Asset\Domain\Entity\AssetVariant}
+ * is created — e.g. a generated thumbnail, webp transcode, or alternate
+ * crop. Tenant scope is inherited from the parent Asset, carried here
+ * to keep subscriber routing simple.
+ */
+final readonly class AssetVariantCreated implements DomainEvent
+{
+    public function __construct(
+        public Uuid $variantId,
+        public Uuid $assetId,
+        public Uuid $tenantId,
+        public string $variantCode,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'asset.variant-created';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->variantId->toRfc4122();
+    }
+}

--- a/apps/api/src/Asset/Domain/Entity/Asset.php
+++ b/apps/api/src/Asset/Domain/Entity/Asset.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Asset\Domain\Entity;
 
+use App\Asset\Contracts\Event\AssetUploaded;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -34,7 +36,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * {@see AssetVariant} and are derived in phase 1 (transformations are
  * out of MVP scope — #37 only handles the original upload).
  */
-class Asset implements TenantScoped
+class Asset extends AggregateRoot implements TenantScoped
 {
     private Uuid $id;
 
@@ -106,6 +108,13 @@ class Asset implements TenantScoped
         }
 
         $this->tenant = $tenant;
+        $this->recordThat(new AssetUploaded(
+            assetId: $this->id,
+            tenantId: $tenant->getId(),
+            code: $this->code,
+            mimeType: $this->mimeType,
+            linkedObjectId: $this->object?->getId(),
+        ));
     }
 
     public function getCode(): string

--- a/apps/api/src/Catalog/Application/Subscriber/AssetLinkSubscriber.php
+++ b/apps/api/src/Catalog/Application/Subscriber/AssetLinkSubscriber.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Subscriber;
+
+use App\Asset\Contracts\Event\AssetUploaded;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Catalog reaction to {@see AssetUploaded}.
+ *
+ * Lives here, not in Asset/, because the work it eventually does belongs
+ * to Catalog (denormalize storage URL into the linked CatalogObject's
+ * `attributes_indexed` so search/exporters do not have to JOIN). For
+ * now, an explicit subscriber proves the cross-BC contract: Asset
+ * publishes events, Catalog consumes them, no Domain reach-over.
+ *
+ * Real denormalization lands together with the search index sync
+ * (RF-19 / epic 0.5).
+ */
+final class AssetLinkSubscriber
+{
+    #[AsMessageHandler]
+    public function onAssetUploaded(AssetUploaded $event): void
+    {
+        // TODO(RF-19/epic-0.5): if $event->linkedObjectId is set, refresh
+        //   the linked CatalogObject's attributes_indexed media block.
+    }
+}

--- a/apps/api/src/Channel/Contracts/Event/CategoryTreeRootAttached.php
+++ b/apps/api/src/Channel/Contracts/Event/CategoryTreeRootAttached.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when a {@see \App\Channel\Domain\Entity\Channel} is wired to
+ * a category tree root (or detached from one). Channel exporters use
+ * this signal to (re)scope which categories they will publish.
+ */
+final readonly class CategoryTreeRootAttached implements DomainEvent
+{
+    public function __construct(
+        public Uuid $channelId,
+        public Uuid $tenantId,
+        public ?Uuid $categoryTreeRootId,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'channel.category-tree-root-attached';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->channelId->toRfc4122();
+    }
+}

--- a/apps/api/src/Channel/Contracts/Event/ChannelCreated.php
+++ b/apps/api/src/Channel/Contracts/Event/ChannelCreated.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when {@see \App\Channel\Domain\Entity\Channel} is first
+ * persisted. Integration adapters subscribe to provision per-channel
+ * state (Shopify location, BaseLinker connection scope, …) without
+ * having to listen on Doctrine's lifecycle events.
+ */
+final readonly class ChannelCreated implements DomainEvent
+{
+    public function __construct(
+        public Uuid $channelId,
+        public Uuid $tenantId,
+        public string $code,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'channel.created';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->channelId->toRfc4122();
+    }
+}

--- a/apps/api/src/Channel/Domain/Entity/Channel.php
+++ b/apps/api/src/Channel/Domain/Entity/Channel.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Channel\Domain\Entity;
 
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Channel\Contracts\Event\CategoryTreeRootAttached;
+use App\Channel\Contracts\Event\ChannelCreated;
 use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -33,7 +36,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * per `ObjectType` so a single channel can have different field shapes
  * for product vs. category exports.
  */
-class Channel implements TenantScoped
+class Channel extends AggregateRoot implements TenantScoped
 {
     private Uuid $id;
 
@@ -93,6 +96,11 @@ class Channel implements TenantScoped
         }
 
         $this->tenant = $tenant;
+        $this->recordThat(new ChannelCreated(
+            channelId: $this->id,
+            tenantId: $tenant->getId(),
+            code: $this->code,
+        ));
     }
 
     public function getCode(): string
@@ -164,5 +172,13 @@ class Channel implements TenantScoped
     public function attachCategoryTreeRoot(?CatalogObject $root): void
     {
         $this->categoryTreeRoot = $root;
+
+        if (null !== $this->tenant) {
+            $this->recordThat(new CategoryTreeRootAttached(
+                channelId: $this->id,
+                tenantId: $this->tenant->getId(),
+                categoryTreeRootId: $root?->getId(),
+            ));
+        }
     }
 }

--- a/apps/api/src/Identity/Contracts/Event/RefreshTokenRotated.php
+++ b/apps/api/src/Identity/Contracts/Event/RefreshTokenRotated.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted on a successful refresh-token rotation in
+ * {@see \App\Identity\Application\RefreshTokenService::rotate()}. Audit
+ * logs and the agent layer attribute side-effects to the freshly
+ * issued token's family.
+ */
+final readonly class RefreshTokenRotated implements DomainEvent
+{
+    public function __construct(
+        public Uuid $tokenId,
+        public Uuid $userId,
+        public Uuid $tenantId,
+        public Uuid $familyId,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'identity.refresh-token-rotated';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->tokenId->toRfc4122();
+    }
+}

--- a/apps/api/src/Identity/Contracts/Event/UserAuthenticated.php
+++ b/apps/api/src/Identity/Contracts/Event/UserAuthenticated.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Event;
+
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when {@see \App\Identity\Domain\Entity\User::recordLogin()} fires —
+ * i.e. on a successful authentication round-trip. Audit logs subscribe to
+ * this; the agent layer (Faza 2) attributes tool runs to the principal.
+ */
+final readonly class UserAuthenticated implements DomainEvent
+{
+    public function __construct(
+        public Uuid $userId,
+        public Uuid $tenantId,
+        public string $email,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'identity.user-authenticated';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->userId->toRfc4122();
+    }
+}

--- a/apps/api/src/Identity/Domain/Entity/User.php
+++ b/apps/api/src/Identity/Domain/Entity/User.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Identity\Domain\Entity;
 
+use App\Identity\Contracts\Event\UserAuthenticated;
 use App\Shared\Application\TenantAware;
+use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -25,7 +27,7 @@ use Symfony\Component\Uid\Uuid;
  * The TenantAware interface lets CurrentTenantProvider read the tenant from
  * the security token's user without coupling Identity to Catalog.
  */
-class User implements UserInterface, PasswordAuthenticatedUserInterface, TenantAware
+class User extends AggregateRoot implements UserInterface, PasswordAuthenticatedUserInterface, TenantAware
 {
     public const string STATUS_ACTIVE = 'active';
     public const string STATUS_DISABLED = 'disabled';
@@ -171,6 +173,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, TenantA
     public function recordLogin(?DateTimeImmutable $when = null): void
     {
         $this->lastLoginAt = $when ?? new DateTimeImmutable();
+        $this->recordThat(new UserAuthenticated(
+            userId: $this->id,
+            tenantId: $this->tenant->getId(),
+            email: $this->email,
+            occurredOn: $this->lastLoginAt,
+        ));
     }
 
     /**


### PR DESCRIPTION
## Summary
Continues RF-16's pattern across the rest of the domain.

- **Asset:** `AssetUploaded` (assignTenant), `AssetVariantCreated` (placeholder DTO — emitted from variant pipeline in epic 0.5)
- **Channel:** `ChannelCreated` (assignTenant), `CategoryTreeRootAttached` (attachCategoryTreeRoot)
- **Identity:** `UserAuthenticated` (recordLogin success), `RefreshTokenRotated` (placeholder DTO — emitted from RefreshTokenService once it publishes through the bus)

`Asset`, `Channel`, `User` now extend `Shared\Domain\AggregateRoot` and route state changes through `recordThat()`.

**Cross-BC subscriber proof of contract:** `Catalog\Application\Subscriber\AssetLinkSubscriber` consumes `AssetUploaded` as a no-op — proves Asset publishes, Catalog consumes, neither reaches into the other's Domain.

## Test plan
- [x] `bin/console doctrine:schema:validate` — mapping correct
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean after auto-fix
- [x] `php bin/phpunit tests/Unit` — 151/151 green
- [x] `bin/console doctrine:fixtures:load` — fixtures load
- [ ] CI: full quality stack green

Closes #167