### PR TITLE
fix(catalog): transliterate Polish chars in generated variant SKUs

### DIFF
--- a/apps/api/src/Catalog/Presentation/Controller/GenerateVariantsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/GenerateVariantsController.php
@@ -220,16 +220,45 @@ final class GenerateVariantsController
     private function renderSku(string $masterSku, array $combination, ?string $template): string
     {
         if (null === $template) {
-            $parts = array_map(static fn ($v): string => strtoupper((string) $v), array_values($combination));
+            $parts = array_map(
+                fn ($v): string => strtoupper($this->slugifyAxisValue((string) $v)),
+                array_values($combination),
+            );
 
             return $masterSku.'-'.implode('-', $parts);
         }
 
         $rendered = str_replace('{master_sku}', $masterSku, $template);
         foreach ($combination as $axis => $value) {
-            $rendered = str_replace('{'.$axis.'}', (string) $value, $rendered);
+            $rendered = str_replace('{'.$axis.'}', $this->slugifyAxisValue((string) $value), $rendered);
         }
 
         return $rendered;
+    }
+
+    /**
+     * Strip diacritics from an axis value before stamping it into a SKU.
+     * Polish characters are mapped 1:1; anything else falls back to iconv
+     * `ASCII//TRANSLIT` and a final regex purge of leftover non-ASCII to
+     * keep SKUs URL-safe and grep-friendly. Empty / unmappable values
+     * collapse to an empty string — the caller's `-` joiner still keeps
+     * the SKU shape parseable.
+     */
+    private function slugifyAxisValue(string $value): string
+    {
+        $polish = [
+            'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n',
+            'ó' => 'o', 'ś' => 's', 'ź' => 'z', 'ż' => 'z',
+            'Ą' => 'A', 'Ć' => 'C', 'Ę' => 'E', 'Ł' => 'L', 'Ń' => 'N',
+            'Ó' => 'O', 'Ś' => 'S', 'Ź' => 'Z', 'Ż' => 'Z',
+        ];
+        $mapped = strtr($value, $polish);
+
+        $transliterated = @iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $mapped);
+        if (false === $transliterated) {
+            $transliterated = $mapped;
+        }
+
+        return (string) preg_replace('/[^A-Za-z0-9_-]/', '', $transliterated);
     }
 }

--- a/apps/api/tests/Api/Catalog/GenerateVariantsApiTest.php
+++ b/apps/api/tests/Api/Catalog/GenerateVariantsApiTest.php
@@ -157,6 +157,63 @@ final class GenerateVariantsApiTest extends CatalogApiTestCase
         self::assertSame(1, $second['skipped_count'] ?? null);
     }
 
+    #[Test]
+    public function postGenerateVariantsTransliteratesPolishCharsInSku(): void
+    {
+        $this->seedAttribute('color', AttributeType::Text);
+        $client = $this->authenticatedClient();
+
+        $master = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'VAR-PL-1',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        $masterId = $master['id'] ?? null;
+        \assert(\is_string($masterId));
+
+        // Default template (no sku_template) — diacritics in axis values
+        // must collapse to ASCII so the SKU stays URL-safe.
+        $defaultTemplate = $client->request(
+            'POST',
+            '/api/products/'.$masterId.'/generate-variants',
+            [
+                'headers' => ['content-type' => 'application/json'],
+                'body' => json_encode([
+                    'axes' => ['color' => ['żółty', 'błękitny']],
+                ], JSON_THROW_ON_ERROR),
+            ],
+        )->toArray();
+
+        $defaultSkus = array_map(
+            static fn (array $row): string => (string) $row['sku'],
+            (array) $defaultTemplate['created'],
+        );
+        self::assertContains('VAR-PL-1-ZOLTY', $defaultSkus);
+        self::assertContains('VAR-PL-1-BLEKITNY', $defaultSkus);
+
+        // Custom template — same transliteration applies, case left intact.
+        $customTemplate = $client->request(
+            'POST',
+            '/api/products/'.$masterId.'/generate-variants',
+            [
+                'headers' => ['content-type' => 'application/json'],
+                'body' => json_encode([
+                    'axes' => ['color' => ['Łososiowy']],
+                    'sku_template' => '{master_sku}-{color}',
+                ], JSON_THROW_ON_ERROR),
+            ],
+        )->toArray();
+
+        $customSkus = array_map(
+            static fn (array $row): string => (string) $row['sku'],
+            (array) $customTemplate['created'],
+        );
+        self::assertContains('VAR-PL-1-Lososiowy', $customSkus);
+    }
+
     private function seedAttribute(string $code, AttributeType $type): void
     {
         $em = $this->em();


### PR DESCRIPTION
## Podsumowanie

Drobny fix do VIEW-07.3 (#433): generator wariantów wstawiał polskie znaki bezpośrednio do SKU, więc oś `color = żółty` produkowała SKU `MASTER-żółty-S` (problem URL-encoding'u, trudniejszy grep, kopiowanie do innych systemów).

Po fiksie — slugify per axis value:
- `żółty` → `zolty`
- `Łososiowy` → `Lososiowy`
- `błękitny` → `blekitny`

Polskie znaki (`ąćęłńóśźż` + uppercase) mapowane 1:1, dla pozostałych znaków diakrytycznych fallback do `iconv ASCII//TRANSLIT//IGNORE` + finalny regex purge non-ASCII (`[^A-Za-z0-9_-]`). Wartości axis ObjectValue na wariancie pozostają oryginalne (`żółty` dalej w atrybucie `color`) — slugify dotyczy wyłącznie SKU code'u.

## Test plan

- [ ] `/products/{id}` → tab Warianty → dodaj oś `color`, wartości `żółty, błękitny` → klik Generate → DevTools: created.sku = `MASTER-ZOLTY` + `MASTER-BLEKITNY` (default template).
- [ ] To samo z custom template `{master_sku}-{color}` → SKU = `MASTER-zolty` + `MASTER-blekitny` (case zachowany jak w template).
- [ ] Wariant w UI dalej pokazuje `color = żółty` w atrybutach (slugify nie dotyka ObjectValue).
- [ ] Regression: oś bez polskich znaków (`red, blue`) — SKU bez zmian (`MASTER-RED`, `MASTER-BLUE`).

PHPUnit: 4 cases (3 istniejące + 1 nowy `transliteratesPolishCharsInSku`) zielone, 20 assertions. PHPStan max — 0 errors.