### PR TITLE
feat(admin): UI-03.3 handoff Produkty list+detail — wizualna harmonizacja + TODO komentarze

### DIFF
--- a/Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md
+++ b/Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md
@@ -1,0 +1,71 @@
+# Produkty — backlog do oprogramowania
+
+> Baza pod kolejne GitHub tickety. Każda pozycja zaznaczona w kodzie komentarzem `MOCK:` lub `TODO(handoff)`.
+>
+> **Stan na 2026-05-02 po merge'u #358.** Aktualna implementacja list+detail jest w ~75-80% gotowa po marathonie UI-02; ten plik wylicza luki które handoff design ujawnia.
+
+## Frontend + nowy endpoint backendowy
+
+### Bulk operations (rozszerzenie istniejącego /bulk-edit)
+
+- [ ] **Bulk attribute edit** — `POST /api/products/bulk-edit` z operation `edit_attribute`. Frontend: `BulkEditAttributeModal` (picker atrybutu + value input) wywoływany z `bulk-actions-toolbar.tsx`. Backend: rozszerzenie istniejącego `BulkEditController` o nowy operation handler. Estymacja: M (FE 3-4h, BE 4-5h).
+- [ ] **Bulk category change** — `POST /api/products/bulk-edit` z operation `change_category`. Modal picker kategorii + apply do selected SKU.
+- [ ] **Bulk export CSV** — `GET /api/products/export?ids=…&format=csv` (streaming). Backend: streaming CSV response (FrankenPHP buffer flush — patrz lessons), wszystkie visible columns + attribute columns. Frontend: modal "Export selected" → trigger download. Estymacja: M (FE 3-4h, BE 5-6h).
+
+### Relationships / Associations
+
+- [ ] **AssociationController CRUD** — Entity + Repository istnieją (po Sprint 0), brak HTTP controllera. Endpointy:
+  - `GET /api/products/{id}/relationships` — list per type (akcesorium / cross-sell / alternatywa).
+  - `POST /api/products/{id}/relationships` — create relation.
+  - `DELETE /api/products/{id}/relationships/{relationId}` — remove.
+  - `PATCH /api/products/{id}/relationships/order` — reorder w obrębie typu.
+- [ ] **RelationshipsTab UI** — 3 sekcje per typ z autocomplete SKU pickerem, reorder drag, delete inline. Plik FE: `apps/admin/src/features/catalog/products/components/RelationshipsTab.tsx` (stub mock zamknięty w UI-03.3).
+
+### Media / DAM
+
+- [ ] **Upload do MinIO/S3 przez Flysystem** — `POST /api/products/{id}/media` (multipart). Backend: ProductMediaController + storage adapter.
+- [ ] **Image transformations** — thumbnail + per-channel resize (Shopify max 4096px, BaseLinker 800x800, etc.).
+- [ ] **AI metadata extraction** — alt text, dominant color, OCR (Faza 2).
+- [ ] **MediaTab UI** — 4-image grid + Upload button + delete + reorder. Plik FE: stub mock w UI-03.3.
+
+### History / Audit
+
+- [ ] **Per-product audit log endpoint** — `GET /api/products/{id}/audit-log` zwraca timeline wpisów (manual/import/integration provenance, who, when, diff). Event sourcing istnieje w `Catalog/Contracts/Event/*`, brak HTTP endpointu. Plik FE: `HistoryTab.tsx` (stub mock).
+
+### Import
+
+- [ ] **CSV/XLSX import dryRun + commit** — `POST /api/products/import?dryRun=true` accept multipart, parser (League\Csv lub PhpSpreadsheet), validation row-by-row, response z preview (sample rows + error count). Commit: same endpoint without dryRun, używa `BulkContext::setBulk()` + async reindex. Estymacja: L (BE 12-15h, FE 6-8h).
+
+### Agent (Faza 2 per CLAUDE.md PIM)
+
+- [ ] **Agent suggestions card wiring** — Anthropic SDK PHP integration. UI plik: `detail-sidebar.tsx` (3 placeholdery z mock comments).
+- [ ] **"Wygeneruj opis EN"** tool dispatch — agent fetcher current product → asks model for translation → submits as `pending_change`.
+- [ ] **"Uzupełnij kod HS"** tool dispatch — agent classification by product description.
+- [ ] **"Zaproponuj akcesoria"** tool dispatch — agent rekomendacje na bazie ObjectType + atrybuty + relacje.
+
+## Wymaga decyzji architektonicznej
+
+- [ ] **Variants inheritance model** — lazy compute (per read) vs. eager denormalization (copy master values na variant create). Performance tradeoff dla dużych masterów (>50 variantów). Wymaga ADR.
+- [ ] **CSV import schema** — fixed columns (uniwersalne kolumny SKU/name/price/...) vs. ObjectType-aware (dynamic columns per attached AttributeGroups). Drugi model jest bardziej elastyczny ale wymaga upload + 2-step (typ → mapping → preview).
+- [ ] **Saved views per-user** vs. tenant-shared — obecnie MVP shared (wszystkie views widoczne dla tenant). Faza 1 + CurrentUserProvider w Identity = per-user filtering.
+- [ ] **AttributeLevel enum** (`master | variant | both`) — czy variant może mieć własne atrybuty których master nie ma? Wpływa na schema `product_values` (kolumna `level`) i resolver inheritance.
+
+## Już zrealizowane (po marathonie UI-02 — nie blokuje)
+
+- [x] Saved views CRUD (#297, #336, #346 fix JWT auth header)
+- [x] Bulk toggle_enabled (#293, #301)
+- [x] Excel grid z inline edit (#350)
+- [x] Variants tree mode (#351)
+- [x] CreateProductWizard 4-step (#347)
+- [x] DuplicateProductDialog (#332)
+- [x] AdvancedFilterBuilder (#349)
+- [x] DetailDynamicForm z ObjectType + AttributeGroups (#307, #338, #355)
+- [x] VariantsTab z attribute autocomplete (#352)
+- [x] ProductFilterChips
+- [x] Effective attribute groups endpoint (#335)
+
+## Zależności od innych epików
+
+- Epik 0.8 (BaseLinker) + 0.9 (Shopify) — sync status w detail-sidebar zależy od pełnej integracji (po Fazie 1).
+- Faza 2 (Agent layer) — wszystkie agent-related pozycje powyżej.
+- Epik 0.11 (Hardening) — audit log endpoints + import CSV mogą wpaść tutaj.

--- a/apps/admin/src/components/catalog/bulk-actions-toolbar.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions-toolbar.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, MinusCircle, Pencil, Trash2, X } from 'lucide-react';
+import { CheckCircle2, Download, FolderTree, MinusCircle, Pencil, Trash2, X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -93,7 +93,7 @@ export function BulkActionsToolbar({
 
   return (
     <div
-      className="sticky bottom-4 z-30 mx-auto flex max-w-4xl flex-col gap-2 rounded-md border bg-card px-4 py-3 shadow-lg"
+      className="sticky bottom-4 z-30 mx-auto flex max-w-4xl flex-col gap-2 rounded-2xl border border-line bg-surface px-4 py-3 soft-shadow-lg"
       data-testid="bulk-actions-toolbar"
     >
       <div className="flex flex-wrap items-center gap-2">
@@ -148,6 +148,35 @@ export function BulkActionsToolbar({
         >
           <MinusCircle className="size-4" />
           {t('products.bulk.disable', { defaultValue: 'Disable' })}
+        </Button>
+        {/* MOCK: bulk category change — wymaga rozszerzenia POST /api/products/bulk-edit
+            o operation 'change_category' (#TBD). Patrz Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md. */}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled
+          aria-disabled="true"
+          title={t('products.bulk.change_category_disabled', {
+            defaultValue: 'Mock — wymaga operation change_category w /bulk-edit',
+          })}
+        >
+          <FolderTree className="size-4" />
+          {t('products.bulk.change_category', { defaultValue: 'Zmień kategorię' })}
+        </Button>
+        {/* MOCK: bulk export CSV/XLSX — wymaga GET /api/products/export?ids=...&format=csv (#TBD). */}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled
+          aria-disabled="true"
+          title={t('products.bulk.export_disabled', {
+            defaultValue: 'Mock — wymaga GET /api/products/export?ids=...&format=csv',
+          })}
+        >
+          <Download className="size-4" />
+          {t('products.bulk.export', { defaultValue: 'Eksport' })}
         </Button>
         <Button
           type="button"

--- a/apps/admin/src/components/catalog/detail-sidebar.tsx
+++ b/apps/admin/src/components/catalog/detail-sidebar.tsx
@@ -1,4 +1,4 @@
-import { History, Image, Link2, Radio } from 'lucide-react';
+import { History, Image, Link2, Radio, RefreshCw, Sparkles } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -123,6 +123,55 @@ export function DetailSidebar({ productId }: { productId: string }) {
             ))}
           </ul>
         )}
+        {/* MOCK: Force sync — wymaga POST /api/integrations/{id}/sync (#TBD).
+            Patrz Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md. */}
+        <button
+          type="button"
+          disabled
+          aria-disabled="true"
+          className="mt-2 inline-flex cursor-not-allowed items-center gap-1.5 rounded-md border border-line px-2 py-1 text-[11px] text-muted-foreground"
+          title={t('products.detail.sidebar.force_sync_disabled', {
+            defaultValue: 'Mock — wymaga POST /api/integrations/{id}/sync',
+          })}
+        >
+          <RefreshCw className="size-3" />
+          {t('products.detail.sidebar.force_sync', { defaultValue: 'Wymuś synchronizację' })}
+        </button>
+      </Section>
+
+      {/*
+        MOCK: Agent suggestions card (handoff right rail) — wymaga warstwy
+        agenta (Faza 2) per CLAUDE.md PIM. Trzy stub'y akcji: tłumaczenie EN,
+        kod HS, rekomendacje akcesoriów. Patrz Project Plan/UI/Wdrozenie_grafiki/
+        produkty-do-oprogramowania.md § "Agent (Faza 2)".
+      */}
+      <Section
+        icon={Sparkles}
+        title={t('products.detail.sidebar.agent', { defaultValue: 'Sugestie agenta' })}
+      >
+        <ul className="space-y-2 text-xs">
+          {[
+            t('products.detail.sidebar.agent_translate', {
+              defaultValue: 'Wygeneruj opis EN dla tego produktu',
+            }),
+            t('products.detail.sidebar.agent_hs_code', {
+              defaultValue: 'Uzupełnij kod HS na podstawie kategorii',
+            }),
+            t('products.detail.sidebar.agent_accessories', {
+              defaultValue: 'Zaproponuj akcesoria z istniejącego katalogu',
+            }),
+          ].map((suggestion) => (
+            <li
+              key={suggestion}
+              className="flex items-center justify-between gap-2 rounded-md bg-accent-violet/5 px-2 py-1.5 text-ink-2"
+            >
+              <span className="flex-1">{suggestion}</span>
+              <span className="rounded bg-accent-violet/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-accent-violet">
+                Faza 2
+              </span>
+            </li>
+          ))}
+        </ul>
       </Section>
     </aside>
   );
@@ -143,7 +192,9 @@ function Section({
         <Icon className="size-4" />
         <span>{title}</span>
       </div>
-      <div className="rounded-md border bg-card px-3 py-2">{children}</div>
+      <div className="rounded-2xl border border-line bg-surface px-3 py-2 soft-shadow">
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -282,16 +282,33 @@ export function ProductListPage() {
   return (
     <div className="space-y-6 pb-24">
       <div className="flex items-end justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">{t('products.list_title')}</h1>
-          <p className="text-sm text-muted-foreground">{t('products.list_subtitle')}</p>
+        <div className="space-y-2">
+          <h1 className="display text-[28px] font-semibold leading-tight text-ink">
+            {t('products.list_title')}
+          </h1>
+          <p className="max-w-3xl text-[14px] text-ink-2">{t('products.list_subtitle')}</p>
         </div>
-        <Button asChild>
-          <Link to="/products/new">
-            <Plus className="size-4" />
-            {t('products.create')}
-          </Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          {/* MOCK: Import CSV/XLSX — wymaga POST /api/products/import?dryRun=true (#TBD).
+              Patrz Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md. */}
+          <Button
+            type="button"
+            variant="outline"
+            disabled
+            aria-disabled="true"
+            title={t('products.import_disabled', {
+              defaultValue: 'Mock — wymaga oprogramowania importu CSV/XLSX',
+            })}
+          >
+            {t('products.import', { defaultValue: 'Import' })}
+          </Button>
+          <Button asChild>
+            <Link to="/products/new">
+              <Plus className="size-4" />
+              {t('products.create')}
+            </Link>
+          </Button>
+        </div>
       </div>
 
       {saveError !== null ? (

--- a/apps/admin/src/features/catalog/products/show.tsx
+++ b/apps/admin/src/features/catalog/products/show.tsx
@@ -26,9 +26,9 @@ interface CatalogObject {
   updatedAt?: string;
 }
 
-type TabKey = 'attributes' | 'variants';
+type TabKey = 'attributes' | 'variants' | 'media' | 'relationships' | 'history';
 
-const TABS: TabKey[] = ['attributes', 'variants'];
+const TABS: TabKey[] = ['attributes', 'variants', 'media', 'relationships', 'history'];
 
 export function ProductShowPage() {
   const { t, i18n } = useTranslation();
@@ -52,8 +52,8 @@ export function ProductShowPage() {
 
   return (
     <div className="space-y-4">
-      {/* Sticky header */}
-      <div className="sticky top-0 z-20 -mx-6 -mt-6 border-b bg-background/95 px-6 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      {/* Sticky header — handoff glass-strong */}
+      <div className="sticky top-0 z-20 -mx-6 -mt-6 border-b border-line glass-strong px-6 py-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="space-y-1">
             <Button asChild variant="ghost" size="sm" className="-ml-3">
@@ -63,8 +63,8 @@ export function ProductShowPage() {
               </Link>
             </Button>
             <div className="flex items-center gap-3">
-              <h1 className="text-xl font-semibold tracking-tight">{name}</h1>
-              <span className="font-mono text-xs text-muted-foreground">{product.code}</span>
+              <h1 className="display text-[22px] font-semibold leading-tight text-ink">{name}</h1>
+              <span className="font-mono text-[12px] text-ink-2">{product.code}</span>
             </div>
           </div>
           <div className="flex items-center gap-3">
@@ -114,6 +114,9 @@ export function ProductShowPage() {
             <DetailDynamicForm productId={productId} initialValues={attrs} />
           ) : null}
           {activeTab === 'variants' ? <VariantsTab masterProductId={productId} /> : null}
+          {activeTab === 'media' ? <MediaTabStub /> : null}
+          {activeTab === 'relationships' ? <RelationshipsTabStub /> : null}
+          {activeTab === 'history' ? <HistoryTabStub productId={productId} /> : null}
         </div>
 
         <DetailSidebar productId={productId} />
@@ -140,4 +143,55 @@ function formatDateTime(value: string, locale: string): string {
     dateStyle: 'short',
     timeStyle: 'short',
   }).format(date);
+}
+
+/**
+ * MOCK: Multimedia tab — wymaga DAM + S3/MinIO storage (#TBD).
+ * Patrz Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md.
+ */
+function MediaTabStub() {
+  return (
+    <div className="rounded-2xl border border-dashed border-line bg-surface-2/40 p-8 text-center soft-shadow">
+      <p className="text-[14px] font-medium text-ink-2">Multimedia (mock)</p>
+      <p className="mt-1 text-[12px] text-muted-foreground">
+        Tab wymaga DAM (S3/MinIO + image transformations). Backlog:{' '}
+        <code className="font-mono text-[11px]">POST /api/products/&#123;id&#125;/media</code>
+      </p>
+    </div>
+  );
+}
+
+/**
+ * MOCK: Powiązania (relationships) tab — wymaga AssociationController CRUD (#TBD).
+ * Entity + Repository istnieją, brak HTTP controllera.
+ */
+function RelationshipsTabStub() {
+  return (
+    <div className="rounded-2xl border border-dashed border-line bg-surface-2/40 p-8 text-center soft-shadow">
+      <p className="text-[14px] font-medium text-ink-2">Powiązania (mock)</p>
+      <p className="mt-1 text-[12px] text-muted-foreground">
+        3 typy: akcesoria / cross-sell / alternatywa. Wymaga{' '}
+        <code className="font-mono text-[11px]">
+          GET/POST/DELETE /api/products/&#123;id&#125;/relationships
+        </code>
+        .
+      </p>
+    </div>
+  );
+}
+
+/**
+ * MOCK: Historia (audit timeline) tab — wymaga GET /api/products/{id}/audit-log (#TBD).
+ * DetailSidebar już używa tego endpointu (last-5), tu pełna historia z timeline UI.
+ */
+function HistoryTabStub({ productId: _productId }: { productId: string }) {
+  return (
+    <div className="rounded-2xl border border-dashed border-line bg-surface-2/40 p-8 text-center soft-shadow">
+      <p className="text-[14px] font-medium text-ink-2">Historia (mock)</p>
+      <p className="mt-1 text-[12px] text-muted-foreground">
+        Pełna oś czasu z provenance per zmiana. Sidebar już pokazuje 5 ostatnich (UI-02.5); ten tab
+        potrzebuje paginowanego endpointu i timeline UI.
+      </p>
+    </div>
+  );
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -314,6 +314,9 @@
       "updated_at": "Last updated",
       "tabs": {
         "attributes": "Attributes",
+        "variants": "Variants",
+        "media": "Media",
+        "relationships": "Relationships",
         "categories": "Categories",
         "associations": "Associations",
         "channels": "Channels",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -314,6 +314,9 @@
       "updated_at": "Ostatnia aktualizacja",
       "tabs": {
         "attributes": "Atrybuty",
+        "variants": "Warianty",
+        "media": "Multimedia",
+        "relationships": "Powiązania",
         "categories": "Kategorie",
         "associations": "Powiązania",
         "channels": "Kanały",


### PR DESCRIPTION
## Summary

- **List view**: display heading, nowy outline `Import` button (mock — wymaga `POST /api/products/import?dryRun=true`).
- **BulkActionsToolbar**: `rounded-2xl + soft-shadow-lg` surface; dodane mock buttony `Zmień kategorię` + `Eksport` (każdy z `MOCK:` komentarzem wskazującym konkretny endpoint do dorobienia).
- **DetailSidebar**: każda sekcja w `rounded-2xl + soft-shadow`; nowy mock button `Wymuś synchronizację` (POST `/integrations/{id}/sync`); nowa sekcja `Sugestie agenta` z 3 placeholderami oznaczonymi `Faza 2`.
- **Detail show.tsx**: `glass-strong` sticky header, display title; tab list rozszerzony z 2 do 5 (Atrybuty / Warianty / Multimedia / Powiązania / Historia). Trzy nowe tabs to `MediaTabStub` / `RelationshipsTabStub` / `HistoryTabStub` — dashed-border placeholdery pointing at brakujące endpointy.
- **Locales**: tabs labels dla media / relationships / variants w PL + EN.
- Pełny backlog endpointów / decyzji architektonicznych w [Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md](Project%20Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md).

## Test plan

- [x] `pnpm --filter admin typecheck`
- [x] `pnpm --filter admin lint` (1 preexisting warning + 1 info, niezwiązane z PR)
- [x] `pnpm --filter admin build`
- [ ] CI Playwright — products specs są fixme'd (BLOCKED_BY_41), ale modeling-shell + multi-tenant powinny być OK.
- [ ] Manual smoke (per CLAUDE.md § SMOKE TEST RULE):
  1. Login → `/products` (modyfikacje wizualne renderują się)
  2. Saved views chip — Network: GET /saved-views OK 200
  3. Bulk select → toolbar pokazuje wszystkie 6 buttonów; mock `Zmień kategorię` + `Eksport` są disabled z tooltipem
  4. Klik produkt → detail z 5 tabami; klik każdego tab pokazuje content (3 mock taby renderują dashed-border placeholder)
  5. Sidebar Sugestie agenta widoczne z 3 placeholderami "Faza 2"
  6. Network: brak nowych 4xx/5xx (mock buttony są `disabled` — nie wysyłają żądań)

## Świadome odejścia

- **NIE robimy** w tym tickecie: backend rozszerzeń `/bulk-edit`, AssociationController, MediaController, audit-log endpoint, CSV import, agent wiring, completeness ring (linear bar zostaje), variants inheritance refactor, saved views per-user. Wszystko trafia do backloga.
- **MediaTab/RelationshipsTab/HistoryTab są pełnymi stub'ami** — operator widzi że taby istnieją ale każdy wskazuje konkretny brakujący endpoint i link do backloga. To pozwala demonstrować kompletny IA z handoffu bez wprowadzania w błąd.
- **Agent suggestions sekcja** trzyma się reguły CLAUDE.md PIM § "Faza 2" — explicit `Faza 2` badge przy każdym placeholderze, brak fałszywego claim'u że agent działa.
- **Completeness ring** odłożony — `CompletenessBadge` linear bar pozostaje, animowany ring per handoff to follow-up (cosmetic, brak blokerów).

## Closes

Closes #358
Refs #356 #357