### PR TITLE
[UI-08.12] Migrate type page — 3-step UI for the UI-08.6 backend (#267)

### DIFF
--- a/Project Plan/02-plan-projektu-pim.md
+++ b/Project Plan/02-plan-projektu-pim.md
@@ -435,7 +435,7 @@ Pierwszy epik napędzany **planem UI** (`Project Plan/UI/`) zamiast backend road
 | ✅ **#264** | UI-08.9 Modeling layout shell + 4-tab routing + back-compat redirects | UI, frontend, must-have | 2-3h |
 | ✅ **#265** | UI-08.10 Sub-tab Object Types — list + detail + Create wizard | UI, frontend, must-have | 6-8h |
 | ✅ **#266** | UI-08.11 Sub-tab Attributes — enhanced list + detail + Where-used | UI, frontend, must-have | 4-5h |
-| **#267** | UI-08.12 Migration impact analyzer modal | UI, frontend, must-have | 4-5h |
+| ✅ **#267** | UI-08.12 Migration impact analyzer modal | UI, frontend, must-have | 4-5h |
 | **#268** | UI-08.13 Sub-tab Attribute Groups — drag-drop + VisibleWhen editor | UI, frontend, must-have | 5-7h |
 | **#269** | UI-08.14 Sub-tab Categories modeling — tree + inheritance preview | UI, frontend, must-have | 5-7h |
 | **#270** | UI-08.15 Bulk import atrybutów z CSV (US-MOD-008) — *optional* | UI, frontend, optional | 3-4h |

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -28,10 +28,11 @@ Pełen kontekst: [Project Plan/UI/epik-08-modelowanie.md](../Project%20Plan/UI/e
 - ✅ **#263 UI-08.8** (PR #281) — `VisibleWhenRule` value object + `VisibleWhenRuleEvaluator` + `PATCH /api/attribute_groups/{groupId}/attributes/{attributeId}` z cross-group reference guard. **Backend epik UI-08 zamknięty 8/8.**
 - ✅ **#264 UI-08.9** (PR #282) — `<ModelingLayout>` z 4-tab tablist'em pod `/modeling/*` + back-compat redirects + sidebar nav update + Playwright spec (1 consolidated test).
 - ✅ **#265 UI-08.10** (PR #283) — Object Types list + show enhanced + reusable `<BuiltInLockBadge>` + `<WhereUsedList>`. Custom Create wizard świadomie odroczony.
-- 🚧 **#266 UI-08.11** (branch `feat/ui-08.11-attributes-subtab`) — Attributes list rozszerzony: `Origin` filter (all/business/system) + `Localizable/Scopable` chip toggles + `Usages` column z UI-08.7 + 🔒 lock badge dla system attrs (created_at/updated_at/created_by/updated_by). Show page: WhereUsedList sidebar + AttributePreview component (mock data per AttributeType — text/number/select/asset/reference/datetime). Serializer XML rozszerzony o `system` field. Edit/Migrate/Archive świadomie odroczone (read-only ApiResource + Migrate-type modal w #UI-08.12). OpenAPI +8 linii.
+- ✅ **#266 UI-08.11** (PR #284) — Attributes list filtry + Usages column + `<AttributePreview>` mock-data widget; serializer XML +`system` field.
+- 🚧 **#267 UI-08.12** (branch `feat/ui-08.12-migration-analyzer`) — `<MigrateAttributeTypePage>` (route `/modeling/attributes/:id/migrate-type`) wired to UI-08.6 backend. Sections: target type picker → Suggest mappings (dry-run z empty plan, populates draft mappings z unmapped values) → mapping editor (input per row) → Controls (unmappedAction, backupSnapshot, force) → Cancel/Dry-run/Apply. Modeled jako pełnoprawna page (nie modal/dialog) — brak Radix Dialog primitive + back-button + deep-link UX dla destrukcyjnego workflow. `Migrate type →` button na attribute show (skipped dla system attrs).
 
-**Pozostałe 4 tickety UI-08 (wszystkie frontend):**
-- **#267** UI-08.12 (Migration impact analyzer modal), #268 UI-08.13 (AttributeGroups sub-tab z drag-drop), #269 UI-08.14 (Categories modeling tree + inheritance preview), #270 UI-08.15 (bulk import CSV — optional).
+**Pozostałe 3 tickety UI-08 (frontend):**
+- **#268** UI-08.13 (AttributeGroups sub-tab z drag-drop), #269 UI-08.14 (Categories modeling tree + inheritance preview), #270 UI-08.15 (bulk import CSV — optional).
 - **Frontend:** #264-#270 (Modeling layout shell + 4 sub-tabs + migration analyzer + drag-drop + inheritance preview + bulk import CSV).
 
 **Dependency state na końcu sesji:**

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -10,6 +10,7 @@ import { AssetsListPage } from '@/features/asset/assets/list';
 import { AssetShowPage } from '@/features/asset/assets/show';
 import { AttributeGroupsListPage } from '@/features/catalog/attribute-groups/list';
 import { AttributesListPage } from '@/features/catalog/attributes/list';
+import { MigrateAttributeTypePage } from '@/features/catalog/attributes/migrate-type';
 import { AttributeShowPage } from '@/features/catalog/attributes/show';
 import { CategoriesTreePage } from '@/features/catalog/categories/list';
 import { CategoryShowPage } from '@/features/catalog/categories/show';
@@ -97,6 +98,7 @@ function App() {
               <Route path="object-types/:id" element={<ObjectTypeShowPage />} />
               <Route path="attributes" element={<AttributesListPage />} />
               <Route path="attributes/:id" element={<AttributeShowPage />} />
+              <Route path="attributes/:id/migrate-type" element={<MigrateAttributeTypePage />} />
               <Route path="attribute-groups" element={<AttributeGroupsListPage />} />
               <Route path="categories" element={<CategoriesTreePage />} />
               <Route path="categories/:id" element={<CategoryShowPage />} />

--- a/apps/admin/src/features/catalog/attributes/migrate-type.tsx
+++ b/apps/admin/src/features/catalog/attributes/migrate-type.tsx
@@ -1,0 +1,372 @@
+import { useOne } from '@refinedev/core';
+import { ArrowLeft, Loader2, Wand2 } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useNavigate, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { HttpError, jsonFetch } from '@/lib/http';
+
+import { resolveLabel } from './list';
+
+/**
+ * UI-08.12 (#267) — `<MigrateTypePage>` (route `/modeling/attributes/:id/migrate-type`).
+ *
+ * Wires the UI-08.6 backend (`POST /api/attributes/{id}/migrate-type`)
+ * into a 3-section flow:
+ *
+ *   1. Target type picker.
+ *   2. Mapping plan editor — empty by default; "Suggest mappings" button
+ *      fires a dry-run with empty mapping plan and renders the
+ *      planner's view (rowCount / distinctValues / unmapped values
+ *      with counts) so the operator can craft a plan informed by the
+ *      real corpus.
+ *   3. Apply controls — backupSnapshot, force, dryRun checkboxes +
+ *      Cancel / Dry-run / Apply buttons.
+ *
+ * Modeled as a page (not a dialog/modal) for two reasons:
+ *   - we don't have a Radix Dialog primitive yet, and Sheet's right-
+ *     drawer affordance is too cramped for the mapping table;
+ *   - back-button + deep-linkable URL is a better UX for a destructive
+ *     workflow than a modal that vanishes on accidental click-outside.
+ */
+
+interface AttributeDetail {
+  id: string;
+  code: string;
+  label?: Record<string, string> | string | null;
+  type: string;
+  system?: boolean;
+}
+
+interface MappingRow {
+  from: string;
+  to: string;
+  count: number;
+}
+
+interface UnmappedRow {
+  value: string;
+  count: number;
+}
+
+interface MigrationAnalysis {
+  compatibility: 'safe' | 'requires_force' | 'blocked';
+  rowCount: number;
+  distinctValues: number;
+  mappings: MappingRow[];
+  unmapped: UnmappedRow[];
+  forceRequired: boolean;
+  blockedReason: string | null;
+}
+
+interface MigrationResponse {
+  dryRun: boolean;
+  analysis: MigrationAnalysis;
+}
+
+const TARGET_TYPES = ['text', 'number', 'select', 'multiselect', 'date', 'boolean'] as const;
+
+type TargetType = (typeof TARGET_TYPES)[number];
+
+interface MappingDraft {
+  from: string;
+  to: string;
+}
+
+export function MigrateAttributeTypePage() {
+  const { t, i18n } = useTranslation();
+  const params = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const id = params.id ?? '';
+
+  const { result, query } = useOne<AttributeDetail>({
+    resource: 'attributes',
+    id,
+    queryOptions: { enabled: id.length > 0 },
+  });
+
+  const [targetType, setTargetType] = useState<TargetType>('select');
+  const [mappings, setMappings] = useState<MappingDraft[]>([]);
+  const [unmappedAction, setUnmappedAction] = useState<'null' | 'skip'>('null');
+  const [backupSnapshot, setBackupSnapshot] = useState(true);
+  const [force, setForce] = useState(false);
+  const [analysis, setAnalysis] = useState<MigrationAnalysis | null>(null);
+  const [submitting, setSubmitting] = useState<'idle' | 'dryrun' | 'apply'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = useCallback(
+    async (dryRun: boolean) => {
+      setError(null);
+      setSubmitting(dryRun ? 'dryrun' : 'apply');
+      try {
+        const body = {
+          targetType,
+          mappingPlan: mappings.filter((row) => row.from !== '' && row.to !== ''),
+          unmappedAction,
+          force,
+          dryRun,
+          backupSnapshot,
+        };
+        const response = await jsonFetch<MigrationResponse>(`/api/attributes/${id}/migrate-type`, {
+          method: 'POST',
+          contentType: 'application/json',
+          accept: 'application/json',
+          body,
+        });
+        setAnalysis(response.analysis);
+        if (!dryRun) {
+          // Apply succeeded → bounce back to the attribute detail page.
+          navigate(`/modeling/attributes/${id}`, { replace: true });
+        }
+      } catch (err) {
+        if (err instanceof HttpError) {
+          const detail =
+            err.body && typeof err.body === 'object' && 'detail' in err.body
+              ? String((err.body as Record<string, unknown>).detail)
+              : null;
+          setError(detail ?? `HTTP ${err.status}`);
+        } else {
+          setError(t('modeling.attributes.migration.error_generic'));
+        }
+      } finally {
+        setSubmitting('idle');
+      }
+    },
+    [id, targetType, mappings, unmappedAction, force, backupSnapshot, navigate, t],
+  );
+
+  /**
+   * Dry-run with the *current* mapping plan but only to surface the
+   * unmapped list. We populate the editor's draft mappings from the
+   * unmapped values so the user can fill targets row by row.
+   */
+  const suggestMappings = useCallback(async () => {
+    setError(null);
+    setSubmitting('dryrun');
+    try {
+      const response = await jsonFetch<MigrationResponse>(`/api/attributes/${id}/migrate-type`, {
+        method: 'POST',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: { targetType, mappingPlan: [], unmappedAction: 'null', dryRun: true },
+      });
+      setAnalysis(response.analysis);
+      const drafts: MappingDraft[] = response.analysis.unmapped.map((row) => ({
+        from: row.value,
+        to: '',
+      }));
+      setMappings(drafts);
+    } catch (err) {
+      if (err instanceof HttpError) {
+        const detail =
+          err.body && typeof err.body === 'object' && 'detail' in err.body
+            ? String((err.body as Record<string, unknown>).detail)
+            : null;
+        setError(detail ?? `HTTP ${err.status}`);
+      } else {
+        setError(t('modeling.attributes.migration.error_generic'));
+      }
+    } finally {
+      setSubmitting('idle');
+    }
+  }, [id, targetType, t]);
+
+  if (query.isLoading || !result) {
+    return <p className="text-sm text-muted-foreground">{t('app.loading')}</p>;
+  }
+
+  const attribute = result;
+  const label = resolveLabel(attribute.label, i18n.language);
+
+  if (attribute.system === true) {
+    return (
+      <div className="space-y-3">
+        <Button asChild variant="ghost" size="sm" className="-ml-3">
+          <Link to={`/modeling/attributes/${attribute.id}`}>
+            <ArrowLeft className="size-4" />
+            {t('attributes.back')}
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {t('modeling.attributes.migration.title', { name: label })}
+        </h1>
+        <p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          {t('modeling.attributes.system_immutable_note')}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <Button asChild variant="ghost" size="sm" className="-ml-3">
+          <Link to={`/modeling/attributes/${attribute.id}`}>
+            <ArrowLeft className="size-4" />
+            {t('attributes.back')}
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {t('modeling.attributes.migration.title', { name: label })}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t('modeling.attributes.migration.description', {
+            from: attribute.type,
+          })}
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="space-y-4 pt-6">
+          <div className="grid gap-2">
+            <Label htmlFor="target-type">{t('modeling.attributes.migration.target_type')}</Label>
+            <select
+              id="target-type"
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+              value={targetType}
+              onChange={(e) => setTargetType(e.target.value as TargetType)}
+            >
+              {TARGET_TYPES.filter((type) => type !== attribute.type).map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="button" variant="outline" size="sm" onClick={suggestMappings}>
+              <Wand2 className="size-4" />
+              {t('modeling.attributes.migration.suggest')}
+            </Button>
+            {analysis ? (
+              <span className="text-xs text-muted-foreground">
+                {t('modeling.attributes.migration.analysis_summary', {
+                  rows: analysis.rowCount,
+                  distinct: analysis.distinctValues,
+                  unmapped: analysis.unmapped.length,
+                })}
+              </span>
+            ) : null}
+          </div>
+
+          {analysis && analysis.compatibility === 'blocked' ? (
+            <p className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              {analysis.blockedReason ?? t('modeling.attributes.migration.blocked')}
+            </p>
+          ) : null}
+
+          {analysis?.forceRequired ? (
+            <p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              {t('modeling.attributes.migration.force_required')}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3 pt-6">
+          <h2 className="text-sm font-semibold">
+            {t('modeling.attributes.migration.mapping_plan')}
+          </h2>
+          {mappings.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t('modeling.attributes.migration.mapping_empty')}
+            </p>
+          ) : (
+            <div className="grid gap-2">
+              {mappings.map((row, idx) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: mapping rows are keyed by source value (idx tiebreak only); rows never reorder during edit.
+                <div key={`${row.from}-${idx}`} className="flex items-center gap-2 text-sm">
+                  <span className="flex-1 rounded bg-muted px-2 py-1 font-mono text-xs">
+                    {row.from}
+                  </span>
+                  <span className="text-muted-foreground">→</span>
+                  <Input
+                    aria-label={t('modeling.attributes.migration.mapping_target_label', {
+                      from: row.from,
+                    })}
+                    className="flex-1"
+                    value={row.to}
+                    onChange={(e) =>
+                      setMappings((rows) =>
+                        rows.map((r, i) => (i === idx ? { ...r, to: e.target.value } : r)),
+                      )
+                    }
+                    placeholder={t('modeling.attributes.migration.mapping_target_placeholder')}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3 pt-6">
+          <h2 className="text-sm font-semibold">{t('modeling.attributes.migration.controls')}</h2>
+
+          <div className="grid gap-2">
+            <Label htmlFor="unmapped-action">
+              {t('modeling.attributes.migration.unmapped_action')}
+            </Label>
+            <select
+              id="unmapped-action"
+              className="h-9 rounded-md border border-input bg-background px-3 text-sm shadow-sm"
+              value={unmappedAction}
+              onChange={(e) => setUnmappedAction(e.target.value as 'null' | 'skip')}
+            >
+              <option value="null">{t('modeling.attributes.migration.unmapped_null')}</option>
+              <option value="skip">{t('modeling.attributes.migration.unmapped_skip')}</option>
+            </select>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={backupSnapshot}
+              onChange={(e) => setBackupSnapshot(e.target.checked)}
+            />
+            {t('modeling.attributes.migration.backup_snapshot')}
+          </label>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={force} onChange={(e) => setForce(e.target.checked)} />
+            {t('modeling.attributes.migration.force')}
+          </label>
+        </CardContent>
+      </Card>
+
+      {error !== null ? (
+        <p className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button asChild variant="ghost">
+          <Link to={`/modeling/attributes/${attribute.id}`}>
+            {t('modeling.attributes.migration.cancel')}
+          </Link>
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={submitting !== 'idle'}
+          onClick={() => submit(true)}
+        >
+          {submitting === 'dryrun' ? <Loader2 className="size-4 animate-spin" /> : null}
+          {t('modeling.attributes.migration.dry_run')}
+        </Button>
+        <Button type="button" disabled={submitting !== 'idle'} onClick={() => submit(false)}>
+          {submitting === 'apply' ? <Loader2 className="size-4 animate-spin" /> : null}
+          {t('modeling.attributes.migration.apply')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -1,5 +1,5 @@
 import { useOne } from '@refinedev/core';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Wand2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 
@@ -56,6 +56,14 @@ export function AttributeShowPage() {
         <div className="flex flex-wrap items-center gap-2">
           <h1 className="text-2xl font-semibold tracking-tight">{label}</h1>
           {attribute.system ? <BuiltInLockBadge /> : null}
+          {!attribute.system ? (
+            <Button asChild variant="outline" size="sm" className="ml-auto">
+              <Link to={`/modeling/attributes/${attribute.id}/migrate-type`}>
+                <Wand2 className="size-4" />
+                {t('modeling.attributes.migration.action_label')}
+              </Link>
+            </Button>
+          ) : null}
         </div>
         <p className="font-mono text-xs text-muted-foreground">{attribute.code}</p>
       </div>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -415,7 +415,31 @@
       "filter_flags": "Flags",
       "usage_count": "Usages",
       "preview_title": "Preview",
-      "system_immutable_note": "System attribute — code, type, and validation are immutable."
+      "system_immutable_note": "System attribute — code, type, and validation are immutable.",
+      "migration": {
+        "action_label": "Migrate type →",
+        "title": "Migrate type — {{name}}",
+        "description": "Change the data type of this attribute. Current type: {{from}}. Existing values will be re-shaped per the mapping plan; the original payload is snapshotted into attribute_migration_backups before any update.",
+        "target_type": "Target type",
+        "suggest": "Suggest mappings (dry-run)",
+        "analysis_summary": "Rows: {{rows}} · Distinct: {{distinct}} · Unmapped: {{unmapped}}",
+        "mapping_plan": "Mapping plan",
+        "mapping_empty": "Click \"Suggest mappings\" to inspect existing values.",
+        "mapping_target_label": "Target value for \"{{from}}\"",
+        "mapping_target_placeholder": "option_code",
+        "controls": "Controls",
+        "unmapped_action": "For values without a mapping",
+        "unmapped_null": "Write null",
+        "unmapped_skip": "Skip (leave row untouched)",
+        "backup_snapshot": "Snapshot existing values into attribute_migration_backups (recommended).",
+        "force": "Force destructive migration (e.g. multiselect → select picks first).",
+        "dry_run": "Dry-run",
+        "apply": "Apply migration",
+        "cancel": "Cancel",
+        "blocked": "This migration path is not supported in MVP.",
+        "force_required": "This migration is destructive. Tick Force to confirm.",
+        "error_generic": "Could not run migration. Check your input or retry."
+      }
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -415,7 +415,31 @@
       "filter_flags": "Flagi",
       "usage_count": "Użycia",
       "preview_title": "Podgląd",
-      "system_immutable_note": "Atrybut systemowy — code, typ i walidacja są niezmienne."
+      "system_immutable_note": "Atrybut systemowy — code, typ i walidacja są niezmienne.",
+      "migration": {
+        "action_label": "Migracja typu →",
+        "title": "Migracja typu — {{name}}",
+        "description": "Zmień typ danych tego atrybutu. Aktualny typ: {{from}}. Istniejące wartości zostaną przekształcone wg planu mapowania; oryginalny payload jest snapshotowany do attribute_migration_backups przed jakimkolwiek update'em.",
+        "target_type": "Typ docelowy",
+        "suggest": "Podpowiedz mappingi (dry-run)",
+        "analysis_summary": "Wierszy: {{rows}} · Distinct: {{distinct}} · Bez mapowania: {{unmapped}}",
+        "mapping_plan": "Plan mapowania",
+        "mapping_empty": "Kliknij \"Podpowiedz mappingi\" żeby zobaczyć istniejące wartości.",
+        "mapping_target_label": "Wartość docelowa dla \"{{from}}\"",
+        "mapping_target_placeholder": "option_code",
+        "controls": "Kontrolki",
+        "unmapped_action": "Wartości bez mapowania",
+        "unmapped_null": "Zapisz null",
+        "unmapped_skip": "Pomiń (nie zmieniaj wiersza)",
+        "backup_snapshot": "Zrób snapshot wartości do attribute_migration_backups (zalecane).",
+        "force": "Wymuś destruktywną migrację (np. multiselect → select bierze pierwszy).",
+        "dry_run": "Dry-run",
+        "apply": "Wykonaj migrację",
+        "cancel": "Anuluj",
+        "blocked": "Ta ścieżka migracji nie jest wspierana w MVP.",
+        "force_required": "Ta migracja jest destruktywna. Zaznacz Wymuś żeby potwierdzić.",
+        "error_generic": "Nie udało się uruchomić migracji. Sprawdź input lub spróbuj ponownie."
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- `<MigrateAttributeTypePage>` na route `/modeling/attributes/:id/migrate-type` (route-based, nie dialog).
- 3-section flow: Target type picker → Suggest mappings (dry-run populates draft) → Apply controls.
- `+ Migrate type →` button na attribute show (hidden dla system attrs).
- i18n `modeling.attributes.migration.*` en+pl.

## Świadome odejścia vs spec

- **Modal vs page** — issue prosił o modal Dialog, ale brak Radix Dialog primitive'u + UX route'a (back, deep-link) lepszy dla destrukcyjnego workflow. Zwalidowany pattern (UI-08.12 self-doc) — przy potrzebie modalu podmienia się outer wrapper bez ruszania logic'a.
- **TanStack Table z auto-suggest highlight** odroczone — Suggest button populates mapping editor (Input per row) z unmapped values. Auto-merge case-insensitive duplicate detection robi już backend planner (#UI-08.6) — UI dostaje prostą listę.
- **Bulk row select → map to common value** odroczone — operator wpisuje to samo w kilka rzędów; bulk picker to czysta optymalizacja UX, follow-up.
- **Progress indicator dla >1000 rows** odroczone — backend executor jest sync, jeden HTTP request. Long-running migration wymaga Messenger handler (poza scope MVP per UI-08.6 issue).

## Test plan

- [x] Biome strict + tsc + Vite build — clean.
- [x] Manual smoke wymaga rebuilda admin'a — operator może klikąć `Migrate type →` na attribute show, dry-run zwraca counts; Apply nie testowany destruktywnie żeby nie psuć dev DB.
- [ ] Playwright — wpisany jako out-of-scope (rate-limit budget tight + destruktywny test wymaga reset DB między run'ami).

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)