### PR TITLE
[0.11.1] 2FA TOTP enrolment + verify + disable endpoints

### DIFF
--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -23,6 +23,7 @@
         "phpdocumentor/reflection-docblock": "^5.6.7",
         "phpstan/phpdoc-parser": "^2.3.2",
         "runtime/frankenphp-symfony": "^0.2",
+        "spomky-labs/otphp": "^11.4",
         "symfony/asset": "7.4.*",
         "symfony/console": "7.4.*",
         "symfony/dotenv": "7.4.*",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8804a1009eccbf895732c9bd73bb4ea6",
+    "content-hash": "9a4a2ed7f7779b6b42c523f28ba3c67f",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -3715,6 +3715,75 @@
             "time": "2024-09-04T18:46:31+00:00"
         },
         {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "reference": "d5b01a39b3415c2cd581d3bd3a3575c1ebbd8e77",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8"
+            },
+            "require-dev": {
+                "infection/infection": "^0",
+                "nikic/php-fuzzer": "^0",
+                "phpunit/phpunit": "^9|^10|^11",
+                "vimeo/psalm": "^4|^5|^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2025-09-24T15:06:41+00:00"
+        },
+        {
             "name": "php-http/discovery",
             "version": "1.20.0",
             "source": {
@@ -4576,6 +4645,76 @@
                 }
             ],
             "time": "2023-12-12T12:06:11+00:00"
+        },
+        {
+            "name": "spomky-labs/otphp",
+            "version": "11.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/otphp.git",
+                "reference": "2a1b503fd1c1a5c751ab3c5cd37f2d2d26ab74ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/otphp/zipball/2a1b503fd1c1a5c751ab3c5cd37f2d2d26ab74ad",
+                "reference": "2a1b503fd1c1a5c751ab3c5cd37f2d2d26ab74ad",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "psr/clock": "^1.0",
+                "symfony/deprecation-contracts": "^3.2"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OTPHP\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/Spomky-Labs/otphp/contributors"
+                }
+            ],
+            "description": "A PHP library for generating one time passwords according to RFC 4226 (HOTP Algorithm) and the RFC 6238 (TOTP Algorithm) and compatible with Google Authenticator",
+            "homepage": "https://github.com/Spomky-Labs/otphp",
+            "keywords": [
+                "FreeOTP",
+                "RFC 4226",
+                "RFC 6238",
+                "google authenticator",
+                "hotp",
+                "otp",
+                "totp"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/otphp/issues",
+                "source": "https://github.com/Spomky-Labs/otphp/tree/11.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-01-23T10:53:01+00:00"
         },
         {
             "name": "symfony/asset",

--- a/apps/api/migrations/Version20260430180000.php
+++ b/apps/api/migrations/Version20260430180000.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Epic 0.11 / ticket #0.11.1 — TOTP 2FA columns on users.
+ *
+ * Three nullable columns hold the per-user TOTP state. `totp_enabled_at`
+ * doubles as the "is 2FA active?" flag (null until the user confirms
+ * their first generated code). Recovery codes are stored as Argon2id
+ * hashes in a JSONB array — one-shot, removed on use.
+ */
+final class Version20260430180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add TOTP 2FA columns (totp_secret, totp_enabled_at, totp_backup_codes) on users.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE users
+              ADD COLUMN totp_secret VARCHAR(128) DEFAULT NULL,
+              ADD COLUMN totp_enabled_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+              ADD COLUMN totp_backup_codes JSONB NOT NULL DEFAULT '[]'::jsonb
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE users
+              DROP COLUMN totp_secret,
+              DROP COLUMN totp_enabled_at,
+              DROP COLUMN totp_backup_codes
+            SQL);
+    }
+}

--- a/apps/api/src/Identity/Application/TotpEnrolmentService.php
+++ b/apps/api/src/Identity/Application/TotpEnrolmentService.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application;
+
+use App\Identity\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use OTPHP\TOTP;
+use OTPHP\TOTPInterface;
+use ParagonIE\ConstantTime\Base32;
+
+use const PASSWORD_ARGON2ID;
+
+/**
+ * Application service that owns the 2FA TOTP enrolment lifecycle (#0.11.1).
+ *
+ * One instance handles three flows:
+ *   - `enrol()`     — provisions a fresh TOTP secret + 10 single-use
+ *                     backup codes; returns the cleartext secret + the
+ *                     `otpauth://` URI an authenticator app scans.
+ *   - `confirm()`   — validates the first code from the user's app and
+ *                     flips the user into "2FA active".
+ *   - `disable()`   — wipes the secret + recovery codes after the user
+ *                     proves possession of the device.
+ *
+ * The service does NOT couple to Symfony Security; the controllers
+ * resolve the authenticated `User` and pass it in. Recovery codes are
+ * hashed with the standard Symfony password hasher (Argon2id by
+ * default) so a database leak never exposes them in cleartext.
+ */
+final readonly class TotpEnrolmentService
+{
+    public const string ISSUER = 'PIM';
+
+    /**
+     * Number of one-shot recovery codes minted at enrolment + each
+     * rotate. The rest of the industry settled on 8–12; 10 is the
+     * shape Symfony Authenticator itself surfaces.
+     */
+    public const int BACKUP_CODE_COUNT = 10;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Allocate fresh secret + recovery codes on the user. The user
+     * remains in "2FA pending" state — `isTotpEnabled()` stays false
+     * until {@see confirm()} accepts the first generated code.
+     *
+     * Returns the cleartext recovery codes ONLY ONCE (caller surfaces
+     * them in the response, then they are gone — only the hashes
+     * persist).
+     *
+     * @return array{secret: string, provisioning_uri: string, backup_codes: list<string>}
+     */
+    public function enrol(User $user): array
+    {
+        $secret = self::generateSecret();
+        $totp = self::makeTotp($secret, $user);
+
+        [$cleartextCodes, $hashedCodes] = $this->generateBackupCodes();
+
+        $user->startTotpEnrolment($secret, $hashedCodes);
+        $this->em->flush();
+
+        return [
+            'secret' => $secret,
+            'provisioning_uri' => $totp->getProvisioningUri(),
+            'backup_codes' => $cleartextCodes,
+        ];
+    }
+
+    /**
+     * Verify the user's first authenticator-app code and flip 2FA on.
+     */
+    public function confirm(User $user, string $code): bool
+    {
+        $secret = $user->getTotpSecret();
+        if (null === $secret || '' === $secret || '' === $code) {
+            return false;
+        }
+        $totp = self::makeTotp($secret, $user);
+        if (!$totp->verify($code, null, 10)) {
+            return false;
+        }
+
+        $user->confirmTotpEnrolment();
+        $this->em->flush();
+
+        return true;
+    }
+
+    /**
+     * Drop the user's 2FA state. Caller must have already verified
+     * possession (TOTP code or backup code) — this method does not
+     * re-check, it just zeroes the columns.
+     */
+    public function disable(User $user): void
+    {
+        $user->disableTotp();
+        $this->em->flush();
+    }
+
+    /**
+     * Verify a code against an active TOTP user. Falls back to the
+     * one-shot backup code list when the TOTP code does not match;
+     * a successful backup code is consumed.
+     */
+    public function verify(User $user, string $code): bool
+    {
+        $secret = $user->getTotpSecret();
+        if (!$user->isTotpEnabled() || null === $secret || '' === $secret || '' === $code) {
+            return false;
+        }
+
+        $totp = self::makeTotp($secret, $user);
+        if ($totp->verify($code, null, 10)) {
+            return true;
+        }
+
+        foreach ($user->getTotpBackupCodes() as $hash) {
+            if (password_verify($code, $hash)) {
+                $user->consumeBackupCode($hash);
+                $this->em->flush();
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{0: list<string>, 1: list<string>}
+     */
+    private function generateBackupCodes(): array
+    {
+        $cleartext = [];
+        $hashed = [];
+        for ($i = 0; $i < self::BACKUP_CODE_COUNT; ++$i) {
+            $code = self::randomBackupCode();
+            $cleartext[] = $code;
+            // PHP-native password_hash with Argon2id — same algorithm
+            // family the Symfony password hasher uses, but without
+            // having to thread a UserPasswordHasher through this
+            // service. Matches Sprint-0 conventions in production.
+            $hashed[] = password_hash($code, PASSWORD_ARGON2ID);
+        }
+
+        return [$cleartext, $hashed];
+    }
+
+    /**
+     * @param non-empty-string $secret
+     */
+    private static function makeTotp(string $secret, User $user): TOTPInterface
+    {
+        $email = $user->getEmail();
+        \assert('' !== $email, 'User email is enforced NOT NULL by the schema.');
+
+        return TOTP::createFromSecret($secret)
+            ->withLabel($email)
+            ->withIssuer(self::ISSUER);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private static function generateSecret(): string
+    {
+        // 20 random bytes → 160-bit shared secret, the RFC 4226 ceiling
+        // and what Google Authenticator / 1Password reach for. base32
+        // encoding strips padding because authenticator apps reject it.
+        $secret = rtrim(Base32::encodeUpper(random_bytes(20)), '=');
+        \assert('' !== $secret);
+
+        return $secret;
+    }
+
+    private static function randomBackupCode(): string
+    {
+        // 10 hex chars (40 bits of entropy) — long enough to brute-force
+        // resist the per-user budget, short enough for a sticky note.
+        return strtolower(bin2hex(random_bytes(5)));
+    }
+}

--- a/apps/api/src/Identity/Domain/Entity/User.php
+++ b/apps/api/src/Identity/Domain/Entity/User.php
@@ -11,6 +11,7 @@ use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use LogicException;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Uid\Uuid;
@@ -59,6 +60,29 @@ class User extends AggregateRoot implements UserInterface, PasswordAuthenticated
 
     private ?DateTimeImmutable $lastLoginAt;
 
+    /**
+     * RFC 6238 TOTP shared secret in base32 encoding. Null while the
+     * user has not started 2FA enrolment, populated by
+     * {@see \App\Identity\Application\TotpEnrolmentService::enrol},
+     * confirmed by `confirmTotpEnrolment()`.
+     *
+     * Stored unencrypted in the column for now — production deployment
+     * will wrap reads/writes through the BYOK encrypter introduced in
+     * 0.11.12 (ADR-0017) once 2FA exits the dev fixtures.
+     */
+    private ?string $totpSecret;
+
+    private ?DateTimeImmutable $totpEnabledAt;
+
+    /**
+     * One-shot recovery codes — Argon2id hashes, single-use. Replenished
+     * via the dedicated rotate endpoint; consumed by the login flow's
+     * fallback path for users locked out of the authenticator app.
+     *
+     * @var list<string>
+     */
+    private array $totpBackupCodes;
+
     private DateTimeImmutable $createdAt;
 
     /**
@@ -79,6 +103,9 @@ class User extends AggregateRoot implements UserInterface, PasswordAuthenticated
         $this->assignedRoles = new ArrayCollection();
         $this->status = self::STATUS_ACTIVE;
         $this->lastLoginAt = null;
+        $this->totpSecret = null;
+        $this->totpEnabledAt = null;
+        $this->totpBackupCodes = [];
         $this->createdAt = new DateTimeImmutable();
     }
 
@@ -199,5 +226,71 @@ class User extends AggregateRoot implements UserInterface, PasswordAuthenticated
     public function removeRole(Role $role): void
     {
         $this->assignedRoles->removeElement($role);
+    }
+
+    public function getTotpSecret(): ?string
+    {
+        return $this->totpSecret;
+    }
+
+    public function isTotpEnabled(): bool
+    {
+        return null !== $this->totpEnabledAt;
+    }
+
+    public function getTotpEnabledAt(): ?DateTimeImmutable
+    {
+        return $this->totpEnabledAt;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getTotpBackupCodes(): array
+    {
+        return $this->totpBackupCodes;
+    }
+
+    /**
+     * Stamps the user with a freshly generated TOTP secret + recovery
+     * codes, but does NOT enable 2FA yet — `confirmTotpEnrolment()`
+     * does that after the first successful code verification, so a
+     * dropped enrolment never locks the user out.
+     *
+     * @param list<string> $backupCodeHashes
+     */
+    public function startTotpEnrolment(string $secret, array $backupCodeHashes): void
+    {
+        $this->totpSecret = $secret;
+        $this->totpBackupCodes = $backupCodeHashes;
+        $this->totpEnabledAt = null;
+    }
+
+    public function confirmTotpEnrolment(?DateTimeImmutable $when = null): void
+    {
+        if (null === $this->totpSecret) {
+            throw new LogicException('Cannot confirm TOTP enrolment before a secret has been provisioned.');
+        }
+        $this->totpEnabledAt = $when ?? new DateTimeImmutable();
+    }
+
+    public function disableTotp(): void
+    {
+        $this->totpSecret = null;
+        $this->totpEnabledAt = null;
+        $this->totpBackupCodes = [];
+    }
+
+    /**
+     * Marks one backup code as consumed. The caller is responsible for
+     * matching the cleartext code against one of the stored hashes;
+     * this method just removes the matching hash from the active list.
+     */
+    public function consumeBackupCode(string $usedHash): void
+    {
+        $this->totpBackupCodes = array_values(array_filter(
+            $this->totpBackupCodes,
+            static fn (string $hash): bool => $hash !== $usedHash,
+        ));
     }
 }

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/User.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/User.orm.xml
@@ -45,6 +45,19 @@
             </options>
         </field>
         <field name="lastLoginAt" type="datetime_immutable" column="last_login_at" nullable="true"/>
+
+        <!-- TOTP 2FA (#0.11.1). Secret + recovery codes are populated by
+             the enrolment endpoint and zeroed when the user disables 2FA.
+             `totpEnabledAt` doubles as a "is 2FA active?" flag — null until
+             the user confirms the first code. -->
+        <field name="totpSecret" type="string" length="128" column="totp_secret" nullable="true"/>
+        <field name="totpEnabledAt" type="datetime_immutable" column="totp_enabled_at" nullable="true"/>
+        <field name="totpBackupCodes" type="json" column="totp_backup_codes">
+            <options>
+                <option name="default">[]</option>
+            </options>
+        </field>
+
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
 
     </entity>

--- a/apps/api/src/Identity/Presentation/TwoFactorController.php
+++ b/apps/api/src/Identity/Presentation/TwoFactorController.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation;
+
+use App\Identity\Application\TotpEnrolmentService;
+use App\Identity\Domain\Entity\User;
+use DateTimeInterface;
+use JsonException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * 2FA TOTP enrolment endpoints (#0.11.1).
+ *
+ *   POST /api/auth/2fa/enrol    — provision a fresh secret + 10
+ *                                  recovery codes (returned ONCE).
+ *                                  Idempotent: replaces any pending
+ *                                  enrolment that has not yet been
+ *                                  confirmed; refuses to overwrite an
+ *                                  ACTIVE 2FA setup.
+ *   POST /api/auth/2fa/verify   — confirm the first authenticator code
+ *                                  and flip 2FA on. Body: `{ code: "123456" }`.
+ *   POST /api/auth/2fa/disable  — wipe the secret + codes after the
+ *                                  user proves possession. Body:
+ *                                  `{ code: "123456" }` (TOTP or backup).
+ *
+ * Login-flow integration (challenging the user for a 2FA code on
+ * `/api/auth/login`) is a follow-up — these endpoints land first so
+ * the persistence + service layer can be exercised independently.
+ */
+final readonly class TwoFactorController
+{
+    public function __construct(
+        private Security $security,
+        private TotpEnrolmentService $enrolment,
+    ) {
+    }
+
+    #[Route(path: '/api/auth/2fa/enrol', methods: ['POST'], name: 'api_auth_2fa_enrol')]
+    public function enrol(): Response
+    {
+        $user = self::requireUser($this->security);
+        if ($user instanceof Response) {
+            return $user;
+        }
+
+        if ($user->isTotpEnabled()) {
+            return self::problem(
+                Response::HTTP_CONFLICT,
+                'TOTP already active',
+                'Disable the existing 2FA setup before re-enrolling.',
+            );
+        }
+
+        $payload = $this->enrolment->enrol($user);
+
+        return new JsonResponse($payload, Response::HTTP_OK);
+    }
+
+    #[Route(path: '/api/auth/2fa/verify', methods: ['POST'], name: 'api_auth_2fa_verify')]
+    public function verify(Request $request): Response
+    {
+        $user = self::requireUser($this->security);
+        if ($user instanceof Response) {
+            return $user;
+        }
+
+        $code = self::readCode($request);
+        if (null === $code) {
+            return self::problem(
+                Response::HTTP_BAD_REQUEST,
+                'Missing verification code',
+                'Provide `code` in the JSON body.',
+            );
+        }
+
+        if (!$this->enrolment->confirm($user, $code)) {
+            return self::problem(
+                Response::HTTP_UNPROCESSABLE_ENTITY,
+                'Invalid verification code',
+                'The code did not match the pending enrolment.',
+            );
+        }
+
+        return new JsonResponse([
+            'enabled' => true,
+            'enabled_at' => $user->getTotpEnabledAt()?->format(DateTimeInterface::ATOM),
+        ]);
+    }
+
+    #[Route(path: '/api/auth/2fa/disable', methods: ['POST'], name: 'api_auth_2fa_disable')]
+    public function disable(Request $request): Response
+    {
+        $user = self::requireUser($this->security);
+        if ($user instanceof Response) {
+            return $user;
+        }
+
+        if (!$user->isTotpEnabled()) {
+            return self::problem(
+                Response::HTTP_CONFLICT,
+                'TOTP not active',
+                '2FA is not enabled for this user.',
+            );
+        }
+
+        $code = self::readCode($request);
+        if (null === $code || !$this->enrolment->verify($user, $code)) {
+            return self::problem(
+                Response::HTTP_UNPROCESSABLE_ENTITY,
+                'Invalid verification code',
+                'A valid TOTP or backup code is required to disable 2FA.',
+            );
+        }
+
+        $this->enrolment->disable($user);
+
+        return new JsonResponse(['enabled' => false]);
+    }
+
+    private static function requireUser(Security $security): User|Response
+    {
+        $user = $security->getUser();
+        if (!$user instanceof User) {
+            return self::problem(
+                Response::HTTP_UNAUTHORIZED,
+                'Unauthorized',
+                'No authenticated user.',
+            );
+        }
+
+        return $user;
+    }
+
+    private static function readCode(Request $request): ?string
+    {
+        $body = $request->getContent();
+        if ('' === $body) {
+            return null;
+        }
+        try {
+            $payload = json_decode($body, true, 4, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+        if (!\is_array($payload) || !isset($payload['code']) || !\is_string($payload['code'])) {
+            return null;
+        }
+        $trimmed = trim($payload['code']);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+
+    private static function problem(int $status, string $title, string $detail): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'type' => 'about:blank',
+                'title' => $title,
+                'status' => $status,
+                'detail' => $detail,
+            ],
+            $status,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
+    }
+}

--- a/apps/api/tests/Api/Identity/TwoFactorEnrolmentApiTest.php
+++ b/apps/api/tests/Api/Identity/TwoFactorEnrolmentApiTest.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Application\TotpEnrolmentService;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use OTPHP\TOTP;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * 2FA TOTP enrolment endpoints (#0.11.1).
+ *
+ * Covers the three endpoints exposed by `TwoFactorController`:
+ *   - POST /api/auth/2fa/enrol   — provisions secret + recovery codes
+ *   - POST /api/auth/2fa/verify  — confirms first authenticator code
+ *   - POST /api/auth/2fa/disable — wipes the setup after re-verification
+ *
+ * Each test runs against a freshly seeded admin user inside its own
+ * tenant; the JWT issued by `/api/auth/login` carries the principal
+ * through to the controller.
+ */
+final class TwoFactorEnrolmentApiTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_CODE = 'demo';
+    private const string ADMIN_EMAIL = 'admin@demo.localhost';
+    private const string ADMIN_PASSWORD = 'changeme';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+        $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        \assert(null !== $superAdmin);
+
+        $tenant = new Tenant(self::TENANT_CODE, 'Demo Tenant');
+        $em->persist($tenant);
+
+        $hasher = $this->passwordHasher();
+        $stub = new User($tenant, self::ADMIN_EMAIL, '');
+        $admin = new User(
+            $tenant,
+            self::ADMIN_EMAIL,
+            $hasher->hashPassword($stub, self::ADMIN_PASSWORD),
+        );
+        $admin->addRole($superAdmin);
+        $em->persist($admin);
+        $em->flush();
+    }
+
+    #[Test]
+    public function enrolReturnsSecretProvisioningUriAndBackupCodes(): void
+    {
+        $client = static::createClient();
+        $token = $this->login($client);
+
+        $response = $client->request('POST', '/api/auth/2fa/enrol', [
+            'headers' => ['Authorization' => 'Bearer '.$token],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $body = self::readEnrolment($response->toArray());
+
+        self::assertNotSame('', $body['secret']);
+        self::assertStringStartsWith('otpauth://totp/', $body['provisioning_uri']);
+        self::assertCount(TotpEnrolmentService::BACKUP_CODE_COUNT, $body['backup_codes']);
+        foreach ($body['backup_codes'] as $code) {
+            self::assertMatchesRegularExpression('/^[0-9a-f]{10}$/', $code);
+        }
+
+        // Persistence side: secret is stored, 2FA NOT yet enabled.
+        $admin = $this->reloadAdmin();
+        self::assertSame($body['secret'], $admin->getTotpSecret());
+        self::assertFalse($admin->isTotpEnabled());
+        self::assertCount(TotpEnrolmentService::BACKUP_CODE_COUNT, $admin->getTotpBackupCodes());
+    }
+
+    #[Test]
+    public function verifyAcceptsCorrectCodeAndEnablesTotp(): void
+    {
+        $client = static::createClient();
+        $token = $this->login($client);
+
+        $enrol = self::readEnrolment($client->request('POST', '/api/auth/2fa/enrol', [
+            'headers' => ['Authorization' => 'Bearer '.$token],
+        ])->toArray());
+
+        $code = TOTP::createFromSecret($enrol['secret'])->now();
+
+        $response = $client->request('POST', '/api/auth/2fa/verify', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+                'content-type' => 'application/json',
+            ],
+            'body' => json_encode(['code' => $code], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertTrue($body['enabled']);
+        self::assertNotNull($body['enabled_at']);
+
+        self::assertTrue($this->reloadAdmin()->isTotpEnabled());
+    }
+
+    #[Test]
+    public function verifyRejectsWrongCode(): void
+    {
+        $client = static::createClient();
+        $token = $this->login($client);
+
+        $client->request('POST', '/api/auth/2fa/enrol', [
+            'headers' => ['Authorization' => 'Bearer '.$token],
+        ]);
+
+        $client->request('POST', '/api/auth/2fa/verify', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+                'content-type' => 'application/json',
+            ],
+            'body' => json_encode(['code' => '000000'], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+        self::assertFalse($this->reloadAdmin()->isTotpEnabled());
+    }
+
+    #[Test]
+    public function disableWipesTheSetupWhenCodeMatches(): void
+    {
+        $client = static::createClient();
+        $token = $this->login($client);
+
+        $enrol = self::readEnrolment($client->request('POST', '/api/auth/2fa/enrol', [
+            'headers' => ['Authorization' => 'Bearer '.$token],
+        ])->toArray());
+        $totp = TOTP::createFromSecret($enrol['secret']);
+
+        $client->request('POST', '/api/auth/2fa/verify', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+                'content-type' => 'application/json',
+            ],
+            'body' => json_encode(['code' => $totp->now()], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseIsSuccessful();
+
+        $client->request('POST', '/api/auth/2fa/disable', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+                'content-type' => 'application/json',
+            ],
+            'body' => json_encode(['code' => $totp->now()], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $admin = $this->reloadAdmin();
+        self::assertFalse($admin->isTotpEnabled());
+        self::assertNull($admin->getTotpSecret());
+        self::assertSame([], $admin->getTotpBackupCodes());
+    }
+
+    #[Test]
+    public function disableAcceptsBackupCodeAsAlternative(): void
+    {
+        $client = static::createClient();
+        $token = $this->login($client);
+
+        $enrol = self::readEnrolment($client->request('POST', '/api/auth/2fa/enrol', [
+            'headers' => ['Authorization' => 'Bearer '.$token],
+        ])->toArray());
+
+        $client->request('POST', '/api/auth/2fa/verify', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+                'content-type' => 'application/json',
+            ],
+            'body' => json_encode(
+                ['code' => TOTP::createFromSecret($enrol['secret'])->now()],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+        self::assertResponseIsSuccessful();
+
+        $backupCode = $enrol['backup_codes'][0];
+
+        $client->request('POST', '/api/auth/2fa/disable', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+                'content-type' => 'application/json',
+            ],
+            'body' => json_encode(['code' => $backupCode], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertFalse($this->reloadAdmin()->isTotpEnabled());
+    }
+
+    #[Test]
+    public function enrolRefusesWhenAlreadyActive(): void
+    {
+        $client = static::createClient();
+        $token = $this->login($client);
+
+        $enrol = self::readEnrolment($client->request('POST', '/api/auth/2fa/enrol', [
+            'headers' => ['Authorization' => 'Bearer '.$token],
+        ])->toArray());
+        $client->request('POST', '/api/auth/2fa/verify', [
+            'headers' => [
+                'Authorization' => 'Bearer '.$token,
+                'content-type' => 'application/json',
+            ],
+            'body' => json_encode(
+                ['code' => TOTP::createFromSecret($enrol['secret'])->now()],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+
+        $client->request('POST', '/api/auth/2fa/enrol', [
+            'headers' => ['Authorization' => 'Bearer '.$token],
+        ]);
+
+        self::assertResponseStatusCodeSame(409);
+    }
+
+    /**
+     * Narrow the loose `array<int|string, mixed>` returned by ApiTestCase
+     * into the structured enrolment payload — keeps PHPStan max happy
+     * while every test still reads `$body['secret']` etc. directly.
+     *
+     * @param array<int|string, mixed> $payload
+     *
+     * @return array{secret: non-empty-string, provisioning_uri: non-empty-string, backup_codes: list<string>}
+     */
+    private static function readEnrolment(array $payload): array
+    {
+        self::assertArrayHasKey('secret', $payload);
+        self::assertArrayHasKey('provisioning_uri', $payload);
+        self::assertArrayHasKey('backup_codes', $payload);
+
+        $secret = $payload['secret'];
+        $provisioningUri = $payload['provisioning_uri'];
+        $backupCodes = $payload['backup_codes'];
+
+        self::assertIsString($secret);
+        self::assertNotSame('', $secret);
+        self::assertIsString($provisioningUri);
+        self::assertNotSame('', $provisioningUri);
+        self::assertIsArray($backupCodes);
+        self::assertIsList($backupCodes);
+        $cleanCodes = [];
+        foreach ($backupCodes as $code) {
+            self::assertIsString($code);
+            self::assertNotSame('', $code);
+            $cleanCodes[] = $code;
+        }
+
+        // PHPStan cannot infer the conditional narrowing into a non-empty
+        // shape from the asserts above — guarantee it explicitly.
+        \assert('' !== $secret);
+        \assert('' !== $provisioningUri);
+
+        return [
+            'secret' => $secret,
+            'provisioning_uri' => $provisioningUri,
+            'backup_codes' => $cleanCodes,
+        ];
+    }
+
+    private function login(\ApiPlatform\Symfony\Bundle\Test\Client $client): string
+    {
+        $response = $client->request('POST', '/api/auth/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(
+                ['email' => self::ADMIN_EMAIL, 'password' => self::ADMIN_PASSWORD],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+        self::assertResponseIsSuccessful();
+
+        $token = $response->toArray()['token'];
+        \assert(\is_string($token));
+
+        return $token;
+    }
+
+    private function reloadAdmin(): User
+    {
+        $em = $this->em();
+        $em->clear();
+        $admin = self::getContainer()->get(UserRepositoryInterface::class)
+            ->findByEmail(self::ADMIN_EMAIL);
+        \assert($admin instanceof User);
+
+        return $admin;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function passwordHasher(): UserPasswordHasherInterface
+    {
+        return self::getContainer()->get(UserPasswordHasherInterface::class);
+    }
+}


### PR DESCRIPTION
## Summary

Backend foundation dla 2FA TOTP (#0.11.1). Login-flow integration (gating `/api/auth/login` na TOTP code gdy user ma 2FA active) — explicit follow-up; te endpointy landują pierwsze żeby schema + service były exercised niezależnie.

### Surface
- `POST /api/auth/2fa/enrol` — provisions secret + 10 one-shot recovery codes (returned ONCE; tylko Argon2id hashe persist'ują). Refuses overwrite na active setup.
- `POST /api/auth/2fa/verify` — confirms pierwszy authenticator code → flips 2FA on.
- `POST /api/auth/2fa/disable` — wipes setup po user proves possession (TOTP code OR backup code; backup codes consumed on use).

### Wiring
- `User` entity rośnie o `totpSecret` / `totpEnabledAt` / `totpBackupCodes`. `isTotpEnabled()` derive z `totpEnabledAt`.
- `TotpEnrolmentService` — secret + provisioning URI via `spomky-labs/otphp` z immutable `withLabel`/`withIssuer` builders. Recovery code hashing via PHP-native `password_hash(PASSWORD_ARGON2ID)`.
- `TwoFactorController` — 3 endpointy za istniejącym JWT firewall.
- Migration `Version20260430180000` dodaje 3 kolumny (totp_secret, totp_enabled_at, totp_backup_codes JSONB default `[]`).

### Świadome odejścia (follow-up)
- **Login-flow challenge**: gdy user ma `isTotpEnabled()=true`, `/api/auth/login` powinien zwrócić challenge zamiast JWT i wymagać drugiego POSTu z TOTP code. To wymaga modyfikacji LoginSuccessHandler + nowego endpointu `/api/auth/2fa/login`. Wystawione jako follow-up bo wymaga osobnej rozwagi nad challenge token format + recovery flow on a 2FA-locked account.
- **Admin UI**: surface "Enable 2FA" + QR display — czeka na user flow definitions (operator decyzja). Backend pozwala enrolować przez API teraz.
- **Login flow rate limiting per-2FA**: limiter dla brute-force na verify endpoint — w follow-up.

## Test plan

- [x] PHPStan max — 0 errors
- [x] Deptrac — 0 violations (27 baseline)
- [x] PHPUnit pełny suite — 384/384 (+6 nowych: TwoFactorEnrolmentApiTest)
- [x] composer audit clean
- [x] Manual smoke: `pim:db:reset` + curl POST /api/auth/2fa/enrol → secret + provisioning_uri (otpauth://) + 10 backup codes returned

Refs: 0.11.1