### PR TITLE
feat(catalog): seed VIEW-02 mockup attributes (IP rating, VAT, currency)

### DIFF
--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -330,7 +330,7 @@ final readonly class DemoCatalogSeeder
     }
 
     /**
-     * @return array<string, array{label: array<string, string>, type: AttributeType, required?: bool, localizable?: bool, rules?: array<string, mixed>, options?: list<array{0: string, 1: array<string, string>, 2?: string, 3?: bool, 4?: bool}>}>
+     * @return array<string, array{label: array<string, string>, type: AttributeType, required?: bool, localizable?: bool, rules?: array<string, mixed>, options?: list<array{0: string, 1: array<string, string>, 2?: string|null, 3?: bool, 4?: bool}>}>
      */
     private static function attributeDefinitions(): array
     {
@@ -454,6 +454,70 @@ final readonly class DemoCatalogSeeder
                 'type' => AttributeType::Text,
                 'localizable' => true,
                 'rules' => ['max_length' => 255],
+            ],
+            // VIEW-02 (#374) — pixel-perfect attribute fixtures matching the
+            // ATTRIBUTES list from `attributes.jsx` mockup: IP rating with 7
+            // hex colors, VAT rate with 5 options + Polish default, currency
+            // with 5 options, plus a few standalone numeric/date attributes
+            // operator can show off in smoke. Position is implicit by array
+            // order; the FE list reads it from the GET response.
+            'ip_rating' => [
+                'label' => ['pl' => 'Klasa szczelności (IP)', 'en' => 'IP rating'],
+                'type' => AttributeType::Select,
+                'options' => [
+                    ['IP20', ['pl' => 'IP20', 'en' => 'IP20'], '#94A3B8', false, false],
+                    ['IP44', ['pl' => 'IP44', 'en' => 'IP44'], '#0EA5E9', false, false],
+                    ['IP54', ['pl' => 'IP54', 'en' => 'IP54'], '#10B981', true, false],
+                    ['IP55', ['pl' => 'IP55', 'en' => 'IP55'], '#22C55E', false, false],
+                    ['IP65', ['pl' => 'IP65', 'en' => 'IP65'], '#F59E0B', false, false],
+                    ['IP67', ['pl' => 'IP67', 'en' => 'IP67'], '#EF4444', false, false],
+                    ['IP68', ['pl' => 'IP68', 'en' => 'IP68'], '#A855F7', false, false],
+                ],
+            ],
+            'vat_rate' => [
+                'label' => ['pl' => 'Stawka VAT', 'en' => 'VAT rate'],
+                'type' => AttributeType::Select,
+                'options' => [
+                    ['vat_23', ['pl' => '23%', 'en' => '23%'], null, true, false],
+                    ['vat_8', ['pl' => '8%', 'en' => '8%'], null, false, false],
+                    ['vat_5', ['pl' => '5%', 'en' => '5%'], null, false, false],
+                    ['vat_0', ['pl' => '0%', 'en' => '0%'], null, false, false],
+                    ['vat_zw', ['pl' => 'ZW (zwolnione)', 'en' => 'Exempt'], null, false, true],
+                ],
+            ],
+            'currency_code' => [
+                'label' => ['pl' => 'Waluta', 'en' => 'Currency'],
+                'type' => AttributeType::Select,
+                'options' => [
+                    ['PLN', ['pl' => 'PLN · złoty', 'en' => 'PLN · Polish złoty'], null, true, false],
+                    ['EUR', ['pl' => 'EUR · euro', 'en' => 'EUR · euro'], null, false, false],
+                    ['USD', ['pl' => 'USD · dolar', 'en' => 'USD · US dollar'], null, false, false],
+                    ['GBP', ['pl' => 'GBP · funt', 'en' => 'GBP · pound sterling'], null, false, false],
+                    ['CHF', ['pl' => 'CHF · frank', 'en' => 'CHF · Swiss franc'], null, false, false],
+                ],
+            ],
+            'warranty_months' => [
+                'label' => ['pl' => 'Gwarancja (msc)', 'en' => 'Warranty (months)'],
+                'type' => AttributeType::Number,
+                'rules' => ['min' => 0, 'max' => 120],
+            ],
+            'voltage' => [
+                'label' => ['pl' => 'Napięcie', 'en' => 'Voltage'],
+                'type' => AttributeType::Metric,
+                'rules' => ['units' => ['V'], 'min' => 0],
+            ],
+            'power_w' => [
+                'label' => ['pl' => 'Moc', 'en' => 'Power'],
+                'type' => AttributeType::Metric,
+                'rules' => ['units' => ['W'], 'min' => 0],
+            ],
+            'requires_referral' => [
+                'label' => ['pl' => 'Wymaga skierowania', 'en' => 'Requires referral'],
+                'type' => AttributeType::Boolean,
+            ],
+            'eol_date' => [
+                'label' => ['pl' => 'Koniec wsparcia', 'en' => 'End of life'],
+                'type' => AttributeType::Date,
             ],
         ];
     }

--- a/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
@@ -49,8 +49,10 @@ final class DemoCatalogSeederTest extends KernelTestCase
         $seeder->seed($this->tenant);
 
         $em = $this->em();
-        // 19 attributes spanning all 10 AttributeType cases.
-        self::assertSame(19, (int) $em->createQuery('SELECT COUNT(a) FROM '.Attribute::class.' a')->getSingleScalarResult());
+        // 27 attributes (19 base + 8 VIEW-02 mockup additions: ip_rating,
+        // vat_rate, currency_code, warranty_months, voltage, power_w,
+        // requires_referral, eol_date) spanning all 10 AttributeType cases.
+        self::assertSame(27, (int) $em->createQuery('SELECT COUNT(a) FROM '.Attribute::class.' a')->getSingleScalarResult());
         // 100 products + 5 categories + 10 assets.
         self::assertSame(100, $this->countObjects(ObjectKind::Product));
         self::assertSame(5, $this->countObjects(ObjectKind::Category));


### PR DESCRIPTION
## Summary

Extends demo seed o 8 atrybutów z mockup `attributes.jsx` ATTRIBUTES table — operator po `pim:db:reset --with-fixtures` widzi 26 atrybutów zamiast 18, w tym `ip_rating` z 7 hex-color options + IP54 default w Allowed Values editor.

## Backend
Nowe atrybuty (z mockup color legend):
- **`ip_rating`** (Select, 7 opcji, IP54 default): zinc IP20 → IP44 sky → IP54 emerald (default) → IP55 green → IP65 amber → IP67 rose → IP68 violet.
- **`vat_rate`** (Select, 5 opcji, 23% default, ZW deprecated).
- **`currency_code`** (Select, 5 opcji, PLN default).
- **`warranty_months`** (Number, 0..120).
- **`voltage`** / **`power_w`** (Metric, V / W).
- **`requires_referral`** (Boolean) — VIEW-03 `wymagania-medyczne` group używa tego jako visible_when source.
- **`eol_date`** (Date).

Schema docblock: `color?: string|null` — nowe opcje (vat_rate, currency_code) bez koloru typecheck cleanly w PHPStan max.

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit (AttributesDenormalizationApiTest): 3/3 ✅ (backward-compat preserved)

## Test plan
- [ ] CI green.
- [ ] Manual smoke po merge: `pim:db:reset --with-fixtures` → lista 26 atrybutów → klik `ip_rating` → klik wartości → Allowed Values editor pokazuje 7 opcji z hex color dot, IP54 z `default` badge.

Refs #374
