### PR TITLE
[UI-08.14] Categories effective-groups preview — the killer feature (#269)

### DIFF
--- a/Project Plan/02-plan-projektu-pim.md
+++ b/Project Plan/02-plan-projektu-pim.md
@@ -437,7 +437,7 @@ Pierwszy epik napędzany **planem UI** (`Project Plan/UI/`) zamiast backend road
 | ✅ **#266** | UI-08.11 Sub-tab Attributes — enhanced list + detail + Where-used | UI, frontend, must-have | 4-5h |
 | ✅ **#267** | UI-08.12 Migration impact analyzer modal | UI, frontend, must-have | 4-5h |
 | ✅ **#268** | UI-08.13 Sub-tab Attribute Groups — drag-drop + VisibleWhen editor | UI, frontend, must-have | 5-7h |
-| **#269** | UI-08.14 Sub-tab Categories modeling — tree + inheritance preview | UI, frontend, must-have | 5-7h |
+| ✅ **#269** | UI-08.14 Sub-tab Categories modeling — tree + inheritance preview | UI, frontend, must-have | 5-7h |
 | **#270** | UI-08.15 Bulk import atrybutów z CSV (US-MOD-008) — *optional* | UI, frontend, optional | 3-4h |
 
 **Dependency graph:** wszystkie sub-tickety blokowane przez `#256` (UI-08.1 ADR-012 + migracje DDL). Frontend tickety dodatkowo blokowane przez `#264` (UI-08.9 layout shell), który wymaga `#259` (form-schema endpoint).

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -30,10 +30,11 @@ Pełen kontekst: [Project Plan/UI/epik-08-modelowanie.md](../Project%20Plan/UI/e
 - ✅ **#265 UI-08.10** (PR #283) — Object Types list + show enhanced + reusable `<BuiltInLockBadge>` + `<WhereUsedList>`. Custom Create wizard świadomie odroczony.
 - ✅ **#266 UI-08.11** (PR #284) — Attributes list filtry + Usages column + `<AttributePreview>` mock-data widget; serializer XML +`system` field.
 - ✅ **#267 UI-08.12** (PR #285) — `<MigrateAttributeTypePage>` 3-step flow (target → suggest → apply) na route `/modeling/attributes/:id/migrate-type`.
-- 🚧 **#268 UI-08.13** (branch `feat/ui-08.13-attribute-groups-subtab`) — AttributeGroups sub-tab: enhanced list (search + system filter + usage counts + create/delete buttons) + create page + show page z members table (PATCH up/down reorder + inline visible_when editor wired do UI-08.8). New custom REST `GET /api/attribute_groups/{id}/attributes` (z `EffectiveAttributeGroupResolver::loadGroupAttributes` reuse). **Świadome odejścia:** brak `@dnd-kit/sortable` (zastąpione up/down PATCH'em — same UX outcome bez nowej depki); attach/detach UI follow-up (wymaga `AttachAttributeToGroup` command nieistniejącego w MVP). i18n keys `modeling.attribute_groups.*` + `modeling.visible_when.*`.
+- ✅ **#268 UI-08.13** (PR #286) — AttributeGroups sub-tab: list/create/show z PATCH up/down reorder + inline visible_when editor + new custom REST `GET /api/attribute_groups/{id}/attributes`.
+- 🚧 **#269 UI-08.14** (branch `feat/ui-08.14-categories-modeling`) — `<EffectiveAttributesPreview>` widget na category show page (PREVIEW_KINDS dropdown → fetch `/api/categories/{id}/effective-groups?objectTypeKind=...` → render dedup'd groups z `BuiltInLockBadge` + `auto_attached` chip + flat attributes list per group). New custom REST controller reusing `EffectiveAttributeGroupResolver::resolveForCategoryPreview`. Manual smoke: zwraca audit group + 4 system attrs dla product preview pod root category. **Świadome odejścia:** drag-drop reparenting (no @dnd-kit/react-arborist), tree filter per ObjectType, override-action UI, "create test object" button — wszystkie wymagają backend extensions które nie istnieją w MVP.
 
-**Pozostałe 2 tickety UI-08 (frontend):**
-- **#269** UI-08.14 (Categories modeling tree + inheritance preview), #270 UI-08.15 (bulk import CSV — optional).
+**Pozostały 1 ticket UI-08 (optional):**
+- **#270** UI-08.15 (bulk import CSV — optional, low priority).
 - **Frontend:** #264-#270 (Modeling layout shell + 4 sub-tabs + migration analyzer + drag-drop + inheritance preview + bulk import CSV).
 
 **Dependency state na końcu sesji:**

--- a/apps/admin/src/features/catalog/categories/show.tsx
+++ b/apps/admin/src/features/catalog/categories/show.tsx
@@ -1,10 +1,14 @@
 import { useOne } from '@refinedev/core';
 import { ArrowLeft } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 
+import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { HttpError, jsonFetch } from '@/lib/http';
 
 interface CategoryDetail {
   id: string;
@@ -70,9 +74,164 @@ export function CategoryShowPage() {
         </CardContent>
       </Card>
 
+      <EffectiveAttributesPreview categoryId={category.id} />
+
       <p className="text-xs text-muted-foreground">{t('categories.write_deferred_note')}</p>
     </div>
   );
+}
+
+interface EffectiveGroupRow {
+  id: string;
+  code: string;
+  label: Record<string, string> | string;
+  is_system_group: boolean;
+  auto_attached: boolean;
+  attributes: { id: string; code: string; type: string; is_system: boolean }[];
+}
+
+interface EffectiveResponse {
+  categoryId: string;
+  objectType: { id: string; code: string; kind: string; label: Record<string, string> };
+  effectiveGroups: EffectiveGroupRow[];
+}
+
+const PREVIEW_KINDS = ['product', 'category', 'asset', 'brand'] as const;
+
+type PreviewKind = (typeof PREVIEW_KINDS)[number];
+
+/**
+ * UI-08.14 (#269) — `<EffectiveAttributesPreview>`.
+ *
+ * Hits /api/categories/{id}/effective-groups?objectTypeKind=... and
+ * renders the deduplicated AttributeGroup list a hypothetical object of
+ * the picked kind would see if placed under this category. The killer
+ * feature competitors (Akeneo, Pimcore) lack natively.
+ */
+function EffectiveAttributesPreview({ categoryId }: { categoryId: string }) {
+  const { t } = useTranslation();
+  const [kind, setKind] = useState<PreviewKind>('product');
+  const [data, setData] = useState<EffectiveResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setData(null);
+
+    jsonFetch<EffectiveResponse>(
+      `/api/categories/${categoryId}/effective-groups?objectTypeKind=${kind}`,
+      { accept: 'application/json' },
+    )
+      .then((payload) => {
+        if (!cancelled) setData(payload);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(
+          err instanceof HttpError && err.status === 404
+            ? t('modeling.inheritance_preview.not_found')
+            : t('modeling.inheritance_preview.error'),
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [categoryId, kind, t]);
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 pt-6">
+        <div className="flex items-end justify-between gap-3">
+          <div className="space-y-1">
+            <h2 className="text-sm font-semibold">{t('modeling.inheritance_preview.title')}</h2>
+            <p className="text-xs text-muted-foreground">
+              {t('modeling.inheritance_preview.description')}
+            </p>
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="preview-kind" className="text-xs uppercase tracking-wide">
+              {t('modeling.inheritance_preview.target_kind')}
+            </Label>
+            <select
+              id="preview-kind"
+              className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+              value={kind}
+              onChange={(e) => setKind(e.target.value as PreviewKind)}
+            >
+              {PREVIEW_KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {k}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {loading ? (
+          <p className="text-sm text-muted-foreground">{t('app.loading')}</p>
+        ) : error !== null ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : data === null || data.effectiveGroups.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('modeling.inheritance_preview.empty')}</p>
+        ) : (
+          <ol className="space-y-2">
+            {data.effectiveGroups.map((group) => (
+              <li
+                key={group.id}
+                className="rounded-md border bg-card px-3 py-2"
+                style={
+                  typeof group.label === 'object' && group.id !== ''
+                    ? { borderLeftColor: 'transparent' }
+                    : undefined
+                }
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-xs text-muted-foreground">{group.code}</span>
+                  <span className="text-sm font-medium">{groupLabel(group.label)}</span>
+                  {group.is_system_group ? <BuiltInLockBadge tone="quiet" /> : null}
+                  {group.auto_attached ? (
+                    <span className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-blue-900">
+                      {t('modeling.attribute_groups.auto_attached')}
+                    </span>
+                  ) : null}
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {t('modeling.inheritance_preview.attribute_count', {
+                      count: group.attributes.length,
+                    })}
+                  </span>
+                </div>
+                {group.attributes.length > 0 ? (
+                  <ul className="mt-2 flex flex-wrap gap-1.5">
+                    {group.attributes.map((attr) => (
+                      <li
+                        key={attr.id}
+                        className="rounded bg-muted px-2 py-0.5 text-[11px] font-mono"
+                      >
+                        {attr.is_system ? '🔒 ' : ''}
+                        {attr.code}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function groupLabel(label: Record<string, string> | string): string {
+  if (typeof label === 'string') return label;
+  return label.en ?? label.pl ?? Object.values(label)[0] ?? '—';
 }
 
 function formatValue(value: unknown): string {

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -485,6 +485,15 @@
       "value": "Value",
       "value_placeholder": "string / true / false",
       "none": "— always visible —"
+    },
+    "inheritance_preview": {
+      "title": "Effective attribute groups preview",
+      "description": "What an object of the chosen kind would see if placed under this category.",
+      "target_kind": "For kind",
+      "attribute_count": "{{count}} attributes",
+      "empty": "No effective groups for this combination.",
+      "error": "Could not load effective groups.",
+      "not_found": "Category or ObjectType not found."
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -485,6 +485,15 @@
       "value": "Wartość",
       "value_placeholder": "string / true / false",
       "none": "— zawsze widoczne —"
+    },
+    "inheritance_preview": {
+      "title": "Podgląd efektywnych grup atrybutów",
+      "description": "Co zobaczy obiekt wybranego rodzaju umieszczony w tej kategorii.",
+      "target_kind": "Dla rodzaju",
+      "attribute_count": "{{count}} atrybutów",
+      "empty": "Brak efektywnych grup dla tej kombinacji.",
+      "error": "Nie udało się pobrać efektywnych grup.",
+      "not_found": "Nie znaleziono kategorii lub typu obiektu."
     }
   }
 }

--- a/apps/api/src/Catalog/Presentation/Controller/CategoryEffectiveGroupsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CategoryEffectiveGroupsController.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use App\Shared\Application\TenantContext;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+use ValueError;
+
+/**
+ * UI-08.14 (#269) — `GET /api/categories/{id}/effective-groups?objectTypeKind=service`.
+ *
+ * Returns the effective AttributeGroup list a hypothetical object of
+ * the given target ObjectType would see if placed under this category.
+ * Powers the `<EffectiveAttributesPreview>` widget on the category
+ * detail page — the killer feature competitors lack.
+ *
+ * Reuses {@see EffectiveAttributeGroupResolver::resolveForCategoryPreview}
+ * directly (UI-08.4 domain service); the layered resolution + dedup
+ * logic is identical to the one we feed to the form-renderer when an
+ * object exists. Output schema mirrors `ObjectFormSchema` from UI-08.4
+ * so the frontend can reuse the same projection.
+ *
+ * Query params:
+ *   - `objectTypeKind` (required) — `product` / `category` / `asset` /
+ *     `brand` / future `custom`. Identifies which ObjectType (per
+ *     tenant) to resolve groups for.
+ */
+final class CategoryEffectiveGroupsController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly EffectiveAttributeGroupResolver $resolver,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    #[Route(
+        '/api/categories/{id}/effective-groups',
+        name: 'pim_categories_effective_groups',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(string $id, Request $request): JsonResponse
+    {
+        $kindParam = $request->query->get('objectTypeKind');
+        if (!\is_string($kindParam) || '' === $kindParam) {
+            throw new BadRequestHttpException('objectTypeKind query parameter is required.');
+        }
+        try {
+            $kind = ObjectKind::from($kindParam);
+        } catch (ValueError $e) {
+            throw new BadRequestHttpException(\sprintf('Unknown objectTypeKind "%s".', $kindParam), $e);
+        }
+
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+
+        $type = $this->objectTypes->findBuiltInByKind($kind, $tenant);
+        if (null === $type) {
+            throw new NotFoundHttpException(\sprintf('Built-in ObjectType for kind "%s" not found.', $kindParam));
+        }
+
+        $category = $this->objects->findById(Uuid::fromString($id));
+        if (null === $category) {
+            throw new NotFoundHttpException(\sprintf('Category "%s" was not found.', $id));
+        }
+
+        $groups = $this->resolver->resolveForCategoryPreview($type, $category);
+        $byGroup = $this->resolver->loadGroupAttributes($groups);
+
+        $effective = [];
+        foreach ($groups as $position => $group) {
+            $junctions = $byGroup[$group->getId()->toRfc4122()] ?? [];
+            $attributes = [];
+            foreach ($junctions as $j) {
+                $attribute = $j->getAttribute();
+                $attributes[] = [
+                    'id' => $attribute->getId()->toRfc4122(),
+                    'code' => $attribute->getCode(),
+                    'type' => $attribute->getType()->value,
+                    'label' => $attribute->getLabel(),
+                    'is_system' => $attribute->isSystem(),
+                    'position' => $j->getPosition(),
+                    'is_required_in_group' => $j->isRequiredInGroup(),
+                    'visible_when' => $j->getVisibleWhen(),
+                ];
+            }
+            $effective[] = [
+                'id' => $group->getId()->toRfc4122(),
+                'code' => $group->getCode(),
+                'label' => $group->getLabel(),
+                'description' => $group->getDescription(),
+                'icon' => $group->getIcon(),
+                'color' => $group->getColor(),
+                'is_system_group' => $group->isSystemGroup(),
+                'auto_attached' => $group->isAutoAttached(),
+                'position' => $position,
+                'attributes' => $attributes,
+            ];
+        }
+
+        return new JsonResponse([
+            'categoryId' => $category->getId()->toRfc4122(),
+            'objectType' => [
+                'id' => $type->getId()->toRfc4122(),
+                'code' => $type->getCode(),
+                'kind' => $type->getKind()->value,
+                'label' => $type->getLabel(),
+            ],
+            'effectiveGroups' => $effective,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- Backend: new custom REST `GET /api/categories/{id}/effective-groups?objectTypeKind=...` reusing `EffectiveAttributeGroupResolver::resolveForCategoryPreview` (UI-08.4).
- Frontend: `<EffectiveAttributesPreview>` widget na category show page z kind picker (`product/category/asset/brand`) + render dedup'd groups z lock badges + flat attribute pills.

## Świadome odejścia

- **Drag-drop reparenting tree** — wymaga `@dnd-kit/sortable` lub `react-arborist` (3 deps) + change-parent endpoint flow.
- **ObjectType filter na tree** — niska wartość bez liczby kategorii, którą jeszcze nie mamy.
- **Override-action UI** ("hide inherited group") — wymaga `override_action` kolumny na `category_attribute_groups` której nie ma.
- **"Create test object in this category"** — `enable_custom_object_types=false` w MVP.

Tree w `categories/list.tsx` zostaje read-only z poprzedniego ticketu (#0.6.5).

## Test plan

- [x] Biome strict + tsc + Vite build — clean.
- [x] PHPStan max + Deptrac — clean (0 violations po przesiadce z `CurrentTenantProvider` na `Shared\Application\TenantContext`).
- [x] Manual smoke: GET dla demo category zwraca audit group + 4 system attrs (datetime + reference) dla product preview.

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)