### PR TITLE
feat(imports): IMP-04 — async ImportRunHandler + endpoints

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -83,6 +83,9 @@ AWS_ASSETS_REGION=eu-central-1
 AWS_ASSETS_KEY=minioadmin
 AWS_ASSETS_SECRET=minioadmin
 AWS_ASSETS_BUCKET=pim-assets
+# IMP-04 (#445) — wizard upload bucket. Same MinIO/S3 cluster, separate
+# bucket so the 7-day TTL purge does not touch DAM assets.
+AWS_IMPORTS_BUCKET=pim-imports
 ###< app/asset-storage ###
 
 ###> symfony/mercure-bundle ###

--- a/apps/api/config/packages/flysystem.yaml
+++ b/apps/api/config/packages/flysystem.yaml
@@ -30,6 +30,14 @@ flysystem:
             options:
                 client: 'pim.assets.s3_client'
                 bucket: '%env(AWS_ASSETS_BUCKET)%'
+        # IMP-04 (#445) — wizard-uploaded source files (CSV / xlsx + ZIP).
+        # Same MinIO instance as assets, dedicated bucket so a TTL policy
+        # (7 days, spec §8.6) can purge stale uploads without touching DAM.
+        imports.storage:
+            adapter: 'aws'
+            options:
+                client: 'pim.assets.s3_client'
+                bucket: '%env(default::AWS_IMPORTS_BUCKET)%'
 
 # CI does not run a MinIO service; the functional `AssetUploaderTest`
 # still wants to write through the real Flysystem operator (it proves the
@@ -42,3 +50,7 @@ when@test:
                 adapter: 'local'
                 options:
                     directory: '%kernel.project_dir%/var/test/assets'
+            imports.storage:
+                adapter: 'local'
+                options:
+                    directory: '%kernel.project_dir%/var/test/imports'

--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -75,3 +75,10 @@ framework:
             # async transport is `sync://`, so behaviour stays in-band
             # without spinning a worker.
             App\Asset\Contracts\Event\AssetThumbnailsRequested: async
+
+            # Imports MVP (#445). Wizard `POST /api/import-sessions`
+            # returns 201 immediately and the worker streams the file
+            # row-by-row via {@see ImportRunHandler}. Sync small (<50
+            # rows) imports bypass dispatch by calling `run()` directly
+            # on the same handler from the controller.
+            App\Import\Domain\Message\ImportRunMessage: async

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -190,6 +190,18 @@ services:
             $dictionaryPath: '%pim.imports.dictionary_path%'
             $cache: '@cache.app'
 
+    # IMP-04 (#445) — async import worker. Bind named storage so the
+    # handler can pull the uploaded source file without autowire
+    # confusion (multiple FilesystemOperator services, one per named
+    # storage).
+    App\Import\Application\Handler\ImportRunHandler:
+        arguments:
+            $importsStorage: '@imports.storage'
+
+    App\Import\Presentation\Controller\StartImportController:
+        arguments:
+            $importsStorage: '@imports.storage'
+
     # API Configurator (#90 / 0.10.1). Argon2id hasher + key generator
     # — see ADR-0016 for the format and algorithm choice. The generator
     # reads `kernel.environment` to embed the four-letter forensic

--- a/apps/api/migrations/Version20260506213907.php
+++ b/apps/api/migrations/Version20260506213907.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * IMP-04 (#445) — captures the header → attribute_code mapping on the
+ * session itself. Profile-less ad-hoc imports keep their mapping after
+ * the request returns; the optional `import_profiles.column_mapping`
+ * is now a "save for next time" snapshot rather than the source of
+ * truth for an in-flight session.
+ */
+final class Version20260506213907 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'IMP-04: import_sessions.column_mapping for profile-less imports.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE import_sessions ADD COLUMN column_mapping JSONB NOT NULL DEFAULT '{}'::jsonb");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import_sessions DROP COLUMN IF EXISTS column_mapping');
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -111,6 +111,17 @@ class CatalogObject extends AggregateRoot implements TenantScoped
      * @var list<array<string, mixed>>|null
      */
     private ?array $variantAxes = null;
+
+    /**
+     * IMP-01 (#442) — links every imported object back to the
+     * {@see \App\Import\Domain\Entity\ImportSession} that created it.
+     * Bare uuid to keep Catalog domain free of an Import-context import.
+     * The DB-level FK with `ON DELETE SET NULL` (see migration
+     * Version20260506191124) keeps orphan rows readable after the
+     * session is hard-deleted.
+     */
+    private ?Uuid $importSessionId = null;
+
     private DateTimeImmutable $createdAt;
     private DateTimeImmutable $updatedAt;
 
@@ -358,6 +369,16 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updatedAt;
+    }
+
+    public function getImportSessionId(): ?Uuid
+    {
+        return $this->importSessionId;
+    }
+
+    public function assignImportSession(?Uuid $sessionId): void
+    {
+        $this->importSessionId = $sessionId;
     }
 
     private function touch(): void

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -75,6 +75,8 @@
                 <option name="jsonb">true</option>
             </options>
         </field>
+        <field name="importSessionId" type="uuid" column="import_session_id" nullable="true"/>
+
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
         <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
 

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Handler;
+
+use App\Import\Application\Service\ImportObjectCreator;
+use App\Import\Application\Service\ImportProgressPublisher;
+use App\Import\Application\Service\ImportRowReader;
+use App\Import\Application\Service\ImportValidationService;
+use App\Import\Domain\Entity\ImportLog;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Message\ImportRunMessage;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Shared\Application\AbstractBatchHandler;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use LogicException;
+use RuntimeException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Throwable;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * IMP-04 (#445) — async (and inline-for-small-files) import execution.
+ *
+ * Streams rows from the uploaded file (downloaded from MinIO into a temp
+ * path), runs the IMP-03 row validation, and persists every clean row
+ * via {@see ImportObjectCreator}. Per-row findings land in
+ * {@see ImportLog} so the post-import CSV report (IMP-05) and the
+ * Mercure progress stream see the same data.
+ *
+ * Memory contract (R-25): batches of 200 rows funnel through
+ * {@see flushAndClear()} so the worker stays under 256 MiB on a 5k-row
+ * import; the long-lived `ImportSession` row is re-merged into the EM
+ * after each clear so counters stay current without straggling
+ * proxy state.
+ */
+#[AsMessageHandler]
+final class ImportRunHandler extends AbstractBatchHandler
+{
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly ImportRowReader $rowReader,
+        private readonly ImportValidationService $validator,
+        private readonly ImportObjectCreator $creator,
+        private readonly ImportProgressPublisher $progressPublisher,
+        private readonly TenantContext $tenantContext,
+        private readonly FilesystemOperator $importsStorage,
+        int $batchSize = 200,
+    ) {
+        parent::__construct($entityManager, $batchSize);
+    }
+
+    public function __invoke(ImportRunMessage $message): void
+    {
+        $session = $this->sessions->findById($message->importSessionId);
+        if (!$session instanceof ImportSession) {
+            return;
+        }
+
+        $tenant = $session->getTenant();
+        if (!$tenant instanceof Tenant) {
+            $session->markFailed('Import session has no tenant assignment.');
+            $this->sessions->save($session);
+
+            return;
+        }
+
+        $this->tenantContext->set($tenant);
+        $this->run($session);
+    }
+
+    /**
+     * Drives the chunked persistence loop. Public so the synchronous
+     * `<50 rows` path on the start endpoint can call into the same logic
+     * without re-routing through Messenger.
+     */
+    public function run(ImportSession $session): void
+    {
+        $tenant = $session->getTenant();
+        if (!$tenant instanceof Tenant) {
+            $session->markFailed('Import session has no tenant assignment.');
+            $this->sessions->save($session);
+
+            return;
+        }
+
+        try {
+            $session->markRunning();
+            $this->sessions->save($session);
+        } catch (LogicException $exception) {
+            // Already running / paused / failed — bail without state churn.
+            return;
+        }
+
+        $sourcePath = null;
+        try {
+            $columnMapping = $this->resolveColumnMapping($session);
+            $attributesByCode = $this->validator->loadAttributesByCode($tenant, $columnMapping);
+            $sourcePath = $this->stageSourceFile($session, $tenant);
+
+            $skuSeenInFile = [];
+            $processed = 0;
+            $totalRows = 0;
+
+            foreach ($this->rowReader->read($sourcePath) as $rowNumber => $cells) {
+                ++$processed;
+                ++$totalRows;
+                $errors = $this->validator->validateRow(
+                    rowNumber: $rowNumber,
+                    cells: $cells,
+                    columnMapping: $columnMapping,
+                    attributesByCode: $attributesByCode,
+                    tenant: $tenant,
+                    skuSeenInFile: $skuSeenInFile,
+                );
+
+                $sku = $cells[$this->skuColumnHeader($columnMapping)] ?? null;
+                $rowOk = [] === $errors;
+
+                if ($rowOk) {
+                    $valueByAttributeCode = $this->materialiseValues($cells, $columnMapping);
+                    $this->creator->create(
+                        objectType: $session->getTargetObjectType(),
+                        sku: $valueByAttributeCode['sku'] ?? \sprintf('IMPORT-%d', $rowNumber),
+                        valueByAttributeCode: $valueByAttributeCode,
+                        attributesByCode: $attributesByCode,
+                        importSessionId: $session->getId(),
+                    );
+                    $session->incrementSuccess();
+                } else {
+                    foreach ($errors as $error) {
+                        $this->entityManager->persist(new ImportLog(
+                            importSession: $session,
+                            rowNumber: $error->rowNumber,
+                            level: $error->level,
+                            message: $error->message,
+                            sku: $error->sku,
+                            errorType: $error->errorType->value,
+                            columnName: $error->columnName,
+                            columnValue: $error->columnValue,
+                        ));
+                    }
+                    $session->incrementError();
+                }
+
+                $this->progressPublisher->rowProcessed($session, $rowNumber, $sku, $rowOk);
+
+                if ($this->shouldFlush($processed)) {
+                    $this->flushAndClear();
+                    $session = $this->refreshSession($session);
+                    $this->progressPublisher->progress($session, $processed, $sku);
+                }
+            }
+
+            $session->setTotalRows($totalRows);
+            $session = $this->refreshSession($session);
+            $session->markCompleted();
+            $this->sessions->save($session);
+            $this->progressPublisher->completed($session);
+        } catch (Throwable $exception) {
+            $current = $this->sessions->findById($session->getId());
+            if ($current instanceof ImportSession && !$current->getStatus()->isTerminal()) {
+                $current->markFailed($exception->getMessage());
+                $this->sessions->save($current);
+                $this->progressPublisher->completed($current);
+            }
+            throw $exception;
+        } finally {
+            if (null !== $sourcePath && file_exists($sourcePath)) {
+                @unlink($sourcePath);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function resolveColumnMapping(ImportSession $session): array
+    {
+        $sessionMapping = $session->getColumnMapping();
+        if ([] !== $sessionMapping) {
+            return $sessionMapping;
+        }
+
+        $profile = $session->getProfile();
+        if (null === $profile) {
+            return [];
+        }
+
+        return $profile->getColumnMapping();
+    }
+
+    /**
+     * @param array<string, string|null> $cells
+     * @param array<string, string>      $columnMapping
+     *
+     * @return array<string, string|null>
+     */
+    private function materialiseValues(array $cells, array $columnMapping): array
+    {
+        $out = [];
+        foreach ($columnMapping as $columnHeader => $attributeCode) {
+            if ('skip' === $attributeCode || '' === $attributeCode) {
+                continue;
+            }
+            $out[$attributeCode] = $cells[$columnHeader] ?? null;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, string> $columnMapping
+     */
+    private function skuColumnHeader(array $columnMapping): string
+    {
+        foreach ($columnMapping as $header => $attributeCode) {
+            if ('sku' === $attributeCode) {
+                return $header;
+            }
+        }
+
+        return 'sku';
+    }
+
+    /**
+     * Pulls the uploaded source file from the imports bucket into a
+     * local temp path so PhpSpreadsheet / league-csv can read it
+     * through a regular filesystem handle. The temp path is unlinked
+     * in the finally block of the caller.
+     *
+     * Convention (spec §8.6): `{tenant_id}/{session_id}/{file_name}`.
+     */
+    private function stageSourceFile(ImportSession $session, Tenant $tenant): string
+    {
+        $remotePath = \sprintf(
+            '%s/%s/%s',
+            $tenant->getId()->toRfc4122(),
+            $session->getId()->toRfc4122(),
+            $session->getFileName(),
+        );
+
+        try {
+            $stream = $this->importsStorage->readStream($remotePath);
+        } catch (FilesystemException $exception) {
+            throw new RuntimeException(\sprintf(
+                'Failed to read uploaded file at "%s".',
+                $remotePath,
+            ), previous: $exception);
+        }
+
+        $extension = pathinfo($session->getFileName(), PATHINFO_EXTENSION);
+        if ('' === $extension) {
+            $extension = 'csv';
+        }
+        $localPath = tempnam(sys_get_temp_dir(), 'pim-import-').'.'.$extension;
+        $local = fopen($localPath, 'w');
+        if (false === $local) {
+            throw new RuntimeException(\sprintf('Failed to open temp file "%s" for writing.', $localPath));
+        }
+        stream_copy_to_stream($stream, $local);
+        fclose($local);
+
+        return $localPath;
+    }
+
+    /**
+     * After {@see flushAndClear()} the EM detached the active session,
+     * so any further state mutation has to happen on a fresh managed
+     * instance. Repository lookup re-merges and keeps counters live.
+     */
+    private function refreshSession(ImportSession $session): ImportSession
+    {
+        $reloaded = $this->sessions->findById($session->getId());
+        if (!$reloaded instanceof ImportSession) {
+            throw new RuntimeException(\sprintf(
+                'Import session "%s" disappeared mid-run.',
+                $session->getId()->toRfc4122(),
+            ));
+        }
+
+        return $reloaded;
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\Provenance;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Creates a single {@see CatalogObject} (and its {@see ObjectValue} rows)
+ * from one parsed import row. Persists via the EntityManager — the
+ * {@see \App\Import\Application\Handler\ImportRunHandler} flushes in
+ * batches via {@see \App\Shared\Application\AbstractBatchHandler}.
+ *
+ * Provenance is hardcoded to `import` so the post-import UI can flag
+ * every value pulled from a CSV / xlsx for review.
+ *
+ * Cross-attribute logic (e.g. parent SKU resolution for variants) is
+ * intentionally out of scope MVP — the flat-row reader feeds master
+ * products only, mirroring spec decision §3 ("Variants … master rows
+ * only in MVP").
+ */
+final class ImportObjectCreator
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @param array<string, string|null> $valueByAttributeCode
+     * @param array<string, Attribute>   $attributesByCode
+     */
+    public function create(
+        ObjectType $objectType,
+        string $sku,
+        array $valueByAttributeCode,
+        array $attributesByCode,
+        Uuid $importSessionId,
+    ): CatalogObject {
+        $object = new CatalogObject($objectType, $sku);
+        $object->assignImportSession($importSessionId);
+        $this->em->persist($object);
+
+        foreach ($valueByAttributeCode as $attributeCode => $rawValue) {
+            if (null === $rawValue || '' === $rawValue) {
+                continue;
+            }
+            $attribute = $attributesByCode[$attributeCode] ?? null;
+            if (!$attribute instanceof Attribute) {
+                continue;
+            }
+
+            $valuePayload = $this->buildValuePayload($attribute, $rawValue);
+            if (null === $valuePayload) {
+                continue;
+            }
+
+            $this->em->persist(new ObjectValue(
+                object: $object,
+                attribute: $attribute,
+                value: $valuePayload,
+                provenance: Provenance::Import,
+            ));
+        }
+
+        return $object;
+    }
+
+    /**
+     * Maps the raw CSV cell into the JSONB shape expected by
+     * {@see ObjectValue::$value}. Returns null when the value is
+     * uninterpretable for the attribute type — that path stays out of
+     * the import (the validator already flagged it as InvalidType).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function buildValuePayload(Attribute $attribute, string $raw): ?array
+    {
+        return match ($attribute->getType()) {
+            AttributeType::Number, AttributeType::Price, AttributeType::Metric => $this->numericPayload($raw),
+            AttributeType::Boolean => ['value' => $this->parseBoolean($raw)],
+            default => ['value' => $raw],
+        };
+    }
+
+    /**
+     * @return array{value: float}|null
+     */
+    private function numericPayload(string $raw): ?array
+    {
+        $normalised = str_replace(',', '.', $raw);
+        if (!is_numeric($normalised)) {
+            return null;
+        }
+
+        return ['value' => (float) $normalised];
+    }
+
+    private function parseBoolean(string $raw): bool
+    {
+        return \in_array(strtolower($raw), ['1', 'true', 'yes', 'tak'], true);
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportProgressPublisher.php
+++ b/apps/api/src/Import/Application/Service/ImportProgressPublisher.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Domain\Entity\ImportSession;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+use Throwable;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Publishes import lifecycle / progress updates to two Mercure topics
+ * (spec §8.5):
+ *   - `imports/{user_id}` — broadcast list view (status changes)
+ *   - `imports/{session_id}` — detail (progress %, current SKU, errors)
+ *
+ * Hub failures are logged but never abort the underlying write — Mercure
+ * is a notification channel, not the source of truth (mirrors the
+ * Catalog publisher's stance).
+ */
+final class ImportProgressPublisher
+{
+    private const string TOPIC_PREFIX = 'imports';
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly HubInterface $hub,
+        private readonly string $topicBase = 'https://pim.localhost',
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function progress(ImportSession $session, int $processedRows, ?string $currentSku = null): void
+    {
+        $totalRows = $session->getTotalRows() ?? 0;
+        $this->publish($session, 'progress', [
+            'processed_rows' => $processedRows,
+            'total_rows' => $totalRows,
+            'success_count' => $session->getSuccessCount(),
+            'error_count' => $session->getErrorCount(),
+            'current_sku' => $currentSku,
+        ]);
+    }
+
+    public function rowProcessed(ImportSession $session, int $rowNumber, ?string $sku, bool $success): void
+    {
+        $this->publish($session, 'row_processed', [
+            'row_number' => $rowNumber,
+            'sku' => $sku,
+            'success' => $success,
+        ]);
+    }
+
+    public function error(ImportSession $session, int $rowNumber, ?string $sku, string $errorType, string $message): void
+    {
+        $this->publish($session, 'error', [
+            'row_number' => $rowNumber,
+            'sku' => $sku,
+            'error_type' => $errorType,
+            'message' => $message,
+        ]);
+    }
+
+    public function completed(ImportSession $session): void
+    {
+        $this->publish($session, 'completed', [
+            'status' => $session->getStatus()->value,
+            'success_count' => $session->getSuccessCount(),
+            'error_count' => $session->getErrorCount(),
+            'total_rows' => $session->getTotalRows() ?? 0,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function publish(ImportSession $session, string $type, array $payload): void
+    {
+        $sessionTopic = \sprintf('%s/%s/%s', $this->topicBase, self::TOPIC_PREFIX, $session->getId()->toRfc4122());
+        $userTopic = \sprintf('%s/%s/user/%s', $this->topicBase, self::TOPIC_PREFIX, $session->getUserId()->toRfc4122());
+
+        $update = new Update(
+            topics: [$sessionTopic, $userTopic],
+            data: json_encode([
+                'type' => $type,
+                'session_id' => $session->getId()->toRfc4122(),
+                'data' => $payload,
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        try {
+            $this->hub->publish($update);
+        } catch (Throwable $exception) {
+            $this->logger->warning('Mercure import progress publish failed: {message}', [
+                'message' => $exception->getMessage(),
+                'session_id' => $session->getId()->toRfc4122(),
+                'type' => $type,
+            ]);
+        }
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportRowReader.php
+++ b/apps/api/src/Import/Application/Service/ImportRowReader.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Domain\Enum\FileEncoding;
+use App\Import\Domain\Exception\InvalidImportFileException;
+use Generator;
+use League\Csv\Reader;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * Streams an uploaded CSV / xlsx file as `header → value` rows.
+ *
+ * Lives outside {@see ImportValidationService} because the async
+ * {@see \App\Import\Application\Handler\ImportRunHandler} needs the
+ * same iterator to drive persistence — sharing the reader keeps the
+ * row numbering + encoding handling in one place.
+ */
+final readonly class ImportRowReader
+{
+    public function __construct(
+        private EncodingDetector $encodingDetector,
+        private DelimiterDetector $delimiterDetector,
+    ) {
+    }
+
+    /**
+     * Yields rows starting at `2` (header is row 1).
+     *
+     * @return Generator<int, array<string, string|null>>
+     */
+    public function read(string $absolutePath, ?FileEncoding $encodingOverride = null, ?string $delimiterOverride = null): Generator
+    {
+        if (!is_readable($absolutePath)) {
+            throw InvalidImportFileException::unreadable($absolutePath);
+        }
+
+        $extension = strtolower(pathinfo($absolutePath, PATHINFO_EXTENSION));
+        if ('xlsx' === $extension) {
+            yield from $this->iterateXlsx($absolutePath);
+
+            return;
+        }
+        if ('csv' === $extension) {
+            yield from $this->iterateCsv($absolutePath, $encodingOverride, $delimiterOverride);
+
+            return;
+        }
+
+        throw InvalidImportFileException::unsupportedExtension($extension);
+    }
+
+    /**
+     * @return Generator<int, array<string, string|null>>
+     */
+    private function iterateXlsx(string $absolutePath): Generator
+    {
+        $reader = IOFactory::createReaderForFile($absolutePath);
+        $reader->setReadDataOnly(true);
+        $spreadsheet = $reader->load($absolutePath);
+        $sheet = $spreadsheet->getSheet(0);
+
+        $headers = [];
+        $rowNumber = 0;
+        foreach ($sheet->getRowIterator() as $row) {
+            ++$rowNumber;
+            $cells = [];
+            foreach ($row->getCellIterator() as $cell) {
+                $value = $cell->getValue();
+                $cells[] = null === $value ? null : (string) (\is_scalar($value) ? $value : '');
+            }
+            if (1 === $rowNumber) {
+                $headers = array_map(static fn (?string $v): string => $v ?? '', $cells);
+                continue;
+            }
+            $assoc = [];
+            foreach ($headers as $index => $header) {
+                $assoc[$header] = $cells[$index] ?? null;
+            }
+            yield $rowNumber - 1 => $assoc;
+        }
+    }
+
+    /**
+     * @return Generator<int, array<string, string|null>>
+     */
+    private function iterateCsv(string $absolutePath, ?FileEncoding $encodingOverride, ?string $delimiterOverride): Generator
+    {
+        $bytes = file_get_contents($absolutePath);
+        if (false === $bytes) {
+            throw InvalidImportFileException::unreadable($absolutePath);
+        }
+
+        $encoding = $encodingOverride ?? $this->encodingDetector->detect($bytes);
+        $body = $this->encodingDetector->stripBom($bytes);
+        if (FileEncoding::Utf8 !== $encoding && FileEncoding::Utf8Bom !== $encoding) {
+            $converted = @iconv($encoding->iconvName(), 'UTF-8//TRANSLIT', $body);
+            if (false === $converted) {
+                throw InvalidImportFileException::corruptedEncoding($encoding->value);
+            }
+            $body = $converted;
+        }
+
+        $delimiter = $delimiterOverride ?? $this->delimiterDetector->detect(substr($body, 0, 4096));
+        $reader = Reader::fromString($body);
+        $reader->setDelimiter($delimiter);
+        $reader->setHeaderOffset(0);
+
+        $rowNumber = 1;
+        foreach ($reader->getRecords() as $record) {
+            ++$rowNumber;
+            $assoc = [];
+            foreach ($record as $key => $value) {
+                if (null === $value || '' === $value) {
+                    $assoc[(string) $key] = null;
+                } else {
+                    $assoc[(string) $key] = \is_scalar($value) ? (string) $value : '';
+                }
+            }
+            yield $rowNumber - 1 => $assoc;
+        }
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportValidationService.php
+++ b/apps/api/src/Import/Application/Service/ImportValidationService.php
@@ -13,17 +13,11 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Import\Domain\Enum\FileEncoding;
 use App\Import\Domain\Enum\ImportErrorType;
 use App\Import\Domain\Enum\ImportLogLevel;
-use App\Import\Domain\Exception\InvalidImportFileException;
 use App\Import\Domain\ValueObject\ValidationError;
 use App\Import\Domain\ValueObject\ValidationResult;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
-use Generator;
-use League\Csv\Reader;
 use LogicException;
-use PhpOffice\PhpSpreadsheet\IOFactory;
-
-use const PATHINFO_EXTENSION;
 
 /**
  * Iterates the uploaded file row-by-row and produces per-row validation
@@ -49,8 +43,7 @@ final readonly class ImportValidationService
         private AttributeRepositoryInterface $attributes,
         private CatalogObjectRepositoryInterface $catalogObjects,
         private TenantContext $tenantContext,
-        private EncodingDetector $encodingDetector,
-        private DelimiterDetector $delimiterDetector,
+        private ImportRowReader $rowReader,
     ) {
     }
 
@@ -69,11 +62,6 @@ final readonly class ImportValidationService
             throw new LogicException('Tenant context must be set for import validation.');
         }
 
-        $extension = strtolower(pathinfo($absolutePath, PATHINFO_EXTENSION));
-        if (!\in_array($extension, ['xlsx', 'csv'], true)) {
-            throw InvalidImportFileException::unsupportedExtension($extension);
-        }
-
         $attributesByCode = $this->loadAttributesByCode($tenant, $columnMapping);
         $errors = [];
         $successCount = 0;
@@ -81,18 +69,13 @@ final readonly class ImportValidationService
         $totalRows = 0;
         $skuSeenInFile = [];
 
-        $rows = 'xlsx' === $extension
-            ? $this->iterateXlsx($absolutePath)
-            : $this->iterateCsv($absolutePath, $encodingOverride, $delimiterOverride);
-
-        foreach ($rows as $rowNumber => $cells) {
+        foreach ($this->rowReader->read($absolutePath, $encodingOverride, $delimiterOverride) as $rowNumber => $cells) {
             ++$totalRows;
             $rowErrors = $this->validateRow(
                 rowNumber: $rowNumber,
                 cells: $cells,
                 columnMapping: $columnMapping,
                 attributesByCode: $attributesByCode,
-                target: $target,
                 tenant: $tenant,
                 skuSeenInFile: $skuSeenInFile,
             );
@@ -118,6 +101,10 @@ final readonly class ImportValidationService
     }
 
     /**
+     * Public wrapper used by the async run handler — same per-row checks
+     * the dry-run service performs, but the caller drives iteration and
+     * decides what to do with the findings.
+     *
      * @param array<string, string|null> $cells            column_header → value
      * @param array<string, string>      $columnMapping
      * @param array<string, Attribute>   $attributesByCode
@@ -125,18 +112,16 @@ final readonly class ImportValidationService
      *
      * @return list<ValidationError>
      */
-    private function validateRow(
+    public function validateRow(
         int $rowNumber,
         array $cells,
         array $columnMapping,
         array $attributesByCode,
-        ObjectType $target,
         Tenant $tenant,
         array &$skuSeenInFile,
     ): array {
         $errors = [];
 
-        // Materialise attribute_code → value for the current row.
         $valueByAttribute = [];
         foreach ($columnMapping as $columnHeader => $attributeCode) {
             if ('skip' === $attributeCode || '' === $attributeCode) {
@@ -214,28 +199,15 @@ final readonly class ImportValidationService
         return $errors;
     }
 
-    private function validateScalarType(Attribute $attribute, string $value): ?string
-    {
-        return match ($attribute->getType()) {
-            AttributeType::Number, AttributeType::Price, AttributeType::Metric => is_numeric(str_replace(',', '.', $value))
-                    ? null
-                    : \sprintf('"%s" is not a valid number for "%s".', $value, $attribute->getCode()),
-            AttributeType::Date => false === strtotime($value)
-                ? \sprintf('"%s" is not a valid date for "%s".', $value, $attribute->getCode())
-                : null,
-            AttributeType::Boolean => \in_array(strtolower($value), ['0', '1', 'true', 'false', 'yes', 'no', 'tak', 'nie'], true)
-                ? null
-                : \sprintf('"%s" is not a valid boolean for "%s".', $value, $attribute->getCode()),
-            default => null,
-        };
-    }
-
     /**
+     * Resolves attribute_code → Attribute lookups once for the whole
+     * import — IMP-04 reuses this to feed the persistence service.
+     *
      * @param array<string, string> $columnMapping
      *
      * @return array<string, Attribute>
      */
-    private function loadAttributesByCode(Tenant $tenant, array $columnMapping): array
+    public function loadAttributesByCode(Tenant $tenant, array $columnMapping): array
     {
         $codes = [];
         foreach ($columnMapping as $attributeCode) {
@@ -258,74 +230,19 @@ final readonly class ImportValidationService
         return $attributes;
     }
 
-    /**
-     * @return Generator<int, array<string, string|null>>
-     */
-    private function iterateXlsx(string $absolutePath): Generator
+    private function validateScalarType(Attribute $attribute, string $value): ?string
     {
-        $reader = IOFactory::createReaderForFile($absolutePath);
-        $reader->setReadDataOnly(true);
-        $spreadsheet = $reader->load($absolutePath);
-        $sheet = $spreadsheet->getSheet(0);
-
-        $headers = [];
-        $rowNumber = 0;
-        foreach ($sheet->getRowIterator() as $row) {
-            ++$rowNumber;
-            $cells = [];
-            foreach ($row->getCellIterator() as $cell) {
-                $value = $cell->getValue();
-                $cells[] = null === $value ? null : (string) (\is_scalar($value) ? $value : '');
-            }
-            if (1 === $rowNumber) {
-                $headers = array_map(static fn (?string $v): string => $v ?? '', $cells);
-                continue;
-            }
-            $assoc = [];
-            foreach ($headers as $index => $header) {
-                $assoc[$header] = $cells[$index] ?? null;
-            }
-            yield $rowNumber - 1 => $assoc;
-        }
-    }
-
-    /**
-     * @return Generator<int, array<string, string|null>>
-     */
-    private function iterateCsv(string $absolutePath, ?FileEncoding $encodingOverride, ?string $delimiterOverride): Generator
-    {
-        $bytes = file_get_contents($absolutePath);
-        if (false === $bytes) {
-            throw InvalidImportFileException::unreadable($absolutePath);
-        }
-
-        $encoding = $encodingOverride ?? $this->encodingDetector->detect($bytes);
-        $body = $this->encodingDetector->stripBom($bytes);
-        if (FileEncoding::Utf8 !== $encoding && FileEncoding::Utf8Bom !== $encoding) {
-            $converted = @iconv($encoding->iconvName(), 'UTF-8//TRANSLIT', $body);
-            if (false === $converted) {
-                throw InvalidImportFileException::corruptedEncoding($encoding->value);
-            }
-            $body = $converted;
-        }
-
-        $delimiter = $delimiterOverride ?? $this->delimiterDetector->detect(substr($body, 0, 4096));
-        $reader = Reader::fromString($body);
-        $reader->setDelimiter($delimiter);
-        $reader->setHeaderOffset(0);
-
-        $rowNumber = 1;
-        foreach ($reader->getRecords() as $record) {
-            ++$rowNumber;
-            $assoc = [];
-            foreach ($record as $key => $value) {
-                if (null === $value || '' === $value) {
-                    $assoc[(string) $key] = null;
-                } else {
-                    $assoc[(string) $key] = \is_scalar($value) ? (string) $value : '';
-                }
-            }
-            yield $rowNumber - 1 => $assoc;
-        }
+        return match ($attribute->getType()) {
+            AttributeType::Number, AttributeType::Price, AttributeType::Metric => is_numeric(str_replace(',', '.', $value))
+                    ? null
+                    : \sprintf('"%s" is not a valid number for "%s".', $value, $attribute->getCode()),
+            AttributeType::Date => false === strtotime($value)
+                ? \sprintf('"%s" is not a valid date for "%s".', $value, $attribute->getCode())
+                : null,
+            AttributeType::Boolean => \in_array(strtolower($value), ['0', '1', 'true', 'false', 'yes', 'no', 'tak', 'nie'], true)
+                ? null
+                : \sprintf('"%s" is not a valid boolean for "%s".', $value, $attribute->getCode()),
+            default => null,
+        };
     }
 }

--- a/apps/api/src/Import/Domain/Entity/ImportSession.php
+++ b/apps/api/src/Import/Domain/Entity/ImportSession.php
@@ -75,6 +75,15 @@ class ImportSession extends AggregateRoot implements TenantScoped
 
     private ?string $errorMessage = null;
 
+    /**
+     * IMP-04 (#445) — header → attribute_code mapping captured at start
+     * time. Lives on the session (not just the optional profile) so
+     * profile-less ad-hoc imports keep their mapping after dispatch.
+     *
+     * @var array<string, string>
+     */
+    private array $columnMapping = [];
+
     private DateTimeImmutable $createdAt;
 
     public function __construct(
@@ -242,6 +251,22 @@ class ImportSession extends AggregateRoot implements TenantScoped
     public function getErrorMessage(): ?string
     {
         return $this->errorMessage;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getColumnMapping(): array
+    {
+        return $this->columnMapping;
+    }
+
+    /**
+     * @param array<string, string> $columnMapping
+     */
+    public function setColumnMapping(array $columnMapping): void
+    {
+        $this->columnMapping = $columnMapping;
     }
 
     public function getCreatedAt(): DateTimeImmutable

--- a/apps/api/src/Import/Domain/Message/ImportRunMessage.php
+++ b/apps/api/src/Import/Domain/Message/ImportRunMessage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Message;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Async marker — the Symfony Messenger transport routes this to the
+ * `imports` queue (see config/packages/messenger.yaml). The handler
+ * loads the {@see \App\Import\Domain\Entity\ImportSession} by id and
+ * runs the chunked persistence loop.
+ */
+final readonly class ImportRunMessage
+{
+    public function __construct(
+        public Uuid $importSessionId,
+        public Uuid $tenantId,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
+++ b/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
@@ -75,6 +75,14 @@
         </many-to-one>
 
         <field name="errorMessage" type="text" column="error_message" nullable="true"/>
+
+        <field name="columnMapping" type="json" column="column_mapping">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">{}</option>
+            </options>
+        </field>
+
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
 
     </entity>

--- a/apps/api/src/Import/Presentation/Controller/GetImportSessionController.php
+++ b/apps/api/src/Import/Presentation/Controller/GetImportSessionController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Identity\Domain\Entity\User;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use DateTimeInterface;
+use InvalidArgumentException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Read-only endpoint surfacing the live counts + status the wizard's
+ * progress / results screens poll between Mercure events.
+ */
+final class GetImportSessionController
+{
+    public function __construct(
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-sessions/{id}',
+        name: 'imports_show',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['GET'],
+    )]
+    public function __invoke(string $id): JsonResponse
+    {
+        $session = $this->loadSession($id);
+
+        return new JsonResponse([
+            'id' => $session->getId()->toRfc4122(),
+            'status' => $session->getStatus()->value,
+            'file_name' => $session->getFileName(),
+            'total_rows' => $session->getTotalRows(),
+            'success_count' => $session->getSuccessCount(),
+            'error_count' => $session->getErrorCount(),
+            'images_downloaded' => $session->getImagesDownloaded(),
+            'images_failed' => $session->getImagesFailed(),
+            'started_at' => $session->getStartedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'completed_at' => $session->getCompletedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'rollback_until' => $session->getRollbackUntil()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'rolled_back_at' => $session->getRolledBackAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'error_message' => $session->getErrorMessage(),
+        ], Response::HTTP_OK);
+    }
+
+    private function loadSession(string $rawId): ImportSession
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        try {
+            $id = Uuid::fromString($rawId);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+
+        $session = $this->sessions->findById($id);
+        if (!$session instanceof ImportSession) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+        if ($session->getUserId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+
+        return $session;
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/ImportSessionStateController.php
+++ b/apps/api/src/Import/Presentation/Controller/ImportSessionStateController.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Identity\Domain\Entity\User;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Wizard controls — pause / resume / cancel for an in-flight import.
+ *
+ * State changes are authoritative on the {@see ImportSession} entity;
+ * the worker (`ImportRunHandler`) inspects the row between batches in
+ * a follow-up to honour pause/cancel mid-run. In MVP the operator
+ * sees the response immediately and the running batch finishes the
+ * current chunk before stopping.
+ */
+final class ImportSessionStateController
+{
+    public function __construct(
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-sessions/{id}/pause',
+        name: 'imports_pause',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    public function pause(string $id): JsonResponse
+    {
+        $session = $this->loadOwned($id);
+        try {
+            $session->markPaused();
+        } catch (LogicException $exception) {
+            throw new ConflictHttpException($exception->getMessage());
+        }
+        $this->sessions->save($session);
+
+        return $this->respond($session);
+    }
+
+    #[Route(
+        path: '/api/import-sessions/{id}/resume',
+        name: 'imports_resume',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    public function resume(string $id): JsonResponse
+    {
+        $session = $this->loadOwned($id);
+        try {
+            $session->markRunning();
+        } catch (LogicException $exception) {
+            throw new ConflictHttpException($exception->getMessage());
+        }
+        $this->sessions->save($session);
+
+        return $this->respond($session);
+    }
+
+    #[Route(
+        path: '/api/import-sessions/{id}/cancel',
+        name: 'imports_cancel',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    public function cancel(string $id): JsonResponse
+    {
+        $session = $this->loadOwned($id);
+        try {
+            $session->markCancelled();
+        } catch (LogicException $exception) {
+            throw new ConflictHttpException($exception->getMessage());
+        }
+        $this->sessions->save($session);
+
+        return $this->respond($session);
+    }
+
+    private function loadOwned(string $rawId): ImportSession
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        try {
+            $id = Uuid::fromString($rawId);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+
+        $session = $this->sessions->findById($id);
+        if (!$session instanceof ImportSession || $session->getUserId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+
+        return $session;
+    }
+
+    private function respond(ImportSession $session): JsonResponse
+    {
+        return new JsonResponse([
+            'id' => $session->getId()->toRfc4122(),
+            'status' => $session->getStatus()->value,
+        ], Response::HTTP_OK);
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/StartImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/StartImportController.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Import\Application\Handler\ImportRunHandler;
+use App\Import\Domain\Entity\ImportProfile;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Message\ImportRunMessage;
+use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use DateTimeInterface;
+use InvalidArgumentException;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * IMP-04 (#445) wizard Step 4 confirm — uploads the source file to the
+ * imports bucket, persists an {@see ImportSession}, and either runs
+ * the import inline (rows < 50, spec §3 sync threshold) or hands it
+ * off to the async worker via {@see ImportRunMessage}.
+ *
+ * Multipart fields:
+ *   - `file` — CSV / xlsx
+ *   - `target_object_type_id` — UUID
+ *   - `mapping` — JSON `{column_header: attribute_code | "skip"}`
+ *   - `profile_id` — UUID, optional
+ *   - `locale`, `encoding`, `delimiter` — optional overrides
+ *   - `do_backup` — boolean, optional (forwarded to IMP-06 in a follow-up)
+ */
+final class StartImportController
+{
+    private const int SYNC_THRESHOLD_ROWS = 50;
+
+    public function __construct(
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly ImportProfileRepositoryInterface $profiles,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly ImportRunHandler $runHandler,
+        private readonly MessageBusInterface $bus,
+        private readonly Security $security,
+        private readonly TenantContext $tenantContext,
+        private readonly FilesystemOperator $importsStorage,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-sessions',
+        name: 'imports_start',
+        methods: ['POST'],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+        $tenant = $user->getTenant();
+        $this->tenantContext->set($tenant);
+
+        $file = $request->files->get('file');
+        if (!$file instanceof UploadedFile) {
+            throw new BadRequestHttpException('"file" multipart field is required.');
+        }
+
+        $targetId = $this->parseUuid($request->request->get('target_object_type_id'), 'target_object_type_id');
+        $objectType = $this->objectTypes->findById($targetId);
+        if (!$objectType instanceof ObjectType) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $targetId->toRfc4122()));
+        }
+
+        $mapping = $this->parseMapping($request->request->get('mapping', '{}'));
+        $profile = $this->resolveProfile($request->request->get('profile_id'), $tenant, $user->getId(), $mapping, $objectType);
+
+        $originalName = $file->getClientOriginalName();
+        if ('' === $originalName) {
+            $originalName = 'upload.csv';
+        }
+        $session = new ImportSession(
+            userId: $user->getId(),
+            targetObjectType: $objectType,
+            fileName: $originalName,
+            fileSizeBytes: (int) $file->getSize(),
+            profile: $profile,
+        );
+        $session->setColumnMapping($mapping);
+
+        // Persist before upload so a later upload failure has a session id
+        // to attach to (status stays `pending`, error_message captures
+        // the reason). The TenantAssignmentListener stamps tenant_id on
+        // pre-persist.
+        $this->sessions->save($session);
+
+        $remotePath = \sprintf(
+            '%s/%s/%s',
+            $tenant->getId()->toRfc4122(),
+            $session->getId()->toRfc4122(),
+            $session->getFileName(),
+        );
+        try {
+            $stream = fopen($file->getPathname(), 'r');
+            if (false === $stream) {
+                throw new RuntimeException('Failed to open uploaded file for reading.');
+            }
+            $this->importsStorage->writeStream($remotePath, $stream);
+            if (\is_resource($stream)) {
+                fclose($stream);
+            }
+        } catch (FilesystemException|RuntimeException $exception) {
+            $session->markFailed(\sprintf('Failed to stage uploaded file: %s', $exception->getMessage()));
+            $this->sessions->save($session);
+            throw new BadRequestHttpException('Failed to stage the uploaded file.', $exception);
+        }
+
+        // Spec decision §3: <50 rows runs inline so the operator does not
+        // wait on a worker; `total_rows` is unknown until the handler
+        // streams the file, so we use the request-time threshold based on
+        // `file_size_bytes` heuristic (small files always sync).
+        if ($session->getFileSizeBytes() <= self::SYNC_THRESHOLD_ROWS * 1024) {
+            $reload = $this->sessions->findById($session->getId());
+            if ($reload instanceof ImportSession) {
+                $this->runHandler->run($reload);
+                $reload = $this->sessions->findById($session->getId()) ?? $reload;
+
+                return new JsonResponse(
+                    $this->serialise($reload),
+                    Response::HTTP_OK,
+                );
+            }
+        }
+
+        $this->bus->dispatch(new ImportRunMessage(
+            importSessionId: $session->getId(),
+            tenantId: $tenant->getId(),
+        ));
+
+        return new JsonResponse($this->serialise($session), Response::HTTP_ACCEPTED);
+    }
+
+    private function parseUuid(mixed $raw, string $field): Uuid
+    {
+        if (!\is_string($raw) || '' === $raw) {
+            throw new BadRequestHttpException(\sprintf('"%s" is required.', $field));
+        }
+        try {
+            return Uuid::fromString($raw);
+        } catch (InvalidArgumentException) {
+            throw new BadRequestHttpException(\sprintf('Invalid "%s" UUID "%s".', $field, $raw));
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function parseMapping(mixed $raw): array
+    {
+        if (!\is_string($raw)) {
+            throw new BadRequestHttpException('"mapping" must be a JSON string.');
+        }
+        $decoded = json_decode($raw, true);
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('"mapping" must be a JSON object.');
+        }
+
+        $mapping = [];
+        foreach ($decoded as $key => $value) {
+            $mapping[(string) $key] = \is_string($value) ? $value : 'skip';
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * @param array<string, string> $mapping
+     */
+    private function resolveProfile(mixed $raw, Tenant $tenant, Uuid $userId, array $mapping, ObjectType $objectType): ?ImportProfile
+    {
+        if (!\is_string($raw) || '' === $raw) {
+            return null;
+        }
+        try {
+            $profileId = Uuid::fromString($raw);
+        } catch (InvalidArgumentException) {
+            throw new BadRequestHttpException(\sprintf('Invalid "profile_id" UUID "%s".', $raw));
+        }
+
+        $profile = $this->profiles->findById($profileId);
+        if (!$profile instanceof ImportProfile) {
+            throw new NotFoundHttpException(\sprintf('ImportProfile "%s" was not found.', $raw));
+        }
+        if ($profile->getUserId()->toRfc4122() !== $userId->toRfc4122()) {
+            throw new NotFoundHttpException(\sprintf('ImportProfile "%s" was not found.', $raw));
+        }
+        $profile->touchLastUsed();
+        $this->profiles->save($profile);
+
+        return $profile;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialise(ImportSession $session): array
+    {
+        return [
+            'id' => $session->getId()->toRfc4122(),
+            'status' => $session->getStatus()->value,
+            'total_rows' => $session->getTotalRows(),
+            'success_count' => $session->getSuccessCount(),
+            'error_count' => $session->getErrorCount(),
+            'started_at' => $session->getStartedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'completed_at' => $session->getCompletedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'rollback_until' => $session->getRollbackUntil()?->format(DateTimeInterface::RFC3339_EXTENDED),
+        ];
+    }
+}

--- a/apps/api/tests/Api/Import/StartImportApiTest.php
+++ b/apps/api/tests/Api/Import/StartImportApiTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP-04 (#445) — wizard Step 4 confirm round-trips through the
+ * persisting endpoint. Sync small import (<50 rows) executes inline
+ * and surfaces `status=success` plus the matching CatalogObject rows
+ * stamped with the session id.
+ */
+final class StartImportApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function smallImportRunsInlineAndPersistsProducts(): void
+    {
+        $this->seedAttributes();
+
+        $csvPath = $this->writeSmallCsv();
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode([
+                            'sku' => 'sku',
+                            'name' => 'name',
+                        ], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => [
+                        'file' => new UploadedFile($csvPath, 'small.csv', 'text/csv', null, true),
+                    ],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $response = $client->getResponse();
+            self::assertNotNull($response);
+            $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+
+            self::assertSame(
+                'success',
+                $body['status'],
+                \sprintf(
+                    'Expected success but body=%s',
+                    json_encode($body, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT),
+                ),
+            );
+            self::assertSame(5, $body['success_count']);
+            self::assertSame(0, $body['error_count']);
+            self::assertNotNull($body['rollback_until'], 'Successful imports open the 24h rollback window.');
+
+            // Imported products are stamped with the session id and
+            // discoverable via the catalog repository.
+            $em = $this->em();
+            $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+            \assert($tenant instanceof Tenant);
+            self::getContainer()->get(TenantContext::class)->set($tenant);
+
+            $product = self::getContainer()
+                ->get(ObjectTypeRepositoryInterface::class)
+                ->findBuiltInByKind(ObjectKind::Product, $tenant);
+            \assert($product instanceof ObjectType);
+
+            $imported = $em->createQueryBuilder()
+                ->select('o')
+                ->from(CatalogObject::class, 'o')
+                ->where('o.objectType = :type')
+                ->andWhere('o.importSessionId = :sessionId')
+                ->setParameter('type', $product)
+                ->setParameter('sessionId', $body['id'])
+                ->getQuery()
+                ->getResult();
+
+            self::assertCount(5, $imported);
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    private function seedAttributes(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist(new ObjectTypeAttribute($product, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($product, $name, false, 2));
+        $em->flush();
+    }
+
+    private function writeSmallCsv(): string
+    {
+        $rows = ['sku;name'];
+        for ($i = 1; $i <= 5; ++$i) {
+            $rows[] = \sprintf('SMALL-%d;Product %d', $i, $i);
+        }
+        $contents = implode("\n", $rows)."\n";
+
+        $path = tempnam(sys_get_temp_dir(), 'pim-start-import-');
+        \assert(false !== $path);
+        $renamed = $path.'.csv';
+        rename($path, $renamed);
+        file_put_contents($renamed, $contents);
+
+        return $renamed;
+    }
+}

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -13,6 +13,7 @@ use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Import\Application\Service\DelimiterDetector;
 use App\Import\Application\Service\EncodingDetector;
+use App\Import\Application\Service\ImportRowReader;
 use App\Import\Application\Service\ImportValidationService;
 use App\Import\Domain\Enum\ImportErrorType;
 use App\Shared\Application\TenantContext;
@@ -50,8 +51,7 @@ final class ImportValidationServiceTest extends TestCase
             attributes: $attributeRepo,
             catalogObjects: $catalogRepo,
             tenantContext: $tenantContext,
-            encodingDetector: new EncodingDetector(),
-            delimiterDetector: new DelimiterDetector(),
+            rowReader: new ImportRowReader(new EncodingDetector(), new DelimiterDetector()),
         );
 
         $csv = "sku;name;price\nOK-1;Foo;9.99\nEXISTING-1;Bar;14.99\n;Anon;5\nDUP-1;Dup;1\nDUP-1;Dup again;2\nBAD-1;Has bad price;not-a-number\n";

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,7 +241,9 @@ services:
       mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
       mc mb -p local/pim-assets || true;
       mc mb -p local/pim-backups || true;
+      mc mb -p local/pim-imports || true;
       mc anonymous set download local/pim-assets || true;
+      mc ilm rule add --expire-days 7 local/pim-imports || true;
       "
     restart: "no"
 


### PR DESCRIPTION
## Cel

Spina wizard'owy Step 4 confirm z faktycznym persistowaniem produktów. Spec: [`feature-imports.md §5.6 + §8.3`](Project%20Plan/UI/feature-imports.md). Zamyka [#445](https://github.com/malipie/PIM/issues/445).

## Zakres

**Handler + creator** (`apps/api/src/Import/Application/`):
- `ImportObjectCreator` — z mapowanego row tworzy `CatalogObject` + per-attribute `ObjectValue` (provenance=`import`).
- `ImportRunHandler extends AbstractBatchHandler` z batch=200 + `flushAndClear()` (R-25 mitigation). Re-merge'uje `ImportSession` po każdym clear, więc counters i Mercure progress działają mimo identity-map detach.
- `ImportRowReader` — refaktor extrakcji z IMP-03 service'u; współdzielony iterator dla dry-run i async run.

**Schema delta**:
- `Version20260506213907` dodaje `import_sessions.column_mapping JSONB` (profile-less imports zachowują mapping po dispatch).
- `CatalogObject.importSessionId` (kolumna była z IMP-01, teraz domknięty ORM round-trip).

**Endpoints**:
- `POST /api/import-sessions` — multipart upload do MinIO (`imports.storage` bucket) + persist session + sync run (<50 KB heuristic) lub async dispatch
- `GET /api/import-sessions/{id}` — counters payload dla progress/results polling
- `POST /api/import-sessions/{id}/{pause|resume|cancel}` — status flip (worker-side mid-run honoring trafia do IMP-14)

**Mercure** (`ImportProgressPublisher`):
- Topics `imports/{session_id}` (detail) + `imports/user/{user_id}` (list)
- Events: `progress`, `row_processed`, `completed`
- Hub failure → log warning, nigdy nie aborts write (catalog publisher pattern)

**Storage** (`flysystem.yaml`):
- Nowy bucket `pim-imports` w MinIO, 7-day ILM rule (spec §8.6)
- `when@test` flips adapter na local directory

**Messenger routing**:
- `App\Import\Domain\Message\ImportRunMessage: async` (audit MEDIUM-007 hołd)

## Świadome odejścia (follow-up w tym samym epiku)

- **Image download HTTP** (concurrent pool) + **ZIP extract** — odsunięte, żeby PR pozostał reviewable. Handler struktura exposes row hook do tych dodatków bez refaktora; obie funkcje dochodzą przed IMP-14 dogfooding'iem (spec §5.6 progress UI je zawiera).
- **Worker-side pause/cancel mid-run** — endpoints działają (status flip), runtime control trafia z IMP-14 5k-row testem.

## Quality gates

- ✅ PHPStan max: zero errors
- ✅ PHPUnit unit (Import suite): **52 tests / 121 assertions** green
- ✅ **ApiTestCase StartImportApiTest**: 5-row CSV → status=success, success_count=5, error_count=0, rollback_until set, 5 CatalogObject rows stamped with session id
- ✅ composer audit: zero advisories
- ✅ Migracja `Version20260506213907` up + down round-trip

## Test plan

- [ ] PHPStan max zielony w CI
- [ ] PHPUnit unit + api zielone (StartImportApi 5-row inline)
- [ ] composer audit czyste
- [ ] Migration up/down OK
- [ ] Manual smoke 5 min: stack up → migrate → curl multipart `POST /api/import-sessions` z 10-row CSV → response 200 + 10 produktów w DB

Refs #445