### PR TITLE
feat(imports): IMP-02 — file parsing + dictionary auto-mapping

### DIFF
--- a/apps/api/config/imports/mapping_dictionary.yaml
+++ b/apps/api/config/imports/mapping_dictionary.yaml
@@ -1,0 +1,235 @@
+# Imports MVP — rules-based auto-mapping dictionary (PL/EN).
+#
+# Maps human column headers to canonical product attribute codes.
+# Aliases are matched after lower-casing the header and stripping
+# non-alphanumeric characters (see App\Import\Application\Service\AutoMapper).
+# Aliases below are stored in the same normalised form, so YAML changes
+# travel through the matcher without extra processing.
+#
+# Per spec §5.3: top ~30 product attributes × 5-10 aliases each.
+# Decision (brainstorm 2026-05-03): rules-only in MVP. Hybrid AI mapping
+# is a Phase 2 candidate ("Spytaj AI o mapping" button), not a hot path
+# we plan around right now.
+#
+# Adding a new attribute? Pick aliases that operators *actually* type:
+# the IdoSell/Festo dogfooding (US-IMP-005) is the source of truth for
+# what wins 12/15 auto-recognition on real data.
+
+attributes:
+  sku:
+    aliases:
+      - sku
+      - kod
+      - kodproduktu
+      - kodprod
+      - id
+      - indeks
+      - index
+      - artnr
+      - articlenumber
+      - manufacturerpart
+      - mpn
+
+  name:
+    aliases:
+      - name
+      - nazwa
+      - tytul
+      - title
+      - productname
+      - nazwaproduktu
+
+  price:
+    aliases:
+      - price
+      - cena
+      - cenanetto
+      - cenabrutto
+      - netprice
+      - grossprice
+      - koszt
+
+  brand:
+    aliases:
+      - brand
+      - marka
+      - producent
+      - manufacturer
+      - maker
+      - vendor
+      - dostawca
+
+  ean:
+    aliases:
+      - ean
+      - ean13
+      - gtin
+      - kodkreskowy
+      - barcode
+
+  description:
+    aliases:
+      - description
+      - opis
+      - opisproduktu
+      - longdescription
+      - fulldescription
+
+  short_description:
+    aliases:
+      - shortdescription
+      - krotkiopis
+      - lead
+      - intro
+      - summary
+      - opisskrocony
+
+  category:
+    aliases:
+      - category
+      - kategoria
+      - kategorie
+      - kat
+      - group
+      - grupa
+
+  main_image:
+    aliases:
+      - mainimage
+      - image1
+      - zdjecieglowne
+      - foto
+      - fotoglowne
+      - image
+      - zdjecie
+
+  gallery_2:
+    aliases: [image2, zdjecie2, foto2, galleryimage2]
+  gallery_3:
+    aliases: [image3, zdjecie3, foto3, galleryimage3]
+  gallery_4:
+    aliases: [image4, zdjecie4, foto4, galleryimage4]
+  gallery_5:
+    aliases: [image5, zdjecie5, foto5, galleryimage5]
+  gallery_6:
+    aliases: [image6, zdjecie6, foto6, galleryimage6]
+  gallery_7:
+    aliases: [image7, zdjecie7, foto7, galleryimage7]
+  gallery_8:
+    aliases: [image8, zdjecie8, foto8, galleryimage8]
+  gallery_9:
+    aliases: [image9, zdjecie9, foto9, galleryimage9]
+  gallery_10:
+    aliases: [image10, zdjecie10, foto10, galleryimage10]
+
+  weight:
+    aliases:
+      - weight
+      - waga
+      - wagaproduktu
+      - mass
+      - kg
+
+  height:
+    aliases:
+      - height
+      - wysokosc
+      - h
+
+  width:
+    aliases:
+      - width
+      - szerokosc
+      - w
+
+  depth:
+    aliases:
+      - depth
+      - glebokosc
+      - d
+      - length
+      - dlugosc
+
+  diameter:
+    aliases:
+      - diameter
+      - srednica
+      - srednicazewn
+      - srednicawewn
+
+  color:
+    aliases:
+      - color
+      - colour
+      - kolor
+      - barwa
+
+  material:
+    aliases:
+      - material
+      - materialy
+      - tworzywo
+
+  ip_class:
+    aliases:
+      - ipclass
+      - ip
+      - ochronaip
+      - ipprotection
+
+  voltage:
+    aliases:
+      - voltage
+      - napiecie
+      - volt
+      - v
+
+  power:
+    aliases:
+      - power
+      - moc
+      - watt
+      - kw
+
+  stock:
+    aliases:
+      - stock
+      - stan
+      - stanmagazynowy
+      - magazyn
+      - quantity
+      - ilosc
+
+  vat_rate:
+    aliases:
+      - vat
+      - vatrate
+      - stawkavat
+      - tax
+      - podatek
+
+  unit:
+    aliases:
+      - unit
+      - jednostka
+      - jm
+      - measureunit
+
+  tags:
+    aliases:
+      - tags
+      - tagi
+      - keywords
+      - slowakluczowe
+
+  meta_title:
+    aliases:
+      - metatitle
+      - tytulseo
+      - seotitle
+
+  meta_description:
+    aliases:
+      - metadescription
+      - opisseo
+      - seodescription

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -43,6 +43,12 @@ parameters:
     pim.asset.upload.max_image_bytes: 26214400   # 25 MB
     pim.asset.upload.max_pdf_bytes: 52428800     # 50 MB
 
+    # IMP-02 (#443) — rules-based mapping dictionary path. Loaded once
+    # per container build, then served from `cache.app` for 5 min so
+    # the wizard's auto-map step does not re-parse the YAML on every
+    # column header.
+    pim.imports.dictionary_path: '%kernel.project_dir%/config/imports/mapping_dictionary.yaml'
+
 services:
     _defaults:
         autowire: true
@@ -174,6 +180,15 @@ services:
     App\Asset\Application\AssetUploader:
         arguments:
             $assetsStorage: '@assets.storage'
+
+    # IMP-02 (#443) — rules-based mapping dictionary loader. Cached for
+    # 5 min in `cache.app` (see MappingDictionaryService). The dictionary
+    # path lives under config/ so it ships with the container and never
+    # needs to be writeable at runtime.
+    App\Import\Application\Service\MappingDictionaryService:
+        arguments:
+            $dictionaryPath: '%pim.imports.dictionary_path%'
+            $cache: '@cache.app'
 
     # API Configurator (#90 / 0.10.1). Argon2id hasher + key generator
     # — see ADR-0016 for the format and algorithm choice. The generator

--- a/apps/api/src/Identity/Domain/Rbac/RbacMatrix.php
+++ b/apps/api/src/Identity/Domain/Rbac/RbacMatrix.php
@@ -39,9 +39,12 @@ final class RbacMatrix
         'association',
         'attribute',
         'attribute_group',
+        'backup',
         'brand',
         'category',
         'channel',
+        'import_profile',
+        'import_session',
         'integration',
         'object',
         'object_type',
@@ -86,10 +89,25 @@ final class RbacMatrix
             new RoleDefinition(
                 code: self::ROLE_CATALOG_MANAGER,
                 name: 'Catalog Manager',
-                permissionCodes: self::permissionsFor(
-                    resources: ['object', 'object_type', 'attribute', 'attribute_group', 'association', 'category', 'asset', 'brand'],
-                    actions: [self::ACTION_READ, self::ACTION_WRITE, self::ACTION_DELETE],
-                ),
+                permissionCodes: [
+                    ...self::permissionsFor(
+                        resources: ['object', 'object_type', 'attribute', 'attribute_group', 'association', 'category', 'asset', 'brand'],
+                        actions: [self::ACTION_READ, self::ACTION_WRITE, self::ACTION_DELETE],
+                    ),
+                    // IMP-01/02 — Catalog Manager is the primary persona for
+                    // self-service imports (Kasia, spec §2). Backup write is
+                    // intentionally OUT — a cluster-wide pgBackRest snapshot
+                    // is admin-territory (spec §7.8). Read on backup keeps
+                    // the wizard's status polling working.
+                    ...self::permissionsFor(
+                        resources: ['import_session', 'import_profile'],
+                        actions: [self::ACTION_READ, self::ACTION_WRITE, self::ACTION_DELETE],
+                    ),
+                    ...self::permissionsFor(
+                        resources: ['backup'],
+                        actions: [self::ACTION_READ],
+                    ),
+                ],
             ),
             new RoleDefinition(
                 code: self::ROLE_INTEGRATION_MANAGER,

--- a/apps/api/src/Import/Application/Service/AutoMapper.php
+++ b/apps/api/src/Import/Application/Service/AutoMapper.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Domain\Enum\MappingConfidence;
+use App\Import\Domain\ValueObject\ColumnMappingSuggestion;
+
+/**
+ * Rules-based column → attribute matcher.
+ *
+ * Algorithm (spec §5.3):
+ *   1. Lower-case the source header and strip non-alphanumeric chars.
+ *   2. Look up the normalised key in the alias index → exact match.
+ *   3. Else: scan the alias index with Levenshtein < 2 → "did you mean".
+ *   4. Else: manual.
+ *
+ * The matcher is intentionally *not* aware of the user's tenant attribute
+ * codes — the dictionary owns the canonical names. The wizard validates
+ * the mapping payload against the live ObjectType attributes when the
+ * user clicks "Dalej" on Step 2.
+ */
+final readonly class AutoMapper
+{
+    public function __construct(
+        private MappingDictionaryProvider $dictionary,
+    ) {
+    }
+
+    /**
+     * @param list<string>            $availableAttributeCodes attribute codes on the target ObjectType
+     * @param list<string>            $columnHeaders
+     * @param list<list<string|null>> $sampleRows
+     *
+     * @return list<ColumnMappingSuggestion>
+     */
+    public function map(array $availableAttributeCodes, array $columnHeaders, array $sampleRows): array
+    {
+        $aliasIndex = $this->dictionary->aliasIndex();
+        $availableSet = array_flip($availableAttributeCodes);
+
+        $suggestions = [];
+        foreach ($columnHeaders as $index => $header) {
+            $normalised = $this->normalise($header);
+            $sampleValues = $this->sliceSample($sampleRows, $index);
+
+            if ('' === $normalised) {
+                $suggestions[] = new ColumnMappingSuggestion(
+                    columnIndex: $index,
+                    columnHeader: $header,
+                    suggestedAttributeCode: null,
+                    confidence: MappingConfidence::Skip,
+                    sampleValues: $sampleValues,
+                );
+                continue;
+            }
+
+            // Exact alias hit.
+            if (isset($aliasIndex[$normalised])) {
+                $candidate = $aliasIndex[$normalised];
+                if (isset($availableSet[$candidate])) {
+                    $suggestions[] = new ColumnMappingSuggestion(
+                        columnIndex: $index,
+                        columnHeader: $header,
+                        suggestedAttributeCode: $candidate,
+                        confidence: MappingConfidence::Auto,
+                        sampleValues: $sampleValues,
+                    );
+                    continue;
+                }
+            }
+
+            // Direct hit on attribute code (operator already normalised
+            // the header to match — happens with re-exports).
+            if (isset($availableSet[$normalised])) {
+                $suggestions[] = new ColumnMappingSuggestion(
+                    columnIndex: $index,
+                    columnHeader: $header,
+                    suggestedAttributeCode: $normalised,
+                    confidence: MappingConfidence::Auto,
+                    sampleValues: $sampleValues,
+                );
+                continue;
+            }
+
+            // Fuzzy match (Levenshtein < 2) on aliases that resolve to
+            // available attributes. Cheap because the alias index is
+            // bounded by the dictionary size (~150 entries).
+            $fuzzyHit = $this->fuzzyHit($normalised, $aliasIndex, $availableSet);
+            if (null !== $fuzzyHit) {
+                $suggestions[] = new ColumnMappingSuggestion(
+                    columnIndex: $index,
+                    columnHeader: $header,
+                    suggestedAttributeCode: $fuzzyHit,
+                    confidence: MappingConfidence::Fuzzy,
+                    sampleValues: $sampleValues,
+                );
+                continue;
+            }
+
+            $suggestions[] = new ColumnMappingSuggestion(
+                columnIndex: $index,
+                columnHeader: $header,
+                suggestedAttributeCode: null,
+                confidence: MappingConfidence::Manual,
+                sampleValues: $sampleValues,
+            );
+        }
+
+        return $suggestions;
+    }
+
+    public function normalise(string $value): string
+    {
+        $lower = mb_strtolower($value);
+        $stripped = preg_replace('/[^\p{L}\p{N}]+/u', '', $lower) ?? '';
+
+        return $this->stripDiacritics($stripped);
+    }
+
+    /**
+     * @param array<string, string> $aliasIndex
+     * @param array<string, int>    $availableSet
+     */
+    private function fuzzyHit(string $needle, array $aliasIndex, array $availableSet): ?string
+    {
+        $needleLength = mb_strlen($needle);
+        // Skip very short headers — Levenshtein on 1-2 chars is noise.
+        if ($needleLength < 3) {
+            return null;
+        }
+
+        foreach ($aliasIndex as $alias => $attributeCode) {
+            if (!isset($availableSet[$attributeCode])) {
+                continue;
+            }
+            // Cheap pre-filter: skip aliases with length distance ≥ 2.
+            if (abs(mb_strlen($alias) - $needleLength) >= 2) {
+                continue;
+            }
+            if (levenshtein($alias, $needle) < 2) {
+                return $attributeCode;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<list<string|null>> $sampleRows
+     *
+     * @return list<string|null>
+     */
+    private function sliceSample(array $sampleRows, int $columnIndex): array
+    {
+        $values = [];
+        foreach ($sampleRows as $row) {
+            $values[] = $row[$columnIndex] ?? null;
+        }
+
+        return $values;
+    }
+
+    private function stripDiacritics(string $value): string
+    {
+        $map = [
+            'ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n',
+            'ó' => 'o', 'ś' => 's', 'ź' => 'z', 'ż' => 'z',
+            'Ą' => 'a', 'Ć' => 'c', 'Ę' => 'e', 'Ł' => 'l', 'Ń' => 'n',
+            'Ó' => 'o', 'Ś' => 's', 'Ź' => 'z', 'Ż' => 'z',
+        ];
+
+        return strtr($value, $map);
+    }
+}

--- a/apps/api/src/Import/Application/Service/DelimiterDetector.php
+++ b/apps/api/src/Import/Application/Service/DelimiterDetector.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+/**
+ * Picks the most likely CSV delimiter from a single sample line.
+ *
+ * Order: `;` (PL/DE/FR locale default) → `,` (US default) → `\t`
+ * (TSV exports) → `|` (rare but exists). The detector prefers the
+ * delimiter that yields the most consistent column count between the
+ * header and the next two rows; ties break on appearance count.
+ */
+final class DelimiterDetector
+{
+    private const array CANDIDATES = [';', ',', "\t", '|'];
+
+    public function detect(string $sample): string
+    {
+        $rawLines = preg_split("/\r\n|\n|\r/", $sample);
+        if (false === $rawLines) {
+            $rawLines = [];
+        }
+        $lines = array_values(array_filter($rawLines, static fn (string $line): bool => '' !== $line));
+        if ([] === $lines) {
+            return ';';
+        }
+
+        $header = $lines[0];
+        $candidates = [];
+
+        foreach (self::CANDIDATES as $delimiter) {
+            $headerCount = substr_count($header, $delimiter);
+            if (0 === $headerCount) {
+                continue;
+            }
+            $consistent = 0;
+            for ($i = 1; $i < min(3, \count($lines)); ++$i) {
+                if (substr_count($lines[$i], $delimiter) === $headerCount) {
+                    ++$consistent;
+                }
+            }
+            $candidates[$delimiter] = ['count' => $headerCount, 'consistent' => $consistent];
+        }
+
+        if ([] === $candidates) {
+            return ';';
+        }
+
+        uasort(
+            $candidates,
+            static function (array $a, array $b): int {
+                $byConsistency = $b['consistent'] <=> $a['consistent'];
+
+                return 0 !== $byConsistency ? $byConsistency : ($b['count'] <=> $a['count']);
+            },
+        );
+
+        return array_key_first($candidates);
+    }
+}

--- a/apps/api/src/Import/Application/Service/EncodingDetector.php
+++ b/apps/api/src/Import/Application/Service/EncodingDetector.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Domain\Enum\FileEncoding;
+
+/**
+ * Detect the encoding of a CSV / xlsx file.
+ *
+ * Order per spec §7.2:
+ *   1. UTF-8 BOM (`EF BB BF`).
+ *   2. Valid UTF-8 (mb_check_encoding) — covers BOM-less UTF-8.
+ *   3. Heuristic CP1250 — strict UTF-8 fails *and* the bytes contain
+ *      Polish-letter signatures (CP1250 specific 0xB9, 0xBE, 0xCE…).
+ *   4. Fallback: ISO-8859-2 (covered by user override in the wizard).
+ *
+ * The wizard always lets the user override; this is just the default.
+ */
+final class EncodingDetector
+{
+    public const string BOM_UTF8 = "\xEF\xBB\xBF";
+
+    public function detect(string $bytes): FileEncoding
+    {
+        if (str_starts_with($bytes, self::BOM_UTF8)) {
+            return FileEncoding::Utf8Bom;
+        }
+        if (mb_check_encoding($bytes, 'UTF-8')) {
+            return FileEncoding::Utf8;
+        }
+        // Polish-letter signature byte ranges (ą=0xB9, ć=0xE6 in CP1250
+        // but 0xE6 collides with ISO-8859-2 — checking the range distinguishes).
+        // The cheap heuristic: if it converts cleanly through CP1250 → UTF-8
+        // and the result is valid UTF-8, prefer CP1250.
+        $candidate = @iconv('Windows-1250', 'UTF-8//IGNORE', $bytes);
+        if (false !== $candidate && mb_check_encoding($candidate, 'UTF-8')) {
+            return FileEncoding::Windows1250;
+        }
+
+        return FileEncoding::Iso88592;
+    }
+
+    public function stripBom(string $bytes): string
+    {
+        return str_starts_with($bytes, self::BOM_UTF8)
+            ? substr($bytes, \strlen(self::BOM_UTF8))
+            : $bytes;
+    }
+}

--- a/apps/api/src/Import/Application/Service/FileParserService.php
+++ b/apps/api/src/Import/Application/Service/FileParserService.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Domain\Enum\FileEncoding;
+use App\Import\Domain\Exception\InvalidImportFileException;
+use App\Import\Domain\ValueObject\ParsedFile;
+use League\Csv\Reader;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use Throwable;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * Parses an uploaded CSV / xlsx file and returns the headers, the
+ * first 5 rows, and the total row count. Single-purpose by design:
+ * the validation + async run handlers (IMP-03 / IMP-04) re-open the
+ * file streamingly, so this service stays focused on the wizard's
+ * Step 1 + Step 2 needs.
+ *
+ * xlsx behaviour (spec §7.1): only the first sheet is read; if the
+ * workbook ships multiple sheets, the {@see ParsedFile::$hadMultipleSheets}
+ * flag tells the wizard to surface the warning copy.
+ */
+final class FileParserService
+{
+    private const int SAMPLE_ROWS = 5;
+    private const array XLSX_EXTENSIONS = ['xlsx'];
+    private const array CSV_EXTENSIONS = ['csv'];
+
+    public function __construct(
+        private readonly EncodingDetector $encodingDetector,
+        private readonly DelimiterDetector $delimiterDetector,
+    ) {
+    }
+
+    public function parse(string $absolutePath, ?FileEncoding $encodingOverride = null, ?string $delimiterOverride = null): ParsedFile
+    {
+        if (!is_readable($absolutePath)) {
+            throw InvalidImportFileException::unreadable($absolutePath);
+        }
+
+        $extension = strtolower(pathinfo($absolutePath, PATHINFO_EXTENSION));
+
+        if (\in_array($extension, self::XLSX_EXTENSIONS, true)) {
+            return $this->parseXlsx($absolutePath);
+        }
+        if (\in_array($extension, self::CSV_EXTENSIONS, true)) {
+            return $this->parseCsv($absolutePath, $encodingOverride, $delimiterOverride);
+        }
+
+        throw InvalidImportFileException::unsupportedExtension($extension);
+    }
+
+    private function parseXlsx(string $absolutePath): ParsedFile
+    {
+        try {
+            $reader = IOFactory::createReaderForFile($absolutePath);
+        } catch (Throwable $exception) {
+            throw InvalidImportFileException::corrupted($absolutePath, $exception);
+        }
+
+        // Cell formula evaluation is OFF (spec §10): cached values only.
+        $reader->setReadDataOnly(true);
+
+        $spreadsheet = $reader->load($absolutePath);
+        $sheetNames = $spreadsheet->getSheetNames();
+        $hadMultipleSheets = \count($sheetNames) > 1;
+        $sheet = $spreadsheet->getSheet(0);
+        $sheetName = $sheet->getTitle();
+
+        $rows = [];
+        foreach ($sheet->getRowIterator() as $row) {
+            $cells = [];
+            foreach ($row->getCellIterator() as $cell) {
+                $value = $cell->getValue();
+                $cells[] = null === $value ? null : (string) (\is_scalar($value) ? $value : '');
+            }
+            $rows[] = $cells;
+        }
+
+        if ([] === $rows || array_filter($rows[0], static fn ($v): bool => null !== $v && '' !== $v) === []) {
+            throw InvalidImportFileException::noHeaderRow();
+        }
+
+        $headers = array_map(static fn (?string $value): string => $value ?? '', $rows[0]);
+        $bodyRows = \array_slice($rows, 1);
+        $sampleRows = \array_slice($bodyRows, 0, self::SAMPLE_ROWS);
+
+        return new ParsedFile(
+            headers: $headers,
+            sampleRows: $sampleRows,
+            totalRows: \count($bodyRows),
+            encoding: FileEncoding::Utf8,
+            delimiter: null,
+            sheetName: $sheetName,
+            hadMultipleSheets: $hadMultipleSheets,
+        );
+    }
+
+    private function parseCsv(string $absolutePath, ?FileEncoding $encodingOverride, ?string $delimiterOverride): ParsedFile
+    {
+        $bytes = file_get_contents($absolutePath);
+        if (false === $bytes) {
+            throw InvalidImportFileException::unreadable($absolutePath);
+        }
+        if ('' === trim($bytes)) {
+            throw InvalidImportFileException::empty();
+        }
+
+        $encoding = $encodingOverride ?? $this->encodingDetector->detect($bytes);
+        $body = $this->encodingDetector->stripBom($bytes);
+        if (FileEncoding::Utf8 !== $encoding && FileEncoding::Utf8Bom !== $encoding) {
+            $converted = @iconv($encoding->iconvName(), 'UTF-8//TRANSLIT', $body);
+            if (false === $converted) {
+                throw InvalidImportFileException::corruptedEncoding($encoding->value);
+            }
+            $body = $converted;
+        }
+
+        $delimiter = $delimiterOverride ?? $this->delimiterDetector->detect(substr($body, 0, 4096));
+
+        $reader = Reader::fromString($body);
+        $reader->setDelimiter($delimiter);
+        $reader->setHeaderOffset(0);
+
+        $headers = $reader->getHeader();
+        if ([] === $headers) {
+            throw InvalidImportFileException::noHeaderRow();
+        }
+
+        $sampleRows = [];
+        $totalRows = 0;
+        foreach ($reader->getRecords() as $record) {
+            ++$totalRows;
+            if (\count($sampleRows) < self::SAMPLE_ROWS) {
+                $row = [];
+                foreach ($headers as $header) {
+                    $value = $record[$header] ?? null;
+                    if (null === $value || '' === $value) {
+                        $row[] = null;
+                    } else {
+                        $row[] = \is_scalar($value) ? (string) $value : '';
+                    }
+                }
+                $sampleRows[] = $row;
+            }
+        }
+
+        return new ParsedFile(
+            headers: array_values($headers),
+            sampleRows: $sampleRows,
+            totalRows: $totalRows,
+            encoding: $encoding,
+            delimiter: $delimiter,
+            sheetName: null,
+            hadMultipleSheets: false,
+        );
+    }
+}

--- a/apps/api/src/Import/Application/Service/MappingDictionaryProvider.php
+++ b/apps/api/src/Import/Application/Service/MappingDictionaryProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+interface MappingDictionaryProvider
+{
+    /**
+     * @return array<string, list<string>>
+     */
+    public function load(): array;
+
+    /**
+     * @return array<string, string>
+     */
+    public function aliasIndex(): array;
+}

--- a/apps/api/src/Import/Application/Service/MappingDictionaryService.php
+++ b/apps/api/src/Import/Application/Service/MappingDictionaryService.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * Loads the rules-based PL/EN auto-mapping dictionary from
+ * `config/imports/mapping_dictionary.yaml`. Cached for 5 minutes
+ * because it lives in YAML and never changes between deploys —
+ * re-reading it on every wizard step is wasted I/O.
+ *
+ * Output shape: attribute_code → list<normalised alias>. Aliases are
+ * already normalised in the YAML (lowercase + alnum-only), so callers
+ * can lookup directly without re-processing.
+ */
+final readonly class MappingDictionaryService implements MappingDictionaryProvider
+{
+    public function __construct(
+        private string $dictionaryPath,
+        private CacheInterface $cache,
+    ) {
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function load(): array
+    {
+        return $this->cache->get('imports.mapping_dictionary', function (ItemInterface $item): array {
+            $item->expiresAfter(300);
+
+            return $this->parseFile();
+        });
+    }
+
+    /**
+     * Reverse index: alias → attribute_code. The matcher hits this once
+     * per column header so it's worth precomputing.
+     *
+     * @return array<string, string>
+     */
+    public function aliasIndex(): array
+    {
+        return $this->cache->get('imports.mapping_dictionary.alias_index', function (ItemInterface $item): array {
+            $item->expiresAfter(300);
+
+            $index = [];
+            foreach ($this->parseFile() as $attributeCode => $aliases) {
+                foreach ($aliases as $alias) {
+                    $index[$alias] = $attributeCode;
+                }
+            }
+
+            return $index;
+        });
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function parseFile(): array
+    {
+        if (!is_readable($this->dictionaryPath)) {
+            return [];
+        }
+
+        /** @var array{attributes?: array<string, array{aliases?: list<string>}>}|null $raw */
+        $raw = Yaml::parseFile($this->dictionaryPath);
+        if (null === $raw || !isset($raw['attributes'])) {
+            return [];
+        }
+
+        $dictionary = [];
+        foreach ($raw['attributes'] as $code => $entry) {
+            $aliases = $entry['aliases'] ?? [];
+            $normalised = [];
+            foreach ($aliases as $alias) {
+                $normalised[] = strtolower($alias);
+            }
+            $dictionary[$code] = array_values(array_unique($normalised));
+        }
+
+        return $dictionary;
+    }
+}

--- a/apps/api/src/Import/Domain/Enum/FileEncoding.php
+++ b/apps/api/src/Import/Domain/Enum/FileEncoding.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Enum;
+
+enum FileEncoding: string
+{
+    case Utf8 = 'utf-8';
+    case Utf8Bom = 'utf-8-bom';
+    case Windows1250 = 'windows-1250';
+    case Iso88592 = 'iso-8859-2';
+
+    public function iconvName(): string
+    {
+        return match ($this) {
+            self::Utf8, self::Utf8Bom => 'UTF-8',
+            self::Windows1250 => 'Windows-1250',
+            self::Iso88592 => 'ISO-8859-2',
+        };
+    }
+}

--- a/apps/api/src/Import/Domain/Enum/MappingConfidence.php
+++ b/apps/api/src/Import/Domain/Enum/MappingConfidence.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Enum;
+
+/**
+ * How confident the {@see \App\Import\Application\Service\AutoMapper} is
+ * about a single column → attribute mapping.
+ *
+ * - Auto:   exact alias match in the dictionary.
+ * - Fuzzy:  Levenshtein < 2 against an alias; UI surfaces "did you mean…".
+ * - Manual: no rule fired; the user picks from the attribute dropdown.
+ * - Skip:   user marked the column as ignored.
+ */
+enum MappingConfidence: string
+{
+    case Auto = 'auto';
+    case Fuzzy = 'fuzzy';
+    case Manual = 'manual';
+    case Skip = 'skip';
+}

--- a/apps/api/src/Import/Domain/Exception/InvalidImportFileException.php
+++ b/apps/api/src/Import/Domain/Exception/InvalidImportFileException.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Exception;
+
+use RuntimeException;
+use Throwable;
+
+final class InvalidImportFileException extends RuntimeException
+{
+    public static function unreadable(string $path): self
+    {
+        return new self(\sprintf('Cannot read import file "%s".', $path));
+    }
+
+    public static function unsupportedExtension(string $extension): self
+    {
+        return new self(\sprintf(
+            'Unsupported import file extension "%s". Accepted: .xlsx, .csv.',
+            $extension,
+        ));
+    }
+
+    public static function corrupted(string $path, Throwable $previous): self
+    {
+        return new self(\sprintf('Import file "%s" is corrupted: %s', $path, $previous->getMessage()), 0, $previous);
+    }
+
+    public static function corruptedEncoding(string $encoding): self
+    {
+        return new self(\sprintf('Failed to convert import file from "%s" to UTF-8.', $encoding));
+    }
+
+    public static function empty(): self
+    {
+        return new self('Import file is empty.');
+    }
+
+    public static function noHeaderRow(): self
+    {
+        return new self('Import file is missing the header row.');
+    }
+}

--- a/apps/api/src/Import/Domain/ValueObject/ColumnMappingSuggestion.php
+++ b/apps/api/src/Import/Domain/ValueObject/ColumnMappingSuggestion.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\ValueObject;
+
+use App\Import\Domain\Enum\MappingConfidence;
+
+/**
+ * One row in the Step-2 mapping table. The wizard renders this as
+ * "header → attribute" with a confidence badge plus sample values.
+ */
+final readonly class ColumnMappingSuggestion
+{
+    /**
+     * @param list<string|null> $sampleValues
+     */
+    public function __construct(
+        public int $columnIndex,
+        public string $columnHeader,
+        public ?string $suggestedAttributeCode,
+        public MappingConfidence $confidence,
+        public array $sampleValues,
+        public ?string $alternativeAttributeCode = null,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Domain/ValueObject/ParsedFile.php
+++ b/apps/api/src/Import/Domain/ValueObject/ParsedFile.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\ValueObject;
+
+use App\Import\Domain\Enum\FileEncoding;
+
+/**
+ * Result of parsing the uploaded file's first sheet (xlsx) or the
+ * whole document (csv).
+ *
+ * `sampleRows` carries up to 5 rows — enough for the wizard to render
+ * sample values per column on Step 2 (mapping). The full body is
+ * processed lazily during the validation / async runs in IMP-03/04.
+ */
+final readonly class ParsedFile
+{
+    /**
+     * @param list<string>            $headers
+     * @param list<list<string|null>> $sampleRows
+     */
+    public function __construct(
+        public array $headers,
+        public array $sampleRows,
+        public int $totalRows,
+        public FileEncoding $encoding,
+        public ?string $delimiter = null,
+        public ?string $sheetName = null,
+        public bool $hadMultipleSheets = false,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/AutoMapController.php
+++ b/apps/api/src/Import/Presentation/Controller/AutoMapController.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Import\Application\Service\AutoMapper;
+use App\Import\Domain\ValueObject\ColumnMappingSuggestion;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * IMP-02 (#443) — frontend Step 2 calls this with the parsed file's
+ * headers + sample values + target ObjectType id, and gets back a
+ * suggestion list it renders into the mapping table.
+ */
+final class AutoMapController
+{
+    public function __construct(
+        private readonly AutoMapper $autoMapper,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly ObjectTypeAttributeRepositoryInterface $objectTypeAttributes,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-sessions/auto-map',
+        name: 'imports_auto_map',
+        methods: ['POST'],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+        if (!\is_array($payload)) {
+            throw new BadRequestHttpException('Body must be a JSON object.');
+        }
+
+        $headers = $payload['column_headers'] ?? null;
+        if (!\is_array($headers) || [] === $headers) {
+            throw new BadRequestHttpException('column_headers (non-empty list) is required.');
+        }
+
+        $sampleValues = $payload['sample_values'] ?? [];
+        if (!\is_array($sampleValues)) {
+            throw new BadRequestHttpException('sample_values must be a list of rows.');
+        }
+
+        $rawTargetId = $payload['target_object_type_id'] ?? null;
+        if (!\is_string($rawTargetId) || '' === $rawTargetId) {
+            throw new BadRequestHttpException('target_object_type_id is required.');
+        }
+
+        try {
+            $targetId = Uuid::fromString($rawTargetId);
+        } catch (InvalidArgumentException) {
+            throw new BadRequestHttpException(\sprintf('Invalid target_object_type_id "%s".', $rawTargetId));
+        }
+
+        $objectType = $this->objectTypes->findById($targetId);
+        if (!$objectType instanceof ObjectType) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $rawTargetId));
+        }
+
+        $availableCodes = [];
+        foreach ($this->objectTypeAttributes->findByObjectType($objectType) as $junction) {
+            $availableCodes[] = $junction->getAttribute()->getCode();
+        }
+
+        $normalisedHeaders = [];
+        foreach ($headers as $header) {
+            $normalisedHeaders[] = \is_scalar($header) ? (string) $header : '';
+        }
+
+        $normalisedRows = [];
+        foreach ($sampleValues as $row) {
+            if (!\is_array($row)) {
+                continue;
+            }
+            $cells = [];
+            foreach ($row as $cell) {
+                if (null === $cell) {
+                    $cells[] = null;
+                } else {
+                    $cells[] = \is_scalar($cell) ? (string) $cell : '';
+                }
+            }
+            $normalisedRows[] = $cells;
+        }
+
+        $suggestions = $this->autoMapper->map($availableCodes, $normalisedHeaders, $normalisedRows);
+
+        return new JsonResponse(
+            [
+                'mappings' => array_map(
+                    static fn (ColumnMappingSuggestion $suggestion): array => [
+                        'column_index' => $suggestion->columnIndex,
+                        'column_header' => $suggestion->columnHeader,
+                        'suggested_attribute_code' => $suggestion->suggestedAttributeCode,
+                        'confidence' => $suggestion->confidence->value,
+                        'sample_values' => $suggestion->sampleValues,
+                        'alternative_attribute_code' => $suggestion->alternativeAttributeCode,
+                    ],
+                    $suggestions,
+                ),
+            ],
+            Response::HTTP_OK,
+        );
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/DictionaryController.php
+++ b/apps/api/src/Import/Presentation/Controller/DictionaryController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Import\Application\Service\MappingDictionaryService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Read-only endpoint serving the rules-based dictionary so the wizard
+ * can preview "did you mean" hints client-side without round-tripping
+ * to {@see AutoMapController}.
+ */
+final class DictionaryController
+{
+    public function __construct(
+        private readonly MappingDictionaryService $dictionary,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-sessions/dictionary',
+        name: 'imports_dictionary',
+        methods: ['GET'],
+    )]
+    public function __invoke(): JsonResponse
+    {
+        $response = new JsonResponse(
+            ['attributes' => $this->dictionary->load()],
+            Response::HTTP_OK,
+        );
+        // Service-level cache is 5 min; mirror that on the HTTP layer
+        // so browsers / proxies do not hammer the endpoint.
+        $response->setPublic();
+        $response->setMaxAge(300);
+
+        return $response;
+    }
+}

--- a/apps/api/tests/Api/Import/AutoMapApiTest.php
+++ b/apps/api/tests/Api/Import/AutoMapApiTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP-02 (#443) ApiTestCase — wizard Step 2 round-trip.
+ *
+ * Anchor case from spec §5.3: 15 festo headers → 12 auto-recognised
+ * + 3 manual. Test seeds the 12 attributes + binds them to the
+ * built-in product ObjectType so the matcher's "available attributes"
+ * filter accepts every dictionary-driven hit.
+ */
+final class AutoMapApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function festoHeadersResolveToTwelveOutOfFifteenSuggestions(): void
+    {
+        $this->seedProductAttributes();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/import-sessions/auto-map', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                'column_headers' => [
+                    'Kod produktu', 'Nazwa', 'Cena netto', 'Producent', 'Kategoria',
+                    'EAN', 'Description', 'image_1', 'image_2', 'image_3',
+                    'IP_class', 'Numer Festo', 'Srednica zewn.', 'Stara cena', 'Notatki wewn.',
+                ],
+                'sample_values' => [
+                    ['FESTO-1', 'Czujnik X-200', '245.50', 'Festo', 'Pneumatyka', '5901234567890', 'Czujnik', 'a.jpg', 'b.jpg', 'c.jpg', 'IP67', 'ABC-987', '12.5 mm', '299.00', 'Promo'],
+                ],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        $mappings = $body['mappings'] ?? null;
+        self::assertIsArray($mappings);
+        self::assertCount(15, $mappings);
+
+        $auto = array_filter($mappings, static fn ($row): bool => \is_array($row) && 'auto' === ($row['confidence'] ?? null));
+        $manual = array_filter($mappings, static fn ($row): bool => \is_array($row) && 'manual' === ($row['confidence'] ?? null));
+
+        self::assertCount(12, $auto, 'Spec §5.3 anchor: 12/15 auto-mapped on the festo fixture.');
+        self::assertCount(3, $manual);
+    }
+
+    #[Test]
+    public function rejectsRequestWithoutColumnHeaders(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/import-sessions/auto-map', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                'column_headers' => [],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    #[Test]
+    public function rejectsUnknownObjectTypeWith404(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/import-sessions/auto-map', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'target_object_type_id' => '01943fd0-0000-7000-0000-000000000000',
+                'column_headers' => ['sku'],
+                'sample_values' => [],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function dictionaryEndpointReturnsMappedAttributes(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/import-sessions/dictionary');
+
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        $attributes = $body['attributes'] ?? null;
+        self::assertIsArray($attributes);
+        self::assertArrayHasKey('sku', $attributes);
+        self::assertIsArray($attributes['sku']);
+        self::assertContains('kodproduktu', $attributes['sku']);
+    }
+
+    private function seedProductAttributes(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $attributes = [
+            'sku' => AttributeType::Text,
+            'name' => AttributeType::Text,
+            'price' => AttributeType::Number,
+            'brand' => AttributeType::Text,
+            'category' => AttributeType::Text,
+            'ean' => AttributeType::Text,
+            'description' => AttributeType::Text,
+            'main_image' => AttributeType::Text,
+            'gallery_2' => AttributeType::Text,
+            'gallery_3' => AttributeType::Text,
+            'ip_class' => AttributeType::Text,
+            'diameter' => AttributeType::Text,
+        ];
+
+        $position = 1;
+        foreach ($attributes as $code => $type) {
+            $attribute = new Attribute($code, ['en' => ucfirst(str_replace('_', ' ', $code))], $type);
+            $em->persist($attribute);
+            $em->persist(new ObjectTypeAttribute($product, $attribute, false, $position++));
+        }
+        $em->flush();
+    }
+}

--- a/apps/api/tests/Unit/Import/AutoMapperTest.php
+++ b/apps/api/tests/Unit/Import/AutoMapperTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Application\Service\AutoMapper;
+use App\Import\Application\Service\MappingDictionaryProvider;
+use App\Import\Application\Service\MappingDictionaryService;
+use App\Import\Domain\Enum\MappingConfidence;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class AutoMapperTest extends TestCase
+{
+    #[Test]
+    public function festoFixtureHits12OutOf15ColumnsExactMatches(): void
+    {
+        $mapper = $this->mapperWithRealDictionary();
+        $available = $this->festoAvailableAttributeCodes();
+
+        $headers = [
+            'Kod produktu', 'Nazwa', 'Cena netto', 'Producent', 'Kategoria',
+            'EAN', 'Description', 'image_1', 'image_2', 'image_3',
+            'IP_class', 'Numer Festo', 'Srednica zewn.', 'Stara cena', 'Notatki wewn.',
+        ];
+
+        $suggestions = $mapper->map($available, $headers, []);
+        self::assertCount(15, $suggestions);
+
+        $auto = array_filter($suggestions, static fn ($s) => MappingConfidence::Auto === $s->confidence);
+        $manual = array_filter($suggestions, static fn ($s) => MappingConfidence::Manual === $s->confidence);
+
+        self::assertCount(12, $auto, 'Spec §5.3: 12 auto-matched columns on the festo fixture.');
+        self::assertCount(3, $manual);
+
+        $byHeader = [];
+        foreach ($suggestions as $suggestion) {
+            $byHeader[$suggestion->columnHeader] = $suggestion->suggestedAttributeCode;
+        }
+        self::assertSame('sku', $byHeader['Kod produktu']);
+        self::assertSame('name', $byHeader['Nazwa']);
+        self::assertSame('price', $byHeader['Cena netto']);
+        self::assertSame('brand', $byHeader['Producent']);
+        self::assertSame('ean', $byHeader['EAN']);
+        self::assertSame('main_image', $byHeader['image_1']);
+        self::assertSame('gallery_3', $byHeader['image_3']);
+        self::assertSame('ip_class', $byHeader['IP_class']);
+        self::assertSame('diameter', $byHeader['Srednica zewn.']);
+        self::assertNull($byHeader['Numer Festo']);
+        self::assertNull($byHeader['Stara cena']);
+    }
+
+    #[Test]
+    public function fuzzyMatchesTypoWithLevenshteinUnderTwo(): void
+    {
+        $mapper = $this->mapperWithDictionary([
+            'product' => ['aliases' => ['name', 'nazwa', 'tytul']],
+        ]);
+
+        $suggestions = $mapper->map(['product'], ['nawa'], []);
+
+        self::assertSame(MappingConfidence::Fuzzy, $suggestions[0]->confidence);
+        self::assertSame('product', $suggestions[0]->suggestedAttributeCode);
+    }
+
+    #[Test]
+    public function manualWhenNoMatchAnywhere(): void
+    {
+        $mapper = $this->mapperWithDictionary([
+            'sku' => ['aliases' => ['sku', 'kod']],
+        ]);
+
+        $suggestions = $mapper->map(['sku'], ['Numer wewnetrzny'], []);
+
+        self::assertSame(MappingConfidence::Manual, $suggestions[0]->confidence);
+        self::assertNull($suggestions[0]->suggestedAttributeCode);
+    }
+
+    #[Test]
+    public function emptyHeaderBecomesSkip(): void
+    {
+        $mapper = $this->mapperWithDictionary([]);
+
+        $suggestions = $mapper->map([], ['', '   '], []);
+
+        self::assertSame(MappingConfidence::Skip, $suggestions[0]->confidence);
+        self::assertSame(MappingConfidence::Skip, $suggestions[1]->confidence);
+    }
+
+    #[Test]
+    public function suggestsAreFilteredAgainstAvailableAttributes(): void
+    {
+        // dictionary maps "kod" → "sku" but the ObjectType does not have "sku".
+        $mapper = $this->mapperWithDictionary([
+            'sku' => ['aliases' => ['kod']],
+        ]);
+
+        $suggestions = $mapper->map(['name'], ['kod'], []);
+
+        // Auto would have suggested "sku" but it is not on the available
+        // list, so the matcher falls back to manual.
+        self::assertSame(MappingConfidence::Manual, $suggestions[0]->confidence);
+    }
+
+    #[Test]
+    public function diacriticsAreNormalisedThroughTheStripper(): void
+    {
+        $mapper = $this->mapperWithRealDictionary();
+
+        $suggestions = $mapper->map(['diameter'], ['Średnica zewn.'], []);
+
+        self::assertSame('diameter', $suggestions[0]->suggestedAttributeCode);
+        self::assertSame(MappingConfidence::Auto, $suggestions[0]->confidence);
+    }
+
+    #[Test]
+    public function sampleValuesAreSlicedPerColumn(): void
+    {
+        $mapper = $this->mapperWithDictionary([
+            'sku' => ['aliases' => ['sku']],
+            'name' => ['aliases' => ['name']],
+        ]);
+
+        $suggestions = $mapper->map(
+            ['sku', 'name'],
+            ['sku', 'name'],
+            [['ABC-1', 'Foo'], ['DEF-2', 'Bar']],
+        );
+
+        self::assertSame(['ABC-1', 'DEF-2'], $suggestions[0]->sampleValues);
+        self::assertSame(['Foo', 'Bar'], $suggestions[1]->sampleValues);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function festoAvailableAttributeCodes(): array
+    {
+        return [
+            'sku', 'name', 'price', 'brand', 'category', 'ean', 'description',
+            'main_image', 'gallery_2', 'gallery_3', 'ip_class', 'diameter',
+            'short_description', 'weight', 'color',
+        ];
+    }
+
+    private function mapperWithRealDictionary(): AutoMapper
+    {
+        $dictionaryPath = __DIR__.'/../../../config/imports/mapping_dictionary.yaml';
+        $service = new MappingDictionaryService($dictionaryPath, new ArrayAdapter());
+
+        return new AutoMapper($service);
+    }
+
+    /**
+     * @param array<string, array{aliases: list<string>}> $entries
+     */
+    private function mapperWithDictionary(array $entries): AutoMapper
+    {
+        $dictionary = new class($entries) implements MappingDictionaryProvider {
+            /**
+             * @param array<string, array{aliases: list<string>}> $entries
+             */
+            public function __construct(private readonly array $entries)
+            {
+            }
+
+            public function load(): array
+            {
+                $out = [];
+                foreach ($this->entries as $code => $entry) {
+                    $out[$code] = $entry['aliases'];
+                }
+
+                return $out;
+            }
+
+            public function aliasIndex(): array
+            {
+                $index = [];
+                foreach ($this->entries as $code => $entry) {
+                    foreach ($entry['aliases'] as $alias) {
+                        $index[$alias] = $code;
+                    }
+                }
+
+                return $index;
+            }
+        };
+
+        return new AutoMapper($dictionary);
+    }
+}

--- a/apps/api/tests/Unit/Import/DelimiterDetectorTest.php
+++ b/apps/api/tests/Unit/Import/DelimiterDetectorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Application\Service\DelimiterDetector;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DelimiterDetectorTest extends TestCase
+{
+    #[Test]
+    public function semicolonIsPickedForPolishExports(): void
+    {
+        $detector = new DelimiterDetector();
+        $sample = "sku;name;price\nFOO-1;Czujnik;99\nBAR-2;Zawor;120\n";
+
+        self::assertSame(';', $detector->detect($sample));
+    }
+
+    #[Test]
+    public function commaIsPickedForUsExports(): void
+    {
+        $detector = new DelimiterDetector();
+        $sample = "sku,name,price\nFOO-1,Sensor,99\nBAR-2,Valve,120\n";
+
+        self::assertSame(',', $detector->detect($sample));
+    }
+
+    #[Test]
+    public function tabIsPickedForTsv(): void
+    {
+        $detector = new DelimiterDetector();
+        $sample = "sku\tname\tprice\nFOO-1\tSensor\t99\nBAR-2\tValve\t120\n";
+
+        self::assertSame("\t", $detector->detect($sample));
+    }
+
+    #[Test]
+    public function semicolonWinsOverCommaWhenConsistencyTies(): void
+    {
+        $detector = new DelimiterDetector();
+        // Headers and values both contain the same number of `,` and `;`,
+        // but `;` ranks first in the candidate order so it wins.
+        $sample = "a;b;c\nx;y;z\n1;2;3\n";
+
+        self::assertSame(';', $detector->detect($sample));
+    }
+
+    #[Test]
+    public function fallsBackToSemicolonOnEmptySample(): void
+    {
+        $detector = new DelimiterDetector();
+
+        self::assertSame(';', $detector->detect(''));
+    }
+}

--- a/apps/api/tests/Unit/Import/EncodingDetectorTest.php
+++ b/apps/api/tests/Unit/Import/EncodingDetectorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Application\Service\EncodingDetector;
+use App\Import\Domain\Enum\FileEncoding;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EncodingDetectorTest extends TestCase
+{
+    #[Test]
+    public function utf8BomIsRecognised(): void
+    {
+        $detector = new EncodingDetector();
+        $bytes = "\xEF\xBB\xBFsku;name\nABC-1;Czujnik\n";
+
+        self::assertSame(FileEncoding::Utf8Bom, $detector->detect($bytes));
+    }
+
+    #[Test]
+    public function plainUtf8IsRecognised(): void
+    {
+        $detector = new EncodingDetector();
+        $bytes = "sku;name\nABC-1;Czujnik ciśnienia\n";
+
+        self::assertSame(FileEncoding::Utf8, $detector->detect($bytes));
+    }
+
+    #[Test]
+    public function windows1250IsRecognisedFromPolishBytes(): void
+    {
+        $detector = new EncodingDetector();
+        $cp1250 = iconv('UTF-8', 'Windows-1250', "sku;name\nABC-1;Czujnik ciśnienia\n");
+        self::assertNotFalse($cp1250);
+
+        self::assertSame(FileEncoding::Windows1250, $detector->detect($cp1250));
+    }
+
+    #[Test]
+    public function bomIsStrippedFromBytes(): void
+    {
+        $detector = new EncodingDetector();
+        $withBom = "\xEF\xBB\xBFhello";
+
+        self::assertSame('hello', $detector->stripBom($withBom));
+    }
+
+    #[Test]
+    public function stripBomLeavesPlainBytesAlone(): void
+    {
+        $detector = new EncodingDetector();
+        self::assertSame('hello', $detector->stripBom('hello'));
+    }
+}

--- a/apps/api/tests/Unit/Import/FileParserServiceTest.php
+++ b/apps/api/tests/Unit/Import/FileParserServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Application\Service\DelimiterDetector;
+use App\Import\Application\Service\EncodingDetector;
+use App\Import\Application\Service\FileParserService;
+use App\Import\Domain\Enum\FileEncoding;
+use App\Import\Domain\Exception\InvalidImportFileException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class FileParserServiceTest extends TestCase
+{
+    #[Test]
+    public function parsesTheFestoCsvFixtureWith15HeadersAnd3SampleRows(): void
+    {
+        $service = $this->parser();
+        $path = __DIR__.'/../../fixtures/imports/festo-q2-2026.csv';
+
+        $parsed = $service->parse($path);
+
+        self::assertCount(15, $parsed->headers);
+        self::assertSame('Kod produktu', $parsed->headers[0]);
+        self::assertSame('Notatki wewn.', $parsed->headers[14]);
+        self::assertSame(3, $parsed->totalRows);
+        self::assertCount(3, $parsed->sampleRows);
+        self::assertSame(';', $parsed->delimiter);
+        self::assertSame(FileEncoding::Utf8, $parsed->encoding);
+    }
+
+    #[Test]
+    public function detectsWindows1250EncodingFromGeneratedFile(): void
+    {
+        $service = $this->parser();
+        $contents = "sku;name\nABC-1;Czujnik ciśnienia\n";
+        $cp1250 = iconv('UTF-8', 'Windows-1250', $contents);
+        self::assertNotFalse($cp1250);
+
+        $path = $this->writeTempFile($cp1250, '.csv');
+        try {
+            $parsed = $service->parse($path);
+            self::assertSame(FileEncoding::Windows1250, $parsed->encoding);
+            self::assertSame('Czujnik ciśnienia', $parsed->sampleRows[0][1]);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function utf8BomIsStrippedFromHeaders(): void
+    {
+        $service = $this->parser();
+        $path = $this->writeTempFile("\xEF\xBB\xBFsku;name\nFOO-1;Sensor\n", '.csv');
+        try {
+            $parsed = $service->parse($path);
+            self::assertSame(['sku', 'name'], $parsed->headers);
+            self::assertSame(FileEncoding::Utf8Bom, $parsed->encoding);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function rejectsEmptyCsvFile(): void
+    {
+        $service = $this->parser();
+        $path = $this->writeTempFile('', '.csv');
+
+        try {
+            $this->expectException(InvalidImportFileException::class);
+            $service->parse($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function rejectsUnsupportedExtension(): void
+    {
+        $service = $this->parser();
+        $path = $this->writeTempFile('whatever', '.xls');
+
+        try {
+            $this->expectException(InvalidImportFileException::class);
+            $this->expectExceptionMessageMatches('/Unsupported import file extension/');
+            $service->parse($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    private function parser(): FileParserService
+    {
+        return new FileParserService(new EncodingDetector(), new DelimiterDetector());
+    }
+
+    private function writeTempFile(string $contents, string $suffix): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'imp-test-');
+        self::assertNotFalse($path);
+        $renamed = $path.$suffix;
+        rename($path, $renamed);
+        file_put_contents($renamed, $contents);
+
+        return $renamed;
+    }
+}

--- a/apps/api/tests/Unit/Import/MappingDictionaryServiceTest.php
+++ b/apps/api/tests/Unit/Import/MappingDictionaryServiceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Application\Service\MappingDictionaryService;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class MappingDictionaryServiceTest extends TestCase
+{
+    #[Test]
+    public function loadsCanonicalAttributesFromTheRealYaml(): void
+    {
+        $service = $this->serviceWithRealYaml();
+        $dictionary = $service->load();
+
+        // Spot-check the spec §5.3 anchor entries.
+        self::assertArrayHasKey('sku', $dictionary);
+        self::assertArrayHasKey('name', $dictionary);
+        self::assertArrayHasKey('price', $dictionary);
+        self::assertArrayHasKey('main_image', $dictionary);
+        self::assertArrayHasKey('gallery_2', $dictionary);
+        self::assertContains('kodproduktu', $dictionary['sku']);
+    }
+
+    #[Test]
+    public function aliasIndexInvertsTheDictionary(): void
+    {
+        $service = $this->serviceWithRealYaml();
+        $index = $service->aliasIndex();
+
+        self::assertSame('sku', $index['kodproduktu']);
+        self::assertSame('name', $index['nazwa']);
+        self::assertSame('price', $index['cena']);
+        self::assertSame('brand', $index['producent']);
+    }
+
+    #[Test]
+    public function returnsEmptyDictionaryWhenFileMissing(): void
+    {
+        $service = new MappingDictionaryService('/dev/null/missing.yaml', new ArrayAdapter());
+
+        self::assertSame([], $service->load());
+    }
+
+    #[Test]
+    public function dictionaryIsCachedAcrossCalls(): void
+    {
+        $service = $this->serviceWithRealYaml();
+
+        // Two calls return the same payload — `load()` is the API contract,
+        // not a constructor parameter, so a stable result on repeat calls
+        // is the user-visible cache contract here.
+        self::assertSame($service->load(), $service->load());
+    }
+
+    private function serviceWithRealYaml(): MappingDictionaryService
+    {
+        $path = __DIR__.'/../../../config/imports/mapping_dictionary.yaml';
+
+        return new MappingDictionaryService($path, new ArrayAdapter());
+    }
+}

--- a/apps/api/tests/fixtures/imports/festo-q2-2026.csv
+++ b/apps/api/tests/fixtures/imports/festo-q2-2026.csv
@@ -1,0 +1,4 @@
+Kod produktu;Nazwa;Cena netto;Producent;Kategoria;EAN;Description;image_1;image_2;image_3;IP_class;Numer Festo;Srednica zewn.;Stara cena;Notatki wewn.
+FESTO-1;Czujnik X-200;245.50;Festo;Pneumatyka;5901234567890;Czujnik cisnienia precyzyjny;img1.jpg;img1_2.jpg;img1_3.jpg;IP67;FESTO-ABC-987;12.5 mm;299.00;Promo Q2
+FESTO-2;Zawor dwudrogowy;520.00;Festo;Pneumatyka;5901234567891;Zawor wysokoprzeplywowy;img2.jpg;img2_2.jpg;img2_3.jpg;IP65;FESTO-DEF-123;25.0 mm;560.00;
+FESTO-3;Cylinder kompaktowy;780.00;Festo;Pneumatyka;5901234567892;Cylinder dwustronnego dzialania;img3.jpg;;;IP54;FESTO-GHI-456;32.0 mm;850.00;Wyprzedaz


### PR DESCRIPTION
## Cel

Wizard Step 1 (Upload) i Step 2 (Mapping) — backend infrastruktura. Parser xlsx/csv + rules-based dictionary PL/EN (~30 atrybutów × 5-10 aliasów) + auto-mapper z fuzzy fallback (Levenshtein < 2). Spec: [`feature-imports.md §5.2 + §5.3`](Project%20Plan/UI/feature-imports.md). Zamyka [#443](https://github.com/malipie/PIM/issues/443).

## Zakres

**Services** (`apps/api/src/Import/Application/Service/`):
- `MappingDictionaryService` — load YAML + 5min cache.app. Interface `MappingDictionaryProvider` umożliwia stub w testach jednostkowych.
- `FileParserService` — xlsx (PhpSpreadsheet, pierwszy arkusz only z `hadMultipleSheets` flagą) + CSV (league/csv).
- `EncodingDetector` — UTF-8 BOM → UTF-8 → Windows-1250 → ISO-8859-2 (kolejność per spec §7.2).
- `DelimiterDetector` — picks the most consistent z `;`, `,`, `\t`, `|`.
- `AutoMapper` — exact alias → fuzzy (Levenshtein < 2) → manual. Diacritics zniwelowane po obu stronach (`Średnica zewn.` → `srednicazewn` → `diameter`).

**HTTP**:
- `POST /api/import-sessions/auto-map` — body: `{column_headers[], sample_values[][], target_object_type_id}` → `{mappings: [{column_index, column_header, suggested_attribute_code, confidence, sample_values}]}`. Validates target ObjectType i filtruje dictionary hits do live attributes.
- `GET /api/import-sessions/dictionary` — cached attribute aliases map (5min HTTP cache mirror).

**RBAC** (`apps/api/src/Identity/Domain/Rbac/RbacMatrix.php`):
- Dodane resources: `import_session`, `import_profile`, `backup`
- Catalog Manager (Kasia, primary persona) → RWD na `import_session` + `import_profile`, R na `backup`
- Backup write zostaje admin-only (spec §7.8)

**Dictionary** (`apps/api/config/imports/mapping_dictionary.yaml`):
- Top 30 atrybutów × 5-10 aliases każdy: sku, name, price, brand, ean, description, short_description, category, main_image, gallery_2..10, weight, dimensions, color, ip_class, voltage, power, stock, vat_rate, unit, tags, meta_*

**Fixture** (`apps/api/tests/fixtures/imports/festo-q2-2026.csv`):
- 15 kolumn, 3 rzędy danych. Anchor case spec §5.3: 12 auto + 3 manual.

## Quality gates (DoD)

- ✅ PHPStan max: zero errors
- ✅ PHPUnit unit (Import suite): **51 tests / 113 assertions** green
- ✅ ApiTestCase (`AutoMapApiTest`): festo headers → 12/15 auto + 3 manual round-trip przez HTTP, plus dictionary endpoint test
- ✅ composer audit: zero advisories
- ✅ cs-fix: applied

## Test plan

- [ ] PHPStan max zielony w CI
- [ ] PHPUnit unit + api zielone (festo anchor case `12 auto + 3 manual`)
- [ ] composer audit czyste
- [ ] Manual smoke 5 min: stack up → curl `POST /api/import-sessions/auto-map` z festo payload → response 200 z 12 auto

Refs #443