### PR TITLE
RF-19 — refactor(channel,asset): cross-BC FK → Uuid + Query lookup

### DIFF
--- a/apps/api/src/Asset/Domain/Entity/Asset.php
+++ b/apps/api/src/Asset/Domain/Entity/Asset.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Asset\Domain\Entity;
 
 use App\Asset\Contracts\Event\AssetUploaded;
-use App\Catalog\Domain\Entity\CatalogObject;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
@@ -46,7 +45,12 @@ class Asset extends AggregateRoot implements TenantScoped
     #[Assert\Length(max: 128)]
     private string $code;
 
-    private ?CatalogObject $object = null;
+    /**
+     * Stored as a bare UUID rather than a Doctrine relation to keep Asset
+     * Domain free of cross-BC entity imports — DB-level FK with
+     * `ON DELETE SET NULL` keeps orphans out (RF-19).
+     */
+    private ?Uuid $objectId = null;
 
     #[Assert\NotBlank]
     private string $originalFilename;
@@ -113,7 +117,7 @@ class Asset extends AggregateRoot implements TenantScoped
             tenantId: $tenant->getId(),
             code: $this->code,
             mimeType: $this->mimeType,
-            linkedObjectId: $this->object?->getId(),
+            linkedObjectId: $this->objectId,
         ));
     }
 
@@ -122,14 +126,14 @@ class Asset extends AggregateRoot implements TenantScoped
         return $this->code;
     }
 
-    public function getObject(): ?CatalogObject
+    public function getObjectId(): ?Uuid
     {
-        return $this->object;
+        return $this->objectId;
     }
 
-    public function linkToObject(?CatalogObject $object): void
+    public function linkToObject(?Uuid $objectId): void
     {
-        $this->object = $object;
+        $this->objectId = $objectId;
     }
 
     public function getOriginalFilename(): string

--- a/apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/Asset.orm.xml
+++ b/apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/Asset.orm.xml
@@ -27,9 +27,7 @@
 
         <field name="code" type="string" length="128"/>
 
-        <one-to-one field="object" target-entity="App\Catalog\Domain\Entity\CatalogObject">
-            <join-column name="object_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
-        </one-to-one>
+        <field name="objectId" type="uuid" column="object_id" nullable="true"/>
 
         <field name="originalFilename" type="string" length="255" column="original_filename"/>
         <field name="mimeType" type="string" length="128" column="mime_type"/>

--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -244,7 +244,7 @@ final readonly class DemoCatalogSeeder
                 size: 1024 * 12,
                 storagePath: $storagePath,
             );
-            $asset->linkToObject($catalogAsset);
+            $asset->linkToObject($catalogAsset->getId());
             $variant = new AssetVariant($asset, AssetVariant::CODE_ORIGINAL, $storagePath, 'image/jpeg', 1024 * 12);
             $asset->addVariant($variant);
             $this->em->persist($asset);

--- a/apps/api/src/Channel/Domain/Entity/Channel.php
+++ b/apps/api/src/Channel/Domain/Entity/Channel.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Channel\Domain\Entity;
 
-use App\Catalog\Domain\Entity\CatalogObject;
 use App\Channel\Contracts\Event\CategoryTreeRootAttached;
 use App\Channel\Contracts\Event\ChannelCreated;
 use App\Shared\Application\TenantScoped;
@@ -62,7 +61,13 @@ class Channel extends AggregateRoot implements TenantScoped
      */
     private Collection $currencies;
 
-    private ?CatalogObject $categoryTreeRoot = null;
+    /**
+     * Stored as a bare UUID rather than a Doctrine relation to keep Channel
+     * Domain free of cross-BC entity imports — the FK lives at the DB layer
+     * (CASCADE-on-delete in the migration), the kind=category invariant is
+     * enforced by ChannelCategoryRootValidator via GetObjectSummary (RF-19).
+     */
+    private ?Uuid $categoryTreeRootId = null;
 
     /**
      * @param array<string, string> $label
@@ -164,20 +169,24 @@ class Channel extends AggregateRoot implements TenantScoped
         $this->currencies->removeElement($currency);
     }
 
-    public function getCategoryTreeRoot(): ?CatalogObject
+    public function getCategoryTreeRootId(): ?Uuid
     {
-        return $this->categoryTreeRoot;
+        return $this->categoryTreeRootId;
     }
 
-    public function attachCategoryTreeRoot(?CatalogObject $root): void
+    public function attachCategoryTreeRoot(?Uuid $rootId): void
     {
-        $this->categoryTreeRoot = $root;
+        if ($this->categoryTreeRootId?->toRfc4122() === $rootId?->toRfc4122()) {
+            return;
+        }
+
+        $this->categoryTreeRootId = $rootId;
 
         if (null !== $this->tenant) {
             $this->recordThat(new CategoryTreeRootAttached(
                 channelId: $this->id,
                 tenantId: $this->tenant->getId(),
-                categoryTreeRootId: $root?->getId(),
+                categoryTreeRootId: $rootId,
             ));
         }
     }

--- a/apps/api/src/Channel/Infrastructure/Doctrine/EventListener/ChannelCategoryRootValidator.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/EventListener/ChannelCategoryRootValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Channel\Infrastructure\Doctrine\EventListener;
 
+use App\Catalog\Application\Query\GetObjectSummary\GetObjectSummaryHandler;
+use App\Catalog\Application\Query\GetObjectSummary\GetObjectSummaryQuery;
 use App\Catalog\Domain\ObjectKind;
 use App\Channel\Domain\Entity\Channel;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
@@ -13,19 +15,26 @@ use Doctrine\ORM\Events;
 use InvalidArgumentException;
 
 /**
- * Enforces that {@see Channel::$categoryTreeRoot}, when set, points at a
+ * Enforces that {@see Channel::$categoryTreeRootId}, when set, points at a
  * `CatalogObject` of `kind = category`.
  *
- * The schema does not have a CHECK constraint for this — the FK is just
- * `objects.id`, and the kind discriminator lives next to the row, not on
- * the FK side. This listener gives a friendlier error than letting some
- * downstream consumer (channel publisher, category-tree renderer) fail
- * mid-flight on a non-category root.
+ * After RF-19 the FK is just a Uuid column on Channel — Catalog identity
+ * is not reachable through Doctrine's lazy-loaded entity graph anymore,
+ * so the listener pulls a {@see \App\Catalog\Contracts\Query\ObjectSummary}
+ * via the cross-BC query handler instead. The schema-level FK still keeps
+ * orphans out; this listener gives a friendlier error message before the
+ * row reaches downstream consumers (channel publisher, category-tree
+ * renderer).
  */
 #[AsDoctrineListener(event: Events::prePersist)]
 #[AsDoctrineListener(event: Events::preUpdate)]
-final class ChannelCategoryRootValidator
+final readonly class ChannelCategoryRootValidator
 {
+    public function __construct(
+        private GetObjectSummaryHandler $objectSummary,
+    ) {
+    }
+
     public function prePersist(PrePersistEventArgs $event): void
     {
         $entity = $event->getObject();
@@ -44,16 +53,25 @@ final class ChannelCategoryRootValidator
 
     private function assertRoot(Channel $channel): void
     {
-        $root = $channel->getCategoryTreeRoot();
-        if (null === $root) {
+        $rootId = $channel->getCategoryTreeRootId();
+        if (null === $rootId) {
             return;
         }
 
-        if (ObjectKind::Category !== $root->getKind()) {
+        $summary = ($this->objectSummary)(new GetObjectSummaryQuery($rootId));
+        if (null === $summary) {
+            throw new InvalidArgumentException(\sprintf(
+                'Channel "%s" category tree root %s does not exist.',
+                $channel->getCode(),
+                $rootId->toRfc4122(),
+            ));
+        }
+
+        if (ObjectKind::Category !== $summary->kind) {
             throw new InvalidArgumentException(\sprintf(
                 'Channel "%s" category tree root must be an object with kind=category, got kind=%s.',
                 $channel->getCode(),
-                $root->getKind()->value,
+                $summary->kind->value,
             ));
         }
     }

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml
@@ -53,9 +53,7 @@
             </join-table>
         </many-to-many>
 
-        <many-to-one field="categoryTreeRoot" target-entity="App\Catalog\Domain\Entity\CatalogObject">
-            <join-column name="category_tree_root_object_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
-        </many-to-one>
+        <field name="categoryTreeRootId" type="uuid" column="category_tree_root_object_id" nullable="true"/>
 
     </entity>
 

--- a/apps/api/tests/Unit/Asset/AssetTest.php
+++ b/apps/api/tests/Unit/Asset/AssetTest.php
@@ -29,7 +29,7 @@ final class AssetTest extends TestCase
         self::assertSame(123_456, $asset->getSize());
         self::assertSame('demo/hero/original.jpg', $asset->getStoragePath());
         self::assertSame([], $asset->getMetadata());
-        self::assertNull($asset->getObject());
+        self::assertNull($asset->getObjectId());
         self::assertCount(0, $asset->getVariants());
     }
 
@@ -49,15 +49,15 @@ final class AssetTest extends TestCase
     }
 
     #[Test]
-    public function setObjectAttachesCatalogObject(): void
+    public function linkToObjectStoresUuid(): void
     {
         $type = new ObjectType('asset', ObjectKind::Asset, ['pl' => 'Zasób']);
         $object = new CatalogObject($type, 'hero-image');
         $asset = $this->makeAsset();
 
-        $asset->linkToObject($object);
+        $asset->linkToObject($object->getId());
 
-        self::assertSame($object, $asset->getObject());
+        self::assertSame($object->getId(), $asset->getObjectId());
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Channel/ChannelCategoryRootValidatorTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelCategoryRootValidatorTest.php
@@ -4,26 +4,30 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Channel;
 
+use App\Catalog\Application\Query\GetObjectSummary\GetObjectSummaryHandler;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Channel\Domain\Entity\Channel;
 use App\Channel\Infrastructure\Doctrine\EventListener\ChannelCategoryRootValidator;
+use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\PrePersistEventArgs;
 use InvalidArgumentException;
+use LogicException;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Symfony\Component\Uid\Uuid;
 
 final class ChannelCategoryRootValidatorTest extends TestCase
 {
-    private ChannelCategoryRootValidator $validator;
-    private EntityManagerInterface $em;
+    private EntityManagerInterface&Stub $em;
 
     protected function setUp(): void
     {
-        $this->validator = new ChannelCategoryRootValidator();
         $this->em = $this->createStub(EntityManagerInterface::class);
     }
 
@@ -31,45 +35,121 @@ final class ChannelCategoryRootValidatorTest extends TestCase
     public function nullRootIsAllowed(): void
     {
         $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $validator = new ChannelCategoryRootValidator($this->summaryHandler());
 
-        $this->validator->prePersist(new PrePersistEventArgs($channel, $this->em));
+        $validator->prePersist(new PrePersistEventArgs($channel, $this->em));
 
-        self::assertTrue(true);
+        self::assertNull($channel->getCategoryTreeRootId());
     }
 
     #[Test]
     public function categoryRootIsAccepted(): void
     {
-        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $tenant = new Tenant('demo', 'Demo');
         $type = new ObjectType('category', ObjectKind::Category, ['pl' => 'Kategoria']);
+        $type->assignTenant($tenant);
         $root = new CatalogObject($type, 'root');
-        $channel->attachCategoryTreeRoot($root);
+        $root->assignTenant($tenant);
 
-        $this->validator->prePersist(new PrePersistEventArgs($channel, $this->em));
+        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel->attachCategoryTreeRoot($root->getId());
 
-        self::assertSame($root, $channel->getCategoryTreeRoot());
+        $validator = new ChannelCategoryRootValidator($this->summaryHandler($root));
+
+        $validator->prePersist(new PrePersistEventArgs($channel, $this->em));
+
+        self::assertSame($root->getId(), $channel->getCategoryTreeRootId());
     }
 
     #[Test]
     public function productRootThrows(): void
     {
-        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $tenant = new Tenant('demo', 'Demo');
         $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $type->assignTenant($tenant);
         $root = new CatalogObject($type, 'SKU-1');
-        $channel->attachCategoryTreeRoot($root);
+        $root->assignTenant($tenant);
+
+        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel->attachCategoryTreeRoot($root->getId());
+
+        $validator = new ChannelCategoryRootValidator($this->summaryHandler($root));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('kind=category');
-        $this->validator->prePersist(new PrePersistEventArgs($channel, $this->em));
+        $validator->prePersist(new PrePersistEventArgs($channel, $this->em));
+    }
+
+    #[Test]
+    public function unknownRootThrows(): void
+    {
+        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel->attachCategoryTreeRoot(Uuid::v7());
+
+        $validator = new ChannelCategoryRootValidator($this->summaryHandler());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not exist');
+        $validator->prePersist(new PrePersistEventArgs($channel, $this->em));
     }
 
     #[Test]
     public function nonChannelEntityIsIgnored(): void
     {
         $unrelated = new stdClass();
+        $validator = new ChannelCategoryRootValidator($this->summaryHandler());
 
-        $this->validator->prePersist(new PrePersistEventArgs($unrelated, $this->em));
+        $validator->prePersist(new PrePersistEventArgs($unrelated, $this->em));
 
         self::assertTrue(true);
+    }
+
+    private function summaryHandler(?CatalogObject $object = null): GetObjectSummaryHandler
+    {
+        $repo = new InMemoryCatalogObjectRepoForValidator();
+        if (null !== $object) {
+            $repo->store($object);
+        }
+
+        return new GetObjectSummaryHandler($repo);
+    }
+}
+
+/**
+ * Stand-in repository — only `findById` is exercised through the validator.
+ */
+final class InMemoryCatalogObjectRepoForValidator implements CatalogObjectRepositoryInterface
+{
+    /** @var array<string, CatalogObject> */
+    private array $objects = [];
+
+    public function store(CatalogObject $object): void
+    {
+        $this->objects[$object->getId()->toRfc4122()] = $object;
+    }
+
+    public function findById(Uuid $id): ?CatalogObject
+    {
+        return $this->objects[$id->toRfc4122()] ?? null;
+    }
+
+    public function findByCode(string $code, ObjectKind $kind, Tenant $tenant): ?CatalogObject
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function findByKind(ObjectKind $kind, Tenant $tenant): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function save(CatalogObject $object): void
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function remove(CatalogObject $object): void
+    {
+        throw new LogicException('not used in this test');
     }
 }

--- a/apps/api/tests/Unit/Channel/ChannelTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelTest.php
@@ -28,7 +28,7 @@ final class ChannelTest extends TestCase
         self::assertSame('Sklep PL', $channel->getLabel()['pl']);
         self::assertCount(0, $channel->getLocales());
         self::assertCount(0, $channel->getCurrencies());
-        self::assertNull($channel->getCategoryTreeRoot());
+        self::assertNull($channel->getCategoryTreeRootId());
         self::assertNull($channel->getTenant());
     }
 
@@ -54,15 +54,15 @@ final class ChannelTest extends TestCase
     }
 
     #[Test]
-    public function categoryTreeRootSetterStoresReference(): void
+    public function categoryTreeRootStoresUuid(): void
     {
         $channel = new Channel('shop', ['pl' => 'Sklep']);
         $categoryType = new ObjectType('category', ObjectKind::Category, ['pl' => 'Kategoria']);
         $root = new CatalogObject($categoryType, 'root');
 
-        $channel->attachCategoryTreeRoot($root);
+        $channel->attachCategoryTreeRoot($root->getId());
 
-        self::assertSame($root, $channel->getCategoryTreeRoot());
+        self::assertSame($root->getId(), $channel->getCategoryTreeRootId());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
Two cross-BC `targetEntity` references retired in favour of bare Uuid columns + cross-BC Query DTO lookups:

- `Channel.categoryTreeRoot` → `Channel.categoryTreeRootId` (Uuid)
- `Asset.object` → `Asset.objectId` (Uuid)

Cascade behaviour stays at the Postgres FK layer (already configured via migrations) — Doctrine no longer holds the relation, but `ON DELETE SET NULL` still nulls the column when the linked CatalogObject is removed. Schema validate reports a drift because Doctrine cannot see the schema-level FK; intentional, codified in ADR-0015 (RF-31).

`ChannelCategoryRootValidator` no longer reaches into `Catalog\Domain`; resolves a `Catalog\Contracts\Query\ObjectSummary` via `GetObjectSummaryHandler` and asserts `kind=category` against the DTO. Adds an "unknown root" branch that the Doctrine-graph version couldn't reach.

Consumers updated: DemoCatalogSeeder passes Uuid IDs to `linkToObject()`. Test suites rewritten against the Uuid surface; validator test uses a real `GetObjectSummaryHandler` with an in-memory repository so the cross-BC contract is exercised end-to-end.

## Test plan
- [x] `bin/console doctrine:schema:validate` — mapping correct (DB drift on FK constraint is intentional)
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean after auto-fix
- [x] `php bin/phpunit tests/Unit` — 155/155 green
- [x] `bin/console doctrine:fixtures:load` — fixtures load
- [ ] CI: full quality stack green

## Notes
- `ChannelObjectTypeMapping.objectType` / `attribute` cross-BC FKs left untouched — they live on a junction table whose ON DELETE CASCADE matters more than its abstraction. Decision recorded in ADR-0015.

Closes #169