### PR TITLE
[0.11.8] Disaster-recovery runbook + CHANGELOG (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to PIM. Format follows [Keep a Changelog](https://keepachangelog.com/),
+versioning per epic milestones (`0.X.Y` matches ticket numbering in
+`Project Plan/02-plan-projektu-pim.md`).
+
+## [Unreleased]
+
+### Added — epic 0.11 hardening
+
+- **0.11.4** Audit log MVP via DH Auditor for catalog schema (ObjectType /
+  Attribute / AttributeGroup / AttributeOption / AssociationType) +
+  Channel / Asset / Identity (User / Role / Permission / Tenant) +
+  API Configurator (ApiProfile / ApiKey). 365-day retention via
+  `pim:audit:cleanup` CLI. (#99 / PR #241)
+- **0.11.2** Rate limiting hardening — sliding-window on
+  `/api/auth/refresh` (30/h/IP) + per-key budget on `X-API-Key`
+  (1000/h/key). `pim:security:unblock-ip` operator escape hatch.
+  (#97 / PR #242)
+- **0.11.3** Full security-headers stack at the Caddy edge — CSP,
+  HSTS, X-Frame-Options, Permissions-Policy, COOP, CORP, Server header
+  stripped. Playwright contract pin to prevent silent regressions.
+  (#98 / PR #243)
+- **0.11.7** Renovate config — patch / pin / digest auto-merge,
+  minor + major manual review with ecosystem grouping (Symfony /
+  Doctrine / API Platform / React+Refine / Vite stack / Playwright /
+  PHPStan). Vulnerability alerts auto-merge regardless of update type.
+  (#102 / PR #244)
+- **0.11.8** This changelog + `docs/runbook/disaster-recovery.md`.
+  (#103 / this PR)
+
+### Audit findings (2026-04-29) closed
+
+- **HIGH-001** End-to-end test for `pim.catalog.enable_custom_object_types`
+  feature flag spinning every layer (API guard / service guard /
+  REST surface). (PR #239)
+- **HIGH-002** Tenant context rebinding on async Messenger handlers.
+  `TenantStamp` + `TenantAwareMessage` interface +
+  `TenantContextRebindingMiddleware`. Defensive pre-emptive fix
+  before Faza 1 async transports. (PR #240)
+
+### Earlier (epic 0.10 — API Configurator MVP)
+
+- **0.10.1** ApiProfile + ApiKey entities + Argon2id hashing + ADR-0016
+  documenting key format. CLI `pim:apikey:generate`. (PR #233)
+- **0.10.2** Admin UI list / create / edit + AP4 CRUD endpoints + Voters.
+  Serializer XML excludes `keyHash` from every group. (PR #234)
+- **0.10.3** Form 4-tab structure (Basic / Attributes / Filters /
+  Preview) + ObjectType / Attribute multiselect + JSON preview.
+  (PR #235)
+- **0.10.4** Webhook config — URL / events / Test / Rotate-secret.
+  HMAC-signed delivery via `WebhookDeliverySubscriber`. (PR #236)
+- **0.10.5** `X-API-Key` authenticator + per-profile serializer
+  context. `Shared\Application\Auth\ApiKeyPrincipal` cross-BC
+  marker. (PR #237)
+- **0.10.6** `/api/profiles/{code}/test` + `/api/profiles/{code}/openapi.json`
+  per-profile OpenAPI export. (PR #238)
+
+For older history (epics 0.1 — 0.9), see git log + `agent/current_status.md`.
+
+[Unreleased]: https://github.com/malipie/PIM/compare/main...HEAD

--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ PHP 8.4 + Symfony 7.4 LTS + API Platform 4 + FrankenPHP 2.x worker mode · Postg
 ## Dokumentacja
 
 - **`CLAUDE.md`** — konstytucja projektu (system prompt dla Claude Code)
+- **`CONTRIBUTING.md`** + **`ONBOARDING.md`** — onboarding nowego developera
+- **`CHANGELOG.md`** — release history per epic
 - **`Project Plan/01-architektura-pim.md`** — pełna architektura, ADR, model danych
 - **`Project Plan/02-plan-projektu-pim.md`** — fazy, milestones, backlog, ryzyka
+- **`docs/adr/`** — Architecture Decision Records (ADR-0000..0016)
+- **`docs/runbook/restore.md`** — pgBackRest PITR walkthrough
+- **`docs/runbook/disaster-recovery.md`** — incident-response playbook (key rotation, breach forensics, async drift)
+- **`docs/multi-tenancy.md`** + **`docs/rbac.md`** — security model deep-dive
 - **`agent/current_status.md`** — aktualna sub-faza i postęp
 - **`agent/lessons.md`** — patterns to follow / avoid, package quirks
 

--- a/docs/runbook/disaster-recovery.md
+++ b/docs/runbook/disaster-recovery.md
@@ -1,0 +1,295 @@
+# Disaster Recovery Runbook
+
+> **Audience:** the on-call operator. Each section follows a SHTF
+> structure — **Symptom**, **Triage**, **Action**. Run commands as
+> written. When in doubt, restore from backup; PIM data is the
+> authoritative copy of customer-facing product information.
+
+This runbook complements:
+
+- [`docs/runbook/restore.md`](restore.md) — PITR walkthrough for pgBackRest.
+- [`docs/multi-tenancy.md`](../multi-tenancy.md) — tenant isolation model.
+- [`docs/rbac.md`](../rbac.md) — RBAC matrix.
+- [`Project Plan/01-architektura-pim.md`](../../Project%20Plan/01-architektura-pim.md) §11 — security architecture.
+
+## Contents
+
+1. [PostgreSQL — point-in-time recovery (PITR)](#1-postgresql--point-in-time-recovery-pitr)
+2. [JWT signing key — emergency rotation](#2-jwt-signing-key--emergency-rotation)
+3. [Argon2id rehash — password / API key drift](#3-argon2id-rehash--password--api-key-drift)
+4. [BYOK Anthropic — per-tenant key provisioning](#4-byok-anthropic--per-tenant-key-provisioning)
+5. [Compromised API key — revocation + forensics](#5-compromised-api-key--revocation--forensics)
+6. [Suspected data breach — containment + audit log forensics](#6-suspected-data-breach--containment--audit-log-forensics)
+7. [Audit log — retention + manual prune](#7-audit-log--retention--manual-prune)
+8. [Async worker stuck — tenant context drift](#8-async-worker-stuck--tenant-context-drift)
+9. [Rate limiter — operator unblock](#9-rate-limiter--operator-unblock)
+
+---
+
+## 1. PostgreSQL — point-in-time recovery (PITR)
+
+**Symptom:** corrupted DB / accidental drop / ransomware / region failure.
+
+**Triage**
+1. Stop write traffic — disable Caddy `/api/*` route or scale `api` to 0.
+2. Identify the target time `T` (just before the destructive event).
+3. Confirm pgBackRest repo is reachable: `docker compose exec database pgbackrest --stanza=pim info`.
+
+**Action** — see full walkthrough in [`docs/runbook/restore.md`](restore.md). Short form:
+
+```bash
+# 1. Run the orchestrator with the recovery target.
+PGBACKREST_TARGET_TIME='2026-04-30 14:30:00 UTC' \
+  ./scripts/pim-backup-restore.sh
+
+# 2. Validate post-restore.
+docker compose exec api php bin/console pim:tenant:audit
+docker compose exec api php bin/console doctrine:migrations:status
+
+# 3. Smoke check the application surface.
+curl -sk https://pim.localhost/api | jq .
+```
+
+**RPO / RTO targets** (production, after #106 / 0.11.11 lands):
+
+| Target          | Sprint 0 baseline | Production |
+|-----------------|-------------------|------------|
+| RPO (data loss) | ~1 h (hourly)     | ≤5 min (WAL streaming) |
+| RTO (downtime)  | manual ~30 min    | ≤15 min (runbook automated) |
+
+---
+
+## 2. JWT signing key — emergency rotation
+
+**Symptom:** suspected leak of `JWT_PASSPHRASE` / private key / kernel
+core dump exposing memory.
+
+**Triage**
+1. Note the time `T_leak`. Anything signed before `T_rotate` is suspect.
+2. Inventory active sessions: `SELECT count(*) FROM refresh_tokens
+   WHERE revoked_at IS NULL AND expires_at > now()`.
+
+**Action**
+
+```bash
+# 1. Generate a fresh keypair.
+docker compose exec api php bin/console lexik:jwt:generate-keypair --overwrite
+
+# 2. Force-revoke every refresh token (logs everyone out).
+docker compose exec api php bin/console doctrine:query:sql \
+  "UPDATE refresh_tokens SET revoked_at = now() WHERE revoked_at IS NULL"
+
+# 3. Rotate the JWT_PASSPHRASE secret in the deployment vault and roll
+#    api containers so the new key + passphrase load.
+#    (Specifics depend on the host orchestrator.)
+
+# 4. Notify all active operator users (out-of-band).
+```
+
+**Verify**: any access token issued before rotation now returns 401
+on `/api/me`. New login → new keypair → access works.
+
+---
+
+## 3. Argon2id rehash — password / API key drift
+
+**Symptom:** PHP / libsodium upgrade pushes the recommended Argon2id
+parameters past what your stored digests carry. Symptom: warnings in
+logs from `password_needs_rehash($hash, PASSWORD_ARGON2ID) → true`.
+
+**Triage** — identify drift volume:
+
+```bash
+docker compose exec api php bin/console doctrine:query:sql \
+  "SELECT count(*) FROM users WHERE password LIKE '\$argon2id\$%'"
+```
+
+**Action**
+
+User passwords rehash on next successful login (Symfony's
+`PasswordAuthenticatedUserInterface` does the dance automatically).
+**No bulk action needed** — let the rehash flow naturally.
+
+API keys rehash on next successful authentication via
+`Argon2idApiKeyHasher::needsRehash()` in
+`ApiKeyAuthenticator::authenticate()`. **No bulk action** — the auth
+hot path takes care of it.
+
+If a user / partner is dormant for >90 days and the rehash queue is
+non-empty, consider a forced password reset email.
+
+---
+
+## 4. BYOK Anthropic — per-tenant key provisioning
+
+**Symptom:** enterprise tenant insists on paying their own LLM bill;
+or the platform key approaches its $1000/month org cap.
+
+**Action** — full BYOK setup lands with **#107 / 0.11.12**. Until then,
+the platform key is shared (`ANTHROPIC_API_KEY` env var on `api`
+container) and per-tenant cost limits live in
+[`Project Plan/01-architektura-pim.md`](../../Project%20Plan/01-architektura-pim.md)
+§8.5 (50 tool calls/h/user, $20/d/tenant, $300/mo/tenant).
+
+After #107: the admin UI exposes `Settings → API keys → Anthropic`.
+The submitted key is encrypted AES-256-GCM with `APP_BYOK_KEY`
+(server-side master) before persistence. Runtime resolver picks
+tenant-specific key when present, falls back to platform key
+otherwise.
+
+**Rotation** — operator submits a fresh key, old one is overwritten.
+No pin to old keys; the previous value is unrecoverable from the DB.
+
+---
+
+## 5. Compromised API key — revocation + forensics
+
+**Symptom:** partner reports leaked key / key appears in a public
+paste / spike in `pim:audit:cleanup --dry-run` numbers from a single
+prefix.
+
+**Action**
+
+```bash
+# 1. Find the row by prefix (operator only sees the prefix).
+docker compose exec api php bin/console doctrine:query:sql \
+  "SELECT id, name, key_prefix, last_used_at FROM api_keys
+   WHERE key_prefix = 'pim_live_a4f2'"
+
+# 2. Revoke (soft-delete — keeps audit trail).
+docker compose exec api php bin/console doctrine:query:sql \
+  "UPDATE api_keys SET revoked_at = now() WHERE id = '<uuid>'"
+
+# 3. Inspect what the key did.
+docker compose exec api php bin/console doctrine:query:sql \
+  "SELECT type, object_id, blame_user, ip, created_at, diffs
+   FROM api_keys_audit
+   WHERE blame_id = '<key uuid as string>'
+   ORDER BY created_at DESC LIMIT 200"
+
+# 4. Generate a replacement key for the partner via CLI.
+docker compose exec api php bin/console pim:apikey:generate \
+  --tenant=<tenant-code> \
+  --name='Partner X — replacement post-leak' \
+  --scopes=<comma-separated-profile-codes>
+# Capture the raw key from stdout. Hand off to partner via secure channel.
+```
+
+The previous key's `last_used_at` and `audit log` rows give you the
+incident window. Cross-reference Caddy access logs (off-line) for
+the source IPs.
+
+---
+
+## 6. Suspected data breach — containment + audit log forensics
+
+**Symptom:** customer data showing up on a leak site / monitoring
+flag on egress traffic.
+
+**Triage** (in this order)
+1. **Contain** — disable suspect API keys + JWT signing key (sections 2 + 5).
+2. **Snapshot** — `pgbackrest backup --type=full` (out-of-cycle full
+   for forensic analysis) + freeze MinIO bucket `pim-backups`.
+3. **Inventory** — what tenants are affected? Audit logs answer:
+
+```bash
+# Per tenant: every change in the last 7 days.
+docker compose exec api php bin/console doctrine:query:sql \
+  "SELECT al.created_at, al.type, al.object_id, al.blame_user, al.ip
+   FROM (SELECT * FROM users_audit
+         UNION ALL SELECT * FROM api_keys_audit
+         UNION ALL SELECT * FROM api_profiles_audit
+         UNION ALL SELECT * FROM channels_audit
+         UNION ALL SELECT * FROM attributes_audit
+         UNION ALL SELECT * FROM object_types_audit) AS al
+   WHERE al.created_at > now() - INTERVAL '7 days'
+     AND al.blame_id IS NOT NULL
+   ORDER BY al.created_at DESC LIMIT 1000"
+```
+
+4. **Notify** — affected tenants + DPA. GDPR clock starts at detection.
+5. **Root cause** — review change log for the past 30 days, focus on
+   commits touching auth / RBAC / TenantFilter.
+
+---
+
+## 7. Audit log — retention + manual prune
+
+The audit log defaults to 365-day retention. Disk pressure or a one-off
+purge requirement can call for ad-hoc pruning.
+
+**Cron** (default — runs daily on prod):
+
+```bash
+docker compose exec api php bin/console pim:audit:cleanup --older-than=365d
+```
+
+**Manual short prune** (e.g. before a backup run on a hot disk):
+
+```bash
+docker compose exec api php bin/console pim:audit:cleanup --older-than=180d --dry-run
+docker compose exec api php bin/console pim:audit:cleanup --older-than=180d
+```
+
+Retention windows shorter than 30 days trigger the GDPR breach
+reporting clock — DO NOT prune below 30 days without legal sign-off.
+
+---
+
+## 8. Async worker stuck — tenant context drift
+
+**Symptom:** worker logs `LogicException: Cannot persist X without a
+current tenant` or rows show up under wrong tenant after a sync run.
+
+**Triage**
+1. Confirm the message in question carries either a `TenantStamp` or
+   implements `TenantAwareMessage` (`App\Shared\Application\TenantAwareMessage`).
+2. If the dispatcher omitted both — that's the bug. Fix the
+   dispatcher; the middleware fails loud by design (see
+   `TenantContextRebindingMiddleware`).
+3. Rebind manually for a one-shot rescue:
+
+```bash
+docker compose exec api php bin/console messenger:consume async \
+  --limit=1 --time-limit=30 -vv
+```
+
+The middleware writes a log line on every successful rebind — search
+worker logs for `Tenant context rebound for async handler` to verify.
+
+---
+
+## 9. Rate limiter — operator unblock
+
+**Symptom:** legitimate operator / NAT egress bumps the auth limiter
+ceiling and is stuck on 429.
+
+**Action**
+
+```bash
+# Single IP.
+docker compose exec api php bin/console pim:security:unblock-ip 1.2.3.4
+
+# Need to forgive many IPs at once (e.g. office NAT)?
+# Loop in shell — the command is idempotent + fast.
+for ip in 203.0.113.10 203.0.113.11 203.0.113.12; do
+  docker compose exec api php bin/console pim:security:unblock-ip "$ip"
+done
+```
+
+The command resets BOTH `auth_login` and `auth_refresh` buckets for
+the supplied IP. API-key budgets aren't covered by this command —
+those are per-key, not per-IP; use the rotate-secret endpoint
+instead.
+
+---
+
+## On-call escalation
+
+1. **Self-resolve** — try the runbook section that matches the symptom.
+2. **Snapshot** — `pgbackrest backup --type=full`, copy `var/log/`
+   off-host, capture `docker compose logs --since=1h`.
+3. **Notify** — operator (Marcin Lipiec) via the team's escalation
+   channel.
+4. **Post-incident** — append a short note to `agent/lessons.md` so
+   the next incident hits the runbook faster.


### PR DESCRIPTION
## Summary

`docs/runbook/disaster-recovery.md` — on-call operator's primary reference dla security/durability incidents.

**9 sekcji w Symptom/Triage/Action format:**
1. PostgreSQL PITR (pgBackRest)
2. JWT signing key emergency rotation
3. Argon2id rehash na PHP/libsodium drift
4. BYOK Anthropic per-tenant provisioning (#107 fully)
5. Compromised API key — revocation + audit-log forensics
6. Suspected data breach — containment + audit log forensics
7. Audit log retention + manual prune
8. Async worker tenant context drift (HIGH-002 follow-up)
9. Rate limiter operator unblock (#97 follow-up)

Plus `CHANGELOG.md` w root (Keep-a-Changelog format) zbiera 0.10 + 0.11 wave history. README updated z linkami do nowych docs.

## Test plan

- [x] Markdown syntax valid (no rendering errors)
- [x] All cross-doc links resolve (READMЕ → docs/runbook/disaster-recovery.md → restore.md)
- [x] Brak production code change

## Powiązania

- Closes #103
- Refs Project Plan §11 (security architecture), HIGH-001 + HIGH-002 audit findings, każdy ticket epiku 0.10 + 0.11