### PR TITLE
[UI-08.1] AttributeGroup as first-class entity (ADR-012)

### DIFF
--- a/Project Plan/01-architektura-pim.md
+++ b/Project Plan/01-architektura-pim.md
@@ -1081,6 +1081,46 @@ Rdzeń elastyczności już istnieje w ADR-006 (`attributes` + EAV `*_values JSON
 - ADR-006 (hybrid attribute model — `attributes` + `*_values JSONB` + `attributes_indexed`) — generalizacja respektuje, nie zmienia.
 - `06-sprint-0-findings.md` §2 (rewizja zakresu MVP 2026-04-27) — finansowanie kosztu generalizacji ze zwolnionego budżetu epiku 0.7.
 
+### ADR-012: Attribute Group as first-class entity for cross-objecttype data modeling
+
+**Status:** Zaakceptowany (2026-05-01)
+
+**Kontekst:**
+ADR-009 wprowadził generic `ObjectType` z parametryzowanym modelem atrybutów (`object_type_attributes` junction). Każdy ObjectType ma swój zestaw atrybutów. To wystarcza dla podstawowego CRUD-a, ale nie rozwiązuje trzech rzeczywistych problemów modelowania, które wyłaniają się przy projektowaniu pierwszej zakładki „Modelowanie" (epik UI-08, `Project Plan/UI/epik-08-modelowanie.md`):
+
+1. **Powielanie sekcji formularzy między ObjectType.** Sekcja „Marketing" (short_description + long_description + tags) ma sens w `Product`, ale również w `Service`, `Subscription`, `Bundle`. W obecnym modelu trzeba albo dodać te 3 atrybuty osobno do każdego ObjectType (powielanie metadanych), albo uznać że to ograniczenie i klient sobie poradzi (UX cierpi).
+2. **Dziedziczenie metadanych po drzewie kategorii.** Realna potrzeba z PRD: kategoria *„Lekarz"* deklaruje grupę „Wymagania medyczne" dla obiektów typu `Service`. Podkategoria *„Chirurg"* dziedziczy + dodaje „Chirurgia szczegóły". Podkategoria *„Ortopeda"* dziedziczy łącznie 5 grup (system Audit + 1 globalna z Service + 3 z Lekarz + 1 z Chirurg) + dodaje 1 własną. PIMCore i Akeneo tego nie robią natywnie — wymaga ręcznego skopiowania atrybutów per kategoria.
+3. **Wymienność grupy jako jednostka.** Migracja grupy „Wymagania medyczne" z ObjectType `Service` do ObjectType `Equipment` (np. firma rozszerza ofertę o sprzęt medyczny) musi być JEDNĄ operacją, nie *„skopiuj 4 atrybuty + zmodyfikuj 7 kategorii + sprawdź czy żadnego nie pominęliśmy"*.
+
+**Rozważane opcje:**
+- **(a)** Status quo: `attribute_groups` jako lekka tabela (już istnieje z `code` + `label` + `position`), `Attribute.group_id` 1:N — atrybut należy do ≤1 grupy, grupy są attribute-tag'em, nie samodzielnym bytem. **Problem:** brak rozwiązania dla problemów 1-3.
+- **(b)** Hard-coded sekcje per ObjectType (jak Akeneo): grupa to enumerator `'identification' | 'marketing' | 'technical_specs'` w `Attribute`, sekcje generowane w UI per ObjectType. **Problem:** brak custom grup w runtime, brak dziedziczenia po drzewie, klient bez admina nie może zmienić sekcji.
+- **(c)** Pełny first-class `AttributeGroup` z M:N attribute ↔ group (junction `attribute_group_attributes`) + M:N obj_type ↔ group (junction `object_type_attribute_groups`) + dziedziczenie po drzewie kategorii (junction `category_attribute_groups`) + opcjonalna `visible_when` reguła per attribute w grupie. Grupa jest wymienną jednostką, ma własny URL (`/modeling/attribute-groups/medical-requirements`), audit log, kontrolę dostępu.
+
+**Decyzja:** Opcja (c).
+
+**Uzasadnienie:**
+Asymetria zysków vs koszt jest podobna jak w ADR-003 (multi-tenant ready, single-tenant deployed) i ADR-009 (generalizacja ObjectType). Koszt schematu: **+1 nowa tabela rozszerzająca `attribute_groups` (description, icon, color, is_system_group, auto_attached) + 3 junction tables (attribute_group_attributes, object_type_attribute_groups, category_attribute_groups)** + listener `EffectiveAttributeGroupResolver` (~80 linii kodu). Zysk: rozwiązuje 3 problemy modelowania, których inne PIM-y nie rozwiązują, daje *killer feature* (inheritance preview w UI Modelowania). Akeneo i Pimcore nie mają tego natywnie — klient pisze SQL skrypty albo modyfikuje 50 podkategorii ręcznie.
+
+**Konsekwencje:**
+- **`attribute_groups` rozszerzona:** istniejące pola (`code`, `label`, `position`) zachowane (back-compat z 0.3.X). Dochodzą: `description JSONB` (multi-locale), `icon VARCHAR(64)`, `color VARCHAR(16)`, `is_system_group BOOLEAN` (true dla grupy „Audit" auto-attached do każdego ObjectType), `auto_attached BOOLEAN` (true gdy grupa dołączana automatycznie do nowego ObjectType — w MVP tylko Audit).
+- **Junction `attribute_group_attributes` (M:N Attribute ↔ AttributeGroup)** — `attribute_group_id, attribute_id, position, is_required_in_group, visible_when JSONB` (PK na (group, attribute)). **Pozostawia istniejący `Attribute.group_id` (1:N) jako deprecated path** — migracja danych do M:N w follow-up po `#UI-08.5` (gdy admin UI obsłuży multi-group attribute attachment). W UI-08.1 oba paths koegzystują (additive only).
+- **Junction `object_type_attribute_groups` (M:N ObjectType ↔ AttributeGroup)** — `object_type_id, attribute_group_id, position` (PK).
+- **Junction `category_attribute_groups`** — `category_object_id, target_object_type_id, attribute_group_id, position` (PK). Katergoria deklaruje która grupa atrybutów ma się pojawić *dla obiektów typu X* w tej kategorii i jej podkategoriach.
+- **Domain service `EffectiveAttributeGroupResolver`** (Catalog/Domain/Service, `#UI-08.4`) — dla danej pary (object_id, category_path) zwraca efektywną listę grup z dziedziczeniem: (1) system auto-attached (Audit), (2) globalne dla ObjectType, (3) dziedziczone po drzewie kategorii od root do leaf, (4) per-object ad-hoc (Faza 1+ nullable). Cache Redis 5min TTL z invalidation hooks.
+- **`visible_when` JSONB** w `attribute_group_attributes` — w MVP tylko `{field, operator: 'equals', value}` (`#UI-08.8`). Faza 1 dochodzi `not_equals`, `in`, `not_in` + composite AND/OR.
+- **Listener `ObjectFormSchemaListener`** — endpoint `GET /api/objects/{id}/form-schema` używa resolvera, frontend renderuje formularz dynamicznie.
+- **Brand jako 4-ty built-in ObjectType** (`#UI-08.2`) — niezależna od ADR-012, ale dochodzi razem z rozszerzeniem `object_types` o `is_built_in/code_immutable/deletable/icon/color`.
+- **Migracja istniejących danych:** w MVP-Final brak legacy AttributeGroup (~5 grup z seedera 0.3.X — 'identification', 'marketing', etc.), więc migracja DDL jest puro additive — tabele istniejące zostają, dochodzą nowe kolumny + 3 junction tables. Migracja `Attribute.group_id` → `attribute_group_attributes` zaplanowana po `#UI-08.5` (gdy admin UI ma drag-drop dla multi-group).
+- **Koszt:** **~30-40h backend (`#UI-08.1` do `#UI-08.8`) + ~30-40h frontend (`#UI-08.9` do `#UI-08.15`)**. Total **~60-80h** w epiku 0.12 / UI-08, post-MVP-Final (epik 0.11), pre-Faza 1 (`Project Plan/02-plan-projektu-pim.md` §3.6).
+- **Słownik domenowy:** „Attribute Group" (a-g w UI) zawsze. Old-aware: w 0.3.X używaliśmy „grupa atrybutów" jako lekkiego konceptu UI; teraz to first-class entity.
+
+**Referencje:**
+- `Project Plan/UI/epik-08-modelowanie.md` §3.5 (motywacja), §3.8 (pełny model encji + DDL), §12 (dependency na backend).
+- ADR-009 (generic ObjectType) — ADR-012 rozszerza, nie zastępuje.
+- ADR-006 (hybrid attribute model) — ADR-012 respektuje (`object_values JSONB` zostaje source of truth dla wartości; AttributeGroup jest tylko o organizacji formularzy + dziedziczeniu).
+- `02-plan-projektu-pim.md` §3.6 (epik 0.12 / UI-08 sequencing).
+
 ## 14. Roadmap rozwoju
 
 Roadmap fazowa, wysokopoziomowa. Szczegółowy backlog i estymacje w dokumencie `02-plan-projektu-pim.md`.

--- a/apps/api/migrations/Version20260501100000.php
+++ b/apps/api/migrations/Version20260501100000.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Epic 0.12 / UI-08.1 — AttributeGroup as first-class entity (ADR-012).
+ *
+ * Extends `attribute_groups` with description/icon/color/is_system_group/auto_attached,
+ * adds three junction tables that wire AttributeGroup into the catalog: M:N with
+ * Attribute (replaces Attribute.group_id 1:N — both paths coexist for now), M:N
+ * with ObjectType (global per-type groups), and M:N with Category × ObjectType
+ * (groups inherited down the category tree for objects of a given kind).
+ *
+ * Existing `Attribute.group_id` 1:N path is deliberately untouched in this
+ * migration — data migration to attribute_group_attributes lands after #UI-08.5
+ * when admin UI handles multi-group attachment. The two paths are both valid
+ * during the transition.
+ *
+ * See ADR-012 in Project Plan/01-architektura-pim.md and the full schema spec
+ * in Project Plan/UI/epik-08-modelowanie.md §3.8 / §12.2.
+ */
+final class Version20260501100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Promote AttributeGroup to first-class entity per ADR-012 (#256 / UI-08.1).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Extend attribute_groups with first-class metadata.
+        $this->addSql('ALTER TABLE attribute_groups ADD COLUMN description JSONB DEFAULT NULL');
+        $this->addSql("ALTER TABLE attribute_groups ADD COLUMN icon VARCHAR(64) DEFAULT NULL");
+        $this->addSql("ALTER TABLE attribute_groups ADD COLUMN color VARCHAR(16) DEFAULT NULL");
+        $this->addSql('ALTER TABLE attribute_groups ADD COLUMN is_system_group BOOLEAN NOT NULL DEFAULT false');
+        $this->addSql('ALTER TABLE attribute_groups ADD COLUMN auto_attached BOOLEAN NOT NULL DEFAULT false');
+
+        // M:N Attribute ↔ AttributeGroup. Coexists with Attribute.group_id 1:N for now.
+        $this->addSql(<<<'SQL'
+            CREATE TABLE attribute_group_attributes (
+              attribute_group_id UUID NOT NULL,
+              attribute_id UUID NOT NULL,
+              position INT NOT NULL DEFAULT 0,
+              is_required_in_group BOOLEAN NOT NULL DEFAULT false,
+              visible_when JSONB DEFAULT NULL,
+              PRIMARY KEY (attribute_group_id, attribute_id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX attribute_group_attributes_group_idx ON attribute_group_attributes (attribute_group_id)');
+        $this->addSql('CREATE INDEX attribute_group_attributes_attribute_idx ON attribute_group_attributes (attribute_id)');
+        $this->addSql('ALTER TABLE attribute_group_attributes ADD CONSTRAINT attribute_group_attributes_group_fk FOREIGN KEY (attribute_group_id) REFERENCES attribute_groups (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE attribute_group_attributes ADD CONSTRAINT attribute_group_attributes_attribute_fk FOREIGN KEY (attribute_id) REFERENCES attributes (id) ON DELETE CASCADE NOT DEFERRABLE');
+
+        // M:N ObjectType ↔ AttributeGroup — globalne grupy dla typu.
+        $this->addSql(<<<'SQL'
+            CREATE TABLE object_type_attribute_groups (
+              object_type_id UUID NOT NULL,
+              attribute_group_id UUID NOT NULL,
+              position INT NOT NULL DEFAULT 0,
+              PRIMARY KEY (object_type_id, attribute_group_id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX object_type_attribute_groups_type_idx ON object_type_attribute_groups (object_type_id)');
+        $this->addSql('CREATE INDEX object_type_attribute_groups_group_idx ON object_type_attribute_groups (attribute_group_id)');
+        $this->addSql('ALTER TABLE object_type_attribute_groups ADD CONSTRAINT object_type_attribute_groups_type_fk FOREIGN KEY (object_type_id) REFERENCES object_types (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE object_type_attribute_groups ADD CONSTRAINT object_type_attribute_groups_group_fk FOREIGN KEY (attribute_group_id) REFERENCES attribute_groups (id) ON DELETE CASCADE NOT DEFERRABLE');
+
+        // M:N Category × ObjectType → AttributeGroup. category_object_id points
+        // at the catalog_objects row that IS the category (kind='category' per
+        // ADR-009); target_object_type_id is which kind of objects under this
+        // category will inherit the group.
+        $this->addSql(<<<'SQL'
+            CREATE TABLE category_attribute_groups (
+              category_object_id UUID NOT NULL,
+              target_object_type_id UUID NOT NULL,
+              attribute_group_id UUID NOT NULL,
+              position INT NOT NULL DEFAULT 0,
+              PRIMARY KEY (category_object_id, target_object_type_id, attribute_group_id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX category_attribute_groups_category_idx ON category_attribute_groups (category_object_id)');
+        $this->addSql('CREATE INDEX category_attribute_groups_target_type_idx ON category_attribute_groups (target_object_type_id)');
+        $this->addSql('CREATE INDEX category_attribute_groups_group_idx ON category_attribute_groups (attribute_group_id)');
+        $this->addSql('ALTER TABLE category_attribute_groups ADD CONSTRAINT category_attribute_groups_category_fk FOREIGN KEY (category_object_id) REFERENCES objects (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE category_attribute_groups ADD CONSTRAINT category_attribute_groups_target_type_fk FOREIGN KEY (target_object_type_id) REFERENCES object_types (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE category_attribute_groups ADD CONSTRAINT category_attribute_groups_group_fk FOREIGN KEY (attribute_group_id) REFERENCES attribute_groups (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE category_attribute_groups');
+        $this->addSql('DROP TABLE object_type_attribute_groups');
+        $this->addSql('DROP TABLE attribute_group_attributes');
+        $this->addSql('ALTER TABLE attribute_groups DROP COLUMN auto_attached');
+        $this->addSql('ALTER TABLE attribute_groups DROP COLUMN is_system_group');
+        $this->addSql('ALTER TABLE attribute_groups DROP COLUMN color');
+        $this->addSql('ALTER TABLE attribute_groups DROP COLUMN icon');
+        $this->addSql('ALTER TABLE attribute_groups DROP COLUMN description');
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/AttributeGroup.php
+++ b/apps/api/src/Catalog/Domain/Entity/AttributeGroup.php
@@ -13,15 +13,22 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Container that groups attributes for admin UX (e.g. "SEO", "Logistics",
- * "Marketing"). A group is purely organisational — it carries a localised
- * label + an ordering position and lives entirely within one tenant.
- *
- * Attributes either belong to one group or stay ungrouped (`group_id` NULL
- * on Attribute). Removing a group leaves its attributes alive but ungrouped
- * (FK ON DELETE SET NULL) so admins do not lose data by re-organising.
+ * "Marketing"). After ADR-012 a group is a first-class entity with its own
+ * URL / audit / icon / colour, used as the unit of attachment to ObjectType
+ * (global) and Category (inherited down the tree).
  *
  * `label` is JSONB `{pl: "...", en: "..."}` so the same row carries every
- * supported locale in MVP — no separate translations table.
+ * supported locale — no separate translations table. `description` follows
+ * the same pattern.
+ *
+ * Two attachment paths to attributes coexist during the UI-08 migration:
+ *  - legacy 1:N `Attribute.group_id` (still alive, written by 0.3.X seeders),
+ *  - first-class M:N via `attribute_group_attributes` junction (ADR-012).
+ *
+ * `is_system_group=true` marks groups managed by the system (e.g. the auto-
+ * attached "Audit" group #UI-08.3) — not deletable, not detachable from
+ * ObjectType, code is immutable. `auto_attached=true` means the group is
+ * automatically wired to every new ObjectType (currently only Audit).
  */
 class AttributeGroup implements TenantScoped
 {
@@ -37,22 +44,48 @@ class AttributeGroup implements TenantScoped
     #[Assert\Type('array')]
     private array $label;
 
+    /**
+     * @var array<string, string>|null
+     */
+    #[Assert\Type('array')]
+    private ?array $description = null;
+
+    #[Assert\Length(max: 64)]
+    private ?string $icon = null;
+
+    #[Assert\Length(max: 16)]
+    private ?string $color = null;
+
+    private bool $isSystemGroup = false;
+    private bool $autoAttached = false;
+
     private int $position;
     private DateTimeImmutable $createdAt;
 
     /**
-     * @param array<string, string> $label
+     * @param array<string, string>      $label
+     * @param array<string, string>|null $description
      */
     public function __construct(
         string $code,
         array $label,
         int $position = 0,
         ?Uuid $id = null,
+        ?array $description = null,
+        ?string $icon = null,
+        ?string $color = null,
+        bool $isSystemGroup = false,
+        bool $autoAttached = false,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->code = $code;
         $this->label = $label;
         $this->position = $position;
+        $this->description = $description;
+        $this->icon = $icon;
+        $this->color = $color;
+        $this->isSystemGroup = $isSystemGroup;
+        $this->autoAttached = $autoAttached;
         $this->createdAt = new DateTimeImmutable();
     }
 
@@ -112,5 +145,51 @@ class AttributeGroup implements TenantScoped
     public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    public function getDescription(): ?array
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param array<string, string>|null $description
+     */
+    public function describe(?array $description): void
+    {
+        $this->description = $description;
+    }
+
+    public function getIcon(): ?string
+    {
+        return $this->icon;
+    }
+
+    public function setIcon(?string $icon): void
+    {
+        $this->icon = $icon;
+    }
+
+    public function getColor(): ?string
+    {
+        return $this->color;
+    }
+
+    public function setColor(?string $color): void
+    {
+        $this->color = $color;
+    }
+
+    public function isSystemGroup(): bool
+    {
+        return $this->isSystemGroup;
+    }
+
+    public function isAutoAttached(): bool
+    {
+        return $this->autoAttached;
     }
 }

--- a/apps/api/src/Catalog/Domain/Entity/AttributeGroupAttribute.php
+++ b/apps/api/src/Catalog/Domain/Entity/AttributeGroupAttribute.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Entity;
+
+/**
+ * Junction connecting an Attribute to an AttributeGroup (M:N) per ADR-012.
+ *
+ * One Attribute may live in many groups (e.g. `description` in both
+ * "Marketing" and "SEO Defaults"); one group bundles many attributes.
+ * Composite PK is the natural `(attribute_group_id, attribute_id)` pair.
+ *
+ * Coexists with the legacy 1:N path on `Attribute.group_id` during the
+ * UI-08 migration. Data migration of the legacy column into this junction
+ * is deferred to follow-up after #UI-08.5 — both relationships are valid
+ * during the transition.
+ *
+ * `position` drives form rendering order inside the group. `isRequired-
+ * InGroup` is *group-local* — different from `ObjectTypeAttribute.required-
+ * ForCompleteness` (which feeds completeness scoring at object level).
+ *
+ * `visibleWhen` carries the optional conditional visibility rule shipped in
+ * #UI-08.8: MVP supports a single `{field, operator: 'equals', value}`
+ * payload; richer composites land in Faza 1+.
+ *
+ * No `tenant_id` column — tenant scope is inherited via the parent
+ * AttributeGroup. Listed in `TenantAuditCommand::INFRA_TABLES` allowlist.
+ */
+class AttributeGroupAttribute
+{
+    private AttributeGroup $attributeGroup;
+    private Attribute $attribute;
+    private int $position = 0;
+    private bool $isRequiredInGroup = false;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $visibleWhen = null;
+
+    /**
+     * @param array<string, mixed>|null $visibleWhen
+     */
+    public function __construct(
+        AttributeGroup $attributeGroup,
+        Attribute $attribute,
+        int $position = 0,
+        bool $isRequiredInGroup = false,
+        ?array $visibleWhen = null,
+    ) {
+        $this->attributeGroup = $attributeGroup;
+        $this->attribute = $attribute;
+        $this->position = $position;
+        $this->isRequiredInGroup = $isRequiredInGroup;
+        $this->visibleWhen = $visibleWhen;
+    }
+
+    public function getAttributeGroup(): AttributeGroup
+    {
+        return $this->attributeGroup;
+    }
+
+    public function getAttribute(): Attribute
+    {
+        return $this->attribute;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function reorder(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    public function isRequiredInGroup(): bool
+    {
+        return $this->isRequiredInGroup;
+    }
+
+    public function changeRequiredInGroup(bool $required): void
+    {
+        $this->isRequiredInGroup = $required;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getVisibleWhen(): ?array
+    {
+        return $this->visibleWhen;
+    }
+
+    /**
+     * @param array<string, mixed>|null $visibleWhen
+     */
+    public function changeVisibleWhen(?array $visibleWhen): void
+    {
+        $this->visibleWhen = $visibleWhen;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CategoryAttributeGroup.php
+++ b/apps/api/src/Catalog/Domain/Entity/CategoryAttributeGroup.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Entity;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Junction declaring an AttributeGroup on a category for a specific
+ * ObjectType (M:N×ObjectType) per ADR-012.
+ *
+ * `categoryObjectId` points at the `objects` row that *is* the category
+ * (kind='category' per ADR-009). `targetObjectTypeId` is which kind of
+ * objects (e.g. `Service`, `Product`) placed under this category — and
+ * its descendants in the ltree — will inherit this group.
+ *
+ * Walked by `EffectiveAttributeGroupResolver` (#UI-08.4) from root to
+ * leaf to compute the effective group list for a (object, category_path)
+ * pair. Groups declared higher in the tree win on conflict; child
+ * categories layer additional groups on top.
+ *
+ * Composite PK is `(category_object_id, target_object_type_id, attribute_-
+ * group_id)` — the same group can be declared on the same category for
+ * different target ObjectTypes (e.g. "Marketing assets" group declared
+ * on category `Promotions` for both `Product` and `Bundle`).
+ *
+ * No `tenant_id` column — tenant scope is inherited via the parent
+ * category (which is a tenant-scoped catalog object). Listed in
+ * `TenantAuditCommand::INFRA_TABLES` allowlist.
+ */
+class CategoryAttributeGroup
+{
+    private Uuid $categoryObjectId;
+    private ObjectType $targetObjectType;
+    private AttributeGroup $attributeGroup;
+    private int $position = 0;
+
+    public function __construct(
+        Uuid $categoryObjectId,
+        ObjectType $targetObjectType,
+        AttributeGroup $attributeGroup,
+        int $position = 0,
+    ) {
+        $this->categoryObjectId = $categoryObjectId;
+        $this->targetObjectType = $targetObjectType;
+        $this->attributeGroup = $attributeGroup;
+        $this->position = $position;
+    }
+
+    public function getCategoryObjectId(): Uuid
+    {
+        return $this->categoryObjectId;
+    }
+
+    public function getTargetObjectType(): ObjectType
+    {
+        return $this->targetObjectType;
+    }
+
+    public function getAttributeGroup(): AttributeGroup
+    {
+        return $this->attributeGroup;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function reorder(int $position): void
+    {
+        $this->position = $position;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/ObjectTypeAttributeGroup.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectTypeAttributeGroup.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Entity;
+
+/**
+ * Junction connecting an AttributeGroup to an ObjectType (M:N) per ADR-012.
+ *
+ * Represents *global* groups attached to an ObjectType — every object of
+ * that type sees these groups in its form schema, regardless of category.
+ * E.g. `Audit` (auto-attached, system-managed) and `Identification` are
+ * always wired here. User-defined groups like "Marketing" attach here too.
+ *
+ * Composite PK is the `(object_type_id, attribute_group_id)` pair.
+ *
+ * For category-driven groups (group declared on a specific category and
+ * inherited by descendants), see `CategoryAttributeGroup`.
+ *
+ * No `tenant_id` column — tenant scope is inherited via the parent
+ * ObjectType. Listed in `TenantAuditCommand::INFRA_TABLES` allowlist.
+ */
+class ObjectTypeAttributeGroup
+{
+    private ObjectType $objectType;
+    private AttributeGroup $attributeGroup;
+    private int $position = 0;
+
+    public function __construct(
+        ObjectType $objectType,
+        AttributeGroup $attributeGroup,
+        int $position = 0,
+    ) {
+        $this->objectType = $objectType;
+        $this->attributeGroup = $attributeGroup;
+        $this->position = $position;
+    }
+
+    public function getObjectType(): ObjectType
+    {
+        return $this->objectType;
+    }
+
+    public function getAttributeGroup(): AttributeGroup
+    {
+        return $this->attributeGroup;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function reorder(int $position): void
+    {
+        $this->position = $position;
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeGroup.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeGroup.orm.xml
@@ -30,6 +30,23 @@
                 <option name="jsonb">true</option>
             </options>
         </field>
+        <field name="description" type="json" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="icon" type="string" length="64" nullable="true"/>
+        <field name="color" type="string" length="16" nullable="true"/>
+        <field name="isSystemGroup" type="boolean" column="is_system_group">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="autoAttached" type="boolean" column="auto_attached">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
         <field name="position" type="integer">
             <options>
                 <option name="default">0</option>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeGroupAttribute.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeGroupAttribute.orm.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\AttributeGroupAttribute"
+            table="attribute_group_attributes">
+
+        <indexes>
+            <index name="attribute_group_attributes_position_idx" columns="attribute_group_id,position"/>
+        </indexes>
+
+        <id name="attributeGroup" association-key="true"/>
+        <id name="attribute" association-key="true"/>
+
+        <many-to-one field="attributeGroup" target-entity="App\Catalog\Domain\Entity\AttributeGroup">
+            <join-column name="attribute_group_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="attribute" target-entity="App\Catalog\Domain\Entity\Attribute">
+            <join-column name="attribute_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="isRequiredInGroup" type="boolean" column="is_required_in_group">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="visibleWhen" type="json" column="visible_when" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CategoryAttributeGroup.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CategoryAttributeGroup.orm.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\CategoryAttributeGroup"
+            table="category_attribute_groups">
+
+        <indexes>
+            <index name="category_attribute_groups_target_idx" columns="category_object_id,target_object_type_id"/>
+        </indexes>
+
+        <id name="categoryObjectId" type="uuid" column="category_object_id"/>
+        <id name="targetObjectType" association-key="true"/>
+        <id name="attributeGroup" association-key="true"/>
+
+        <many-to-one field="targetObjectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
+            <join-column name="target_object_type_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="attributeGroup" target-entity="App\Catalog\Domain\Entity\AttributeGroup">
+            <join-column name="attribute_group_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectTypeAttributeGroup.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectTypeAttributeGroup.orm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\ObjectTypeAttributeGroup"
+            table="object_type_attribute_groups">
+
+        <indexes>
+            <index name="object_type_attribute_groups_position_idx" columns="object_type_id,position"/>
+        </indexes>
+
+        <id name="objectType" association-key="true"/>
+        <id name="attributeGroup" association-key="true"/>
+
+        <many-to-one field="objectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
+            <join-column name="object_type_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="attributeGroup" target-entity="App\Catalog\Domain\Entity\AttributeGroup">
+            <join-column name="attribute_group_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
@@ -80,6 +80,11 @@ final class TenantAuditCommand extends Command
         'channel_object_type_mappings',
         // Asset variants (#37) inherit tenant scope from the parent Asset.
         'asset_variants',
+        // ADR-012 / UI-08.1 — AttributeGroup junction tables. Tenant scope
+        // inherited via the parent AttributeGroup / ObjectType / category row.
+        'attribute_group_attributes',
+        'object_type_attribute_groups',
+        'category_attribute_groups',
     ];
 
     /**

--- a/apps/api/tests/Unit/Catalog/AttributeGroupFirstClassTest.php
+++ b/apps/api/tests/Unit/Catalog/AttributeGroupFirstClassTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Entity\CategoryAttributeGroup;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use App\Catalog\Domain\ObjectKind;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Covers the first-class AttributeGroup data model introduced by ADR-012
+ * (#256 / UI-08.1) — extended AttributeGroup metadata + 3 junction
+ * entities (attribute / object-type / category × object-type).
+ */
+final class AttributeGroupFirstClassTest extends TestCase
+{
+    #[Test]
+    public function attributeGroupCarriesNewFirstClassFields(): void
+    {
+        $group = new AttributeGroup(
+            code: 'medical-requirements',
+            label: ['pl' => 'Wymagania medyczne', 'en' => 'Medical requirements'],
+            position: 4,
+            description: ['pl' => 'Atrybuty specyficzne dla usług medycznych', 'en' => 'Medical service attributes'],
+            icon: 'stethoscope',
+            color: '#EF4444',
+            isSystemGroup: false,
+            autoAttached: false,
+        );
+
+        self::assertSame('medical-requirements', $group->getCode());
+        self::assertSame('Wymagania medyczne', $group->getLabel()['pl']);
+        self::assertSame(4, $group->getPosition());
+        self::assertNotNull($group->getDescription());
+        self::assertSame('Medical service attributes', $group->getDescription()['en']);
+        self::assertSame('stethoscope', $group->getIcon());
+        self::assertSame('#EF4444', $group->getColor());
+        self::assertFalse($group->isSystemGroup());
+        self::assertFalse($group->isAutoAttached());
+    }
+
+    #[Test]
+    public function systemGroupSurfacesFlags(): void
+    {
+        $audit = new AttributeGroup(
+            code: 'audit',
+            label: ['pl' => 'Audyt', 'en' => 'Audit'],
+            isSystemGroup: true,
+            autoAttached: true,
+        );
+
+        self::assertTrue($audit->isSystemGroup());
+        self::assertTrue($audit->isAutoAttached());
+    }
+
+    #[Test]
+    public function attributeGroupAttributeJunctionPreservesPositionAndVisibilityRule(): void
+    {
+        $group = new AttributeGroup('marketing', ['pl' => 'Marketing', 'en' => 'Marketing']);
+        $attribute = new Attribute('description', ['pl' => 'Opis', 'en' => 'Description'], AttributeType::Text);
+
+        $junction = new AttributeGroupAttribute(
+            attributeGroup: $group,
+            attribute: $attribute,
+            position: 7,
+            isRequiredInGroup: true,
+            visibleWhen: ['field' => 'is_premium', 'operator' => 'equals', 'value' => true],
+        );
+
+        self::assertSame($group, $junction->getAttributeGroup());
+        self::assertSame($attribute, $junction->getAttribute());
+        self::assertSame(7, $junction->getPosition());
+        self::assertTrue($junction->isRequiredInGroup());
+        self::assertSame('is_premium', $junction->getVisibleWhen()['field']);
+    }
+
+    #[Test]
+    public function attributeGroupAttributeReorderAndRequiredAreMutable(): void
+    {
+        $group = new AttributeGroup('marketing', ['pl' => 'Marketing']);
+        $attribute = new Attribute('description', ['pl' => 'Opis'], AttributeType::Text);
+
+        $junction = new AttributeGroupAttribute($group, $attribute);
+        self::assertSame(0, $junction->getPosition());
+        self::assertFalse($junction->isRequiredInGroup());
+        self::assertNull($junction->getVisibleWhen());
+
+        $junction->reorder(2);
+        $junction->changeRequiredInGroup(true);
+        $junction->changeVisibleWhen(['field' => 'enabled', 'operator' => 'equals', 'value' => true]);
+
+        self::assertSame(2, $junction->getPosition());
+        self::assertTrue($junction->isRequiredInGroup());
+        self::assertNotNull($junction->getVisibleWhen());
+    }
+
+    #[Test]
+    public function objectTypeAttributeGroupJunctionWiresGlobalGroup(): void
+    {
+        $service = new ObjectType('service', ObjectKind::Custom, ['pl' => 'Usługa']);
+        $audit = new AttributeGroup('audit', ['pl' => 'Audyt'], isSystemGroup: true, autoAttached: true);
+
+        $junction = new ObjectTypeAttributeGroup($service, $audit, position: 999);
+
+        self::assertSame($service, $junction->getObjectType());
+        self::assertSame($audit, $junction->getAttributeGroup());
+        self::assertSame(999, $junction->getPosition());
+
+        $junction->reorder(1000);
+        self::assertSame(1000, $junction->getPosition());
+    }
+
+    #[Test]
+    public function categoryAttributeGroupTracksCategoryTargetTypeAndGroup(): void
+    {
+        $service = new ObjectType('service', ObjectKind::Custom, ['pl' => 'Usługa']);
+        $medicalReqs = new AttributeGroup(
+            'medical-requirements',
+            ['pl' => 'Wymagania medyczne'],
+        );
+        $categoryId = Uuid::v7();
+
+        $junction = new CategoryAttributeGroup(
+            categoryObjectId: $categoryId,
+            targetObjectType: $service,
+            attributeGroup: $medicalReqs,
+            position: 3,
+        );
+
+        self::assertSame($categoryId, $junction->getCategoryObjectId());
+        self::assertSame($service, $junction->getTargetObjectType());
+        self::assertSame($medicalReqs, $junction->getAttributeGroup());
+        self::assertSame(3, $junction->getPosition());
+
+        $junction->reorder(5);
+        self::assertSame(5, $junction->getPosition());
+    }
+}

--- a/apps/api/tests/Unit/Catalog/AttributeGroupFirstClassTest.php
+++ b/apps/api/tests/Unit/Catalog/AttributeGroupFirstClassTest.php
@@ -40,8 +40,9 @@ final class AttributeGroupFirstClassTest extends TestCase
         self::assertSame('medical-requirements', $group->getCode());
         self::assertSame('Wymagania medyczne', $group->getLabel()['pl']);
         self::assertSame(4, $group->getPosition());
-        self::assertNotNull($group->getDescription());
-        self::assertSame('Medical service attributes', $group->getDescription()['en']);
+        $description = $group->getDescription();
+        self::assertNotNull($description);
+        self::assertSame('Medical service attributes', $description['en']);
         self::assertSame('stethoscope', $group->getIcon());
         self::assertSame('#EF4444', $group->getColor());
         self::assertFalse($group->isSystemGroup());
@@ -80,7 +81,9 @@ final class AttributeGroupFirstClassTest extends TestCase
         self::assertSame($attribute, $junction->getAttribute());
         self::assertSame(7, $junction->getPosition());
         self::assertTrue($junction->isRequiredInGroup());
-        self::assertSame('is_premium', $junction->getVisibleWhen()['field']);
+        $rule = $junction->getVisibleWhen();
+        self::assertNotNull($rule);
+        self::assertSame('is_premium', $rule['field']);
     }
 
     #[Test]

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4211,7 +4211,7 @@
                         ]
                     }
                 ],
-                "description": "Container that groups attributes for admin UX (e.g. \"SEO\", \"Logistics\",\n\"Marketing\"). A group is purely organisational \u2014 it carries a localised\nlabel + an ordering position and lives entirely within one tenant.\n\nAttributes either belong to one group or stay ungrouped (`group_id` NULL\non Attribute). Removing a group leaves its attributes alive but ungrouped\n(FK ON DELETE SET NULL) so admins do not lose data by re-organising.\n\n`label` is JSONB `{pl: \"...\", en: \"...\"}` so the same row carries every\nsupported locale in MVP \u2014 no separate translations table."
+                "description": "Container that groups attributes for admin UX (e.g. \"SEO\", \"Logistics\",\n\"Marketing\"). After ADR-012 a group is a first-class entity with its own\nURL / audit / icon / colour, used as the unit of attachment to ObjectType\n(global) and Category (inherited down the tree).\n\n`label` is JSONB `{pl: \"...\", en: \"...\"}` so the same row carries every\nsupported locale \u2014 no separate translations table. `description` follows\nthe same pattern.\n\nTwo attachment paths to attributes coexist during the UI-08 migration:\n - legacy 1:N `Attribute.group_id` (still alive, written by 0.3.X seeders),\n - first-class M:N via `attribute_group_attributes` junction (ADR-012).\n\n`is_system_group=true` marks groups managed by the system (e.g. the auto-\nattached \"Audit\" group #UI-08.3) \u2014 not deletable, not detachable from\nObjectType, code is immutable. `auto_attached=true` means the group is\nautomatically wired to every new ObjectType (currently only Audit)."
             },
             "CatalogObject-admin.read": {
                 "type": "object",
@@ -5219,7 +5219,7 @@
         },
         {
             "name": "AttributeGroup",
-            "description": "Container that groups attributes for admin UX (e.g. \"SEO\", \"Logistics\",\n\"Marketing\"). A group is purely organisational \u2014 it carries a localised\nlabel + an ordering position and lives entirely within one tenant.\n\nAttributes either belong to one group or stay ungrouped (`group_id` NULL\non Attribute). Removing a group leaves its attributes alive but ungrouped\n(FK ON DELETE SET NULL) so admins do not lose data by re-organising.\n\n`label` is JSONB `{pl: \"...\", en: \"...\"}` so the same row carries every\nsupported locale in MVP \u2014 no separate translations table."
+            "description": "Container that groups attributes for admin UX (e.g. \"SEO\", \"Logistics\",\n\"Marketing\"). After ADR-012 a group is a first-class entity with its own\nURL / audit / icon / colour, used as the unit of attachment to ObjectType\n(global) and Category (inherited down the tree).\n\n`label` is JSONB `{pl: \"...\", en: \"...\"}` so the same row carries every\nsupported locale \u2014 no separate translations table. `description` follows\nthe same pattern.\n\nTwo attachment paths to attributes coexist during the UI-08 migration:\n - legacy 1:N `Attribute.group_id` (still alive, written by 0.3.X seeders),\n - first-class M:N via `attribute_group_attributes` junction (ADR-012).\n\n`is_system_group=true` marks groups managed by the system (e.g. the auto-\nattached \"Audit\" group #UI-08.3) \u2014 not deletable, not detachable from\nObjectType, code is immutable. `auto_attached=true` means the group is\nautomatically wired to every new ObjectType (currently only Audit)."
         },
         {
             "name": "CatalogObject",


### PR DESCRIPTION
## Summary

- Pierwszy ticket epiku **UI-08 Modelowanie** (#256), blocker dla pozostałych.
- **ADR-012** dodany do `Project Plan/01-architektura-pim.md` §13 — *"Attribute Group as first-class entity for cross-objecttype data modeling"*.
- Rozszerzenie `attribute_groups` o `description JSONB`, `icon`, `color`, `is_system_group`, `auto_attached`.
- Trzy nowe junction tables: `attribute_group_attributes` (M:N Attribute), `object_type_attribute_groups` (M:N ObjectType), `category_attribute_groups` (M:N Category × ObjectType).
- Cztery zaktualizowane/nowe Doctrine entities + ORM XML mappings.
- Tenant audit allowlist (`TenantAuditCommand::INFRA_TABLES`) updated o 3 nowe junction tables.
- 6 nowych unit testów w `AttributeGroupFirstClassTest`.

**Świadome odejście:** legacy 1:N `Attribute.group_id` zostawione w spokoju. Data migration do junction `attribute_group_attributes` zaplanowana w follow-up po `#UI-08.5` (gdy admin UI ma drag-drop multi-group).

## Test plan

- [x] PHPStan max — clean.
- [x] Deptrac 0 violations + 27 baseline.
- [x] Migracja `Version20260501100000` przeszła clean (drop schema → migrate up → 19 migrations).
- [x] Unit tests — `AttributeGroupFirstClassTest` 6/6 (231 → 237 total).
- [ ] CI — Biome / tsc / vite (no admin changes, expect green).
- [ ] CI — Api integration tests (uwaga: pre-existing infra issue z `test.service_container` na origin/main, niezwiązane z tym PR).

Closes #256