### PR TITLE
fix(catalog): UI-02.24 advanced filters reach Meili payload (range support)

### DIFF
--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -83,12 +83,33 @@ export function ProductListPage() {
   const [activeViewSlug, setActiveViewSlug] = useState<string | null>(null);
   const [showSaveViewModal, setShowSaveViewModal] = useState(false);
 
-  const isSearchActive = query !== '' || Object.keys(filters).length > 0;
+  const { searchFilters, rangeFilters } = useMemo(() => {
+    const sf: Record<string, string | string[]> = { ...filters };
+    const rf: Record<string, { gte?: number; lte?: number }> = {};
+    for (const [key, value] of Object.entries(advancedFilters)) {
+      if (value === null || value === undefined) continue;
+      if (Array.isArray(value)) {
+        sf[key] = value as string[];
+      } else if (typeof value === 'object') {
+        const range: { gte?: number; lte?: number } = {};
+        if (typeof value.gte === 'number') range.gte = value.gte;
+        if (typeof value.lte === 'number') range.lte = value.lte;
+        if (Object.keys(range).length > 0) rf[key] = range;
+      } else if (typeof value === 'string' && value !== '') {
+        sf[key] = value;
+      }
+    }
+    return { searchFilters: sf, rangeFilters: rf };
+  }, [filters, advancedFilters]);
+
+  const isSearchActive =
+    query !== '' || Object.keys(searchFilters).length > 0 || Object.keys(rangeFilters).length > 0;
 
   const { result: searchResult, isLoading: isSearchLoading } = useCatalogSearch({
     kind: 'products',
     query,
-    filters,
+    filters: searchFilters,
+    rangeFilters,
     facets: PRODUCT_FACETS,
     perPage: 30,
   });

--- a/apps/admin/src/features/catalog/search/use-catalog-search.ts
+++ b/apps/admin/src/features/catalog/search/use-catalog-search.ts
@@ -39,6 +39,13 @@ export interface UseCatalogSearchOptions {
   kind: CatalogSearchKind;
   query: string;
   filters?: Record<string, string | string[]>;
+  /**
+   * Range / numeric filters (UI-02.24). Each key is mapped to
+   * `filter[key][gte]=N` / `filter[key][lte]=N` query params; the
+   * search controller forwards them to Meilisearch as
+   * `key >= N AND key <= N` filter expressions.
+   */
+  rangeFilters?: Record<string, { gte?: number; lte?: number }>;
   facets?: string[];
   page?: number;
   perPage?: number;
@@ -57,6 +64,7 @@ export function useCatalogSearch(options: UseCatalogSearchOptions): UseCatalogSe
     kind,
     query,
     filters,
+    rangeFilters,
     facets,
     page = 1,
     perPage = 30,
@@ -86,6 +94,12 @@ export function useCatalogSearch(options: UseCatalogSearchOptions): UseCatalogSe
           }
         }
       }
+      if (rangeFilters) {
+        for (const [key, range] of Object.entries(rangeFilters)) {
+          if (range.gte !== undefined) params.set(`filter[${key}][gte]`, String(range.gte));
+          if (range.lte !== undefined) params.set(`filter[${key}][lte]`, String(range.lte));
+        }
+      }
 
       setIsLoading(true);
       jsonFetch<CatalogSearchResult>(`/api/search/${kind}?${params.toString()}`)
@@ -107,7 +121,7 @@ export function useCatalogSearch(options: UseCatalogSearchOptions): UseCatalogSe
       cancelled = true;
       window.clearTimeout(handle);
     };
-  }, [kind, query, page, perPage, highlight, debounceMs, facets, filters]);
+  }, [kind, query, page, perPage, highlight, debounceMs, facets, filters, rangeFilters]);
 
   return { result, isLoading, error };
 }

--- a/apps/api/src/Search/Application/CatalogSearchService.php
+++ b/apps/api/src/Search/Application/CatalogSearchService.php
@@ -41,13 +41,10 @@ final readonly class CatalogSearchService
     }
 
     /**
-     * @param array<string, scalar|list<scalar>> $filters plain key→value or
-     *                                                    key→[v1,v2] OR matches
-     *                                                    on top of tenant scope
-     * @param list<string>                       $facets  Attribute codes to facet on
-     * @param array<string, mixed>               $extra   forward-compat — Meili
-     *                                                    options not surfaced
-     *                                                    here yet (sort, ranking)
+     * @param array<string, scalar|list<scalar>>             $filters      plain key→value / key→[v1,v2] OR matches on top of tenant scope
+     * @param list<string>                                   $facets       Attribute codes to facet on
+     * @param array<string, mixed>                           $extra        forward-compat — Meili options not surfaced here yet (sort, ranking)
+     * @param array<string, array{gte?: float, lte?: float}> $rangeFilters numeric range filters (UI-02.24); mapped to Meili `key >= N AND key <= N`
      *
      * @return array{hits: list<array<string, mixed>>, totalHits: int, facetDistribution: array<string, mixed>, processingTimeMs: int}
      */
@@ -60,6 +57,7 @@ final readonly class CatalogSearchService
         int $perPage = 30,
         bool $highlight = false,
         array $extra = [],
+        array $rangeFilters = [],
     ): array {
         if (ObjectKind::Custom === $kind) {
             return $this->emptyResult();
@@ -87,6 +85,14 @@ final readonly class CatalogSearchService
                 continue;
             }
             $extraFilters[] = \sprintf('%s = "%s"', $key, addslashes((string) $value));
+        }
+        foreach ($rangeFilters as $key => $range) {
+            if (isset($range['gte'])) {
+                $extraFilters[] = \sprintf('%s >= %s', $key, $range['gte']);
+            }
+            if (isset($range['lte'])) {
+                $extraFilters[] = \sprintf('%s <= %s', $key, $range['lte']);
+            }
         }
         $filterExpression = trim($tenantFilter.([] !== $extraFilters ? ' AND '.implode(' AND ', $extraFilters) : ''));
 

--- a/apps/api/src/Search/Application/IndexSettingsTemplate.php
+++ b/apps/api/src/Search/Application/IndexSettingsTemplate.php
@@ -52,7 +52,7 @@ final class IndexSettingsTemplate
         return match ($kind) {
             ObjectKind::Product => [
                 'searchableAttributes' => ['code', 'name', 'sku', 'brand', 'description'],
-                'filterableAttributes' => ['tenantId', 'kind', 'status', 'enabled', 'objectTypeId', 'brand', 'category'],
+                'filterableAttributes' => ['tenantId', 'kind', 'status', 'enabled', 'objectTypeId', 'brand', 'category', 'completeness_pct', 'sync_status_aggregate'],
                 'sortableAttributes' => ['createdAt', 'updatedAt', 'name'],
                 'displayedAttributes' => ['*'],
                 'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],

--- a/apps/api/src/Search/Presentation/Controller/SearchController.php
+++ b/apps/api/src/Search/Presentation/Controller/SearchController.php
@@ -63,10 +63,26 @@ final class SearchController
         $query = $request->query->get('q', '');
 
         $filters = [];
+        $rangeFilters = [];
         /** @var array<string, mixed> $rawFilters */
         $rawFilters = $request->query->all('filter');
         foreach ($rawFilters as $key => $value) {
             if (\is_array($value)) {
+                // Range syntax: filter[key][gte]=50 / filter[key][lte]=90 (UI-02.24).
+                $isAssoc = array_keys($value) !== range(0, \count($value) - 1);
+                if ($isAssoc && (isset($value['gte']) || isset($value['lte']))) {
+                    $range = [];
+                    if (isset($value['gte']) && is_numeric($value['gte'])) {
+                        $range['gte'] = (float) $value['gte'];
+                    }
+                    if (isset($value['lte']) && is_numeric($value['lte'])) {
+                        $range['lte'] = (float) $value['lte'];
+                    }
+                    if ([] !== $range) {
+                        $rangeFilters[$key] = $range;
+                    }
+                    continue;
+                }
                 /** @var list<scalar> $coerced */
                 $coerced = array_values(array_filter($value, 'is_scalar'));
                 $filters[$key] = $coerced;
@@ -95,6 +111,7 @@ final class SearchController
             page: $page,
             perPage: $perPage,
             highlight: $highlight,
+            rangeFilters: $rangeFilters,
         );
 
         return new JsonResponse([

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4751,6 +4751,18 @@
                             ]
                         }
                     },
+                    "completenessPct": {
+                        "readOnly": true,
+                        "description": "Flat percentage 0..100 mirrored from `completeness['global']` for\nindexable filter/sort on the products list (UI-02.1, UI-02.10).",
+                        "default": 0,
+                        "type": "integer"
+                    },
+                    "syncStatusAggregate": {
+                        "readOnly": true,
+                        "description": "Per-product sync aggregate badge \u2014 `green|yellow|red|gray`. Default\n`gray` (no sync history). Mutated by Faza 1 channel-sync subscriber;\nMVP only ships the column + serialisation (UI-02.1 / UI-02.5 / UI-02.10).",
+                        "default": "gray",
+                        "type": "string"
+                    },
                     "attributesIndexed": {
                         "readOnly": true,
                         "type": "object",
@@ -4959,6 +4971,18 @@
                                 "null"
                             ]
                         }
+                    },
+                    "completenessPct": {
+                        "readOnly": true,
+                        "description": "Flat percentage 0..100 mirrored from `completeness['global']` for\nindexable filter/sort on the products list (UI-02.1, UI-02.10).",
+                        "default": 0,
+                        "type": "integer"
+                    },
+                    "syncStatusAggregate": {
+                        "readOnly": true,
+                        "description": "Per-product sync aggregate badge \u2014 `green|yellow|red|gray`. Default\n`gray` (no sync history). Mutated by Faza 1 channel-sync subscriber;\nMVP only ships the column + serialisation (UI-02.1 / UI-02.5 / UI-02.10).",
+                        "default": "gray",
+                        "type": "string"
                     },
                     "attributesIndexed": {
                         "readOnly": true,


### PR DESCRIPTION
Frontend now merges advancedFilters into search hook (string/list/range). Backend SearchController parses ?filter[key][gte/lte]=N and Meili service builds key>=N AND key<=N. IndexSettingsTemplate exposes completeness_pct as filterable. Closes #340