### PR TITLE
feat(catalog): /objects/:code placeholder for promoted ObjectTypes

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -24,6 +24,7 @@ import { ModelingLayout } from '@/features/catalog/modeling/layout';
 import { ObjectTypesListPage } from '@/features/catalog/object-types/list';
 import { ObjectTypeWizardPage } from '@/features/catalog/object-types/new';
 import { ObjectTypeShowPage } from '@/features/catalog/object-types/show';
+import { ObjectListingPlaceholder } from '@/features/catalog/objects/placeholder';
 import { ProductCreatePage } from '@/features/catalog/products/create';
 import { ProductListPage } from '@/features/catalog/products/list';
 import { ProductShowPage } from '@/features/catalog/products/show';
@@ -176,6 +177,10 @@ function App() {
               />
               <Route path="/assets" element={<AssetsListPage />} />
               <Route path="/assets/:id" element={<AssetShowPage />} />
+              {/* VIEW-08 (#427): generic listing for custom ObjectTypes
+                  promoted to the main menu. Placeholder until B-2 ships
+                  the metadata-driven `<ObjectListingPage />`. */}
+              <Route path="/objects/:code" element={<ObjectListingPlaceholder />} />
               <Route path="/catalogs-pdf" element={<CatalogsPdfPage />} />
               <Route path="/settings" element={<SettingsLayout />}>
                 <Route index element={<SettingsIndex />} />

--- a/apps/admin/src/features/catalog/objects/placeholder.tsx
+++ b/apps/admin/src/features/catalog/objects/placeholder.tsx
@@ -1,0 +1,55 @@
+import { Construction } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+
+/**
+ * VIEW-08 (#427) — placeholder for object_type listings reachable via
+ * `/objects/:code` after operator promotes a custom ObjectType to the
+ * main menu via `/settings/menu`. The full generic listing ships in the
+ * follow-up B-2 ticket (`<ObjectListingPage />` driven by ObjectType
+ * `listing_config`); until then we render a Construction card so the
+ * sidebar entry doesn't 404 → fallback to /dashboard.
+ */
+export function ObjectListingPlaceholder() {
+  const { t } = useTranslation();
+  const params = useParams<{ code: string }>();
+  const code = params.code ?? '';
+
+  return (
+    <div className="flex min-h-[420px] flex-col items-center justify-center gap-4 rounded-lg border border-dashed bg-background p-8 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-accent-violet/10 text-accent-violet">
+        <Construction className="size-6" />
+      </div>
+      <div className="space-y-1">
+        <h2 className="display text-xl font-semibold tracking-tight">
+          {t('objects.placeholder.title', {
+            defaultValue: 'Widok „{{code}}" w przygotowaniu',
+            code,
+          })}
+        </h2>
+        <p className="max-w-md text-sm text-muted-foreground">
+          {t('objects.placeholder.description', {
+            defaultValue:
+              'Generyczna strona listingu dla custom ObjectType jest planowana w follow-upie VIEW-08 B-2. Na razie pozycję możesz ukryć z menu przez Ustawienia → Menu.',
+          })}
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button asChild variant="outline" size="sm">
+          <Link to="/settings/menu">
+            {t('objects.placeholder.manage_menu', {
+              defaultValue: 'Zarządzaj menu',
+            })}
+          </Link>
+        </Button>
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/dashboard">
+            {t('settings.placeholder.back', { defaultValue: 'Wróć do pulpitu' })}
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

After VIEW-08 (#427) operator can promote a custom ObjectType (e.g. „Subskrypcja") to the main sidebar via `/settings/menu`. The `effective` controller routes non-built-in entries to `/objects/{code}`, but the React Router had no matching `Route` — clicks on those sidebar entries fell through to the `*` catch-all and bounced back to `/dashboard`. Confusing UX.

This PR adds a Construction-style placeholder card on `/objects/:code` so the sidebar entry resolves to a clear „view in progress" panel with links to `/settings/menu` (manage menu) and `/dashboard` (back).

The full metadata-driven listing (`ObjectListingPage` driven by `ObjectType.listing_config`) is the follow-up B-2 ticket from the VIEW-08 plan — out of scope here.

## Changes
- `apps/admin/src/features/catalog/objects/placeholder.tsx` — new `ObjectListingPlaceholder` component (Construction icon + heading + back/manage actions, i18n keys with sensible defaults)
- `apps/admin/src/App.tsx` — `<Route path="/objects/:code" element={<ObjectListingPlaceholder />} />` registered before the `*` fallback

## Tests
- `pnpm typecheck` clean
- `pnpm lint` clean (only pre-existing `attributes/show.tsx` warning unrelated to this PR)

## Test plan
- [x] Typecheck + lint
- [ ] After merge: `/settings/menu` → push custom ObjectType to Visible → click entry in sidebar → placeholder renders, no /dashboard bounce

🤖 Generated with [Claude Code](https://claude.com/claude-code)