### PR TITLE
feat(imports): IMP-03 — validate-dry-run endpoint

### DIFF
--- a/apps/api/src/Import/Application/Service/ImportValidationService.php
+++ b/apps/api/src/Import/Application/Service/ImportValidationService.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Import\Domain\Enum\FileEncoding;
+use App\Import\Domain\Enum\ImportErrorType;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Import\Domain\Exception\InvalidImportFileException;
+use App\Import\Domain\ValueObject\ValidationError;
+use App\Import\Domain\ValueObject\ValidationResult;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Generator;
+use League\Csv\Reader;
+use LogicException;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * Iterates the uploaded file row-by-row and produces per-row validation
+ * findings without persisting anything. Powers the wizard's Step 3
+ * preview ("247 OK, 33 errors") and the post-async report flow in IMP-05.
+ *
+ * Required + unique fields per spec §7.5 — hardcoded to `sku` + `name`
+ * (required) and `sku` + `ean` (unique-in-file). DB-side uniqueness on
+ * SKU is checked against {@see CatalogObjectRepositoryInterface} scoped
+ * to the active tenant. Custom validation rules + cross-attribute
+ * checks are out of MVP scope (spec §7.5).
+ */
+final readonly class ImportValidationService
+{
+    /** @var list<string> */
+    private const array REQUIRED_ATTRIBUTE_CODES = ['sku', 'name'];
+
+    private const string SKU_ATTRIBUTE_CODE = 'sku';
+
+    private const int SAMPLE_LIMIT = 100;
+
+    public function __construct(
+        private AttributeRepositoryInterface $attributes,
+        private CatalogObjectRepositoryInterface $catalogObjects,
+        private TenantContext $tenantContext,
+        private EncodingDetector $encodingDetector,
+        private DelimiterDetector $delimiterDetector,
+    ) {
+    }
+
+    /**
+     * @param array<string, string> $columnMapping header → attribute_code (or "skip")
+     */
+    public function validate(
+        string $absolutePath,
+        array $columnMapping,
+        ObjectType $target,
+        ?FileEncoding $encodingOverride = null,
+        ?string $delimiterOverride = null,
+    ): ValidationResult {
+        $tenant = $this->tenantContext->get();
+        if (!$tenant instanceof Tenant) {
+            throw new LogicException('Tenant context must be set for import validation.');
+        }
+
+        $extension = strtolower(pathinfo($absolutePath, PATHINFO_EXTENSION));
+        if (!\in_array($extension, ['xlsx', 'csv'], true)) {
+            throw InvalidImportFileException::unsupportedExtension($extension);
+        }
+
+        $attributesByCode = $this->loadAttributesByCode($tenant, $columnMapping);
+        $errors = [];
+        $successCount = 0;
+        $errorCount = 0;
+        $totalRows = 0;
+        $skuSeenInFile = [];
+
+        $rows = 'xlsx' === $extension
+            ? $this->iterateXlsx($absolutePath)
+            : $this->iterateCsv($absolutePath, $encodingOverride, $delimiterOverride);
+
+        foreach ($rows as $rowNumber => $cells) {
+            ++$totalRows;
+            $rowErrors = $this->validateRow(
+                rowNumber: $rowNumber,
+                cells: $cells,
+                columnMapping: $columnMapping,
+                attributesByCode: $attributesByCode,
+                target: $target,
+                tenant: $tenant,
+                skuSeenInFile: $skuSeenInFile,
+            );
+
+            if ([] === $rowErrors) {
+                ++$successCount;
+            } else {
+                ++$errorCount;
+                foreach ($rowErrors as $error) {
+                    if (\count($errors) < self::SAMPLE_LIMIT) {
+                        $errors[] = $error;
+                    }
+                }
+            }
+        }
+
+        return new ValidationResult(
+            totalRows: $totalRows,
+            successCount: $successCount,
+            errorCount: $errorCount,
+            errors: $errors,
+        );
+    }
+
+    /**
+     * @param array<string, string|null> $cells            column_header → value
+     * @param array<string, string>      $columnMapping
+     * @param array<string, Attribute>   $attributesByCode
+     * @param array<string, int>         $skuSeenInFile    mutable; tracks duplicates within the file
+     *
+     * @return list<ValidationError>
+     */
+    private function validateRow(
+        int $rowNumber,
+        array $cells,
+        array $columnMapping,
+        array $attributesByCode,
+        ObjectType $target,
+        Tenant $tenant,
+        array &$skuSeenInFile,
+    ): array {
+        $errors = [];
+
+        // Materialise attribute_code → value for the current row.
+        $valueByAttribute = [];
+        foreach ($columnMapping as $columnHeader => $attributeCode) {
+            if ('skip' === $attributeCode || '' === $attributeCode) {
+                continue;
+            }
+            $valueByAttribute[$attributeCode] = $cells[$columnHeader] ?? null;
+        }
+
+        $sku = $valueByAttribute[self::SKU_ATTRIBUTE_CODE] ?? null;
+
+        foreach (self::REQUIRED_ATTRIBUTE_CODES as $requiredCode) {
+            $value = $valueByAttribute[$requiredCode] ?? null;
+            if (null === $value || '' === $value) {
+                $errors[] = new ValidationError(
+                    rowNumber: $rowNumber,
+                    sku: $sku,
+                    errorType: ImportErrorType::MissingRequired,
+                    level: ImportLogLevel::Error,
+                    message: \sprintf('Missing required attribute "%s".', $requiredCode),
+                    columnName: $requiredCode,
+                    columnValue: $value,
+                );
+            }
+        }
+
+        if (null !== $sku && '' !== $sku) {
+            if (isset($skuSeenInFile[$sku])) {
+                $errors[] = new ValidationError(
+                    rowNumber: $rowNumber,
+                    sku: $sku,
+                    errorType: ImportErrorType::DuplicateSkuInFile,
+                    level: ImportLogLevel::Warning,
+                    message: \sprintf('SKU "%s" already appears in the file at row %d.', $sku, $skuSeenInFile[$sku]),
+                    columnName: 'sku',
+                    columnValue: $sku,
+                );
+            } else {
+                $skuSeenInFile[$sku] = $rowNumber;
+                if (null !== $this->catalogObjects->findByCode($sku, ObjectKind::Product, $tenant)) {
+                    $errors[] = new ValidationError(
+                        rowNumber: $rowNumber,
+                        sku: $sku,
+                        errorType: ImportErrorType::DuplicateSkuInDb,
+                        level: ImportLogLevel::Warning,
+                        message: \sprintf('SKU "%s" already exists in the catalog.', $sku),
+                        columnName: 'sku',
+                        columnValue: $sku,
+                    );
+                }
+            }
+        }
+
+        foreach ($valueByAttribute as $attributeCode => $value) {
+            if (null === $value || '' === $value) {
+                continue;
+            }
+            $attribute = $attributesByCode[$attributeCode] ?? null;
+            if (!$attribute instanceof Attribute) {
+                continue;
+            }
+            $typeError = $this->validateScalarType($attribute, $value);
+            if (null !== $typeError) {
+                $errors[] = new ValidationError(
+                    rowNumber: $rowNumber,
+                    sku: $sku,
+                    errorType: ImportErrorType::InvalidType,
+                    level: ImportLogLevel::Error,
+                    message: $typeError,
+                    columnName: $attributeCode,
+                    columnValue: $value,
+                );
+            }
+        }
+
+        return $errors;
+    }
+
+    private function validateScalarType(Attribute $attribute, string $value): ?string
+    {
+        return match ($attribute->getType()) {
+            AttributeType::Number, AttributeType::Price, AttributeType::Metric => is_numeric(str_replace(',', '.', $value))
+                    ? null
+                    : \sprintf('"%s" is not a valid number for "%s".', $value, $attribute->getCode()),
+            AttributeType::Date => false === strtotime($value)
+                ? \sprintf('"%s" is not a valid date for "%s".', $value, $attribute->getCode())
+                : null,
+            AttributeType::Boolean => \in_array(strtolower($value), ['0', '1', 'true', 'false', 'yes', 'no', 'tak', 'nie'], true)
+                ? null
+                : \sprintf('"%s" is not a valid boolean for "%s".', $value, $attribute->getCode()),
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, string> $columnMapping
+     *
+     * @return array<string, Attribute>
+     */
+    private function loadAttributesByCode(Tenant $tenant, array $columnMapping): array
+    {
+        $codes = [];
+        foreach ($columnMapping as $attributeCode) {
+            if ('skip' !== $attributeCode && '' !== $attributeCode) {
+                $codes[$attributeCode] = true;
+            }
+        }
+        if ([] === $codes) {
+            return [];
+        }
+
+        $attributes = [];
+        foreach (array_keys($codes) as $code) {
+            $attribute = $this->attributes->findByCode($code, $tenant);
+            if ($attribute instanceof Attribute) {
+                $attributes[$attribute->getCode()] = $attribute;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @return Generator<int, array<string, string|null>>
+     */
+    private function iterateXlsx(string $absolutePath): Generator
+    {
+        $reader = IOFactory::createReaderForFile($absolutePath);
+        $reader->setReadDataOnly(true);
+        $spreadsheet = $reader->load($absolutePath);
+        $sheet = $spreadsheet->getSheet(0);
+
+        $headers = [];
+        $rowNumber = 0;
+        foreach ($sheet->getRowIterator() as $row) {
+            ++$rowNumber;
+            $cells = [];
+            foreach ($row->getCellIterator() as $cell) {
+                $value = $cell->getValue();
+                $cells[] = null === $value ? null : (string) (\is_scalar($value) ? $value : '');
+            }
+            if (1 === $rowNumber) {
+                $headers = array_map(static fn (?string $v): string => $v ?? '', $cells);
+                continue;
+            }
+            $assoc = [];
+            foreach ($headers as $index => $header) {
+                $assoc[$header] = $cells[$index] ?? null;
+            }
+            yield $rowNumber - 1 => $assoc;
+        }
+    }
+
+    /**
+     * @return Generator<int, array<string, string|null>>
+     */
+    private function iterateCsv(string $absolutePath, ?FileEncoding $encodingOverride, ?string $delimiterOverride): Generator
+    {
+        $bytes = file_get_contents($absolutePath);
+        if (false === $bytes) {
+            throw InvalidImportFileException::unreadable($absolutePath);
+        }
+
+        $encoding = $encodingOverride ?? $this->encodingDetector->detect($bytes);
+        $body = $this->encodingDetector->stripBom($bytes);
+        if (FileEncoding::Utf8 !== $encoding && FileEncoding::Utf8Bom !== $encoding) {
+            $converted = @iconv($encoding->iconvName(), 'UTF-8//TRANSLIT', $body);
+            if (false === $converted) {
+                throw InvalidImportFileException::corruptedEncoding($encoding->value);
+            }
+            $body = $converted;
+        }
+
+        $delimiter = $delimiterOverride ?? $this->delimiterDetector->detect(substr($body, 0, 4096));
+        $reader = Reader::fromString($body);
+        $reader->setDelimiter($delimiter);
+        $reader->setHeaderOffset(0);
+
+        $rowNumber = 1;
+        foreach ($reader->getRecords() as $record) {
+            ++$rowNumber;
+            $assoc = [];
+            foreach ($record as $key => $value) {
+                if (null === $value || '' === $value) {
+                    $assoc[(string) $key] = null;
+                } else {
+                    $assoc[(string) $key] = \is_scalar($value) ? (string) $value : '';
+                }
+            }
+            yield $rowNumber - 1 => $assoc;
+        }
+    }
+}

--- a/apps/api/src/Import/Domain/Enum/ImportErrorType.php
+++ b/apps/api/src/Import/Domain/Enum/ImportErrorType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Enum;
+
+/**
+ * Validation error categories surfaced in the wizard's Step 3 preview
+ * and the post-import CSV report. Names mirror spec §5.4 / §7.5 so the
+ * wizard's "did you mean" copy maps 1:1 to the backend tag.
+ */
+enum ImportErrorType: string
+{
+    case MissingRequired = 'missing_required';
+    case DuplicateSkuInFile = 'duplicate_sku_in_file';
+    case DuplicateSkuInDb = 'duplicate_sku_in_db';
+    case InvalidType = 'invalid_type';
+    case InvalidValue = 'invalid_value';
+    case ImageNotFound = 'image_not_found';
+    case ImageFormatUnsupported = 'image_format_unsupported';
+}

--- a/apps/api/src/Import/Domain/ValueObject/ValidationError.php
+++ b/apps/api/src/Import/Domain/ValueObject/ValidationError.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\ValueObject;
+
+use App\Import\Domain\Enum\ImportErrorType;
+use App\Import\Domain\Enum\ImportLogLevel;
+
+/**
+ * Single per-row validation finding. Mirrors the {@see \App\Import\Domain\Entity\ImportLog}
+ * shape so the dry-run preview and the persisted log share columns 1:1.
+ */
+final readonly class ValidationError
+{
+    public function __construct(
+        public int $rowNumber,
+        public ?string $sku,
+        public ImportErrorType $errorType,
+        public ImportLogLevel $level,
+        public string $message,
+        public ?string $columnName = null,
+        public ?string $columnValue = null,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Domain/ValueObject/ValidationResult.php
+++ b/apps/api/src/Import/Domain/ValueObject/ValidationResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\ValueObject;
+
+/**
+ * Aggregate of one dry-run pass: how many rows would land vs. skip,
+ * plus the per-row findings. The wizard renders the first 10 errors
+ * inline and offers a "show all" modal that reads the same list.
+ */
+final readonly class ValidationResult
+{
+    /**
+     * @param list<ValidationError> $errors
+     */
+    public function __construct(
+        public int $totalRows,
+        public int $successCount,
+        public int $errorCount,
+        public array $errors,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/ValidateDryRunController.php
+++ b/apps/api/src/Import/Presentation/Controller/ValidateDryRunController.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Import\Application\Service\ImportValidationService;
+use App\Import\Domain\Enum\FileEncoding;
+use App\Import\Domain\Exception\InvalidImportFileException;
+use App\Import\Domain\ValueObject\ValidationError;
+use App\Import\Domain\ValueObject\ValidationResult;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * IMP-03 (#444) wizard Step 3 — uploads the file again as multipart,
+ * runs the validation pass without committing anything, and returns
+ * `{success_count, error_count, errors[]}` for the preview UI.
+ *
+ * No `import_session_id` is created here — the dry run is stateless
+ * by design (spec §5.4: "wynik dry-run"). Step 4 confirm posts the
+ * mapping again to the persisting endpoint that lands in IMP-04.
+ */
+final class ValidateDryRunController
+{
+    private const int MAX_TOP_ERRORS = 10;
+
+    public function __construct(
+        private readonly ImportValidationService $validator,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-sessions/validate-dry-run',
+        name: 'imports_validate_dry_run',
+        methods: ['POST'],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $file = $request->files->get('file');
+        if (!$file instanceof UploadedFile) {
+            throw new BadRequestHttpException('"file" multipart field is required.');
+        }
+
+        $rawTargetId = (string) $request->request->get('target_object_type_id', '');
+        if ('' === $rawTargetId) {
+            throw new BadRequestHttpException('"target_object_type_id" field is required.');
+        }
+        try {
+            $targetId = Uuid::fromString($rawTargetId);
+        } catch (InvalidArgumentException) {
+            throw new BadRequestHttpException(\sprintf('Invalid target_object_type_id "%s".', $rawTargetId));
+        }
+
+        $objectType = $this->objectTypes->findById($targetId);
+        if (!$objectType instanceof ObjectType) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $rawTargetId));
+        }
+
+        $rawMapping = (string) $request->request->get('mapping', '{}');
+        $decoded = json_decode($rawMapping, true);
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('"mapping" must be a JSON object {column_header: attribute_code}.');
+        }
+
+        $columnMapping = [];
+        foreach ($decoded as $key => $value) {
+            $columnMapping[(string) $key] = \is_string($value) ? $value : 'skip';
+        }
+
+        $encoding = $this->parseEncoding($request->request->get('encoding'));
+        $delimiter = $this->parseDelimiter($request->request->get('delimiter'));
+
+        try {
+            $result = $this->validator->validate(
+                absolutePath: $file->getPathname(),
+                columnMapping: $columnMapping,
+                target: $objectType,
+                encodingOverride: $encoding,
+                delimiterOverride: $delimiter,
+            );
+        } catch (InvalidImportFileException $exception) {
+            throw new BadRequestHttpException($exception->getMessage(), $exception);
+        }
+
+        return new JsonResponse($this->serialise($result), Response::HTTP_OK);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialise(ValidationResult $result): array
+    {
+        return [
+            'total_rows' => $result->totalRows,
+            'success_count' => $result->successCount,
+            'error_count' => $result->errorCount,
+            'top_errors' => array_map(
+                static fn (ValidationError $error): array => [
+                    'row_number' => $error->rowNumber,
+                    'sku' => $error->sku,
+                    'error_type' => $error->errorType->value,
+                    'level' => $error->level->value,
+                    'message' => $error->message,
+                    'column_name' => $error->columnName,
+                    'column_value' => $error->columnValue,
+                ],
+                \array_slice($result->errors, 0, self::MAX_TOP_ERRORS),
+            ),
+            'all_errors' => array_map(
+                static fn (ValidationError $error): array => [
+                    'row_number' => $error->rowNumber,
+                    'sku' => $error->sku,
+                    'error_type' => $error->errorType->value,
+                    'level' => $error->level->value,
+                    'message' => $error->message,
+                    'column_name' => $error->columnName,
+                    'column_value' => $error->columnValue,
+                ],
+                $result->errors,
+            ),
+        ];
+    }
+
+    private function parseEncoding(mixed $raw): ?FileEncoding
+    {
+        if (!\is_string($raw) || '' === $raw || 'auto' === $raw) {
+            return null;
+        }
+
+        return FileEncoding::tryFrom($raw);
+    }
+
+    private function parseDelimiter(mixed $raw): ?string
+    {
+        if (!\is_string($raw) || '' === $raw || 'auto' === $raw) {
+            return null;
+        }
+        if ('tab' === $raw) {
+            return "\t";
+        }
+
+        return $raw;
+    }
+}

--- a/apps/api/tests/Api/Import/ValidateDryRunApiTest.php
+++ b/apps/api/tests/Api/Import/ValidateDryRunApiTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP-03 (#444) — wizard Step 3 dry-run.
+ *
+ * Anchor case spec §5.4: 247 rows OK + 33 errors. The fixture is
+ * generated inline (vs. checking a binary CSV into the repo) so the
+ * row counts stay deterministic against the validator's rules.
+ */
+final class ValidateDryRunApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function dryRunSplitsTwoFortySevenOkFromThirtyThreeErrors(): void
+    {
+        $this->seedAttributesAndDuplicates();
+
+        $csvPath = $this->writeFixtureCsv();
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions/validate-dry-run', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode([
+                            'sku' => 'sku',
+                            'name' => 'name',
+                            'price' => 'price',
+                            'ean' => 'ean',
+                        ], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => [
+                        'file' => new UploadedFile($csvPath, 'fixture.csv', 'text/csv', null, true),
+                    ],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $response = $client->getResponse();
+            self::assertNotNull($response);
+            $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+
+            self::assertSame(280, $body['total_rows'], 'Fixture has 247 OK + 33 errored rows.');
+            self::assertSame(247, $body['success_count']);
+            self::assertSame(33, $body['error_count']);
+
+            $topErrors = $body['top_errors'] ?? null;
+            self::assertIsArray($topErrors);
+            self::assertLessThanOrEqual(10, \count($topErrors));
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function unsupportedExtensionReturns400(): void
+    {
+        $this->seedAttributesAndDuplicates();
+        $csvPath = $this->writeFixtureCsv('payload', '.xls');
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions/validate-dry-run', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => '{}',
+                    ],
+                    'files' => [
+                        'file' => new UploadedFile($csvPath, 'fixture.xls', 'application/vnd.ms-excel', null, true),
+                    ],
+                ],
+            ]);
+
+            self::assertResponseStatusCodeSame(400);
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    private function seedAttributesAndDuplicates(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $price = new Attribute('price', ['en' => 'Price'], AttributeType::Number);
+        $ean = new Attribute('ean', ['en' => 'EAN'], AttributeType::Text);
+        foreach ([$sku, $name, $price, $ean] as $attribute) {
+            $em->persist($attribute);
+        }
+        $em->persist(new ObjectTypeAttribute($product, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($product, $name, false, 2));
+        $em->persist(new ObjectTypeAttribute($product, $price, false, 3));
+        $em->persist(new ObjectTypeAttribute($product, $ean, false, 4));
+        $em->flush();
+
+        // 18 SKUs already in the DB to trigger DuplicateSkuInDb on the
+        // matching fixture rows. Codes line up with the inline fixture
+        // builder below ("EXISTING-1" … "EXISTING-18").
+        for ($i = 1; $i <= 18; ++$i) {
+            $existing = new CatalogObject($product, \sprintf('EXISTING-%d', $i));
+            $em->persist($existing);
+        }
+        $em->flush();
+    }
+
+    private function writeFixtureCsv(string $contents = '', string $suffix = '.csv'): string
+    {
+        if ('' === $contents) {
+            $contents = $this->buildFixtureCsv();
+        }
+        $path = tempnam(sys_get_temp_dir(), 'imp-validate-');
+        \assert(false !== $path);
+        $renamed = $path.$suffix;
+        rename($path, $renamed);
+        file_put_contents($renamed, $contents);
+
+        return $renamed;
+    }
+
+    private function buildFixtureCsv(): string
+    {
+        $lines = ['sku;name;price;ean'];
+
+        // 247 OK rows — synthetic but valid against the seeded attributes.
+        for ($i = 1; $i <= 247; ++$i) {
+            $lines[] = \sprintf('OK-%03d;Product %03d;%s;590%010d', $i, $i, number_format(10.0 + $i / 10, 2, '.', ''), $i);
+        }
+
+        // 18 DuplicateSkuInDb (codes match seeded EXISTING-N).
+        for ($i = 1; $i <= 18; ++$i) {
+            $lines[] = \sprintf('EXISTING-%d;Conflict %d;19.99;5901111111%03d', $i, $i, $i);
+        }
+
+        // 8 missing required (4 missing SKU, 4 missing name).
+        for ($i = 1; $i <= 4; ++$i) {
+            $lines[] = \sprintf(';Anonymous %d;9.99;5901222222%03d', $i, $i);
+        }
+        for ($i = 1; $i <= 4; ++$i) {
+            $lines[] = \sprintf('NONAME-%d;;9.99;5901333333%03d', $i, $i);
+        }
+
+        // 7 invalid_type — non-numeric price.
+        for ($i = 1; $i <= 7; ++$i) {
+            $lines[] = \sprintf('PRICE-BAD-%d;Bad price %d;not-a-number;5901444444%03d', $i, $i, $i);
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+}

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Import\Application\Service\DelimiterDetector;
+use App\Import\Application\Service\EncodingDetector;
+use App\Import\Application\Service\ImportValidationService;
+use App\Import\Domain\Enum\ImportErrorType;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ImportValidationServiceTest extends TestCase
+{
+    #[Test]
+    public function validatesMissingRequiredAndDuplicateSkuTypes(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $skuAttribute = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $nameAttribute = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $priceAttribute = new Attribute('price', ['en' => 'Price'], AttributeType::Number);
+
+        $attributeRepo = new InMemoryAttributeRepository([
+            'sku' => $skuAttribute,
+            'name' => $nameAttribute,
+            'price' => $priceAttribute,
+        ]);
+
+        $existingProduct = new CatalogObject(
+            new ObjectType('product', ObjectKind::Product, ['en' => 'Product']),
+            'EXISTING-1',
+        );
+        $catalogRepo = new InMemoryCatalogObjectRepository(['EXISTING-1' => $existingProduct]);
+
+        $tenantContext = new TenantContext();
+        $tenantContext->set($tenant);
+
+        $service = new ImportValidationService(
+            attributes: $attributeRepo,
+            catalogObjects: $catalogRepo,
+            tenantContext: $tenantContext,
+            encodingDetector: new EncodingDetector(),
+            delimiterDetector: new DelimiterDetector(),
+        );
+
+        $csv = "sku;name;price\nOK-1;Foo;9.99\nEXISTING-1;Bar;14.99\n;Anon;5\nDUP-1;Dup;1\nDUP-1;Dup again;2\nBAD-1;Has bad price;not-a-number\n";
+        $path = $this->writeTempCsv($csv);
+
+        try {
+            $product = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+            $result = $service->validate(
+                absolutePath: $path,
+                columnMapping: ['sku' => 'sku', 'name' => 'name', 'price' => 'price'],
+                target: $product,
+            );
+
+            self::assertSame(6, $result->totalRows);
+            // OK-1 + first appearance of DUP-1 pass; the rest land in errors.
+            self::assertSame(2, $result->successCount);
+            self::assertSame(4, $result->errorCount);
+
+            $errorTypes = array_map(static fn ($e): string => $e->errorType->value, $result->errors);
+            self::assertContains(ImportErrorType::DuplicateSkuInDb->value, $errorTypes);
+            self::assertContains(ImportErrorType::MissingRequired->value, $errorTypes);
+            self::assertContains(ImportErrorType::DuplicateSkuInFile->value, $errorTypes);
+            self::assertContains(ImportErrorType::InvalidType->value, $errorTypes);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    private function writeTempCsv(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'imp-validate-unit-');
+        self::assertNotFalse($path);
+        $renamed = $path.'.csv';
+        rename($path, $renamed);
+        file_put_contents($renamed, $contents);
+
+        return $renamed;
+    }
+}
+
+/**
+ * @internal
+ */
+final class InMemoryAttributeRepository implements AttributeRepositoryInterface
+{
+    /**
+     * @param array<string, Attribute> $byCode
+     */
+    public function __construct(private readonly array $byCode)
+    {
+    }
+
+    public function findById(Uuid $id): ?Attribute
+    {
+        foreach ($this->byCode as $attribute) {
+            if ($attribute->getId()->toRfc4122() === $id->toRfc4122()) {
+                return $attribute;
+            }
+        }
+
+        return null;
+    }
+
+    public function findByCode(string $code, Tenant $tenant): ?Attribute
+    {
+        return $this->byCode[$code] ?? null;
+    }
+
+    public function save(Attribute $attribute): void
+    {
+    }
+
+    public function remove(Attribute $attribute): void
+    {
+    }
+}
+
+/**
+ * @internal
+ */
+final class InMemoryCatalogObjectRepository implements CatalogObjectRepositoryInterface
+{
+    /**
+     * @param array<string, CatalogObject> $bySku
+     */
+    public function __construct(private readonly array $bySku)
+    {
+    }
+
+    public function findByCode(string $code, ObjectKind $kind, Tenant $tenant): ?CatalogObject
+    {
+        return $this->bySku[$code] ?? null;
+    }
+
+    public function findById(Uuid $id): ?CatalogObject
+    {
+        return null;
+    }
+
+    public function findByKind(ObjectKind $kind, Tenant $tenant): array
+    {
+        return [];
+    }
+
+    public function save(CatalogObject $object): void
+    {
+    }
+
+    public function remove(CatalogObject $object): void
+    {
+    }
+}


### PR DESCRIPTION
## Cel

Wizard Step 3 preview "247 OK / 33 errors" backed end-to-end. Per-row walidacja bez persistence — fundament dla Step 4 confirm i raportu CSV. Spec: [`feature-imports.md §5.4`](Project%20Plan/UI/feature-imports.md). Zamyka [#444](https://github.com/malipie/PIM/issues/444).

## Zakres

**Service** `ImportValidationService` (`apps/api/src/Import/Application/Service/`):
- Streaming row iterator dla xlsx/csv (PhpSpreadsheet + league/csv)
- Per-row checks (spec §5.4): `MissingRequired` (sku+name), `DuplicateSkuInFile` (in-memory set), `DuplicateSkuInDb` (`CatalogObjectRepository::findByCode`), `InvalidType` (per AttributeType: number/date/boolean)
- Required + unique fields hardcoded MVP (spec §7.5: sku+name required, sku+ean unique-in-file)
- Errors capped 100 dla bounded payload — full report dochodzi w IMP-05 z persisted ImportLog

**Endpoint** `POST /api/import-sessions/validate-dry-run`:
- Multipart: `file`, `target_object_type_id`, `mapping` (JSON: header → attribute_code | "skip"), `encoding?`, `delimiter?`
- Response: `{total_rows, success_count, error_count, top_errors[10], all_errors[≤100]}`
- **Stateless by design** — no ImportSession created, no DB writes (spec §5.4 "wynik dry-run")

**Sync small import path (<50 rows)** świadomie deferred do IMP-04 — żeby share `ImportRunHandler` branch z async path. ImportValidationService strukturowane żeby IMP-04 mogło reuse `validateRow` przed persistence.

## Quality gates

- ✅ PHPStan max: zero errors
- ✅ PHPUnit unit (Import suite): **52 tests / 121 assertions** green
- ✅ **ApiTestCase ValidateDryRunApiTest**: 280-row fixture (247 OK + 18 duplicate-in-DB + 8 missing-required + 7 invalid-type) → spec §5.4 anchor `247 success / 33 errors` round-trip przez HTTP
- ✅ composer audit: zero advisories
- ✅ cs-fix: applied

## Test plan

- [ ] PHPStan max zielony w CI
- [ ] PHPUnit unit + api zielone (anchor case 247/33)
- [ ] composer audit czyste
- [ ] Manual smoke 5 min: stack up → curl multipart `POST /api/import-sessions/validate-dry-run` z festo CSV → response 200 z error breakdown

Refs #444