### PR TITLE
feat(modeling): VIEW-01c — menu visibility + ordering + dynamic sidebar

### DIFF
--- a/apps/admin/src/components/modeling/menu-ordering-list.tsx
+++ b/apps/admin/src/components/modeling/menu-ordering-list.tsx
@@ -1,0 +1,176 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useQueryClient } from '@tanstack/react-query';
+import { GripVertical } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
+import { ObjectTypeIcon } from '@/components/modeling/object-type-icon';
+import { jsonFetch } from '@/lib/http';
+import {
+  SIDEBAR_OBJECT_TYPES_QUERY_KEY,
+  type SidebarObjectType,
+  useObjectTypesMenu,
+} from '@/lib/use-object-types-menu';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  language: string;
+}
+
+/**
+ * VIEW-01c (#414) — drag-and-drop reorder of the visible sidebar entries.
+ * Wraps `useObjectTypesMenu` so the same payload powers both the sidebar
+ * and the Settings ordering control. POST `/api/object_types/menu/reorder`
+ * after each drag, optimistic update on the cached query, fallback
+ * invalidate-on-error so a partial failure rolls back.
+ */
+export function MenuOrderingList({ language }: Props) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const { data: items = [], isLoading } = useObjectTypesMenu();
+  const [error, setError] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = items.findIndex((row) => row.id === active.id);
+    const newIndex = items.findIndex((row) => row.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+
+    const reordered = arrayMove(items, oldIndex, newIndex);
+    queryClient.setQueryData<SidebarObjectType[]>(SIDEBAR_OBJECT_TYPES_QUERY_KEY, reordered);
+
+    setError(null);
+    try {
+      await jsonFetch('/api/object_types/menu/reorder', {
+        method: 'POST',
+        contentType: 'application/json',
+        body: { order: reordered.map((row) => row.id) },
+      });
+      void queryClient.invalidateQueries({ queryKey: SIDEBAR_OBJECT_TYPES_QUERY_KEY });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'unknown');
+      void queryClient.invalidateQueries({ queryKey: SIDEBAR_OBJECT_TYPES_QUERY_KEY });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <p className="text-[12.5px] text-muted-foreground">
+        {t('app.loading', { defaultValue: 'Ładowanie…' })}
+      </p>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-zinc-200 px-4 py-6 text-center text-[12.5px] text-zinc-500">
+        {t('object_types.menu_ordering_empty', {
+          defaultValue:
+            'Żaden typ nie jest widoczny w menu. Włącz „Widoczne w menu" w ustawieniach typu.',
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="mb-3 text-[12px] text-muted-foreground">
+        {t('object_types.menu_ordering_drag_hint', {
+          defaultValue: 'Przeciągnij wiersze, żeby zmienić kolejność menu.',
+        })}
+      </p>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={items.map((row) => row.id)} strategy={verticalListSortingStrategy}>
+          <div className="space-y-1.5">
+            {items.map((row) => (
+              <SortableMenuRow key={row.id} row={row} language={language} />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+      {error !== null ? (
+        <p role="alert" className="mt-3 rounded-md bg-rose-50 px-3 py-2 text-[12px] text-rose-700">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function SortableMenuRow({ row, language }: { row: SidebarObjectType; language: string }) {
+  const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: row.id,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const labelText = row.label[language] ?? row.label.pl ?? row.label.en ?? row.code;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'flex items-center gap-3 rounded-xl border border-zinc-100 bg-white px-3 py-2.5',
+        isDragging && 'border-zinc-300 bg-zinc-50 shadow-sm',
+      )}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label={t('object_types.menu_ordering_drag_handle', {
+          defaultValue: 'Uchwyt do przeciągania',
+        })}
+        className="cursor-grab text-zinc-400 hover:text-zinc-700"
+      >
+        <GripVertical className="size-4" />
+      </button>
+      <ObjectTypeIcon icon={row.icon} color={row.color} kind={row.kind} size="sm" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-[13.5px] font-medium tracking-tight">{labelText}</span>
+          {row.builtIn ? (
+            <BuiltInLockBadge />
+          ) : (
+            <span className="rounded-md bg-emerald-50 px-1.5 py-0.5 text-[10.5px] font-medium uppercase tracking-wide text-emerald-700">
+              custom
+            </span>
+          )}
+        </div>
+        <div className="truncate font-mono text-[11px] text-zinc-400">{row.code}</div>
+      </div>
+      <span className="num shrink-0 text-[11px] tabular-nums text-zinc-400">
+        #{row.menuPosition}
+      </span>
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -14,6 +14,7 @@ import { FieldDisplay } from '@/components/modeling/field-display';
 import { type AttachedGroup, GroupCard } from '@/components/modeling/group-card';
 import { IconPicker } from '@/components/modeling/icon-picker';
 import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
+import { MenuOrderingList } from '@/components/modeling/menu-ordering-list';
 import { ObjectTypeIcon } from '@/components/modeling/object-type-icon';
 import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
 import { StatBox } from '@/components/modeling/stat-box';
@@ -22,6 +23,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { resolveLabel } from '@/features/catalog/attributes/list';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { useCurrentWorkspace } from '@/lib/use-current-workspace';
+import { SIDEBAR_OBJECT_TYPES_QUERY_KEY } from '@/lib/use-object-types-menu';
 
 interface ObjectTypeDetail {
   id: string;
@@ -37,6 +39,8 @@ interface ObjectTypeDetail {
   hierarchical?: boolean;
   hasVariants?: boolean;
   abstract?: boolean;
+  displayInMenu?: boolean;
+  menuPosition?: number;
   allowedParentTypeIds?: string[];
   completenessRules?: Record<string, unknown> | null;
 }
@@ -137,6 +141,16 @@ export function ObjectTypeShowPage() {
         setError(e instanceof Error ? e.message : 'unknown');
       }
       return false;
+    }
+  };
+
+  const handleDisplayInMenuChange = async (next: boolean): Promise<void> => {
+    const ok = await handlePatch({ displayInMenu: next });
+    if (ok) {
+      // Invalidate the sidebar query so the dynamic nav re-renders without
+      // a hard reload — the sidebar reads from `/api/object_types/menu`,
+      // which now includes (or excludes) this type.
+      await queryClient.invalidateQueries({ queryKey: SIDEBAR_OBJECT_TYPES_QUERY_KEY });
     }
   };
 
@@ -468,6 +482,27 @@ export function ObjectTypeShowPage() {
             locked={isBuiltIn}
             onChange={(next) => void handlePatch({ abstract: next })}
           />
+          <SettingToggleRow
+            label={t('object_types.setting_display_in_menu_label', {
+              defaultValue: 'Widoczne w menu',
+            })}
+            description={t('object_types.setting_display_in_menu_desc', {
+              defaultValue:
+                'Typ pojawia się jako pozycja w menu po lewej. Built-in: Produkty/Kategorie/Multimedia/Marki domyślnie tak.',
+            })}
+            checked={Boolean(objectType.displayInMenu)}
+            onChange={(next) => void handleDisplayInMenuChange(next)}
+          />
+          {objectType.displayInMenu ? (
+            <div className="border-t border-zinc-100 pt-5">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="text-[11.5px] font-medium text-zinc-500">
+                  {t('object_types.menu_ordering_section', { defaultValue: 'Kolejność menu' })}
+                </div>
+              </div>
+              <MenuOrderingList language={i18n.language} />
+            </div>
+          ) : null}
           <div className="border-t border-zinc-100 pt-5">
             <div className="mb-2 text-[11.5px] font-medium text-zinc-500">
               {t('object_types.allowed_parent_types_label', {

--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -1,18 +1,21 @@
 import {
   Boxes,
   Cog,
+  FolderTree,
   Image,
   LayoutDashboard,
   type LucideIcon,
   Package,
   Settings2,
   Share2,
+  Tag,
   Workflow,
   Wrench,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router';
 
+import { type SidebarObjectType, useObjectTypesMenu } from '@/lib/use-object-types-menu';
 import { cn } from '@/lib/utils';
 
 import { UserMenu } from './user-menu';
@@ -21,44 +24,14 @@ interface NavLeaf {
   to?: string;
   icon: LucideIcon;
   label: string;
+  /** Pre-resolved label for dynamic items (skips i18n keys). */
+  resolvedLabel?: string;
   comingSoon?: boolean;
   /** MOCK count badge shown after the label (e.g. "12 847"). */
   count?: string;
-  /** MOCK kind tag shown next to count (e.g. "CUSTOM"). */
+  /** Kind tag shown next to count — e.g. CUSTOM for tenant-defined types. */
   kindTag?: string;
 }
-
-interface NavSection {
-  id: string;
-  items: NavLeaf[];
-}
-
-// MOCK counts per UI-03c handoff — replace with live `useList(pageSize=1)`
-// queries when a backend `GET /api/sidebar/counts` endpoint ships.
-const NAV_SECTIONS: NavSection[] = [
-  {
-    id: 'main',
-    items: [
-      { to: '/dashboard', icon: LayoutDashboard, label: 'nav.dashboard' },
-      { to: '/products', icon: Package, label: 'nav.products', count: '12 847' },
-      {
-        icon: Wrench,
-        label: 'nav.services',
-        comingSoon: true,
-        kindTag: 'CUSTOM',
-        count: '84',
-      },
-      { to: '/channels', icon: Share2, label: 'nav.publications' },
-      { to: '/assets', icon: Image, label: 'nav.multimedia', count: '8 421' },
-      { icon: Workflow, label: 'nav.workflow', comingSoon: true },
-      { to: '/api-profiles', icon: Cog, label: 'nav.settings' },
-    ],
-  },
-  {
-    id: 'modeling',
-    items: [{ to: '/modeling', icon: Settings2, label: 'nav.modeling' }],
-  },
-];
 
 interface SidebarNavProps {
   onNavigate?: () => void;
@@ -78,12 +51,63 @@ const disabledLeafClass = cn(
   'cursor-not-allowed text-muted-foreground/60',
 );
 
-export function SidebarNav({ onNavigate }: SidebarNavProps) {
-  const { t } = useTranslation();
+/**
+ * VIEW-01c (#414) — pick a sensible icon + sugar-path route per ObjectKind.
+ * Built-in kinds get their dedicated icon + the legacy `/products`,
+ * `/categories`, `/assets`, `/brands` URL. Custom kinds fall back to a
+ * generic Wrench icon and the `/object-types/{code}` instance-list route.
+ */
+function leafForObjectType(
+  row: SidebarObjectType,
+  language: string,
+): { to: string; icon: LucideIcon; label: string } {
+  const label = row.label[language] ?? row.label.pl ?? row.label.en ?? row.code;
+  switch (row.kind) {
+    case 'product':
+      return { to: '/products', icon: Package, label };
+    case 'category':
+      return { to: '/categories', icon: FolderTree, label };
+    case 'asset':
+      return { to: '/assets', icon: Image, label };
+    case 'brand':
+      return { to: '/brands', icon: Tag, label };
+    default:
+      return { to: `/object-types/${row.code}`, icon: Wrench, label };
+  }
+}
 
-  // Liczba aktywnych modułów = wszystkie wired nav items (wszystkie sekcje, bez comingSoon).
-  const activeModulesCount = NAV_SECTIONS.flatMap((section) => section.items).filter(
-    (item) => !item.comingSoon,
+export function SidebarNav({ onNavigate }: SidebarNavProps) {
+  const { t, i18n } = useTranslation();
+  const { data: objectTypesMenu = [] } = useObjectTypesMenu();
+
+  const dynamicItems: NavLeaf[] = objectTypesMenu.map((row) => {
+    const leaf = leafForObjectType(row, i18n.language);
+    return {
+      to: leaf.to,
+      icon: leaf.icon,
+      // Resolved at fetch time — no i18n key.
+      label: row.code,
+      resolvedLabel: leaf.label,
+      kindTag: row.builtIn ? undefined : 'CUSTOM',
+    };
+  });
+
+  // Static skeleton — surrounding the dynamic ObjectType slot are pieces
+  // that are not ObjectType-driven (Dashboard, channels/publications,
+  // workflow, API profiles / Settings).
+  const mainBefore: NavLeaf[] = [
+    { to: '/dashboard', icon: LayoutDashboard, label: 'nav.dashboard' },
+  ];
+  const mainAfter: NavLeaf[] = [
+    { to: '/channels', icon: Share2, label: 'nav.publications' },
+    { icon: Workflow, label: 'nav.workflow', comingSoon: true },
+    { to: '/api-profiles', icon: Cog, label: 'nav.settings' },
+  ];
+  const modeling: NavLeaf[] = [{ to: '/modeling', icon: Settings2, label: 'nav.modeling' }];
+
+  const allActiveItems = [...mainBefore, ...dynamicItems, ...mainAfter, ...modeling];
+  const activeModulesCount = allActiveItems.filter(
+    (item) => !item.comingSoon && item.to !== undefined,
   ).length;
 
   const renderTrailing = (item: NavLeaf) => (
@@ -100,11 +124,12 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
   );
 
   const renderLeaf = (item: NavLeaf, key: string) => {
+    const labelText = item.resolvedLabel ?? t(item.label);
     if (item.comingSoon || !item.to) {
       return (
         <span key={key} className={disabledLeafClass} aria-disabled="true">
           <item.icon className="size-4" />
-          <span className="flex-1">{t(item.label)}</span>
+          <span className="flex-1">{labelText}</span>
           {renderTrailing(item)}
           <span className="rounded bg-muted px-1.5 py-0.5 text-xs uppercase text-muted-foreground">
             {t('nav.soon')}
@@ -116,11 +141,13 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
     return (
       <NavLink key={key} to={item.to} onClick={onNavigate} className={leafLinkClass}>
         <item.icon className="size-4" />
-        <span className="flex-1">{t(item.label)}</span>
+        <span className="flex-1">{labelText}</span>
         {renderTrailing(item)}
       </NavLink>
     );
   };
+
+  const mainItems = [...mainBefore, ...dynamicItems, ...mainAfter];
 
   return (
     <>
@@ -133,17 +160,12 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
         <div className="px-3 pb-1 pt-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
           {t('nav.workspace_label', { defaultValue: 'Workspace' })}
         </div>
-        {NAV_SECTIONS.map((section, sectionIndex) => (
-          <div
-            key={section.id}
-            className={cn(
-              'flex flex-col gap-1',
-              sectionIndex > 0 && 'mt-2 border-t border-border pt-2',
-            )}
-          >
-            {section.items.map((item) => renderLeaf(item, item.to ?? item.label))}
-          </div>
-        ))}
+        <div className="flex flex-col gap-1">
+          {mainItems.map((item, idx) => renderLeaf(item, `${item.to ?? item.label}-${idx}`))}
+        </div>
+        <div className="mt-2 flex flex-col gap-1 border-t border-border pt-2">
+          {modeling.map((item) => renderLeaf(item, item.to ?? item.label))}
+        </div>
       </nav>
       <div className="border-t p-3">
         <div className="mb-2 px-1 text-[11px] text-muted-foreground">

--- a/apps/admin/src/lib/use-object-types-menu.ts
+++ b/apps/admin/src/lib/use-object-types-menu.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+export interface SidebarObjectType {
+  id: string;
+  code: string;
+  kind: string;
+  label: Record<string, string>;
+  icon: string | null;
+  color: string | null;
+  builtIn: boolean;
+  menuPosition: number;
+  hierarchical: boolean;
+  hasVariants: boolean;
+}
+
+export const SIDEBAR_OBJECT_TYPES_QUERY_KEY = ['object_types', 'menu'] as const;
+
+/**
+ * VIEW-01c (#414) — Reads `GET /api/object_types/menu`, the lean payload
+ * the dynamic sidebar consumes. Filtered to `display_in_menu = true`,
+ * sorted by `menu_position ASC, code ASC`. Cached for 60s — sidebar
+ * layout is sticky between renders, no need to revalidate per route.
+ */
+export function useObjectTypesMenu() {
+  return useQuery<SidebarObjectType[]>({
+    queryKey: SIDEBAR_OBJECT_TYPES_QUERY_KEY,
+    queryFn: () =>
+      jsonFetch<SidebarObjectType[]>('/api/object_types/menu', {
+        accept: 'application/json',
+      }),
+    staleTime: 60_000,
+  });
+}

--- a/apps/api/migrations/Version20260503231801.php
+++ b/apps/api/migrations/Version20260503231801.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * VIEW-01c (#414) — Menu visibility + ordering on ObjectType.
+ *
+ * Adds two columns to `object_types`:
+ *   - `display_in_menu BOOLEAN NOT NULL DEFAULT FALSE` — toggles whether
+ *     the type renders as a primary sidebar entry. Operator-controlled
+ *     UX preference, not a domain invariant; built-in rows can flip it
+ *     (different from `hierarchical` / `has_variants` / `abstract`,
+ *     which are platform contracts).
+ *   - `menu_position INT NOT NULL DEFAULT 0` — ascending sort key used
+ *     by GET /api/object_types/menu and the sidebar.
+ *
+ * Backfill: existing built-in `kind=product/category/asset` rows get
+ * `display_in_menu=TRUE` with positions 10/20/30 so the default sidebar
+ * keeps the legacy hardcoded layout. Custom rows stay hidden by default;
+ * the operator opts them in via the Settings toggle.
+ *
+ * Index `idx_object_types_menu (display_in_menu, menu_position)` keeps
+ * GET /api/object_types/menu under p95 < 300ms even on 200+ types per
+ * tenant — the typical query is `WHERE display_in_menu = true ORDER BY
+ * menu_position ASC`.
+ */
+final class Version20260503231801 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'VIEW-01c #414 — ObjectType.displayInMenu + menuPosition columns + sidebar visibility backfill.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE object_types ADD COLUMN display_in_menu BOOLEAN NOT NULL DEFAULT FALSE');
+        $this->addSql('ALTER TABLE object_types ADD COLUMN menu_position INT NOT NULL DEFAULT 0');
+
+        $this->addSql("COMMENT ON COLUMN object_types.display_in_menu IS 'Sidebar visibility flag (operator-controlled, not a domain invariant)'");
+        $this->addSql("COMMENT ON COLUMN object_types.menu_position IS 'Ascending sort key for the sidebar'");
+
+        // Backfill built-ins so the default sidebar matches the legacy
+        // hardcoded layout (Produkty/Kategorie/Multimedia).
+        $this->addSql("UPDATE object_types SET display_in_menu = TRUE, menu_position = 10 WHERE kind = 'product' AND is_built_in = TRUE");
+        $this->addSql("UPDATE object_types SET display_in_menu = TRUE, menu_position = 20 WHERE kind = 'category' AND is_built_in = TRUE");
+        $this->addSql("UPDATE object_types SET display_in_menu = TRUE, menu_position = 30 WHERE kind = 'asset' AND is_built_in = TRUE");
+        $this->addSql("UPDATE object_types SET display_in_menu = TRUE, menu_position = 40 WHERE kind = 'brand' AND is_built_in = TRUE");
+
+        $this->addSql('CREATE INDEX idx_object_types_menu ON object_types (display_in_menu, menu_position)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_object_types_menu');
+        $this->addSql('ALTER TABLE object_types DROP COLUMN IF EXISTS menu_position');
+        $this->addSql('ALTER TABLE object_types DROP COLUMN IF EXISTS display_in_menu');
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php
@@ -29,13 +29,13 @@ use Doctrine\ORM\EntityManagerInterface;
 final readonly class BuiltInObjectTypeSeeder
 {
     /**
-     * @var array<string, array{ObjectKind, array<string, string>, string, string}>
+     * @var array<string, array{ObjectKind, array<string, string>, string, string, int}>
      */
     private const array DEFINITIONS = [
-        'product' => [ObjectKind::Product, ['pl' => 'Produkt', 'en' => 'Product'], 'Package', '#3B82F6'],
-        'category' => [ObjectKind::Category, ['pl' => 'Kategoria', 'en' => 'Category'], 'FolderTree', '#10B981'],
-        'asset' => [ObjectKind::Asset, ['pl' => 'Zasób', 'en' => 'Asset'], 'Image', '#8B5CF6'],
-        'brand' => [ObjectKind::Brand, ['pl' => 'Marka', 'en' => 'Brand'], 'Tag', '#F59E0B'],
+        'product' => [ObjectKind::Product, ['pl' => 'Produkt', 'en' => 'Product'], 'Package', '#3B82F6', 10],
+        'category' => [ObjectKind::Category, ['pl' => 'Kategoria', 'en' => 'Category'], 'FolderTree', '#10B981', 20],
+        'asset' => [ObjectKind::Asset, ['pl' => 'Zasób', 'en' => 'Asset'], 'Image', '#8B5CF6', 30],
+        'brand' => [ObjectKind::Brand, ['pl' => 'Marka', 'en' => 'Brand'], 'Tag', '#F59E0B', 40],
     ];
 
     public function __construct(
@@ -56,7 +56,7 @@ final readonly class BuiltInObjectTypeSeeder
 
         try {
             $created = 0;
-            foreach (self::DEFINITIONS as $code => [$kind, $label, $icon, $color]) {
+            foreach (self::DEFINITIONS as $code => [$kind, $label, $icon, $color, $menuPosition]) {
                 $existing = $this->repository->findBuiltInByKind($kind, $tenant);
                 if (null !== $existing) {
                     continue;
@@ -78,6 +78,13 @@ final readonly class BuiltInObjectTypeSeeder
                 } elseif (ObjectKind::Category === $kind) {
                     $type->setHierarchical(true);
                 }
+
+                // VIEW-01c (#414): every built-in is visible in the sidebar by
+                // default. Positions 10/20/30 with a step of 10 leave room for
+                // custom rows to be inserted between built-ins via the
+                // operator's drag-and-drop reorder.
+                $type->setDisplayInMenu(true);
+                $type->setMenuPosition($menuPosition);
 
                 $this->em->persist($type);
                 ++$created;

--- a/apps/api/src/Catalog/Application/ObjectTypeService.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeService.php
@@ -13,9 +13,11 @@ use App\Catalog\Domain\Exception\ObjectTypeCodeConflictException;
 use App\Catalog\Domain\Exception\ObjectTypeHasInstancesException;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
 
 /**
  * Application service that owns ObjectType lifecycle invariants.
@@ -46,6 +48,7 @@ final readonly class ObjectTypeService
     public function __construct(
         private EntityManagerInterface $em,
         private ObjectTypeAttributeRepositoryInterface $junctions,
+        private ObjectTypeRepositoryInterface $repository,
         private Connection $connection,
         private bool $enableCustomObjectTypes,
     ) {
@@ -124,6 +127,8 @@ final readonly class ObjectTypeService
         ?bool $abstract = null,
         ?array $allowedParentTypeIds = null,
         ?array $completenessRules = null,
+        ?bool $displayInMenu = null,
+        ?int $menuPosition = null,
     ): ObjectType {
         $isBuiltIn = $objectType->isBuiltIn();
 
@@ -167,10 +172,51 @@ final readonly class ObjectTypeService
             }
             $objectType->updateCompletenessRules($completenessRules);
         }
+        // VIEW-01c (#414): displayInMenu + menuPosition are operator-controlled
+        // UX preferences, NOT domain invariants — built-in rows can flip them
+        // freely (different from hierarchical / hasVariants / abstract).
+        if (null !== $displayInMenu) {
+            $objectType->setDisplayInMenu($displayInMenu);
+        }
+        if (null !== $menuPosition) {
+            $objectType->setMenuPosition($menuPosition);
+        }
 
         $this->em->flush();
 
         return $objectType;
+    }
+
+    /**
+     * VIEW-01c (#414) — atomic reorder for the sidebar drag-and-drop. The
+     * full ordered list of `display_in_menu=true` UUIDs is rewritten in one
+     * transaction; positions are normalized to multiples of 10 so future
+     * inserts have room.
+     *
+     * @param list<\Symfony\Component\Uid\Uuid> $orderedIds
+     *
+     * @throws InvalidArgumentException when an UUID is unknown or hidden
+     */
+    public function reorderMenu(array $orderedIds): void
+    {
+        if ([] === $orderedIds) {
+            return;
+        }
+
+        $position = 10;
+        foreach ($orderedIds as $id) {
+            $type = $this->repository->findById($id);
+            if (null === $type) {
+                throw new InvalidArgumentException(\sprintf('ObjectType "%s" not found.', $id->toRfc4122()));
+            }
+            if (!$type->isDisplayInMenu()) {
+                throw new InvalidArgumentException(\sprintf('ObjectType "%s" is not displayed in the menu.', $id->toRfc4122()));
+            }
+            $type->setMenuPosition($position);
+            $position += 10;
+        }
+
+        $this->em->flush();
     }
 
     public function delete(ObjectType $objectType): void

--- a/apps/api/src/Catalog/Domain/Entity/ObjectType.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectType.php
@@ -79,6 +79,17 @@ class ObjectType implements TenantScoped
     private bool $abstract = false;
 
     /**
+     * VIEW-01c (#414) — sidebar surface controls. `displayInMenu=true` makes
+     * the type render as its own primary nav entry; `menuPosition` orders it
+     * (ascending). Built-ins ship with both flags set by the seeder so the
+     * default sidebar matches the existing layout. Unlike the other Settings
+     * toggles, these two are NOT domain invariants — built-in rows can
+     * change them freely (UX preference, not platform contract).
+     */
+    private bool $displayInMenu = false;
+    private int $menuPosition = 0;
+
+    /**
      * UUID list of ObjectTypes allowed as parent. Plain JSONB list (not a
      * junction) — N stays small (≤ 5 typical), and the only consumer is the
      * detail view's Allowed parent types chip strip. A junction would cost
@@ -306,6 +317,37 @@ class ObjectType implements TenantScoped
     public function setAbstract(bool $value): void
     {
         $this->abstract = $value;
+        $this->touch();
+    }
+
+    public function isDisplayInMenu(): bool
+    {
+        return $this->displayInMenu;
+    }
+
+    /**
+     * Symfony PropertyAccess accessor alias — surface as `displayInMenu`
+     * property in normalized output (mirrors `getHasVariants`).
+     */
+    public function getDisplayInMenu(): bool
+    {
+        return $this->displayInMenu;
+    }
+
+    public function setDisplayInMenu(bool $value): void
+    {
+        $this->displayInMenu = $value;
+        $this->touch();
+    }
+
+    public function getMenuPosition(): int
+    {
+        return $this->menuPosition;
+    }
+
+    public function setMenuPosition(int $value): void
+    {
+        $this->menuPosition = $value;
         $this->touch();
     }
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
@@ -70,6 +70,16 @@
                 <option name="default">false</option>
             </options>
         </field>
+        <field name="displayInMenu" type="boolean" column="display_in_menu">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="menuPosition" type="integer" column="menu_position">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
         <field name="allowedParentTypeIds" type="json" column="allowed_parent_type_ids">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Catalog/Infrastructure/Serializer/ObjectType.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/ObjectType.xml
@@ -57,6 +57,12 @@
             <group>admin:read</group>
             <group>integration:read</group>
         </attribute>
+        <attribute name="displayInMenu">
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="menuPosition">
+            <group>admin:read</group>
+        </attribute>
         <attribute name="allowedParentTypeIds">
             <group>admin:read</group>
         </attribute>

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectTypeMenuController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectTypeMenuController.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\ObjectTypeService;
+use Doctrine\DBAL\Connection;
+use InvalidArgumentException;
+use Stringable;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-01c (#414) — sidebar menu surface for ObjectTypes.
+ *
+ * `GET /api/object_types/menu` returns the lean payload the dynamic
+ * sidebar reads (id / code / kind / label / icon / color / builtIn /
+ * menuPosition / hierarchical / hasVariants), filtered to
+ * `display_in_menu = TRUE` and ordered by `menu_position ASC, code ASC`.
+ *
+ * `POST /api/object_types/menu/reorder` accepts the full ordered list
+ * of UUIDs the operator dragged into shape and rewrites positions in
+ * one transaction (multiples of 10 to leave room for inserts).
+ */
+final class ObjectTypeMenuController
+{
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly ObjectTypeService $service,
+    ) {
+    }
+
+    #[Route(
+        '/api/object_types/menu',
+        name: 'pim_object_types_menu',
+        methods: ['GET'],
+        priority: 200,
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function list(): JsonResponse
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                    SELECT id, code, kind, label, icon, color, is_built_in,
+                           menu_position, hierarchical, has_variants
+                    FROM object_types
+                    WHERE display_in_menu = TRUE
+                    ORDER BY menu_position ASC, code ASC
+                SQL,
+        );
+
+        $entries = [];
+        foreach ($rows as $row) {
+            $labelRaw = $row['label'] ?? null;
+            if (\is_string($labelRaw)) {
+                $decoded = json_decode($labelRaw, true);
+                $labelRaw = \is_array($decoded) ? $decoded : [];
+            }
+            $label = [];
+            if (\is_array($labelRaw)) {
+                foreach ($labelRaw as $k => $v) {
+                    if (\is_string($k) && \is_string($v)) {
+                        $label[$k] = $v;
+                    }
+                }
+            }
+
+            $entries[] = [
+                'id' => self::stringify($row['id'] ?? ''),
+                'code' => self::stringify($row['code'] ?? ''),
+                'kind' => self::stringify($row['kind'] ?? ''),
+                'label' => $label,
+                'icon' => $row['icon'] ?? null,
+                'color' => $row['color'] ?? null,
+                'builtIn' => (bool) ($row['is_built_in'] ?? false),
+                'menuPosition' => self::intify($row['menu_position'] ?? 0),
+                'hierarchical' => (bool) ($row['hierarchical'] ?? false),
+                'hasVariants' => (bool) ($row['has_variants'] ?? false),
+            ];
+        }
+
+        return new JsonResponse($entries);
+    }
+
+    #[Route(
+        '/api/object_types/menu/reorder',
+        name: 'pim_object_types_menu_reorder',
+        methods: ['POST'],
+        priority: 200,
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function reorder(Request $request): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+        if (!\is_array($payload)) {
+            throw new BadRequestHttpException('Body must be a JSON object.');
+        }
+        $rawOrder = $payload['order'] ?? null;
+        if (!\is_array($rawOrder)) {
+            throw new BadRequestHttpException('Field "order" must be an array of UUIDs.');
+        }
+
+        $uuids = [];
+        foreach ($rawOrder as $rawId) {
+            if (!\is_string($rawId) || !Uuid::isValid($rawId)) {
+                throw new BadRequestHttpException(\sprintf('Invalid UUID in "order": %s', \is_string($rawId) ? $rawId : '(non-string)'));
+            }
+            $uuids[] = Uuid::fromString($rawId);
+        }
+
+        try {
+            $this->service->reorderMenu($uuids);
+        } catch (InvalidArgumentException $e) {
+            throw new HttpException(Response::HTTP_UNPROCESSABLE_ENTITY, $e->getMessage(), $e);
+        }
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private static function stringify(mixed $value): string
+    {
+        return \is_scalar($value) || $value instanceof Stringable ? (string) $value : '';
+    }
+
+    private static function intify(mixed $value): int
+    {
+        return \is_scalar($value) ? (int) $value : 0;
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
@@ -70,6 +70,8 @@ final class UpdateObjectTypeController
                 abstract: $this->boolOrNull($body['abstract'] ?? null),
                 allowedParentTypeIds: $this->idListOrNull($body['allowedParentTypeIds'] ?? null),
                 completenessRules: $this->mapOrNull($body['completenessRules'] ?? null),
+                displayInMenu: $this->boolOrNull($body['displayInMenu'] ?? null),
+                menuPosition: $this->intOrNull($body['menuPosition'] ?? null),
             );
         } catch (BuiltInObjectTypeException $e) {
             throw new HttpException(Response::HTTP_FORBIDDEN, $e->getMessage(), $e);
@@ -90,6 +92,8 @@ final class UpdateObjectTypeController
             'abstract' => $objectType->isAbstract(),
             'allowedParentTypeIds' => $objectType->getAllowedParentTypeIds(),
             'completenessRules' => $objectType->getCompletenessRules(),
+            'displayInMenu' => $objectType->isDisplayInMenu(),
+            'menuPosition' => $objectType->getMenuPosition(),
             'schemaVersion' => $objectType->getSchemaVersion(),
         ]);
     }
@@ -146,6 +150,17 @@ final class UpdateObjectTypeController
             return $raw;
         }
         throw new BadRequestHttpException('Boolean fields must be true or false.');
+    }
+
+    private function intOrNull(mixed $raw): ?int
+    {
+        if (null === $raw) {
+            return null;
+        }
+        if (\is_int($raw)) {
+            return $raw;
+        }
+        throw new BadRequestHttpException('Integer fields must be a number.');
     }
 
     /**

--- a/apps/api/tests/Api/Catalog/CustomKindFeatureFlagApiTest.php
+++ b/apps/api/tests/Api/Catalog/CustomKindFeatureFlagApiTest.php
@@ -147,6 +147,7 @@ final class CustomKindFeatureFlagApiTest extends CatalogApiTestCase
         return new ObjectTypeService(
             $this->em(),
             self::getContainer()->get(ObjectTypeAttributeRepositoryInterface::class),
+            self::getContainer()->get(\App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface::class),
             self::getContainer()->get(\Doctrine\DBAL\Connection::class),
             $flag,
         );

--- a/apps/api/tests/Api/Catalog/ObjectTypeMenuApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectTypeMenuApiTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * VIEW-01c (#414) — Menu visibility + ordering on ObjectType.
+ *
+ * Verifies the BE half of the dynamic sidebar contract:
+ * `GET /api/object_types/menu` (lean payload, sorted),
+ * `PATCH /api/object_types/{id}` accepting `displayInMenu` + `menuPosition`,
+ * and `POST /api/object_types/menu/reorder` rewriting positions atomically.
+ */
+final class ObjectTypeMenuApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function getMenuReturnsBuiltInsByDefault(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/object_types/menu');
+
+        self::assertResponseIsSuccessful();
+        /** @var list<array{kind: string, builtIn: bool, menuPosition: int}> $payload */
+        $payload = $response->toArray();
+
+        $byKind = [];
+        foreach ($payload as $row) {
+            $byKind[$row['kind']] = $row;
+        }
+        self::assertArrayHasKey('product', $byKind);
+        self::assertArrayHasKey('category', $byKind);
+        self::assertArrayHasKey('asset', $byKind);
+        self::assertSame(10, $byKind['product']['menuPosition']);
+        self::assertSame(20, $byKind['category']['menuPosition']);
+        self::assertSame(30, $byKind['asset']['menuPosition']);
+        self::assertTrue($byKind['product']['builtIn']);
+    }
+
+    #[Test]
+    public function patchDisplayInMenuOnCustomType(): void
+    {
+        $custom = $this->createCustomType('subscription');
+        $id = $custom->getId()->toRfc4122();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('PATCH', '/api/object_types/'.$id, [
+            'json' => ['displayInMenu' => true, 'menuPosition' => 25],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        self::assertResponseIsSuccessful();
+
+        /** @var array<string, mixed> $body */
+        $body = $response->toArray();
+        self::assertTrue($body['displayInMenu']);
+        self::assertSame(25, $body['menuPosition']);
+
+        /** @var list<array{code: string}> $menu */
+        $menu = $client->request('GET', '/api/object_types/menu')->toArray();
+        $codes = array_map(static fn (array $row): string => $row['code'], $menu);
+        self::assertContains('subscription', $codes);
+    }
+
+    #[Test]
+    public function patchDisplayInMenuOnBuiltInIsAllowed(): void
+    {
+        $id = $this->objectTypeIdFor(ObjectKind::Product);
+        $client = $this->authenticatedClient();
+
+        // Different from hierarchical/hasVariants/abstract: menu fields are
+        // operator UX preferences, not domain invariants — toggling on a
+        // built-in must succeed (not 403).
+        $response = $client->request('PATCH', '/api/object_types/'.$id, [
+            'json' => ['displayInMenu' => false],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        self::assertResponseIsSuccessful();
+
+        /** @var list<array{kind: string}> $menu */
+        $menu = $client->request('GET', '/api/object_types/menu')->toArray();
+        $kinds = array_map(static fn (array $row): string => $row['kind'], $menu);
+        self::assertNotContains('product', $kinds);
+    }
+
+    #[Test]
+    public function reorderMenuPersistsNewOrder(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $productId = $this->objectTypeIdFor(ObjectKind::Product);
+        $categoryId = $this->objectTypeIdFor(ObjectKind::Category);
+        $assetId = $this->objectTypeIdFor(ObjectKind::Asset);
+        $brandId = $this->objectTypeIdFor(ObjectKind::Brand);
+
+        // Reverse the default 10/20/30/40 order.
+        $client->request('POST', '/api/object_types/menu/reorder', [
+            'json' => ['order' => [$brandId, $assetId, $categoryId, $productId]],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        /** @var list<array{kind: string}> $menu */
+        $menu = $client->request('GET', '/api/object_types/menu')->toArray();
+        $kindOrder = array_map(static fn (array $row): string => $row['kind'], $menu);
+        self::assertSame(['brand', 'asset', 'category', 'product'], $kindOrder);
+    }
+
+    #[Test]
+    public function reorderMenuRejectsHiddenObjectType(): void
+    {
+        $custom = $this->createCustomType('hidden_one');
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/object_types/menu/reorder', [
+            'json' => ['order' => [$custom->getId()->toRfc4122()]],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    #[Test]
+    public function reorderMenuRejectsUnknownUuid(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/object_types/menu/reorder', [
+            'json' => ['order' => ['00000000-0000-7000-8000-000000000000']],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    #[Test]
+    public function serializerExposesNewFieldsInGetCollection(): void
+    {
+        $client = $this->authenticatedClient();
+        /** @var array<string, mixed> $payload */
+        $payload = $client->request('GET', '/api/object_types')->toArray();
+        $items = $payload['hydra:member'] ?? $payload['member'] ?? [];
+        self::assertIsArray($items);
+        self::assertNotEmpty($items);
+
+        foreach ($items as $row) {
+            self::assertIsArray($row);
+            self::assertArrayHasKey('displayInMenu', $row);
+            self::assertArrayHasKey('menuPosition', $row);
+        }
+    }
+
+    private function createCustomType(string $code): ObjectType
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        try {
+            $type = new ObjectType($code, ObjectKind::Custom, ['en' => ucfirst($code)]);
+            $this->em()->persist($type);
+            $this->em()->flush();
+
+            // Sanity: refetch through the repo so identity-mapped tenant is set.
+            $live = self::getContainer()
+                ->get(ObjectTypeRepositoryInterface::class)
+                ->findById($type->getId());
+            \assert(null !== $live);
+
+            return $live;
+        } finally {
+            self::getContainer()->get(TenantContext::class)->clear();
+        }
+    }
+}

--- a/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
+++ b/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
@@ -164,6 +164,7 @@ final class ObjectTypeServiceTest extends KernelTestCase
         return new ObjectTypeService(
             $this->em(),
             self::getContainer()->get(ObjectTypeAttributeRepositoryInterface::class),
+            self::getContainer()->get(\App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface::class),
             self::getContainer()->get(\Doctrine\DBAL\Connection::class),
             $flag,
         );


### PR DESCRIPTION
## Summary

Drugi ticket z dwóch — operator może teraz **dodać dowolny ObjectType (built-in lub custom) do menu po lewej** oraz **przeciągnąć kolejność** w nowej sekcji „Kolejność menu" w Ustawieniach. Sidebar po lewej nie jest już hardcoded — dynamicznie czyta listę z `/api/object_types/menu`, więc każda zmiana na detalu OT od razu odbija się w nawigacji.

## Backend (#414)

- **Migracja** `20260503231801` — dodaje `display_in_menu BOOLEAN` i `menu_position INT` do `object_types`, backfilluje built-iny (Product=10, Category=20, Asset=30, Brand=40), zakłada index `(display_in_menu, menu_position)`.
- **Entity / ORM / Serializer** — nowe pola w `ObjectType`, mapping XML, group `admin:read`.
- **`ObjectTypeService::update`** — przyjmuje nowe pola; **NIE** są zablokowane na built-inie (różnica vs. hierarchical/hasVariants/abstract — to UX preference, nie domain invariant).
- **`ObjectTypeService::reorderMenu`** — atomic permutacja UUIDów na pozycje 10/20/30/...; 422 jeśli któryś UUID nie istnieje lub ma displayInMenu=FALSE.
- **`ObjectTypeMenuController`**:
  - `GET /api/object_types/menu` — lean payload `[{id, code, kind, label, icon, color, builtIn, menuPosition, hierarchical, hasVariants}]`, filter `display_in_menu=TRUE`, sort `menu_position ASC, code ASC`. Priority 200 (przed API Platform GetItem).
  - `POST /api/object_types/menu/reorder` body `{ order: string[] }` → 204.
- **`UpdateObjectTypeController`** — body parsing dla `displayInMenu` + `menuPosition`, response wzbogacony.
- **Seeder built-inów** — świeże tenanty dostają backfill jak migracja.
- **7 PHPUnit ApiTestCase** w `ObjectTypeMenuApiTest.php`: built-ins by default, PATCH na custom, PATCH na built-in (różnica vs. hierarchical = 200, nie 403), reorder persists, reject hidden, reject unknown UUID, serializer exposure.

## Frontend

- **`useObjectTypesMenu` hook** + `SIDEBAR_OBJECT_TYPES_QUERY_KEY` — wspólny cache key, staleTime 60s.
- **`MenuOrderingList`** komponent — `DndContext + SortableContext + verticalListSortingStrategy + arrayMove + optimistic update + fallback invalidate-on-error`. Pattern 1:1 z `attribute-groups/show.tsx`. Pointer + Keyboard sensors (a11y).
- **`object-types/show.tsx`** — Settings card dostaje czwarty `SettingToggleRow` „Widoczne w menu" + conditional sub-sekcja „Kolejność menu" widoczna tylko gdy displayInMenu=ON.
- **`sidebar-nav.tsx`** — pełny refactor. Slot między Dashboard a Channels iteruje po `useObjectTypesMenu()`. Mapping kind→ikona+route: Product→Package+/products, Category→FolderTree+/categories, Asset→Image+/assets, Brand→Tag+/brands, Custom→Wrench+/object-types/{code}. Custom typy dostają badge „CUSTOM".

## Quality gates

- [x] `pnpm typecheck` (apps/admin) — green
- [x] `pnpm lint` — green
- [x] `composer phpstan` — green
- [x] `composer cs-check` — green
- [x] `vendor/bin/phpunit tests/Api/Catalog` — 141/141 green w tym 7 nowych
- [ ] **Smoke (operator)** — wymagany przed claim „działa":
  1. `pnpm stack:up`, login `admin@demo.localhost / changeme`
  2. Modeling → Object Types → wybierz Product → Settings: toggle „Widoczne w menu" jest ON. Wyłącz. F5. Sidebar bez „Produkty". Włącz. F5. Sidebar znowu z „Produkty"
  3. Asset detal → przeciągnij „Produkty" pod „Kategorie". Network: `POST /menu/reorder` 204. Sidebar w nowej kolejności
  4. Stwórz custom OT przez wizard → otwórz detal → włącz „Widoczne w menu". Sidebar pokazuje nowy entry z badge CUSTOM
  5. Regression: hierarchical / variants / abstract na built-in dalej dają 403 (locking nie złamany)
  6. DevTools Console: brak czerwonych errorów

## Decyzja architektoniczna

`displayInMenu` + `menuPosition` ŚWIADOMIE NIE są zablokowane na built-inach (operator może je flipować). To różnica względem `hierarchical`/`hasVariants`/`abstract`, które są platform contracts. Powód: te dwa pola są UX preference (kto ma ją widzieć w menu, w jakiej kolejności), nie domain invariant.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)