### PR TITLE
RF-30 — feat(tests): DAMA Doctrine Test Bundle + TenantFactory

### DIFF
--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -99,6 +99,7 @@
         }
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^8.6",
         "deptrac/deptrac": "^4.6",
         "doctrine/doctrine-fixtures-bundle": "^4",
         "friendsofphp/php-cs-fixer": "^3.65",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de7bb167960760686a8266ae8f586049",
+    "content-hash": "2269348419867e5aec27141bdb38873b",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -9340,6 +9340,75 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.2",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<11.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
+            },
+            "time": "2026-01-21T07:39:44+00:00"
         },
         {
             "name": "deptrac/deptrac",

--- a/apps/api/config/bundles.php
+++ b/apps/api/config/bundles.php
@@ -11,4 +11,5 @@ return [
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/apps/api/config/packages/test/dama_doctrine_test_bundle.yaml
+++ b/apps/api/config/packages/test/dama_doctrine_test_bundle.yaml
@@ -1,0 +1,8 @@
+# DAMA Doctrine Test Bundle (RF-30): wraps every test in a transaction
+# that is rolled back on tearDown. Foundry's ResetDatabase trait still
+# rebuilds the schema once per test session; DAMA cuts the per-test
+# fixture cost by replacing TRUNCATE with ROLLBACK.
+dama_doctrine_test:
+    enable_static_connection: true
+    enable_static_meta_data_cache: true
+    enable_static_query_cache: true

--- a/apps/api/config/reference.php
+++ b/apps/api/config/reference.php
@@ -1851,6 +1851,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         read_only?: bool|Param, // Converts a file system to read-only // Default: false
  *     }>,
  * }
+ * @psalm-type DamaDoctrineTestConfig = array{
+ *     enable_static_connection?: mixed, // Default: true
+ *     enable_static_meta_data_cache?: bool|Param, // Default: true
+ *     enable_static_query_cache?: bool|Param, // Default: true
+ *     connection_keys?: list<mixed>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1903,6 +1909,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         twig?: TwigConfig,
  *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
  *         flysystem?: FlysystemConfig,
+ *         dama_doctrine_test?: DamaDoctrineTestConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/apps/api/src/Shared/Infrastructure/Foundry/TenantFactory.php
+++ b/apps/api/src/Shared/Infrastructure/Foundry/TenantFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Foundry;
+
+use App\Shared\Domain\Tenant;
+use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
+
+/**
+ * @extends PersistentProxyObjectFactory<Tenant>
+ */
+final class TenantFactory extends PersistentProxyObjectFactory
+{
+    public static function class(): string
+    {
+        return Tenant::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaults(): array
+    {
+        return [
+            'code' => self::faker()->unique()->slug(2),
+            'name' => self::faker()->company(),
+        ];
+    }
+}

--- a/apps/api/symfony.lock
+++ b/apps/api/symfony.lock
@@ -13,6 +13,15 @@
             "src/ApiResource/.gitignore"
         ]
     },
+    "dama/doctrine-test-bundle": {
+        "version": "8.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "8.3",
+            "ref": "dfc51177476fb39d014ed89944cde53dc3326d23"
+        }
+    },
     "deptrac/deptrac": {
         "version": "4.6",
         "recipe": {


### PR DESCRIPTION
## Summary
- `dama/doctrine-test-bundle` registered for the test environment. Wraps every test in a transaction and rolls back on tearDown — Foundry's `ResetDatabase` still rebuilds the schema once per session, per-test fixtures now cost a ROLLBACK instead of a TRUNCATE.
- `Shared\Infrastructure\Foundry\TenantFactory` — first per-entity Foundry factory. Produces unique-coded demo tenants for Integration / Api tests.

Remaining per-entity factories (CatalogObject, ObjectType, Attribute, Asset, User, Role, etc.) intentionally deferred — they land opportunistically when the test using them gets touched, rather than a 19-factory mass PR.

## Test plan
- [x] `composer phpstan` — 0 errors
- [x] `composer cs-check` — clean
- [x] `composer deptrac` — 0 violations
- [x] `php bin/phpunit --testsuite=unit` — 155/155 green
- [ ] CI: full quality stack green (Integration + Api suites validate DAMA wiring)

Closes #179