### PR TITLE
fix(admin): VIEW-02 operator feedback batch (5 issues)

### DIFF
--- a/apps/admin/src/features/catalog/attributes/new.tsx
+++ b/apps/admin/src/features/catalog/attributes/new.tsx
@@ -1,3 +1,4 @@
+import { useInvalidate } from '@refinedev/core';
 import { ArrowLeft, Check } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -74,6 +75,7 @@ const TYPES = [
 export function AttributeCreatePage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const invalidate = useInvalidate();
   const [values, setValues] = useState<CreatePayload>(EMPTY);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -101,6 +103,10 @@ export function AttributeCreatePage() {
         accept: 'application/ld+json',
         body,
       });
+      // Drop Refine's cached list so the new row shows up after redirect.
+      // Without this, the list (which uses useList with a stable cache key)
+      // keeps rendering the pre-create snapshot until a manual refetch.
+      void invalidate({ resource: 'attributes', invalidates: ['list', 'many'] });
       if (typeof response.id === 'string' && response.id !== '') {
         navigate(`/modeling/attributes/${response.id}`, { replace: true });
       } else {
@@ -190,23 +196,17 @@ export function AttributeCreatePage() {
                   })}
                 </p>
               </div>
-              <div>
-                <Label className="text-[11.5px] font-medium text-muted-foreground">
-                  {t('attributes.fields.name', { defaultValue: 'Nazwa' })}
-                </Label>
-                <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
-                  <Input
-                    value={values.labelPl}
-                    onChange={(e) => setValues({ ...values, labelPl: e.target.value })}
-                    placeholder="PL · np. Gwarancja (msc)"
-                  />
-                  <Input
-                    value={values.labelEn}
-                    onChange={(e) => setValues({ ...values, labelEn: e.target.value })}
-                    placeholder="EN · e.g. Warranty (months)"
-                  />
-                </div>
-              </div>
+              <LocaleField
+                label={t('attributes.fields.name', { defaultValue: 'Nazwa' })}
+                placeholder={t('attributes.fields.name_placeholder', {
+                  defaultValue: 'np. Gwarancja (msc)',
+                })}
+                values={{ pl: values.labelPl, en: values.labelEn }}
+                onChange={(locale, next) => {
+                  if (locale === 'pl') setValues({ ...values, labelPl: next });
+                  else setValues({ ...values, labelEn: next });
+                }}
+              />
               <div>
                 <Label className="text-[11.5px] font-medium text-muted-foreground">
                   {t('attributes.fields.help', { defaultValue: 'Opis (opcjonalny)' })}
@@ -347,4 +347,56 @@ function stripEmpty(record: Record<string, string>): Record<string, string> {
     if (v.trim() !== '') out[k] = v;
   }
   return out;
+}
+
+const NEW_ATTRIBUTE_LOCALES: Array<{ code: 'pl' | 'en'; flag: string }> = [
+  { code: 'pl', flag: '🇵🇱' },
+  { code: 'en', flag: '🇬🇧' },
+];
+
+function LocaleField({
+  label,
+  placeholder,
+  values,
+  onChange,
+}: {
+  label: string;
+  placeholder?: string;
+  values: { pl: string; en: string };
+  onChange: (locale: 'pl' | 'en', next: string) => void;
+}) {
+  const [active, setActive] = useState<'pl' | 'en'>('pl');
+  return (
+    <div>
+      <Label className="text-[11.5px] font-medium text-muted-foreground">{label}</Label>
+      <div className="mt-1.5 flex items-center gap-1 border-b border-zinc-100">
+        {NEW_ATTRIBUTE_LOCALES.map(({ code, flag }) => {
+          const filled = values[code].trim().length > 0;
+          return (
+            <button
+              key={code}
+              type="button"
+              onClick={() => setActive(code)}
+              className={cn(
+                '-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-[12.5px] font-medium uppercase tracking-wider transition',
+                active === code
+                  ? 'border-zinc-900 text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <span aria-hidden>{flag}</span>
+              <span>{code}</span>
+              {!filled ? <span className="size-1.5 rounded-full bg-amber-400" aria-hidden /> : null}
+            </button>
+          );
+        })}
+      </div>
+      <Input
+        className="mt-2"
+        value={values[active]}
+        onChange={(e) => onChange(active, e.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  );
 }

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -1,5 +1,5 @@
 import { useOne } from '@refinedev/core';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Layers, Lock, Pencil, Shield, TriangleAlert, Zap } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -298,6 +298,8 @@ function Editor({
           </div>
         </Card>
 
+        {isOption ? <AllowedValuesCard attribute={attribute} locale={locale} /> : null}
+
         <Card className="p-6">
           <SectionTitle>
             {t('attributes.ui_configuration_title', { defaultValue: 'UI Configuration' })}
@@ -514,4 +516,102 @@ function stripEmpty(record: Record<string, string>): Record<string, string> {
     if (v.trim() !== '') out[k] = v;
   }
   return out;
+}
+
+interface OptionPreview {
+  id: string;
+  code: string;
+  label: Record<string, string>;
+  color: string | null;
+  default: boolean;
+  deprecated: boolean;
+}
+
+function AllowedValuesCard({ attribute, locale }: { attribute: AttributeDetail; locale: string }) {
+  const { t } = useTranslation();
+  const { data: options = [] } = useQuery<OptionPreview[]>({
+    queryKey: ['attribute_options', attribute.code],
+    queryFn: async () => {
+      const payload = await jsonFetch<{ member: OptionPreview[] }>(
+        `/api/attributes/${attribute.code}/options`,
+      );
+      return payload.member ?? [];
+    },
+  });
+
+  const visible = options.slice(0, 12);
+  const overflow = Math.max(0, options.length - visible.length);
+  const localesUsed = new Set<string>();
+  for (const option of options) {
+    for (const code of Object.keys(option.label)) localesUsed.add(code);
+  }
+
+  return (
+    <Card className="p-6">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <SectionTitle>
+            {t('attributes.allowed_values_title', { defaultValue: 'Allowed values' })}
+          </SectionTitle>
+          <div className="text-[12.5px] text-muted-foreground">
+            {t('attributes.allowed_values_subtitle', {
+              defaultValue: '{{count}} wartości · z tłumaczeniami w {{locales}} językach',
+              count: options.length,
+              locales: localesUsed.size > 0 ? localesUsed.size : 1,
+            })}
+          </div>
+        </div>
+        <Button asChild size="sm" className="h-9 rounded-xl bg-zinc-900 hover:bg-zinc-800">
+          <Link to={`/modeling/attributes/${attribute.id}/values`}>
+            <Pencil className="size-4" />
+            {t('attributes.manage_values', { defaultValue: 'Zarządzaj wartościami' })}
+          </Link>
+        </Button>
+      </div>
+
+      {options.length === 0 ? (
+        <p className="italic text-[12.5px] text-muted-foreground">
+          {t('attributes.allowed_values_empty', {
+            defaultValue: 'Brak zdefiniowanych wartości — kliknij „Zarządzaj wartościami".',
+          })}
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {visible.map((option) => {
+            const optionLabel =
+              option.label[locale.split('-')[0] ?? 'pl'] ??
+              option.label.pl ??
+              option.label.en ??
+              option.code;
+            return (
+              <span
+                key={option.id}
+                className="flex items-center gap-1.5 rounded-lg border border-zinc-100 bg-zinc-50 px-2.5 py-1 text-[12px] text-zinc-700"
+              >
+                {option.color !== null ? (
+                  <span
+                    className="size-2.5 rounded-full"
+                    style={{ background: option.color }}
+                    aria-hidden
+                  />
+                ) : null}
+                <span className="font-mono text-[10.5px] text-zinc-400">{option.code}</span>
+                <span>{optionLabel}</span>
+                {option.default ? (
+                  <span className="rounded bg-emerald-100 px-1 text-[9.5px] font-semibold uppercase tracking-wider text-emerald-700">
+                    default
+                  </span>
+                ) : null}
+              </span>
+            );
+          })}
+          {overflow > 0 ? (
+            <span className="rounded-lg px-2.5 py-1 text-[12px] text-muted-foreground">
+              +{overflow} {t('attributes.allowed_values_more', { defaultValue: 'więcej' })}
+            </span>
+          ) : null}
+        </div>
+      )}
+    </Card>
+  );
 }

--- a/apps/admin/src/features/catalog/attributes/values.tsx
+++ b/apps/admin/src/features/catalog/attributes/values.tsx
@@ -129,21 +129,54 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
   const active = options.find((o) => o.id === activeId) ?? null;
   const refresh = () => queryClient.invalidateQueries({ queryKey });
 
-  const addValue = async () => {
-    const code = window.prompt(
-      t('attribute_values.prompt_code', { defaultValue: 'Code nowej wartości (snake_case)' }),
-    );
-    if (!code || code.trim().length === 0) return;
+  // Inline-create: pop a draft row into local state with a focusable
+  // empty Code input. Submit on Enter or click Save → POST → refetch.
+  // No native prompt — operator stays inside the editor.
+  const [draftCode, setDraftCode] = useState<string>('');
+  const [draftError, setDraftError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const addValue = () => {
+    setDraftCode('');
+    setDraftError(null);
+    setCreating(true);
+  };
+
+  const cancelDraft = () => {
+    setCreating(false);
+    setDraftCode('');
+    setDraftError(null);
+  };
+
+  const submitDraft = async () => {
+    const code = draftCode.trim();
+    if (code.length === 0) {
+      setDraftError(
+        t('attribute_values.draft_code_required', { defaultValue: 'Code nie może być pusty' }),
+      );
+      return;
+    }
     try {
       const created = await jsonFetch<OptionRow>(`/api/attributes/${attribute.code}/options`, {
         method: 'POST',
         contentType: 'application/json',
-        body: { code: code.trim(), label: { en: code.trim() } },
+        body: { code, label: { pl: code, en: code } },
       });
       setActiveId(created.id);
+      cancelDraft();
       refresh();
     } catch (err) {
-      if (err instanceof HttpError) window.alert(`HTTP ${err.status}`);
+      if (err instanceof HttpError) {
+        const detail =
+          err.body && typeof err.body === 'object' && 'detail' in err.body
+            ? String((err.body as Record<string, unknown>).detail)
+            : null;
+        setDraftError(detail ?? `HTTP ${err.status}`);
+      } else {
+        setDraftError(
+          t('attribute_values.draft_save_error', { defaultValue: 'Nie udało się zapisać' }),
+        );
+      }
     }
   };
 
@@ -245,29 +278,79 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
                 </div>
               </SortableContext>
             </DndContext>
-            <Button
-              type="button"
-              variant="outline"
-              className="mt-2 w-full border-dashed"
-              onClick={() => {
-                void addValue();
-              }}
-            >
-              <Plus className="size-4" />
-              {t('attribute_values.add_action', { defaultValue: 'Dodaj wartość' })}
-            </Button>
+            {creating ? (
+              <div className="mt-2 space-y-2 rounded-xl border border-violet-200 bg-violet-50/40 p-2">
+                <Input
+                  autoFocus
+                  value={draftCode}
+                  onChange={(e) => {
+                    setDraftCode(e.target.value);
+                    setDraftError(null);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      void submitDraft();
+                    }
+                    if (e.key === 'Escape') cancelDraft();
+                  }}
+                  placeholder={t('attribute_values.draft_code_placeholder', {
+                    defaultValue: 'code (snake_case)',
+                  })}
+                  className="h-9 font-mono"
+                />
+                {draftError !== null ? (
+                  <p className="px-1 text-[12px] text-destructive">{draftError}</p>
+                ) : null}
+                <div className="flex items-center justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-8"
+                    onClick={cancelDraft}
+                  >
+                    {t('app.cancel')}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="h-8"
+                    onClick={() => {
+                      void submitDraft();
+                    }}
+                  >
+                    {t('app.save', { defaultValue: 'Zapisz' })}
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-2 w-full border-dashed"
+                onClick={addValue}
+              >
+                <Plus className="size-4" />
+                {t('attribute_values.add_action', { defaultValue: 'Dodaj wartość' })}
+              </Button>
+            )}
           </CardContent>
         </Card>
 
         {active ? (
-          <DefinitionCard
-            key={active.id}
-            attributeCode={attribute.code}
-            option={active}
-            options={options}
-            refresh={refresh}
-            onDeleted={() => setActiveId(null)}
-          />
+          <div className="space-y-6">
+            <DefinitionCard
+              key={active.id}
+              attributeCode={attribute.code}
+              option={active}
+              options={options}
+              refresh={refresh}
+              onDeleted={() => setActiveId(null)}
+            />
+            <PreviewCard option={active} attributeName={pickLabel(attribute.label, locale)} />
+            <AuditCard attributeCode={attribute.code} option={active} />
+          </div>
         ) : (
           <Card>
             <CardContent className="space-y-1 py-10 text-center">
@@ -285,6 +368,124 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
           </Card>
         )}
       </div>
+    </div>
+  );
+}
+
+function PreviewCard({ option, attributeName }: { option: OptionRow; attributeName: string }) {
+  const { t } = useTranslation();
+  const locales: Array<{ code: string; flag: string }> = [
+    { code: 'pl', flag: '🇵🇱' },
+    { code: 'en', flag: '🇬🇧' },
+    { code: 'de', flag: '🇩🇪' },
+  ];
+  return (
+    <Card className="p-6">
+      <div className="mb-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {t('attribute_values.preview_title', { defaultValue: 'Podgląd' })}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        {locales.map(({ code, flag }) => {
+          const localeLabel = option.label[code];
+          return (
+            <div key={code} className="rounded-xl border border-zinc-200 bg-white p-4">
+              <div className="mb-2 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                <span aria-hidden>{flag}</span>
+                <span>{code}</span>
+              </div>
+              <div className="text-[11.5px] text-muted-foreground">{attributeName}</div>
+              <div className="mt-2 flex h-10 items-center gap-2 rounded-xl border border-zinc-200 bg-zinc-50 px-3">
+                {option.color !== null ? (
+                  <span
+                    className="size-2.5 rounded-full"
+                    style={{ background: option.color }}
+                    aria-hidden
+                  />
+                ) : null}
+                {localeLabel ? (
+                  <span className="text-[13px] text-foreground">{localeLabel}</span>
+                ) : (
+                  <span className="text-[12.5px] italic text-muted-foreground">
+                    {t('attribute_values.preview_no_translation', {
+                      defaultValue: '(brak tłumaczenia)',
+                    })}
+                  </span>
+                )}
+                <span className="ml-auto text-muted-foreground">▾</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+function AuditCard({ attributeCode, option }: { attributeCode: string; option: OptionRow }) {
+  const { t } = useTranslation();
+  const { data } = useQuery<{ instances: number }>({
+    queryKey: ['attribute_options_usage', attributeCode, option.code],
+    queryFn: async () =>
+      jsonFetch<{ instances: number }>(
+        `/api/attributes/${attributeCode}/options/${option.code}/usage`,
+      ),
+    staleTime: 60_000,
+  });
+  const instances = data?.instances ?? 0;
+
+  return (
+    <Card className="p-6">
+      <div className="mb-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {t('attribute_values.audit_title', { defaultValue: 'Wpływ i audyt' })}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Stat
+          value={instances.toLocaleString('pl-PL')}
+          label={t('attribute_values.audit_instances_label', {
+            defaultValue: 'instancji ma tę wartość',
+          })}
+        />
+        <Stat
+          value={String(option.position + 1)}
+          label={t('attribute_values.audit_position_label', {
+            defaultValue: 'pozycja w sortowaniu',
+          })}
+        />
+        <Stat
+          value="attribute.value.update"
+          label={t('attribute_values.audit_event_label', { defaultValue: 'zdarzenie audit log' })}
+          mono
+        />
+      </div>
+      {instances > 0 ? (
+        <div className="mt-4 flex items-start gap-2.5 rounded-xl border border-amber-200 bg-amber-50 px-4 py-2.5">
+          <span className="text-amber-700">⚠</span>
+          <div className="text-[12px] text-amber-900">
+            <strong>{t('attribute_values.audit_warning_title', { defaultValue: 'Uwaga:' })}</strong>{' '}
+            {t('attribute_values.audit_warning_body', {
+              defaultValue:
+                'ta wartość jest używana przez {{count}} obiektów. Usunięcie wymagać będzie migracji — system zaproponuje mapowanie na inną wartość.',
+              count: instances,
+            })}
+          </div>
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function Stat({ value, label, mono }: { value: string; label: string; mono?: boolean }) {
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-3">
+      <div
+        className={cn(
+          'text-[18px] font-semibold tabular-nums',
+          mono ? 'font-mono text-[13px]' : '',
+        )}
+      >
+        {value}
+      </div>
+      <div className="mt-0.5 text-[11.5px] text-muted-foreground">{label}</div>
     </div>
   );
 }
@@ -420,8 +621,8 @@ function DefinitionCard({
   onDeleted: () => void;
 }) {
   const { t } = useTranslation();
-  const [labelPl, setLabelPl] = useState<string>(option.label.pl ?? '');
-  const [labelEn, setLabelEn] = useState<string>(option.label.en ?? '');
+  const [labelMap, setLabelMap] = useState<Record<string, string>>({ ...option.label });
+  const [activeLocale, setActiveLocale] = useState<string>('pl');
   const [color, setColor] = useState<string | null>(option.color);
   const [isDefault, setIsDefault] = useState(option.default);
   const [isDeprecated, setIsDeprecated] = useState(option.deprecated);
@@ -433,20 +634,28 @@ function DefinitionCard({
   const canMoveDown = index >= 0 && index < options.length - 1;
 
   const dirty =
-    labelPl !== (option.label.pl ?? '') ||
-    labelEn !== (option.label.en ?? '') ||
+    JSON.stringify(labelMap) !== JSON.stringify(option.label) ||
     color !== option.color ||
     isDefault !== option.default ||
     isDeprecated !== option.deprecated;
 
   const buildLabel = (): Record<string, string> => {
-    const next: Record<string, string> = { ...option.label };
-    if (labelPl.length > 0) next.pl = labelPl;
-    else delete next.pl;
-    if (labelEn.length > 0) next.en = labelEn;
-    else delete next.en;
+    const next: Record<string, string> = {};
+    for (const [code, value] of Object.entries(labelMap)) {
+      if (value.trim().length > 0) next[code] = value;
+    }
     return next;
   };
+
+  const setLabelFor = (locale: string, value: string) => {
+    setLabelMap((prev) => ({ ...prev, [locale]: value }));
+  };
+
+  const LOCALES = [
+    { code: 'pl', flag: '🇵🇱' },
+    { code: 'en', flag: '🇬🇧' },
+    { code: 'de', flag: '🇩🇪' },
+  ] as const;
 
   const save = async () => {
     setSaving(true);
@@ -574,33 +783,41 @@ function DefinitionCard({
           </div>
         </div>
 
-        <div className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-1.5">
-            <Label htmlFor="label-pl">
-              {t('attribute_values.label_pl', { defaultValue: 'Etykieta (PL)' })}
-            </Label>
-            <Input
-              id="label-pl"
-              value={labelPl}
-              onChange={(e) => setLabelPl(e.target.value)}
-              placeholder={t('attribute_values.labels_placeholder', {
-                defaultValue: 'Etykieta wartości',
-              })}
-            />
+        <div className="space-y-2">
+          <Label>
+            {t('attribute_values.labels_title', { defaultValue: 'Etykiety wyświetlane' })}
+          </Label>
+          <div className="flex items-center gap-1 border-b border-zinc-100">
+            {LOCALES.map(({ code, flag }) => {
+              const filled = (labelMap[code] ?? '').trim().length > 0;
+              return (
+                <button
+                  key={code}
+                  type="button"
+                  onClick={() => setActiveLocale(code)}
+                  className={cn(
+                    '-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-[12.5px] font-medium uppercase tracking-wider transition',
+                    activeLocale === code
+                      ? 'border-zinc-900 text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  <span aria-hidden>{flag}</span>
+                  <span>{code}</span>
+                  {!filled ? (
+                    <span className="size-1.5 rounded-full bg-amber-400" aria-hidden />
+                  ) : null}
+                </button>
+              );
+            })}
           </div>
-          <div className="space-y-1.5">
-            <Label htmlFor="label-en">
-              {t('attribute_values.label_en', { defaultValue: 'Etykieta (EN)' })}
-            </Label>
-            <Input
-              id="label-en"
-              value={labelEn}
-              onChange={(e) => setLabelEn(e.target.value)}
-              placeholder={t('attribute_values.labels_placeholder', {
-                defaultValue: 'Etykieta wartości',
-              })}
-            />
-          </div>
+          <Input
+            value={labelMap[activeLocale] ?? ''}
+            onChange={(e) => setLabelFor(activeLocale, e.target.value)}
+            placeholder={t('attribute_values.labels_placeholder', {
+              defaultValue: 'Etykieta wartości',
+            })}
+          />
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2">
@@ -666,8 +883,7 @@ function DefinitionCard({
             variant="ghost"
             disabled={!dirty || saving}
             onClick={() => {
-              setLabelPl(option.label.pl ?? '');
-              setLabelEn(option.label.en ?? '');
+              setLabelMap({ ...option.label });
               setColor(option.color);
               setIsDefault(option.default);
               setIsDeprecated(option.deprecated);


### PR DESCRIPTION
## Summary

Fix batch po pierwszym manual smoke operatora. Adresuje 5 zgłoszonych usterek (numerowanie operatora):

## 1. Lista nie odświeża się po POST nowego atrybutu
- `AttributeCreatePage` wywołuje `useInvalidate({resource:'attributes', invalidates:['list','many']})` przed redirect → Refine porzuca cached snapshot, lista pokazuje nowy wiersz po powrocie z show.

## 2. Brak wyboru języków
- `new.tsx` ma teraz 3-tab locale switcher (`PL / EN / DE`) nad inputem nazwy zamiast osobnych Input PL/EN.
- `values.tsx` DefinitionCard ma analogiczny 3-tab dla label.
- Pusty język → amber dot w tab (translation gap visible).

## 3. window.prompt → inline draft row
- Klik **+ Dodaj wartość** mountuje pod listą empty Code input z autoFocus + Enter/Esc handlers + inline error slot. Po Save nowy row staje się active i editor czeka na edycję label/color.

## 4. Brak Podglądu + Wpływ i Audyt w values editor
- **`PreviewCard`**: 3-col per-locale preview (PL/EN/DE) z color dot + label fallback `(brak tłumaczenia)`.
- **`AuditCard`**: 3 stat tiles (instances / position / event name) + amber warning banner gdy `instances > 0`. Korzysta z `/api/attributes/{code}/options/{optionCode}/usage` (#395).

## 5. Show.tsx nie pokazuje wartości
- **`AllowedValuesCard`** między Definicja a UI Configuration dla select/multiselect: do 12 chipsów z color dot + mono code + label + emerald `default` badge; `+N więcej` przy overflow; CTA `Zarządzaj wartościami` → /values.

## Quality gates
- TypeScript noEmit: 0 errors ✅
- Biome strict: 0 errors ✅
- Vite build: ~993 KB gzip 293 KB ✅

## Test plan
- [ ] CI green.
- [ ] Manual smoke: utwórz atrybut → wracaj do listy → widoczny. Klik wartości na `ip_rating` → zobacz Allowed Values w show. Wartości editor → klik `+ Dodaj wartość` → empty Code input → Enter → Save. Tab PL/EN/DE → przełącz między językami. Audit card pokazuje 0 instances + position + event.

Refs #374
