### PR TITLE
RF-29 — refactor(tests): split Functional into Integration + Api + Architecture

### DIFF
--- a/apps/api/phpunit.dist.xml
+++ b/apps/api/phpunit.dist.xml
@@ -9,6 +9,7 @@
          failOnWarning="true"
          bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
+         defaultTestSuite="all"
 >
     <php>
         <ini name="display_errors" value="1" />
@@ -18,8 +19,28 @@
     </php>
 
     <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>tests</directory>
+        <!-- Pure-PHP, no Doctrine, no kernel boot. -->
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <!-- Boots the kernel + hits the test database (Foundry ResetDatabase). -->
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+        <!-- HTTP-level tests via ApiTestCase / Refine REST + JWT. -->
+        <testsuite name="api">
+            <directory>tests/Api</directory>
+        </testsuite>
+        <!-- Static fitness tests: Deptrac analyse + custom PHPStan rules. -->
+        <testsuite name="architecture">
+            <directory>tests/Architecture</directory>
+        </testsuite>
+        <!-- Default — running `bin/phpunit` without arguments executes the lot. -->
+        <testsuite name="all">
+            <directory>tests/Unit</directory>
+            <directory>tests/Integration</directory>
+            <directory>tests/Api</directory>
+            <directory>tests/Architecture</directory>
         </testsuite>
     </testsuites>
 

--- a/apps/api/tests/Api/Identity/AuthApiTest.php
+++ b/apps/api/tests/Api/Identity/AuthApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Identity;
+namespace App\Tests\Api\Identity;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Identity\Application\RbacSeeder;

--- a/apps/api/tests/Api/Identity/MeEndpointTest.php
+++ b/apps/api/tests/Api/Identity/MeEndpointTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Identity;
+namespace App\Tests\Api\Identity;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Identity\Application\RbacSeeder;

--- a/apps/api/tests/Api/Identity/RbacSchemaTest.php
+++ b/apps/api/tests/Api/Identity/RbacSchemaTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Identity;
+namespace App\Tests\Api\Identity;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Identity\Domain\Entity\Permission;

--- a/apps/api/tests/Api/Identity/RbacSeederTest.php
+++ b/apps/api/tests/Api/Identity/RbacSeederTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Identity;
+namespace App\Tests\Api\Identity;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Identity\Application\RbacSeeder;

--- a/apps/api/tests/Api/Identity/RefreshTokenApiTest.php
+++ b/apps/api/tests/Api/Identity/RefreshTokenApiTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Identity;
+namespace App\Tests\Api\Identity;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;

--- a/apps/api/tests/Architecture/Deptrac/DeptracAnalyseTest.php
+++ b/apps/api/tests/Architecture/Deptrac/DeptracAnalyseTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\Deptrac;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * Smoke test that the Deptrac ruleset stays green inside the test suite,
+ * not just in CI. The CLI binary itself does the work; we only invoke it,
+ * capture the exit code, and surface the same number of violations PHPUnit
+ * sees (so a `bin/phpunit --testsuite=architecture` run is enough to catch
+ * a freshly-introduced cross-BC import without relying on remote CI).
+ *
+ * The test is tagged with the `architecture` group; running it requires
+ * the binary at vendor/bin/deptrac which is `composer install`'d on every
+ * CI run + every developer setup.
+ */
+#[Group('architecture')]
+final class DeptracAnalyseTest extends TestCase
+{
+    #[Test]
+    public function rulesetPasses(): void
+    {
+        $process = new Process(
+            command: ['vendor/bin/deptrac', 'analyse', '--no-progress', '--no-cache', '--report-uncovered'],
+            cwd: \dirname(__DIR__, 3),
+            timeout: 120,
+        );
+        $process->run();
+
+        self::assertSame(
+            0,
+            $process->getExitCode(),
+            "Deptrac analyse failed:\n".$process->getOutput().$process->getErrorOutput(),
+        );
+    }
+}

--- a/apps/api/tests/Integration/Asset/AssetUploaderTest.php
+++ b/apps/api/tests/Integration/Asset/AssetUploaderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Asset;
+namespace App\Tests\Integration\Asset;
 
 use App\Asset\Application\AssetUploader;
 use App\Asset\Domain\Entity\AssetVariant;

--- a/apps/api/tests/Integration/Catalog/AssociationTypeSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/AssociationTypeSeederTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Catalog;
+namespace App\Tests\Integration\Catalog;
 
 use App\Catalog\Application\BuiltInAssociationTypeSeeder;
 use App\Catalog\Domain\Repository\AssociationTypeRepositoryInterface;

--- a/apps/api/tests/Integration/Catalog/AttributesIndexedSyncListenerTest.php
+++ b/apps/api/tests/Integration/Catalog/AttributesIndexedSyncListenerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Catalog;
+namespace App\Tests\Integration\Catalog;
 
 use App\Catalog\Application\BulkContext;
 use App\Catalog\Domain\AttributeType;

--- a/apps/api/tests/Integration/Catalog/BuiltInObjectTypeSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/BuiltInObjectTypeSeederTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Catalog;
+namespace App\Tests\Integration\Catalog;
 
 use App\Catalog\Application\BuiltInObjectTypeSeeder;
 use App\Catalog\Domain\ObjectKind;

--- a/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Catalog;
+namespace App\Tests\Integration\Catalog;
 
 use App\Catalog\Application\BuiltInObjectTypeSeeder;
 use App\Catalog\Application\DemoCatalogSeeder;

--- a/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
+++ b/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Catalog;
+namespace App\Tests\Integration\Catalog;
 
 use App\Catalog\Application\ObjectTypeService;
 use App\Catalog\Domain\AttributeType;

--- a/apps/api/tests/Integration/Maintenance/TenantAuditCommandTest.php
+++ b/apps/api/tests/Integration/Maintenance/TenantAuditCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Functional\Maintenance;
+namespace App\Tests\Integration\Maintenance;
 
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Console\Application;


### PR DESCRIPTION
## Summary
- `tests/Integration/` — kernel-booting, Foundry ResetDatabase tests (services, listeners, fixtures)
- `tests/Api/` — `ApiTestCase` HTTP-level tests (auth, RBAC schema, /api/auth/me, refresh token)
- `tests/Architecture/` — static fitness tests; `DeptracAnalyseTest` shells out to `vendor/bin/deptrac` so the ruleset stays green inside `bin/phpunit --testsuite=architecture` too.

`phpunit.dist.xml` gets four named testsuites + an `all` umbrella. `defaultTestSuite="all"` keeps `bin/phpunit` running everything (CI equivalence preserved).

## Test plan
- [x] `bin/phpunit --testsuite=unit` — 155/155 green
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean
- [x] `composer deptrac` — 0 violations
- [ ] CI: full quality stack green (Integration + Api suites validated through Docker)

Closes #180