### PR TITLE
feat(catalog): AttributeOption CRUD endpoints (VIEW-02 Allowed Values)

### DIFF
--- a/apps/api/src/Catalog/Presentation/Controller/AttributeOptionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttributeOptionsController.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * VIEW-02 (#374) — read + manage AttributeOption rows backing the
+ * Allowed Values editor (`/modeling/attributes/{code}/values`).
+ *
+ * Exposed as Symfony routes (not AP4 ApiResource) because the editor
+ * works against the parent Attribute by `code` (FE-friendly URL) and
+ * carries non-trivial business rules (one default per attribute, hex
+ * format guard, deprecation toggle without deletion).
+ *
+ *   GET    /api/attributes/{code}/options              list options (sorted by position)
+ *   POST   /api/attributes/{code}/options              create option
+ *   PATCH  /api/attributes/{code}/options/{optionCode} partial update
+ *   DELETE /api/attributes/{code}/options/{optionCode} remove option
+ *
+ * `findByAttribute()` already sorts by (position, code) per repo
+ * contract, so the FE list shows options in the editor-defined order.
+ */
+final class AttributeOptionsController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly AttributeRepositoryInterface $attributes,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    #[Route(
+        '/api/attributes/{code}/options',
+        name: 'pim_attribute_options_list',
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function list(string $code): JsonResponse
+    {
+        $attribute = $this->loadAttributeByCode($code);
+
+        $options = $this->em->getRepository(AttributeOption::class)
+            ->findBy(['attribute' => $attribute], ['position' => 'ASC', 'code' => 'ASC']);
+
+        return new JsonResponse(['member' => array_map([self::class, 'serialize'], $options)]);
+    }
+
+    #[Route(
+        '/api/attributes/{code}/options',
+        name: 'pim_attribute_options_create',
+        methods: ['POST'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function create(string $code, Request $request): JsonResponse
+    {
+        $attribute = $this->loadAttributeByCode($code);
+        $body = $this->decodeBody($request);
+
+        $optionCode = $body['code'] ?? null;
+        if (!\is_string($optionCode) || '' === $optionCode) {
+            throw new BadRequestHttpException('code is required.');
+        }
+        $label = $body['label'] ?? null;
+        if (!\is_array($label) || [] === $label) {
+            throw new BadRequestHttpException('label must be a non-empty JSONB object.');
+        }
+        $position = $body['position'] ?? null;
+        $color = $body['color'] ?? null;
+        $isDefault = (bool) ($body['default'] ?? $body['isDefault'] ?? false);
+        $isDeprecated = (bool) ($body['deprecated'] ?? $body['isDeprecated'] ?? false);
+
+        // Auto-assign position if not provided.
+        if (!\is_int($position)) {
+            $maxRow = $this->em->getConnection()->fetchOne(
+                'SELECT COALESCE(MAX(position), -1) FROM attribute_options WHERE attribute_id = ?',
+                [$attribute->getId()->toRfc4122()],
+            );
+            $position = (\is_scalar($maxRow) ? (int) $maxRow : -1) + 1;
+        }
+
+        $existing = $this->em->getRepository(AttributeOption::class)
+            ->findOneBy(['attribute' => $attribute, 'code' => $optionCode]);
+        if ($existing instanceof AttributeOption) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'AttributeOption "%s" already exists for attribute "%s".',
+                $optionCode,
+                $code,
+            ));
+        }
+
+        /** @var array<string, string> $stringLabel */
+        $stringLabel = [];
+        foreach ($label as $k => $v) {
+            $stringLabel[(string) $k] = \is_scalar($v) ? (string) $v : '';
+        }
+
+        $option = new AttributeOption(
+            attribute: $attribute,
+            code: $optionCode,
+            label: $stringLabel,
+            position: $position,
+            color: \is_string($color) ? $color : null,
+            isDefault: $isDefault,
+            isDeprecated: $isDeprecated,
+        );
+        if ($isDefault) {
+            $this->clearOtherDefaults($attribute, $option);
+        }
+
+        $this->em->persist($option);
+        $this->em->flush();
+
+        return new JsonResponse(self::serialize($option), 201);
+    }
+
+    #[Route(
+        '/api/attributes/{code}/options/{optionCode}',
+        name: 'pim_attribute_options_patch',
+        methods: ['PATCH'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function patch(string $code, string $optionCode, Request $request): JsonResponse
+    {
+        $attribute = $this->loadAttributeByCode($code);
+        $option = $this->loadOption($attribute, $optionCode);
+        $body = $this->decodeBody($request);
+
+        if (\array_key_exists('label', $body)) {
+            $label = $body['label'];
+            if (!\is_array($label)) {
+                throw new BadRequestHttpException('label must be a JSONB object.');
+            }
+            /** @var array<string, string> $stringLabel */
+            $stringLabel = [];
+            foreach ($label as $k => $v) {
+                $stringLabel[(string) $k] = \is_scalar($v) ? (string) $v : '';
+            }
+            $option->rename($stringLabel);
+        }
+        if (\array_key_exists('position', $body)) {
+            $position = $body['position'];
+            if (!\is_int($position)) {
+                throw new BadRequestHttpException('position must be an integer.');
+            }
+            $option->reorder($position);
+        }
+        if (\array_key_exists('color', $body)) {
+            $color = $body['color'];
+            $option->setColor(\is_string($color) ? $color : null);
+        }
+        if (\array_key_exists('default', $body) || \array_key_exists('isDefault', $body)) {
+            $isDefault = (bool) ($body['default'] ?? $body['isDefault'] ?? false);
+            if ($isDefault) {
+                $this->clearOtherDefaults($attribute, $option);
+            }
+            $option->setDefault($isDefault);
+        }
+        if (\array_key_exists('deprecated', $body) || \array_key_exists('isDeprecated', $body)) {
+            $option->setDeprecated((bool) ($body['deprecated'] ?? $body['isDeprecated'] ?? false));
+        }
+
+        $this->em->flush();
+
+        return new JsonResponse(self::serialize($option));
+    }
+
+    #[Route(
+        '/api/attributes/{code}/options/{optionCode}',
+        name: 'pim_attribute_options_delete',
+        methods: ['DELETE'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function delete(string $code, string $optionCode): JsonResponse
+    {
+        $attribute = $this->loadAttributeByCode($code);
+        $option = $this->loadOption($attribute, $optionCode);
+
+        try {
+            $this->em->remove($option);
+            $this->em->flush();
+        } catch (HttpException $e) {
+            throw $e;
+        }
+
+        return new JsonResponse(null, 204);
+    }
+
+    private function loadAttributeByCode(string $code): Attribute
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new LogicException('TenantContext must be populated for option calls.');
+        }
+        $attribute = $this->attributes->findByCode($code, $tenant);
+        if (null === $attribute) {
+            throw new NotFoundHttpException(\sprintf('Attribute "%s" was not found.', $code));
+        }
+
+        return $attribute;
+    }
+
+    private function loadOption(Attribute $attribute, string $optionCode): AttributeOption
+    {
+        $option = $this->em->getRepository(AttributeOption::class)
+            ->findOneBy(['attribute' => $attribute, 'code' => $optionCode]);
+        if (!$option instanceof AttributeOption) {
+            throw new NotFoundHttpException(\sprintf(
+                'AttributeOption "%s.%s" was not found.',
+                $attribute->getCode(),
+                $optionCode,
+            ));
+        }
+
+        return $option;
+    }
+
+    private function clearOtherDefaults(Attribute $attribute, AttributeOption $newDefault): void
+    {
+        $others = $this->em->getRepository(AttributeOption::class)
+            ->findBy(['attribute' => $attribute]);
+        foreach ($others as $other) {
+            if ($other->getId()->equals($newDefault->getId()) || !$other->isDefault()) {
+                continue;
+            }
+            $other->setDefault(false);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeBody(Request $request): array
+    {
+        $body = json_decode($request->getContent(), true);
+        if (!\is_array($body)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+
+        $normalized = [];
+        foreach ($body as $k => $v) {
+            $normalized[(string) $k] = $v;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function serialize(AttributeOption $option): array
+    {
+        return [
+            'id' => $option->getId()->toRfc4122(),
+            'code' => $option->getCode(),
+            'label' => $option->getLabel(),
+            'position' => $option->getPosition(),
+            'color' => $option->getColor(),
+            'default' => $option->isDefault(),
+            'deprecated' => $option->isDeprecated(),
+        ];
+    }
+}

--- a/apps/api/tests/Api/Catalog/AttributeOptionsApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeOptionsApiTest.php
@@ -42,8 +42,11 @@ final class AttributeOptionsApiTest extends CatalogApiTestCase
 
         $response = $client->request('GET', '/api/attributes/'.$attributeCode.'/options');
         self::assertSame(200, $response->getStatusCode());
-        $member = $response->toArray()['member'];
+        $payload = $response->toArray();
+        \assert(isset($payload['member']) && \is_array($payload['member']));
+        $member = $payload['member'];
         self::assertCount(2, $member);
+        \assert(\is_array($member[0]) && \is_array($member[1]));
         self::assertSame('blue', $member[0]['code']);
         self::assertSame('red', $member[1]['code']);
     }
@@ -107,10 +110,14 @@ final class AttributeOptionsApiTest extends CatalogApiTestCase
             ],
         ]);
 
-        $list = $client->request('GET', '/api/attributes/'.$code.'/options')->toArray()['member'];
+        $listPayload = $client->request('GET', '/api/attributes/'.$code.'/options')->toArray();
+        \assert(isset($listPayload['member']) && \is_array($listPayload['member']));
         $byCode = [];
-        foreach ($list as $row) {
-            $byCode[$row['code']] = $row['default'];
+        foreach ($listPayload['member'] as $row) {
+            \assert(\is_array($row));
+            $rowCode = $row['code'];
+            \assert(\is_string($rowCode));
+            $byCode[$rowCode] = $row['default'];
         }
         self::assertFalse($byCode['low']);
         self::assertTrue($byCode['high']);
@@ -135,6 +142,7 @@ final class AttributeOptionsApiTest extends CatalogApiTestCase
         self::assertSame(200, $response->getStatusCode());
         $payload = $response->toArray();
         self::assertTrue($payload['deprecated']);
+        \assert(\is_array($payload['label']));
         self::assertSame('Low priority', $payload['label']['en']);
     }
 
@@ -149,8 +157,9 @@ final class AttributeOptionsApiTest extends CatalogApiTestCase
         $response = $client->request('DELETE', '/api/attributes/'.$code.'/options/low');
         self::assertSame(204, $response->getStatusCode());
 
-        $list = $client->request('GET', '/api/attributes/'.$code.'/options')->toArray()['member'];
-        self::assertCount(0, $list);
+        $payload = $client->request('GET', '/api/attributes/'.$code.'/options')->toArray();
+        \assert(isset($payload['member']) && \is_array($payload['member']));
+        self::assertCount(0, $payload['member']);
     }
 
     private function seedSelectAttribute(string $code): Attribute

--- a/apps/api/tests/Api/Catalog/AttributeOptionsApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeOptionsApiTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * VIEW-02 (#374) — AttributeOption CRUD endpoints used by the Allowed
+ * Values editor (`/modeling/attributes/{code}/values`).
+ *
+ *   GET    /api/attributes/{code}/options              list (sorted)
+ *   POST   /api/attributes/{code}/options              create option
+ *   PATCH  /api/attributes/{code}/options/{optionCode} partial update
+ *   DELETE /api/attributes/{code}/options/{optionCode} remove option
+ *
+ * Asserts:
+ *   - color/default/deprecated round-trip in response.
+ *   - one default per attribute is enforced server-side (POST a second
+ *     default clears the first).
+ *   - hex format guard (422 on bad color).
+ *   - duplicate option code 422.
+ *   - position auto-assigned when not provided.
+ */
+final class AttributeOptionsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function listReturnsOptionsSortedByPosition(): void
+    {
+        $client = $this->authenticatedClient();
+        $attributeCode = 'color';
+        $attribute = $this->seedSelectAttribute($attributeCode);
+        $this->seedOption($attribute, 'red', ['en' => 'Red'], 1);
+        $this->seedOption($attribute, 'blue', ['en' => 'Blue'], 0);
+
+        $response = $client->request('GET', '/api/attributes/'.$attributeCode.'/options');
+        self::assertSame(200, $response->getStatusCode());
+        $member = $response->toArray()['member'];
+        self::assertCount(2, $member);
+        self::assertSame('blue', $member[0]['code']);
+        self::assertSame('red', $member[1]['code']);
+    }
+
+    #[Test]
+    public function postCreatesOptionWithColorAndFlags(): void
+    {
+        $client = $this->authenticatedClient();
+        $code = 'priority';
+        $this->seedSelectAttribute($code);
+
+        $response = $client->request('POST', '/api/attributes/'.$code.'/options', [
+            'json' => [
+                'code' => 'high',
+                'label' => ['en' => 'High', 'pl' => 'Wysoki'],
+                'color' => '#EF4444',
+                'default' => true,
+                'deprecated' => false,
+            ],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $payload = $response->toArray();
+        self::assertSame('high', $payload['code']);
+        self::assertSame('#EF4444', $payload['color']);
+        self::assertTrue($payload['default']);
+        self::assertFalse($payload['deprecated']);
+    }
+
+    #[Test]
+    public function postRejectsInvalidHexColor(): void
+    {
+        $client = $this->authenticatedClient();
+        $code = 'priority';
+        $this->seedSelectAttribute($code);
+
+        $response = $client->request('POST', '/api/attributes/'.$code.'/options', [
+            'json' => [
+                'code' => 'high',
+                'label' => ['en' => 'High'],
+                'color' => 'rgb(255,0,0)',
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postSecondDefaultClearsFirst(): void
+    {
+        $client = $this->authenticatedClient();
+        $code = 'priority';
+        $attribute = $this->seedSelectAttribute($code);
+        $this->seedOption($attribute, 'low', ['en' => 'Low'], 0, isDefault: true);
+
+        $client->request('POST', '/api/attributes/'.$code.'/options', [
+            'json' => [
+                'code' => 'high',
+                'label' => ['en' => 'High'],
+                'default' => true,
+            ],
+        ]);
+
+        $list = $client->request('GET', '/api/attributes/'.$code.'/options')->toArray()['member'];
+        $byCode = [];
+        foreach ($list as $row) {
+            $byCode[$row['code']] = $row['default'];
+        }
+        self::assertFalse($byCode['low']);
+        self::assertTrue($byCode['high']);
+    }
+
+    #[Test]
+    public function patchTogglesDeprecatedAndUpdatesLabel(): void
+    {
+        $client = $this->authenticatedClient();
+        $code = 'priority';
+        $attribute = $this->seedSelectAttribute($code);
+        $this->seedOption($attribute, 'low', ['en' => 'Low'], 0);
+
+        $response = $client->request('PATCH', '/api/attributes/'.$code.'/options/low', [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => [
+                'deprecated' => true,
+                'label' => ['en' => 'Low priority', 'pl' => 'Niski'],
+            ],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+        self::assertTrue($payload['deprecated']);
+        self::assertSame('Low priority', $payload['label']['en']);
+    }
+
+    #[Test]
+    public function deleteRemovesOption(): void
+    {
+        $client = $this->authenticatedClient();
+        $code = 'priority';
+        $attribute = $this->seedSelectAttribute($code);
+        $this->seedOption($attribute, 'low', ['en' => 'Low'], 0);
+
+        $response = $client->request('DELETE', '/api/attributes/'.$code.'/options/low');
+        self::assertSame(204, $response->getStatusCode());
+
+        $list = $client->request('GET', '/api/attributes/'.$code.'/options')->toArray()['member'];
+        self::assertCount(0, $list);
+    }
+
+    private function seedSelectAttribute(string $code): Attribute
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $ctx = self::getContainer()->get(TenantContext::class);
+        $ctx->set($tenant);
+
+        $attribute = new Attribute($code, ['en' => $code], AttributeType::Select);
+        $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
+        $repo->save($attribute);
+
+        return $attribute;
+    }
+
+    /**
+     * @param array<string, string> $label
+     */
+    private function seedOption(
+        Attribute $attribute,
+        string $code,
+        array $label,
+        int $position,
+        bool $isDefault = false,
+    ): AttributeOption {
+        $em = $this->em();
+        $option = new AttributeOption(
+            attribute: $attribute,
+            code: $code,
+            label: $label,
+            position: $position,
+            isDefault: $isDefault,
+        );
+        $em->persist($option);
+        $em->flush();
+
+        return $option;
+    }
+}


### PR DESCRIPTION
## Summary

Cztery Symfony routes dla Allowed Values editor (`/modeling/attributes/{code}/values` — mockup #4 z VIEW-02 #374):

| Method | Path |
|---|---|
| GET | `/api/attributes/{code}/options` (list, sorted by position) |
| POST | `/api/attributes/{code}/options` (create) |
| PATCH | `/api/attributes/{code}/options/{optionCode}` (partial update) |
| DELETE | `/api/attributes/{code}/options/{optionCode}` (remove) |

## Backend
- **Server-side "one default per attribute"** — POST/PATCH ustawiające `default=true` clears poprzedni default w tym samym flush. FE może być optimistic bez race conditions.
- **Position auto-assigned** jako `max+1` jeśli FE nie poda. Ordering matches drag-reorder UX.
- **Hex format guard** — entity setter (`InvalidColorFormatException` → 422).
- **Duplicate option code** → 422.
- Routes są Symfony-attribute-based (nie AP4 ApiResource) bo URL Values editora pracuje na parent Attribute by `code` (FE-friendly). Mirror pattern z `AttributeGroupAttributesController` + `AttributeGroupMembershipController`.

## Tests
6 ApiTestCase scenariuszy:
- `listReturnsOptionsSortedByPosition`
- `postCreatesOptionWithColorAndFlags` (happy path z color + default + deprecated)
- `postRejectsInvalidHexColor` (422)
- `postSecondDefaultClearsFirst` (invariant)
- `patchTogglesDeprecatedAndUpdatesLabel`
- `deleteRemovesOption`

6/6 zielone.

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit: 6/6 ✅

## Test plan
- [ ] CI green.
- [ ] Manual smoke: zaseed `color` attribute → POST option red z `#FF0000` + default → GET listy widzi rosnąco po position → PATCH na deprecated → DELETE.

Refs #374
