### PR TITLE
feat(imports): IMP-06 — pgBackRest manual snapshot trigger

### DIFF
--- a/apps/api/config/packages/framework.yaml
+++ b/apps/api/config/packages/framework.yaml
@@ -54,6 +54,16 @@ framework:
             limit: 10
             interval: '1 hour'
 
+        # IMP-06 (#447) — manual pgBackRest snapshot. Spec §7.8 caps
+        # at 1/h/tenant so a power-click on the Step 4 checkbox
+        # cannot saturate the disk. Sliding window so back-to-back
+        # legitimate retries (network blip, second attempt the next
+        # minute) wait the full hour, not just the next tick.
+        backup_trigger:
+            policy: 'sliding_window'
+            limit: 1
+            interval: '1 hour'
+
         # Refresh-token rotation (#28). The cookie-driven path is
         # invoked by every browser session every ~15 minutes, but
         # the only legitimate caller is a single tab — 30/h/IP

--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -82,3 +82,9 @@ framework:
             # rows) imports bypass dispatch by calling `run()` directly
             # on the same handler from the controller.
             App\Import\Domain\Message\ImportRunMessage: async
+
+            # Imports MVP (#447). pgBackRest snapshot can take 5-30
+            # minutes — handler runs out-of-band so `POST /api/backups`
+            # returns 202 immediately and the wizard polls
+            # `GET /api/backups/{id}` for status.
+            App\Backup\Domain\Message\BackupSnapshotMessage: async

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -202,6 +202,12 @@ services:
         arguments:
             $importsStorage: '@imports.storage'
 
+    # IMP-06 (#447) — production runs against the local pgBackRest
+    # binary; tests + CI use a stub via `when@test` (see services
+    # block at the bottom of this file in test environment).
+    App\Backup\Application\Service\BackupRunnerInterface:
+        alias: App\Backup\Infrastructure\Service\PgBackRestRunner
+
     # API Configurator (#90 / 0.10.1). Argon2id hasher + key generator
     # — see ADR-0016 for the format and algorithm choice. The generator
     # reads `kernel.environment` to embed the four-letter forensic
@@ -285,4 +291,17 @@ when@test:
         # mercure.yaml continue to be "used").
         Symfony\Component\Mercure\HubInterface:
             alias: App\Tests\Support\InMemoryMercureHub
+            public: true
+
+        # IMP-06 (#447) — keep the pgbackrest CLI off the test box.
+        # The stub honours the same contract so the handler flow
+        # (mark running → run → mark completed/failed) is exercised
+        # end-to-end through the messenger bus.
+        App\Tests\Support\InMemoryBackupRunner:
+            public: true
+            autowire: false
+            autoconfigure: false
+
+        App\Backup\Application\Service\BackupRunnerInterface:
+            alias: App\Tests\Support\InMemoryBackupRunner
             public: true

--- a/apps/api/src/Backup/Application/Handler/BackupSnapshotHandler.php
+++ b/apps/api/src/Backup/Application/Handler/BackupSnapshotHandler.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Application\Handler;
+
+use App\Backup\Application\Service\BackupRunnerInterface;
+use App\Backup\Domain\Entity\Backup;
+use App\Backup\Domain\Message\BackupSnapshotMessage;
+use App\Backup\Domain\Repository\BackupRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Throwable;
+
+/**
+ * IMP-06 (#447) — drives the pgBackRest snapshot lifecycle.
+ *
+ * State machine: pending → running → completed / failed. The runner
+ * is injected behind {@see BackupRunnerInterface} so tests can stub
+ * the CLI invocation without ever spawning a process.
+ */
+#[AsMessageHandler]
+final readonly class BackupSnapshotHandler
+{
+    private LoggerInterface $logger;
+
+    public function __construct(
+        private BackupRepositoryInterface $backups,
+        private BackupRunnerInterface $runner,
+        private TenantContext $tenantContext,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function __invoke(BackupSnapshotMessage $message): void
+    {
+        $backup = $this->backups->findById($message->backupId);
+        if (!$backup instanceof Backup) {
+            $this->logger->warning('Backup snapshot {id} not found, skipping.', [
+                'id' => $message->backupId->toRfc4122(),
+            ]);
+
+            return;
+        }
+
+        $tenant = $backup->getTenant();
+        if (!$tenant instanceof Tenant) {
+            $backup->markFailed('Backup row has no tenant assignment.');
+            $this->backups->save($backup);
+
+            return;
+        }
+
+        $this->tenantContext->set($tenant);
+
+        try {
+            $backup->markRunning();
+            $this->backups->save($backup);
+        } catch (LogicException) {
+            // Already running / terminal — bail without state churn.
+            return;
+        }
+
+        try {
+            $result = $this->runner->run();
+        } catch (Throwable $exception) {
+            $current = $this->backups->findById($backup->getId());
+            if ($current instanceof Backup) {
+                $current->markFailed($exception->getMessage());
+                $this->backups->save($current);
+            }
+            throw $exception;
+        }
+
+        $current = $this->backups->findById($backup->getId());
+        if (!$current instanceof Backup) {
+            return;
+        }
+
+        if ($result->success) {
+            $current->markCompleted($result->sizeBytes, $result->pgbackrestLabel);
+        } else {
+            $current->markFailed($result->errorMessage ?? 'pgBackRest failed without details.');
+        }
+        $this->backups->save($current);
+    }
+}

--- a/apps/api/src/Backup/Application/Service/BackupRunResult.php
+++ b/apps/api/src/Backup/Application/Service/BackupRunResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Application\Service;
+
+final readonly class BackupRunResult
+{
+    public function __construct(
+        public bool $success,
+        public int $sizeBytes,
+        public ?string $pgbackrestLabel,
+        public ?string $errorMessage = null,
+    ) {
+    }
+
+    public static function success(int $sizeBytes, ?string $label = null): self
+    {
+        return new self(true, $sizeBytes, $label);
+    }
+
+    public static function failure(string $message): self
+    {
+        return new self(false, 0, null, $message);
+    }
+}

--- a/apps/api/src/Backup/Application/Service/BackupRunnerInterface.php
+++ b/apps/api/src/Backup/Application/Service/BackupRunnerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Application\Service;
+
+/**
+ * Abstraction over the actual snapshot tool. Production wires this to
+ * {@see PgBackRestRunner} which shells out to `pgbackrest`. The test
+ * suite uses {@see InMemoryBackupRunner} so it stays infra-free.
+ */
+interface BackupRunnerInterface
+{
+    public function run(): BackupRunResult;
+}

--- a/apps/api/src/Backup/Domain/Message/BackupSnapshotMessage.php
+++ b/apps/api/src/Backup/Domain/Message/BackupSnapshotMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Domain\Message;
+
+use Symfony\Component\Uid\Uuid;
+
+final readonly class BackupSnapshotMessage
+{
+    public function __construct(
+        public Uuid $backupId,
+        public Uuid $tenantId,
+    ) {
+    }
+}

--- a/apps/api/src/Backup/Infrastructure/Service/PgBackRestRunner.php
+++ b/apps/api/src/Backup/Infrastructure/Service/PgBackRestRunner.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Infrastructure\Service;
+
+use App\Backup\Application\Service\BackupRunnerInterface;
+use App\Backup\Application\Service\BackupRunResult;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Calls the local pgBackRest binary against the configured stanza.
+ *
+ * The container layout (docker-compose `database` service) ships
+ * pgBackRest 2.x with the `pim` stanza pre-configured against MinIO.
+ * In production the operator wires the `repo1-s3-*` env vars; this
+ * runner just invokes the CLI from inside the api container so the
+ * Symfony worker keeps its lifecycle separate from the database
+ * server.
+ *
+ * Output discipline: pgBackRest writes its progress to stderr and the
+ * final summary to stdout. We capture both so the failure path can
+ * surface the operator-actionable line, not just "exit code 50".
+ */
+final readonly class PgBackRestRunner implements BackupRunnerInterface
+{
+    private const string DEFAULT_STANZA = 'pim';
+    private const int TIMEOUT_SECONDS = 1800;
+
+    public function __construct(
+        private string $stanza = self::DEFAULT_STANZA,
+    ) {
+    }
+
+    public function run(): BackupRunResult
+    {
+        $process = new Process([
+            'pgbackrest',
+            \sprintf('--stanza=%s', $this->stanza),
+            'backup',
+        ]);
+        $process->setTimeout(self::TIMEOUT_SECONDS);
+
+        try {
+            $process->mustRun();
+        } catch (ProcessFailedException $exception) {
+            $message = trim($process->getErrorOutput());
+            if ('' === $message) {
+                $message = $exception->getMessage();
+            }
+
+            return BackupRunResult::failure($message);
+        }
+
+        $infoProcess = new Process([
+            'pgbackrest',
+            \sprintf('--stanza=%s', $this->stanza),
+            '--output=json',
+            'info',
+        ]);
+        $infoProcess->setTimeout(60);
+
+        try {
+            $infoProcess->mustRun();
+            $payload = $infoProcess->getOutput();
+        } catch (ProcessFailedException) {
+            $payload = '';
+        }
+
+        return BackupRunResult::success(
+            sizeBytes: $this->extractSizeFromInfo($payload),
+            label: $this->extractLatestLabelFromInfo($payload),
+        );
+    }
+
+    private function extractSizeFromInfo(string $payload): int
+    {
+        $latest = $this->latestBackupEntry($payload);
+        if (null === $latest) {
+            return 0;
+        }
+        $info = $latest['info'] ?? null;
+        if (!\is_array($info)) {
+            return 0;
+        }
+        $size = $info['size'] ?? null;
+        if (\is_int($size)) {
+            return $size;
+        }
+
+        return is_numeric($size) ? (int) $size : 0;
+    }
+
+    private function extractLatestLabelFromInfo(string $payload): ?string
+    {
+        $latest = $this->latestBackupEntry($payload);
+        if (null === $latest) {
+            return null;
+        }
+        $label = $latest['label'] ?? null;
+
+        return \is_string($label) ? $label : null;
+    }
+
+    /**
+     * @return array<int|string, mixed>|null
+     */
+    private function latestBackupEntry(string $payload): ?array
+    {
+        $decoded = json_decode($payload, true);
+        if (!\is_array($decoded) || !\is_array($decoded[0] ?? null)) {
+            return null;
+        }
+        $stanzas = $decoded[0]['backup'] ?? null;
+        if (!\is_array($stanzas) || [] === $stanzas) {
+            return null;
+        }
+        $latest = end($stanzas);
+
+        return \is_array($latest) ? $latest : null;
+    }
+}

--- a/apps/api/src/Backup/Presentation/Controller/GetBackupController.php
+++ b/apps/api/src/Backup/Presentation/Controller/GetBackupController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Presentation\Controller;
+
+use App\Backup\Domain\Entity\Backup;
+use App\Backup\Domain\Repository\BackupRepositoryInterface;
+use DateTimeInterface;
+use InvalidArgumentException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Status polling endpoint for the wizard's Step 4 backup checkbox.
+ * The frontend polls every 5 s while `status` ∈ {pending, running}
+ * and unblocks the "Uruchom import" button on `completed` / surfaces
+ * the error on `failed`.
+ */
+final class GetBackupController
+{
+    public function __construct(
+        private readonly BackupRepositoryInterface $backups,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/backups/{id}',
+        name: 'backups_show',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['GET'],
+    )]
+    public function __invoke(string $id): JsonResponse
+    {
+        try {
+            $uuid = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Backup "%s" was not found.', $id));
+        }
+
+        $backup = $this->backups->findById($uuid);
+        if (!$backup instanceof Backup) {
+            throw new NotFoundHttpException(\sprintf('Backup "%s" was not found.', $id));
+        }
+
+        if (!$this->security->isGranted('READ', $backup)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        return new JsonResponse([
+            'id' => $backup->getId()->toRfc4122(),
+            'status' => $backup->getStatus()->value,
+            'triggered_by_action' => $backup->getTriggeredByAction()->value,
+            'pgbackrest_label' => $backup->getPgbackrestLabel(),
+            'size_bytes' => $backup->getSizeBytes(),
+            'started_at' => $backup->getStartedAt()->format(DateTimeInterface::RFC3339_EXTENDED),
+            'completed_at' => $backup->getCompletedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'error_message' => $backup->getErrorMessage(),
+        ], Response::HTTP_OK);
+    }
+}

--- a/apps/api/src/Backup/Presentation/Controller/TriggerBackupController.php
+++ b/apps/api/src/Backup/Presentation/Controller/TriggerBackupController.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Backup\Presentation\Controller;
+
+use App\Backup\Domain\Entity\Backup;
+use App\Backup\Domain\Enum\BackupTriggerAction;
+use App\Backup\Domain\Message\BackupSnapshotMessage;
+use App\Backup\Domain\Repository\BackupRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Application\TenantContext;
+use DateTimeInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * IMP-06 (#447) — wizard Step 4 "Utwórz backup" checkbox + admin
+ * Settings page trigger.
+ *
+ * Tied to `IS_GRANTED('backup','write')` — the `backup:write`
+ * permission lives only on the super_admin role today (RbacMatrix +
+ * IMP-02 — Catalog Manager has read but not write). The 1/h/tenant
+ * sliding-window limiter prevents accidental double-clicks from
+ * saturating the disk.
+ */
+final class TriggerBackupController
+{
+    public function __construct(
+        private readonly BackupRepositoryInterface $backups,
+        private readonly MessageBusInterface $bus,
+        private readonly RateLimiterFactoryInterface $backupTriggerLimiter,
+        private readonly Security $security,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/backups',
+        name: 'backups_trigger',
+        methods: ['POST'],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+        if (!$this->security->isGranted('WRITE', Backup::class)) {
+            throw new AccessDeniedHttpException();
+        }
+        $tenant = $user->getTenant();
+        $this->tenantContext->set($tenant);
+
+        $limiter = $this->backupTriggerLimiter->create($tenant->getId()->toRfc4122());
+        $reservation = $limiter->consume();
+        if (!$reservation->isAccepted()) {
+            throw new TooManyRequestsHttpException(
+                $reservation->getRetryAfter()->getTimestamp() - time(),
+                'Rate limit reached: max 1 backup per hour per tenant.',
+            );
+        }
+
+        $payload = json_decode($request->getContent(), true);
+        $rawAction = \is_array($payload) ? ($payload['triggered_by_action'] ?? 'manual') : 'manual';
+        if (!\is_string($rawAction)) {
+            throw new BadRequestHttpException('"triggered_by_action" must be a string.');
+        }
+        $action = BackupTriggerAction::tryFrom($rawAction);
+        if (null === $action) {
+            throw new BadRequestHttpException(\sprintf(
+                'Unsupported triggered_by_action "%s". Allowed: manual, pre_import, scheduled.',
+                $rawAction,
+            ));
+        }
+
+        $backup = new Backup(
+            triggeredByUserId: $user->getId(),
+            triggeredByAction: $action,
+        );
+        $this->backups->save($backup);
+
+        $this->bus->dispatch(new BackupSnapshotMessage(
+            backupId: $backup->getId(),
+            tenantId: $tenant->getId(),
+        ));
+
+        $reload = $this->backups->findById($backup->getId()) ?? $backup;
+
+        return new JsonResponse([
+            'id' => $reload->getId()->toRfc4122(),
+            'status' => $reload->getStatus()->value,
+            'triggered_by_action' => $reload->getTriggeredByAction()->value,
+            'started_at' => $reload->getStartedAt()->format(DateTimeInterface::RFC3339_EXTENDED),
+        ], Response::HTTP_ACCEPTED);
+    }
+}

--- a/apps/api/tests/Api/Backup/BackupApiTest.php
+++ b/apps/api/tests/Api/Backup/BackupApiTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Backup;
+
+use App\Backup\Domain\Enum\BackupStatus;
+use App\Backup\Domain\Repository\BackupRepositoryInterface;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use App\Tests\Support\InMemoryBackupRunner;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP-06 (#447) — round-trips the manual snapshot trigger + status
+ * polling endpoints. The pgBackRest CLI stays off the test box; the
+ * {@see InMemoryBackupRunner} stub honours the contract so the
+ * handler flow runs in-band on `sync://`.
+ */
+final class BackupApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function triggerEndpointDispatchesAndCompletesBackup(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/backups', [
+            'extra' => [
+                'parameters' => [],
+            ],
+            'body' => json_encode(['triggered_by_action' => 'manual'], JSON_THROW_ON_ERROR),
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+
+        self::assertResponseStatusCodeSame(202);
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('id', $body);
+
+        // sync:// transport runs the handler in-band, so by the time
+        // we read it back the status is already terminal.
+        $id = $body['id'] ?? null;
+        self::assertIsString($id);
+        $repo = self::getContainer()->get(BackupRepositoryInterface::class);
+        $reload = $repo->findById(Uuid::fromString($id));
+        self::assertNotNull($reload);
+        self::assertSame(BackupStatus::Completed, $reload->getStatus());
+        self::assertSame(12_345_678, $reload->getSizeBytes());
+        self::assertSame('TEST-LABEL', $reload->getPgbackrestLabel());
+    }
+
+    #[Test]
+    public function triggerEndpointSurfacesPgbackrestFailureAsBackupFailed(): void
+    {
+        $client = $this->authenticatedClient();
+
+        // Flip the stub after the client boots the kernel so the
+        // controller resolves the same shared instance.
+        $runner = self::getContainer()->get(InMemoryBackupRunner::class);
+        \assert($runner instanceof InMemoryBackupRunner);
+        $runner->shouldSucceed = false;
+        $runner->errorMessage = 'disk full';
+
+        $client->request('POST', '/api/backups', [
+            'body' => json_encode(['triggered_by_action' => 'pre_import'], JSON_THROW_ON_ERROR),
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+
+        self::assertResponseStatusCodeSame(202);
+        $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+
+        $id = $body['id'] ?? null;
+        self::assertIsString($id);
+        $repo = self::getContainer()->get(BackupRepositoryInterface::class);
+        $reload = $repo->findById(Uuid::fromString($id));
+        self::assertNotNull($reload);
+        self::assertSame(BackupStatus::Failed, $reload->getStatus());
+        self::assertSame('disk full', $reload->getErrorMessage());
+    }
+
+    #[Test]
+    public function statusEndpointReturnsCurrentBackupShape(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/backups', [
+            'body' => json_encode(['triggered_by_action' => 'manual'], JSON_THROW_ON_ERROR),
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        $created = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($created);
+        $createdId = $created['id'] ?? null;
+        self::assertIsString($createdId);
+
+        $client->request('GET', \sprintf('/api/backups/%s', $createdId));
+        self::assertResponseIsSuccessful();
+        $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertSame('completed', $body['status']);
+        self::assertSame('manual', $body['triggered_by_action']);
+        self::assertNotNull($body['completed_at']);
+    }
+}

--- a/apps/api/tests/Api/Backup/BackupApiTest.php
+++ b/apps/api/tests/Api/Backup/BackupApiTest.php
@@ -9,6 +9,9 @@ use App\Backup\Domain\Repository\BackupRepositoryInterface;
 use App\Tests\Api\Catalog\CatalogApiTestCase;
 use App\Tests\Support\InMemoryBackupRunner;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
 use Symfony\Component\Uid\Uuid;
 
 use const JSON_THROW_ON_ERROR;
@@ -40,8 +43,8 @@ final class BackupApiTest extends CatalogApiTestCase
         self::assertIsArray($body);
         self::assertArrayHasKey('id', $body);
 
-        // sync:// transport runs the handler in-band, so by the time
-        // we read it back the status is already terminal.
+        $this->consumeAsyncQueue();
+
         $id = $body['id'] ?? null;
         self::assertIsString($id);
         $repo = self::getContainer()->get(BackupRepositoryInterface::class);
@@ -73,6 +76,8 @@ final class BackupApiTest extends CatalogApiTestCase
         $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
         self::assertIsArray($body);
 
+        $this->consumeAsyncQueue();
+
         $id = $body['id'] ?? null;
         self::assertIsString($id);
         $repo = self::getContainer()->get(BackupRepositoryInterface::class);
@@ -95,6 +100,8 @@ final class BackupApiTest extends CatalogApiTestCase
         $createdId = $created['id'] ?? null;
         self::assertIsString($createdId);
 
+        $this->consumeAsyncQueue();
+
         $client->request('GET', \sprintf('/api/backups/%s', $createdId));
         self::assertResponseIsSuccessful();
         $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
@@ -102,5 +109,27 @@ final class BackupApiTest extends CatalogApiTestCase
         self::assertSame('completed', $body['status']);
         self::assertSame('manual', $body['triggered_by_action']);
         self::assertNotNull($body['completed_at']);
+    }
+
+    /**
+     * Drains the in-memory async transport so the snapshot handler
+     * runs synchronously inside the test. Local dev sets the messenger
+     * DSN to `sync://` and the dispatch is in-band; CI overrides to
+     * `in-memory://` and the messages would otherwise sit in the
+     * queue.
+     */
+    private function consumeAsyncQueue(): void
+    {
+        $transport = self::getContainer()->get('messenger.transport.async');
+        // sync:// transport processes inline so `get()` is a no-op there.
+        if (!$transport instanceof InMemoryTransport) {
+            return;
+        }
+        $bus = self::getContainer()->get(MessageBusInterface::class);
+
+        foreach ($transport->get() as $envelope) {
+            $bus->dispatch($envelope->with(new ReceivedStamp('async')));
+            $transport->ack($envelope);
+        }
     }
 }

--- a/apps/api/tests/Support/InMemoryBackupRunner.php
+++ b/apps/api/tests/Support/InMemoryBackupRunner.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support;
+
+use App\Backup\Application\Service\BackupRunnerInterface;
+use App\Backup\Application\Service\BackupRunResult;
+
+/**
+ * Test stub for {@see BackupRunnerInterface}. Returns a canned
+ * success / failure so the handler + controller flow can be
+ * exercised without ever spawning a pgbackrest process.
+ */
+final class InMemoryBackupRunner implements BackupRunnerInterface
+{
+    public bool $shouldSucceed = true;
+    public int $sizeBytes = 12_345_678;
+    public ?string $label = 'TEST-LABEL';
+    public string $errorMessage = 'pgbackrest stub failure';
+
+    public function run(): BackupRunResult
+    {
+        return $this->shouldSucceed
+            ? BackupRunResult::success($this->sizeBytes, $this->label)
+            : BackupRunResult::failure($this->errorMessage);
+    }
+}


### PR DESCRIPTION
## Cel

Wizard "Utwórz backup" checkbox (Step 4) + admin Settings page trigger. Spec: [`feature-imports.md §5.5 + §7.8`](Project%20Plan/UI/feature-imports.md). Zamyka [#447](https://github.com/malipie/PIM/issues/447).

## Zakres

**Service** (`apps/api/src/Backup/Application/Service/`):
- `BackupRunnerInterface` — abstrakcja over actual tool. `PgBackRestRunner` (prod) shells out do `pgbackrest --stanza=pim backup` przez `Symfony\Process` + parses `--output=json info` dla latest label + size. `InMemoryBackupRunner` (tests) → CI nigdy nie spawnuje procesu.
- `BackupSnapshotHandler` — state machine pending → running → completed/failed. Runner failures → `Backup.error_message`. Unexpected throwable → status='failed' przed re-raise.

**Endpoints**:
- `POST /api/backups` — JSON `{triggered_by_action}` → 202 + id + status. Gated `backup:write` permission (super_admin only; Catalog Manager read-only per IMP-02). **Sliding-window rate limiter 1/h/tenant** (spec §7.8).
- `GET /api/backups/{id}` — status polling. Inline BackupVoter check, cross-tenant read → 403.

**Routing**:
- `App\Backup\Domain\Message\BackupSnapshotMessage` → async (audit MEDIUM-007 hołd). Test/dev `sync://`.

## Świadome odejścia

- **Mercure progress events** dla backup state changes — można dodać po ImportProgressPublisher pattern. Klient wizard'a poll'uje GET status co 5s wystarczy w MVP.
- **Restore endpoint** — out of MVP scope (spec §7.8: "out of scope manual UI, idzie przez admin runbook").

## Quality gates

- ✅ PHPStan max: zero errors
- ✅ PHPUnit unit (Import + Backup): **52 tests / 121 assertions** green
- ✅ ApiTestCase BackupApiTest: **3 cases / 22 assertions** — happy path (handler completes, size+label round-trip), failure path (runner failure → status='failed' + error message), status polling shape
- ✅ composer audit: zero advisories

## Test plan

- [ ] PHPStan max + PHPUnit zielone w CI
- [ ] composer audit czyste
- [ ] Manual smoke 5 min: stack up → curl `POST /api/backups` z admin JWT → 202 + status='pending'; poll `GET /api/backups/{id}` → 'completed'

Refs #447