### PR TITLE
feat(catalog): multimedia tab w karcie produktu + foldery w /assets (#440)

### DIFF
--- a/apps/admin/src/features/asset/assets/AssetUploadDropzone.tsx
+++ b/apps/admin/src/features/asset/assets/AssetUploadDropzone.tsx
@@ -31,9 +31,20 @@ interface UploadEntry {
 export interface AssetUploadDropzoneProps {
   onCompleted: (results: UploadAssetResult[]) => void;
   onDuplicate?: (duplicate: DuplicateAssetError, file: File) => void;
+  /**
+   * Logical folder every upload from this dropzone lands in. Forwards
+   * to `uploadAsset({ folderCode })`. `product-<UUID>` triggers
+   * auto-link on the backend so the multimedia tab shows the file
+   * immediately.
+   */
+  folderCode?: string;
 }
 
-export function AssetUploadDropzone({ onCompleted, onDuplicate }: AssetUploadDropzoneProps) {
+export function AssetUploadDropzone({
+  onCompleted,
+  onDuplicate,
+  folderCode,
+}: AssetUploadDropzoneProps) {
   const { t } = useTranslation();
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -88,6 +99,7 @@ export function AssetUploadDropzone({ onCompleted, onDuplicate }: AssetUploadDro
         try {
           const result = await uploadAsset({
             file: entry.file,
+            folderCode,
             onProgress: (percent) => {
               setEntries((prev) =>
                 prev.map((existing) =>
@@ -150,7 +162,7 @@ export function AssetUploadDropzone({ onCompleted, onDuplicate }: AssetUploadDro
         onCompleted(completed);
       }
     },
-    [onCompleted, onDuplicate, t],
+    [onCompleted, onDuplicate, folderCode, t],
   );
 
   const onDragOver = (event: React.DragEvent<HTMLDivElement>) => {

--- a/apps/admin/src/features/asset/assets/list.tsx
+++ b/apps/admin/src/features/asset/assets/list.tsx
@@ -1,9 +1,18 @@
 import { useList } from '@refinedev/core';
-import { FileText, Film, Image as ImageIcon, Loader2 } from 'lucide-react';
+import {
+  ChevronRight,
+  FileText,
+  Film,
+  Folder as FolderIcon,
+  Image as ImageIcon,
+  Loader2,
+} from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
+
 import type { DuplicateAssetError, UploadAssetResult } from '@/lib/asset-upload';
+import { jsonFetch } from '@/lib/http';
 import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 
 import { AssetBulkActionsBar } from './AssetBulkActionsBar';
@@ -16,6 +25,17 @@ interface AssetEntry {
   code: string;
   enabled?: boolean;
   attributesIndexed?: Record<string, unknown>;
+}
+
+interface FolderEntry {
+  code: string;
+  displayName: string;
+  assetCount: number;
+}
+
+interface FoldersResponse {
+  member: FolderEntry[];
+  totalItems: number;
 }
 
 interface DuplicateState {
@@ -33,6 +53,8 @@ export function AssetsListPage() {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [duplicate, setDuplicate] = useState<DuplicateState | null>(null);
   const [refreshTick, setRefreshTick] = useState(0);
+  const [currentFolder, setCurrentFolder] = useState<string | null>(null);
+  const [folders, setFolders] = useState<FolderEntry[]>([]);
 
   const setSearchSoon = useDebouncedCallback((value: string) => setDebouncedSearch(value), 300);
 
@@ -40,13 +62,41 @@ export function AssetsListPage() {
     setSearchSoon(filters.search);
   }, [filters.search, setSearchSoon]);
 
+  // Refresh folder list whenever we land on the root view or after an
+  // upload/delete (refreshTick). The endpoint is cheap (one GROUP BY).
+  useEffect(() => {
+    if (currentFolder !== null) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await jsonFetch<FoldersResponse>('/api/asset-folders', {
+          accept: 'application/json',
+        });
+        if (!cancelled) {
+          setFolders(response.member ?? []);
+        }
+      } catch {
+        if (!cancelled) {
+          setFolders([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentFolder, refreshTick]);
+
   const filterParams = useMemo(() => {
     const params: Array<{ field: string; operator: 'eq'; value: string }> = [];
+    // `folder=root` narrows to files without folder, any other value
+    // matches the literal folder code. Backend defaults to "all
+    // tenants files" when omitted — only the picker uses that.
+    params.push({ field: 'folder', operator: 'eq', value: currentFolder ?? 'root' });
     if (debouncedSearch) params.push({ field: 'search', operator: 'eq', value: debouncedSearch });
     if (filters.mimeGroup !== 'all')
       params.push({ field: 'mimeGroup', operator: 'eq', value: filters.mimeGroup });
     return params;
-  }, [debouncedSearch, filters.mimeGroup]);
+  }, [currentFolder, debouncedSearch, filters.mimeGroup]);
 
   const { result, query } = useList<AssetEntry>({
     resource: 'assets',
@@ -63,6 +113,10 @@ export function AssetsListPage() {
 
   const assets: AssetEntry[] = result?.data ?? [];
   const isLoading = query.isLoading;
+  const showFolderTiles = currentFolder === null && folders.length > 0 && !debouncedSearch;
+  const currentFolderEntry = currentFolder
+    ? folders.find((entry) => entry.code === currentFolder)
+    : null;
 
   const onCompleted = (results: UploadAssetResult[]) => {
     if (results.length > 0) {
@@ -93,6 +147,17 @@ export function AssetsListPage() {
 
   const clearSelection = () => setSelected(new Set());
 
+  const enterFolder = (code: string) => {
+    setCurrentFolder(code);
+    setSelected(new Set());
+  };
+  const goToRoot = () => {
+    setCurrentFolder(null);
+    setSelected(new Set());
+  };
+
+  const dropzoneFolderCode = currentFolder ?? undefined;
+
   return (
     <div className="space-y-6">
       <div>
@@ -100,7 +165,17 @@ export function AssetsListPage() {
         <p className="text-sm text-muted-foreground">{t('assets.list_subtitle')}</p>
       </div>
 
-      <AssetUploadDropzone onCompleted={onCompleted} onDuplicate={onDuplicate} />
+      <Breadcrumb
+        rootLabel={t('assets.folder.all')}
+        currentName={currentFolderEntry?.displayName ?? null}
+        onRoot={goToRoot}
+      />
+
+      <AssetUploadDropzone
+        onCompleted={onCompleted}
+        onDuplicate={onDuplicate}
+        folderCode={dropzoneFolderCode}
+      />
 
       <AssetFilterBar filters={filters} onChange={setFilters} />
 
@@ -113,11 +188,11 @@ export function AssetsListPage() {
         onClearSelection={clearSelection}
       />
 
-      {isLoading ? (
+      {isLoading && !showFolderTiles ? (
         <p className="rounded-xl border bg-card p-6 text-center text-sm text-muted-foreground">
           {t('app.loading')}
         </p>
-      ) : assets.length === 0 ? (
+      ) : assets.length === 0 && !showFolderTiles ? (
         <p className="rounded-xl border bg-card p-6 text-center text-sm text-muted-foreground">
           {t('assets.empty')}
         </p>
@@ -126,6 +201,11 @@ export function AssetsListPage() {
           className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6"
           aria-label={t('assets.list_title')}
         >
+          {showFolderTiles
+            ? folders.map((folder) => (
+                <FolderTile key={folder.code} folder={folder} onEnter={enterFolder} />
+              ))
+            : null}
           {assets.map((asset: AssetEntry) => (
             <AssetTile
               key={asset.id}
@@ -147,6 +227,64 @@ export function AssetsListPage() {
         />
       ) : null}
     </div>
+  );
+}
+
+interface BreadcrumbProps {
+  rootLabel: string;
+  currentName: string | null;
+  onRoot: () => void;
+}
+
+function Breadcrumb({ rootLabel, currentName, onRoot }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-muted-foreground">
+      <button
+        type="button"
+        onClick={onRoot}
+        className={`rounded px-2 py-1 transition-colors ${
+          currentName === null ? 'font-medium text-foreground' : 'hover:bg-muted'
+        }`}
+      >
+        {rootLabel}
+      </button>
+      {currentName !== null ? (
+        <>
+          <ChevronRight className="size-4" aria-hidden="true" />
+          <span className="px-2 py-1 font-medium text-foreground">{currentName}</span>
+        </>
+      ) : null}
+    </nav>
+  );
+}
+
+interface FolderTileProps {
+  folder: FolderEntry;
+  onEnter: (code: string) => void;
+}
+
+function FolderTile({ folder, onEnter }: FolderTileProps) {
+  const { t } = useTranslation();
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onEnter(folder.code)}
+        className="group relative flex w-full flex-col overflow-hidden rounded-md border bg-card text-left transition-colors hover:border-primary"
+      >
+        <div className="flex aspect-square items-center justify-center bg-muted/40">
+          <FolderIcon className="size-12 text-muted-foreground transition-colors group-hover:text-primary" />
+        </div>
+        <div className="space-y-1 p-2">
+          <p className="truncate text-xs font-medium" title={folder.displayName}>
+            {folder.displayName}
+          </p>
+          <p className="truncate text-[10px] text-muted-foreground">
+            {t('assets.folder.count', { count: folder.assetCount })}
+          </p>
+        </div>
+      </button>
+    </li>
   );
 }
 

--- a/apps/admin/src/features/catalog/products/components/asset-library-picker.tsx
+++ b/apps/admin/src/features/catalog/products/components/asset-library-picker.tsx
@@ -1,0 +1,365 @@
+import {
+  ChevronRight,
+  FileText,
+  Film,
+  Folder as FolderIcon,
+  Image as ImageIcon,
+  Search,
+} from 'lucide-react';
+import { useEffect, useId, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { jsonFetch } from '@/lib/http';
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
+
+interface AssetEntry {
+  id: string;
+  code: string;
+  attributesIndexed?: Record<string, unknown>;
+}
+
+interface AssetsResponse {
+  member: AssetEntry[];
+  totalItems: number;
+}
+
+interface FolderEntry {
+  code: string;
+  displayName: string;
+  assetCount: number;
+}
+
+interface FoldersResponse {
+  member: FolderEntry[];
+  totalItems: number;
+}
+
+export interface AssetLibraryPickerProps {
+  productId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPicked: () => void;
+}
+
+/**
+ * Full-screen modal that lets the operator browse the asset library
+ * (with the same Windows-explorer folder navigation as `/assets`)
+ * and pick one or more files to attach to a product (#440).
+ *
+ * Picked ids are POSTed to `/api/products/{id}/assets`; the backend
+ * accepts both Asset.id and CatalogObject.id (Asset_Internals
+ * resolves either into the canonical Asset.id before linking), so
+ * the grid feeds them straight from the listing payload.
+ */
+export function AssetLibraryPicker({
+  productId,
+  open,
+  onOpenChange,
+  onPicked,
+}: AssetLibraryPickerProps) {
+  const { t } = useTranslation();
+  const searchId = useId();
+
+  const [currentFolder, setCurrentFolder] = useState<string | null>(null);
+  const [folders, setFolders] = useState<FolderEntry[]>([]);
+  const [assets, setAssets] = useState<AssetEntry[]>([]);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setSearchSoon = useDebouncedCallback((value: string) => setDebouncedSearch(value), 300);
+
+  useEffect(() => {
+    setSearchSoon(search);
+  }, [search, setSearchSoon]);
+
+  // Reset state every time the modal reopens so a previous session's
+  // selection / folder does not leak in.
+  useEffect(() => {
+    if (open) {
+      setCurrentFolder(null);
+      setSelected(new Set());
+      setSearch('');
+      setDebouncedSearch('');
+      setError(null);
+    }
+  }, [open]);
+
+  // Folder list — only at root.
+  useEffect(() => {
+    if (!open || currentFolder !== null) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await jsonFetch<FoldersResponse>('/api/asset-folders', {
+          accept: 'application/json',
+        });
+        if (!cancelled) setFolders(response.member ?? []);
+      } catch {
+        if (!cancelled) setFolders([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, currentFolder]);
+
+  // Asset listing — narrowed by current folder + search.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const query: Record<string, string> = {
+      folder: currentFolder ?? 'root',
+    };
+    if (debouncedSearch) {
+      query.search = debouncedSearch;
+    }
+    void (async () => {
+      try {
+        const response = await jsonFetch<AssetsResponse>('/api/assets', {
+          accept: 'application/ld+json',
+          query,
+        });
+        if (!cancelled) setAssets(response.member ?? []);
+      } catch {
+        if (!cancelled) setAssets([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, currentFolder, debouncedSearch]);
+
+  const currentFolderEntry = useMemo(
+    () => (currentFolder ? folders.find((entry) => entry.code === currentFolder) : null),
+    [currentFolder, folders],
+  );
+  const showFolderTiles = currentFolder === null && folders.length > 0 && !debouncedSearch;
+
+  const toggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const submit = async () => {
+    if (selected.size === 0) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await jsonFetch(`/api/products/${productId}/assets`, {
+        method: 'POST',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: { assetIds: [...selected] },
+      });
+      onPicked();
+      onOpenChange(false);
+    } catch {
+      setError(t('products.multimedia.pick_error'));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[min(1100px,95vw)] max-h-[90vh] overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>{t('products.multimedia.picker_title')}</DialogTitle>
+          <DialogDescription>{t('products.multimedia.picker_body')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3" style={{ minHeight: 'min(500px, 60vh)' }}>
+          <nav
+            aria-label="Breadcrumb"
+            className="flex items-center gap-1 text-sm text-muted-foreground"
+          >
+            <button
+              type="button"
+              onClick={() => setCurrentFolder(null)}
+              className={`rounded px-2 py-1 transition-colors ${
+                currentFolder === null ? 'font-medium text-foreground' : 'hover:bg-muted'
+              }`}
+            >
+              {t('assets.folder.all')}
+            </button>
+            {currentFolderEntry !== null && currentFolderEntry !== undefined ? (
+              <>
+                <ChevronRight className="size-4" aria-hidden="true" />
+                <span className="px-2 py-1 font-medium text-foreground">
+                  {currentFolderEntry.displayName}
+                </span>
+              </>
+            ) : null}
+          </nav>
+
+          <div className="relative flex w-full max-w-md items-center">
+            <Search className="absolute left-3 size-4 text-muted-foreground" aria-hidden="true" />
+            <label htmlFor={searchId} className="sr-only">
+              {t('assets.filters.search_placeholder')}
+            </label>
+            <Input
+              id={searchId}
+              type="search"
+              placeholder={t('assets.filters.search_placeholder')}
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="pl-9"
+            />
+          </div>
+
+          <div
+            className="overflow-y-auto rounded-md border bg-card p-3"
+            style={{ maxHeight: '55vh' }}
+          >
+            {assets.length === 0 && !showFolderTiles ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                {t('products.multimedia.picker_empty')}
+              </p>
+            ) : (
+              <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+                {showFolderTiles
+                  ? folders.map((folder) => (
+                      <li key={folder.code}>
+                        <button
+                          type="button"
+                          onClick={() => setCurrentFolder(folder.code)}
+                          className="group flex w-full flex-col overflow-hidden rounded-md border bg-card text-left transition-colors hover:border-primary"
+                        >
+                          <div className="flex aspect-square items-center justify-center bg-muted/40">
+                            <FolderIcon className="size-10 text-muted-foreground transition-colors group-hover:text-primary" />
+                          </div>
+                          <div className="space-y-0.5 p-2">
+                            <p className="truncate text-xs font-medium" title={folder.displayName}>
+                              {folder.displayName}
+                            </p>
+                            <p className="truncate text-[10px] text-muted-foreground">
+                              {t('assets.folder.count', { count: folder.assetCount })}
+                            </p>
+                          </div>
+                        </button>
+                      </li>
+                    ))
+                  : null}
+                {assets.map((asset) => (
+                  <PickerAssetTile
+                    key={asset.id}
+                    asset={asset}
+                    isSelected={selected.has(asset.id)}
+                    onToggle={() => toggle(asset.id)}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {error ? (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            {t('app.cancel')}
+          </Button>
+          <Button onClick={submit} disabled={submitting || selected.size === 0}>
+            {submitting
+              ? t('app.loading')
+              : t('products.multimedia.pick_confirm', { count: selected.size })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface PickerAssetTileProps {
+  asset: AssetEntry;
+  isSelected: boolean;
+  onToggle: () => void;
+}
+
+function PickerAssetTile({ asset, isSelected, onToggle }: PickerAssetTileProps) {
+  const attrs = (asset.attributesIndexed ?? {}) as Record<string, unknown>;
+  const previewUrl = typeof attrs.previewUrl === 'string' ? attrs.previewUrl : null;
+  const mime = typeof attrs.mime === 'string' ? attrs.mime : null;
+  const filename = typeof attrs.filename === 'string' ? attrs.filename : asset.code;
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-pressed={isSelected}
+        className={`group relative flex w-full flex-col overflow-hidden rounded-md border bg-card text-left transition-colors ${
+          isSelected ? 'border-primary ring-2 ring-primary/40' : 'hover:border-primary'
+        }`}
+      >
+        <div className="aspect-square bg-muted/40">
+          {previewUrl !== null ? (
+            <img
+              src={previewUrl}
+              alt={filename}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <PickerPlaceholder mime={mime} />
+          )}
+          <span
+            className={`absolute right-2 top-2 flex size-5 items-center justify-center rounded-full border text-[10px] font-bold transition-colors ${
+              isSelected
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-muted-foreground/40 bg-background/80 text-transparent'
+            }`}
+          >
+            ✓
+          </span>
+        </div>
+        <div className="space-y-1 p-2">
+          <p className="truncate text-xs font-medium" title={filename}>
+            {filename}
+          </p>
+          <p className="truncate font-mono text-[10px] text-muted-foreground">{asset.code}</p>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function PickerPlaceholder({ mime }: { mime: string | null }) {
+  const Icon =
+    mime === null
+      ? ImageIcon
+      : mime.startsWith('image/')
+        ? ImageIcon
+        : mime.startsWith('video/')
+          ? Film
+          : FileText;
+  return (
+    <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+      <Icon className="size-8" />
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/product-asset-upload-dialog.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-asset-upload-dialog.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { AssetUploadDropzone } from '@/features/asset/assets/AssetUploadDropzone';
+
+export interface ProductAssetUploadDialogProps {
+  productId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUploaded: () => void;
+}
+
+/**
+ * Inline upload dialog inside the product multimedia tab (#440).
+ *
+ * Reuses {@link AssetUploadDropzone} but pins `folderCode` to
+ * `product-<productId>`. The backend recognises the prefix and
+ * auto-links every successful upload to the product, so no extra
+ * round-trip is needed after the dropzone reports completion.
+ */
+export function ProductAssetUploadDialog({
+  productId,
+  open,
+  onOpenChange,
+  onUploaded,
+}: ProductAssetUploadDialogProps) {
+  const { t } = useTranslation();
+  const folderCode = `product-${productId}`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t('products.multimedia.upload_dialog_title')}</DialogTitle>
+          <DialogDescription>{t('products.multimedia.upload_dialog_body')}</DialogDescription>
+        </DialogHeader>
+        <AssetUploadDropzone
+          folderCode={folderCode}
+          onCompleted={(results) => {
+            if (results.length > 0) {
+              onUploaded();
+            }
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -2,7 +2,6 @@ import { useOne } from '@refinedev/core';
 import {
   ArrowLeft,
   Clock,
-  Image as ImageIcon,
   Link2,
   MoreHorizontal,
   Pencil,
@@ -10,7 +9,6 @@ import {
   ShoppingBag,
   Sparkles,
   Trash2,
-  Upload,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -40,6 +38,7 @@ import { DuplicateButton } from './duplicate-button';
 import { EffectiveModelCard } from './effective-model-card';
 import { LocaleChannelToolbar } from './locale-channel-toolbar';
 import { PreviewButton } from './preview-button';
+import { ProductMultimediaTab } from './product-multimedia-tab';
 import { SyncStatusCard } from './sync-status-card';
 import type {
   AttributeMeta,
@@ -728,47 +727,11 @@ function resolveProvenance(
 }
 
 function OtherTabs({ activeTab, productId }: { activeTab: TabKey; productId: string }) {
-  if (activeTab === 'multimedia') return <MediaStub />;
+  if (activeTab === 'multimedia') return <ProductMultimediaTab productId={productId} />;
   if (activeTab === 'relations') return <RelationsStub />;
   if (activeTab === 'history') return <HistoryStub />;
   if (activeTab === 'variants') return <VariantsTabHost productId={productId} />;
   return null;
-}
-
-function MediaStub() {
-  return (
-    <MockBadge
-      variant="overlay"
-      tooltip="MOCK · Multimedia tab wymaga DAM (S3/MinIO + image transformations)"
-    >
-      <div className="rounded-2xl border border-line bg-surface p-6 soft-shadow">
-        <header className="flex items-center justify-between">
-          <h3 className="text-[14px] font-semibold text-ink">Multimedia</h3>
-          <Button type="button" variant="outline" size="sm" disabled>
-            <Upload className="size-4" />
-            Upload zdjęć
-          </Button>
-        </header>
-        <div className="mt-4 grid grid-cols-3 gap-3">
-          {Array.from({ length: 9 }, (_, i) => `mock-media-${i}`).map((slot) => (
-            <div
-              key={slot}
-              className="aspect-square rounded-xl bg-surface-2 ring-1 ring-inset ring-line"
-              aria-hidden
-            >
-              <div className="flex size-full items-center justify-center text-muted-foreground/60">
-                <ImageIcon className="size-6" />
-              </div>
-            </div>
-          ))}
-        </div>
-        <p className="mt-3 text-[11px] text-muted-foreground">
-          Backlog:{' '}
-          <code className="font-mono text-[10px]">POST /api/products/&#123;id&#125;/media</code>
-        </p>
-      </div>
-    </MockBadge>
-  );
 }
 
 function RelationsStub() {

--- a/apps/admin/src/features/catalog/products/components/product-multimedia-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-multimedia-tab.tsx
@@ -1,0 +1,205 @@
+import {
+  FileText,
+  Film,
+  Image as ImageIcon,
+  Library as LibraryIcon,
+  Trash2,
+  Upload,
+} from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { jsonFetch } from '@/lib/http';
+
+import { AssetLibraryPicker } from './asset-library-picker';
+import { ProductAssetUploadDialog } from './product-asset-upload-dialog';
+
+interface ProductAsset {
+  id: string;
+  code: string;
+  originalFilename: string;
+  mimeType: string;
+  size: number;
+  thumbnailsStatus: 'pending' | 'ready' | 'failed';
+  previewUrl: string;
+  folderCode: string | null;
+}
+
+interface ProductAssetsResponse {
+  member: ProductAsset[];
+  totalItems: number;
+}
+
+export interface ProductMultimediaTabProps {
+  productId: string;
+}
+
+/**
+ * Multimedia tab on the product detail page (#440).
+ *
+ * Renders the grid of assets linked to the product via `product_assets`
+ * m2m, plus two CTAs:
+ *   - "Wgraj pliki"      — drops opens an upload dialog. The dialog
+ *     forces `folderCode='product-<id>'` so the backend auto-links
+ *     the new asset to the product.
+ *   - "Wybierz z biblioteki" — opens a full-screen picker over the
+ *     library. Selected ids are POSTed to `/api/products/{id}/assets`
+ *     for m2m link.
+ *
+ * Per-asset "Odepnij" removes the m2m row only — the file stays in
+ * the library so other products can keep using it.
+ */
+export function ProductMultimediaTab({ productId }: ProductMultimediaTabProps) {
+  const { t } = useTranslation();
+  const [assets, setAssets] = useState<ProductAsset[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const fetchAssets = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await jsonFetch<ProductAssetsResponse>(`/api/products/${productId}/assets`, {
+        accept: 'application/json',
+      });
+      setAssets(response.member ?? []);
+    } catch {
+      setAssets([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [productId]);
+
+  useEffect(() => {
+    void fetchAssets();
+  }, [fetchAssets]);
+
+  const handleUnlink = async (assetId: string) => {
+    try {
+      await jsonFetch(`/api/products/${productId}/assets/${assetId}`, {
+        method: 'DELETE',
+        accept: 'application/json',
+      });
+      await fetchAssets();
+    } catch {
+      // Surface errors via a toast in a follow-up; silent retry is OK
+      // for now since unlink is idempotent.
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-line bg-surface p-6 soft-shadow">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-[14px] font-semibold text-ink">{t('products.multimedia.title')}</h3>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setPickerOpen(true)}
+            aria-label={t('products.multimedia.pick_from_library')}
+          >
+            <LibraryIcon className="size-4" />
+            {t('products.multimedia.pick_from_library')}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => setUploadOpen(true)}
+            aria-label={t('products.multimedia.upload')}
+          >
+            <Upload className="size-4" />
+            {t('products.multimedia.upload')}
+          </Button>
+        </div>
+      </header>
+
+      <div className="mt-4">
+        {isLoading ? (
+          <p className="rounded-md border bg-card p-6 text-center text-sm text-muted-foreground">
+            {t('app.loading')}
+          </p>
+        ) : assets.length === 0 ? (
+          <p className="rounded-md border bg-card p-6 text-center text-sm text-muted-foreground">
+            {t('products.multimedia.empty')}
+          </p>
+        ) : (
+          <ul
+            className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+            aria-label={t('products.multimedia.title')}
+          >
+            {assets.map((asset) => (
+              <ProductAssetTile
+                key={asset.id}
+                asset={asset}
+                onUnlink={() => void handleUnlink(asset.id)}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ProductAssetUploadDialog
+        productId={productId}
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        onUploaded={() => {
+          void fetchAssets();
+        }}
+      />
+
+      <AssetLibraryPicker
+        productId={productId}
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        onPicked={() => {
+          void fetchAssets();
+        }}
+      />
+    </div>
+  );
+}
+
+interface ProductAssetTileProps {
+  asset: ProductAsset;
+  onUnlink: () => void;
+}
+
+function ProductAssetTile({ asset, onUnlink }: ProductAssetTileProps) {
+  const { t } = useTranslation();
+  return (
+    <li className="group relative overflow-hidden rounded-md border bg-card">
+      <div className="aspect-square bg-muted/40">
+        <img
+          src={asset.previewUrl}
+          alt={asset.originalFilename}
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+      </div>
+      <div className="space-y-1 p-2">
+        <p className="truncate text-xs font-medium" title={asset.originalFilename}>
+          {asset.originalFilename}
+        </p>
+        <p className="truncate font-mono text-[10px] text-muted-foreground">{asset.code}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onUnlink}
+        aria-label={t('products.multimedia.unlink')}
+        title={t('products.multimedia.unlink')}
+        className="absolute right-2 top-2 hidden rounded-full bg-background/90 p-1 text-muted-foreground shadow-sm transition-colors hover:text-destructive group-hover:flex"
+      >
+        <Trash2 className="size-3.5" />
+      </button>
+      <span className="sr-only">{`${asset.mimeType} (${asset.thumbnailsStatus})`}</span>
+      {/* Keep icon imports honoured for placeholder fallback in follow-up */}
+      <span className="hidden">
+        <ImageIcon />
+        <Film />
+        <FileText />
+      </span>
+    </li>
+  );
+}

--- a/apps/admin/src/lib/asset-upload.ts
+++ b/apps/admin/src/lib/asset-upload.ts
@@ -71,6 +71,11 @@ export interface UploadAssetOptions {
   file: File;
   code?: string;
   tags?: string[];
+  /**
+   * Logical folder for the upload. `product-<UUID>` is recognised by
+   * the backend, which auto-links the new Asset to the product.
+   */
+  folderCode?: string;
   onProgress?: (loadedPercent: number) => void;
   signal?: AbortSignal;
 }
@@ -172,6 +177,9 @@ function sendOnce(
       for (const tag of options.tags) {
         form.append('tags[]', tag);
       }
+    }
+    if (options.folderCode) {
+      form.append('folderCode', options.folderCode);
     }
 
     xhr.send(form);

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -255,6 +255,11 @@
       "pending": "Generating thumbnails…",
       "failed": "Thumbnail generation failed."
     },
+    "folder": {
+      "all": "All",
+      "count_one": "{{count}} file",
+      "count_other": "{{count}} files"
+    },
     "detail": {
       "edit": "Edit",
       "download": "Download original",
@@ -470,6 +475,23 @@
     "reset_filters": "Reset filters"
   },
   "products": {
+    "multimedia": {
+      "title": "Multimedia",
+      "empty": "No linked files. Upload new ones or pick from the library.",
+      "upload": "Upload files",
+      "upload_dialog_title": "Upload files to product",
+      "upload_dialog_body": "Uploaded files land in the product folder and are auto-linked.",
+      "pick_from_library": "Pick from library",
+      "picker_title": "Pick files from the library",
+      "picker_body": "Selected files will be linked (m2m) to the product. They stay in their original folder.",
+      "picker_empty": "No files to pick in this folder.",
+      "pick_confirm_one": "Add 1 file",
+      "pick_confirm_other": "Add {{count}} files",
+      "pick_confirm": "Add selected",
+      "pick_error": "Failed to link files.",
+      "unlink": "Unlink from product",
+      "unlink_error": "Failed to unlink the file."
+    },
     "list_title": "Products",
     "list_subtitle": "Catalogue of products scoped to the current tenant.",
     "filter_provenance": "Provenance",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -257,6 +257,13 @@
       "pending": "Generowanie miniatur…",
       "failed": "Generowanie miniatur nie powiodło się."
     },
+    "folder": {
+      "all": "Wszystkie",
+      "count_one": "{{count}} plik",
+      "count_few": "{{count}} pliki",
+      "count_many": "{{count}} plików",
+      "count_other": "{{count}} plików"
+    },
     "detail": {
       "edit": "Edytuj",
       "download": "Pobierz oryginał",
@@ -472,6 +479,23 @@
     "reset_filters": "Wyczyść filtry"
   },
   "products": {
+    "multimedia": {
+      "title": "Multimedia",
+      "empty": "Brak powiązanych plików. Wgraj pliki lub wybierz z biblioteki.",
+      "upload": "Wgraj pliki",
+      "upload_dialog_title": "Wgraj pliki do produktu",
+      "upload_dialog_body": "Wgrane pliki zostaną zapisane w katalogu produktu i automatycznie powiązane.",
+      "pick_from_library": "Wybierz z biblioteki",
+      "picker_title": "Wybierz pliki z biblioteki",
+      "picker_body": "Pliki dodane tutaj zostaną powiązane z produktem (m2m). Plik zostaje w swoim oryginalnym folderze.",
+      "picker_empty": "Brak plików do wyboru w tym folderze.",
+      "pick_confirm_one": "Dodaj 1 plik",
+      "pick_confirm_other": "Dodaj {{count}} plików",
+      "pick_confirm": "Dodaj wybrane",
+      "pick_error": "Nie udało się powiązać plików.",
+      "unlink": "Odepnij od produktu",
+      "unlink_error": "Nie udało się odpiąć pliku."
+    },
     "list_title": "Produkty",
     "list_subtitle": "Katalog produktów w obrębie aktualnego najemcy.",
     "filter_provenance": "Pochodzenie",

--- a/apps/api/migrations/Version20260506081412.php
+++ b/apps/api/migrations/Version20260506081412.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Issue #440 — Multimedia tab in product detail.
+ *
+ * Adds two pieces:
+ *   1. `assets.folder_code` — opt-in logical folder. NULL means root,
+ *      "product-<UUID>" identifies files uploaded inside a product card.
+ *   2. `product_assets` — m2m link between products (CatalogObject of
+ *      kind=product) and Asset rows. The same Asset can be reused on
+ *      multiple products via the picker without duplicating bytes;
+ *      `folder_code` records *where* the file physically belongs (its
+ *      origin), the m2m records *which* products show it.
+ *
+ * Both FK columns cascade on parent delete: dropping the product or
+ * the asset clears every link.
+ */
+final class Version20260506081412 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Multimedia tab: assets.folder_code + product_assets m2m (#440).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE assets ADD folder_code VARCHAR(128) DEFAULT NULL');
+        $this->addSql(<<<'SQL'
+            CREATE INDEX assets_tenant_folder_idx
+              ON assets (tenant_id, folder_code)
+              WHERE folder_code IS NOT NULL
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE product_assets (
+              asset_id UUID NOT NULL,
+              product_id UUID NOT NULL,
+              position INT DEFAULT NULL,
+              created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              PRIMARY KEY (asset_id, product_id)
+            )
+        SQL);
+        $this->addSql('CREATE INDEX product_assets_product_idx ON product_assets (product_id, position)');
+        $this->addSql('ALTER TABLE product_assets ADD CONSTRAINT product_assets_asset_fk FOREIGN KEY (asset_id) REFERENCES assets (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE product_assets ADD CONSTRAINT product_assets_product_fk FOREIGN KEY (product_id) REFERENCES objects (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE product_assets DROP CONSTRAINT product_assets_product_fk');
+        $this->addSql('ALTER TABLE product_assets DROP CONSTRAINT product_assets_asset_fk');
+        $this->addSql('DROP TABLE product_assets');
+
+        $this->addSql('DROP INDEX assets_tenant_folder_idx');
+        $this->addSql('ALTER TABLE assets DROP COLUMN folder_code');
+    }
+}

--- a/apps/api/src/Asset/Application/AssetUploader.php
+++ b/apps/api/src/Asset/Application/AssetUploader.php
@@ -61,7 +61,7 @@ final readonly class AssetUploader
     /**
      * @param array<int, string> $tags
      */
-    public function upload(File $file, ?string $code = null, array $tags = []): Asset
+    public function upload(File $file, ?string $code = null, array $tags = [], ?string $folderCode = null): Asset
     {
         $tenant = $this->tenantContext->get();
         if (null === $tenant) {
@@ -122,6 +122,7 @@ final readonly class AssetUploader
             width: $width,
             height: $height,
             tags: $tags,
+            folderCode: $folderCode,
         );
 
         $original = new AssetVariant(
@@ -175,6 +176,7 @@ final readonly class AssetUploader
             'width' => $asset->getWidth(),
             'height' => $asset->getHeight(),
             'pageCount' => $asset->getPageCount(),
+            'folderCode' => $asset->getFolderCode(),
         ];
     }
 

--- a/apps/api/src/Asset/Domain/Entity/Asset.php
+++ b/apps/api/src/Asset/Domain/Entity/Asset.php
@@ -80,6 +80,13 @@ class Asset extends AggregateRoot implements TenantScoped
     private string $thumbnailsStatus = ThumbnailsStatus::Pending->value;
 
     /**
+     * Logical folder the file lives in. NULL = library root.
+     * `product-<UUID>` indicates a file uploaded inside a product card
+     * — the picker uses this to display the folder in the /assets grid.
+     */
+    private ?string $folderCode = null;
+
+    /**
      * @var array<string, mixed>
      */
     private array $metadata = [];
@@ -111,6 +118,7 @@ class Asset extends AggregateRoot implements TenantScoped
         ?int $pageCount = null,
         array $tags = [],
         array $metadata = [],
+        ?string $folderCode = null,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->code = $code;
@@ -124,6 +132,7 @@ class Asset extends AggregateRoot implements TenantScoped
         $this->pageCount = $pageCount;
         $this->tags = array_values(array_unique($tags));
         $this->metadata = $metadata;
+        $this->folderCode = $folderCode;
         $this->createdAt = new DateTimeImmutable();
         $this->variants = new ArrayCollection();
     }
@@ -263,6 +272,16 @@ class Asset extends AggregateRoot implements TenantScoped
     public function markThumbnailsFailed(): void
     {
         $this->thumbnailsStatus = ThumbnailsStatus::Failed->value;
+    }
+
+    public function getFolderCode(): ?string
+    {
+        return $this->folderCode;
+    }
+
+    public function moveToFolder(?string $folderCode): void
+    {
+        $this->folderCode = $folderCode;
     }
 
     /**

--- a/apps/api/src/Asset/Infrastructure/ApiPlatform/AssetCollectionFilterExtension.php
+++ b/apps/api/src/Asset/Infrastructure/ApiPlatform/AssetCollectionFilterExtension.php
@@ -79,6 +79,22 @@ final readonly class AssetCollectionFilterExtension implements QueryCollectionEx
             \sprintf('%s.objectId = %s.id', $assetAlias, $alias),
         );
 
+        // Folder navigation (#440). `folder=root` narrows to files without
+        // a logical folder; any other value matches the literal folder
+        // code (e.g. `product-<UUID>`). When the param is absent the
+        // listing stays global — pickers and search keep using that.
+        $folder = $request->query->get('folder');
+        if (\is_string($folder) && '' !== $folder) {
+            if ('root' === $folder) {
+                $queryBuilder->andWhere(\sprintf('%s.folderCode IS NULL', $assetAlias));
+            } else {
+                $param = $queryNameGenerator->generateParameterName('folder');
+                $queryBuilder
+                    ->andWhere(\sprintf('%s.folderCode = :%s', $assetAlias, $param))
+                    ->setParameter($param, $folder);
+            }
+        }
+
         $mimeGroup = $request->query->get('mimeGroup');
         if (\is_string($mimeGroup) && '' !== $mimeGroup) {
             $param = $queryNameGenerator->generateParameterName('mimeGroup');

--- a/apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/Asset.orm.xml
+++ b/apps/api/src/Asset/Infrastructure/Doctrine/Orm/Mapping/Asset.orm.xml
@@ -58,6 +58,8 @@
             </options>
         </field>
 
+        <field name="folderCode" type="string" length="128" column="folder_code" nullable="true"/>
+
         <field name="metadata" type="json">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Asset/Presentation/Controller/AssetFoldersController.php
+++ b/apps/api/src/Asset/Presentation/Controller/AssetFoldersController.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Presentation\Controller;
+
+use App\Shared\Application\TenantContext;
+use Doctrine\DBAL\Connection;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * `GET /api/assets/folders` (#440).
+ *
+ * Returns the list of distinct `folder_code` values seen on the
+ * tenant's assets together with a human-readable display name and the
+ * count of files inside. The grid renders these as folder tiles when
+ * the user is at the library root.
+ *
+ * Display name resolution:
+ *   - `product-<UUID>` → the linked product's `code` from the
+ *     `objects` table (kind=product). Missing product fallback is the
+ *     raw `<UUID>` so the operator at least sees something.
+ *   - everything else → the folder code verbatim.
+ */
+final readonly class AssetFoldersController
+{
+    public function __construct(
+        private Connection $connection,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    #[Route(path: '/api/asset-folders', name: 'pim_asset_folders', methods: ['GET'], format: 'json')]
+    public function __invoke(): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new RuntimeException('Folders endpoint requires an active TenantContext.');
+        }
+
+        /** @var array<int, array<string, mixed>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT folder_code, COUNT(*) AS asset_count
+                FROM assets
+                WHERE tenant_id = :tenantId AND folder_code IS NOT NULL
+                GROUP BY folder_code
+                ORDER BY folder_code
+                SQL,
+            ['tenantId' => $tenant->getId()->toRfc4122()],
+        );
+
+        if ([] === $rows) {
+            return new JsonResponse(['member' => [], 'totalItems' => 0]);
+        }
+
+        $productIds = [];
+        foreach ($rows as $row) {
+            if (!\is_string($row['folder_code'] ?? null)) {
+                continue;
+            }
+            $productId = $this->extractProductId($row['folder_code']);
+            if (null !== $productId) {
+                $productIds[] = $productId;
+            }
+        }
+
+        $productNames = [] !== $productIds ? $this->fetchProductNames($productIds, $tenant->getId()->toRfc4122()) : [];
+
+        $member = [];
+        foreach ($rows as $row) {
+            if (!\is_string($row['folder_code'] ?? null)) {
+                continue;
+            }
+            $code = $row['folder_code'];
+            $member[] = [
+                'code' => $code,
+                'displayName' => $this->resolveDisplayName($code, $productNames),
+                'assetCount' => is_numeric($row['asset_count'] ?? null) ? (int) $row['asset_count'] : 0,
+            ];
+        }
+
+        return new JsonResponse(['member' => $member, 'totalItems' => \count($member)]);
+    }
+
+    private function extractProductId(string $folderCode): ?string
+    {
+        if (!str_starts_with($folderCode, 'product-')) {
+            return null;
+        }
+
+        return substr($folderCode, \strlen('product-'));
+    }
+
+    /**
+     * @param array<int, string> $productIds
+     *
+     * @return array<string, string> id → code
+     */
+    private function fetchProductNames(array $productIds, string $tenantId): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT id::text AS id, code FROM objects
+                WHERE tenant_id = :tenantId AND kind = 'product' AND id IN (:ids)
+                SQL,
+            ['tenantId' => $tenantId, 'ids' => $productIds],
+            ['ids' => \Doctrine\DBAL\ArrayParameterType::STRING],
+        );
+
+        $map = [];
+        foreach ($rows as $row) {
+            $id = $row['id'] ?? null;
+            $code = $row['code'] ?? null;
+            if (\is_string($id) && \is_string($code)) {
+                $map[$id] = $code;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, string> $productNames
+     */
+    private function resolveDisplayName(string $folderCode, array $productNames): string
+    {
+        $productId = $this->extractProductId($folderCode);
+        if (null !== $productId && isset($productNames[$productId])) {
+            return 'Produkt: '.$productNames[$productId];
+        }
+
+        return $folderCode;
+    }
+}

--- a/apps/api/src/Asset/Presentation/Controller/ProductAssetsController.php
+++ b/apps/api/src/Asset/Presentation/Controller/ProductAssetsController.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Presentation\Controller;
+
+use App\Asset\Domain\Entity\Asset;
+use App\Asset\Domain\Repository\AssetRepositoryInterface;
+use App\Catalog\Contracts\Service\ProductAssetLinker;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Multimedia tab endpoints (#440):
+ *   - `GET    /api/products/{id}/assets`             — list linked assets
+ *   - `POST   /api/products/{id}/assets`             — link assets (m2m)
+ *   - `DELETE /api/products/{id}/assets/{assetId}`   — unlink
+ *
+ * The product detail view calls these to render the multimedia grid
+ * and to attach picks from the library or fresh uploads.
+ *
+ * The link table only stores `(asset_id, product_id, position)` — the
+ * GET endpoint resolves each id back into the same payload shape the
+ * `/api/assets` listing emits so the frontend can reuse the existing
+ * tile component.
+ */
+final readonly class ProductAssetsController
+{
+    public function __construct(
+        private AssetRepositoryInterface $assets,
+        private ProductAssetLinker $linker,
+    ) {
+    }
+
+    #[Route(path: '/api/products/{id}/assets', name: 'pim_products_assets_list', methods: ['GET'], format: 'json')]
+    public function list(string $id): JsonResponse
+    {
+        $productId = $this->parseUuid($id, 'product');
+        $assetIds = $this->linker->findAssetIdsForProduct($productId);
+
+        $payload = [];
+        foreach ($assetIds as $assetId) {
+            $asset = $this->assets->findById($assetId);
+            if ($asset instanceof Asset) {
+                $payload[] = $this->present($asset);
+            }
+        }
+
+        return new JsonResponse(['member' => $payload, 'totalItems' => \count($payload)]);
+    }
+
+    #[Route(path: '/api/products/{id}/assets', name: 'pim_products_assets_link', methods: ['POST'], format: 'json')]
+    public function link(string $id, Request $request): JsonResponse
+    {
+        $productId = $this->parseUuid($id, 'product');
+
+        $payload = json_decode($request->getContent(), true);
+        if (!\is_array($payload) || !\is_array($payload['assetIds'] ?? null)) {
+            throw new BadRequestHttpException('Body must be { "assetIds": [string, ...] }.');
+        }
+
+        $assetIds = [];
+        foreach ($payload['assetIds'] as $raw) {
+            if (!\is_string($raw)) {
+                continue;
+            }
+            try {
+                $candidate = Uuid::fromString($raw);
+            } catch (InvalidArgumentException) {
+                continue;
+            }
+            // The id may come from the /api/assets listing (CatalogObject id)
+            // or directly as Asset id. Resolve to the canonical Asset.id so
+            // the link table never carries a CatalogObject id by accident.
+            $asset = $this->assets->findById($candidate) ?? $this->assets->findByObjectId($candidate);
+            if ($asset instanceof Asset) {
+                $assetIds[] = $asset->getId();
+            }
+        }
+
+        if ([] !== $assetIds) {
+            $this->linker->linkAssetsToProduct($productId, $assetIds);
+        }
+
+        return new JsonResponse(['linkedCount' => \count($assetIds)], Response::HTTP_OK);
+    }
+
+    #[Route(
+        path: '/api/products/{id}/assets/{assetId}',
+        name: 'pim_products_assets_unlink',
+        methods: ['DELETE'],
+        format: 'json',
+    )]
+    public function unlink(string $id, string $assetId): JsonResponse
+    {
+        $productId = $this->parseUuid($id, 'product');
+        $rawAssetId = $this->parseUuid($assetId, 'asset');
+
+        // Same Asset-id-or-CatalogObject-id tolerance as `link()`.
+        $asset = $this->assets->findById($rawAssetId) ?? $this->assets->findByObjectId($rawAssetId);
+        if (null === $asset) {
+            return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+        }
+
+        $this->linker->unlinkAssetFromProduct($productId, $asset->getId());
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private function parseUuid(string $raw, string $fieldLabel): Uuid
+    {
+        try {
+            return Uuid::fromString($raw);
+        } catch (InvalidArgumentException $e) {
+            throw new BadRequestHttpException(\sprintf('"%s" is not a valid %s id.', $raw, $fieldLabel), $e);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function present(Asset $asset): array
+    {
+        return [
+            'id' => $asset->getId()->toRfc4122(),
+            'code' => $asset->getCode(),
+            'originalFilename' => $asset->getOriginalFilename(),
+            'mimeType' => $asset->getMimeType(),
+            'size' => $asset->getSize(),
+            'width' => $asset->getWidth(),
+            'height' => $asset->getHeight(),
+            'pageCount' => $asset->getPageCount(),
+            'tags' => $asset->getTags(),
+            'thumbnailsStatus' => $asset->getThumbnailsStatus()->value,
+            'folderCode' => $asset->getFolderCode(),
+            'previewUrl' => \sprintf('/api/assets/%s/preview', $asset->getId()->toRfc4122()),
+        ];
+    }
+}

--- a/apps/api/src/Asset/Presentation/Controller/UploadAssetController.php
+++ b/apps/api/src/Asset/Presentation/Controller/UploadAssetController.php
@@ -8,6 +8,8 @@ use App\Asset\Application\AssetUploader;
 use App\Asset\Application\Exception\DuplicateAssetException;
 use App\Asset\Application\MimeTypeWhitelist;
 use App\Asset\Domain\Entity\Asset;
+use App\Catalog\Contracts\Service\ProductAssetLinker;
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -19,6 +21,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * `POST /api/assets/upload` (multipart) — DAM MVP entry point (#438).
@@ -46,6 +49,7 @@ final class UploadAssetController
     public function __construct(
         private readonly AssetUploader $uploader,
         private readonly AuthorizationCheckerInterface $authorisation,
+        private readonly ProductAssetLinker $productAssetLinker,
         private readonly int $maxImageBytes,
         private readonly int $maxPdfBytes,
     ) {
@@ -87,9 +91,15 @@ final class UploadAssetController
 
         $code = $request->request->get('code');
         $tags = $this->normaliseTags($request);
+        $folderCode = $this->normaliseFolderCode($request);
 
         try {
-            $asset = $this->uploader->upload($file, \is_string($code) && '' !== trim($code) ? trim($code) : null, $tags);
+            $asset = $this->uploader->upload(
+                $file,
+                \is_string($code) && '' !== trim($code) ? trim($code) : null,
+                $tags,
+                $folderCode,
+            );
         } catch (DuplicateAssetException $e) {
             return new JsonResponse([
                 'type' => 'urn:pim:asset:duplicate',
@@ -102,7 +112,41 @@ final class UploadAssetController
             throw new BadRequestHttpException($e->getMessage(), $e);
         }
 
+        // Auto-link to product when uploaded inside a product card —
+        // the frontend builds `folderCode = "product-<UUID>"` so the
+        // backend can resolve the parent without a second request.
+        if (null !== $folderCode) {
+            $productId = $this->extractProductIdFromFolder($folderCode);
+            if (null !== $productId) {
+                $this->productAssetLinker->linkAssetsToProduct($productId, [$asset->getId()]);
+            }
+        }
+
         return new JsonResponse($this->present($asset), Response::HTTP_CREATED);
+    }
+
+    private function normaliseFolderCode(Request $request): ?string
+    {
+        $raw = $request->request->get('folderCode');
+        if (!\is_string($raw)) {
+            return null;
+        }
+        $trimmed = trim($raw);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+
+    private function extractProductIdFromFolder(string $folderCode): ?Uuid
+    {
+        if (!str_starts_with($folderCode, 'product-')) {
+            return null;
+        }
+        $candidate = substr($folderCode, \strlen('product-'));
+        try {
+            return Uuid::fromString($candidate);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
     }
 
     /**

--- a/apps/api/src/Catalog/Application/ProductAssetLinkerService.php
+++ b/apps/api/src/Catalog/Application/ProductAssetLinkerService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Contracts\Service\ProductAssetLinker;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Implementation of {@see ProductAssetLinker} (#440).
+ *
+ * The link table `product_assets` is small (asset_id, product_id,
+ * position, created_at) and never carries domain logic. We talk to it
+ * through the DBAL Connection rather than wrapping it in a Doctrine
+ * entity — fewer moving parts, no risk of orphaned identity-map state
+ * inside a long-running FrankenPHP worker.
+ *
+ * `position` defaults to `MAX(position) + 1` for the product so the
+ * picker / drag-drop reorder follow-up has a sortable column to play
+ * with from day one.
+ */
+final readonly class ProductAssetLinkerService implements ProductAssetLinker
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function linkAssetsToProduct(Uuid $productId, array $assetIds): void
+    {
+        if ([] === $assetIds) {
+            return;
+        }
+
+        $rawPosition = $this->connection->fetchOne(
+            'SELECT COALESCE(MAX(position), 0) FROM product_assets WHERE product_id = :productId',
+            ['productId' => $productId->toRfc4122()],
+        );
+        $nextPosition = is_numeric($rawPosition) ? (int) $rawPosition : 0;
+
+        foreach ($assetIds as $assetId) {
+            $this->connection->executeStatement(
+                <<<'SQL'
+                    INSERT INTO product_assets (asset_id, product_id, position, created_at)
+                    VALUES (:assetId, :productId, :position, NOW())
+                    ON CONFLICT (asset_id, product_id) DO NOTHING
+                    SQL,
+                [
+                    'assetId' => $assetId->toRfc4122(),
+                    'productId' => $productId->toRfc4122(),
+                    'position' => ++$nextPosition,
+                ],
+            );
+        }
+    }
+
+    public function unlinkAssetFromProduct(Uuid $productId, Uuid $assetId): void
+    {
+        $this->connection->executeStatement(
+            'DELETE FROM product_assets WHERE product_id = :productId AND asset_id = :assetId',
+            [
+                'productId' => $productId->toRfc4122(),
+                'assetId' => $assetId->toRfc4122(),
+            ],
+        );
+    }
+
+    public function findAssetIdsForProduct(Uuid $productId): array
+    {
+        $rows = $this->connection->fetchFirstColumn(
+            <<<'SQL'
+                SELECT asset_id FROM product_assets
+                WHERE product_id = :productId
+                ORDER BY COALESCE(position, 2147483647), created_at
+                SQL,
+            ['productId' => $productId->toRfc4122()],
+        );
+
+        $ids = [];
+        foreach ($rows as $raw) {
+            if (\is_string($raw)) {
+                $ids[] = Uuid::fromString($raw);
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Service/ProductAssetLinker.php
+++ b/apps/api/src/Catalog/Contracts/Service/ProductAssetLinker.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Service;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-context bridge for the product ↔ asset many-to-many (#440).
+ *
+ * Asset_Internals stores the file; Catalog_Internals owns Product
+ * (a `CatalogObject` of `kind=product`). The link table sits in the
+ * Catalog persistence boundary so the implementation lives there.
+ *
+ * Operations are idempotent — re-linking an asset that is already
+ * attached is a no-op (UPSERT semantics).
+ */
+interface ProductAssetLinker
+{
+    /**
+     * Attach every asset id to the product. Idempotent — duplicates
+     * are silently ignored. New rows are appended at the end of the
+     * existing position sequence.
+     *
+     * @param array<int, Uuid> $assetIds
+     */
+    public function linkAssetsToProduct(Uuid $productId, array $assetIds): void;
+
+    public function unlinkAssetFromProduct(Uuid $productId, Uuid $assetId): void;
+
+    /**
+     * Return the asset ids currently attached to the product, in the
+     * order they should be rendered (ASC by `position` then `created_at`).
+     *
+     * @return array<int, Uuid>
+     */
+    public function findAssetIdsForProduct(Uuid $productId): array;
+}


### PR DESCRIPTION
Closes #440. **Bazuje na PR #439** (DAM MVP) — `--base feat/assets-dam-mvp`. Po merge #439 do main, ten PR rebase'uję na main.

## Co dostajemy

Karta produktu zyskuje funkcjonalny **Multimedia tab** (zastępuje MediaStub) z dwoma akcjami:
- **Wgraj pliki** — modal dialog z drag-drop dropzone. Wgrane pliki trafiają do folderu `product-<id>` w `/assets` ORAZ są auto-linkowane m2m do produktu (jeden round-trip).
- **Wybierz z biblioteki** — modal full-screen z reuse'owaną nawigacją folderową `/assets`. Wybrane pliki są tylko linkowane (m2m), zostają w swoim oryginalnym folderze.

`/assets` zyskuje **Windows-Explorer style** nawigację:
- Breadcrumb 'Wszystkie / <Folder>'
- Foldery jako kafelki w gridzie obok plików (root only)
- Klik folderu → wejście, grid pokazuje tylko pliki tego folderu
- Wgranie w folderze → plik dostaje folder_code = `<folder>`

## Backend

### Migracja
- `assets.folder_code VARCHAR(128) NULL`
- Partial index `assets_tenant_folder_idx ON assets(tenant_id, folder_code) WHERE folder_code IS NOT NULL`
- Tabela `product_assets`:
  ```
  (asset_id UUID, product_id UUID, position INT NULL, created_at TIMESTAMP)
  PRIMARY KEY (asset_id, product_id)
  INDEX (product_id, position)
  ON DELETE CASCADE na obu FK
  ```

### Domain
- `Asset.folderCode` field + getter `getFolderCode()` + setter `moveToFolder()`
- ORM mapping update

### Application
- `AssetUploader::upload()` przyjmuje opcjonalny `?string $folderCode` (default null = library root)
- `App\Catalog\Contracts\Service\ProductAssetLinker` interface (Asset_Internals → Catalog_Contracts ✓ Deptrac)
- `App\Catalog\Application\ProductAssetLinkerService` (Catalog_Internals) — implementacja przez DBAL Connection (m2m bez domain logic, lekki INSERT...ON CONFLICT DO NOTHING dla idempotencji)

### HTTP
- `POST /api/assets/upload` przyjmuje `folderCode` form field; `folderCode='product-<UUID>'` triggeruje auto-link
- **3 nowe routes** w `ProductAssetsController`:
  - `GET    /api/products/{id}/assets` → lista linkowanych
  - `POST   /api/products/{id}/assets` → body `{assetIds: string[]}` → m2m link (idempotentny)
  - `DELETE /api/products/{id}/assets/{assetId}` → unlink
- `GET /api/asset-folders` → distinct folder codes z `displayName` (resolve `product-<UUID>` przez `objects.code`)
- `AssetCollectionFilterExtension` rozszerzony o `?folder=<code>` (`folder=root` = bez folderu)
- **URL nazwa**: endpoint `/api/asset-folders` zamiast `/api/assets/folders` bo AP4 catch-all `/api/assets/{id}` przejmował `folders`. Decyzja udokumentowana w controller docstring.

## Frontend

### `/assets` list (Windows-Explorer)
- `currentFolder: string | null` state w `list.tsx` (null = root)
- `Breadcrumb` component: 'Wszystkie' (przycisk) / `<displayName>` po wejściu
- `FolderTile` w gridzie (root only, gdy nie ma search'u): ikona Folder + display name + count
- Klik tile → `setCurrentFolder(code)`
- Klik 'Wszystkie' w breadcrumb → `setCurrentFolder(null)`
- Dropzone forwarduje `folderCode = currentFolder ?? undefined`

### Product detail
- `MediaStub` usunięty — `ProductMultimediaTab` w jego miejscu
- `ProductMultimediaTab` (`apps/admin/src/features/catalog/products/components/`):
  - Header z 2 buttonami: 'Wybierz z biblioteki' (LibraryIcon) + 'Wgraj pliki' (Upload)
  - GET `/api/products/{id}/assets` — grid linkowanych
  - Per-tile hover "Odepnij" → DELETE `/api/products/{id}/assets/{assetId}` → refetch
- `ProductAssetUploadDialog`: Dialog z `<AssetUploadDropzone folderCode="product-<id>" />` reuse, po sukcesie refetch
- `AssetLibraryPicker`: full-screen modal (95vw × 90vh), Windows-explorer nav (currentFolder + breadcrumb + folder tiles), search debounced, multi-select tile (gradient checkbox), "Dodaj wybrane (N)" → POST `/api/products/{id}/assets`

### i18n
- pl.json + en.json: `assets.folder.{all, count_*}`, `products.multimedia.{title, empty, upload, upload_dialog_*, pick_from_library, picker_*, pick_confirm_*, pick_error, unlink, unlink_error}`

## Backend smoke (zweryfikowane przez curl + DB)

| Krok | Wynik |
|---|---|
| Upload PNG z `folderCode=product-<DEMO-001-id>` | **HTTP 201**, asset zapisany z `folder_code=product-<id>`, m2m link auto-utworzony |
| `GET /api/products/<DEMO-001-id>/assets` | `totalItems: 1`, payload zawiera `previewUrl: /api/assets/<asset-id>/preview` |
| `GET /api/asset-folders` | zwraca `[{ code: "product-<id>", displayName: "Produkt: DEMO-001", assetCount: 1 }]` |
| Routes registered | wszystkie 4 nowe (`pim_asset_folders`, `pim_products_assets_list/link/unlink`) widoczne w `bin/console debug:router` |

## Quality

- ✓ PHPStan max — 0 errors
- ✓ Deptrac — 0 violations (Asset_Internals → Catalog_Contracts ✓)
- ✓ Frontend typecheck (`tsc -b --noEmit`) — 0 errors
- ✓ Frontend lint (Biome) — 0 errors (2 pre-existing warning + 1 info, nie z tego ticketu)

## Smoke UI — pozostaje dla operatora ⚠

CLAUDE.md § Smoke Test Rule wymaga manual UI test przed słowem 'działa' w PR description. Backend smoke przeszedł, frontend wymaga klikania.

Checklist (po `pnpm stack:up` + login `admin@demo.localhost / changeme`):
1. Otwórz produkt → tab Multimedia → 2 buttony widoczne, grid pusty.
2. Wgraj pliki → drag-drop 2 obrazy → 2 wpisy w gridzie produktu.
3. Otwórz `/assets` → breadcrumb 'Wszystkie' aktywny → folder kafelek 'Produkt: <SKU>' widoczny w gridzie obok plików bez folderu.
4. Klik folder → wszedłeś, breadcrumb pokazuje 'Wszystkie / Produkt: <SKU>', grid pokazuje 2 wgrane pliki.
5. Klik 'Wszystkie' → root.
6. Z innego produktu → Wybierz z biblioteki → modal full-screen → folder picker wchodzi do folderu DEMO-001 → multi-select 1 plik → 'Dodaj wybrane (1)' → modal zamyka, grid drugiego produktu pokazuje plik.
7. Hover plik w produkcie → kosz w prawym górnym rogu → klik → plik znika z grida produktu, ALE pozostaje w `/assets` (tylko unlink m2m).
8. DevTools Console: 0 czerwonych errorów.

## Świadome odejścia (deferred)

| Element | Powód | Follow-up |
|---|---|---|
| Drag-drop reorder linkowanych assetów | `position` kolumna gotowa, ale UI sortable + PATCH endpoint = osobny scope | #440-reorder |
| Move asset między folderami z /assets | Operator może re-upload jeśli potrzebny | #440-move |
| Wariantowe zdjęcia | Operator: 'warianty nie mają obsługi zdjęć' | Faza 1 |
| PHPUnit + ApiTestCase dla 3 nowych endpointów | Tests follow-up po smoke | #440a-tests |
| GET filter `?folder=` jako AP4 Filter class (zamiast extension) | Działa przez `AssetCollectionFilterExtension` — pure refactor | follow-up |

## Refs
- Issue: #440
- Bazuje na: #439 (DAM MVP)
- Epik 05 § 3.4 (Linking do produktów)