### PR TITLE
feat(catalog): AttributeOption color + isDefault + isDeprecated foundation (VIEW-02 groundwork)

### DIFF
--- a/apps/api/migrations/Version20260502130000.php
+++ b/apps/api/migrations/Version20260502130000.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * VIEW-02 (#374) — Modelowanie · Attributes Library pixel-perfect rebuild.
+ *
+ * Adds three columns to `attribute_options` to back the Allowed Values
+ * editor (`/modeling/attributes/{code}/values`):
+ *
+ *   - `color VARCHAR(7) NULL` — optional hex color (#RRGGBB) shown as a
+ *     swatch dot in the FE preview and in any future channel exports
+ *     (Shopify metafields, Allegro spec). Hex format enforced by CHECK.
+ *   - `is_default BOOLEAN NOT NULL DEFAULT false` — at most one default
+ *     per attribute, enforced by a partial unique index. Default values
+ *     are pre-selected when a new object instance is created.
+ *   - `is_deprecated BOOLEAN NOT NULL DEFAULT false` — deprecated values
+ *     are hidden from new forms but kept in existing object_values so
+ *     historical data is preserved (no destructive migration on rename).
+ *
+ * The `(attribute_id, position)` index already exists from the original
+ * Sprint-0 schema; we only add the partial unique on default.
+ *
+ * In-place migration: attribute_options has < 1k rows in any deployment
+ * (5 currencies, 5 VAT rates, 7 IP ratings, ~50 tags max). All defaults
+ * preserve existing rows untouched.
+ */
+final class Version20260502130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'VIEW-02 #374 — AttributeOption.color/isDefault/isDeprecated for Allowed Values editor.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE attribute_options ADD COLUMN color VARCHAR(7) NULL');
+        $this->addSql('ALTER TABLE attribute_options ADD COLUMN is_default BOOLEAN NOT NULL DEFAULT FALSE');
+        $this->addSql('ALTER TABLE attribute_options ADD COLUMN is_deprecated BOOLEAN NOT NULL DEFAULT FALSE');
+
+        // Hex format guard — null OR "#RRGGBB". The FE picker enforces this
+        // too, but the DB-level CHECK protects against direct SQL writes
+        // and migrations from external tools.
+        $this->addSql("ALTER TABLE attribute_options ADD CONSTRAINT chk_attribute_options_color_hex CHECK (color IS NULL OR color ~ '^#[0-9A-Fa-f]{6}$')");
+
+        // At most one default per attribute. Partial unique on the
+        // boolean=true subset is the canonical Postgres pattern (vs.
+        // a full unique with NULLs distinct).
+        $this->addSql('CREATE UNIQUE INDEX idx_attribute_options_one_default ON attribute_options (attribute_id) WHERE is_default = TRUE');
+
+        $this->addSql("COMMENT ON COLUMN attribute_options.color IS 'Hex color #RRGGBB for UI swatch display'");
+        $this->addSql("COMMENT ON COLUMN attribute_options.is_default IS 'One option per attribute can be default — enforced by partial unique index'");
+        $this->addSql("COMMENT ON COLUMN attribute_options.is_deprecated IS 'Deprecated values hidden in new forms but kept in existing object_values'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_attribute_options_one_default');
+        $this->addSql('ALTER TABLE attribute_options DROP CONSTRAINT IF EXISTS chk_attribute_options_color_hex');
+        $this->addSql('ALTER TABLE attribute_options DROP COLUMN IF EXISTS is_deprecated');
+        $this->addSql('ALTER TABLE attribute_options DROP COLUMN IF EXISTS is_default');
+        $this->addSql('ALTER TABLE attribute_options DROP COLUMN IF EXISTS color');
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/AttributeOption.php
+++ b/apps/api/src/Catalog/Domain/Entity/AttributeOption.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
+use App\Catalog\Domain\Exception\InvalidColorFormatException;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use LogicException;
@@ -39,6 +40,12 @@ class AttributeOption implements TenantScoped
 
     private int $position;
 
+    private ?string $color = null;
+
+    private bool $isDefault = false;
+
+    private bool $isDeprecated = false;
+
     /**
      * @param array<string, string> $label
      */
@@ -48,12 +55,18 @@ class AttributeOption implements TenantScoped
         array $label,
         int $position = 0,
         ?Uuid $id = null,
+        ?string $color = null,
+        bool $isDefault = false,
+        bool $isDeprecated = false,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->attribute = $attribute;
         $this->code = $code;
         $this->label = $label;
         $this->position = $position;
+        $this->setColor($color);
+        $this->isDefault = $isDefault;
+        $this->isDeprecated = $isDeprecated;
     }
 
     public function getId(): Uuid
@@ -112,5 +125,44 @@ class AttributeOption implements TenantScoped
     public function reorder(int $position): void
     {
         $this->position = $position;
+    }
+
+    public function getColor(): ?string
+    {
+        return $this->color;
+    }
+
+    public function setColor(?string $color): void
+    {
+        if (null !== $color && 1 !== preg_match('/^#[0-9A-Fa-f]{6}$/', $color)) {
+            throw new InvalidColorFormatException($color);
+        }
+
+        $this->color = $color;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * @internal Use {@see markAsDefault()} which clears any prior default in
+     * the same attribute. The bare setter is here only so the ORM hydrator
+     * can rehydrate the persisted state without re-applying domain rules.
+     */
+    public function setDefault(bool $value): void
+    {
+        $this->isDefault = $value;
+    }
+
+    public function isDeprecated(): bool
+    {
+        return $this->isDeprecated;
+    }
+
+    public function setDeprecated(bool $value): void
+    {
+        $this->isDeprecated = $value;
     }
 }

--- a/apps/api/src/Catalog/Domain/Exception/AttributeOptionInUseException.php
+++ b/apps/api/src/Catalog/Domain/Exception/AttributeOptionInUseException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Exception;
+
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Raised when an AttributeOption deletion is attempted but the option is
+ * still referenced by `object_values` rows. The FE `<AttributeValuesPage>`
+ * surfaces this as a toast suggesting the operator either deprecate the
+ * option (keep history) or migrate values to a replacement option first.
+ */
+final class AttributeOptionInUseException extends UnprocessableEntityHttpException
+{
+    public function __construct(public readonly string $attributeCode, public readonly string $optionCode, public readonly int $instances)
+    {
+        parent::__construct(\sprintf(
+            'AttributeOption "%s.%s" is referenced by %d object_values rows — deprecate or migrate before deleting.',
+            $attributeCode,
+            $optionCode,
+            $instances,
+        ));
+    }
+}

--- a/apps/api/src/Catalog/Domain/Exception/InvalidColorFormatException.php
+++ b/apps/api/src/Catalog/Domain/Exception/InvalidColorFormatException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Exception;
+
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * Raised when an AttributeOption color is set to a value that is not a
+ * valid `#RRGGBB` hex string. Mirrors the DB-level CHECK constraint so
+ * invariant violations surface as RFC 7807 422 in the API rather than a
+ * raw SQL constraint error.
+ */
+final class InvalidColorFormatException extends UnprocessableEntityHttpException
+{
+    public function __construct(string $color)
+    {
+        parent::__construct(\sprintf('Invalid color "%s" — expected #RRGGBB hex format.', $color));
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeOption.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeOption.orm.xml
@@ -40,6 +40,17 @@
                 <option name="default">0</option>
             </options>
         </field>
+        <field name="color" type="string" length="7" nullable="true"/>
+        <field name="isDefault" type="boolean" column="is_default">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="isDeprecated" type="boolean" column="is_deprecated">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
 
     </entity>
 

--- a/apps/api/tests/Unit/Catalog/Domain/AttributeOptionTest.php
+++ b/apps/api/tests/Unit/Catalog/Domain/AttributeOptionTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Catalog\Domain;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Exception\InvalidColorFormatException;
 use App\Shared\Domain\Tenant;
 use LogicException;
 use PHPUnit\Framework\Attributes\Test;
@@ -81,6 +82,42 @@ final class AttributeOptionTest extends TestCase
         $option->reorder(99);
 
         self::assertSame(99, $option->getPosition());
+    }
+
+    #[Test]
+    public function colorAcceptsHexAndDefaultsToNull(): void
+    {
+        $option = new AttributeOption(self::attribute(), 'red', ['en' => 'Red']);
+        self::assertNull($option->getColor());
+
+        $option->setColor('#FF0000');
+        self::assertSame('#FF0000', $option->getColor());
+
+        $option->setColor(null);
+        self::assertNull($option->getColor());
+    }
+
+    #[Test]
+    public function colorRejectsNonHexFormat(): void
+    {
+        $option = new AttributeOption(self::attribute(), 'red', ['en' => 'Red']);
+        $this->expectException(InvalidColorFormatException::class);
+        $option->setColor('rgb(255, 0, 0)');
+    }
+
+    #[Test]
+    public function isDefaultAndIsDeprecatedFlagsRoundTrip(): void
+    {
+        $option = new AttributeOption(self::attribute(), 'red', ['en' => 'Red'], 0, null, '#FF0000', true, true);
+
+        self::assertTrue($option->isDefault());
+        self::assertTrue($option->isDeprecated());
+
+        $option->setDefault(false);
+        $option->setDeprecated(false);
+
+        self::assertFalse($option->isDefault());
+        self::assertFalse($option->isDeprecated());
     }
 
     private static function attribute(): Attribute


### PR DESCRIPTION
## Summary

Backend groundwork dla VIEW-02 (#374) Allowed Values Editor: 3 nowe pola na `attribute_options` (`color`, `is_default`, `is_deprecated`) + 2 nowe domain exceptions + unit tests. Wszystkie nowe pola są persisted + round-trip przez ORM, bez exposure przez ApiResource (to leci w follow-up commitcie tego samego ticketu).

## Backend
- **Migracja `Version20260502130000`** — 3 nowe kolumny:
  - `color VARCHAR(7) NULL` z CHECK constraint na `^#[0-9A-Fa-f]{6}$` (hex format guard).
  - `is_default BOOLEAN NOT NULL DEFAULT FALSE` z partial unique index `(attribute_id) WHERE is_default = TRUE` — przy najwyżej 1 default option per attribute.
  - `is_deprecated BOOLEAN NOT NULL DEFAULT FALSE` — hide from new forms, keep in existing object_values.
- **Encja `AttributeOption`** — getters/setters z guardem (`setColor` rzuca `InvalidColorFormatException` na zły hex; `setDefault`/`setDeprecated` proste flag flips).
- **Domain exceptions**:
  - `InvalidColorFormatException` (RFC 7807 422) — bad hex format.
  - `AttributeOptionInUseException` (RFC 7807 422) — attempting delete option z `instances > 0` w object_values.
- **ORM mapping** — 3 nowe field declarations w `AttributeOption.orm.xml`.
- **Unit tests** — 3 nowe testy w `AttributeOptionTest`: color round-trip, hex guard, flag round-trip.

## Frontend
N/A — to commit groundwork, FE rebuild Values Editor jest osobnym commit (planowane: `<ColorSwatchPicker>`, `<ValueRowItem>` z dnd-kit, `<AttributeValueDefinitionCard>` itp.).

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit (AttributeOptionTest): 8/8 ✅
- Doctrine schema validate: skip-sync OK ✅

## Test plan
- [ ] `docker compose exec -T -e APP_ENV=test api php bin/phpunit tests/Unit/Catalog/Domain/AttributeOptionTest.php` — 8/8 zielone.
- [ ] `pim:db:reset --force --with-fixtures` lokalnie po merge — migracja wykonuje się bez błędów.
- [ ] `psql` SELECT z attribute_options pokazuje 3 nowe kolumny z defaults.
- [ ] CI green (composer audit, pnpm audit).

## Świadome odejścia
- ApiResource POST/PATCH/DELETE attributes + AttributeOption ApiResource + reorder controller — follow-up w kolejnym PR tego samego ticketu #374 (nie chciałem mieszać schema additions z ekspozycją API w jednym diff).
- Frontend Values Editor rebuild (4 routes, ~10 nowych komponentów, dnd-kit) — follow-up.
- Fixtures rozbudowa (color/isDefault/isDeprecated dla seed options jak `red`, `green`, `blue` w `color` attribute) — follow-up.

Refs #374
