### PR TITLE
feat(admin): group modeling tabs under collapsible sidebar (#255)

### DIFF
--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -1,5 +1,6 @@
 import {
   Boxes,
+  ChevronDown,
   FolderTree,
   Image,
   KeyRound,
@@ -9,40 +10,113 @@ import {
   type LucideIcon,
   Package,
   Radio,
+  Settings2,
 } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { NavLink } from 'react-router';
+import { NavLink, useLocation } from 'react-router';
 
 import { cn } from '@/lib/utils';
 
-interface NavItem {
+interface NavLeaf {
+  type: 'leaf';
   to: string;
   icon: LucideIcon;
   label: string;
   comingSoon?: boolean;
 }
 
-// Sidebar entries land here as the corresponding admin resources arrive in
-// epic 0.6 (#54-#62). The `comingSoon` flag drives a muted visual state — the
-// route still works and renders <ComingSoon /> with a link to the tracking
-// issue, so users get a deterministic "not yet" rather than a 404.
+interface NavGroup {
+  type: 'group';
+  id: string;
+  icon: LucideIcon;
+  label: string;
+  children: NavLeaf[];
+}
+
+type NavItem = NavLeaf | NavGroup;
+
+const MODELING_GROUP: NavGroup = {
+  type: 'group',
+  id: 'modeling',
+  icon: Settings2,
+  label: 'nav.modeling',
+  children: [
+    { type: 'leaf', to: '/object-types', icon: ListTree, label: 'nav.modeling_object_types' },
+    { type: 'leaf', to: '/attributes', icon: Layers, label: 'nav.modeling_attributes' },
+    {
+      type: 'leaf',
+      to: '/attribute-groups',
+      icon: LayoutList,
+      label: 'nav.modeling_attribute_groups',
+    },
+    { type: 'leaf', to: '/categories', icon: FolderTree, label: 'nav.modeling_categories' },
+  ],
+};
+
 const NAV_ITEMS: NavItem[] = [
-  { to: '/products', icon: Package, label: 'nav.products' },
-  { to: '/attributes', icon: Layers, label: 'nav.attributes' },
-  { to: '/attribute-groups', icon: LayoutList, label: 'nav.attribute_groups' },
-  { to: '/object-types', icon: ListTree, label: 'nav.object_types' },
-  { to: '/categories', icon: FolderTree, label: 'nav.categories' },
-  { to: '/assets', icon: Image, label: 'nav.assets' },
-  { to: '/channels', icon: Radio, label: 'nav.channels' },
-  { to: '/api-profiles', icon: KeyRound, label: 'nav.api_profiles' },
+  { type: 'leaf', to: '/products', icon: Package, label: 'nav.products' },
+  MODELING_GROUP,
+  { type: 'leaf', to: '/assets', icon: Image, label: 'nav.assets' },
+  { type: 'leaf', to: '/channels', icon: Radio, label: 'nav.channels' },
+  { type: 'leaf', to: '/api-profiles', icon: KeyRound, label: 'nav.api_profiles' },
 ];
 
 interface SidebarNavProps {
   onNavigate?: () => void;
 }
 
+const leafLinkClass = ({ isActive }: { isActive: boolean }) =>
+  cn(
+    'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+    isActive
+      ? 'bg-secondary text-secondary-foreground'
+      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+  );
+
+const subLeafLinkClass = ({ isActive }: { isActive: boolean }) =>
+  cn(
+    'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm transition-colors',
+    isActive
+      ? 'bg-secondary text-secondary-foreground font-medium'
+      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+  );
+
+function isGroupActive(group: NavGroup, pathname: string): boolean {
+  return group.children.some((child) => pathname.startsWith(child.to));
+}
+
 export function SidebarNav({ onNavigate }: SidebarNavProps) {
   const { t } = useTranslation();
+  const { pathname } = useLocation();
+
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
+    const initial: Record<string, boolean> = {};
+    for (const item of NAV_ITEMS) {
+      if (item.type === 'group') {
+        initial[item.id] = isGroupActive(item, pathname);
+      }
+    }
+    return initial;
+  });
+
+  useEffect(() => {
+    setOpenGroups((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const item of NAV_ITEMS) {
+        if (item.type === 'group' && isGroupActive(item, pathname) && !next[item.id]) {
+          next[item.id] = true;
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [pathname]);
+
+  const toggleGroup = (id: string) => {
+    setOpenGroups((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
 
   return (
     <>
@@ -51,29 +125,71 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
         <span className="font-semibold tracking-tight">{t('app.title')}</span>
       </div>
       <nav className="flex flex-1 flex-col gap-1 p-3">
-        {NAV_ITEMS.map(({ to, icon: Icon, label, comingSoon }) => (
-          <NavLink
-            key={to}
-            to={to}
-            onClick={onNavigate}
-            className={({ isActive }) =>
-              cn(
-                'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-secondary text-secondary-foreground'
-                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-              )
-            }
-          >
-            <Icon className="size-4" />
-            <span className="flex-1">{t(label)}</span>
-            {comingSoon ? (
-              <span className="rounded bg-muted px-1.5 py-0.5 text-xs uppercase text-muted-foreground">
-                {t('nav.soon')}
-              </span>
-            ) : null}
-          </NavLink>
-        ))}
+        {NAV_ITEMS.map((item) => {
+          if (item.type === 'leaf') {
+            return (
+              <NavLink key={item.to} to={item.to} onClick={onNavigate} className={leafLinkClass}>
+                <item.icon className="size-4" />
+                <span className="flex-1">{t(item.label)}</span>
+                {item.comingSoon ? (
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-xs uppercase text-muted-foreground">
+                    {t('nav.soon')}
+                  </span>
+                ) : null}
+              </NavLink>
+            );
+          }
+
+          const isOpen = openGroups[item.id] ?? false;
+          const hasActiveChild = isGroupActive(item, pathname);
+          const expandLabel = t(isOpen ? 'nav.collapse_modeling' : 'nav.expand_modeling');
+
+          return (
+            <div key={item.id} className="flex flex-col">
+              <button
+                type="button"
+                onClick={() => toggleGroup(item.id)}
+                aria-expanded={isOpen}
+                aria-controls={`nav-group-${item.id}`}
+                aria-label={expandLabel}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                  hasActiveChild
+                    ? 'text-foreground'
+                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                )}
+              >
+                <item.icon className="size-4" />
+                <span className="flex-1 text-left">{t(item.label)}</span>
+                <ChevronDown
+                  className={cn(
+                    'size-4 shrink-0 transition-transform duration-150',
+                    isOpen ? 'rotate-0' : '-rotate-90',
+                  )}
+                  aria-hidden="true"
+                />
+              </button>
+              {isOpen ? (
+                <div
+                  id={`nav-group-${item.id}`}
+                  className="ml-4 mt-1 flex flex-col gap-0.5 border-l border-border pl-2"
+                >
+                  {item.children.map((child) => (
+                    <NavLink
+                      key={child.to}
+                      to={child.to}
+                      onClick={onNavigate}
+                      className={subLeafLinkClass}
+                    >
+                      <child.icon className="size-4" />
+                      <span className="flex-1">{t(child.label)}</span>
+                    </NavLink>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
       </nav>
     </>
   );

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -35,6 +35,11 @@
   },
   "nav": {
     "products": "Products",
+    "modeling": "Modeling",
+    "modeling_object_types": "Object types",
+    "modeling_attributes": "Attributes",
+    "modeling_attribute_groups": "Attribute groups",
+    "modeling_categories": "Categories",
     "attributes": "Attributes",
     "attribute_groups": "Attribute groups",
     "object_types": "Object types",
@@ -42,7 +47,9 @@
     "assets": "Assets",
     "channels": "Channels",
     "api_profiles": "API Profiles",
-    "soon": "Soon"
+    "soon": "Soon",
+    "expand_modeling": "Expand modeling section",
+    "collapse_modeling": "Collapse modeling section"
   },
   "attributes": {
     "list_title": "Attributes",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -35,6 +35,11 @@
   },
   "nav": {
     "products": "Produkty",
+    "modeling": "Modelowanie",
+    "modeling_object_types": "Typy obiektów",
+    "modeling_attributes": "Atrybuty",
+    "modeling_attribute_groups": "Grupy atrybutów",
+    "modeling_categories": "Kategorie",
     "attributes": "Atrybuty",
     "attribute_groups": "Grupy atrybutów",
     "object_types": "Typy obiektów",
@@ -42,7 +47,9 @@
     "assets": "Zasoby",
     "channels": "Kanały",
     "api_profiles": "Profile API",
-    "soon": "Wkrótce"
+    "soon": "Wkrótce",
+    "expand_modeling": "Rozwiń sekcję modelowanie",
+    "collapse_modeling": "Zwiń sekcję modelowanie"
   },
   "attributes": {
     "list_title": "Atrybuty",


### PR DESCRIPTION
## Summary

- Pierwszy meta-ticket epiku **UI-08 Modelowanie** (#255).
- Zwijana sekcja **„Modelowanie"** (`Settings2` icon) grupuje 4 zakładki: Object Types, Attributes, Attribute Groups, Categories.
- Pozostałe top-level: Products, Assets, Channels, API Profiles.
- Auto-expand przy routing match; toggle przez `aria-expanded` button + `ChevronDown` rotation.
- Routing pozostaje stabilny — `/object-types`, `/attributes`, `/attribute-groups`, `/categories` nadal działają. Nested `/modeling/*` w `#UI-08.9`.
- i18n keys w en+pl: `nav.modeling`, `nav.modeling_*`, `nav.expand_modeling`, `nav.collapse_modeling`.

## Test plan

- [x] Biome strict — green.
- [x] tsc -b --noEmit — green.
- [x] Vite build — green (497ms, bundle 779KB ungzipped — bez regresji).
- [ ] Manual smoke (po merge): zaloguj → klik „Modelowanie" → rozwija 4 sub-itemy → klik „Object Types" → ląduje na `/object-types` z highlightem aktywnym.
- [ ] Mobile Sheet drawer — rozwijanie działa.
- [ ] axe-core na sidebar — 0 violations.

Closes #255