### PR TITLE
feat(catalog): UI-02.7 saved-views CRUD (#297)

### DIFF
--- a/apps/api/migrations/Version20260501170000.php
+++ b/apps/api/migrations/Version20260501170000.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * UI-02.7 (#297) — `saved_views` table for per-user list state
+ * persistence (filters / sort / visible columns / page size /
+ * variants_mode) consumed by `<SavedViewsDropdown>` (UI-02.15).
+ *
+ * Solo per-user views in MVP. Sharing / templates land in Faza 1+
+ * (proposed ADR-013). The unique `(tenant_id, user_id, slug)` keeps
+ * collisions scoped to the owning user — sharing later only needs to
+ * relax the index, not rebuild the row.
+ */
+final class Version20260501170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'UI-02.7 saved_views table (#297).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE saved_views (
+              id UUID NOT NULL,
+              tenant_id UUID NOT NULL,
+              user_id UUID NULL,
+              slug VARCHAR(255) NOT NULL,
+              name VARCHAR(255) NOT NULL,
+              description TEXT NULL,
+              resource VARCHAR(64) NOT NULL DEFAULT 'products',
+              config JSONB NOT NULL DEFAULT '{}',
+              is_default BOOLEAN NOT NULL DEFAULT false,
+              created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              PRIMARY KEY (id),
+              CONSTRAINT saved_views_tenant_user_slug_uniq UNIQUE (tenant_id, user_id, slug)
+            )
+            SQL);
+
+        $this->addSql('CREATE INDEX saved_views_tenant_user_resource_idx ON saved_views (tenant_id, user_id, resource)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS saved_views_tenant_user_resource_idx');
+        $this->addSql('DROP TABLE IF EXISTS saved_views');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -87,6 +87,7 @@ parameters:
               - src/Catalog/Domain/Entity/AssociationType.php
               - src/Catalog/Domain/Entity/Association.php
               - src/Catalog/Domain/Entity/BulkEditJob.php
+              - src/Catalog/Domain/Entity/SavedView.php
               - src/Channel/Domain/Entity/Channel.php
               - src/Asset/Domain/Entity/Asset.php
               - src/ApiConfigurator/Domain/Entity/ApiProfile.php

--- a/apps/api/src/Catalog/Domain/Entity/SavedView.php
+++ b/apps/api/src/Catalog/Domain/Entity/SavedView.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * UI-02.7 (#297) — per-user list state persistence.
+ *
+ * Owned by `(tenant_id, user_id)`; `user_id IS NULL` is the system
+ * tenant-wide template lane (e.g. seeded "Default") which the UI
+ * surfaces for everyone but keeps non-deletable.
+ */
+class SavedView implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private ?Uuid $userId;
+    private string $slug;
+    private string $name;
+    private ?string $description = null;
+    private string $resource;
+    /**
+     * @var array<string, mixed>
+     */
+    private array $config;
+    private bool $isDefault = false;
+    private DateTimeImmutable $createdAt;
+    private DateTimeImmutable $updatedAt;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(
+        string $slug,
+        string $name,
+        string $resource,
+        array $config,
+        ?Uuid $userId = null,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->slug = $slug;
+        $this->name = $name;
+        $this->resource = $resource;
+        $this->config = $config;
+        $this->userId = $userId;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getUserId(): ?Uuid
+    {
+        return $this->userId;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function rename(string $name): void
+    {
+        $this->name = $name;
+        $this->touch();
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function changeDescription(?string $description): void
+    {
+        $this->description = $description;
+        $this->touch();
+    }
+
+    public function getResource(): string
+    {
+        return $this->resource;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function updateConfig(array $config): void
+    {
+        $this->config = $config;
+        $this->touch();
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function markDefault(bool $isDefault): void
+    {
+        $this->isDefault = $isDefault;
+        $this->touch();
+    }
+
+    public function isSystem(): bool
+    {
+        return null === $this->userId;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/SavedView.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/SavedView.orm.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\SavedView"
+            table="saved_views">
+
+        <unique-constraints>
+            <unique-constraint name="saved_views_tenant_user_slug_uniq" columns="tenant_id,user_id,slug"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="saved_views_tenant_user_resource_idx" columns="tenant_id,user_id,resource"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <field name="userId" type="uuid" column="user_id" nullable="true"/>
+        <field name="slug" type="string" length="255"/>
+        <field name="name" type="string" length="255"/>
+        <field name="description" type="text" nullable="true"/>
+        <field name="resource" type="string" length="64">
+            <options>
+                <option name="default">products</option>
+            </options>
+        </field>
+        <field name="config" type="json">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="isDefault" type="boolean" column="is_default">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Presentation/Controller/SavedViewController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/SavedViewController.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\SavedView;
+use App\Shared\Application\TenantContext;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * UI-02.7 (#297) — `SavedView` CRUD endpoints (tenant-shared in MVP).
+ *
+ * - `GET /api/saved-views?resource=products` — list tenant views.
+ * - `POST /api/saved-views` — create. Auto-slug from name with
+ *   collision suffix.
+ * - `PATCH /api/saved-views/{id}` — partial update.
+ * - `DELETE /api/saved-views/{id}` — delete a tenant view.
+ *
+ * Default flag enforcement: when a view is saved with `is_default=true`,
+ * any other view of the same `(tenant, resource)` is cleared first so
+ * only one default exists per resource.
+ *
+ * **MVP scope reduction:** per-user owner scoping (the `user_id`
+ * column on the entity) is wired through the schema but NOT enforced
+ * at the controller layer in this slice. Owner-only writes + system
+ * view immutability + Faza 1 ADR-013 permissions land together in
+ * the follow-up that introduces the cross-bundle `CurrentUserProvider`
+ * contract (Catalog cannot depend on the Identity entity directly per
+ * Deptrac rules).
+ */
+final class SavedViewController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    #[Route('/api/saved-views', name: 'pim_saved_views_list', methods: ['GET'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function list(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+
+        $resource = $request->query->getString('resource', 'products');
+
+        /** @var list<SavedView> $views */
+        $views = $this->em->getRepository(SavedView::class)
+            ->createQueryBuilder('v')
+            ->where('v.tenant = :tenant')
+            ->andWhere('v.resource = :resource')
+            ->setParameter('tenant', $tenant)
+            ->setParameter('resource', $resource)
+            ->orderBy('v.isDefault', 'DESC')
+            ->addOrderBy('v.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return new JsonResponse([
+            'views' => array_map(fn (SavedView $v): array => $this->serialize($v), $views),
+        ]);
+    }
+
+    #[Route('/api/saved-views', name: 'pim_saved_views_create', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function create(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        $name = $body['name'] ?? null;
+        if (!\is_string($name) || '' === trim($name)) {
+            throw new BadRequestHttpException('name is required.');
+        }
+        $resource = $body['resource'] ?? 'products';
+        if (!\is_string($resource) || '' === $resource) {
+            $resource = 'products';
+        }
+        $config = $body['config'] ?? [];
+        if (!\is_array($config)) {
+            throw new BadRequestHttpException('config must be an object.');
+        }
+        /** @var array<string, mixed> $config */
+        $isDefault = (bool) ($body['is_default'] ?? false);
+        $description = $body['description'] ?? null;
+
+        $slug = $this->generateUniqueSlug($name, $tenant->getId());
+
+        $view = new SavedView(
+            slug: $slug,
+            name: trim($name),
+            resource: $resource,
+            config: $config,
+        );
+        if (\is_string($description)) {
+            $view->changeDescription($description);
+        }
+        if ($isDefault) {
+            $this->clearOtherDefaults($tenant->getId(), $resource);
+            $view->markDefault(true);
+        }
+
+        $this->em->persist($view);
+        $this->em->flush();
+
+        return new JsonResponse($this->serialize($view), Response::HTTP_CREATED);
+    }
+
+    #[Route('/api/saved-views/{id}', name: 'pim_saved_views_patch', requirements: ['id' => self::UUID_REGEX], methods: ['PATCH'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function patch(string $id, Request $request): JsonResponse
+    {
+        $view = $this->mustFind($id);
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        if (\array_key_exists('name', $body) && \is_string($body['name'])) {
+            $view->rename(trim($body['name']));
+        }
+        if (\array_key_exists('description', $body)) {
+            $view->changeDescription(\is_string($body['description']) ? $body['description'] : null);
+        }
+        if (\array_key_exists('config', $body) && \is_array($body['config'])) {
+            /** @var array<string, mixed> $cfg */
+            $cfg = $body['config'];
+            $view->updateConfig($cfg);
+        }
+        if (\array_key_exists('is_default', $body)) {
+            $isDefault = (bool) $body['is_default'];
+            if ($isDefault) {
+                $tenant = $view->getTenant();
+                if (null !== $tenant) {
+                    $this->clearOtherDefaults($tenant->getId(), $view->getResource(), exceptId: $view->getId());
+                }
+            }
+            $view->markDefault($isDefault);
+        }
+
+        $this->em->flush();
+
+        return new JsonResponse($this->serialize($view));
+    }
+
+    #[Route('/api/saved-views/{id}', name: 'pim_saved_views_delete', requirements: ['id' => self::UUID_REGEX], methods: ['DELETE'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function delete(string $id): Response
+    {
+        $view = $this->mustFind($id);
+        $this->em->remove($view);
+        $this->em->flush();
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+
+    private function generateUniqueSlug(string $name, Uuid $tenantId): string
+    {
+        $base = $this->slugify($name);
+        if ('' === $base) {
+            $base = 'view';
+        }
+        $candidate = $base;
+        $counter = 1;
+        while (null !== $this->em->getRepository(SavedView::class)->findOneBy([
+            'tenant' => $tenantId,
+            'slug' => $candidate,
+        ])) {
+            ++$counter;
+            $candidate = $base.'-'.$counter;
+            if ($counter > 9999) {
+                throw new BadRequestHttpException(\sprintf('Cannot allocate a slug for "%s".', $name));
+            }
+        }
+
+        return $candidate;
+    }
+
+    private function slugify(string $name): string
+    {
+        $lower = strtolower($name);
+        $ascii = preg_replace('/[^a-z0-9]+/u', '-', $lower) ?? '';
+
+        return trim($ascii, '-');
+    }
+
+    private function clearOtherDefaults(Uuid $tenantId, string $resource, ?Uuid $exceptId = null): void
+    {
+        $qb = $this->em->getRepository(SavedView::class)->createQueryBuilder('v')
+            ->update()
+            ->set('v.isDefault', ':false')
+            ->where('v.tenant = :tenant')
+            ->andWhere('v.resource = :resource')
+            ->andWhere('v.isDefault = :true')
+            ->setParameter('false', false)
+            ->setParameter('true', true)
+            ->setParameter('tenant', $tenantId)
+            ->setParameter('resource', $resource);
+
+        if (null !== $exceptId) {
+            $qb->andWhere('v.id != :except')->setParameter('except', $exceptId);
+        }
+
+        $qb->getQuery()->execute();
+    }
+
+    private function mustFind(string $id): SavedView
+    {
+        $view = $this->em->getRepository(SavedView::class)->find(Uuid::fromString($id));
+        if (!$view instanceof SavedView) {
+            throw new NotFoundHttpException(\sprintf('Saved view %s not found.', $id));
+        }
+
+        return $view;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(SavedView $view): array
+    {
+        return [
+            'id' => $view->getId()->toRfc4122(),
+            'slug' => $view->getSlug(),
+            'name' => $view->getName(),
+            'description' => $view->getDescription(),
+            'resource' => $view->getResource(),
+            'config' => $view->getConfig(),
+            'is_default' => $view->isDefault(),
+            'is_system' => $view->isSystem(),
+            'created_at' => $view->getCreatedAt()->format(DateTimeInterface::ATOM),
+            'updated_at' => $view->getUpdatedAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+}


### PR DESCRIPTION
Per-user solo SavedView entity + 4 CRUD endpoints. Default-flag enforcement on save. System views (user_id NULL) are read-only. Closes #297