### PR TITLE
fix(modeling): restore /objects/:code placeholder + AuditLog w wizardzie

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -24,6 +24,7 @@ import { ModelingLayout } from '@/features/catalog/modeling/layout';
 import { ObjectTypesListPage } from '@/features/catalog/object-types/list';
 import { ObjectTypeWizardPage } from '@/features/catalog/object-types/new';
 import { ObjectTypeShowPage } from '@/features/catalog/object-types/show';
+import { ObjectListingPlaceholder } from '@/features/catalog/objects/placeholder';
 import { ProductCreatePage } from '@/features/catalog/products/create';
 import { ProductListPage } from '@/features/catalog/products/list';
 import { ProductShowPage } from '@/features/catalog/products/show';
@@ -176,6 +177,10 @@ function App() {
               />
               <Route path="/assets" element={<AssetsListPage />} />
               <Route path="/assets/:id" element={<AssetShowPage />} />
+              {/* VIEW-08 (#427): generic listing for custom ObjectTypes
+                  promoted to the main menu. Placeholder until B-2 ships
+                  the metadata-driven `<ObjectListingPage />`. */}
+              <Route path="/objects/:code" element={<ObjectListingPlaceholder />} />
               <Route path="/catalogs-pdf" element={<CatalogsPdfPage />} />
               <Route path="/settings" element={<SettingsLayout />}>
                 <Route index element={<SettingsIndex />} />

--- a/apps/admin/src/components/modeling/object-type-wizard.tsx
+++ b/apps/admin/src/components/modeling/object-type-wizard.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
 
 import { AddAttributesToObjectTypeDialog } from '@/components/modeling/add-attributes-to-object-type-dialog';
+import { AuditLogIndicator } from '@/components/modeling/audit-log-indicator';
 import { ColorPicker, DEFAULT_WIZARD_COLORS } from '@/components/modeling/color-picker';
 import { CreateAttributeForObjectTypeDialog } from '@/components/modeling/create-attribute-for-object-type-dialog';
 import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inline-dialog';
@@ -274,17 +275,20 @@ export function ObjectTypeWizard() {
 
   return (
     <div>
-      <Button
-        asChild
-        variant="ghost"
-        size="sm"
-        className="-ml-3 mb-4 gap-1.5 text-[12.5px] font-medium text-zinc-500 hover:text-zinc-900"
-      >
-        <Link to="/modeling/object-types">
-          <ArrowLeft className="size-3.5" />
-          {t('object_types.back_to_list', { defaultValue: 'Wstecz do listy Object Types' })}
-        </Link>
-      </Button>
+      <div className="mb-4 flex items-center justify-between">
+        <Button
+          asChild
+          variant="ghost"
+          size="sm"
+          className="-ml-3 gap-1.5 text-[12.5px] font-medium text-zinc-500 hover:text-zinc-900"
+        >
+          <Link to="/modeling/object-types">
+            <ArrowLeft className="size-3.5" />
+            {t('object_types.back_to_list', { defaultValue: 'Wstecz do listy Object Types' })}
+          </Link>
+        </Button>
+        <AuditLogIndicator />
+      </div>
 
       <header className="mb-6 flex items-start justify-between gap-6">
         <div className="flex-1">

--- a/apps/admin/src/features/catalog/objects/placeholder.tsx
+++ b/apps/admin/src/features/catalog/objects/placeholder.tsx
@@ -1,0 +1,55 @@
+import { Construction } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+
+/**
+ * VIEW-08 (#427) — placeholder for object_type listings reachable via
+ * `/objects/:code` after operator promotes a custom ObjectType to the
+ * main menu via `/settings/menu`. The full generic listing ships in the
+ * follow-up B-2 ticket (`<ObjectListingPage />` driven by ObjectType
+ * `listing_config`); until then we render a Construction card so the
+ * sidebar entry doesn't 404 → fallback to /dashboard.
+ */
+export function ObjectListingPlaceholder() {
+  const { t } = useTranslation();
+  const params = useParams<{ code: string }>();
+  const code = params.code ?? '';
+
+  return (
+    <div className="flex min-h-[420px] flex-col items-center justify-center gap-4 rounded-lg border border-dashed bg-background p-8 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-accent-violet/10 text-accent-violet">
+        <Construction className="size-6" />
+      </div>
+      <div className="space-y-1">
+        <h2 className="display text-xl font-semibold tracking-tight">
+          {t('objects.placeholder.title', {
+            defaultValue: 'Widok „{{code}}" w przygotowaniu',
+            code,
+          })}
+        </h2>
+        <p className="max-w-md text-sm text-muted-foreground">
+          {t('objects.placeholder.description', {
+            defaultValue:
+              'Generyczna strona listingu dla custom ObjectType jest planowana w follow-upie VIEW-08 B-2. Na razie pozycję możesz ukryć z menu przez Ustawienia → Menu.',
+          })}
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Button asChild variant="outline" size="sm">
+          <Link to="/settings/menu">
+            {t('objects.placeholder.manage_menu', {
+              defaultValue: 'Zarządzaj menu',
+            })}
+          </Link>
+        </Button>
+        <Button asChild variant="ghost" size="sm">
+          <Link to="/dashboard">
+            {t('settings.placeholder.back', { defaultValue: 'Wróć do pulpitu' })}
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Podsumowanie

Dwie poprawki zgłoszone przez operatora po smoke teście main po VIEW-08:

1. **Regresja placeholder** — w VIEW-08 (#427) operator promował custom ObjectType (np. `Usługi`) do menu głównego. Dla nie-built-in entries effective-menu controller routuje do `/objects/{code}`, ale React Router na main nie ma tej trasy, więc klik spada do `*` → `/dashboard`. PR #431 (`feat/object-listing-placeholder`) miał to naprawić ale jest **OPEN**, nie zmergeowany. Cherry-pickuję commit `d6c5c21` (placeholder + route w `App.tsx`) — gdy #431 zostanie zmergeowany jako odrębny PR będzie to no-op (możemy ten jego zamknąć, albo ten zamknie operator).
2. **Brakujący `AuditLogIndicator`** w wizardzie `/modeling/object-types/new`. W edycji custom ObjectType (`/modeling/object-types/:id`) prawy górny róg ma przycisk `Audit log` (z `MockBadge`). Wizard tego nie miał — dodaję go obok back-buttona w tym samym layoucie co `show.tsx`.

## Zmiany

- `apps/admin/src/App.tsx` — route `/objects/:code` → `<ObjectListingPlaceholder />` (cherry-pick #431).
- `apps/admin/src/features/catalog/objects/placeholder.tsx` — komponent placeholder (cherry-pick #431).
- `apps/admin/src/components/modeling/object-type-wizard.tsx` — wrap back-buttona w flex container z `<AuditLogIndicator />` po prawej, importowany z `@/components/modeling/audit-log-indicator`.

## Test plan

- [ ] Login → `Ustawienia → Ustawienia Menu` → promuj custom ObjectType (np. `Usługi`) do widocznego menu → klik w sidebar `Usługi` → ląduje na `/objects/uslugi` z placeholderem `View in progress`, NIE na `/dashboard`.
- [ ] `/modeling/object-types/new` → header ma `Wstecz do listy Object Types` po lewej + `Audit log` (MockBadge) po prawej, identyczny layout jak w `/modeling/object-types/:id` show.tsx.
- [ ] Click na `Audit log` przycisk: disabled, kursor `not-allowed`, tooltip `MOCK · Audit log wymaga endpointu BE`.
- [ ] Reszta wizard'u (steps, tworzenie ObjectType, walidacje) bez regresji.