### PR TITLE
[0.11.2] Rate limiting — refresh + API key endpoints + unblock CLI (#97)

### DIFF
--- a/apps/api/config/packages/framework.yaml
+++ b/apps/api/config/packages/framework.yaml
@@ -54,6 +54,27 @@ framework:
             limit: 10
             interval: '1 hour'
 
+        # Refresh-token rotation (#28). The cookie-driven path is
+        # invoked by every browser session every ~15 minutes, but
+        # the only legitimate caller is a single tab — 30/h/IP
+        # absorbs honest tab churn while clamping a stolen-cookie
+        # replay loop (where a malicious script polls /refresh
+        # to siphon access tokens). 0.11.2 hardening.
+        auth_refresh:
+            policy: 'sliding_window'
+            limit: 30
+            interval: '1 hour'
+
+        # Public API surface for X-API-Key callers (#94). Per-key
+        # budget reuses the request key's `keyPrefix` so a partner
+        # cannot exhaust budget for another partner. 1000/h is the
+        # default; ApiProfile.rateLimitPerHour overrides per profile
+        # in a follow-up — this is the floor.
+        api_key:
+            policy: 'sliding_window'
+            limit: 1000
+            interval: '1 hour'
+
 when@test:
     framework:
         test: true

--- a/apps/api/src/ApiConfigurator/Infrastructure/Security/ApiKeyRateLimitListener.php
+++ b/apps/api/src/ApiConfigurator/Infrastructure/Security/ApiKeyRateLimitListener.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ApiConfigurator\Infrastructure\Security;
+
+use App\Shared\Application\Auth\ApiKeyPrincipal;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Per-key rate limiter for `X-API-Key` requests (#97 / 0.11.2).
+ *
+ * Bucket key = `keyPrefix` so two partners sharing a profile do not
+ * exhaust each other's budget. 1000/h sliding window is the floor;
+ * `ApiProfile.rateLimitPerHour` overrides per profile in a follow-up.
+ *
+ * Runs at negative priority — after the firewall has authenticated
+ * the request, so `getToken()->getUser()` returns the principal.
+ * Anonymous requests pass through (other firewalls reject them
+ * upstream); JWT-authenticated requests pass through (admins use
+ * their JWT, not the per-key limiter).
+ */
+#[AsEventListener(event: RequestEvent::class, priority: -8)]
+final readonly class ApiKeyRateLimitListener
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        private RateLimiterFactoryInterface $apiKeyLimiter,
+    ) {
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $token = $this->tokenStorage->getToken();
+        $user = $token?->getUser();
+        if (!$user instanceof ApiKeyPrincipal) {
+            return;
+        }
+
+        $limiter = $this->apiKeyLimiter->create($user->getUserIdentifier());
+        $consumed = $limiter->consume();
+        if ($consumed->isAccepted()) {
+            return;
+        }
+
+        $retryAfter = $consumed->getRetryAfter();
+        $secondsUntilReset = max(1, $retryAfter->getTimestamp() - time());
+
+        throw new TooManyRequestsHttpException(
+            $secondsUntilReset,
+            'API key rate limit exceeded. Try again later.',
+            null,
+            0,
+            ['Retry-After' => (string) $secondsUntilReset],
+        );
+    }
+}

--- a/apps/api/src/Identity/Presentation/AuthRefreshRateLimitListener.php
+++ b/apps/api/src/Identity/Presentation/AuthRefreshRateLimitListener.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * Rate limiter on `/api/auth/refresh` (#97 / 0.11.2).
+ *
+ * 30 attempts per IP per 1-hour sliding window. A real browser
+ * tab refreshes the access token every ~15 minutes — at most ~5
+ * legitimate calls per hour per tab — so 30/h covers a small honest
+ * burst while clamping a stolen-cookie replay loop (where a
+ * malicious script polls `/refresh` to siphon fresh access tokens).
+ *
+ * Mirrors {@see AuthLoginRateLimitListener} — runs at priority 32 so
+ * the limiter checks before the Lexik refresh-cookie consumer.
+ */
+#[AsEventListener(event: RequestEvent::class, priority: 32)]
+final readonly class AuthRefreshRateLimitListener
+{
+    public function __construct(
+        private RateLimiterFactoryInterface $authRefreshLimiter,
+    ) {
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if ('POST' !== $request->getMethod()) {
+            return;
+        }
+
+        if ('/api/auth/refresh' !== $request->getPathInfo()) {
+            return;
+        }
+
+        $limiter = $this->authRefreshLimiter->create($request->getClientIp() ?? 'unknown');
+        $consumed = $limiter->consume();
+        if ($consumed->isAccepted()) {
+            return;
+        }
+
+        $retryAfter = $consumed->getRetryAfter();
+        $secondsUntilReset = max(1, $retryAfter->getTimestamp() - time());
+
+        throw new TooManyRequestsHttpException(
+            $secondsUntilReset,
+            'Too many refresh-token attempts. Try again later.',
+            null,
+            0,
+            ['Retry-After' => (string) $secondsUntilReset],
+        );
+    }
+}

--- a/apps/api/src/Identity/Presentation/Command/UnblockIpCommand.php
+++ b/apps/api/src/Identity/Presentation/Command/UnblockIpCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+use const FILTER_VALIDATE_IP;
+
+/**
+ * Operator escape hatch: clears the rate-limiter buckets keyed on a
+ * given IP across the auth surface (#97 / 0.11.2).
+ *
+ * Symfony's RateLimiter persists per-key state in the cache pool. The
+ * fastest way to reset a single principal is `RateLimiterFactory::create($key)
+ * ->reset()` — the limiter implementations override `reset()` to clear
+ * exactly that key without touching others. We hit both auth limiters
+ * keyed on IP so a forgiveness flow does not need a separate command
+ * per endpoint.
+ */
+#[AsCommand(
+    name: 'pim:security:unblock-ip',
+    description: 'Reset rate-limiter buckets for a given IP across auth endpoints.',
+)]
+final class UnblockIpCommand extends Command
+{
+    public function __construct(
+        private readonly RateLimiterFactoryInterface $authLoginLimiter,
+        private readonly RateLimiterFactoryInterface $authRefreshLimiter,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('ip', InputArgument::REQUIRED, 'IP address to forgive (matches the limiter key).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        /** @var string $ip */
+        $ip = $input->getArgument('ip');
+
+        if (false === filter_var($ip, FILTER_VALIDATE_IP)) {
+            $io->error(\sprintf('"%s" is not a valid IP address.', $ip));
+
+            return Command::INVALID;
+        }
+
+        $this->authLoginLimiter->create($ip)->reset();
+        $this->authRefreshLimiter->create($ip)->reset();
+
+        $io->success(\sprintf('Rate-limiter buckets cleared for IP %s on auth_login + auth_refresh.', $ip));
+
+        return Command::SUCCESS;
+    }
+}

--- a/apps/api/tests/Api/Identity/AuthRefreshRateLimitTest.php
+++ b/apps/api/tests/Api/Identity/AuthRefreshRateLimitTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Coverage for the refresh-token rate limiter (#97 / 0.11.2).
+ *
+ * 30 attempts per IP per hour — the listener returns 429 with
+ * `Retry-After` on the 31st call, regardless of whether the cookie
+ * is valid (rotation attempts and replay attempts compete for the
+ * same budget).
+ */
+final class AuthRefreshRateLimitTest extends ApiTestCase
+{
+    protected static ?bool $alwaysBootKernel = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reset the bucket for the BrowserKit default IP between tests.
+        self::getContainer()->get('limiter.auth_refresh')->create('127.0.0.1')->reset();
+    }
+
+    #[Test]
+    public function thirtyFirstRefreshAttemptInWindowReturns429(): void
+    {
+        $client = static::createClient();
+
+        // 30 cookie-less attempts — Lexik returns 401 for each (no token
+        // payload to refresh). The limiter ticks anyway, so the 31st
+        // call gets 429 from the listener before Lexik even runs.
+        for ($i = 1; $i <= 30; ++$i) {
+            $r = $client->request('POST', '/api/auth/refresh');
+            self::assertNotSame(429, $r->getStatusCode(), 'Attempt #'.$i.' must not be rate-limited yet.');
+        }
+
+        $response = $client->request('POST', '/api/auth/refresh');
+        self::assertResponseStatusCodeSame(429);
+        self::assertNotNull($response->getHeaders(throw: false)['retry-after'][0] ?? null);
+    }
+}

--- a/apps/api/tests/Api/Identity/RefreshTokenApiTest.php
+++ b/apps/api/tests/Api/Identity/RefreshTokenApiTest.php
@@ -45,6 +45,7 @@ final class RefreshTokenApiTest extends ApiTestCase
         parent::setUp();
 
         self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+        self::getContainer()->get('limiter.auth_refresh')->create('127.0.0.1')->reset();
 
         $em = $this->em();
         self::getContainer()->get(RbacSeeder::class)->seed();

--- a/apps/api/tests/Integration/Identity/UnblockIpCommandTest.php
+++ b/apps/api/tests/Integration/Identity/UnblockIpCommandTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Identity;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+
+/**
+ * `pim:security:unblock-ip` operator escape hatch (#97 / 0.11.2).
+ *
+ * Asserts the command resets both auth limiters keyed on the supplied
+ * IP — a previously locked-out address can immediately log in again.
+ */
+final class UnblockIpCommandTest extends KernelTestCase
+{
+    #[Test]
+    public function unblockResetsAuthLimitersForGivenIp(): void
+    {
+        self::bootKernel();
+        // Use the test container (`getContainer()`) — the production
+        // service is private, but Symfony's test container exposes
+        // private services for inspection. The CLI under test uses
+        // injected factories so production wiring stays clean.
+        $login = self::getContainer()->get('limiter.auth_login');
+        self::assertInstanceOf(RateLimiterFactoryInterface::class, $login);
+        $refresh = self::getContainer()->get('limiter.auth_refresh');
+        self::assertInstanceOf(RateLimiterFactoryInterface::class, $refresh);
+
+        // Exhaust both buckets for 1.2.3.4 — sixth login + thirty-first
+        // refresh would 429 in the live listener.
+        for ($i = 0; $i < 5; ++$i) {
+            $login->create('1.2.3.4')->consume();
+        }
+        for ($i = 0; $i < 30; ++$i) {
+            $refresh->create('1.2.3.4')->consume();
+        }
+        self::assertFalse($login->create('1.2.3.4')->consume()->isAccepted());
+        self::assertFalse($refresh->create('1.2.3.4')->consume()->isAccepted());
+
+        $tester = $this->commandTester();
+        $exit = $tester->execute(['ip' => '1.2.3.4']);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        // After reset both buckets accept again.
+        self::assertTrue($login->create('1.2.3.4')->consume()->isAccepted());
+        self::assertTrue($refresh->create('1.2.3.4')->consume()->isAccepted());
+    }
+
+    #[Test]
+    public function rejectsInvalidIp(): void
+    {
+        $tester = $this->commandTester();
+        $exit = $tester->execute(['ip' => 'not-an-ip']);
+
+        self::assertSame(Command::INVALID, $exit);
+        self::assertStringContainsString('not a valid IP', $tester->getDisplay());
+    }
+
+    private function commandTester(): CommandTester
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+        $command = $application->find('pim:security:unblock-ip');
+
+        return new CommandTester($command);
+    }
+}


### PR DESCRIPTION
## Summary

#48 lądował baseline limiter dla `/api/auth/login`. Ten ticket dorzuca brakujące endpointy + operator escape hatch.

- **`AuthRefreshRateLimitListener`** — 30/h/IP sliding window dla `/api/auth/refresh`. Browser tab refresh ~5x/h legalnie; clamping stolen-cookie replay loop.
- **`ApiKeyRateLimitListener`** — 1000/h/key sliding window dla `X-API-Key` requests. Bucket per `keyPrefix` (partner isolation). `ApiProfile.rateLimitPerHour` overrides per profile w follow-up.
- **`pim:security:unblock-ip <ip>`** CLI — operator escape hatch, resets both auth limiters dla danego IP (NAT egress forgiveness).

## Świadome odejścia

- **Email alert po 3 fail attempts** → wymaga mailer setup; follow-up.
- **CAPTCHA (Turnstile/hCaptcha)** → external dep, skip dla MVP.
- **Audit log dla auth fails** → już pokrywany przez DH Auditor (#99) na User entity.

## Test plan

- [x] PHPStan max — clean
- [x] Deptrac — 0 violations + 27 baseline
- [x] PHPUnit — 341/341 (+ 4 nowe: refresh 31. attempt 429, unblock CLI resets oba limitery, unblock rejects invalid IP)
- [x] Composer audit — clean

## Powiązania

- Closes #97
- Refs #48 baseline limiter, #94 ApiKeyAuthenticator