### PR TITLE
fix(catalog): expose wysiwyg in modeling create/picker dialogs

### DIFF
--- a/apps/admin/src/components/modeling/add-attributes-from-library-dialog.tsx
+++ b/apps/admin/src/components/modeling/add-attributes-from-library-dialog.tsx
@@ -36,6 +36,7 @@ const TYPE_OPTIONS = [
   'relation',
   'price',
   'metric',
+  'wysiwyg',
 ] as const;
 
 interface Props {

--- a/apps/admin/src/components/modeling/add-attributes-to-object-type-dialog.tsx
+++ b/apps/admin/src/components/modeling/add-attributes-to-object-type-dialog.tsx
@@ -32,6 +32,7 @@ const TYPE_OPTIONS = [
   'relation',
   'price',
   'metric',
+  'wysiwyg',
 ] as const;
 
 interface Props {

--- a/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
@@ -24,6 +24,7 @@ const TYPES = [
   'relation',
   'price',
   'metric',
+  'wysiwyg',
 ] as const;
 
 interface Props {

--- a/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
@@ -24,6 +24,7 @@ const TYPES = [
   'relation',
   'price',
   'metric',
+  'wysiwyg',
 ] as const;
 
 interface Props {


### PR DESCRIPTION
Follow-up po #425 — czterem modeling dialogom (group detail "Stwórz nowy", object-type detail "Stwórz nowy", "Z biblioteki", "Dodaj do ObjectType") brakowało `wysiwyg` w lokalnej liście typów. Backend już akceptuje. Test plan: w `/modeling/attribute-groups/{id}` → "Stwórz nowy" → siatka pokazuje `wysiwyg` jako 13. opcję; POST 201; atrybut pojawia się w grupie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)