### PR TITLE
fix(admin): always refetch attributes list on mount (VIEW-02)

### DIFF
--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -68,6 +68,12 @@ export function AttributesListPage() {
   const { result, query: listQuery } = useList<AttributeRow>({
     resource: 'attributes',
     pagination: { mode: 'off' },
+    // Always refetch on mount + window focus so the list never serves a
+    // stale snapshot after the operator creates / edits an attribute on
+    // a sibling page (new.tsx, show.tsx, values.tsx) and clicks back.
+    // The 5-minute Refine default is a footgun for navigation-driven
+    // CRUD flows where one tab can change data the other tab caches.
+    queryOptions: { refetchOnMount: 'always', refetchOnWindowFocus: true, staleTime: 0 },
   });
 
   const attributes = result.data;


### PR DESCRIPTION
Operator workflow:
1. POST nowy atrybut → redirect do show.
2. Klik 'Zarządzaj wartościami' → values editor.
3. Klik 'Wstecz do biblioteki Attributes' → list. **Brak nowego atrybutu.**

Przyczyna: Refine `useList` ma 5-minutowy default staleTime + `refetchOnMount: false`. Po pierwszej wizycie listy cache trzyma się tygodnia. Invalidate w #398 nie trzyma w długim flow (multi-step navigation through show + values).

Naprawa: `useList({queryOptions: {refetchOnMount: 'always', staleTime: 0, refetchOnWindowFocus: true}})` w list.tsx — zawsze refetchuje przy entry.

Refs #374