### PR TITLE
[MEDIUM-003] DB query duration histogram on /api/metrics

### DIFF
--- a/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/QueryTimingMiddleware.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/QueryTimingMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine\Middleware;
+
+use App\Shared\Infrastructure\Metrics\QueryDurationHistogram;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+
+/**
+ * DBAL Driver middleware that times every query via wrapper
+ * Connection / Statement objects and records into the in-memory
+ * {@see QueryDurationHistogram} (audit MEDIUM-003).
+ *
+ * Tagged with `doctrine.middleware` (autoconfigured) — Symfony's
+ * Doctrine bundle resolves the chain so this wraps the real driver
+ * without touching `doctrine.yaml`.
+ */
+final readonly class QueryTimingMiddleware implements Middleware
+{
+    public function __construct(private QueryDurationHistogram $histogram)
+    {
+    }
+
+    public function wrap(Driver $driver): Driver
+    {
+        return new TimingDriver($driver, $this->histogram);
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/TimingConnection.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/TimingConnection.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine\Middleware;
+
+use App\Shared\Infrastructure\Metrics\QueryDurationHistogram;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+
+final class TimingConnection extends AbstractConnectionMiddleware
+{
+    public function __construct(
+        Connection $connection,
+        private readonly QueryDurationHistogram $histogram,
+    ) {
+        parent::__construct($connection);
+    }
+
+    public function prepare(string $sql): Statement
+    {
+        return new TimingStatement(parent::prepare($sql), $this->histogram);
+    }
+
+    public function query(string $sql): Result
+    {
+        $start = hrtime(true);
+        try {
+            return parent::query($sql);
+        } finally {
+            $this->histogram->observe((hrtime(true) - $start) / 1_000_000_000);
+        }
+    }
+
+    public function exec(string $sql): int|string
+    {
+        $start = hrtime(true);
+        try {
+            return parent::exec($sql);
+        } finally {
+            $this->histogram->observe((hrtime(true) - $start) / 1_000_000_000);
+        }
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/TimingDriver.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/TimingDriver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine\Middleware;
+
+use App\Shared\Infrastructure\Metrics\QueryDurationHistogram;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use SensitiveParameter;
+
+final class TimingDriver extends AbstractDriverMiddleware
+{
+    public function __construct(
+        Driver $driver,
+        private readonly QueryDurationHistogram $histogram,
+    ) {
+        parent::__construct($driver);
+    }
+
+    public function connect(
+        #[SensitiveParameter]
+        array $params,
+    ): Connection {
+        return new TimingConnection(parent::connect($params), $this->histogram);
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/TimingStatement.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/TimingStatement.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine\Middleware;
+
+use App\Shared\Infrastructure\Metrics\QueryDurationHistogram;
+use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
+use Doctrine\DBAL\Driver\Result;
+use Doctrine\DBAL\Driver\Statement;
+
+final class TimingStatement extends AbstractStatementMiddleware
+{
+    public function __construct(
+        Statement $statement,
+        private readonly QueryDurationHistogram $histogram,
+    ) {
+        parent::__construct($statement);
+    }
+
+    public function execute(): Result
+    {
+        $start = hrtime(true);
+        try {
+            return parent::execute();
+        } finally {
+            $this->histogram->observe((hrtime(true) - $start) / 1_000_000_000);
+        }
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Metrics/MetricsController.php
+++ b/apps/api/src/Shared/Infrastructure/Metrics/MetricsController.php
@@ -10,26 +10,32 @@ use Symfony\Component\Routing\Attribute\Route;
 /**
  * Prometheus-compatible scrape endpoint.
  *
- * Sprint 0 ships only the metric called out as the runtime guardrail in the
- * architecture — `frankenphp_worker_memory_bytes` — plus a couple of trivially
- * derivable companions. A full pipeline (Prometheus scrape config, alertmanager
- * thresholds, messenger consumer lag, business metrics) lands in epik 0.11
- * (#103-#105). The endpoint stays available in dev so the bulk-import
- * benchmark (ticket 0.0.13) has a runtime counterpart for ad-hoc inspection.
+ * Surface today:
+ * - `frankenphp_worker_memory_bytes` (architecture sekcja 3.10 guardrail).
+ * - `frankenphp_worker_peak_memory_bytes`, `frankenphp_worker_pid` companions.
+ * - `db_query_duration_seconds` histogram (audit MEDIUM-003) — emitted by
+ *   the {@see \App\Shared\Infrastructure\Doctrine\Middleware\QueryTimingMiddleware}
+ *   so ops can wire `histogram_quantile(0.95, …)` / `0.99` alerts on
+ *   slow DB without re-enabling SQL logging in production.
  *
- * Numbers reported are "memory of whichever worker handled THIS scrape" — fine
- * for single-worker dev. In production with multiple FrankenPHP workers behind
- * the edge Caddy, scraping reaches one randomly, so the alert threshold is set
- * on the rolling max across scrapes.
+ * Numbers reported are "for whichever worker handled THIS scrape" — fine
+ * for single-worker dev. In production with multiple FrankenPHP workers
+ * behind the edge Caddy, scraping reaches one randomly, so alert
+ * thresholds watch the rolling max across scrapes.
  */
-final class MetricsController
+final readonly class MetricsController
 {
+    public function __construct(private QueryDurationHistogram $queryHistogram)
+    {
+    }
+
     #[Route(path: '/api/metrics', name: 'app_metrics', methods: ['GET'])]
     public function __invoke(): Response
     {
         $resident = \memory_get_usage(true);
         $peak = \memory_get_peak_usage(true);
         $pid = \getmypid();
+        $queryMetrics = $this->queryHistogram->render();
 
         $body = <<<METRICS
             # HELP frankenphp_worker_memory_bytes Resident PHP memory of the FrankenPHP worker that handled the scrape.
@@ -41,6 +47,9 @@ final class MetricsController
             # HELP frankenphp_worker_pid Process id of the worker that handled the scrape.
             # TYPE frankenphp_worker_pid gauge
             frankenphp_worker_pid {$pid}
+            # HELP db_query_duration_seconds Wall-clock duration of every Doctrine DBAL query handled by this worker since boot.
+            # TYPE db_query_duration_seconds histogram
+            {$queryMetrics}
 
             METRICS;
 

--- a/apps/api/src/Shared/Infrastructure/Metrics/QueryDurationHistogram.php
+++ b/apps/api/src/Shared/Infrastructure/Metrics/QueryDurationHistogram.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Metrics;
+
+/**
+ * In-memory Prometheus histogram for Doctrine DBAL query durations
+ * (audit MEDIUM-003).
+ *
+ * Logging is OFF in production (memory discipline — sekcja 3.10 of the
+ * architecture), but ops still needs to see when a query starts taking
+ * meaningfully longer. The histogram aggregates each query's wall-clock
+ * runtime into bucketed counters that Prometheus scrapes every N
+ * seconds, so p95 / p99 alerts can be wired to `histogram_quantile`
+ * without re-enabling SQL logging.
+ *
+ * State lives on the worker — same lifetime as
+ * {@see MetricsController} reads
+ * from `memory_get_usage()`. With multiple FrankenPHP workers behind
+ * Caddy, scraping reaches one randomly; alerts watch the rolling max
+ * across scrapes (same caveat as the worker memory metric).
+ */
+final class QueryDurationHistogram
+{
+    /**
+     * Bucket upper bounds in seconds. Aligned with Prometheus client_php
+     * defaults; covers sub-millisecond cache hits up to 10s long-running
+     * reports.
+     *
+     * @var list<float>
+     */
+    public const array DEFAULT_BUCKETS = [
+        0.001,
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+    ];
+
+    /** @var list<float> */
+    private array $buckets;
+
+    /** @var array<int, int> bucket index → cumulative count */
+    private array $bucketCounts;
+
+    private int $count = 0;
+
+    private float $sum = 0.0;
+
+    /**
+     * @param list<float>|null $buckets ascending bucket boundaries; null
+     *                                  uses {@see DEFAULT_BUCKETS}
+     */
+    public function __construct(?array $buckets = null)
+    {
+        $this->buckets = $buckets ?? self::DEFAULT_BUCKETS;
+        $this->bucketCounts = array_fill(0, \count($this->buckets), 0);
+    }
+
+    public function observe(float $durationSeconds): void
+    {
+        ++$this->count;
+        $this->sum += $durationSeconds;
+
+        foreach ($this->buckets as $index => $upperBound) {
+            if ($durationSeconds <= $upperBound) {
+                ++$this->bucketCounts[$index];
+            }
+        }
+    }
+
+    /**
+     * Render a Prometheus exposition snippet (no leading TYPE/HELP — the
+     * caller composes them). Histogram bucket lines use the canonical
+     * `le="<upper>"` label including the `+Inf` overflow bucket. The
+     * cumulative `_count` is identical to the `+Inf` bucket per spec.
+     */
+    public function render(): string
+    {
+        $lines = [];
+        foreach ($this->buckets as $index => $upperBound) {
+            $lines[] = \sprintf(
+                'db_query_duration_seconds_bucket{le="%s"} %d',
+                self::formatBucketBound($upperBound),
+                $this->bucketCounts[$index],
+            );
+        }
+        $lines[] = \sprintf('db_query_duration_seconds_bucket{le="+Inf"} %d', $this->count);
+        $lines[] = \sprintf('db_query_duration_seconds_sum %s', self::formatFloat($this->sum));
+        $lines[] = \sprintf('db_query_duration_seconds_count %d', $this->count);
+
+        return implode("\n", $lines);
+    }
+
+    public function count(): int
+    {
+        return $this->count;
+    }
+
+    public function sum(): float
+    {
+        return $this->sum;
+    }
+
+    /**
+     * @return list<float>
+     */
+    public function buckets(): array
+    {
+        return $this->buckets;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function bucketCounts(): array
+    {
+        return $this->bucketCounts;
+    }
+
+    private static function formatBucketBound(float $value): string
+    {
+        // Match Prometheus convention: short decimals without trailing
+        // zeros so `0.005` stays `0.005` and `1.0` becomes `1`.
+        $formatted = rtrim(rtrim(\sprintf('%.6f', $value), '0'), '.');
+
+        return '' === $formatted ? '0' : $formatted;
+    }
+
+    private static function formatFloat(float $value): string
+    {
+        return rtrim(rtrim(\sprintf('%.6f', $value), '0'), '.');
+    }
+}

--- a/apps/api/tests/Integration/Metrics/MetricsEndpointTest.php
+++ b/apps/api/tests/Integration/Metrics/MetricsEndpointTest.php
@@ -70,14 +70,4 @@ final class MetricsEndpointTest extends WebTestCase
             'Histogram count must be positive after at least one request through the kernel.',
         );
     }
-
-    protected static function getKernelClass(): string
-    {
-        return \App\Kernel::class;
-    }
-
-    protected static function createKernel(array $options = []): \Symfony\Component\HttpKernel\KernelInterface
-    {
-        return parent::createKernel(['environment' => 'test'] + $options);
-    }
 }

--- a/apps/api/tests/Integration/Metrics/MetricsEndpointTest.php
+++ b/apps/api/tests/Integration/Metrics/MetricsEndpointTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Metrics;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * `/api/metrics` Prometheus surface — locks in the metric families the
+ * scrape endpoint is expected to expose.
+ *
+ * The histogram lines (audit MEDIUM-003) populate after the kernel
+ * issues at least one DBAL query, which the request lifecycle already
+ * does (RequestTenantSubscriber reads `tenants`). The test verifies
+ * the response exposition format, not specific bucket counts —
+ * Prometheus tolerates eventually-consistent counter values.
+ */
+final class MetricsEndpointTest extends WebTestCase
+{
+    use ResetDatabase;
+
+    #[Test]
+    public function exposesWorkerAndDbHistogramMetrics(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/api/metrics');
+
+        self::assertSame(200, $client->getResponse()->getStatusCode());
+        self::assertStringContainsString(
+            'text/plain',
+            (string) $client->getResponse()->headers->get('content-type'),
+        );
+
+        $body = (string) $client->getResponse()->getContent();
+
+        // Existing FrankenPHP worker gauges stay intact.
+        self::assertStringContainsString('frankenphp_worker_memory_bytes', $body);
+        self::assertStringContainsString('frankenphp_worker_peak_memory_bytes', $body);
+        self::assertStringContainsString('frankenphp_worker_pid', $body);
+
+        // New DB histogram surface (audit MEDIUM-003).
+        self::assertStringContainsString('# TYPE db_query_duration_seconds histogram', $body);
+        self::assertStringContainsString('db_query_duration_seconds_bucket{le="0.001"}', $body);
+        self::assertStringContainsString('db_query_duration_seconds_bucket{le="0.5"}', $body);
+        self::assertStringContainsString('db_query_duration_seconds_bucket{le="+Inf"}', $body);
+        self::assertStringContainsString('db_query_duration_seconds_sum ', $body);
+        self::assertStringContainsString('db_query_duration_seconds_count ', $body);
+    }
+
+    #[Test]
+    public function histogramCountIsPositiveAfterTheRequestLifecycle(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/api/metrics');
+
+        $body = (string) $client->getResponse()->getContent();
+        if (1 !== preg_match('/^db_query_duration_seconds_count (\d+)$/m', $body, $matches)) {
+            self::fail('db_query_duration_seconds_count line not found in response.');
+        }
+
+        // The request lifecycle (RequestTenantSubscriber + Symfony's
+        // SecurityListener etc.) hits the database before the controller
+        // runs; the histogram must have observed at least one query.
+        self::assertGreaterThan(
+            0,
+            (int) $matches[1],
+            'Histogram count must be positive after at least one request through the kernel.',
+        );
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected static function createKernel(array $options = []): \Symfony\Component\HttpKernel\KernelInterface
+    {
+        return parent::createKernel(['environment' => 'test'] + $options);
+    }
+}

--- a/apps/api/tests/Integration/Metrics/QueryDurationHistogramTest.php
+++ b/apps/api/tests/Integration/Metrics/QueryDurationHistogramTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Metrics;
+
+use App\Shared\Infrastructure\Metrics\QueryDurationHistogram;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Locks in the DB-query histogram telemetry (audit MEDIUM-003).
+ *
+ * Boots the kernel, runs a couple of queries through the live DBAL
+ * connection (which the {@see \App\Shared\Infrastructure\Doctrine\Middleware\QueryTimingMiddleware}
+ * decorates), then asserts both the in-memory histogram counters and
+ * the rendered Prometheus exposition reflect those queries.
+ */
+final class QueryDurationHistogramTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    #[Test]
+    public function recordsEveryDoctrineQueryIntoTheHistogram(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $histogram = $container->get(QueryDurationHistogram::class);
+        self::assertInstanceOf(QueryDurationHistogram::class, $histogram);
+
+        // Force a deterministic baseline — ResetDatabase already ran a
+        // bunch of queries while rebuilding the schema, so we capture
+        // the count "before" and assert delta-only.
+        $before = $histogram->count();
+
+        $connection = $container->get('doctrine')->getConnection();
+        self::assertInstanceOf(Connection::class, $connection);
+
+        // Hit several distinct DBAL paths so all wrappers are exercised:
+        // - executeQuery → Statement::execute via the wrapped TimingStatement
+        // - executeStatement → DELETE no-op via TimingStatement
+        // - direct exec on the wrapped TimingConnection
+        $connection->executeQuery('SELECT 1');
+        $connection->executeQuery('SELECT 2');
+        $connection->executeStatement('SELECT 3');
+
+        $delta = $histogram->count() - $before;
+        self::assertGreaterThanOrEqual(
+            3,
+            $delta,
+            'Each Doctrine query should produce at least one histogram observation.',
+        );
+        self::assertGreaterThan(
+            0.0,
+            $histogram->sum(),
+            'Cumulative query duration must be a positive wall-clock measurement.',
+        );
+    }
+
+    #[Test]
+    public function rendersPrometheusExpositionWithBucketsSumAndCount(): void
+    {
+        $histogram = new QueryDurationHistogram();
+        $histogram->observe(0.0008);
+        $histogram->observe(0.04);
+        $histogram->observe(0.5);
+
+        $rendered = $histogram->render();
+
+        // Bucket lines are present and cumulative — every observation
+        // ≤ upper-bound increments that bucket.
+        self::assertStringContainsString('db_query_duration_seconds_bucket{le="0.001"} 1', $rendered);
+        self::assertStringContainsString('db_query_duration_seconds_bucket{le="0.05"} 2', $rendered);
+        self::assertStringContainsString('db_query_duration_seconds_bucket{le="0.5"} 3', $rendered);
+        self::assertStringContainsString('db_query_duration_seconds_bucket{le="+Inf"} 3', $rendered);
+
+        self::assertStringContainsString('db_query_duration_seconds_sum 0.5408', $rendered);
+        self::assertStringContainsString('db_query_duration_seconds_count 3', $rendered);
+    }
+}


### PR DESCRIPTION
## Summary

- `QueryDurationHistogram` (Prometheus-style histogram, in-memory worker singleton, default Prometheus client_php buckets 1ms…10s).
- `QueryTimingMiddleware` (Doctrine DBAL driver middleware) wraps Driver → Connection → Statement i mierzy każdy `query`/`exec`/`Statement::execute` przez `hrtime(true)`. Auto-taged `doctrine.middleware` przez DoctrineBundle autoconfigure.
- `MetricsController` rozszerzony o renderowanie histogramu obok `frankenphp_worker_memory_bytes`.
- Operator wpina `histogram_quantile(0.95, sum by (le) (rate(db_query_duration_seconds_bucket[5m])))` na p95/p99 alerting bez włączania SQL loggera w prod (architektura sekcja 3.10 — logging off w prod dla memory discipline).

## Test plan

- [x] PHPStan max — 0 errors
- [x] Deptrac — 0 violations (27 baseline)
- [x] PHPUnit pełny suite — 357/357 (+2 nowe testy: histogram + metrics endpoint)
- [x] Manual smoke: `curl http://api/api/metrics` → expozycja zawiera linie `db_query_duration_seconds_bucket{le="..."}` + `_sum` + `_count` z monotonicznie rosnącymi wartościami w kolejnych scrape'ach

Refs: audit MEDIUM-003 (2026-04-29)