### PR TITLE
feat(catalog): product detail — Usuń produkt menu pod 3 kropkami

### DIFF
--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -9,6 +9,7 @@ import {
   Save,
   ShoppingBag,
   Sparkles,
+  Trash2,
   Upload,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
@@ -17,6 +18,13 @@ import { Link, useNavigate } from 'react-router';
 
 import type { Provenance } from '@/components/provenance-badge';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { MockBadge } from '@/components/ui/mock-badge';
 import { toast } from '@/components/ui/toast';
@@ -102,6 +110,8 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
   const product = isEditMode ? result : null;
   const attrs = useMemo(
@@ -220,6 +230,27 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     setIsEditing(false);
   };
 
+  const handleDelete = async (): Promise<void> => {
+    if (mode !== 'edit' || id === '' || isDeleting) return;
+    setIsDeleting(true);
+    try {
+      await jsonFetch(`/api/products/${id}`, { method: 'DELETE' });
+      toast.success(
+        t('products.detail.delete.success', {
+          defaultValue: 'Usunięto produkt {{code}}',
+          code: product?.code ?? id,
+        }),
+      );
+      navigate('/products');
+    } catch {
+      toast.error(
+        t('products.detail.delete.failed', { defaultValue: 'Nie udało się usunąć produktu' }),
+      );
+      setIsDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  };
+
   if (isEditMode && (query.isLoading || product === null || product === undefined)) {
     return <p className="text-sm text-muted-foreground">{t('app.loading')}</p>;
   }
@@ -288,16 +319,41 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
             <div className="ml-auto flex items-center gap-2">
               <PreviewButton disabled={mode === 'create'} />
               {mode === 'edit' && id !== '' ? <DuplicateButton productId={id} /> : null}
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="size-9 rounded-xl bg-white soft-shadow"
-                aria-label={t('products.detail.actions.more', { defaultValue: 'Więcej' })}
-                disabled
-              >
-                <MoreHorizontal className="size-4" />
-              </Button>
+              {mode === 'edit' && id !== '' ? (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="size-9 rounded-xl bg-white soft-shadow"
+                      aria-label={t('products.detail.actions.more', { defaultValue: 'Więcej' })}
+                    >
+                      <MoreHorizontal className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-56">
+                    <DropdownMenuItem
+                      onSelect={() => setShowDeleteConfirm(true)}
+                      className="text-rose-600 focus:bg-rose-50 focus:text-rose-700"
+                    >
+                      <Trash2 className="mr-2 size-4" />
+                      {t('products.detail.actions.delete', { defaultValue: 'Usuń produkt' })}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-9 rounded-xl bg-white soft-shadow"
+                  aria-label={t('products.detail.actions.more', { defaultValue: 'Więcej' })}
+                  disabled
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              )}
               <span className="mx-1 h-6 w-px bg-zinc-200" />
               {isEditing ? (
                 <>
@@ -559,6 +615,42 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
           </aside>
         ) : null}
       </div>
+
+      <Dialog
+        open={showDeleteConfirm}
+        onOpenChange={(next) => {
+          if (!next && !isDeleting) setShowDeleteConfirm(false);
+        }}
+      >
+        <DialogContent>
+          <div className="space-y-2">
+            <DialogTitle>
+              {t('products.detail.delete.confirm_title', { defaultValue: 'Usunąć produkt?' })}
+            </DialogTitle>
+            <DialogDescription>
+              {t('products.detail.delete.confirm_body', {
+                defaultValue:
+                  'Czy na pewno chcesz usunąć produkt {{code}}? Tej operacji nie da się cofnąć.',
+                code: product?.code ?? '',
+              })}
+            </DialogDescription>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => setShowDeleteConfirm(false)}
+              disabled={isDeleting}
+            >
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button variant="destructive" onClick={() => void handleDelete()} disabled={isDeleting}>
+              {isDeleting
+                ? t('products.detail.delete.deleting', { defaultValue: 'Usuwanie…' })
+                : t('products.detail.delete.confirm_submit', { defaultValue: 'Usuń produkt' })}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -578,7 +578,16 @@
         "edit": "Edit",
         "save": "Save changes",
         "create": "Create product",
-        "cancel": "Cancel"
+        "cancel": "Cancel",
+        "delete": "Delete product"
+      },
+      "delete": {
+        "confirm_title": "Delete product?",
+        "confirm_body": "Are you sure you want to delete product {{code}}? This action cannot be undone.",
+        "confirm_submit": "Delete product",
+        "deleting": "Deleting…",
+        "success": "Deleted product {{code}}",
+        "failed": "Could not delete product"
       },
       "preview": {
         "unavailable": "Product preview — feature in progress"

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -580,7 +580,16 @@
         "edit": "Edytuj",
         "save": "Zapisz zmiany",
         "create": "Utwórz produkt",
-        "cancel": "Anuluj"
+        "cancel": "Anuluj",
+        "delete": "Usuń produkt"
+      },
+      "delete": {
+        "confirm_title": "Usunąć produkt?",
+        "confirm_body": "Czy na pewno chcesz usunąć produkt {{code}}? Tej operacji nie da się cofnąć.",
+        "confirm_submit": "Usuń produkt",
+        "deleting": "Usuwanie…",
+        "success": "Usunięto produkt {{code}}",
+        "failed": "Nie udało się usunąć produktu"
       },
       "preview": {
         "unavailable": "Podgląd produktu — funkcja w przygotowaniu"


### PR DESCRIPTION
## Podsumowanie

W headerze edycji produktu (`/products/{id}`) przycisk z trzema kropkami (MoreHorizontal) był renderowany jako disabled placeholder bez akcji. Operator zgłosił, że ma się pod nim rozwijać menu z pozycją **Usuń produkt**.

## Zmiany

- **Dropdown menu** (shadcn `DropdownMenu`) podłączone pod 3-kropki, jedna pozycja `Usuń produkt` (`Trash2` icon, czerwony hover, jak w `product-row-actions.tsx` w liście).
- **Confirm dialog** (shadcn `Dialog`) — wyskakujące okienko z tytułem `Usunąć produkt?` + treścią `Czy na pewno chcesz usunąć produkt {{code}}? Tej operacji nie da się cofnąć.` + buttony `Anuluj` / `Usuń produkt` (variant destructive).
- **Backend call** — `DELETE /api/products/{id}` (istniejący ApiResource endpoint, używany już w liście `product-row-actions.tsx`).
- **Success path** — toast `Usunięto produkt {{code}}` + `navigate('/products')`.
- **Error path** — toast `Nie udało się usunąć produktu` + dialog zamyka się; operator może spróbować ponownie z menu.
- Przycisk pozostaje disabled placeholder w trybie `create` — nie ma czego usuwać.
- i18n keys (`products.detail.actions.delete`, `products.detail.delete.*`) w pl.json + en.json synced.

## Test plan

- [ ] `/products/{id}` (tryb edycji) → klik 3-kropki → rozwija się menu z `Usuń produkt` (czerwony tekst, ikona `Trash2`).
- [ ] Klik `Usuń produkt` → otwiera się dialog z tytułem `Usunąć produkt?` + opisem `Czy na pewno chcesz usunąć produkt {{SKU}}? Tej operacji nie da się cofnąć.` + buttony `Anuluj` (ghost) / `Usuń produkt` (destructive).
- [ ] Klik `Anuluj` → dialog zamyka się, produkt nadal istnieje.
- [ ] Klik `Usuń produkt` → DevTools Network: DELETE `/api/products/{id}` 204; button pokazuje `Usuwanie…`; po sukcesie toast `Usunięto produkt {{code}}` + przekierowanie na `/products`.
- [ ] Lista produktów po przekierowaniu — usunięty produkt nieobecny.
- [ ] `/products/new` (tryb create) → 3-kropki nadal disabled (nie ma czego usuwać).
- [ ] EN locale: `/products/{id}?lng=en` (jeśli toggle języka działa) → menu `Delete product`, dialog `Delete product?` + `Are you sure you want to delete product {{code}}?`.

Typecheck + Biome (na zmienionych plikach) zielone.