### PR TITLE
fix(admin): UI-02.25 Excel single-click edit + visible save errors

### DIFF
--- a/apps/admin/src/components/catalog/excel-like-grid.tsx
+++ b/apps/admin/src/components/catalog/excel-like-grid.tsx
@@ -84,7 +84,16 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
     }
     setActive({ rowIdx, colKey });
     setSelectionEnd({ rowIdx, colKey });
-    setEditing(null);
+    // Single-click → enter edit mode for editable cells (UI-02.25). Operators
+    // expect spreadsheet-style "click and type"; the legacy "click to select
+    // then double-click to edit" lost users every time. Read-only cells still
+    // highlight without opening the editor.
+    const col = columns.find((c) => c.key === colKey);
+    if (col !== undefined && col.readOnly !== true) {
+      setEditing({ rowIdx, colKey });
+    } else {
+      setEditing(null);
+    }
   };
 
   const handleCellDoubleClick = (rowIdx: number, colKey: string): void => {

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -82,6 +82,7 @@ export function ProductListPage() {
   const [viewMode, setViewMode] = useState<ViewMode>('table');
   const [activeViewSlug, setActiveViewSlug] = useState<string | null>(null);
   const [showSaveViewModal, setShowSaveViewModal] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const isSearchActive = query !== '' || Object.keys(filters).length > 0;
 
@@ -214,6 +215,24 @@ export function ProductListPage() {
         </Button>
       </div>
 
+      {saveError !== null ? (
+        <div
+          role="alert"
+          className="flex items-center justify-between rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-800"
+        >
+          <span>{saveError}</span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setSaveError(null)}
+            aria-label={t('app.dismiss', { defaultValue: 'Dismiss' })}
+          >
+            {t('app.dismiss', { defaultValue: 'Dismiss' })}
+          </Button>
+        </div>
+      ) : null}
+
       <div className="flex flex-wrap items-center gap-3">
         <CatalogSearchBox value={query} onChange={setQuery} isLoading={isSearchLoading} />
         <SavedViewsDropdown
@@ -306,11 +325,20 @@ export function ProductListPage() {
                   onCommit={(rowIdx, colKey, value) => {
                     const target = visible[rowIdx];
                     if (target === undefined) return;
+                    setSaveError(null);
                     void jsonFetch(`/api/products/${target.id}`, {
                       method: 'PATCH',
-                      body: { attributesIndexed: { [colKey]: value } },
+                      body: { attributes: { [colKey]: value } },
                       contentType: 'application/merge-patch+json',
-                    }).then(() => refetch());
+                    })
+                      .then(() => refetch())
+                      .catch((err: unknown) => {
+                        setSaveError(
+                          err instanceof Error
+                            ? `${target.sku} → ${colKey}: ${err.message}`
+                            : `${target.sku} → ${colKey}: save failed`,
+                        );
+                      });
                   }}
                 />
               </div>


### PR DESCRIPTION
Single-click opens editor for editable cells. PATCH onCommit catches errors and surfaces them in a dismissible banner. Body shape now matches #338 fix (attributes vs attributesIndexed). Closes #341