### PR TITLE
feat(admin): Produkty pixel-perfect — Completeness ring + agent suggestions + tab stubs (UI-03b)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-actions-toolbar.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions-toolbar.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
+import { MockBadge } from '@/components/ui/mock-badge';
 import { jsonFetch } from '@/lib/http';
 
 import { BulkEditModal } from './bulk-edit-modal';
@@ -151,33 +152,53 @@ export function BulkActionsToolbar({
         </Button>
         {/* MOCK: bulk category change — wymaga rozszerzenia POST /api/products/bulk-edit
             o operation 'change_category' (#TBD). Patrz Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md. */}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled
-          aria-disabled="true"
-          title={t('products.bulk.change_category_disabled', {
-            defaultValue: 'Mock — wymaga operation change_category w /bulk-edit',
-          })}
-        >
-          <FolderTree className="size-4" />
-          {t('products.bulk.change_category', { defaultValue: 'Zmień kategorię' })}
-        </Button>
+        <span className="inline-flex items-center gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled
+            aria-disabled="true"
+            title={t('products.bulk.change_category_disabled', {
+              defaultValue: 'Mock — wymaga operation change_category w /bulk-edit',
+            })}
+          >
+            <FolderTree className="size-4" />
+            {t('products.bulk.change_category', { defaultValue: 'Zmień kategorię' })}
+            <kbd className="ml-1.5 rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
+              K
+            </kbd>
+          </Button>
+          <MockBadge
+            tooltip={t('products.bulk.change_category_disabled', {
+              defaultValue: 'Mock — wymaga operation change_category w /bulk-edit',
+            })}
+          />
+        </span>
         {/* MOCK: bulk export CSV/XLSX — wymaga GET /api/products/export?ids=...&format=csv (#TBD). */}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled
-          aria-disabled="true"
-          title={t('products.bulk.export_disabled', {
-            defaultValue: 'Mock — wymaga GET /api/products/export?ids=...&format=csv',
-          })}
-        >
-          <Download className="size-4" />
-          {t('products.bulk.export', { defaultValue: 'Eksport' })}
-        </Button>
+        <span className="inline-flex items-center gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled
+            aria-disabled="true"
+            title={t('products.bulk.export_disabled', {
+              defaultValue: 'Mock — wymaga GET /api/products/export?ids=...&format=csv',
+            })}
+          >
+            <Download className="size-4" />
+            {t('products.bulk.export', { defaultValue: 'Eksport' })}
+            <kbd className="ml-1.5 rounded bg-muted px-1 py-0.5 font-mono text-[10px] text-muted-foreground">
+              X
+            </kbd>
+          </Button>
+          <MockBadge
+            tooltip={t('products.bulk.export_disabled', {
+              defaultValue: 'Mock — wymaga GET /api/products/export?ids=...&format=csv',
+            })}
+          />
+        </span>
         <Button
           type="button"
           variant="destructive"

--- a/apps/admin/src/features/catalog/products/components/agent-suggestions-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/agent-suggestions-card.tsx
@@ -1,0 +1,105 @@
+import { FileText, Image as ImageIcon, Sparkles, Tag } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { MockBadge } from '@/components/ui/mock-badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface AgentSuggestion {
+  id: string;
+  icon: typeof Sparkles;
+  titleKey: string;
+  defaultTitle: string;
+  hintKey: string;
+  defaultHint: string;
+}
+
+const SUGGESTIONS: readonly AgentSuggestion[] = [
+  {
+    id: 'description',
+    icon: FileText,
+    titleKey: 'products.agent.suggestion_description_title',
+    defaultTitle: 'Uzupełnij opis dla SEO',
+    hintKey: 'products.agent.suggestion_description_hint',
+    defaultHint: 'Brakuje description.en — agent może zaproponować tłumaczenie.',
+  },
+  {
+    id: 'image',
+    icon: ImageIcon,
+    titleKey: 'products.agent.suggestion_image_title',
+    defaultTitle: 'Dodaj zdjęcie 4:5 dla Instagram',
+    hintKey: 'products.agent.suggestion_image_hint',
+    defaultHint: 'Channel Instagram wymaga 4:5; obecne 1:1.',
+  },
+  {
+    id: 'category',
+    icon: Tag,
+    titleKey: 'products.agent.suggestion_category_title',
+    defaultTitle: 'Wybierz kategorię nadrzędną',
+    hintKey: 'products.agent.suggestion_category_hint',
+    defaultHint: 'Produkt nie ma przypisanej kategorii — agent może zaproponować.',
+  },
+] as const;
+
+/**
+ * UI-03b detail-sidebar mock surface (#366) for the agent layer.
+ *
+ * The real agent integration ships in epic 0.7 (Faza 2). This card renders
+ * three hardcoded suggestions so the operator sees the intended placement
+ * + density next to the Completeness ring and the rest of DetailSidebar.
+ *
+ * Each "Zastosuj" CTA is wrapped in MockBadge — the buttons are disabled
+ * and explain why on hover.
+ */
+export function AgentSuggestionsCard() {
+  const { t } = useTranslation();
+  const tooltip = t('products.agent.mock_tooltip', {
+    defaultValue: 'MOCK · Wymaga warstwy agenta (epik 0.7, Faza 2)',
+  });
+
+  return (
+    <section className="relative rounded-2xl border border-line bg-surface p-4 soft-shadow">
+      <MockBadge variant="corner" tooltip={tooltip} />
+      <header className="mb-3 flex items-center gap-2">
+        <Sparkles className="size-4 text-accent-violet" />
+        <h3 className="text-[13px] font-semibold text-ink">
+          {t('products.agent.title', { defaultValue: 'Sugestie agenta' })}
+        </h3>
+      </header>
+      <ul className="space-y-3">
+        {SUGGESTIONS.map((s) => {
+          const Icon = s.icon;
+          return (
+            <li key={s.id} className="flex items-start gap-3 rounded-xl bg-surface-2/60 p-3">
+              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-accent-violet/10 text-accent-violet">
+                <Icon className="size-3.5" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-[12.5px] font-medium text-ink">
+                  {t(s.titleKey, { defaultValue: s.defaultTitle })}
+                </p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  {t(s.hintKey, { defaultValue: s.defaultHint })}
+                </p>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled
+                      className="mt-1.5 h-6 px-2 text-[11px]"
+                    >
+                      {t('products.agent.apply', { defaultValue: 'Zastosuj' })}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>{tooltip}</TooltipContent>
+                </Tooltip>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/completeness-ring.tsx
+++ b/apps/admin/src/features/catalog/products/components/completeness-ring.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface CompletenessRingProps {
+  /** 0..100 */
+  pct: number;
+  /** Pixel size for width / height. Default 56. */
+  size?: number;
+  /** Stroke width. Default 5. */
+  stroke?: number;
+  className?: string;
+}
+
+/**
+ * UI-03b detail-page completeness indicator (#366).
+ *
+ * Replaces the linear `<CompletenessBadge>` in the product show header
+ * with an animated SVG ring. Color tracks the percent: violet 0–50,
+ * amber 50–80, emerald 80–100. The stroke animates from 0 → target on
+ * mount so the visual transition reads as "computing completeness".
+ */
+export function CompletenessRing({ pct, size = 56, stroke = 5, className }: CompletenessRingProps) {
+  const clamped = Math.max(0, Math.min(100, Math.round(pct)));
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const [animatedPct, setAnimatedPct] = useState(0);
+
+  useEffect(() => {
+    // Stroke animates from 0 → target via stroke-dashoffset transition.
+    const timer = window.requestAnimationFrame(() => setAnimatedPct(clamped));
+    return () => window.cancelAnimationFrame(timer);
+  }, [clamped]);
+
+  const dashOffset = circumference * (1 - animatedPct / 100);
+  const color =
+    clamped >= 80
+      ? 'var(--color-accent-emerald)'
+      : clamped >= 50
+        ? 'var(--color-accent-amber)'
+        : 'var(--color-accent-violet)';
+
+  return (
+    <div
+      className={cn('relative inline-flex items-center justify-center', className)}
+      style={{ width: size, height: size }}
+      role="img"
+      aria-label={`${clamped}%`}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        className="-rotate-90"
+        aria-hidden
+      >
+        <title>Completeness {clamped}%</title>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="var(--color-line, #ececea)"
+          strokeWidth={stroke}
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          style={{ transition: 'stroke-dashoffset 600ms ease-out' }}
+        />
+      </svg>
+      <span className="num absolute text-[12px] font-semibold text-ink">{clamped}%</span>
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -306,6 +306,7 @@ export function ProductListPage() {
             <Link to="/products/new">
               <Plus className="size-4" />
               {t('products.create')}
+              <kbd className="ml-1.5 rounded bg-white/15 px-1 py-0.5 font-mono text-[10px]">⌘N</kbd>
             </Link>
           </Button>
         </div>

--- a/apps/admin/src/features/catalog/products/show.tsx
+++ b/apps/admin/src/features/catalog/products/show.tsx
@@ -1,17 +1,29 @@
 import { useOne } from '@refinedev/core';
-import { ArrowLeft, Pencil } from 'lucide-react';
+import {
+  ArrowLeft,
+  Clock,
+  Image as ImageIcon,
+  Link2,
+  Pencil,
+  ShoppingBag,
+  Sparkles,
+  Upload,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 
-import { CompletenessBadge } from '@/components/catalog/completeness-badge';
 import { DetailDynamicForm } from '@/components/catalog/detail-dynamic-form';
 import { DetailGroupNav } from '@/components/catalog/detail-group-nav';
 import { DetailSidebar } from '@/components/catalog/detail-sidebar';
 import { SyncAggregateIcon } from '@/components/catalog/sync-aggregate-icon';
 import { VariantsTab } from '@/components/catalog/variants-tab';
 import { Button } from '@/components/ui/button';
+import { MockBadge } from '@/components/ui/mock-badge';
 import { cn } from '@/lib/utils';
+
+import { AgentSuggestionsCard } from './components/agent-suggestions-card';
+import { CompletenessRing } from './components/completeness-ring';
 
 interface CatalogObject {
   id: string;
@@ -68,7 +80,7 @@ export function ProductShowPage() {
             </div>
           </div>
           <div className="flex items-center gap-3">
-            <CompletenessBadge pct={product.completenessPct ?? 0} />
+            <CompletenessRing pct={product.completenessPct ?? 0} />
             <SyncAggregateIcon status={sync} />
             <Button asChild>
               <Link to={`/products/${product.id}/edit`}>
@@ -119,7 +131,10 @@ export function ProductShowPage() {
           {activeTab === 'history' ? <HistoryTabStub productId={productId} /> : null}
         </div>
 
-        <DetailSidebar productId={productId} />
+        <div className="space-y-4">
+          <AgentSuggestionsCard />
+          <DetailSidebar productId={productId} />
+        </div>
       </div>
 
       <p className="text-xs text-muted-foreground">
@@ -147,51 +162,138 @@ function formatDateTime(value: string, locale: string): string {
 
 /**
  * MOCK: Multimedia tab — wymaga DAM + S3/MinIO storage (#TBD).
- * Patrz Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md.
+ * Visualised as a 3x3 placeholder grid with Upload CTA + MockBadge overlay.
  */
 function MediaTabStub() {
   return (
-    <div className="rounded-2xl border border-dashed border-line bg-surface-2/40 p-8 text-center soft-shadow">
-      <p className="text-[14px] font-medium text-ink-2">Multimedia (mock)</p>
-      <p className="mt-1 text-[12px] text-muted-foreground">
-        Tab wymaga DAM (S3/MinIO + image transformations). Backlog:{' '}
-        <code className="font-mono text-[11px]">POST /api/products/&#123;id&#125;/media</code>
-      </p>
-    </div>
+    <MockBadge
+      variant="overlay"
+      tooltip="MOCK · Multimedia tab wymaga DAM (S3/MinIO + image transformations)"
+    >
+      <div className="rounded-2xl border border-line bg-surface p-6 soft-shadow">
+        <header className="flex items-center justify-between">
+          <h3 className="text-[14px] font-semibold text-ink">Multimedia</h3>
+          <Button type="button" variant="outline" size="sm" disabled>
+            <Upload className="size-4" />
+            Upload zdjęć
+          </Button>
+        </header>
+        <div className="mt-4 grid grid-cols-3 gap-3">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder grid
+              key={i}
+              className="aspect-square rounded-xl bg-surface-2 ring-1 ring-inset ring-line"
+              aria-hidden
+            >
+              <div className="flex size-full items-center justify-center text-muted-foreground/60">
+                <ImageIcon className="size-6" />
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="mt-3 text-[11px] text-muted-foreground">
+          Backlog:{' '}
+          <code className="font-mono text-[10px]">POST /api/products/&#123;id&#125;/media</code>
+        </p>
+      </div>
+    </MockBadge>
   );
 }
 
 /**
  * MOCK: Powiązania (relationships) tab — wymaga AssociationController CRUD (#TBD).
- * Entity + Repository istnieją, brak HTTP controllera.
+ * Visualised as 3 mock relationship cards (cross-sell, up-sell, related).
  */
 function RelationshipsTabStub() {
+  const types: Array<{ kind: string; label: string; count: number }> = [
+    { kind: 'cross-sell', label: 'Cross-sell', count: 4 },
+    { kind: 'up-sell', label: 'Up-sell', count: 2 },
+    { kind: 'related', label: 'Powiązane', count: 6 },
+  ];
+
   return (
-    <div className="rounded-2xl border border-dashed border-line bg-surface-2/40 p-8 text-center soft-shadow">
-      <p className="text-[14px] font-medium text-ink-2">Powiązania (mock)</p>
-      <p className="mt-1 text-[12px] text-muted-foreground">
-        3 typy: akcesoria / cross-sell / alternatywa. Wymaga{' '}
-        <code className="font-mono text-[11px]">
-          GET/POST/DELETE /api/products/&#123;id&#125;/relationships
-        </code>
-        .
-      </p>
-    </div>
+    <MockBadge variant="overlay" tooltip="MOCK · Powiązania wymagają AssociationController (#TBD)">
+      <div className="space-y-3">
+        {types.map((t) => (
+          <div
+            key={t.kind}
+            className="flex items-center justify-between rounded-2xl border border-line bg-surface p-4 soft-shadow"
+          >
+            <div className="flex items-center gap-3">
+              <span className="flex size-8 items-center justify-center rounded-lg bg-accent-blue/10 text-accent-blue">
+                <ShoppingBag className="size-4" />
+              </span>
+              <div>
+                <p className="text-[13.5px] font-semibold text-ink">{t.label}</p>
+                <p className="text-[11px] text-muted-foreground">{t.count} produktów powiązanych</p>
+              </div>
+            </div>
+            <Button type="button" variant="ghost" size="sm" disabled>
+              Edytuj
+            </Button>
+          </div>
+        ))}
+      </div>
+    </MockBadge>
   );
 }
 
 /**
  * MOCK: Historia (audit timeline) tab — wymaga GET /api/products/{id}/audit-log (#TBD).
- * DetailSidebar już używa tego endpointu (last-5), tu pełna historia z timeline UI.
+ * Visualised as a 3-event vertical timeline with Lucide Clock icons.
  */
 function HistoryTabStub({ productId: _productId }: { productId: string }) {
+  const events = [
+    {
+      who: 'Marcin Lipiec',
+      when: '5 min temu',
+      what: 'Zmieniono description.pl',
+      tone: 'bg-accent-violet/10 text-accent-violet',
+    },
+    {
+      who: 'agent.sonnet',
+      when: '2 godz. temu',
+      what: 'Wzbogacono kod HS (taryfa UE 2026)',
+      tone: 'bg-accent-emerald/10 text-accent-emerald',
+    },
+    {
+      who: 'Anna Wiśniewska',
+      when: 'wczoraj',
+      what: 'Dodano 3 zdjęcia produktu',
+      tone: 'bg-accent-blue/10 text-accent-blue',
+    },
+  ];
+
   return (
-    <div className="rounded-2xl border border-dashed border-line bg-surface-2/40 p-8 text-center soft-shadow">
-      <p className="text-[14px] font-medium text-ink-2">Historia (mock)</p>
-      <p className="mt-1 text-[12px] text-muted-foreground">
-        Pełna oś czasu z provenance per zmiana. Sidebar już pokazuje 5 ostatnich (UI-02.5); ten tab
-        potrzebuje paginowanego endpointu i timeline UI.
-      </p>
-    </div>
+    <MockBadge variant="overlay" tooltip="MOCK · Pełna timeline wymaga endpointu audit-log">
+      <div className="rounded-2xl border border-line bg-surface p-5 soft-shadow">
+        <header className="mb-4 flex items-center gap-2">
+          <Sparkles className="size-4 text-muted-foreground" />
+          <h3 className="text-[14px] font-semibold text-ink">Historia zmian</h3>
+        </header>
+        <ol className="relative space-y-4 border-l border-line pl-6">
+          {events.map((e) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static MOCK timeline; replace with real audit ids when /audit-log endpoint ships
+            <li key={`${e.who}-${e.when}`} className="relative">
+              <span
+                className={`absolute -left-[31px] flex size-5 items-center justify-center rounded-full ring-2 ring-background ${e.tone}`}
+              >
+                <Clock className="size-2.5" />
+              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-[13px] font-medium text-ink">{e.who}</span>
+                <span className="text-[11px] text-muted-foreground">{e.when}</span>
+              </div>
+              <p className="mt-0.5 text-[12.5px] text-ink-2">{e.what}</p>
+            </li>
+          ))}
+        </ol>
+        <div className="mt-3 flex items-center gap-2 text-[11px] text-muted-foreground">
+          <Link2 className="size-3" />
+          Sidebar pokazuje 5 ostatnich; pełna paginowana historia czeka na endpoint.
+        </div>
+      </div>
+    </MockBadge>
   );
 }


### PR DESCRIPTION
## Summary

UI-03b Phase 2 polish for the Produkty pages (#366), depending on the shared `MockBadge` from #363.

**Bulk toolbar** (`apps/admin/src/components/catalog/bulk-actions-toolbar.tsx`):
- Disabled "Zmień kategorię" + "Eksport" buttons now wrapped with `MockBadge` siblings + `<kbd>K</kbd>` / `<kbd>X</kbd>` shortcut hints
- "Bulk edit attribute" + Enable / Disable / Delete keep their wired behaviour (no MockBadge — they use `POST /api/products/bulk-edit` already)

**List header** (`apps/admin/src/features/catalog/products/list.tsx`):
- "Nowy produkt" CTA gets a `<kbd>⌘N</kbd>` shortcut hint inline (purely visual; keyboard handler arrives with the agent layer in Faza 2)

**Show header — Completeness ring**:
- New `apps/admin/src/features/catalog/products/components/completeness-ring.tsx` — animated SVG circle, `stroke-dashoffset` interpolated 0 → target on mount
- Color tracks the percent: violet 0–50, amber 50–80, emerald 80–100
- `<CompletenessBadge>` (linear bar) replaced in `show.tsx` header by `<CompletenessRing>`
- Linear `<CompletenessBadge>` stays available for list rows (no behaviour change in `list.tsx`)

**Detail right sidebar — agent suggestions**:
- New `apps/admin/src/features/catalog/products/components/agent-suggestions-card.tsx` — 3 mock suggestions ("Uzupełnij opis dla SEO", "Dodaj zdjęcie 4:5 dla Instagram", "Wybierz kategorię nadrzędną") with violet-accent icons
- Card has `MockBadge variant="corner"` and "Zastosuj" CTAs are wrapped in tooltips pointing at epic 0.7 Faza 2
- Mounted next to existing `<DetailSidebar>` so the right column now reads: Agent suggestions + Detail sidebar

**Tab stub visualisations** (`show.tsx`):
- `MediaTabStub`: 3×3 placeholder grid with `<ImageIcon>` glyphs + disabled "Upload zdjęć" CTA, wrapped in `MockBadge variant="overlay"`
- `RelationshipsTabStub`: 3 mock relationship cards (Cross-sell / Up-sell / Powiązane) with `<ShoppingBag>` glyph + count + disabled "Edytuj"
- `HistoryTabStub`: vertical timeline (border-left, 3 mock events) with `<Clock>` icons coloured per event tone — Marcin Lipiec, agent.sonnet, Anna Wiśniewska
- All three wrapped in `MockBadge variant="overlay"` so the operator sees the placeholder + tooltip pointing at the missing endpoint

## Test plan

- [x] `pnpm --filter admin lint` — clean
- [x] `pnpm --filter admin typecheck` — clean
- [x] `pnpm --filter admin build` — clean
- [ ] CI suite — green on this PR
- [ ] Manual smoke (operator):
  1. `/products` → grid renders, "Nowy produkt" button shows `⌘N` kbd hint
  2. Select 2+ rows → bulk toolbar shows disabled "Zmień kategorię" + "Eksport" with MockBadges and kbd `K` / `X`; Enable / Disable / Delete stay live
  3. Click any product → detail header shows animated CompletenessRing (violet/amber/emerald per pct), kbd elements where applicable
  4. Right sidebar shows Agent suggestions card (3 mock items with MockBadge corner) above Detail sidebar
  5. Tab `Multimedia` → 3×3 placeholder grid + Upload CTA, MockBadge overlay
  6. Tab `Powiązania` → 3 relationship cards, MockBadge overlay
  7. Tab `Historia` → vertical timeline 3 events, MockBadge overlay
  8. Console clean, brak 4xx/5xx (placeholder UI uses existing endpoints; mock surfaces are static)

## Out of scope

- Backend bulk operations (`change_category`, `export csv`) — placeholder UI only
- Real agent suggestions backend — placeholder UI (epic 0.7 Faza 2)
- Real media upload, relationships CRUD, full history wiring — separate BE epics
- Variants tree polish — already shipped in UI-02

## References

- Phase 1 polish: PR #361
- Blocker: PR #367 (#363) — `<MockBadge>` shared component
- Existing reuse: `CreateProductWizard`, `DetailDynamicForm`, `ExcelLikeGrid`, `BulkActionsToolbar`, `DetailSidebar`
- Makieta: `Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md`
- Epic META: #362
