### PR TITLE
feat(catalog): per-option usage endpoint for VIEW-02 audit card

### DIFF
--- a/apps/api/src/Catalog/Presentation/Controller/AttributeOptionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttributeOptionsController.php
@@ -19,6 +19,8 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
+use const JSON_THROW_ON_ERROR;
+
 /**
  * VIEW-02 (#374) — read + manage AttributeOption rows backing the
  * Allowed Values editor (`/modeling/attributes/{code}/values`).
@@ -59,6 +61,45 @@ final class AttributeOptionsController
             ->findBy(['attribute' => $attribute], ['position' => 'ASC', 'code' => 'ASC']);
 
         return new JsonResponse(['member' => array_map([self::class, 'serialize'], $options)]);
+    }
+
+    /**
+     * VIEW-02 (#374) — per-option instance count for the Allowed Values
+     * editor's `<AttributeValueAuditCard>`. Counts every `object_value`
+     * row whose `value` JSONB references the option code:
+     *   - select   → `value->>'value' = '{optionCode}'`
+     *   - multiselect → `value->'option_codes' ? '{optionCode}'`
+     *
+     * The single SQL covers both shapes via OR — JSONB `?` operator on
+     * a non-array value is `false` so the select branch only matches
+     * `value->>'value'`. Tenant scoping piggybacks on object_values
+     * (already tenant-stamped via Doctrine listener).
+     */
+    #[Route(
+        '/api/attributes/{code}/options/{optionCode}/usage',
+        name: 'pim_attribute_options_usage',
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function usage(string $code, string $optionCode): JsonResponse
+    {
+        $attribute = $this->loadAttributeByCode($code);
+        $option = $this->loadOption($attribute, $optionCode);
+
+        // Postgres JSONB containment (`@>`) lets us cover both shapes
+        // without using the `?` JSONB operator (DBAL parses `?` as a
+        // bind placeholder).
+        $selectShape = json_encode(['value' => $option->getCode()], JSON_THROW_ON_ERROR);
+        $multiShape = json_encode(['option_codes' => [$option->getCode()]], JSON_THROW_ON_ERROR);
+        $row = $this->em->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM object_values'
+            .' WHERE attribute_id = ?'
+            .' AND (value @> ?::jsonb OR value @> ?::jsonb)',
+            [$attribute->getId()->toRfc4122(), $selectShape, $multiShape],
+        );
+        $instances = \is_scalar($row) ? (int) $row : 0;
+
+        return new JsonResponse(['instances' => $instances]);
     }
 
     #[Route(

--- a/apps/api/tests/Api/Catalog/AttributeOptionsApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeOptionsApiTest.php
@@ -162,6 +162,32 @@ final class AttributeOptionsApiTest extends CatalogApiTestCase
         self::assertCount(0, $payload['member']);
     }
 
+    #[Test]
+    public function usageReturnsInstanceCountForOption(): void
+    {
+        $client = $this->authenticatedClient();
+        $code = 'priority';
+        $attribute = $this->seedSelectAttribute($code);
+        $this->seedOption($attribute, 'low', ['en' => 'Low'], 0);
+
+        // Brand-new option is unused — instances=0.
+        $response = $client->request('GET', '/api/attributes/'.$code.'/options/low/usage');
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+        self::assertSame(0, $payload['instances']);
+    }
+
+    #[Test]
+    public function usageReturns404ForUnknownOption(): void
+    {
+        $client = $this->authenticatedClient();
+        $code = 'priority';
+        $this->seedSelectAttribute($code);
+
+        $response = $client->request('GET', '/api/attributes/'.$code.'/options/nonexistent/usage');
+        self::assertSame(404, $response->getStatusCode());
+    }
+
     private function seedSelectAttribute(string $code): Attribute
     {
         $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);


### PR DESCRIPTION
## Summary

Per-option usage endpoint dla VIEW-02 (#374) AttributeValueAuditCard. Operator widzi w Allowed Values editor "instancji ma tę wartość" stat + warning banner gdy próbuje usunąć in-use option.

## Backend
- **`GET /api/attributes/{code}/options/{optionCode}/usage`** → `{instances: int}`.
- SQL: Postgres JSONB containment (`value @> ?::jsonb`) covers select (`{"value":"X"}`) i multiselect (`{"option_codes":["X"]}`) bez konfliktu z DBAL bind placeholders (operator `?` koliduje).

## Tests
2 nowe ApiTestCase:
- `usageReturnsInstanceCountForOption` (200, instances=0).
- `usageReturns404ForUnknownOption` (404).

8/8 zielone.

## Quality gates
- PHPStan max: 0 errors ✅
- PHPUnit: 8/8 ✅

Refs #374
