### PR TITLE
chore(plan): groom epik-UI-08 Modelowanie backlog + add Project Plan/UI/

### DIFF
--- a/Project Plan/02-plan-projektu-pim.md
+++ b/Project Plan/02-plan-projektu-pim.md
@@ -406,9 +406,45 @@ Tydzień 6-9:  Epik 0.6 (admin UI core)
 Tydzień 9-11: Epik 0.7 (agent layer)
 Tydzień 11-13: Epik 0.8, 0.9 (integracje BaseLinker + Shopify)
 Tydzień 13-14: Epik 0.10, 0.11 (API config + hardening)
+Tydzień 14-16: Epik 0.12 / UI-08 (Modelowanie — patrz §3.6)
 ```
 
 Założenie: 10h pracy człowieka tygodniowo (część etatu). Przy pełnym etacie (40h/tydzień) → MVP w 4-5 tygodni.
+
+### 3.6 Epik 0.12 / UI-08 — Modelowanie (post-MVP-Final, pre-Faza 1) — DODANY 2026-05-01
+
+Pierwszy epik napędzany **planem UI** (`Project Plan/UI/`) zamiast backend roadmapy. Definiuje zakładkę „Modelowanie" w admin UI (Object Types / Attributes / Attribute Groups / Categories — 4 sub-taby) + wprowadza **Attribute Group jako first-class entity** (ADR-012) i `EffectiveAttributeGroupResolver` z dziedziczeniem po drzewie kategorii — funkcjonalność, której Akeneo i Pimcore nie mają natywnie.
+
+**Tracking:** GitHub label `epik-UI-08` + cross-cutting tag `UI`. Plan szczegółowy: [`Project Plan/UI/epik-08-modelowanie.md`](UI/epik-08-modelowanie.md) (~960 linii).
+
+**Sequencing:** wchodzi **po MVP-Final (epik 0.11)**, **przed Fazą 1**. Spójne z notą `Project Plan/UI/epik-08-modelowanie.md` §15 (+42-56h impact na Faza 0). Total estymacja epiku: **60-80h** (różnica vs §15 wynika z atomowego ujęcia całości w jeden epik zamiast rozproszenia po 0.3/0.6).
+
+**Backlog (16 issues):**
+
+| # | Ticket | Tagi | Estymacja |
+|---|---|---|---|
+| **#255** | META — reorganizacja sidebar (zwijana sekcja „Modelowanie") | UI, frontend, must-have | 2-4h |
+| **#256** | UI-08.1 ADR-012 + migracje DDL + Doctrine entities | UI, backend, blocker, docs, must-have | 4-6h |
+| **#257** | UI-08.2 ObjectType built-in flags + Brand seed (4-ty built-in) | UI, backend, must-have | 2-3h |
+| **#258** | UI-08.3 System attributes + auto-attach Audit group | UI, backend, must-have | 2-3h |
+| **#259** | UI-08.4 EffectiveAttributeGroupResolver + form-schema endpoint + Redis cache | UI, backend, must-have | 4-6h |
+| **#260** | UI-08.5 ApiResource AttributeGroup CRUD + CQRS handlers + voter | UI, backend, must-have | 3-4h |
+| **#261** | UI-08.6 Attribute migrate-type endpoint (mapping plan + dry-run) | UI, backend, must-have | 4-5h |
+| **#262** | UI-08.7 Where-used endpoints (attributes / groups / object_types) | UI, backend, must-have | 2-3h |
+| **#263** | UI-08.8 visible_when storage + evaluator (MVP: equals) | UI, backend, must-have | 3-4h |
+| **#264** | UI-08.9 Modeling layout shell + 4-tab routing + back-compat redirects | UI, frontend, must-have | 2-3h |
+| **#265** | UI-08.10 Sub-tab Object Types — list + detail + Create wizard | UI, frontend, must-have | 6-8h |
+| **#266** | UI-08.11 Sub-tab Attributes — enhanced list + detail + Where-used | UI, frontend, must-have | 4-5h |
+| **#267** | UI-08.12 Migration impact analyzer modal | UI, frontend, must-have | 4-5h |
+| **#268** | UI-08.13 Sub-tab Attribute Groups — drag-drop + VisibleWhen editor | UI, frontend, must-have | 5-7h |
+| **#269** | UI-08.14 Sub-tab Categories modeling — tree + inheritance preview | UI, frontend, must-have | 5-7h |
+| **#270** | UI-08.15 Bulk import atrybutów z CSV (US-MOD-008) — *optional* | UI, frontend, optional | 3-4h |
+
+**Dependency graph:** wszystkie sub-tickety blokowane przez `#256` (UI-08.1 ADR-012 + migracje DDL). Frontend tickety dodatkowo blokowane przez `#264` (UI-08.9 layout shell), który wymaga `#259` (form-schema endpoint).
+
+**Persona główna:** Adam (NEW) — Architekt informacji, 35-45 lat, używa raz na 1-2 tygodnie. W mniejszych firmach Marcin/Kasia są w roli Adama. **MVP: brak role gating** (każdy zalogowany user ma full access do Modelowania), permissions deferred do Fazy 1 (kandydat ADR-013).
+
+**Zaktualizowana wycena (sekcja 7):** total Faza 0 + Faza 1 + Faza 2 dochodzi 60-80h (epik 0.12 / UI-08 dodatkowo do baseline).
 
 ## 4. Faza 1 — Integracje (BaseLinker + Shopify) + production-ready
 

--- a/Project Plan/UI/00-plan-ui.md
+++ b/Project Plan/UI/00-plan-ui.md
@@ -1,0 +1,206 @@
+# Plan UI — druga część projektu PIM
+
+> **Cel:** zaprojektowanie pełnego UI dla wszystkich przepływów operatorskich i adminowych systemu PIM, na bazie [PRD](../PRD/PRD-PIM.md) i [pełnego podsumowania wywiadu PRD](../PRD/sesja-pelna-podsumowanie.md).
+> **Status:** W TRAKCIE — Modelowanie (epik 08) detal'owany; pozostałe 7 epików jako placeholdery do iteracyjnego rozpisania.
+> **Stack UI:** React 19 + Vite 6 + Refine.dev + shadcn/ui (Radix + Tailwind) + React Router 7 + React Hook Form + Zod (per `CLAUDE.md` § Stack i ADR-005).
+
+---
+
+## 1. Cele projektowania UI
+
+1. **Wow-factor demo dla pierwszego pilota** — UI musi sprzedawać produkt w pierwszych 30 sekundach (Cmd+K, agentic feel, polish wykonania).
+2. **Self-dogfooding ready** — Marcin używa PIM-u na własnym IdoSell (2k SKU) + Shopify (200 SKU). UI ma działać dla niego *od dnia 1*.
+3. **Persona-first** — każdy widok zaprojektowany pod konkretną personę (Kasia / Magda / Piotr / Tomasz / Adam) z `Project Plan/03-funkcjonalnosci-mvp.md` § 3.
+4. **Polish accessibility** — WCAG 2.1 AA od MVP-Final (epik 0.11.9 backendu). shadcn na Radix daje a11y za darmo, ale custom widgety wymagają walidacji axe-core.
+5. **i18n od dnia 1** — wszystkie user-facing stringi przez `t()` (react-i18next), klucze angielskie, tłumaczenia w `pl/en/` (możliwe dalej).
+6. **Demo na małym ekranie** — Tomasz (Owner) ma dashboard responsive z poziomu telefonu (read-only). Reszta widoków desktop-first, ale nie *desktop-only*.
+
+## 2. Personas — kto z UI korzysta
+
+| Persona | Rola | Główne zakładki | Z PRD |
+|---|---|---|---|
+| **Tomasz, 48** | Owner / CEO / super-admin | Dashboard, Audit log, Settings | § 4.2 |
+| **Kasia, 32** | Catalog Manager (main user) | Produkty, Multimedia, Publikacje, Workflow | § 4.2 |
+| **Magda, 29** | Marketing Specialist | Produkty (opisy SEO), Multimedia, Publikacje | § 4.2 |
+| **Piotr, 38** | IT/Integration Specialist | Publikacje, Ustawienia (integracje, API keys) | § 4.2 |
+| **Adam, 40** ⭐ NEW | Architekt informacji (typowy użytkownik Modelowania) | **Modelowanie** + Ustawienia | brakuje w PRD — wprowadzony przy projektowaniu UI |
+| **Marcin (dogfooding)** | Founder + first user | wszystkie | § 4.2 |
+
+**Uproszczenie MVP — brak role gating dla Modelowania.** W obecnej wersji **każdy zalogowany użytkownik widzi i może używać zakładki Modelowanie**, niezależnie od roli. Adam jest *typową* personą tego widoku (architectural mindset, rzadziej loguje się niż Kasia), ale UX nie chowa zakładki.
+
+To jest **świadome uproszczenie** dla MVP:
+- Mniej kompleksowości wokół permission model'u w pierwszych miesiącach.
+- Mid-market klient w pierwszych 2-3 osobowych zespołach często nie ma dedykowanego Model Admina — Kasia / Marcin / Tomasz robi to sam.
+- W praktyce zmiany w Modelowaniu są *rzadkie* (raz na 1-2 tygodnie), więc free-for-all nie generuje chaosu.
+
+**Co dochodzi w przyszłości** (Faza 1+ kandydat ADR-013):
+- Granularne permissions per persona (Kasia widzi *tylko* Object Types do których ma `view`, nie modyfikuje schematu).
+- Audit log każdej zmiany w Modelowaniu (od dnia 1 *jest* — z Doctrine AuditBundle, sekcja 7 archi).
+- Approval flow dla destrukcyjnych operacji (delete ObjectType, change attribute type).
+
+**Adam (NEW persona) — Architekt informacji:**
+- 35-45 lat, doświadczenie 8-15 lat w IT/data engineering / business analysis.
+- W mniejszych firmach to *Marcin sam* (założyciel + dogfooding), w większych mid-market — dedykowany Head of Data lub fractional przez agencję wdrożeniową.
+- Zna struktury danych (relacyjne + JSON), nie programuje codziennie, ale rozumie schema migrations.
+- **Frekwencja użycia:** Adam (lub osoba w roli Adama) loguje się raz na 1-2 tygodnie (gdy biznes potrzebuje nowej kategorii / nowego atrybutu / nowego typu obiektu). Nie codziennie.
+- W MVP UX nie chroni przed Kasią pomyłkowo edytującą model — *konwencja* + audit log są wystarczające. Jeśli okaże się to problemem w pilotach, wprowadzamy permissions w Fazie 1.
+
+## 3. Struktura menu — operator + admin
+
+### 3.1 Menu główne (sidebar)
+
+```
+┌─────────────────────┐
+│ 🏠 Dashboard        │  ← epik-01, wszyscy
+│ 📦 Produkty         │  ← epik-02, Kasia/Magda primary
+│ 🛠  Usługi           │  ← epik-03, Kasia (custom ObjectType "service")
+│ 📤 Publikacje       │  ← epik-04, Kasia/Piotr
+│ 🖼  Multimedia       │  ← epik-05, Kasia/Magda
+│ ⚙️  Workflow         │  ← epik-06, Kasia/Tomasz
+│ ⚙️  Ustawienia       │  ← epik-07, Tomasz/Piotr
+├─────────────────────┤
+│ ⚙️  Modelowanie      │  ← epik-08, dostępne dla wszystkich (MVP — bez role gating)
+└─────────────────────┘
+```
+
+**Ważne:** *Usługi* (epik-03) to **przykład custom ObjectType** stworzonego w Modelowaniu. W praktyce klient w branży medycznej / fryzjerskiej / SaaS doda własny ObjectType, a system automatycznie wygeneruje pozycję menu pod nią. *Usługi* to konkret dla pierwszych pilotów (medyczne, fryzjerskie) oraz dla Marcina (dogfooding może objąć custom kind).
+
+### 3.2 Generic mechanizm menu — `ObjectType` jako pozycja
+
+Pozycje 2/3 (*Produkty*, *Usługi*) są **dynamicznie generowane na podstawie tabeli `object_types`** (z ADR-009):
+- `kind=product` → Produkty (predefiniowany).
+- `kind=category` → NIE pojawia się jako menu (Categories są zarządzane *wewnątrz* Modelowania + jako tree view embedded w Produktach).
+- `kind=asset` → Multimedia (predefiniowany, ale UX wyspecjalizowany).
+- `kind=brand` → Marki (zarządzane w Modelowaniu jako lookup, nie jako top-level menu).
+- `kind=service`, `kind=location`, `kind=event`, `kind=*custom*` → dynamicznie dodawane do menu między *Produkty* a *Publikacje*.
+
+Implikacja UX: gdy Adam w Modelowaniu dodaje nowy ObjectType `Subscription` (kind=custom), Kasia po refresh strony widzi nową pozycję *„Subskrypcje"* w sidebar między Usługami a Publikacjami. To jest *"agentic-first" effect* dla samego UI — system rośnie elastycznie, bez deploya kodu.
+
+## 4. Zasady projektowe (cross-epic)
+
+### 4.1 Spójność wizualna
+- **Layout:** Refine layout standard (sidebar + topbar + content area + optional right sidebar dla detail/preview).
+- **Typografia:** shadcn defaults (Inter font). Nagłówki H1-H4, body text 14px, mono dla kodów / SKU.
+- **Kolory:** dark/light mode (Tailwind tokens). Provenance colors:
+  - 🟢 manual — green-500
+  - 🔵 import — blue-500
+  - 🟣 agent — purple-500 (Faza 2 only)
+  - ⚫ integration — gray-500
+- **Ikony:** Lucide (z `lucide-react`). Konsystentny rozmiar (16px inline, 20px buttons, 24px sidebar).
+
+### 4.2 Wzorce interakcji
+- **Cmd+K command palette** — globalny, dostępny zewszad (Faza 1 baseline, Beta-Demo MVP).
+- **Right sidebar detail/preview** — alternatywa do modal, dla edit/preview na liście.
+- **Bulk actions** — toolbar pojawia się po zaznaczeniu pierwszego rekordu.
+- **Auto-save z debounce** — 3s lub Cmd+S, *nie* explicit Save button (poza modal'ami).
+- **Diff modal przed save** — dla zmian wpływających na >1 rekord lub krytycznych pól.
+- **Provenance badges** — przy każdym polu w formularzu, klikalne tooltip.
+- **Inline validation** — Zod + React Hook Form, błędy pod polem.
+- **Keyboard shortcuts** — `?` pokazuje dostępne shortcut'y dla widoku.
+
+### 4.3 Stany kraytkowe (loading / empty / error)
+- **Loading:** skeleton screens (shadcn `Skeleton` component), nie spinnery.
+- **Empty state:** ilustracja + CTA *„dodaj pierwszy X"*.
+- **Error:** alert + retry button + link do logu (Sentry trace ID dla Pro/Enterprise tier).
+
+### 4.4 Mobile
+- **Dashboard mobile-friendly** (Tomasz read-only).
+- **Reszta desktop-first**, ale nie blokujemy mobile (responsive grid + breakpoint sm/md/lg/xl).
+- **Touch targets ≥44px** dla mobile-friendly sekcji.
+
+## 5. Roadmap UI (mapowanie na fazy backendu)
+
+| Faza UI | Co wchodzi | Mapping na MVP/Faza 1/2 |
+|---|---|---|
+| **Szkielet** | Layout, sidebar, routing, login/auth, base widoki (placeholder content) | MVP-Alpha epik 0.6.1 |
+| **Modelowanie** | Pełna zakładka Modelowanie (epik-08), widoki Object Types / Attributes / Attribute Groups / Categories | MVP-Alpha epik 0.3 + 0.6 |
+| **Produkty + Multimedia** | Lista produktów, dynamiczny formularz edycji, DAM lite, provenance badges | MVP-Alpha + MVP-Final |
+| **Publikacje** | Sync jobs panel, integracje (BaseLinker/Shopify), API Configurator, generator feedów | MVP-Final epik 0.10 + Faza 1 |
+| **Workflow + Settings** | Workflow stanów (Faza 1), settings (users, roles, integrations, API keys, locale, BYOK) | Faza 1 epik 0.11 |
+| **Dashboard** | KPI widget, sync status, completeness charts | MVP-Final epik 0.11.10 |
+| **Polish** | Cmd+K full, agentic flows, dark mode, mobile breakpoints | Faza 2 + iteracje |
+
+**Sequencing:**
+1. **Najpierw szkielet** (Faza UI A) — żeby wszystkie ścieżki nawigacyjne były skonsumowalne, z placeholder content.
+2. **Modelowanie + Produkty** (Faza UI B) — *to jest kościec produktu*. Bez Modelowania klient nie zacznie używać. Bez Produktów nie ma co modelować.
+3. **Multimedia + Publikacje** (Faza UI C) — żeby end-to-end flow był live (od stworzenia produktu po publikację na Shopify).
+4. **Workflow + Settings** (Faza UI D) — operacyjna dojrzałość (multi-user, auth, integracje, BYOK).
+5. **Dashboard** (Faza UI E) — *„Tomasz patrzy na liczby"* — to jest *polerka* dla pitch'u, nie *foundational*.
+
+Implikacja: Modelowanie i Produkty są **dwoma najważniejszymi epikami UI**. Wszystko inne to dodatek.
+
+## 6. Konwencje per epik
+
+Każdy plik `epik-XX-NAZWA.md` ma:
+
+```markdown
+# Epik XX — [Nazwa]
+
+## Status: [placeholder | szkic | szczegół | ready-to-build]
+
+## 1. Cel epiku
+[1-2 zdania]
+
+## 2. Persony
+[lista person z PRD § 4 — które używają tej zakładki]
+
+## 3. Kluczowe widoki
+[wireframes / ASCII mock-upy / linki do Figmy]
+
+## 4. User stories
+[lista US-EPXX-001, US-EPXX-002, ...]
+
+## 5. Business rules / edge cases
+[jak system zachowuje się w nietypowych sytuacjach]
+
+## 6. Dependency na backend
+[które ADR / encje / endpointy z Project Plan/01-architektura-pim.md są wymagane]
+
+## 7. Komponenty Refine + shadcn
+[lista komponentów do wybrania / customizacji]
+
+## 8. Open questions
+[lista TBD / TODO]
+```
+
+## 7. Lista epików — status
+
+| # | Epik | Status | Plik | Persona główna | GitHub tracking |
+|---|------|--------|------|---|---|
+| 01 | Dashboard | 🔵 placeholder | [`epik-01-dashboard.md`](epik-01-dashboard.md) | Tomasz (Owner) | — |
+| 02 | Produkty | 🔵 placeholder | [`epik-02-produkty.md`](epik-02-produkty.md) | Kasia (Catalog Manager) | — |
+| 03 | Usługi | 🔵 placeholder | [`epik-03-uslugi.md`](epik-03-uslugi.md) | Kasia + custom rola per branża | — |
+| 04 | Publikacje | 🔵 placeholder | [`epik-04-publikacje.md`](epik-04-publikacje.md) | Kasia + Piotr (IT) | — |
+| 05 | Multimedia | 🔵 placeholder | [`epik-05-multimedia.md`](epik-05-multimedia.md) | Kasia + Magda (Marketing) | — |
+| 06 | Workflow | 🔵 placeholder | [`epik-06-workflow.md`](epik-06-workflow.md) | Kasia + Tomasz | — |
+| 07 | Ustawienia | 🔵 placeholder | [`epik-07-ustawienia.md`](epik-07-ustawienia.md) | Tomasz + Piotr | — |
+| **08** | **Modelowanie** | 🟢 **szczegół — backlog GitHub utworzony 2026-05-01** | [`epik-08-modelowanie.md`](epik-08-modelowanie.md) | **Adam (NEW)** | label `epik-UI-08` (#255 META + #256–#270 sub-tickety, 16 issues, ~60-80h) |
+
+**Legenda:**
+- 🔵 placeholder — szkielet pliku z TODO listą, gotowy do iteracyjnego rozpisania.
+- 🟡 szkic — pierwsza wersja widoków + user stories, niezamknięta.
+- 🟢 szczegół — pełen design, gotowy do wireframe'owania w Figma.
+- ⚫ ready-to-build — Figma + frontend dev może implementować.
+
+## 8. Otwarte kwestie planu UI
+
+1. **Brand i naming produktu** — projekt wciąż „PIM" (working name). Wpływa na logo, kolory, typografię. Otwarte z PRD § 14.2.
+2. **External UX designer — kontrakt czy in-house?** — w PRD § 13.5 wzmiankowane *„external UX designer 10-20h kontrakt"*. Decyzja przed Fazą UI B (Modelowanie + Produkty).
+3. **Dark mode w MVP czy Faza 2?** — shadcn ma to w core, koszt to ~4-6h dyscypliny przy implementacji. Otwarte.
+4. **Mobile breakpoints — które widoki musi obsługiwać mobile?** — Dashboard tak, Produkty edit tak (Tomasz w terenie sprawdza), reszta desktop-only.
+5. **Figma vs ASCII wireframes vs klikalny prototyp** — dla Modelowania (epik 08) zaczynam od ASCII (najszybsze), Figma dochodzi gdy designer wchodzi.
+6. **Komponentowy ślad** — czy używamy `shadcn-blocks` (gotowe layouty) czy budujemy own — decyzja per epik.
+7. **Storybook** — czy wprowadzamy od dnia 1 (dyscyplina komponentów) czy później (gdy library urośnie).
+8. **i18n strategia** — `react-i18next` (z `CLAUDE.md`), ale kto pisze tłumaczenia w MVP (PL + EN minimum)? Marcin sam czy crowdsource?
+
+## 9. Powiązane dokumenty
+
+- [`PRD-PIM.md`](../PRD/PRD-PIM.md) — pełen PRD produktu, w szczególności § 4 (persony) i § 5 (model danych).
+- [`sesja-pelna-podsumowanie.md`](../PRD/sesja-pelna-podsumowanie.md) — kontekst decyzji produktowych i UX.
+- [`Project Plan/01-architektura-pim.md`](../../Project%20Plan/01-architektura-pim.md) — backend + ADR-y, które kierują UI (szczególnie ADR-005 stack frontend, ADR-009 ObjectType).
+- [`Project Plan/03-funkcjonalnosci-mvp.md`](../../Project%20Plan/03-funkcjonalnosci-mvp.md) — pełne persony + 17 user stories MVP.
+- [`Zrodla/PIMCore/objects-pimcore.md`](../PIMCore/objects-pimcore.md) — analiza referencyjnego modelu PIMCore (kontekst dla Modelowania).
+
+---
+
+*Plan wersjonowany w `Zrodla/UI/`. Iteracje per epik, każdy w osobnym pliku. Master plan aktualizuje się w sekcji 7 (status epików) gdy któryś dojrzewa.*

--- a/Project Plan/UI/epik-01-dashboard.md
+++ b/Project Plan/UI/epik-01-dashboard.md
@@ -1,0 +1,70 @@
+# Epik 01 — Dashboard
+
+## Status: 🔵 placeholder
+
+## 1. Cel epiku
+
+Główny ekran startowy admina — *„Tomasz patrzy na liczby"*. Daje 5-7 KPI w 5 sekund, mobile-friendly (Tomasz w terenie sprawdza z telefonu). Read-only w MVP, drill-down do szczegółów w Fazie 1.
+
+## 2. Persony
+
+- **Tomasz, 48** (Owner/CEO) — primary user, codzienny check.
+- **Marcin (founder dogfooding)** — używa do walidacji własnego sklepu.
+- **Kasia, 32** (Catalog Manager) — zaczyna dzień od Dashboard, widzi co wymaga uwagi.
+
+## 3. Kluczowe widoki
+
+**Top KPI band (4-6 widget'ów):**
+- SKU active / total.
+- Completeness average (% z czerwonym/żółtym/zielonym indicator'em).
+- Sync status per integration (kolorowy dot per kanał, last sync timestamp).
+- Top 10 *„most edited products"* (sygnał aktywności).
+- Pending agent changes (Faza 2 — inbox count).
+- Status backupów (last successful, RPO indicator).
+
+**Wykresy (Faza 1+):**
+- Produkty dodane/zmodyfikowane w ostatnich 30 dniach (Recharts).
+- Completeness per family / per kategoria.
+- Sync velocity per kanał.
+
+**Mobile widok:**
+- Read-only.
+- Pojedyncza kolumna (każdy KPI jako card).
+- Pull-to-refresh.
+
+## 4. User stories
+
+- **US-EP01-001:** Tomasz widzi dashboard od razu po login z 5 KPI w 5 sekund.
+- **US-EP01-002:** Tomasz na wakacjach z telefonu sprawdza, czy synch z BaseLinker poszedł w nocy.
+- **US-EP01-003:** Kasia rano klika *„Top 10 most edited products"* żeby zobaczyć co Magda robiła wczoraj.
+- _[TODO: doprecyzować po pierwszym pilotażu, które KPI faktycznie używane]_
+
+## 5. Business rules / edge cases
+
+- _[TODO: empty state — co widzimy gdy nowy klient z 0 produktów]_
+- _[TODO: error state — co gdy API nie odpowiada (cache last successful values?)]_
+- _[TODO: drill-down — klik w KPI prowadzi gdzie?]_
+
+## 6. Dependency na backend
+
+- Endpoint `/api/dashboard/stats` (do dodania) — pre-aggregated KPI per tenant.
+- Mercure SSE channel `/.well-known/mercure?topic=dashboard.{tenant_id}` — real-time refresh.
+- Doctrine query optimization (cached aggregates) — KPI nie może liczyć on-the-fly z 50k SKU.
+
+## 7. Komponenty Refine + shadcn
+
+- `shadcn/ui Card` — bazowy widget KPI.
+- `recharts` (już w stacku) — Line/Bar/Pie charts.
+- `shadcn/ui Tabs` — przełączanie między widokami (np. *„Today / 7 days / 30 days"*).
+- Custom `KPIWidget` component (icon + value + delta + trend arrow).
+
+## 8. Open questions
+
+- [ ] Lista finalnych KPI w MVP — które 5-7 widget'ów?
+- [ ] Personalizacja dashboard'u (klient sam wybiera widget'y) — MVP czy Faza 2?
+- [ ] Drill-down navigation — gdzie klika prowadzi?
+- [ ] Dark mode na mobile — czy auto-detect od system theme?
+
+---
+
+*Plik wersjonowany w `Zrodla/UI/`. Status: placeholder — do iteracji po pierwszym pilotażu, gdy zobaczymy, które KPI faktycznie patrzy klient.*

--- a/Project Plan/UI/epik-02-produkty.md
+++ b/Project Plan/UI/epik-02-produkty.md
@@ -1,0 +1,95 @@
+# Epik 02 — Produkty
+
+## Status: 🔵 placeholder
+
+## 1. Cel epiku
+
+Pełen workflow zarządzania katalogiem produktów (`ObjectType=product`) — *core PIM-u*, codzienne narzędzie pracy Kasi (Catalog Manager). Lista + edycja pojedyncza + bulk actions + import + agent commands (Cmd+K w MVP-Beta-Demo).
+
+## 2. Persony
+
+- **Kasia, 32** (Catalog Manager) — primary user, 80% czasu pracy.
+- **Magda, 29** (Marketing) — secondary, edytuje opisy SEO + kategorie.
+- **Marcin (founder dogfooding)** — pierwszy real-world klient, IdoSell + Shopify migracja katalogu do PIM-u.
+
+## 3. Kluczowe widoki
+
+### 3.1 Lista produktów (List view)
+- Tabela z kolumnami: SKU, Name, Brand, Family, Categories, Completeness%, Channels (dots), Actions.
+- Filtry: family, kategoria, brand, completeness range, provenance, status (enabled), channel publication status.
+- Sortowanie po dowolnej kolumnie.
+- Bulk actions: bulk edit attribute, add/remove category, change family (z ostrzeżeniem), publish to channels.
+- Cursor-based pagination (>1000 produktów).
+- Saved filters (*„moje 230 czerwonych produktów do dorobienia"*).
+
+### 3.2 Detail produktu (Edit view)
+- Layout: sticky header (SKU, name, completeness%, channel dots) + left sidebar (sections nav: Identyfikacja / Opis / Atrybuty techniczne / Kategorie / Marketing / Channels / Locales / History) + main content + right sidebar (related products, integration status, audit log compact).
+- **Dynamiczny formularz** — pokazuje tylko atrybuty z family + kategorii (z dziedziczeniem inheritance variant→master→brand z ADR-009).
+- **Provenance badges** przy każdym polu (klikalne, tooltip z source).
+- **Lock icon** obok pola (*„zablokuj przed nadpisaniem importem"*).
+- **Localizable tabs** (PL/EN/...) dla atrybutów `localizable`.
+- **Channel sub-tabs** (Web/BaseLinker/Datasheet) dla atrybutów `scopable`.
+- **Auto-save 3s debounce** lub Cmd+S.
+- **Diff modal** przed save dla zmian wpływających na publikację.
+
+### 3.3 Create product
+- Wizard 3-step lub single form z minimum required.
+- Wybierz family → wybierz kategorię → wypełnij wymagane atrybuty.
+- Cmd+K shortcut: *„stwórz produkt sku=ABC123 family=Czujniki"* (Faza 1).
+
+### 3.4 Variants management
+- Master + variants axis (z ADR-010 Axis-Driven Variants).
+- Generator variants po deklaracji axes (3 colors × 4 sizes → propose 12 variants).
+- Per-variant override tylko `level=variant` atrybutów.
+
+### 3.5 Import (placeholder MVP, fuller w Fazie 1)
+- Drag-drop XLSX/CSV.
+- Mapping wizard (klient definiuje column → attribute mapping).
+- Preview 5 wierszy.
+- Conflict resolution (nadpisz / merge / skip per istniejący SKU).
+- Provenance: `import` z meta `{supplier, file, date}`.
+
+## 4. User stories (z `Project Plan/03-funkcjonalnosci-mvp.md`)
+
+- US-001: Import produktów z Excel/CSV od dostawcy z mapowaniem kolumn.
+- US-002: Edycja atrybutów pojedynczego produktu z dynamicznym formularzem.
+- US-003: Sprawdzenie completeness — które produkty są niepełne.
+- US-004: Bulk edit atrybutów dla wielu produktów.
+- US-005: Dodanie nowego atrybutu/rodziny przez agenta (Cmd+K) — *cross-epic z Modelowaniem*.
+- US-006: Pisanie opisów SEO i treści marketingowych per locale.
+- US-007: Zarządzanie kategoriami (drzewo, drag-drop) — *kandydat do epiku 02 albo osobno do Modelowania*.
+
+## 5. Business rules / edge cases
+
+- _[TODO: zachowanie przy zmianie family — co dzieje się z atrybutami które nie pasują]_
+- _[TODO: lockable fields — czy lock'owanie blokuje też agent edits w Fazie 2?]_
+- _[TODO: konflikty bulk edit (50 produktów + zmiana atrybutu, niektóre już mają inną wartość)]_
+- _[TODO: undo / rollback po bulk edit (do 24h?)]_
+
+## 6. Dependency na backend
+
+- ADR-006 (Hybrid attribute model) — `object_values` + `attributes_indexed JSONB`.
+- ADR-009 (Generic ObjectType) — Product jako kind=`product`.
+- ADR-010 (Axis-Driven Variants) — variants encja z `master_object_id`.
+- ADR-011 (Per-tenant locale fallback chain) — fallback przy lookup wartości.
+- Doctrine listener `attributes-indexed-rebuild` — async dla bulk path.
+
+## 7. Komponenty Refine + shadcn
+
+- Refine `useTable`, `useForm`, `useShow`, `useDelete`, `useUpdate`, `useCreate`.
+- shadcn `Table`, `DataTable` (TanStack Table integration), `Form`, `Tabs`, `Sheet` (right sidebar), `Dialog` (diff modal).
+- Custom `DynamicAttributeForm` — pole formularza generowane na podstawie `Attribute.type`.
+- Custom `ProvenanceBadge` — komponent pokazujący 4 warianty (manual/import/agent/integration).
+- `react-dropzone` (już w stacku) — drag-drop import.
+
+## 8. Open questions
+
+- [ ] Categories management — w epiku 02 (osobny widok tree pod Produktami) czy w Modelowaniu (epik 08)?
+- [ ] Variants UX — pełen matrix grid vs lista z filter'em (przy 100+ variants)?
+- [ ] Bulk edit confirm flow — modal vs sticky toolbar with progress?
+- [ ] Smart filters / saved searches — MVP czy Faza 1?
+- [ ] AI assist w polu opisu (Faza 1: *„wygeneruj SEO opis z atrybutów"*) — UX wewnątrz pola czy osobny button?
+
+---
+
+*Plik wersjonowany w `Zrodla/UI/`. Status: placeholder — najważniejszy epik operatorski po Modelowaniu, do priorytetowej iteracji.*

--- a/Project Plan/UI/epik-03-uslugi.md
+++ b/Project Plan/UI/epik-03-uslugi.md
@@ -1,0 +1,75 @@
+# Epik 03 — Usługi (Services)
+
+## Status: 🔵 placeholder
+
+## 1. Cel epiku
+
+Zarządzanie obiektami typu **Usługa** (`ObjectType=service`) — przykład **custom ObjectType** dodanego przez Adama w Modelowaniu (epik 08). Pozycja menu generowana **dynamicznie** z `object_types` table — gdy klient w Modelowaniu doda kolejny custom kind (np. `subscription`, `event`), pojawi się analogiczna pozycja menu obok Usług.
+
+Rzeczywiste use case'y dla pierwszych pilotów:
+- **Branża medyczna:** Lekarz / Chirurg / Ortopeda / Pediatra (z kategoriami w drzewie).
+- **Branża fryzjerska:** Strzyżenie męskie / Damskie / Koloryzacja / Manicure.
+- **Doradztwo / SaaS:** Konsultacje / Subskrypcje / Webinary.
+
+## 2. Persony
+
+- **Kasia / Magda** w roli content editor dla usług (analog do produktów).
+- **Custom rola per branża** — np. *„Recepcjonistka medyczna"* (krótka edycja cennika + grafiku) — Faza 2 z permission system.
+- **Adam** — definiuje `ObjectType=service` + jego attribute groups + categories drzewo (w Modelowaniu, epik 08).
+
+## 3. Kluczowe widoki
+
+**Generic UI = analog do epiku 02 (Produkty), z parametryzacją per `kind`:**
+
+- Lista usług (Table view) — kolumny dynamicznie generowane z `ObjectType.list_columns_config`. Domyślnie: SKU, Name, Category, Pricing, Duration, Status.
+- Detail usługi (Edit view) — dynamiczny formularz z efektywną listą Attribute Groups (z dziedziczenia kategorii).
+- Create service — wizard analogiczny do produktów, ale z innymi default fields.
+- Categories management dla `kind=service` — tree z drag-drop (osobny ObjectType `category` ale z filter'em na Service).
+
+**Specyfika Usług (vs Produkty):**
+- **Brak wariantów** w typowym scenariuszu (Lekarz nie ma wariantów color×size). Ale ADR-010 to wspiera, gdyby klient zażądał (np. *„Konsultacja: online vs osobista"*).
+- **Hierarchia kategorii głęboka** (Service → Lekarz → Chirurg → Ortopeda) — kluczowy use case dla Adama z rozmowy źródłowej.
+- **Pricing per kanał** mniejszy niż per locale (większość usług sprzedawanych w 1 walucie / kraju) — ale `scopable` flag wciąż przydatny.
+- **Brak DAM heavy** — usługa rzadko ma 50 zdjęć, częściej ikona + 1-2 zdjęcia ilustracyjne.
+
+## 4. User stories
+
+- **US-EP03-001:** Adam (lub Marcin sam) definiuje w Modelowaniu nowy `ObjectType=service` + Attribute Groups (Cennik podstawowy, Czas trwania, Wymagania medyczne, Refundacja NFZ) — patrz epik 08.
+- **US-EP03-002:** Kasia po dodaniu typu *Service* widzi nową pozycję menu *„Usługi"*. Klika i widzi listę pustą + CTA *„dodaj pierwszą usługę"*.
+- **US-EP03-003:** Kasia tworzy usługę *„Konsultacja ortopedyczna"* w kategorii Lekarz/Chirurg/Ortopeda. System dynamicznie pokazuje formularz z efektywnymi grupami atrybutów (Identyfikacja + Opis + Cennik medyczny + Wymagania medyczne + Refundacja NFZ + Chirurgia szczegóły + Ortopedia + Audyt).
+- **US-EP03-004:** Kasia bulk-edit'uje 30 usług ortopedycznych — zmienia `requires_referral=true` na wszystkich.
+- **US-EP03-005:** Magda generuje opisy SEO usług (Faza 1, BYOK).
+- _[TODO: integracja z systemem rezerwacji / kalendarzem — Faza 2/3?]_
+- _[TODO: integracja z NFZ API — out of scope MVP, Faza 3+ na zlecenie]_
+
+## 5. Business rules / edge cases
+
+- _[TODO: gdy Adam usuwa Attribute Group z Modelowania, co z istniejącymi wartościami (cascade delete? soft delete? migrate)]_
+- _[TODO: różnice walidacji per branża (lekarska wymaga PWZ, fryzjer nie)]_
+- _[TODO: kategorie multi-parent (chirurg ortopeda należy do *Chirurg* AND *Ortopeda*) — czy wspieramy?]_
+
+## 6. Dependency na backend
+
+- ADR-009 (Generic ObjectType) — *to jest fundament* tego epiku. Bez niego Usługi nie istnieją.
+- Proponowany **ADR-012 (Attribute Group as first-class entity)** — z epiku 08 — *kluczowa zależność* dla dziedziczenia atrybutów per kategoria.
+- ADR-006 (Hybrid attribute model) — `object_values` parametryzowany per `object_type_id`.
+- Doctrine listener wykrywający dodanie nowego ObjectType i automatycznie konfigurujący generic CRUD endpointy + admin UI.
+
+## 7. Komponenty Refine + shadcn
+
+- **Wszystko współdzielone z epikiem 02 (Produkty)** — generic CRUD components parametryzowane przez `object_type_id`.
+- Custom `DynamicSidebarNav` — komponent który czyta `object_types` i generuje pozycje menu dynamicznie.
+- Custom `EffectiveAttributeGroupResolver` — service zwracający efektywną listę Attribute Groups dla `(object_type, category_path)` z dziedziczenia.
+
+## 8. Open questions
+
+- [ ] Czy Usługi *muszą* być w sidebar od dnia 1, czy pojawiają się dopiero po dodaniu pierwszej Service przez Adama?
+- [ ] UX *„dodaj pierwszą usługę"* — wizard wprowadzający, który prowadzi przez Modelowanie najpierw?
+- [ ] Ikona menu — auto-generated z `ObjectType.icon` field? Picker w Modelowaniu?
+- [ ] Naming display vs code — w sidebar pokazujemy display name (`Usługi`), nie code (`service`).
+- [ ] Search across all ObjectTypes — czy globalny search obejmuje custom kindy?
+- [ ] Custom kindy w Cmd+K — czy agent (Faza 2) może tworzyć obiekty custom kind?
+
+---
+
+*Plik wersjonowany w `Zrodla/UI/`. Status: placeholder — kluczowy showcase elastyczności PIM-u dla mid-market poza retail.*

--- a/Project Plan/UI/epik-04-publikacje.md
+++ b/Project Plan/UI/epik-04-publikacje.md
@@ -1,0 +1,90 @@
+# Epik 04 — Publikacje
+
+## Status: 🔵 placeholder
+
+## 1. Cel epiku
+
+Zarządzanie syndykacją danych do kanałów zewnętrznych — *„co się dzieje z moim katalogiem po edycji"*. Sync jobs panel, integracje (BaseLinker / Shopify / w przyszłości Magento / IdoSell / Comarch), API Configurator (drugi USP — klient sam tworzy endpointy/feedy), webhooks management.
+
+## 2. Persony
+
+- **Kasia, 32** — trigger publikacji (manual/bulk), monitoring statusu sync.
+- **Piotr, 38** (IT/Integration) — primary user dla API Configurator, debug failed syncs, webhooks management.
+- **Tomasz** — read-only check status (z Dashboard'u również).
+
+## 3. Kluczowe widoki
+
+### 3.1 Sync Jobs panel
+- Lista wszystkich sync'ów (running / success / failed / partial) z filtrami (status, integration, date range).
+- Per-job detail: stats (X new, Y updated, Z errors), progress bar dla running, expandable error list z retry per item.
+- **Live updates przez Mercure SSE** — gdy sync się kończy, status w UI aktualizuje się bez refresh.
+
+### 3.2 Integracje (Connectors panel)
+- Lista zainstalowanych connectorów (BaseLinker, Shopify, własny custom).
+- Per-connector: status (zielone/żółte/czerwone), last sync timestamp, configuration link.
+- *„Add Integration"* wizard — Piotr konfiguruje credentials + mapping atrybutów + test sync 3 produktów.
+- **Tier gating** — Starter ma 2 connectory, Pro 5, Enterprise wszystkie (z PRD § 12.2).
+
+### 3.3 API Configurator (drugi USP — *most important view of this epic*)
+- **Tabs:**
+  - **Feeds** — klient tworzy XML feedy (Google Shopping template predefiniowany + custom).
+  - **Exports** — CSV exporty z mapping wizard'em.
+  - **Imports** — CSV importer z mapping (wzajemne z eksportami).
+  - **API Endpoints** (Faza 1) — custom REST endpoint generator.
+  - **Webhooks** (Faza 1) — outbound webhooks per event.
+- **Mapping wizard:**
+  - Wybierz ObjectType source (np. `product`).
+  - Wybierz fields → mapuj na docelowe nazwy (np. PIM `description.pl` → XML `<g:description>`).
+  - Filter (które obiekty trafiają do feedu — wszystkie / kategoria X / smart filter).
+  - Schedule (cron — co 1h, co 6h, daily 2:00 UTC, manual only).
+  - **Preview output** — pokazuje rzeczywisty XML/CSV/JSON dla 5 sample produktów.
+  - Save → generuje URL feedu z autoryzacją (API key).
+
+### 3.4 Webhooks (Faza 1)
+- Lista subscribed webhooks (event → URL → status).
+- Retry policy konfigurowalny per webhook.
+- HMAC signing setup.
+
+## 4. User stories (z `Project Plan/03-funkcjonalnosci-mvp.md`)
+
+- US-008: Trigger publikacji na kanały + status.
+- US-014: Integration panel (lista wszystkich + status + live error log).
+- US-015: Add integration wizard (credentials, mapowania, test sync).
+- US-016: Per-item retry (failed items → retry one-click).
+- US-017: API Configurator (generowanie kluczy API + scope per profile).
+- **US-EP04-NEW-001:** Klient w API Configurator tworzy feed Google Shopping w 5 minut bez developera.
+- **US-EP04-NEW-002:** Klient dodaje custom feed XML dla partnera B2B (mapping pól + filter + schedule).
+
+## 5. Business rules / edge cases
+
+- _[TODO: rate limiting publish actions — bulk publish 5000 SKU vs API limits Shopify (Exponential Backoff per ADR architi)]_
+- _[TODO: failed sync notifications — alert email/Slack/inapp dla Kasi i Piotra]_
+- _[TODO: webhook delivery failure handling]_
+- _[TODO: feed regeneration scheduling — co gdy klient zmienia mapping w trakcie generowania]_
+
+## 6. Dependency na backend
+
+- Architektura sekcja 3.10 + 7.x — Symfony Messenger handlers, Exponential Backoff dla Shopify.
+- ADR-008 (API Platform 4) — wszystkie kanały korzystają z tych samych endpointów co admin.
+- Epik 0.10 z `Project Plan/02-plan-projektu-pim.md` — API Configurator pełen scope MVP (XML feeds + CSV + UI form configurator + Google Shopping predef).
+- Mercure SSE dla live updates statusu sync.
+
+## 7. Komponenty Refine + shadcn
+
+- Refine `useList` dla sync jobs lista.
+- shadcn `Tabs`, `DataTable`, `Sheet`, `Dialog`, `Form`, `Select`, `Card`.
+- Custom `MappingWizard` component (drag-drop fields → targets).
+- Custom `XMLPreview` / `CSVPreview` — show output sample.
+- Custom `LiveStatusBadge` — Mercure-connected indicator.
+
+## 8. Open questions
+
+- [ ] UX dla *„dodaj custom integration"* — wizard step-by-step czy single form?
+- [ ] Mapping wizard — drag-drop UI czy dropdown (które bardziej intuicyjne dla Piotra)?
+- [ ] Czy trigger ręczny *„Publish to Shopify"* idzie z list view (per produkt) czy z detail view?
+- [ ] Jak prezentujemy *„rate limit reached"* (Shopify 429) — ostrzeżenie + auto-retry vs manual?
+- [ ] Custom REST endpoint UX — *„zaprojektuj endpoint"* wizard czy code editor (gibsze, ale wymaga znajomości API)?
+
+---
+
+*Plik wersjonowany w `Zrodla/UI/`. Status: placeholder — drugi USP (API Configurator) musi być wow demo'em w pitch'u Enterprise.*

--- a/Project Plan/UI/epik-05-multimedia.md
+++ b/Project Plan/UI/epik-05-multimedia.md
@@ -1,0 +1,94 @@
+# Epik 05 — Multimedia (DAM)
+
+## Status: 🔵 placeholder
+
+## 1. Cel epiku
+
+Digital Asset Management — zarządzanie zdjęciami, PDF-ami, w przyszłości video / 360° / lookbookami. *Asset* jako predefiniowany ObjectType (`kind=asset`) z dedykowanym UX-em (drag-drop upload, masowe miniaturki, przypisywanie do produktów/usług/kategorii).
+
+## 2. Persony
+
+- **Kasia** — upload zdjęć produktowych z plików dostawcy, link do produktów.
+- **Magda** — upload lifestyle photos dla D2C, organizacja w kolekcjach, akceptacja content (Faza 2).
+- **Marcin (dogfooding)** — własne zdjęcia produktów IdoSell + Shopify, migracja DAM-a.
+
+## 3. Kluczowe widoki
+
+### 3.1 Asset Library (List view)
+- Grid view (default) — thumbnails + metadata overlay (filename, size, linked products count).
+- List view (alternative) — Table z filtrowaniem po extension, date, linked product, tag.
+- Bulk select → bulk action: link to product, add tag, archive, delete.
+- Filters: type (image / PDF / video Faza 1), size range, upload date, by-product, by-tag.
+- Search by filename / metadata.
+
+### 3.2 Upload (drag-drop)
+- Multi-file drag-drop area (dziaa zewszad — globalny dropzone gdy klient przeciąga plik).
+- Progress per plik z możliwością anulowania.
+- Auto-rejected: za duży plik (>10 MB), zła ekstensja, duplikat (z opcją *„override"* lub *„keep both"*).
+- Po upload — auto-thumbnails 200×200 i 800×800 (Imagick).
+
+### 3.3 Asset detail
+- Sticky header: filename, size, dimensions, format.
+- Lewa kolumna: preview (image / PDF first page).
+- Prawa kolumna: metadata, tags, linked products list (z możliwością unlink), provenance, audit log.
+- W trybie edit: rename, retag, replace file (z zachowaniem ID + linked products — *do uzgodnienia*).
+
+### 3.4 Linking do produktów (cross-epic z Produkty)
+- W detail produktu: sekcja *„Images"* z drag-drop existing assets + upload inline.
+- Główne zdjęcie (main image) — wyróżnione, drag do *„main"* slot.
+- Galeria (do 10) — kolejność drag-drop.
+
+### 3.5 PDF support (MVP — z PRD § 9.3)
+- Upload + auto-preview pierwszej strony jako thumbnail.
+- Open PDF in lightbox (browser PDF viewer).
+- Linkowanie do produktów (np. datasheet PDF).
+
+### 3.6 Cloudinary integration (Faza 1)
+- Settings widok (*"Use Cloudinary as DAM backend"*) — Piotr konfiguruje API credentials.
+- Migration wizard (*"przenieś istniejące asset'y do Cloudinary"*) — Faza 1+.
+- Po włączeniu: upload trafia do Cloudinary, transformacje (resize per kanał) generowane on-demand.
+
+## 4. User stories
+
+- US-009: Upload i zarządzanie zdjęciami (DAM lite) — z `Project Plan/03-funkcjonalnosci-mvp.md`.
+- **US-EP05-001:** Kasia drag-drop'uje 50 zdjęć, system robi thumbnails automatycznie, łączy z produktami.
+- **US-EP05-002:** Magda upload'uje lookbook PDF (10 stron), system generuje preview pierwszej strony, link do kolekcji produktów.
+- **US-EP05-003:** Piotr (Faza 1) konfiguruje Cloudinary jako backend — istniejące asset'y migrują, nowe trafiają do Cloudinary.
+- _[TODO: AI metadata extraction (alt text, tags) — Faza 2]_
+- _[TODO: variant generation per kanał (Shopify 1024×1024, Allegro 1200×1200) — Faza 1]_
+
+## 5. Business rules / edge cases
+
+- _[TODO: replace file — zachowanie ID i linked products czy tworzenie nowego asseta]_
+- _[TODO: delete asset linked to N produktów — confirm cascade lub block]_
+- _[TODO: storage quota per tier — limity przestrzeni na własnym DAM]_
+- _[TODO: PDF max size — limity dla preview generation]_
+- _[TODO: video upload — limit 100MB w Fazie 1?]_
+
+## 6. Dependency na backend
+
+- Sekcja 5.2 architektury — encja `Asset` (jako kind=asset ObjectType).
+- Flysystem abstraction (sekcja 3.2 archi) — adapter MinIO default, Cloudinary w Fazie 1.
+- Imagick (sekcja 12.3 archi) — thumbnails generation.
+- ADR-009 — Asset jako predefiniowany ObjectType z extra logiką storage.
+- Pattern: każdy Asset ma `storage_path`, custom listenery dla `kind=asset` zarządzają fizycznym uploadem.
+
+## 7. Komponenty Refine + shadcn
+
+- `react-dropzone` (już w stacku) — drag-drop globalny + per-product.
+- shadcn `Card`, `Dialog`, `Sheet`, `Tabs`, `AspectRatio`.
+- Custom `AssetGrid` — masonry grid z lazy loading (intersection observer).
+- Custom `AssetLightbox` — zoom/pan dla obrazów, browser PDF viewer dla PDF.
+- Custom `AssetUploader` — z progress per plik + retry per failed.
+
+## 8. Open questions
+
+- [ ] Folder structure — czy DAM ma drzewo folderów / kolekcje / tagi (które bardziej intuicyjne)?
+- [ ] Bulk tagging — w grid view zaznaczam → Apply tag → modal — czy szybciej?
+- [ ] Video preview — generujemy poster frame on-upload (server-side ffmpeg) czy lazy?
+- [ ] Compression — czy auto-optymalizujemy zdjęcia (mozjpeg / squoosh) na upload?
+- [ ] Mobile upload — czy z telefonu można upload'ować zdjęcia (Kasia w terenie u dostawcy)?
+
+---
+
+*Plik wersjonowany w `Zrodla/UI/`. Status: placeholder — DAM lite w MVP, Cloudinary adapter w Fazie 1, advanced (AI metadata, video) w Fazie 2.*

--- a/Project Plan/UI/epik-06-workflow.md
+++ b/Project Plan/UI/epik-06-workflow.md
@@ -1,0 +1,83 @@
+# Epik 06 — Workflow
+
+## Status: 🔵 placeholder
+
+## 1. Cel epiku
+
+Zarządzanie stanami obiektów (`draft → review → approved → published`) i approval flow. **W MVP minimalna namiastka** (`enabled` boolean jako proxy dla *„draft / live"*). Pełen Symfony Workflow z multi-step approval — Faza 1 (z PRD § 7).
+
+## 2. Persony
+
+- **Kasia** — pracuje codziennie z draft'ami przed akceptacją.
+- **Tomasz** (Owner) — review i approve'uje krytyczne zmiany (cena flagowych produktów, opisy nowych marek).
+- **Magda** (Faza 2) — approval content marketing.
+
+## 3. Kluczowe widoki
+
+### 3.1 MVP — `enabled` boolean tylko
+- W detail produktu: toggle *„Enabled"* (live / paused) — `Object.enabled` boolean.
+- `enabled=false` → produkt nie idzie do kanałów (filter w sync handlerach).
+- W list view: filter *„Show only enabled / Show only disabled"*.
+
+### 3.2 Faza 1 — pełen workflow
+- **State machine konfigurowalny per ObjectType** (Symfony Workflow): `draft → review → approved → published`.
+- Per-state UI: stylized badge w list view, sticky header w detail.
+- Action buttons: *„Submit for review"*, *„Approve"*, *„Reject"*, *„Revert to draft"*.
+- Permission per state — np. tylko user z rolą `super_admin` może `approved → published`.
+
+### 3.3 Faza 1 — Approval inbox
+- Widok *„My pending approvals"* (Tomasz / supervisor).
+- Bulk approve / reject z optional komentarzem.
+- Notyfikacje (in-app + email) przy nowym pending item.
+
+### 3.4 Faza 2 — Workflow per atrybut
+- *„Cena wymaga approval CFO"*.
+- *„Opisy free-for-all (auto-publish)"*.
+- Granularne permissions per pole.
+
+### 3.5 Audit trail (cross-epic z Ustawienia / Dashboard)
+- *„Kto zmienił status produktu X 3 dni temu"* — z audit log (Doctrine AuditBundle epik 0.11.4).
+- Filter audit po user / entity / time range / action.
+
+## 4. User stories
+
+- US-013: Audit log (kto co kiedy zmienił, filter by date/user/entity) — z `Project Plan/03-funkcjonalnosci-mvp.md`.
+- **US-EP06-001 (MVP):** Kasia toggle'uje *„Enabled"* na produkcie żeby zatrzymać publikację bez usuwania.
+- **US-EP06-002 (Faza 1):** Kasia submit'uje 30 produktów do review przed publikacją kampanii świątecznej.
+- **US-EP06-003 (Faza 1):** Tomasz w *„My pending approvals"* widzi 30 produktów, akceptuje 28, odrzuca 2 z komentarzem.
+- _[TODO: workflow per ObjectType — czy wszystkie typy mają taki sam state machine?]_
+- _[TODO: rollback z published do draft — kiedy dozwolony?]_
+
+## 5. Business rules / edge cases
+
+- _[TODO: produkt w stanie `published` zostaje zedytowany — czy wraca do `draft` automatycznie czy klient sam decyduje?]_
+- _[TODO: kanały publikacji — czy każdy kanał ma swój workflow (na Shopify approved, na BaseLinker draft)?]_
+- _[TODO: bulk state change — wymaga approval per produkt czy bulk approve?]_
+- _[TODO: integration z agentem Faza 2 — agent tworzy zmiany w stanie `pending_changes`, approve flow]_
+
+## 6. Dependency na backend
+
+- ADR-006 — Doctrine listener przyjmuje `enabled` flagi w sync handlerach.
+- Symfony Workflow component (Faza 1) — definicje state machines per ObjectType.
+- Audit log z DoctrineAuditBundle (epik 0.11.4 z planu).
+- `pending_changes` table jako pusta migracja w MVP (z rewizji 2026-04-27, dla Fazy 2 agent).
+
+## 7. Komponenty Refine + shadcn
+
+- shadcn `Switch` (toggle enabled/disabled).
+- shadcn `Badge` (stan workflow z kolorami).
+- shadcn `DropdownMenu` (transitions actions).
+- Custom `WorkflowStateBadge` — komponent renderujący current state + available transitions.
+- Custom `ApprovalInbox` — widok inbox-style z bulk actions.
+
+## 8. Open questions
+
+- [ ] Czy MVP `enabled` jest *jedynym* polem stanu, czy dochodzi `visibility: public/internal/archived` (obok)?
+- [ ] Dla Usług (custom kind) — czy ten sam workflow co Produkty czy parametryzowany w Modelowaniu?
+- [ ] Approval notifications — email w MVP? In-app SSE w Fazie 1? Slack webhook w Fazie 2?
+- [ ] Workflow versioning — gdy Adam zmienia state machine, co się dzieje z obiektami w stanach starych?
+- [ ] Cross-channel workflow — czy publish to Shopify zawsze w parze z BaseLinker, czy per-channel?
+
+---
+
+*Plik wersjonowany w `Zrodla/UI/`. Status: placeholder — w MVP minimum (enabled boolean), pełen Symfony Workflow w Fazie 1.*

--- a/Project Plan/UI/epik-07-ustawienia.md
+++ b/Project Plan/UI/epik-07-ustawienia.md
@@ -1,0 +1,118 @@
+# Epik 07 — Ustawienia (Settings)
+
+## Status: 🔵 placeholder
+
+## 1. Cel epiku
+
+Konfiguracja systemu — users, roles (Faza 1+), locales, currencies, BYOK keys (LLM), Anthropic settings, billing (Faza 2), integrations credentials, notifications. *„Wszystko czego nie chcemy mieszać z codzienną pracą Kasi"*.
+
+## 2. Persony
+
+- **Tomasz** (Owner) — billing, users, plan upgrades.
+- **Piotr** (IT) — integrations credentials, API keys, locales setup, BYOK keys.
+- **Adam** (jeśli różni od Marcina) — locales fallback chain (z ADR-011), default values na ObjectType.
+- **Marcin (dogfooding)** — wszystko (jest właścicielem wszystkiego).
+
+## 3. Kluczowe widoki — sekcje Settings
+
+### 3.1 Profile (per user)
+- Zmiana hasła, email, 2FA setup.
+- Personal preferences (default landing page, dark mode toggle, language).
+
+### 3.2 Users & Roles (Faza 1)
+- Lista użytkowników w tenancie + invite flow.
+- Per user: role, permissions, last login, active.
+- Role management — predefiniowane (super_admin, catalog_manager, marketing, integration_manager, viewer) z możliwością custom (Faza 2).
+- _[Uproszczenie MVP: role gating wyłączone (per użytkownika), wszyscy mają wszystko. Dochodzi w Fazie 1.]_
+
+### 3.3 Locales & Currencies
+- Lista włączonych locales (PL, EN, DE, CS, ...).
+- **Per-tenant fallback chain configuration** (z ADR-011):
+  - *„dla `de` fallback na `en`, dla `cs` fallback na `pl`"*.
+  - UI: drag-drop list of fallback chains.
+- Currencies management (PLN, EUR, USD, ...).
+- Default locale + default currency.
+
+### 3.4 Channels
+- Lista zdefiniowanych kanałów (web sklep / BaseLinker / Shopify / custom).
+- Per-channel: configuration credentials (read-only — managed in Publikacje epik 04), associated locales + currencies.
+- _[Uwaga: pełna konfiguracja channel'a jest w Publikacje (epik 04 § 3.2 Integracje), tu tylko overview.]_
+
+### 3.5 BYOK / AI Keys
+- **Anthropic API key** (input z reveal/hide toggle).
+- **Test connection** button — robi próbny tool call do Anthropic, pokazuje balans tokenów.
+- Per-tenant Anthropic billing usage (last 30 days, current month).
+- Hard limits config (z sekcji 8.5 archi: 50 tool calls/h, $20/dzień, $300/mies — klient widzi current vs limit).
+- Future (Faza 2): wybór providera (OpenAI / Mistral / Azure / Ollama).
+- _[BYOK domyślne dla wszystkich on-prem klientów — z PRD § 10.4]_
+
+### 3.6 Backups
+- Status pgBackRest backups (last full / differential / WAL).
+- Restore time tested (last successful restore drill).
+- Manual *„Trigger backup now"* button.
+- Faza 1+: rollback to point-in-time (PITR).
+
+### 3.7 Audit log (jeśli osobny od Workflow epik 06 § 3.5)
+- Filter audit po user / entity / time range / action.
+- Export audit log do CSV.
+
+### 3.8 Notifications
+- Per-user preferences (email / in-app / Slack webhook Faza 2).
+- Subscriptions: failed sync, completeness threshold, agent budget exceeded, backup failed.
+
+### 3.9 Billing (Faza 2 — z SaaS aktywacją)
+- Current plan + tier.
+- Usage (SKU count, users, AI calls, paid connectors).
+- Upgrade / downgrade flow.
+- Invoices history + download PDF.
+- _[Faza 2 z SaaS aktywacją; w MVP single-tenant managed billing przez fakturę manualną.]_
+
+### 3.10 Tenant settings (advanced)
+- Tenant code, name, owner email.
+- Branding (logo, primary color) — Faza 2.
+- Custom domain — Faza 2.
+
+## 4. User stories
+
+- **US-EP07-001:** Tomasz invituje 2 nowe osoby (Kasia, Magda) w Fazie 1 z konkretną rolą.
+- **US-EP07-002:** Piotr konfiguruje BYOK Anthropic key, testuje connection, widzi balans.
+- **US-EP07-003:** Piotr aktywuje 3 dodatkowe locales (DE, CS, EN) + ustawia fallback chain (DE→EN, CS→PL).
+- **US-EP07-004:** Tomasz monitoruje cost AI w sekcji BYOK — w 25 dniu miesiąca widzi że zbliża się do $300/mies cap.
+- **US-EP07-005:** Kasia w Profile zmienia language na EN (domyślnie była PL).
+- _[TODO: enterprise SLA — klient enterprise widzi metryki uptime own tenant'a]_
+
+## 5. Business rules / edge cases
+
+- _[TODO: usuwanie ostatniego super_admin — block]_
+- _[TODO: invitation expiry — link wygasa po 7 dniach]_
+- _[TODO: API key rotation — ile krócej żyje, jak wymusić rotację]_
+- _[TODO: BYOK key zmiana w trakcie agent run — co dzieje się z trwającymi tool calls]_
+- _[TODO: locale removal — co z istniejącymi wartościami w tym locale]_
+
+## 6. Dependency na backend
+
+- ADR-003 (multi-tenant) — multi-tenant settings per tenant.
+- Sekcja 8.5 archi — BYOK + hard limits + alerty.
+- Sekcja 9.4 archi — szyfrowanie wrażliwych pól (BYOK keys AES-256-GCM).
+- Symfony Vault / ENV vars dla secrets management.
+- Architektura sekcja 11.1a — RLS aktywacja przed multi-tenant SaaS w Fazie 1.
+
+## 7. Komponenty Refine + shadcn
+
+- shadcn `Tabs` — sekcje Settings (Profile / Users / Locales / Channels / BYOK / Backups / ...).
+- shadcn `Form`, `Input`, `Select`, `Switch`, `Button`.
+- Custom `SecretInput` — input z reveal/hide + copy-to-clipboard.
+- Custom `UsageMeter` — visualizacja current vs limit.
+- Custom `FallbackChainEditor` — drag-drop UI dla locale fallback.
+
+## 8. Open questions
+
+- [ ] Czy Modelowanie powinno być pod Ustawieniami (jako sub-tab) czy osobno? *Decyzja: osobno (epik 08), bo Modelowanie ma własną głębokość.*
+- [ ] Categories management — w epiku 02 (Produkty), epiku 08 (Modelowanie), czy własny sub-tab w Settings?
+- [ ] Single Sign-On (SSO/SAML) — Faza 3+ (per PRD § 11.5).
+- [ ] White-label theming — Faza 3+.
+- [ ] Tenant branding — kiedy pojawia się w UI (Faza 2 z SaaS)?
+
+---
+
+*Plik wersjonowany w `Zrodla/UI/`. Status: placeholder — Settings rośnie iteracyjnie, najpierw absolute essentials (Profile, BYOK, Locales), reszta dochodzi.*

--- a/Project Plan/UI/epik-08-modelowanie.md
+++ b/Project Plan/UI/epik-08-modelowanie.md
@@ -1,0 +1,958 @@
+# Epik 08 — Modelowanie
+
+## Status: 🟢 szczegół (in progress)
+
+> **Flagowy epik UI** — definiuje schemat danych całego systemu. Bez Modelowania klient nie zacznie używać PIM-u (każdy klient definiuje minimum 1-2 custom Object Types lub Attribute Groups specyficzne dla swojej branży).
+
+---
+
+## 1. Cel epiku
+
+Zakładka, w której **Adam** (architekt informacji) lub **Marcin (founder, dogfooding)** lub **Kasia (gdy nie ma osobnego Adama)** definiuje:
+- **Object Types** — typy obiektów w systemie (Produkt, Kategoria, Zasób, Marka — built-in; Usługa, Subskrypcja, Lokalizacja, dowolny — custom).
+- **Attributes** — globalna biblioteka atrybutów reusable across types (`description`, `voltage`, `appointment_duration`).
+- **Attribute Groups** ⭐ NEW concept — first-class entity grupująca atrybuty w sekcje formularza, wymienna jednostka przypinana do ObjectType / Category / pojedynczego obiektu.
+- **Categories** — drzewo kategorii z deklaracjami Attribute Groups dla obiektów należących do tej kategorii.
+
+Cel UX: *„nie-developer (Adam, ale też Marcin/Kasia w mniejszych firmach) może w 30 minut zdefiniować model danych dla nowej branży (np. usługi medyczne) bez pisania kodu i bez Pimcore-style miesiąca konfiguracji"*.
+
+## 2. Persony
+
+| Persona | Częstość użycia | Co robi |
+|---|---|---|
+| **Adam, 40** ⭐ NEW | Raz na 1-2 tyg. | Główne use case'y: dodaje nowy Attribute, tworzy nowy Object Type per wymaganiu biznesu, modyfikuje Attribute Groups |
+| **Marcin (dogfooding)** | Często w MVP | Definiuje model dla własnego sklepu, eksperymentuje z UX |
+| **Kasia, 32** | Rzadko, ale możliwa | Gdy nie ma Adama (mniejsze firmy) — Kasia z konwencją + audit logiem może modyfikować model. **MVP: brak role gating, full access.** |
+
+## 3. Konteksty teoretyczne (z rozmowy źródłowej)
+
+### 3.1 Trzy ortogonalne wymiary, które trzeba rozdzielić
+
+W tradycyjnych PIM (Pimcore, Akeneo) te wymiary się mieszają, co prowadzi do chaosu:
+
+1. **Czym jest obiekt?** (Produkt / Kategoria / Usługa / Asset / cokolwiek innego) → **Object Type**.
+2. **Jakie pola/atrybuty go opisują?** (sku, description, voltage, czas trwania, cena) → **Attribute**.
+3. **W którym fragmencie taksonomii się znajduje?** (Fryzjer → Strzyżenie / Lekarz → Chirurg → Ortopeda) → **Category** (sama też ObjectType, ale specjalna).
+
+W naszym Modelowaniu te trzy wymiary mają **osobne sub-zakładki** (Tab 1, 2, 4), plus **Attribute Group** (Tab 3) jako klejąca abstrakcja.
+
+### 3.2 Reguła decyzyjna: Object Type vs Category
+
+| Pytanie | Jeśli TAK → | Jeśli NIE → |
+|---|---|---|
+| Czy to opisuje *rodzaj rzeczy* w świecie (różny model danych)? | **Object Type** | Category |
+| Czy to opisuje *gdzie* w taksonomii ta sama rzecz się znajduje? | **Category** | Object Type |
+
+**Praktyka:**
+- *„Produkt"* vs *„Usługa"* vs *„Asset"* → różne Object Types (mają różne modele danych).
+- *„Fryzjer"* vs *„Lekarz"* → różne kategorie usługi (oba to nadal Usługa).
+- *„Chirurg"* vs *„Ortopeda"* → różne podkategorie kategorii Lekarz.
+
+**Test:** czy ten sam fizyczny obiekt zmienia kategorię? Jeśli tak — to Category. Czy zmienia ObjectType? Praktycznie nigdy.
+
+### 3.3 Subtype vs Category — kiedy co
+
+| Różnica modelu danych | Wybór |
+|---|---|
+| <30% atrybutów się różni | **Category** (jeden ObjectType + kategorie wariujące) |
+| 30-70% | Eksperyment, można refaktorować później |
+| >70% | **Subtype** (osobne Object Types) |
+
+**Przykład:** usługa lekarska vs fryzjerska to ~50%, *Category* jest dobrym wyborem (oba to `kind=service`). Gdyby doszła *„Service: SaaS subscription"* z zupełnie innym modelem (license keys, billing cycles, MRR) — osobny ObjectType `kind=subscription`.
+
+### 3.4 Built-in vs Custom Object Types
+
+**Built-in** (`is_built_in=true`, `code_immutable=true`, `deletable=false`):
+- `product` — fundament PIM-u, integracje go nazywają wprost (`/api/products`, mapping SAP/Edito).
+- `category` — hierarchia jako mechanizm domeny, `is_hierarchical=true`, specjalna zdolność deklarowania attribute groups.
+- `asset` — DAM ma szczególne potrzeby (metadata EXIF, transformacje, CDN URLs).
+- `brand` — marka jako 4-ty predefiniowany ObjectType (decyzja PRD § 4 + ADR-009 update).
+
+**Custom** (`is_built_in=false`):
+- `service`, `location`, `event`, `subscription`, `bundle`, `person`, dowolne.
+- Pełna kontrola: code, settings (is_hierarchical, has_variants, is_abstract), attribute groups, deletion (jeśli brak instancji).
+
+**Kłódka 🔒 w UI:** built-in fields są *visible* dla wszystkich, ale `code` / fundamentalne flagi są disabled z tooltipem *„System type — limited customization"*.
+
+### 3.5 Attribute Group jako first-class entity (proponowany ADR-012) ⭐ NEW
+
+**To jest abstrakcja, której Pimcore i Akeneo nie mają (lub mają słabo):**
+- W Pimcore — grupowanie jest *„doklejone"* do Class Definition.
+- W Akeneo — Attribute Group jest tylko sortowaniem UI, bez własnej semantyki.
+
+**U nas — Attribute Group jako pierwszorzędny obywatel:**
+- Ma własny URL (`/modeling/attribute-groups/medical-requirements`).
+- Jest wymienną jednostką (przeniesienie grupy między ObjectType to jedna operacja).
+- Może mieć własny audit, wersjonowanie, kontrolę dostępu (Faza 1+).
+
+**Trzy poziomy przypinania Attribute Group:**
+
+1. **Globalnie do ObjectType** — atrybuty wspólne dla wszystkich obiektów tego typu. *„Każdy Produkt ma name, sku, description"*.
+2. **Per kategoria w hierarchii** — atrybuty dziedziczone w dół drzewa kategorii. *„Kategoria Lekarz definiuje grupę Wymagania medyczne, podkategoria Chirurg dziedziczy + dodaje Chirurgia szczegóły, Ortopeda dziedziczy + dodaje Ortopedia"*.
+3. **Per indywidualny obiekt** — opcjonalnie ad-hoc dodatkowa grupa do konkretnego produktu (rzadkie, ale potrzebne dla ekstremalnych edge case'ów).
+
+### 3.6 System attributes vs business attributes
+
+System attributes (`is_system=true`):
+- `created_at`, `updated_at`, `created_by`, `updated_by`, `id`.
+- Automatycznie dodawane do każdego ObjectType jako specjalna grupa **"Audyt"** (`auto_attached=true`).
+- Read-only w UI, niemodyfikowalne, niezmienne.
+- Pimcore nie ma tego jako atrybutów; Akeneo też nie. **U nas tak — wszystko jest atrybutem.**
+
+### 3.7 Visibility rules (`visible_when`)
+
+Atrybut w grupie może mieć regułę warunkowej widoczności:
+
+```yaml
+attribute: nfz_code
+visible_when: is_nfz_eligible == true
+```
+
+Bez tego użytkownicy się gubią (formularz pokazuje 50 pól, użytkownik nie wie które wypełnić). Akeneo tego nie ma natywnie.
+
+### 3.8 Pełen model encji (delta wobec ADR-009)
+
+```
+object_types (id, code, name, is_hierarchical, is_abstract, has_variants, is_built_in, code_immutable, deletable)
+attributes (id, code, type, localizable, scopable, is_system, validation_rules, ui_config)
+attribute_groups (id, code, name, description, icon, color, is_system_group)  ⭐ NEW
+attribute_group_attributes (attribute_group_id, attribute_id, position, is_required_in_group, visible_when_jsonb)
+object_type_attribute_groups (object_type_id, attribute_group_id, position)
+  ← globalne grupy dla ObjectType
+category_attribute_groups (category_object_id, target_object_type_id, attribute_group_id, position)
+  ← grupy deklarowane przez kategorię dla obiektów określonego typu
+```
+
+Plus istniejące (z ADR-009):
+- `objects (id, kind, parent_id, ...)` — polimorficzne, kind = ObjectType code.
+- `object_values (object_id, attribute_id, value, locale, channel, provenance)` — EAV.
+- `attributes_indexed JSONB` — denormalizowany cache.
+
+---
+
+## 4. Layout zakładki Modelowanie — 4 sub-tabs
+
+```
+┌─ Modelowanie ─────────────────────────────────────────┐
+│                                                        │
+│  ┌─[Object Types]─[Attributes]─[Attribute Groups]─┐   │
+│  │                                                   │   │
+│  │  [Categories]                                    │   │
+│  │                                                   │   │
+│  │  ┌──────────────────────────────────────────┐  │   │
+│  │  │                                            │  │   │
+│  │  │    Active sub-tab content here            │  │   │
+│  │  │                                            │  │   │
+│  │  │                                            │  │   │
+│  │  │                                            │  │   │
+│  │  └──────────────────────────────────────────┘  │   │
+│  └───────────────────────────────────────────────┘   │
+└────────────────────────────────────────────────────────┘
+```
+
+URL routing:
+- `/modeling/object-types` (default landing).
+- `/modeling/attributes`.
+- `/modeling/attribute-groups`.
+- `/modeling/categories` (osobna pozycja w nawigacji wewnętrznej, bo Categories ma też daily-use view dla operatora — *do uzgodnienia czy ten sub-tab wewnątrz Modelowania, czy osobna pozycja w sidebar*).
+
+---
+
+## 5. Sub-tab 1: Object Types
+
+### 5.1 List view
+
+```
+┌─ Object Types ─────────────────────────────────────────┐
+│                                          [+ New Type]  │
+│                                                         │
+│  🔒 Built-in (system)                                   │
+│  ┌─────────────────────────────────────────────────┐  │
+│  │ 📦 Product        | hierarchical: false  | 1247  │  │
+│  │ 📂 Category       | hierarchical: TRUE   | 134   │  │
+│  │ 🖼  Asset          | hierarchical: false  | 5421  │  │
+│  │ 🏷  Brand          | hierarchical: false  | 87    │  │
+│  └─────────────────────────────────────────────────┘  │
+│                                                         │
+│  ✏️  Custom (your organization)                          │
+│  ┌─────────────────────────────────────────────────┐  │
+│  │ 🏥 Service        | hierarchical: false  | 24    │  │
+│  │ 📍 Location       | hierarchical: false  | 5     │  │
+│  │ 🔄 Subscription   | hierarchical: false  | 0     │  │
+│  └─────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Kolumny:**
+- Ikona + nazwa wyświetlana.
+- `code` (mono font).
+- `is_hierarchical` flaga.
+- Liczba instancji (`COUNT(*)` z `objects WHERE kind=...`).
+- Actions: Edit (Sheet drawer right-side) / Delete (only custom + 0 instances).
+
+**Filtry / search:** tylko dla custom (built-in zazwyczaj 4-5).
+
+### 5.2 Detail view (built-in — Product)
+
+```
+┌─ Product ──────────────────────────────────────  🔒 ──┐
+│  System type — limited customization                  │
+│                                                        │
+│  Display name:       [Produkty                  ]  ✏️ │
+│  Display name (EN):  [Products                  ]  ✏️ │
+│  Code:               product                       🔒 │
+│  Icon:               [📦                        ]  ✏️ │
+│  Color (badge):      [#3B82F6 ▼                 ]  ✏️ │
+│                                                        │
+│  ─── Built-in attribute groups ───────── 🔒 ──────    │
+│  ┌─ Identification (auto-attached) ───────────────┐  │
+│  │  Atrybuty: sku (required), name, slug         🔒 │  │
+│  └─────────────────────────────────────────────────┘  │
+│  ┌─ Audit (auto-attached) ────────────────────────┐  │
+│  │  Atrybuty: created_at, updated_at, created_by │🔒 │  │
+│  └─────────────────────────────────────────────────┘  │
+│                                                        │
+│  ─── Custom attribute groups ──────────────────────   │
+│  ┌─ Marketing                              [edit] 🗑 │  │
+│  │  Atrybuty: short_description, long_description, │  │
+│  │  tags                                            │  │
+│  └─────────────────────────────────────────────────┘  │
+│  ┌─ Technical specifications              [edit] 🗑 │  │
+│  │  Atrybuty: voltage, current, dimensions          │  │
+│  └─────────────────────────────────────────────────┘  │
+│  [+ Add attribute group]                              │
+│                                                        │
+│  ─── Settings ──────────────────────────────────────  │
+│  ☐ Is hierarchical                              🔒    │
+│  ☑ Has variants                                 🔒    │
+│  ☐ Is abstract                                  🔒    │
+│  Allowed parent types:  Category ✓                    │
+│                                                        │
+│  Variant axes (jeśli has_variants):                   │
+│  [color] × [size]                          [edit]     │
+│                                                        │
+│  ─── Where used ────────────────────────────────────  │
+│  • 1247 instances exist                                │
+│  • Used in 12 categories                              │
+│  • Referenced by 8 API integrations                   │
+└────────────────────────────────────────────────────────┘
+```
+
+**Kluczowe elementy:**
+- 🔒 wszędzie gdzie pole/grupa jest niemodyfikowalna z tooltipem *„System type — protected"*.
+- ✏️ przy polach modyfikowalnych (display name, icon, color, custom groups, allowed parent types).
+- *„Built-in attribute groups"* osobno od *„Custom"* — wizualnie jasne co jest fundament a co dodano.
+
+### 5.3 Detail view (custom — Service)
+
+```
+┌─ Service ────────────────────────────────── ✏️ ──────┐
+│  Custom type — full control                          │
+│                                                       │
+│  Display name:       [Usługi                    ]   │
+│  Display name (EN):  [Services                  ]   │
+│  Code:               [service                   ]   │
+│  Icon:               [🏥                        ]   │
+│  Color:              [#10B981 ▼                 ]   │
+│                                                       │
+│  ─── Required base attribute groups ─── 🔒 ───────   │
+│  (auto-attached for every Object Type)                │
+│  ┌─ Identification ──────────────────────────────┐  │
+│  │  sku (required), name, slug                  🔒 │  │
+│  └────────────────────────────────────────────────┘  │
+│  ┌─ Audit ───────────────────────────────────────┐  │
+│  │  created_at, updated_at, created_by          🔒 │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                       │
+│  ─── Custom attribute groups ──────────────────────  │
+│  ┌─ Pricing                              [edit] 🗑 │  │
+│  │  base_price, currency, vat_rate                 │  │
+│  └────────────────────────────────────────────────┘  │
+│  ┌─ Scheduling                           [edit] 🗑 │  │
+│  │  appointment_duration, requires_appointment      │  │
+│  └────────────────────────────────────────────────┘  │
+│  [+ Add attribute group]                              │
+│                                                       │
+│  ─── Settings ─────────────────────────────────────  │
+│  ☐ Is hierarchical                                   │
+│  ☐ Has variants                                      │
+│  ☐ Is abstract                                       │
+│                                                       │
+│  Allowed parent types:                                │
+│  ☑ Category                                          │
+│  ☐ Service (self-referential, np. usługa składowa)   │
+│                                                       │
+│  ─── Where used ───────────────────────────────────  │
+│  • 24 instances exist                                 │
+│  • Used in 8 categories (Lekarz, Fryzjer, ...)       │
+│                                                       │
+│  ─────────────────────────────────────────────────   │
+│                                                       │
+│  [Delete this Object Type]                            │
+│  Note: Disabled because 24 instances exist.           │
+│  Migrate or delete instances first.                   │
+└───────────────────────────────────────────────────────┘
+```
+
+### 5.4 Create new Object Type — wizard
+
+```
+Step 1: Basics
+  - Display name (PL): [_________]
+  - Display name (EN): [_________]
+  - Code (auto-generated from PL, editable): [_________]
+  - Icon picker: [emoji / Lucide icon]
+  - Color: [color picker]
+
+Step 2: Settings
+  - Is hierarchical? (jak Category)
+  - Has variants? (jak Product)
+  - Is abstract? (czy można tworzyć instancje)
+  - Allowed parent types (multi-select)
+
+Step 3: Initial attribute groups
+  - Auto-attach: Identification, Audit (always)
+  - Add existing groups (from library) — multi-select.
+  - Or skip and add later.
+
+Step 4: Confirm
+  - Preview: jak będzie wyglądał formularz tego typu.
+  - Confirm + Create.
+```
+
+Po Create — automatycznie pojawia się nowa pozycja w sidebar admin app po refresh (`Sidebar` czyta `object_types` table).
+
+---
+
+## 6. Sub-tab 2: Attributes
+
+### 6.1 List view (global library)
+
+```
+┌─ Attributes ─────────────────────────────────────────┐
+│  Search: [_____________]  Type: [all ▼]  [+ New]    │
+│                                                        │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ Code              | Type     | Used in (count)  │  │
+│  ├────────────────────────────────────────────────┤  │
+│  │ 🔒 sku             | text     | 4 types, 1 group  │ │
+│  │ 🔒 name            | text     | 4 types, 1 group  │ │
+│  │ 🔒 created_at      | datetime | 4 types (system)  │ │
+│  │ description       | richtext | 3 types, 2 groups │  │
+│  │ voltage           | number   | 1 type, 1 group   │  │
+│  │ appointment_dur.. | number   | 1 type (service)  │  │
+│  │ ...                                              │  │
+│  └────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────┘
+```
+
+**Filtry:**
+- Type (text, number, select, ...).
+- System vs business attributes.
+- Localizable / scopable flags.
+- Where-used (czy jest używany, w ilu types/groups).
+
+**Bulk actions:**
+- Bulk import from CSV (US-MOD-008).
+- Bulk archive (atrybuty unused — kandydaci do cleanup'u).
+
+### 6.2 Detail view (Attribute)
+
+```
+┌─ Attribute: voltage ─────────────────────────────────┐
+│                                                        │
+│  Code:                [voltage                  ]    │
+│  Display name:        [Napięcie                 ]    │
+│  Display name (EN):   [Voltage                  ]    │
+│  Type:                [number ▼                 ]    │
+│  Unit (jeśli metric): [V                        ]    │
+│                                                        │
+│  ─── Flags ─────────────────────────────────────────  │
+│  ☐ Localizable (per locale)                           │
+│  ☑ Scopable (per channel)                             │
+│  ☐ Unique                                             │
+│                                                        │
+│  ─── Validation ────────────────────────────────────  │
+│  Min: [0      ]                                       │
+│  Max: [10000  ]                                       │
+│  Allowed values: (n/a for number)                     │
+│                                                        │
+│  ─── UI Configuration ──────────────────────────────  │
+│  Widget:    [number-with-unit ▼]                     │
+│  Placeholder: [np. 230                 ]              │
+│  Helper text: [Napięcie znamionowe w V ]              │
+│                                                        │
+│  ─── Where used ────────────────────────────────────  │
+│  Groups:                                               │
+│  • Technical specifications                           │
+│  • Power consumption                                   │
+│                                                        │
+│  Object Types:                                         │
+│  • Product (via Technical specifications)             │
+│                                                        │
+│  Categories that declare attribute groups using this:│
+│  • Elektronika (via Technical specifications)         │
+│                                                        │
+│  Total instances with non-null voltage: 247           │
+│                                                        │
+│  ─── Preview ───────────────────────────────────────  │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ Napięcie: [230___] V                           │  │
+│  │           Napięcie znamionowe w V              │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                        │
+│  ─── Actions ───────────────────────────────────────  │
+│  [Edit attribute]  [Migrate type → ...]  [Archive]    │
+└────────────────────────────────────────────────────────┘
+```
+
+### 6.3 Edit attribute — dangerous changes
+
+Niektóre zmiany na atrybucie wpływają na *wszystkie* obiekty go używające. UI pokazuje *„Migration impact"* przed save:
+
+```
+┌─ Migrate attribute "material" from text → select ────┐
+│                                                        │
+│  Current: text (free-form input)                      │
+│  Target:  select (predefined options)                 │
+│                                                        │
+│  ─── Impact analysis ────────────────────────────────  │
+│  • 3,247 produktów ma wartość w tym atrybucie.       │
+│  • 47 unikalnych wartości tekstowych:                 │
+│    - "stal nierdzewna" (1,820)                        │
+│    - "AISI 316L" (892)                                │
+│    - "Stal nierdz." (267)  ← prawdopodobnie duplikat │
+│    - ... (44 inne)                                    │
+│                                                        │
+│  ─── Mapping plan ──────────────────────────────────  │
+│  Map existing values to select options:               │
+│  - "stal nierdzewna" → [Stal nierdzewna ▼]           │
+│  - "AISI 316L"       → [AISI 316L      ▼]            │
+│  - "Stal nierdz."    → [Stal nierdzewna ▼] (merge)   │
+│  - ... [Auto-suggest with AI Faza 2]                 │
+│                                                        │
+│  Unmapped values (will become NULL):                  │
+│  - "stal" (12 produktów)                              │
+│  - [skip / map to "other"]                            │
+│                                                        │
+│  ─── Confirmation ──────────────────────────────────  │
+│  ☐ Backup snapshot przed migracją (recommended)       │
+│  ☐ Dry-run first (no actual changes)                  │
+│                                                        │
+│  [Cancel]  [Dry-run]  [Apply Migration]               │
+└────────────────────────────────────────────────────────┘
+```
+
+To jest **kluczowy enterprise feature** — Akeneo i Pimcore tego nie mają natywnie (klient pisze SQL skrypty ręcznie).
+
+---
+
+## 7. Sub-tab 3: Attribute Groups ⭐ NEW first-class entity
+
+### 7.1 List view
+
+```
+┌─ Attribute Groups ───────────────────────────────────┐
+│  Search: [_____________]  [+ New Group]              │
+│                                                        │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ Group                  | Attributes | Used in   │  │
+│  ├────────────────────────────────────────────────┤  │
+│  │ 🔒 Identification       | 3          | 4 types  │  │
+│  │ 🔒 Audit                | 5          | 4 types  │  │
+│  │ Marketing              | 4          | 1 type   │  │
+│  │ Technical specifications| 12        | 1 type   │  │
+│  │ Pricing                | 3          | 2 types  │  │
+│  │ Wymagania medyczne     | 4          | 1 cat.   │  │
+│  │ Refundacja NFZ         | 4          | 1 cat.   │  │
+│  │ Chirurgia szczegóły    | 3          | 1 cat.   │  │
+│  │ Ortopedia              | 2          | 1 cat.   │  │
+│  └────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────┘
+```
+
+### 7.2 Detail view (Attribute Group)
+
+```
+┌─ Attribute Group: Wymagania medyczne ────────────────┐
+│                                                        │
+│  Code:           [wymagania-medyczne          ]      │
+│  Display name:   [Wymagania medyczne          ]      │
+│  Display name EN:[Medical requirements        ]      │
+│  Description:    [Atrybuty specyficzne dla    ]      │
+│                  [usług medycznych — referrals]      │
+│  Icon:           [🏥                          ]      │
+│  Color:          [#EF4444 ▼                  ]      │
+│                                                        │
+│  ─── Attributes in this group ──────────────────────  │
+│  (drag-drop to reorder)                               │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ ☰ requires_referral    ☑ required  visible_when│  │
+│  │ ☰ min_age              ☐ required             │  │
+│  │ ☰ contraindications   ☐ required             │  │
+│  │ ☰ specialist_required  ☐ required             │  │
+│  └────────────────────────────────────────────────┘  │
+│  [+ Add attribute from library]                       │
+│  [+ Create new attribute (in library + add here)]    │
+│                                                        │
+│  ─── Visibility rules per attribute ────────────────  │
+│  contraindications:                                   │
+│    visible_when: requires_referral == true            │
+│    [Edit rule]                                        │
+│                                                        │
+│  ─── Where used ────────────────────────────────────  │
+│  Used directly by:                                    │
+│  • Object Type: (none — only via category)           │
+│                                                        │
+│  Declared by categories:                              │
+│  • Category: Lekarz (target type: Service)            │
+│    Inherited by: Chirurg, Ortopeda, Pediatra,        │
+│    Internista (4 sub-categories)                      │
+│                                                        │
+│  Affected objects:                                    │
+│  • 17 services in Lekarz tree have this group        │
+│                                                        │
+│  ─── Preview UI ────────────────────────────────────  │
+│  [Pokaż jak ta grupa będzie wyglądać w formularzu]   │
+└────────────────────────────────────────────────────────┘
+```
+
+### 7.3 Add attribute to group (inline)
+
+```
+┌─ Add attribute to "Wymagania medyczne" ──────────────┐
+│                                                        │
+│  Search library:   [______________]                   │
+│                                                        │
+│  Existing attributes:                                  │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ ○ requires_referral   (boolean)                │  │
+│  │ ○ min_age             (number)                 │  │
+│  │ ● contraindications   (richtext, localizable)  │  │
+│  │ ○ specialist_required (boolean)                │  │
+│  │ ○ ...                                          │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                        │
+│  Settings for this group:                             │
+│  ☐ Required in this group                             │
+│  Position in form: [auto / 1 / 2 / 3 ...]            │
+│  Visibility rule:  [No rule ▼]                       │
+│    [+ Add visible_when condition]                    │
+│                                                        │
+│  [Cancel]  [Add to group]                             │
+│                                                        │
+│  Or: [Create new attribute]                          │
+└────────────────────────────────────────────────────────┘
+```
+
+### 7.4 Visible_when rule editor
+
+```
+┌─ Visibility rule: contraindications ─────────────────┐
+│                                                        │
+│  Show this attribute when:                            │
+│                                                        │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ requires_referral  [equals ▼]  [true     ▼]   │  │
+│  └────────────────────────────────────────────────┘  │
+│  [+ AND condition]   [+ OR condition]                 │
+│                                                        │
+│  Otherwise: hidden in form                            │
+│                                                        │
+│  Test rule:                                           │
+│  Input: requires_referral = true   → [VISIBLE]        │
+│  Input: requires_referral = false  → [HIDDEN]         │
+│                                                        │
+│  [Cancel]  [Save rule]                                │
+└────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 8. Sub-tab 4: Categories (modeling view)
+
+### 8.1 Tree view + attribute groups declaration
+
+```
+┌─ Categories (modeling) ──────────────────────────────┐
+│                                                        │
+│  Object Type filter: [Service ▼]   [+ New category]  │
+│                                                        │
+│  ┌─ Service (root, all services here) ──────────────┐ │
+│  │ ├─ 🏥 Lekarz                                   ▼  │ │
+│  │ │  Declared groups (for Service):                │ │
+│  │ │   • Cennik medyczny                           │ │
+│  │ │   • Wymagania medyczne                        │ │
+│  │ │   • Refundacja NFZ                            │ │
+│  │ │   [+ Declare group]                           │ │
+│  │ │                                                │ │
+│  │ │  ├─ Internista                                │ │
+│  │ │  │  Declared groups: (none — inherits all)    │ │
+│  │ │  │                                             │ │
+│  │ │  ├─ 🦴 Chirurg                              ▼  │ │
+│  │ │  │  Declared groups:                          │ │
+│  │ │  │   • Chirurgia szczegóły                    │ │
+│  │ │  │                                             │ │
+│  │ │  │  ├─ Chirurg ogólny                         │ │
+│  │ │  │  └─ Ortopeda                              ▼ │ │
+│  │ │  │     Declared groups:                       │ │
+│  │ │  │      • Ortopedia                            │ │
+│  │ │  │                                             │ │
+│  │ │  └─ Pediatra                                  │ │
+│  │ │                                                │ │
+│  │ └─ 💇 Fryzjer                                  ▼  │ │
+│  │    Declared groups (for Service):               │ │
+│  │     • Cennik podstawowy                         │ │
+│  │     • Specyfika fryzjerska                      │ │
+│  │    ├─ Strzyżenie męskie                         │ │
+│  │    ├─ Strzyżenie damskie                        │ │
+│  │    └─ Koloryzacja                               │ │
+│  └────────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────────┘
+```
+
+### 8.2 Category detail (Ortopeda)
+
+```
+┌─ Category: Ortopeda ─────────────────────────────────┐
+│                                                        │
+│  Code:           [ortopeda                    ]      │
+│  Display name:   [Ortopeda                    ]      │
+│  Path:           service.lekarz.chirurg.ortopeda     │
+│  Parent:         [Chirurg ▼]                         │
+│  Sort order:     [3]                                  │
+│                                                        │
+│  ─── Attribute groups for this category ────────────  │
+│  Target Object Type: [Service ▼]                     │
+│                                                        │
+│  Inherited from parents (read-only):                  │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ ✓ Cennik medyczny      (from Lekarz)           │  │
+│  │ ✓ Wymagania medyczne   (from Lekarz)           │  │
+│  │ ✓ Refundacja NFZ       (from Lekarz)           │  │
+│  │ ✓ Chirurgia szczegóły  (from Chirurg)          │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                        │
+│  Declared directly:                                   │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ ✓ Ortopedia                            [edit]🗑│  │
+│  └────────────────────────────────────────────────┘  │
+│  [+ Declare group]                                    │
+│                                                        │
+│  ─── Effective preview for object in this category ──│
+│  An object of type "Service" placed in "Ortopeda"    │
+│  will see these attribute groups:                     │
+│                                                        │
+│  ┌────────────────────────────────────────────────┐  │
+│  │ 🔒 Identification (from Service ObjectType)     │  │
+│  │ 🔒 Audit          (from Service ObjectType)     │  │
+│  │  Cennik medyczny (inherited from Lekarz)       │  │
+│  │  Wymagania medyczne (inherited from Lekarz)    │  │
+│  │  Refundacja NFZ  (inherited from Lekarz)       │  │
+│  │  Chirurgia szczegóły (inherited from Chirurg)  │  │
+│  │  Ortopedia       (declared here)               │  │
+│  └────────────────────────────────────────────────┘  │
+│                                                        │
+│  [+ Create test object in this category]              │
+└────────────────────────────────────────────────────────┘
+```
+
+To jest **inheritance preview** — Adam widzi co Kasia zobaczy w formularzu *„Stwórz nową usługę → Ortopeda"*. Akeneo tego nie ma; Pimcore tego nie ma. *Killer feature.*
+
+### 8.3 Override / disable inherited group
+
+Czasem kategoria-dziecko chce *wyłączyć* grupę odziedziczoną z rodzica (rzadkie, ale potrzebne):
+
+```
+[+ Override inherited group]
+  → wybierz grupę: Wymagania medyczne (from Lekarz)
+  → akcja: ☑ Hide in this category and descendants
+  
+  Result: dla obiektów w tej kategorii grupa "Wymagania medyczne" nie pokaże się.
+```
+
+### 8.4 Category cycle prevention
+
+System blokuje próby tworzenia cykli (Lekarz → Chirurg → Lekarz). Walidacja przy save w bazie + UI ostrzeżenie z preview drzewa.
+
+---
+
+## 9. User stories
+
+| ID | Persona | Story |
+|---|---|---|
+| US-MOD-001 | Adam | Tworzy nowy ObjectType "Service" z code, display name, settings (is_hierarchical=false, has_variants=false). Auto-attached: Identification + Audit groups. |
+| US-MOD-002 | Adam | Definiuje atrybut `appointment_duration` (number, minutes), dodaje do nowej grupy "Scheduling". |
+| US-MOD-003 | Adam | Tworzy Attribute Group "Wymagania medyczne" z 4 atrybutami. Reusable bundle. |
+| US-MOD-004 | Adam | Tworzy kategorię "Lekarz" w drzewie Service. Deklaruje że obiekty Service w tej kategorii dostają grupy: "Cennik medyczny", "Wymagania medyczne", "Refundacja NFZ". |
+| US-MOD-005 | Adam | Tworzy podkategorię "Chirurg" pod "Lekarz". Deklaruje grupę "Chirurgia szczegóły". Sprawdza inheritance preview — widzi że Chirurg dziedziczy 3 grupy z Lekarz + ma 1 własną. |
+| US-MOD-006 | Adam | Tworzy podkategorię "Ortopeda" pod "Chirurg". Deklaruje grupę "Ortopedia". Inheritance preview pokazuje sumarycznie 5 grup (Identification + Audit + 3 z Lekarz + 1 z Chirurg + 1 z Ortopeda). |
+| US-MOD-007 | Adam | Klika "+ Create test object in this category" — system tworzy testową usługę w Ortopedzie i otwiera w nowym tabie do wypełnienia. Walidacja działa. |
+| US-MOD-008 | Adam | Bulk import 50 atrybutów technicznych z CSV (kable: voltage, current, ampacity, conductor_count, ...). |
+| US-MOD-009 | Adam | Migracja atrybutu `material` z text na select. Widzi impact analysis (3247 produktów, 47 unikalnych wartości, sugerowane mapping z auto-merge duplikatów). Robi dry-run, akceptuje, wykonuje. |
+| US-MOD-010 | Adam | Definiuje visible_when rule: `nfz_code` widoczny tylko gdy `is_nfz_eligible == true`. Testuje regułę z dwoma input'ami. |
+| US-MOD-011 | Adam (lub Kasia) | Where-used dla atrybutu `voltage` — widzi że jest w 2 grupach, używany przez 1 ObjectType (Product), w 247 instancjach. |
+| US-MOD-012 | Adam | Próbuje usunąć ObjectType "Service" — system blokuje (24 instancje istnieją), proponuje migrate-and-delete workflow. |
+| US-MOD-013 | Adam | Kopia ObjectType "Service" jako "ServicePremium" z odziedziczonymi grupami + dodaje `vip_features` group. |
+
+## 10. Business rules / edge cases
+
+### 10.1 Konflikty Attribute Groups
+- **Rule:** atrybut nie może być w dwóch grupach w tym samym formularzu obiektu (system to wymusza).
+- **Edge case:** Lekarz deklaruje grupę X (zawiera atrybut `material`), Service ObjectType ma globalną grupę Y (też zawiera `material`). Konflikt → walidacja przy save modelu, nie w runtime.
+
+### 10.2 Cykle w drzewie kategorii
+- **Rule:** kategoria nie może być rodzicem swojego przodka.
+- **Implementacja:** ltree trigger w Postgres + walidacja UI.
+
+### 10.3 Delete protection
+- **ObjectType built-in:** zawsze blokowane.
+- **ObjectType custom z instancjami:** blokowane do migrate-and-delete.
+- **Attribute Group:** blokowane jeśli używana przez co najmniej 1 ObjectType lub Category. Confirm modal *„Detach from N usages first"*.
+- **Attribute:** blokowane jeśli ma wartości w `object_values`. Confirm migration plan.
+
+### 10.4 Code immutability
+- **Built-in ObjectType code:** niezmienne (na zawsze, by nie łamać integracji).
+- **Built-in Attribute code:** niezmienne (`sku`, `created_at`, etc.).
+- **Custom ObjectType code:** zmienne, ale ostrzeżenie *„This will break X integrations"* + audit log.
+- **Custom Attribute code:** zmienne z impact warning.
+
+### 10.5 System attributes auto-attachment
+- Każdy nowy ObjectType (built-in lub custom) **automatycznie** dostaje grupę "Audyt" (`is_system=true`).
+- Klient **nie może** odpiąć tej grupy. UI pokazuje ją z 🔒.
+- Powód: każdy obiekt MUSI mieć `created_at` / `updated_at` dla audit log + sortowania.
+
+### 10.6 Visibility rule limits
+- **MVP:** tylko proste `attribute == value` rules (1 condition).
+- **Faza 1:** AND/OR composite rules.
+- **Faza 2:** complex expressions (np. `created_at > 30 days ago AND brand IN ['Bosch', 'Festo']`).
+
+### 10.7 Mass attribute changes (migration workflow)
+- **Type changes** (text → select, number → metric): wymagają mapping plan + dry-run + backup.
+- **Type changes destructive** (richtext → boolean): blokowane (dane lost), force flag z explicite confirmation.
+- **Localization changes** (non-localizable → localizable): all existing values → default locale; klient może później distribute.
+
+### 10.8 Model versioning (Faza 2 kandydat)
+- Każda modyfikacja modelu (ObjectType / Attribute / AttributeGroup / Category) tworzy *„model version"*.
+- Obiekty są *pinned* do wersji modelu przy tworzeniu.
+- Migration to nowej wersji modelu — explicit event z zatwierdzeniem.
+
+---
+
+## 11. Permissions (deferred MVP)
+
+**MVP:** brak role gating. Każdy zalogowany user ma full access do Modelowania.
+
+**Faza 1 (proponowany ADR-013 *„User personas and modeling permissions"*):**
+- `model_admin` — pełen dostęp do Modelowania (default dla Adama).
+- `model_viewer` — read-only widok Modelowania (Piotr może czytać żeby debugować integracje, nie modyfikować).
+- `content_editor` — brak dostępu do Modelowania (Kasia, Magda).
+- `super_admin` — overrides everything (Tomasz, Marcin).
+
+**Audit log** od dnia 1 (Doctrine AuditBundle, epik 0.11.4 z planu) — każda zmiana w Modelowaniu jest logowana z user_id + timestamp + diff. Nawet bez role gating, mamy *trace* kto co zmienił.
+
+---
+
+## 12. Dependency na backend
+
+### 12.1 ADR-y, które musimy zaktualizować lub stworzyć
+
+- **ADR-009** (rozszerzenie) — Brand jako 4-ty predefiniowany ObjectType, Attribute Group jako encja first-class.
+- **ADR-012** (NEW) — *„Attribute Group as first-class entity for cross-objecttype data modeling"*. Patrz § 3.5 + § 3.8 (DDL).
+- **ADR-013** (NEW, Faza 1) — *„User personas and modeling permissions"* — granularne role + permissions.
+
+### 12.2 Encje + tabele (delta vs ADR-009)
+
+```sql
+-- Nowa tabela
+CREATE TABLE attribute_groups (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    code VARCHAR(128) NOT NULL,
+    name JSONB NOT NULL,             -- {"pl": "Wymagania medyczne", "en": "Medical requirements"}
+    description JSONB,
+    icon VARCHAR(64),
+    color VARCHAR(16),
+    is_system_group BOOLEAN NOT NULL DEFAULT false,
+    auto_attached BOOLEAN NOT NULL DEFAULT false,  -- Audit grupa
+    UNIQUE (tenant_id, code)
+);
+
+-- Junction: Attribute → AttributeGroup
+CREATE TABLE attribute_group_attributes (
+    attribute_group_id UUID NOT NULL REFERENCES attribute_groups(id) ON DELETE CASCADE,
+    attribute_id UUID NOT NULL REFERENCES attributes(id),
+    position INTEGER NOT NULL DEFAULT 0,
+    is_required_in_group BOOLEAN NOT NULL DEFAULT false,
+    visible_when JSONB,             -- conditional visibility
+    PRIMARY KEY (attribute_group_id, attribute_id)
+);
+
+-- Junction: ObjectType → AttributeGroup (globalne grupy dla typu)
+CREATE TABLE object_type_attribute_groups (
+    object_type_id UUID NOT NULL REFERENCES object_types(id) ON DELETE CASCADE,
+    attribute_group_id UUID NOT NULL REFERENCES attribute_groups(id),
+    position INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (object_type_id, attribute_group_id)
+);
+
+-- Junction: Category → AttributeGroup (dziedziczone grupy w drzewie)
+CREATE TABLE category_attribute_groups (
+    category_object_id UUID NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+    target_object_type_id UUID NOT NULL REFERENCES object_types(id),
+    attribute_group_id UUID NOT NULL REFERENCES attribute_groups(id),
+    position INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (category_object_id, target_object_type_id, attribute_group_id)
+);
+
+-- Update: object_types
+ALTER TABLE object_types ADD COLUMN is_built_in BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE object_types ADD COLUMN code_immutable BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE object_types ADD COLUMN deletable BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE object_types ADD COLUMN icon VARCHAR(64);
+ALTER TABLE object_types ADD COLUMN color VARCHAR(16);
+
+-- Seed built-in
+INSERT INTO object_types (code, name, is_built_in, code_immutable, deletable, is_hierarchical, has_variants)
+VALUES
+  ('product',  '{"pl":"Produkt","en":"Product"}',     true, true, false, false, true),
+  ('category', '{"pl":"Kategoria","en":"Category"}',  true, true, false, true,  false),
+  ('asset',    '{"pl":"Zasób","en":"Asset"}',         true, true, false, false, false),
+  ('brand',    '{"pl":"Marka","en":"Brand"}',         true, true, false, false, false);
+
+-- Update: attributes
+ALTER TABLE attributes ADD COLUMN is_system BOOLEAN NOT NULL DEFAULT false;
+
+-- Seed system attributes (auto-attached)
+INSERT INTO attributes (code, type, is_system) VALUES
+  ('id', 'uuid', true),
+  ('created_at', 'datetime', true),
+  ('updated_at', 'datetime', true),
+  ('created_by', 'reference:user', true),
+  ('updated_by', 'reference:user', true);
+```
+
+### 12.3 Domain service
+
+`EffectiveAttributeGroupResolver` — service który dla danej pary `(object_id, category_path)` zwraca **efektywną listę Attribute Groups** z dziedziczeniem:
+
+```php
+class EffectiveAttributeGroupResolver
+{
+    /**
+     * @return array<AttributeGroup>
+     */
+    public function resolve(Object $object): array
+    {
+        $groups = [];
+        
+        // 1. System auto-attached groups (Audit)
+        $groups[] = $this->getSystemAuditGroup();
+        
+        // 2. Globalne grupy dla ObjectType
+        foreach ($object->getObjectType()->getAttributeGroups() as $group) {
+            $groups[] = $group;
+        }
+        
+        // 3. Grupy dziedziczone z drzewa kategorii (od root do leaf)
+        foreach ($object->getCategoryPath() as $category) {
+            foreach ($category->getDeclaredAttributeGroups($object->getKind()) as $group) {
+                if (!$this->isAlreadyInList($groups, $group)) {
+                    $groups[] = $group;
+                }
+            }
+        }
+        
+        // 4. Per-object ad-hoc grupy (jeśli)
+        foreach ($object->getAdHocAttributeGroups() as $group) {
+            $groups[] = $group;
+        }
+        
+        return $groups;
+    }
+}
+```
+
+Cache: dla danego `(object_type_id, category_path)` lista jest stabilna — cache w Redis z TTL 5 min, invalidacja na każdą zmianę modelu.
+
+### 12.4 Doctrine listener
+
+Listener `ObjectFormSchemaListener` — gdy klient otwiera formularz produktu/usługi/etc., serwer zwraca *zsynchronizowaną listę grup + atrybutów* używając `EffectiveAttributeGroupResolver`. Frontend renderuje formularz dynamicznie.
+
+---
+
+## 13. Komponenty Refine + shadcn
+
+### 13.1 Generic admin patterns
+- `Refine.Resource` per sub-tab (`object-types`, `attributes`, `attribute-groups`, `categories-modeling`).
+- `useTable`, `useForm`, `useShow`, `useCreate`, `useUpdate`, `useDelete` — standardowy Refine.
+
+### 13.2 shadcn components
+- `Tabs` — top-level 4 sub-tabs.
+- `Table` + `DataTable` (TanStack Table) — list views.
+- `Sheet` (right drawer) — detail view per Object Type / Attribute / Group.
+- `Dialog` — wizard create new + migration impact.
+- `Form` + `FormField` — Zod + React Hook Form.
+- `Input`, `Select`, `Switch`, `Combobox` (shadcn) — base inputs.
+- `Card`, `Badge`, `Tooltip` — info display.
+- `Tree` (custom, brak w shadcn — może wykorzystać `react-arborist`) — drzewo kategorii.
+
+### 13.3 Custom components
+
+| Komponent | Rola |
+|---|---|
+| `BuiltInLockBadge` | 🔒 ikona z tooltipem *„System type — protected"*. |
+| `WhereUsedList` | Komponent pokazujący gdzie atrybut/grupa jest używana (groups, types, categories, instance count). |
+| `EffectiveAttributesPreview` | Pokazuje *„this is what user will see"* dla danego (ObjectType, Category) combo. |
+| `MigrationImpactAnalyzer` | Modal pokazujący impact zmiany typu atrybutu (count, distinct values, suggested mapping). |
+| `VisibleWhenRuleEditor` | Builder dla conditional visibility rules. |
+| `CategoryTreeWithGroups` | Drzewo kategorii z embedded declared groups per category. |
+| `AttributeFromLibraryPicker` | Search + select z biblioteki atrybutów. |
+| `IconPicker` | Picker dla emoji + Lucide icons. |
+| `ColorPicker` | shadcn-style color picker (hex). |
+
+### 13.4 react-arborist
+
+Dla drzewa kategorii (sub-tab 4) — `react-arborist` jest najmocniejszą biblioteką tree dla React (drag-drop, virtualization dla 1000+ węzłów, keyboard navigation). MIT.
+
+---
+
+## 14. Open questions
+
+- [ ] **Categories management** — dwa widoki (modeling tu + daily-use w Produktach lub osobny epik)? Decyzja: **modeling tu** (deklaracja attribute groups), **daily-use** w epiku 02 Produkty (drag-drop produkty między kategoriami).
+- [ ] **Sub-tab Categories vs osobna pozycja sidebar** — może lepiej osobna pozycja menu *„Kategorie"* (zamiast 4-tej zakładki w Modelowaniu)? Argument za osobnymi: Categories są *często* zmieniane przez Magdę (kampanie marketingowe), nie tylko *„raz na 1-2 tyg."* jak inne aspekty Modelowania. Ale wtedy 9 pozycji menu zamiast 8.
+- [ ] **Attribute Group nesting** — czy AG może zawierać sub-AGs (zamiast płaskiej listy atrybutów)? Nie w MVP (over-engineering), ale Faza 2 kandydat.
+- [ ] **System attributes — które dokładnie auto-attached?** Lista: `id`, `created_at`, `updated_at`, `created_by`, `updated_by`, `tenant_id`. Czy `enabled`, `position`, `slug` też?
+- [ ] **Category tree depth limit** — Postgres ltree wspiera ~256 levels, ale UX'owo gubię się powyżej 5-6 levels. Soft warning? Hard limit?
+- [ ] **Multi-parent categories** — czy obiekt może być w wielu kategoriach (np. *„Konsultacja online"* w `Lekarz` AND `Telemedycyna`)? Akeneo i Pimcore: TAK. My: rozważyć czy w MVP czy Faza 1.
+- [ ] **Versioned model** — Faza 2 lub MVP-Final? Wpływa na to, czy obiekty *„starych"* wersji modelu się ładują po zmianie schematu.
+- [ ] **Localized vs system-wide names** — czy `display_name` jest zawsze multi-locale (PL/EN), czy może być system-wide angielskie?
+- [ ] **Permissions deferred** — kiedy ADR-013? Po jakim signal'u? Pierwszym pilocie? Pierwszej skardze klienta?
+- [ ] **Wizard *„Create new ObjectType"*** — multi-step (lepszy onboarding) czy single-form (szybciej)? Adam doświadczony — single, Marcin nowy — multi.
+- [ ] **Test objects creation** — przycisk *„Create test object"* w Category detail (US-MOD-007) — czy tworzy w prawdziwej tabeli, czy w dedicated `test_objects` (sandboxie)?
+
+---
+
+## 15. Wpisanie do roadmapy backend (delta vs `Project Plan/02-plan-projektu-pim.md`)
+
+Modelowanie wpływa na:
+- **Epik 0.3** (Domain model — Catalog) — dochodzi tabela `attribute_groups`, junction tables, listener `EffectiveAttributeGroupResolver`. Estymacja: **+12-16h** ponad obecny scope (już zwiększony o brand + variants + multi-level inheritance).
+- **Epik 0.6** (Admin UI — core CRUD) — Modelowanie jest *swoim własnym* zestawem widoków, nie delta na innych. Dochodzi nowa pozycja menu + 4 widoki listy + 4 widoki detail + wizardy. Estymacja: **+30-40h** (samodzielny zestaw widoków + komponenty custom).
+- **Epik 0.11** (Hardening) — audit log obejmuje zmiany w Modelowaniu (już planowane przez DoctrineAuditBundle, brak dodatkowego scope).
+
+**Total impact na Faza 0:** **+42-56h**. Aktualny budżet ~270-380h → **~310-440h**. Wciąż w zakresie *„pełen MVP"* (Marcin akceptuje +50-80h scope, PRD § 12.1).
+
+---
+
+## 16. Co dalej
+
+1. **Walidacja koncepcji** z Marcinem (lub Adamem jeśli zatrudniony) — czy 4 sub-tabs to dobra struktura, czy lepsze coś innego.
+2. **Wireframes w Figma** — przekazać ten plik external UX designerowi (z PRD § 13.5 *„external UX designer 10-20h kontrakt"*).
+3. **Klikalny prototyp** — przed implementacją, żeby walidacja flow z Adamem była realna (nie ASCII).
+4. **Przepisanie ADR-009 + napisanie ADR-012** — formalne ADR dla Attribute Group jako first-class.
+5. **Aktualizacja `Project Plan/02-plan-projektu-pim.md`** epik 0.3 i 0.6 estymacji.
+6. **Aktualizacja `Project Plan/03-funkcjonalnosci-mvp.md`** — dodać Adam jako persona + user stories US-MOD-001 do US-MOD-013.
+
+---
+
+*Plik wersjonowany w `Zrodla/UI/`. Status: szczegół. Następna iteracja: walidacja z Marcinem (lub designer'em) + Figma wireframes + ADR-012 draft.*

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -4,7 +4,23 @@
 
 Wcześniejsze epiki: **MVP-Alpha 0.4 (8/8) ✅ + 0.5 (5/5) ✅ + 0.6 (9/9) ✅** — w main (#210..#231). Operator zaakceptował 2026-04-30 kierunek **MVP-Final → Faza 1 → Faza 2** zamiast skoku do Fazy 2 (epik 0.7 Agent layer odsunięty per ADR R-27 cost runaway: BYOK + monitoring + Org-level Anthropic cap muszą iść pierwsze).
 
+## 2026-05-01: Backlog UI Modelowanie utworzony (epik UI-08)
+
+**16 issues** w GitHub pod nową etykietą `epik-UI-08` + cross-cutting tag `UI`:
+- **#255** META — reorganizacja sidebar (zwijana sekcja „Modelowanie" grupująca Object Types / Attributes / Attribute Groups / Categories).
+- **#256–#263** Backend (8): UI-08.1 ADR-012 + migracje DDL (blocker), UI-08.2 ObjectType built-in flags + brand seed, UI-08.3 system attributes + Audit auto-attach, UI-08.4 EffectiveAttributeGroupResolver + form-schema endpoint, UI-08.5 AttributeGroup CRUD ApiResource, UI-08.6 attribute migrate-type endpoint, UI-08.7 where-used endpoints, UI-08.8 visible_when storage + evaluator.
+- **#264–#270** Frontend (7): UI-08.9 Modeling layout shell + 4-tab routing, UI-08.10 Object Types sub-tab (list/detail/wizard), UI-08.11 Attributes sub-tab enhanced, UI-08.12 Migration impact analyzer modal, UI-08.13 AttributeGroups sub-tab z drag-drop, UI-08.14 Categories modeling tree + inheritance preview, UI-08.15 (optional) bulk import CSV.
+
+**Estymacja całości: 60-80h.** Sequencing zatwierdzony przez operatora: epik wpada **po MVP-Final (epik 0.11)**, **przed Fazą 1** — jako „epik 0.12 / UI-08 Modelowanie". Spójne z notą `Project Plan/UI/epik-08-modelowanie.md` §15. Dependency: cały epik blokowany przez UI-08.1 (ADR-012 + migracje DDL).
+
+Pełen kontekst: [Project Plan/UI/epik-08-modelowanie.md](../Project%20Plan/UI/epik-08-modelowanie.md) (~960 linii) + [Project Plan/UI/00-plan-ui.md](../Project%20Plan/UI/00-plan-ui.md) §3.1.
+
 ## Następny krok
+**Implementacja epiku UI-08 rozpoczęta od META ticketu** (#255) — operator włączył bypass-permissions mode 2026-05-01 dla całego epiku UI-08 (wzorzec autonomous z epiku 0.3). Kolejność: #255 META (sidebar grupowanie) → #256 UI-08.1 (ADR-012 + migracje, blocker) → reszta w dependency order.
+
+Po UI-08 wraca normalny scope MVP-Final epik 0.11 (Hardening + a11y + analytics + pgBackRest + BYOK), 32-46h estymacja.
+
+## Następny krok (HISTORYCZNY — zachowany dla audit trail)
 **#90 (0.10.1) ApiProfile + ApiKey + Argon2id hashing** GOTOWE — branch `feat/0.10.1-api-configurator-entities` ma wszystkie quality gates green (PHPStan max + Deptrac + 305 PHPUnit testów + composer audit). Plik commitnąć + push + PR + CI poll + merge. **Następne tickety epiku 0.10:** #91 admin UI lista profiles, #92 attribute/format picker + JSON preview, #93 webhook config, #94 ApiProfileVoter + ApiKeyAuthenticator + serializer context, #95 endpoint test + per-profile OpenAPI export.
 
 Operator zapowiedział że po zamknięciu epiku 0.10 zrobimy świadomy audit "co jest faktycznie MVP-ready vs façade UI bez backendu" (write paths Categories/Channels/Assets, schema editor, drag-drop upload odroczone w 0.6) — celem przygotowanie widoków/funkcjonalności do MVP demo state.

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -4,6 +4,15 @@
 
 ## Patterns to Follow
 
+### Plan UI jako separate driver (post-2026-05-01)
+
+- **Plan UI w `Project Plan/UI/` napędza nowe epiki UI-XX równolegle do backend roadmapy 0.X.Y.** Pierwszy materializowany: epik **UI-08 Modelowanie** (#255 META + #256–#270 sub-tickety). Konwencja:
+  - GitHub label `epik-UI-XX` per UI epik (kolor `#1D76DB` jak inne epiki).
+  - Cross-cutting label `UI` (kolor `#FBCA04` jak `frontend`) na każdym tickecie pochodzącym z planu UI — ułatwia filtrowanie w GitHub UI bez zgadywania konkretnego epik labela.
+  - Tickety meta (reorganizacja sidebar, design system bumps, base layout changes) tagujemy `UI` **bez** epik labela jeśli scope dotyczy wielu UI domen.
+  - Why: docelowa struktura admina (Dashboard / Produkty / Multimedia / Publikacje / Workflow / Ustawienia / Modelowanie z `00-plan-ui.md` §3.1) ma 7 osobnych epików produktowych, niespójnych z numeracją 0.X.Y backendu. Numeracja UI-XX = osobna oś tracking, mapowanie na backend faz przez tabelę w `00-plan-ui.md` §5 (Roadmap UI).
+  - How to apply: gdy nowy epik UI dojrzewa do *„szczegółu"* (sekcja 7 statusu w `00-plan-ui.md`), tworzymy `epik-UI-XX` label + N sub-ticketów; aktualizujemy `Project Plan/02-plan-projektu-pim.md` o sekcję `### Epik 0.Y / UI-XX — [Nazwa]` w odpowiednim miejscu sequencingu (zwykle post-MVP-Final, pre-Faza 1).
+
 ### Memory management (FrankenPHP worker mode)
 
 - **`AbstractBatchHandler` jako baza dla każdego Symfony Messenger handlera batch.** Po `flush()` w pętli — `$entityManager->clear()`. Bez tego worker w worker-mode w 50k SKU import zje cały RAM i zabije proces na OOM (ryzyko R-25, "Krytyczny" wpływ). **Zwalidowane w #13:** prod env, 50 000 inserts → 14 MiB peak FLAT z clear, 150 MiB rosnąco bez clear. Class: `App\Messaging\AbstractBatchHandler` (`flushAndClear()` + `shouldFlush(int)`).
@@ -1111,3 +1120,22 @@ Self-audit ujawnił 12 znalezisk; korekty wprowadzone w drugiej iteracji:
 - **CQRS Application/Command slice per UseCase** — `Command` + `Handler` w jednej namespace per akcja: `Application/Command/CreateApiProfile/{CreateApiProfileCommand,CreateApiProfileHandler}.php`. Wzorzec z Catalog (#41). State Processor (`Infrastructure/ApiPlatform/State/<Entity>Processor.php`) dispatch do MessageBus, unwrap `HandlerFailedException` → real `HttpException` (otherwise 500 maskuje 422/404/409).
 
 - **ApiResource w nowym BC** = wymóg dodania alias dla `<BC>` w API Platform `mapping.paths` (api_platform.yaml). Bez tego AP4 nie znajduje XML resources → endpoints nie istnieją (404 z `/api/api_profiles`). Pattern equivalent do Doctrine ORM mapping.
+
+## Lessons z 0.12 / UI-08 (Modelowanie — backlog grooming, 2026-05-01)
+
+- **Pierwszy non-numeryczny epik (UI-XX zamiast 0.X.Y)** — etykieta `epik-UI-XX` jako konwencja dla ticketów napędzanych planem UI (`Project Plan/UI/`). Pattern w sekcji „Patterns to Follow" → „Plan UI jako separate driver". Numeracja sub-ticketów `UI-XX.N` (zamiast `0.X.N`) podkreśla osobną oś tracking.
+
+- **Cross-cutting tag `UI` + epik-specific tag `epik-UI-08`** — dwa labele zamiast jednego, bo UI tickety mogą być meta (cross-epik scope, np. design system bumps) i wtedy mają tylko `UI` bez epik-spec. Filtrowanie w GitHub: `label:UI` zwraca cały plan UI, `label:epik-UI-08` tylko Modelowanie.
+
+- **Backlog grooming zamiast Plan Mode dla split'u dużego planu na tickety** — zamiast pełnego Plan Mode (eksploracja kodu + Plan agent + ExitPlanMode), gdy user prosi o „rozpisz tickety w GitHub issues dla [plan file]", workflow to:
+  1. Read plan file całość (1 Read).
+  2. Sprawdzić istniejące labele (`gh label list`).
+  3. Sprawdzić aktualny stan kodu touchowanego przez plan (1-2 Read na key files żeby zrozumieć current state).
+  4. AskUserQuestion dla 2-3 ambiguous decisions (struktura: 1 epic vs N podticketów, sequencing).
+  5. Write plan file → ExitPlanMode → execute (gh label create + gh issue create per ticket).
+  
+  Heurystyka: gdy plan UI ma >800 linii (`epik-08-modelowanie.md` ma ~960), split na 12-16 sub-ticketów po ~3-7h każdy. Granularność per sub-ticket = ~3-7h żeby PR-y były atomowe i CI nie zatonął.
+
+- **gh issue create z polskimi znakami w title** wymaga `--title` w **single quotes** (zsh) lub `--title-file`. Heredoc dla `--body` zawodzi gdy title ma `"` cudzysłowy (np. „Modelowanie") — interpolation kompiluje się dwukrotnie. Pattern: `--body-file /tmp/issue-N.md` (Write najpierw plik tymczasowy), title w single quotes z escape'em jeśli sam ma `'`.
+
+- **Etykiety `UI` (#FBCA04 yellow)** świadomie rozróżniają od `frontend` (też yellow, ale `#FBCA04` to ten sam hex — distinguish by name, nie kolorem; oba widoczne razem na ticketach UI). Dla kontrastu epikowego: `epik-UI-XX` używa `#1D76DB` (niebieski jak inne `epik-0.X`), nie nowy kolor.


### PR DESCRIPTION
## Summary

- Adds `Project Plan/UI/` (8 plików: master + 7 placeholderów + szczegółowy [epik-08-modelowanie.md](https://github.com/malipie/PIM/blob/chore/ui-08-backlog-grooming/Project%20Plan/UI/epik-08-modelowanie.md)).
- Grooms full backlog dla epiku UI-08 Modelowanie (16 issues #255–#270).
- Wprowadza konwencję `epik-UI-XX` + cross-cutting tag `UI` dla ticketów napędzanych planem UI (`Project Plan/UI/`).
- Aktualizuje `Project Plan/02-plan-projektu-pim.md` (sekcja 3.6 — Epik 0.12 / UI-08), `agent/current_status.md`, `agent/lessons.md` (Patterns to Follow + sekcja per-ticket).

Sequencing zatwierdzony: epik UI-08 wpada **po MVP-Final (epik 0.11)**, **przed Fazą 1**. Total estymacja **60-80h**.

## Test plan

- [ ] Manual review `Project Plan/UI/epik-08-modelowanie.md` (~960 linii)
- [ ] Weryfikacja 16 issues w GitHub: filter `label:epik-UI-08` zwraca 15 (#256-#270), filter `label:UI` zwraca 16 (META + 15)
- [ ] `agent/current_status.md` pokazuje aktualny stan + linki do issues
- [ ] `Project Plan/02-plan-projektu-pim.md` §3.6 ma pełną tabelę 16 ticketów z estymacjami