### PR TITLE
feat(catalog): AttributeGroup behavior flags foundation (VIEW-03 groundwork)

### DIFF
--- a/apps/api/migrations/Version20260502140000.php
+++ b/apps/api/migrations/Version20260502140000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * VIEW-03 (#375) — Modelowanie · Attribute Groups pixel-perfect rebuild.
+ *
+ * Adds three boolean columns to `attribute_groups` to back the
+ * Behavior toggles in the create form (NewAttributeGroupView mockup,
+ * `groups-categories.jsx:570–576`):
+ *
+ *   - `is_required_section BOOLEAN NOT NULL DEFAULT FALSE` — group is
+ *     always rendered in product forms (cannot be skipped/collapsed).
+ *   - `is_shared BOOLEAN NOT NULL DEFAULT TRUE` — group can be attached
+ *     to multiple ObjectTypes (default), vs. exclusive to one.
+ *   - `has_conditional_visibility BOOLEAN NOT NULL DEFAULT FALSE` —
+ *     group rendering is gated by `visible_when` rules per attribute
+ *     in the junction table.
+ *
+ * In-place migration: attribute_groups has < 100 rows in any deployment
+ * (12 in current demo seed + tenant-specific extensions). Defaults
+ * preserve existing rows untouched (`is_shared=TRUE` matches current
+ * implicit behavior).
+ */
+final class Version20260502140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'VIEW-03 #375 — AttributeGroup behavior toggles (is_required_section, is_shared, has_conditional_visibility).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE attribute_groups ADD COLUMN is_required_section BOOLEAN NOT NULL DEFAULT FALSE');
+        $this->addSql('ALTER TABLE attribute_groups ADD COLUMN is_shared BOOLEAN NOT NULL DEFAULT TRUE');
+        $this->addSql('ALTER TABLE attribute_groups ADD COLUMN has_conditional_visibility BOOLEAN NOT NULL DEFAULT FALSE');
+
+        $this->addSql("COMMENT ON COLUMN attribute_groups.is_required_section IS 'Group always rendered in form (cannot be skipped/collapsed)'");
+        $this->addSql("COMMENT ON COLUMN attribute_groups.is_shared IS 'Group can be attached to multiple ObjectTypes (vs. exclusive to one)'");
+        $this->addSql("COMMENT ON COLUMN attribute_groups.has_conditional_visibility IS 'Group rendering controlled by visible_when rules per attribute'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE attribute_groups DROP COLUMN IF EXISTS has_conditional_visibility');
+        $this->addSql('ALTER TABLE attribute_groups DROP COLUMN IF EXISTS is_shared');
+        $this->addSql('ALTER TABLE attribute_groups DROP COLUMN IF EXISTS is_required_section');
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/AttributeGroup.php
+++ b/apps/api/src/Catalog/Domain/Entity/AttributeGroup.php
@@ -59,6 +59,25 @@ class AttributeGroup implements TenantScoped
     private bool $isSystemGroup = false;
     private bool $autoAttached = false;
 
+    /**
+     * Group always rendered in product forms (cannot be skipped/collapsed).
+     * UI mapping: `Wymagana sekcja` toggle in NewAttributeGroupView mockup.
+     */
+    private bool $isRequiredSection = false;
+
+    /**
+     * Group can be attached to multiple ObjectTypes. Default true matches
+     * existing implicit behavior — every group was always shareable.
+     * UI mapping: `Współdzielona` toggle in NewAttributeGroupView mockup.
+     */
+    private bool $isShared = true;
+
+    /**
+     * Group rendering gated by `visible_when` rules per attribute in
+     * the junction. UI mapping: `Conditional visibility` toggle.
+     */
+    private bool $hasConditionalVisibility = false;
+
     private int $position;
     private DateTimeImmutable $createdAt;
 
@@ -76,6 +95,9 @@ class AttributeGroup implements TenantScoped
         ?string $color = null,
         bool $isSystemGroup = false,
         bool $autoAttached = false,
+        bool $isRequiredSection = false,
+        bool $isShared = true,
+        bool $hasConditionalVisibility = false,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->code = $code;
@@ -86,6 +108,9 @@ class AttributeGroup implements TenantScoped
         $this->color = $color;
         $this->isSystemGroup = $isSystemGroup;
         $this->autoAttached = $autoAttached;
+        $this->isRequiredSection = $isRequiredSection;
+        $this->isShared = $isShared;
+        $this->hasConditionalVisibility = $hasConditionalVisibility;
         $this->createdAt = new DateTimeImmutable();
     }
 
@@ -200,6 +225,36 @@ class AttributeGroup implements TenantScoped
     public function isSystemGroup(): bool
     {
         return $this->isSystemGroup;
+    }
+
+    public function isRequiredSection(): bool
+    {
+        return $this->isRequiredSection;
+    }
+
+    public function setRequiredSection(bool $value): void
+    {
+        $this->isRequiredSection = $value;
+    }
+
+    public function isShared(): bool
+    {
+        return $this->isShared;
+    }
+
+    public function setShared(bool $value): void
+    {
+        $this->isShared = $value;
+    }
+
+    public function hasConditionalVisibility(): bool
+    {
+        return $this->hasConditionalVisibility;
+    }
+
+    public function setConditionalVisibility(bool $value): void
+    {
+        $this->hasConditionalVisibility = $value;
     }
 
     public function isAutoAttached(): bool

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeGroup.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/AttributeGroup.orm.xml
@@ -47,6 +47,21 @@
                 <option name="default">false</option>
             </options>
         </field>
+        <field name="isRequiredSection" type="boolean" column="is_required_section">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="isShared" type="boolean" column="is_shared">
+            <options>
+                <option name="default">true</option>
+            </options>
+        </field>
+        <field name="hasConditionalVisibility" type="boolean" column="has_conditional_visibility">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
         <field name="position" type="integer">
             <options>
                 <option name="default">0</option>

--- a/apps/api/tests/Unit/Catalog/AttributeGroupBehaviorFlagsTest.php
+++ b/apps/api/tests/Unit/Catalog/AttributeGroupBehaviorFlagsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * VIEW-03 (#375) — covers the three behavior flags surfaced by the
+ * NewAttributeGroupView mockup (`Wymagana sekcja` / `Współdzielona`
+ * / `Conditional visibility`). Asserts:
+ *   - defaults match the mockup checkboxes (false / true / false),
+ *   - getters/setters round-trip without invariant violations,
+ *   - constructor accepts explicit values for fixture/seeder usage.
+ */
+final class AttributeGroupBehaviorFlagsTest extends TestCase
+{
+    #[Test]
+    public function defaultsMatchMockupCheckboxes(): void
+    {
+        $group = new AttributeGroup('marketing', ['pl' => 'Marketing']);
+
+        self::assertFalse($group->isRequiredSection(), 'Wymagana sekcja default off');
+        self::assertTrue($group->isShared(), 'Współdzielona default on (matches existing implicit shareability)');
+        self::assertFalse($group->hasConditionalVisibility(), 'Conditional visibility default off');
+    }
+
+    #[Test]
+    public function settersRoundTrip(): void
+    {
+        $group = new AttributeGroup('marketing', ['pl' => 'Marketing']);
+
+        $group->setRequiredSection(true);
+        $group->setShared(false);
+        $group->setConditionalVisibility(true);
+
+        self::assertTrue($group->isRequiredSection());
+        self::assertFalse($group->isShared());
+        self::assertTrue($group->hasConditionalVisibility());
+
+        $group->setRequiredSection(false);
+        $group->setShared(true);
+        $group->setConditionalVisibility(false);
+
+        self::assertFalse($group->isRequiredSection());
+        self::assertTrue($group->isShared());
+        self::assertFalse($group->hasConditionalVisibility());
+    }
+
+    #[Test]
+    public function constructorAcceptsExplicitFlagsForFixtures(): void
+    {
+        $group = new AttributeGroup(
+            code: 'wymagania-medyczne',
+            label: ['pl' => 'Wymagania medyczne'],
+            position: 5,
+            id: null,
+            description: ['pl' => 'Atrybuty specyficzne dla usług medycznych'],
+            icon: '🩺',
+            color: '#ef4444',
+            isSystemGroup: false,
+            autoAttached: false,
+            isRequiredSection: true,
+            isShared: false,
+            hasConditionalVisibility: true,
+        );
+
+        self::assertTrue($group->isRequiredSection());
+        self::assertFalse($group->isShared());
+        self::assertTrue($group->hasConditionalVisibility());
+    }
+}


### PR DESCRIPTION
## Summary

Backend groundwork dla VIEW-03 (#375) — 3 nowe pola behavior flags na `attribute_groups` (`is_required_section`, `is_shared`, `has_conditional_visibility`) + entity rozszerzenie + unit tests. Mappuje toggle'e z `NewAttributeGroupView` mockup (`groups-categories.jsx:570–576`):
- `Wymagana sekcja` desc „Grupa zawsze widoczna w formularzu" → `is_required_section`.
- `Współdzielona` desc „Może być dołączona do wielu ObjectType" → `is_shared` (default true zachowuje aktualne implicit behavior).
- `Conditional visibility` desc „Pokaż grupę warunkowo (visible_when)" → `has_conditional_visibility`.

## Backend
- **Migracja `Version20260502140000`** — 3 nowe boolean kolumny z defaults + COMMENTs.
- **Encja `AttributeGroup`** — properties + getters/setters + constructor accepts explicit values (dla fixtures/seeders).
- **ORM mapping** — 3 nowe field declarations w `AttributeGroup.orm.xml`.
- **Unit tests** — `AttributeGroupBehaviorFlagsTest` (3 testy, 9 asercji): defaults match mockup, setter round-trip, constructor explicit values.

## Frontend
N/A — to commit groundwork. Pełen FE rebuild list/show/create + 2 popupy + 10 nowych komponentów = follow-up commit w tym samym tickecie #375.

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit (AttributeGroup): 9/9 ✅ (3 nowe + 6 z `AttributeGroupFirstClassTest`)
- Doctrine schema validate: skip-sync OK ✅

## Test plan
- [ ] `docker compose exec -T -e APP_ENV=test api php bin/phpunit tests/Unit/Catalog/AttributeGroup` — 9/9 zielone.
- [ ] `pim:db:reset --force --with-fixtures` lokalnie — migracja zaaplikowana bez błędów.
- [ ] CI green.

## Świadome odejścia (follow-up #375)
- ApiResource `AttributeGroupInput`/`AttributeGroupPatchInput` rozszerzenie o 3 nowe pola.
- 3 nowe endpointy (`bulk-attach`, `detach`, `reorder`) + custom controllery.
- `POST /api/attributes` rozszerzenie o `attachToGroups: string[]` dla popupu „Stwórz nowy".
- Frontend rebuild 3 stron + 2 popupy + 10 komponentów + i18n + e2e.
- Fixtures rozbudowa (12 grup z mockupu z kolorami i ikonami + 2 visible_when rules).

Refs #375
