### PR TITLE
fix(catalog): wire parent_id filter on /api/products (#429)

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/ParentIdFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/ParentIdFilter.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * `?parent_id=<uuid>` — exact match on `CatalogObject.parent_id`.
+ *
+ * Drives the `<VariantsListCard />` (VIEW-07 #420) which lists variants
+ * of a master product (`/api/products?parent_id={master_id}`). Without
+ * this filter AP4 silently ignored the param and returned the first
+ * cursor page — UI naïvely rendered DEMO-099/DEMO-098/... as „variants
+ * of DEMO-100", which is a lie. Issue #429.
+ *
+ * Empty / non-UUID values are skipped — the filter is a no-op when the
+ * param is absent or malformed (returning an unfiltered list is a less
+ * surprising fallback than a 500). Tenant scoping still applies via
+ * `TenantFilter` so cross-tenant lookups are impossible.
+ */
+final class ParentIdFilter implements FilterInterface
+{
+    private const string PARAMETER = 'parent_id';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('parentId');
+        $queryBuilder
+            ->andWhere(\sprintf('IDENTITY(%s.parent) = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'parent',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on parent_id — returns rows whose parent points at the given UUID (variants of a master product, children of a category).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -67,6 +67,14 @@
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\CompletenessFilter</filter>
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\StatusFilter</filter>
             <!--
+                #429: parent_id exact match for variant listing
+                (`/api/products?parent_id={master_id}`) and category
+                children. Without it AP4 silently ignored the param and
+                VariantsListCard rendered the first 30 products as
+                bogus "variants" of the open master.
+            -->
+            <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\ParentIdFilter</filter>
+            <!--
                 OrderFilter + RangeFilter pinned to `id` are mandatory for
                 cursor pagination (`paginationViaCursor` below) — lessons #0.0.3
                 docu the AP4 trio. Without RangeFilter the `?id[lt]=...`

--- a/apps/api/tests/Api/Catalog/CatalogFiltersApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogFiltersApiTest.php
@@ -40,6 +40,62 @@ final class CatalogFiltersApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function parentIdFilterReturnsOnlyDirectChildren(): void
+    {
+        // 1 master + 3 variants of master + 2 unrelated products.
+        $em = $this->em();
+        $tenant = $this->tenant();
+        $context = self::getContainer()->get(TenantContext::class);
+        $context->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $repo = self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+        $master = new CatalogObject($type, 'PARENT-MASTER');
+        $repo->save($master);
+        foreach (['PARENT-VARIANT-A', 'PARENT-VARIANT-B', 'PARENT-VARIANT-C'] as $code) {
+            $variant = new CatalogObject($type, $code);
+            $variant->assignParent($master);
+            $repo->save($variant);
+        }
+        $unrelatedA = new CatalogObject($type, 'UNRELATED-A');
+        $repo->save($unrelatedA);
+        $unrelatedB = new CatalogObject($type, 'UNRELATED-B');
+        $repo->save($unrelatedB);
+        $em->flush();
+        $em->clear();
+
+        $client = $this->authenticatedClient();
+        $body = $client
+            ->request('GET', \sprintf('/api/products?parent_id=%s', $master->getId()->toRfc4122()))
+            ->toArray();
+
+        $codes = $this->codesFrom($body);
+        self::assertCount(3, $codes);
+        self::assertContains('PARENT-VARIANT-A', $codes);
+        self::assertContains('PARENT-VARIANT-B', $codes);
+        self::assertContains('PARENT-VARIANT-C', $codes);
+        self::assertNotContains('PARENT-MASTER', $codes);
+        self::assertNotContains('UNRELATED-A', $codes);
+    }
+
+    #[Test]
+    public function parentIdFilterIgnoresInvalidUuid(): void
+    {
+        $this->seedProducts(['INVALID-PARENT-A', 'INVALID-PARENT-B']);
+
+        $client = $this->authenticatedClient();
+        // Non-UUID — filter is a no-op so the unfiltered list still
+        // contains both seed rows. Keeps the FE robust against stale
+        // master ids in URL state.
+        $body = $client->request('GET', '/api/products?parent_id=not-a-uuid')->toArray();
+
+        self::assertGreaterThanOrEqual(2, $body['totalItems'] ?? 0);
+    }
+
+    #[Test]
     public function statusFilterRespectsEnumWhitelist(): void
     {
         $this->seedProducts(['SKU-A', 'SKU-B'], status: CatalogObject::STATUS_PUBLISHED);

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -2130,6 +2130,18 @@
                         "explode": false
                     },
                     {
+                        "name": "parent_id",
+                        "in": "query",
+                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "order[id]",
                         "in": "query",
                         "description": "",
@@ -2416,6 +2428,18 @@
                         "deprecated": false,
                         "schema": {
                             "type": "boolean"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "parent_id",
+                        "in": "query",
+                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
                         },
                         "style": "form",
                         "explode": false
@@ -3017,6 +3041,18 @@
                         "deprecated": false,
                         "schema": {
                             "type": "boolean"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "parent_id",
+                        "in": "query",
+                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
                         },
                         "style": "form",
                         "explode": false


### PR DESCRIPTION
## Summary

`VariantsListCard` (VIEW-07 #420, `variants-list-card.tsx:24`) calls `GET /api/products?parent_id={master_id}` to populate the sidebar variants card on the product detail. AP4 had **no SearchFilter registered** on `parent_id`, so the param was silently ignored and the endpoint returned the first cursor page (30 latest products). The FE naïvely rendered DEMO-099/DEMO-098/... as „variants of DEMO-100" — they're independent master products.

## Fix

- New `ParentIdFilter` (FQCN `App\Catalog\Infrastructure\ApiPlatform\Filter\ParentIdFilter`, exact UUID match) wired into the `CatalogObject` ApiResource alongside the existing custom filters.
- Empty / non-UUID values → no-op (filter falls through to the unfiltered list rather than 500-ing on stale FE state).
- Tenant scoping unchanged — `TenantFilter` still applies, so cross-tenant lookups are impossible.

## Tests

- `CatalogFiltersApiTest::parentIdFilterReturnsOnlyDirectChildren` — 1 master + 3 variants + 2 unrelated → `?parent_id={master_id}` returns exactly the 3 variants.
- `CatalogFiltersApiTest::parentIdFilterIgnoresInvalidUuid` — `?parent_id=not-a-uuid` falls through (no-op).
- All 10 filter tests green: `composer phpstan` clean.

## Live smoke

```
GET /api/products?parent_id={DEMO-100_id} → 3 items (DEMO-100-BIAŁY, -CZARNY, -CZERWONY)
GET /api/products?parent_id={DEMO-099_id} → 0 items
```

Closes #429.

## Test plan
- [x] PHPStan max — clean
- [x] PHPUnit `CatalogFiltersApiTest` — 10/10
- [x] Manual smoke against `/api/products?parent_id=...` on demo dataset
- [ ] After merge: detail DEMO-100 → tab Warianty pokazuje 3 SKU; detail DEMO-099 → pusta lista

🤖 Generated with [Claude Code](https://claude.com/claude-code)