### PR TITLE
feat(catalog): wire AttributeGroup behavior flags through the API (VIEW-03)

### DIFF
--- a/apps/api/src/Catalog/Application/Command/CreateAttributeGroup/CreateAttributeGroupCommand.php
+++ b/apps/api/src/Catalog/Application/Command/CreateAttributeGroup/CreateAttributeGroupCommand.php
@@ -17,6 +17,9 @@ final readonly class CreateAttributeGroupCommand
         public ?string $icon = null,
         public ?string $color = null,
         public int $position = 0,
+        public bool $requiredSection = false,
+        public bool $shared = true,
+        public bool $conditionalVisibility = false,
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/CreateAttributeGroup/CreateAttributeGroupHandler.php
+++ b/apps/api/src/Catalog/Application/Command/CreateAttributeGroup/CreateAttributeGroupHandler.php
@@ -41,6 +41,9 @@ final readonly class CreateAttributeGroupHandler
             description: $command->description,
             icon: $command->icon,
             color: $command->color,
+            isRequiredSection: $command->requiredSection,
+            isShared: $command->shared,
+            hasConditionalVisibility: $command->conditionalVisibility,
         );
 
         $this->repository->save($group);

--- a/apps/api/src/Catalog/Application/Command/UpdateAttributeGroup/UpdateAttributeGroupCommand.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateAttributeGroup/UpdateAttributeGroupCommand.php
@@ -22,6 +22,9 @@ final readonly class UpdateAttributeGroupCommand
         public bool $clearIcon = false,
         public bool $clearColor = false,
         public bool $clearDescription = false,
+        public ?bool $requiredSection = null,
+        public ?bool $shared = null,
+        public ?bool $conditionalVisibility = null,
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/UpdateAttributeGroup/UpdateAttributeGroupHandler.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateAttributeGroup/UpdateAttributeGroupHandler.php
@@ -47,6 +47,15 @@ final readonly class UpdateAttributeGroupHandler
         } elseif (null !== $command->color) {
             $group->setColor($command->color);
         }
+        if (null !== $command->requiredSection) {
+            $group->setRequiredSection($command->requiredSection);
+        }
+        if (null !== $command->shared) {
+            $group->setShared($command->shared);
+        }
+        if (null !== $command->conditionalVisibility) {
+            $group->setConditionalVisibility($command->conditionalVisibility);
+        }
 
         $this->repository->save($group);
     }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeGroupInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeGroupInput.php
@@ -47,4 +47,27 @@ final class AttributeGroupInput
     #[Assert\PositiveOrZero]
     #[Groups(['attribute_group:create'])]
     public int $position = 0;
+
+    /**
+     * VIEW-03 (#375) — Behavior toggle "Wymagana sekcja". Group is always
+     * rendered in product forms (cannot be skipped/collapsed).
+     */
+    #[Groups(['attribute_group:create'])]
+    public bool $requiredSection = false;
+
+    /**
+     * VIEW-03 (#375) — Behavior toggle "Współdzielona". Group can be
+     * attached to multiple ObjectTypes (default true matches existing
+     * implicit behavior — every group was always shareable).
+     */
+    #[Groups(['attribute_group:create'])]
+    public bool $shared = true;
+
+    /**
+     * VIEW-03 (#375) — Behavior toggle "Conditional visibility". Group
+     * rendering gated by `visible_when` rules per attribute in the
+     * junction table.
+     */
+    #[Groups(['attribute_group:create'])]
+    public bool $conditionalVisibility = false;
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeGroupPatchInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeGroupPatchInput.php
@@ -46,4 +46,17 @@ final class AttributeGroupPatchInput
     #[Assert\PositiveOrZero]
     #[Groups(['attribute_group:patch'])]
     public ?int $position = null;
+
+    /**
+     * VIEW-03 (#375) — Behavior toggles. Null means "not provided" so the
+     * Update handler skips them; non-null applies the new value.
+     */
+    #[Groups(['attribute_group:patch'])]
+    public ?bool $requiredSection = null;
+
+    #[Groups(['attribute_group:patch'])]
+    public ?bool $shared = null;
+
+    #[Groups(['attribute_group:patch'])]
+    public ?bool $conditionalVisibility = null;
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeGroupProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeGroupProcessor.php
@@ -80,6 +80,9 @@ final readonly class AttributeGroupProcessor implements ProcessorInterface
             icon: $data->icon,
             color: $data->color,
             position: $data->position,
+            requiredSection: $data->requiredSection,
+            shared: $data->shared,
+            conditionalVisibility: $data->conditionalVisibility,
         );
 
         $envelope = $this->dispatch($command);
@@ -121,6 +124,9 @@ final readonly class AttributeGroupProcessor implements ProcessorInterface
             icon: $data->icon,
             color: $data->color,
             position: $data->position,
+            requiredSection: $data->requiredSection,
+            shared: $data->shared,
+            conditionalVisibility: $data->conditionalVisibility,
         );
         $this->dispatch($command);
 

--- a/apps/api/tests/Api/Catalog/AttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeGroupsApiTest.php
@@ -165,6 +165,52 @@ final class AttributeGroupsApiTest extends CatalogApiTestCase
         self::assertSame(401, $response->getStatusCode());
     }
 
+    #[Test]
+    public function postPersistsBehaviorFlagsFromInput(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/attribute_groups', [
+            'json' => [
+                'code' => 'wymagania-medyczne',
+                'label' => ['pl' => 'Wymagania medyczne'],
+                'requiredSection' => true,
+                'shared' => false,
+                'conditionalVisibility' => true,
+            ],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $payload = $response->toArray();
+        self::assertTrue($payload['requiredSection']);
+        self::assertFalse($payload['shared']);
+        self::assertTrue($payload['conditionalVisibility']);
+    }
+
+    #[Test]
+    public function patchTogglesBehaviorFlags(): void
+    {
+        $client = $this->authenticatedClient();
+        $created = $client->request('POST', '/api/attribute_groups', [
+            'json' => ['code' => 'pricing', 'label' => ['en' => 'Pricing']],
+        ]);
+        $id = self::extractId($created->toArray());
+
+        $patch = $client->request('PATCH', '/api/attribute_groups/'.$id, [
+            'json' => [
+                'requiredSection' => true,
+                'conditionalVisibility' => true,
+            ],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+
+        self::assertSame(200, $patch->getStatusCode());
+        $payload = $patch->toArray();
+        self::assertTrue($payload['requiredSection']);
+        self::assertTrue($payload['conditionalVisibility']);
+        // shared preserves prior value (default true) since it was not in the patch payload
+        self::assertTrue($payload['shared']);
+    }
+
     /**
      * @param array<int|string, mixed> $payload
      */

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4581,6 +4581,21 @@
                         "minimum": 0,
                         "default": 0,
                         "type": "integer"
+                    },
+                    "requiredSection": {
+                        "description": "VIEW-03 (#375) \u2014 Behavior toggle \"Wymagana sekcja\". Group is always\nrendered in product forms (cannot be skipped/collapsed).",
+                        "default": false,
+                        "type": "boolean"
+                    },
+                    "shared": {
+                        "description": "VIEW-03 (#375) \u2014 Behavior toggle \"Wsp\u00f3\u0142dzielona\". Group can be\nattached to multiple ObjectTypes (default true matches existing\nimplicit behavior \u2014 every group was always shareable).",
+                        "default": true,
+                        "type": "boolean"
+                    },
+                    "conditionalVisibility": {
+                        "description": "VIEW-03 (#375) \u2014 Behavior toggle \"Conditional visibility\". Group\nrendering gated by `visible_when` rules per attribute in the\njunction table.",
+                        "default": false,
+                        "type": "boolean"
                     }
                 }
             },
@@ -4624,6 +4639,25 @@
                         "minimum": 0,
                         "type": [
                             "integer",
+                            "null"
+                        ]
+                    },
+                    "requiredSection": {
+                        "description": "VIEW-03 (#375) \u2014 Behavior toggles. Null means \"not provided\" so the\nUpdate handler skips them; non-null applies the new value.",
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "shared": {
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
+                    },
+                    "conditionalVisibility": {
+                        "type": [
+                            "boolean",
                             "null"
                         ]
                     }


### PR DESCRIPTION
## Summary

Wire AttributeGroup behavior flags (z #379 schema/entity) przez API write path. FE create form (NewAttributeGroupView §3.4c #375) potrzebuje POST/PATCH dla 3 toggle'ów: Wymagana sekcja / Współdzielona / Conditional visibility.

## Backend
- **`AttributeGroupInput`** — 3 nowe pola: `requiredSection` (default false), `shared` (default true), `conditionalVisibility` (default false). Defaults match mockup checkboxes.
- **`AttributeGroupPatchInput`** — 3 nowe nullable pola; null = "field absent" (preserve), non-null = apply.
- **`CreateAttributeGroupCommand`** / **`UpdateAttributeGroupCommand`** — extra constructor args z defaults, istniejące callers compile unchanged.
- **`AttributeGroupProcessor`** — passes flags from DTO → command.
- **`UpdateAttributeGroupHandler`** — applies flags tylko gdy non-null w patch payload (partial update semantics).

## Tests
- 2 nowe ApiTestCase scenariusze w `AttributeGroupsApiTest`:
  - `postPersistsBehaviorFlagsFromInput` (POST z wszystkimi 3 flags, non-default values).
  - `patchTogglesBehaviorFlags` (partial PATCH, asserts unchanged field preserves prior value).
- 12/12 zielone (10 starych + 2 nowe).

OpenAPI snapshot regenerated (+34 linie dla 3 nowych properties na obu AttributeGroup.create + AttributeGroup.patch shapes).

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit: 12/12 ✅
- OpenAPI snapshot ✅

## Test plan
- [ ] CI green.
- [ ] Manual smoke: `curl POST /api/attribute_groups -d '{...,"requiredSection":true,"shared":false,"conditionalVisibility":true}'` → 201 z polami w response.

## Świadome odejścia (follow-up VIEW-03)
- 3 nowe endpointy: `POST /api/attribute_groups/{id}/attributes/bulk-attach`, `DELETE .../attributes/{attributeId}`, `POST .../attributes/reorder`.
- Rozszerzenie `POST /api/attributes` o `attachToGroups: string[]`.
- Rozszerzenie `GET /api/attribute_groups/{id}/usage` o `instancesAffected`, `typesUsed`, `categoriesUsed`.
- Fixtures rozbudowanie o 12 grup z mockupu z behavior flags + 2 visible_when rules.
- FE rebuild list/show/create + 2 popupy.

Refs #375
