### PR TITLE
feat(catalog): bulk-attach/detach/reorder for AttributeGroup members (VIEW-03)

### DIFF
--- a/apps/api/src/Catalog/Application/Command/BulkAttachAttributesToGroup/BulkAttachAttributesToGroupCommand.php
+++ b/apps/api/src/Catalog/Application/Command/BulkAttachAttributesToGroup/BulkAttachAttributesToGroupCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\BulkAttachAttributesToGroup;
+
+use Symfony\Component\Uid\Uuid;
+
+final readonly class BulkAttachAttributesToGroupCommand
+{
+    /**
+     * @param list<string> $attributeCodes
+     */
+    public function __construct(
+        public Uuid $attributeGroupId,
+        public array $attributeCodes,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/BulkAttachAttributesToGroup/BulkAttachAttributesToGroupHandler.php
+++ b/apps/api/src/Catalog/Application/Command/BulkAttachAttributesToGroup/BulkAttachAttributesToGroupHandler.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\BulkAttachAttributesToGroup;
+
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * VIEW-03 (#375) — bulk attach (M:N) for the "Z biblioteki" popup.
+ *
+ * Idempotent: codes already present in the group are silently skipped
+ * so the FE multi-select can re-submit without 409s. Position is
+ * auto-assigned as `max(position) + 1` per attached row to keep the
+ * drag-reorder UI stable.
+ *
+ * Validation:
+ *   - empty payload → 422 (defensive — FE disables submit but the API
+ *     guard backs it up).
+ *   - unknown code → 422 with the failing code in the message.
+ *   - cross-tenant code → 422 (findByCode is tenant-scoped so unknown
+ *     codes from another tenant collapse into the same branch).
+ */
+#[AsMessageHandler]
+final readonly class BulkAttachAttributesToGroupHandler
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private AttributeGroupRepositoryInterface $groups,
+        private AttributeRepositoryInterface $attributes,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    /**
+     * @return list<string> attribute codes that were newly attached (deduped against pre-existing junction rows)
+     */
+    public function __invoke(BulkAttachAttributesToGroupCommand $command): array
+    {
+        if ([] === $command->attributeCodes) {
+            throw new UnprocessableEntityHttpException('attributeCodes must contain at least one entry.');
+        }
+
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new LogicException('Cannot bulk-attach attributes without an authenticated tenant.');
+        }
+
+        $group = $this->groups->findById($command->attributeGroupId);
+        if (null === $group) {
+            throw new NotFoundHttpException(\sprintf(
+                'AttributeGroup "%s" was not found.',
+                $command->attributeGroupId->toRfc4122(),
+            ));
+        }
+
+        $junctionRepo = $this->em->getRepository(AttributeGroupAttribute::class);
+        $maxRow = $this->em->getConnection()->fetchOne(
+            'SELECT COALESCE(MAX(position), -1) FROM attribute_group_attributes WHERE attribute_group_id = ?',
+            [$command->attributeGroupId->toRfc4122()],
+        );
+        $existingPosition = \is_scalar($maxRow) ? (int) $maxRow : -1;
+
+        $attached = [];
+        foreach ($command->attributeCodes as $code) {
+            $attribute = $this->attributes->findByCode($code, $tenant);
+            if (null === $attribute) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Attribute "%s" was not found in this tenant.',
+                    $code,
+                ));
+            }
+
+            $existing = $junctionRepo->findOneBy(['attributeGroup' => $group, 'attribute' => $attribute]);
+            if ($existing instanceof AttributeGroupAttribute) {
+                continue;
+            }
+
+            $junction = new AttributeGroupAttribute(
+                attributeGroup: $group,
+                attribute: $attribute,
+                position: ++$existingPosition,
+            );
+            $this->em->persist($junction);
+            $attached[] = $code;
+        }
+
+        $this->em->flush();
+
+        return $attached;
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/DetachAttributeFromGroup/DetachAttributeFromGroupCommand.php
+++ b/apps/api/src/Catalog/Application/Command/DetachAttributeFromGroup/DetachAttributeFromGroupCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\DetachAttributeFromGroup;
+
+use Symfony\Component\Uid\Uuid;
+
+final readonly class DetachAttributeFromGroupCommand
+{
+    public function __construct(
+        public Uuid $attributeGroupId,
+        public Uuid $attributeId,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/DetachAttributeFromGroup/DetachAttributeFromGroupHandler.php
+++ b/apps/api/src/Catalog/Application/Command/DetachAttributeFromGroup/DetachAttributeFromGroupHandler.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\DetachAttributeFromGroup;
+
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * VIEW-03 (#375) — detach an attribute from a group (junction-only delete).
+ *
+ * The Attribute itself is not removed — only the membership in the group.
+ * System groups (e.g. `audit`) reject detachment of system attributes
+ * (`is_system=true`); the FE removes the trash button for those rows but
+ * the BE guard is the source of truth.
+ *
+ * Cascade: ObjectValue rows referencing the detached attribute stay
+ * intact; they remain visible through the global Attributes Library
+ * until separately deleted/migrated.
+ */
+#[AsMessageHandler]
+final readonly class DetachAttributeFromGroupHandler
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private AttributeGroupRepositoryInterface $groups,
+    ) {
+    }
+
+    public function __invoke(DetachAttributeFromGroupCommand $command): void
+    {
+        $group = $this->groups->findById($command->attributeGroupId);
+        if (null === $group) {
+            throw new NotFoundHttpException(\sprintf(
+                'AttributeGroup "%s" was not found.',
+                $command->attributeGroupId->toRfc4122(),
+            ));
+        }
+
+        $attribute = $this->em->find(Attribute::class, $command->attributeId);
+        if (null === $attribute) {
+            throw new NotFoundHttpException(\sprintf(
+                'Attribute "%s" was not found.',
+                $command->attributeId->toRfc4122(),
+            ));
+        }
+
+        $junction = $this->em->getRepository(AttributeGroupAttribute::class)->findOneBy([
+            'attributeGroup' => $group,
+            'attribute' => $attribute,
+        ]);
+        if (!$junction instanceof AttributeGroupAttribute) {
+            throw new NotFoundHttpException(\sprintf(
+                'Attribute "%s" is not a member of AttributeGroup "%s".',
+                $attribute->getCode(),
+                $group->getCode(),
+            ));
+        }
+
+        if ($group->isSystemGroup() && $attribute->isSystem()) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'System attribute "%s" cannot be detached from system group "%s".',
+                $attribute->getCode(),
+                $group->getCode(),
+            ));
+        }
+
+        $this->em->remove($junction);
+        $this->em->flush();
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/ReorderGroupAttributes/ReorderGroupAttributesCommand.php
+++ b/apps/api/src/Catalog/Application/Command/ReorderGroupAttributes/ReorderGroupAttributesCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\ReorderGroupAttributes;
+
+use Symfony\Component\Uid\Uuid;
+
+final readonly class ReorderGroupAttributesCommand
+{
+    /**
+     * @param list<string> $attributeCodesInOrder
+     */
+    public function __construct(
+        public Uuid $attributeGroupId,
+        public array $attributeCodesInOrder,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/ReorderGroupAttributes/ReorderGroupAttributesHandler.php
+++ b/apps/api/src/Catalog/Application/Command/ReorderGroupAttributes/ReorderGroupAttributesHandler.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Command\ReorderGroupAttributes;
+
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * VIEW-03 (#375) — bulk reorder attributes in a group.
+ *
+ * Single transaction: applies new positions in payload order. Validates
+ * that the payload is a strict permutation of the existing membership
+ * (same set, no duplicates, no missing) — partial reorders go through
+ * the per-junction PATCH endpoint instead.
+ */
+#[AsMessageHandler]
+final readonly class ReorderGroupAttributesHandler
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private AttributeGroupRepositoryInterface $groups,
+    ) {
+    }
+
+    public function __invoke(ReorderGroupAttributesCommand $command): void
+    {
+        $group = $this->groups->findById($command->attributeGroupId);
+        if (null === $group) {
+            throw new NotFoundHttpException(\sprintf(
+                'AttributeGroup "%s" was not found.',
+                $command->attributeGroupId->toRfc4122(),
+            ));
+        }
+
+        $junctions = $this->em->getRepository(AttributeGroupAttribute::class)->findBy(['attributeGroup' => $group]);
+        $byCode = [];
+        foreach ($junctions as $junction) {
+            $byCode[$junction->getAttribute()->getCode()] = $junction;
+        }
+
+        if (\count($command->attributeCodesInOrder) !== \count($byCode)) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Reorder payload size (%d) does not match group membership size (%d).',
+                \count($command->attributeCodesInOrder),
+                \count($byCode),
+            ));
+        }
+
+        $seen = [];
+        foreach ($command->attributeCodesInOrder as $code) {
+            if (isset($seen[$code])) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Duplicate attribute code "%s" in reorder payload.',
+                    $code,
+                ));
+            }
+            $seen[$code] = true;
+
+            if (!isset($byCode[$code])) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Attribute "%s" is not a member of group "%s".',
+                    $code,
+                    $group->getCode(),
+                ));
+            }
+        }
+
+        $position = 0;
+        foreach ($command->attributeCodesInOrder as $code) {
+            $byCode[$code]->reorder($position++);
+        }
+
+        $this->em->flush();
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/AttributeGroupMembershipController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttributeGroupMembershipController.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\Command\BulkAttachAttributesToGroup\BulkAttachAttributesToGroupCommand;
+use App\Catalog\Application\Command\DetachAttributeFromGroup\DetachAttributeFromGroupCommand;
+use App\Catalog\Application\Command\ReorderGroupAttributes\ReorderGroupAttributesCommand;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-03 (#375) — bulk membership operations for the Attribute Group
+ * detail view: the "Z biblioteki" attach popup, the per-row trash
+ * (detach), and drag-reorder of group members.
+ *
+ * Routes intentionally live alongside the existing single-junction
+ * `AttributeGroupAttributeController` (PATCH ...{attributeId}) so the
+ * URL structure self-documents the parent → child relationship and
+ * AttributeGroupVoter (`attribute_group:write`) gates writes uniformly.
+ */
+final class AttributeGroupMembershipController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly MessageBusInterface $bus,
+    ) {
+    }
+
+    /**
+     * `POST /api/attribute_groups/{groupId}/attributes/bulk-attach`
+     *
+     * Body: `{ "attributeCodes": ["code_a", "code_b", ...] }`
+     *
+     * Returns 200 with `{ attached: [...] }` listing codes that were
+     * actually inserted (codes already present are silently skipped to
+     * keep the FE multi-select idempotent).
+     */
+    #[Route(
+        '/api/attribute_groups/{groupId}/attributes/bulk-attach',
+        name: 'pim_attribute_group_attributes_bulk_attach',
+        requirements: ['groupId' => self::UUID_REGEX],
+        methods: ['POST'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function bulkAttach(string $groupId, Request $request): JsonResponse
+    {
+        $body = json_decode($request->getContent(), true);
+        if (!\is_array($body)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+
+        $codes = $body['attributeCodes'] ?? null;
+        if (!\is_array($codes)) {
+            throw new BadRequestHttpException('attributeCodes must be an array of strings.');
+        }
+        $normalized = [];
+        foreach ($codes as $code) {
+            if (!\is_string($code) || '' === $code) {
+                throw new BadRequestHttpException('attributeCodes must contain non-empty strings only.');
+            }
+            $normalized[] = $code;
+        }
+
+        $envelope = $this->dispatch(new BulkAttachAttributesToGroupCommand(
+            attributeGroupId: Uuid::fromString($groupId),
+            attributeCodes: $normalized,
+        ));
+
+        $stamp = $envelope->last(HandledStamp::class);
+        $attached = $stamp instanceof HandledStamp ? $stamp->getResult() : [];
+
+        return new JsonResponse(['attached' => \is_array($attached) ? $attached : []]);
+    }
+
+    /**
+     * `DELETE /api/attribute_groups/{groupId}/attributes/{attributeId}`
+     *
+     * Removes the junction row only. The Attribute itself stays in the
+     * global library. System attributes in the system audit group are
+     * 422 (immutable membership).
+     */
+    #[Route(
+        '/api/attribute_groups/{groupId}/attributes/{attributeId}',
+        name: 'pim_attribute_group_attributes_detach',
+        requirements: ['groupId' => self::UUID_REGEX, 'attributeId' => self::UUID_REGEX],
+        methods: ['DELETE'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function detach(string $groupId, string $attributeId): Response
+    {
+        $this->dispatch(new DetachAttributeFromGroupCommand(
+            attributeGroupId: Uuid::fromString($groupId),
+            attributeId: Uuid::fromString($attributeId),
+        ));
+
+        return new Response(null, 204);
+    }
+
+    /**
+     * `POST /api/attribute_groups/{groupId}/attributes/reorder`
+     *
+     * Body: `{ "order": ["code_a", "code_b", "code_c"] }`
+     *
+     * Payload must be a strict permutation of current membership; the
+     * handler raises 422 on mismatched size, duplicates, or unknown
+     * codes. Single-row partial reorders go through the per-junction
+     * PATCH endpoint instead.
+     */
+    #[Route(
+        '/api/attribute_groups/{groupId}/attributes/reorder',
+        name: 'pim_attribute_group_attributes_reorder',
+        requirements: ['groupId' => self::UUID_REGEX],
+        methods: ['POST'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function reorder(string $groupId, Request $request): Response
+    {
+        $body = json_decode($request->getContent(), true);
+        if (!\is_array($body)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+
+        $order = $body['order'] ?? null;
+        if (!\is_array($order)) {
+            throw new BadRequestHttpException('order must be an array of attribute code strings.');
+        }
+        $normalized = [];
+        foreach ($order as $code) {
+            if (!\is_string($code) || '' === $code) {
+                throw new BadRequestHttpException('order must contain non-empty strings only.');
+            }
+            $normalized[] = $code;
+        }
+
+        $this->dispatch(new ReorderGroupAttributesCommand(
+            attributeGroupId: Uuid::fromString($groupId),
+            attributeCodesInOrder: $normalized,
+        ));
+
+        return new Response(null, 204);
+    }
+
+    private function dispatch(object $message): \Symfony\Component\Messenger\Envelope
+    {
+        try {
+            return $this->bus->dispatch($message);
+        } catch (HandlerFailedException $e) {
+            $previous = $e->getPrevious();
+            if ($previous instanceof HttpException) {
+                throw $previous;
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/apps/api/tests/Api/Catalog/AttributeGroupMembershipApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeGroupMembershipApiTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInSystemAttributesSeeder;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * VIEW-03 (#375) — covers the 3 membership endpoints feeding the
+ * Attributes-in-this-group card on the AttributeGroupDetail mockup:
+ *  - POST /api/attribute_groups/{id}/attributes/bulk-attach (popup "Z biblioteki")
+ *  - DELETE /api/attribute_groups/{id}/attributes/{attributeId} (per-row trash)
+ *  - POST /api/attribute_groups/{id}/attributes/reorder (drag-reorder)
+ */
+final class AttributeGroupMembershipApiTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(BuiltInSystemAttributesSeeder::class)->seed($tenant);
+    }
+
+    #[Test]
+    public function bulkAttachAddsNewMembersAndSkipsDuplicates(): void
+    {
+        $client = $this->authenticatedClient();
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        // Seed 2 attributes the test will attach.
+        $this->seedAttribute('brand', AttributeType::Text);
+        $this->seedAttribute('warranty_months', AttributeType::Number);
+
+        // Create a fresh business group via API so we exercise the full path.
+        $created = $client->request('POST', '/api/attribute_groups', [
+            'json' => ['code' => 'marketing', 'label' => ['pl' => 'Marketing']],
+        ]);
+        $groupId = $created->toArray()['id'] ?? null;
+        \assert(\is_string($groupId));
+
+        // First call: both codes attached.
+        $resp1 = $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/bulk-attach', [
+            'json' => ['attributeCodes' => ['brand', 'warranty_months']],
+        ]);
+        self::assertSame(200, $resp1->getStatusCode());
+        $payload1 = $resp1->toArray();
+        self::assertSame(['brand', 'warranty_months'], $payload1['attached']);
+
+        // Second call: no-op idempotent (both codes already in the group).
+        $resp2 = $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/bulk-attach', [
+            'json' => ['attributeCodes' => ['brand']],
+        ]);
+        self::assertSame(200, $resp2->getStatusCode());
+        self::assertSame([], $resp2->toArray()['attached']);
+    }
+
+    #[Test]
+    public function bulkAttachRejectsUnknownCode(): void
+    {
+        $client = $this->authenticatedClient();
+        $created = $client->request('POST', '/api/attribute_groups', [
+            'json' => ['code' => 'logistics', 'label' => ['pl' => 'Logistyka']],
+        ]);
+        $groupId = $created->toArray()['id'] ?? null;
+        \assert(\is_string($groupId));
+
+        $resp = $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/bulk-attach', [
+            'json' => ['attributeCodes' => ['nonexistent_attr_code']],
+        ]);
+
+        self::assertSame(422, $resp->getStatusCode());
+    }
+
+    #[Test]
+    public function detachRemovesJunctionWithoutDeletingAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $attrId = $this->seedAttribute('brand', AttributeType::Text);
+        $created = $client->request('POST', '/api/attribute_groups', [
+            'json' => ['code' => 'marketing', 'label' => ['pl' => 'Marketing']],
+        ]);
+        $groupId = $created->toArray()['id'] ?? null;
+        \assert(\is_string($groupId));
+
+        $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/bulk-attach', [
+            'json' => ['attributeCodes' => ['brand']],
+        ]);
+
+        $resp = $client->request('DELETE', '/api/attribute_groups/'.$groupId.'/attributes/'.$attrId->toRfc4122());
+        self::assertSame(204, $resp->getStatusCode());
+
+        // Attribute itself stays in the global library.
+        /** @var AttributeRepositoryInterface $repo */
+        $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
+        self::assertNotNull($repo->findById($attrId));
+    }
+
+    #[Test]
+    public function reorderAppliesNewPositionsInPayloadOrder(): void
+    {
+        $client = $this->authenticatedClient();
+        $aId = $this->seedAttribute('color', AttributeType::Text);
+        $bId = $this->seedAttribute('brand', AttributeType::Text);
+        $cId = $this->seedAttribute('size', AttributeType::Text);
+        unset($aId, $bId, $cId);
+
+        $created = $client->request('POST', '/api/attribute_groups', [
+            'json' => ['code' => 'marketing', 'label' => ['pl' => 'Marketing']],
+        ]);
+        $groupId = $created->toArray()['id'] ?? null;
+        \assert(\is_string($groupId));
+
+        $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/bulk-attach', [
+            'json' => ['attributeCodes' => ['color', 'brand', 'size']],
+        ]);
+
+        $resp = $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/reorder', [
+            'json' => ['order' => ['size', 'color', 'brand']],
+        ]);
+        self::assertSame(204, $resp->getStatusCode());
+
+        // Verify positions: size=0, color=1, brand=2.
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $group = self::getContainer()->get(AttributeGroupRepositoryInterface::class)->findByCode('marketing', $tenant);
+        \assert($group instanceof AttributeGroup);
+
+        $junctions = $em->getRepository(AttributeGroupAttribute::class)->findBy(['attributeGroup' => $group]);
+        $byCode = [];
+        foreach ($junctions as $j) {
+            $byCode[$j->getAttribute()->getCode()] = $j->getPosition();
+        }
+        self::assertSame(0, $byCode['size']);
+        self::assertSame(1, $byCode['color']);
+        self::assertSame(2, $byCode['brand']);
+    }
+
+    #[Test]
+    public function reorderRejectsSizeMismatch(): void
+    {
+        $client = $this->authenticatedClient();
+        $this->seedAttribute('color', AttributeType::Text);
+        $this->seedAttribute('brand', AttributeType::Text);
+
+        $created = $client->request('POST', '/api/attribute_groups', [
+            'json' => ['code' => 'marketing', 'label' => ['pl' => 'Marketing']],
+        ]);
+        $groupId = $created->toArray()['id'] ?? null;
+        \assert(\is_string($groupId));
+
+        $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/bulk-attach', [
+            'json' => ['attributeCodes' => ['color', 'brand']],
+        ]);
+
+        $resp = $client->request('POST', '/api/attribute_groups/'.$groupId.'/attributes/reorder', [
+            'json' => ['order' => ['color']],
+        ]);
+        self::assertSame(422, $resp->getStatusCode());
+    }
+
+    private function seedAttribute(string $code, AttributeType $type): \Symfony\Component\Uid\Uuid
+    {
+        /** @var TenantContext $ctx */
+        $ctx = self::getContainer()->get(TenantContext::class);
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $ctx->set($tenant);
+
+        $attribute = new Attribute($code, ['en' => $code], $type);
+        /** @var AttributeRepositoryInterface $repo */
+        $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
+        $repo->save($attribute);
+
+        return $attribute->getId();
+    }
+}

--- a/apps/api/tests/Api/Catalog/AttributeGroupMembershipApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeGroupMembershipApiTest.php
@@ -106,7 +106,6 @@ final class AttributeGroupMembershipApiTest extends CatalogApiTestCase
         self::assertSame(204, $resp->getStatusCode());
 
         // Attribute itself stays in the global library.
-        /** @var AttributeRepositoryInterface $repo */
         $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
         self::assertNotNull($repo->findById($attrId));
     }
@@ -177,14 +176,12 @@ final class AttributeGroupMembershipApiTest extends CatalogApiTestCase
 
     private function seedAttribute(string $code, AttributeType $type): \Symfony\Component\Uid\Uuid
     {
-        /** @var TenantContext $ctx */
         $ctx = self::getContainer()->get(TenantContext::class);
         $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
         \assert($tenant instanceof Tenant);
         $ctx->set($tenant);
 
         $attribute = new Attribute($code, ['en' => $code], $type);
-        /** @var AttributeRepositoryInterface $repo */
         $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
         $repo->save($attribute);
 


### PR DESCRIPTION
## Summary

Trzy membership endpointy dla AttributeGroupDetail Card "Attributes in this group" (VIEW-03 #375):

| Method | Path | Trigger UI |
|---|---|---|
| POST | `/api/attribute_groups/{id}/attributes/bulk-attach` | Popup "Z biblioteki" |
| DELETE | `/api/attribute_groups/{id}/attributes/{attributeId}` | Per-row trash icon |
| POST | `/api/attribute_groups/{id}/attributes/reorder` | Drag-reorder dnd-kit |

## Backend
- **`bulk-attach`**: idempotent (codes już w grupie pomijane silently), response `{attached: [...]}` tylko nowymi codes. Position auto-assigned `max+1`. Walidacja: empty 422, unknown code 422, cross-tenant code 422.
- **`detach`**: junction-only delete (Attribute zostaje w globalnej bibliotece). System group + system attribute → 422.
- **`reorder`**: payload musi być strict permutation aktualnej membership. Mismatched size / duplicates / unknown codes → 422.

Pattern: 3 CQRS commands + handlers, jeden Symfony Presentation controller (`AttributeGroupMembershipController`) z `@Route` attribute routing. HandlerFailedException unwrap dla real HTTP exceptions.

## Tests
5 ApiTestCase scenariuszy w `AttributeGroupMembershipApiTest`:
- bulkAttach happy path + idempotent re-submit
- bulkAttach unknown code 422
- detach removes junction, attribute zostaje
- reorder applies new positions
- reorder size mismatch 422

5/5 zielone.

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit: 5/5 ✅

## Test plan
- [ ] CI green.
- [ ] Manual smoke: bulk-attach + detach + reorder przez curl.

Refs #375
