### PR TITLE
feat(catalog): UI-02.3 bulk-edit endpoint + job tracking (#293)

### DIFF
--- a/apps/api/migrations/Version20260501150000.php
+++ b/apps/api/migrations/Version20260501150000.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * UI-02.3 (#293) — `bulk_edit_jobs` audit + status table.
+ *
+ * Tracks every POST `/api/products/bulk-edit` invocation so the
+ * frontend can poll job status (`<BulkEditProgressModal>` UI-02.11) and
+ * recover after a tab close. MVP runs the operation synchronously
+ * inside the request — the row is the audit trail for a Faza 1 async
+ * dispatch (Symfony Messenger queue `catalog`).
+ *
+ * Operation semantics + payload schema enforced in PHP, not as DB
+ * CHECK, since the operation matrix is a moving target through MVP +
+ * Faza 1 (publish, bulk delete, change family).
+ */
+final class Version20260501150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'UI-02.3 bulk_edit_jobs audit + status table (#293).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE bulk_edit_jobs (
+              id UUID NOT NULL,
+              tenant_id UUID NOT NULL,
+              user_id UUID NULL,
+              operation VARCHAR(64) NOT NULL,
+              payload JSONB NOT NULL DEFAULT '{}',
+              total INT NOT NULL DEFAULT 0,
+              processed INT NOT NULL DEFAULT 0,
+              errors_count INT NOT NULL DEFAULT 0,
+              first_errors JSONB NOT NULL DEFAULT '[]',
+              status VARCHAR(16) NOT NULL DEFAULT 'pending',
+              created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              completed_at TIMESTAMP(0) WITHOUT TIME ZONE NULL,
+              PRIMARY KEY (id)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX bulk_edit_jobs_tenant_status_idx ON bulk_edit_jobs (tenant_id, status, created_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS bulk_edit_jobs_tenant_status_idx');
+        $this->addSql('DROP TABLE IF EXISTS bulk_edit_jobs');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -86,6 +86,7 @@ parameters:
               - src/Catalog/Domain/Entity/ObjectValue.php
               - src/Catalog/Domain/Entity/AssociationType.php
               - src/Catalog/Domain/Entity/Association.php
+              - src/Catalog/Domain/Entity/BulkEditJob.php
               - src/Channel/Domain/Entity/Channel.php
               - src/Asset/Domain/Entity/Asset.php
               - src/ApiConfigurator/Domain/Entity/ApiProfile.php

--- a/apps/api/src/Catalog/Domain/Entity/BulkEditJob.php
+++ b/apps/api/src/Catalog/Domain/Entity/BulkEditJob.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * UI-02.3 (#293) — bulk-edit job audit + status record.
+ *
+ * One row per POST `/api/products/bulk-edit`. MVP executes the
+ * operation synchronously inside the request and updates this row to
+ * `completed` / `failed` before responding; the GET status endpoint
+ * exists so the frontend can recover after a tab close (Faza 1 async
+ * dispatch will re-use the same row).
+ */
+class BulkEditJob implements TenantScoped
+{
+    public const string STATUS_PENDING = 'pending';
+    public const string STATUS_RUNNING = 'running';
+    public const string STATUS_COMPLETED = 'completed';
+    public const string STATUS_FAILED = 'failed';
+
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private ?Uuid $userId;
+    private string $operation;
+    /**
+     * @var array<string, mixed>
+     */
+    private array $payload;
+    private int $total = 0;
+    private int $processed = 0;
+    private int $errorsCount = 0;
+    /**
+     * @var list<array{objectId: string, message: string}>
+     */
+    private array $firstErrors = [];
+    private string $status = self::STATUS_PENDING;
+    private DateTimeImmutable $createdAt;
+    private ?DateTimeImmutable $completedAt = null;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function __construct(
+        string $operation,
+        array $payload,
+        int $total,
+        ?Uuid $userId = null,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->operation = $operation;
+        $this->payload = $payload;
+        $this->total = $total;
+        $this->userId = $userId;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getUserId(): ?Uuid
+    {
+        return $this->userId;
+    }
+
+    public function getOperation(): string
+    {
+        return $this->operation;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    public function getProcessed(): int
+    {
+        return $this->processed;
+    }
+
+    public function recordProgress(int $processed): void
+    {
+        $this->processed = $processed;
+    }
+
+    public function getErrorsCount(): int
+    {
+        return $this->errorsCount;
+    }
+
+    /**
+     * @return list<array{objectId: string, message: string}>
+     */
+    public function getFirstErrors(): array
+    {
+        return $this->firstErrors;
+    }
+
+    public function recordError(string $objectId, string $message): void
+    {
+        ++$this->errorsCount;
+        if (\count($this->firstErrors) < 100) {
+            $this->firstErrors[] = ['objectId' => $objectId, 'message' => $message];
+        }
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function markRunning(): void
+    {
+        $this->status = self::STATUS_RUNNING;
+    }
+
+    public function markCompleted(): void
+    {
+        $this->status = self::STATUS_COMPLETED;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function markFailed(): void
+    {
+        $this->status = self::STATUS_FAILED;
+        $this->completedAt = new DateTimeImmutable();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getCompletedAt(): ?DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/BulkEditJob.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/BulkEditJob.orm.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\BulkEditJob"
+            table="bulk_edit_jobs">
+
+        <indexes>
+            <index name="bulk_edit_jobs_tenant_status_idx" columns="tenant_id,status,created_at"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="userId" type="uuid" column="user_id" nullable="true"/>
+        <field name="operation" type="string" length="64"/>
+        <field name="payload" type="json">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="total" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="processed" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="errorsCount" type="integer" column="errors_count">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="firstErrors" type="json" column="first_errors">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">[]</option>
+            </options>
+        </field>
+        <field name="status" type="string" length="16">
+            <options>
+                <option name="default">pending</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="completedAt" type="datetime_immutable" column="completed_at" nullable="true"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Presentation/Controller/BulkEditController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkEditController.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\BulkEditJob;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * UI-02.3 (#293) — bulk edit endpoint + job status read.
+ *
+ * MVP scope: synchronous execution inside the request, capped at 5000
+ * `product_ids[]` per call. Two operations supported in this slice:
+ *   - `toggle_enabled` — payload `{enabled: bool}`.
+ *   - `set_attribute_value` — payload `{attribute_code: string, value: scalar}`.
+ *
+ * Per-row failures are collected on the `BulkEditJob` row (first 100
+ * `firstErrors` plus a counter) instead of failing the whole batch.
+ *
+ * **Out of MVP slice (Faza 1+):** async dispatch via Messenger (the
+ * `BulkEditJob` row already supports it — runner just flips status to
+ * `running` and persists), Mercure progress events, `add_to_category`
+ * + `remove_from_category` + `delete` operations, publish-to-channels.
+ */
+final class BulkEditController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    private const int MAX_IDS = 5000;
+
+    private const array SUPPORTED_OPERATIONS = ['toggle_enabled', 'set_attribute_value'];
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly TenantContext $tenantContext,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Priority `200` to keep this above the API Platform `/api/products/{id}`
+     * collection route.
+     */
+    #[Route(
+        '/api/products/bulk-edit',
+        name: 'pim_products_bulk_edit',
+        methods: ['POST'],
+        priority: 200,
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function bulkEdit(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        $operation = $body['operation'] ?? null;
+        if (!\is_string($operation) || !\in_array($operation, self::SUPPORTED_OPERATIONS, true)) {
+            throw new BadRequestHttpException(\sprintf(
+                'operation must be one of: %s.',
+                implode(', ', self::SUPPORTED_OPERATIONS),
+            ));
+        }
+
+        $rawIds = $body['product_ids'] ?? null;
+        if (!\is_array($rawIds) || [] === $rawIds) {
+            throw new BadRequestHttpException('product_ids must be a non-empty array of UUID strings.');
+        }
+        if (\count($rawIds) > self::MAX_IDS) {
+            throw new BadRequestHttpException(\sprintf('product_ids capped at %d entries per call.', self::MAX_IDS));
+        }
+
+        $payload = $body['payload'] ?? [];
+        if (!\is_array($payload)) {
+            throw new BadRequestHttpException('payload must be an object.');
+        }
+        /** @var array<string, mixed> $payload */
+        $job = new BulkEditJob(
+            operation: $operation,
+            payload: $payload,
+            total: \count($rawIds),
+        );
+        $this->em->persist($job);
+        $this->em->flush();
+
+        $job->markRunning();
+
+        $processed = 0;
+        foreach ($rawIds as $rawId) {
+            try {
+                if (!\is_string($rawId)) {
+                    throw new BadRequestHttpException('product_ids entries must be UUID strings.');
+                }
+                $uuid = Uuid::fromString($rawId);
+                $object = $this->objects->findById($uuid);
+                if (!$object instanceof CatalogObject || ObjectKind::Product !== $object->getKind()) {
+                    throw new NotFoundHttpException(\sprintf('Product %s not found.', $rawId));
+                }
+
+                $this->applyOperation($operation, $object, $payload);
+
+                ++$processed;
+            } catch (Throwable $e) {
+                $job->recordError(\is_string($rawId) ? $rawId : '<invalid>', $e->getMessage());
+            }
+        }
+
+        $job->recordProgress($processed);
+        $job->markCompleted();
+        $this->em->flush();
+
+        return new JsonResponse(
+            $this->serializeJob($job),
+            Response::HTTP_ACCEPTED,
+        );
+    }
+
+    #[Route(
+        '/api/bulk-edit-jobs/{id}',
+        name: 'pim_bulk_edit_jobs_show',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+        priority: 200,
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function show(string $id): JsonResponse
+    {
+        $job = $this->em->getRepository(BulkEditJob::class)->find(Uuid::fromString($id));
+        if (!$job instanceof BulkEditJob) {
+            throw new NotFoundHttpException(\sprintf('Bulk edit job %s not found.', $id));
+        }
+
+        return new JsonResponse($this->serializeJob($job));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function applyOperation(string $operation, CatalogObject $object, array $payload): void
+    {
+        switch ($operation) {
+            case 'toggle_enabled':
+                $enabled = $payload['enabled'] ?? null;
+                if (!\is_bool($enabled)) {
+                    throw new BadRequestHttpException('payload.enabled must be a boolean.');
+                }
+                $object->changeEnabled($enabled);
+                break;
+
+            case 'set_attribute_value':
+                $code = $payload['attribute_code'] ?? null;
+                $value = $payload['value'] ?? null;
+                if (!\is_string($code) || '' === $code) {
+                    throw new BadRequestHttpException('payload.attribute_code is required.');
+                }
+                $current = $object->getAttributesIndexed();
+                $current[$code] = $value;
+                $object->updateAttributeIndex($current);
+                break;
+        }
+
+        $this->objects->save($object);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeJob(BulkEditJob $job): array
+    {
+        return [
+            'id' => $job->getId()->toRfc4122(),
+            'operation' => $job->getOperation(),
+            'status' => $job->getStatus(),
+            'total' => $job->getTotal(),
+            'processed' => $job->getProcessed(),
+            'errors_count' => $job->getErrorsCount(),
+            'first_errors' => $job->getFirstErrors(),
+            'payload' => $job->getPayload(),
+            'created_at' => $job->getCreatedAt()->format(DateTimeInterface::ATOM),
+            'completed_at' => $job->getCompletedAt()?->format(DateTimeInterface::ATOM),
+        ];
+    }
+}


### PR DESCRIPTION
Vertical slice for products list bulk actions: POST /api/products/bulk-edit (toggle_enabled + set_attribute_value, sync execution capped at 5000 IDs, per-row error collection) + GET /api/bulk-edit-jobs/{id} status read. Async via Messenger / Mercure / additional operations deferred to Faza 1 per ticket out-of-scope. Closes #293