### PR TITLE
feat(catalog): seed audit system group with VIEW-03 behavior flags

### DIFF
--- a/apps/api/src/Catalog/Application/BuiltInSystemAttributesSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInSystemAttributesSeeder.php
@@ -101,6 +101,11 @@ final readonly class BuiltInSystemAttributesSeeder
                     color: '#64748B',
                     isSystemGroup: true,
                     autoAttached: true,
+                    // VIEW-03 (#375) behavior flags: audit is required + non-shared
+                    // (each ObjectType gets its own auto-attached copy) + non-conditional.
+                    isRequiredSection: true,
+                    isShared: false,
+                    hasConditionalVisibility: false,
                 );
                 $this->em->persist($auditGroup);
                 $this->em->flush();


### PR DESCRIPTION
## Summary

Update `BuiltInSystemAttributesSeeder` żeby seed audit grupy spell explicit'em behavior flags z VIEW-03 (#375) zamiast polegać na constructor defaults.

## Backend
Audit system group (`code='audit'`) na fresh fixtures load:
- `isRequiredSection: true` — audit fields są zawsze widoczne w formularzu produktu.
- `isShared: false` — każdy ObjectType dostaje osobną auto-attached kopię audit group (driven by `autoAttached=true`).
- `hasConditionalVisibility: false` — brak `visible_when` na system attrs.

Bez tego fresh `pim:db:reset --with-fixtures` produkuje audit row z domyślnymi false/true/false, co mismatch'uje system-group semantics z mockupu.

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit (AttributeGroupsApiTest): 7/7 ✅
- Smoke: po `pim:db:reset --with-fixtures`, `GET /api/attribute_groups` zwraca audit z `requiredSection: true, shared: false, conditionalVisibility: false`.

## Test plan
- [ ] CI green.
- [ ] Manual: po merge → `pim:db:reset` → `curl /api/attribute_groups` → audit ma poprawne flagi.

Refs #375
