### PR TITLE
feat(modeling): wizard — Udostępnij do głównego menu toggle (step Settings)

### DIFF
--- a/apps/admin/src/components/modeling/object-type-wizard.tsx
+++ b/apps/admin/src/components/modeling/object-type-wizard.tsx
@@ -84,6 +84,7 @@ export function ObjectTypeWizard() {
   const [hierarchical, setHierarchical] = useState(false);
   const [hasVariants, setHasVariants] = useState(false);
   const [abstractFlag, setAbstractFlag] = useState(false);
+  const [exposeToMainMenu, setExposeToMainMenu] = useState(false);
   const [pickedGroupIds, setPickedGroupIds] = useState<Set<string>>(new Set());
   const [pickedAttributeIds, setPickedAttributeIds] = useState<Set<string>>(new Set());
   const [declareGroupOpen, setDeclareGroupOpen] = useState(false);
@@ -228,6 +229,22 @@ export function ObjectTypeWizard() {
         }
       }
 
+      // VIEW-08 follow-up — POST /api/object_types nie obsługuje
+      // exposeToMainMenu w body, więc gdy operator włączył toggle w
+      // step 3, dosyłamy PATCH zaraz po stworzeniu.
+      let exposeFailed = false;
+      if (exposeToMainMenu) {
+        try {
+          await jsonFetch(`/api/object_types/${created.id}`, {
+            method: 'PATCH',
+            contentType: 'application/merge-patch+json',
+            body: { exposeToMainMenu: true },
+          });
+        } catch {
+          exposeFailed = true;
+        }
+      }
+
       const issues: string[] = [];
       if (failedGroups.length > 0) {
         issues.push(
@@ -242,6 +259,14 @@ export function ObjectTypeWizard() {
           t('object_type_wizard.attach_attrs_partial_error', {
             defaultValue: '{{count}} atrybutów nie zostało dołączonych',
             count: failedAttrs,
+          }),
+        );
+      }
+      if (exposeFailed) {
+        issues.push(
+          t('object_type_wizard.expose_menu_failed', {
+            defaultValue:
+              'Nie udało się włączyć „Udostępnij do głównego menu" — ustaw ręcznie w detalu',
           }),
         );
       }
@@ -640,6 +665,38 @@ export function ObjectTypeWizard() {
                   checked={abstractFlag}
                   onChange={setAbstractFlag}
                 />
+                {/* VIEW-08 (#427) — main menu candidacy. Mirrors show.tsx
+                    so operator can promote the new ObjectType in the
+                    same step instead of doing a separate PATCH later. */}
+                <div className="border-t border-zinc-100 pt-5">
+                  <SettingToggleRow
+                    label={t('object_types.setting_expose_menu_label', {
+                      defaultValue: 'Udostępnij do głównego menu',
+                    })}
+                    description={t('object_types.setting_expose_menu_desc', {
+                      defaultValue:
+                        'Po włączeniu ten ObjectType pojawi się jako dostępna pozycja w Ustawieniach → Menu. Tam zdecydujesz, czy ostatecznie pojawi się w głównym menu i w jakiej kolejności.',
+                    })}
+                    checked={exposeToMainMenu}
+                    onChange={setExposeToMainMenu}
+                  />
+                  {exposeToMainMenu ? (
+                    <div className="mt-2 text-[11.5px] text-zinc-500">
+                      {t('object_types.setting_expose_menu_link_prefix', {
+                        defaultValue: 'Zarządzaj kolejnością i widocznością w',
+                      })}{' '}
+                      <Link
+                        to="/settings/menu"
+                        className="text-accent-violet underline underline-offset-2 hover:text-accent-violet/80"
+                      >
+                        {t('object_types.setting_expose_menu_link', {
+                          defaultValue: 'Ustawienia → Menu',
+                        })}
+                      </Link>
+                      .
+                    </div>
+                  ) : null}
+                </div>
               </>
             ) : null}
             {step === 4 ? (


### PR DESCRIPTION
## Podsumowanie

W show.tsx custom ObjectType (`/modeling/object-types/:id`) jest sekcja Settings z toggle **Udostępnij do głównego menu** + opisem + linkiem do `Ustawienia → Menu`. Wizard `/modeling/object-types/new` nie miał tego toggle — operator musiał najpierw utworzyć ObjectType, potem otworzyć detal i tam włączyć.

Ten PR dodaje 1:1 kopię toggle do step **Settings** wizard'u.

## Implementacja

- Nowy state `exposeToMainMenu` (default false).
- `<SettingToggleRow>` z identycznymi kluczami i18n (`object_types.setting_expose_menu_*`) — dziedziczy istniejące tłumaczenia z show.tsx.
- Gdy włączony → render conditional `<Link to=\"/settings/menu\">Ustawienia → Menu</Link>` (jak w show.tsx).
- POST `/api/object_types` body schema nie obsługuje `exposeToMainMenu`, więc po `created.id` dosyłam `PATCH /api/object_types/{id}` z `{ exposeToMainMenu: true }`.
- Błąd PATCH → wpisany do tej samej `attach_partial_prefix` banner-listy co failed groups/attrs (operator nie traci kontekstu).

Backend bez zmian — `ObjectTypeService::update()` (linia 172) już wspiera ten field przez PATCH.

## Test plan

- [ ] `/modeling/object-types/new` → step 3 (Ustawienia) → toggle **Udostępnij do głównego menu** widoczny pod **Is abstract** z separatorem (border-t).
- [ ] Włącz toggle → pojawia się tekst `Zarządzaj kolejnością i widocznością w Ustawienia → Menu` z linkiem (analog do show.tsx).
- [ ] Klik linka → ląduje na `/settings/menu`.
- [ ] Submit z toggle on → DevTools Network: POST `/api/object_types` 201, potem PATCH `/api/object_types/{id}` 200 z body `{ exposeToMainMenu: true }`.
- [ ] Po nawigacji do detalu nowego typu — toggle w show.tsx już jest on (potwierdza persistencję).
- [ ] `/settings/menu` → nowy typ pojawia się w sekcji `Dostępne (ukryte)` (zgodnie z opisem toggle).
- [ ] Submit z toggle off → tylko POST, brak PATCH.