### PR TITLE
feat(catalog): POST /api/attributes accepts attachToGroups (VIEW-03)

### DIFF
--- a/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeCommand.php
+++ b/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeCommand.php
@@ -10,6 +10,7 @@ final readonly class CreateAttributeCommand
      * @param array<string, string>      $label
      * @param array<string, string>|null $help
      * @param array<string, mixed>       $validationRules
+     * @param list<string>               $attachToGroups
      */
     public function __construct(
         public string $code,
@@ -21,6 +22,7 @@ final readonly class CreateAttributeCommand
         public bool $required = false,
         public array $validationRules = [],
         public int $position = 0,
+        public array $attachToGroups = [],
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeHandler.php
@@ -6,10 +6,14 @@ namespace App\Catalog\Application\Command\CreateAttribute;
 
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Uid\Uuid;
 
@@ -18,12 +22,20 @@ use Symfony\Component\Uid\Uuid;
  * CreateAttributeGroupHandler (#260) pattern: tenant guard, code
  * uniqueness check, then save through the repository which flushes
  * the EM under the hood (single attribute create path).
+ *
+ * VIEW-03 (#375) — when `attachToGroups` is non-empty, the handler
+ * also creates AttributeGroupAttribute junction rows for each listed
+ * group code in the same flush. Unknown group codes raise 422 before
+ * any data is persisted (transactional all-or-nothing for the popup
+ * „Stwórz nowy" UX in the FE).
  */
 #[AsMessageHandler]
 final readonly class CreateAttributeHandler
 {
     public function __construct(
         private AttributeRepositoryInterface $repository,
+        private AttributeGroupRepositoryInterface $groupRepository,
+        private EntityManagerInterface $em,
         private TenantContext $tenantContext,
     ) {
     }
@@ -41,6 +53,20 @@ final readonly class CreateAttributeHandler
             ));
         }
 
+        // Pre-validate group codes before any persistence so the create
+        // either fully succeeds or no row is touched.
+        $groups = [];
+        foreach ($command->attachToGroups as $groupCode) {
+            $group = $this->groupRepository->findByCode($groupCode, $tenant);
+            if (null === $group) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'AttributeGroup "%s" was not found in this tenant.',
+                    $groupCode,
+                ));
+            }
+            $groups[] = $group;
+        }
+
         $attribute = new Attribute(
             code: $command->code,
             label: $command->label,
@@ -54,6 +80,26 @@ final readonly class CreateAttributeHandler
         $attribute->reorder($command->position);
 
         $this->repository->save($attribute);
+
+        // Junction rows go through the EM directly — repository->save()
+        // already flushed once but the M:N attaches are cohesive with
+        // the create from the operator's POV (single API call).
+        foreach ($groups as $group) {
+            $maxRow = $this->em->getConnection()->fetchOne(
+                'SELECT COALESCE(MAX(position), -1) FROM attribute_group_attributes WHERE attribute_group_id = ?',
+                [$group->getId()->toRfc4122()],
+            );
+            $position = (\is_scalar($maxRow) ? (int) $maxRow : -1) + 1;
+            $junction = new AttributeGroupAttribute(
+                attributeGroup: $group,
+                attribute: $attribute,
+                position: $position,
+            );
+            $this->em->persist($junction);
+        }
+        if ([] !== $groups) {
+            $this->em->flush();
+        }
 
         return $attribute->getId();
     }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
@@ -69,4 +69,20 @@ final class AttributeInput
     #[Assert\PositiveOrZero]
     #[Groups(['attribute:create'])]
     public int $position = 0;
+
+    /**
+     * VIEW-03 (#375) — popup „Stwórz nowy" in AttributeGroup detail
+     * (groups-categories.jsx:813–953) creates the attribute and
+     * attaches it to one or more groups atomically in the same request.
+     * Each entry is an AttributeGroup code (not UUID, FE-friendly).
+     * Unknown codes return 422 from the handler.
+     *
+     * Empty array (default) keeps the legacy POST behaviour from #381 —
+     * attribute lands in the global library only.
+     *
+     * @var list<string>
+     */
+    #[Assert\Type('array')]
+    #[Groups(['attribute:create'])]
+    public array $attachToGroups = [];
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeProcessor.php
@@ -81,6 +81,7 @@ final readonly class AttributeProcessor implements ProcessorInterface
             required: $data->required,
             validationRules: $data->validationRules,
             position: $data->position,
+            attachToGroups: $data->attachToGroups,
         );
 
         $envelope = $this->dispatch($command);

--- a/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
@@ -144,6 +144,70 @@ final class AttributesCrudApiTest extends CatalogApiTestCase
         self::assertSame(422, $response->getStatusCode());
     }
 
+    #[Test]
+    public function postWithAttachToGroupsCreatesJunctionRows(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/attribute_groups', [
+            'json' => ['code' => 'marketing', 'label' => ['pl' => 'Marketing']],
+        ]);
+
+        $response = $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'campaign_tag',
+                'label' => ['en' => 'Campaign tag'],
+                'type' => 'text',
+                'attachToGroups' => ['marketing'],
+            ],
+        ]);
+        self::assertSame(201, $response->getStatusCode());
+
+        $list = $client->request('GET', '/api/attribute_groups/'.$this->resolveGroupId('marketing').'/attributes');
+        $payload = $list->toArray();
+        \assert(isset($payload['members']) && \is_array($payload['members']));
+        $codes = [];
+        foreach ($payload['members'] as $row) {
+            \assert(\is_array($row));
+            $attribute = $row['attribute'] ?? null;
+            \assert(\is_array($attribute));
+            $code = $attribute['code'] ?? '';
+            \assert(\is_string($code));
+            $codes[] = $code;
+        }
+        self::assertContains('campaign_tag', $codes);
+    }
+
+    #[Test]
+    public function postWithUnknownGroupCodeReturns422(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'campaign_tag',
+                'label' => ['en' => 'Campaign tag'],
+                'type' => 'text',
+                'attachToGroups' => ['nonexistent_group_code'],
+            ],
+        ]);
+        self::assertSame(422, $response->getStatusCode());
+
+        $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::assertNull($repo->findByCode('campaign_tag', $tenant));
+    }
+
+    private function resolveGroupId(string $code): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $repo = self::getContainer()->get(\App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface::class);
+        $group = $repo->findByCode($code, $tenant);
+        \assert(null !== $group);
+
+        return $group->getId()->toRfc4122();
+    }
+
     private function seedAttribute(string $code, AttributeType $type): \Symfony\Component\Uid\Uuid
     {
         $ctx = self::getContainer()->get(TenantContext::class);

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4735,6 +4735,13 @@
                         "minimum": 0,
                         "default": 0,
                         "type": "integer"
+                    },
+                    "attachToGroups": {
+                        "description": "VIEW-03 (#375) \u2014 popup \u201eStw\u00f3rz nowy\" in AttributeGroup detail\n(groups-categories.jsx:813\u2013953) creates the attribute and\nattaches it to one or more groups atomically in the same request.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             },


### PR DESCRIPTION
## Summary

Rozszerzenie `POST /api/attributes` o opcjonalne `attachToGroups: list<string>` — atomic create + attach dla popupu „Stwórz nowy" w AttributeGroupDetail (mockup #4 z VIEW-03 #375).

## Backend
- **`AttributeInput.attachToGroups`** — nowe pole, default `[]` preserves legacy POST behaviour (#381).
- **`CreateAttributeCommand.attachToGroups`** — extra constructor arg, defaults preserve binary-compat.
- **`CreateAttributeHandler`** — pre-validates wszystkie group codes PRZED tworzeniem attribute (atomic, unknown code 422 + zero rows touched). Junction rows insert z auto-assigned position (max+1) per group.
- **`AttributeProcessor`** — passes from DTO to command.

## Tests
2 nowe ApiTestCase scenariusze:
- `postWithAttachToGroupsCreatesJunctionRows` (happy path: 201 + GET membership shows new code).
- `postWithUnknownGroupCodeReturns422` (atomic rollback — attribute not findable po fail).

8/8 zielone (6 starych + 2 nowe).

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit: 8/8 ✅
- OpenAPI snapshot regenerated ✅

## Test plan
- [ ] CI green.
- [ ] Manual: `curl POST /api/attributes -d '{"code":"warranty","label":{"en":"W"},"type":"text","attachToGroups":["marketing"]}'` → 201 + atrybut widoczny w `/api/attribute_groups/{marketingId}/attributes`.

Refs #375
