### PR TITLE
chore(admin): drop '+ Dodaj własny moduł' placeholder from sidebar

### DIFF
--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -5,7 +5,6 @@ import {
   LayoutDashboard,
   type LucideIcon,
   Package,
-  Plus,
   Settings2,
   Share2,
   Workflow,
@@ -14,7 +13,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router';
 
-import { MockBadge } from '@/components/ui/mock-badge';
 import { cn } from '@/lib/utils';
 
 import { UserMenu } from './user-menu';
@@ -146,20 +144,6 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
             {section.items.map((item) => renderLeaf(item, item.to ?? item.label))}
           </div>
         ))}
-        {/* "+ Dodaj własny moduł" — placeholder dopóki ObjectType create flow nie obsłuży nav extension */}
-        <button
-          type="button"
-          disabled
-          className={cn(
-            'mt-2 flex cursor-not-allowed items-center gap-2 rounded-md border border-dashed border-border px-3 py-2 text-sm font-medium text-muted-foreground/70',
-          )}
-        >
-          <Plus className="size-4" />
-          <span className="flex-1 text-left">
-            {t('nav.add_custom_module', { defaultValue: '+ Dodaj własny moduł' })}
-          </span>
-          <MockBadge />
-        </button>
       </nav>
       <div className="border-t p-3">
         <div className="mb-2 px-1 text-[11px] text-muted-foreground">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -46,7 +46,6 @@
     "modeling": "Modeling",
     "soon": "Soon",
     "workspace_label": "Workspace",
-    "add_custom_module": "+ Add custom module",
     "active_modules_count_one": "{{count}} active module",
     "active_modules_count_other": "{{count}} active modules"
   },

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -46,7 +46,6 @@
     "modeling": "Modelowanie",
     "soon": "Wkrótce",
     "workspace_label": "Workspace",
-    "add_custom_module": "+ Dodaj własny moduł",
     "active_modules_count_one": "{{count}} moduł aktywny",
     "active_modules_count_few": "{{count}} moduły aktywne",
     "active_modules_count_many": "{{count}} modułów aktywnych",


### PR DESCRIPTION
Operator request: remove disabled MOCK button. Sprzątam button + unused Plus/MockBadge imports + nav.add_custom_module i18n keys.

Refs #374