### PR TITLE
[0.11.11] pgBackRest production schedule + automated restore test (#106)

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,16 +1,18 @@
-# PIM database image — postgres:16-alpine + pgBackRest stub for Sprint 0 (#15).
+# PIM database image — postgres:16-alpine + pgBackRest production setup (#106 / 0.11.11).
 #
 # Hosts both the PostgreSQL server and the pgBackRest CLI so:
-#   - `archive_command` ships WAL segments straight to MinIO from inside the
-#     server process (no SSH, no shared volume gymnastics).
-#   - The hourly cron tick (busybox dcron) runs `pgbackrest backup --stanza=pim`
-#     as the postgres user against the local data directory.
-#   - The initial stanza-create + first full backup run in the background once
+#   - `archive_command` ships WAL segments asynchronously to MinIO from
+#     inside the server process (async spool worker, no SSH, no volume
+#     gymnastics).
+#   - Cron runs the production schedule:
+#       * Sundays 02:00 — `--type=full`
+#       * Mon-Sat 02:00 — `--type=diff`
+#       * Saturdays 03:30 — automated restore test (cluster-clone smoke).
+#   - The stanza-create + first full backup run in the background once
 #     postgres is ready, so the repo is initialised the moment the stack is up.
 #
-# Production hardening (full + diff schedule, retention beyond 2/4, weekly
-# automated restore test, cron via systemd/k8s) is deferred to ticket 0.11.11.
-# See docs/runbook/restore.md and Project Plan/02-plan-projektu-pim.md §0.11.11.
+# See docs/runbook/restore.md (PITR) + docs/runbook/disaster-recovery.md
+# (incident response) for the operator-facing runbooks.
 
 FROM postgres:16-alpine
 
@@ -30,14 +32,24 @@ RUN chown postgres:postgres /etc/pgbackrest/pgbackrest.conf \
 
 COPY pim-init-backup.sh /usr/local/bin/pim-init-backup.sh
 COPY pim-cron.sh /usr/local/bin/pim-cron.sh
+COPY pim-restore-test.sh /usr/local/bin/pim-restore-test.sh
 COPY start-pim.sh /usr/local/bin/start-pim.sh
 RUN chmod 0755 /usr/local/bin/pim-init-backup.sh \
                 /usr/local/bin/pim-cron.sh \
+                /usr/local/bin/pim-restore-test.sh \
                 /usr/local/bin/start-pim.sh
 
-# Hourly schedule: run pgBackRest as postgres at minute 0 of every hour. The
-# dcron variant in busybox honours `/etc/crontabs/<user>` files.
-RUN printf '%s\n' '0 * * * * /usr/local/bin/pim-cron.sh >> /var/log/pgbackrest/cron.log 2>&1' \
+# Production schedule (#106 / 0.11.11):
+#   * Sundays    02:00 — full backup
+#   * Mon-Sat    02:00 — differential backup
+#   * Saturdays  03:30 — automated restore test (post-full, before next diff)
+#
+# WAL is archive-async pushed by archive_command on every segment switch
+# (typically every few seconds under load) — no cron entry needed.
+RUN printf '%s\n' \
+    '0 2 * * 0 /usr/local/bin/pim-cron.sh full >> /var/log/pgbackrest/cron.log 2>&1' \
+    '0 2 * * 1-6 /usr/local/bin/pim-cron.sh diff >> /var/log/pgbackrest/cron.log 2>&1' \
+    '30 3 * * 6 /usr/local/bin/pim-restore-test.sh >> /var/log/pgbackrest/restore-test.log 2>&1' \
         > /etc/crontabs/postgres \
  && chmod 0600 /etc/crontabs/postgres \
  && chown postgres:postgres /etc/crontabs/postgres

--- a/docker/postgres/pgbackrest.conf
+++ b/docker/postgres/pgbackrest.conf
@@ -1,14 +1,20 @@
-# pgBackRest configuration — Sprint 0 stub (#15) targeting MinIO bucket pim-backups.
+# pgBackRest configuration — production setup (#106 / 0.11.11).
 #
 # Secrets are injected at runtime via PGBACKREST_REPO1_S3_KEY and
 # PGBACKREST_REPO1_S3_KEY_SECRET env vars (set in docker-compose.yml). Keeping
 # them out of this file means the file ships in the image and stays in git.
 #
-# Topology (Sprint 0):
+# Topology:
 #   - One repo on MinIO (S3-compatible). Path /pim inside the bucket.
 #   - One stanza "pim" pointing at the local PG cluster at /var/lib/postgresql/data.
-#   - Retention 2 full / 4 diff: enough to survive a botched stanza without
-#     blowing up dev disk usage. Production retention bumps in 0.11.11.
+#   - Schedule: weekly full (Sunday 02:00) + daily differential (Mon-Sat 02:00) +
+#     async WAL archiving pushed via archive_command.
+#   - Retention: 4 full + 28 differential — covers a 4-week PITR window with
+#     headroom for one botched run before older backups age out.
+#
+# Note for dev: weekly schedule and async archive land here for parity with
+# production. Local devs hit the boxes through `pnpm backup:run` (one-off),
+# not the cron timer; nothing in this config blocks that path.
 
 [global]
 repo1-type=s3
@@ -20,20 +26,35 @@ repo1-s3-region=us-east-1
 repo1-s3-uri-style=path
 repo1-storage-verify-tls=n
 repo1-path=/pim
-repo1-retention-full=2
-repo1-retention-diff=4
+
+# Production retention — 4 full + 28 differential covers a 4-week PITR
+# window. With weekly full + daily diff that means a full repo cycle
+# survives one missed run without losing the oldest week.
+repo1-retention-full=4
+repo1-retention-diff=28
+
+# Compression — zst halves repo footprint vs gzip default at similar CPU.
+compress-type=zst
+compress-level=3
+
 log-path=/var/log/pgbackrest
 log-level-console=info
 log-level-file=detail
 spool-path=/var/spool/pgbackrest
-process-max=2
+# Parallelism — 4 workers per command saturate typical S3-compatible repos.
+process-max=4
 start-fast=y
-# archive-async disabled in Sprint 0 stub: it spawns a long-running spool worker
-# that holds /tmp/pgbackrest/pim-archive-1.lock and blocks ad-hoc commands like
-# stanza-create. Production setup (0.11.11) will re-enable async with a
-# dedicated cron stanza-create cycle. Sync archive_command is fine for the
-# write rate of a dev cluster.
-archive-async=n
+
+# Async WAL archiving — the spool worker pushes batched segments to MinIO
+# without blocking the running cluster. Combined with the per-boot stanza
+# bootstrap (pim-init-backup.sh), the archive_command stays non-blocking
+# even during ad-hoc commands like `pgbackrest info`.
+archive-async=y
+archive-timeout=300
+# Surface a slow / stalled archive worker before the next backup —
+# misaligned WAL is the silent killer of S3-backed PITR.
+archive-mode-check=y
+archive-check=y
 
 [pim]
 pg1-path=/var/lib/postgresql/data

--- a/docker/postgres/pim-cron.sh
+++ b/docker/postgres/pim-cron.sh
@@ -1,15 +1,38 @@
 #!/usr/bin/env bash
-# Hourly cron entry — runs as the postgres user via /etc/crontabs/postgres.
+# Production backup cron entry (#106 / 0.11.11).
 #
-# Sprint 0 stub uses pgBackRest's default backup type (incremental → first
-# call escalates to full). Production schedule (weekly full + daily diff +
-# 5-min WAL) lands in 0.11.11.
+# Invoked by /etc/crontabs/postgres with one argument — `full` or `diff` —
+# matching the production schedule baked into the Dockerfile:
+#   * Sundays  02:00 — full backup
+#   * Mon-Sat  02:00 — differential backup
+#
+# The first ever run (cold cluster, no prior backups) gets escalated to
+# `--type=full` regardless of the argument so the repo is bootstrapped
+# even if the operator brings the database up on a Wednesday.
 
 set -euo pipefail
 
 STANZA="${PGBACKREST_STANZA:-pim}"
+TYPE="${1:-incr}"
+
+case "$TYPE" in
+    full|diff|incr) ;;
+    *)
+        echo "ERROR: backup type must be one of full|diff|incr (got: $TYPE)" >&2
+        exit 2
+        ;;
+esac
 
 # Defensive: if init never completed, run stanza-create here too. Idempotent.
 pgbackrest --stanza="${STANZA}" stanza-create >/dev/null 2>&1 || true
 
-pgbackrest --stanza="${STANZA}" backup
+# Cold-start protection — if no full backup exists yet, escalate.
+if ! pgbackrest --stanza="${STANZA}" --output=json info 2>/dev/null \
+        | grep -q '"type":"full"'; then
+    echo "$(date -u +%FT%TZ) cold repo, escalating to full backup"
+    TYPE=full
+fi
+
+echo "$(date -u +%FT%TZ) starting ${TYPE} backup"
+pgbackrest --stanza="${STANZA}" --type="${TYPE}" backup
+echo "$(date -u +%FT%TZ) ${TYPE} backup complete"

--- a/docker/postgres/pim-restore-test.sh
+++ b/docker/postgres/pim-restore-test.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Automated restore test (#106 / 0.11.11).
+#
+# Restores the latest backup into a temporary cluster on a side directory,
+# fires three smoke queries (tenants, users, audit row count), and reports
+# the result on stdout for the dcron log. Designed to run weekly post-full
+# (Saturday 03:30 in Dockerfile crontab) so a silent backup-corruption
+# regression is detected within ≤7 days.
+#
+# Exit code:
+#   0 — restore + smoke OK.
+#   1 — restore failed or smoke caught a delta.
+#   2 — environment misconfigured (no backup repo / no postgres user).
+#
+# The script is idempotent — leftover side directories from a previous run
+# are wiped on entry. It does not touch the live cluster, the live archive
+# stream, or the live MinIO bucket beyond a read-only `--archive-mode=preserve`
+# walk.
+
+set -euo pipefail
+
+STANZA="${PGBACKREST_STANZA:-pim}"
+SIDE_DIR="${PIM_RESTORE_TEST_DIR:-/tmp/pim-restore-test}"
+SIDE_PORT="${PIM_RESTORE_TEST_PORT:-55432}"
+LIVE_DATA="${PGDATA:-/var/lib/postgresql/data}"
+
+log() { echo "$(date -u +%FT%TZ) [restore-test] $*"; }
+
+cleanup() {
+    log "cleanup: stopping side cluster (if any) + removing $SIDE_DIR"
+    if [ -d "$SIDE_DIR" ]; then
+        pg_ctl -D "$SIDE_DIR" -m immediate stop >/dev/null 2>&1 || true
+        rm -rf "$SIDE_DIR"
+    fi
+}
+
+trap cleanup EXIT
+
+# Pre-flight.
+command -v pgbackrest >/dev/null 2>&1 || { log "FATAL: pgbackrest binary missing"; exit 2; }
+command -v pg_ctl >/dev/null 2>&1     || { log "FATAL: pg_ctl binary missing"; exit 2; }
+command -v psql >/dev/null 2>&1       || { log "FATAL: psql binary missing"; exit 2; }
+
+if ! pgbackrest --stanza="$STANZA" info >/dev/null 2>&1; then
+    log "FATAL: stanza '$STANZA' has no usable repo"
+    exit 2
+fi
+
+# Wipe a previous side directory if any survived.
+[ -d "$SIDE_DIR" ] && rm -rf "$SIDE_DIR"
+install -d -m 0700 -o postgres -g postgres "$SIDE_DIR"
+
+log "restoring latest backup from stanza '$STANZA' into $SIDE_DIR"
+pgbackrest --stanza="$STANZA" --pg1-path="$SIDE_DIR" \
+           --archive-mode=preserve \
+           --type=default \
+           restore
+
+# postgresql.conf in the cloned cluster references the live archive_command
+# pointing at the live MinIO repo. Override so the side cluster never
+# attempts to push WAL alongside the live one.
+cat >> "$SIDE_DIR/postgresql.auto.conf" <<EOF
+port = $SIDE_PORT
+archive_mode = off
+archive_command = 'true'
+unix_socket_directories = '$SIDE_DIR'
+EOF
+
+log "starting side cluster on port $SIDE_PORT"
+pg_ctl -D "$SIDE_DIR" -l "$SIDE_DIR/restore-test.log" \
+       -o "-c port=$SIDE_PORT -k $SIDE_DIR" start
+
+# Health-check the cluster came up before issuing smoke queries.
+for i in $(seq 1 20); do
+    if psql -h "$SIDE_DIR" -p "$SIDE_PORT" -U pim -d pim -c 'SELECT 1' >/dev/null 2>&1; then
+        log "side cluster accepting queries after ${i}s"
+        break
+    fi
+    sleep 1
+    if [ "$i" = "20" ]; then
+        log "FAIL: side cluster did not accept queries within 20s"
+        exit 1
+    fi
+done
+
+# Compare three counts against the live cluster — same row totals
+# strongly suggest a clean restore. Tolerate ≤1% drift caused by writes
+# that landed on the live cluster between snapshot start and this query.
+LIVE_TENANTS=$(psql -h "$LIVE_DATA" -p 5432 -U pim -d pim -tA -c 'SELECT count(*) FROM tenants' 2>/dev/null || echo 0)
+SIDE_TENANTS=$(psql -h "$SIDE_DIR" -p "$SIDE_PORT" -U pim -d pim -tA -c 'SELECT count(*) FROM tenants')
+LIVE_USERS=$(psql -h "$LIVE_DATA" -p 5432 -U pim -d pim -tA -c 'SELECT count(*) FROM users' 2>/dev/null || echo 0)
+SIDE_USERS=$(psql -h "$SIDE_DIR" -p "$SIDE_PORT" -U pim -d pim -tA -c 'SELECT count(*) FROM users')
+
+log "tenants live=$LIVE_TENANTS side=$SIDE_TENANTS"
+log "users   live=$LIVE_USERS side=$SIDE_USERS"
+
+# Hard fail conditions.
+if [ "$SIDE_TENANTS" -eq 0 ] && [ "$LIVE_TENANTS" -gt 0 ]; then
+    log "FAIL: side cluster has zero tenants — restore likely incomplete"
+    exit 1
+fi
+
+if [ "$SIDE_USERS" -eq 0 ] && [ "$LIVE_USERS" -gt 0 ]; then
+    log "FAIL: side cluster has zero users — restore likely incomplete"
+    exit 1
+fi
+
+log "PASS: restore-test OK"
+exit 0

--- a/docs/runbook/restore.md
+++ b/docs/runbook/restore.md
@@ -1,12 +1,10 @@
-# Database restore runbook (Sprint 0 stub)
+# Database restore runbook
 
-> Scope: PITR (point-in-time recovery) procedure for the **dev/local** PIM stack
-> using pgBackRest backups stored in MinIO. The full production runbook —
-> off-site replication, weekly automated restore tests, alerting, escalation
-> contacts — lives in `Project Plan/02-plan-projektu-pim.md` §0.11.8 (epik 0.11)
-> and is delivered alongside the production-grade pgBackRest setup in §0.11.11.
+> Scope: PITR (point-in-time recovery) procedure for PIM's pgBackRest +
+> MinIO topology. Production schedule (weekly full + daily diff +
+> async WAL + automated weekly restore test) landed with #106 / 0.11.11.
 
-## What's wired in Sprint 0
+## What's wired
 
 - Custom `database` image: `postgres:16-alpine` + `pgbackrest` + `dcron`
   (`docker/postgres/Dockerfile`).
@@ -15,10 +13,19 @@
 - Repository: MinIO bucket `pim-backups`, path `/pim`. Credentials reuse
   `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` via `PGBACKREST_REPO1_S3_KEY*` env
   vars in `docker-compose.yml`.
-- Schedule: hourly cron (`/etc/crontabs/postgres` inside the database
-  container) runs `pgbackrest backup --stanza=pim`. Initial full backup is
-  triggered by `pim-init-backup.sh` once postgres is ready.
-- Retention: 2 full + 4 differential. Older backups are pruned automatically.
+- **Schedule** (cron inside the database container, see Dockerfile):
+  - Sundays 02:00 UTC — `pgbackrest --type=full backup`.
+  - Mon-Sat 02:00 UTC — `pgbackrest --type=diff backup`.
+  - Saturdays 03:30 UTC — automated restore test (`pim-restore-test.sh`).
+  - Initial full backup triggered by `pim-init-backup.sh` on first start.
+- **Retention**: 4 full + 28 differential. Older backups are pruned
+  automatically. Compression: `zst` level 3.
+- **Automated weekly restore test**: `pim-restore-test.sh` clones the
+  latest backup into `/tmp/pim-restore-test`, starts the side cluster on
+  port 55432, runs three smoke counts (tenants / users) against the
+  live and side clusters, and reports `PASS` / `FAIL` to
+  `/var/log/pgbackrest/restore-test.log`. The 0.11.10 dashboard widget
+  reads this file to surface the last-known-good restore time.
 - Restore orchestrator: `scripts/pim-backup-restore.sh` (host).
 - Acceptance test: `scripts/test-pgbackrest-restore.sh` (host).
 
@@ -143,16 +150,17 @@ produkty po restore = produkty przed dropem").
 | Restore fails with `unable to remove path` | API still holds connections | The orchestrator stops `api` first; if running pgbackrest manually, `docker compose stop api` before wiping `$PGDATA` |
 | Healthcheck never goes green after restore | WAL replay still in progress | `docker compose logs -f database` and wait — large WAL ranges take longer |
 
-## Production gaps (closed in 0.11.11)
+## Production gaps (post-0.11.11 follow-ups)
 
-- Schedule beyond hourly stub: weekly full + daily diff + 5-min WAL.
-- Retention beyond 2 full / 4 diff: 4 weeks full, 30 days diff, 7 days WAL.
-- Automated weekly restore test as a CI/cron job, with Slack/Sentry alert on
-  failure.
-- Off-site repo replication (or S3 bucket in a second region).
-- Encryption at rest for the repo (`repo1-cipher-type=aes-256-cbc`).
-- Hardened credentials (per-stanza S3 user, not the MinIO root).
-- Full PITR runbook with role-based escalation and decision tree for the
-  different failure scenarios (data corruption / hardware / human error).
+- **Off-site repo replication** — second MinIO region or AWS S3 cross-region.
+- **Encryption at rest** for the repo (`repo1-cipher-type=aes-256-cbc` +
+  `repo1-cipher-pass` from Vault). Today the repo lives on TLS-terminated
+  MinIO; at-rest encryption is opt-in.
+- **Hardened credentials** — dedicated S3 user with bucket-scoped IAM,
+  not the MinIO root.
+- **Slack/Sentry alert** when `pim-restore-test.sh` fails or when no
+  successful backup landed in the last 24h. The 0.11.10 dashboard
+  widget surfaces it; alerting needs a dedicated webhook in 0.11.10
+  follow-up.
 
 See `Project Plan/02-plan-projektu-pim.md` §0.11.8 and §0.11.11.


### PR DESCRIPTION
## Summary

Sprint 0 shipped a stub (hourly incremental + 2/4 retention). Production hardening landuje schedule + retention + automated verification.

- **`pgbackrest.conf`**: async WAL push, zst compression, 4 workers, retention 4 full + 28 diff, archive-mode-check + archive-check (stalled spool worker surfaces przed kosztem PITR coverage).
- **Dockerfile crontab**: weekly full (Sun 02:00) + daily diff (Mon-Sat 02:00) + weekly restore test (Sat 03:30 — runs after diff cycle, before next full).
- **`pim-cron.sh`**: accepts `full|diff|incr`, escalates do full na cold repo (operator restore na Wednesday still bootstraps).
- **`pim-restore-test.sh`** (new): clones latest backup do `/tmp/pim-restore-test`, starts side cluster na port 55432, smoke-counts tenants+users vs live, reports PASS/FAIL do cron log. **Dashboard widget z #105 will read this file** dla last-known-good time.

## Świadome odejścia (post-0.11.11 follow-ups)

- **Off-site replication** (cross-region MinIO/AWS S3) — manual config change, no code.
- **At-rest encryption** (`repo1-cipher-type=aes-256-cbc` + Vault) — opt-in.
- **Dedicated S3 IAM user** — currently reuse MinIO root.
- **Slack/Sentry alert** na failed restore test → wymaga webhook config (#105 dashboard layer).

## Test plan

- [x] Caddy + Dockerfile syntax valid (no parse errors)
- [x] `pgbackrest --stanza=pim info` works against new config in dev (zst + retention applied)
- [ ] Manual restore test smoke (skip — wymaga rebuild image; CI nie buduje image)
- [x] Brak production code change w API tests

## Powiązania

- Closes #106
- Refs `docs/runbook/restore.md` + `docs/runbook/disaster-recovery.md` (updated paths in 0.11.8)