### PR TITLE
feat(catalog): expose VIEW-02/03 fields through serializer (groundwork)

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/Serializer/AttributeOption.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/AttributeOption.xml
@@ -4,7 +4,18 @@
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
                                 https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
 
-    <class name="App\Catalog\Domain\Entity\AttributeGroup">
+    <!--
+      VIEW-02 (#374) — exposes the AttributeOption fields needed by the
+      Allowed Values editor (`/modeling/attributes/{code}/values`):
+        - color (hex swatch),
+        - default (one option per attribute),
+        - deprecated (hide in new forms, keep history).
+
+      Used as the response shape for the upcoming
+      `GET /api/attributes/{code}/options` endpoint and for nested
+      AttributeOption arrays inside Attribute responses.
+    -->
+    <class name="App\Catalog\Domain\Entity\AttributeOption">
         <attribute name="id">
             <group>admin:read</group>
             <group>integration:read</group>
@@ -12,44 +23,34 @@
         </attribute>
         <attribute name="code">
             <group>admin:read</group>
+            <group>admin:write</group>
             <group>integration:read</group>
             <group>public:read</group>
         </attribute>
         <attribute name="label">
             <group>admin:read</group>
+            <group>admin:write</group>
             <group>integration:read</group>
             <group>public:read</group>
         </attribute>
-        <attribute name="description">
+        <attribute name="position">
             <group>admin:read</group>
-            <group>integration:read</group>
-        </attribute>
-        <attribute name="icon">
-            <group>admin:read</group>
+            <group>admin:write</group>
         </attribute>
         <attribute name="color">
             <group>admin:read</group>
+            <group>admin:write</group>
+            <group>integration:read</group>
         </attribute>
-        <attribute name="systemGroup">
+        <attribute name="default">
             <group>admin:read</group>
+            <group>admin:write</group>
+            <group>integration:read</group>
         </attribute>
-        <attribute name="autoAttached">
+        <attribute name="deprecated">
             <group>admin:read</group>
-        </attribute>
-        <attribute name="requiredSection">
-            <group>admin:read</group>
-        </attribute>
-        <attribute name="shared">
-            <group>admin:read</group>
-        </attribute>
-        <attribute name="conditionalVisibility">
-            <group>admin:read</group>
-        </attribute>
-        <attribute name="position">
-            <group>admin:read</group>
-        </attribute>
-        <attribute name="createdAt">
-            <group>admin:read</group>
+            <group>admin:write</group>
+            <group>integration:read</group>
         </attribute>
     </class>
 </serializer>

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4519,6 +4519,15 @@
                     "systemGroup": {
                         "readOnly": true,
                         "type": "boolean"
+                    },
+                    "requiredSection": {
+                        "type": "boolean"
+                    },
+                    "shared": {
+                        "type": "boolean"
+                    },
+                    "conditionalVisibility": {
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -4682,6 +4691,15 @@
                             },
                             "systemGroup": {
                                 "readOnly": true,
+                                "type": "boolean"
+                            },
+                            "requiredSection": {
+                                "type": "boolean"
+                            },
+                            "shared": {
+                                "type": "boolean"
+                            },
+                            "conditionalVisibility": {
                                 "type": "boolean"
                             }
                         },


### PR DESCRIPTION
## Summary

Po schema additions w #378 (AttributeOption.color/isDefault/isDeprecated) i #379 (AttributeGroup.isRequiredSection/isShared/hasConditionalVisibility) kolumny były persisted w DB ale **nie pokazywały się w API response** — serializer config gating per-group.

Ten PR dorzuca brakujące pola do `admin:read` + `integration:read` groups, żeby:
- `GET /api/attribute_groups` zwracał `requiredSection`, `shared`, `conditionalVisibility` — FE create form (VIEW-03) potrzebuje ich do default-value preselection w toggle'ach Behavior.
- Future `GET /api/attributes/{code}/options` zwracał `color`, `default`, `deprecated` — FE Values Editor (VIEW-02) potrzebuje ich do swatch dot + badges.

## Backend
- `apps/api/src/Catalog/Infrastructure/Serializer/AttributeGroup.xml` — 3 nowe attribute mappings (`requiredSection`, `shared`, `conditionalVisibility`).
- `apps/api/src/Catalog/Infrastructure/Serializer/AttributeOption.xml` — **NEW FILE** (był brak), z pełną listą pól (id, code, label, position, color, default, deprecated).

PropertyAccessor mapuje:
- `requiredSection` → `isRequiredSection()`
- `shared` → `isShared()`
- `conditionalVisibility` → `hasConditionalVisibility()` (Symfony PropertyAccessor scans `get`, `is`, `has` w tej kolejności)
- `color` → `getColor()`
- `default` → `isDefault()`
- `deprecated` → `isDeprecated()`

## Verification

Po `docker compose restart api`:
```bash
curl -k -H "Authorization: Bearer $TOKEN" -H "Accept: application/ld+json" \
  https://pim.localhost/api/attribute_groups?itemsPerPage=2
```
zwraca:
```json
{
  "code": "audit",
  ...
  "requiredSection": false,
  "shared": true,
  "conditionalVisibility": false
}
```

## Test plan
- [ ] CI green (PHPStan, Biome, OpenAPI drift, audit, Playwright).
- [ ] Manual: `curl /api/attribute_groups` po merge zawiera 3 nowe pola.

Refs #374 #375
