### PR TITLE
[UI-08.11] Attributes sub-tab — filters + Usages column + WhereUsedList (#266)

### DIFF
--- a/Project Plan/02-plan-projektu-pim.md
+++ b/Project Plan/02-plan-projektu-pim.md
@@ -434,7 +434,7 @@ Pierwszy epik napędzany **planem UI** (`Project Plan/UI/`) zamiast backend road
 | ✅ **#263** | UI-08.8 visible_when storage + evaluator (MVP: equals) | UI, backend, must-have | 3-4h |
 | ✅ **#264** | UI-08.9 Modeling layout shell + 4-tab routing + back-compat redirects | UI, frontend, must-have | 2-3h |
 | ✅ **#265** | UI-08.10 Sub-tab Object Types — list + detail + Create wizard | UI, frontend, must-have | 6-8h |
-| **#266** | UI-08.11 Sub-tab Attributes — enhanced list + detail + Where-used | UI, frontend, must-have | 4-5h |
+| ✅ **#266** | UI-08.11 Sub-tab Attributes — enhanced list + detail + Where-used | UI, frontend, must-have | 4-5h |
 | **#267** | UI-08.12 Migration impact analyzer modal | UI, frontend, must-have | 4-5h |
 | **#268** | UI-08.13 Sub-tab Attribute Groups — drag-drop + VisibleWhen editor | UI, frontend, must-have | 5-7h |
 | **#269** | UI-08.14 Sub-tab Categories modeling — tree + inheritance preview | UI, frontend, must-have | 5-7h |

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -27,10 +27,11 @@ Pełen kontekst: [Project Plan/UI/epik-08-modelowanie.md](../Project%20Plan/UI/e
 - ✅ **#262 UI-08.7** (PR #280) — 3 custom REST endpoints `GET /api/{attributes|attribute_groups|object_types}/{id}/usage`. `UsageQueryService` (DBAL-only, tag-aware cache 60s TTL) + `UsageController`.
 - ✅ **#263 UI-08.8** (PR #281) — `VisibleWhenRule` value object + `VisibleWhenRuleEvaluator` + `PATCH /api/attribute_groups/{groupId}/attributes/{attributeId}` z cross-group reference guard. **Backend epik UI-08 zamknięty 8/8.**
 - ✅ **#264 UI-08.9** (PR #282) — `<ModelingLayout>` z 4-tab tablist'em pod `/modeling/*` + back-compat redirects + sidebar nav update + Playwright spec (1 consolidated test).
-- 🚧 **#265 UI-08.10** (branch `feat/ui-08.10-object-types-subtab`) — Object Types list + show enhanced. Reusable `<BuiltInLockBadge>` + `<WhereUsedList>` (modeling/* components, używane przez UI-08.11/.13/.14 też). Lista pokazuje icon + color + instance count z UI-08.7 usage endpoint. Show grid 1+sidebar z WhereUsedList. Serializer XML rozszerzony o `codeImmutable/deletable/icon/color`. Custom Create wizard świadomie odroczony — backend POST endpoint nie istnieje (ApiResource read-only) + custom kinds feature flag `pim.catalog.enable_custom_object_types=false` w MVP. OpenAPI snapshot refresh +48 linii.
+- ✅ **#265 UI-08.10** (PR #283) — Object Types list + show enhanced + reusable `<BuiltInLockBadge>` + `<WhereUsedList>`. Custom Create wizard świadomie odroczony.
+- 🚧 **#266 UI-08.11** (branch `feat/ui-08.11-attributes-subtab`) — Attributes list rozszerzony: `Origin` filter (all/business/system) + `Localizable/Scopable` chip toggles + `Usages` column z UI-08.7 + 🔒 lock badge dla system attrs (created_at/updated_at/created_by/updated_by). Show page: WhereUsedList sidebar + AttributePreview component (mock data per AttributeType — text/number/select/asset/reference/datetime). Serializer XML rozszerzony o `system` field. Edit/Migrate/Archive świadomie odroczone (read-only ApiResource + Migrate-type modal w #UI-08.12). OpenAPI +8 linii.
 
-**Pozostałe 5 ticketów UI-08 (wszystkie frontend):**
-- **#266** UI-08.11 (Attributes sub-tab enhanced), #267 UI-08.12 (Migration impact analyzer modal), #268 UI-08.13 (AttributeGroups sub-tab z drag-drop), #269 UI-08.14 (Categories modeling tree + inheritance preview), #270 UI-08.15 (bulk import CSV — optional).
+**Pozostałe 4 tickety UI-08 (wszystkie frontend):**
+- **#267** UI-08.12 (Migration impact analyzer modal), #268 UI-08.13 (AttributeGroups sub-tab z drag-drop), #269 UI-08.14 (Categories modeling tree + inheritance preview), #270 UI-08.15 (bulk import CSV — optional).
 - **Frontend:** #264-#270 (Modeling layout shell + 4 sub-tabs + migration analyzer + drag-drop + inheritance preview + bulk import CSV).
 
 **Dependency state na końcu sesji:**

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -1,9 +1,10 @@
 import { useList } from '@refinedev/core';
 import { Eye } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
+import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { Button } from '@/components/ui/button';
 import {
   Table,
@@ -13,6 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
+import { jsonFetch } from '@/lib/http';
 
 interface AttributeRow {
   id: string;
@@ -23,8 +25,11 @@ interface AttributeRow {
   required?: boolean;
   localizable?: boolean;
   scopable?: boolean;
+  system?: boolean;
   position?: number;
 }
+
+type SystemFilter = 'all' | 'system' | 'business';
 
 const TYPES: ReadonlyArray<string> = [
   'text',
@@ -43,6 +48,9 @@ const TYPES: ReadonlyArray<string> = [
 export function AttributesListPage() {
   const { t, i18n } = useTranslation();
   const [typeFilter, setTypeFilter] = useState<string>('');
+  const [systemFilter, setSystemFilter] = useState<SystemFilter>('all');
+  const [localizableOnly, setLocalizableOnly] = useState(false);
+  const [scopableOnly, setScopableOnly] = useState(false);
 
   const { result, query } = useList<AttributeRow>({
     resource: 'attributes',
@@ -51,9 +59,16 @@ export function AttributesListPage() {
 
   const attributes = result.data;
   const isLoading = query.isLoading;
+  const usageCounts = useAttributeUsageCounts(attributes);
 
-  const visible =
-    typeFilter === '' ? attributes : attributes.filter((row) => row.type === typeFilter);
+  const visible = attributes.filter((row) => {
+    if (typeFilter !== '' && row.type !== typeFilter) return false;
+    if (systemFilter === 'system' && row.system !== true) return false;
+    if (systemFilter === 'business' && row.system === true) return false;
+    if (localizableOnly && row.localizable !== true) return false;
+    if (scopableOnly && row.scopable !== true) return false;
+    return true;
+  });
 
   return (
     <div className="space-y-6">
@@ -62,40 +77,82 @@ export function AttributesListPage() {
         <p className="text-sm text-muted-foreground">{t('attributes.list_subtitle')}</p>
       </div>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <span className="text-xs uppercase tracking-wide text-muted-foreground">
-          {t('attributes.filter_type')}
-        </span>
-        <Button
-          type="button"
-          variant={typeFilter === '' ? 'secondary' : 'ghost'}
-          size="sm"
-          onClick={() => setTypeFilter('')}
-        >
-          {t('attributes.filter_all')}
-        </Button>
-        {TYPES.map((type) => (
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">
+            {t('attributes.filter_type')}
+          </span>
           <Button
-            key={type}
             type="button"
-            variant={typeFilter === type ? 'secondary' : 'ghost'}
+            variant={typeFilter === '' ? 'secondary' : 'ghost'}
             size="sm"
-            onClick={() => setTypeFilter(type)}
+            onClick={() => setTypeFilter('')}
           >
-            {type}
+            {t('attributes.filter_all')}
           </Button>
-        ))}
+          {TYPES.map((type) => (
+            <Button
+              key={type}
+              type="button"
+              variant={typeFilter === type ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => setTypeFilter(type)}
+            >
+              {type}
+            </Button>
+          ))}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs uppercase tracking-wide text-muted-foreground">
+            {t('modeling.attributes.filter_origin')}
+          </span>
+          {(['all', 'business', 'system'] as const).map((value) => (
+            <Button
+              key={value}
+              type="button"
+              variant={systemFilter === value ? 'secondary' : 'ghost'}
+              size="sm"
+              onClick={() => setSystemFilter(value)}
+            >
+              {t(`modeling.attributes.filter_origin_${value}`)}
+            </Button>
+          ))}
+          <span className="ml-2 text-xs uppercase tracking-wide text-muted-foreground">
+            {t('modeling.attributes.filter_flags')}
+          </span>
+          <Button
+            type="button"
+            variant={localizableOnly ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setLocalizableOnly((v) => !v)}
+            aria-pressed={localizableOnly}
+          >
+            {t('attributes.flags.localizable')}
+          </Button>
+          <Button
+            type="button"
+            variant={scopableOnly ? 'secondary' : 'ghost'}
+            size="sm"
+            onClick={() => setScopableOnly((v) => !v)}
+            aria-pressed={scopableOnly}
+          >
+            {t('attributes.flags.scopable')}
+          </Button>
+        </div>
       </div>
 
       <div className="rounded-xl border bg-card">
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead className="w-[200px]">{t('attributes.fields.code')}</TableHead>
+              <TableHead className="w-[220px]">{t('attributes.fields.code')}</TableHead>
               <TableHead>{t('attributes.fields.label')}</TableHead>
               <TableHead className="w-[140px]">{t('attributes.fields.type')}</TableHead>
               <TableHead className="w-[160px]">{t('attributes.fields.group')}</TableHead>
               <TableHead className="w-[180px]">{t('attributes.fields.flags')}</TableHead>
+              <TableHead className="w-[110px] text-right">
+                {t('modeling.attributes.usage_count')}
+              </TableHead>
               <TableHead className="w-[80px] text-right">
                 <span className="sr-only">{t('attributes.fields.actions')}</span>
               </TableHead>
@@ -104,20 +161,25 @@ export function AttributesListPage() {
           <TableBody>
             {isLoading ? (
               <TableRow>
-                <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
+                <TableCell colSpan={7} className="py-10 text-center text-muted-foreground">
                   {t('app.loading')}
                 </TableCell>
               </TableRow>
             ) : visible.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
+                <TableCell colSpan={7} className="py-10 text-center text-muted-foreground">
                   {t('attributes.empty')}
                 </TableCell>
               </TableRow>
             ) : (
               visible.map((row) => (
                 <TableRow key={row.id}>
-                  <TableCell className="font-mono text-xs">{row.code}</TableCell>
+                  <TableCell className="font-mono text-xs">
+                    <span className="inline-flex items-center gap-2">
+                      {row.system ? <BuiltInLockBadge tone="quiet" /> : null}
+                      {row.code}
+                    </span>
+                  </TableCell>
                   <TableCell className="font-medium">
                     {resolveLabel(row.label, i18n.language)}
                   </TableCell>
@@ -134,9 +196,12 @@ export function AttributesListPage() {
                     {row.localizable ? <Flag>{t('attributes.flags.localizable')}</Flag> : null}
                     {row.scopable ? <Flag>{t('attributes.flags.scopable')}</Flag> : null}
                   </TableCell>
+                  <TableCell className="text-right font-mono text-sm tabular-nums text-muted-foreground">
+                    {usageCounts[row.id] ?? '—'}
+                  </TableCell>
                   <TableCell className="text-right">
                     <Button asChild variant="ghost" size="sm">
-                      <Link to={`/attributes/${row.id}`}>
+                      <Link to={`/modeling/attributes/${row.id}`}>
                         <Eye className="size-4" />
                         <span className="sr-only">{t('attributes.actions.view')}</span>
                       </Link>
@@ -179,4 +244,40 @@ function resolveGroupLabel(group: AttributeRow['group'], locale: string): string
   if (typeof group === 'string') return group;
   if (group.label) return resolveLabel(group.label, locale);
   return group.code ?? '—';
+}
+
+/**
+ * Per-row instance count from the UI-08.7 usage endpoint. Each row gets
+ * its own request — `/api/attributes/{id}/usage` is a single-row reader.
+ * The widget tolerates 404 / network errors (count stays "—") so the
+ * list still renders cleanly when the endpoint is unavailable.
+ */
+function useAttributeUsageCounts(rows: AttributeRow[]): Record<string, number> {
+  const [counts, setCounts] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const next: Record<string, number> = {};
+      await Promise.all(
+        rows.map(async (row) => {
+          try {
+            const usage = await jsonFetch<{ instanceCount: number }>(
+              `/api/attributes/${row.id}/usage`,
+              { accept: 'application/json' },
+            );
+            next[row.id] = usage.instanceCount;
+          } catch {
+            // tolerate — row keeps "—"
+          }
+        }),
+      );
+      if (!cancelled) setCounts(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [rows]);
+
+  return counts;
 }

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -3,6 +3,8 @@ import { ArrowLeft } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 
+import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
+import { WhereUsedList } from '@/components/modeling/where-used-list';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
@@ -17,6 +19,7 @@ interface AttributeDetail {
   required?: boolean;
   localizable?: boolean;
   scopable?: boolean;
+  system?: boolean;
   validationRules?: Record<string, unknown> | null;
   position?: number;
   group?: { id: string; code?: string; label?: Record<string, string> | string } | string | null;
@@ -50,44 +53,96 @@ export function AttributeShowPage() {
             {t('attributes.back')}
           </Link>
         </Button>
-        <h1 className="text-2xl font-semibold tracking-tight">{label}</h1>
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-2xl font-semibold tracking-tight">{label}</h1>
+          {attribute.system ? <BuiltInLockBadge /> : null}
+        </div>
         <p className="font-mono text-xs text-muted-foreground">{attribute.code}</p>
       </div>
 
-      <Card>
-        <CardContent className="grid gap-3 pt-6 sm:grid-cols-2">
-          <DetailRow label={t('attributes.fields.type')}>
-            <span className="rounded bg-muted px-2 py-0.5 text-xs uppercase tracking-wide">
-              {attribute.type}
-            </span>
-          </DetailRow>
-          {help !== '—' ? (
-            <DetailRow label={t('attributes.fields.help')}>
-              <span className="text-sm">{help}</span>
+      <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+        <Card>
+          <CardContent className="grid gap-3 pt-6 sm:grid-cols-2">
+            <DetailRow label={t('attributes.fields.type')}>
+              <span className="rounded bg-muted px-2 py-0.5 text-xs uppercase tracking-wide">
+                {attribute.type}
+              </span>
             </DetailRow>
-          ) : null}
-          <DetailRow label={t('attributes.fields.required')}>
-            <FlagBadge value={attribute.required ?? false} />
-          </DetailRow>
-          <DetailRow label={t('attributes.fields.localizable')}>
-            <FlagBadge value={attribute.localizable ?? false} />
-          </DetailRow>
-          <DetailRow label={t('attributes.fields.scopable')}>
-            <FlagBadge value={attribute.scopable ?? false} />
-          </DetailRow>
-          {attribute.validationRules && Object.keys(attribute.validationRules).length > 0 ? (
-            <DetailRow label={t('attributes.fields.validation')}>
-              <pre className="rounded bg-muted px-2 py-1 text-xs">
-                {JSON.stringify(attribute.validationRules, null, 2)}
-              </pre>
+            {help !== '—' ? (
+              <DetailRow label={t('attributes.fields.help')}>
+                <span className="text-sm">{help}</span>
+              </DetailRow>
+            ) : null}
+            <DetailRow label={t('attributes.fields.required')}>
+              <FlagBadge value={attribute.required ?? false} />
             </DetailRow>
-          ) : null}
-        </CardContent>
-      </Card>
+            <DetailRow label={t('attributes.fields.localizable')}>
+              <FlagBadge value={attribute.localizable ?? false} />
+            </DetailRow>
+            <DetailRow label={t('attributes.fields.scopable')}>
+              <FlagBadge value={attribute.scopable ?? false} />
+            </DetailRow>
+            {attribute.validationRules && Object.keys(attribute.validationRules).length > 0 ? (
+              <DetailRow label={t('attributes.fields.validation')}>
+                <pre className="rounded bg-muted px-2 py-1 text-xs">
+                  {JSON.stringify(attribute.validationRules, null, 2)}
+                </pre>
+              </DetailRow>
+            ) : null}
+            <DetailRow label={t('modeling.attributes.preview_title')}>
+              <AttributePreview type={attribute.type} />
+            </DetailRow>
+          </CardContent>
+        </Card>
+        <WhereUsedList resource="attributes" id={attribute.id} />
+      </div>
 
-      <p className="text-xs text-muted-foreground">{t('attributes.write_deferred_note')}</p>
+      <p className="text-xs text-muted-foreground">
+        {attribute.system
+          ? t('modeling.attributes.system_immutable_note')
+          : t('attributes.write_deferred_note')}
+      </p>
     </div>
   );
+}
+
+/**
+ * UI-08.11 (#266) — minimal mock-data preview per AttributeType.
+ * Renders the kind of widget the user would see for that type (input,
+ * select-like chip, asset placeholder). Live data preview lands in
+ * Phase 2 once the form-renderer ships.
+ */
+function AttributePreview({ type }: { type: string }) {
+  switch (type) {
+    case 'number':
+    case 'price':
+    case 'metric':
+      return <span className="font-mono text-xs">42</span>;
+    case 'boolean':
+      return (
+        <span className="rounded bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-900">
+          true
+        </span>
+      );
+    case 'select':
+    case 'multiselect':
+    case 'multi_select':
+      return (
+        <span className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary-foreground">
+          option
+        </span>
+      );
+    case 'date':
+    case 'datetime':
+      return <span className="font-mono text-xs">2026-01-01</span>;
+    case 'asset':
+      return <span className="font-mono text-xs text-muted-foreground">[asset]</span>;
+    case 'reference':
+    case 'relation':
+      return <span className="font-mono text-xs text-muted-foreground">[ref]</span>;
+    default:
+      return <span className="text-xs text-muted-foreground">sample text</span>;
+  }
 }
 
 function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -406,6 +406,16 @@
       "attached_groups": "Attached attribute groups",
       "api_profiles": "API profiles referencing this",
       "category_attachments": "Category attachments"
+    },
+    "attributes": {
+      "filter_origin": "Origin",
+      "filter_origin_all": "All",
+      "filter_origin_business": "Business",
+      "filter_origin_system": "System",
+      "filter_flags": "Flags",
+      "usage_count": "Usages",
+      "preview_title": "Preview",
+      "system_immutable_note": "System attribute — code, type, and validation are immutable."
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -406,6 +406,16 @@
       "attached_groups": "Przypięte grupy atrybutów",
       "api_profiles": "Profile API odwołujące się",
       "category_attachments": "Przypisania w kategoriach"
+    },
+    "attributes": {
+      "filter_origin": "Pochodzenie",
+      "filter_origin_all": "Wszystkie",
+      "filter_origin_business": "Biznesowe",
+      "filter_origin_system": "Systemowe",
+      "filter_flags": "Flagi",
+      "usage_count": "Użycia",
+      "preview_title": "Podgląd",
+      "system_immutable_note": "Atrybut systemowy — code, typ i walidacja są niezmienne."
     }
   }
 }

--- a/apps/api/src/Catalog/Infrastructure/Serializer/Attribute.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/Attribute.xml
@@ -50,6 +50,9 @@
             <group>admin:write</group>
             <group>integration:read</group>
         </attribute>
+        <attribute name="system">
+            <group>admin:read</group>
+        </attribute>
         <attribute name="validationRules">
             <group>admin:read</group>
             <group>admin:write</group>

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4333,6 +4333,10 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "system": {
+                        "readOnly": true,
+                        "type": "boolean"
+                    },
                     "localizable": {
                         "readOnly": true,
                         "type": "boolean"
@@ -4432,6 +4436,10 @@
                                 "readOnly": true,
                                 "type": "string",
                                 "format": "date-time"
+                            },
+                            "system": {
+                                "readOnly": true,
+                                "type": "boolean"
                             },
                             "localizable": {
                                 "readOnly": true,


### PR DESCRIPTION
## Summary

- Origin filter (`all`/`business`/`system`) + `Localizable`/`Scopable` chip toggles w list view.
- Usage count column populated z UI-08.7 endpoint per row.
- 🔒 `<BuiltInLockBadge tone='quiet'>` przy system attrs (created_at/updated_at/created_by/updated_by).
- Show page: 1+sidebar grid z `<WhereUsedList>` + `<AttributePreview>` mock-data widget per AttributeType.
- Backend serializer XML rozszerzony o `system` field. OpenAPI snapshot +8 linii.

## Świadome odejścia

- **Edit Sheet drawer** — Attribute ApiResource jest read-only (`POST/PATCH/DELETE` brak); UI-08.5 odblokował to dla AttributeGroup, dla Attribute zostaje follow-up.
- **Archive button** — brak `is_archived` flag w domain entity; będzie razem z Faza 1 lifecycle ticket'em.
- **`Migrate type →` button** — modal pojawi się w #UI-08.12 (kolejny ticket).
- **Live preview** — Phase 2 razem z form-renderer'em w admin UI; tu mock-data.

## Test plan

- [x] Biome strict + tsc + Vite build — clean.
- [x] Manual smoke — system attribute `created_at` w demo tenancie wyświetla 🔒 lock badge + system note; usage count column wypełnia się dla każdego rzędu.
- [ ] Playwright — pre-existing modeling-shell.spec już pokrywa nawigację do `/modeling/attributes`. Dedicated spec dla sub-tab odroczony (rate-limit budget + same filtry to refresh state UI bez backendu).

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)