### PR TITLE
feat(imports): IMP-07 — import profiles CRUD

### DIFF
--- a/apps/api/config/packages/api_platform.yaml
+++ b/apps/api/config/packages/api_platform.yaml
@@ -14,6 +14,7 @@ api_platform:
             - '%kernel.project_dir%/src/Channel/Infrastructure/ApiPlatform/Resource'
             - '%kernel.project_dir%/src/Asset/Infrastructure/ApiPlatform/Resource'
             - '%kernel.project_dir%/src/ApiConfigurator/Infrastructure/ApiPlatform/Resource'
+            - '%kernel.project_dir%/src/Import/Infrastructure/ApiPlatform/Resource'
 
     # AP4 default content negotiation: JSON-LD (Hydra) for application use,
     # plain JSON kept available for tooling that does not understand

--- a/apps/api/config/packages/framework.yaml
+++ b/apps/api/config/packages/framework.yaml
@@ -17,6 +17,7 @@ framework:
                 - '%kernel.project_dir%/src/Channel/Infrastructure/Serializer'
                 - '%kernel.project_dir%/src/Asset/Infrastructure/Serializer'
                 - '%kernel.project_dir%/src/ApiConfigurator/Infrastructure/Serializer'
+                - '%kernel.project_dir%/src/Import/Infrastructure/Serializer'
 
     #esi: true
     #fragments: true

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfile.xml
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfile.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+                               https://api-platform.com/schema/metadata/resources-3.0.xsd">
+
+    <resource class="App\Import\Domain\Entity\ImportProfile"
+              shortName="ImportProfile">
+
+        <normalizationContext>
+            <values>
+                <value name="groups">
+                    <values>
+                        <value>import_profile:read</value>
+                    </values>
+                </value>
+            </values>
+        </normalizationContext>
+
+        <operations>
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/import-profiles{._format}"
+                       security="is_granted('READ', 'App\\Import\\Domain\\Entity\\ImportProfile')"/>
+
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/import-profiles/{id}{._format}"
+                       security="is_granted('READ', object)"/>
+
+            <operation class="ApiPlatform\Metadata\Post"
+                       uriTemplate="/import-profiles{._format}"
+                       input="App\Import\Infrastructure\ApiPlatform\Resource\ImportProfileInput"
+                       processor="App\Import\Infrastructure\ApiPlatform\State\ImportProfileProcessor"
+                       security="is_granted('CREATE', 'App\\Import\\Domain\\Entity\\ImportProfile')"/>
+
+            <operation class="ApiPlatform\Metadata\Patch"
+                       uriTemplate="/import-profiles/{id}{._format}"
+                       input="App\Import\Infrastructure\ApiPlatform\Resource\ImportProfilePatchInput"
+                       processor="App\Import\Infrastructure\ApiPlatform\State\ImportProfileProcessor"
+                       security="is_granted('UPDATE', object)"/>
+
+            <operation class="ApiPlatform\Metadata\Delete"
+                       uriTemplate="/import-profiles/{id}{._format}"
+                       processor="App\Import\Infrastructure\ApiPlatform\State\ImportProfileProcessor"
+                       security="is_granted('DELETE', object)"/>
+        </operations>
+    </resource>
+</resources>

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfileInput.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfileInput.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Wire payload for {@see \App\Import\Domain\Entity\ImportProfile} POST.
+ *
+ * Mapped through {@see \App\Import\Infrastructure\ApiPlatform\State\ImportProfileProcessor},
+ * which resolves the target ObjectType, stamps user/tenant from the
+ * security token, and persists the row. The DTO stays plain — Domain
+ * entity ctor enforces invariants.
+ */
+final class ImportProfileInput
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public string $name = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Uuid]
+    public string $targetObjectTypeId = '';
+
+    /**
+     * @var array<string, string>
+     */
+    public array $columnMapping = [];
+
+    public ?string $locale = null;
+
+    public ?string $encoding = null;
+
+    public ?string $delimiter = null;
+
+    /**
+     * One of: `http`, `zip`, `none`.
+     */
+    public ?string $imageSource = null;
+
+    public ?string $imageZipNamingConvention = null;
+}

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfilePatchInput.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfilePatchInput.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\ApiPlatform\Resource;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Patch DTO — every field optional. The processor only writes the
+ * ones the caller actually included in the JSON merge-patch payload.
+ */
+final class ImportProfilePatchInput
+{
+    #[Assert\Length(max: 255)]
+    public ?string $name = null;
+
+    /**
+     * @var array<string, string>|null
+     */
+    public ?array $columnMapping = null;
+
+    public ?string $locale = null;
+
+    public ?string $encoding = null;
+
+    public ?string $delimiter = null;
+
+    public ?string $imageSource = null;
+
+    public ?string $imageZipNamingConvention = null;
+}

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/State/ImportProfileProcessor.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/State/ImportProfileProcessor.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\DeleteOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\State\ProcessorInterface;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Import\Domain\Entity\ImportProfile;
+use App\Import\Domain\Enum\ImportImageSource;
+use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
+use App\Import\Infrastructure\ApiPlatform\Resource\ImportProfileInput;
+use App\Import\Infrastructure\ApiPlatform\Resource\ImportProfilePatchInput;
+use App\Shared\Application\TenantContext;
+use InvalidArgumentException;
+use LogicException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @implements ProcessorInterface<ImportProfileInput|ImportProfilePatchInput|ImportProfile, ImportProfile|null>
+ */
+final readonly class ImportProfileProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private ImportProfileRepositoryInterface $profiles,
+        private ObjectTypeRepositoryInterface $objectTypes,
+        private Security $security,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     * @param array<string, mixed> $context
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?ImportProfile
+    {
+        if ($operation instanceof DeleteOperationInterface) {
+            return $this->handleDelete($uriVariables);
+        }
+        if ($operation instanceof Post) {
+            return $this->handlePost($data);
+        }
+        if ($operation instanceof Patch) {
+            return $this->handlePatch($data, $uriVariables);
+        }
+
+        throw new LogicException(\sprintf(
+            'ImportProfileProcessor cannot handle operation "%s".',
+            $operation::class,
+        ));
+    }
+
+    private function handlePost(mixed $data): ImportProfile
+    {
+        if (!$data instanceof ImportProfileInput) {
+            throw new LogicException('ImportProfileProcessor expects ImportProfileInput on Post.');
+        }
+
+        $user = $this->currentUser();
+        $tenant = $user->getTenant();
+        $this->tenantContext->set($tenant);
+
+        try {
+            $targetTypeId = Uuid::fromString($data->targetObjectTypeId);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $data->targetObjectTypeId));
+        }
+        $type = $this->objectTypes->findById($targetTypeId);
+        if (!$type instanceof ObjectType) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $data->targetObjectTypeId));
+        }
+
+        if (null !== $this->profiles->findByName($tenant, $user->getId(), $data->name)) {
+            throw new ConflictHttpException(\sprintf(
+                'Import profile "%s" already exists for this user.',
+                $data->name,
+            ));
+        }
+
+        $profile = new ImportProfile(
+            userId: $user->getId(),
+            name: $data->name,
+            targetObjectType: $type,
+        );
+        $profile->setColumnMapping($data->columnMapping);
+        $profile->setLocale($data->locale);
+        $profile->setEncoding($data->encoding);
+        $profile->setDelimiter($data->delimiter);
+        $profile->setImageZipNamingConvention($data->imageZipNamingConvention);
+        if (null !== $data->imageSource) {
+            $source = ImportImageSource::tryFrom($data->imageSource);
+            if (null !== $source) {
+                $profile->setImageSource($source);
+            }
+        }
+        $this->profiles->save($profile);
+
+        return $profile;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handlePatch(mixed $data, array $uriVariables): ImportProfile
+    {
+        if (!$data instanceof ImportProfilePatchInput) {
+            throw new LogicException('ImportProfileProcessor expects ImportProfilePatchInput on Patch.');
+        }
+
+        $profile = $this->loadProfile($uriVariables);
+
+        if (null !== $data->name && $data->name !== $profile->getName()) {
+            $existing = $this->profiles->findByName($profile->getTenant() ?? throw new LogicException('tenant'), $profile->getUserId(), $data->name);
+            if (null !== $existing && $existing->getId()->toRfc4122() !== $profile->getId()->toRfc4122()) {
+                throw new ConflictHttpException(\sprintf(
+                    'Import profile "%s" already exists for this user.',
+                    $data->name,
+                ));
+            }
+            $profile->rename($data->name);
+        }
+        if (null !== $data->columnMapping) {
+            $profile->setColumnMapping($data->columnMapping);
+        }
+        if (null !== $data->locale) {
+            $profile->setLocale($data->locale);
+        }
+        if (null !== $data->encoding) {
+            $profile->setEncoding($data->encoding);
+        }
+        if (null !== $data->delimiter) {
+            $profile->setDelimiter($data->delimiter);
+        }
+        if (null !== $data->imageZipNamingConvention) {
+            $profile->setImageZipNamingConvention($data->imageZipNamingConvention);
+        }
+        if (null !== $data->imageSource) {
+            $source = ImportImageSource::tryFrom($data->imageSource);
+            if (null !== $source) {
+                $profile->setImageSource($source);
+            }
+        }
+
+        $this->profiles->save($profile);
+
+        return $profile;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function handleDelete(array $uriVariables): null
+    {
+        $profile = $this->loadProfile($uriVariables);
+        $this->profiles->remove($profile);
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $uriVariables
+     */
+    private function loadProfile(array $uriVariables): ImportProfile
+    {
+        $rawId = $uriVariables['id'] ?? null;
+        if ($rawId instanceof Uuid) {
+            $id = $rawId;
+        } elseif (\is_string($rawId) && '' !== $rawId) {
+            try {
+                $id = Uuid::fromString($rawId);
+            } catch (InvalidArgumentException) {
+                throw new NotFoundHttpException(\sprintf('Import profile "%s" was not found.', $rawId));
+            }
+        } else {
+            throw new NotFoundHttpException('Import profile not found.');
+        }
+
+        $profile = $this->profiles->findById($id);
+        if (!$profile instanceof ImportProfile) {
+            throw new NotFoundHttpException(\sprintf('Import profile "%s" was not found.', $id->toRfc4122()));
+        }
+
+        return $profile;
+    }
+
+    private function currentUser(): User
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        return $user;
+    }
+}

--- a/apps/api/src/Import/Infrastructure/Serializer/ImportProfile.xml
+++ b/apps/api/src/Import/Infrastructure/Serializer/ImportProfile.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping
+                                https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <class name="App\Import\Domain\Entity\ImportProfile">
+        <attribute name="id">
+            <group>import_profile:read</group>
+        </attribute>
+        <attribute name="name">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
+        <attribute name="userId">
+            <group>import_profile:read</group>
+        </attribute>
+        <attribute name="targetObjectType">
+            <group>import_profile:read</group>
+        </attribute>
+        <attribute name="columnMapping">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
+        <attribute name="locale">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
+        <attribute name="encoding">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
+        <attribute name="delimiter">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
+        <attribute name="imageSource">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
+        <attribute name="imageZipNamingConvention">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
+        <attribute name="lastUsedAt">
+            <group>import_profile:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>import_profile:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/apps/api/tests/Api/Import/ImportProfileApiTest.php
+++ b/apps/api/tests/Api/Import/ImportProfileApiTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP-07 (#448) — wizard's "Saved profiles" CRUD round-trip. Voter
+ * + per-user ownership are covered in unit tests already; this case
+ * pins the HTTP shape + the duplicate-name conflict that the wizard
+ * surfaces on the profile manager modal (spec §5.8).
+ */
+final class ImportProfileApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function createListAndPatchRoundTripsThroughTheEndpoint(): void
+    {
+        $client = $this->authenticatedClient();
+        $targetId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        // POST
+        $client->request('POST', '/api/import-profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'name' => 'Festo Q2 2026',
+                'targetObjectTypeId' => $targetId,
+                'columnMapping' => ['Kod produktu' => 'sku', 'Nazwa' => 'name'],
+                'encoding' => 'utf-8',
+                'delimiter' => ';',
+                'imageSource' => 'http',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $created = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($created);
+        self::assertSame('Festo Q2 2026', $created['name']);
+        $profileId = $created['id'] ?? null;
+        self::assertIsString($profileId);
+
+        // GET collection
+        $client->request('GET', '/api/import-profiles');
+        self::assertResponseIsSuccessful();
+        $list = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($list);
+        $items = $list['member'] ?? $list['hydra:member'] ?? null;
+        self::assertIsArray($items);
+        self::assertGreaterThanOrEqual(1, \count($items));
+
+        // PATCH — rename
+        $client->request('PATCH', \sprintf('/api/import-profiles/%s', $profileId), [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode(['name' => 'Festo Q3 2026'], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseIsSuccessful();
+        $patched = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($patched);
+        self::assertSame('Festo Q3 2026', $patched['name']);
+    }
+
+    #[Test]
+    public function duplicateNameForSameUserReturns409(): void
+    {
+        $client = $this->authenticatedClient();
+        $targetId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $payload = json_encode([
+            'name' => 'Festo Q4',
+            'targetObjectTypeId' => $targetId,
+            'columnMapping' => [],
+        ], JSON_THROW_ON_ERROR);
+
+        $client->request('POST', '/api/import-profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => $payload,
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        $client->request('POST', '/api/import-profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => $payload,
+        ]);
+        self::assertResponseStatusCodeSame(409);
+    }
+
+    #[Test]
+    public function deleteRemovesProfile(): void
+    {
+        $client = $this->authenticatedClient();
+        $targetId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $client->request('POST', '/api/import-profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'name' => 'Trash Me',
+                'targetObjectTypeId' => $targetId,
+                'columnMapping' => [],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $created = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($created);
+        $profileId = $created['id'] ?? null;
+        self::assertIsString($profileId);
+
+        $client->request('DELETE', \sprintf('/api/import-profiles/%s', $profileId));
+        self::assertResponseStatusCodeSame(204);
+
+        $client->request('GET', \sprintf('/api/import-profiles/%s', $profileId));
+        self::assertResponseStatusCodeSame(404);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -4437,6 +4437,485 @@
                 ]
             }
         },
+        "/api/import-profiles": {
+            "get": {
+                "operationId": "api_import-profiles_get_collection",
+                "tags": [
+                    "ImportProfile"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ImportProfile collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "ImportProfile.jsonld-import_profile.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/ImportProfile.jsonld-import_profile.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/ImportProfile-import_profile.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of ImportProfile resources.",
+                "description": "Retrieves the collection of ImportProfile resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ]
+            },
+            "post": {
+                "operationId": "api_import-profiles_post",
+                "tags": [
+                    "ImportProfile"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "ImportProfile resource created",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImportProfile.jsonld-import_profile.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImportProfile-import_profile.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Creates a ImportProfile resource.",
+                "description": "Creates a ImportProfile resource.",
+                "parameters": [],
+                "requestBody": {
+                    "description": "The new ImportProfile resource",
+                    "content": {
+                        "application/ld+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ImportProfile.ImportProfileInput"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ImportProfile.ImportProfileInput"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
+        "/api/import-profiles/{id}": {
+            "get": {
+                "operationId": "api_import-profiles_id_get",
+                "tags": [
+                    "ImportProfile"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ImportProfile resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImportProfile.jsonld-import_profile.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImportProfile-import_profile.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a ImportProfile resource.",
+                "description": "Retrieves a ImportProfile resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ImportProfile identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "delete": {
+                "operationId": "api_import-profiles_id_delete",
+                "tags": [
+                    "ImportProfile"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "ImportProfile resource deleted"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Removes the ImportProfile resource.",
+                "description": "Removes the ImportProfile resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ImportProfile identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ]
+            },
+            "patch": {
+                "operationId": "api_import-profiles_id_patch",
+                "tags": [
+                    "ImportProfile"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ImportProfile resource updated",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImportProfile.jsonld-import_profile.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ImportProfile-import_profile.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Updates the ImportProfile resource.",
+                "description": "Updates the ImportProfile resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ImportProfile identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "requestBody": {
+                    "description": "The updated ImportProfile resource",
+                    "content": {
+                        "application/merge-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ImportProfile.ImportProfilePatchInput.jsonMergePatch"
+                            }
+                        }
+                    },
+                    "required": true
+                }
+            }
+        },
         "/api/locales": {
             "get": {
                 "operationId": "api_locales_get_collection",
@@ -7298,6 +7777,279 @@
                     "@type"
                 ]
             },
+            "ImportProfile-import_profile.read": {
+                "type": "object",
+                "description": "Per-user saved configuration for the import wizard (\"smart memory\").\n\nEditing a profile only affects future imports; historical\n{@see ImportSession} rows do not pull mapping changes from their\nprofile retroactively (decision: spec \u00a75.8).",
+                "properties": {
+                    "id": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uuid"
+                    },
+                    "userId": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "name": {
+                        "maxLength": 255,
+                        "type": "string"
+                    },
+                    "targetObjectType": {
+                        "type": "string",
+                        "format": "iri-reference",
+                        "example": "https://example.com/"
+                    },
+                    "columnMapping": {
+                        "description": "Map of source column header \u2192 target attribute id (or \"skip\").",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "locale": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "encoding": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "delimiter": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "imageSource": {
+                        "default": "none",
+                        "type": "string"
+                    },
+                    "imageZipNamingConvention": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "lastUsedAt": {
+                        "readOnly": true,
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "createdAt": {
+                        "readOnly": true,
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "ImportProfile.ImportProfileInput": {
+                "type": "object",
+                "description": "Per-user saved configuration for the import wizard (\"smart memory\").\n\nEditing a profile only affects future imports; historical\n{@see ImportSession} rows do not pull mapping changes from their\nprofile retroactively (decision: spec \u00a75.8).",
+                "required": [
+                    "name",
+                    "targetObjectTypeId"
+                ],
+                "properties": {
+                    "name": {
+                        "maxLength": 255,
+                        "default": "",
+                        "type": "string"
+                    },
+                    "targetObjectTypeId": {
+                        "format": "uuid",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "default": "",
+                        "type": "string"
+                    },
+                    "columnMapping": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "locale": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "encoding": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "delimiter": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "imageSource": {
+                        "description": "One of: `http`, `zip`, `none`.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "imageZipNamingConvention": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "ImportProfile.ImportProfilePatchInput.jsonMergePatch": {
+                "type": "object",
+                "description": "Per-user saved configuration for the import wizard (\"smart memory\").\n\nEditing a profile only affects future imports; historical\n{@see ImportSession} rows do not pull mapping changes from their\nprofile retroactively (decision: spec \u00a75.8).",
+                "properties": {
+                    "name": {
+                        "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "columnMapping": {
+                        "type": [
+                            "object",
+                            "null"
+                        ],
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "locale": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "encoding": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "delimiter": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "imageSource": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "imageZipNamingConvention": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                }
+            },
+            "ImportProfile.jsonld-import_profile.read": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/HydraItemBaseSchema"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "uuid"
+                            },
+                            "userId": {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "targetObjectType": {
+                                "type": "string",
+                                "format": "iri-reference",
+                                "example": "https://example.com/"
+                            },
+                            "columnMapping": {
+                                "description": "Map of source column header \u2192 target attribute id (or \"skip\").",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "locale": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "encoding": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "delimiter": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "imageSource": {
+                                "default": "none",
+                                "type": "string"
+                            },
+                            "imageZipNamingConvention": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "lastUsedAt": {
+                                "readOnly": true,
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "format": "date-time"
+                            },
+                            "createdAt": {
+                                "readOnly": true,
+                                "type": "string",
+                                "format": "date-time"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ]
+                    }
+                ],
+                "description": "Per-user saved configuration for the import wizard (\"smart memory\").\n\nEditing a profile only affects future imports; historical\n{@see ImportSession} rows do not pull mapping changes from their\nprofile retroactively (decision: spec \u00a75.8)."
+            },
             "Locale-admin.read": {
                 "type": "object",
                 "properties": {
@@ -7759,6 +8511,10 @@
         {
             "name": "ApiProfile",
             "description": "A named projection over the public API for a class of integrators.\n\nPer ADR-009 the profile filter is parameterised on `objectTypeIds`\n(UUID list of `ObjectType` rows visible through this profile) plus\n`includedAttributes` (attribute codes to publish) plus `filters`\n(JSONB dict of canonical filter parameters, e.g. `status=enabled`).\nOne canonical request \u2014 `GET /api/products` keyed by an `ApiKey`\nscoped to a profile \u2014 narrows to a per-profile view by the\nserializer context built from this row (#94).\n\nWebhook fields (`webhookUrl` + `webhookEvents`) are configuration\nonly at this point. Delivery + retry policy lands in #93."
+        },
+        {
+            "name": "ImportProfile",
+            "description": "Per-user saved configuration for the import wizard (\"smart memory\").\n\nEditing a profile only affects future imports; historical\n{@see ImportSession} rows do not pull mapping changes from their\nprofile retroactively (decision: spec \u00a75.8)."
         }
     ],
     "webhooks": {}


### PR DESCRIPTION
## Cel

API Platform CRUD dla `ImportProfile` + wizard "Saved profiles" flow. Solo per user (spec §3). Spec: [`feature-imports.md §5.8`](Project%20Plan/UI/feature-imports.md). Zamyka [#448](https://github.com/malipie/PIM/issues/448).

## Zakres

**Resources** (`apps/api/src/Import/Infrastructure/`):
- `ApiPlatform/Resource/ImportProfile.xml` — GetCollection/Get/Post/Patch/Delete na `/api/import-profiles`
- `ApiPlatform/Resource/ImportProfileInput` + `ImportProfilePatchInput` DTOs (Patch partial)
- `ApiPlatform/State/ImportProfileProcessor` — direct repository writes (no command bus). Duplicate name → 409 Conflict
- `Serializer/ImportProfile.xml` — `import_profile:read` groups

**Voter integration**: per-user ownership ride on `ImportProfileVoter` z IMP-01. `last_used_at` touched przez `StartImportController` (IMP-04) gdy profile attached.

## Quality gates

- ✅ PHPStan max: zero errors
- ✅ PHPUnit unit: 52 tests / 121 assertions green
- ✅ ApiTestCase ImportProfileApiTest: **3 cases / 18 assertions** — POST/GET-list/PATCH round-trip, 409 Conflict (duplicate name), DELETE 204 + GET 404
- ✅ composer audit: zero advisories

Refs #448