### PR TITLE
fix(modeling): align attribute type filters with backend enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ Icon?
 # Pre-Sprint-0 referencje (puste, niepotrzebne w repo)
 agent_sample/
 
+# Lokalne backupy (pg_dump + MinIO snapshoty) — zostają na Synology, nie w repo
+/backups/
+
 # Lokalne źródła referencyjne (Akeneo, Pimcore extracts) — nie wysyłamy na repo
 Zrodla/
 

--- a/apps/admin/src/features/api-configurator/api-profiles/form.tsx
+++ b/apps/admin/src/features/api-configurator/api-profiles/form.tsx
@@ -585,11 +585,11 @@ function sampleValueForType(type: string): unknown {
       return '2026-04-30';
     case 'select':
       return 'option_a';
-    case 'multi_select':
+    case 'multiselect':
       return ['option_a', 'option_b'];
     case 'price':
       return { amount: 99.99, currency: 'PLN' };
-    case 'measurement':
+    case 'metric':
       return { value: 10, unit: 'kg' };
     case 'asset':
     case 'reference':

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -33,16 +33,17 @@ type SystemFilter = 'all' | 'system' | 'business';
 
 const TYPES: ReadonlyArray<string> = [
   'text',
-  'textarea',
   'number',
   'boolean',
   'select',
-  'multi_select',
+  'multiselect',
   'date',
+  'datetime',
   'asset',
   'reference',
+  'relation',
   'price',
-  'measurement',
+  'metric',
 ];
 
 export function AttributesListPage() {


### PR DESCRIPTION
## Summary
- Drop orphan `textarea` (not in backend enum), rename `multi_select` → `multiselect` and `measurement` → `metric`, add missing `datetime` + `relation` buttons in `<AttributesListPage>`'s TYPES constant so all 12 canonical \`App\Catalog\Domain\AttributeType\` cases get a filter chip.
- Apply the same rename to \`api-profiles/form.tsx\` sample-value helper so the dummy payload uses canonical enum names.

## Why
Modeling → Atrybuty footnote promises "Seeder dostarcza MVP zestaw atrybutów", and the API does return all 23 seeded rows for the demo tenant. But clicking \`multi_select\`/\`measurement\` filtered to 0 (mismatched enum strings) and \`datetime\` (2 rows) + \`relation\` (1 row) had no button at all — 5 of 23 seeded attributes were unreachable through the filter UI.

## Smoke test (live backend)
\`curl /api/attributes\` for tenant demo returns:
| type | count |
| --- | --- |
| text | 9 |
| number | 1 |
| boolean | 1 |
| select | 2 |
| multiselect | 1 |
| date | 1 |
| datetime | 2 |
| asset | 1 |
| reference | 2 |
| relation | 1 |
| price | 1 |
| metric | 1 |
| **sum** | **23** |

After the fix every chip in the UI corresponds to a real enum value, and clicking any chip filters to a non-empty subset of the seeder data.

## Test plan
- [ ] CI green (typecheck / Biome / Vite build / Playwright / PHPUnit untouched).
- [ ] Pull main, log in \`admin@demo.localhost / changeme\`, open Modelowanie → Atrybuty → click \`multiselect\` → 1 row; click \`metric\` → 1 row; click \`datetime\` → 2 rows; click \`relation\` → 1 row.

Closes #354