### PR TITLE
feat(admin): Pulpit pixel-perfect — range picker + MOCK badges + skeleton loaders (UI-03b)

### DIFF
--- a/apps/admin/src/features/dashboard/components/ActivityChart.tsx
+++ b/apps/admin/src/features/dashboard/components/ActivityChart.tsx
@@ -1,18 +1,25 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ACTIVITY_30D } from '../mock-data';
+import { MockBadge } from '@/components/ui/mock-badge';
+import { cn } from '@/lib/utils';
+
+import { ACTIVITY_BY_RANGE, type ActivityRange } from '../mock-data';
+
+const RANGES: ActivityRange[] = ['7d', '30d', '90d'];
 
 /**
- * MOCK component — 30-day activity chart (added vs modified).
- * Backend: GET /api/dashboard/activity?range=30d (do dorobienia).
+ * MOCK component — activity chart with range picker.
+ * Backend: GET /api/dashboard/activity?range=7d|30d|90d (do dorobienia).
  * Patrz Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md.
  */
 export function ActivityChart() {
   const { t } = useTranslation();
+  const [range, setRange] = useState<ActivityRange>('30d');
+  const points = ACTIVITY_BY_RANGE[range];
   const max = useMemo(
-    () => Math.max(...ACTIVITY_30D.map((p) => Math.max(p.added, p.modified))),
-    [],
+    () => Math.max(...points.map((p) => Math.max(p.added, p.modified))),
+    [points],
   );
 
   const width = 720;
@@ -23,14 +30,17 @@ export function ActivityChart() {
   const innerH = height - padY * 2;
 
   const buildPath = (key: 'added' | 'modified') =>
-    ACTIVITY_30D.map((point, i) => {
-      const x = padX + (i / (ACTIVITY_30D.length - 1)) * innerW;
-      const y = padY + innerH - (point[key] / max) * innerH;
-      return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`;
-    }).join(' ');
+    points
+      .map((point, i) => {
+        const x = padX + (i / (points.length - 1)) * innerW;
+        const y = padY + innerH - (point[key] / max) * innerH;
+        return `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`;
+      })
+      .join(' ');
 
   return (
-    <div className="rounded-2xl border border-line bg-surface p-5 soft-shadow">
+    <div className="relative rounded-2xl border border-line bg-surface p-5 soft-shadow">
+      <MockBadge variant="corner" />
       <div className="flex items-baseline justify-between">
         <h3 className="text-[15px] font-semibold text-ink">{t('dashboard.activity.title')}</h3>
         <div className="flex items-center gap-3 text-[12px] text-muted-foreground">
@@ -42,10 +52,29 @@ export function ActivityChart() {
             <span className="size-2 rounded-full bg-accent-violet" />
             {t('dashboard.activity.legend_modified')}
           </span>
-          {/* MOCK: range picker (7d/30d/90d) — wymaga GET /api/dashboard/activity?range=… (#TBD) */}
-          <span className="rounded-md border border-line px-2 py-0.5 text-[11px] text-muted-foreground">
-            30d
-          </span>
+          <div
+            className="flex items-center gap-0.5 rounded-md border border-line p-0.5"
+            role="tablist"
+            aria-label={t('dashboard.activity.range_aria', { defaultValue: 'Zakres aktywności' })}
+          >
+            {RANGES.map((r) => (
+              <button
+                key={r}
+                type="button"
+                role="tab"
+                aria-selected={range === r}
+                onClick={() => setRange(r)}
+                className={cn(
+                  'rounded px-2 py-0.5 text-[11px] font-medium transition-colors',
+                  range === r
+                    ? 'bg-accent-violet/10 text-accent-violet'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {t(`dashboard.activity.range_${r}`, { defaultValue: r })}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
       <svg

--- a/apps/admin/src/features/dashboard/components/AlertCenter.tsx
+++ b/apps/admin/src/features/dashboard/components/AlertCenter.tsx
@@ -1,6 +1,7 @@
-import { AlertTriangle, BellRing, Info } from 'lucide-react';
+import { AlertTriangle, BellRing, Info, Settings2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { MockBadge } from '@/components/ui/mock-badge';
 import { cn } from '@/lib/utils';
 
 import { ALERTS, type AlertSeverity } from '../mock-data';
@@ -30,10 +31,23 @@ const SEVERITY_STYLE: Record<
 export function AlertCenter() {
   const { t } = useTranslation();
   return (
-    <div className="rounded-2xl border border-line bg-surface soft-shadow">
+    <div className="relative rounded-2xl border border-line bg-surface soft-shadow">
+      <MockBadge variant="corner" />
       <div className="flex items-center justify-between border-b border-line px-5 py-4">
         <h3 className="text-[15px] font-semibold text-ink">{t('dashboard.alerts.title')}</h3>
-        <span className="text-[12px] text-muted-foreground">{t('dashboard.alerts.subtitle')}</span>
+        <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
+          <span>{t('dashboard.alerts.subtitle')}</span>
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            className="inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-line px-2 py-0.5 text-[11px] text-muted-foreground"
+          >
+            <Settings2 className="size-3" />
+            {t('dashboard.alerts.configure', { defaultValue: 'Skonfiguruj alerty' })}
+          </button>
+          <MockBadge />
+        </div>
       </div>
       <ul className="divide-y divide-line">
         {ALERTS.map((alert) => {

--- a/apps/admin/src/features/dashboard/components/ChannelDistribution.tsx
+++ b/apps/admin/src/features/dashboard/components/ChannelDistribution.tsx
@@ -1,5 +1,8 @@
+import { Download } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { MockBadge } from '@/components/ui/mock-badge';
 
 import { CHANNEL_DISTRIBUTION } from '../mock-data';
 
@@ -17,12 +20,25 @@ export function ChannelDistribution() {
     [],
   );
   return (
-    <div className="rounded-2xl border border-line bg-surface p-5 soft-shadow">
+    <div className="relative rounded-2xl border border-line bg-surface p-5 soft-shadow">
+      <MockBadge variant="corner" />
       <div className="flex items-baseline justify-between">
         <h3 className="text-[15px] font-semibold text-ink">{t('dashboard.channel_dist.title')}</h3>
-        <span className="num text-[12px] text-muted-foreground">
-          {total.toLocaleString('pl-PL')} {t('dashboard.channel_dist.unit')}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="num text-[12px] text-muted-foreground">
+            {total.toLocaleString('pl-PL')} {t('dashboard.channel_dist.unit')}
+          </span>
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            className="inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-line px-2 py-0.5 text-[11px] text-muted-foreground"
+          >
+            <Download className="size-3" />
+            {t('dashboard.channel_dist.export', { defaultValue: 'Eksportuj raport' })}
+          </button>
+          <MockBadge />
+        </div>
       </div>
       <div
         className="mt-4 flex h-3 w-full overflow-hidden rounded-full bg-surface-2"

--- a/apps/admin/src/features/dashboard/components/CompletenessMetrics.tsx
+++ b/apps/admin/src/features/dashboard/components/CompletenessMetrics.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
+import { MockBadge } from '@/components/ui/mock-badge';
+
 import { COMPLETENESS } from '../mock-data';
 
 /**
@@ -43,7 +45,8 @@ function Ring({ percent }: { percent: number }) {
 export function CompletenessMetrics() {
   const { t } = useTranslation();
   return (
-    <div className="rounded-2xl border border-line bg-surface p-5 soft-shadow">
+    <div className="relative rounded-2xl border border-line bg-surface p-5 soft-shadow">
+      <MockBadge variant="corner" />
       <h3 className="text-[15px] font-semibold text-ink">{t('dashboard.completeness.title')}</h3>
       <p className="mt-1 text-[12px] text-muted-foreground">
         {t('dashboard.completeness.subtitle')}

--- a/apps/admin/src/features/dashboard/components/HeroAgentPanel.tsx
+++ b/apps/admin/src/features/dashboard/components/HeroAgentPanel.tsx
@@ -1,6 +1,7 @@
 import { Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { MockBadge } from '@/components/ui/mock-badge';
 import { cn } from '@/lib/utils';
 
 /**
@@ -17,6 +18,7 @@ export function HeroAgentPanel() {
         'relative overflow-hidden rounded-3xl border border-line bg-gradient-to-br from-violet-50 via-white to-white p-8 soft-shadow-lg',
       )}
     >
+      <MockBadge variant="corner" />
       <div className="flex items-start justify-between gap-6">
         <div className="max-w-2xl">
           <div className="mb-3 inline-flex items-center gap-1.5 rounded-full bg-accent-violet/10 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-accent-violet">
@@ -28,7 +30,7 @@ export function HeroAgentPanel() {
           </h1>
           <p className="mt-2 text-[15px] text-ink-2">{t('dashboard.hero.subtitle')}</p>
         </div>
-        <div className="hidden shrink-0 sm:block">
+        <div className="hidden shrink-0 items-center gap-2 sm:flex">
           {/* MOCK: command palette CTA — wymaga agent layer (Faza 2, #TBD) */}
           <button
             type="button"
@@ -46,6 +48,7 @@ export function HeroAgentPanel() {
               ⌘K
             </kbd>
           </button>
+          <MockBadge tooltip={t('dashboard.hero.cta_disabled_hint') ?? undefined} />
         </div>
       </div>
     </div>

--- a/apps/admin/src/features/dashboard/components/KpiCards.tsx
+++ b/apps/admin/src/features/dashboard/components/KpiCards.tsx
@@ -1,52 +1,226 @@
-import { ArrowUpRight, Boxes, FolderTree, Layers, Tags } from 'lucide-react';
+import {
+  AlertTriangle,
+  ArrowUpRight,
+  Boxes,
+  CheckCircle2,
+  Clock,
+  FolderTree,
+  Layers,
+  ShieldCheck,
+  SlidersHorizontal,
+  Tags,
+} from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { Button } from '@/components/ui/button';
+import { MockBadge } from '@/components/ui/mock-badge';
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 
-import { KPI_TILES, type KpiTile } from '../mock-data';
+import {
+  KPI_DEFAULT_SELECTION,
+  KPI_MAX_SELECTION,
+  KPI_TILES,
+  type KpiKey,
+  type KpiTile,
+} from '../mock-data';
 
-/**
- * MOCK component — 4 KPI tiles z deltą.
- * Backend: GET /api/dashboard/kpis (do dorobienia).
- * Patrz Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md.
- */
-const ICONS: Record<KpiTile['key'], typeof Boxes> = {
+const ICONS: Record<KpiKey, typeof Boxes> = {
   products: Boxes,
   attributes: Tags,
   families: Layers,
   categories: FolderTree,
+  enabled_share: CheckCircle2,
+  completeness_avg: ShieldCheck,
+  last_sync_minutes: Clock,
+  open_alerts: AlertTriangle,
 };
 
+const STORAGE_KEY = 'pim.dashboard.kpi.selection';
+
+function loadSelection(): KpiKey[] {
+  if (typeof window === 'undefined') {
+    return KPI_DEFAULT_SELECTION;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return KPI_DEFAULT_SELECTION;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((k): k is KpiKey => KPI_TILES.some((tile) => tile.key === k))
+    ) {
+      return parsed.slice(0, KPI_MAX_SELECTION);
+    }
+  } catch {
+    // fall through to defaults
+  }
+  return KPI_DEFAULT_SELECTION;
+}
+
+function persistSelection(selection: KpiKey[]) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(selection));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+/**
+ * MOCK component — KPI tiles, user picks 4 of 8 candidates.
+ * Backend: GET /api/dashboard/kpis (do dorobienia). Selection persists in
+ * localStorage per UI-03b plan; production will move to workspace_settings.
+ */
 export function KpiCards() {
   const { t } = useTranslation();
+  const [selection, setSelection] = useState<KpiKey[]>(KPI_DEFAULT_SELECTION);
+
+  useEffect(() => {
+    setSelection(loadSelection());
+  }, []);
+
+  const visibleTiles: KpiTile[] = selection
+    .map((key) => KPI_TILES.find((tile) => tile.key === key))
+    .filter((tile): tile is KpiTile => Boolean(tile));
+
+  const toggle = (key: KpiKey) => {
+    setSelection((prev) => {
+      const next = prev.includes(key)
+        ? prev.filter((k) => k !== key)
+        : prev.length >= KPI_MAX_SELECTION
+          ? prev
+          : [...prev, key];
+      persistSelection(next);
+      return next;
+    });
+  };
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-      {KPI_TILES.map((tile) => {
-        const Icon = ICONS[tile.key];
-        return (
-          <div
-            key={tile.key}
-            className={cn('rounded-2xl border border-line bg-surface p-5 soft-shadow')}
+    <div className="space-y-3">
+      <div className="flex items-center justify-end">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-xs text-muted-foreground hover:text-foreground"
+            >
+              <SlidersHorizontal className="size-3.5" />
+              <span>{t('dashboard.kpi.settings_trigger', { defaultValue: 'Wybierz KPI' })}</span>
+            </Button>
+          </SheetTrigger>
+          <SheetContent
+            side="right"
+            className="w-full sm:max-w-md"
+            closeLabel={t('app.close', { defaultValue: 'Zamknij' })}
           >
-            <div className="flex items-start justify-between">
-              <span className="text-[13px] font-medium text-muted-foreground">
-                {t(`dashboard.kpi.${tile.key}`)}
-              </span>
-              <Icon className="size-4 text-muted-foreground" />
+            <div className="flex items-center justify-between border-b border-line px-4 py-3">
+              <SheetTitle>
+                {t('dashboard.kpi.settings_title', { defaultValue: 'Wybierz KPI' })}
+              </SheetTitle>
             </div>
-            <div className="mt-3 flex items-baseline gap-2">
-              <span className="num display text-[28px] font-semibold text-ink">
-                {tile.value.toLocaleString('pl-PL')}
-              </span>
-              <span className="num inline-flex items-center gap-0.5 rounded-md bg-accent-emerald/10 px-1.5 py-0.5 text-[11px] font-medium text-accent-emerald">
-                <ArrowUpRight className="size-3" />+{tile.delta}
-              </span>
+            <MockBadge
+              variant="overlay"
+              tooltip={t('dashboard.kpi.settings_mock_tooltip', {
+                defaultValue: 'Konfiguracja zapisywana lokalnie (localStorage), MOCK',
+              })}
+            >
+              <div className="mt-4 space-y-2 px-4 pb-4">
+                <p className="text-sm text-muted-foreground">
+                  {t('dashboard.kpi.settings_description', {
+                    defaultValue:
+                      'Wybierz do {{max}} kafelków na pulpicie. Selekcja zapisuje się w przeglądarce.',
+                    max: KPI_MAX_SELECTION,
+                  })}
+                </p>
+                <ul className="divide-y divide-line">
+                  {KPI_TILES.map((tile) => {
+                    const checked = selection.includes(tile.key);
+                    const disabled = !checked && selection.length >= KPI_MAX_SELECTION;
+                    return (
+                      <li key={tile.key} className="py-2">
+                        <label
+                          className={cn(
+                            'flex cursor-pointer items-center gap-3 text-sm',
+                            disabled && 'cursor-not-allowed opacity-50',
+                          )}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            disabled={disabled}
+                            onChange={() => toggle(tile.key)}
+                            className="size-4"
+                          />
+                          <span className="flex-1">{t(`dashboard.kpi.${tile.key}`)}</span>
+                          <span className="text-[11px] text-muted-foreground">
+                            {tile.value.toLocaleString('pl-PL')}
+                            {tile.unit ?? ''}
+                          </span>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <p className="text-[11px] text-muted-foreground">
+                  {t('dashboard.kpi.settings_count', {
+                    defaultValue: '{{count}} z {{max}} wybranych',
+                    count: selection.length,
+                    max: KPI_MAX_SELECTION,
+                  })}
+                </p>
+              </div>
+            </MockBadge>
+          </SheetContent>
+        </Sheet>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {visibleTiles.map((tile) => {
+          const Icon = ICONS[tile.key];
+          const isPositive = tile.delta >= 0;
+          return (
+            <div
+              key={tile.key}
+              className={cn('relative rounded-2xl border border-line bg-surface p-5 soft-shadow')}
+            >
+              <MockBadge variant="corner" />
+              <div className="flex items-start justify-between">
+                <span className="text-[13px] font-medium text-muted-foreground">
+                  {t(`dashboard.kpi.${tile.key}`)}
+                </span>
+                <Icon className="size-4 text-muted-foreground" />
+              </div>
+              <div className="mt-3 flex items-baseline gap-2">
+                <span className="num display text-[28px] font-semibold text-ink">
+                  {tile.value.toLocaleString('pl-PL')}
+                  {tile.unit ? (
+                    <span className="ml-1 text-[16px] text-muted-foreground">{tile.unit}</span>
+                  ) : null}
+                </span>
+                <span
+                  className={cn(
+                    'num inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[11px] font-medium',
+                    isPositive
+                      ? 'bg-accent-emerald/10 text-accent-emerald'
+                      : 'bg-accent-rose/10 text-accent-rose',
+                  )}
+                >
+                  <ArrowUpRight className={cn('size-3', !isPositive && 'rotate-90')} />
+                  {isPositive ? '+' : ''}
+                  {tile.delta}
+                </span>
+              </div>
+              <span className="mt-1 block text-[11px] text-muted-foreground">{tile.hint}</span>
             </div>
-            <span className="mt-1 block text-[11px] text-muted-foreground">{tile.hint}</span>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/features/dashboard/components/RecentAgentActivity.tsx
+++ b/apps/admin/src/features/dashboard/components/RecentAgentActivity.tsx
@@ -1,5 +1,7 @@
+import { Filter } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { MockBadge } from '@/components/ui/mock-badge';
 import { cn } from '@/lib/utils';
 
 import { AGENT_ACTIVITY, type AgentStatus } from '../mock-data';
@@ -19,14 +21,25 @@ const STATUS_BADGE: Record<AgentStatus, { label: string; className: string }> = 
 export function RecentAgentActivity() {
   const { t } = useTranslation();
   return (
-    <div className="rounded-2xl border border-line bg-surface soft-shadow">
+    <div className="relative rounded-2xl border border-line bg-surface soft-shadow">
+      <MockBadge variant="corner" />
       <div className="flex items-center justify-between border-b border-line px-5 py-4">
         <h3 className="text-[15px] font-semibold text-ink">
           {t('dashboard.agent_activity.title')}
         </h3>
-        <span className="text-[12px] text-muted-foreground">
-          {t('dashboard.agent_activity.subtitle')}
-        </span>
+        <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
+          <span>{t('dashboard.agent_activity.subtitle')}</span>
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            className="inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-line px-2 py-0.5 text-[11px] text-muted-foreground"
+          >
+            <Filter className="size-3" />
+            {t('dashboard.agent_activity.filter', { defaultValue: 'Filtruj' })}
+          </button>
+          <MockBadge />
+        </div>
       </div>
       <ul className="divide-y divide-line">
         {AGENT_ACTIVITY.map((row) => {

--- a/apps/admin/src/features/dashboard/components/SyncsStatusPanel.tsx
+++ b/apps/admin/src/features/dashboard/components/SyncsStatusPanel.tsx
@@ -1,6 +1,7 @@
 import { RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { MockBadge } from '@/components/ui/mock-badge';
 import { cn } from '@/lib/utils';
 
 import { SYNCS, type SyncStatus } from '../mock-data';
@@ -19,20 +20,24 @@ const STATUS_DOT: Record<SyncStatus, string> = {
 export function SyncsStatusPanel() {
   const { t } = useTranslation();
   return (
-    <div className="rounded-2xl border border-line bg-surface soft-shadow">
+    <div className="relative rounded-2xl border border-line bg-surface soft-shadow">
+      <MockBadge variant="corner" />
       <div className="flex items-center justify-between border-b border-line px-5 py-4">
         <h3 className="text-[15px] font-semibold text-ink">{t('dashboard.syncs.title')}</h3>
-        {/* MOCK: button "Wymuś synchronizację" — wymaga POST /api/integrations/{id}/sync (#TBD) */}
-        <button
-          type="button"
-          disabled
-          aria-disabled="true"
-          className="inline-flex cursor-not-allowed items-center gap-1.5 rounded-xl border border-line px-2.5 py-1 text-[12px] text-muted-foreground"
-          title={t('dashboard.syncs.force_disabled') ?? ''}
-        >
-          <RefreshCw className="size-3" />
-          {t('dashboard.syncs.force')}
-        </button>
+        <div className="flex items-center gap-2">
+          {/* MOCK: button "Wymuś synchronizację" — wymaga POST /api/integrations/{id}/sync (#TBD) */}
+          <button
+            type="button"
+            disabled
+            aria-disabled="true"
+            className="inline-flex cursor-not-allowed items-center gap-1.5 rounded-xl border border-line px-2.5 py-1 text-[12px] text-muted-foreground"
+            title={t('dashboard.syncs.force_disabled') ?? ''}
+          >
+            <RefreshCw className="size-3" />
+            {t('dashboard.syncs.force')}
+          </button>
+          <MockBadge tooltip={t('dashboard.syncs.force_disabled') ?? undefined} />
+        </div>
       </div>
       <ul className="divide-y divide-line">
         {SYNCS.map((s) => (

--- a/apps/admin/src/features/dashboard/components/TopEditedProducts.tsx
+++ b/apps/admin/src/features/dashboard/components/TopEditedProducts.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
+import { MockBadge } from '@/components/ui/mock-badge';
+
 import { TOP_EDITED } from '../mock-data';
 
 /**
@@ -10,7 +12,8 @@ import { TOP_EDITED } from '../mock-data';
 export function TopEditedProducts() {
   const { t } = useTranslation();
   return (
-    <div className="rounded-2xl border border-line bg-surface soft-shadow">
+    <div className="relative rounded-2xl border border-line bg-surface soft-shadow">
+      <MockBadge variant="corner" />
       <div className="flex items-center justify-between border-b border-line px-5 py-4">
         <h3 className="text-[15px] font-semibold text-ink">{t('dashboard.top_edited.title')}</h3>
         <span className="text-[12px] text-muted-foreground">

--- a/apps/admin/src/features/dashboard/components/skeletons/ChartSkeleton.tsx
+++ b/apps/admin/src/features/dashboard/components/skeletons/ChartSkeleton.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils';
+
+interface ChartSkeletonProps {
+  /** Optional title placeholder height/width hint; defaults look like ActivityChart. */
+  className?: string;
+}
+
+/**
+ * Skeleton placeholder for a chart card (e.g. ActivityChart, ChannelDistribution).
+ */
+export function ChartSkeleton({ className }: ChartSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-2xl border border-line bg-surface p-5 soft-shadow',
+        className,
+      )}
+    >
+      <div className="flex items-baseline justify-between">
+        <div className="h-4 w-40 rounded bg-muted" />
+        <div className="h-3 w-24 rounded bg-muted/70" />
+      </div>
+      <div className="mt-5 h-[180px] w-full rounded-md bg-muted/40" />
+    </div>
+  );
+}

--- a/apps/admin/src/features/dashboard/components/skeletons/KpiSkeleton.tsx
+++ b/apps/admin/src/features/dashboard/components/skeletons/KpiSkeleton.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils';
+
+/**
+ * Skeleton placeholder for KpiCards block. Matches the 4-column grid +
+ * card layout so the dashboard does not jump when real data arrives.
+ */
+export function KpiSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton row
+          key={i}
+          className={cn('animate-pulse rounded-2xl border border-line bg-surface p-5 soft-shadow')}
+        >
+          <div className="flex items-start justify-between">
+            <div className="h-3 w-20 rounded bg-muted" />
+            <div className="size-4 rounded bg-muted" />
+          </div>
+          <div className="mt-3 h-7 w-24 rounded bg-muted" />
+          <div className="mt-1 h-3 w-16 rounded bg-muted/70" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/admin/src/features/dashboard/components/skeletons/ListSkeleton.tsx
+++ b/apps/admin/src/features/dashboard/components/skeletons/ListSkeleton.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils';
+
+interface ListSkeletonProps {
+  rows?: number;
+  className?: string;
+}
+
+/**
+ * Skeleton placeholder for list cards (TopEditedProducts, AlertCenter,
+ * RecentAgentActivity, SyncsStatusPanel, CompletenessMetrics).
+ */
+export function ListSkeleton({ rows = 5, className }: ListSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        'animate-pulse rounded-2xl border border-line bg-surface p-5 soft-shadow',
+        className,
+      )}
+    >
+      <div className="flex items-baseline justify-between">
+        <div className="h-4 w-32 rounded bg-muted" />
+        <div className="h-3 w-20 rounded bg-muted/70" />
+      </div>
+      <div className="mt-4 space-y-3">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton row
+            key={i}
+            className="flex items-center gap-3"
+          >
+            <div className="size-8 rounded-md bg-muted/60" />
+            <div className="flex-1 space-y-1.5">
+              <div className="h-3 w-3/4 rounded bg-muted" />
+              <div className="h-2.5 w-1/2 rounded bg-muted/60" />
+            </div>
+            <div className="h-3 w-12 rounded bg-muted/60" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/dashboard/mock-data.ts
+++ b/apps/admin/src/features/dashboard/mock-data.ts
@@ -8,19 +8,44 @@
  * other than features/dashboard/.
  */
 
+export type KpiKey =
+  | 'products'
+  | 'attributes'
+  | 'families'
+  | 'categories'
+  | 'enabled_share'
+  | 'completeness_avg'
+  | 'last_sync_minutes'
+  | 'open_alerts';
+
 export interface KpiTile {
-  key: 'products' | 'attributes' | 'families' | 'categories';
+  key: KpiKey;
   value: number;
   delta: number;
   hint: string;
+  /** Optional unit suffix shown next to the value (e.g. "%", "min"). */
+  unit?: string;
 }
 
+/**
+ * Catalogue of available KPI tiles. The user picks 4 of these in the KPI
+ * settings sheet; selection persists in localStorage (MOCK — no backend).
+ */
 export const KPI_TILES: KpiTile[] = [
   { key: 'products', value: 12_847, delta: 184, hint: 'last 30 days' },
   { key: 'attributes', value: 312, delta: 12, hint: 'last 30 days' },
   { key: 'families', value: 47, delta: 2, hint: 'last 30 days' },
   { key: 'categories', value: 184, delta: 8, hint: 'last 30 days' },
+  { key: 'enabled_share', value: 92, delta: 3, hint: 'enabled / total', unit: '%' },
+  { key: 'completeness_avg', value: 87, delta: 4, hint: 'all channels', unit: '%' },
+  { key: 'last_sync_minutes', value: 8, delta: -2, hint: 'minutes ago', unit: 'min' },
+  { key: 'open_alerts', value: 5, delta: -1, hint: 'last 24h' },
 ];
+
+/** Default KPI selection used when the user has not customised the dashboard. */
+export const KPI_DEFAULT_SELECTION: KpiKey[] = ['products', 'attributes', 'families', 'categories'];
+
+export const KPI_MAX_SELECTION = 4;
 
 export interface ActivityPoint {
   day: number;
@@ -28,14 +53,28 @@ export interface ActivityPoint {
   modified: number;
 }
 
-export const ACTIVITY_30D: ActivityPoint[] = Array.from({ length: 30 }, (_, i) => {
-  const weekend = i % 7 === 5 || i % 7 === 6;
-  return {
-    day: i + 1,
-    added: weekend ? 4 + (i % 3) : 18 + ((i * 7) % 14),
-    modified: weekend ? 9 + (i % 4) : 32 + ((i * 11) % 22),
-  };
-});
+/** Range of days the activity chart can render. 30d is the default. */
+export type ActivityRange = '7d' | '30d' | '90d';
+
+const buildActivity = (length: number): ActivityPoint[] =>
+  Array.from({ length }, (_, i) => {
+    const weekend = i % 7 === 5 || i % 7 === 6;
+    return {
+      day: i + 1,
+      added: weekend ? 4 + (i % 3) : 18 + ((i * 7) % 14),
+      modified: weekend ? 9 + (i % 4) : 32 + ((i * 11) % 22),
+    };
+  });
+
+export const ACTIVITY_7D: ActivityPoint[] = buildActivity(7);
+export const ACTIVITY_30D: ActivityPoint[] = buildActivity(30);
+export const ACTIVITY_90D: ActivityPoint[] = buildActivity(90);
+
+export const ACTIVITY_BY_RANGE: Record<ActivityRange, ActivityPoint[]> = {
+  '7d': ACTIVITY_7D,
+  '30d': ACTIVITY_30D,
+  '90d': ACTIVITY_90D,
+};
 
 export interface TopEditedProduct {
   sku: string;

--- a/apps/admin/src/features/dashboard/page.tsx
+++ b/apps/admin/src/features/dashboard/page.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import { ActivityChart } from './components/ActivityChart';
 import { AlertCenter } from './components/AlertCenter';
 import { ChannelDistribution } from './components/ChannelDistribution';
@@ -6,17 +8,53 @@ import { HeroAgentPanel } from './components/HeroAgentPanel';
 import { KpiCards } from './components/KpiCards';
 import { RecentAgentActivity } from './components/RecentAgentActivity';
 import { SyncsStatusPanel } from './components/SyncsStatusPanel';
+import { ChartSkeleton } from './components/skeletons/ChartSkeleton';
+import { KpiSkeleton } from './components/skeletons/KpiSkeleton';
+import { ListSkeleton } from './components/skeletons/ListSkeleton';
 import { TopEditedProducts } from './components/TopEditedProducts';
 
 /**
- * Dashboard page — handoff mock (epik UI-03 #356).
+ * Dashboard page — handoff mock (epik UI-03 #356, polished in UI-03b #364).
  *
  * All blocks are static mocks; the wiring with real backend endpoints lives in
  * Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md.
  *
- * The component itself is "use-client safe" (no DOM-only APIs at module load).
+ * The 300 ms setTimeout simulates a network delay so the skeleton loaders are
+ * visible during smoke testing — once TanStack Query is wired to live endpoints
+ * this state will be driven by `useQuery({ ... }).isPending`.
  */
+const SKELETON_DELAY_MS = 300;
+
 export function DashboardPage() {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setLoading(false), SKELETON_DELAY_MS);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="space-y-6 px-4 py-6 sm:px-6 lg:px-10">
+        <ChartSkeleton className="h-[120px]" />
+        <KpiSkeleton />
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2">
+            <ChartSkeleton />
+            <ListSkeleton rows={6} />
+            <ChartSkeleton />
+          </div>
+          <div className="space-y-6">
+            <ListSkeleton rows={4} />
+            <ChartSkeleton />
+            <ListSkeleton rows={5} />
+            <ListSkeleton rows={5} />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6 px-4 py-6 sm:px-6 lg:px-10">
       <HeroAgentPanel />

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -74,12 +74,25 @@
       "products": "Products",
       "attributes": "Attributes",
       "families": "Families",
-      "categories": "Categories"
+      "categories": "Categories",
+      "enabled_share": "Enabled products",
+      "completeness_avg": "Average completeness",
+      "last_sync_minutes": "Last sync",
+      "open_alerts": "Open alerts",
+      "settings_trigger": "Pick KPIs",
+      "settings_title": "Pick KPIs",
+      "settings_description": "Pick up to {{max}} tiles for the dashboard. Selection persists in the browser.",
+      "settings_count": "{{count}} of {{max}} selected",
+      "settings_mock_tooltip": "Selection persists in localStorage, MOCK"
     },
     "activity": {
-      "title": "Activity (30 days)",
+      "title": "Activity",
       "legend_added": "added",
-      "legend_modified": "modified"
+      "legend_modified": "modified",
+      "range_aria": "Activity range",
+      "range_7d": "7 days",
+      "range_30d": "30 days",
+      "range_90d": "90 days"
     },
     "top_edited": {
       "title": "Most edited",
@@ -96,15 +109,18 @@
     },
     "agent_activity": {
       "title": "Recent agent activity",
-      "subtitle": "last 6 audit entries"
+      "subtitle": "last 6 audit entries",
+      "filter": "Filter"
     },
     "alerts": {
       "title": "Alerts",
-      "subtitle": "last 5"
+      "subtitle": "last 5",
+      "configure": "Configure alerts"
     },
     "channel_dist": {
       "title": "Channel distribution",
-      "unit": "products"
+      "unit": "products",
+      "export": "Export report"
     }
   },
   "attributes": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -76,12 +76,25 @@
       "products": "Produkty",
       "attributes": "Atrybuty",
       "families": "Rodziny",
-      "categories": "Kategorie"
+      "categories": "Kategorie",
+      "enabled_share": "Aktywne produkty",
+      "completeness_avg": "Średnia kompletność",
+      "last_sync_minutes": "Ostatnia synchronizacja",
+      "open_alerts": "Otwarte alerty",
+      "settings_trigger": "Wybierz KPI",
+      "settings_title": "Wybierz KPI",
+      "settings_description": "Wybierz do {{max}} kafelków na pulpicie. Selekcja zapisuje się w przeglądarce.",
+      "settings_count": "{{count}} z {{max}} wybranych",
+      "settings_mock_tooltip": "Konfiguracja zapisywana lokalnie (localStorage), MOCK"
     },
     "activity": {
-      "title": "Aktywność (30 dni)",
+      "title": "Aktywność",
       "legend_added": "dodane",
-      "legend_modified": "zmodyfikowane"
+      "legend_modified": "zmodyfikowane",
+      "range_aria": "Zakres aktywności",
+      "range_7d": "7 dni",
+      "range_30d": "30 dni",
+      "range_90d": "90 dni"
     },
     "top_edited": {
       "title": "Najczęściej edytowane",
@@ -98,15 +111,18 @@
     },
     "agent_activity": {
       "title": "Ostatnia aktywność agenta",
-      "subtitle": "ostatnie 6 wpisów audit"
+      "subtitle": "ostatnie 6 wpisów audit",
+      "filter": "Filtruj"
     },
     "alerts": {
       "title": "Alerty",
-      "subtitle": "ostatnie 5"
+      "subtitle": "ostatnie 5",
+      "configure": "Skonfiguruj alerty"
     },
     "channel_dist": {
       "title": "Dystrybucja kanałów",
-      "unit": "produktów"
+      "unit": "produktów",
+      "export": "Eksportuj raport"
     }
   },
   "attributes": {


### PR DESCRIPTION
## Summary

UI-03b Phase 2 polish for the Pulpit (#364) on top of the admin shell from #363.

**ActivityChart** (`apps/admin/src/features/dashboard/components/ActivityChart.tsx`):
- Range picker (7d / 30d / 90d) with violet-accent active tab styling
- Local state, points read from `ACTIVITY_BY_RANGE` in mock-data
- Corner `MockBadge` sygnalizujący że dane są MOCK

**KpiCards** (`apps/admin/src/features/dashboard/components/KpiCards.tsx`):
- Operator picks **4 of 8** candidate KPI tiles via Sheet "Wybierz KPI"
- Selection persists in `localStorage` (key `pim.dashboard.kpi.selection`)
- Sheet wrapped in `MockBadge variant="overlay"` (configuration is local-only)
- Tiles render with optional unit suffix (`%`, `min`) and red/green delta arrow

**Mock data extension** (`apps/admin/src/features/dashboard/mock-data.ts`):
- `KpiKey` union grew from 4 → 8 keys (added `enabled_share`, `completeness_avg`, `last_sync_minutes`, `open_alerts`)
- `KPI_DEFAULT_SELECTION` + `KPI_MAX_SELECTION` constants
- `ActivityRange` union (`'7d' | '30d' | '90d'`) + `buildActivity` helper
- `ACTIVITY_BY_RANGE` record exposing all three datasets

**MOCK badges on disabled CTAs**:
- HeroAgentPanel — agent CTA (gating Faza 2)
- AlertCenter — "Skonfiguruj alerty"
- ChannelDistribution — "Eksportuj raport"
- RecentAgentActivity — "Filtruj"
- SyncsStatusPanel — "Wymuś synchronizację"
- TopEditedProducts, CompletenessMetrics — corner MockBadge only (data MOCK)

**Skeleton loaders** (`apps/admin/src/features/dashboard/components/skeletons/`):
- `KpiSkeleton`, `ChartSkeleton` (with `className` prop), `ListSkeleton` (`rows` prop)
- 300 ms setTimeout in `page.tsx` symuluje load — wymienialne na `useQuery({ ... }).isPending` gdy backend dorobimy

**i18n keys** (`pl.json` + `en.json`):
- `dashboard.kpi.{enabled_share, completeness_avg, last_sync_minutes, open_alerts, settings_trigger, settings_title, settings_description, settings_count, settings_mock_tooltip}`
- `dashboard.activity.{range_aria, range_7d, range_30d, range_90d}`
- `dashboard.alerts.configure`
- `dashboard.channel_dist.export`
- `dashboard.agent_activity.filter`

## Test plan

- [x] `pnpm --filter admin lint` — clean
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm --filter admin build` — clean
- [ ] CI suite — green on this PR
- [ ] Manual smoke (operator):
  1. Login → `/` → `/dashboard` (UI-03b #363)
  2. ~300 ms skeleton loaders visible on first paint, then real (mock) blocks
  3. 9 bloków renderuje się; każdy ma corner MockBadge
  4. ActivityChart range picker przełącza 7d / 30d / 90d (visualnie zmienia liczbę punktów)
  5. KpiCards "Wybierz KPI" sheet otwiera się — 8 opcji z checkboxami, max 4 wybrane (5+ disabled), persystencja w localStorage między reloadami
  6. Hover na disabled buttons (Skonfiguruj alerty, Eksportuj raport, Filtruj, Wymuś, Uruchom agenta) pokazuje MockBadge tooltip
  7. Console clean, brak 4xx/5xx (mock-data nie woła API)

## Out of scope

- Backend endpointy (`GET /api/dashboard/{kpis,activity,top-edited,completeness,channel-distribution,alerts}` + `POST /api/integrations/{id}/sync`) — placeholder UI tylko
- Agent layer (Hero CTA + Recent agent activity backend) — gating Faza 2
- Migracja KPI selection persystencji do `workspace_settings` — pozostaje localStorage do BE

## References

- Phase 1 dashboard skeleton: PR #359
- Blocker: PR #367 (#363) — `<MockBadge>` shared component
- Mock data source: `apps/admin/src/features/dashboard/mock-data.ts`
- Makieta: `Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md`
- Epic META: #362
