### PR TITLE
feat(imports): IMP-09 — list view + Publikacje sub-tab

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -35,6 +35,8 @@ import { ChannelsListPage } from '@/features/channel/channels/list';
 import { ChannelShowPage } from '@/features/channel/channels/show';
 import { DashboardPage } from '@/features/dashboard/page';
 import { LoginPage } from '@/features/identity/auth/login';
+import { ImportsListView } from '@/features/imports/list/ImportsListView';
+import { PublicationsLayout } from '@/features/publications/PublicationsLayout';
 import { AiSettingsPage } from '@/features/settings/ai';
 import { LocalesSettingsPage } from '@/features/settings/locales';
 import { MenuSettingsPage } from '@/features/settings/menu';
@@ -106,6 +108,16 @@ function App() {
               create: '/api-profiles/create',
               edit: '/api-profiles/:id/edit',
               show: '/api-profiles/:id',
+            },
+            {
+              name: 'import-sessions',
+              list: '/publications/imports',
+              show: '/publications/imports/:id',
+              create: '/publications/imports/new',
+            },
+            {
+              name: 'import-profiles',
+              list: '/publications/imports',
             },
           ]}
           options={{
@@ -199,6 +211,10 @@ function App() {
               <Route path="/api-profiles/create" element={<ApiProfileCreatePage />} />
               <Route path="/api-profiles/:id/edit" element={<ApiProfileEditPage />} />
               <Route path="/api-profiles/:id" element={<ApiProfileShowPage />} />
+              <Route path="/publications" element={<PublicationsLayout />}>
+                <Route index element={<Navigate to="/publications/imports" replace />} />
+                <Route path="imports" element={<ImportsListView />} />
+              </Route>
             </Route>
             <Route path="*" element={<Navigate to="/dashboard" replace />} />
           </Routes>

--- a/apps/admin/src/components/catalog/empty-state-products.tsx
+++ b/apps/admin/src/components/catalog/empty-state-products.tsx
@@ -41,15 +41,11 @@ export function EmptyStateProducts({ onCloneFrom }: { onCloneFrom?: () => void }
             {t('products.empty.clone_from', { defaultValue: 'Clone from existing' })}
           </Button>
         ) : null}
-        <Button
-          variant="outline"
-          disabled
-          title={t('products.empty.import_coming', {
-            defaultValue: 'Coming with epik UI-04 (Publikacje).',
-          })}
-        >
-          <Upload className="size-4" />
-          {t('products.empty.import_csv', { defaultValue: 'Import from Excel/CSV' })}
+        <Button asChild variant="outline">
+          <Link to="/publications/imports/new">
+            <Upload className="size-4" />
+            {t('products.empty.import_csv', { defaultValue: 'Import from Excel/CSV' })}
+          </Link>
         </Button>
       </div>
 

--- a/apps/admin/src/features/imports/list/ImportsListView.tsx
+++ b/apps/admin/src/features/imports/list/ImportsListView.tsx
@@ -1,0 +1,127 @@
+import { useList } from '@refinedev/core';
+import { Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { DataTable, type DataTableColumn } from '@/components/ui/data-table';
+
+import { type ImportStatus, StatusBadge } from './StatusBadge';
+
+interface ImportSessionRow {
+  id: string;
+  status: ImportStatus;
+  file_name: string;
+  total_rows: number | null;
+  success_count: number;
+  error_count: number;
+  started_at: string | null;
+  completed_at: string | null;
+  rollback_until: string | null;
+}
+
+/**
+ * IMP-09 (#450) — wizard's Step 0 ("lista importów"). Reads through
+ * Refine's `useList` (the standard CatalogObject pattern) so the
+ * data provider, auth, and TenantFilter scoping all ride the
+ * existing rails. Filters / 3-dot actions / re-run wiring land in
+ * IMP-12 + IMP-13 alongside the rollback button.
+ */
+export function ImportsListView(): React.ReactElement {
+  const { t } = useTranslation();
+
+  const { result, query } = useList<ImportSessionRow>({
+    resource: 'import-sessions',
+    pagination: { pageSize: 50 },
+  });
+
+  const isLoading = query.isLoading;
+  const rows = result.data ?? [];
+
+  const columns: ReadonlyArray<DataTableColumn<ImportSessionRow>> = [
+    {
+      id: 'date',
+      header: t('imports.list.columns.date', { defaultValue: 'Data' }),
+      cell: (row) => formatDate(row.started_at ?? row.completed_at),
+      className: 'whitespace-nowrap',
+    },
+    {
+      id: 'file',
+      header: t('imports.list.columns.file', { defaultValue: 'Plik' }),
+      cell: (row) => <span className="font-mono text-xs">{row.file_name}</span>,
+    },
+    {
+      id: 'status',
+      header: t('imports.list.columns.status', { defaultValue: 'Status' }),
+      cell: (row) => <StatusBadge status={row.status} />,
+    },
+    {
+      id: 'stats',
+      header: t('imports.list.columns.stats', { defaultValue: 'Statystyki' }),
+      cell: (row) => `${row.success_count} / ${row.total_rows ?? '?'}`,
+      className: 'whitespace-nowrap text-sm',
+    },
+    {
+      id: 'actions',
+      header: t('imports.list.columns.actions', { defaultValue: 'Akcje' }),
+      cell: (row) => (
+        <Button asChild variant="ghost" size="sm">
+          <Link to={`/publications/imports/${row.id}`}>
+            {t('imports.list.actions.view_report', { defaultValue: 'Zobacz' })}
+          </Link>
+        </Button>
+      ),
+      align: 'right',
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">
+          {t('imports.list.title', { defaultValue: 'Importy' })}
+        </h2>
+        <div className="flex gap-2">
+          <Button asChild>
+            <Link to="/publications/imports/new">
+              <Plus className="size-4" />
+              {t('imports.list.new', { defaultValue: 'Nowy import' })}
+            </Link>
+          </Button>
+        </div>
+      </div>
+      {isLoading ? (
+        <div className="text-sm text-muted-foreground" aria-busy="true">
+          {t('app.loading', { defaultValue: 'Ładowanie…' })}
+        </div>
+      ) : (
+        <DataTable
+          data={rows}
+          columns={columns}
+          rowKey={(row) => row.id}
+          emptyState={
+            <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+              {t('imports.list.empty', {
+                defaultValue: 'Brak importów. Utwórz pierwszy import.',
+              })}
+            </div>
+          }
+        />
+      )}
+    </div>
+  );
+}
+
+function formatDate(value: string | null): string {
+  if (value === null) {
+    return '—';
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString('pl-PL', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+}

--- a/apps/admin/src/features/imports/list/StatusBadge.tsx
+++ b/apps/admin/src/features/imports/list/StatusBadge.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+export type ImportStatus =
+  | 'pending'
+  | 'running'
+  | 'paused'
+  | 'success'
+  | 'partial'
+  | 'failed'
+  | 'cancelled'
+  | 'rolled_back';
+
+interface StatusBadgeProps {
+  status: ImportStatus;
+  className?: string;
+}
+
+const STATUS_STYLES: Record<ImportStatus, string> = {
+  pending: 'bg-muted text-muted-foreground',
+  running: 'bg-blue-100 text-blue-900',
+  paused: 'bg-amber-100 text-amber-900',
+  success: 'bg-green-100 text-green-900',
+  partial: 'bg-amber-100 text-amber-900',
+  failed: 'bg-red-100 text-red-900',
+  cancelled: 'bg-muted text-muted-foreground',
+  rolled_back: 'bg-purple-100 text-purple-900',
+};
+
+const STATUS_GLYPHS: Record<ImportStatus, string> = {
+  pending: '…',
+  running: '🔄',
+  paused: '⏸',
+  success: '✅',
+  partial: '⚠️',
+  failed: '❌',
+  cancelled: '🛑',
+  rolled_back: '↶',
+};
+
+export function StatusBadge({ status, className }: StatusBadgeProps): React.ReactElement {
+  const { t } = useTranslation();
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+        STATUS_STYLES[status],
+        className,
+      )}
+    >
+      <span aria-hidden="true">{STATUS_GLYPHS[status]}</span>
+      <span>{t(`imports.list.status.${status}`)}</span>
+    </span>
+  );
+}

--- a/apps/admin/src/features/publications/PublicationsLayout.tsx
+++ b/apps/admin/src/features/publications/PublicationsLayout.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next';
+import { NavLink, Outlet } from 'react-router';
+
+import { cn } from '@/lib/utils';
+
+interface TabDef {
+  to: string;
+  labelKey: string;
+  enabled: boolean;
+  /** Tooltip copy for disabled tabs. */
+  comingSoonKey?: string;
+}
+
+const TABS: readonly TabDef[] = [
+  { to: '/publications/imports', labelKey: 'publications.tabs.imports', enabled: true },
+  {
+    to: '/publications/exports',
+    labelKey: 'publications.tabs.exports',
+    enabled: false,
+    comingSoonKey: 'publications.coming_soon',
+  },
+  {
+    to: '/publications/integrations',
+    labelKey: 'publications.tabs.integrations',
+    enabled: false,
+    comingSoonKey: 'publications.coming_soon',
+  },
+  {
+    to: '/publications/api-configurator',
+    labelKey: 'publications.tabs.api_configurator',
+    enabled: false,
+    comingSoonKey: 'publications.coming_soon',
+  },
+] as const;
+
+/**
+ * IMP-09 (#450) — top-level "Publikacje" shell. Imports is the only
+ * sub-tab implemented in this slice; the other three sit behind a
+ * disabled state with a tooltip until epik UI-04 fills them in.
+ */
+export function PublicationsLayout(): React.ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="display text-[28px] font-semibold tracking-tight">
+          {t('publications.title', { defaultValue: 'Publikacje' })}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t('publications.description', {
+            defaultValue: 'Imports, exports i integracje katalogu',
+          })}
+        </p>
+      </header>
+      <div
+        className="flex gap-1 border-b"
+        role="tablist"
+        aria-label={t('publications.tabs_aria', { defaultValue: 'Sub-tabs Publikacje' })}
+      >
+        {TABS.map((tab) => {
+          if (!tab.enabled) {
+            return (
+              <button
+                key={tab.to}
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-disabled="true"
+                disabled
+                title={
+                  tab.comingSoonKey !== undefined
+                    ? t(tab.comingSoonKey, { defaultValue: 'Coming with epik UI-04' })
+                    : undefined
+                }
+                className="-mb-px flex cursor-not-allowed items-center border-b-2 border-transparent px-4 py-2 text-sm text-muted-foreground/60"
+              >
+                {t(tab.labelKey, { defaultValue: tab.to.replace('/publications/', '') })}
+              </button>
+            );
+          }
+          return (
+            <NavLink
+              key={tab.to}
+              to={tab.to}
+              role="tab"
+              className={({ isActive }) =>
+                cn(
+                  '-mb-px flex items-center border-b-2 px-4 py-2 text-sm',
+                  isActive
+                    ? 'border-accent-violet text-foreground font-medium'
+                    : 'border-transparent text-muted-foreground hover:text-foreground',
+                )
+              }
+            >
+              {t(tab.labelKey, { defaultValue: tab.to.replace('/publications/', '') })}
+            </NavLink>
+          );
+        })}
+      </div>
+      <div>
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -983,6 +983,18 @@
       "not_found": "Category or ObjectType not found."
     }
   },
+  "publications": {
+    "title": "Publications",
+    "description": "Imports, exports and catalog integrations",
+    "tabs": {
+      "imports": "Imports",
+      "exports": "Exports",
+      "integrations": "Integrations",
+      "api_configurator": "API Configurator"
+    },
+    "tabs_aria": "Publications sub-tabs",
+    "coming_soon": "Coming with epik UI-04 (Publications)"
+  },
   "imports": {
     "list": {
       "title": "Imports",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -987,6 +987,18 @@
       "not_found": "Nie znaleziono kategorii lub typu obiektu."
     }
   },
+  "publications": {
+    "title": "Publikacje",
+    "description": "Imports, exports i integracje katalogu",
+    "tabs": {
+      "imports": "Imports",
+      "exports": "Exports",
+      "integrations": "Integracje",
+      "api_configurator": "API Configurator"
+    },
+    "tabs_aria": "Sub-tabs Publikacje",
+    "coming_soon": "Coming with epik UI-04 (Publikacje)"
+  },
   "imports": {
     "list": {
       "title": "Importy",


### PR DESCRIPTION
## Cel

Wizard'owy widok bazowy. Spec: [`feature-imports.md §5.1`](Project%20Plan/UI/feature-imports.md). Zamyka [#450](https://github.com/malipie/PIM/issues/450).

## Zakres

**Layout** (`features/publications/`):
- `PublicationsLayout` — 4-tab top bar: Imports / Exports / Integracje / API Configurator. Imports enabled, reszta disabled z "Coming with epik UI-04" tooltip.

**List view** (`features/imports/list/`):
- `ImportsListView` — Refine `useList` na resource `import-sessions` + DataTable z IMP-08. Status badges, "Nowy import" CTA, empty state.
- `StatusBadge` — emoji + Tailwind colour per status, i18n labels `imports.list.status.*`.

**Routing**:
- `/publications` Route z index → `/publications/imports`
- Refine resources `import-sessions` + `import-profiles` w App.tsx

**Empty state**:
- `EmptyStateProducts` — "Importuj z Excel/CSV" CTA enabled, deep-link do `/publications/imports/new`

**i18n**:
- New `publications.*` namespace (PL + EN)

## Świadome odejścia

- **Filtry list** (Status/Date range/User) + **3-dot actions menu** — landują z IMP-12 razem z rollback button (zachowanie row-level state)
- **Refine resources extension** dla `import-sessions/dictionary` itp. — dodaje IMP-10 gdy używa endpointów

## Quality gates

- ✅ Biome strict: zero errors
- ✅ TypeScript noEmit: zero errors

Refs #450