### PR TITLE
fix(catalog): expose wysiwyg type in attribute create form + list filter

### DIFF
--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -44,6 +44,7 @@ const TYPE_FILTERS = [
   'relation',
   'price',
   'metric',
+  'wysiwyg',
 ] as const;
 
 type TypeFilter = (typeof TYPE_FILTERS)[number];

--- a/apps/admin/src/features/catalog/attributes/new.tsx
+++ b/apps/admin/src/features/catalog/attributes/new.tsx
@@ -73,6 +73,7 @@ const TYPES = [
   'relation',
   'price',
   'metric',
+  'wysiwyg',
 ] as const;
 
 export function AttributeCreatePage() {

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
@@ -46,7 +46,7 @@ final class AttributeInput
     public ?array $help = null;
 
     #[Assert\NotBlank]
-    #[Assert\Choice(choices: ['text', 'number', 'select', 'multiselect', 'date', 'boolean', 'asset', 'relation', 'price', 'metric'])]
+    #[Assert\Choice(choices: ['text', 'number', 'select', 'multiselect', 'date', 'boolean', 'asset', 'relation', 'price', 'metric', 'wysiwyg'])]
     #[Groups(['attribute:create'])]
     public string $type = 'text';
 

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -5658,7 +5658,8 @@
                             "asset",
                             "relation",
                             "price",
-                            "metric"
+                            "metric",
+                            "wysiwyg"
                         ],
                         "default": "text",
                         "type": "string"


### PR DESCRIPTION
## Summary

Po VIEW-07.2 `wysiwyg` enum case przeszedł BE-FE, ale admin `/modeling/attributes/new` nadal pokazywał tylko 10 oryginalnych typów. Operator nie mógł utworzyć nowego atrybutu typu wysiwyg z UI.

## Changes

- `AttributeInput::$type` `Assert\Choice` rozszerzony o `wysiwyg` (bez tego AP4 processor odrzucał POST z 422).
- `attributes/new.tsx` `TYPES` tuple +`wysiwyg` (11. button w siatce typu).
- `attributes/list.tsx` `TYPE_FILTERS` +`wysiwyg` (chip filtra w liście).

## Out of scope

`migrate-type.tsx` allowlist celowo bez zmian — konwersja istniejących `text`/`textarea` do `wysiwyg` wymaga dedykowanego transform planu (osobny ticket).

## Test plan

- [ ] `/modeling/attributes/new` → 11 buttonów typu, w tym `wysiwyg`.
- [ ] Klik `wysiwyg` + wypełnij code/label → POST 201, brak 422.
- [ ] Lista `/modeling/attributes` → filtr `wysiwyg` pokazuje atrybuty tego typu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)