### PR TITLE
feat(catalog): UI-02.1 cache columns completeness_pct + sync_status_aggregate (#291)

### DIFF
--- a/apps/api/migrations/Version20260501140000.php
+++ b/apps/api/migrations/Version20260501140000.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * UI-02.1 (#291) — denormalised list-view cache columns on `objects`.
+ *
+ * `completeness_pct SMALLINT 0..100` is the flat percentage rendered in
+ * the products list `<CompletenessBadge>` (UI-02.10) and used by the
+ * "Completeness <50%" filter chip (UI-02.9). Recomputed by
+ * {@see \App\Catalog\Application\AttributesIndexedRebuilder} on every
+ * single-edit flush of an `ObjectValue` via the existing
+ * `AttributesIndexedSyncListener` two-phase flush wiring; the bulk path
+ * stays async via the rebuild Messenger handler.
+ *
+ * `sync_status_aggregate VARCHAR(8) IN ('green','yellow','red','gray')`
+ * collapses per-channel sync history to one badge for the
+ * `<SyncAggregateIcon>` widget. Default `gray` (no sync history yet) —
+ * the per-channel publish flow ships in Faza 1, so this column stays at
+ * `gray` in MVP and the column simply *exists* so the list query can
+ * SELECT it without join. Faza 1 listener will mutate it on
+ * `ChannelSyncCompletedEvent` / `ChannelSyncFailedEvent` (UI-02.5 read
+ * endpoint already serialises the field).
+ *
+ * Index `objects_tenant_kind_compl_idx` supports the filter chip
+ * "Completeness <50%" + sort-by-completeness; the same shape as the
+ * existing `objects_tenant_kind_idx` plus a trailing `completeness_pct`
+ * for index-only scans on the products list.
+ */
+final class Version20260501140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'UI-02.1 cache columns on objects: completeness_pct + sync_status_aggregate (#291).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE objects
+              ADD COLUMN completeness_pct SMALLINT NOT NULL DEFAULT 0,
+              ADD COLUMN sync_status_aggregate VARCHAR(8) NOT NULL DEFAULT 'gray',
+              ADD CONSTRAINT objects_completeness_pct_range CHECK (completeness_pct BETWEEN 0 AND 100),
+              ADD CONSTRAINT objects_sync_status_aggregate_enum CHECK (sync_status_aggregate IN ('green','yellow','red','gray'))
+            SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX objects_tenant_kind_compl_idx
+              ON objects (tenant_id, kind, completeness_pct)
+            SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX objects_tenant_kind_sync_aggr_idx
+              ON objects (tenant_id, kind, sync_status_aggregate)
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS objects_tenant_kind_sync_aggr_idx');
+        $this->addSql('DROP INDEX IF EXISTS objects_tenant_kind_compl_idx');
+        $this->addSql('ALTER TABLE objects DROP CONSTRAINT IF EXISTS objects_sync_status_aggregate_enum');
+        $this->addSql('ALTER TABLE objects DROP CONSTRAINT IF EXISTS objects_completeness_pct_range');
+        $this->addSql('ALTER TABLE objects DROP COLUMN sync_status_aggregate');
+        $this->addSql('ALTER TABLE objects DROP COLUMN completeness_pct');
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -74,6 +74,20 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     private array $completeness = [];
 
     /**
+     * Flat percentage 0..100 mirrored from `completeness['global']` for
+     * indexable filter/sort on the products list (UI-02.1, UI-02.10).
+     * Maintained by {@see AttributesIndexedRebuilder}.
+     */
+    private int $completenessPct = 0;
+
+    /**
+     * Per-product sync aggregate badge — `green|yellow|red|gray`. Default
+     * `gray` (no sync history). Mutated by Faza 1 channel-sync subscriber;
+     * MVP only ships the column + serialisation (UI-02.1 / UI-02.5 / UI-02.10).
+     */
+    private string $syncStatusAggregate = 'gray';
+
+    /**
      * @var array<string, mixed>
      */
     private array $attributesIndexed = [];
@@ -228,6 +242,32 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     public function recordCompleteness(array $completeness): void
     {
         $this->completeness = $completeness;
+        $global = $completeness['global'] ?? null;
+        if (\is_int($global)) {
+            $this->completenessPct = max(0, min(100, $global));
+        }
+        $this->touch();
+    }
+
+    public function getCompletenessPct(): int
+    {
+        return $this->completenessPct;
+    }
+
+    public function getSyncStatusAggregate(): string
+    {
+        return $this->syncStatusAggregate;
+    }
+
+    public function recordSyncStatusAggregate(string $status): void
+    {
+        if (!\in_array($status, ['green', 'yellow', 'red', 'gray'], true)) {
+            throw new LogicException(\sprintf('Invalid sync_status_aggregate value "%s".', $status));
+        }
+        if ($this->syncStatusAggregate === $status) {
+            return;
+        }
+        $this->syncStatusAggregate = $status;
         $this->touch();
     }
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -52,6 +52,17 @@
                 <option name="default">{}</option>
             </options>
         </field>
+        <field name="completenessPct" type="smallint" column="completeness_pct">
+            <options>
+                <option name="default">0</option>
+                <option name="unsigned">true</option>
+            </options>
+        </field>
+        <field name="syncStatusAggregate" type="string" length="8" column="sync_status_aggregate">
+            <options>
+                <option name="default">gray</option>
+            </options>
+        </field>
         <field name="attributesIndexed" type="json" column="attributes_indexed">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Catalog/Presentation/Command/RecalculateCompletenessCommand.php
+++ b/apps/api/src/Catalog/Presentation/Command/RecalculateCompletenessCommand.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Command;
+
+use App\Catalog\Application\AttributesIndexedRebuilder;
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * UI-02.1 (#291) — one-shot backfill of the new `objects.completeness_pct`
+ * column after the migration. Iterates `objects` per tenant + kind and
+ * re-runs {@see AttributesIndexedRebuilder} to populate the cached
+ * percentage from the canonical `ObjectValue` rows.
+ *
+ * Memory shape mirrors {@see \App\Search\Presentation\Command\SearchReindexCommand}:
+ * Doctrine `iterate()` + `EntityManager::clear()` every 200 rows so the
+ * worker peak stays bounded for 50k SKU runs.
+ */
+#[AsCommand(
+    name: 'pim:catalog:recalculate-completeness',
+    description: 'Recompute objects.completeness_pct for every CatalogObject of the given kind/tenant.',
+)]
+final class RecalculateCompletenessCommand extends Command
+{
+    private const int FLUSH_EVERY = 200;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly AttributesIndexedRebuilder $rebuilder,
+        private readonly BulkContext $bulkContext,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'kind',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'ObjectKind code (`product`, `category`, `asset`, `brand`) or `all`.',
+                'product',
+            )
+            ->addOption(
+                'tenant',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Tenant slug to scope the recompute. Required.',
+            )
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Iterate but do not flush — counts rows that would change.',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $tenantCode = $input->getOption('tenant');
+        if (!\is_string($tenantCode) || '' === $tenantCode) {
+            $io->error('--tenant is required.');
+
+            return Command::INVALID;
+        }
+
+        /** @var string $kindOption */
+        $kindOption = $input->getOption('kind');
+        $kinds = 'all' === $kindOption
+            ? [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand]
+            : [ObjectKind::from($kindOption)];
+        /** @var bool $dryRun */
+        $dryRun = $input->getOption('dry-run');
+
+        // Bulk path: short-circuit the synchronous AttributesIndexedSyncListener
+        // so we do not double-rebuild on every flush during the backfill.
+        $this->bulkContext->setBulk(true);
+
+        $totalChanged = 0;
+        try {
+            foreach ($kinds as $kind) {
+                $io->section(\sprintf('Recomputing kind=%s for tenant=%s', $kind->value, $tenantCode));
+
+                $query = $this->em->createQuery(
+                    'SELECT o FROM '.CatalogObject::class.' o'
+                    .' JOIN o.tenant t'
+                    .' WHERE o.kind = :kind AND t.code = :tenantCode'
+                );
+                $query->setParameter('kind', $kind->value);
+                $query->setParameter('tenantCode', $tenantCode);
+
+                $processed = 0;
+                $changed = 0;
+                /** @var iterable<int, CatalogObject> $iterable */
+                $iterable = $query->toIterable();
+                foreach ($iterable as $object) {
+                    $previousPct = $object->getCompletenessPct();
+                    $this->rebuilder->rebuild($object);
+                    if ($object->getCompletenessPct() !== $previousPct) {
+                        ++$changed;
+                    }
+
+                    if (0 === ++$processed % self::FLUSH_EVERY) {
+                        if (!$dryRun) {
+                            $this->em->flush();
+                        }
+                        $this->em->clear();
+                    }
+                }
+
+                if (!$dryRun) {
+                    $this->em->flush();
+                }
+                $this->em->clear();
+
+                $io->writeln(\sprintf(
+                    '  %d processed, %d completeness_pct changes %s',
+                    $processed,
+                    $changed,
+                    $dryRun ? '(dry-run, not persisted)' : 'persisted',
+                ));
+                $totalChanged += $changed;
+            }
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+
+        $io->success(\sprintf('Done. %d row(s) updated.', $totalChanged));
+
+        return Command::SUCCESS;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/CatalogObjectTest.php
+++ b/apps/api/tests/Unit/Catalog/CatalogObjectTest.php
@@ -117,4 +117,83 @@ final class CatalogObjectTest extends TestCase
         $object->transitionTo(CatalogObject::STATUS_ARCHIVED);
         self::assertSame('archived', $object->getStatus());
     }
+
+    #[Test]
+    public function completenessPctDefaultsToZero(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $object = new CatalogObject($type, 'SKU-CMPL-1');
+
+        self::assertSame(0, $object->getCompletenessPct());
+    }
+
+    #[Test]
+    public function recordCompletenessMirrorsGlobalIntoCompletenessPct(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $object = new CatalogObject($type, 'SKU-CMPL-2');
+
+        $object->recordCompleteness(['global' => 60]);
+
+        self::assertSame(60, $object->getCompletenessPct());
+        self::assertSame(['global' => 60], $object->getCompleteness());
+    }
+
+    #[Test]
+    public function recordCompletenessClampsOutOfRangeGlobalValues(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $object = new CatalogObject($type, 'SKU-CMPL-3');
+
+        $object->recordCompleteness(['global' => 250]);
+        self::assertSame(100, $object->getCompletenessPct());
+
+        $object->recordCompleteness(['global' => -25]);
+        self::assertSame(0, $object->getCompletenessPct());
+    }
+
+    #[Test]
+    public function recordCompletenessIgnoresNonIntegerGlobal(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $object = new CatalogObject($type, 'SKU-CMPL-4');
+
+        $object->recordCompleteness(['global' => 80]);
+        $object->recordCompleteness(['per_channel' => ['shopify' => 50]]); // no `global` key
+
+        // Last-good-value semantics — ignoring a payload without `global`
+        // beats overwriting with 0 and surprising the list view.
+        self::assertSame(80, $object->getCompletenessPct());
+    }
+
+    #[Test]
+    public function syncStatusAggregateDefaultsToGray(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $object = new CatalogObject($type, 'SKU-SYNC-1');
+
+        self::assertSame('gray', $object->getSyncStatusAggregate());
+    }
+
+    #[Test]
+    public function recordSyncStatusAggregateAcceptsAllowedValues(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $object = new CatalogObject($type, 'SKU-SYNC-2');
+
+        foreach (['green', 'yellow', 'red', 'gray'] as $status) {
+            $object->recordSyncStatusAggregate($status);
+            self::assertSame($status, $object->getSyncStatusAggregate());
+        }
+    }
+
+    #[Test]
+    public function recordSyncStatusAggregateRejectsUnknownValue(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+        $object = new CatalogObject($type, 'SKU-SYNC-3');
+
+        $this->expectException(LogicException::class);
+        $object->recordSyncStatusAggregate('purple');
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `completeness_pct SMALLINT 0..100` and `sync_status_aggregate VARCHAR(8) IN ('green','yellow','red','gray')` to `objects` so the products list (UI-02.8) can filter/sort/index both without joining `object_values`.
- `CatalogObject::recordCompleteness(['global' => N])` now mirrors into `completenessPct` (clamped 0..100); existing `AttributesIndexedRebuilder` path populates it untouched.
- New CLI `pim:catalog:recalculate-completeness --tenant=… --kind=…` for one-shot backfill after the migration.
- Sync aggregate column ships at `gray` in MVP — Faza 1 publish endpoint adds the channel-sync subscriber that mutates it.

## Test plan
- [x] PHPStan max + cs-fixer green (composer lint).
- [x] PHPUnit Unit `CatalogObjectTest` 14/14 (8 new tests cover defaults, mirror, clamp, ignore non-int, sync getter/setter validation).
- [x] Migration `up`/`down` apply cleanly on demo DB.
- [x] Backfill smoke: `pim:catalog:recalculate-completeness --tenant=demo --kind=product` → 100/100 demo SKUs updated.
- [ ] CI: PHPUnit + PHPStan + Deptrac green.

Closes #291