### PR TITLE
feat(admin): UI-02.8 completeness + sync columns (#298)

### DIFF
--- a/apps/admin/src/components/catalog/completeness-badge.tsx
+++ b/apps/admin/src/components/catalog/completeness-badge.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * UI-02.10 (#300) — flat completeness percentage rendered as a coloured
+ * progress bar plus the numeric label. Colour coding matches the brief
+ * in `Project Plan/UI/epik-02-produkty.md` §4.5: red <50, yellow
+ * 50-90, green >90.
+ */
+export function CompletenessBadge({
+  pct,
+  totalAttributes,
+  filledAttributes,
+}: {
+  pct: number;
+  totalAttributes?: number;
+  filledAttributes?: number;
+}) {
+  const { t } = useTranslation();
+  const safe = Math.max(0, Math.min(100, Math.round(pct)));
+  const tone = safe >= 90 ? 'bg-emerald-500' : safe >= 50 ? 'bg-amber-500' : 'bg-rose-500';
+
+  const tooltip =
+    totalAttributes !== undefined && filledAttributes !== undefined
+      ? t('products.completeness.tooltip', {
+          pct: safe,
+          filled: filledAttributes,
+          total: totalAttributes,
+          defaultValue: '{{pct}}% — wypełnione {{filled}}/{{total}} atrybutów',
+        })
+      : `${safe}%`;
+
+  return (
+    <div className="flex items-center gap-2" title={tooltip}>
+      <meter
+        min={0}
+        max={100}
+        low={50}
+        high={90}
+        optimum={95}
+        value={safe}
+        aria-label={`${safe}%`}
+        className="h-2 w-20 overflow-hidden rounded-full bg-muted"
+      >
+        <div className={`h-full ${tone}`} style={{ width: `${safe}%` }} />
+      </meter>
+      <span className="text-xs tabular-nums text-muted-foreground">{safe}%</span>
+    </div>
+  );
+}

--- a/apps/admin/src/components/catalog/sync-aggregate-icon.tsx
+++ b/apps/admin/src/components/catalog/sync-aggregate-icon.tsx
@@ -1,0 +1,29 @@
+import { Circle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export type SyncAggregate = 'green' | 'yellow' | 'red' | 'gray';
+
+const TONE: Record<SyncAggregate, string> = {
+  green: 'fill-emerald-500 text-emerald-500',
+  yellow: 'fill-amber-500 text-amber-500',
+  red: 'fill-rose-500 text-rose-500',
+  gray: 'fill-muted-foreground text-muted-foreground',
+};
+
+/**
+ * UI-02.10 (#300) — single-icon channel sync aggregate badge.
+ *
+ * Per `Project Plan/UI/epik-02-produkty.md` §4.5 / §11.5. Tooltip
+ * surfaces the per-channel breakdown once UI-02.5 channels-status is
+ * wired through (placeholder text in MVP).
+ */
+export function SyncAggregateIcon({ status }: { status: SyncAggregate }) {
+  const { t } = useTranslation();
+  const tone = TONE[status];
+
+  return (
+    <div className="inline-flex items-center" title={t(`products.sync.${status}`, status)}>
+      <Circle className={`size-3 ${tone}`} aria-label={status} />
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -4,6 +4,8 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
+import { CompletenessBadge } from '@/components/catalog/completeness-badge';
+import { SyncAggregateIcon } from '@/components/catalog/sync-aggregate-icon';
 import { type Provenance, ProvenanceBadge } from '@/components/provenance-badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -30,6 +32,8 @@ interface CatalogObjectListEntry {
   status?: string;
   createdAt?: string;
   attributesIndexed?: Record<string, unknown>;
+  completenessPct?: number;
+  syncStatusAggregate?: string;
 }
 
 interface ProductRow {
@@ -41,7 +45,11 @@ interface ProductRow {
   createdAt: string;
   enabled: boolean;
   status: string | null;
+  completenessPct: number;
+  syncStatusAggregate: SyncAggregate;
 }
+
+type SyncAggregate = 'green' | 'yellow' | 'red' | 'gray';
 
 const PRODUCT_FACETS = ['enabled', 'status'];
 const PROVENANCE_OPTIONS: ReadonlyArray<Provenance> = ['manual', 'import', 'integration', 'agent'];
@@ -223,6 +231,12 @@ export function ProductListPage() {
                 <TableHead className="w-[180px]">{t('products.fields.sku')}</TableHead>
                 <TableHead>{t('products.fields.name')}</TableHead>
                 <TableHead className="w-[160px]">{t('products.fields.brand')}</TableHead>
+                <TableHead className="w-[140px]">
+                  {t('products.fields.completeness', { defaultValue: 'Compl.' })}
+                </TableHead>
+                <TableHead className="w-[60px]">
+                  {t('products.fields.sync', { defaultValue: 'Sync' })}
+                </TableHead>
                 <TableHead className="w-[110px]">{t('products.fields.status')}</TableHead>
                 <TableHead className="w-[180px]">{t('products.fields.created_at')}</TableHead>
                 <TableHead className="w-[120px] text-right">
@@ -233,13 +247,13 @@ export function ProductListPage() {
             <TableBody>
               {isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="py-10 text-center text-muted-foreground">
+                  <TableCell colSpan={9} className="py-10 text-center text-muted-foreground">
                     {t('app.loading')}
                   </TableCell>
                 </TableRow>
               ) : visible.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="py-10 text-center text-muted-foreground">
+                  <TableCell colSpan={9} className="py-10 text-center text-muted-foreground">
                     {isSearchActive ? t('search.no_results') : t('products.empty')}
                   </TableCell>
                 </TableRow>
@@ -260,6 +274,12 @@ export function ProductListPage() {
                     <TableCell className="font-mono text-xs">{product.sku}</TableCell>
                     <TableCell className="font-medium">{product.name}</TableCell>
                     <TableCell>{product.brand ?? '—'}</TableCell>
+                    <TableCell>
+                      <CompletenessBadge pct={product.completenessPct} />
+                    </TableCell>
+                    <TableCell>
+                      <SyncAggregateIcon status={product.syncStatusAggregate} />
+                    </TableCell>
                     <TableCell>
                       <StatusBadge enabled={product.enabled} status={product.status} />
                     </TableCell>
@@ -331,7 +351,16 @@ function buildRow(entry: CatalogObjectListEntry): ProductRow {
     createdAt: entry.createdAt ?? '',
     enabled: entry.enabled !== false,
     status: typeof entry.status === 'string' ? entry.status : null,
+    completenessPct: typeof entry.completenessPct === 'number' ? entry.completenessPct : 0,
+    syncStatusAggregate: normaliseSyncAggregate(entry.syncStatusAggregate),
   };
+}
+
+function normaliseSyncAggregate(raw: string | undefined): SyncAggregate {
+  if (raw === 'green' || raw === 'yellow' || raw === 'red' || raw === 'gray') {
+    return raw;
+  }
+  return 'gray';
 }
 
 function formatDateTime(value: string, locale: string): string {


### PR DESCRIPTION
Wire UI-02.1 cache fields into the products list. Adds reusable <CompletenessBadge> + <SyncAggregateIcon>. TanStack Table refactor deferred. Closes #298