### PR TITLE
feat(modeling): expose create custom ObjectType flow in admin

### DIFF
--- a/apps/admin/src/components/modeling/create-custom-object-type-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-custom-object-type-dialog.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { jsonFetch } from '@/lib/http';
+
+interface CreatedObjectType {
+  id: string;
+  code: string;
+  kind: string;
+  label: Record<string, string>;
+  builtIn: boolean;
+}
+
+/**
+ * UI-02 follow-up — Create-custom-ObjectType form over the new
+ * `POST /api/object_types` endpoint. The DB schema and service
+ * layer have supported `kind=custom` from day 1 (R-29 mitigation);
+ * this dialog finally exposes the path to operators today instead
+ * of waiting for the Faza 2 schema-add agent.
+ */
+export function CreateCustomObjectTypeDialog({
+  onClose,
+  onCreated,
+}: {
+  onClose: () => void;
+  onCreated: (created: CreatedObjectType) => void;
+}) {
+  const { t } = useTranslation();
+  const [code, setCode] = useState('');
+  const [labelPl, setLabelPl] = useState('');
+  const [labelEn, setLabelEn] = useState('');
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent): Promise<void> => {
+    event.preventDefault();
+    setError(null);
+    const trimmedCode = code.trim();
+    const label: Record<string, string> = {};
+    if (labelPl.trim() !== '') label.pl = labelPl.trim();
+    if (labelEn.trim() !== '') label.en = labelEn.trim();
+    if (trimmedCode === '' || Object.keys(label).length === 0) {
+      setError(
+        t('object_types.create_custom.validation', {
+          defaultValue: 'Code and at least one label entry are required.',
+        }),
+      );
+      return;
+    }
+    setIsPending(true);
+    try {
+      const response = await jsonFetch<CreatedObjectType>('/api/object_types', {
+        method: 'POST',
+        body: { code: trimmedCode, label },
+      });
+      onCreated(response);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'unknown');
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <Sheet
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <SheetContent side="right" className="w-[420px] p-6">
+        <SheetTitle>
+          {t('object_types.create_custom.title', { defaultValue: 'Create custom ObjectType' })}
+        </SheetTitle>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {t('object_types.create_custom.subtitle', {
+            defaultValue:
+              'Custom kinds (e.g. service, kit, bundle) ship with no built-in business logic — only the schema. Attach AttributeGroups and start adding rows from the modeling UI.',
+          })}
+        </p>
+        <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="custom-ot-code" className="text-sm font-medium">
+              {t('object_types.create_custom.code_label', { defaultValue: 'Code' })}
+            </label>
+            <Input
+              id="custom-ot-code"
+              value={code}
+              onChange={(e) => setCode(e.target.value.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
+              placeholder="service"
+              autoFocus
+            />
+            <p className="text-xs text-muted-foreground">
+              {t('object_types.create_custom.code_hint', {
+                defaultValue: 'Lowercase letters, digits, underscore. Must be unique per tenant.',
+              })}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="custom-ot-label-pl" className="text-sm font-medium">
+              {t('object_types.create_custom.label_pl', { defaultValue: 'Label (PL)' })}
+            </label>
+            <Input
+              id="custom-ot-label-pl"
+              value={labelPl}
+              onChange={(e) => setLabelPl(e.target.value)}
+              placeholder="Usługa"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="custom-ot-label-en" className="text-sm font-medium">
+              {t('object_types.create_custom.label_en', { defaultValue: 'Label (EN)' })}
+            </label>
+            <Input
+              id="custom-ot-label-en"
+              value={labelEn}
+              onChange={(e) => setLabelEn(e.target.value)}
+              placeholder="Service"
+            />
+          </div>
+
+          {error !== null ? <p className="text-sm text-rose-600">{error}</p> : null}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" type="button" onClick={onClose} disabled={isPending}>
+              {t('app.cancel', { defaultValue: 'Cancel' })}
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending
+                ? t('object_types.create_custom.submitting', { defaultValue: 'Creating…' })
+                : t('object_types.create_custom.submit', { defaultValue: 'Create' })}
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/admin/src/features/catalog/object-types/list.tsx
+++ b/apps/admin/src/features/catalog/object-types/list.tsx
@@ -1,10 +1,11 @@
 import { useList } from '@refinedev/core';
-import { Eye } from 'lucide-react';
+import { Eye, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
+import { CreateCustomObjectTypeDialog } from '@/components/modeling/create-custom-object-type-dialog';
 import { Button } from '@/components/ui/button';
 import {
   Table,
@@ -40,6 +41,7 @@ export function ObjectTypesListPage() {
   const types = result.data;
   const isLoading = query.isLoading;
   const instanceCounts = useObjectTypeInstanceCounts(types);
+  const [createOpen, setCreateOpen] = useState(false);
 
   const builtIn = types.filter((row) => row.builtIn !== false);
   const custom = types.filter((row) => row.builtIn === false);
@@ -127,22 +129,83 @@ export function ObjectTypesListPage() {
       <section className="space-y-3">
         <header className="flex items-center justify-between">
           <h2 className="text-sm font-medium">{t('object_types.custom_title')}</h2>
-          <span className="rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900">
-            {t('object_types.phase_2_badge')}
-          </span>
-        </header>
-        <div className="rounded-xl border border-dashed bg-muted/30 px-4 py-6 text-sm text-muted-foreground">
-          <p className="mb-2">{t('object_types.custom_disabled_explanation')}</p>
-          <Button type="button" variant="outline" size="sm" disabled>
-            {t('object_types.create_custom_disabled')}
+          <Button type="button" size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="size-4" />
+            {t('object_types.create_custom_action', { defaultValue: 'Create custom ObjectType' })}
           </Button>
-          {custom.length > 0 ? (
-            <p className="mt-3 text-xs">
-              {t('object_types.custom_present_note', { count: custom.length })}
-            </p>
-          ) : null}
+        </header>
+        <div className="rounded-xl border bg-card">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[180px]">{t('object_types.fields.code')}</TableHead>
+                <TableHead>{t('object_types.fields.label')}</TableHead>
+                <TableHead className="w-[120px]">{t('object_types.fields.kind')}</TableHead>
+                <TableHead className="w-[120px] text-right">
+                  {t('object_types.fields.instance_count')}
+                </TableHead>
+                <TableHead className="w-[120px]">
+                  {t('object_types.fields.schema_version')}
+                </TableHead>
+                <TableHead className="w-[80px] text-right">
+                  <span className="sr-only">{t('object_types.fields.actions')}</span>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {custom.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
+                    {t('object_types.custom_empty', {
+                      defaultValue: 'No custom ObjectTypes yet — create your first one above.',
+                    })}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                custom.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell className="font-mono text-xs">
+                      <span className="inline-flex items-center gap-2">
+                        <ColorSwatch color={row.color} />
+                        {row.code}
+                      </span>
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      {resolveLabel(row.label, i18n.language)}
+                    </TableCell>
+                    <TableCell>
+                      <KindBadge kind={row.kind} />
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-sm tabular-nums">
+                      {instanceCounts[row.id] ?? '—'}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground tabular-nums">
+                      {row.schemaVersion ?? 1}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button asChild variant="ghost" size="sm">
+                        <Link to={`/modeling/object-types/${row.id}`}>
+                          <Eye className="size-4" />
+                          <span className="sr-only">{t('object_types.actions.view')}</span>
+                        </Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
         </div>
       </section>
+
+      {createOpen ? (
+        <CreateCustomObjectTypeDialog
+          onClose={() => setCreateOpen(false)}
+          onCreated={() => {
+            void query.refetch();
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -171,7 +171,20 @@
     "phase_2_badge": "Faza 2",
     "custom_disabled_explanation": "Custom ObjectTypes (kind=custom) are stored in the database from day one but disabled by feature flag in MVP. The schema-add agent in Faza 2 will mint and configure them through natural-language requests.",
     "create_custom_disabled": "Create custom ObjectType",
+    "create_custom_action": "Create custom ObjectType",
+    "custom_empty": "No custom ObjectTypes yet — create your first one above.",
     "custom_present_note": "{{count}} custom ObjectType(s) exist in this tenant; visible after Faza 2 unlock.",
+    "create_custom": {
+      "title": "Create custom ObjectType",
+      "subtitle": "Custom kinds (e.g. service, kit, bundle) ship with no built-in business logic — only the schema. Attach AttributeGroups and start adding rows from the modeling UI.",
+      "code_label": "Code",
+      "code_hint": "Lowercase letters, digits, underscore. Must be unique per tenant.",
+      "label_pl": "Label (PL)",
+      "label_en": "Label (EN)",
+      "validation": "Code and at least one label entry are required.",
+      "submit": "Create",
+      "submitting": "Creating…"
+    },
     "empty": "No object types for the current tenant.",
     "write_deferred_note": "Editing built-in ObjectTypes (label / labelAttribute / imageAttribute / completenessRules) is deferred to the schema-add agent flow (Faza 2).",
     "fields": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -171,7 +171,20 @@
     "phase_2_badge": "Faza 2",
     "custom_disabled_explanation": "Custom ObjectTypes (kind=custom) są w bazie od dnia 1, ale wyłączone feature flagiem w MVP. Schema-add agent w Fazie 2 będzie tworzył i konfigurował je z naturalnego języka.",
     "create_custom_disabled": "Utwórz custom ObjectType",
+    "create_custom_action": "Utwórz custom ObjectType",
+    "custom_empty": "Brak custom ObjectTypes — utwórz pierwszy przez przycisk powyżej.",
     "custom_present_note": "{{count}} custom ObjectType istnieje w tym najemcy; widoczne po odblokowaniu w Fazie 2.",
+    "create_custom": {
+      "title": "Utwórz custom ObjectType",
+      "subtitle": "Custom kindy (np. service, kit, bundle) startują bez wbudowanej logiki biznesowej — sam schemat. Podłącz AttributeGroup-y i zacznij dodawać rekordy z modelowania.",
+      "code_label": "Kod",
+      "code_hint": "Małe litery, cyfry, podkreślenie. Musi być unikalny w obrębie najemcy.",
+      "label_pl": "Etykieta (PL)",
+      "label_en": "Etykieta (EN)",
+      "validation": "Kod oraz przynajmniej jedna etykieta są wymagane.",
+      "submit": "Utwórz",
+      "submitting": "Tworzenie…"
+    },
     "empty": "Brak typów obiektów dla aktualnego najemcy.",
     "write_deferred_note": "Edycja predefiniowanych ObjectType (label / labelAttribute / imageAttribute / completenessRules) odroczona do agentowego flow schema-add (Faza 2).",
     "fields": {

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -51,6 +51,14 @@ MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
 APP_DEFAULT_TENANT_CODE=demo
 ###< app/multi-tenancy ###
 
+###> app/feature-flags ###
+# Custom ObjectType creation gate. The DB schema accepts `kind=custom`
+# from day 1 (R-29 mitigation); flip to `false` to lock down the
+# /api/object_types POST + the modeling UI Create button (Faza 1
+# ADR-013 will tie this to per-role permissions).
+CATALOG_ENABLE_CUSTOM_OBJECT_TYPES=true
+###< app/feature-flags ###
+
 ###> app/byok ###
 # Master key for BYOK (Bring Your Own Key) Anthropic encryption (#107
 # / 0.11.12, ADR-0017). Base64 of 32 random bytes (AES-256-GCM key).

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -24,7 +24,14 @@ parameters:
     # mitigation: "custom kinds without UX support is an over-engineering
     # trap"). Tests pass the flag through the constructor directly when
     # they need to exercise the unlocked path.
-    pim.catalog.enable_custom_object_types: false
+    # 2026-05-01 (UI-02 follow-up): flipped to true so the modeling UI
+    # exposes a Create custom ObjectType flow today. The DB schema has
+    # supported `kind=custom` rows from day 1 (R-29 mitigation), and the
+    # admin already has the form (`<CreateCustomObjectTypeDialog>`)
+    # backed by the new `POST /api/object_types` endpoint. Override
+    # back to `false` per-tenant once role gating ships in Faza 1
+    # ADR-013.
+    pim.catalog.enable_custom_object_types: '%env(bool:CATALOG_ENABLE_CUSTOM_OBJECT_TYPES)%'
 
 services:
     _defaults:

--- a/apps/api/src/Catalog/Presentation/Controller/CreateCustomObjectTypeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CreateCustomObjectTypeController.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\ObjectTypeService;
+use App\Catalog\Domain\Exception\DisabledFeatureException;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Throwable;
+
+/**
+ * UI-02 follow-up — POST `/api/object_types` for custom kinds.
+ *
+ * The base ApiResource for `ObjectType` is read-only (ADR-009 §schema +
+ * `apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/ObjectType.xml`).
+ * Custom ObjectType creation needed a thin write surface so the modeling
+ * UI Create dialog has a target — this controller delegates straight to
+ * `ObjectTypeService::create(kind=custom)`, which already enforces:
+ *   - feature flag (`pim.catalog.enable_custom_object_types`) — flip the
+ *     env var `CATALOG_ENABLE_CUSTOM_OBJECT_TYPES` to gate per environment;
+ *   - tenant scope (TenantAssignmentListener stamps the row);
+ *   - schema invariants (label JSONB, code uniqueness via DB index).
+ *
+ * Built-in / system kinds (product / category / asset / brand) stay
+ * read-only — operators manage them only via DB seed.
+ */
+final class CreateCustomObjectTypeController
+{
+    public function __construct(
+        private readonly ObjectTypeService $service,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    /**
+     * Priority 200 wins against the API Platform read-only Get collection
+     * route on the same path.
+     */
+    #[Route(
+        '/api/object_types',
+        name: 'pim_object_types_create_custom',
+        methods: ['POST'],
+        priority: 200,
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        $code = $body['code'] ?? null;
+        if (!\is_string($code) || '' === trim($code)) {
+            throw new BadRequestHttpException('code is required.');
+        }
+        $code = trim($code);
+
+        $rawLabel = $body['label'] ?? null;
+        if (!\is_array($rawLabel) || [] === $rawLabel) {
+            throw new BadRequestHttpException('label is required (per-locale map, e.g. {"pl": "...", "en": "..."}).');
+        }
+        $label = [];
+        foreach ($rawLabel as $locale => $value) {
+            if (\is_string($locale) && \is_string($value) && '' !== trim($value)) {
+                $label[$locale] = trim($value);
+            }
+        }
+        if ([] === $label) {
+            throw new BadRequestHttpException('label must contain at least one non-empty entry.');
+        }
+
+        // Reject collisions early with a clear 409 (the DB unique index
+        // would also catch it but the message would be opaque).
+        if (null !== $this->objectTypes->findByCode($code, $tenant)) {
+            throw new ConflictHttpException(\sprintf('ObjectType with code "%s" already exists.', $code));
+        }
+
+        try {
+            $objectType = $this->service->create(
+                code: $code,
+                kind: ObjectKind::Custom,
+                label: $label,
+                builtIn: false,
+            );
+        } catch (DisabledFeatureException $e) {
+            throw new HttpException(Response::HTTP_FORBIDDEN, $e->getMessage(), $e);
+        } catch (Throwable $e) {
+            throw new HttpException(Response::HTTP_UNPROCESSABLE_ENTITY, $e->getMessage(), $e);
+        }
+
+        return new JsonResponse([
+            'id' => $objectType->getId()->toRfc4122(),
+            'code' => $objectType->getCode(),
+            'kind' => $objectType->getKind()->value,
+            'label' => $objectType->getLabel(),
+            'builtIn' => $objectType->isBuiltIn(),
+        ], Response::HTTP_CREATED);
+    }
+}

--- a/apps/api/tests/Api/Catalog/CustomKindFeatureFlagApiTest.php
+++ b/apps/api/tests/Api/Catalog/CustomKindFeatureFlagApiTest.php
@@ -44,12 +44,11 @@ final class CustomKindFeatureFlagApiTest extends CatalogApiTestCase
     #[Test]
     public function apiGuardThrowsWhenFlagDisabled(): void
     {
-        // Read the same parameter the production wiring binds to, so
-        // the test exercises the live default rather than a hard-coded
-        // boolean. Listing-side resolution stays delegated to AP4.
-        $flag = self::getContainer()->getParameter('pim.catalog.enable_custom_object_types');
-        self::assertFalse($flag, 'Default flag must stay OFF in MVP.');
-
+        // The parameter default flipped to ON in 2026-05-01 (UI-02 follow-up:
+        // modeling UI now exposes a Create custom ObjectType flow). The guard
+        // contract itself stays unchanged — operators that override
+        // `CATALOG_ENABLE_CUSTOM_OBJECT_TYPES=false` per environment must
+        // still see custom-kind writes blocked at the API edge.
         $guard = new CustomObjectTypeApiGuard(false);
 
         $this->expectException(DisabledFeatureException::class);


### PR DESCRIPTION
## Summary
- Backend: ship `POST /api/object_types` controller (priority 200 over the read-only collection) reusing `ObjectTypeService::create(kind=Custom)` with feature-flag + tenant + code-uniqueness enforcement.
- Backend: flip `pim.catalog.enable_custom_object_types` to env-driven via `CATALOG_ENABLE_CUSTOM_OBJECT_TYPES=true` so MVP can opt in today (Faza 1 ADR-013 will tie this to per-role permissions).
- Frontend: new `<CreateCustomObjectTypeDialog>` Sheet (code + PL/EN labels, code-sanitising hint, error surfacing) wired into the modeling list page; custom rows now render in their own table mirrored after the built-in section so Refine `useList` refetch picks them up after creation.

## Why
The DB schema and service guard have supported `kind=custom` from day 1 (R-29 mitigation: "custom kinds without UX support is an over-engineering trap"), but the API resource is read-only and the modeling UI surfaced a disabled placeholder button gated to "Faza 2". Operators flagged the comment in the modeling view; with the form already drafted in dialog form there was no reason to keep custom creation behind the flag.

## Smoke-tested (live backend, https://pim.localhost)
| Step | Verified |
| --- | --- |
| `POST /api/object_types` happy path (`{code:"service_test", label:{pl,en}}`) | `HTTP 201` + JSON `{id, code, kind:"custom", label, builtIn:false}` |
| Duplicate code | `HTTP 409 ObjectType with code "service_test" already exists.` |
| Missing `code` field | `HTTP 400 code is required.` |
| Empty `label` map | `HTTP 400 label must contain at least one non-empty entry.` |
| Unauthenticated request | `HTTP 401` |
| `GET /api/object_types?kind=custom` includes new row | new `service_test` (kind=custom, builtIn=false) appears alongside built-ins |

Frontend: `pnpm typecheck`, `pnpm lint`, `pnpm build` all clean. Vite dev server hot-reloaded `create-custom-object-type-dialog.tsx` over HMR; the modeling page now renders the live "Create custom ObjectType" button + custom-rows table.

## Test plan
- [ ] CI green (PHPStan max, Biome strict, vitest, ApiTestCase, Playwright)
- [ ] Pull main, restart api worker, log in, open `/modeling/object-types` → click "Create custom ObjectType" → fill code `kit` + labels → submit → row appears in custom table + navigable via Eye icon

Refs #270