### PR TITLE
[0.11.12] BYOK Anthropic per-tenant — AES-256-GCM at rest (#107)

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -51,6 +51,15 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 APP_DEFAULT_TENANT_CODE=demo
 ###< app/multi-tenancy ###
 
+###> app/byok ###
+# Master key for BYOK (Bring Your Own Key) Anthropic encryption (#107
+# / 0.11.12, ADR-0017). Base64 of 32 random bytes (AES-256-GCM key).
+# Generate fresh: `openssl rand -base64 32`. Production rotates by
+# adding APP_BYOK_KEY_V2, V3, … and bumping the version map in
+# services.yaml — old rows lazy-reencrypt on next read.
+APP_BYOK_KEY_V1=Gkb8pFTeCtekIu1uEfl1meyLjgLNBHl08qlwuXcOMoc=
+###< app/byok ###
+
 ###> lexik/jwt-authentication-bundle ###
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -154,6 +154,18 @@ services:
         arguments:
             $environment: '%kernel.environment%'
 
+    # BYOK Anthropic encryption (#107 / 0.11.12, ADR-0017). The master
+    # key map is split out as a parameter so rotation = bump env var +
+    # add the version to this map. Existing rows keep decrypting with
+    # their original version until lazy-reencrypted on next read.
+    App\Shared\Infrastructure\Crypto\AesGcmEncryptionService:
+        arguments:
+            $rawKeysByVersion:
+                1: '%env(default::APP_BYOK_KEY_V1)%'
+
+    App\Shared\Application\Crypto\EncryptionServiceInterface:
+        alias: App\Shared\Infrastructure\Crypto\AesGcmEncryptionService
+
     # API Configurator (#94 / 0.10.5). Decorator chain wraps the
     # default + #41 KindAware + #42 ContextScope builders. Priority
     # 20 keeps it on the outside so the public-read groups override

--- a/apps/api/migrations/Version20260430160000.php
+++ b/apps/api/migrations/Version20260430160000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Epic 0.11 / ticket #107 — BYOK per-tenant Anthropic config.
+ *
+ * One config per tenant: ciphertext (base64 of nonce ‖ ciphertext ‖
+ * tag from libsodium AEAD), the master-key version that produced it
+ * (per ADR-0017), the display prefix, and lifecycle timestamps.
+ *
+ * `tenant_id` is `UNIQUE` so the platform cannot accidentally hold
+ * two BYOK rows per tenant. ON DELETE CASCADE — a removed tenant
+ * also removes the encrypted secret.
+ */
+final class Version20260430160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add tenant_agent_configs for BYOK Anthropic per-tenant (#107).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE tenant_agent_configs (
+              id UUID NOT NULL,
+              tenant_id UUID NOT NULL,
+              anthropic_api_key_encrypted TEXT NOT NULL,
+              encryption_key_version INT NOT NULL,
+              key_prefix VARCHAR(16) NOT NULL,
+              enabled_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              disabled_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+              last_used_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+              created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              PRIMARY KEY (id)
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX tenant_agent_configs_tenant_uniq ON tenant_agent_configs (tenant_id)');
+        $this->addSql('ALTER TABLE tenant_agent_configs ADD CONSTRAINT tenant_agent_configs_tenant_fk FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE tenant_agent_configs DROP CONSTRAINT tenant_agent_configs_tenant_fk');
+        $this->addSql('DROP TABLE tenant_agent_configs');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -89,3 +89,4 @@ parameters:
               - src/Asset/Domain/Entity/Asset.php
               - src/ApiConfigurator/Domain/Entity/ApiProfile.php
               - src/ApiConfigurator/Domain/Entity/ApiKey.php
+              - src/Identity/Domain/Entity/TenantAgentConfig.php

--- a/apps/api/src/Identity/Application/ByokKeyManager.php
+++ b/apps/api/src/Identity/Application/ByokKeyManager.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application;
+
+use App\Identity\Domain\Entity\TenantAgentConfig;
+use App\Identity\Domain\Repository\TenantAgentConfigRepositoryInterface;
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Application\Crypto\EncryptionServiceInterface;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+
+/**
+ * Coordinates BYOK key lifecycle for a tenant (#107 / 0.11.12):
+ *
+ * - **set** — encrypt + persist (creates row or rotates existing key).
+ * - **disable** — soft-disable without losing the ciphertext (operator
+ *   can re-enable later by setting a fresh key).
+ * - **resolveKey** — read path used by the agent client factory:
+ *   decrypts, lazy re-encrypts to the active master version when
+ *   `EncryptionService::needsRotation()` returns true, bumps
+ *   `last_used_at`. Returns `null` when no row / disabled, so the
+ *   caller can fall through to the platform key.
+ *
+ * The plaintext key never reaches a callee outside this service except
+ * through `resolveKey()` — and even there it's a transient string the
+ * caller is expected to hand straight to the Anthropic SDK.
+ */
+final readonly class ByokKeyManager
+{
+    private const int PREFIX_LENGTH = 8;
+
+    public function __construct(
+        private TenantAgentConfigRepositoryInterface $configs,
+        private EncryptionServiceInterface $encryption,
+    ) {
+    }
+
+    public function setKey(Tenant $tenant, string $plaintextApiKey): TenantAgentConfig
+    {
+        $secret = $this->encryption->encrypt($plaintextApiKey);
+        $prefix = substr($plaintextApiKey, 0, self::PREFIX_LENGTH);
+
+        $existing = $this->configs->findForTenant($tenant);
+        if (null === $existing) {
+            $config = new TenantAgentConfig(
+                anthropicApiKeyEncrypted: $secret->ciphertext,
+                encryptionKeyVersion: $secret->version,
+                keyPrefix: $prefix,
+            );
+            $this->configs->save($config);
+
+            return $config;
+        }
+
+        $existing->rotateKey($secret->ciphertext, $secret->version, $prefix);
+        $this->configs->save($existing);
+
+        return $existing;
+    }
+
+    public function disable(Tenant $tenant): void
+    {
+        $config = $this->configs->findForTenant($tenant);
+        if (null === $config) {
+            return;
+        }
+
+        $config->disable(new DateTimeImmutable());
+        $this->configs->save($config);
+    }
+
+    /**
+     * Plaintext API key for the tenant, or `null` if BYOK is not
+     * configured / disabled. Caller MUST pass the result to the LLM
+     * client immediately — do not store, log, or echo.
+     */
+    public function resolveKey(Tenant $tenant): ?string
+    {
+        $config = $this->configs->findForTenant($tenant);
+        if (null === $config || !$config->isEnabled()) {
+            return null;
+        }
+
+        $secret = new EncryptedSecret(
+            ciphertext: $config->getAnthropicApiKeyEncrypted(),
+            version: $config->getEncryptionKeyVersion(),
+        );
+        $plaintext = $this->encryption->decrypt($secret);
+
+        if ($this->encryption->needsRotation($secret)) {
+            $rotated = $this->encryption->encrypt($plaintext);
+            $config->reencrypt($rotated->ciphertext, $rotated->version);
+        }
+
+        $config->markUsed(new DateTimeImmutable());
+        $this->configs->save($config);
+
+        return $plaintext;
+    }
+}

--- a/apps/api/src/Identity/Domain/Entity/TenantAgentConfig.php
+++ b/apps/api/src/Identity/Domain/Entity/TenantAgentConfig.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Per-tenant Anthropic BYOK row (#107 / 0.11.12).
+ *
+ * One config per tenant — the runtime resolver returns the platform
+ * key when no row is present (or `disabledAt !== null`).
+ *
+ * The plaintext key never lives on this object — only the base64
+ * ciphertext + the master key version + a 6-character display
+ * prefix (`sk-ant-…`) the admin sees in the UI.
+ */
+class TenantAgentConfig implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    /**
+     * Base64 of `nonce ‖ ciphertext ‖ tag` from libsodium AEAD output.
+     * Opaque to callers — encryption service decodes.
+     */
+    #[Assert\NotBlank]
+    private string $anthropicApiKeyEncrypted;
+
+    /**
+     * Master-key version used to produce the ciphertext (per ADR-0017).
+     * Resolver lazy re-encrypts to the active version on read.
+     */
+    #[Assert\Positive]
+    private int $encryptionKeyVersion;
+
+    /**
+     * First ~6 chars of the plaintext key — `sk-ant-`. Safe to log
+     * and to render in the admin UI; useless to an attacker.
+     */
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 16)]
+    private string $keyPrefix;
+
+    private DateTimeImmutable $enabledAt;
+
+    private ?DateTimeImmutable $disabledAt = null;
+
+    private ?DateTimeImmutable $lastUsedAt = null;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        string $anthropicApiKeyEncrypted,
+        int $encryptionKeyVersion,
+        string $keyPrefix,
+        ?Uuid $id = null,
+        ?DateTimeImmutable $enabledAt = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->anthropicApiKeyEncrypted = $anthropicApiKeyEncrypted;
+        $this->encryptionKeyVersion = $encryptionKeyVersion;
+        $this->keyPrefix = $keyPrefix;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+        $this->enabledAt = $enabledAt ?? $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getAnthropicApiKeyEncrypted(): string
+    {
+        return $this->anthropicApiKeyEncrypted;
+    }
+
+    public function getEncryptionKeyVersion(): int
+    {
+        return $this->encryptionKeyVersion;
+    }
+
+    public function getKeyPrefix(): string
+    {
+        return $this->keyPrefix;
+    }
+
+    /**
+     * Replace the stored ciphertext (lazy rotation, key change).
+     * Bumps `updatedAt` and re-enables the row if it was disabled.
+     */
+    public function rotateKey(string $newCiphertext, int $newVersion, string $newPrefix): void
+    {
+        $this->anthropicApiKeyEncrypted = $newCiphertext;
+        $this->encryptionKeyVersion = $newVersion;
+        $this->keyPrefix = $newPrefix;
+        $this->disabledAt = null;
+        $this->touch();
+    }
+
+    /**
+     * Lazy re-encrypt to a newer master-key version without changing
+     * the underlying secret. Used on read when the encryption service
+     * flags `needsRotation()` true.
+     */
+    public function reencrypt(string $newCiphertext, int $newVersion): void
+    {
+        $this->anthropicApiKeyEncrypted = $newCiphertext;
+        $this->encryptionKeyVersion = $newVersion;
+        $this->touch();
+    }
+
+    public function disable(DateTimeImmutable $when): void
+    {
+        if (null === $this->disabledAt) {
+            $this->disabledAt = $when;
+            $this->touch();
+        }
+    }
+
+    public function isEnabled(): bool
+    {
+        return null === $this->disabledAt;
+    }
+
+    public function getEnabledAt(): DateTimeImmutable
+    {
+        return $this->enabledAt;
+    }
+
+    public function getDisabledAt(): ?DateTimeImmutable
+    {
+        return $this->disabledAt;
+    }
+
+    public function getLastUsedAt(): ?DateTimeImmutable
+    {
+        return $this->lastUsedAt;
+    }
+
+    public function markUsed(DateTimeImmutable $when): void
+    {
+        $this->lastUsedAt = $when;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Identity/Domain/Repository/TenantAgentConfigRepositoryInterface.php
+++ b/apps/api/src/Identity/Domain/Repository/TenantAgentConfigRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Repository;
+
+use App\Identity\Domain\Entity\TenantAgentConfig;
+use App\Shared\Domain\Tenant;
+
+interface TenantAgentConfigRepositoryInterface
+{
+    public function save(TenantAgentConfig $config): void;
+
+    public function remove(TenantAgentConfig $config): void;
+
+    /**
+     * BYOK is 1:1 per tenant — at most one row per tenant id.
+     */
+    public function findForTenant(Tenant $tenant): ?TenantAgentConfig;
+}

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/TenantAgentConfig.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/TenantAgentConfig.orm.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Identity\Domain\Entity\TenantAgentConfig"
+            table="tenant_agent_configs"
+            repository-class="App\Identity\Infrastructure\Doctrine\Repository\DoctrineTenantAgentConfigRepository">
+
+        <unique-constraints>
+            <unique-constraint name="tenant_agent_configs_tenant_uniq" columns="tenant_id"/>
+        </unique-constraints>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant" fetch="EAGER">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="anthropicApiKeyEncrypted" type="text" column="anthropic_api_key_encrypted"/>
+        <field name="encryptionKeyVersion" type="integer" column="encryption_key_version"/>
+        <field name="keyPrefix" type="string" length="16" column="key_prefix"/>
+
+        <field name="enabledAt" type="datetime_immutable" column="enabled_at"/>
+        <field name="disabledAt" type="datetime_immutable" column="disabled_at" nullable="true"/>
+        <field name="lastUsedAt" type="datetime_immutable" column="last_used_at" nullable="true"/>
+
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineTenantAgentConfigRepository.php
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineTenantAgentConfigRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Doctrine\Repository;
+
+use App\Identity\Domain\Entity\TenantAgentConfig;
+use App\Identity\Domain\Repository\TenantAgentConfigRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<TenantAgentConfig>
+ */
+class DoctrineTenantAgentConfigRepository extends ServiceEntityRepository implements TenantAgentConfigRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TenantAgentConfig::class);
+    }
+
+    public function save(TenantAgentConfig $config): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($config);
+        $em->flush();
+    }
+
+    public function remove(TenantAgentConfig $config): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($config);
+        $em->flush();
+    }
+
+    public function findForTenant(Tenant $tenant): ?TenantAgentConfig
+    {
+        // The TenantFilter narrows the row set to the active tenant, so
+        // findOneBy without an explicit tenant arg still returns at most
+        // one row — the unique index `(tenant_id)` from the migration
+        // guarantees that.
+        return $this->findOneBy(['tenant' => $tenant]);
+    }
+}

--- a/apps/api/src/Identity/Presentation/Command/SetByokKeyCommand.php
+++ b/apps/api/src/Identity/Presentation/Command/SetByokKeyCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Command;
+
+use App\Identity\Application\ByokKeyManager;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * `pim:byok:set` — operator alternative to the (future) admin UI.
+ *
+ * Sets / rotates a tenant's Anthropic API key. The plaintext is read
+ * from stdin (interactive prompt without echo) so it never lands in
+ * shell history. Saves the encrypted ciphertext per ADR-0017 and
+ * prints only the safe display prefix.
+ */
+#[AsCommand(
+    name: 'pim:byok:set',
+    description: 'Set or rotate an Anthropic API key for a tenant (BYOK, AES-256-GCM at rest).',
+)]
+final class SetByokKeyCommand extends Command
+{
+    public function __construct(
+        private readonly ByokKeyManager $manager,
+        private readonly TenantRepositoryInterface $tenants,
+        private readonly TenantContext $tenantContext,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('tenant', null, InputOption::VALUE_REQUIRED, 'Tenant code or UUID.')
+            ->addOption('disable', null, InputOption::VALUE_NONE, 'Disable BYOK for the tenant (keeps the ciphertext for re-enable).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        /** @var string $tenantOption */
+        $tenantOption = $input->getOption('tenant');
+        if ('' === $tenantOption) {
+            $io->error('Missing required --tenant option.');
+
+            return Command::INVALID;
+        }
+
+        $tenant = Uuid::isValid($tenantOption)
+            ? $this->tenants->findById(Uuid::fromString($tenantOption))
+            : $this->tenants->findByCode($tenantOption);
+
+        if (null === $tenant) {
+            $io->error(\sprintf('Tenant "%s" not found.', $tenantOption));
+
+            return Command::FAILURE;
+        }
+
+        $this->tenantContext->set($tenant);
+
+        if (true === $input->getOption('disable')) {
+            $this->manager->disable($tenant);
+            $io->success(\sprintf('BYOK disabled for tenant "%s".', $tenant->getCode()));
+
+            return Command::SUCCESS;
+        }
+
+        $question = new Question('Anthropic API key (paste, hidden): ');
+        $question->setHidden(true);
+        $question->setHiddenFallback(false);
+        $answer = $io->askQuestion($question);
+        $plaintext = \is_string($answer) ? $answer : '';
+        if ('' === $plaintext) {
+            $io->error('Empty API key — refusing to save.');
+
+            return Command::INVALID;
+        }
+        if (\strlen($plaintext) < 16) {
+            $io->error('API key looks too short — refusing to save.');
+
+            return Command::INVALID;
+        }
+
+        $config = $this->manager->setKey($tenant, $plaintext);
+
+        $io->success(\sprintf(
+            'BYOK key stored for tenant "%s" (prefix %s, encryption v%d).',
+            $tenant->getCode(),
+            $config->getKeyPrefix(),
+            $config->getEncryptionKeyVersion(),
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/apps/api/src/Shared/Application/Crypto/EncryptedSecret.php
+++ b/apps/api/src/Shared/Application/Crypto/EncryptedSecret.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Crypto;
+
+/**
+ * Wire format for an at-rest secret: opaque base64 ciphertext + the
+ * key version that produced it. Stored as two columns rather than a
+ * single concatenated blob so audit-log diffs stay readable and a
+ * future Vault swap can replace the version field with a Vault key id
+ * without touching the ciphertext column.
+ */
+final readonly class EncryptedSecret
+{
+    public function __construct(
+        /**
+         * Base64 encoding of `nonce || ciphertext || authTag` — opaque
+         * to callers, decoded inside the encryption service only.
+         */
+        public string $ciphertext,
+        /**
+         * Master key version this blob was produced with. Numeric so
+         * monotonic rotation tooling stays trivial; the application
+         * loads `APP_BYOK_KEY_V<n>` per version up to the current.
+         */
+        public int $version,
+    ) {
+    }
+}

--- a/apps/api/src/Shared/Application/Crypto/EncryptionServiceInterface.php
+++ b/apps/api/src/Shared/Application/Crypto/EncryptionServiceInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application\Crypto;
+
+/**
+ * AEAD-style encryption surface for at-rest secrets (#107 / 0.11.12).
+ *
+ * Returns base64-encoded `(version || ciphertext-with-tag)` blobs so
+ * a Doctrine TEXT column suffices and a future Vault swap can reuse
+ * the same column shape — the version field carries cipher + key
+ * generation in one opaque token (per ADR-0017).
+ *
+ * `encrypt()` always uses the configured "active" version. `decrypt()`
+ * accepts any version still loaded into the runtime — older versions
+ * stay decryptable until operators sweep them.
+ */
+interface EncryptionServiceInterface
+{
+    public function encrypt(string $plaintext): EncryptedSecret;
+
+    public function decrypt(EncryptedSecret $secret): string;
+
+    /**
+     * `true` when the secret was encrypted with a version older than
+     * the current active one. Callers can lazy-reencrypt on the next
+     * write — same pattern Argon2id uses for password rehash.
+     */
+    public function needsRotation(EncryptedSecret $secret): bool;
+}

--- a/apps/api/src/Shared/Infrastructure/Crypto/AesGcmEncryptionService.php
+++ b/apps/api/src/Shared/Infrastructure/Crypto/AesGcmEncryptionService.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Crypto;
+
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Application\Crypto\EncryptionServiceInterface;
+use RuntimeException;
+
+use const SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES;
+
+/**
+ * AES-256-GCM at-rest encryption backed by libsodium (#107 / 0.11.12).
+ *
+ * See ADR-0017 for the algorithm + versioning rationale.
+ *
+ * Configured with a map of `version => 32-byte master key`. The
+ * highest-numbered version is the "active" one used for new writes;
+ * older versions stay loaded so existing rows decrypt without a
+ * forced sweep.
+ */
+final readonly class AesGcmEncryptionService implements EncryptionServiceInterface
+{
+    /**
+     * @var array<int, string> map of version → raw 32-byte key
+     */
+    private array $keysByVersion;
+
+    private int $activeVersion;
+
+    /**
+     * @param array<int, string> $rawKeysByVersion map of version → base64-encoded
+     *                                             32-byte key (the env var format)
+     */
+    public function __construct(array $rawKeysByVersion)
+    {
+        if ([] === $rawKeysByVersion) {
+            throw new RuntimeException(
+                'BYOK encryption requires at least one master key. '.
+                'Set APP_BYOK_KEY_V1=<base64 32-byte> in env.',
+            );
+        }
+
+        // Constants are not defined at boot when libsodium is missing — use
+        // the literal byte length (32 = SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES).
+        // The AES-256-GCM availability check moves to encrypt()/decrypt() so
+        // a host without AES-NI can still boot and route traffic that does
+        // not touch BYOK paths (PHPStan introspection, CI runners, etc.).
+        $decoded = [];
+        foreach ($rawKeysByVersion as $version => $b64Key) {
+            $raw = base64_decode($b64Key, true);
+            if (false === $raw || 32 !== \strlen($raw)) {
+                throw new RuntimeException(\sprintf(
+                    'BYOK master key version %d is not a valid base64 32-byte string.',
+                    $version,
+                ));
+            }
+            $decoded[$version] = $raw;
+        }
+        ksort($decoded);
+
+        $this->keysByVersion = $decoded;
+        /** @var int $maxVersion */
+        $maxVersion = max(array_keys($decoded));
+        $this->activeVersion = $maxVersion;
+    }
+
+    private function assertCipherAvailable(): void
+    {
+        if (\function_exists('sodium_crypto_aead_aes256gcm_is_available')
+            && sodium_crypto_aead_aes256gcm_is_available()) {
+            return;
+        }
+
+        throw new RuntimeException(
+            'libsodium AES-256-GCM not available on this host. '.
+            'Recompile PHP with --with-sodium or run on AES-NI hardware.',
+        );
+    }
+
+    public function encrypt(string $plaintext): EncryptedSecret
+    {
+        $this->assertCipherAvailable();
+
+        $key = $this->keysByVersion[$this->activeVersion];
+        $nonce = random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES);
+        // No additional data (AAD) in MVP — version field is the contract,
+        // not a free-form context binding. Add AAD if we ever need to bind
+        // ciphertexts to e.g. tenant_id (defence in depth).
+        $ciphertext = sodium_crypto_aead_aes256gcm_encrypt(
+            $plaintext,
+            (string) $this->activeVersion,
+            $nonce,
+            $key,
+        );
+
+        return new EncryptedSecret(
+            ciphertext: base64_encode($nonce.$ciphertext),
+            version: $this->activeVersion,
+        );
+    }
+
+    public function decrypt(EncryptedSecret $secret): string
+    {
+        $this->assertCipherAvailable();
+
+        if (!isset($this->keysByVersion[$secret->version])) {
+            throw new RuntimeException(\sprintf(
+                'BYOK master key version %d is not loaded — operator must keep '.
+                'older versions in env until ciphertexts are swept.',
+                $secret->version,
+            ));
+        }
+
+        $blob = base64_decode($secret->ciphertext, true);
+        if (false === $blob || \strlen($blob) <= SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES) {
+            throw new RuntimeException('BYOK ciphertext is malformed.');
+        }
+
+        $nonce = substr($blob, 0, SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES);
+        $ciphertext = substr($blob, SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES);
+
+        $plaintext = sodium_crypto_aead_aes256gcm_decrypt(
+            $ciphertext,
+            (string) $secret->version,
+            $nonce,
+            $this->keysByVersion[$secret->version],
+        );
+        if (false === $plaintext) {
+            // GCM auth tag mismatch — ciphertext was tampered with or the
+            // wrong key was used. Either way: do not surface what failed.
+            throw new RuntimeException('BYOK ciphertext failed integrity check.');
+        }
+
+        return $plaintext;
+    }
+
+    public function needsRotation(EncryptedSecret $secret): bool
+    {
+        return $secret->version < $this->activeVersion;
+    }
+}

--- a/apps/api/tests/Integration/Identity/ByokKeyManagerTest.php
+++ b/apps/api/tests/Integration/Identity/ByokKeyManagerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Identity;
+
+use App\Identity\Application\ByokKeyManager;
+use App\Identity\Domain\Repository\TenantAgentConfigRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * End-to-end coverage for the BYOK lifecycle (#107 / 0.11.12):
+ * set → resolve → disable → resolve-after-disable.
+ */
+final class ByokKeyManagerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!\function_exists('sodium_crypto_aead_aes256gcm_is_available')
+            || !sodium_crypto_aead_aes256gcm_is_available()) {
+            self::markTestSkipped('AES-256-GCM not available on this host.');
+        }
+    }
+
+    #[Test]
+    public function setKeyEncryptsAndStoresWithDisplayPrefix(): void
+    {
+        $tenant = $this->seedTenant();
+        $manager = $this->byok();
+
+        $config = $manager->setKey($tenant, 'sk-ant-api03-secret-1234567890');
+
+        self::assertSame('sk-ant-a', $config->getKeyPrefix());
+        self::assertSame(1, $config->getEncryptionKeyVersion());
+        self::assertNotEmpty($config->getAnthropicApiKeyEncrypted());
+        // Plaintext must not appear anywhere in the stored ciphertext.
+        self::assertStringNotContainsString('secret-1234567890', $config->getAnthropicApiKeyEncrypted());
+    }
+
+    #[Test]
+    public function resolveKeyReturnsPlaintextForBoundTenant(): void
+    {
+        $tenant = $this->seedTenant();
+        $manager = $this->byok();
+
+        $manager->setKey($tenant, 'sk-ant-resolve-flow-test');
+        $resolved = $manager->resolveKey($tenant);
+
+        self::assertSame('sk-ant-resolve-flow-test', $resolved);
+    }
+
+    #[Test]
+    public function resolveKeyReturnsNullWhenNoConfig(): void
+    {
+        $tenant = $this->seedTenant();
+        $manager = $this->byok();
+
+        self::assertNull($manager->resolveKey($tenant));
+    }
+
+    #[Test]
+    public function disableHidesTheKeyFromResolver(): void
+    {
+        $tenant = $this->seedTenant();
+        $manager = $this->byok();
+
+        $manager->setKey($tenant, 'sk-ant-disable-flow');
+        self::assertNotNull($manager->resolveKey($tenant));
+
+        $manager->disable($tenant);
+        self::assertNull($manager->resolveKey($tenant), 'Disabled BYOK must fall through to the platform key.');
+
+        // Re-setting the key re-enables the row in place.
+        $manager->setKey($tenant, 'sk-ant-after-reenable');
+        self::assertSame('sk-ant-after-reenable', $manager->resolveKey($tenant));
+    }
+
+    #[Test]
+    public function rotateOverwritesPreviousCiphertext(): void
+    {
+        $tenant = $this->seedTenant();
+        $manager = $this->byok();
+
+        $manager->setKey($tenant, 'sk-ant-original-key');
+        $first = $this->repo()->findForTenant($tenant)?->getAnthropicApiKeyEncrypted();
+        \assert(\is_string($first));
+
+        $manager->setKey($tenant, 'sk-ant-rotated-key');
+        $second = $this->repo()->findForTenant($tenant)?->getAnthropicApiKeyEncrypted();
+
+        self::assertNotSame($first, $second, 'Ciphertext must change on rotation.');
+        self::assertSame('sk-ant-rotated-key', $manager->resolveKey($tenant));
+    }
+
+    private function seedTenant(): Tenant
+    {
+        $em = $this->em();
+        $tenant = new Tenant('byok-demo', 'BYOK Demo');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        return $tenant;
+    }
+
+    private function byok(): ByokKeyManager
+    {
+        $svc = self::getContainer()->get(ByokKeyManager::class);
+        self::assertInstanceOf(ByokKeyManager::class, $svc);
+
+        return $svc;
+    }
+
+    private function repo(): TenantAgentConfigRepositoryInterface
+    {
+        $repo = self::getContainer()->get(TenantAgentConfigRepositoryInterface::class);
+        self::assertInstanceOf(TenantAgentConfigRepositoryInterface::class, $repo);
+
+        return $repo;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Shared/Infrastructure/Crypto/AesGcmEncryptionServiceTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Crypto/AesGcmEncryptionServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Crypto;
+
+use App\Shared\Application\Crypto\EncryptedSecret;
+use App\Shared\Infrastructure\Crypto\AesGcmEncryptionService;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Coverage for the BYOK at-rest encryption surface (#107 / 0.11.12).
+ *
+ * Skips itself on hosts without AES-NI hardware (libsodium AES-256-GCM
+ * `is_available()` returns false on emulated ARM and on some CI
+ * runners). The runtime check in `encrypt()` covers production safety;
+ * the test gives operators a fast smoke when running locally on the
+ * supported hardware.
+ */
+final class AesGcmEncryptionServiceTest extends TestCase
+{
+    private const string KEY_V1 = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=';
+    private const string KEY_V2 = 'IB8eHRwbGhkYFxYVFBMSERAPDg0MCwoJCAcGBQQDAgEA';
+
+    protected function setUp(): void
+    {
+        if (!\function_exists('sodium_crypto_aead_aes256gcm_is_available')
+            || !sodium_crypto_aead_aes256gcm_is_available()) {
+            self::markTestSkipped('AES-256-GCM not available (no AES-NI / libsodium build).');
+        }
+    }
+
+    #[Test]
+    public function rejectsEmptyKeyMap(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('requires at least one master key');
+        new AesGcmEncryptionService([]);
+    }
+
+    #[Test]
+    public function rejectsKeyOfWrongLength(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not a valid base64 32-byte string');
+        new AesGcmEncryptionService([1 => base64_encode('too-short')]);
+    }
+
+    #[Test]
+    public function encryptDecryptRoundTrip(): void
+    {
+        $service = new AesGcmEncryptionService([1 => self::KEY_V1]);
+        $plaintext = 'sk-ant-api03-secret-12345';
+
+        $secret = $service->encrypt($plaintext);
+
+        self::assertSame(1, $secret->version);
+        self::assertNotSame($plaintext, $secret->ciphertext);
+        self::assertSame($plaintext, $service->decrypt($secret));
+    }
+
+    #[Test]
+    public function tamperedCiphertextIsRejected(): void
+    {
+        $service = new AesGcmEncryptionService([1 => self::KEY_V1]);
+        $secret = $service->encrypt('important-secret');
+
+        $tampered = new EncryptedSecret(
+            ciphertext: substr_replace($secret->ciphertext, 'X', -3, 1),
+            version: 1,
+        );
+
+        $this->expectException(RuntimeException::class);
+        // Either malformed (base64 fails) or auth-tag mismatch (GCM
+        // rejects). Both surface as the same hardened message.
+        $this->expectExceptionMessageMatches('/(integrity check|malformed)/');
+        $service->decrypt($tampered);
+    }
+
+    #[Test]
+    public function differentVersionDecodesAndRotatesLazily(): void
+    {
+        $serviceV1 = new AesGcmEncryptionService([1 => self::KEY_V1]);
+        $secret = $serviceV1->encrypt('hello');
+
+        // Operator adds V2; reading the V1 ciphertext still works,
+        // and `needsRotation()` flags it for lazy re-encrypt.
+        $serviceV2 = new AesGcmEncryptionService([
+            1 => self::KEY_V1,
+            2 => self::KEY_V2,
+        ]);
+
+        self::assertSame('hello', $serviceV2->decrypt($secret));
+        self::assertTrue($serviceV2->needsRotation($secret));
+
+        // Fresh writes go to V2.
+        $rotated = $serviceV2->encrypt('hello');
+        self::assertSame(2, $rotated->version);
+        self::assertFalse($serviceV2->needsRotation($rotated));
+    }
+
+    #[Test]
+    public function decryptRejectsUnknownVersion(): void
+    {
+        $service = new AesGcmEncryptionService([1 => self::KEY_V1]);
+        $unknown = new EncryptedSecret(ciphertext: 'AAA=', version: 999);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not loaded');
+        $service->decrypt($unknown);
+    }
+}

--- a/apps/api/tests/Unit/Shared/Infrastructure/Crypto/AesGcmEncryptionServiceTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Crypto/AesGcmEncryptionServiceTest.php
@@ -22,7 +22,7 @@ use RuntimeException;
 final class AesGcmEncryptionServiceTest extends TestCase
 {
     private const string KEY_V1 = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=';
-    private const string KEY_V2 = 'IB8eHRwbGhkYFxYVFBMSERAPDg0MCwoJCAcGBQQDAgEA';
+    private const string KEY_V2 = 'ifn4K04hpi/Gq5KqHYBlstuaxuofrlJmQw4wPYdWTTY=';
 
     protected function setUp(): void
     {

--- a/docs/adr/0017-byok-encryption-strategy.md
+++ b/docs/adr/0017-byok-encryption-strategy.md
@@ -1,0 +1,140 @@
+# 0017. BYOK encryption — AES-256-GCM with versioned master key
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Marcin Lipiec, Senior Staff Engineer
+
+## Context and Problem Statement
+
+Risk **R-27** ("agent cost runaway") in `Project Plan/02-plan-projektu-pim.md`
+puts the worst-case at $1000–10000 if the platform-issued Anthropic key
+leaks or an abuse loop hits the budget. Mitigation **(b)** in the
+matrix: BYOK — enterprise tenants pay their own LLM bill against a
+key they control. Operationalising BYOK forces three concrete
+decisions:
+
+1. How is the secret stored at rest?
+2. How does the runtime resolver pick between tenant key and platform key?
+3. What is the rotation contract when the master encryption key is
+   compromised (or the cipher recommendation moves)?
+
+This ADR settles (1) and (3). (2) is a runtime contract that lands
+with the agent layer (epic 0.7 / Faza 2) — the storage shape proposed
+here is forward-compatible with the resolver.
+
+## Decision Drivers
+
+- The platform must never store, log, or echo the plaintext key.
+  Operators can submit and rotate; nobody — including a DB administrator
+  with a read replica — should be able to recover an existing key from
+  storage.
+- A single dump of the database without the master key must be
+  cryptographically useless against the BYOK rows.
+- Master-key rotation must not require decrypt-then-re-encrypt of every
+  row at the moment of rotation. Operators read at most one row per
+  request; on-the-fly re-encryption on hot path is acceptable.
+- The cipher choice must survive a future PHP / libsodium upgrade
+  without forcing a forklift migration.
+
+## Considered Options
+
+1. **AES-256-GCM via `sodium_crypto_aead_aes256gcm_*`** — authenticated
+   encryption with associated data (AEAD), 256-bit key, embedded
+   tag detects tampering, native to libsodium on PHP 8.4.
+2. **ChaCha20-Poly1305 via `sodium_crypto_aead_chacha20poly1305_ietf_*`**
+   — same AEAD properties, software-friendly without AES-NI.
+3. **AES-256-CBC + HMAC-SHA-256** — encrypt-then-MAC, requires two
+   keys + manual MAC validation. Easy to get wrong.
+4. **Plaintext + DB column-level encryption** (Postgres `pgcrypto`) —
+   key sits next to data on disk, defeats the point.
+5. **HashiCorp Vault transit engine** — proper KMS, but introduces a
+   runtime dependency PIM does not own and a network round-trip per
+   read.
+
+## Decision Outcome
+
+**Chosen: AES-256-GCM via libsodium (option 1)**, with a versioned master
+key and on-read rehash semantics.
+
+### Storage shape
+
+- `tenant_agent_config` table (per-tenant 1:1):
+  - `tenant_id` (FK)
+  - `anthropic_api_key_encrypted` — bytea, the libsodium output
+    (nonce ‖ ciphertext ‖ tag) base64-encoded for portability across
+    pgsql client libraries.
+  - `encryption_key_version` — int, points at a specific master key
+    in the runtime configuration (`APP_BYOK_KEY_V1`,
+    `APP_BYOK_KEY_V2`, …). Defaults to the latest version on insert.
+  - `key_prefix` — first ~6 chars of the plaintext, stored alongside
+    the ciphertext for display (`sk-ant-…`). Safe to log, useless on
+    its own.
+  - `enabled_at`, `disabled_at` — tenant can pause BYOK without
+    deleting the row.
+  - `last_used_at` — bumped by the resolver on every successful read,
+    surfaces dormant rows for audit.
+
+### Master key
+
+- 32 bytes of random material per version (`sodium_crypto_aead_aes256gcm_keygen`),
+  base64 in env: `APP_BYOK_KEY_V1`, `APP_BYOK_KEY_V2`, etc.
+- The application boots with **all known versions** loaded — the
+  resolver picks by `encryption_key_version` to decrypt, always
+  encrypts new writes with the highest declared version.
+- On a successful decrypt against an older version, the row is
+  **lazily re-encrypted** with the latest version on the same write
+  cycle — same cooldown shape as Argon2id rehash on auth.
+
+### Rotation
+
+- Compromise: bump `APP_BYOK_KEY_V<N+1>`, deploy. Existing rows
+  decrypt with V<N>, lazy re-encrypt to V<N+1> on first read. After
+  the soak window (~2 weeks) operators can sweep dormant rows by
+  calling the resolver in a CLI (`pim:byok:sweep`).
+- Cipher: same lazy path covers a hypothetical future migration to a
+  successor cipher — `encryption_key_version` is opaque enough to
+  carry both key generation AND cipher choice.
+
+### Consequences
+
+- **Positive:** AEAD tag detects tampered ciphertext on every read.
+  Master key separation means a DB dump is useless to an attacker.
+  Rotation is zero-downtime and bounded — no fleet-wide rewrite.
+- **Negative:** AES-NI dependency for fast AES-GCM. Servers without
+  AES-NI fall back to constant-time software AES which is ~5× slower
+  but still well below network latency. The resolver runs once per
+  agent call, not per request, so the cost is invisible.
+- **Follow-ups:**
+  - **#107 follow-up** — Anthropic client factory + admin UI for the
+    BYOK form (lands together with epic 0.7 Beta-Min).
+  - **`pim:byok:sweep`** CLI for proactive re-encrypt under a forced
+    rotation window (Faza 2 hardening).
+  - **Vault transit engine** as a follow-up swap when the operator
+    stack grows past one host — the storage shape is compatible
+    (`encryption_key_version` becomes a Vault key id).
+
+## Alternatives Considered
+
+- **ChaCha20-Poly1305** — equally secure, slightly faster on
+  AES-NI-less hardware. Rejected: AES-GCM is the ecosystem default
+  (TLS, SSH, JWT) so operators reach for tools that speak it. The
+  rotation strategy generalises so a future migration to ChaCha is
+  cheap.
+- **AES-256-CBC + HMAC-SHA-256** — rejected: two-key invariants are
+  easy to break (forget to MAC validate, MAC the wrong slice). AEAD
+  primitive removes the foot-gun.
+- **pgcrypto** — rejected: stores the plaintext or the key in the
+  same place as the data, defeats the point.
+- **Vault transit** — rejected for MVP: introduces a hard runtime
+  dependency. Re-evaluate when ≥3 hosts share the application
+  cluster (`Project Plan/02-plan-projektu-pim.md` §11.x Faza 2).
+
+## Links
+
+- Project Plan §8.5 (Bezpieczeństwo agenta — limits + BYOK)
+- Project Plan §11 (security posture)
+- R-27 (agent cost runaway) — Project Plan §6 risks table
+- Related ADRs: ADR-0016 (API key Argon2id format — uses the same
+  "lazy rehash on read" pattern)
+- Tickets: #107 (this ADR introduced), epic 0.7 (Anthropic client
+  factory consumer)


### PR DESCRIPTION
## Summary

R-27 (agent cost runaway) mitigation: enterprise tenants podadzą własny Anthropic key. Storage half ships now — runtime resolver + admin UI dochodzi z epic 0.7 Faza 2 agent layer.

**ADR-0017** udokumentował: AES-256-GCM via libsodium + versioned master key + lazy re-encrypt on read (same shape jak Argon2id rehash).

**Komponenty:**
- `Shared\Application\Crypto`: `EncryptionServiceInterface` + `EncryptedSecret` VO. Forward-compat z Vault transit swap.
- `Shared\Infrastructure\Crypto\AesGcmEncryptionService`: AES-NI runtime probe per-call (boot na CI runners bez AES-NI OK).
- `Identity\Domain\Entity\TenantAgentConfig`: 1:1 per tenant, ciphertext + version + display prefix + lifecycle.
- `Identity\Application\ByokKeyManager`: set / disable / resolve + lazy re-encrypt on read + `last_used_at` bump.
- `pim:byok:set` CLI: hidden stdin prompt — plaintext nie ląduje w shell history.
- Migration `tenant_agent_configs` (UNIQUE tenant, ON DELETE CASCADE).

## Świadome odejścia

- **Anthropic client factory + admin UI** → epic 0.7 Faza 2 (agent layer).
- **Vault transit swap** → follow-up gdy ≥3 hosts share cluster (Project Plan §11.x).
- **`pim:byok:sweep` CLI** dla forced rotation window → Faza 2 hardening.

## Test plan

- [x] PHPStan max — clean
- [x] Deptrac — 0 violations
- [x] **PHPUnit unit** — 6 tests `AesGcmEncryptionServiceTest` (round-trip, tampering rejected, multi-version rotation, unknown version rejected). Skipped on hosts bez AES-NI.
- [x] **PHPUnit integration** — 5 tests `ByokKeyManagerTest` (set / resolve / disable / re-enable / rotate, plaintext absent from ciphertext).
- [x] Composer audit — clean
- ⚠ **Search test pre-existing flake** w pełnej suite — niezwiązany z 0.11.12 (tracked w follow-up).

## Powiązania

- Closes #107
- Refs ADR-0017 (BYOK encryption strategy), Project Plan §8.5 (R-27 mitigation)