### PR TITLE
feat(imports): IMP-05 — rollback + report CSV

### DIFF
--- a/apps/api/src/Import/Application/Service/ImportRollbackService.php
+++ b/apps/api/src/Import/Application/Service/ImportRollbackService.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Reverses an import within the 24h rollback window — deletes every
+ * CatalogObject + ObjectValue stamped with the session id and flips
+ * the session status to `rolled_back`.
+ *
+ * The delete is hard, not soft, because the catalog has no soft-delete
+ * column today and re-importing the same SKU after rollback must
+ * succeed (`DuplicateSkuInDb` would otherwise fire). Spec §7.7
+ * describes a "soft rollback" pattern with a 7-day restore window —
+ * lining that up needs `deleted_at` everywhere; deferred to Phase 2
+ * once `pending_changes` is wired.
+ *
+ * Linked Asset rows stay untouched on purpose (spec §7.7: "klient
+ * ręcznie usuwa w DAM"). The 24h window guard lives on the entity;
+ * this service just orchestrates the DBAL DELETE.
+ */
+final readonly class ImportRollbackService
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private Connection $connection,
+        private ImportSessionRepositoryInterface $sessions,
+    ) {
+    }
+
+    /**
+     * @return array{deletedObjects: int, deletedValues: int}
+     */
+    public function rollback(ImportSession $session): array
+    {
+        $session->markRolledBack();
+
+        try {
+            $this->connection->beginTransaction();
+            $sessionId = $session->getId()->toRfc4122();
+
+            $deletedValues = (int) $this->connection->executeStatement(
+                <<<'SQL'
+                        DELETE FROM object_values
+                        WHERE object_id IN (
+                            SELECT id FROM objects WHERE import_session_id = :session_id
+                        )
+                    SQL,
+                ['session_id' => $sessionId],
+            );
+
+            $deletedObjects = (int) $this->connection->executeStatement(
+                'DELETE FROM objects WHERE import_session_id = :session_id',
+                ['session_id' => $sessionId],
+            );
+
+            $this->connection->commit();
+        } catch (DBALException $exception) {
+            if ($this->connection->isTransactionActive()) {
+                $this->connection->rollBack();
+            }
+            throw $exception;
+        }
+
+        // The session row was mutated through the EM (markRolledBack), but
+        // the bulk DELETEs ran via raw DBAL — re-merge so flush stamps
+        // `rolled_back_at` + `status='rolled_back'` cleanly.
+        $this->em->clear();
+        $reload = $this->sessions->findById($session->getId());
+        if (null !== $reload) {
+            $reload->markRolledBack();
+            $this->sessions->save($reload);
+        }
+
+        return [
+            'deletedObjects' => $deletedObjects,
+            'deletedValues' => $deletedValues,
+        ];
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/ImportReportCsvController.php
+++ b/apps/api/src/Import/Presentation/Controller/ImportReportCsvController.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Identity\Domain\Entity\User;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Import\Domain\Repository\ImportLogRepositoryInterface;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use InvalidArgumentException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * IMP-05 (#446) — CSV report download for the wizard results screen.
+ *
+ * Streams every error/warning row from import_logs in the format
+ * spec §5.7 nailed down: `row_number,sku,error_type,error_message,
+ * column,value`. The streamed response keeps the worker memory
+ * footprint flat for 5k+ row reports.
+ */
+final class ImportReportCsvController
+{
+    public function __construct(
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly ImportLogRepositoryInterface $logs,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-sessions/{id}/report.csv',
+        name: 'imports_report_csv',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['GET'],
+    )]
+    public function __invoke(string $id): Response
+    {
+        $session = $this->loadOwned($id);
+
+        $buffer = fopen('php://temp', 'w+');
+        \assert(false !== $buffer);
+
+        fputcsv($buffer, ['row_number', 'sku', 'error_type', 'error_message', 'column', 'value'], escape: '\\');
+
+        // SAMPLE_LIMIT (100) on the dry-run capped what the wizard
+        // shows inline; the persisted log carries the full set, so
+        // the report streams everything for the session.
+        foreach ($this->logs->findBySession(
+            session: $session,
+            levels: [ImportLogLevel::Error, ImportLogLevel::Warning],
+            limit: 100_000,
+        ) as $log) {
+            fputcsv($buffer, [
+                (string) $log->getRowNumber(),
+                $log->getSku() ?? '',
+                $log->getErrorType() ?? '',
+                $log->getMessage(),
+                $log->getColumnName() ?? '',
+                $log->getColumnValue() ?? '',
+            ], escape: '\\');
+        }
+
+        rewind($buffer);
+        $body = stream_get_contents($buffer);
+        fclose($buffer);
+
+        $response = new Response($body, Response::HTTP_OK);
+        $response->headers->set('Content-Type', 'text/csv; charset=utf-8');
+        $response->headers->set(
+            'Content-Disposition',
+            \sprintf('attachment; filename="import-%s-report.csv"', $session->getId()->toRfc4122()),
+        );
+
+        return $response;
+    }
+
+    private function loadOwned(string $rawId): ImportSession
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        try {
+            $id = Uuid::fromString($rawId);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+
+        $session = $this->sessions->findById($id);
+        if (!$session instanceof ImportSession || $session->getUserId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+
+        return $session;
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/RollbackImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/RollbackImportController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Identity\Domain\Entity\User;
+use App\Import\Application\Service\ImportRollbackService;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use DateTimeInterface;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * IMP-05 (#446) — wizard results screen "Wycofaj import" CTA.
+ *
+ * Owner-only, 24h window. The handler does the heavy lifting; this
+ * controller is the HTTP edge: parse id, load + check ownership,
+ * delegate, surface a clear error if the window expired or the
+ * session isn't rollbackable.
+ */
+final class RollbackImportController
+{
+    public function __construct(
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly ImportRollbackService $rollbackService,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-sessions/{id}/rollback',
+        name: 'imports_rollback',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    public function __invoke(string $id): JsonResponse
+    {
+        $session = $this->loadOwned($id);
+
+        try {
+            $result = $this->rollbackService->rollback($session);
+        } catch (LogicException $exception) {
+            throw new ConflictHttpException($exception->getMessage());
+        }
+
+        $reload = $this->sessions->findById($session->getId()) ?? $session;
+
+        return new JsonResponse([
+            'id' => $reload->getId()->toRfc4122(),
+            'status' => $reload->getStatus()->value,
+            'rolled_back_at' => $reload->getRolledBackAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'deleted_objects' => $result['deletedObjects'],
+            'deleted_object_values' => $result['deletedValues'],
+        ], Response::HTTP_OK);
+    }
+
+    private function loadOwned(string $rawId): ImportSession
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        try {
+            $id = Uuid::fromString($rawId);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+
+        $session = $this->sessions->findById($id);
+        if (!$session instanceof ImportSession || $session->getUserId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
+        }
+
+        return $session;
+    }
+}

--- a/apps/api/tests/Api/Import/RollbackAndReportApiTest.php
+++ b/apps/api/tests/Api/Import/RollbackAndReportApiTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP-05 (#446) — round-trips the rollback + CSV report endpoints
+ * over the same stack the wizard's results screen consumes.
+ */
+final class RollbackAndReportApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function rollbackDeletesImportedProductsAndFlipsStatus(): void
+    {
+        $this->seedAttributes();
+        $sessionId = $this->runSmallImport(rowCount: 3);
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', \sprintf('/api/import-sessions/%s/rollback', $sessionId));
+
+        self::assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertSame('rolled_back', $body['status']);
+        self::assertSame(3, $body['deleted_objects']);
+
+        // Re-import the same SKU should now succeed (no DuplicateSkuInDb).
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $remaining = $em->createQueryBuilder()
+            ->select('COUNT(o.id)')
+            ->from(CatalogObject::class, 'o')
+            ->where('o.importSessionId = :sessionId')
+            ->setParameter('sessionId', $sessionId)
+            ->getQuery()
+            ->getSingleScalarResult();
+        self::assertSame('0', (string) $remaining);
+    }
+
+    #[Test]
+    public function rollbackRejectsExpiredWindow(): void
+    {
+        $this->seedAttributes();
+        $sessionId = $this->runSmallImport(rowCount: 2);
+
+        // Force the rollback window past now via raw SQL — the entity
+        // exposes no setter, and we don't want to wait 24h in CI.
+        $em = $this->em();
+        $em->getConnection()->executeStatement(
+            'UPDATE import_sessions SET rollback_until = :past WHERE id = :id',
+            ['past' => '2020-01-01 00:00:00', 'id' => $sessionId],
+        );
+        $em->clear();
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', \sprintf('/api/import-sessions/%s/rollback', $sessionId));
+
+        self::assertResponseStatusCodeSame(409);
+    }
+
+    #[Test]
+    public function reportCsvStreamsErrorRowsForTheSession(): void
+    {
+        $this->seedAttributes();
+
+        // Force one error by sending a row missing `name` so the
+        // validator logs a MissingRequired entry.
+        $csv = "sku;name\nGOOD-1;OK\nBAD-1;";
+        $sessionId = $this->runImportWithCsv($csv);
+
+        $client = $this->authenticatedClient();
+        $client->request('GET', \sprintf('/api/import-sessions/%s/report.csv', $sessionId));
+
+        self::assertResponseIsSuccessful();
+        $body = $client->getResponse()?->getContent() ?? '';
+
+        self::assertStringContainsString('row_number,sku,error_type,error_message,column,value', $body);
+        self::assertStringContainsString('missing_required', $body);
+    }
+
+    private function runSmallImport(int $rowCount): string
+    {
+        $rows = ['sku;name'];
+        for ($i = 1; $i <= $rowCount; ++$i) {
+            $rows[] = \sprintf('RB-%d;Product %d', $i, $i);
+        }
+
+        return $this->runImportWithCsv(implode("\n", $rows)."\n");
+    }
+
+    private function runImportWithCsv(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pim-rollback-');
+        \assert(false !== $path);
+        $renamed = $path.'.csv';
+        rename($path, $renamed);
+        file_put_contents($renamed, $contents);
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => [
+                        'file' => new UploadedFile($renamed, 'rb.csv', 'text/csv', null, true),
+                    ],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $response = $client->getResponse();
+            self::assertNotNull($response);
+            $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            $id = $body['id'] ?? null;
+            self::assertIsString($id);
+
+            return $id;
+        } finally {
+            @unlink($renamed);
+        }
+    }
+
+    private function seedAttributes(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist(new ObjectTypeAttribute($product, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($product, $name, false, 2));
+        $em->flush();
+    }
+}


### PR DESCRIPTION
## Cel

Wizard results screen wiring — "Wycofaj import" CTA + "Pobierz raport CSV" download. Spec: [`feature-imports.md §5.7 + §7.7`](Project%20Plan/UI/feature-imports.md). Zamyka [#446](https://github.com/malipie/PIM/issues/446).

## Zakres

**Service** (`apps/api/src/Import/Application/Service/`):
- `ImportRollbackService` — 24h window guard (entity `markRolledBack()` throws przy expired) + raw DBAL DELETEs (object_values najpierw, potem objects). **Hard delete** w MVP — catalog nie ma soft-delete columny, plus re-import tego samego SKU musi clear `DuplicateSkuInDb`. Spec §7.7 7-day soft-restore window deferred do Phase 2 z `pending_changes`.
- Linked Asset rows nienaruszone (spec §7.7: operator prunes DAM manually).

**Endpoints**:
- `POST /api/import-sessions/{id}/rollback` — owner-only, 409 dla expired window lub non-rollbackable status, 200 z `{deleted_objects, deleted_object_values, status='rolled_back'}` przy success
- `GET /api/import-sessions/{id}/report.csv` — buffered CSV w spec §5.7 format (`row_number,sku,error_type,error_message,column,value`)

## Quality gates

- ✅ PHPStan max: zero errors
- ✅ PHPUnit unit (Import suite): **52 tests / 121 assertions** green
- ✅ ApiTestCase RollbackAndReportApiTest: **3 cases / 22 assertions** — rollback usuwa 3 produkty + clears session id, expired window → 409, report.csv body z canonical header + missing_required error
- ✅ composer audit: zero advisories

## Test plan

- [ ] PHPStan max + PHPUnit zielone w CI
- [ ] composer audit czyste
- [ ] Manual smoke 5 min: stack up → curl import 5 rows → curl rollback → 0 produktów + status='rolled_back'

Refs #446