### PR TITLE
RF-20 — feat(shared): domain-event dispatcher + failure transport + idempotency

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -1,22 +1,32 @@
 framework:
     messenger:
-        # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
-        # failure_transport: failed
+        # Failed-handler envelopes are routed here so the worker pool can be
+        # restarted without losing payloads. `messenger:failed:show` lists
+        # them; `messenger:failed:retry` replays the queue.
+        failure_transport: failed
 
         transports:
-            # https://symfony.com/doc/current/messenger.html#transport-configuration
-            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
-            # failed: 'doctrine://default?queue_name=failed'
             sync: 'sync://'
+            # Async transport ships in Faza 1 together with the worker pool.
+            # The DSN is read from MESSENGER_TRANSPORT_DSN (defaults to
+            # doctrine://default?queue_name=async).
+            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            failed: 'doctrine://default?queue_name=failed'
+
+        buses:
+            messenger.bus.default:
+                middleware:
+                    - 'App\Shared\Infrastructure\Messenger\IdempotencyMiddleware'
+                    - doctrine_transaction
 
         routing:
-            # Route your messages to the transports
-            # 'App\Message\YourMessage': async
+            # Domain events stay on the synchronous bus until async transports
+            # come online. The dispatcher routes per concrete event class
+            # rather than by namespace so subscribers keep their typing.
+            # 'App\Catalog\Contracts\Event\ObjectCreated': async
 
 # when@test:
 #    framework:
 #        messenger:
 #            transports:
-#                # replace with your transport name here (e.g., my_transport: 'in-memory://')
-#                # For more Messenger testing tools, see https://github.com/zenstruck/messenger-test
 #                async: 'in-memory://'

--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -15,6 +15,14 @@ framework:
 
         buses:
             messenger.bus.default:
+                # Domain events emitted by AggregateRoot::recordThat() may have
+                # no subscribers in MVP (UserAuthenticated, RefreshTokenRotated)
+                # — Faza 1+ adds them. allow_no_handlers stops Messenger from
+                # raising NoHandlerForMessageException in that case while still
+                # delivering to every registered handler.
+                default_middleware:
+                    enabled: true
+                    allow_no_handlers: true
                 middleware:
                     - 'App\Shared\Infrastructure\Messenger\IdempotencyMiddleware'
                     - doctrine_transaction

--- a/apps/api/migrations/Version20260429170000.php
+++ b/apps/api/migrations/Version20260429170000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Add `processed_messages` table for the IdempotencyMiddleware (RF-20).
+ *
+ * Holds Messenger envelope ids that have already been handled. Subscribers
+ * stamped with the middleware short-circuit when they see a duplicate id —
+ * makes safe-by-default at-least-once delivery (Doctrine async transport
+ * retries) idempotent at the handler boundary.
+ *
+ * Stays empty until async transports come online (epic 0.5+); the table is
+ * provisioned ahead of time so the first async handler does not need a
+ * schema migration too.
+ */
+final class Version20260429170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add processed_messages table for Messenger idempotency middleware (#170).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE processed_messages (
+                message_id UUID PRIMARY KEY,
+                handler_class VARCHAR(255) NOT NULL,
+                processed_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL
+            )
+        SQL);
+        $this->addSql('CREATE INDEX processed_messages_handler_idx ON processed_messages (handler_class)');
+        $this->addSql('CREATE INDEX processed_messages_processed_at_idx ON processed_messages (processed_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE processed_messages');
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Messenger/DomainEventDispatcher.php
+++ b/apps/api/src/Shared/Infrastructure/Messenger/DomainEventDispatcher.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Messenger;
+
+use App\Shared\Domain\AggregateRoot;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * Pulls buffered domain events from every {@see AggregateRoot} that
+ * Doctrine just flushed and dispatches them through the default
+ * Messenger bus.
+ *
+ * Why postFlush rather than onFlush: events emitted from a domain
+ * method may need the persisted state (auto-generated ids, the row
+ * actually being there for downstream queries) — Symfony's onFlush
+ * fires before Doctrine commits, postFlush after. The trade-off is
+ * we cannot abort the flush from a subscriber; subscribers that need
+ * to fail loudly should throw and the unit-of-work catches it the
+ * same way it would for any post-commit listener.
+ *
+ * UnitOfWork iteration:
+ *   - identityMap holds every managed entity (insertions are already
+ *     in there at postFlush). We walk it once and skip non-aggregates.
+ *   - pullEvents() empties the buffer so a second flush in the same
+ *     request does not replay the same events.
+ */
+#[AsDoctrineListener(event: Events::postFlush)]
+final readonly class DomainEventDispatcher
+{
+    public function __construct(
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function postFlush(PostFlushEventArgs $event): void
+    {
+        $unitOfWork = $event->getObjectManager()->getUnitOfWork();
+
+        foreach ($unitOfWork->getIdentityMap() as $entities) {
+            foreach ($entities as $entity) {
+                if (!$entity instanceof AggregateRoot) {
+                    continue;
+                }
+
+                foreach ($entity->pullEvents() as $domainEvent) {
+                    $this->messageBus->dispatch($domainEvent);
+                }
+            }
+        }
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Messenger/IdempotencyMiddleware.php
+++ b/apps/api/src/Shared/Infrastructure/Messenger/IdempotencyMiddleware.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Messenger;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+
+/**
+ * Drops duplicate-handle attempts on top of Doctrine's at-least-once
+ * delivery semantics (sync now, async transports in Faza 1+). Logic:
+ *
+ *   1. On a worker run (ConsumedByWorkerStamp present), look up the
+ *      envelope's TransportMessageIdStamp.
+ *   2. INSERT the id into processed_messages with handler_class set to
+ *      the receiver tag — Postgres' UNIQUE constraint on message_id
+ *      surfaces a UniqueConstraintViolationException if the same id
+ *      was already handled, in which case the middleware short-circuits.
+ *   3. Otherwise it forwards the envelope down the stack and lets the
+ *      handler run normally.
+ *
+ * Synchronous dispatches (no ConsumedByWorkerStamp) skip the middleware
+ * entirely — sync handlers run inside the originating transaction and
+ * are idempotent by construction (a single commit cannot replay).
+ */
+final readonly class IdempotencyMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $consumed = $envelope->last(ConsumedByWorkerStamp::class);
+        if (null === $consumed) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        $idStamp = $envelope->last(TransportMessageIdStamp::class);
+        if (null === $idStamp) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        $rawId = $idStamp->getId();
+        if (!\is_string($rawId) && !\is_int($rawId)) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+        $messageId = (string) $rawId;
+        if ('' === $messageId) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        try {
+            $this->connection->insert('processed_messages', [
+                'message_id' => $messageId,
+                'handler_class' => $envelope->getMessage()::class,
+                'processed_at' => new DateTimeImmutable()->format('Y-m-d H:i:s'),
+            ]);
+        } catch (UniqueConstraintViolationException) {
+            // Already processed — short-circuit, return envelope as-is.
+            return $envelope;
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}


### PR DESCRIPTION
## Summary
Wires the dispatcher between aggregates and Symfony Messenger. After Doctrine UoW commits, every `App\Shared\Domain\AggregateRoot` in the identity map is asked to `pullEvents()`; events flow into the default Messenger bus and reach the subscribers wired up in RF-16/17.

- `Shared/Infrastructure/Messenger/DomainEventDispatcher` — Doctrine `#[AsDoctrineListener(postFlush)]`. Destructive pull so a second flush in the same request does not replay.
- `Shared/Infrastructure/Messenger/IdempotencyMiddleware` — INSERT-then-handle against `processed_messages`. Doctrine `UniqueConstraintViolationException` short-circuits duplicate ids without invoking the handler. Skips when there is no `ConsumedByWorkerStamp` (sync dispatch is single-commit, already at-most-once).
- `migrations/Version20260429170000.php` — `CREATE TABLE processed_messages` (message_id UUID PK, handler_class, processed_at) + supporting indexes.
- `config/packages/messenger.yaml` — `failure_transport: failed` enabled, failed Doctrine transport registered, IdempotencyMiddleware wired before `doctrine_transaction`. Async transport DSN stays commented; sync remains default until Faza 1.

## Test plan
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean after auto-fix
- [x] `php bin/phpunit tests/Unit` — 155/155 green
- [x] `bin/console doctrine:migrations:execute Version20260429170000 --up` — migration applied locally
- [x] `bin/console doctrine:fixtures:load` — dispatcher invoked on every flush; no observable side effects (subscribers are no-ops)
- [ ] CI: full quality stack green

## Notes
- Async transport + worker pool defer to Faza 1. Today every event lands on `messenger.bus.default` synchronously — same semantics as a direct method call, but routed through the same surface async will use later (no consumer rewrite needed when DSN flips on).
- The IdempotencyMiddleware short-circuits *before* `doctrine_transaction` opens its tx, so a duplicated message never enters the application transaction. That keeps the table small (only successfully started handlers leave a row) and simplifies retention.

Closes #170