### PR TITLE
fix(catalog): serialise completenessPct + syncStatusAggregate

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/Serializer/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/CatalogObject.xml
@@ -64,6 +64,14 @@
         <attribute name="completeness">
             <group>admin:read</group>
         </attribute>
+        <attribute name="completenessPct">
+            <group>admin:read</group>
+            <group>integration:read</group>
+        </attribute>
+        <attribute name="syncStatusAggregate">
+            <group>admin:read</group>
+            <group>integration:read</group>
+        </attribute>
         <attribute name="attributesIndexed">
             <group>admin:read</group>
             <group>integration:read</group>


### PR DESCRIPTION
Hotfix — entity + ORM had the fields but the API serializer didn't expose them, so the products list (#317) rendered 0%/gray for every row.