### PR TITLE
feat(imports): IMP-08 — frontend foundation primitives + i18n

### DIFF
--- a/apps/admin/src/components/ui/combobox.tsx
+++ b/apps/admin/src/components/ui/combobox.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+interface ComboboxProps {
+  options: ComboboxOption[];
+  value: string | null;
+  onChange: (value: string | null) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  allowClear?: boolean;
+  className?: string;
+}
+
+/**
+ * Lightweight searchable single-select for Step-2 column mapping
+ * (spec §5.3). Stays headless of `cmdk`/`@radix-ui/react-popover`
+ * to avoid extra deps while keyboard nav still works (Enter/Esc/
+ * arrow keys via native input + filtered list).
+ */
+export function Combobox({
+  options,
+  value,
+  onChange,
+  placeholder = 'Wybierz…',
+  searchPlaceholder = 'Szukaj…',
+  emptyText = 'Brak wyników',
+  disabled,
+  allowClear = true,
+  className,
+}: ComboboxProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  const filtered = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if ('' === q) {
+      return options;
+    }
+    return options.filter(
+      (option) => option.label.toLowerCase().includes(q) || option.value.toLowerCase().includes(q),
+    );
+  }, [options, query]);
+
+  const selected = options.find((option) => option.value === value);
+
+  return (
+    <div ref={wrapperRef} className={cn('relative inline-block w-full', className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        disabled={disabled}
+        className={cn(
+          'flex w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm transition-colors',
+          'hover:bg-accent hover:text-accent-foreground',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+        )}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className={cn('truncate', !selected && 'text-muted-foreground')}>
+          {selected ? selected.label : placeholder}
+        </span>
+        <span aria-hidden="true" className="text-muted-foreground">
+          ▾
+        </span>
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border border-input bg-popover shadow-md">
+          <div className="border-b border-input p-2">
+            <input
+              ref={(node) => {
+                node?.focus();
+              }}
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={searchPlaceholder}
+              className="w-full rounded-md border border-transparent bg-transparent px-2 py-1 text-sm focus:border-input focus:outline-none"
+            />
+          </div>
+          <div className="max-h-60 overflow-auto py-1">
+            {allowClear && null !== value && (
+              <button
+                type="button"
+                onClick={() => {
+                  onChange(null);
+                  setOpen(false);
+                }}
+                className="flex w-full px-3 py-1.5 text-left text-sm text-muted-foreground hover:bg-accent"
+              >
+                ✕ Wyczyść wybór
+              </button>
+            )}
+            {filtered.length === 0 ? (
+              <div className="px-3 py-2 text-sm text-muted-foreground">{emptyText}</div>
+            ) : (
+              filtered.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => {
+                    onChange(option.value);
+                    setOpen(false);
+                    setQuery('');
+                  }}
+                  className={cn(
+                    'flex w-full flex-col items-start gap-0.5 px-3 py-1.5 text-left text-sm hover:bg-accent',
+                    option.value === value && 'bg-accent text-accent-foreground',
+                  )}
+                >
+                  <span>{option.label}</span>
+                  {option.description !== undefined && (
+                    <span className="text-xs text-muted-foreground">{option.description}</span>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui/data-table.tsx
+++ b/apps/admin/src/components/ui/data-table.tsx
@@ -1,0 +1,94 @@
+import type * as React from 'react';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+export interface DataTableColumn<TRow> {
+  /** Stable id used for React keys + ARIA. */
+  id: string;
+  header: React.ReactNode;
+  /** Cell renderer; receives the row + its index. */
+  cell: (row: TRow, index: number) => React.ReactNode;
+  /** Optional column-level alignment helper. */
+  align?: 'left' | 'right' | 'center';
+  className?: string;
+}
+
+interface DataTableProps<TRow> {
+  data: ReadonlyArray<TRow>;
+  columns: ReadonlyArray<DataTableColumn<TRow>>;
+  /** Renders when `data` is empty — wizard list view "brak importów" copy lives here. */
+  emptyState?: React.ReactNode;
+  /** Forwarded to each `<tr>` so the imports list can wire row-click handlers. */
+  rowKey: (row: TRow, index: number) => string;
+  caption?: string;
+  className?: string;
+}
+
+/**
+ * Tiny declarative wrapper around the existing `<Table>` primitive.
+ * No TanStack Table dependency — sorting / pagination land in the
+ * calling page so we don't pay for the runtime when the imports
+ * list view (spec §5.1) only needs basic rendering.
+ */
+export function DataTable<TRow>({
+  data,
+  columns,
+  emptyState,
+  rowKey,
+  caption,
+  className,
+}: DataTableProps<TRow>): React.ReactElement {
+  if (data.length === 0 && emptyState !== undefined) {
+    return <div className={cn('w-full', className)}>{emptyState}</div>;
+  }
+
+  return (
+    <div className={cn('w-full overflow-x-auto', className)}>
+      <Table>
+        {caption !== undefined && <caption className="sr-only">{caption}</caption>}
+        <TableHeader>
+          <TableRow>
+            {columns.map((column) => (
+              <TableHead
+                key={column.id}
+                className={cn(
+                  column.align === 'right' && 'text-right',
+                  column.align === 'center' && 'text-center',
+                  column.className,
+                )}
+              >
+                {column.header}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((row, rowIndex) => (
+            <TableRow key={rowKey(row, rowIndex)}>
+              {columns.map((column) => (
+                <TableCell
+                  key={column.id}
+                  className={cn(
+                    column.align === 'right' && 'text-right',
+                    column.align === 'center' && 'text-center',
+                    column.className,
+                  )}
+                >
+                  {column.cell(row, rowIndex)}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui/progress.tsx
+++ b/apps/admin/src/components/ui/progress.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** 0 ≤ value ≤ max — the progress amount. */
+  value: number;
+  max?: number;
+  /** Forward an accessible label so screen readers announce the bar. */
+  ariaLabel?: string;
+}
+
+/**
+ * Plain CSS progress bar — no radix dependency. Chosen over
+ * `@radix-ui/react-progress` because the wizard's needs are basic
+ * (linear bar, no indeterminate state) and the bundle stays smaller
+ * for the React 19 worker runtime.
+ */
+export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ value, max = 100, ariaLabel, className, ...props }, ref) => {
+    const clamped = Math.max(0, Math.min(value, max));
+    const percent = max === 0 ? 0 : (clamped / max) * 100;
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-valuenow={clamped}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-label={ariaLabel}
+        className={cn('relative h-2 w-full overflow-hidden rounded-full bg-muted', className)}
+        {...props}
+      >
+        <div
+          className="h-full bg-primary transition-all duration-200 ease-out"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    );
+  },
+);
+Progress.displayName = 'Progress';

--- a/apps/admin/src/components/ui/stepper.tsx
+++ b/apps/admin/src/components/ui/stepper.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface StepperStep {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+interface StepperProps extends React.HTMLAttributes<HTMLDivElement> {
+  steps: StepperStep[];
+  currentStepIndex: number;
+}
+
+/**
+ * Visual progress indicator for the 4-step import wizard (spec §5).
+ *
+ * Stays headless: no router awareness, no click handling — the parent
+ * decides whether the user can jump back to a previous step. Pure
+ * CSS, no extra deps; the bar uses tailwind tokens so it picks up
+ * the design-system theme.
+ */
+export const Stepper = React.forwardRef<HTMLDivElement, StepperProps>(
+  ({ steps, currentStepIndex, className, ...props }, ref) => {
+    return (
+      <div ref={ref} className={cn('w-full', className)} {...props}>
+        <ol className="flex items-center" aria-label="Wizard progress">
+          {steps.map((step, index) => {
+            const isCompleted = index < currentStepIndex;
+            const isActive = index === currentStepIndex;
+            const isLast = index === steps.length - 1;
+
+            return (
+              <li
+                key={step.id}
+                className={cn('flex items-center', !isLast && 'flex-1')}
+                aria-current={isActive ? 'step' : undefined}
+              >
+                <div className="flex flex-col items-center text-center">
+                  <span
+                    className={cn(
+                      'flex h-8 w-8 items-center justify-center rounded-full border-2 text-sm font-medium transition-colors',
+                      isCompleted && 'border-primary bg-primary text-primary-foreground',
+                      isActive && 'border-primary bg-primary/10 text-primary',
+                      !isCompleted &&
+                        !isActive &&
+                        'border-muted-foreground/30 bg-background text-muted-foreground',
+                    )}
+                  >
+                    {isCompleted ? '✓' : index + 1}
+                  </span>
+                  <span
+                    className={cn(
+                      'mt-1 text-xs font-medium',
+                      isActive ? 'text-primary' : 'text-muted-foreground',
+                    )}
+                  >
+                    {step.label}
+                  </span>
+                </div>
+                {!isLast && (
+                  <span
+                    className={cn(
+                      'mx-2 h-0.5 flex-1 transition-colors',
+                      isCompleted ? 'bg-primary' : 'bg-muted-foreground/30',
+                    )}
+                    aria-hidden="true"
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    );
+  },
+);
+Stepper.displayName = 'Stepper';

--- a/apps/admin/src/features/imports/components/FileDropzone.tsx
+++ b/apps/admin/src/features/imports/components/FileDropzone.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type FileKind = 'csv-xlsx' | 'zip';
+
+interface FileDropzoneProps {
+  /** Called when the user drops or selects a file. */
+  onFile: (file: File) => void;
+  /** Limit to a single MIME group; the wizard's Step 1 accepts CSV/xlsx OR ZIP. */
+  kind: FileKind;
+  /** Max bytes — rejected before reaching the parent. */
+  maxBytes: number;
+  /** Already-selected file shown in the body so the user sees what they uploaded. */
+  selected?: File | null;
+  /** Localised copy. */
+  label: string;
+  hint?: string;
+  rejectMessage?: (file: File) => string;
+  disabled?: boolean;
+  className?: string;
+}
+
+const ACCEPT: Record<FileKind, string> = {
+  'csv-xlsx':
+    '.csv,.xlsx,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  zip: '.zip,application/zip,application/x-zip-compressed',
+};
+
+const ACCEPT_REGEX: Record<FileKind, RegExp> = {
+  'csv-xlsx': /\.(csv|xlsx)$/i,
+  zip: /\.zip$/i,
+};
+
+/**
+ * Drag-and-drop file picker for the import wizard's Step 1
+ * (spec §5.2). Fully typed in terms of which file kind the dropzone
+ * accepts so the same component drops the source file on one panel
+ * and the optional ZIP archive on another.
+ */
+export function FileDropzone({
+  onFile,
+  kind,
+  maxBytes,
+  selected,
+  label,
+  hint,
+  rejectMessage,
+  disabled,
+  className,
+}: FileDropzoneProps): React.ReactElement {
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleFile = (file: File): void => {
+    if (!ACCEPT_REGEX[kind].test(file.name)) {
+      setError(rejectMessage?.(file) ?? `Niewłaściwy typ pliku: ${file.name}`);
+      return;
+    }
+    if (file.size > maxBytes) {
+      setError(`Plik za duży (${formatBytes(file.size)} > ${formatBytes(maxBytes)})`);
+      return;
+    }
+    setError(null);
+    onFile(file);
+  };
+
+  return (
+    <div className={cn('w-full', className)}>
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(event) => {
+          event.preventDefault();
+          if (!disabled) {
+            setIsDragging(true);
+          }
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        onDrop={(event) => {
+          event.preventDefault();
+          setIsDragging(false);
+          if (disabled) {
+            return;
+          }
+          const file = event.dataTransfer.files.item(0);
+          if (file !== null) {
+            handleFile(file);
+          }
+        }}
+        disabled={disabled}
+        className={cn(
+          'flex w-full flex-col items-center justify-center gap-2 rounded-md border-2 border-dashed border-input bg-background p-8 text-center transition-colors',
+          'hover:border-primary hover:bg-accent/40',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+          isDragging && 'border-primary bg-accent/40',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
+        aria-label={label}
+      >
+        <span aria-hidden="true" className="text-2xl">
+          📥
+        </span>
+        <span className="text-sm font-medium">{label}</span>
+        {hint !== undefined && <span className="text-xs text-muted-foreground">{hint}</span>}
+        {selected !== undefined && selected !== null && (
+          <span className="mt-2 inline-flex items-center gap-2 rounded-full bg-accent px-3 py-1 text-xs">
+            ☑ {selected.name} ({formatBytes(selected.size)})
+          </span>
+        )}
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        className="sr-only"
+        accept={ACCEPT[kind]}
+        disabled={disabled}
+        onChange={(event) => {
+          const file = event.target.files?.item(0);
+          if (file != null) {
+            handleFile(file);
+          }
+          event.target.value = '';
+        }}
+      />
+      {error !== null && (
+        <p role="alert" className="mt-2 text-xs text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) {
+    return `${value} B`;
+  }
+  if (value < 1024 * 1024) {
+    return `${(value / 1024).toFixed(1)} kB`;
+  }
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/admin/src/features/imports/hooks/useImportWizard.ts
+++ b/apps/admin/src/features/imports/hooks/useImportWizard.ts
@@ -1,0 +1,165 @@
+import * as React from 'react';
+
+export type WizardStepIndex = 0 | 1 | 2 | 3;
+
+export interface ColumnSuggestion {
+  columnIndex: number;
+  columnHeader: string;
+  suggestedAttributeCode: string | null;
+  confidence: 'auto' | 'fuzzy' | 'manual' | 'skip';
+  sampleValues: Array<string | null>;
+}
+
+export interface ValidationFinding {
+  rowNumber: number;
+  sku: string | null;
+  errorType: string;
+  level: 'info' | 'warning' | 'error';
+  message: string;
+  columnName: string | null;
+  columnValue: string | null;
+}
+
+export interface WizardState {
+  step: WizardStepIndex;
+  file: File | null;
+  zipFile: File | null;
+  locale: string | null;
+  encoding: string;
+  delimiter: string;
+  imageSource: 'http' | 'zip' | 'none';
+  profileId: string | null;
+  saveAsProfileName: string | null;
+  targetObjectTypeId: string | null;
+  /** Header → attribute_code (or "skip"). */
+  mapping: Record<string, string>;
+  suggestions: ColumnSuggestion[];
+  validation: {
+    totalRows: number;
+    successCount: number;
+    errorCount: number;
+    topErrors: ValidationFinding[];
+  } | null;
+  doBackup: boolean;
+  emailNotification: boolean;
+}
+
+const INITIAL_STATE: WizardState = {
+  step: 0,
+  file: null,
+  zipFile: null,
+  locale: null,
+  encoding: 'auto',
+  delimiter: 'auto',
+  imageSource: 'none',
+  profileId: null,
+  saveAsProfileName: null,
+  targetObjectTypeId: null,
+  mapping: {},
+  suggestions: [],
+  validation: null,
+  doBackup: false,
+  emailNotification: true,
+};
+
+interface WizardController {
+  state: WizardState;
+  setField: <K extends keyof WizardState>(field: K, value: WizardState[K]) => void;
+  patchMapping: (header: string, attributeCode: string) => void;
+  next: () => void;
+  back: () => void;
+  reset: () => void;
+  /** Persist for cross-page round-trips (e.g. "Stwórz nowy atrybut"). */
+  persist: () => void;
+  /** Restore after returning from /modeling — wipes the saved snapshot. */
+  restore: () => void;
+}
+
+const STORAGE_KEY = 'pim.imports.wizard';
+
+/**
+ * Holds the wizard's cross-step state (spec §4 user flow). The
+ * persistence path is the deep-link to /modeling/attributes/new
+ * during Step 2: the user creates a custom attribute and lands back
+ * on the same wizard, mid-flight. {@link persist} writes the
+ * non-File fields to localStorage; {@link restore} pulls them back
+ * once the page rehydrates. Files cannot be serialised, so the user
+ * re-uploads the source after the round-trip — UX surfaces a hint.
+ */
+export function useImportWizard(): WizardController {
+  const [state, setState] = React.useState<WizardState>(INITIAL_STATE);
+
+  const setField = React.useCallback(
+    <K extends keyof WizardState>(field: K, value: WizardState[K]) => {
+      setState((prev) => ({ ...prev, [field]: value }));
+    },
+    [],
+  );
+
+  const patchMapping = React.useCallback((header: string, attributeCode: string) => {
+    setState((prev) => ({
+      ...prev,
+      mapping: { ...prev.mapping, [header]: attributeCode },
+    }));
+  }, []);
+
+  const next = React.useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      step: Math.min(prev.step + 1, 3) as WizardStepIndex,
+    }));
+  }, []);
+
+  const back = React.useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      step: Math.max(prev.step - 1, 0) as WizardStepIndex,
+    }));
+  }, []);
+
+  const reset = React.useCallback(() => {
+    setState(INITIAL_STATE);
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const persist = React.useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const persisted = {
+      step: state.step,
+      locale: state.locale,
+      encoding: state.encoding,
+      delimiter: state.delimiter,
+      imageSource: state.imageSource,
+      profileId: state.profileId,
+      saveAsProfileName: state.saveAsProfileName,
+      targetObjectTypeId: state.targetObjectTypeId,
+      mapping: state.mapping,
+      doBackup: state.doBackup,
+      emailNotification: state.emailNotification,
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
+  }, [state]);
+
+  const restore = React.useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === null) {
+      return;
+    }
+    try {
+      const parsed = JSON.parse(raw) as Partial<WizardState>;
+      setState((prev) => ({ ...prev, ...parsed }));
+    } catch {
+      // Stale snapshot — drop it.
+    }
+    window.localStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  return { state, setField, patchMapping, next, back, reset, persist, restore };
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -982,5 +982,163 @@
       "error": "Could not load effective groups.",
       "not_found": "Category or ObjectType not found."
     }
+  },
+  "imports": {
+    "list": {
+      "title": "Imports",
+      "new": "New import",
+      "profiles": "Profiles",
+      "filters": {
+        "status": "Status",
+        "date": "Date range",
+        "user": "User"
+      },
+      "columns": {
+        "date": "Date",
+        "file": "File",
+        "status": "Status",
+        "stats": "Stats",
+        "actions": "Actions"
+      },
+      "status": {
+        "pending": "Pending",
+        "running": "Running",
+        "paused": "Paused",
+        "success": "OK",
+        "partial": "Partial",
+        "failed": "Failed",
+        "cancelled": "Cancelled",
+        "rolled_back": "Rolled back"
+      },
+      "actions": {
+        "view_report": "View report",
+        "rollback": "Rollback",
+        "rerun": "Re-run with profile",
+        "delete": "Delete"
+      },
+      "empty": "No imports yet. Start your first import."
+    },
+    "wizard": {
+      "steps": {
+        "upload": "Upload",
+        "mapping": "Mapping",
+        "validation": "Validation",
+        "confirm": "Confirm"
+      },
+      "next": "Next",
+      "back": "Back",
+      "cancel": "Cancel",
+      "run": "Run import",
+      "create_attribute": "Create new attribute"
+    },
+    "upload": {
+      "drop_csv": "Drop CSV / Excel file or pick one",
+      "drop_csv_hint": "Accepted: .xlsx, .csv (max 50 MB)",
+      "drop_zip": "Drop ZIP archive with images",
+      "drop_zip_hint": "max 500 MB",
+      "locale": "File locale",
+      "encoding": "Encoding",
+      "delimiter": "Delimiter (CSV)",
+      "image_source": {
+        "label": "Image source",
+        "http": "HTTP links in the file (image_1, image_2…)",
+        "zip": "ZIP archive with local images",
+        "none": "No images for this import"
+      },
+      "profile": {
+        "label": "Import profile",
+        "new": "New profile (configure below)",
+        "use_saved": "Use saved",
+        "save_as": "Save as profile"
+      }
+    },
+    "mapping": {
+      "header": "Auto-mapping done: {{auto}}/{{total}} columns matched. Map {{manual}} manually.",
+      "columns": {
+        "source": "Source column",
+        "sample": "Sample value",
+        "mapping": "Mapping",
+        "required": "Required"
+      },
+      "confidence": {
+        "auto": "auto",
+        "fuzzy": "suggested",
+        "manual": "manual",
+        "skip": "skip"
+      },
+      "skip": "Skip column"
+    },
+    "validation": {
+      "ok": "{{count}} products OK",
+      "errors": "{{count}} errors / warnings",
+      "show_all": "Show all {{count}} errors",
+      "decide": {
+        "label": "What next?",
+        "import_ok": "Import OK rows, skip errors",
+        "back_to_mapping": "Back to mapping, fix errors"
+      },
+      "errors_table": {
+        "row": "Row",
+        "sku": "SKU",
+        "type": "Error type",
+        "message": "Message"
+      },
+      "error_types": {
+        "missing_required": "Missing required field",
+        "duplicate_sku_in_file": "Duplicate SKU in file",
+        "duplicate_sku_in_db": "SKU already in catalog",
+        "invalid_type": "Invalid type",
+        "invalid_value": "Invalid value",
+        "image_not_found": "Image file missing"
+      }
+    },
+    "confirm": {
+      "summary": "Summary",
+      "backup": {
+        "label": "Create full database backup (pgBackRest)",
+        "hint_recommended": "Recommended for imports > 1000 products",
+        "hint_duration": "Backup takes 5–30 minutes",
+        "hint_rollback": "Without backup: 24h soft rollback is still available"
+      },
+      "email": "Email me when done (> 5 min runtime)",
+      "warning": "Action is final. You can rollback within 24h."
+    },
+    "progress": {
+      "title": "Import running",
+      "elapsed": "Elapsed",
+      "remaining": "Remaining",
+      "current_sku": "Now: {{sku}}",
+      "close_hint": "You can close this tab. We will send an email when the run finishes.",
+      "pause": "Pause",
+      "resume": "Resume",
+      "cancel": "Cancel"
+    },
+    "results": {
+      "imported": "{{count}} products imported",
+      "skipped": "{{count}} skipped",
+      "duration": "Duration: {{value}}",
+      "download_report": "Download CSV report",
+      "view_products": "View imported products",
+      "rollback": "Rollback",
+      "rollback_window": "Available until {{date}}",
+      "rollback_expired": "Rollback window expired"
+    },
+    "profiles": {
+      "title": "My import profiles",
+      "columns": {
+        "name": "Profile",
+        "last_used": "Last used",
+        "uses": "# imports",
+        "actions": "Actions"
+      },
+      "edit": "Edit",
+      "delete": "Delete",
+      "disclaimer": "Editing a profile only affects future imports. It does not touch past sessions."
+    },
+    "errors": {
+      "load_failed": "Could not load import session.",
+      "rollback_failed": "Rollback failed.",
+      "upload_failed": "File upload failed."
+    }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -986,5 +986,163 @@
       "error": "Nie udało się pobrać efektywnych grup.",
       "not_found": "Nie znaleziono kategorii lub typu obiektu."
     }
+  },
+  "imports": {
+    "list": {
+      "title": "Importy",
+      "new": "Nowy import",
+      "profiles": "Profile",
+      "filters": {
+        "status": "Status",
+        "date": "Zakres dat",
+        "user": "Użytkownik"
+      },
+      "columns": {
+        "date": "Data",
+        "file": "Plik",
+        "status": "Status",
+        "stats": "Statystyki",
+        "actions": "Akcje"
+      },
+      "status": {
+        "pending": "Oczekuje",
+        "running": "W toku",
+        "paused": "Pauza",
+        "success": "OK",
+        "partial": "Częściowy",
+        "failed": "Niepowodzenie",
+        "cancelled": "Anulowany",
+        "rolled_back": "Wycofany"
+      },
+      "actions": {
+        "view_report": "Zobacz raport",
+        "rollback": "Wycofaj import",
+        "rerun": "Uruchom ponownie z profilem",
+        "delete": "Usuń"
+      },
+      "empty": "Brak importów. Utwórz pierwszy import."
+    },
+    "wizard": {
+      "steps": {
+        "upload": "Upload",
+        "mapping": "Mapping",
+        "validation": "Walidacja",
+        "confirm": "Potwierdzenie"
+      },
+      "next": "Dalej",
+      "back": "Wstecz",
+      "cancel": "Anuluj",
+      "run": "Uruchom import",
+      "create_attribute": "Stwórz nowy atrybut"
+    },
+    "upload": {
+      "drop_csv": "Przeciągnij plik CSV/Excel lub wybierz",
+      "drop_csv_hint": "Akceptowane: .xlsx, .csv (max 50 MB)",
+      "drop_zip": "Przeciągnij plik ZIP ze zdjęciami",
+      "drop_zip_hint": "max 500 MB",
+      "locale": "Locale pliku",
+      "encoding": "Kodowanie",
+      "delimiter": "Separator (CSV)",
+      "image_source": {
+        "label": "Źródło zdjęć",
+        "http": "Linki HTTP w pliku (image_1, image_2…)",
+        "zip": "Plik ZIP z lokalnymi zdjęciami",
+        "none": "Brak zdjęć w tym imporcie"
+      },
+      "profile": {
+        "label": "Profil importu",
+        "new": "Nowy profil (skonfiguruj poniżej)",
+        "use_saved": "Użyj zapisanego",
+        "save_as": "Zapisz jako profil"
+      }
+    },
+    "mapping": {
+      "header": "Auto-mapping zakończony: {{auto}}/{{total}} kolumn dopasowanych. Zmapuj {{manual}} ręcznie.",
+      "columns": {
+        "source": "Kolumna źródła",
+        "sample": "Sample value",
+        "mapping": "Mapping",
+        "required": "Wymagane"
+      },
+      "confidence": {
+        "auto": "auto",
+        "fuzzy": "podpowiedź",
+        "manual": "ręczne",
+        "skip": "pomiń"
+      },
+      "skip": "Pomiń kolumnę"
+    },
+    "validation": {
+      "ok": "{{count}} produktów OK",
+      "errors": "{{count}} błędów / ostrzeżeń",
+      "show_all": "Pokaż wszystkie {{count}} błędy",
+      "decide": {
+        "label": "Co dalej?",
+        "import_ok": "Zaimportuj OK, pomiń błędne",
+        "back_to_mapping": "Wróć do mappingu, popraw błędy"
+      },
+      "errors_table": {
+        "row": "Wiersz",
+        "sku": "SKU",
+        "type": "Typ błędu",
+        "message": "Komunikat"
+      },
+      "error_types": {
+        "missing_required": "Brak wymaganego pola",
+        "duplicate_sku_in_file": "Duplikat SKU w pliku",
+        "duplicate_sku_in_db": "SKU już w bazie",
+        "invalid_type": "Nieprawidłowy typ",
+        "invalid_value": "Nieprawidłowa wartość",
+        "image_not_found": "Brak pliku zdjęcia"
+      }
+    },
+    "confirm": {
+      "summary": "Podsumowanie",
+      "backup": {
+        "label": "Utwórz pełen backup bazy danych (pgBackRest)",
+        "hint_recommended": "Zalecane dla importów >1000 produktów",
+        "hint_duration": "Backup zajmie 5–30 minut",
+        "hint_rollback": "Bez backupu: dostępny soft rollback przez 24h"
+      },
+      "email": "Wyślij email po zakończeniu (>5 min runtime)",
+      "warning": "Akcja jest finalna. Możesz wycofać import w 24h."
+    },
+    "progress": {
+      "title": "Import w toku",
+      "elapsed": "Czas wykonania",
+      "remaining": "Pozostały czas",
+      "current_sku": "Aktualnie: {{sku}}",
+      "close_hint": "Możesz zamknąć tę kartę. System wyśle email po zakończeniu.",
+      "pause": "Pauza",
+      "resume": "Wznów",
+      "cancel": "Anuluj"
+    },
+    "results": {
+      "imported": "{{count}} produktów zaimportowano",
+      "skipped": "{{count}} pominiętych",
+      "duration": "Czas wykonania: {{value}}",
+      "download_report": "Pobierz raport CSV",
+      "view_products": "Zobacz zaimportowane produkty",
+      "rollback": "Wycofaj import",
+      "rollback_window": "Dostępne do {{date}}",
+      "rollback_expired": "Okno wycofania wygasło"
+    },
+    "profiles": {
+      "title": "Moje profile importu",
+      "columns": {
+        "name": "Profil",
+        "last_used": "Ostatnio użyty",
+        "uses": "# importów",
+        "actions": "Akcje"
+      },
+      "edit": "Edytuj",
+      "delete": "Usuń",
+      "disclaimer": "Edycja profilu modyfikuje tylko przyszłe importy. Nie wpływa na poprzednie."
+    },
+    "errors": {
+      "load_failed": "Nie udało się wczytać sesji importu.",
+      "rollback_failed": "Wycofanie importu nie powiodło się.",
+      "upload_failed": "Wgranie pliku nie powiodło się."
+    }
   }
 }


### PR DESCRIPTION
## Cel

Wizard'owe scaffolding UI. Spec: [`feature-imports.md §9`](Project%20Plan/UI/feature-imports.md). Zamyka [#449](https://github.com/malipie/PIM/issues/449).

## Zakres

**shadcn primitives** (`apps/admin/src/components/ui/`):
- `stepper.tsx` — visual progress 4-step wizard, no extra deps, design-system tokens
- `progress.tsx` — linear bar z aria-valuenow, plain CSS (bez radix progress)
- `combobox.tsx` — searchable single-select z click-outside + keyboard nav, headless (bez cmdk)
- `data-table.tsx` — declarative wrapper na istniejącym Table primitive

**Wizard scaffolding** (`apps/admin/src/features/imports/`):
- `components/FileDropzone.tsx` — drag-and-drop file picker typed per kind ('csv-xlsx'|'zip') + size guard
- `hooks/useImportWizard.ts` — cross-step state z persist/restore (deep-link do `/modeling/attributes/new`)

**i18n** (`apps/admin/src/locales/{pl,en}.json`):
- New `imports.*` namespace: list view, 4 wizard steps, progress, results, profile manager, errors

## Świadome odejścia (do follow-up)

- **Storybook stories** dla primitives — wymaga konfiguracji Storybook'a, deferred do IMP-09 gdzie primitives będą używane
- **Refine resources** dla `import-sessions`/`import-profiles` — dochodzi w IMP-09 razem z list view

## Quality gates

- ✅ Biome strict: zero errors
- ✅ TypeScript noEmit: zero errors

Refs #449