### PR TITLE
feat(catalog): Attribute POST/PATCH/DELETE ApiResource (VIEW-02)

### DIFF
--- a/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeCommand.php
+++ b/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeCommand.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\CreateAttribute;
+
+final readonly class CreateAttributeCommand
+{
+    /**
+     * @param array<string, string>      $label
+     * @param array<string, string>|null $help
+     * @param array<string, mixed>       $validationRules
+     */
+    public function __construct(
+        public string $code,
+        public array $label,
+        public string $type,
+        public ?array $help = null,
+        public bool $localizable = false,
+        public bool $scopable = false,
+        public bool $required = false,
+        public array $validationRules = [],
+        public int $position = 0,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\CreateAttribute;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use LogicException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-02 (#374) — creates a tenant-scoped Attribute. Mirrors the
+ * CreateAttributeGroupHandler (#260) pattern: tenant guard, code
+ * uniqueness check, then save through the repository which flushes
+ * the EM under the hood (single attribute create path).
+ */
+#[AsMessageHandler]
+final readonly class CreateAttributeHandler
+{
+    public function __construct(
+        private AttributeRepositoryInterface $repository,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    public function __invoke(CreateAttributeCommand $command): Uuid
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new LogicException('Cannot create Attribute without an authenticated tenant.');
+        }
+        if (null !== $this->repository->findByCode($command->code, $tenant)) {
+            throw new ConflictHttpException(\sprintf(
+                'Attribute with code "%s" already exists for this tenant.',
+                $command->code,
+            ));
+        }
+
+        $attribute = new Attribute(
+            code: $command->code,
+            label: $command->label,
+            type: AttributeType::from($command->type),
+        );
+        $attribute->updateHelp($command->help);
+        $attribute->changeLocalizable($command->localizable);
+        $attribute->changeScopable($command->scopable);
+        $attribute->changeRequired($command->required);
+        $attribute->updateValidationRules($command->validationRules);
+        $attribute->reorder($command->position);
+
+        $this->repository->save($attribute);
+
+        return $attribute->getId();
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/DeleteAttribute/DeleteAttributeCommand.php
+++ b/apps/api/src/Catalog/Application/Command/DeleteAttribute/DeleteAttributeCommand.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\DeleteAttribute;
+
+use Symfony\Component\Uid\Uuid;
+
+final readonly class DeleteAttributeCommand
+{
+    public function __construct(public Uuid $id)
+    {
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/DeleteAttribute/DeleteAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/DeleteAttribute/DeleteAttributeHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\DeleteAttribute;
+
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * VIEW-02 (#374) — deletes an Attribute. System attributes (`is_system=true`)
+ * are non-deletable per UI-08.3 (#258); the FE removes the trash button for
+ * system rows but the BE guard is the source of truth.
+ *
+ * Cascade behavior: the AttributeOption.attribute_id FK has
+ * ON DELETE CASCADE so options vanish with the attribute. ObjectValue
+ * rows referencing the attribute are NOT cascaded — Postgres FK is
+ * RESTRICT (Sprint 0 design). If the operator wants to remove an
+ * attribute that's still in use, the AttributeMigration flow (Sprint 0
+ * `/migrate-type` endpoint) is the supported path.
+ */
+#[AsMessageHandler]
+final readonly class DeleteAttributeHandler
+{
+    public function __construct(
+        private AttributeRepositoryInterface $repository,
+    ) {
+    }
+
+    public function __invoke(DeleteAttributeCommand $command): void
+    {
+        $attribute = $this->repository->findById($command->id);
+        if (null === $attribute) {
+            throw new NotFoundHttpException(\sprintf(
+                'Attribute "%s" was not found.',
+                $command->id->toRfc4122(),
+            ));
+        }
+
+        if ($attribute->isSystem()) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'System attribute "%s" cannot be deleted.',
+                $attribute->getCode(),
+            ));
+        }
+
+        $this->repository->remove($attribute);
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeCommand.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\UpdateAttribute;
+
+use Symfony\Component\Uid\Uuid;
+
+final readonly class UpdateAttributeCommand
+{
+    /**
+     * @param array<string, string>|null $label
+     * @param array<string, string>|null $help
+     * @param array<string, mixed>|null  $validationRules
+     */
+    public function __construct(
+        public Uuid $id,
+        public ?array $label = null,
+        public ?array $help = null,
+        public ?bool $localizable = null,
+        public ?bool $scopable = null,
+        public ?bool $required = null,
+        public ?array $validationRules = null,
+        public ?int $position = null,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeHandler.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\UpdateAttribute;
+
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * VIEW-02 (#374) — partial update for an Attribute.
+ *
+ * Patch payload contains only the fields the operator changed; null
+ * fields are skipped. System attributes (`is_system=true`, e.g.
+ * `created_at` / `updated_by`) reject mutating ops on `localizable`,
+ * `scopable`, `required` and `validationRules` — only `label` and
+ * `help` are translatable on system attributes (mirrors the system
+ * AttributeGroup contract from #260 §10.5).
+ */
+#[AsMessageHandler]
+final readonly class UpdateAttributeHandler
+{
+    public function __construct(
+        private AttributeRepositoryInterface $repository,
+    ) {
+    }
+
+    public function __invoke(UpdateAttributeCommand $command): void
+    {
+        $attribute = $this->repository->findById($command->id);
+        if (null === $attribute) {
+            throw new NotFoundHttpException(\sprintf(
+                'Attribute "%s" was not found.',
+                $command->id->toRfc4122(),
+            ));
+        }
+
+        if (null !== $command->label) {
+            $attribute->rename($command->label);
+        }
+        if (null !== $command->help) {
+            $attribute->updateHelp($command->help);
+        }
+        if (null !== $command->position) {
+            $attribute->reorder($command->position);
+        }
+
+        // System attributes: reject any structural changes; the operator
+        // can only re-translate label/help. UI surfaces this via the
+        // BuiltInLockBadge — calls bypassing the UI hit this guard.
+        if ($attribute->isSystem()) {
+            $attemptsStructuralChange = null !== $command->localizable
+                || null !== $command->scopable
+                || null !== $command->required
+                || null !== $command->validationRules;
+            if ($attemptsStructuralChange) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'System attribute "%s" — only label and help are editable.',
+                    $attribute->getCode(),
+                ));
+            }
+
+            $this->repository->save($attribute);
+
+            return;
+        }
+
+        if (null !== $command->localizable) {
+            $attribute->changeLocalizable($command->localizable);
+        }
+        if (null !== $command->scopable) {
+            $attribute->changeScopable($command->scopable);
+        }
+        if (null !== $command->required) {
+            $attribute->changeRequired($command->required);
+        }
+        if (null !== $command->validationRules) {
+            $attribute->updateValidationRules($command->validationRules);
+        }
+
+        $this->repository->save($attribute);
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml
@@ -24,6 +24,43 @@
             <operation class="ApiPlatform\Metadata\Get"
                        uriTemplate="/attributes/{id}{._format}"
                        security="is_granted('READ', object)"/>
+
+            <operation class="ApiPlatform\Metadata\Post"
+                       uriTemplate="/attributes{._format}"
+                       input="App\Catalog\Infrastructure\ApiPlatform\Resource\AttributeInput"
+                       processor="App\Catalog\Infrastructure\ApiPlatform\State\AttributeProcessor"
+                       security="is_granted('CREATE', 'App\\Catalog\\Domain\\Entity\\Attribute')">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>attribute:create</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Patch"
+                       uriTemplate="/attributes/{id}{._format}"
+                       input="App\Catalog\Infrastructure\ApiPlatform\Resource\AttributePatchInput"
+                       processor="App\Catalog\Infrastructure\ApiPlatform\State\AttributeProcessor"
+                       security="is_granted('UPDATE', object)">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>attribute:patch</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <operation class="ApiPlatform\Metadata\Delete"
+                       uriTemplate="/attributes/{id}{._format}"
+                       processor="App\Catalog\Infrastructure\ApiPlatform\State\AttributeProcessor"
+                       security="is_granted('DELETE', object)"/>
         </operations>
     </resource>
 </resources>

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * VIEW-02 (#374) — POST input shape for `/api/attributes`. Mirrors the
+ * AttributeGroupInput (#260) pattern: AP4 default Doctrine processor
+ * cannot hydrate the Attribute aggregate's typed constructor + custom
+ * setters with guards, so this DTO is the deserialisation target for
+ * `AttributeProcessor`.
+ *
+ * Field naming follows the FE create form (see VIEW-02 ticket §3.4c):
+ *   - code (snake_case, immutable post-create)
+ *   - label (JSONB { pl, en, ... })
+ *   - help (JSONB, optional)
+ *   - type (one of 10 AttributeType enum values)
+ *   - flags: localizable, scopable, required
+ *   - validationRules (JSONB, e.g. { max_length: 280 })
+ */
+final class AttributeInput
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 64)]
+    #[Assert\Regex('/^[a-z][a-z0-9_]{0,63}$/', message: 'Code must be snake_case starting with a lowercase letter.')]
+    #[Groups(['attribute:create'])]
+    public string $code = '';
+
+    /**
+     * @var array<string, string>
+     */
+    #[Assert\NotBlank]
+    #[Assert\Type('array')]
+    #[Groups(['attribute:create'])]
+    public array $label = [];
+
+    /**
+     * @var array<string, string>|null
+     */
+    #[Assert\Type('array')]
+    #[Groups(['attribute:create'])]
+    public ?array $help = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Choice(choices: ['text', 'number', 'select', 'multiselect', 'date', 'boolean', 'asset', 'relation', 'price', 'metric'])]
+    #[Groups(['attribute:create'])]
+    public string $type = 'text';
+
+    #[Groups(['attribute:create'])]
+    public bool $localizable = false;
+
+    #[Groups(['attribute:create'])]
+    public bool $scopable = false;
+
+    #[Groups(['attribute:create'])]
+    public bool $required = false;
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[Assert\Type('array')]
+    #[Groups(['attribute:create'])]
+    public array $validationRules = [];
+
+    #[Assert\PositiveOrZero]
+    #[Groups(['attribute:create'])]
+    public int $position = 0;
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributePatchInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributePatchInput.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * VIEW-02 (#374) — PATCH input shape for `/api/attributes/{id}`. Every
+ * field is nullable so we can distinguish "not provided" from "set to
+ * empty"; the Update handler only applies fields that are non-null in
+ * the patch payload.
+ *
+ * `code` and `type` are intentionally absent — code is immutable
+ * post-create and type changes go through the dedicated migrate-type
+ * flow (Sprint 0 endpoint, not editable through PATCH).
+ */
+final class AttributePatchInput
+{
+    /**
+     * @var array<string, string>|null
+     */
+    #[Assert\Type('array')]
+    #[Groups(['attribute:patch'])]
+    public ?array $label = null;
+
+    /**
+     * @var array<string, string>|null
+     */
+    #[Assert\Type('array')]
+    #[Groups(['attribute:patch'])]
+    public ?array $help = null;
+
+    #[Groups(['attribute:patch'])]
+    public ?bool $localizable = null;
+
+    #[Groups(['attribute:patch'])]
+    public ?bool $scopable = null;
+
+    #[Groups(['attribute:patch'])]
+    public ?bool $required = null;
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    #[Assert\Type('array')]
+    #[Groups(['attribute:patch'])]
+    public ?array $validationRules = null;
+
+    #[Assert\PositiveOrZero]
+    #[Groups(['attribute:patch'])]
+    public ?int $position = null;
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeProcessor.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\Catalog\Application\Command\CreateAttribute\CreateAttributeCommand;
+use App\Catalog\Application\Command\DeleteAttribute\DeleteAttributeCommand;
+use App\Catalog\Application\Command\UpdateAttribute\UpdateAttributeCommand;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Infrastructure\ApiPlatform\Resource\AttributeInput;
+use App\Catalog\Infrastructure\ApiPlatform\Resource\AttributePatchInput;
+use LogicException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-02 (#374) — AP4 State Processor for Attribute. Mirrors
+ * AttributeGroupProcessor (#260): bridges DTOs into CQRS commands and
+ * unwraps Messenger HandlerFailedException so AP4 surfaces the original
+ * 404/409/422 instead of a generic 500.
+ *
+ * @implements ProcessorInterface<AttributeInput|AttributePatchInput|Attribute, Attribute|null>
+ */
+final readonly class AttributeProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private MessageBusInterface $bus,
+        private AttributeRepositoryInterface $attributes,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?Attribute
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            return $this->handleDelete($uriVariables);
+        }
+
+        if ($operation instanceof Post) {
+            return $this->handlePost($data);
+        }
+
+        if ($operation instanceof Patch) {
+            return $this->handlePatch($data, $uriVariables);
+        }
+
+        throw new LogicException(\sprintf(
+            'AttributeProcessor cannot handle operation "%s".',
+            $operation::class,
+        ));
+    }
+
+    private function handlePost(mixed $data): Attribute
+    {
+        if (!$data instanceof AttributeInput) {
+            throw new LogicException('AttributeProcessor expects AttributeInput on Post.');
+        }
+
+        $command = new CreateAttributeCommand(
+            code: $data->code,
+            label: $data->label,
+            type: $data->type,
+            help: $data->help,
+            localizable: $data->localizable,
+            scopable: $data->scopable,
+            required: $data->required,
+            validationRules: $data->validationRules,
+            position: $data->position,
+        );
+
+        $envelope = $this->dispatch($command);
+        $newId = $this->extractResult($envelope);
+        if (!$newId instanceof Uuid) {
+            throw new LogicException('CreateAttributeHandler returned an unexpected result.');
+        }
+
+        $created = $this->attributes->findById($newId);
+        if (null === $created) {
+            throw new LogicException('Newly created Attribute could not be re-loaded.');
+        }
+
+        return $created;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handlePatch(mixed $data, array $uriVariables): Attribute
+    {
+        if (!$data instanceof AttributePatchInput) {
+            throw new LogicException('AttributeProcessor expects AttributePatchInput on Patch.');
+        }
+
+        $id = $this->idFromUriVariables($uriVariables);
+        $existing = $this->attributes->findById($id);
+        if (null === $existing) {
+            throw new NotFoundHttpException(\sprintf(
+                'Attribute "%s" was not found.',
+                $id->toRfc4122(),
+            ));
+        }
+
+        $command = new UpdateAttributeCommand(
+            id: $id,
+            label: $data->label,
+            help: $data->help,
+            localizable: $data->localizable,
+            scopable: $data->scopable,
+            required: $data->required,
+            validationRules: $data->validationRules,
+            position: $data->position,
+        );
+        $this->dispatch($command);
+
+        $reloaded = $this->attributes->findById($id);
+        if (null === $reloaded) {
+            throw new LogicException('Updated Attribute could not be re-loaded.');
+        }
+
+        return $reloaded;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handleDelete(array $uriVariables): null
+    {
+        $id = $this->idFromUriVariables($uriVariables);
+        $this->dispatch(new DeleteAttributeCommand($id));
+
+        return null;
+    }
+
+    private function dispatch(object $message): Envelope
+    {
+        try {
+            return $this->bus->dispatch($message);
+        } catch (HandlerFailedException $e) {
+            $previous = $e->getPrevious();
+            if ($previous instanceof HttpException) {
+                throw $previous;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function idFromUriVariables(array $uriVariables): Uuid
+    {
+        $raw = $uriVariables['id'] ?? null;
+        if ($raw instanceof Uuid) {
+            return $raw;
+        }
+        if (!\is_string($raw) || '' === $raw) {
+            throw new LogicException('AttributeProcessor requires {id} URI variable.');
+        }
+
+        return Uuid::fromString($raw);
+    }
+
+    private function extractResult(Envelope $envelope): mixed
+    {
+        $stamp = $envelope->last(HandledStamp::class);
+
+        return $stamp instanceof HandledStamp ? $stamp->getResult() : null;
+    }
+}

--- a/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInSystemAttributesSeeder;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * VIEW-02 (#374) — Attribute CRUD ApiResource smoke + invariants.
+ *
+ * Mirrors AttributeGroupsApiTest (#260) for the new POST/PATCH/DELETE
+ * operations. Asserts:
+ *   - POST creates a tenant-scoped attribute with proper validation.
+ *   - PATCH partial update touches only provided fields.
+ *   - DELETE removes a custom attribute; system attributes (`is_system=true`)
+ *     are 422 (UI-08.3 immutability).
+ *   - Code uniqueness within tenant is enforced (409).
+ *   - Code regex (snake_case) is validated (422).
+ */
+final class AttributesCrudApiTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        // Seeder creates `created_at`/`updated_at`/etc. system attrs we
+        // exercise the delete-protection guard against.
+        self::getContainer()->get(BuiltInSystemAttributesSeeder::class)->seed($tenant);
+    }
+
+    #[Test]
+    public function postCreatesAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'warranty_months',
+                'label' => ['en' => 'Warranty (months)', 'pl' => 'Gwarancja (msc)'],
+                'type' => 'number',
+                'localizable' => false,
+                'required' => true,
+                'validationRules' => ['min' => 0, 'max' => 120],
+                'position' => 10,
+            ],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $payload = $response->toArray();
+        self::assertSame('warranty_months', $payload['code']);
+        self::assertSame('number', $payload['type']);
+        self::assertTrue($payload['required']);
+        self::assertSame(10, $payload['position']);
+    }
+
+    #[Test]
+    public function postRejectsNonSnakeCaseCode(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'WarrantyMonths',
+                'label' => ['en' => 'Warranty'],
+                'type' => 'number',
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postRejectsDuplicateCodeForSameTenant(): void
+    {
+        $this->seedAttribute('brand', AttributeType::Text);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'brand',
+                'label' => ['en' => 'Brand again'],
+                'type' => 'text',
+            ],
+        ]);
+
+        self::assertSame(409, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function patchUpdatesProvidedFieldsOnly(): void
+    {
+        $id = $this->seedAttribute('brand', AttributeType::Text);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('PATCH', '/api/attributes/'.$id->toRfc4122(), [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => [
+                'label' => ['en' => 'Brand renamed', 'pl' => 'Marka'],
+                'localizable' => true,
+            ],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+        self::assertSame(['en' => 'Brand renamed', 'pl' => 'Marka'], $payload['label']);
+        self::assertTrue($payload['localizable']);
+    }
+
+    #[Test]
+    public function deleteRemovesCustomAttribute(): void
+    {
+        $id = $this->seedAttribute('warranty_months', AttributeType::Number);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('DELETE', '/api/attributes/'.$id->toRfc4122());
+
+        self::assertSame(204, $response->getStatusCode());
+
+        /** @var AttributeRepositoryInterface $repo */
+        $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
+        self::assertNull($repo->findById($id));
+    }
+
+    #[Test]
+    public function deleteRejectsSystemAttributeWith422(): void
+    {
+        // BuiltInSystemAttributesSeeder seeds `created_at` as a system
+        // attribute — picking it up by code ensures we hit the guard.
+        /** @var AttributeRepositoryInterface $repo */
+        $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $system = $repo->findByCode('created_at', $tenant);
+        \assert($system instanceof Attribute);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('DELETE', '/api/attributes/'.$system->getId()->toRfc4122());
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    private function seedAttribute(string $code, AttributeType $type): \Symfony\Component\Uid\Uuid
+    {
+        /** @var TenantContext $ctx */
+        $ctx = self::getContainer()->get(TenantContext::class);
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $ctx->set($tenant);
+
+        $attribute = new Attribute($code, ['en' => $code], $type);
+        /** @var AttributeRepositoryInterface $repo */
+        $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
+        $repo->save($attribute);
+
+        return $attribute->getId();
+    }
+}

--- a/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
@@ -123,7 +123,6 @@ final class AttributesCrudApiTest extends CatalogApiTestCase
 
         self::assertSame(204, $response->getStatusCode());
 
-        /** @var AttributeRepositoryInterface $repo */
         $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
         self::assertNull($repo->findById($id));
     }
@@ -133,7 +132,6 @@ final class AttributesCrudApiTest extends CatalogApiTestCase
     {
         // BuiltInSystemAttributesSeeder seeds `created_at` as a system
         // attribute — picking it up by code ensures we hit the guard.
-        /** @var AttributeRepositoryInterface $repo */
         $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
         $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
         \assert($tenant instanceof Tenant);
@@ -148,14 +146,12 @@ final class AttributesCrudApiTest extends CatalogApiTestCase
 
     private function seedAttribute(string $code, AttributeType $type): \Symfony\Component\Uid\Uuid
     {
-        /** @var TenantContext $ctx */
         $ctx = self::getContainer()->get(TenantContext::class);
         $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
         \assert($tenant instanceof Tenant);
         $ctx->set($tenant);
 
         $attribute = new Attribute($code, ['en' => $code], $type);
-        /** @var AttributeRepositoryInterface $repo */
         $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
         $repo->save($attribute);
 

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -1082,6 +1082,112 @@
                         "explode": true
                     }
                 ]
+            },
+            "post": {
+                "operationId": "api_attributes_post",
+                "tags": [
+                    "Attribute"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Attribute resource created",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Attribute.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Attribute-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Creates a Attribute resource.",
+                "description": "Creates a Attribute resource.",
+                "parameters": [],
+                "requestBody": {
+                    "description": "The new Attribute resource",
+                    "content": {
+                        "application/ld+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Attribute.AttributeInput-attribute.create"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Attribute.AttributeInput-attribute.create"
+                            }
+                        }
+                    },
+                    "required": true
+                }
             }
         },
         "/api/attributes/{id}": {
@@ -1165,6 +1271,210 @@
                         "explode": false
                     }
                 ]
+            },
+            "delete": {
+                "operationId": "api_attributes_id_delete",
+                "tags": [
+                    "Attribute"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Attribute resource deleted"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Removes the Attribute resource.",
+                "description": "Removes the Attribute resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Attribute identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "api_attributes_id_patch",
+                "tags": [
+                    "Attribute"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Attribute resource updated",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Attribute.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Attribute-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Updates the Attribute resource.",
+                "description": "Updates the Attribute resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Attribute identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "requestBody": {
+                    "description": "The updated Attribute resource",
+                    "content": {
+                        "application/merge-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Attribute.AttributePatchInput-attribute.patch.jsonMergePatch"
+                            }
+                        }
+                    },
+                    "required": true
+                }
             }
         },
         "/api/attribute_groups": {
@@ -4353,6 +4663,141 @@
                 "required": [
                     "code"
                 ]
+            },
+            "Attribute.AttributeInput-attribute.create": {
+                "type": "object",
+                "description": "A single tenant-scoped attribute definition.\n\nAttributes describe the shape of `Object` values (per ADR-009 generic\nObjectType model). One attribute can be reused across many ObjectTypes\nvia the `object_type_attributes` junction (added in #32) \u2014 e.g. `name`\non every kind, `seo_title` on `product` + `category`.\n\n`validation_rules` is plain JSONB in #31. The per-type interpreter that\nenforces \"min/max for `number`\", \"max_length for `text`\", etc. lands in\n#39 (0.3.9). Until then it is a structured payload the entity stores\nverbatim \u2014 admins can already configure it; nothing on the server side\ntrips on out-of-range values yet.\n\n`group_id` FK is nullable + ON DELETE SET NULL \u2014 removing an attribute\ngroup leaves its members ungrouped rather than deleting them.",
+                "required": [
+                    "code",
+                    "label",
+                    "type"
+                ],
+                "properties": {
+                    "code": {
+                        "maxLength": 64,
+                        "pattern": "^([a-z][a-z0-9_]{0,63})$",
+                        "default": "",
+                        "type": "string"
+                    },
+                    "label": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "help": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "type": {
+                        "enum": [
+                            "text",
+                            "number",
+                            "select",
+                            "multiselect",
+                            "date",
+                            "boolean",
+                            "asset",
+                            "relation",
+                            "price",
+                            "metric"
+                        ],
+                        "default": "text",
+                        "type": "string"
+                    },
+                    "localizable": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "scopable": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "required": {
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "validationRules": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "position": {
+                        "minimum": 0,
+                        "default": 0,
+                        "type": "integer"
+                    }
+                }
+            },
+            "Attribute.AttributePatchInput-attribute.patch.jsonMergePatch": {
+                "type": "object",
+                "description": "A single tenant-scoped attribute definition.\n\nAttributes describe the shape of `Object` values (per ADR-009 generic\nObjectType model). One attribute can be reused across many ObjectTypes\nvia the `object_type_attributes` junction (added in #32) \u2014 e.g. `name`\non every kind, `seo_title` on `product` + `category`.\n\n`validation_rules` is plain JSONB in #31. The per-type interpreter that\nenforces \"min/max for `number`\", \"max_length for `text`\", etc. lands in\n#39 (0.3.9). Until then it is a structured payload the entity stores\nverbatim \u2014 admins can already configure it; nothing on the server side\ntrips on out-of-range values yet.\n\n`group_id` FK is nullable + ON DELETE SET NULL \u2014 removing an attribute\ngroup leaves its members ungrouped rather than deleting them.",
+                "properties": {
+                    "label": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "help": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "localizable": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "scopable": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "required": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "validationRules": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    },
+                    "position": {
+                        "minimum": 0,
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    }
+                }
             },
             "Attribute.jsonld-admin.read": {
                 "allOf": [


### PR DESCRIPTION
## Summary

Wires create/edit/delete operations dla Attributes Library (VIEW-02 #374). FE pixel-perfect rebuild w follow-up commit potrzebuje tych endpointów do `<AttributeCreatePage>` (POST), edit-in-place na `<AttributeShowPage>` (PATCH) i Danger Zone delete.

## Backend
- **`POST /api/attributes`** — create custom attribute. Validacje: code regex snake_case + długość cap, type enum 10 wartości (10 typów MVP, system types out of FE scope), tenant-scoped uniqueness 409.
- **`PATCH /api/attributes/{id}`** — partial update. Tylko podane pola modyfikuje. System attributes (`is_system=true`) → 422 dla structural changes (UI-08.3 contract); akceptuje tylko `label`/`help`.
- **`DELETE /api/attributes/{id}`** — remove custom attribute. System attrs 422. Cascade: `attribute_options` ON DELETE CASCADE, `object_values` RESTRICT (migrate-type flow handles in-use deletion).

Pattern wzorowany na `AttributeGroupProcessor` (#260):
- 3 CQRS commands + handlers w `Catalog/Application/Command/`.
- AP4 State Processor `AttributeProcessor` unwraps Messenger `HandlerFailedException` żeby AP4 dostał real HTTP exception (404/409/422) zamiast 500.

## Frontend
N/A — to BE-only commit. FE rebuild w follow-up.

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit (AttributesCrudApiTest): **6/6** ✅
  - postCreatesAttribute (happy path, position 10, validationRules, required)
  - postRejectsNonSnakeCaseCode (422)
  - postRejectsDuplicateCodeForSameTenant (409)
  - patchUpdatesProvidedFieldsOnly (label rename + localizable toggle, partial)
  - deleteRemovesCustomAttribute (204 + repository find returns null)
  - deleteRejectsSystemAttributeWith422 (created_at via BuiltInSystemAttributesSeeder)
- OpenAPI snapshot regenerated (+445 lines, new POST/PATCH/DELETE operations)

## Test plan
- [ ] CI green.
- [ ] Manual smoke: `curl POST /api/attributes -H "Authorization: Bearer $TOKEN" -d '{"code":"test_attr","label":{"en":"Test"},"type":"text"}'` → 201.

## Świadome odejścia (follow-up VIEW-02)
- AttributeOption ApiResource (GET nested `/api/attributes/{id}/options`, POST/PATCH/DELETE, reorder controller).
- Per-option usage endpoint.
- FE rebuild list/show/create + values editor (~10 nowych komponentów).
- Fixtures rozbudowanie o color/isDefault dla seed options.

Refs #374
