### PR TITLE
fix(catalog): raise Attribute list pagination cap from 30 to 200

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml
@@ -20,6 +20,7 @@
         <operations>
             <operation class="ApiPlatform\Metadata\GetCollection"
                        uriTemplate="/attributes{._format}"
+                       paginationItemsPerPage="200"
                        security="is_granted('READ', 'App\\Catalog\\Domain\\Entity\\Attribute')"/>
             <operation class="ApiPlatform\Metadata\Get"
                        uriTemplate="/attributes/{id}{._format}"


### PR DESCRIPTION
## Summary

Default API Platform pagination capped `/api/attributes` at 30 items per page. The modeling library list (`apps/admin/src/features/catalog/attributes/list.tsx`) calls `useList({ pagination: { mode: 'off' } })` but the dataProvider only forwards `page`, never `itemsPerPage` — so the backend always returned its default of 30. With 42 attributes in seed (after VIEW-02 mockup additions in #394) every attribute past the 30th was invisible, and the FE search input only filters the rows that actually arrived, so newly created attributes silently fell off the end.

## Backend

- `apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/Attribute.xml` — added `paginationItemsPerPage="200"` to the `GetCollection /attributes` operation.

## Frontend

N/A — `useList` already requests pagination off, the BE cap was the limiting factor.

## Why 200 (not infinite, not a real pager)

The Attribute library is admin-side modeling — bounded by design. Realistic ceilings for large tenants are 50–200 entries; 500+ would be a smell, not an expected state. 200 covers all realistic shapes without a pager UI. If a tenant ever crosses 200 we ship cursor pagination + server-side search rather than raising this further.

## Quality gates

- Smoke-tested locally: `GET /api/attributes` now returns `totalItems=42 returned=42` (was `totalItems=42 returned=30`).
- No FE/BE code logic changed — XML metadata only, so PHPStan/PHPUnit/Playwright unaffected.

## Test plan

- [ ] Login `admin@demo.localhost / changeme`
- [ ] Modeling → Atrybuty: confirm "{count} atrybutów w bibliotece" matches the row count (was 42 vs. 30 visible)
- [ ] Search "vat" / "currency" / "ip_rating" — all should match (these were past the 30th attribute)
- [ ] Create new attribute via `+ Nowy atrybut` → after Zapisz zmiany on detail it should appear in the list

Refs #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)