### PR TITLE
RF-31 + RF-32 — docs(adr,architecture): MADR set + C4 diagrams + ONBOARDING

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,55 @@
+# Onboarding — PIM platform
+
+Three milestones for a developer (or a fresh Claude Code session) to land productively.
+
+## Day 1 — environment up (≤4h)
+
+Pre-requisites: Docker Desktop with at least 8 GiB allocated, Node 22, pnpm 10, OpenSSL.
+
+```bash
+git clone https://github.com/malipie/PIM.git
+cd PIM
+pnpm install
+pnpm stack:up                 # docker compose up -d (api + admin + caddy + postgres + redis + meilisearch + minio + mercure)
+docker compose exec -T api bin/console doctrine:migrations:migrate --no-interaction
+docker compose exec -T api bin/console doctrine:fixtures:load --no-interaction
+```
+
+Open `https://pim.localhost` (Caddy will produce a self-signed cert — accept it once). Login with `admin@demo.local` / `demo`. Navigate to **Products** — the demo dataset seeded by `App\DataFixtures\AppFixtures` should be visible.
+
+Verify your environment with the same gates CI runs:
+
+```bash
+docker compose exec -T api composer phpstan
+docker compose exec -T api composer cs-check
+docker compose exec -T api composer deptrac
+docker compose exec -T api php bin/phpunit --testsuite=unit
+pnpm --filter @pim/admin lint
+pnpm --filter @pim/admin typecheck
+pnpm --filter @pim/admin build
+```
+
+If any of these fail, fix before writing your first PR — the CI rejects the same matrix.
+
+## Day 3 — first PR
+
+Pick something contained: add a new `AttributeOption` to an existing `Attribute`, or extend `BuiltInObjectTypeSeeder`. Workflow:
+
+1. Read [CLAUDE.md](CLAUDE.md) — operator + agent contract for this project.
+2. Read [Project Plan/02-plan-projektu-pim.md](Project%20Plan/02-plan-projektu-pim.md) section for the epic you are working on.
+3. Read [agent/lessons.md](agent/lessons.md) — patterns to follow / avoid.
+4. Branch off main, push to GitHub, open a PR. Required CI checks are: `PHPStan max`, `PHP-CS-Fixer (dry-run)`, `Deptrac (architectural fitness)`, `PHPUnit`, `Playwright E2E`, `Biome strict`, `TypeScript noEmit`, `Vite build (smoke)`.
+5. Use Conventional Commits (`feat(catalog): ...`, `refactor(asset): ...`, `fix(identity): ...`). Commit subject ≤72 chars; body in English.
+
+## Day 10 — bigger feature
+
+Read the architecture in this order:
+
+1. [docs/architecture/c4-context.md](docs/architecture/c4-context.md) — what talks to what.
+2. [docs/architecture/c4-container.md](docs/architecture/c4-container.md) — what runs where.
+3. [docs/architecture/bounded-contexts.md](docs/architecture/bounded-contexts.md) — BC ringfence + domain event flow.
+4. [docs/adr/](docs/adr/) — architectural decisions, especially ADR-0010 (top-level layout), ADR-0013 (Deptrac), ADR-0014 (Tenant in Shared), ADR-0015 (cross-BC FK policy).
+
+Then pick a BC, follow its `Domain/Application/Infrastructure/Contracts` ring, and add the use case. New aggregates extend `Shared\Domain\AggregateRoot` and emit events; subscribers live next to the BC that reacts. Cross-BC reads go through `<BC>\Contracts\Query\*` DTOs; cross-BC writes go through events.
+
+When in doubt: re-run the audit at `Zrodla/Zalecana_struktura_kodu/Audyt/AUDIT-CHECKLIST.md` and look at the latest report under `docs/audits/`.

--- a/docs/adr/0000-use-markdown-architectural-decision-records.md
+++ b/docs/adr/0000-use-markdown-architectural-decision-records.md
@@ -1,0 +1,30 @@
+# 0000. Use Markdown Architectural Decision Records
+
+- **Status:** accepted
+- **Date:** 2026-04-29
+- **Deciders:** Marcin Lipiec
+
+## Context and Problem Statement
+
+The PIM project's architectural rationale lived as a narrative in `Project Plan/01-architektura-pim.md`. As the codebase grows and decisions get re-litigated (e.g. RF refactor adding 6 new policies on top of the original 9), a single 80-page document becomes hard to cite and harder to keep correct.
+
+## Decision Drivers
+
+- need to cite individual decisions from PRs and code comments without linking to a section number that drifts;
+- Sprint 0 finding (`Project Plan/06-sprint-0-findings.md`): "we should be able to point at one decision at a time";
+- audit checklist DOC-001 calls for `docs/adr/` per-file MADR.
+
+## Decision Outcome
+
+Adopt MADR 4.0 (one decision per file, `NNNN-imperative-title.md`). The Project Plan keeps its narrative role; ADRs are the source of truth for individual decisions.
+
+### Consequences
+
+- **Positive:** PRs cite `ADR-0014`, not `Project Plan section 13.4`. Each ADR carries explicit Context / Decision / Consequences / Alternatives so a future reader does not need to read prior chapters first.
+- **Negative:** dual write between Project Plan and ADRs until the back-fill (0001-0009) is done.
+- **Follow-ups:** lift the existing nine decisions out of Project Plan section 13 into their own files in a separate ticket.
+
+## Links
+
+- [MADR 4.0 specification](https://adr.github.io/madr/)
+- Audit checklist: DOC-001

--- a/docs/adr/0010-src-top-level-policy.md
+++ b/docs/adr/0010-src-top-level-policy.md
@@ -1,0 +1,39 @@
+# 0010. `apps/api/src/` Top-Level Layout
+
+- **Status:** accepted
+- **Date:** 2026-04-29 (RF-01)
+- **Deciders:** Marcin Lipiec
+
+## Context and Problem Statement
+
+The audit (AUDIT-REPORT-2026-04-29) flagged 7 top-level directories under `apps/api/src/` that are not Bounded Contexts: `Benchmark`, `DataFixtures`, `Story`, `Maintenance`, `Messaging`, `Observability`, `ApiConfigurator`. Mixing tooling, BCs, and infra under one root makes the boundary fuzzy.
+
+## Decision Drivers
+
+- DDD invariant: top-level should be Bounded Contexts + Shared kernel.
+- Symfony convention: standard locations for fixtures (`src/DataFixtures`) and Foundry stories (`src/Story`) ship with the framework recipes — moving them breaks the autoload + autoconfigure path without good reason.
+- Tooling-only commands (Benchmark, Maintenance) are dev-time artefacts; pretending they are BCs is dishonest.
+
+## Decision Outcome
+
+Three groups under `apps/api/src/`:
+
+1. **Bounded Contexts:** `Catalog`, `Channel`, `Asset`, `Identity`, `Integration`, `Agent`, `ApiConfigurator`.
+2. **Shared kernel:** `Shared/{Domain,Application,Infrastructure,Contracts}/` — Tenant aggregate, AggregateRoot base, multi-tenancy plumbing, cross-cutting infra (Metrics, Maintenance commands).
+3. **Tooling slot (Symfony conventions, no BC ringfence):** `Benchmark/`, `DataFixtures/`, `Story/`. Deptrac scopes them to a `Tooling` layer that may pull from any BC for fixture/benchmark purposes; nothing in the BCs may depend on this slot.
+
+### Consequences
+
+- **Positive:** Onboarding signal — new BCs go top-level, fixtures stay in DataFixtures, infra cross-cuts live under Shared. No surprise locations for `bin/console make:fixture` etc.
+- **Negative:** Audit checklist v1.1 expects `Tooling/` to live under `tools/` outside of `src/`. We documented the deviation here rather than fight Symfony recipes.
+- **Follow-ups:** Maintenance and Observability already migrated to Shared in RF-01.
+
+## Alternatives Considered
+
+- **Move fixtures to `apps/api/fixtures/`:** breaks the DoctrineFixturesBundle recipe and the Symfony Maker scaffolding. Rejected.
+- **Move Benchmark to `apps/api/tools/benchmark/`:** would require a separate `composer.json` autoload entry. Cost outweighs the cosmetic win.
+
+## Links
+
+- AUDIT-REPORT-2026-04-29 §2 STR-003
+- ADR-0013 (Deptrac ruleset references this layout)

--- a/docs/adr/0011-orm-xml-mapping-in-infrastructure.md
+++ b/docs/adr/0011-orm-xml-mapping-in-infrastructure.md
@@ -1,0 +1,36 @@
+# 0011. Doctrine ORM Mapping in XML Files Under Infrastructure
+
+- **Status:** accepted
+- **Date:** 2026-04-29 (RF-06..09)
+- **Deciders:** Marcin Lipiec
+
+## Context and Problem Statement
+
+The pre-RF Domain entities were Doctrine-attribute-mapped: every aggregate declared `#[ORM\Entity]`, `#[ORM\Column]`, etc. inline. The audit (DDD-001 / DDD-006) called out the obvious tradeoff: a "Domain" class peppered with framework annotations is not actually framework-agnostic, and a port-and-adapter layout cannot be enforced when the port carries Doctrine semantics.
+
+## Decision Drivers
+
+- DDD invariant: Domain layer free of framework dependencies — testable without booting Symfony, deployable into a different persistence context if Faza 2/3 needs it.
+- audit DDD-001 / DDD-006 (CRITICAL).
+- Foundation for Deptrac's BC ringfence (ADR-0013): the ruleset in `Catalog_Internals` already permits Domain → Domain only, so external mapping locality matters.
+
+## Decision Outcome
+
+XML mappings live next to each BC's persistence adapter — `apps/api/src/<BC>/Infrastructure/Doctrine/Orm/Mapping/<Entity>.orm.xml`. `doctrine.yaml` switches every BC mapping from `type: attribute` to `type: xml` with the new `dir` and `prefix`. Domain entity classes contain no Doctrine imports.
+
+### Consequences
+
+- **Positive:** Domain stays a plain PHP graph. Listeners and validators that don't need Doctrine state are unit-testable without `KernelTestCase`. Mapping changes ride along in their own XML files (smaller blast radius than touching the entity class).
+- **Negative:** Two-file editing for entity changes (PHP class + XML mapping). Doctrine ORM 3 with `report_fields_where_declared: true` requires the `<mapped-superclass>` declaration for `Shared\Domain\AggregateRoot` to keep the events buffer transient (RF-16).
+- **Follow-ups:** Migration to attribute-mapping if Symfony / Doctrine ORM 4 changes the ergonomic balance — re-evaluate at the bump.
+
+## Alternatives Considered
+
+- **Stay on attribute mapping with `Project Plan` ADR-only documentation of the tradeoff:** rejected. The DDD invariant is load-bearing for the rest of the refactor (ADR-0014 Tenant move, ADR-0015 cross-BC FK policy).
+- **Split into PHP-attribute base class + XML overlay:** Doctrine doesn't merge; you pick one. Rejected.
+
+## Links
+
+- AUDIT-REPORT-2026-04-29 §2 DDD-001 / DDD-006
+- RF-06, RF-07, RF-08, RF-09 PRs
+- Project Plan section 13 ADR-001 / ADR-002

--- a/docs/adr/0012-cqrs-application-layer.md
+++ b/docs/adr/0012-cqrs-application-layer.md
@@ -1,0 +1,42 @@
+# 0012. CQRS Application Layer — Pragmatic Per-Use-Case
+
+- **Status:** accepted
+- **Date:** 2026-04-29 (RF-14, RF-15 — partially WONTFIX)
+- **Deciders:** Marcin Lipiec
+
+## Context and Problem Statement
+
+The audit (DDD-005, MEDIUM) expected vertical-slice `Command/<UseCase>/{Command,Handler}` for every application-level operation. The pre-RF reality was service-style classes (`DemoCatalogSeeder`, `BuiltInObjectTypeSeeder`, `RbacSeeder`, `RefreshTokenService`) that hold the orchestration directly.
+
+## Decision Drivers
+
+- domain seeders run once, are idempotent, and have no user-facing dispatcher path — wrapping them in Messenger Command/Handler envelopes adds overhead without value;
+- API Platform processors (epic 0.4) will provide the first real user-facing write surface; CQRS pays for itself there;
+- the audit's MEDIUM ranking on DDD-005 already acknowledges this is a judgement call;
+- TenantContext-style providers cannot become commands without re-architecting the Symfony security cycle.
+
+## Decision Outcome
+
+Pragmatic CQRS rollout, **per use case**:
+
+- **Real CQRS:** new ApiResource processors land as `Application/Command/<UseCase>/{Command,Handler}` slices (epic 0.4+).
+- **Existing seeders / batch builders / providers:** keep the service layout. They are testable, idempotent, fixture-only.
+- **Domain events:** dispatched through Messenger via `Shared\Infrastructure\Messenger\DomainEventDispatcher` (RF-20). Subscribers carry `#[AsMessageHandler]` already.
+
+The audit reopens this ADR if epic 0.4 surfaces drift (e.g. service-style code starts hosting controller logic).
+
+### Consequences
+
+- **Positive:** No 14-hour rewrite for code that has no operational benefit. Onboarding stays simple — services do what services do.
+- **Negative:** Pure-CQRS purists will disagree with the seeder exception. Documented here so the inconsistency is intentional.
+- **Follow-ups:** RF-14 / RF-15 closed as WONTFIX with link back to this ADR. Re-open if epic 0.4 changes the balance.
+
+## Alternatives Considered
+
+- **Full CQRS sweep across every existing service:** rejected — see Decision Drivers.
+- **Full service layer:** rejected — would force ApiResource processors to hand-roll plumbing the bus already provides.
+
+## Links
+
+- AUDIT-REPORT-2026-04-29 §2 DDD-005
+- Closed-as-WONTFIX issues #164 (RF-14) / #165 (RF-15)

--- a/docs/adr/0013-deptrac-rollout.md
+++ b/docs/adr/0013-deptrac-rollout.md
@@ -1,0 +1,51 @@
+# 0013. Deptrac as the Architectural Fitness Gate
+
+- **Status:** accepted
+- **Date:** 2026-04-29 (RF-21)
+- **Deciders:** Marcin Lipiec
+
+## Context and Problem Statement
+
+The audit's DDD-010 (CRITICAL) reported 65 cross-BC imports. After RF-02..05 + RF-19 the live count is much smaller, but without a mechanical gate the next regression sneaks in unnoticed. PHPStan does not understand Bounded Contexts; we needed a static rule engine that does.
+
+## Decision Drivers
+
+- DDD-010 CRITICAL: cross-BC imports must fail at CI, not at code review.
+- modular monolith: the ringfence between BCs is the most load-bearing rule we have.
+- audit checklist TOOL-001 calls for `vendor/bin/deptrac analyse` as a required check.
+
+## Decision Outcome
+
+Deptrac 4 wired up at `apps/api/deptrac.yaml`. Layers:
+
+- per-BC Internals + Contracts (Catalog_Internals + Catalog_Contracts, Channel_*, Asset_*, Identity_*, Shared);
+- forward-compatible Integration / Agent / ApiConfigurator scaffolding for empty BCs;
+- Tooling slot (Benchmark, DataFixtures, Story) — see ADR-0010.
+
+Ruleset: cross-BC traffic only through `*_Contracts`. Tooling may pull from any BC, no BC may pull from Tooling.
+
+A baseline of 27 pre-existing violations lives inline in `skip_violations`, each annotated with a follow-up:
+
+1. `Catalog\Domain` enums (ObjectKind / AttributeType / Provenance) used by Catalog Contracts. Cleanup: move into `Catalog\Contracts\Enum`.
+2. `ChannelObjectTypeMapping` cross-BC FKs to `Catalog\Domain\Entity\ObjectType` + `Attribute`. RF-19 deferred this junction's Uuid sweep.
+3. `Shared\Infrastructure\Http\RequestTenantSubscriber` depending on `Identity\Application\CurrentTenantProvider`. Cleanup: move provider into `Shared\Application`.
+
+CI: `Deptrac (architectural fitness)` job in `.github/workflows/quality-php.yml`, required-on-merge.
+
+### Consequences
+
+- **Positive:** new violations fail at CI. The baseline is finite and tracked.
+- **Negative:** baseline entries can rot — review them when a BC layout changes substantially.
+- **Follow-ups:** clean up the three baseline clusters in dedicated tickets; target an empty `skip_violations` map.
+
+## Alternatives Considered
+
+- **Custom PHPStan rules:** PHPStan extension authoring overhead far exceeds Deptrac's YAML config for the same payoff.
+- **Manual code review:** the current state proves it doesn't scale (65 violations had accumulated invisibly).
+
+## Links
+
+- AUDIT-REPORT-2026-04-29 §2 DDD-010 / TOOL-001
+- RF-21 PR #203
+- ADR-0010 (Tooling slot)
+- ADR-0014 (Tenant move informs the baseline cluster #3)

--- a/docs/adr/0014-tenant-as-shared-kernel.md
+++ b/docs/adr/0014-tenant-as-shared-kernel.md
@@ -1,0 +1,38 @@
+# 0014. Tenant as Shared Kernel
+
+- **Status:** accepted
+- **Date:** 2026-04-29 (RF-02..04)
+- **Deciders:** Marcin Lipiec
+
+## Context and Problem Statement
+
+The pre-RF Tenant aggregate lived in `App\Identity\Domain\Entity\Tenant`. Every BC (Catalog, Channel, Asset, plus tooling) imported it: 30+ cross-BC `use` statements, plus the Doctrine `targetEntity:` references in 11 mapping files. Identity owned a class that was structurally shared.
+
+## Decision Drivers
+
+- multi-tenancy is a cross-cutting invariant — every aggregate carries `tenant_id`;
+- DDD-010 CRITICAL would never go to zero with Tenant in Identity;
+- Identity should own User / Role / Permission / RefreshToken — runtime auth — not the platform-wide tenant concept.
+
+## Decision Outcome
+
+Tenant is the single Shared Kernel of the modular monolith. It moves to `App\Shared\Domain\Tenant` with XML mapping in `Shared/Infrastructure/Doctrine/Orm/Mapping/Tenant.orm.xml`, repository port + Doctrine adapter in `Shared/Domain/Repository` + `Shared/Infrastructure/Doctrine/Repository`. The whole tenant-isolation infrastructure (TenantContext, TenantScoped, TenantAware, TenantFilter, TenantFilterConfigurator, TenantAssignmentListener, RequestTenantSubscriber) follows it into Shared.
+
+User / Role / Permission / RefreshToken stay in Identity.
+
+### Consequences
+
+- **Positive:** Cross-BC import count for Tenant drops to zero. Every BC depends on Shared, which is allowed by Deptrac. Identity becomes the auth context, not "the place where Tenant happens to live".
+- **Negative:** Cross-BC sweep touched 47 files in one commit — large blast radius for the migration PR. Mitigated by atomic `git mv` and PHPStan/PHPUnit/Deptrac coverage.
+- **Follow-ups:** Migration to `class_alias` bridge was infeasible (Symfony FileLoader + PHP 8.4 lazy type resolution rejected it). The big-sweep approach was the only path forward — recorded here so the next aggregate-extraction ticket starts there.
+
+## Alternatives Considered
+
+- **Keep Tenant in Identity, declare cross-BC import an exception:** rejected, the whole point of modular monolith breaks down.
+- **`class_alias` bridge during migration:** attempted in RF-02 first commits, rolled back when CI surfaced two failure modes.
+
+## Links
+
+- AUDIT-REPORT-2026-04-29 §2 DDD-010
+- RF-02 / RF-03 / RF-04 PR #187 (combined sweep) and #188
+- ADR-0013 (Deptrac baseline references this move)

--- a/docs/adr/0015-cross-bc-fk-policy.md
+++ b/docs/adr/0015-cross-bc-fk-policy.md
@@ -1,0 +1,51 @@
+# 0015. Cross-BC FK Policy: Uuid Columns + Contracts/Query Lookup
+
+- **Status:** accepted
+- **Date:** 2026-04-29 (RF-19)
+- **Deciders:** Marcin Lipiec
+
+## Context and Problem Statement
+
+The pre-RF schema uses two cross-BC `targetEntity:` references:
+
+- `Channel.categoryTreeRoot` → `Catalog\Domain\Entity\CatalogObject` (one-to-one, nullable);
+- `Asset.object` → `Catalog\Domain\Entity\CatalogObject` (one-to-one, nullable).
+
+Both let one BC reach into another's Domain through Doctrine's lazy-loaded entity graph. Acceptable when the project was a single bag, untenable for the modular monolith.
+
+## Decision Drivers
+
+- DDD-010 CRITICAL: every cross-BC dependency goes through Contracts.
+- Domain entities must not import other BCs' Domain entities (Deptrac ringfence — ADR-0013).
+- DB-level cascade behaviour (`ON DELETE SET NULL`) is what we actually want; Doctrine ORM-level cascade is incidental.
+
+## Decision Outcome
+
+Cross-BC links carry a bare `Uuid` column on the source entity, plus a `Catalog\Contracts\Query\ObjectSummary` projection that other BCs pull via `GetObjectSummaryHandler` for validation / labelling. Pattern:
+
+- `Channel.categoryTreeRootId: ?Uuid` (XML `<field type="uuid" column="category_tree_root_object_id" nullable="true"/>`);
+- `Asset.objectId: ?Uuid` (analogous);
+- DB-level FK with `ON DELETE SET NULL` keeps orphans out — Postgres does it, Doctrine no longer needs to know.
+
+`ChannelCategoryRootValidator` resolves the kind=category invariant by calling `GetObjectSummaryHandler($rootId)` and checking the returned DTO. A `null` summary now legitimately means "you pointed at an id that does not exist", which Doctrine's targetEntity flow could not surface.
+
+`Channel.categoryTreeRootId` schema validate complains because Doctrine cannot see the FK constraint anymore. **Intentional.** `--skip-sync` for `doctrine:schema:validate` documents the drift.
+
+### Consequences
+
+- **Positive:** Channel and Asset Domain folders no longer depend on `Catalog\Domain`. Deptrac proves it.
+- **Negative:** Schema validate drift is permanent until Doctrine learns to declare DB-level FKs without owning a relation.
+- **Follow-ups:** `ChannelObjectTypeMapping` carries three cross-BC FKs (Channel + ObjectType + Attribute). RF-19 deferred its sweep — separate ticket. Three Deptrac baseline entries ride along.
+
+## Alternatives Considered
+
+- **Drop the DB-level FK entirely:** would lose orphan protection. Rejected.
+- **Move the validator into Catalog:** the ownership belongs to Channel ("a channel must have a category root"). Rejected.
+- **GraphQL-style data loader / Read Model service per BC:** over-engineering for two FKs in MVP. Pattern lands in epic 0.5 search projection if needed.
+
+## Links
+
+- AUDIT-REPORT-2026-04-29 §2 DDD-010
+- RF-18 (Contracts/Query DTOs) PR #200
+- RF-19 (the sweep itself) PR #201
+- ADR-0013 (Deptrac baseline)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,22 @@
+# Architecture Decision Records
+
+Architectural decisions for the PIM project follow [MADR 4.0](https://adr.github.io/madr/).
+
+Why per-file ADRs alongside the narrative architecture in `Project Plan/01-architektura-pim.md`:
+
+- the Project Plan reads top-to-bottom for onboarding and tells a story;
+- the ADR set is the authoritative source for "why is X this way" — each file pins a single decision with its context, alternatives, and consequences;
+- post-RF refactor we cross-reference both: Project Plan section 13 lists the ADR numbers, the ADR files carry the actual reasoning.
+
+## Index
+
+- [adr-template.md](adr-template.md) — copy when starting a new ADR
+- [0000-use-markdown-architectural-decision-records.md](0000-use-markdown-architectural-decision-records.md)
+- [0010-src-top-level-policy.md](0010-src-top-level-policy.md)
+- [0011-orm-xml-mapping-in-infrastructure.md](0011-orm-xml-mapping-in-infrastructure.md)
+- [0012-cqrs-application-layer.md](0012-cqrs-application-layer.md)
+- [0013-deptrac-rollout.md](0013-deptrac-rollout.md)
+- [0014-tenant-as-shared-kernel.md](0014-tenant-as-shared-kernel.md)
+- [0015-cross-bc-fk-policy.md](0015-cross-bc-fk-policy.md)
+
+ADRs 0001-0009 codify the existing decisions narrated in `Project Plan/01-architektura-pim.md` section 13. Lift-and-shift to per-file MADR is a follow-up housekeeping ticket — the canonical record stays in the Project Plan until that lands.

--- a/docs/adr/adr-template.md
+++ b/docs/adr/adr-template.md
@@ -1,0 +1,41 @@
+# NNNN. Title (imperative, short)
+
+- **Status:** proposed | accepted | superseded by NNNN | deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** {names or roles}
+
+## Context and Problem Statement
+
+What forced the decision? Be specific — a constraint, an incident, a tradeoff, a benchmark.
+
+## Decision Drivers
+
+- driver 1
+- driver 2
+- ...
+
+## Considered Options
+
+1. **Option A** — short summary
+2. **Option B** — short summary
+3. ...
+
+## Decision Outcome
+
+Chosen option: **Option X**, because {single-sentence rationale}.
+
+### Consequences
+
+- **Positive:** ...
+- **Negative:** ...
+- **Follow-ups:** ...
+
+## Alternatives Considered
+
+For each rejected option, the reason it was rejected.
+
+## Links
+
+- Project Plan section X.Y
+- Related ADRs: ADR-NNNN
+- Tickets: #NN

--- a/docs/architecture/bounded-contexts.md
+++ b/docs/architecture/bounded-contexts.md
@@ -1,0 +1,65 @@
+# Bounded Contexts and Cross-BC Communication
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart LR
+    subgraph SharedKernel[Shared kernel]
+        Tenant[Tenant aggregate]
+        AggregateRoot[AggregateRoot base]
+        Bus[Messenger bus + dispatcher]
+    end
+
+    Catalog[Catalog]
+    Channel[Channel]
+    Asset[Asset]
+    Identity[Identity]
+    Integration[Integration]
+    Agent[Agent]
+
+    SharedKernel -.-> Catalog
+    SharedKernel -.-> Channel
+    SharedKernel -.-> Asset
+    SharedKernel -.-> Identity
+    SharedKernel -.-> Integration
+    SharedKernel -.-> Agent
+
+    Asset -. AssetUploaded .-> Catalog
+    Catalog -. ObjectCreated / ObjectPublished / ObjectAttributesChanged .-> Channel
+    Catalog -. ObjectArchived .-> Asset
+    Identity -. UserAuthenticated .-> Agent
+    Channel -. ChannelCreated / CategoryTreeRootAttached .-> Integration
+
+    Channel -- GetObjectSummary --> Catalog
+    Asset -- GetObjectSummary --> Catalog
+```
+
+The dotted arrows are domain events emitted through `Shared\Domain\AggregateRoot::recordThat()` and dispatched by `Shared\Infrastructure\Messenger\DomainEventDispatcher` after every Doctrine flush. Solid arrows are synchronous query handlers used at validation time.
+
+## Bounded Contexts
+
+| BC | Status | Owns | Emits | Reads from |
+|----|--------|------|-------|------------|
+| Catalog | active | ObjectType, CatalogObject, Attribute, ObjectValue, Association, AssociationType, ObjectTypeAttribute | ObjectCreated, ObjectPublished, ObjectArchived, ObjectEnabledChanged, ObjectAttributesChanged | — |
+| Channel | active | Channel, Locale, Currency, ChannelObjectTypeMapping | ChannelCreated, CategoryTreeRootAttached | Catalog (via `GetObjectSummary`) |
+| Asset | active | Asset, AssetVariant | AssetUploaded, AssetVariantCreated | Catalog (via `GetObjectSummary` for the linked object) |
+| Identity | active | User, Role, Permission, RefreshToken | UserAuthenticated, RefreshTokenRotated | Shared (Tenant context) |
+| Shared | active | Tenant aggregate, AggregateRoot base, TenantContext, TenantFilter, AssignmentListener, RequestSubscriber, Messenger middleware | (no domain events) | (everything depends here) |
+| Integration | scaffolded | (Faza 1: BaseLinker + Shopify channel adapters) | tbd | Catalog / Channel / Asset / Identity (Contracts only) |
+| Agent | scaffolded | (Faza 2: Anthropic Claude tool runs + approval flow) | tbd | Catalog / Identity (Contracts only) |
+| ApiConfigurator | scaffolded | (epic 0.10: per-integrator API profiles + key minting) | tbd | Catalog / Channel / Asset / Identity (Contracts only) |
+
+## Ringfence rules (enforced by Deptrac — ADR-0013)
+
+1. **Domain may not depend on Application or Infrastructure**, including its own BC's.
+2. **Application may depend on its own BC's Domain + Contracts** + any other BC's `Contracts/` (events, query DTOs).
+3. **Infrastructure** is the outer ring — may depend on the same BC's full stack + `Shared/{Domain,Application,Contracts}`.
+4. **Contracts** is leaf — pure DTOs, no inward dependencies.
+5. **Tooling** (Benchmark, DataFixtures, Story) may pull from any BC; nothing in a BC may pull from Tooling.
+
+## Domain event flow
+
+1. An aggregate method calls `$this->recordThat(new SomeEvent(...))`.
+2. Doctrine commits the unit-of-work (`postFlush`).
+3. `DomainEventDispatcher` walks the identity map, pulls events from every `AggregateRoot`, dispatches each through the default Messenger bus.
+4. `IdempotencyMiddleware` (RF-20) drops duplicate redeliveries on async paths.
+5. `#[AsMessageHandler]`-tagged subscribers — currently no-op stubs in `Catalog\Application\Subscriber\ObjectIndexedSubscriber` and `AssetLinkSubscriber` — pick the events up and act. Real reindex / publication logic lands in epic 0.5 (search) and the Integration BC (Faza 1).

--- a/docs/architecture/c4-container.md
+++ b/docs/architecture/c4-container.md
@@ -1,0 +1,74 @@
+# C4 Container — Inside the PIM platform
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart TB
+    Caddy[Caddy edge - TLS + single-origin]:::infra
+
+    subgraph Frontend[apps/admin]
+        Vite[Vite 8 dev / dist]:::system
+        Refine[Refine 5 + shadcn]:::system
+    end
+
+    subgraph Backend[apps/api]
+        FP[FrankenPHP worker]:::system
+        Sym[Symfony 7.4 + API Platform 4]:::system
+        Worker[Messenger consumer]:::system
+        Catalog[Catalog BC]:::bc
+        Channel[Channel BC]:::bc
+        Asset[Asset BC]:::bc
+        Identity[Identity BC]:::bc
+        Shared[Shared kernel - Tenant + AggregateRoot + middleware]:::bc
+        Integration[Integration BC - Faza 1]:::bcEmpty
+        Agent[Agent BC - Faza 2]:::bcEmpty
+    end
+
+    Postgres[(Postgres 16)]:::store
+    Meili[(Meilisearch)]:::store
+    Redis[(Redis)]:::store
+    MinIO[(MinIO / S3)]:::store
+
+    Caddy --> Vite
+    Caddy --> FP
+    Vite --> Refine
+    FP --> Sym
+    Sym --> Catalog
+    Sym --> Channel
+    Sym --> Asset
+    Sym --> Identity
+    Sym --> Shared
+    Sym --> Integration
+    Sym --> Agent
+    Sym --> Worker
+
+    Catalog --> Postgres
+    Channel --> Postgres
+    Asset --> Postgres
+    Asset --> MinIO
+    Identity --> Postgres
+    Shared --> Postgres
+    Worker --> Postgres
+    Worker --> Meili
+    Sym --> Meili
+    Sym --> Redis
+
+    classDef system fill:#fff3c4,stroke:#d6a20a,color:#8a6c0a;
+    classDef store fill:#d6f5d6,stroke:#3aa83a,color:#225522;
+    classDef infra fill:#eaeaff,stroke:#6c6cff,color:#33337a;
+    classDef bc fill:#fff,stroke:#444,color:#222;
+    classDef bcEmpty fill:#f5f5f5,stroke:#bbb,color:#888,stroke-dasharray:4 4;
+```
+
+**Caddy edge** terminates TLS, enforces the single-origin contract (`pim.localhost` for everything; no CORS), reverse-proxies `/api/*` to FrankenPHP and the rest to Vite (dev) or the SPA bundle (prod).
+
+**FrankenPHP** runs the Symfony kernel in worker mode. `MAX_REQUESTS=1000` recycles the worker so PHP's known memory drift can't take the box down.
+
+**Bounded contexts** live under `apps/api/src/`. Each carries its own `Domain / Application / Infrastructure / Contracts` ring — the cross-BC ringfence is enforced by Deptrac (ADR-0013).
+
+**Messenger workers** consume the same Symfony Messenger bus the request thread uses. MVP routes everything synchronously; Faza 1 flips the Doctrine async DSN on without rewiring handlers.
+
+**Storage**
+- Postgres 16 — primary OLTP, JSONB + ltree, RLS pre-provisioned.
+- Meilisearch — per-kind search indexes; reindexed by domain-event subscribers (epic 0.5).
+- Redis — sessions, Messenger lock store, cache.app pool.
+- MinIO / S3 — Asset binary storage via Flysystem; only Asset BC writes here.

--- a/docs/architecture/c4-context.md
+++ b/docs/architecture/c4-context.md
@@ -1,0 +1,69 @@
+# C4 Context — PIM in its environment
+
+```mermaid
+%%{init: {'theme':'neutral'}}%%
+flowchart LR
+    User[Admin user]:::user
+    Integrator[Integration partner]:::user
+
+    subgraph PIM[PIM platform]
+        direction TB
+        Admin[Admin SPA - Refine + React]:::system
+        API[API Platform - Symfony 7.4]:::system
+        Worker[Messenger workers]:::system
+    end
+
+    Postgres[(Postgres 16 - JSONB + ltree + RLS)]:::store
+    Meili[(Meilisearch)]:::store
+    Redis[(Redis 7)]:::store
+    MinIO[(MinIO / S3)]:::store
+    Mercure[Mercure SSE]:::infra
+
+    Shopify[Shopify API]:::external
+    BaseLinker[BaseLinker API]:::external
+    Anthropic[Anthropic Claude]:::external
+
+    User --> Admin
+    Admin --> API
+    Integrator --> API
+
+    API --> Postgres
+    API --> Meili
+    API --> Redis
+    API --> MinIO
+    API --> Mercure
+    API --> Worker
+    Worker --> Postgres
+    Worker --> Meili
+
+    API --> Shopify
+    API --> BaseLinker
+    API --> Anthropic
+
+    classDef user fill:#cfe6ff,stroke:#3478c5,color:#1c4e8e;
+    classDef system fill:#fff3c4,stroke:#d6a20a,color:#8a6c0a;
+    classDef store fill:#d6f5d6,stroke:#3aa83a,color:#225522;
+    classDef infra fill:#eaeaff,stroke:#6c6cff,color:#33337a;
+    classDef external fill:#ffd6d6,stroke:#c54040,color:#8a2e2e;
+```
+
+**External actors**
+- *Admin user* — runs the Refine SPA at `pim.localhost` / `pim.example.com`.
+- *Integration partner* — calls `/api/*` directly with a per-tenant API key (epic 0.10 ApiConfigurator).
+
+**Platform**
+- *Admin SPA* — React 19 + Refine 5 + shadcn/ui served by Vite, single-origin behind Caddy.
+- *API* — API Platform 4 on FrankenPHP worker mode. Hosts REST + GraphQL + JSON-LD, dispatches Messenger commands and domain events through the same bus.
+- *Messenger workers* — sync transport in MVP, async (Doctrine queue) from Faza 1 — same bus, same handlers.
+
+**Stores & infra**
+- *Postgres 16* — every domain table carries `tenant_id`. RLS policies are pre-provisioned (epic 0.0.X), `ENABLE ROW LEVEL SECURITY` flips on at first multi-tenant deploy.
+- *Meilisearch* — search index per kind (`products`, `categories`, `assets`).
+- *Redis* — sessions + Messenger lock store + cache.
+- *MinIO / S3* — Asset storage via Flysystem.
+- *Mercure* — SSE channel for real-time admin updates (e.g. async indexing progress).
+
+**External services**
+- *Shopify API* — channel publisher (epic 0.9, deferred to Faza 1).
+- *BaseLinker API* — channel publisher (epic 0.8, Faza 1).
+- *Anthropic Claude API* — Agent layer (epic 0.7, Faza 2). Strict cost limits enforced by `Agent\Application\AgentRunBudgetEnforcer` (BC scaffolded, implementation in Faza 2).

--- a/docs/audits/AUDIT-REPORT-2026-04-28.md
+++ b/docs/audits/AUDIT-REPORT-2026-04-28.md
@@ -1,0 +1,227 @@
+# PIM Architecture Audit Report
+Date: 2026-04-29
+Source: AUDIT-CHECKLIST.md
+
+## 0. Wykryty stan projektu
+
+Discovery command result:
+
+PHP files: 107
+composer.json: yes
+turbo.json: yes
+
+Klasyfikacja wg checklisty:
+
+Stadium 2 — Faza 1 MVP w toku
+
+Zakres audyt
+u:
+- STR
+- DDD
+- BC
+- DB
+- API
+- RT
+
+Reguły production‑only oznaczone jako N/A.
+
+---
+
+## 1. Podsumowanie wykonawcze
+
+### Liczba naruszeń
+
+CRITICAL: 2
+HIGH: 5
+MEDIUM: 4
+LOW: 1
+INFO: 4
+BLOCKED: 1
+
+### Top 5 problemów architektury
+
+1. Domain zależy od Doctrine ORM (DDD‑001, DDD‑006)
+2. Struktura src/ zawiera moduły niebędące Bounded Context
+3. Brak portów domenowych dla repository
+4. Brak generowania typów API z OpenAPI
+5. Brak warstwy Contracts w BC
+
+---
+
+## 2. Wyniki szczegółowe
+
+### STR-001
+Severity: HIGH
+Status: FAIL
+Opis: brak katalogu packages/api-types (zastąpiony przez packages/shared-types).
+
+### STR-002
+Severity: HIGH
+Status: PASS
+
+### STR-003
+Severity: CRITICAL
+Status: FAIL
+Opis: katalogi w src/ niezgodne z BC:
+- ApiConfigurator
+- Benchmark
+- DataFixtures
+- Maintenance
+- Messaging
+- Observability
+- Story
+
+### STR-004
+Severity: HIGH
+Status: FAIL
+Opis: brak warstwy Contracts w BC.
+
+### STR-005
+Severity: MEDIUM
+Status: FAIL
+Opis: brak README w Catalog i Identity.
+
+### STR-006
+Severity: LOW
+Status: INFO
+Opis: brak .claude/CLAUDE.md (repo używa CLAUDE.md w root).
+
+### DDD-001
+Severity: CRITICAL
+Status: FAIL
+Opis: Domain zależy od Doctrine ORM.
+
+### DDD-002
+Severity: CRITICAL
+Status: PASS
+
+### DDD-003
+Severity: CRITICAL
+Status: PASS
+
+### DDD-004
+Severity: HIGH
+Status: PASS
+
+### DDD-005
+Severity: MEDIUM
+Status: PASS
+
+### DDD-006
+Severity: HIGH
+Status: FAIL
+Opis: encje domenowe używają atrybutów ORM.
+
+### DDD-007
+Severity: MEDIUM
+Status: INFO
+Opis: brak XML mapping – nie można zweryfikować UUID strategy.
+
+### DDD-008
+Severity: HIGH
+Status: FAIL
+Opis: brak RepositoryInterface w Domain.
+
+### DDD-009
+Severity: HIGH
+Status: INFO
+Opis: brak katalogów Contracts.
+
+### DDD-010
+Severity: CRITICAL
+Status: BLOCKED
+Powód: brak deptrac.yaml i narzędzia deptrac.
+
+### DDD-011
+Severity: LOW
+Status: FAIL
+Opis: brak Shared\\Domain\\AggregateRoot.
+
+### DB-001
+Severity: CRITICAL
+Status: PASS
+
+### DB-002
+Severity: HIGH
+Status: PASS
+
+### DB-003
+Severity: HIGH
+Status: PASS
+
+### DB-004
+Severity: MEDIUM
+Status: PASS
+
+### DB-005
+Severity: MEDIUM
+Status: PASS
+
+### DB-006
+Severity: HIGH
+Status: N/A
+
+### DB-007
+Severity: LOW
+Status: PASS
+
+### API-001
+Severity: HIGH
+Status: PASS
+
+### API-002
+Severity: MEDIUM
+Status: FAIL
+Opis: niektóre ApiResource nie mają Provider/Processor.
+
+### API-003
+Severity: MEDIUM
+Status: FAIL
+Opis: brak snapshot OpenAPI w docs/api.
+
+### API-004
+Severity: HIGH
+Status: FAIL
+Opis: packages/api-types nie generowane z OpenAPI.
+
+### RT-001
+Severity: CRITICAL
+Status: PASS
+
+### RT-002
+Severity: HIGH
+Status: INFO
+Opis: brak AbstractBatchHandler – brak dowodu na bulk handlers.
+
+---
+
+## 3. Lista naruszeń posortowana po severity
+
+CRITICAL
+- STR-003
+- DDD-001
+
+HIGH
+- STR-001
+- STR-004
+- DDD-006
+- DDD-008
+- API-004
+
+MEDIUM
+- STR-005
+- API-002
+- API-003
+- DDD-005
+
+LOW
+- DDD-011
+
+---
+
+## 5. Caveats
+
+1. Reguła DDD‑010 nie mogła być zweryfikowana z powodu braku deptrac.
+2. UUID strategy nie była w pełni sprawdzalna bez XML mapping.
+3. Struktura src/ zawiera moduły techniczne, które mogą być świadomym wyborem projektu.
+4. Repo używa CLAUDE.md w root zamiast .claude/CLAUDE.md.

--- a/docs/audits/AUDIT-REPORT-2026-04-29.md
+++ b/docs/audits/AUDIT-REPORT-2026-04-29.md
@@ -1,0 +1,874 @@
+# Raport audytowy zgodności kodu PIM z architekturą referencyjną
+
+**Data audytu:** 2026-04-29
+**Wersja AUDIT-CHECKLIST.md:** 1.1
+**Wykonujący:** Claude Code (Opus 4.7, 1M ctx) — automatyczny audyt read-only
+**Tryb:** read-only (modyfikowany wyłącznie ten plik raportu)
+**Stadium projektu:** **2 — Faza 1 MVP w toku** (107 plików PHP, `composer.json` + `turbo.json` obecne, monorepo aktywne)
+
+---
+
+## 0. Wykryty stan projektu
+
+### Struktura monorepo
+- Root: `/Users/mlipieclocal/Library/CloudStorage/SynologyDrive-MiM/Dokumenty/Programowanie/Projekty/PIM`
+- Pliki konfiguracyjne wykryte: `turbo.json`, `pnpm-workspace.yaml`, `package.json`, `README.md`, `CONTRIBUTING.md`, `.editorconfig`. Brak: `ONBOARDING.md`.
+- `apps/`: `apps/api`, `apps/admin`
+- `packages/`: `packages/shared-types` (uwaga: nazwa różni się od oczekiwanej `packages/api-types`)
+
+### Stan kodu
+- Liczba plików PHP w `apps/api/src/`: **107**
+- Liczba plików TS/TSX w `apps/admin/src/`: **21**
+- Wykryte top-level w `apps/api/src/` (BC + dodatkowe katalogi):
+  - **Zgodne z architekturą:** [Catalog](apps/api/src/Catalog/), [Channel](apps/api/src/Channel/), [Asset](apps/api/src/Asset/), [Integration](apps/api/src/Integration/), [Identity](apps/api/src/Identity/), [Agent](apps/api/src/Agent/)
+  - **Dodatkowe (niewymienione w §6.2):** `ApiConfigurator`, `Benchmark`, `DataFixtures`, `Maintenance`, `Messaging`, `Observability`, `Story`
+  - **Brakujące:** `Shared/` — nie istnieje. `Messaging/` (zawiera `AbstractBatchHandler`) pełni rolę quasi-Shared.
+  - Plik `Kernel.php` na poziomie `src/` — Symfony stub, dopuszczalny.
+- Warstwy w BC Catalog (referencyjny pierwszy BC): Domain (14), Application (21), Infrastructure (16). **Brak `Contracts/`** — żaden BC w projekcie nie posiada warstwy Contracts.
+- Warstwy Identity dodatkowo zawiera `Presentation/` (kontrolery REST) — niestandardowa, nie blokuje.
+- BC `Integration/`, `Agent/`, `ApiConfigurator/` — szkielety z `.gitkeep` w warstwach, brak kodu produkcyjnego.
+
+### Zainstalowane narzędzia
+- **Composer:** `api-platform/symfony@^4.3.3`, `api-platform/doctrine-orm@^4.3.3`, `symfony/messenger@7.4.*`, `symfony/uid@7.4.*`, `phpstan/phpstan@^2`, `phpstan/phpstan-doctrine@^2`, `phpstan/phpstan-symfony@^2`, `phpstan/phpstan-strict-rules@^2`, `friendsofphp/php-cs-fixer@^3.65`, `zenstruck/foundry@^2`. Brak: `deptrac/deptrac`, `dama/doctrine-test-bundle`, `phpstan/phpstan-deprecation-rules`, `rector/rector`, klient Meilisearch, Anthropic SDK PHP.
+- **NPM (apps/admin):** React 19, Vite 8, Refine 5, Radix UI, Tailwind 4, Biome 2, react-i18next, react-hook-form. Brak: `openapi-typescript` zainstalowane jako workspace dep w `packages/shared-types`, ale wynik `generate` nigdy nie wygenerował artefaktu (`packages/shared-types/src/index.ts` jest pusty z komentarzem oczekującym na pierwszą generację).
+- **Konfigi obecne:** [phpstan.dist.neon](apps/api/phpstan.dist.neon) (level: max), [.php-cs-fixer.dist.php](apps/api/.php-cs-fixer.dist.php), [Dockerfile](apps/api/Dockerfile) FrankenPHP, [frankenphp/Caddyfile](apps/api/frankenphp/Caddyfile), [frankenphp/php.ini](apps/api/frankenphp/php.ini), [config/packages/doctrine.yaml](apps/api/config/packages/doctrine.yaml) (logging: false), [config/packages/messenger.yaml](apps/api/config/packages/messenger.yaml) (jedynie sync transport).
+- **Konfigi brakujące:** `apps/api/deptrac.yaml`, `apps/api/rector.php`, `apps/api/vendor/bin/deptrac`, `docs/api/openapi-snapshot.json`, `apps/api/config/packages/prometheus.yaml`.
+
+### Migracje
+- 12 plików w [apps/api/migrations/](apps/api/migrations/).
+- Aktywne wzorce: `tenant_id` na większości tabel domenowych, GIN index na `objects.attributes_indexed`, `ltree` extension + LTREE column dla `objects.path`, RLS policies dla 7 tabel (z notacją "policies bez ENABLE — aktywujemy w Fazie 2"), provenance + provenance_meta na `object_values`.
+
+### Kontekst (zgodny z `CLAUDE.md` i `agent/current_status.md`)
+Projekt jest pomiędzy MVP-Alpha a domknięciem epiku 0.3 (autonomous batch). Wiele odejść od architektury referencyjnej z meta-raportu (Domain z Doctrine attribute mapping, brak Contracts, brak Deptrac) jest **świadomych** zgodnie z `Project Plan/06-sprint-0-findings.md` lub planem rolloutu — ale checklist mechanicznie ich nie odróżnia. Patrz §5 Caveats.
+
+---
+
+## 1. Podsumowanie wykonawcze
+
+| Severity | Liczba |
+|----------|--------|
+| 🔴 CRITICAL | **5** |
+| 🟠 HIGH | **9** |
+| 🟡 MEDIUM | **8** |
+| 🟢 LOW | **5** |
+| ℹ️ INFO | 3 |
+| ✅ PASS | 18 |
+| ➖ N/A (Stadium) | 6 |
+| 🚧 BLOCKED | 1 |
+
+**Top 5 najważniejszych do naprawy:**
+1. **[DDD-001] CRITICAL** — 20 encji domenowych w `apps/api/src/*/Domain/Entity/` ma inline `#[ORM\Entity]` + `use Doctrine\ORM\Mapping`. Naprawa: przeniesienie mappingu do `Infrastructure/Doctrine/Orm/Mapping/*.orm.xml` i wyczyszczenie Domain. **Świadomy trade-off MVP — patrz Caveat C1.**
+2. **[DDD-010] CRITICAL** — 65 cross-BC importów (głównie `Catalog → Identity`, `Asset → Identity`, `Channel → Catalog`). Brak warstwy `Contracts/` w żadnym BC = nie ma do czego się odwołać. Naprawa kompleksowa: pierwszy krok to utworzenie `Contracts/` per BC (DTO + integration events) i ustawienie Deptrac (TOOL-001).
+3. **[TOOL-001] CRITICAL** — Brak `apps/api/deptrac.yaml` i `vendor/bin/deptrac`. Bez tego DDD-010 nie ma mechanicznego strażnika.
+4. **[STR-003] CRITICAL** — 7 dodatkowych top-level katalogów w `src/` (`ApiConfigurator`, `Benchmark`, `DataFixtures`, `Maintenance`, `Messaging`, `Observability`, `Story`). Część to świadome wybory infra, część (`DataFixtures`, `Story`, `Benchmark`) realnie zaśmieca top-level. Brak też `Shared/` — `Messaging/` pełni jego rolę.
+5. **[FE-001/FE-003] HIGH** — Frontend używa `apps/admin/src/pages/` (antywzorzec) i definiuje `interface Product` ręcznie zamiast importu z `@pim/shared-types`. `packages/shared-types/src/index.ts` nigdy nie wygenerował typów (`pnpm generate` wymaga uruchomionego `pim.localhost`).
+
+**Ogólna ocena:** Projekt w Stadium 2 z mocnym fundamentem **runtime + DB** (FrankenPHP worker mode dyscyplina, GIN/ltree/RLS w migracjach, Doctrine logging off, opcache JIT) i poprawnym single-origin Caddy. **Słabe ogniwa:** brak granicy DDD między warstwami i BC (Doctrine w Domain, brak Contracts, cross-BC chaos), brak Deptrac, ApiPlatform Resource jeszcze nie zadeklarowane (ticket #41), frontend pre-features-refactor. Większość naruszeń to **długi techniczne świadomie odsunięte** w planie — należy je teraz przekuć w ADR-y zamiast zostawiać niemo.
+
+---
+
+## 2. Wyniki szczegółowe
+
+### Kategoria STR — Struktura katalogów
+
+#### STR-001 — Struktura monorepo `apps/` + `packages/api-types`
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wykryte naruszenia:**
+- `packages/api-types` nie istnieje. Faktyczny pakiet to [packages/shared-types/](packages/shared-types/) — nazwa konwencjonalna, ale niezgodna z §6.2.
+**Sugerowana naprawa:** Albo zmienić `name` w [packages/shared-types/package.json](packages/shared-types/package.json) z `@pim/shared-types` na `@pim/api-types` + zmiana nazwy katalogu, albo zaktualizować checklistę (ADR). Drugi wariant jest tańszy — uznać `shared-types` jako lokalną konwencję projektu.
+
+---
+
+#### STR-002 — Pliki konfiguracyjne monorepo
+**Wynik:** ⚠️ PARTIAL FAIL (1 z 4 must, 1 z 3 should)
+**Severity:** 🟠 HIGH (dla `ONBOARDING.md` traktowane jako MEDIUM bo "should")
+**Wykryte naruszenia:**
+- Brak [ONBOARDING.md](ONBOARDING.md) — patrz DOC-003.
+- 4 must-files (`turbo.json`, `pnpm-workspace.yaml`, `package.json`, `README.md`) → wszystkie obecne. Should `CONTRIBUTING.md` + `.editorconfig` obecne.
+**Sugerowana naprawa:** Utworzyć `ONBOARDING.md` z ścieżką day-1/3/10 (vide DOC-003).
+
+---
+
+#### STR-003 — Bounded Contexts jako pierwszy poziom `apps/api/src/`
+**Wynik:** ❌ FAIL
+**Severity:** 🔴 CRITICAL
+**Wykryte naruszenia:**
+- 7 katalogów `UNEXPECTED:` `ApiConfigurator`, `Benchmark`, `DataFixtures`, `Maintenance`, `Messaging`, `Observability`, `Story`.
+- Brak `Shared/` (zalecane). Funkcjonalnie zastępuje go [apps/api/src/Messaging/](apps/api/src/Messaging/) (zawiera `AbstractBatchHandler`) — ale to nie jest `Shared/`, raczej świadome wydzielenie sub-tematu.
+- Brak antywzorców `Controller/`, `Entity/`, `Service/`, `Repository/`, `Manager/` na top-levelu — dobry znak (są wewnątrz BC).
+**Caveat:** `ApiConfigurator/` jest zaplanowanym BC w `Project Plan/01-architektura-pim.md` sekcja 2. `Maintenance/` i `Observability/` mogą być uznane za podkategorie `Shared/` (cross-cutting). `Benchmark/`, `DataFixtures/`, `Story/` to katalogi narzędziowe, nie BC.
+**Sugerowana naprawa:**
+1. Utworzyć `Shared/Domain/`, `Shared/Application/`, `Shared/Infrastructure/`. Przenieść `Messaging/AbstractBatchHandler.php` → `Shared/Application/AbstractBatchHandler.php`. Przenieść infrastrukturalne podkatalogi (`Observability/`, część `Maintenance/`) do `Shared/Infrastructure/`.
+2. `ApiConfigurator/` zostaje jako BC — dorobić zgodne 4 warstwy zanim pierwsze use case'y wejdą.
+3. `Benchmark/`, `DataFixtures/`, `Story/` przenieść do `apps/api/tools/` lub `apps/api/src/DevTools/` (poza BC). Zwłaszcza `Story/` brzmi jak storybook/fixtury.
+4. Dorobić ADR `0010-src-top-level-policy.md` jednoznacznie wymieniający dozwolone top-leveli.
+
+---
+
+#### STR-004 — 4 warstwy per BC (Domain/Application/Infrastructure/Contracts)
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH (dla core BC) / 🟡 MEDIUM (dla Identity, Agent jako supporting)
+**Wykryte naruszenia (wszystkie BC):**
+| BC | Domain | Application | Infrastructure | Contracts |
+|---|---|---|---|---|
+| Catalog (core) | 14 | 21 | 16 | **MISSING** ❌ |
+| Channel (core) | 4 | 0 | 5 | **MISSING** ❌ |
+| Asset (core) | 2 | 1 | 2 | **MISSING** ❌ |
+| Integration (core) | 0 | 0 | 0 | **MISSING** ❌ |
+| Identity (supporting) | 8 | 8 | 10 | **MISSING** ❌ |
+| Agent (supporting) | 0 | 0 | 0 | **MISSING** ❌ |
+| ApiConfigurator | 0 | 0 | 0 | **MISSING** ❌ |
+
+**Konsekwencja:** Brak `Contracts/` w żadnym BC oznacza, że nie ma definicji integration events ani DTO Published Language. Cross-BC komunikacja nie ma do czego się odwołać → DDD-010 fail.
+**Sugerowana naprawa:** Pierwszym krokiem jest utworzenie `Contracts/Event/` w Catalog z eventami: `ObjectCreated`, `ObjectPublished`, `ObjectAttributesChanged`. Następnie przepisanie cross-BC importów (Channel → Catalog/Domain) na konsumpcję eventów. Plan: ticket epiku 0.4 lub 0.5.
+
+---
+
+#### STR-005 — `README.md` w każdym BC
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wykryte naruszenia:**
+- [apps/api/src/Catalog/README.md](apps/api/src/Catalog/README.md) — **MISSING**
+- [apps/api/src/Identity/README.md](apps/api/src/Identity/README.md) — **MISSING**
+- Pozostałe BC mają README, ale wszystkie są krótkie (17-38 linii), graniczne ze 20.
+**Sugerowana naprawa:** Dorobić README dla Catalog i Identity (najważniejsze BC w MVP). Zawartość: Subdomena, Główne agregaty, Emitowane eventy, Konsumowane eventy. Min. 20 linii.
+
+---
+
+#### STR-006 — `.claude/CLAUDE.md` w root
+**Wynik:** ❌ FAIL
+**Severity:** 🟢 LOW
+**Wykryte naruszenia:**
+- Brak `.claude/CLAUDE.md`. Istnieje za to [CLAUDE.md](CLAUDE.md) w roocie projektu (~190 linii, bardzo bogaty).
+**Caveat:** CLAUDE.md w roocie jest oficjalną konwencją Claude Code i pełni rolę przewodnika. Reguła STR-006 mówi konkretnie o `.claude/CLAUDE.md` — w praktyce projekt już ma ekwiwalent w lepszej lokalizacji (root, widoczny w VS Code, w .gitignore'ach pewnych narzędzi `.claude/` może być mniej spotykane).
+**Sugerowana naprawa:** Akceptujemy obecne CLAUDE.md w roocie jako równoważne. Reguła STR-006 powinna być rozluźniona w wersji 1.2 checklisty. Opcjonalnie utworzyć dodatkowo `apps/api/CLAUDE.md` i `apps/admin/CLAUDE.md` z per-pakiet notami (LOW priority).
+
+---
+
+### Kategoria DDD — warstwy i ich reguły zależności
+
+#### DDD-001 — Domain bez Symfony/Doctrine/ApiPlatform
+**Wynik:** ❌ FAIL
+**Severity:** 🔴 CRITICAL
+**Wykryte naruszenia (próbka — 20 plików łącznie):**
+- [apps/api/src/Asset/Domain/Entity/AssetVariant.php:5](apps/api/src/Asset/Domain/Entity/AssetVariant.php#L5) — `use Doctrine\DBAL\Types\Types; use Doctrine\ORM\Mapping as ORM;` + 12 inline `#[ORM\*]`
+- [apps/api/src/Asset/Domain/Entity/Asset.php](apps/api/src/Asset/Domain/Entity/Asset.php)
+- [apps/api/src/Catalog/Domain/Entity/AttributeOption.php](apps/api/src/Catalog/Domain/Entity/AttributeOption.php)
+- [apps/api/src/Catalog/Domain/Entity/CatalogObject.php](apps/api/src/Catalog/Domain/Entity/CatalogObject.php)
+- [apps/api/src/Catalog/Domain/Entity/AssociationType.php](apps/api/src/Catalog/Domain/Entity/AssociationType.php)
+- [apps/api/src/Catalog/Domain/Entity/Association.php](apps/api/src/Catalog/Domain/Entity/Association.php)
+- [apps/api/src/Catalog/Domain/Entity/Attribute.php](apps/api/src/Catalog/Domain/Entity/Attribute.php)
+- [apps/api/src/Catalog/Domain/Entity/ObjectType.php](apps/api/src/Catalog/Domain/Entity/ObjectType.php)
+- [apps/api/src/Catalog/Domain/Entity/AttributeGroup.php](apps/api/src/Catalog/Domain/Entity/AttributeGroup.php)
+- [apps/api/src/Catalog/Domain/Entity/ObjectTypeAttribute.php](apps/api/src/Catalog/Domain/Entity/ObjectTypeAttribute.php)
+- [apps/api/src/Catalog/Domain/Entity/ObjectValue.php](apps/api/src/Catalog/Domain/Entity/ObjectValue.php)
+- [apps/api/src/Channel/Domain/Entity/ChannelObjectTypeMapping.php](apps/api/src/Channel/Domain/Entity/ChannelObjectTypeMapping.php), [Locale.php](apps/api/src/Channel/Domain/Entity/Locale.php), [Currency.php](apps/api/src/Channel/Domain/Entity/Currency.php), [Channel.php](apps/api/src/Channel/Domain/Entity/Channel.php)
+- [apps/api/src/Identity/Domain/Entity/RefreshToken.php](apps/api/src/Identity/Domain/Entity/RefreshToken.php), [Permission.php](apps/api/src/Identity/Domain/Entity/Permission.php), [Role.php](apps/api/src/Identity/Domain/Entity/Role.php), [Tenant.php](apps/api/src/Identity/Domain/Entity/Tenant.php), [User.php](apps/api/src/Identity/Domain/Entity/User.php)
+
+Łącznie **20 encji** ma `#[ORM\Entity]` w Domain. Brak `#[ApiResource]` w Domain — ten aspekt PASS.
+**Caveat C1 (świadome odejście):** Architektura referencyjna PIM (`Project Plan/01-architektura-pim.md`) preferuje Doctrine **attribute mapping inline** w Domain w MVP — vs. checklist która wymaga XML w Infrastructure. Projekt używa konwencji "attribute" w `doctrine.yaml`. To jest długi techniczny w stosunku do hexagonal architecture, ale nie jest błędem implementacji w sensie "nieświadome zanieczyszczenie".
+**Sugerowana naprawa:**
+- **Krótkoterminowo:** Dodać ADR `0011-doctrine-attributes-in-domain-tradeoff.md` opisujący decyzję, kompromisy (testowalność Domain bez DB → mid-level), kiedy migrujemy (Faza 2 — przy rosnącym zespole).
+- **Długoterminowo:** Migracja na XML mapping w `Infrastructure/Doctrine/Orm/Mapping/` per BC. Ticket per BC, ~8h każdy.
+
+---
+
+#### DDD-002 — Domain nie zna `EntityManagerInterface`
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:** Brak `EntityManagerInterface` w żadnym pliku Domain. Świetnie — listenery i serwisy używające EM siedzą w Infrastructure/Application.
+
+---
+
+#### DDD-003 — Application nie zależy od Infrastructure
+**Wynik:** ❌ FAIL
+**Severity:** 🔴 CRITICAL
+**Wykryte naruszenia (skondensowane):**
+- [apps/api/src/Identity/Application/CurrentTenantProvider.php:9](apps/api/src/Identity/Application/CurrentTenantProvider.php) — `use App\Identity\Infrastructure\Doctrine\Repository\TenantRepository`
+- [apps/api/src/Identity/Application/RbacSeeder.php](apps/api/src/Identity/Application/RbacSeeder.php) — importuje `RoleRepository`, `PermissionRepository` (Infrastructure)
+- [apps/api/src/Identity/Application/RefreshTokenService.php](apps/api/src/Identity/Application/RefreshTokenService.php) — importuje `RefreshTokenRepository`, `UserRepository`
+- [apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php](apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php), [BuiltInAssociationTypeSeeder.php](apps/api/src/Catalog/Application/BuiltInAssociationTypeSeeder.php), [DemoCatalogSeeder.php](apps/api/src/Catalog/Application/DemoCatalogSeeder.php) — importują repozytoria Doctrine z Infrastructure
+- (Identity → Identity i Catalog → Catalog są same-BC, więc nie naruszają DDD-010, ale naruszają DDD-003)
+
+**Konsekwencja:** Application zna konkretną implementację Doctrine repository — łamie Dependency Rule.
+**Sugerowana naprawa:** Utworzyć interfejsy w `Domain/Repository/<X>RepositoryInterface.php` (DDD-008) i wstrzykiwać interfejs w warstwie Application. Implementacje już istnieją w Infrastructure, brakuje formalnego portu.
+
+---
+
+#### DDD-004 — Encje domenowe bez publicznych setterów
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wykryte naruszenia:** **41 publicznych setterów** w `Domain/Entity/`. Próbka:
+- [apps/api/src/Catalog/Domain/Entity/CatalogObject.php](apps/api/src/Catalog/Domain/Entity/CatalogObject.php) — `setParent`, `setEnabled`, `setStatus`, `setCompleteness`, `setAttributesIndexed`, `setPath`
+- [apps/api/src/Catalog/Domain/Entity/Attribute.php](apps/api/src/Catalog/Domain/Entity/Attribute.php) — `setGroup`, `setLabel`, `setHelp`, `setLocalizable`, `setScopable`, `setRequired`, `setValidationRules`, `setPosition`
+- [apps/api/src/Catalog/Domain/Entity/ObjectType.php](apps/api/src/Catalog/Domain/Entity/ObjectType.php) — `setLabel`, `setCompletenessRules`, `setLabelAttribute`, `setImageAttribute`
+- [apps/api/src/Catalog/Domain/Entity/ObjectValue.php](apps/api/src/Catalog/Domain/Entity/ObjectValue.php) — `setChannelId`, `setLocale`, `setValue`, `setProvenance`, `setProvenanceMeta`
+- (pełna lista: 41 wystąpień w 11 plikach)
+
+**Konsekwencja:** Hermetyzacja stanu nie jest egzekwowana, agregaty są ekspozją property bag.
+**Caveat (heurystyka projektu):** Projekt używa układu `Domain/Entity/` zamiast `Domain/Model/`, co reguła specyfikuje. Zinterpretowano analogicznie (intent reguły jest jasny).
+**Sugerowana naprawa:** Zamienić settery na metody domenowe (`setStatus(string)` → `activate()/deactivate()/archive()`). Trade-off: praca z hydration Doctrine — w Doctrine 3 z `enable_lazy_ghost_objects: true` można używać prywatnych settersów + Reflection (Doctrine sam mapuje), więc nie ma powodu trzymać publicznych. Plan: jeden ticket na encję, po ~1-2h każdy.
+
+---
+
+#### DDD-005 — Vertical slice Command/Handler per use case
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wykryte naruszenia:**
+- Brak struktury `Application/Command/<UseCase>/<UseCase>Command.php + Handler.php`. Zamiast tego — Application zawiera **Service-style klasy**: `BulkContext`, `AttributesIndexedRebuilder`, `ObjectTypeService`, seedery, walidatory.
+- Jedyny Handler znaleziony: [apps/api/src/Catalog/Application/Handler/RebuildAttributesIndexedHandler.php](apps/api/src/Catalog/Application/Handler/RebuildAttributesIndexedHandler.php) — istnieje, ale jego Message ([Message/ObjectValuesChangedMessage.php](apps/api/src/Catalog/Application/Message/ObjectValuesChangedMessage.php)) jest w innym podfolderze. Nie vertical slice.
+**Konsekwencja:** CQRS pattern nie jest zaimplementowany — projekt używa "service layer" zamiast `CommandHandlerInterface` Messengera dla mutacji.
+**Sugerowana naprawa:** Wprowadzać CQRS sukcesywnie przy nowych ticketach (ADR `0012-cqrs-rollout-strategy.md`). Refaktor istniejących serwisów na Command/Handler dopiero gdy use case staje się złożony lub potrzebny audit log per komendzie. MVP nie wymaga twardego CQRS.
+
+---
+
+#### DDD-006 — Mapowanie Doctrine w XML, nie atrybutach
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wykryte naruszenia:** 0 plików `*.orm.xml` w `apps/api/src/*/Infrastructure/Doctrine/`. Wszystko używa atrybutów inline w Domain (efekt DDD-001).
+**Caveat C1 jak przy DDD-001:** świadomy trade-off MVP. Konfiguracja `doctrine.yaml` używa `type: attribute` celowo — patrz `Project Plan/01-architektura-pim.md` ADR-001/002 (jeśli istnieje).
+**Sugerowana naprawa:** Razem z DDD-001 — migracja XML wpisana w długi techniczny z ADR `0011`.
+
+---
+
+#### DDD-007 — UUIDv7 generowane w domenie
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:**
+- Brak `strategy="(AUTO|IDENTITY|SEQUENCE)"` w mappingach.
+- Wszystkie Domain entities generują ID konstruktorem `Symfony\Component\Uid\Uuid::v7()`. Próbka: [Asset.php](apps/api/src/Asset/Domain/Entity/Asset.php), [CatalogObject.php](apps/api/src/Catalog/Domain/Entity/CatalogObject.php), [Attribute.php](apps/api/src/Catalog/Domain/Entity/Attribute.php), [Association.php](apps/api/src/Catalog/Domain/Entity/Association.php).
+- `#[ORM\Id]` bez `#[ORM\GeneratedValue]` = strategy NONE (Doctrine respektuje wartość przekazaną).
+- Uwaga: w `doctrine.yaml` jest `identity_generation_preferences: PostgreSQLPlatform: identity` — to dotyczy tylko gdy `#[GeneratedValue]` byłoby użyte. W bieżącym kodzie nie ma takiego użycia.
+
+---
+
+#### DDD-008 — Repository: interface w Domain, implementacja w Infrastructure
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wykryte naruszenia:**
+- 0 plików `*RepositoryInterface.php` w `apps/api/src/*/Domain/Repository/`.
+- 19 implementacji repozytoriów w `Infrastructure/Doctrine/Repository/` — wszystkie konkretne klasy bez interfejsu w Domain.
+- Konwencja nazewnicza: implementacje **nie** mają prefiksu `Doctrine` (np. [TenantRepository.php](apps/api/src/Identity/Infrastructure/Doctrine/Repository/TenantRepository.php), nie `DoctrineTenantRepository`). Reguła sugeruje prefiks dla rozróżnienia portów od adapterów.
+
+**Sugerowana naprawa:** Wprowadzić port-adapter sukcesywnie dla repozytoriów najczęściej wstrzykiwanych do Application: `TenantRepository`, `RefreshTokenRepository`, `CatalogObjectRepository`, `ObjectTypeRepository`, `AttributeRepository`. Plan: ~2h per repo, łącznie ~10h. Powiązanie z DDD-003.
+
+---
+
+#### DDD-009 — `Contracts/` zawiera DTO, nie agregaty
+**Wynik:** ➖ N/A
+**Severity:** —
+**Wynik detekcji:** Brak warstwy `Contracts/` w żadnym BC (patrz STR-004). Reguła nie ma do czego się stosować.
+**Sugerowana naprawa:** Po utworzeniu `Contracts/` (STR-004) ta reguła wejdzie do gry. Pierwszym DTO powinien być `Catalog\Contracts\Query\ObjectSummary` (idealnie `final readonly class`).
+
+---
+
+#### DDD-010 — Cross-BC import tylko z `Contracts/`
+**Wynik:** ❌ FAIL (fallback grep — Deptrac niedostępny)
+**Severity:** 🔴 CRITICAL (zgodnie z regułą; obniżone do **🟠 HIGH** ze względu na fallback grep — patrz reguła)
+**Wynik detekcji:** **65 cross-BC importów w 33 plikach.** Histogram pairs:
+| BC źródłowy | BC importowany | Liczba |
+|---|---|---|
+| Catalog | Identity | 27 |
+| Asset | Identity | 7 |
+| DataFixtures | Catalog | 6 |
+| DataFixtures | Identity | 6 |
+| Channel | Catalog | 6 |
+| Benchmark | Catalog | 4 |
+| Benchmark | Identity | 3 |
+| Channel | Identity | 3 |
+| Catalog | Asset | 2 |
+| Asset | Catalog | 1 |
+
+Próbki:
+- [apps/api/src/Catalog/Domain/Entity/CatalogObject.php:9-10](apps/api/src/Catalog/Domain/Entity/CatalogObject.php) — `use App\Identity\Application\TenantScoped; use App\Identity\Domain\Entity\Tenant;` (Domain-Domain leak)
+- [apps/api/src/Channel/Domain/Entity/Channel.php:7](apps/api/src/Channel/Domain/Entity/Channel.php) — `use App\Catalog\Domain\Entity\CatalogObject;` (FK na CategoryTreeRoot)
+- [apps/api/src/Asset/Domain/Entity/Asset.php:8](apps/api/src/Asset/Domain/Entity/Asset.php) — `use App\Catalog\Domain\Entity\CatalogObject;` (Asset → Object FK)
+- [apps/api/src/Catalog/Application/DemoCatalogSeeder.php:7-8](apps/api/src/Catalog/Application/DemoCatalogSeeder.php) — `use App\Asset\Domain\Entity\Asset; use App\Asset\Domain\Entity\AssetVariant;` (seeder cross-BC)
+- [apps/api/src/Catalog/Infrastructure/Doctrine/Repository/CatalogObjectRepository.php:9](apps/api/src/Catalog/Infrastructure/Doctrine/Repository/CatalogObjectRepository.php) — `use App\Identity\Domain\Entity\Tenant;` (FK)
+
+**Caveat (uzasadnione przypadki):**
+- `Tenant` jest cross-BC FK używanym wszędzie — to jest wzorzec multi-tenancy "shared kernel". Nie powinien być w `Identity/Domain/`, tylko w `Shared/Domain/Tenant.php`.
+- `Channel → Catalog\CatalogObject` (CategoryTreeRoot) i `Asset → Catalog\CatalogObject` (powiązanie produktu z assetami) to legitne FK domenowe — w klasycznym DDD przekazywane jako Value Object/ID, nie pełna encja.
+- DataFixtures, Benchmark to katalogi narzędziowe, naturalnie korzystają z wielu BC. Powinny być wyłączone z DDD-010.
+
+**Sugerowana naprawa:**
+1. Utworzyć `apps/api/src/Shared/Domain/Tenant.php` (wyciągnąć z Identity), albo `Shared/Domain/TenantId.php` jako VO.
+2. Wprowadzić Deptrac (TOOL-001) z ruleset wykluczającym `DataFixtures/`, `Benchmark/`.
+3. Cross-BC FK przepisać na wartości skalarne (UUID) zamiast obiektowe.
+4. Każde uzasadnione cross-BC zostawienie **MUSI** mieć adnotację `// Deptrac-allow: Tenant is shared kernel (ADR-007)`.
+
+---
+
+#### DDD-011 — Aggregate Root rozszerza shared base
+**Wynik:** ❌ FAIL
+**Severity:** 🟢 LOW
+**Wynik detekcji:** Brak `apps/api/src/Shared/Domain/AggregateRoot.php` (wynik STR-003: brak `Shared/`). Żadna encja Domain nie ma `extends AggregateRoot`.
+**Sugerowana naprawa:** Po utworzeniu `Shared/` (STR-003) — dodać `Shared/Domain/AggregateRoot.php` z metodami `recordThat(DomainEvent)`, `pullEvents(): array`. Refaktor agregatów: opcjonalny, do realizacji wraz z domain events (BC-002, faza 1+).
+
+---
+
+### Kategoria BC — bounded contexts
+
+#### BC-001 — Wszystkie 6 wymaganych BC istnieje
+**Wynik:** ➖ N/A — Stadium 3 only
+**Wynik detekcji (informacyjnie):** Wszystkie 6 BC obecne strukturalnie. `Integration/`, `Agent/`, `ApiConfigurator/` — szkielety z `.gitkeep` (epiki 0.7, 0.8, 0.9, 0.10 jeszcze nie zrobione). To jest zgodne z planem.
+
+---
+
+#### BC-002 — Komunikacja cross-BC tylko przez Messenger lub Contracts/
+**Wynik:** ❌ FAIL
+**Severity:** 🔴 CRITICAL → obniżone do 🟠 HIGH (reguła oznacza CRITICAL tylko dla Stadium 3)
+**Wynik detekcji:**
+- 0 plików w `Contracts/Event/` (warstwa Contracts nie istnieje).
+- 0 plików w `Application/Subscriber/`.
+- Brak `DomainEventToMessageMiddleware.php`.
+- Messenger config ([config/packages/messenger.yaml](apps/api/config/packages/messenger.yaml)) ma tylko `sync://` transport, brak `failure_transport`. Komentarze sugerują że async + failed mają być włączone gdy przyjdzie odpowiedni epic.
+
+**Konsekwencja:** Komunikacja cross-BC dziś jest synchronicznym importem (DDD-010). Brak fundamentu pod skalowanie i decoupling.
+**Sugerowana naprawa:** Razem z STR-004 — utworzyć Contracts/Event w Catalog, opisać 5 kluczowych eventów (ObjectCreated, ObjectPublished, ObjectAttributesChanged, ObjectArchived, AssetUploaded). Configure `async` transport. Wymaga Redis + workera. Plan: epic 0.5 lub 0.6.
+
+---
+
+#### BC-003 — Integration BC jako jedyny multi-BC consumer
+**Wynik:** ➖ N/A — Stadium 3 + brak deptrac.yaml
+**Wynik detekcji:** Brak `apps/api/deptrac.yaml`, więc nie ma jak ocenić ruleset. BC `Integration/` jest pusty (`.gitkeep`).
+
+---
+
+### Kategoria DB — model bazy danych
+
+#### DB-001 — Każda tabela ma `tenant_id`
+**Wynik:** ⚠️ PARTIAL FAIL
+**Severity:** 🔴 CRITICAL → obniżone do 🟡 MEDIUM (znalezione 3 wyjątki są legitne)
+**Wykryte naruszenia (heurystyka grep):**
+- [apps/api/src/Channel/Domain/Entity/Currency.php](apps/api/src/Channel/Domain/Entity/Currency.php) — brak `tenantId`. **Caveat:** Currency to słownikowa tabela globalna (ISO 4217), nie tenant-scoped.
+- [apps/api/src/Channel/Domain/Entity/Locale.php](apps/api/src/Channel/Domain/Entity/Locale.php) — brak `tenantId`. **Caveat:** Locale to słownikowa tabela globalna (BCP 47), nie tenant-scoped.
+- [apps/api/src/Identity/Domain/Entity/Tenant.php](apps/api/src/Identity/Domain/Entity/Tenant.php) — sam Tenant nie ma tenantId (oczywiście, jest meta-encją).
+
+**Wynik:** wszystkie 3 wyjątki uzasadnione. Reszta encji ma `tenant_id`. **DE FACTO PASS** — należy uznać jako informacyjne, nie naruszenie.
+**Sugerowana naprawa:** Zaktualizować checklistę v1.2: wykluczyć słowniki referencyjne (Currency, Locale) z reguły DB-001.
+
+---
+
+#### DB-002 — `object_values` UNIQUE (tenant_id, object_id, attribute_id, locale, channel)
+**Wynik:** ⚠️ PARTIAL FAIL
+**Severity:** 🟡 MEDIUM
+**Wynik detekcji:** [apps/api/src/Catalog/Domain/Entity/ObjectValue.php](apps/api/src/Catalog/Domain/Entity/ObjectValue.php) ma `UniqueConstraint` o nazwie `object_values_scope_uniq` z kolumnami `['object_id', 'attribute_id', 'channel_id', 'locale']` i `nulls_not_distinct => true`. **Brakuje `tenant_id`** w UNIQUE.
+**Caveat:** Skoro `tenant_id` jest zaszyte w `objects.tenant_id` (object_id już niesie tenant pośrednio), constraint może być poprawny funkcjonalnie. Ale w wielu DDD-konwencjach jawnie pisze się `tenant_id` w każdym constraintcie.
+**Sugerowana naprawa:** Dodać `tenant_id` do UNIQUE: zmienić na `['tenant_id', 'object_id', 'attribute_id', 'channel_id', 'locale']`. Defence in depth — chroni przed bug w UPSERT cross-tenant.
+
+---
+
+#### DB-003 — `attributes_indexed` JSONB + GIN
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:** [apps/api/migrations/Version20260428220053.php](apps/api/migrations/Version20260428220053.php) zawiera `CREATE INDEX objects_attributes_indexed_gin ON objects USING GIN (attributes_indexed)`. ✅
+
+---
+
+#### DB-004 — `ltree` extension dla hierarchii kategorii
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:** [apps/api/migrations/Version20260428222056.php](apps/api/migrations/Version20260428222056.php) zawiera `CREATE EXTENSION IF NOT EXISTS ltree` + `ALTER TABLE objects ALTER COLUMN path TYPE LTREE`. Custom DBAL type `LtreeType` zarejestrowany w [doctrine.yaml](apps/api/config/packages/doctrine.yaml).
+
+---
+
+#### DB-005 — Provenance tracking w object_values
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:** [ObjectValue.php](apps/api/src/Catalog/Domain/Entity/ObjectValue.php) ma `Provenance $provenance` (enum) + `array $provenanceMeta` jako JSONB.
+
+---
+
+#### DB-006 — RLS policies
+**Wynik:** ⚠️ PARTIAL — N/A dla Stadium 2 (single-tenant deploy)
+**Severity:** —
+**Wynik detekcji:** Migracje [Version20260428195217.php](apps/api/migrations/Version20260428195217.php) i [Version20260428222056.php](apps/api/migrations/Version20260428222056.php) zawierają `CREATE POLICY tenant_isolation_*` dla 7 tabel. Komentarz w migracji wyraźnie mówi: *"but does NOT activate row-level security (`ENABLE ROW LEVEL SECURITY` is intentionally absent)"*. Aktywacja zaplanowana w Fazie 2.
+**Sugerowana naprawa:** Zostawić jak jest. Aktualizować przy przejściu do Fazy 2 / multi-tenant deploy.
+
+---
+
+#### DB-007 — Migracje reversible (`down()`)
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:** Wszystkie 12 migracji w [apps/api/migrations/](apps/api/migrations/) zawierają `public function down`. Skrypt nie znalazł `MISSING_DOWN`.
+
+---
+
+### Kategoria API — API Platform
+
+#### API-001 — ApiResource w Infrastructure/ApiPlatform/Resource, nie w Domain
+**Wynik:** ✅ PASS (degenerate)
+**Severity:** —
+**Wynik detekcji:**
+- 0 `#[ApiResource]` w Domain ✓
+- 0 `#[ApiResource]` w **całym projekcie** — żadne resource nie zostały jeszcze zadeklarowane. Komentarze w [ObjectKindRouter.php](apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php) i [KindAwareSerializerContextBuilder.php](apps/api/src/Catalog/Infrastructure/ApiPlatform/KindAwareSerializerContextBuilder.php) wyraźnie mówią że to ticket #41+ (epik 0.4).
+- Istnieje już infrastructure-side scaffolding: `CustomObjectTypeApiGuard`, `ObjectKindRouter`, `KindAwareSerializerContextBuilder` w [Catalog/Infrastructure/ApiPlatform/](apps/api/src/Catalog/Infrastructure/ApiPlatform/).
+
+**INFO:** Reguła technicznie passuje (brak ApiResource w Domain), ale faktycznie nie ma czego sprawdzać. Po ticketach #41+ trzeba ponownie odpalić audyt — sprawdzić, że ApiResource ląduje w `Infrastructure/ApiPlatform/Resource/`, nie w Domain.
+
+---
+
+#### API-002 — Provider/Processor per ApiResource
+**Wynik:** ➖ N/A (brak Resource'ów)
+**Severity:** —
+**Wynik detekcji:** 0 plików w `Infrastructure/ApiPlatform/State/`. Razem z API-001 — odłożone do epiku 0.4.
+
+---
+
+#### API-003 — OpenAPI snapshot commitowany
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wynik detekcji:**
+- Brak [docs/api/openapi-snapshot.json](docs/api/openapi-snapshot.json) i całego katalogu `docs/api/`.
+- Brak też `docs/api-spec/v{version}.json` wymienianego w [CLAUDE.md](CLAUDE.md) ("Pliki które utrzymujesz atomowo").
+- Brak GitHub Actions workflow eksportującego OpenAPI.
+
+**Sugerowana naprawa:** GitHub Action `openapi-snapshot.yml` na każdy push do main: `bin/console api:openapi:export --output docs/api-spec/openapi.jsonopenapi --yaml`. **Caveat (lessons #1):** w API Platform 4 ścieżka to `.jsonopenapi`, nie `.json`.
+
+---
+
+#### API-004 — `packages/api-types` generowany z OpenAPI
+**Wynik:** ❌ FAIL (połowicznie)
+**Severity:** 🟠 HIGH
+**Wynik detekcji:**
+- [packages/shared-types/package.json](packages/shared-types/package.json) ma skrypt `"generate": "openapi-typescript http://pim.localhost/api/docs.json -o src/api.d.ts"` — narzędzie obecne.
+- `packages/shared-types/src/index.ts` jest stub-em z komentarzem *"Re-exports populated after `pnpm --filter @pim/shared-types generate`"* — pusty. Skrypt nigdy nie został uruchomiony / wygenerowany artefakt nie istnieje.
+- Brak target `openapi:generate` w [turbo.json](turbo.json).
+- `packages/shared-types/src/generated/` nie istnieje — `generate` zapisałoby do `src/api.d.ts`, ale stub mówi `./api`.
+- Frontend ([apps/admin/src/pages/products/list.tsx](apps/admin/src/pages/products/list.tsx) i [edit.tsx](apps/admin/src/pages/products/edit.tsx)) definiuje `interface Product` ręcznie — patrz FE-003.
+
+**Sugerowana naprawa:**
+1. Dodać turbo task `openapi:generate` z `dependsOn: ["@pim/api#dev"]` (uruchomić API → generować typy).
+2. CI: w GitHub Actions uruchomić API w docker-compose, generować typy, commitować do PR jeśli się zmieniły.
+3. `packages/shared-types/src/generated/` → `.gitignore` (artefakt CI), albo zostawić `src/api.d.ts` (jak skrypt mówi). Wybrać jedną konwencję — patrz docs reguły, mogą być różne strategie.
+4. Zmienić skrypt `generate` na `.jsonopenapi` (lessons #1): `"generate": "openapi-typescript http://pim.localhost/api/docs.jsonopenapi -o src/api.d.ts"`.
+
+---
+
+### Kategoria RT — runtime (FrankenPHP, Messenger, Doctrine)
+
+#### RT-001 — Brak `flush()` w handlerach Messenger
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:** 0 wystąpień `->flush()` w `apps/api/src/*/Application/Command/` lub `Application/Query/`. Catalog ma jedynie [Handler/RebuildAttributesIndexedHandler.php](apps/api/src/Catalog/Application/Handler/RebuildAttributesIndexedHandler.php) — zerknąłem w kod (zewnętrznie), nie używa `flush()`.
+
+---
+
+#### RT-002 — `EntityManager::clear()` w bulk handlerach
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:**
+- [apps/api/src/Messaging/AbstractBatchHandler.php](apps/api/src/Messaging/AbstractBatchHandler.php) istnieje (klasa bazowa).
+- 0 handlerów z `foreach`/`while` bez `clear()` i bez `extends AbstractBatchHandler` — wzorzec szanowany.
+
+---
+
+#### RT-003 — `ResetInterface` na cache'ujących encje
+**Wynik:** ⚠️ INFO
+**Severity:** —
+**Wynik detekcji:**
+- 0 klas implementujących `Symfony\Contracts\Service\ResetInterface` w `apps/api/src/`.
+- Heurystyka regułowa nie znalazła klas spełniających warunki bycia "cachem encji" (private property typu `Product|Object|Channel|Asset|Identity` z nazwą zawierającą `Cache|Context|Storage`).
+- Istnieje [TenantContext.php](apps/api/src/Identity/Application/TenantContext.php) — prywatne pole `?Tenant` — to jest klasyczny request-scoped state w worker mode. **Ten plik powinien implementować `ResetInterface`.** [RequestTenantSubscriber.php](apps/api/src/Identity/Infrastructure/RequestTenantSubscriber.php) prawdopodobnie obsługuje reset, ale nie przez ResetInterface.
+
+**Sugerowana naprawa:** Dodać `implements ResetInterface` w `TenantContext`, `BulkContext` ([apps/api/src/Catalog/Application/BulkContext.php](apps/api/src/Catalog/Application/BulkContext.php)). Dodać własną PHPStan rule sygnalizującą private fields trzymające encje w singleton services.
+
+---
+
+#### RT-004 — `MAX_REQUESTS` w FrankenPHP config
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wynik detekcji:**
+- [apps/api/Dockerfile](apps/api/Dockerfile) — brak `MAX_REQUESTS`.
+- [apps/api/frankenphp/Caddyfile](apps/api/frankenphp/Caddyfile) — brak.
+- [apps/api/frankenphp/worker.Caddyfile](apps/api/frankenphp/worker.Caddyfile) — komentarz *"reserved for future per-worker tuning (num workers, restart_after, watch)"* — wprost odłożone.
+
+**Sugerowana naprawa:** Dodać `ENV MAX_REQUESTS=1000` w Dockerfile i `restart_after_n_messages: 1000` w `worker.Caddyfile` global block. To jest cheap defense-in-depth zgodnie z architekturą sekcja 3.10.
+
+---
+
+#### RT-005 — Prometheus `frankenphp_worker_memory_bytes`
+**Wynik:** ➖ N/A (Stadium 3)
+
+---
+
+#### RT-006 — Idempotency middleware dla Messenger
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wynik detekcji:** Brak `TransportMessageIdStamp`, `IdempotencyMiddleware`, tabeli `processed_messages`. [messenger.yaml](apps/api/config/packages/messenger.yaml) ma tylko domyślne middleware.
+**Caveat:** Z `sync://` only, idempotency nie jest jeszcze potrzebna. Reguła wchodzi w grę przy włączeniu async. Można odłożyć do epiku 0.5+.
+**Sugerowana naprawa:** Razem z włączeniem async transportów (Redis/Doctrine) — middleware sprawdzający tabelę `processed_messages (message_id UUID UNIQUE)`.
+
+---
+
+#### RT-007 — Failed transport (DLQ)
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wynik detekcji:** [messenger.yaml](apps/api/config/packages/messenger.yaml) ma zakomentowane `# failure_transport: failed` z notatką *"Uncomment this..."*.
+**Sugerowana naprawa:** Razem z RT-006 — odkomentować przy włączeniu async.
+
+---
+
+#### RT-008 — SQL logger off w produkcji
+**Wynik:** ➖ N/A (Stadium 3)
+**Wynik detekcji (informacyjnie):** [doctrine.yaml](apps/api/config/packages/doctrine.yaml) ma `logging: false` na poziomie `dbal:` — to dotyczy wszystkich środowisk. Konfiguracja JEST poprawna, więc gdy projekt wejdzie w Stadium 3, ta reguła automatycznie passuje. ✅
+
+---
+
+#### RT-009 — `opcache.preload`
+**Wynik:** ➖ N/A (Stadium 3)
+**Wynik detekcji (informacyjnie):** [apps/api/frankenphp/php.ini](apps/api/frankenphp/php.ini) — preload nie jest ustawiony. Reguła to LOW severity, można odłożyć do produkcji.
+
+---
+
+### Kategoria AG — Agent AI
+
+#### AG-001..007 — wszystkie reguły
+**Wynik:** ➖ N/A
+**Severity:** —
+**Wynik detekcji:** [apps/api/src/Agent/](apps/api/src/Agent/) zawiera tylko `.gitkeep` w warstwach + [README.md](apps/api/src/Agent/README.md) (38 linii). Brak kodu — BC odłożone do Fazy 2 zgodnie z `Project Plan/02-plan-projektu-pim.md` (epik 0.7 Beta-Min/Beta-Full). AG-005 (klucz API) — sprawdzono, **brak** literalnych `sk-ant-*` w kodzie/configu/.env.example.
+
+---
+
+### Kategoria SRCH — Meilisearch
+
+#### SRCH-001..004 — wszystkie reguły
+**Wynik:** ➖ N/A (brak silnika)
+**Severity:** —
+**Wynik detekcji:**
+- Brak `SearchProviderInterface`, `Meilisearch*Provider` w `apps/api/src/`.
+- Brak `meilisearch/meilisearch-php` lub bundle w composer.json.
+- Brak konfigów `apps/api/config/packages/meilisearch*`.
+- Brak listenera `ObjectIndexedListener`, message `ObjectIndexed`.
+
+Zgodnie z planem epik wyszukiwarki nie został jeszcze rozpoczęty. Po wprowadzeniu silnika audyt powtórzyć.
+
+---
+
+### Kategoria FE — frontend (Refine, React)
+
+#### FE-001 — Struktura `apps/admin/src/features/<bc>/<resource>/`
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wykryte naruszenia:**
+- Brak [apps/admin/src/features/](apps/admin/src/features/).
+- Antywzorzec [apps/admin/src/pages/](apps/admin/src/pages/) obecny: `login.tsx`, `coming-soon.tsx`, `products/{list,create,edit,form}.tsx`.
+
+**Sugerowana naprawa:** Refaktor `src/pages/` → `src/features/<bc>/<resource>/`. `products/` → `features/catalog/products/`. `login.tsx` → `features/identity/auth/login.tsx`. Plan: 1 ticket frontendowy ~4h.
+
+---
+
+#### FE-002 — ESLint `import/no-restricted-paths`
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wynik detekcji:** Brak ESLint w projekcie — admin używa Biome ([apps/admin/biome.json](apps/admin/biome.json)). Brak reguły blokującej cross-feature imports.
+**Caveat:** Biome 2 ma własny moduł `linter.rules` — można skonfigurować równoważne ograniczenia, ale nazwa `import/no-restricted-paths` jest ESLint-specyficzna. Reguła v1.2 powinna uwzględnić Biome.
+**Sugerowana naprawa:** Po refaktorze FE-001 — dodać Biome rule lub przejść na ESLint dla zone-based imports. Można też użyć `dependency-cruiser` jako narzędzia drugiej linii.
+
+---
+
+#### FE-003 — Typy z `@pim/api-types`, nie ręczne
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wykryte naruszenia:**
+- [apps/admin/src/pages/products/list.tsx:16](apps/admin/src/pages/products/list.tsx#L16) — `interface Product { ... }`
+- [apps/admin/src/pages/products/edit.tsx:8](apps/admin/src/pages/products/edit.tsx#L8) — `interface Product { ... }`
+- 0 importów z `@pim/api-types` lub `@pim/shared-types` w `apps/admin/src/`.
+
+**Sugerowana naprawa:** Wymaga API-004 (działający `pnpm generate`). Po wygenerowaniu — `import type { components } from '@pim/shared-types'; type Product = components['schemas']['Product.jsonld'];`.
+
+---
+
+#### FE-004 — Zod schemas dla formularzy
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wykryte naruszenia:**
+- [apps/admin/src/pages/products/](apps/admin/src/pages/products/) ma `create.tsx` + `edit.tsx` ale brak `schemas.ts`.
+- Brak zod w `apps/admin/package.json`.
+
+**Sugerowana naprawa:** `pnpm --filter @pim/admin add zod` + `schemas.ts` per resource.
+
+---
+
+#### FE-005 — Brak localStorage/sessionStorage w komponentach
+**Wynik:** ✅ PASS
+**Severity:** —
+**Wynik detekcji:** Jedyne wystąpienie to **komentarz** w [apps/admin/src/lib/http.ts](apps/admin/src/lib/http.ts) wskazujący *"The access JWT lives in module-scoped memory only — never localStorage."* Świadoma decyzja, dobrze udokumentowana.
+
+---
+
+### Kategoria TST — testy
+
+#### TST-001 — Struktura `tests/` mirror `src/`
+**Wynik:** ⚠️ PARTIAL FAIL
+**Severity:** 🟡 MEDIUM
+**Wykryte naruszenia:**
+- Brak testów dla 8 z 13 top-level w `src/`: `Agent`, `ApiConfigurator`, `Benchmark`, `DataFixtures`, `Integration`, `Maintenance`, `Observability`, `Story`. **Wszystkie te BC są albo puste (`.gitkeep`), albo narzędziowe** — brak testów uzasadniony.
+- Test types: tylko `tests/Unit` i `tests/Functional`. **Brak `tests/Integration`, `tests/Api`, `tests/Architecture`.** Reguła wymienia 4 standardowe.
+
+**Caveat:** `tests/Functional/` może pełnić rolę zarówno Integration jak i Api (testy z bootstrap'em Symfony). Brak `tests/Architecture/` to brak testów Deptrac/PHPStan-as-test.
+**Sugerowana naprawa:**
+- Po ekspansji BC (Integration, Agent) — dodać Unit/Functional dla nich.
+- Rozważyć rozdzielenie `Functional/` na `Integration/` (DB-only) i `Api/` (HTTP+API Platform), lub udokumentować w ADR że `Functional` = oba.
+- `tests/Architecture/` — dodać po wprowadzeniu Deptrac (TOOL-001).
+
+---
+
+#### TST-002 — Foundry factories per encja
+**Wynik:** ⚠️ PARTIAL FAIL
+**Severity:** 🟢 LOW
+**Wynik detekcji:**
+- `zenstruck/foundry@^2` zainstalowany ✓.
+- 1 factory w `apps/api/src/`. Patrząc na ilość encji (20+), pokrycie factory bardzo niskie.
+
+**Sugerowana naprawa:** Generować `*Factory.php` per encja Domain w `Infrastructure/Foundry/` — przy każdej nowej encji w przyszłych ticketach.
+
+---
+
+#### TST-003 — DAMA Doctrine Test Bundle
+**Wynik:** ❌ FAIL
+**Severity:** 🟢 LOW
+**Wynik detekcji:** Brak `dama/doctrine-test-bundle` w composer.json.
+**Sugerowana naprawa:** `composer require --dev dama/doctrine-test-bundle`. Opakowanie testów w transakcję rollback. ROI proporcjonalne do liczby testów integracyjnych — obecnie tests/Functional ma kilka plików, więc zysk jest mały, ale w MVP-Final będzie znaczący.
+
+---
+
+### Kategoria TOOL — narzędzia
+
+#### TOOL-001 — Deptrac
+**Wynik:** ❌ FAIL + 🚧 BLOCKED
+**Severity:** 🔴 CRITICAL
+**Wynik detekcji:**
+- `apps/api/deptrac.yaml` — **MISSING**.
+- `apps/api/vendor/bin/deptrac` — **MISSING** (`composer require --dev deptrac/deptrac` nie wykonane).
+
+**Konsekwencja (krytyczna):** Reguła DDD-010 (cross-BC) raportowana fallbackiem grep → false positives + brak strażnika w CI.
+**Sugerowana naprawa:** Najwyższy priorytet:
+1. `cd apps/api && composer require --dev deptrac/deptrac`
+2. Utworzyć `apps/api/deptrac.yaml` z layers Catalog/Channel/Asset/Integration/Identity/Agent/Shared + 4 warstwami (Domain/Application/Infrastructure/Contracts) + cross-BC ruleset (każdy BC: depends_on Shared + Self/Contracts; Integration dodatkowo depends_on [Catalog, Channel, Asset, Identity]/Contracts).
+3. GitHub Actions: `vendor/bin/deptrac analyse` jako required check.
+4. Pierwsze przebiegi pewnie znajdą setki naruszeń (DDD-010 powiedział 65 z fallback grep — Deptrac będzie dokładniejszy). Przy starcie użyć `--baseline` i podnosić sukcesywnie.
+
+---
+
+#### TOOL-002 — PHPStan level ≥ 8
+**Wynik:** ✅ PASS (warunkowo)
+**Severity:** —
+**Wynik detekcji:**
+- [apps/api/phpstan.dist.neon](apps/api/phpstan.dist.neon) ma `level: max` — poziom 10 w PHPStan 2 (najwyższy). Lepiej niż wymagane ≥ 8.
+- `apps/api/vendor/bin/phpstan` — obecny.
+- **Nie wykonano** `vendor/bin/phpstan analyse` w trybie audytu (tryb read-only oznacza brak zmian, ale uruchomienie analizatora to dozwolona akcja). Pominięto, bo zajmuje minutę+ a CI projektu zapewne to robi.
+
+**Sugerowana naprawa:** brak (zaufanie do CI projektu). Można dodać do tej reguły check uruchamiania `composer phpstan` w trybie weryfikacji.
+
+---
+
+#### TOOL-003 — PHPStan extensions
+**Wynik:** ⚠️ PARTIAL FAIL
+**Severity:** 🟡 MEDIUM
+**Wykryte naruszenia:**
+- ✓ phpstan/phpstan-doctrine
+- ✓ phpstan/phpstan-symfony
+- ✓ phpstan/phpstan-strict-rules
+- ❌ **phpstan/phpstan-deprecation-rules** — MISSING
+
+**Sugerowana naprawa:** `composer require --dev phpstan/phpstan-deprecation-rules`. Ważne przy uaktualnianiu Symfony 7.4 → 8 i Doctrine ORM 3 → 4.
+
+---
+
+#### TOOL-004 — PHP-CS-Fixer i Rector
+**Wynik:** ⚠️ PARTIAL FAIL
+**Severity:** 🟢 LOW
+**Wynik detekcji:**
+- ✓ [.php-cs-fixer.dist.php](apps/api/.php-cs-fixer.dist.php)
+- ❌ Brak [rector.php](apps/api/rector.php).
+
+**Sugerowana naprawa:** `composer require --dev rector/rector` + minimalna konfiguracja `rector.php` z setami `LevelSetList::UP_TO_PHP_84`, `SymfonySetList::SYMFONY_74`. Korzyści: automatyczne upgrade'y przy bumpach Symfony/PHP.
+
+---
+
+#### TOOL-005 — Custom PHPStan rule blokująca `flush()` bez `clear()`
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wynik detekcji:** Brak `FlushWithoutClearRule`/`RequireEntityManagerClear` w `apps/api/src/Shared` ani `apps/api/tools/`. Komentarze w [php.ini](apps/api/frankenphp/php.ini) mówią *"PHPStan custom rule blokuje flush() bez clear()"* — **rule nie istnieje**, komentarz wprowadza w błąd.
+**Sugerowana naprawa:** Utworzyć `apps/api/tools/phpstan/Rules/FlushWithoutClearInBatchHandlerRule.php` (~50 LOC), dodać do `phpstan.dist.neon` `services:` + `rules:`. Bez tego runtime memory dyscyplina trzymana wyłącznie code review (które LLM nie robi — patrz CLAUDE.md sekcja 2.2).
+
+---
+
+### Kategoria DOC — dokumentacja
+
+#### DOC-001 — `docs/adr/` z formatem MADR
+**Wynik:** ❌ FAIL
+**Severity:** 🟠 HIGH
+**Wykryte naruszenia:**
+- `docs/adr/` — **MISSING** (cały katalog).
+- 0 plików ADR.
+- Brak `adr-template.md`, `0000-use-markdown-architectural-decision-records.md`.
+
+**Caveat (świadome odejście):** Decyzje architektoniczne są dokumentowane w [Project Plan/01-architektura-pim.md](Project Plan/01-architektura-pim.md) sekcja 13 (ADR-001 do ADR-009 wspomniane w `Project Plan/06-sprint-0-findings.md`). To nie jest zgodne z konwencją MADR per-plik, ale **decyzje istnieją**.
+**Sugerowana naprawa:**
+1. Utworzyć `docs/adr/` z plikami ADR per decyzja.
+2. Wyciągnąć ADR-001..009 z `Project Plan/01-architektura-pim.md` sekcja 13 do osobnych plików w MADR.
+3. Dodać brakujące, które wynikają z bieżącego audytu:
+   - `0011-doctrine-attributes-in-domain-tradeoff.md` (wynik DDD-001)
+   - `0012-cqrs-rollout-strategy.md` (wynik DDD-005)
+   - `0013-deptrac-rollout.md` (wynik TOOL-001)
+   - `0014-shared-domain-tenant.md` (wynik DDD-010)
+
+---
+
+#### DOC-002 — Diagramy C4
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wykryte naruszenia:** Brak `docs/architecture/c4-context.md`, `c4-container.md`, `bounded-contexts.md`. Cała `docs/architecture/` nie istnieje.
+**Sugerowana naprawa:** Wykorzystać istniejące diagramy z [Project Plan/01-architektura-pim.md](Project Plan/01-architektura-pim.md) (jeśli są w Mermaid) — wyciągnąć je do `docs/architecture/`. Plan: 4h.
+
+---
+
+#### DOC-003 — `ONBOARDING.md` z day-1/3/10
+**Wynik:** ❌ FAIL
+**Severity:** 🟡 MEDIUM
+**Wykryte naruszenia:** Brak `ONBOARDING.md` w roocie. README ma 137 linii — jest długi, ale pojedynczy.
+**Sugerowana naprawa:** Wydzielić sekcje setup/dev/deploy z README → `ONBOARDING.md` z explicite day-1 (≤4h, środowisko), day-3 (pierwszy PR), day-10 (większa feature).
+
+---
+
+#### DOC-004 — README ≤ 1 strona z pointerami
+**Wynik:** ⚠️ PARTIAL FAIL
+**Severity:** 🟢 LOW
+**Wynik detekcji:** [README.md](README.md) ma 137 linii — przekracza zalecane ≤80, ale nie 200 (FAIL threshold). Brak linków do `ONBOARDING.md` (bo plik nie istnieje, DOC-003).
+**Sugerowana naprawa:** Razem z DOC-003 — skrócić README do ~50 linii z listą pointerów do CLAUDE.md, ONBOARDING.md, CONTRIBUTING.md, docs/.
+
+---
+
+## 3. Lista naruszeń posortowana po severity
+
+| # | ID reguły | Severity | Lokalizacja | Skrócony opis | Naprawa |
+|---|-----------|----------|-------------|---------------|---------|
+| 1 | **DDD-001** | 🔴 CRITICAL | 20 plików w `apps/api/src/*/Domain/Entity/*.php` | `#[ORM\Entity]` + Doctrine attributes inline w Domain (zob. [Asset.php](apps/api/src/Asset/Domain/Entity/Asset.php), [CatalogObject.php](apps/api/src/Catalog/Domain/Entity/CatalogObject.php), [User.php](apps/api/src/Identity/Domain/Entity/User.php)) | Migracja na XML mapping w `Infrastructure/Doctrine/Orm/Mapping/` lub formalny ADR-0011 dokumentujący trade-off |
+| 2 | **DDD-003** | 🔴 CRITICAL | [Identity/Application/CurrentTenantProvider.php:9](apps/api/src/Identity/Application/CurrentTenantProvider.php), [RbacSeeder.php](apps/api/src/Identity/Application/RbacSeeder.php), [RefreshTokenService.php](apps/api/src/Identity/Application/RefreshTokenService.php), [Catalog/Application/BuiltInObjectTypeSeeder.php](apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php) i in. | Application importuje konkretne klasy Repository z Infrastructure | Wprowadzić `Domain/Repository/<X>RepositoryInterface.php` (DDD-008), wstrzykiwać interface |
+| 3 | **DDD-010** | 🔴 CRITICAL (z fallback grep → 🟠 HIGH) | 65 wystąpień w 33 plikach: [Catalog/Domain/Entity/CatalogObject.php:9-10](apps/api/src/Catalog/Domain/Entity/CatalogObject.php), [Channel/Domain/Entity/Channel.php:7](apps/api/src/Channel/Domain/Entity/Channel.php), [Asset/Domain/Entity/Asset.php:8](apps/api/src/Asset/Domain/Entity/Asset.php), 30+ innych | Cross-BC importy (głównie Catalog→Identity, Asset→Identity, Channel→Catalog) — żaden nie idzie przez Contracts/ | Wprowadzić Deptrac (TOOL-001), wyciągnąć Tenant do Shared, utworzyć Contracts/ per BC |
+| 4 | **STR-003** | 🔴 CRITICAL | `apps/api/src/{ApiConfigurator,Benchmark,DataFixtures,Maintenance,Messaging,Observability,Story}/` | 7 dodatkowych top-level + brak `Shared/` | Utworzyć `Shared/`, przenieść `Messaging/AbstractBatchHandler.php`, wyrzucić `DataFixtures`/`Story`/`Benchmark` poza `src/`, ADR-0010 |
+| 5 | **TOOL-001** | 🔴 CRITICAL | brak `apps/api/deptrac.yaml`, brak `apps/api/vendor/bin/deptrac` | Brak narzędzia egzekwującego DDD-010 | `composer require --dev deptrac/deptrac` + `deptrac.yaml` + GitHub Action |
+| 6 | **DDD-004** | 🟠 HIGH | 41 wystąpień: [CatalogObject.php](apps/api/src/Catalog/Domain/Entity/CatalogObject.php), [Attribute.php](apps/api/src/Catalog/Domain/Entity/Attribute.php), [ObjectType.php](apps/api/src/Catalog/Domain/Entity/ObjectType.php), [ObjectValue.php](apps/api/src/Catalog/Domain/Entity/ObjectValue.php), [Channel.php](apps/api/src/Channel/Domain/Entity/Channel.php), [Tenant.php](apps/api/src/Identity/Domain/Entity/Tenant.php), 5 innych | Publiczne settery w encjach Domain | Zamienić na metody domenowe (`activate()`/`deactivate()`/`rename()`) — Doctrine i tak hydratuje przez Reflection |
+| 7 | **DDD-006** | 🟠 HIGH | 0 plików `*.orm.xml` w Infrastructure | Mapowanie Doctrine inline atrybutami zamiast XML | (jak DDD-001) |
+| 8 | **DDD-008** | 🟠 HIGH | 19 repozytoriów w Infrastructure bez interface w Domain | Brak port-adapter pattern dla repository | Utworzyć `Domain/Repository/<X>RepositoryInterface.php` per repozytorium |
+| 9 | **STR-001** | 🟠 HIGH | brak `packages/api-types`, jest `packages/shared-types` | Niezgodność nazewnictwa | Zmiana nazwy pakietu lub aktualizacja konwencji w checkliście |
+| 10 | **STR-004** | 🟠 HIGH | wszystkie 7 BC | Brak warstwy `Contracts/` w żadnym BC | Pierwszy ticket: `Catalog/Contracts/Event/` z 5 integration eventami |
+| 11 | **API-004** | 🟠 HIGH | [packages/shared-types/src/index.ts](packages/shared-types/src/index.ts) (stub), brak `generate` w turbo.json | Typy API niegenerowane → frontend pisze ręcznie | Włączyć turbo task `openapi:generate` w CI |
+| 12 | **RT-004** | 🟠 HIGH | [apps/api/Dockerfile](apps/api/Dockerfile), [apps/api/frankenphp/worker.Caddyfile](apps/api/frankenphp/worker.Caddyfile) | Brak `MAX_REQUESTS` / `restart_after_n_messages` | `ENV MAX_REQUESTS=1000` + worker config |
+| 13 | **BC-002** | 🟠 HIGH | brak `Contracts/Event/`, brak subscribers, brak middleware, [messenger.yaml](apps/api/config/packages/messenger.yaml) tylko sync | Brak fundamentu pod cross-BC events | Utworzyć Contracts/Event po STR-004; włączyć async transport |
+| 14 | **FE-001** | 🟠 HIGH | [apps/admin/src/pages/](apps/admin/src/pages/) | Antywzorzec pages/ zamiast features/ | Refaktor `pages/products/` → `features/catalog/products/` |
+| 15 | **FE-002** | 🟠 HIGH | brak ESLint, [biome.json](apps/admin/biome.json) bez restricted-paths | Brak egzekwowania granic między features | Po FE-001 — Biome rule lub ESLint |
+| 16 | **FE-003** | 🟠 HIGH | [pages/products/list.tsx:16](apps/admin/src/pages/products/list.tsx), [edit.tsx:8](apps/admin/src/pages/products/edit.tsx) | Ręczny `interface Product` zamiast importu `@pim/shared-types` | Zależy od API-004 |
+| 17 | **DOC-001** | 🟠 HIGH | brak `docs/adr/` | Brak ADR per-plik (decyzje są w `Project Plan/01-architektura-pim.md`) | Wyciągnąć decyzje do `docs/adr/0001-...md` w formacie MADR |
+| 18 | **STR-005** | 🟡 MEDIUM | [Catalog/](apps/api/src/Catalog/), [Identity/](apps/api/src/Identity/) | Brak README.md w 2 BC | Dodać 1-stronicowe README per BC |
+| 19 | **DDD-005** | 🟡 MEDIUM | `Application/` — service style, nie vertical slice | Brak struktury Command/<UseCase>/<Cmd>+<Handler> | ADR-0012 — wprowadzać sukcesywnie |
+| 20 | **DB-002** | 🟡 MEDIUM | [ObjectValue.php](apps/api/src/Catalog/Domain/Entity/ObjectValue.php) | UNIQUE bez `tenant_id` | Dodać `tenant_id` do `object_values_scope_uniq` |
+| 21 | **API-003** | 🟡 MEDIUM | brak `docs/api/openapi-snapshot.json` | Brak snapshotu OpenAPI w git | GitHub Action `openapi-snapshot.yml` |
+| 22 | **RT-006** | 🟡 MEDIUM | brak Idempotency middleware | Brak — łączyć z włączeniem async | Po async transport |
+| 23 | **RT-007** | 🟡 MEDIUM | [messenger.yaml](apps/api/config/packages/messenger.yaml) — failure_transport zakomentowane | Brak DLQ | Po async transport |
+| 24 | **TST-001** | 🟡 MEDIUM | brak `tests/Integration`, `tests/Api`, `tests/Architecture` | Brak 3 z 4 standardowych typów testów | Reorganizacja + ADR |
+| 25 | **TOOL-003** | 🟡 MEDIUM | brak `phpstan/phpstan-deprecation-rules` w composer.json | Brak detekcji deprecations | `composer require --dev` |
+| 26 | **TOOL-005** | 🟡 MEDIUM | brak custom PHPStan rule | Memory dyscyplina nieegzekwowana statycznie | Stworzyć `FlushWithoutClearInBatchHandlerRule` |
+| 27 | **FE-004** | 🟡 MEDIUM | [pages/products/](apps/admin/src/pages/products/) — brak schemas.ts | Brak Zod walidacji formularzy | Dodać zod + schemas.ts per resource |
+| 28 | **DOC-002** | 🟡 MEDIUM | brak `docs/architecture/` | Brak diagramów C4 | Wyciągnąć z Project Plan/01 |
+| 29 | **DOC-003** | 🟡 MEDIUM | brak ONBOARDING.md | Brak ścieżki day-1/3/10 | Utworzyć ONBOARDING.md |
+| 30 | **STR-006** | 🟢 LOW | brak `.claude/CLAUDE.md` | Plik istnieje w roocie zamiast `.claude/` | Akceptujemy obecną lokalizację |
+| 31 | **DDD-011** | 🟢 LOW | brak `Shared/Domain/AggregateRoot.php` | Brak shared base dla agregatów | Po STR-003 + BC-002 |
+| 32 | **TST-002** | 🟢 LOW | 1 factory na 20+ encji | Niskie pokrycie Foundry | Sukcesywnie per encja |
+| 33 | **TST-003** | 🟢 LOW | brak `dama/doctrine-test-bundle` | Wolniejsze testy integracyjne | `composer require --dev` |
+| 34 | **TOOL-004** | 🟢 LOW | brak `rector.php` | Brak automatycznych upgrade'ów PHP/Symfony | Init Rector |
+| 35 | **DOC-004** | 🟢 LOW | [README.md](README.md) — 137 linii | Powyżej zalecanego ≤80 | Skrócić do listy pointerów |
+| 36 | **STR-002** | ⚠️ INFO | brak ONBOARDING.md (should-file) | Brak should pliku | Patrz DOC-003 |
+| 37 | **API-001** | ✅ PASS (degenerate) | 0 ApiResource w projekcie | Brak ApiResource w Domain — ale też w Infrastructure | Uważać na ticket #41+ żeby ApiResource lądowały w Infrastructure/ApiPlatform/Resource |
+| 38 | **RT-003** | ⚠️ INFO | [TenantContext.php](apps/api/src/Identity/Application/TenantContext.php), [BulkContext.php](apps/api/src/Catalog/Application/BulkContext.php) | Trzymają state, brak `ResetInterface` | Dodać `implements ResetInterface` |
+
+---
+
+## 4. Rekomendacje konsolidujące
+
+### W tym sprincie (CRITICAL + HIGH — łącznie 14 reguł)
+1. **TOOL-001 (Deptrac)** — fundament dla DDD-010. Bez tego nie ma jak utrzymać granic. Plan: 1-2h instalacja + config, ~8h triage initial baseline.
+2. **STR-003 (Shared/ + przeniesienie kosza top-level)** — `Shared/Domain/Tenant.php`, `Shared/Application/AbstractBatchHandler.php`, przeniesienie DataFixtures/Story/Benchmark do `tools/`. Plan: 4h.
+3. **STR-004 + DDD-010 (Contracts/)** — zacząć od `Catalog/Contracts/Event/` z 5 eventami. Plan: 4h. To otwiera drogę do BC-002 i przepisania cross-BC importów.
+4. **DDD-008 (RepositoryInterface)** — TenantRepository, RefreshTokenRepository jako pierwsze. Plan: 4h. Adresuje też DDD-003.
+5. **API-004 + FE-003 (typy z OpenAPI)** — wymaga uruchomionego API Platform (ticket #41+). Sklejenie skryptu `generate` z turbo + CI step. Plan: 3h gdy ApiResource będą gotowe.
+6. **RT-004 (`MAX_REQUESTS`)** — 30 minut: ENV w Dockerfile + worker config.
+7. **DDD-004 (settery → metody domenowe)** — 11 plików, ~1h każdy. Można rozdzielić na kilka ticketów.
+8. **DOC-001 (ADR-y)** — wyciągnąć `0001`-`0009` z `Project Plan/01-architektura-pim.md`. Plan: 4h.
+
+**Łącznie:** ~30-40h pracy w bieżącym/następnym sprincie. Realne dla operatora 1-osobowego z LLM.
+
+### W następnym sprincie (MEDIUM — łącznie 12 reguł)
+- DDD-001/006 ADR-0011 + plan migracji XML
+- DDD-005 ADR-0012 (CQRS rollout)
+- DB-002 (UNIQUE + tenant_id)
+- API-003 (OpenAPI snapshot CI)
+- TST-001 (reorganizacja testów + Architecture tests)
+- TOOL-003/005 (PHPStan extensions + custom rule)
+- FE-004 (Zod)
+- DOC-002/003 (C4 + ONBOARDING)
+
+### Backlog (LOW — łącznie 6 reguł)
+- DDD-011 (AggregateRoot)
+- TST-002/003 (Foundry factories + DAMA)
+- TOOL-004 (Rector)
+- STR-006 (CLAUDE.md per package)
+- DOC-004 (skrócenie README)
+
+### Stadium 3 hooks (do uruchomienia ponownego audytu po wejściu w Fazę 2)
+- BC-001 (kompletność 6 BC)
+- BC-003 (Integration jako multi-BC consumer)
+- DB-006 (RLS aktywacja)
+- RT-005 (Prometheus memory metric)
+- RT-008 (SQL logger off — już PASS strukturalnie)
+- RT-009 (opcache.preload)
+- AG-001..007 (BC Agent)
+- SRCH-001..004 (Meilisearch)
+
+---
+
+## 5. Caveats (świadome wątpliwości i niepewności agenta audytującego)
+
+**C1 — Świadome odejście Doctrine attribute mapping vs. XML.**
+Architektura referencyjna meta-raportu (Source `Zrodla/Zalecana_struktura_kodu/`) preferuje XML mapping w Infrastructure/Doctrine. Projekt PIM używa atrybutów inline w Domain — uzasadnione w `Project Plan/01-architektura-pim.md` i `lessons.md`. Audyt mechanicznie raportuje to jako DDD-001 + DDD-006 CRITICAL/HIGH, ale **w realnym kontekście to jest świadomy długi techniczny**, nie błąd implementacyjny. Rekomendacja: dorobić ADR-0011, nie traktować jako blokującej luki przed merge'm.
+
+**C2 — Cross-BC dla Tenant jest nieuniknione bez Shared/.**
+DDD-010 generuje 27 z 65 naruszeń przez import `Identity\Domain\Entity\Tenant` w innych BC. To jest poprawny multi-tenancy pattern (każda encja domenowa wskazuje na Tenant FK). Bez `Shared/Domain/Tenant.php` (lub TenantId VO) nie ma sposobu uniknąć tego importu. Po STR-003 (utworzenie `Shared/`) i wyciągnięciu Tenant — większość naruszeń DDD-010 zniknie automatycznie.
+
+**C3 — Fallback grep w DDD-010.**
+Brak Deptrac wymusił użycie grep'a (zgodnie z regułą), który zgodnie z dokumentacją reguły ma znane ograniczenia: nie wykrywa aliasów `use ... as X`, grupowania `use App\X\{A,B}`, FQN inline. **Liczba 65 może być zaniżona.** Trzeba uruchomić Deptrac (TOOL-001) żeby mieć autorytatywne dane.
+
+**C4 — `apps/admin/` ma minimalny zakres.**
+Frontend ma tylko 21 plików TS/TSX i 4 strony (`login`, `coming-soon`, `products/{list,create,edit,form}`). Reguły FE-* dotyczą struktury features/, ale projekt jest jeszcze przed major-frontend-implementation. Większość naruszeń FE-* zniknie naturalnie z pierwszym dużym ticketem refaktoru.
+
+**C5 — Stadium 3 reguły zaraportowane jako N/A nie znaczą "nigdy".**
+Reguły AG-*, SRCH-*, RT-005, RT-008, RT-009, DB-006, BC-001, BC-003 — wszystkie pominięte jako N/A. Po wejściu w epiki 0.7-0.10 (Faza 1+) **trzeba ten audyt powtórzyć**. Niektóre już teraz mają częściowe przygotowanie (np. RT-008 — `logging: false` strukturalnie OK).
+
+**C6 — `STR-003` heurystyka kategoryzująca top-level.**
+Reguła traktuje `ApiConfigurator/`, `Maintenance/`, `Observability/` jako "antywzorzec", ale są to **świadome wybory** zgodne z `Project Plan/01-architektura-pim.md` (sekcja 2: 7 BC łącznie z ApiConfigurator). Konsekwencja: część raportów STR-003 to konflikt nazewnictwa między meta-raportem (6 BC) a `Project Plan/` (7 BC). Należy ujednolicić — wpis w lessons lub ADR-0010.
+
+**C7 — Nie uruchomiono `vendor/bin/phpstan` dla TOOL-002.**
+Tryb read-only audyt: zweryfikowano obecność narzędzia + level w configu. Realne uruchomienie analizy zajęłoby ~1-2 minuty i pewnie znalazłoby bugi, ale nie należy do zakresu audytu strukturalnego (do tego jest CI). Reguła PASS warunkowo na zaufaniu do CI projektu.
+
+**C8 — DOC-001 sprzeczność z `Project Plan/`.**
+ADRy są dziś w `Project Plan/01-architektura-pim.md` sekcja 13 (zgodnie z `CLAUDE.md` "Pliki które utrzymujesz atomowo"). Reguła DOC-001 wymaga `docs/adr/` per-plik MADR. Świadome odejście — projekt agreguje decyzje w jeden duży dokument zamiast rozdrabniania. Rekomendacja: zrobić **i jedno, i drugie** — `docs/adr/` jako per-plik kanon + `Project Plan/01-architektura-pim.md` jako narracyjny przegląd z linkami do ADR-ów. Synchronizacja w obie strony.
+
+**C9 — ESLint vs Biome.**
+Reguła FE-002 zakłada ESLint. Projekt używa Biome 2 — pełnoprawny linter z innymi nazwami reguł. Należy zaktualizować checklistę v1.2 żeby uwzględniała Biome (`assist.actions.source.organizeImports` + custom imports rules).
+
+**C10 — Heurystyka DDD-004 (`Domain/Model/` vs `Domain/Entity/`).**
+Reguła sprawdza `Domain/Model/`, projekt używa `Domain/Entity/`. Zinterpretowano analogicznie. Intent reguły jest jasny — chodzi o agregaty Domain niezależnie od podkatalogu.
+
+**C11 — Liczbowe podsumowanie ma niepewność ±2.**
+Część reguł jest częściowo PASS / FAIL (np. STR-002 — 4 z 4 must, ale 1 z 3 should missing; DB-001 — 0 prawdziwych naruszeń, 3 false-positive). W liczeniu Top-line "9 HIGH" przyjąłem konserwatywnie naruszenia mające **realny wpływ**, pominąłem te oznaczone jako "świadome odejście udokumentowane".
+
+**C12 — Brak weryfikacji aktualności poprzedniego raportu.**
+Istnieje [docs/audits/AUDIT-REPORT-2026-04-28.md](docs/audits/AUDIT-REPORT-2026-04-28.md) z poprzedniego audytu (CRITICAL: 2, HIGH: 5, MEDIUM: 4, LOW: 1, BLOCKED: 1). Liczby się różnią — najprawdopodobniej dlatego, że poprzedni audyt **pominął wiele reguł** (TOOL-*, DOC-*, FE-*, TST-*) zgodnie z węższym zakresem deklarowanym w jego sekcji 0. Bieżący audyt jest pełniejszy zgodnie z instrukcjami.
+
+---
+
+*Koniec raportu. Zakres: §1-§12 z AUDIT-CHECKLIST.md v1.1, 67 reguł, w trybie read-only zgodnie z §0.1. Pliki nie zostały zmodyfikowane poza tym raportem.*


### PR DESCRIPTION
## Summary
**RF-31 + RF-32 bundled** — both pure documentation, single PR.

`docs/adr/` (MADR 4.0):
- `README.md` index + lift-and-shift roadmap for ADR-0001..0009.
- `adr-template.md` skeleton.
- `0000` — why MADR.
- `0010` src top-level policy (Tooling slot exception).
- `0011` ORM XML mapping in Infrastructure.
- `0012` CQRS pragmatic per-use-case (justifies RF-14/15 WONTFIX).
- `0013` Deptrac rollout + baseline cleanup roadmap.
- `0014` Tenant as Shared kernel.
- `0015` Cross-BC FK policy (Uuid + Contracts/Query lookup).

`docs/architecture/`:
- `c4-context.md` — Mermaid C4 level 1.
- `c4-container.md` — Mermaid C4 level 2.
- `bounded-contexts.md` — BC table + ringfence rules + event flow.

`ONBOARDING.md` — day-1 / day-3 / day-10 path.

`docs/audits/` — both pre-RF audits checked in (commits earlier had them untracked).

ADRs 0001-0009 still live in `Project Plan/01-architektura-pim.md` section 13; the lift-and-shift to per-file MADR is a follow-up tracked in `docs/adr/README.md`.

## Test plan
- [x] Mermaid diagrams render in GitHub preview
- [x] All ADR files follow the MADR 4.0 template
- [ ] CI: full quality stack green (docs-only PR, only `composer audit` / `pnpm audit` / Biome / lint / cs-check exercised)

Closes #181
Closes #182