### PR TITLE
feat(catalog): surface loose ObjectType attributes in effective groups (VIEW-07.1)

### DIFF
--- a/apps/admin/src/features/catalog/products/components/effective-model-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/effective-model-card.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import { Card } from '@/components/ui/card';
-
 import type { GroupMeta } from './types';
+import { SYNTHETIC_DEFAULT_GROUP_ID } from './types';
 
 export interface EffectiveModelCardProps {
   groups: GroupMeta[];
@@ -37,18 +37,20 @@ export function EffectiveModelCard({
         })}
       </p>
       <ul className="space-y-1.5 text-[12px]">
-        {groups.map((group) => {
-          const label = group.label[lang] ?? group.code;
-          const source = resolveSource(group, objectTypeName, categoryName);
-          const isSystem = group.code === 'audit' || group.code === 'identification';
-          return (
-            <li key={group.id} className="flex items-center gap-2 rounded-lg px-2 py-1">
-              {isSystem ? <Lock className="size-3 text-zinc-300" aria-hidden /> : null}
-              <span className="truncate font-medium text-zinc-800">{label}</span>
-              <span className="ml-auto truncate text-[10.5px] text-zinc-500">{source}</span>
-            </li>
-          );
-        })}
+        {groups
+          .filter((group) => group.id !== SYNTHETIC_DEFAULT_GROUP_ID)
+          .map((group) => {
+            const label = group.label[lang] ?? group.code;
+            const source = resolveSource(group, objectTypeName, categoryName);
+            const isSystem = group.code === 'audit' || group.code === 'identification';
+            return (
+              <li key={group.id} className="flex items-center gap-2 rounded-lg px-2 py-1">
+                {isSystem ? <Lock className="size-3 text-zinc-300" aria-hidden /> : null}
+                <span className="truncate font-medium text-zinc-800">{label}</span>
+                <span className="ml-auto truncate text-[10.5px] text-zinc-500">{source}</span>
+              </li>
+            );
+          })}
       </ul>
       <Link
         to="/modeling/object-types"

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -57,3 +57,15 @@ export interface EffectiveAttributeGroups {
 }
 
 export type ProductDetailMode = 'edit' | 'create';
+
+/**
+ * Sentinel UUID returned by `GET /api/products/{id}/effective-attribute-groups`
+ * for the synthetic "default" bucket holding ObjectType-attached attributes
+ * that are not declared in any AttributeGroup. The frontend matches this id
+ * verbatim to (a) skip the bucket in the "Effective model" sidebar listing,
+ * (b) render its body the same way every other group renders.
+ *
+ * Backend constant lives in
+ * `App\Catalog\Presentation\Controller\ProductReadEndpointsController::SYNTHETIC_DEFAULT_GROUP_ID`.
+ */
+export const SYNTHETIC_DEFAULT_GROUP_ID = '00000000-0000-0000-0000-000000000000';

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -7,6 +7,7 @@ namespace App\Catalog\Presentation\Controller;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
@@ -44,10 +45,23 @@ final class ProductReadEndpointsController
     private const int AUDIT_DEFAULT_LIMIT = 20;
     private const int AUDIT_MAX_LIMIT = 200;
 
+    /**
+     * Sentinel UUID returned for the synthetic "default" group that
+     * carries ObjectType-attached attributes which are not declared in
+     * any AttributeGroup. The all-zero UUID is recognised by the
+     * frontend (`EffectiveModelCard`) as the bucket for ungrouped
+     * fields and hidden from the "Effective model" sidebar listing —
+     * see VIEW-07.1 (#421+).
+     */
+    public const string SYNTHETIC_DEFAULT_GROUP_ID = '00000000-0000-0000-0000-000000000000';
+
+    public const string SYNTHETIC_DEFAULT_GROUP_CODE = 'default';
+
     public function __construct(
         private readonly CatalogObjectRepositoryInterface $objects,
         private readonly EffectiveAttributeGroupResolver $resolver,
         private readonly Connection $connection,
+        private readonly ObjectTypeAttributeRepositoryInterface $objectTypeAttributes,
     ) {
     }
 
@@ -137,12 +151,17 @@ final class ProductReadEndpointsController
         $groups = $this->resolver->resolve($product);
         $byGroup = $this->resolver->loadGroupAttributes($groups);
 
+        // Track every Attribute UUID already exposed via a real group so
+        // the synthetic "default" bucket below never duplicates them.
+        $seenAttributeIds = [];
+
         $effective = [];
         foreach ($groups as $position => $group) {
             $junctions = $byGroup[$group->getId()->toRfc4122()] ?? [];
             $attributes = [];
             foreach ($junctions as $j) {
                 $attribute = $j->getAttribute();
+                $seenAttributeIds[$attribute->getId()->toRfc4122()] = true;
                 $attributes[] = [
                     'id' => $attribute->getId()->toRfc4122(),
                     'code' => $attribute->getCode(),
@@ -163,6 +182,53 @@ final class ProductReadEndpointsController
                 'is_system_group' => $group->isSystemGroup(),
                 'position' => $position,
                 'attributes' => $attributes,
+            ];
+        }
+
+        // VIEW-07.1 (#421+) — surface ObjectType-attached attributes
+        // that are not declared in any AttributeGroup. Without this the
+        // detail page renders only the audit group whenever an
+        // ObjectType uses "loose" attributes (the default Klimas seed
+        // pattern). The synthetic group is appended last so curated
+        // grouping always wins the sort order; an all-zero UUID acts as
+        // a sentinel for the frontend to recognise + hide it from the
+        // "Effective model" sidebar listing.
+        $junctions = $this->objectTypeAttributes->findByObjectType($product->getObjectType());
+        usort(
+            $junctions,
+            static fn ($a, $b): int => $a->getSortOrder() <=> $b->getSortOrder(),
+        );
+        $defaultAttributes = [];
+        foreach ($junctions as $junction) {
+            $attribute = $junction->getAttribute();
+            $key = $attribute->getId()->toRfc4122();
+            if (isset($seenAttributeIds[$key])) {
+                continue;
+            }
+            $seenAttributeIds[$key] = true;
+            $defaultAttributes[] = [
+                'id' => $key,
+                'code' => $attribute->getCode(),
+                'type' => $attribute->getType()->value,
+                'label' => $attribute->getLabel(),
+                'is_system' => $attribute->isSystem(),
+                'position' => $junction->getSortOrder(),
+                'is_required_in_group' => $junction->isRequiredForCompleteness(),
+                'visible_when' => null,
+            ];
+        }
+
+        if ([] !== $defaultAttributes) {
+            $effective[] = [
+                'id' => self::SYNTHETIC_DEFAULT_GROUP_ID,
+                'code' => self::SYNTHETIC_DEFAULT_GROUP_CODE,
+                'label' => ['pl' => 'Atrybuty', 'en' => 'Attributes'],
+                'icon' => null,
+                'color' => null,
+                'is_system_group' => false,
+                'is_synthetic' => true,
+                'position' => \count($effective),
+                'attributes' => $defaultAttributes,
             ];
         }
 

--- a/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInSystemAttributesSeeder;
+use App\Catalog\Application\ObjectTypeService;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Catalog\Presentation\Controller\ProductReadEndpointsController;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * VIEW-07.1 (#421+) — `GET /api/products/{id}/effective-attribute-groups`
+ * synthetic "default" group coverage. Verifies that ObjectType-attached
+ * attributes which are not declared in any AttributeGroup are still
+ * surfaced to the form-renderer in a sentinel-id bucket the frontend
+ * recognises.
+ */
+final class EffectiveAttributeGroupsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function exposesLooseObjectTypeAttributesInDefaultGroup(): void
+    {
+        $client = $this->authenticatedClient();
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $productType = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        // Attach two loose attributes (no AttributeGroup membership) to
+        // the built-in product ObjectType.
+        $brandAttr = new Attribute('brand_view07', ['pl' => 'Marka', 'en' => 'Brand'], AttributeType::Text);
+        $weightAttr = new Attribute('weight_view07', ['pl' => 'Waga', 'en' => 'Weight'], AttributeType::Number);
+        $em = $this->em();
+        $em->persist($brandAttr);
+        $em->persist($weightAttr);
+        $em->flush();
+
+        $service = self::getContainer()->get(ObjectTypeService::class);
+        $service->assignAttribute($productType, $brandAttr, required: false, sortOrder: 0);
+        $service->assignAttribute($productType, $weightAttr, required: false, sortOrder: 1);
+
+        $tenantContext->clear();
+
+        // Create a product so the endpoint has a concrete subject.
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'V071-LOOSE',
+                'objectTypeId' => $productType->getId()->toRfc4122(),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+        $id = $created['id'] ?? null;
+        \assert(\is_string($id));
+
+        $response = $client->request('GET', '/api/products/'.$id.'/effective-attribute-groups');
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+
+        $groups = $body['groups'] ?? [];
+        \assert(\is_array($groups));
+        $defaultGroup = null;
+        foreach ($groups as $group) {
+            \assert(\is_array($group));
+            if (ProductReadEndpointsController::SYNTHETIC_DEFAULT_GROUP_ID === ($group['id'] ?? null)) {
+                $defaultGroup = $group;
+                break;
+            }
+        }
+
+        self::assertNotNull($defaultGroup, 'Synthetic default group missing from response.');
+        self::assertSame('default', $defaultGroup['code'] ?? null);
+        self::assertTrue($defaultGroup['is_synthetic'] ?? false);
+        self::assertFalse($defaultGroup['is_system_group'] ?? true);
+
+        $defaultAttributes = $defaultGroup['attributes'] ?? [];
+        \assert(\is_array($defaultAttributes));
+        $codes = array_map(
+            static function ($attr): ?string {
+                \assert(\is_array($attr));
+                $code = $attr['code'] ?? null;
+
+                return \is_string($code) ? $code : null;
+            },
+            $defaultAttributes,
+        );
+
+        self::assertContains('brand_view07', $codes);
+        self::assertContains('weight_view07', $codes);
+    }
+
+    #[Test]
+    public function omitsDefaultGroupWhenEveryAttributeBelongsToAGroup(): void
+    {
+        $client = $this->authenticatedClient();
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $productType = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'V071-CLEAN',
+                'objectTypeId' => $productType->getId()->toRfc4122(),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+        $id = $created['id'] ?? null;
+        \assert(\is_string($id));
+
+        $response = $client->request('GET', '/api/products/'.$id.'/effective-attribute-groups');
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+
+        $groups = $body['groups'] ?? [];
+        \assert(\is_array($groups));
+        foreach ($groups as $group) {
+            \assert(\is_array($group));
+            self::assertNotSame(
+                ProductReadEndpointsController::SYNTHETIC_DEFAULT_GROUP_ID,
+                $group['id'] ?? null,
+                'Synthetic default group should be absent when no loose attributes are attached.',
+            );
+        }
+    }
+
+    #[Test]
+    public function looseAttributeAlsoMemberOfRealGroupIsNotDuplicated(): void
+    {
+        $client = $this->authenticatedClient();
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $productType = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        // The audit AttributeGroup is auto-attached to product by the
+        // built-in seeder. Its `created_at` attribute is also attached
+        // through ObjectTypeAttribute on the same ObjectType — that is
+        // the realistic shape today. The endpoint must surface the
+        // attribute exactly once (under the audit group, not in the
+        // synthetic default bucket).
+        self::getContainer()->get(BuiltInSystemAttributesSeeder::class)->seed($tenant);
+        $createdAt = self::getContainer()
+            ->get(AttributeRepositoryInterface::class)
+            ->findByCode('created_at', $tenant);
+        \assert(null !== $createdAt);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+        $service = self::getContainer()->get(ObjectTypeService::class);
+        $service->assignAttribute($productType, $createdAt, required: false, sortOrder: 99);
+        $tenantContext->clear();
+
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'V071-DEDUP',
+                'objectTypeId' => $productType->getId()->toRfc4122(),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+        $id = $created['id'] ?? null;
+        \assert(\is_string($id));
+
+        $response = $client->request('GET', '/api/products/'.$id.'/effective-attribute-groups');
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+
+        $occurrences = 0;
+        $bodyGroups = $body['groups'] ?? [];
+        \assert(\is_array($bodyGroups));
+        foreach ($bodyGroups as $group) {
+            \assert(\is_array($group));
+            $attributes = $group['attributes'] ?? [];
+            \assert(\is_array($attributes));
+            foreach ($attributes as $attr) {
+                \assert(\is_array($attr));
+                if ('created_at' === ($attr['code'] ?? null)) {
+                    ++$occurrences;
+                }
+            }
+        }
+
+        self::assertSame(1, $occurrences, 'Attribute exposed in a real group must not also appear in the synthetic default group.');
+    }
+}


### PR DESCRIPTION
## Summary

Bug fix dla VIEW-07: na karcie produktu (np. DEMO-100) wyświetlała się tylko grupa Audyt. Atrybuty ObjectType (`name`, `sku`, `brand`, `price`, …) — przypięte do ObjectType jako "luźne", bez przynależności do AttributeGroup — były pomijane przez `GET /api/products/{id}/effective-attribute-groups`.

Wybór operatora: **wariant B (backend fix)**, czyste API.

## Backend

`ProductReadEndpointsController::effectiveAttributeGroups` dokleja syntetyczną grupę `default` na końcu listy gdy istnieją luźne atrybuty:

- `id`: sentinel `00000000-0000-0000-0000-000000000000`
- `code`: `default`
- `is_synthetic`: true
- `attributes`: junctions `ObjectTypeAttribute` które nie pojawiły się w żadnej realnej grupie, posortowane po `sortOrder`
- pomijane gdy puste (zero zmian dla obecnych ObjectType-ów z pełnym groupingiem)

Nowa dependency w controllerze: `ObjectTypeAttributeRepositoryInterface`.

## Frontend

`EffectiveModelCard` filtruje syntetyczną grupę z listy w sidebarze (po `id === SYNTHETIC_DEFAULT_GROUP_ID`). W body widoku grupa renderuje się jako normalny `AttrGroupCard` — ten sam layout co inne grupy.

`types.ts` eksportuje stałą `SYNTHETIC_DEFAULT_GROUP_ID` z komentarzem wskazującym na backendowy odpowiednik.

## Quality gates

- PHPStan max: 0.
- Biome strict: 0.
- TypeScript `--noEmit`: 0.
- Vite build: OK.
- PHPUnit `EffectiveAttributeGroupsApiTest`: 3/3.
- composer audit + pnpm audit: 0 vulnerabilities.

## Test plan

- [ ] `/products/DEMO-100` → karta pokazuje grupę „Atrybuty" z 16 polami (name, sku, brand, color, size, tags, price, weight, height, in_stock, release_date, main_image, related_to, short_description, description) + grupę Audyt z 4 systemowymi.
- [ ] Sidebar „Efektywny model" pokazuje wyłącznie realne grupy (Audyt + przyszłe), bez syntetycznej `Atrybuty`.
- [ ] DevTools: `GET /api/products/{id}/effective-attribute-groups` zawiera grupę z `id: "00000000-0000-0000-0000-000000000000"`, `is_synthetic: true`.
- [ ] `/products/new` → po utworzeniu produktu syntetyczna grupa też się renderuje (w trybie edycji).

🤖 Generated with [Claude Code](https://claude.com/claude-code)