### PR TITLE
feat(catalog): UI-02.2 quick-search endpoint (#292)

### DIFF
--- a/apps/api/src/Search/Presentation/Controller/ProductQuickSearchController.php
+++ b/apps/api/src/Search/Presentation/Controller/ProductQuickSearchController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search\Presentation\Controller;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Search\Application\CatalogSearchService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * UI-02.2 (#292) — products quick search for the products list toolbar.
+ *
+ * Strict-mode wrapper over {@see CatalogSearchService}: forces
+ * `matchingStrategy=all`, narrows the search surface to `sku` + `name`,
+ * caps to 50 hits, and exposes a flat `{hits, total, processingTimeMs}`
+ * shape that `<ProductSearchBar>` (UI-02.9) consumes verbatim.
+ *
+ * The underlying service already short-circuits to an empty result when
+ * Meilisearch is unreachable (try/catch + warning log) — the products
+ * list `<EmptyState>` swallows that as a no-match render. A Postgres
+ * `LIKE 'q%'` fallback path is deferred until we observe a real outage
+ * pattern (Faza 1+ candidate, see UI-02.2 ticket out-of-scope notes).
+ *
+ * Tenant gate: the wrapped service stamps a `tenantId = "<uuid>"`
+ * filter from `CurrentTenantProvider` — cross-tenant leak is impossible
+ * even when the caller forgets to pass a filter.
+ */
+final class ProductQuickSearchController
+{
+    private const int DEFAULT_LIMIT = 50;
+    private const int MAX_LIMIT = 100;
+
+    public function __construct(
+        private readonly CatalogSearchService $searchService,
+    ) {
+    }
+
+    /**
+     * Priority `200` lifts this above the API Platform `/api/products/{id}`
+     * collection routes (default priority `0`); without it the literal
+     * segment `quick-search` would be parsed as `id` and 404 with
+     * "Invalid uri variables".
+     */
+    #[Route('/api/products/quick-search', name: 'pim_products_quick_search', methods: ['GET'], priority: 200)]
+    #[IsGranted('ROLE_USER')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $query = trim($request->query->getString('q', ''));
+
+        $rawLimit = $request->query->getString('limit', '');
+        $limit = '' === $rawLimit
+            ? self::DEFAULT_LIMIT
+            : max(1, min(self::MAX_LIMIT, (int) $rawLimit));
+
+        if ('' === $query) {
+            return new JsonResponse([
+                'hits' => [],
+                'total' => 0,
+                'processingTimeMs' => 0,
+            ]);
+        }
+
+        $result = $this->searchService->search(
+            kind: ObjectKind::Product,
+            query: $query,
+            page: 1,
+            perPage: $limit,
+            extra: [
+                'matchingStrategy' => 'all',
+                'attributesToSearchOn' => ['sku', 'name', 'code'],
+            ],
+        );
+
+        return new JsonResponse([
+            'hits' => $result['hits'],
+            'total' => $result['totalHits'],
+            'processingTimeMs' => $result['processingTimeMs'],
+        ]);
+    }
+}

--- a/apps/api/tests/Api/Catalog/QuickSearchApiTest.php
+++ b/apps/api/tests/Api/Catalog/QuickSearchApiTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Search\Application\BulkCatalogObjectIndexer;
+use App\Search\Application\IndexSettingsTemplate;
+use App\Search\Application\MeilisearchIndexProvisioner;
+use App\Search\Infrastructure\MeilisearchClientFactory;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Throwable;
+
+/**
+ * UI-02.2 (#292) — `/api/products/quick-search` strict-mode endpoint.
+ */
+final class QuickSearchApiTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        try {
+            self::getContainer()->get(MeilisearchClientFactory::class)->create()->health();
+        } catch (Throwable) {
+            self::markTestSkipped('Meilisearch container not available; covered by Playwright stack.');
+        }
+
+        self::getContainer()->get(MeilisearchIndexProvisioner::class)->provision();
+
+        $client = self::getContainer()->get(MeilisearchClientFactory::class)->create();
+        $client->index(IndexSettingsTemplate::indexName(ObjectKind::Product))->deleteAllDocuments();
+        usleep(300_000);
+    }
+
+    #[Test]
+    public function emptyQueryReturnsEmptyHitsWithoutHittingMeili(): void
+    {
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/products/quick-search?q=')->toArray();
+
+        self::assertSame([], $body['hits']);
+        self::assertSame(0, $body['total']);
+    }
+
+    #[Test]
+    public function strictPrefixSearchOnSku(): void
+    {
+        $this->seedProduct('TST-001');
+        $this->seedProduct('TST-002');
+        $this->seedProduct('OTHER-XYZ');
+        $this->forceReindex();
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/products/quick-search?q=TST')->toArray();
+
+        self::assertGreaterThanOrEqual(2, $body['total']);
+        $hits = $body['hits'];
+        \assert(\is_array($hits));
+        $codes = [];
+        foreach ($hits as $hit) {
+            \assert(\is_array($hit));
+            $code = $hit['code'] ?? null;
+            if (\is_string($code)) {
+                $codes[] = $code;
+            }
+        }
+        self::assertContains('TST-001', $codes);
+        self::assertContains('TST-002', $codes);
+        self::assertNotContains('OTHER-XYZ', $codes);
+    }
+
+    #[Test]
+    public function limitParameterIsClampedToMax(): void
+    {
+        for ($i = 0; $i < 5; ++$i) {
+            $this->seedProduct(\sprintf('LIM-%03d', $i));
+        }
+        $this->forceReindex();
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/products/quick-search?q=LIM&limit=999')->toArray();
+
+        $hits = $body['hits'];
+        \assert(\is_array($hits));
+        self::assertLessThanOrEqual(100, \count($hits));
+    }
+
+    private function seedProduct(string $code): void
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $context = self::getContainer()->get(TenantContext::class);
+        $context->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        self::getContainer()->get(CatalogObjectRepositoryInterface::class)->save($object);
+    }
+
+    private function forceReindex(): void
+    {
+        self::getContainer()->get(BulkCatalogObjectIndexer::class)->reindex(kind: ObjectKind::Product);
+        usleep(600_000);
+    }
+}


### PR DESCRIPTION
## Summary
- New `GET /api/products/quick-search?q=&limit=` strict-prefix Meilisearch endpoint scoped to `[sku, name, code]`.
- Flat `{hits, total, processingTimeMs}` shape designed for the products list `<ProductSearchBar>` (UI-02.9).
- Default `limit=50`, max `100`; empty `q` short-circuits without hitting Meili.
- Tenant gate inherited from `CatalogSearchService`.
- Route `priority: 200` keeps it ahead of the API Platform `/api/products/{id}` collection.

## Test plan
- [x] PHPStan max + cs-fixer green (composer lint).
- [x] Local smoke after `restart api`: `GET /api/products/quick-search?q=DEMO` → `{hits:[],total:0,processingTimeMs:42}` (empty index, expected).
- [ ] CI: PHPUnit (incl. new `QuickSearchApiTest` — empty/strict-prefix/limit-cap) + Playwright stack runs the actual Meilisearch path.

Closes #292