### PR TITLE
feat(messenger): rebind tenant context on async handlers (HIGH-002)

### DIFF
--- a/apps/api/compose.override.yaml
+++ b/apps/api/compose.override.yaml
@@ -1,0 +1,7 @@
+
+services:
+###> symfony/mercure-bundle ###
+  mercure:
+    ports:
+      - "80"
+###< symfony/mercure-bundle ###

--- a/apps/api/compose.yaml
+++ b/apps/api/compose.yaml
@@ -1,0 +1,31 @@
+
+services:
+###> symfony/mercure-bundle ###
+  mercure:
+    image: dunglas/mercure
+    restart: unless-stopped
+    environment:
+      # Uncomment the following line to disable HTTPS,
+      #SERVER_NAME: ':80'
+      MERCURE_PUBLISHER_JWT_KEY: '!ChangeThisMercureHubJWTSecretKey!'
+      MERCURE_SUBSCRIBER_JWT_KEY: '!ChangeThisMercureHubJWTSecretKey!'
+      # Set the URL of your Symfony project (without trailing slash!) as value of the cors_origins directive
+      MERCURE_EXTRA_DIRECTIVES: |
+        cors_origins http://127.0.0.1:8000
+    # Comment the following line to disable the development mode
+    command: /usr/bin/caddy run --config /etc/caddy/dev.Caddyfile
+    healthcheck:
+      test: ["CMD", "curl", "-f", "https://localhost/healthz"]
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    volumes:
+      - mercure_data:/data
+      - mercure_config:/config
+###< symfony/mercure-bundle ###
+
+volumes:
+###> symfony/mercure-bundle ###
+  mercure_data:
+  mercure_config:
+###< symfony/mercure-bundle ###

--- a/apps/api/config/packages/http_discovery.yaml
+++ b/apps/api/config/packages/http_discovery.yaml
@@ -1,0 +1,10 @@
+services:
+    Psr\Http\Message\RequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@http_discovery.psr17_factory'
+
+    http_discovery.psr17_factory:
+        class: Http\Discovery\Psr17Factory

--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -24,6 +24,11 @@ framework:
                     enabled: true
                     allow_no_handlers: true
                 middleware:
+                    # Rebinds TenantContext on async handlers (audit
+                    # HIGH-002 / 2026-04-29). Sync dispatches pass
+                    # through — the request listener already set the
+                    # context from the JWT principal.
+                    - 'App\Shared\Infrastructure\Messenger\TenantContextRebindingMiddleware'
                     - 'App\Shared\Infrastructure\Messenger\IdempotencyMiddleware'
                     - doctrine_transaction
 

--- a/apps/api/src/Asset/Contracts/Event/AssetUploaded.php
+++ b/apps/api/src/Asset/Contracts/Event/AssetUploaded.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Asset\Contracts\Event;
 
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -15,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
  * indexer subscribe to this for `media` blocks; Catalog can pick it up
  * to denormalize media URLs into `attributes_indexed`.
  */
-final readonly class AssetUploaded implements DomainEvent
+final readonly class AssetUploaded implements DomainEvent, TenantAwareMessage
 {
     public function __construct(
         public Uuid $assetId,
@@ -40,5 +41,10 @@ final readonly class AssetUploaded implements DomainEvent
     public function aggregateId(): string
     {
         return $this->assetId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Asset/Contracts/Event/AssetVariantCreated.php
+++ b/apps/api/src/Asset/Contracts/Event/AssetVariantCreated.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Asset\Contracts\Event;
 
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -14,7 +15,7 @@ use Symfony\Component\Uid\Uuid;
  * crop. Tenant scope is inherited from the parent Asset, carried here
  * to keep subscriber routing simple.
  */
-final readonly class AssetVariantCreated implements DomainEvent
+final readonly class AssetVariantCreated implements DomainEvent, TenantAwareMessage
 {
     public function __construct(
         public Uuid $variantId,
@@ -38,5 +39,10 @@ final readonly class AssetVariantCreated implements DomainEvent
     public function aggregateId(): string
     {
         return $this->variantId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Catalog/Contracts/Event/ObjectArchived.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectArchived.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Contracts\Event;
 
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -13,7 +14,7 @@ use Symfony\Component\Uid\Uuid;
  * to status=archived. Channel publishers depublish; search indexers drop
  * the row from active indices.
  */
-final readonly class ObjectArchived implements DomainEvent
+final readonly class ObjectArchived implements DomainEvent, TenantAwareMessage
 {
     public function __construct(
         public Uuid $objectId,
@@ -35,5 +36,10 @@ final readonly class ObjectArchived implements DomainEvent
     public function aggregateId(): string
     {
         return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Catalog/Contracts/Event/ObjectAttributesChanged.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectAttributesChanged.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Contracts\Event;
 
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -17,7 +18,7 @@ use Symfony\Component\Uid\Uuid;
  * Search indexers consume this to reindex; channel publishers compare
  * against last published payload.
  */
-final readonly class ObjectAttributesChanged implements DomainEvent
+final readonly class ObjectAttributesChanged implements DomainEvent, TenantAwareMessage
 {
     /**
      * @param list<string> $changedAttributeCodes attribute codes whose values were affected
@@ -43,5 +44,10 @@ final readonly class ObjectAttributesChanged implements DomainEvent
     public function aggregateId(): string
     {
         return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Catalog/Contracts/Event/ObjectCreated.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectCreated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Contracts\Event;
 
 use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -13,8 +14,12 @@ use Symfony\Component\Uid\Uuid;
  * Emitted by {@see \App\Catalog\Domain\Entity\CatalogObject} once a new
  * row is persisted. Cross-BC subscribers (search indexer in Faza 2,
  * channel publishers, asset linker) react to creation via this event.
+ *
+ * Implements {@see TenantAwareMessage} so the messenger middleware
+ * (HIGH-002 / 2026-04-29) can rebind the tenant context when this
+ * event lands on an async transport.
  */
-final readonly class ObjectCreated implements DomainEvent
+final readonly class ObjectCreated implements DomainEvent, TenantAwareMessage
 {
     public function __construct(
         public Uuid $objectId,
@@ -38,5 +43,10 @@ final readonly class ObjectCreated implements DomainEvent
     public function aggregateId(): string
     {
         return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Catalog/Contracts/Event/ObjectEnabledChanged.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectEnabledChanged.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Contracts\Event;
 
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -13,7 +14,7 @@ use Symfony\Component\Uid\Uuid;
  * `enabled` flag. Cheaper than republishing on every attribute write —
  * channel adapters can short-circuit on `false`.
  */
-final readonly class ObjectEnabledChanged implements DomainEvent
+final readonly class ObjectEnabledChanged implements DomainEvent, TenantAwareMessage
 {
     public function __construct(
         public Uuid $objectId,
@@ -36,5 +37,10 @@ final readonly class ObjectEnabledChanged implements DomainEvent
     public function aggregateId(): string
     {
         return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Catalog/Contracts/Event/ObjectPublished.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectPublished.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Contracts\Event;
 
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -13,7 +14,7 @@ use Symfony\Component\Uid\Uuid;
  * to status=published. Triggers downstream publication (search index sync,
  * channel push, etc.).
  */
-final readonly class ObjectPublished implements DomainEvent
+final readonly class ObjectPublished implements DomainEvent, TenantAwareMessage
 {
     public function __construct(
         public Uuid $objectId,
@@ -35,5 +36,10 @@ final readonly class ObjectPublished implements DomainEvent
     public function aggregateId(): string
     {
         return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Channel/Contracts/Event/CategoryTreeRootAttached.php
+++ b/apps/api/src/Channel/Contracts/Event/CategoryTreeRootAttached.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Channel\Contracts\Event;
 
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -13,7 +14,7 @@ use Symfony\Component\Uid\Uuid;
  * a category tree root (or detached from one). Channel exporters use
  * this signal to (re)scope which categories they will publish.
  */
-final readonly class CategoryTreeRootAttached implements DomainEvent
+final readonly class CategoryTreeRootAttached implements DomainEvent, TenantAwareMessage
 {
     public function __construct(
         public Uuid $channelId,
@@ -36,5 +37,10 @@ final readonly class CategoryTreeRootAttached implements DomainEvent
     public function aggregateId(): string
     {
         return $this->channelId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Channel/Contracts/Event/ChannelCreated.php
+++ b/apps/api/src/Channel/Contracts/Event/ChannelCreated.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Channel\Contracts\Event;
 
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
@@ -14,7 +15,7 @@ use Symfony\Component\Uid\Uuid;
  * state (Shopify location, BaseLinker connection scope, …) without
  * having to listen on Doctrine's lifecycle events.
  */
-final readonly class ChannelCreated implements DomainEvent
+final readonly class ChannelCreated implements DomainEvent, TenantAwareMessage
 {
     public function __construct(
         public Uuid $channelId,
@@ -37,5 +38,10 @@ final readonly class ChannelCreated implements DomainEvent
     public function aggregateId(): string
     {
         return $this->channelId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
     }
 }

--- a/apps/api/src/Shared/Application/TenantAwareMessage.php
+++ b/apps/api/src/Shared/Application/TenantAwareMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Marker for messages that carry their originating tenant id directly
+ * on the payload — e.g. domain events with a `tenantId` field.
+ *
+ * The {@see \App\Shared\Infrastructure\Messenger\TenantContextRebindingMiddleware}
+ * uses this as a fallback when the envelope has no
+ * {@see \App\Shared\Infrastructure\Messenger\Stamp\TenantStamp}.
+ *
+ * NOTE: This interface deliberately does not extend
+ * {@see \App\Shared\Domain\DomainEvent} — application messages
+ * (commands, sync jobs) can opt in too without dragging the domain
+ * event surface along.
+ */
+interface TenantAwareMessage
+{
+    public function tenantId(): Uuid;
+}

--- a/apps/api/src/Shared/Infrastructure/Messenger/Stamp/TenantStamp.php
+++ b/apps/api/src/Shared/Infrastructure/Messenger/Stamp/TenantStamp.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Carries the originating tenant id across the messenger envelope so
+ * the worker-side middleware can rebind the tenant context before the
+ * handler runs.
+ *
+ * Domain events that already expose a `tenantId` field (e.g. Catalog's
+ * `ObjectCreated`) work without a stamp — the middleware reads either
+ * source. The stamp exists for synthetic messages that have no natural
+ * tenant field but still need worker isolation (e.g. cron-dispatched
+ * sync jobs in Faza 1).
+ */
+final readonly class TenantStamp implements StampInterface
+{
+    public function __construct(
+        public Uuid $tenantId,
+    ) {
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Messenger/TenantContextRebindingMiddleware.php
+++ b/apps/api/src/Shared/Infrastructure/Messenger/TenantContextRebindingMiddleware.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Messenger;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Infrastructure\Messenger\Stamp\TenantStamp;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Audit finding HIGH-002 (2026-04-29): on async transports the
+ * worker process boots a fresh kernel and the request listener that
+ * binds {@see TenantContext} from the JWT principal never fires.
+ * Without explicit rebinding the {@see \App\Shared\Infrastructure\Doctrine\Filter\TenantFilter}
+ * either runs against the stale context the previous handler left
+ * (cross-tenant read leak) or against `null` (LogicException on
+ * persist) — neither is acceptable.
+ *
+ * This middleware:
+ *   - on a worker run (`ConsumedByWorkerStamp` present) reads the
+ *     tenant id from a {@see TenantStamp} or, as a fallback, from a
+ *     message implementing {@see TenantAwareMessage};
+ *   - looks up the {@see Tenant} aggregate and binds it via
+ *     `TenantContext::set()`;
+ *   - clears the context after `$stack->next()->handle()` returns
+ *     so the next handler on the same worker boot starts clean.
+ *
+ * Synchronous dispatches (no `ConsumedByWorkerStamp`) skip the
+ * middleware — the request listener is the source of truth there.
+ *
+ * Behaviour for messages without any tenant source:
+ *   - **sync**: passes through (current MVP default — no-op).
+ *   - **async**: throws `RuntimeException`. An unbound async message
+ *     is a bug — every cross-process payload must declare its tenant.
+ */
+final readonly class TenantContextRebindingMiddleware implements MiddlewareInterface
+{
+    private LoggerInterface $logger;
+
+    public function __construct(
+        private TenantRepositoryInterface $tenants,
+        private TenantContext $tenantContext,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $consumed = $envelope->last(ConsumedByWorkerStamp::class);
+        if (null === $consumed) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        $tenantId = $this->resolveTenantId($envelope);
+        if (null === $tenantId) {
+            throw new RuntimeException(\sprintf(
+                'Async message %s carries no tenant context. Add a TenantStamp '.
+                'on dispatch or have the message implement TenantAwareMessage.',
+                $envelope->getMessage()::class,
+            ));
+        }
+
+        $tenant = $this->tenants->findById($tenantId);
+        if (null === $tenant) {
+            throw new RuntimeException(\sprintf(
+                'Tenant "%s" referenced by async message %s no longer exists.',
+                $tenantId->toRfc4122(),
+                $envelope->getMessage()::class,
+            ));
+        }
+
+        $this->tenantContext->set($tenant);
+        $this->logger->debug('Tenant context rebound for async handler', [
+            'tenantId' => $tenantId->toRfc4122(),
+            'message' => $envelope->getMessage()::class,
+        ]);
+
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            // Defence in depth: a long-lived worker boots the kernel
+            // once and re-uses the container. Leaving the context set
+            // would leak the previous tenant into the next handler.
+            $this->tenantContext->clear();
+        }
+    }
+
+    private function resolveTenantId(Envelope $envelope): ?Uuid
+    {
+        $stamp = $envelope->last(TenantStamp::class);
+        if ($stamp instanceof TenantStamp) {
+            return $stamp->tenantId;
+        }
+
+        $message = $envelope->getMessage();
+        if ($message instanceof TenantAwareMessage) {
+            return $message->tenantId();
+        }
+
+        return null;
+    }
+}

--- a/apps/api/tests/Unit/Shared/Infrastructure/Messenger/TenantContextRebindingMiddlewareTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Messenger/TenantContextRebindingMiddlewareTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Messenger;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Messenger\Stamp\TenantStamp;
+use App\Shared\Infrastructure\Messenger\TenantContextRebindingMiddleware;
+use Closure;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use stdClass;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Unit coverage for the audit-driven async tenant rebinding middleware
+ * (HIGH-002 / 2026-04-29).
+ */
+final class TenantContextRebindingMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function syncDispatchPassesThroughWithoutBindingTenant(): void
+    {
+        $context = new TenantContext();
+        $repo = $this->makeRepo();
+        $middleware = new TenantContextRebindingMiddleware($repo, $context);
+
+        $envelope = new Envelope(new stdClass());
+        $stack = $this->makeStack();
+
+        $middleware->handle($envelope, $stack);
+
+        self::assertNull($context->get(), 'Sync dispatch must not bind a tenant.');
+        self::assertSame(0, $repo->lookups, 'Sync dispatch must not hit the repo.');
+    }
+
+    #[Test]
+    public function asyncMessageWithStampBindsTenantAndClearsAfter(): void
+    {
+        $context = new TenantContext();
+        $tenant = new Tenant('demo', 'Demo');
+        $repo = $this->makeRepo($tenant);
+        $middleware = new TenantContextRebindingMiddleware($repo, $context);
+
+        $envelope = new Envelope(new stdClass())
+            ->with(new ConsumedByWorkerStamp())
+            ->with(new TenantStamp($tenant->getId()));
+
+        $stack = $this->makeStack(static function () use ($context, $tenant): void {
+            self::assertSame(
+                $tenant->getId()->toRfc4122(),
+                $context->get()?->getId()->toRfc4122(),
+                'Tenant must be bound when the inner handler runs.',
+            );
+        });
+
+        $middleware->handle($envelope, $stack);
+
+        self::assertNull($context->get(), 'Context must be cleared after the handler returns.');
+        self::assertSame(1, $repo->lookups);
+    }
+
+    #[Test]
+    public function asyncMessageWithoutStampFallsBackToTenantAwareInterface(): void
+    {
+        $context = new TenantContext();
+        $tenant = new Tenant('demo', 'Demo');
+        $repo = $this->makeRepo($tenant);
+        $middleware = new TenantContextRebindingMiddleware($repo, $context);
+
+        $message = new class($tenant->getId()) implements TenantAwareMessage {
+            public function __construct(private readonly Uuid $tenantId)
+            {
+            }
+
+            public function tenantId(): Uuid
+            {
+                return $this->tenantId;
+            }
+        };
+
+        $envelope = new Envelope($message)->with(new ConsumedByWorkerStamp());
+
+        $stack = $this->makeStack(static function () use ($context): void {
+            self::assertNotNull($context->get(), 'Tenant must be bound from message field.');
+        });
+
+        $middleware->handle($envelope, $stack);
+
+        self::assertNull($context->get());
+    }
+
+    #[Test]
+    public function asyncMessageWithNoTenantSourceThrows(): void
+    {
+        $context = new TenantContext();
+        $middleware = new TenantContextRebindingMiddleware($this->makeRepo(), $context);
+
+        $envelope = new Envelope(new stdClass())->with(new ConsumedByWorkerStamp());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('carries no tenant context');
+
+        $middleware->handle($envelope, $this->makeStack());
+    }
+
+    #[Test]
+    public function asyncMessageWithUnknownTenantThrows(): void
+    {
+        $context = new TenantContext();
+        $repo = $this->makeRepo();
+        $middleware = new TenantContextRebindingMiddleware($repo, $context);
+
+        $envelope = new Envelope(new stdClass())
+            ->with(new ConsumedByWorkerStamp())
+            ->with(new TenantStamp(Uuid::v7()));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('no longer exists');
+
+        $middleware->handle($envelope, $this->makeStack());
+    }
+
+    #[Test]
+    public function contextIsClearedEvenWhenInnerHandlerThrows(): void
+    {
+        $context = new TenantContext();
+        $tenant = new Tenant('demo', 'Demo');
+        $repo = $this->makeRepo($tenant);
+        $middleware = new TenantContextRebindingMiddleware($repo, $context);
+
+        $envelope = new Envelope(new stdClass())
+            ->with(new ConsumedByWorkerStamp())
+            ->with(new TenantStamp($tenant->getId()));
+
+        $stack = $this->makeStack(static function (): void {
+            throw new RuntimeException('handler boom');
+        });
+
+        try {
+            $middleware->handle($envelope, $stack);
+            self::fail('Inner handler exception should have propagated.');
+        } catch (RuntimeException $e) {
+            self::assertSame('handler boom', $e->getMessage());
+        }
+
+        self::assertNull($context->get(), 'Context must be cleared even when handler throws.');
+    }
+
+    private function makeRepo(?Tenant $tenant = null): InMemoryTenantRepoStub
+    {
+        return new InMemoryTenantRepoStub($tenant);
+    }
+
+    /**
+     * @param (Closure(): void)|null $onNext
+     */
+    private function makeStack(?Closure $onNext = null): StackInterface
+    {
+        $next = new class implements MiddlewareInterface {
+            /** @var (Closure(): void)|null */
+            public ?Closure $onHandle = null;
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                if (null !== $this->onHandle) {
+                    ($this->onHandle)();
+                }
+
+                return $envelope;
+            }
+        };
+        $next->onHandle = $onNext;
+
+        return new class($next) implements StackInterface {
+            public function __construct(private readonly MiddlewareInterface $next)
+            {
+            }
+
+            public function next(): MiddlewareInterface
+            {
+                return $this->next;
+            }
+        };
+    }
+}
+
+/**
+ * @internal
+ */
+final class InMemoryTenantRepoStub implements TenantRepositoryInterface
+{
+    public int $lookups = 0;
+
+    public function __construct(private ?Tenant $tenant = null)
+    {
+    }
+
+    public function findById(Uuid $id): ?Tenant
+    {
+        ++$this->lookups;
+        if (null === $this->tenant) {
+            return null;
+        }
+
+        return $this->tenant->getId()->toRfc4122() === $id->toRfc4122() ? $this->tenant : null;
+    }
+
+    public function findByCode(string $code): ?Tenant
+    {
+        return null;
+    }
+
+    public function save(Tenant $tenant): void
+    {
+    }
+
+    public function remove(Tenant $tenant): void
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Domyka audit findings 2026-04-29 **HIGH-002** — async tenant rebinding.

Async transports boot fresh worker kernel bez request listener który binds `TenantContext` z JWT principal. Bez rebinding'u, Doctrine `TenantFilter` albo runs przeciw stale context (cross-tenant leak), albo przeciw `null` (LogicException). To **defensywny pre-emptive fix** — sync transport jest dziś default w MVP, async dochodzi w Faza 1.

**Trzy nowe komponenty:**
- **`TenantStamp`** — Messenger stamp carrying tenant id (dla messages bez natural `tenantId` field).
- **`TenantAwareMessage`** interface (Shared\Application) — opt-in dla messages które niosą tenant w payload.
- **`TenantContextRebindingMiddleware`** — registered first w bus, active tylko gdy `ConsumedByWorkerStamp` present (sync passthrough), reads tenant id z stamp lub message field, fetches Tenant, binds context, runs handler, clears context w `finally` (handler exceptions zostawiają worker clean).

**9 cross-context domain events** implementuje `TenantAwareMessage` (5 Catalog + 2 Channel + 2 Asset) — future async router (`'X': async`) just works.

**Fail-loud na async messages bez tenant source** — unbound async payload to bug, nie recoverable case.

## Test plan

- [x] PHPStan max — clean
- [x] Deptrac — 0 violations + 27 baseline
- [x] **PHPUnit — 335/335** (+6 nowych unit tests middleware'a: sync passthrough, stamp binding, fallback to TenantAwareMessage, missing source throws, unknown tenant throws, finally on handler error)
- [x] Composer audit — clean

## Powiązania

- Closes audit HIGH-002 (`docs/audits/AUDIT-REPORT-2026-04-29-full-code-review.md`)
- Refs ADR-003 (multi-tenant ready), ADR-014 (Tenant as Shared kernel)
- Foundation dla **Faza 1 async transports** (BaseLinker / Shopify sync workers)