### PR TITLE
feat(modeling): VIEW-03b list+create pixel-perfect + dnd-kit reorder + visibility rules

### DIFF
--- a/apps/admin/src/features/catalog/attribute-groups/create.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/create.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Check } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
@@ -7,37 +7,37 @@ import { ATTRIBUTE_GROUP_SWATCHES, ColorPicker } from '@/components/modeling/col
 import { ATTRIBUTE_GROUP_ICONS, IconPicker } from '@/components/modeling/icon-picker';
 import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { HttpError, jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
 
 /**
- * VIEW-03 (#375) — pixel-perfect rebuild of the AttributeGroup create
- * form (`NewAttributeGroupView` in `groups-categories.jsx:482–603`).
+ * VIEW-03b — pixel-perfect rebuild of `NewAttributeGroupView`
+ * (`groups-categories.jsx:482–603`):
  *
- * Upgrades over the UI-08.13 minimal form (#268):
- *   - 8-swatch ColorPicker preset (was: free-text hex input).
- *   - 14-emoji IconPicker preset (was: free-text Lucide name).
- *   - 3 behavior toggles (Wymagana sekcja / Współdzielona /
- *     Conditional visibility) backed by VIEW-03 schema additions.
- *   - Sidebar Preview + Następnie cards still deferred to follow-up
- *     (full-width form is the MVP; sidebar polish in VIEW-03b).
- *
- * Posts to `POST /api/attribute_groups` (UI-08.5 #260 + VIEW-03 #382
- * extension for the 3 boolean flags).
+ *   - Back link "Wstecz do Attribute Groups".
+ *   - Header (flex justify-between): live color icon 14×14 + caption +
+ *     live title `displayName` + Pimcore/Akeneo description; right
+ *     buttons "Anuluj | + Utwórz grupę".
+ *   - Grid 1fr+320px:
+ *     - Left Card: Identyfikacja (Code mono + helper + Nazwa PL/EN tabs
+ *       + Description), Wygląd (8-swatch ColorPicker + 14-icon IconPicker),
+ *       Zachowanie (3 SettingToggleRow).
+ *     - Right aside: Card "Podgląd" (live color icon + name + code) +
+ *       Card "Następnie" (3-step roadmap).
  */
 
 interface CreatePayload {
   code: string;
-  labelEn: string;
   labelPl: string;
-  descriptionEn: string;
+  labelEn: string;
   descriptionPl: string;
+  descriptionEn: string;
   icon: string;
   color: string;
-  position: number;
   requiredSection: boolean;
   shared: boolean;
   conditionalVisibility: boolean;
@@ -45,13 +45,12 @@ interface CreatePayload {
 
 const EMPTY: CreatePayload = {
   code: '',
-  labelEn: '',
   labelPl: '',
-  descriptionEn: '',
+  labelEn: '',
   descriptionPl: '',
+  descriptionEn: '',
   icon: ATTRIBUTE_GROUP_ICONS[0],
   color: ATTRIBUTE_GROUP_SWATCHES[0],
-  position: 0,
   requiredSection: false,
   shared: true,
   conditionalVisibility: false,
@@ -61,18 +60,23 @@ export function AttributeGroupCreatePage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [values, setValues] = useState<CreatePayload>(EMPTY);
+  const [activeLocale, setActiveLocale] = useState<'pl' | 'en'>('pl');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const displayName =
+    values.labelPl.trim() ||
+    values.labelEn.trim() ||
+    t('modeling.attributeGroups.create.title_default', { defaultValue: 'Nazwa grupy' });
+
+  const handleSubmit = async () => {
     setError(null);
     setSubmitting(true);
     try {
       const body: Record<string, unknown> = {
         code: values.code,
         label: stripEmpty({ pl: values.labelPl, en: values.labelEn }),
-        position: values.position,
+        position: 0,
         requiredSection: values.requiredSection,
         shared: values.shared,
         conditionalVisibility: values.conditionalVisibility,
@@ -101,177 +105,305 @@ export function AttributeGroupCreatePage() {
             : null;
         setError(detail ?? `HTTP ${err.status}`);
       } else {
-        setError(t('modeling.attribute_groups.create_error'));
+        setError(
+          t('modeling.attributeGroups.create.error', {
+            defaultValue: 'Nie udało się utworzyć grupy',
+          }),
+        );
       }
     } finally {
       setSubmitting(false);
     }
   };
 
+  const valid = values.code.trim().length > 0 && values.labelPl.trim().length > 0;
+
   return (
     <div className="space-y-6">
-      <div className="space-y-1">
-        <Button asChild variant="ghost" size="sm" className="-ml-3">
-          <Link to="/modeling/attribute-groups">
-            <ArrowLeft className="size-4" />
-            {t('attribute_groups.back')}
-          </Link>
-        </Button>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          {t('modeling.attribute_groups.create_title')}
-        </h1>
-      </div>
+      <Link
+        to="/modeling/attribute-groups"
+        className="inline-flex items-center gap-1.5 text-[12.5px] font-medium text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="size-4" />
+        {t('modeling.attributeGroups.back_to_library', {
+          defaultValue: 'Wstecz do Attribute Groups',
+        })}
+      </Link>
 
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <Card>
-          <CardContent className="grid gap-4 pt-6">
-            <FormRow id="code" label={t('attribute_groups.fields.code')}>
-              <Input
-                id="code"
-                value={values.code}
-                onChange={(e) => setValues({ ...values, code: e.target.value })}
-                pattern="[a-z0-9_-]+"
-                required
-              />
-            </FormRow>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <FormRow id="label-pl" label={t('modeling.attribute_groups.label_pl')}>
-                <Input
-                  id="label-pl"
-                  value={values.labelPl}
-                  onChange={(e) => setValues({ ...values, labelPl: e.target.value })}
-                />
-              </FormRow>
-              <FormRow id="label-en" label={t('modeling.attribute_groups.label_en')}>
-                <Input
-                  id="label-en"
-                  value={values.labelEn}
-                  onChange={(e) => setValues({ ...values, labelEn: e.target.value })}
-                />
-              </FormRow>
+      <div className="flex flex-wrap items-start justify-between gap-6">
+        <div className="flex min-w-0 flex-1 items-start gap-4">
+          <div
+            className="grid size-14 shrink-0 place-items-center rounded-2xl text-[24px]"
+            style={{ background: `${values.color}18`, color: values.color }}
+          >
+            {values.icon}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[13px] font-medium text-muted-foreground">
+              {t('modeling.attributeGroups.create.caption', {
+                defaultValue: 'Nowa Attribute Group',
+              })}
             </div>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <FormRow id="desc-pl" label={t('modeling.attribute_groups.description_pl')}>
-                <Textarea
-                  id="desc-pl"
-                  value={values.descriptionPl}
-                  onChange={(e) => setValues({ ...values, descriptionPl: e.target.value })}
-                  rows={2}
-                />
-              </FormRow>
-              <FormRow id="desc-en" label={t('modeling.attribute_groups.description_en')}>
-                <Textarea
-                  id="desc-en"
-                  value={values.descriptionEn}
-                  onChange={(e) => setValues({ ...values, descriptionEn: e.target.value })}
-                  rows={2}
-                />
-              </FormRow>
-            </div>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="space-y-6 pt-6">
-            <div className="space-y-3">
-              <Label>{t('modeling.attribute_groups.color')}</Label>
-              <ColorPicker
-                selected={values.color}
-                onSelect={(hex) => setValues({ ...values, color: hex })}
-                options={ATTRIBUTE_GROUP_SWATCHES}
-              />
-            </div>
-            <div className="space-y-3">
-              <Label>{t('modeling.attribute_groups.icon')}</Label>
-              <IconPicker
-                selected={values.icon}
-                onSelect={(icon) => setValues({ ...values, icon })}
-                options={ATTRIBUTE_GROUP_ICONS}
-              />
-            </div>
-            <FormRow id="position" label={t('attribute_groups.fields.position')}>
-              <Input
-                id="position"
-                type="number"
-                min={0}
-                value={values.position}
-                onChange={(e) =>
-                  setValues({ ...values, position: Number.parseInt(e.target.value, 10) || 0 })
-                }
-              />
-            </FormRow>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardContent className="space-y-4 pt-6">
-            <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
-              {t('modeling.attribute_groups.behavior_title', { defaultValue: 'Zachowanie' })}
-            </div>
-            <SettingToggleRow
-              label={t('modeling.attribute_groups.behavior_required_label', {
-                defaultValue: 'Wymagana sekcja',
+            <h1 className="font-display text-[28px] font-semibold tracking-tight">{displayName}</h1>
+            <p className="mt-1 max-w-2xl text-[13px] text-muted-foreground">
+              {t('modeling.attributeGroups.create.description', {
+                defaultValue:
+                  'Grupa to wielokrotnego użytku zbiór atrybutów (np. „Wymiary", „Bezpieczeństwo"), który można dołączać do dowolnego ObjectType. Po utworzeniu zacznij dodawać atrybuty z biblioteki.',
               })}
-              description={t('modeling.attribute_groups.behavior_required_desc', {
-                defaultValue: 'Grupa zawsze widoczna w formularzu',
-              })}
-              checked={values.requiredSection}
-              onChange={(next) => setValues({ ...values, requiredSection: next })}
-            />
-            <SettingToggleRow
-              label={t('modeling.attribute_groups.behavior_shared_label', {
-                defaultValue: 'Współdzielona',
-              })}
-              description={t('modeling.attribute_groups.behavior_shared_desc', {
-                defaultValue: 'Może być dołączona do wielu ObjectType',
-              })}
-              checked={values.shared}
-              onChange={(next) => setValues({ ...values, shared: next })}
-            />
-            <SettingToggleRow
-              label={t('modeling.attribute_groups.behavior_conditional_label', {
-                defaultValue: 'Conditional visibility',
-              })}
-              description={t('modeling.attribute_groups.behavior_conditional_desc', {
-                defaultValue: 'Pokaż grupę warunkowo (visible_when)',
-              })}
-              checked={values.conditionalVisibility}
-              onChange={(next) => setValues({ ...values, conditionalVisibility: next })}
-            />
-          </CardContent>
-        </Card>
-
-        {error !== null ? (
-          <p className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-            {error}
-          </p>
-        ) : null}
-
-        <div className="flex flex-wrap items-center gap-2">
-          <Button asChild variant="ghost">
-            <Link to="/modeling/attribute-groups">{t('app.cancel')}</Link>
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button asChild variant="ghost" size="sm" className="h-9 rounded-xl">
+            <Link to="/modeling/attribute-groups">
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Link>
           </Button>
-          <Button type="submit" disabled={submitting}>
-            {t('modeling.attribute_groups.create_submit')}
+          <Button
+            type="button"
+            disabled={!valid || submitting}
+            onClick={() => {
+              void handleSubmit();
+            }}
+            className="h-9 rounded-xl bg-zinc-900 hover:bg-zinc-800"
+          >
+            <Check className="size-4" />
+            {t('modeling.attributeGroups.create.submit_action', {
+              defaultValue: 'Utwórz grupę',
+            })}
           </Button>
         </div>
-      </form>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+        <Card className="space-y-6 p-6">
+          <Section
+            title={t('modeling.attributeGroups.definition_title', {
+              defaultValue: 'Identyfikacja',
+            })}
+          >
+            <div className="space-y-4">
+              <div>
+                <Label className="text-[11.5px] font-medium text-muted-foreground" htmlFor="code">
+                  Code
+                </Label>
+                <Input
+                  id="code"
+                  value={values.code}
+                  onChange={(e) => setValues({ ...values, code: e.target.value })}
+                  pattern="[a-z][a-z0-9_-]*"
+                  placeholder="np. wymiary"
+                  className="mt-1.5 h-10 font-mono"
+                />
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  {t('modeling.attributeGroups.create.code_helper', {
+                    defaultValue: 'Niezmienialny po utworzeniu. Używany w API i mapowaniach.',
+                  })}
+                </p>
+              </div>
+
+              <div>
+                <Label className="text-[11.5px] font-medium text-muted-foreground">
+                  {t('modeling.attributeGroups.fields.name', { defaultValue: 'Nazwa' })}
+                </Label>
+                <div className="mt-1.5 flex items-center gap-1 border-b border-zinc-100">
+                  {(['pl', 'en'] as const).map((lc) => {
+                    const filled =
+                      (lc === 'pl' ? values.labelPl : values.labelEn).trim().length > 0;
+                    return (
+                      <button
+                        key={lc}
+                        type="button"
+                        onClick={() => setActiveLocale(lc)}
+                        className={cn(
+                          '-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-[12.5px] font-medium uppercase tracking-wider transition',
+                          activeLocale === lc
+                            ? 'border-zinc-900 text-foreground'
+                            : 'border-transparent text-muted-foreground hover:text-foreground',
+                        )}
+                      >
+                        <span>{lc === 'pl' ? '🇵🇱' : '🇬🇧'}</span>
+                        <span>{lc}</span>
+                        {!filled ? (
+                          <span className="size-1.5 rounded-full bg-amber-400" aria-hidden />
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+                <Input
+                  className="mt-2"
+                  value={activeLocale === 'pl' ? values.labelPl : values.labelEn}
+                  onChange={(e) =>
+                    setValues({
+                      ...values,
+                      ...(activeLocale === 'pl'
+                        ? { labelPl: e.target.value }
+                        : { labelEn: e.target.value }),
+                    })
+                  }
+                  placeholder="np. Wymiary"
+                />
+              </div>
+
+              <div>
+                <Label className="text-[11.5px] font-medium text-muted-foreground">
+                  {t('modeling.attributeGroups.fields.description_optional', {
+                    defaultValue: 'Opis (opcjonalny)',
+                  })}
+                </Label>
+                <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
+                  <Textarea
+                    rows={2}
+                    value={values.descriptionPl}
+                    onChange={(e) => setValues({ ...values, descriptionPl: e.target.value })}
+                    placeholder="PL · krótki opis grupy"
+                  />
+                  <Textarea
+                    rows={2}
+                    value={values.descriptionEn}
+                    onChange={(e) => setValues({ ...values, descriptionEn: e.target.value })}
+                    placeholder="EN · short description"
+                  />
+                </div>
+              </div>
+            </div>
+          </Section>
+
+          <Section
+            title={t('modeling.attributeGroups.appearance_title', { defaultValue: 'Wygląd' })}
+          >
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div>
+                <Label className="text-[11.5px] font-medium text-muted-foreground">
+                  {t('modeling.attributeGroups.fields.color', { defaultValue: 'Kolor' })}
+                </Label>
+                <div className="mt-2">
+                  <ColorPicker
+                    selected={values.color}
+                    onSelect={(c) => setValues({ ...values, color: c })}
+                    options={ATTRIBUTE_GROUP_SWATCHES}
+                  />
+                </div>
+              </div>
+              <div>
+                <Label className="text-[11.5px] font-medium text-muted-foreground">
+                  {t('modeling.attributeGroups.fields.icon', { defaultValue: 'Ikona' })}
+                </Label>
+                <div className="mt-2">
+                  <IconPicker
+                    selected={values.icon}
+                    onSelect={(ic) => setValues({ ...values, icon: ic })}
+                    options={ATTRIBUTE_GROUP_ICONS}
+                  />
+                </div>
+              </div>
+            </div>
+          </Section>
+
+          <Section
+            title={t('modeling.attributeGroups.behavior_title', { defaultValue: 'Zachowanie' })}
+          >
+            <div className="space-y-3">
+              <SettingToggleRow
+                label={t('modeling.attributeGroups.behavior_required_section_label', {
+                  defaultValue: 'Wymagana sekcja',
+                })}
+                description={t('modeling.attributeGroups.behavior_required_section_desc', {
+                  defaultValue: 'Grupa zawsze widoczna w formularzu',
+                })}
+                checked={values.requiredSection}
+                onChange={(next) => setValues({ ...values, requiredSection: next })}
+              />
+              <SettingToggleRow
+                label={t('modeling.attributeGroups.behavior_shared_label', {
+                  defaultValue: 'Współdzielona',
+                })}
+                description={t('modeling.attributeGroups.behavior_shared_desc', {
+                  defaultValue: 'Może być dołączona do wielu ObjectType',
+                })}
+                checked={values.shared}
+                onChange={(next) => setValues({ ...values, shared: next })}
+              />
+              <SettingToggleRow
+                label={t('modeling.attributeGroups.behavior_conditional_label', {
+                  defaultValue: 'Conditional visibility',
+                })}
+                description={t('modeling.attributeGroups.behavior_conditional_desc', {
+                  defaultValue: 'Pokaż grupę warunkowo (visible_when)',
+                })}
+                checked={values.conditionalVisibility}
+                onChange={(next) => setValues({ ...values, conditionalVisibility: next })}
+              />
+            </div>
+          </Section>
+
+          {error !== null ? (
+            <p className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+        </Card>
+
+        <aside className="space-y-3">
+          <Card className="p-5">
+            <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              {t('modeling.attributeGroups.preview_card_title', { defaultValue: 'Podgląd' })}
+            </div>
+            <div className="mt-3 flex items-center gap-2.5">
+              <div
+                className="grid size-10 shrink-0 place-items-center rounded-2xl text-[18px]"
+                style={{ background: `${values.color}18`, color: values.color }}
+              >
+                {values.icon}
+              </div>
+              <div className="min-w-0">
+                <div className="truncate text-[13.5px] font-semibold tracking-tight">
+                  {displayName}
+                </div>
+                <div className="truncate font-mono text-[11px] text-muted-foreground">
+                  {values.code.trim() ||
+                    t('modeling.attributeGroups.create.preview_code_placeholder', {
+                      defaultValue: 'code…',
+                    })}
+                </div>
+              </div>
+            </div>
+          </Card>
+          <Card className="p-5">
+            <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              {t('modeling.attributeGroups.next_card_title', { defaultValue: 'Następnie' })}
+            </div>
+            <ul className="mt-3 space-y-1.5 text-[12px] text-muted-foreground">
+              <li>
+                1. {t('modeling.attributeGroups.next_step_1', { defaultValue: 'Utwórz grupę' })}
+              </li>
+              <li>
+                2.{' '}
+                {t('modeling.attributeGroups.next_step_2', {
+                  defaultValue: 'Dodaj atrybuty z biblioteki',
+                })}
+              </li>
+              <li>
+                3.{' '}
+                {t('modeling.attributeGroups.next_step_3', {
+                  defaultValue: 'Dołącz grupę do ObjectType',
+                })}
+              </li>
+            </ul>
+          </Card>
+        </aside>
+      </div>
     </div>
   );
 }
 
-function FormRow({
-  id,
-  label,
-  children,
-}: {
-  id: string;
-  label: string;
-  children: React.ReactNode;
-}) {
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="space-y-1.5">
-      <Label htmlFor={id}>{label}</Label>
+    <div>
+      <div className="mb-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {title}
+      </div>
       {children}
     </div>
   );

--- a/apps/admin/src/features/catalog/attribute-groups/list.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/list.tsx
@@ -1,23 +1,16 @@
 import { useList } from '@refinedev/core';
-import { Eye, Trash2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { ChevronRight, Lock, Plus, Search } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
-import { ModelingPageHeader } from '@/components/modeling/modeling-page-header';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
+import { Card } from '@/components/ui/card';
 import { resolveLabel } from '@/features/catalog/attributes/list';
-import { HttpError, jsonFetch } from '@/lib/http';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
 
 interface AttributeGroupRow {
   id: string;
@@ -27,253 +20,263 @@ interface AttributeGroupRow {
   icon?: string | null;
   color?: string | null;
   systemGroup?: boolean;
-  autoAttached?: boolean;
   position?: number;
 }
 
+interface UsageResp {
+  attributeCount: number;
+  directlyAttachedTo: {
+    objectTypes: { id: string }[];
+    categories: { id: string }[];
+  };
+}
+
+/**
+ * VIEW-03b — pixel-perfect rebuild of `AttributeGroupsView`
+ * (`groups-categories.jsx:3–80`):
+ *
+ *   - caption "{N} grup atrybutów" + violet ⭐ FIRST-CLASS ENTITY badge.
+ *   - title "Attribute Groups", description Pimcore/Akeneo positioning.
+ *   - CTA "+ Nowa grupa" (zinc-900) → /modeling/attribute-groups/new.
+ *   - Single Card with sticky search top, 2 sections:
+ *     * System (auto-attached) — lock badge prefix.
+ *     * Business groups.
+ *   - Each row: 6-col grid (icon 44 / name+desc 1.6fr / code 1fr / N attr
+ *     120 / N typy·N kat. 120 / chevron 28). Hover bg-zinc-50/70. Click →
+ *     /modeling/attribute-groups/{id} (router pushes UUID; ticket VIEW-03b
+ *     keeps the existing :id route for backward compat with VIEW-03).
+ */
 export function AttributeGroupsListPage() {
   const { t, i18n } = useTranslation();
   const [search, setSearch] = useState('');
-  const [systemFilter, setSystemFilter] = useState<'all' | 'system' | 'business'>('all');
-  const [reloadKey, setReloadKey] = useState(0);
-  const [error, setError] = useState<string | null>(null);
 
   const { result, query } = useList<AttributeGroupRow>({
     resource: 'attribute_groups',
     pagination: { mode: 'off' },
-    queryOptions: { queryKey: ['attribute_groups', reloadKey] },
+    queryOptions: { refetchOnMount: 'always', refetchOnWindowFocus: true, staleTime: 0 },
   });
 
   const groups = result.data;
   const isLoading = query.isLoading;
-  const usageCounts = useAttributeGroupUsageCounts(groups, reloadKey);
+  const usage = useGroupsUsage(groups);
 
-  const visible = groups.filter((row) => {
-    if (systemFilter === 'system' && row.systemGroup !== true) return false;
-    if (systemFilter === 'business' && row.systemGroup === true) return false;
+  const filtered = groups.filter((row) => {
     if (search === '') return true;
     const needle = search.toLowerCase();
     if (row.code.toLowerCase().includes(needle)) return true;
-    const label = resolveLabel(row.label, i18n.language).toLowerCase();
-    return label.includes(needle);
+    const labelStr = resolveLabel(row.label, i18n.language).toLowerCase();
+    return labelStr.includes(needle);
   });
 
-  const handleDelete = async (row: AttributeGroupRow) => {
-    setError(null);
-    if (!window.confirm(t('attribute_groups.delete_confirm', { name: row.code }))) {
-      return;
-    }
-    try {
-      await jsonFetch(`/api/attribute_groups/${row.id}`, {
-        method: 'DELETE',
-        accept: 'application/json',
-      });
-      setReloadKey((k) => k + 1);
-    } catch (err) {
-      if (err instanceof HttpError) {
-        const detail =
-          err.body && typeof err.body === 'object' && 'detail' in err.body
-            ? String((err.body as Record<string, unknown>).detail)
-            : null;
-        setError(detail ?? `HTTP ${err.status}`);
-      } else {
-        setError(t('attribute_groups.delete_error'));
-      }
-    }
-  };
+  const sortByPosition = (a: AttributeGroupRow, b: AttributeGroupRow) =>
+    (a.position ?? 0) - (b.position ?? 0);
+  const systemGroups = filtered.filter((r) => r.systemGroup === true).sort(sortByPosition);
+  const businessGroups = filtered.filter((r) => r.systemGroup !== true).sort(sortByPosition);
 
   return (
     <div className="space-y-6">
-      <ModelingPageHeader
-        caption={t('attribute_groups.list_caption', {
-          defaultValue: '{{count}} grup atrybutów',
-          count: groups.length,
-        })}
-        title={t('attribute_groups.list_title')}
-        description={
-          <span>
-            {t('attribute_groups.list_description', {
-              defaultValue:
-                'Grupy atrybutów porządkują pola w formularzach i kontrolują widoczność. Pierwszoklasowy byt domeny (ADR-012) — przypinany do ObjectType i Category, z visible_when regułami.',
-            })}{' '}
-            <span className="ml-1 inline-flex items-center gap-1 rounded-full bg-accent-violet/10 px-2 py-0.5 align-middle text-[10.5px] font-medium uppercase tracking-wide text-accent-violet">
-              ⭐ first-class entity (ADR-012)
+      <div className="space-y-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="text-[13px] font-medium text-muted-foreground">
+              {t('modeling.attributeGroups.list_caption', {
+                defaultValue: '{{count}} grup atrybutów',
+                count: groups.length,
+              })}
             </span>
-          </span>
-        }
-        ctaLabel={t('modeling.attribute_groups.create_action')}
-        ctaTo="/modeling/attribute-groups/new"
-      />
-
-      <div className="flex flex-wrap items-center gap-2">
-        <Input
-          aria-label={t('modeling.attribute_groups.search')}
-          placeholder={t('modeling.attribute_groups.search_placeholder')}
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="w-[260px]"
-        />
-        {(['all', 'business', 'system'] as const).map((value) => (
-          <Button
-            key={value}
-            type="button"
-            variant={systemFilter === value ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => setSystemFilter(value)}
-          >
-            {t(`modeling.attribute_groups.filter_${value}`)}
+            <span className="rounded bg-violet-100 px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-violet-700">
+              {t('modeling.attributeGroups.list_first_class_badge', {
+                defaultValue: '⭐ first-class entity',
+              })}
+            </span>
+          </div>
+          <h1 className="font-display text-[28px] font-semibold tracking-tight">
+            {t('modeling.attributeGroups.list_title', { defaultValue: 'Attribute Groups' })}
+          </h1>
+          <p className="mt-1 max-w-3xl text-[13px] text-muted-foreground">
+            {t('modeling.attributeGroups.list_description', {
+              defaultValue:
+                'Grupa atrybutów jako wymienialna jednostka — przypinasz ją do ObjectType (globalnie) lub Category (z dziedziczeniem). Pimcore nie ma tej abstrakcji, Akeneo traktuje ją tylko jako sortowanie. U nas — własny URL, audit, wersjonowanie.',
+            })}
+          </p>
+        </div>
+        <div>
+          <Button asChild size="sm" className="h-9 rounded-xl bg-zinc-900 hover:bg-zinc-800">
+            <Link to="/modeling/attribute-groups/new">
+              <Plus className="size-4" />
+              {t('modeling.attributeGroups.create_action', { defaultValue: 'Nowa grupa' })}
+            </Link>
           </Button>
-        ))}
+        </div>
       </div>
 
-      {error !== null ? (
-        <p className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-          {error}
-        </p>
-      ) : null}
+      <Card className="p-2">
+        <div className="flex items-center gap-3 border-b border-zinc-100 px-4 py-3">
+          <Search className="size-4 text-muted-foreground" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('modeling.attributeGroups.search_placeholder', {
+              defaultValue: 'Szukaj grup…',
+            })}
+            className="flex-1 bg-transparent text-[13.5px] outline-none placeholder:text-muted-foreground"
+          />
+        </div>
 
-      <div className="rounded-2xl border border-line bg-surface soft-shadow">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-[220px]">{t('attribute_groups.fields.code')}</TableHead>
-              <TableHead>{t('attribute_groups.fields.label')}</TableHead>
-              <TableHead className="w-[120px] text-right">
-                {t('modeling.attribute_groups.attributes_count')}
-              </TableHead>
-              <TableHead className="w-[160px] text-right">
-                {t('modeling.where_used.attached_object_types')}
-              </TableHead>
-              <TableHead className="w-[100px] text-right">
-                {t('attribute_groups.fields.position')}
-              </TableHead>
-              <TableHead className="w-[120px] text-right">
-                <span className="sr-only">{t('attributes.fields.actions')}</span>
-              </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
-              <TableRow>
-                <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
-                  {t('app.loading')}
-                </TableCell>
-              </TableRow>
-            ) : visible.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="py-10 text-center text-muted-foreground">
-                  {t('attribute_groups.empty')}
-                </TableCell>
-              </TableRow>
-            ) : (
-              visible
-                .slice()
-                .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
-                .map((group) => {
-                  const usage = usageCounts[group.id];
-                  return (
-                    <TableRow key={group.id}>
-                      <TableCell className="font-mono text-xs">
-                        <span className="inline-flex items-center gap-2">
-                          {group.color ? (
-                            <span
-                              aria-hidden
-                              className="inline-block size-3 rounded-full border"
-                              style={{ backgroundColor: group.color }}
-                            />
-                          ) : null}
-                          {group.systemGroup ? <BuiltInLockBadge tone="quiet" /> : null}
-                          {group.code}
-                        </span>
-                      </TableCell>
-                      <TableCell className="font-medium">
-                        {resolveLabel(group.label, i18n.language)}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums text-muted-foreground">
-                        {usage?.attributeCount ?? '—'}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums text-muted-foreground">
-                        {usage?.attachedObjectTypes ?? '—'}
-                      </TableCell>
-                      <TableCell className="text-right tabular-nums text-muted-foreground">
-                        {group.position ?? '—'}
-                      </TableCell>
-                      <TableCell className="space-x-1 text-right">
-                        <Button asChild variant="ghost" size="sm">
-                          <Link to={`/modeling/attribute-groups/${group.id}`}>
-                            <Eye className="size-4" />
-                            <span className="sr-only">{t('attribute_groups.actions.view')}</span>
-                          </Link>
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          disabled={
-                            group.systemGroup === true ||
-                            (usage !== undefined &&
-                              (usage.attachedObjectTypes > 0 || usage.attachedCategories > 0))
-                          }
-                          onClick={() => handleDelete(group)}
-                          aria-label={t('attribute_groups.actions.delete')}
-                        >
-                          <Trash2 className="size-4" />
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
-            )}
-          </TableBody>
-        </Table>
-      </div>
+        {isLoading ? (
+          <p className="px-5 py-10 text-center text-sm text-muted-foreground">{t('app.loading')}</p>
+        ) : filtered.length === 0 ? (
+          <p className="px-5 py-12 text-center text-sm text-muted-foreground">
+            {t('modeling.attributeGroups.empty', {
+              defaultValue: 'Brak grup spełniających kryteria.',
+            })}
+          </p>
+        ) : (
+          <>
+            {systemGroups.length > 0 ? (
+              <>
+                <SectionDivider
+                  withLock
+                  label={t('modeling.attributeGroups.section_system_label', {
+                    defaultValue: 'System (auto-attached)',
+                  })}
+                />
+                <div className="divide-y divide-zinc-50">
+                  {systemGroups.map((row) => (
+                    <GroupRowItem
+                      key={row.id}
+                      row={row}
+                      locale={i18n.language}
+                      usage={usage[row.id]}
+                    />
+                  ))}
+                </div>
+              </>
+            ) : null}
+            {businessGroups.length > 0 ? (
+              <>
+                <SectionDivider
+                  className={systemGroups.length > 0 ? 'mt-1' : ''}
+                  label={t('modeling.attributeGroups.section_business_label', {
+                    defaultValue: 'Business groups',
+                  })}
+                />
+                <div className="divide-y divide-zinc-50">
+                  {businessGroups.map((row) => (
+                    <GroupRowItem
+                      key={row.id}
+                      row={row}
+                      locale={i18n.language}
+                      usage={usage[row.id]}
+                    />
+                  ))}
+                </div>
+              </>
+            ) : null}
+          </>
+        )}
+      </Card>
     </div>
   );
 }
 
-interface UsageCount {
-  attributeCount: number;
-  attachedObjectTypes: number;
-  attachedCategories: number;
+function SectionDivider({
+  label,
+  withLock,
+  className,
+}: {
+  label: string;
+  withLock?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 border-b border-zinc-100 px-4 py-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground',
+        className,
+      )}
+    >
+      {withLock ? <Lock className="size-3" /> : null}
+      <span>{label}</span>
+    </div>
+  );
 }
 
-function useAttributeGroupUsageCounts(
-  rows: AttributeGroupRow[],
-  reloadKey: number,
-): Record<string, UsageCount> {
-  const [counts, setCounts] = useState<Record<string, UsageCount>>({});
+function GroupRowItem({
+  row,
+  locale,
+  usage,
+}: {
+  row: AttributeGroupRow;
+  locale: string;
+  usage?: UsageResp;
+}) {
+  const { t } = useTranslation();
+  const labelStr = resolveLabel(row.label, locale);
+  const descStr = resolveLabel(row.description, locale);
+  const color = row.color ?? '#71717a';
+  const attrCount = usage?.attributeCount ?? 0;
+  const typesUsed = usage?.directlyAttachedTo.objectTypes.length ?? 0;
+  const categoriesUsed = usage?.directlyAttachedTo.categories.length ?? 0;
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      const next: Record<string, UsageCount> = {};
-      await Promise.all(
-        rows.map(async (row) => {
-          try {
-            const usage = await jsonFetch<{
-              directlyAttachedTo: {
-                objectTypes: { id: string }[];
-                categories: { id: string }[];
-              };
-              attributeCount: number;
-            }>(`/api/attribute_groups/${row.id}/usage`, { accept: 'application/json' });
-            next[row.id] = {
-              attributeCount: usage.attributeCount,
-              attachedObjectTypes: usage.directlyAttachedTo.objectTypes.length,
-              attachedCategories: usage.directlyAttachedTo.categories.length,
-            };
-          } catch {
-            // tolerate
-          }
+  return (
+    <Link
+      to={`/modeling/attribute-groups/${row.id}`}
+      className="group grid w-full grid-cols-[44px_1.6fr_1fr_120px_120px_28px] items-center gap-3 px-4 py-3.5 text-left transition hover:bg-zinc-50/70"
+    >
+      <span
+        className="grid size-9 place-items-center rounded-xl text-[16px]"
+        style={{ background: `${color}18`, color }}
+      >
+        {row.icon ?? '📦'}
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="flex items-center gap-2">
+          <span className="truncate text-[13.5px] font-semibold tracking-tight">{labelStr}</span>
+          {row.systemGroup ? <BuiltInLockBadge /> : null}
+        </span>
+        {descStr !== '—' ? (
+          <span className="truncate text-[11.5px] text-muted-foreground">{descStr}</span>
+        ) : null}
+      </span>
+      <span className="truncate font-mono text-[11.5px] text-muted-foreground">{row.code}</span>
+      <span className="text-[12px] tabular-nums">
+        <span className="font-medium">{attrCount}</span>{' '}
+        <span className="text-muted-foreground">
+          {t('modeling.attributeGroups.row_attrs_count_suffix', { defaultValue: 'atrybutów' })}
+        </span>
+      </span>
+      <span className="text-[12px] tabular-nums">
+        <span className="text-zinc-700">
+          <span className="font-medium">{typesUsed}</span> typy
+        </span>
+        <span className="text-zinc-300"> · </span>
+        <span className="text-zinc-700">
+          <span className="font-medium">{categoriesUsed}</span> kat.
+        </span>
+      </span>
+      <span className="flex justify-end">
+        <ChevronRight className="size-4 text-zinc-300 group-hover:text-zinc-700" />
+      </span>
+    </Link>
+  );
+}
+
+function useGroupsUsage(rows: AttributeGroupRow[]): Record<string, UsageResp> {
+  const queries = useQueries({
+    queries: rows.map((row) => ({
+      queryKey: ['attribute-group-usage', row.id] as const,
+      queryFn: () =>
+        jsonFetch<UsageResp>(`/api/attribute_groups/${row.id}/usage`, {
+          accept: 'application/json',
         }),
-      );
-      if (!cancelled) setCounts(next);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [rows, reloadKey]);
-  // ^ reloadKey is intentional — bump triggers a refetch after a list mutation.
-
-  return counts;
+      staleTime: 60_000,
+    })),
+  });
+  const map: Record<string, UsageResp> = {};
+  for (let i = 0; i < rows.length; i += 1) {
+    const data = queries[i]?.data;
+    if (data !== undefined) map[rows[i].id] = data;
+  }
+  return map;
 }

--- a/apps/admin/src/features/catalog/attribute-groups/show.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/show.tsx
@@ -1,6 +1,23 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useOne } from '@refinedev/core';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { GripVertical, Lock, Plus, Save, Trash2, X } from 'lucide-react';
+import { Eye, GripVertical, Lock, Plus, Save, Trash2, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
@@ -256,6 +273,49 @@ function Editor({
     }
   };
 
+  // dnd-kit: sortable wiring for the members list. Drag handles only fire
+  // on long-press / pointer-down, so checkboxes and trash icons keep their
+  // own click events without competing with drag activation. Reorder posts
+  // a strict permutation of current member codes; on error we fall back to
+  // refetching (the BE state is authoritative).
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const onDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (over === null || active.id === over.id) return;
+      const oldIndex = sortedMembers.findIndex((m) => m.attribute.id === active.id);
+      const newIndex = sortedMembers.findIndex((m) => m.attribute.id === over.id);
+      if (oldIndex < 0 || newIndex < 0) return;
+
+      const reordered = arrayMove(sortedMembers, oldIndex, newIndex).map((m, i) => ({
+        ...m,
+        position: i,
+      }));
+
+      // Optimistic update: rewrite the cached members list so the UI
+      // settles to the new order before the BE confirms.
+      queryClient.setQueryData(['attribute_groups', group.id, 'attributes'], reordered);
+
+      try {
+        await jsonFetch(`/api/attribute_groups/${group.id}/attributes/reorder`, {
+          method: 'POST',
+          contentType: 'application/json',
+          accept: 'application/json',
+          body: { order: reordered.map((m) => m.attribute.code) },
+        });
+        await reload();
+      } catch {
+        // BE rejected the permutation — pull authoritative state.
+        await reload();
+      }
+    },
+    [group.id, queryClient, reload, sortedMembers],
+  );
+
   const groupName = resolveLabel(group.label, locale);
 
   return (
@@ -449,65 +509,99 @@ function Editor({
               })}
             </button>
           ) : (
-            <div className="space-y-1.5">
-              {sortedMembers.map((row) => {
-                const labelStr = resolveLabel(row.attribute.label, locale);
-                return (
-                  <div
-                    key={row.attribute.id}
-                    className="grid grid-cols-[24px_1.5fr_120px_180px_100px_28px] items-center gap-3 rounded-xl border border-zinc-100 bg-white px-3 py-2.5 transition hover:border-zinc-200 hover:bg-zinc-50/60"
-                  >
-                    <GripVertical className="size-4 text-zinc-300" />
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="truncate font-mono text-[13px] font-medium">
-                          {row.attribute.code}
-                        </span>
-                        {row.attribute.is_system ? <BuiltInLockBadge /> : null}
-                      </div>
-                      <div className="truncate text-[11.5px] text-muted-foreground">{labelStr}</div>
-                    </div>
-                    <span className="rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium uppercase text-muted-foreground">
-                      {row.attribute.type}
-                    </span>
-                    {row.visible_when ? (
-                      <span className="inline-flex items-center gap-1.5 rounded-lg bg-violet-50 px-2 py-1 font-mono text-[11px] text-violet-700">
-                        when {row.visible_when.field}={String(row.visible_when.value)}
-                      </span>
-                    ) : (
-                      <span className="text-[11px] text-zinc-300">
-                        {t('modeling.attributeGroups.members_no_visibility_rule', {
-                          defaultValue: 'brak reguły widoczności',
-                        })}
-                      </span>
-                    )}
-                    <label className="flex items-center gap-1.5 text-[11.5px] text-muted-foreground">
-                      <input
-                        type="checkbox"
-                        className="size-3.5 rounded"
-                        checked={row.is_required_in_group}
-                        onChange={(e) => {
-                          void toggleRequired(row.attribute.id, e.target.checked);
-                        }}
-                      />
-                      required
-                    </label>
-                    <button
-                      type="button"
-                      onClick={() => {
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={(e) => {
+                void onDragEnd(e);
+              }}
+            >
+              <SortableContext
+                items={sortedMembers.map((m) => m.attribute.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-1.5">
+                  {sortedMembers.map((row) => (
+                    <SortableMemberRow
+                      key={row.attribute.id}
+                      row={row}
+                      locale={locale}
+                      onToggleRequired={(next) => {
+                        void toggleRequired(row.attribute.id, next);
+                      }}
+                      onDetach={() => {
                         void detach(row.attribute.id);
                       }}
-                      className="grid size-7 place-items-center justify-self-end rounded text-zinc-300 hover:text-rose-600"
-                      aria-label={t('app.remove', { defaultValue: 'Usuń' })}
-                    >
-                      <Trash2 className="size-4" />
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
           )}
         </Card>
+
+        {sortedMembers.some((m) => m.visible_when !== null) ? (
+          <Card className="p-6">
+            <div className="mb-4 flex items-center gap-2">
+              <SectionTitle as="span">
+                {t('modeling.attributeGroups.rules_title', { defaultValue: 'Visibility rules' })}
+              </SectionTitle>
+              <span className="rounded bg-violet-100 px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-violet-700">
+                {t('modeling.attributeGroups.rules_visible_when_badge', {
+                  defaultValue: 'visible_when',
+                })}
+              </span>
+            </div>
+            <div className="space-y-1 rounded-2xl border border-violet-200 bg-violet-50/40 p-4">
+              {sortedMembers
+                .filter((m) => m.visible_when !== null)
+                .map((m) => (
+                  <div key={m.attribute.id} className="flex items-center gap-3 py-1">
+                    <span className="font-mono text-[12.5px] font-medium">{m.attribute.code}</span>
+                    <span className="text-[11.5px] text-muted-foreground">visible_when</span>
+                    <span className="rounded border border-violet-200 bg-white px-2 py-0.5 font-mono text-[12.5px] text-violet-700">
+                      {m.visible_when?.field}={String(m.visible_when?.value)}
+                    </span>
+                    <button
+                      type="button"
+                      disabled
+                      title={t('modeling.attributeGroups.rules_edit_action_pending', {
+                        defaultValue: 'Edytor reguły — VIEW-03c',
+                      })}
+                      className="ml-auto inline-flex items-center gap-1 text-[11.5px] text-muted-foreground/60"
+                    >
+                      <Eye className="size-3.5" />
+                      {t('modeling.attributeGroups.rules_edit_action', {
+                        defaultValue: 'Edit rule',
+                      })}
+                    </button>
+                  </div>
+                ))}
+            </div>
+            <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50/40 px-4 py-3">
+                <div className="text-[11px] font-medium uppercase tracking-wider text-emerald-700">
+                  {t('modeling.attributeGroups.rules_test_pass_status', {
+                    defaultValue: 'VISIBLE',
+                  })}
+                </div>
+                <div className="mt-0.5 font-mono text-[12px] text-emerald-900">
+                  test: rule met → field visible in form
+                </div>
+              </div>
+              <div className="rounded-xl border border-zinc-200 bg-zinc-50 px-4 py-3">
+                <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                  {t('modeling.attributeGroups.rules_test_fail_status', {
+                    defaultValue: 'HIDDEN',
+                  })}
+                </div>
+                <div className="mt-0.5 font-mono text-[12px] text-zinc-700">
+                  test: rule fails → field hidden in form
+                </div>
+              </div>
+            </div>
+          </Card>
+        ) : null}
 
         {/* Where used */}
         <Card className="p-6">
@@ -629,6 +723,85 @@ function SectionTitle({
     <Tag className="mb-4 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
       {children}
     </Tag>
+  );
+}
+
+function SortableMemberRow({
+  row,
+  locale,
+  onToggleRequired,
+  onDetach,
+}: {
+  row: MemberRow;
+  locale: string;
+  onToggleRequired: (next: boolean) => void;
+  onDetach: () => void;
+}) {
+  const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: row.attribute.id,
+  });
+  const labelStr = resolveLabel(row.attribute.label, locale);
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="grid grid-cols-[24px_1.5fr_120px_180px_100px_28px] items-center gap-3 rounded-xl border border-zinc-100 bg-white px-3 py-2.5 transition hover:border-zinc-200 hover:bg-zinc-50/60"
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label={t('modeling.attributeGroups.drag_handle', { defaultValue: 'Przeciągnij' })}
+        className="grid size-6 cursor-grab place-items-center text-zinc-300 hover:text-zinc-500 active:cursor-grabbing"
+      >
+        <GripVertical className="size-4" />
+      </button>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-mono text-[13px] font-medium">{row.attribute.code}</span>
+          {row.attribute.is_system ? <BuiltInLockBadge /> : null}
+        </div>
+        <div className="truncate text-[11.5px] text-muted-foreground">{labelStr}</div>
+      </div>
+      <span className="rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium uppercase text-muted-foreground">
+        {row.attribute.type}
+      </span>
+      {row.visible_when ? (
+        <span className="inline-flex items-center gap-1.5 rounded-lg bg-violet-50 px-2 py-1 font-mono text-[11px] text-violet-700">
+          when {row.visible_when.field}={String(row.visible_when.value)}
+        </span>
+      ) : (
+        <span className="text-[11px] text-zinc-300">
+          {t('modeling.attributeGroups.members_no_visibility_rule', {
+            defaultValue: 'brak reguły widoczności',
+          })}
+        </span>
+      )}
+      <label className="flex items-center gap-1.5 text-[11.5px] text-muted-foreground">
+        <input
+          type="checkbox"
+          className="size-3.5 rounded"
+          checked={row.is_required_in_group}
+          onChange={(e) => onToggleRequired(e.target.checked)}
+        />
+        required
+      </label>
+      <button
+        type="button"
+        onClick={onDetach}
+        className="grid size-7 place-items-center justify-self-end rounded text-zinc-300 hover:text-rose-600"
+        aria-label={t('app.remove', { defaultValue: 'Usuń' })}
+      >
+        <Trash2 className="size-4" />
+      </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

VIEW-03b (#404) closes the four conscious deferrals from VIEW-03 (#403):

1. **List page pixel-perfect rebuild** — single Card with sticky search top, two sections (System auto-attached / Business groups), 6-col rows with color icon emoji
2. **Create page pixel-perfect rebuild** — header with live color icon + grid `1fr+320px` (left Card with Identyfikacja / Wygląd 8-swatch + 14-icon / Zachowanie 3 toggles; right aside Podgląd + Następnie cards)
3. **dnd-kit drag-reorder in members** — Sortable wrapper, optimistic update via `queryClient.setQueryData`, POST `/api/attribute_groups/{id}/attributes/reorder` with permutation; rollback by refetch on error
4. **Visibility rules Card** — warunkowo widoczna gdy `members.some(m => m.visible_when)`, agreguje wszystkie reguły + 2 test cards (emerald VISIBLE / zinc HIDDEN); Edit rule placeholder disabled (full editor → VIEW-03c)

## Frontend
- `list.tsx` — full pixel-perfect rebuild
- `create.tsx` — full pixel-perfect rebuild reusing existing `ATTRIBUTE_GROUP_SWATCHES` / `ATTRIBUTE_GROUP_ICONS` pickers
- `show.tsx` — dnd-kit Sortable + Visibility rules Card added; existing detail layout from VIEW-03 preserved

## Backend
N/A — `reorder` endpoint already exists, contract confirmed (`{order: [code1, code2, ...]}`).

## Quality gates
- TypeScript noEmit: 0 errors
- Biome strict: 0 errors (2 pre-existing warnings, none introduced)
- Vite build: success

## Test plan
- [ ] Login `admin@demo.localhost / changeme`
- [ ] Modeling → Attribute Groups: confirm caption + violet badge + sections (System / Business)
- [ ] Search "ident" → list filters; clear → both sections render
- [ ] Click row → detail page (VIEW-03 layout)
- [ ] `+ Nowa grupa` → create form with live color icon header + sidebar Podgląd updates as you type Code/Nazwa
- [ ] Pick color swatch + emoji icon → live header + sidebar update
- [ ] Submit → redirect to detail
- [ ] On a group with multiple attrs: drag one row → optimistic move → on success persists, on F5 the order matches
- [ ] On a group with `visible_when` rule: Visibility rules Card appears with rule + 2 test cards

## Świadome odejścia
- VIEW-03c (visible_when rule editor popup) — placeholder disabled link

Refs #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)