### PR TITLE
feat(admin): UI-03.2 handoff Modelowanie — wizualna harmonizacja + TODO komentarze

### DIFF
--- a/Project Plan/UI/Wdrozenie_grafiki/modelowanie-do-oprogramowania.md
+++ b/Project Plan/UI/Wdrozenie_grafiki/modelowanie-do-oprogramowania.md
@@ -1,0 +1,66 @@
+# Modelowanie — backlog do oprogramowania
+
+> Baza pod kolejne GitHub tickety. Każda pozycja zaznaczona w kodzie komentarzem `MOCK:` (przy bloku UI z hardkodowanymi danymi) lub `TODO(handoff)` (przy luce w wiringu).
+>
+> **Konwencja**: pojedyncza pozycja → osobny issue na GitHubie z labelami `frontend` (+ ewentualnie `backend`), `must-have` / `optional`, `UI`, `epik-UI-03` (lub przeniesione do nowego epika gdy tematyka backendu się rozjedzie).
+>
+> Stan na 2026-05-01 po merge'u #357. Aktualna implementacja modelowania jest w ~60% gotowa — ten plik wylicza luki.
+
+## Object Types
+
+### Frontend + nowy endpoint backendowy
+- [ ] **NewObjectType wizard (4 kroki)** — Identyfikacja → Atrybuty → Ustawienia → Podsumowanie. Backend: `POST /api/object_types` (dziś brak; istnieje tylko `CreateCustomObjectTypeDialog` minimal). Estymacja: L (FE 8-10h, BE 6-8h).
+- [ ] **Edit ObjectType** (icon, color, hierarchical / hasVariants / isAbstract toggle) — `PATCH /api/object_types/{id}` (dziś brak).
+- [ ] **Drag-reorder grup atrybutów** w detailu — `PATCH /api/object_types/{id}/groups/order` z dnd-kit po stronie FE.
+- [ ] **Audit log section** w detailu (last 5 changes — who/when/diff) — `GET /api/object_types/{id}/audit-log`. Pliki FE: `apps/admin/src/features/catalog/object-types/show.tsx` (sekcja oznaczona MOCK).
+- [ ] **Icon picker** (lucide subset) + **color picker** (akcent palette) w wizardzie + edit form.
+
+## Attributes
+
+### Frontend + nowy endpoint backendowy
+- [ ] **AttributeValuesView** (full-page editor select / multi-select values) — locale tabs, color swatches, default/deprecated toggles, drag-reorder. Endpointy: `GET/POST/PATCH/DELETE /api/attributes/{id}/values`. Wymaga **nowej encji `attribute_values`** (czy istnieje? Sprint 0 tabele do potwierdzenia). Pliki FE: `apps/admin/src/features/catalog/attributes/values.tsx` (placeholder mock zamknięty w UI-03.2). Estymacja: L (FE 12-15h, BE 14-18h).
+- [ ] **Kolumna "Wartości"** violet badge z licznikiem dla select / multi-select — wymaga endpointu `/values` (count). Plik FE: `apps/admin/src/features/catalog/attributes/list.tsx` (komponent `ValuesBadge` ma TODO comment "—" zamiast prawdziwego count).
+- [ ] **NewAttribute form** — `POST /api/attributes` (dziś brak; lista oznacza `attributes.write_deferred_note`).
+- [ ] **Edit Attribute metadata** — `PATCH /api/attributes/{id}`.
+- [ ] **MigrationImpactModal** — `POST /api/attributes/{code}/migrate?dryRun=true` zwraca `{ affectedInstances, suggestedMapping, sampleDiff }`. Następnie `POST /api/attributes/{code}/migrate` commituje. Strona migrate-type istnieje (UI-08.12 #267) — ale brakuje pełnego dryRun preview UI per handoff.
+- [ ] **DELETE Attribute** z guardrails (rejects if used in groups) — `DELETE /api/attributes/{id}`.
+
+## Attribute Groups (ADR-012 first-class entity ⭐)
+
+### Frontend + nowy endpoint backendowy
+- [ ] **Sticky detail header** z close + icon + name + edit button per handoff.
+- [ ] **Sekcja "Atrybuty in this group"** w detailu z:
+  - Drag-reorder — `PATCH /api/attribute_groups/{id}/attributes/order`.
+  - **AddAttributeFromLibraryModal** — picker existing attributes z multi-select + filter po type. Endpoint: `POST /api/attribute_groups/{id}/attributes`.
+  - **CreateAttributeInGroupModal** — skrócona forma New Attribute + auto-attach do current grupy (jeden POST + atomic).
+- [ ] **NewAttributeGroup form** — `POST /api/attribute_groups`. Strona `attribute-groups/create.tsx` istnieje minimum, brak icon/color picker handoff style.
+- [ ] **Edit Group metadata** — `PATCH /api/attribute_groups/{id}`.
+- [ ] **Visibility rules section** (`visible_when` JSON rules) z preview "test" działający na sample produktach.
+
+### Wymaga decyzji architektonicznej
+- [ ] **`visible_when` rule format** — JsonLogic vs custom JSON-DSL vs hand-rolled rule builder (jak w handoff prototype). Wpływa na schema `attribute_groups.visible_when` JSONB column oraz UI rule builder. Zob. handoff CLAUDE.md "Open architecture decisions" pkt 5. Wymaga ADR.
+
+## Categories
+
+### Frontend + nowy endpoint backendowy
+- [ ] **Two-column layout 320px tree + flex detail** per handoff. Aktualnie `categories/list.tsx` to one-column tree, `categories/show.tsx` to standalone page. Trzeba przebudować na sticky detail panel obok drzewa.
+- [ ] **ObjectType filter chips** (Service / Product / Asset) w headerze listy — wymaga listing categories po `objectType.kind`.
+- [ ] **Drag-and-drop tree** — move subtree to new parent. Endpoint: `PATCH /api/categories/{id}/move` (z cascade ltree update). Estymacja: L (FE 8-10h dnd-kit + BE 8-10h ltree cascade).
+- [ ] **Attach/detach groups at node** — `POST /api/categories/{id}/groups/{groupCode}` + DELETE. Aktualnie effective-groups read-only.
+- [ ] **Declared directly section** w detailu z edit/delete buttons per group (różnicować od inherited).
+- [ ] **Inherited from parents section** read-only z arrow → source category (link do parent category).
+
+### Już zrealizowane (UI-08.14 #269 — nie blokuje)
+- [x] **Effective preview card** z provenance — endpoint `/api/categories/{id}/effective-groups` istnieje, FE renderuje listę z sortowaniem auto/system/manual.
+
+## Cross-cutting (Modelowanie)
+
+- [ ] **schema_rev counter** w stopce / topbar (`model schema rev 47`) — wymaga global schema rev tracking po stronie BE (kolumna `schema_rev` na każdej tabeli modelowej + bump na każdą migrację) i FE indicator.
+- [ ] **Audit log per encja** (last 5 changes w detailu) — wspólny endpoint `GET /api/{resource}/{id}/audit-log` dla object_types / attributes / attribute_groups / categories.
+- [ ] **LocaleTabs** dla pól multilingual (label, description) — handoff specyfikuje `LocaleTabs` z primary `pl` non-removable + chips do dodawania innych z `LOCALE_LIBRARY` (14 langs). Aktualnie mamy plain JSONB inputs.
+
+## Zależności od innych epików
+
+- Epik 0.6 (Admin UI core CRUD) — bazowe formularze już zrealizowane, ale POST/PATCH dla resource modeli jeszcze nie wszystkie.
+- Epik 0.11 (Hardening + analityka) — schema_rev + audit_log endpoints to kandydaty do tego epiku.
+- Faza 2 (Agent layer) — visible_when rule builder mógłby być pisany przez agenta (chat-driven) dla nietechnicznych użytkowników, ale to dalsze rozważanie.

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -14,6 +14,7 @@ import { AttributeGroupShowPage } from '@/features/catalog/attribute-groups/show
 import { AttributesListPage } from '@/features/catalog/attributes/list';
 import { MigrateAttributeTypePage } from '@/features/catalog/attributes/migrate-type';
 import { AttributeShowPage } from '@/features/catalog/attributes/show';
+import { AttributeValuesPage } from '@/features/catalog/attributes/values';
 import { CategoriesTreePage } from '@/features/catalog/categories/list';
 import { CategoryShowPage } from '@/features/catalog/categories/show';
 import { ModelingLayout } from '@/features/catalog/modeling/layout';
@@ -108,6 +109,7 @@ function App() {
               <Route path="attributes" element={<AttributesListPage />} />
               <Route path="attributes/:id" element={<AttributeShowPage />} />
               <Route path="attributes/:id/migrate-type" element={<MigrateAttributeTypePage />} />
+              <Route path="attributes/:id/values" element={<AttributeValuesPage />} />
               <Route path="attribute-groups" element={<AttributeGroupsListPage />} />
               <Route path="attribute-groups/new" element={<AttributeGroupCreatePage />} />
               <Route path="attribute-groups/:id" element={<AttributeGroupShowPage />} />

--- a/apps/admin/src/features/catalog/attribute-groups/list.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/list.tsx
@@ -84,11 +84,19 @@ export function AttributeGroupsListPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-2">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">
-            {t('attribute_groups.list_title')}
-          </h1>
-          <p className="text-sm text-muted-foreground">{t('attribute_groups.list_subtitle')}</p>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <h1 className="display text-[28px] font-semibold leading-tight text-ink">
+              {t('attribute_groups.list_title')}
+            </h1>
+            <span className="inline-flex items-center gap-1 rounded-full bg-accent-violet/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-accent-violet">
+              ⭐{' '}
+              {t('attribute_groups.first_class_badge', {
+                defaultValue: 'first-class entity (ADR-012)',
+              })}
+            </span>
+          </div>
+          <p className="max-w-3xl text-[14px] text-ink-2">{t('attribute_groups.list_subtitle')}</p>
         </div>
         <Button asChild>
           <Link to="/modeling/attribute-groups/new">
@@ -125,7 +133,7 @@ export function AttributeGroupsListPage() {
         </p>
       ) : null}
 
-      <div className="rounded-xl border bg-card">
+      <div className="rounded-2xl border border-line bg-surface soft-shadow">
         <Table>
           <TableHeader>
             <TableRow>

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -1,5 +1,5 @@
 import { useList } from '@refinedev/core';
-import { Eye } from 'lucide-react';
+import { Eye, Layers } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
@@ -73,9 +73,11 @@ export function AttributesListPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">{t('attributes.list_title')}</h1>
-        <p className="text-sm text-muted-foreground">{t('attributes.list_subtitle')}</p>
+      <div className="space-y-2">
+        <h1 className="display text-[28px] font-semibold leading-tight text-ink">
+          {t('attributes.list_title')}
+        </h1>
+        <p className="max-w-3xl text-[14px] text-ink-2">{t('attributes.list_subtitle')}</p>
       </div>
 
       <div className="space-y-2">
@@ -142,7 +144,7 @@ export function AttributesListPage() {
         </div>
       </div>
 
-      <div className="rounded-xl border bg-card">
+      <div className="rounded-2xl border border-line bg-surface soft-shadow">
         <Table>
           <TableHeader>
             <TableRow>
@@ -154,6 +156,9 @@ export function AttributesListPage() {
               <TableHead className="w-[110px] text-right">
                 {t('modeling.attributes.usage_count')}
               </TableHead>
+              <TableHead className="w-[120px]">
+                {t('attributes.fields.values_column', { defaultValue: 'Wartości' })}
+              </TableHead>
               <TableHead className="w-[80px] text-right">
                 <span className="sr-only">{t('attributes.fields.actions')}</span>
               </TableHead>
@@ -162,13 +167,13 @@ export function AttributesListPage() {
           <TableBody>
             {isLoading ? (
               <TableRow>
-                <TableCell colSpan={7} className="py-10 text-center text-muted-foreground">
+                <TableCell colSpan={8} className="py-10 text-center text-muted-foreground">
                   {t('app.loading')}
                 </TableCell>
               </TableRow>
             ) : visible.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} className="py-10 text-center text-muted-foreground">
+                <TableCell colSpan={8} className="py-10 text-center text-muted-foreground">
                   {t('attributes.empty')}
                 </TableCell>
               </TableRow>
@@ -185,9 +190,7 @@ export function AttributesListPage() {
                     {resolveLabel(row.label, i18n.language)}
                   </TableCell>
                   <TableCell>
-                    <span className="rounded bg-muted px-2 py-0.5 text-xs uppercase tracking-wide">
-                      {row.type}
-                    </span>
+                    <TypeBadge type={row.type} />
                   </TableCell>
                   <TableCell className="text-xs text-muted-foreground">
                     {resolveGroupLabel(row.group, i18n.language)}
@@ -197,8 +200,11 @@ export function AttributesListPage() {
                     {row.localizable ? <Flag>{t('attributes.flags.localizable')}</Flag> : null}
                     {row.scopable ? <Flag>{t('attributes.flags.scopable')}</Flag> : null}
                   </TableCell>
-                  <TableCell className="text-right font-mono text-sm tabular-nums text-muted-foreground">
+                  <TableCell className="num text-right text-[12px] text-muted-foreground">
                     {usageCounts[row.id] ?? '—'}
+                  </TableCell>
+                  <TableCell>
+                    <ValuesBadge type={row.type} attributeId={row.id} />
                   </TableCell>
                   <TableCell className="text-right">
                     <Button asChild variant="ghost" size="sm">
@@ -225,6 +231,65 @@ function Flag({ children }: { children: React.ReactNode }) {
     <span className="rounded bg-secondary px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-secondary-foreground">
       {children}
     </span>
+  );
+}
+
+/**
+ * Type-aware badge per handoff accent palette.
+ * Mapping: text/zinc, number/blue, select+multiselect/amber, boolean/emerald,
+ * date/datetime/sky, money/emerald, asset/violet, reference+relation/rose.
+ */
+function TypeBadge({ type }: { type: string }) {
+  const tone =
+    type === 'number' || type === 'metric' || type === 'price'
+      ? 'bg-accent-blue/10 text-accent-blue'
+      : type === 'select' || type === 'multiselect'
+        ? 'bg-accent-amber/10 text-accent-amber'
+        : type === 'boolean'
+          ? 'bg-accent-emerald/10 text-accent-emerald'
+          : type === 'date' || type === 'datetime'
+            ? 'bg-accent-sky/10 text-accent-sky'
+            : type === 'asset'
+              ? 'bg-accent-violet/10 text-accent-violet'
+              : type === 'reference' || type === 'relation'
+                ? 'bg-accent-rose/10 text-accent-rose'
+                : 'bg-muted text-muted-foreground';
+  return (
+    <span
+      className={`rounded-md px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide ${tone}`}
+    >
+      {type}
+    </span>
+  );
+}
+
+/**
+ * MOCK: violet "N wartości" badge for select/multiselect attributes —
+ * clicking should open the AttributeValuesView at
+ * /modeling/attributes/{id}/values. Both the count and the editor route
+ * require GET/POST/PATCH/DELETE /api/attributes/{id}/values which does
+ * not exist yet (see Project Plan/UI/Wdrozenie_grafiki/modelowanie-do-oprogramowania.md).
+ *
+ * For now the badge:
+ *  - renders a hard-coded "—" count for select / multiselect (we do not
+ *    know the real count without the endpoint),
+ *  - links to the placeholder route (which renders a banner explaining
+ *    the missing backend) so the UI flow exists end-to-end.
+ *  - shows "—" disabled span for non-select types (handoff convention).
+ */
+function ValuesBadge({ type, attributeId }: { type: string; attributeId: string }) {
+  if (type !== 'select' && type !== 'multiselect') {
+    return <span className="text-[12px] text-muted-foreground">—</span>;
+  }
+  return (
+    <Link
+      to={`/modeling/attributes/${attributeId}/values`}
+      className="inline-flex items-center gap-1 rounded-md bg-accent-violet/10 px-2 py-0.5 text-[11px] font-medium text-accent-violet hover:bg-accent-violet/15"
+    >
+      <Layers className="size-3" />
+      {/* MOCK: count — wymaga GET /api/attributes/{id}/values (#TBD) */}
+      <span>— wartości</span>
+    </Link>
   );
 }
 

--- a/apps/admin/src/features/catalog/attributes/values.tsx
+++ b/apps/admin/src/features/catalog/attributes/values.tsx
@@ -1,0 +1,53 @@
+import { ArrowLeft, Layers } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+
+/**
+ * UI-03.2 placeholder for AttributeValuesView (epik UI-03 #357).
+ *
+ * The handoff design specifies a full-page editor for select/multi-select
+ * attribute values: locale tabs, color swatches, default/deprecated
+ * toggles, drag-reorder. None of that is implementable yet — there is no
+ * backend (`GET/POST/PATCH/DELETE /api/attributes/{id}/values`) and the
+ * `attribute_values` entity itself is in the backlog. This page renders
+ * as a banner so the click flow from the list view (violet "Wartości"
+ * badge → here) exists end-to-end.
+ *
+ * MOCK: full AttributeValuesView — wymaga endpointów /values + entity
+ * attribute_values (patrz Project Plan/UI/Wdrozenie_grafiki/modelowanie-do-oprogramowania.md).
+ */
+export function AttributeValuesPage() {
+  const { t } = useTranslation();
+  const { id = '' } = useParams<{ id: string }>();
+
+  return (
+    <div className="space-y-6 px-4 py-6 sm:px-6 lg:px-10">
+      <div>
+        <Button asChild variant="ghost" size="sm">
+          <Link to={`/modeling/attributes/${id}`}>
+            <ArrowLeft className="size-4" />
+            {t('attribute_values.back', { defaultValue: 'Wróć do atrybutu' })}
+          </Link>
+        </Button>
+      </div>
+
+      <div className="rounded-3xl border border-accent-violet/30 bg-accent-violet/5 p-8 soft-shadow">
+        <div className="mb-3 inline-flex items-center gap-1.5 rounded-full bg-accent-violet/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-accent-violet">
+          <Layers className="size-3.5" />
+          {t('attribute_values.mock_badge', { defaultValue: 'Wymaga oprogramowania' })}
+        </div>
+        <h1 className="display text-[28px] font-semibold leading-tight text-ink">
+          {t('attribute_values.title', { defaultValue: 'Wartości atrybutu' })}
+        </h1>
+        <p className="mt-2 max-w-3xl text-[14px] text-ink-2">
+          {t('attribute_values.mock_body', {
+            defaultValue:
+              'Pełna edycja wartości select / multi-select (etykiety per locale, kolory, default, deprecated, kolejność) wymaga endpointów /api/attributes/{id}/values. Tracking w Project Plan/UI/Wdrozenie_grafiki/modelowanie-do-oprogramowania.md.',
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/categories/list.tsx
+++ b/apps/admin/src/features/catalog/categories/list.tsx
@@ -37,13 +37,17 @@ export function CategoriesTreePage() {
   return (
     <div className="space-y-6">
       <div className="flex items-end justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">{t('categories.list_title')}</h1>
-          <p className="text-sm text-muted-foreground">{t('categories.list_subtitle')}</p>
+        <div className="space-y-2">
+          <h1 className="display text-[28px] font-semibold leading-tight text-ink">
+            {t('categories.list_title')}
+          </h1>
+          <p className="max-w-3xl text-[14px] text-ink-2">{t('categories.list_subtitle')}</p>
         </div>
+        {/* MOCK: ObjectType filter chips (Service / Product / Asset) — wymaga listing po kind (#TBD) */}
+        {/* MOCK: Drag-and-drop subtree move — wymaga PATCH /api/categories/{id}/move (#TBD) */}
       </div>
 
-      <div className="rounded-xl border bg-card p-3">
+      <div className="rounded-2xl border border-line bg-surface p-3 soft-shadow">
         {query.isLoading ? (
           <p className="py-6 text-center text-sm text-muted-foreground">{t('app.loading')}</p>
         ) : tree.length === 0 ? (

--- a/apps/admin/src/features/catalog/categories/show.tsx
+++ b/apps/admin/src/features/catalog/categories/show.tsx
@@ -40,17 +40,17 @@ export function CategoryShowPage() {
 
   return (
     <div className="space-y-6">
-      <div className="space-y-1">
+      <div className="space-y-2">
         <Button asChild variant="ghost" size="sm" className="-ml-3">
           <Link to="/modeling/categories">
             <ArrowLeft className="size-4" />
             {t('categories.back')}
           </Link>
         </Button>
-        <h1 className="text-2xl font-semibold tracking-tight">{name}</h1>
-        <p className="font-mono text-xs text-muted-foreground">{category.code}</p>
+        <h1 className="display text-[28px] font-semibold leading-tight text-ink">{name}</h1>
+        <p className="font-mono text-[12px] text-ink-2">{category.code}</p>
         {category.path ? (
-          <p className="text-xs text-muted-foreground">
+          <p className="text-[12px] text-muted-foreground">
             {t('categories.fields.path')}: <code className="font-mono">{category.path}</code>
           </p>
         ) : null}
@@ -146,12 +146,17 @@ function EffectiveAttributesPreview({ categoryId }: { categoryId: string }) {
   }, [categoryId, kind, t]);
 
   return (
-    <Card>
+    <Card className="border-accent-violet/30 bg-accent-violet/5 soft-shadow">
       <CardContent className="space-y-4 pt-6">
         <div className="flex items-end justify-between gap-3">
           <div className="space-y-1">
-            <h2 className="text-sm font-semibold">{t('modeling.inheritance_preview.title')}</h2>
-            <p className="text-xs text-muted-foreground">
+            <div className="inline-flex items-center gap-1.5 rounded-full bg-accent-violet/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-accent-violet">
+              effective preview
+            </div>
+            <h2 className="text-[15px] font-semibold text-ink">
+              {t('modeling.inheritance_preview.title')}
+            </h2>
+            <p className="text-[12px] text-muted-foreground">
               {t('modeling.inheritance_preview.description')}
             </p>
           </div>

--- a/apps/admin/src/features/catalog/object-types/list.tsx
+++ b/apps/admin/src/features/catalog/object-types/list.tsx
@@ -48,17 +48,19 @@ export function ObjectTypesListPage() {
 
   return (
     <div className="space-y-8">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">{t('object_types.list_title')}</h1>
-        <p className="text-sm text-muted-foreground">{t('object_types.list_subtitle')}</p>
+      <div className="space-y-2">
+        <h1 className="display text-[28px] font-semibold leading-tight text-ink">
+          {t('object_types.list_title')}
+        </h1>
+        <p className="max-w-3xl text-[14px] text-ink-2">{t('object_types.list_subtitle')}</p>
       </div>
 
       <section className="space-y-3">
         <header className="flex items-center justify-between">
-          <h2 className="text-sm font-medium">{t('object_types.built_in_title')}</h2>
+          <h2 className="text-[15px] font-semibold text-ink">{t('object_types.built_in_title')}</h2>
           <BuiltInLockBadge />
         </header>
-        <div className="rounded-xl border bg-card">
+        <div className="rounded-2xl border border-line bg-surface soft-shadow">
           <Table>
             <TableHeader>
               <TableRow>
@@ -128,13 +130,13 @@ export function ObjectTypesListPage() {
 
       <section className="space-y-3">
         <header className="flex items-center justify-between">
-          <h2 className="text-sm font-medium">{t('object_types.custom_title')}</h2>
+          <h2 className="text-[15px] font-semibold text-ink">{t('object_types.custom_title')}</h2>
           <Button type="button" size="sm" onClick={() => setCreateOpen(true)}>
             <Plus className="size-4" />
             {t('object_types.create_custom_action', { defaultValue: 'Create custom ObjectType' })}
           </Button>
         </header>
-        <div className="rounded-xl border bg-card">
+        <div className="rounded-2xl border border-line bg-surface soft-shadow">
           <Table>
             <TableHeader>
               <TableRow>
@@ -213,16 +215,18 @@ export function ObjectTypesListPage() {
 function KindBadge({ kind }: { kind: string }) {
   const tone =
     kind === 'product'
-      ? 'bg-blue-100 text-blue-900'
+      ? 'bg-accent-blue/10 text-accent-blue'
       : kind === 'category'
-        ? 'bg-emerald-100 text-emerald-900'
+        ? 'bg-accent-emerald/10 text-accent-emerald'
         : kind === 'asset'
-          ? 'bg-purple-100 text-purple-900'
+          ? 'bg-accent-violet/10 text-accent-violet'
           : kind === 'brand'
-            ? 'bg-amber-100 text-amber-900'
+            ? 'bg-accent-amber/10 text-accent-amber'
             : 'bg-muted text-muted-foreground';
   return (
-    <span className={`rounded px-2 py-0.5 text-xs font-medium uppercase tracking-wide ${tone}`}>
+    <span
+      className={`rounded-md px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide ${tone}`}
+    >
       {kind}
     </span>
   );

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -106,6 +106,25 @@ export function ObjectTypeShowPage() {
         <WhereUsedList resource="object_types" id={objectType.id} />
       </div>
 
+      {/*
+        MOCK: audit log (last 5 changes — who/when/diff) — wymaga
+        GET /api/object_types/{id}/audit-log (#TBD).
+        Patrz Project Plan/UI/Wdrozenie_grafiki/modelowanie-do-oprogramowania.md.
+      */}
+      <Card className="border-dashed border-line bg-surface-2/40">
+        <CardContent className="space-y-1 pt-6">
+          <h2 className="text-[15px] font-semibold text-ink">
+            {t('object_types.audit_log_title', { defaultValue: 'Historia zmian (5 ostatnich)' })}
+          </h2>
+          <p className="text-[12px] text-muted-foreground">
+            {t('object_types.audit_log_mock', {
+              defaultValue:
+                'Mock — wymaga endpointu /api/object_types/{id}/audit-log. Patrz backlog modelowania.',
+            })}
+          </p>
+        </CardContent>
+      </Card>
+
       <p className="text-xs text-muted-foreground">{t('object_types.write_deferred_note')}</p>
     </div>
   );


### PR DESCRIPTION
## Summary

- Wszystkie 4 sub-taby Modelowania (Object Types / Attributes / Attribute Groups / Categories) dostają handoff polish: `display` headings, soft-shadow cards, accent palette badges (violet/emerald/blue/amber/sky/rose).
- Attributes list: nowa kolumna **Wartości** z violet badge dla select/multi-select, klikalna → placeholder `/modeling/attributes/:id/values`.
- Attribute Groups list: badge `⭐ first-class entity` (ADR-012) w nagłówku.
- Categories show: violet-bordered card dla `EffectiveAttributesPreview` (killer feature handoff).
- Object Types show: dashed audit-log placeholder card z `MOCK:` linkiem do GET endpointu w backlogu.
- Backlog endpointów / decyzji architektonicznych w [Project Plan/UI/Wdrozenie_grafiki/modelowanie-do-oprogramowania.md](Project%20Plan/UI/Wdrozenie_grafiki/modelowanie-do-oprogramowania.md).

## Test plan

- [x] `pnpm --filter admin typecheck`
- [x] `pnpm --filter admin lint`
- [x] `pnpm --filter admin build`
- [ ] CI Playwright — modeling-shell test już sprawdza tablist + tab switch + redirect; brak nowych spec, modyfikacje są wizualne.
- [ ] Manual smoke: login → /modeling, klik każdy z 4 tabów, otwórz detail row z każdej zakładki, sprawdź Console clean + brak nowych 4xx/5xx.

## Świadome odejścia

- **NIE robimy** w tym tickecie: NewObjectType wizard (4-step), AttributeValuesView (full editor), MigrationImpactModal, drag-reorder, audit log per encja, schema_rev counter, visible_when rule builder, dnd-kit dla kategorii. Wszystko trafia do backloga jako kolejne tickety (każdy wymaga endpointu BE którego dziś nie ma).
- **AttributeValuesPage** jest pełnym placeholder mock — kliknięcie violet badge w liście atrybutów prowadzi tutaj zamiast 404, ale UI tylko mówi "wymaga oprogramowania" (z linkiem do backloga). To pozwala demonstrować flow bez dezorientowania operatora.
- **EffectiveAttributesPreview** już istniał (UI-08.14 #269) — tu tylko visual polish (violet border + badge), backend zostaje.

## Closes

Closes #357
Refs #356 #358