### PR TITLE
feat(catalog): zakładka Warianty — inline edit + dziedziczenie atrybutów + UX polish (VIEW-07.3)

### DIFF
--- a/apps/admin/e2e/view-07-3-products-variants.spec.ts
+++ b/apps/admin/e2e/view-07-3-products-variants.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * VIEW-07.3 (#432) — variants tab: master attribute inheritance,
+ * inline edit through global toggle, copy-to-others propagation,
+ * default-collapsed cards with expand/collapse all, generator above
+ * the list.
+ *
+ * Like VIEW-07, this is a single test running the full happy path so
+ * we don't trip the dev-mode 5/15min auth rate limiter. Marked
+ * `fixme` in CI for the same reason — see view-07-products-edit-create
+ * spec doc.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('VIEW-07.3 variants tab — generate inherits attributes + inline edit + copy-to-others', async ({
+  page,
+}) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  // Create the master product through the REST API to skip the UI
+  // create flow that VIEW-07 already covers.
+  const sku = uniqueSku('V73');
+  const objectTypesResponse = await page.request.get('/api/object_types');
+  const objectTypesBody = (await objectTypesResponse.json()) as {
+    member?: Array<{ id: string; kind: string; isBuiltIn: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; isBuiltIn: boolean }>;
+  };
+  const types = objectTypesBody.member ?? objectTypesBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.isBuiltIn);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  const masterResponse = await page.request.post('/api/products', {
+    headers: { 'content-type': 'application/ld+json' },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: { brand: 'Playwright Inc.', name: `Master ${sku}` },
+    },
+  });
+  expect(masterResponse.status()).toBe(201);
+  const master = (await masterResponse.json()) as { id: string };
+
+  // Open the detail page → Warianty tab.
+  await page.goto(`/products/${master.id}`);
+  await page.getByRole('tab', { name: /warianty|variants/i }).click();
+
+  // Generator is rendered above the list.
+  await expect(page.getByRole('button', { name: /generate variants/i })).toBeVisible();
+
+  // Add the `color` axis with two values.
+  const axisCodeInput = page.getByPlaceholder('color').first();
+  await axisCodeInput.fill('color');
+  const axisValueInput = page.getByPlaceholder(/add value & press enter/i).first();
+  await axisValueInput.fill('red');
+  await axisValueInput.press('Enter');
+  await axisValueInput.fill('blue');
+  await axisValueInput.press('Enter');
+
+  // Computed default is shown as the SKU template placeholder.
+  const skuTemplateInput = page.locator('#variants-sku-template');
+  await expect(skuTemplateInput).toHaveAttribute('placeholder', '{master_sku}-{color}');
+
+  // Generate — backend copies brand from master + stamps `color=red|blue`.
+  const generateResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/generate-variants') && response.request().method() === 'POST',
+  );
+  await page.getByRole('button', { name: /generate variants/i }).click();
+  const generated = await generateResponse;
+  expect(generated.status()).toBe(201);
+  const generatedBody = (await generated.json()) as { created_count: number };
+  expect(generatedBody.created_count).toBe(2);
+
+  // List re-fetches via reloadKey; both variants should appear collapsed by default.
+  await expect(page.getByText(`${sku}-red`)).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText(`${sku}-blue`)).toBeVisible();
+
+  // Expand all to inspect the inherited attributes.
+  await page.getByRole('button', { name: /rozwiń wszystkie|expand all/i }).click();
+  // brand inherited from master visible in at least one variant card.
+  await expect(page.getByText('Playwright Inc.').first()).toBeVisible({ timeout: 10_000 });
+
+  // Toggle global edit mode → first variant's `name` becomes an input.
+  await page.getByRole('button', { name: /^(edytuj warianty|edit variants)$/i }).click();
+  await expect(page.getByRole('button', { name: /^(zapisz|save)$/i })).toBeVisible();
+
+  // Smoke: at least one Copy button is rendered now (replaces ProvenanceBadge in variants).
+  const copyButtons = page.getByRole('button', {
+    name: /kopiuj wartość .* do innych wariantów|copy .* to other variants/i,
+  });
+  await expect(copyButtons.first()).toBeVisible();
+
+  // Cancel — exits edit mode without saving.
+  await page.getByRole('button', { name: /^(anuluj|cancel)$/i }).click();
+  await expect(
+    page.getByRole('button', { name: /^(edytuj warianty|edit variants)$/i }),
+  ).toBeVisible();
+
+  // Validation: unknown axis code returns 400 from backend (fail-fast guard).
+  const unknownAxisResponse = await page.request.post(
+    `/api/products/${master.id}/generate-variants`,
+    {
+      headers: { 'content-type': 'application/json' },
+      data: { axes: { mystery_axis_xyz: ['foo'] } },
+    },
+  );
+  expect(unknownAxisResponse.status()).toBe(400);
+});

--- a/apps/admin/src/components/catalog/variants-tab.tsx
+++ b/apps/admin/src/components/catalog/variants-tab.tsx
@@ -33,6 +33,7 @@ interface GenerateVariantsResponse {
 
 /**
  * UI-02.18 (#308) — Variants tab for the product detail page.
+ * VIEW-07.3 (#432) — dynamic SKU template default + onGenerated callback.
  *
  * Slice covers the axes editor + matrix generator, both wired to the
  * UI-02.6 backend (`POST /api/products/{master_id}/generate-variants`).
@@ -41,14 +42,25 @@ interface GenerateVariantsResponse {
  * - Per-axis add/remove + per-value chip removal.
  * - Generate button posts the cartesian product spec; the response
  *   reports created vs skipped (existing SKU collisions).
- * - SKU template (optional). Default `{master_sku}-{values_joined}`.
- *
- * Per-variant Excel-like grid lands once UI-02.12 is integrated into
- * the variant list view; the matrix generator output already returns
- * the new SKUs so a follow-up just needs to reuse `<ExcelLikeGrid>`
- * over the variants collection.
+ * - SKU template (optional). Default computed from current axes:
+ *   `{master_sku}-{axis_1}-...-{axis_n}`. Empty input falls back to
+ *   the computed default at submit time.
+ * - `onGenerated` fires after a successful POST so the host
+ *   (`VariantsTabHost`) can re-fetch the variants list.
  */
-export function VariantsTab({ masterProductId }: { masterProductId: string }) {
+function buildDefaultSkuTemplate(axes: AxisDraft[]): string {
+  const codes = axes.map((a) => a.code.trim()).filter((c) => c !== '');
+  if (codes.length === 0) return '{master_sku}';
+  return `{master_sku}-${codes.map((c) => `{${c}}`).join('-')}`;
+}
+
+export function VariantsTab({
+  masterProductId,
+  onGenerated,
+}: {
+  masterProductId: string;
+  onGenerated?: () => void;
+}) {
   const { t } = useTranslation();
   const [axes, setAxes] = useState<AxisDraft[]>([{ code: 'color', values: [] }]);
   const [attributes, setAttributes] = useState<SchemaAttribute[]>([]);
@@ -118,12 +130,15 @@ export function VariantsTab({ masterProductId }: { masterProductId: string }) {
         }
       }
       const body: Record<string, unknown> = { axes: axesPayload };
-      if (skuTemplate.trim() !== '') body.sku_template = skuTemplate.trim();
+      const template =
+        skuTemplate.trim() !== '' ? skuTemplate.trim() : buildDefaultSkuTemplate(axes);
+      body.sku_template = template;
       const result = await jsonFetch<GenerateVariantsResponse>(
         `/api/products/${masterProductId}/generate-variants`,
         { method: 'POST', body },
       );
       setResponse(result);
+      onGenerated?.();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'unknown');
     } finally {
@@ -174,7 +189,7 @@ export function VariantsTab({ masterProductId }: { masterProductId: string }) {
           id="variants-sku-template"
           value={skuTemplate}
           onChange={(e) => setSkuTemplate(e.target.value)}
-          placeholder="{master_sku}-{color}-{size}"
+          placeholder={buildDefaultSkuTemplate(axes)}
         />
       </div>
 

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -1,4 +1,4 @@
-import { Lock } from 'lucide-react';
+import { Copy, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { WysiwygEditor } from '@/components/catalog/wysiwyg-editor';
 import { type Provenance, ProvenanceBadge } from '@/components/provenance-badge';
@@ -16,6 +16,14 @@ export interface AttrRowProps {
   isEditing: boolean;
   isLocked: boolean;
   onChange: (next: unknown) => void;
+  /**
+   * VIEW-07.3 (#432) — when present, the RHS slot renders a Copy
+   * action instead of the ProvenanceBadge. Used by `VariantsTabHost`
+   * to let operators broadcast a single attribute value to every
+   * other variant. The provenance signal is preserved in the button's
+   * tooltip so we don't lose it for Faza 2 inheritance work.
+   */
+  onCopyToOthers?: () => void;
 }
 
 /**
@@ -33,6 +41,7 @@ export function AttrRow({
   isEditing,
   isLocked,
   onChange,
+  onCopyToOthers,
 }: AttrRowProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
@@ -138,7 +147,25 @@ export function AttrRow({
       </div>
 
       <div className="flex items-center gap-1 pt-1.5">
-        <ProvenanceBadge provenance={provenance} />
+        {onCopyToOthers !== undefined ? (
+          <button
+            type="button"
+            onClick={onCopyToOthers}
+            title={t('products.detail.variants.copy_to_others', {
+              defaultValue: 'Kopiuj do innych wariantów · Source: {{provenance}}',
+              provenance: t(`provenance.${provenance}`, { defaultValue: provenance }),
+            })}
+            aria-label={t('products.detail.variants.copy_to_others_aria', {
+              defaultValue: 'Kopiuj wartość {{label}} do innych wariantów',
+              label,
+            })}
+            className="rounded-md p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+          >
+            <Copy className="size-3.5" aria-hidden />
+          </button>
+        ) : (
+          <ProvenanceBadge provenance={provenance} />
+        )}
       </div>
     </div>
   );

--- a/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
+++ b/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { VariantsTab } from '@/components/catalog/variants-tab';
 import type { Provenance } from '@/components/provenance-badge';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/toast';
 import { jsonFetch } from '@/lib/http';
 
 import { AttrGroupCard } from './attr-group-card';
@@ -25,18 +27,25 @@ export interface VariantsTabHostProps {
 }
 
 /**
- * VIEW-07 (#420) — Variants tab body. Two stacked sections per the
- * operator's spec: (1) per-variant collapsible cards in the same
- * AttrGroupCard style as the Atrybuty tab, (2) the existing axes
- * editor + matrix generator from UI-02.18 kept below the list so the
- * cartesian-product flow remains discoverable.
+ * VIEW-07 (#420) — Variants tab body.
+ * VIEW-07.3 (#432) — generator above list, default-collapsed cards
+ * with global expand/collapse toggles, inline edit through a global
+ * `Edytuj warianty` toggle (per-variant dirty state, batch save with
+ * `Promise.allSettled`), and the per-attribute "Copy to other
+ * variants" action that replaces the ProvenanceBadge in the variant
+ * RHS slot.
  */
 export function VariantsTabHost({ productId }: VariantsTabHostProps) {
   const { t } = useTranslation();
   const [variants, setVariants] = useState<VariantRow[]>([]);
   const [groups, setGroups] = useState<GroupMeta[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+  const [dirtyByVariant, setDirtyByVariant] = useState<Record<string, Record<string, unknown>>>({});
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [reloadKey, setReloadKey] = useState<number>(0);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is the intentional re-fetch trigger after Generate/Save (bumped via setReloadKey).
   useEffect(() => {
     let cancelled = false;
     if (productId === '') return;
@@ -46,7 +55,6 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
         const list = body.member ?? body['hydra:member'] ?? [];
         const arr = Array.isArray(list) ? list : [];
         setVariants(arr);
-        setExpanded(new Set(arr.map((v) => v.id)));
       }),
       jsonFetch<{ groups: GroupMeta[] }>(
         `/api/products/${productId}/effective-attribute-groups`,
@@ -57,11 +65,9 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
     return () => {
       cancelled = true;
     };
-  }, [productId]);
+  }, [productId, reloadKey]);
 
   const variantAttributes = useMemo<AttributeMeta[]>(() => {
-    // Variant cards show the master's attributes, but only the editable
-    // ones — system fields (created_at, etc.) collapse to noise here.
     return groups.flatMap((g) => g.attributes.filter((a) => !a.is_system));
   }, [groups]);
 
@@ -74,37 +80,180 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
     });
   };
 
+  const expandAll = (): void => {
+    setExpanded(new Set(variants.map((v) => v.id)));
+  };
+
+  const collapseAll = (): void => {
+    setExpanded(new Set());
+  };
+
+  const setVariantField = (variantId: string, code: string, value: unknown): void => {
+    setDirtyByVariant((prev) => ({
+      ...prev,
+      [variantId]: { ...(prev[variantId] ?? {}), [code]: value },
+    }));
+  };
+
+  const fieldValue = (variantId: string, code: string, base: Record<string, unknown>): unknown => {
+    const dirty = dirtyByVariant[variantId];
+    if (dirty !== undefined && Object.hasOwn(dirty, code)) return dirty[code];
+    return base[code];
+  };
+
+  const copyToOthers = (sourceVariantId: string, code: string): void => {
+    const sourceVariant = variants.find((v) => v.id === sourceVariantId);
+    if (sourceVariant === undefined) return;
+    const sourceAttrs = unwrap(sourceVariant.attributesIndexed ?? {});
+    const value = fieldValue(sourceVariantId, code, sourceAttrs);
+    const others = variants.filter((v) => v.id !== sourceVariantId);
+    if (others.length === 0) return;
+    setDirtyByVariant((prev) => {
+      const next = { ...prev };
+      for (const v of others) {
+        next[v.id] = { ...(next[v.id] ?? {}), [code]: value };
+      }
+      return next;
+    });
+    toast.success(
+      t('products.detail.variants.copy_to_others.success', {
+        defaultValue: 'Skopiowano do {{count}} wariantów',
+        count: others.length,
+      }),
+    );
+  };
+
+  const cancelEdit = (): void => {
+    setDirtyByVariant({});
+    setIsEditing(false);
+  };
+
+  const handleSaveAll = async (): Promise<void> => {
+    if (isSaving) return;
+    const targets = Object.entries(dirtyByVariant).filter(([, d]) => Object.keys(d).length > 0);
+    if (targets.length === 0) {
+      setIsEditing(false);
+      return;
+    }
+    setIsSaving(true);
+    const results = await Promise.allSettled(
+      targets.map(([id, attributes]) =>
+        jsonFetch(`/api/products/${id}`, {
+          method: 'PATCH',
+          contentType: 'application/merge-patch+json',
+          body: { attributes },
+        }).then(() => id),
+      ),
+    );
+    const failedIds = results
+      .map((r, idx) => (r.status === 'rejected' ? targets[idx]?.[0] : null))
+      .filter((x): x is string => x !== null && x !== undefined);
+    const failedSkus = failedIds
+      .map((id) => variants.find((v) => v.id === id)?.code ?? id)
+      .join(', ');
+    if (failedIds.length === 0) {
+      toast.success(
+        t('products.detail.variants.save.success', { defaultValue: 'Zapisano warianty' }),
+      );
+      setDirtyByVariant({});
+      setIsEditing(false);
+    } else {
+      toast.error(
+        t('products.detail.variants.save.partial', {
+          defaultValue: 'Zapisano {{ok}}/{{total}}. Błędy: {{skus}}',
+          ok: targets.length - failedIds.length,
+          total: targets.length,
+          skus: failedSkus,
+        }),
+      );
+      setDirtyByVariant((prev) => {
+        const next: Record<string, Record<string, unknown>> = {};
+        for (const id of failedIds) if (prev[id] !== undefined) next[id] = prev[id];
+        return next;
+      });
+    }
+    setReloadKey((k) => k + 1);
+    setIsSaving(false);
+  };
+
   return (
     <div className="space-y-3">
+      <div className="rounded-2xl border border-zinc-100 bg-zinc-50/40 p-1">
+        <VariantsTab masterProductId={productId} onGenerated={() => setReloadKey((k) => k + 1)} />
+      </div>
+
       <div>
-        <header className="mb-3">
-          <h3 className="text-[14px] font-semibold tracking-tight">
-            {t('products.detail.variants.list_title', { defaultValue: 'Lista wariantów' })}
-          </h3>
-          <p className="num text-[11.5px] text-zinc-500">
-            {t('products.detail.variants.count', {
-              count: variants.length,
-              defaultValue: '{{count}} wariantów',
-            })}
-          </p>
+        <header className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <h3 className="text-[14px] font-semibold tracking-tight">
+              {t('products.detail.variants.list_title', { defaultValue: 'Lista wariantów' })}
+            </h3>
+            <p className="num text-[11.5px] text-zinc-500">
+              {t('products.detail.variants.count', {
+                count: variants.length,
+                defaultValue: '{{count}} wariantów',
+              })}
+            </p>
+          </div>
+          {variants.length > 0 ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button type="button" variant="ghost" size="sm" onClick={expandAll}>
+                {t('products.detail.variants.expand_all', { defaultValue: 'Rozwiń wszystkie' })}
+              </Button>
+              <Button type="button" variant="ghost" size="sm" onClick={collapseAll}>
+                {t('products.detail.variants.collapse_all', { defaultValue: 'Zwiń wszystkie' })}
+              </Button>
+              <span className="mx-1 h-5 w-px bg-zinc-200" aria-hidden />
+              {isEditing ? (
+                <>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={cancelEdit}
+                    disabled={isSaving}
+                  >
+                    {t('products.detail.variants.cancel', { defaultValue: 'Anuluj' })}
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => void handleSaveAll()}
+                    disabled={isSaving}
+                  >
+                    {t('products.detail.variants.save', { defaultValue: 'Zapisz' })}
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => setIsEditing(true)}
+                  aria-pressed={isEditing}
+                >
+                  {t('products.detail.variants.edit', { defaultValue: 'Edytuj warianty' })}
+                </Button>
+              )}
+            </div>
+          ) : null}
         </header>
         {variants.length === 0 ? (
           <p className="rounded-2xl border border-dashed border-zinc-300 bg-white px-5 py-8 text-center text-[13px] text-muted-foreground">
             {t('products.detail.variants.empty_body', {
               defaultValue:
-                'Brak wariantów. Wygeneruj je z osi w sekcji poniżej lub dodaj ręcznie.',
+                'Brak wariantów. Wygeneruj je z osi w sekcji powyżej lub dodaj ręcznie.',
             })}
           </p>
         ) : (
           <div className="space-y-3">
             {variants.map((variant) => {
-              const attrs = unwrap(variant.attributesIndexed ?? {});
-              const filled = countFilled(variantAttributes, attrs);
+              const baseAttrs = unwrap(variant.attributesIndexed ?? {});
+              const filled = countFilled(variantAttributes, baseAttrs, dirtyByVariant[variant.id]);
               return (
                 <AttrGroupCard
                   key={variant.id}
                   id={`variant-${variant.id}`}
-                  title={variantTitle(variant, attrs)}
+                  title={variantTitle(variant, baseAttrs)}
                   filledCount={filled}
                   totalCount={variantAttributes.length}
                   expanded={expanded.has(variant.id)}
@@ -114,12 +263,15 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
                     <AttrRow
                       key={`${variant.id}-${attr.code}`}
                       attribute={attr}
-                      value={attrs[attr.code]}
+                      value={fieldValue(variant.id, attr.code, baseAttrs)}
                       provenance={resolveProv(attr, variant.attributesIndexed)}
                       locale={'pl' satisfies ProductLocale}
-                      isEditing={false}
-                      isLocked
-                      onChange={() => undefined}
+                      isEditing={isEditing && !attr.is_system}
+                      isLocked={attr.is_system}
+                      onChange={(next) => setVariantField(variant.id, attr.code, next)}
+                      onCopyToOthers={
+                        isEditing ? () => copyToOthers(variant.id, attr.code) : undefined
+                      }
                     />
                   ))}
                 </AttrGroupCard>
@@ -127,10 +279,6 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
             })}
           </div>
         )}
-      </div>
-
-      <div className="rounded-2xl border border-zinc-100 bg-zinc-50/40 p-1">
-        <VariantsTab masterProductId={productId} />
       </div>
     </div>
   );
@@ -148,10 +296,14 @@ function unwrap(raw: Record<string, unknown>): Record<string, unknown> {
   return out;
 }
 
-function countFilled(attrs: AttributeMeta[], values: Record<string, unknown>): number {
+function countFilled(
+  attrs: AttributeMeta[],
+  base: Record<string, unknown>,
+  dirty: Record<string, unknown> | undefined,
+): number {
   let n = 0;
   for (const a of attrs) {
-    const v = values[a.code];
+    const v = dirty !== undefined && Object.hasOwn(dirty, a.code) ? dirty[a.code] : base[a.code];
     if (v === undefined || v === null) continue;
     if (typeof v === 'string' && v.trim() === '') continue;
     n += 1;

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -669,7 +669,17 @@
       "variants": {
         "list_title": "Variants list",
         "count": "{{count}} variants",
-        "empty_body": "No variants. Generate from axes below or add manually."
+        "empty_body": "No variants. Generate from axes above or add manually.",
+        "expand_all": "Expand all",
+        "collapse_all": "Collapse all",
+        "edit": "Edit variants",
+        "save": "Save",
+        "cancel": "Cancel",
+        "save.success": "Variants saved",
+        "save.partial": "Saved {{ok}}/{{total}}. Errors: {{skus}}",
+        "copy_to_others": "Copy to other variants · Source: {{provenance}}",
+        "copy_to_others_aria": "Copy {{label}} to other variants",
+        "copy_to_others.success": "Copied to {{count}} variants"
       }
     }
   },

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -671,7 +671,17 @@
       "variants": {
         "list_title": "Lista wariantów",
         "count": "{{count}} wariantów",
-        "empty_body": "Brak wariantów. Wygeneruj je z osi w sekcji poniżej lub dodaj ręcznie."
+        "empty_body": "Brak wariantów. Wygeneruj je z osi w sekcji powyżej lub dodaj ręcznie.",
+        "expand_all": "Rozwiń wszystkie",
+        "collapse_all": "Zwiń wszystkie",
+        "edit": "Edytuj warianty",
+        "save": "Zapisz",
+        "cancel": "Anuluj",
+        "save.success": "Zapisano warianty",
+        "save.partial": "Zapisano {{ok}}/{{total}}. Błędy: {{skus}}",
+        "copy_to_others": "Kopiuj do innych wariantów · Source: {{provenance}}",
+        "copy_to_others_aria": "Kopiuj wartość {{label}} do innych wariantów",
+        "copy_to_others.success": "Skopiowano do {{count}} wariantów"
       }
     }
   },

--- a/apps/api/src/Catalog/Presentation/Controller/GenerateVariantsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/GenerateVariantsController.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace App\Catalog\Presentation\Controller;
 
+use App\Catalog\Application\ObjectAttributesUpserter;
+use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -39,10 +45,17 @@ use Symfony\Component\Uid\Uuid;
  * collisions are skipped (counted but not persisted) — re-running the
  * endpoint after a partial failure is idempotent.
  *
- * Out of MVP slice (Faza 1+): variant-level value seeding (price /
- * stock), axes editor PATCH, master-with-variants delete protection,
- * `Attribute.level=master|variant` enum, `VariantValueResolver`
- * inheritance service.
+ * Each generated variant inherits master attribute values 1:1 with
+ * `Provenance::Manual` (via direct copy of `ObjectValue` rows that
+ * preserves `channel_id` + `locale` scope) and stamps the axis values
+ * (e.g. `color=red`, `size=S`) on top through `ObjectAttributesUpserter`.
+ * The axes editor (#308) ensures axis codes resolve to registered
+ * `Attribute`s — unknown codes return 400 to fail fast.
+ *
+ * Out of MVP slice (Faza 1+): axes editor PATCH, master-with-variants
+ * delete protection, `Attribute.level=master|variant` enum,
+ * `VariantValueResolver` inheritance service (replaces direct copy with
+ * reactive `inherited` provenance — schema change required).
  */
 final class GenerateVariantsController
 {
@@ -50,6 +63,9 @@ final class GenerateVariantsController
 
     public function __construct(
         private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly ObjectValueRepositoryInterface $values,
+        private readonly AttributeRepositoryInterface $attributes,
+        private readonly ObjectAttributesUpserter $upserter,
         private readonly TenantContext $tenantContext,
     ) {
     }
@@ -104,6 +120,19 @@ final class GenerateVariantsController
 
         $skuTemplate = $body['sku_template'] ?? null;
 
+        // Fail fast: every axis code must resolve to a registered Attribute on
+        // this tenant's schema, otherwise the generated variants would silently
+        // miss their axis ObjectValue stamp on save below.
+        foreach (array_keys($axes) as $axisCode) {
+            $axisAttribute = $this->attributes->findByCode($axisCode, $tenant);
+            if (!$axisAttribute instanceof Attribute) {
+                throw new BadRequestHttpException(\sprintf(
+                    'Axis code "%s" is not a registered attribute on this object type.',
+                    $axisCode,
+                ));
+            }
+        }
+
         $combinations = $this->cartesianProduct($axes);
 
         $created = [];
@@ -118,6 +147,28 @@ final class GenerateVariantsController
             $variant = new CatalogObject($master->getObjectType(), $sku);
             $variant->assignParent($master);
             $this->objects->save($variant);
+
+            // 1. Direct-copy each ObjectValue from master so the variant inherits
+            //    name/brand/description/etc. with the same channel + locale scope.
+            //    Provenance resets to Manual — variant is a fresh canonical write,
+            //    not an inherited import/agent value (mirrors DuplicateProductController).
+            foreach ($this->values->findByObject($master) as $masterValue) {
+                $cloned = new ObjectValue(
+                    object: $variant,
+                    attribute: $masterValue->getAttribute(),
+                    value: $masterValue->getValue(),
+                    provenance: Provenance::Manual,
+                );
+                $cloned->changeChannelId($masterValue->getChannelId());
+                $cloned->changeLocale($masterValue->getLocale());
+                $this->values->save($cloned);
+            }
+
+            // 2. Stamp axis values (color=red, size=S) — overrides whatever the
+            //    master had on those axis attributes. Order matters: copy first,
+            //    upsert axes second so axes win.
+            $this->upserter->upsert($variant, $combination, Provenance::Manual);
+
             $created[] = ['sku' => $sku, 'axis_values' => $combination];
         }
 

--- a/apps/api/tests/Api/Catalog/GenerateVariantsApiTest.php
+++ b/apps/api/tests/Api/Catalog/GenerateVariantsApiTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * VIEW-07.3 (#432) — coverage for `POST /api/products/{id}/generate-variants`
+ * after master attribute inheritance + axis stamping landed on top of the
+ * UI-02.6 (#296) endpoint shape.
+ *
+ * Asserts:
+ *   - Variant created with master's attribute values cloned as ObjectValue
+ *     rows (Provenance::Manual) plus axis values stamped on top.
+ *   - Unknown axis code (no Attribute on the schema) returns 400 fail-fast.
+ *   - SKU collisions on a re-run are reported via skipped_existing without
+ *     duplicating ObjectValue rows.
+ */
+final class GenerateVariantsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function postGenerateVariantsInheritsMasterAttributesAndStampsAxisValues(): void
+    {
+        $this->seedAttribute('brand', AttributeType::Text);
+        $this->seedAttribute('color', AttributeType::Text);
+        $this->seedAttribute('size', AttributeType::Text);
+
+        $client = $this->authenticatedClient();
+
+        $master = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'VAR-MASTER-1',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+                'attributes' => ['brand' => 'Acme'],
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        $masterId = $master['id'] ?? null;
+        \assert(\is_string($masterId));
+
+        $response = $client->request('POST', '/api/products/'.$masterId.'/generate-variants', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'axes' => [
+                    'color' => ['red', 'blue'],
+                    'size' => ['S'],
+                ],
+                'sku_template' => '{master_sku}-{color}-{size}',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+        $body = $response->toArray();
+        self::assertSame(2, $body['created_count'] ?? null);
+        self::assertSame(0, $body['skipped_count'] ?? null);
+
+        $createdSkus = array_map(static fn (array $row): string => (string) $row['sku'], (array) $body['created']);
+        self::assertContains('VAR-MASTER-1-red-S', $createdSkus);
+        self::assertContains('VAR-MASTER-1-blue-S', $createdSkus);
+
+        // Inspect one variant: brand inherited + color/size stamped, all manual.
+        $variant = $this->reloadObject('VAR-MASTER-1-red-S');
+        $values = self::getContainer()->get(ObjectValueRepositoryInterface::class)
+            ->findByObject($variant);
+
+        $byCode = [];
+        foreach ($values as $value) {
+            $byCode[$value->getAttribute()->getCode()] = $value;
+        }
+
+        self::assertArrayHasKey('brand', $byCode, 'Brand must be inherited from master.');
+        self::assertSame(['value' => 'Acme'], $byCode['brand']->getValue());
+        self::assertSame(Provenance::Manual, $byCode['brand']->getProvenance());
+
+        self::assertArrayHasKey('color', $byCode, 'Color axis must be stamped on the variant.');
+        self::assertSame(['value' => 'red'], $byCode['color']->getValue());
+        self::assertSame(Provenance::Manual, $byCode['color']->getProvenance());
+
+        self::assertArrayHasKey('size', $byCode);
+        self::assertSame(['value' => 'S'], $byCode['size']->getValue());
+    }
+
+    #[Test]
+    public function postGenerateVariantsRejectsUnknownAxisCode(): void
+    {
+        // No `mystery` Attribute seeded — must fail fast before any variants exist.
+        $client = $this->authenticatedClient();
+
+        $master = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'VAR-MASTER-2',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        $masterId = $master['id'] ?? null;
+        \assert(\is_string($masterId));
+
+        $response = $client->request('POST', '/api/products/'.$masterId.'/generate-variants', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'axes' => ['mystery' => ['foo']],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    #[Test]
+    public function postGenerateVariantsSkipsExistingSkusOnRerun(): void
+    {
+        $this->seedAttribute('color', AttributeType::Text);
+        $client = $this->authenticatedClient();
+
+        $master = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'VAR-MASTER-3',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        $masterId = $master['id'] ?? null;
+        \assert(\is_string($masterId));
+
+        $payload = json_encode([
+            'axes' => ['color' => ['red']],
+            'sku_template' => '{master_sku}-{color}',
+        ], JSON_THROW_ON_ERROR);
+
+        $first = $client->request('POST', '/api/products/'.$masterId.'/generate-variants', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => $payload,
+        ])->toArray();
+        self::assertSame(1, $first['created_count'] ?? null);
+
+        $second = $client->request('POST', '/api/products/'.$masterId.'/generate-variants', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => $payload,
+        ])->toArray();
+        self::assertSame(0, $second['created_count'] ?? null);
+        self::assertSame(1, $second['skipped_count'] ?? null);
+    }
+
+    private function seedAttribute(string $code, AttributeType $type): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $context = self::getContainer()->get(TenantContext::class);
+        $context->set($tenant);
+
+        $attribute = new Attribute($code, ['en' => ucfirst($code)], $type);
+        self::getContainer()->get(AttributeRepositoryInterface::class)->save($attribute);
+    }
+
+    private function reloadObject(string $code): \App\Catalog\Domain\Entity\CatalogObject
+    {
+        $em = $this->em();
+        $em->clear();
+
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $context = self::getContainer()->get(TenantContext::class);
+        $context->set($tenant);
+
+        $object = self::getContainer()->get(CatalogObjectRepositoryInterface::class)
+            ->findByCode($code, ObjectKind::Product, $tenant);
+        \assert(null !== $object);
+
+        return $object;
+    }
+}


### PR DESCRIPTION
## Podsumowanie

VIEW-07.3 — sześć ulepszeń zakładki **Warianty** w szczegółach produktu (#432). Po manualnym smoke teście VIEW-07 operator zgłosił, że zakładka jest niedokończona (warianty puste, edycja nie działa, generator pod listą, badge zajmuje miejsce na akcję). Ten PR domyka cały scope.

### Backend
- `GenerateVariantsController`:
  - inject `ObjectValueRepositoryInterface`, `AttributeRepositoryInterface`, `ObjectAttributesUpserter`,
  - **walidacja osi** — nieznany kod osi → 400 (fail-fast zamiast silent drop axis value),
  - **kopia atrybutów mastera** 1:1 jako `ObjectValue` (Provenance::Manual, channel/locale zachowane — pattern z `DuplicateProductController`),
  - **stamp wartości osi** (np. `color=red, size=S`) przez `ObjectAttributesUpserter` — kolejność: copy → upsert (axes wygrywają),
  - aktualizacja docblock — usunięcie `variant-level value seeding` z out-of-MVP listy.
- Nowy `GenerateVariantsApiTest` (3 cases): seeds attributes + axes / rejects unknown axis / skips existing.

### Frontend
- `VariantsTab` — `buildDefaultSkuTemplate(axes)` jako live placeholder + computed default sent na submit (gdy pole puste); prop `onGenerated` wywoływany po sukcesie POST.
- `AttrRow` — nowy prop `onCopyToOthers?: () => void`. Gdy podany, RHS slot renderuje ikonę Copy z tooltipem zawierającym provenance (signal preserved pod Fazę 2). Master strona przekazuje undefined → fallback do `ProvenanceBadge` (zero regresji).
- `VariantsTabHost` — pełny rewrite: generator NAD listą, default zwinięte karty, toolbar z `Rozwiń wszystkie / Zwiń wszystkie / Edytuj warianty / Anuluj / Zapisz`, edit mode (per-variant `dirtyByVariant`), `Promise.allSettled` save + per-failed-SKU error toast (lekcja UI-02 #341), `reloadKey` mechanism do refetch'a po Generate/Save, handler `copyToOthers` propagujący wartość do dirty pozostałych wariantów.
- i18n keys (`products.detail.variants.*`) w `pl.json` + `en.json` synced.

### Testy
- PHPUnit `GenerateVariantsApiTest` — 3/3 zielone (17 assertions).
- PHPStan max — 0 errors na zmienionych plikach.
- Biome strict — 0 errors (1 warning `useExhaustiveDependencies` zsupresowany świadomie — `reloadKey` jest intencjonalnym triggerem refetch'a).
- Vite build — zielony.
- Playwright `view-07-3-products-variants.spec.ts` — happy path + walidacja 400. CI marked `fixme` z powodu auth rate-limitera (5/15min) zgodnie z konwencją VIEW-07.

### Świadome decyzje (poza zakresem)
- Reaktywne dziedziczenie wartości master → wariant (`VariantValueResolver` z `provenance=inherited`) — Faza 2, wymaga zmiany schemy. Obecnie 1:1 copy z `Provenance::Manual`.
- Audit log dla `generate-variants` — wymaga audit endpointu (nie istnieje w MVP).
- Per-channel + per-locale value override w wariancie (UI nie eksponuje, backend zachowuje scope mastera).

## Test plan

- [ ] Zaloguj `admin@demo.localhost / changeme` → otwórz dowolny produkt (najlepiej z wypełnionym `brand`) → tab `Warianty`.
- [ ] Generator widoczny **nad** listą wariantów (punkt 6).
- [ ] Dodaj oś `color`, wartości `red, blue` → SKU template ma placeholder `{master_sku}-{color}` (punkt 2). Dodaj oś `size`, `S, M` → placeholder `{master_sku}-{color}-{size}`.
- [ ] Klik `Generate variants` → DevTools Network: POST `/generate-variants` 201, response `{created_count: 4}`.
- [ ] Po refresh listy: każdy wariant ma `attributesIndexed` zawierające atrybuty mastera (np. `brand`) + ustawione osie (`color=red, size=S`). (punkt 1)
- [ ] Wszystkie 4 warianty są **zwinięte** domyślnie (punkt 5). Klik `Rozwiń wszystkie` → rozwija; `Zwiń wszystkie` → zwija.
- [ ] Klik `Edytuj warianty` → atrybuty stają się inputami; ikona Copy zamiast badge `RĘCZNIE` (punkt 4).
- [ ] Tooltip ikony Copy: `Kopiuj do innych wariantów · Source: Manual`.
- [ ] Zmień `name` w 1. wariancie → klik Copy obok `name` → `name` w pozostałych 3 wariantach pokazuje skopiowaną wartość (dirty); toast `Skopiowano do 3 wariantów`.
- [ ] Klik `Zapisz` → 4× PATCH `/api/products/{variantId}` 200; toast `Zapisano warianty`; po refresh strony wartości persystowane. (punkt 3)
- [ ] Klik `Edytuj warianty` → zmień coś → `Anuluj` → wartości wracają do oryginału.
- [ ] Walidacja 400: dodaj oś `mystery_axis_xyz` (nieistniejąca jako Attribute) → Generate → DevTools 400; toast error.
- [ ] Console: brak czerwonych errorów.

Closes #432