### PR TITLE
[UI-08.2] ObjectType built-in flags + brand as 4-th built-in

### DIFF
--- a/apps/api/migrations/Version20260501110000.php
+++ b/apps/api/migrations/Version20260501110000.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * UI-08.2 — ObjectType built-in flags + brand as 4-th built-in (#257).
+ *
+ * Adds `code_immutable`, `deletable`, `icon`, `color` columns on
+ * object_types (`is_built_in` already exists from #33). Marks the existing
+ * three built-ins (product / category / asset) as code-immutable +
+ * undeletable in line with the platform-owned semantics introduced by
+ * ADR-009 and reaffirmed in epik-08-modelowanie §3.4. Seeds `brand` as a
+ * 4-th built-in (per `Project Plan/UI/epik-08-modelowanie.md` §3.4 — brand
+ * has its own DAM-like footprint and integrations bind to it directly).
+ */
+final class Version20260501110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ObjectType built-in flags (code_immutable/deletable/icon/color) + brand 4-th built-in (#257).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE object_types ADD COLUMN code_immutable BOOLEAN NOT NULL DEFAULT false');
+        $this->addSql('ALTER TABLE object_types ADD COLUMN deletable BOOLEAN NOT NULL DEFAULT true');
+        $this->addSql('ALTER TABLE object_types ADD COLUMN icon VARCHAR(64) DEFAULT NULL');
+        $this->addSql('ALTER TABLE object_types ADD COLUMN color VARCHAR(16) DEFAULT NULL');
+
+        // Lock existing 3 built-ins (product, category, asset).
+        $this->addSql(<<<'SQL'
+            UPDATE object_types
+            SET code_immutable = true, deletable = false,
+                icon = CASE kind
+                    WHEN 'product' THEN 'Package'
+                    WHEN 'category' THEN 'FolderTree'
+                    WHEN 'asset' THEN 'Image'
+                END,
+                color = CASE kind
+                    WHEN 'product' THEN '#3B82F6'
+                    WHEN 'category' THEN '#10B981'
+                    WHEN 'asset' THEN '#8B5CF6'
+                END
+            WHERE is_built_in = true AND kind IN ('product', 'category', 'asset')
+        SQL);
+
+        // Seed brand as 4-th built-in per tenant.
+        $this->addSql(<<<'SQL'
+            INSERT INTO object_types (
+                id, tenant_id, code, kind, is_built_in, code_immutable, deletable,
+                icon, color, label, completeness_rules, schema_version,
+                created_at, updated_at
+            )
+            SELECT gen_random_uuid(), t.id, 'brand', 'brand', true, true, false,
+                   'Tag', '#F59E0B',
+                   '{"pl":"Marka","en":"Brand"}'::jsonb, '{}'::jsonb, 1,
+                   NOW(), NOW()
+            FROM tenants t
+            WHERE NOT EXISTS (
+                SELECT 1 FROM object_types o
+                WHERE o.tenant_id = t.id AND o.kind = 'brand' AND o.is_built_in = true
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("DELETE FROM object_types WHERE kind = 'brand' AND is_built_in = true");
+        $this->addSql('ALTER TABLE object_types DROP COLUMN color');
+        $this->addSql('ALTER TABLE object_types DROP COLUMN icon');
+        $this->addSql('ALTER TABLE object_types DROP COLUMN deletable');
+        $this->addSql('ALTER TABLE object_types DROP COLUMN code_immutable');
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/ObjectType.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectType.php
@@ -46,6 +46,14 @@ class ObjectType implements TenantScoped
     private ObjectKind $kind;
 
     private bool $isBuiltIn = false;
+    private bool $codeImmutable = false;
+    private bool $deletable = true;
+
+    #[Assert\Length(max: 64)]
+    private ?string $icon = null;
+
+    #[Assert\Length(max: 16)]
+    private ?string $color = null;
 
     /**
      * @var array<string, string>
@@ -121,6 +129,63 @@ class ObjectType implements TenantScoped
     public function markBuiltIn(): void
     {
         $this->isBuiltIn = true;
+        $this->touch();
+    }
+
+    public function isCodeImmutable(): bool
+    {
+        return $this->codeImmutable;
+    }
+
+    public function lockCode(): void
+    {
+        $this->codeImmutable = true;
+        $this->touch();
+    }
+
+    public function isDeletable(): bool
+    {
+        return $this->deletable;
+    }
+
+    public function markUndeletable(): void
+    {
+        $this->deletable = false;
+        $this->touch();
+    }
+
+    public function getIcon(): ?string
+    {
+        return $this->icon;
+    }
+
+    public function setIcon(?string $icon): void
+    {
+        $this->icon = $icon;
+        $this->touch();
+    }
+
+    public function getColor(): ?string
+    {
+        return $this->color;
+    }
+
+    public function setColor(?string $color): void
+    {
+        $this->color = $color;
+        $this->touch();
+    }
+
+    /**
+     * @throws LogicException when code_immutable is set
+     */
+    public function changeCode(string $code): void
+    {
+        if ($this->codeImmutable) {
+            throw new LogicException('ObjectType code is immutable for this row.');
+        }
+
+        $this->code = $code;
         $this->touch();
     }
 

--- a/apps/api/src/Catalog/Domain/ObjectKind.php
+++ b/apps/api/src/Catalog/Domain/ObjectKind.php
@@ -26,6 +26,7 @@ enum ObjectKind: string
     case Product = 'product';
     case Category = 'category';
     case Asset = 'asset';
+    case Brand = 'brand';
     case Custom = 'custom';
 
     public function isBuiltIn(): bool

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php
@@ -41,6 +41,10 @@ final class ObjectKindRouter
             'path' => '/api/assets',
             'groups' => ['object:read', 'object:read:asset'],
         ],
+        'brand' => [
+            'path' => '/api/brands',
+            'groups' => ['object:read', 'object:read:brand'],
+        ],
     ];
 
     /**
@@ -84,6 +88,6 @@ final class ObjectKindRouter
      */
     public static function builtInKinds(): array
     {
-        return [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset];
+        return [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand];
     }
 }

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
@@ -31,6 +31,18 @@
                 <option name="default">false</option>
             </options>
         </field>
+        <field name="codeImmutable" type="boolean" column="code_immutable">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="deletable" type="boolean">
+            <options>
+                <option name="default">true</option>
+            </options>
+        </field>
+        <field name="icon" type="string" length="64" nullable="true"/>
+        <field name="color" type="string" length="16" nullable="true"/>
         <field name="label" type="json">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Search/Application/IndexSettingsTemplate.php
+++ b/apps/api/src/Search/Application/IndexSettingsTemplate.php
@@ -38,6 +38,7 @@ final class IndexSettingsTemplate
             ObjectKind::Product => 'products',
             ObjectKind::Category => 'categories',
             ObjectKind::Asset => 'assets',
+            ObjectKind::Brand => 'brands',
             ObjectKind::Custom => throw new LogicException('Custom kind has no MVP index — phase 2/3 unlock.'),
         };
     }
@@ -70,6 +71,13 @@ final class IndexSettingsTemplate
                 'displayedAttributes' => ['*'],
                 'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
             ],
+            ObjectKind::Brand => [
+                'searchableAttributes' => ['code', 'name', 'description'],
+                'filterableAttributes' => ['tenantId', 'kind', 'enabled', 'objectTypeId'],
+                'sortableAttributes' => ['createdAt', 'updatedAt', 'name'],
+                'displayedAttributes' => ['*'],
+                'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
+            ],
             ObjectKind::Custom => throw new LogicException('Custom kind has no MVP settings template.'),
         };
     }
@@ -79,6 +87,6 @@ final class IndexSettingsTemplate
      */
     public static function indexedKinds(): array
     {
-        return [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset];
+        return [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand];
     }
 }

--- a/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/ObjectKindRouterTest.php
+++ b/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/ObjectKindRouterTest.php
@@ -49,10 +49,12 @@ final class ObjectKindRouterTest extends TestCase
     }
 
     #[Test]
-    public function builtInKindsListMatchesAdr009(): void
+    public function builtInKindsListMatchesAdr009AndAdr012(): void
     {
+        // ADR-009 ships product / category / asset; ADR-012 (#257 / UI-08.2)
+        // adds brand as 4-th built-in.
         self::assertSame(
-            [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset],
+            [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand],
             ObjectKindRouter::builtInKinds(),
         );
     }

--- a/apps/api/tests/Unit/Catalog/ObjectKindTest.php
+++ b/apps/api/tests/Unit/Catalog/ObjectKindTest.php
@@ -12,10 +12,12 @@ use PHPUnit\Framework\TestCase;
 final class ObjectKindTest extends TestCase
 {
     #[Test]
-    public function fourCasesAreDefinedExactly(): void
+    public function fiveCasesAreDefinedExactly(): void
     {
-        // ADR-009 fixes the kind enum at four values; guard against drift.
-        self::assertCount(4, ObjectKind::cases());
+        // ADR-009 + ADR-012 fix the kind enum at five values (Product +
+        // Category + Asset + Brand built-ins, plus Custom escape hatch);
+        // guard against drift.
+        self::assertCount(5, ObjectKind::cases());
     }
 
     #[Test]
@@ -35,6 +37,7 @@ final class ObjectKindTest extends TestCase
         yield 'product is built-in' => [ObjectKind::Product, true];
         yield 'category is built-in' => [ObjectKind::Category, true];
         yield 'asset is built-in' => [ObjectKind::Asset, true];
+        yield 'brand is built-in' => [ObjectKind::Brand, true];
         yield 'custom is NOT built-in' => [ObjectKind::Custom, false];
     }
 

--- a/apps/api/tests/Unit/Catalog/ObjectTypeBuiltInFlagsTest.php
+++ b/apps/api/tests/Unit/Catalog/ObjectTypeBuiltInFlagsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the built-in / immutability / icon / colour metadata introduced
+ * by UI-08.2 (#257). The data layer also seeds Brand as the 4-th built-in
+ * with code-immutable + undeletable; the migration is exercised by the
+ * Doctrine pipeline, here we focus on the entity invariants.
+ */
+final class ObjectTypeBuiltInFlagsTest extends TestCase
+{
+    #[Test]
+    public function freshObjectTypeIsNotBuiltInAndDeletableWithMutableCode(): void
+    {
+        $type = new ObjectType('subscription', ObjectKind::Custom, ['pl' => 'Subskrypcja']);
+
+        self::assertFalse($type->isBuiltIn());
+        self::assertFalse($type->isCodeImmutable());
+        self::assertTrue($type->isDeletable());
+        self::assertNull($type->getIcon());
+        self::assertNull($type->getColor());
+    }
+
+    #[Test]
+    public function lockingMakesCodeImmutableAndChangeCodeThrows(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $type->markBuiltIn();
+        $type->lockCode();
+
+        self::assertTrue($type->isCodeImmutable());
+
+        $this->expectException(LogicException::class);
+        $type->changeCode('product_renamed');
+    }
+
+    #[Test]
+    public function changeCodeWorksForCustomKindWithoutLock(): void
+    {
+        $type = new ObjectType('subscription', ObjectKind::Custom, ['pl' => 'Subskrypcja']);
+        $type->changeCode('membership');
+
+        self::assertSame('membership', $type->getCode());
+    }
+
+    #[Test]
+    public function markUndeletableFlipsDeletableFlag(): void
+    {
+        $type = new ObjectType('asset', ObjectKind::Asset, ['pl' => 'Zasób']);
+        self::assertTrue($type->isDeletable());
+
+        $type->markUndeletable();
+        self::assertFalse($type->isDeletable());
+    }
+
+    #[Test]
+    public function iconAndColorAreFreelyEditable(): void
+    {
+        $type = new ObjectType('brand', ObjectKind::Brand, ['pl' => 'Marka', 'en' => 'Brand']);
+
+        $type->setIcon('Tag');
+        $type->setColor('#F59E0B');
+
+        self::assertSame('Tag', $type->getIcon());
+        self::assertSame('#F59E0B', $type->getColor());
+
+        $type->setIcon(null);
+        self::assertNull($type->getIcon());
+    }
+
+    #[Test]
+    public function brandKindIsBuiltInButCustomIsNot(): void
+    {
+        self::assertTrue(ObjectKind::Brand->isBuiltIn());
+        self::assertFalse(ObjectKind::Custom->isBuiltIn());
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4233,6 +4233,7 @@
                             "product",
                             "category",
                             "asset",
+                            "brand",
                             "custom"
                         ]
                     },
@@ -4433,6 +4434,7 @@
                                     "product",
                                     "category",
                                     "asset",
+                                    "brand",
                                     "custom"
                                 ]
                             },
@@ -5022,6 +5024,7 @@
                             "product",
                             "category",
                             "asset",
+                            "brand",
                             "custom"
                         ]
                     },
@@ -5112,6 +5115,7 @@
                                     "product",
                                     "category",
                                     "asset",
+                                    "brand",
                                     "custom"
                                 ]
                             },


### PR DESCRIPTION
## Summary

- Drugi ticket epiku **UI-08 Modelowanie** (#257).
- Migracja `Version20260501110000` dodaje `code_immutable`, `deletable`, `icon`, `color` kolumny w `object_types`.
- Seed **brand** jako 4-ty built-in per tenant (kind=`brand`, code-immutable, undeletable, icon=`Tag`, color=`#F59E0B`).
- Update istniejących built-ins (product/category/asset): `code_immutable=true, deletable=false` + default icon/color.
- `ObjectKind` enum: nowy case `Brand` (5 cases total).
- `ObjectKindRouter` + `IndexSettingsTemplate` include `brand` (path `/api/brands`, indeks Meilisearch `brands`).
- 6 nowych unit testów (`ObjectTypeBuiltInFlagsTest`) + update istniejących (`ObjectKindTest`, `ObjectKindRouterTest`).

## Test plan

- [x] PHPStan max — clean.
- [x] Deptrac — 0 violations + 27 baseline (zwiększone o 326 allowed).
- [x] PHPUnit Unit — 244/244 zielone (nowych: 6).
- [x] Migracja sprawdzona end-to-end (drop schema → migrate up).
- [x] OpenAPI snapshot regenerated (`docs/api-spec/v0.json`).
- [ ] CI pipeline pełny.

Closes #257