### PR TITLE
RF-18 — feat(catalog): Contracts/Query DTOs (ObjectSummary, ObjectTypeSummary)

### DIFF
--- a/apps/api/src/Catalog/Application/Query/GetObjectSummary/GetObjectSummaryHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectSummary/GetObjectSummaryHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query\GetObjectSummary;
+
+use App\Catalog\Contracts\Query\ObjectSummary;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use LogicException;
+
+/**
+ * Resolves a {@see GetObjectSummaryQuery} to {@see ObjectSummary}, or
+ * returns null when the row is missing. Plain service — invoked
+ * synchronously by cross-BC validators (e.g. ChannelCategoryRootValidator
+ * after RF-19), no Messenger envelope needed.
+ */
+final readonly class GetObjectSummaryHandler
+{
+    public function __construct(
+        private CatalogObjectRepositoryInterface $repository,
+    ) {
+    }
+
+    public function __invoke(GetObjectSummaryQuery $query): ?ObjectSummary
+    {
+        $object = $this->repository->findById($query->objectId);
+        if (null === $object) {
+            return null;
+        }
+
+        $tenant = $object->getTenant();
+        if (null === $tenant) {
+            // TenantAssignmentListener stamps tenant on prePersist; a hydrated
+            // row without tenant means the row is mid-flight (unsaved) which
+            // a read-side query should never see.
+            throw new LogicException('CatalogObject hydrated without a tenant — corrupt fixture or persistence bug.');
+        }
+
+        $labelAttributeCode = $object->getObjectType()->getLabelAttribute()?->getCode();
+        $indexed = $object->getAttributesIndexed();
+        $label = [];
+        if (null !== $labelAttributeCode && isset($indexed[$labelAttributeCode]) && \is_array($indexed[$labelAttributeCode])) {
+            /** @var array<string, string> $rawLabel */
+            $rawLabel = array_filter(
+                $indexed[$labelAttributeCode],
+                static fn ($v): bool => \is_string($v),
+            );
+            $label = $rawLabel;
+        }
+
+        return new ObjectSummary(
+            id: $object->getId(),
+            kind: $object->getKind(),
+            code: $object->getCode(),
+            label: $label,
+            tenantId: $tenant->getId(),
+            parentId: $object->getParent()?->getId(),
+        );
+    }
+}

--- a/apps/api/src/Catalog/Application/Query/GetObjectSummary/GetObjectSummaryQuery.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectSummary/GetObjectSummaryQuery.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query\GetObjectSummary;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC entry point for fetching a single {@see \App\Catalog\Contracts\Query\ObjectSummary}.
+ * Other BCs (Channel, Asset) pass a Uuid; the handler resolves the row
+ * and returns a final-readonly DTO so callers cannot mutate Catalog
+ * state through the read path.
+ */
+final readonly class GetObjectSummaryQuery
+{
+    public function __construct(public Uuid $objectId)
+    {
+    }
+}

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeSummary/GetObjectTypeSummaryHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeSummary/GetObjectTypeSummaryHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query\GetObjectTypeSummary;
+
+use App\Catalog\Contracts\Query\ObjectTypeSummary;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use LogicException;
+
+final readonly class GetObjectTypeSummaryHandler
+{
+    public function __construct(
+        private ObjectTypeRepositoryInterface $repository,
+    ) {
+    }
+
+    public function __invoke(GetObjectTypeSummaryQuery $query): ?ObjectTypeSummary
+    {
+        $objectType = $this->repository->findById($query->objectTypeId);
+        if (null === $objectType) {
+            return null;
+        }
+
+        $tenant = $objectType->getTenant();
+        if (null === $tenant) {
+            throw new LogicException('ObjectType hydrated without a tenant — corrupt fixture or persistence bug.');
+        }
+
+        return new ObjectTypeSummary(
+            id: $objectType->getId(),
+            kind: $objectType->getKind(),
+            code: $objectType->getCode(),
+            label: $objectType->getLabel(),
+            tenantId: $tenant->getId(),
+            isBuiltIn: $objectType->isBuiltIn(),
+        );
+    }
+}

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeSummary/GetObjectTypeSummaryQuery.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeSummary/GetObjectTypeSummaryQuery.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query\GetObjectTypeSummary;
+
+use Symfony\Component\Uid\Uuid;
+
+final readonly class GetObjectTypeSummaryQuery
+{
+    public function __construct(public Uuid $objectTypeId)
+    {
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ObjectSummary.php
+++ b/apps/api/src/Catalog/Contracts/Query/ObjectSummary.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+use App\Catalog\Domain\ObjectKind;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC read projection of {@see \App\Catalog\Domain\Entity\CatalogObject}.
+ *
+ * The minimum surface other BCs need to validate or describe an object
+ * without crossing into Catalog's Domain. RF-19 swaps the legacy
+ * `Channel.categoryTreeRoot` / `Asset.object` `targetEntity` references
+ * out for `Uuid` columns and resolves them through this DTO via the
+ * GetObjectSummary query handler.
+ */
+final readonly class ObjectSummary
+{
+    /**
+     * @param array<string, string> $label
+     */
+    public function __construct(
+        public Uuid $id,
+        public ObjectKind $kind,
+        public string $code,
+        public array $label,
+        public Uuid $tenantId,
+        public ?Uuid $parentId = null,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/ObjectTypeSummary.php
+++ b/apps/api/src/Catalog/Contracts/Query/ObjectTypeSummary.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+use App\Catalog\Domain\ObjectKind;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC read projection of {@see \App\Catalog\Domain\Entity\ObjectType}.
+ * Channel and Asset BCs pull this through GetObjectTypeSummary instead of
+ * type-hinting the full Domain entity in their FK relations.
+ */
+final readonly class ObjectTypeSummary
+{
+    /**
+     * @param array<string, string> $label
+     */
+    public function __construct(
+        public Uuid $id,
+        public ObjectKind $kind,
+        public string $code,
+        public array $label,
+        public Uuid $tenantId,
+        public bool $isBuiltIn,
+    ) {
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application\Query;
+
+use App\Catalog\Application\Query\GetObjectSummary\GetObjectSummaryHandler;
+use App\Catalog\Application\Query\GetObjectSummary\GetObjectSummaryQuery;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class GetObjectSummaryHandlerTest extends TestCase
+{
+    #[Test]
+    public function returnsNullForUnknownObjectId(): void
+    {
+        $repo = new InMemoryCatalogObjectRepo();
+        $handler = new GetObjectSummaryHandler($repo);
+
+        self::assertNull($handler(new GetObjectSummaryQuery(Uuid::v7())));
+    }
+
+    #[Test]
+    public function projectsObjectIntoSummaryDto(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $type->assignTenant($tenant);
+
+        $object = new CatalogObject($type, 'PROD-001');
+        $object->assignTenant($tenant);
+
+        $repo = new InMemoryCatalogObjectRepo();
+        $repo->store($object);
+
+        $summary = (new GetObjectSummaryHandler($repo))(new GetObjectSummaryQuery($object->getId()));
+
+        self::assertNotNull($summary);
+        self::assertSame($object->getId(), $summary->id);
+        self::assertSame(ObjectKind::Product, $summary->kind);
+        self::assertSame('PROD-001', $summary->code);
+        self::assertSame($tenant->getId(), $summary->tenantId);
+        self::assertNull($summary->parentId);
+    }
+
+    #[Test]
+    public function projectsLabelFromAttributesIndexedWhenLabelAttributeIsSet(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $name = new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text);
+        $name->assignTenant($tenant);
+
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $type->assignTenant($tenant);
+        $type->assignLabelAttribute($name);
+
+        $object = new CatalogObject($type, 'PROD-002');
+        $object->assignTenant($tenant);
+        $object->updateAttributeIndex(['name' => ['pl' => 'Buty', 'en' => 'Shoes']]);
+
+        $repo = new InMemoryCatalogObjectRepo();
+        $repo->store($object);
+
+        $summary = (new GetObjectSummaryHandler($repo))(new GetObjectSummaryQuery($object->getId()));
+
+        self::assertNotNull($summary);
+        self::assertSame(['pl' => 'Buty', 'en' => 'Shoes'], $summary->label);
+    }
+}
+
+/**
+ * Minimal in-memory repository so the handler can be exercised without booting
+ * the kernel. Only `findById` is used; everything else is unsupported.
+ */
+final class InMemoryCatalogObjectRepo implements CatalogObjectRepositoryInterface
+{
+    /** @var array<string, CatalogObject> */
+    private array $objects = [];
+
+    public function store(CatalogObject $object): void
+    {
+        $this->objects[$object->getId()->toRfc4122()] = $object;
+    }
+
+    public function findById(Uuid $id): ?CatalogObject
+    {
+        return $this->objects[$id->toRfc4122()] ?? null;
+    }
+
+    public function findByCode(string $code, ObjectKind $kind, Tenant $tenant): ?CatalogObject
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function findByKind(ObjectKind $kind, Tenant $tenant): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function save(CatalogObject $object): void
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function remove(CatalogObject $object): void
+    {
+        throw new LogicException('not used in this test');
+    }
+}


### PR DESCRIPTION
## Summary
Cross-BC read projections so Channel/Asset can describe Catalog rows without reaching into `Catalog\Domain`.

- `Contracts/Query/ObjectSummary` — final readonly: id, kind, code, label, tenantId, parentId
- `Contracts/Query/ObjectTypeSummary` — final readonly: id, kind, code, label, tenantId, isBuiltIn
- `Application/Query/GetObjectSummary/{Query,Handler}` — plain `final readonly` service exposing `__invoke`. Synchronous; no Messenger envelope.
- `Application/Query/GetObjectTypeSummary/{Query,Handler}` — twin handler.
- `tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php` covers null, basic projection, and label resolution from `attributes_indexed` via the configured `labelAttribute`.

Foundation RF-19 leans on when swapping `Channel.categoryTreeRoot` / `Asset.object` out of `targetEntity` relations into `Uuid` + lookup-by-id.

## Test plan
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean after auto-fix
- [x] `php bin/phpunit tests/Unit` — 154/154 green (3 new)
- [ ] CI: full quality stack green

Closes #168