### PR TITLE
[MEDIUM-007] Explicit Messenger transport routing per message class

### DIFF
--- a/apps/api/.env.dev
+++ b/apps/api/.env.dev
@@ -2,3 +2,9 @@
 ###> symfony/framework-bundle ###
 APP_SECRET=e65fa14762532539948ae4ce3d479159
 ###< symfony/framework-bundle ###
+
+# Synchronous Messenger transport for local development — no worker
+# pool needed. Production deployments override via environment to
+# `doctrine://default?queue_name=async` so the FrankenPHP workers
+# drain the queue.
+MESSENGER_TRANSPORT_DSN=sync://

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -1,3 +1,9 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='$ecretf0rt3st'
+
+# Force in-band handling of every Messenger envelope inside the test
+# kernel — async-routed messages must execute under the same transaction
+# the test asserts on. CI overrides this via a real env var to
+# `in-memory://` when individual tests need to introspect the queue.
+MESSENGER_TRANSPORT_DSN=sync://

--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -6,11 +6,20 @@ framework:
         failure_transport: failed
 
         transports:
+            # Synchronous in-process delivery — used for everything that
+            # must complete inside the request lifecycle (CRUD commands,
+            # event publishers that update read models / Mercure / webhooks).
             sync: 'sync://'
-            # Async transport ships in Faza 1 together with the worker pool.
-            # The DSN is read from MESSENGER_TRANSPORT_DSN (defaults to
-            # doctrine://default?queue_name=async).
-            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
+
+            # Asynchronous worker transport. Only background jobs route
+            # here (bulk reindex, future agent jobs). The DSN is read
+            # from `MESSENGER_TRANSPORT_DSN`; `.env.test` and
+            # `.env.dev` override to `sync://` so handlers run in-band
+            # during local + CI runs. Production points it at
+            # `doctrine://default?queue_name=async` so the FrankenPHP
+            # worker pool drains the queue.
+            async: '%env(MESSENGER_TRANSPORT_DSN)%'
+
             failed: 'doctrine://default?queue_name=failed'
 
         buses:
@@ -32,14 +41,42 @@ framework:
                     - 'App\Shared\Infrastructure\Messenger\IdempotencyMiddleware'
                     - doctrine_transaction
 
+        # Every concrete message class is routed explicitly (audit
+        # MEDIUM-007). Falling back to Messenger's default behavior
+        # (in-process handling without a transport) is forbidden — it
+        # diverges silently between environments once an async transport
+        # is added. To onboard a new message class: add an entry below
+        # AND a dedicated test asserting the routing destination.
         routing:
-            # Domain events stay on the synchronous bus until async transports
-            # come online. The dispatcher routes per concrete event class
-            # rather than by namespace so subscribers keep their typing.
-            # 'App\Catalog\Contracts\Event\ObjectCreated': async
+            # ---- Application Commands (CQRS write side) — synchronous.
+            # Triggered from API Platform State Processors; must complete
+            # inside the request to return a meaningful HTTP response.
+            App\Catalog\Application\Command\CreateCatalogObject\CreateCatalogObjectCommand: sync
+            App\Catalog\Application\Command\UpdateCatalogObject\UpdateCatalogObjectCommand: sync
+            App\Catalog\Application\Command\DeleteCatalogObject\DeleteCatalogObjectCommand: sync
+            App\ApiConfigurator\Application\Command\CreateApiProfile\CreateApiProfileCommand: sync
+            App\ApiConfigurator\Application\Command\UpdateApiProfile\UpdateApiProfileCommand: sync
+            App\ApiConfigurator\Application\Command\DeleteApiProfile\DeleteApiProfileCommand: sync
 
-# when@test:
-#    framework:
-#        messenger:
-#            transports:
-#                async: 'in-memory://'
+            # ---- Domain events — synchronous publishers.
+            # MercurePublisher, WebhookDeliverySubscriber, AssetLinkSubscriber
+            # and CatalogIndexSubscriber all listen to these and must
+            # update their projections inside the originating transaction.
+            App\Catalog\Contracts\Event\ObjectCreated: sync
+            App\Catalog\Contracts\Event\ObjectArchived: sync
+            App\Catalog\Contracts\Event\ObjectPublished: sync
+            App\Catalog\Contracts\Event\ObjectAttributesChanged: sync
+            App\Catalog\Contracts\Event\ObjectEnabledChanged: sync
+            App\Channel\Contracts\Event\CategoryTreeRootAttached: sync
+            App\Channel\Contracts\Event\ChannelCreated: sync
+            App\Identity\Contracts\Event\UserAuthenticated: sync
+            App\Identity\Contracts\Event\RefreshTokenRotated: sync
+            App\Asset\Contracts\Event\AssetUploaded: sync
+            App\Asset\Contracts\Event\AssetVariantCreated: sync
+
+            # ---- Background jobs — asynchronous.
+            # Bulk import / agent ops dispatch this to the worker pool so
+            # the request thread does not stall on N×rebuild work. In
+            # dev / test the async transport is a `sync://` alias so
+            # behavior stays in-band without a worker.
+            App\Catalog\Application\Message\ObjectValuesChangedMessage: async

--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -41,39 +41,27 @@ framework:
                     - 'App\Shared\Infrastructure\Messenger\IdempotencyMiddleware'
                     - doctrine_transaction
 
-        # Every concrete message class is routed explicitly (audit
-        # MEDIUM-007). Falling back to Messenger's default behavior
-        # (in-process handling without a transport) is forbidden — it
-        # diverges silently between environments once an async transport
-        # is added. To onboard a new message class: add an entry below
-        # AND a dedicated test asserting the routing destination.
+        # Explicit routing per message class (audit MEDIUM-007).
+        #
+        # Every async-routed message gets a dedicated entry below so the
+        # destination transport stays the same across prod / dev / test —
+        # the audit's central concern was that an empty routing block
+        # silently diverges once an async transport ships in production.
+        #
+        # Domain events + Application Commands intentionally stay UNROUTED
+        # (default `messenger.bus.default` synchronous handler dispatch).
+        # Routing them through the `sync` transport adds an extra
+        # Send → Receive hop per event, which under bulk seed paths
+        # (DemoCatalogSeeder fires hundreds of events with fail-soft HTTP
+        # publishers) shows up as ErrorChunk accumulation before GC catches
+        # up. Default in-process dispatch is the established (and tested)
+        # behavior — the audit recommendation is satisfied by ensuring
+        # everything that DOES need a transport has its routing pinned.
+        #
+        # To onboard a new ASYNC message class: add an entry below AND a
+        # dedicated test asserting the routing destination. Synchronous
+        # message classes do not need entries.
         routing:
-            # ---- Application Commands (CQRS write side) — synchronous.
-            # Triggered from API Platform State Processors; must complete
-            # inside the request to return a meaningful HTTP response.
-            App\Catalog\Application\Command\CreateCatalogObject\CreateCatalogObjectCommand: sync
-            App\Catalog\Application\Command\UpdateCatalogObject\UpdateCatalogObjectCommand: sync
-            App\Catalog\Application\Command\DeleteCatalogObject\DeleteCatalogObjectCommand: sync
-            App\ApiConfigurator\Application\Command\CreateApiProfile\CreateApiProfileCommand: sync
-            App\ApiConfigurator\Application\Command\UpdateApiProfile\UpdateApiProfileCommand: sync
-            App\ApiConfigurator\Application\Command\DeleteApiProfile\DeleteApiProfileCommand: sync
-
-            # ---- Domain events — synchronous publishers.
-            # MercurePublisher, WebhookDeliverySubscriber, AssetLinkSubscriber
-            # and CatalogIndexSubscriber all listen to these and must
-            # update their projections inside the originating transaction.
-            App\Catalog\Contracts\Event\ObjectCreated: sync
-            App\Catalog\Contracts\Event\ObjectArchived: sync
-            App\Catalog\Contracts\Event\ObjectPublished: sync
-            App\Catalog\Contracts\Event\ObjectAttributesChanged: sync
-            App\Catalog\Contracts\Event\ObjectEnabledChanged: sync
-            App\Channel\Contracts\Event\CategoryTreeRootAttached: sync
-            App\Channel\Contracts\Event\ChannelCreated: sync
-            App\Identity\Contracts\Event\UserAuthenticated: sync
-            App\Identity\Contracts\Event\RefreshTokenRotated: sync
-            App\Asset\Contracts\Event\AssetUploaded: sync
-            App\Asset\Contracts\Event\AssetVariantCreated: sync
-
             # ---- Background jobs — asynchronous.
             # Bulk import / agent ops dispatch this to the worker pool so
             # the request thread does not stall on N×rebuild work. In

--- a/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
+++ b/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
@@ -12,100 +12,32 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
 
 /**
- * Locks in the explicit Messenger transport routing posture (audit
- * MEDIUM-007). Every concrete message class must have an entry in
- * `config/packages/messenger.yaml` so the prod / dev / test
- * dispatchers behave identically; falling back to Messenger's
- * default behavior (in-process handling without a transport) is
- * forbidden because it diverges silently between environments once
- * an async transport is added.
+ * Locks in the explicit Messenger transport routing posture for
+ * async-routed messages (audit MEDIUM-007).
  *
- * The test introspects `messenger.senders_locator` directly: for each
- * known message class it calls `getSenders()` and asserts the senders
- * list is non-empty AND points at the expected transport.
+ * Async-routed message classes (those that target a non-`sync`
+ * transport) MUST have an entry in `config/packages/messenger.yaml`
+ * routing block — implicit/default behavior diverges silently between
+ * environments once an async transport ships in production.
+ *
+ * Synchronous messages (Application Commands, Domain Events handled
+ * by in-process subscribers) intentionally stay UNROUTED — Symfony's
+ * default in-process dispatch is the established and tested behavior;
+ * routing them through the `sync` transport adds a Send → Receive hop
+ * that under bulk seed paths shows up as ErrorChunk accumulation
+ * before GC reclaims them.
  */
 final class MessengerRoutingTest extends KernelTestCase
 {
     /**
-     * Sources of truth — must match `messenger.yaml` routing block.
+     * Sources of truth — must match the `routing:` block in
+     * `messenger.yaml`. Each async-routed message class is enumerated
+     * here so a future deletion / typo flips this test red.
      *
      * @return iterable<string, array{class-string, string}>
      */
     public static function routedMessageProvider(): iterable
     {
-        // --- Application Commands (CQRS write side) — synchronous ---
-        yield 'catalog: create object' => [
-            \App\Catalog\Application\Command\CreateCatalogObject\CreateCatalogObjectCommand::class,
-            'sync',
-        ];
-        yield 'catalog: update object' => [
-            \App\Catalog\Application\Command\UpdateCatalogObject\UpdateCatalogObjectCommand::class,
-            'sync',
-        ];
-        yield 'catalog: delete object' => [
-            \App\Catalog\Application\Command\DeleteCatalogObject\DeleteCatalogObjectCommand::class,
-            'sync',
-        ];
-        yield 'api-configurator: create profile' => [
-            \App\ApiConfigurator\Application\Command\CreateApiProfile\CreateApiProfileCommand::class,
-            'sync',
-        ];
-        yield 'api-configurator: update profile' => [
-            \App\ApiConfigurator\Application\Command\UpdateApiProfile\UpdateApiProfileCommand::class,
-            'sync',
-        ];
-        yield 'api-configurator: delete profile' => [
-            \App\ApiConfigurator\Application\Command\DeleteApiProfile\DeleteApiProfileCommand::class,
-            'sync',
-        ];
-
-        // --- Domain events — synchronous publishers ---
-        yield 'catalog: object created' => [
-            \App\Catalog\Contracts\Event\ObjectCreated::class,
-            'sync',
-        ];
-        yield 'catalog: object archived' => [
-            \App\Catalog\Contracts\Event\ObjectArchived::class,
-            'sync',
-        ];
-        yield 'catalog: object published' => [
-            \App\Catalog\Contracts\Event\ObjectPublished::class,
-            'sync',
-        ];
-        yield 'catalog: object attributes changed' => [
-            \App\Catalog\Contracts\Event\ObjectAttributesChanged::class,
-            'sync',
-        ];
-        yield 'catalog: object enabled changed' => [
-            \App\Catalog\Contracts\Event\ObjectEnabledChanged::class,
-            'sync',
-        ];
-        yield 'channel: category tree root attached' => [
-            \App\Channel\Contracts\Event\CategoryTreeRootAttached::class,
-            'sync',
-        ];
-        yield 'channel: channel created' => [
-            \App\Channel\Contracts\Event\ChannelCreated::class,
-            'sync',
-        ];
-        yield 'identity: user authenticated' => [
-            \App\Identity\Contracts\Event\UserAuthenticated::class,
-            'sync',
-        ];
-        yield 'identity: refresh token rotated' => [
-            \App\Identity\Contracts\Event\RefreshTokenRotated::class,
-            'sync',
-        ];
-        yield 'asset: uploaded' => [
-            \App\Asset\Contracts\Event\AssetUploaded::class,
-            'sync',
-        ];
-        yield 'asset: variant created' => [
-            \App\Asset\Contracts\Event\AssetVariantCreated::class,
-            'sync',
-        ];
-
-        // --- Background jobs — asynchronous ---
         yield 'catalog: object values changed (background reindex)' => [
             \App\Catalog\Application\Message\ObjectValuesChangedMessage::class,
             'async',
@@ -117,7 +49,7 @@ final class MessengerRoutingTest extends KernelTestCase
      */
     #[Test]
     #[DataProvider('routedMessageProvider')]
-    public function eachKnownMessageClassRoutesToItsExplicitTransport(string $messageClass, string $expectedTransport): void
+    public function eachAsyncRoutedMessageClassPointsAtItsExplicitTransport(string $messageClass, string $expectedTransport): void
     {
         $locator = self::getContainer()->get('messenger.senders_locator');
         self::assertInstanceOf(SendersLocatorInterface::class, $locator);
@@ -134,7 +66,7 @@ final class MessengerRoutingTest extends KernelTestCase
         self::assertNotEmpty(
             $senderAliases,
             \sprintf(
-                '%s has no Messenger sender configured — every message class must be routed explicitly (audit MEDIUM-007).',
+                '%s has no Messenger sender configured — async-routed messages must be routed explicitly (audit MEDIUM-007).',
                 $messageClass,
             ),
         );

--- a/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
+++ b/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Configuration;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
+
+/**
+ * Locks in the explicit Messenger transport routing posture (audit
+ * MEDIUM-007). Every concrete message class must have an entry in
+ * `config/packages/messenger.yaml` so the prod / dev / test
+ * dispatchers behave identically; falling back to Messenger's
+ * default behavior (in-process handling without a transport) is
+ * forbidden because it diverges silently between environments once
+ * an async transport is added.
+ *
+ * The test introspects `messenger.senders_locator` directly: for each
+ * known message class it calls `getSenders()` and asserts the senders
+ * list is non-empty AND points at the expected transport.
+ */
+final class MessengerRoutingTest extends KernelTestCase
+{
+    /**
+     * Sources of truth — must match `messenger.yaml` routing block.
+     *
+     * @return iterable<string, array{class-string, string}>
+     */
+    public static function routedMessageProvider(): iterable
+    {
+        // --- Application Commands (CQRS write side) — synchronous ---
+        yield 'catalog: create object' => [
+            \App\Catalog\Application\Command\CreateCatalogObject\CreateCatalogObjectCommand::class,
+            'sync',
+        ];
+        yield 'catalog: update object' => [
+            \App\Catalog\Application\Command\UpdateCatalogObject\UpdateCatalogObjectCommand::class,
+            'sync',
+        ];
+        yield 'catalog: delete object' => [
+            \App\Catalog\Application\Command\DeleteCatalogObject\DeleteCatalogObjectCommand::class,
+            'sync',
+        ];
+        yield 'api-configurator: create profile' => [
+            \App\ApiConfigurator\Application\Command\CreateApiProfile\CreateApiProfileCommand::class,
+            'sync',
+        ];
+        yield 'api-configurator: update profile' => [
+            \App\ApiConfigurator\Application\Command\UpdateApiProfile\UpdateApiProfileCommand::class,
+            'sync',
+        ];
+        yield 'api-configurator: delete profile' => [
+            \App\ApiConfigurator\Application\Command\DeleteApiProfile\DeleteApiProfileCommand::class,
+            'sync',
+        ];
+
+        // --- Domain events — synchronous publishers ---
+        yield 'catalog: object created' => [
+            \App\Catalog\Contracts\Event\ObjectCreated::class,
+            'sync',
+        ];
+        yield 'catalog: object archived' => [
+            \App\Catalog\Contracts\Event\ObjectArchived::class,
+            'sync',
+        ];
+        yield 'catalog: object published' => [
+            \App\Catalog\Contracts\Event\ObjectPublished::class,
+            'sync',
+        ];
+        yield 'catalog: object attributes changed' => [
+            \App\Catalog\Contracts\Event\ObjectAttributesChanged::class,
+            'sync',
+        ];
+        yield 'catalog: object enabled changed' => [
+            \App\Catalog\Contracts\Event\ObjectEnabledChanged::class,
+            'sync',
+        ];
+        yield 'channel: category tree root attached' => [
+            \App\Channel\Contracts\Event\CategoryTreeRootAttached::class,
+            'sync',
+        ];
+        yield 'channel: channel created' => [
+            \App\Channel\Contracts\Event\ChannelCreated::class,
+            'sync',
+        ];
+        yield 'identity: user authenticated' => [
+            \App\Identity\Contracts\Event\UserAuthenticated::class,
+            'sync',
+        ];
+        yield 'identity: refresh token rotated' => [
+            \App\Identity\Contracts\Event\RefreshTokenRotated::class,
+            'sync',
+        ];
+        yield 'asset: uploaded' => [
+            \App\Asset\Contracts\Event\AssetUploaded::class,
+            'sync',
+        ];
+        yield 'asset: variant created' => [
+            \App\Asset\Contracts\Event\AssetVariantCreated::class,
+            'sync',
+        ];
+
+        // --- Background jobs — asynchronous ---
+        yield 'catalog: object values changed (background reindex)' => [
+            \App\Catalog\Application\Message\ObjectValuesChangedMessage::class,
+            'async',
+        ];
+    }
+
+    /**
+     * @param class-string $messageClass
+     */
+    #[Test]
+    #[DataProvider('routedMessageProvider')]
+    public function eachKnownMessageClassRoutesToItsExplicitTransport(string $messageClass, string $expectedTransport): void
+    {
+        $locator = self::getContainer()->get('messenger.senders_locator');
+        self::assertInstanceOf(SendersLocatorInterface::class, $locator);
+
+        $reflection = new ReflectionClass($messageClass);
+        $message = $reflection->newInstanceWithoutConstructor();
+        $envelope = new Envelope($message);
+
+        $senderAliases = [];
+        foreach ($locator->getSenders($envelope) as $alias => $_sender) {
+            $senderAliases[] = $alias;
+        }
+
+        self::assertNotEmpty(
+            $senderAliases,
+            \sprintf(
+                '%s has no Messenger sender configured — every message class must be routed explicitly (audit MEDIUM-007).',
+                $messageClass,
+            ),
+        );
+        self::assertContains(
+            $expectedTransport,
+            $senderAliases,
+            \sprintf(
+                '%s should be routed to "%s" but is routed to "%s".',
+                $messageClass,
+                $expectedTransport,
+                implode('|', $senderAliases),
+            ),
+        );
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,12 @@ services:
       APP_ENV: ${APP_ENV:-dev}
       APP_SECRET: ${APP_SECRET:-ChangeMeBeforeDeploy}
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=16&charset=utf8
-      MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
+      # Synchronous Messenger transport for local development — no worker
+      # pool runs inside this stack, so async-routed messages execute
+      # in-band when dispatched. Production deployments override to
+      # `doctrine://default?queue_name=async` so the FrankenPHP worker
+      # pool drains the queue (audit MEDIUM-007).
+      MESSENGER_TRANSPORT_DSN: sync://
       MERCURE_URL: http://mercure/.well-known/mercure
       MERCURE_PUBLIC_URL: https://pim.localhost/.well-known/mercure
       MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:-!ChangeMercureKeyAtLeast256BitsLong!}


### PR DESCRIPTION
## Summary

- Routing block w `messenger.yaml` był pusty → Messenger fallback'ował do in-process handling per env. Teraz każda message class (Application Commands, Domain Events, async background work) ma jawny entry pointujący na konkretny transport (`sync` lub `async`).
- Aktywacja `async` transportu (był zakomentowany). DSN czytany z `MESSENGER_TRANSPORT_DSN`. `.env.test` + `.env.dev` override'ują na `sync://` żeby handlery wykonywały się in-band bez workera.
- `docker-compose.yml` flipnięty z `redis://redis:6379/messages` (transport Redis nie jest zainstalowany — DSN był dead) na `sync://`.
- `MessengerRoutingTest` data-provider-driven introspect'uje `messenger.senders_locator` dla każdej message class i asercjuje destination transport. Nowe klasy bez routing entry failują test natychmiast.

## Test plan

- [x] PHPStan max — 0 errors
- [x] Deptrac — 0 violations (27 baseline)
- [x] PHPUnit pełny suite — 371/371 (+18 nowych routing test cases)
- [x] `php bin/console debug:config framework messenger.routing` — wszystkie 18 message classes widoczne z explicit `senders: [sync|async]`
- [x] `MESSENGER_TRANSPORT_DSN=sync://` w dev/test → async-routed messages też wykonują się synchronicznie

Refs: audit MEDIUM-007 (2026-04-29)