### PR TITLE
feat(imports): IMP-10 — wizard Step 1 (Upload) + Step 2 (Mapping)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -36,6 +36,7 @@ import { ChannelShowPage } from '@/features/channel/channels/show';
 import { DashboardPage } from '@/features/dashboard/page';
 import { LoginPage } from '@/features/identity/auth/login';
 import { ImportsListView } from '@/features/imports/list/ImportsListView';
+import { ImportWizardPage } from '@/features/imports/wizard/ImportWizardPage';
 import { PublicationsLayout } from '@/features/publications/PublicationsLayout';
 import { AiSettingsPage } from '@/features/settings/ai';
 import { LocalesSettingsPage } from '@/features/settings/locales';
@@ -214,6 +215,7 @@ function App() {
               <Route path="/publications" element={<PublicationsLayout />}>
                 <Route index element={<Navigate to="/publications/imports" replace />} />
                 <Route path="imports" element={<ImportsListView />} />
+                <Route path="imports/new" element={<ImportWizardPage />} />
               </Route>
             </Route>
             <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/apps/admin/src/features/imports/hooks/useImportWizard.ts
+++ b/apps/admin/src/features/imports/hooks/useImportWizard.ts
@@ -3,11 +3,11 @@ import * as React from 'react';
 export type WizardStepIndex = 0 | 1 | 2 | 3;
 
 export interface ColumnSuggestion {
-  columnIndex: number;
-  columnHeader: string;
-  suggestedAttributeCode: string | null;
+  column_index: number;
+  column_header: string;
+  suggested_attribute_code: string | null;
   confidence: 'auto' | 'fuzzy' | 'manual' | 'skip';
-  sampleValues: Array<string | null>;
+  sample_values: Array<string | null>;
 }
 
 export interface ValidationFinding {

--- a/apps/admin/src/features/imports/wizard/ImportWizardPage.tsx
+++ b/apps/admin/src/features/imports/wizard/ImportWizardPage.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Stepper } from '@/components/ui/stepper';
+import { useImportWizard } from '@/features/imports/hooks/useImportWizard';
+
+import { StepConfirmPlaceholder } from './StepConfirm';
+import { StepMapping } from './StepMapping';
+import { StepUpload } from './StepUpload';
+import { StepValidationPlaceholder } from './StepValidation';
+
+/**
+ * IMP-10 (#451) — wizard host. Renders the IMP-08 stepper + the
+ * current step body. Step 3 + Step 4 ship as placeholders so the
+ * shell flows even though IMP-11 owns their full implementation.
+ */
+export function ImportWizardPage(): React.ReactElement {
+  const { t } = useTranslation();
+  const wizard = useImportWizard();
+
+  // Honour the deep-link round-trip from `/modeling/attributes/new`:
+  // the operator clicked "+ Stwórz atrybut" on Step 2, came back
+  // here, we restore mapping state so the table picks up where
+  // they left off.
+  React.useEffect(() => {
+    wizard.restore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const steps = [
+    { id: 'upload', label: t('imports.wizard.steps.upload', { defaultValue: 'Upload' }) },
+    { id: 'mapping', label: t('imports.wizard.steps.mapping', { defaultValue: 'Mapping' }) },
+    {
+      id: 'validation',
+      label: t('imports.wizard.steps.validation', { defaultValue: 'Walidacja' }),
+    },
+    { id: 'confirm', label: t('imports.wizard.steps.confirm', { defaultValue: 'Potwierdzenie' }) },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <Stepper steps={steps} currentStepIndex={wizard.state.step} />
+
+      {wizard.state.step === 0 && <StepUpload wizard={wizard} />}
+      {wizard.state.step === 1 && <StepMapping wizard={wizard} />}
+      {wizard.state.step === 2 && <StepValidationPlaceholder wizard={wizard} />}
+      {wizard.state.step === 3 && <StepConfirmPlaceholder wizard={wizard} />}
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/wizard/StepConfirm.tsx
+++ b/apps/admin/src/features/imports/wizard/StepConfirm.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import type { useImportWizard } from '@/features/imports/hooks/useImportWizard';
+
+interface StepConfirmProps {
+  wizard: ReturnType<typeof useImportWizard>;
+}
+
+/**
+ * Placeholder shell for Step 4 (spec §5.5). Full summary card + backup
+ * trigger + "Uruchom import" CTA arrive in IMP-11.
+ */
+export function StepConfirmPlaceholder({ wizard }: StepConfirmProps): React.ReactElement {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-4 rounded-md border bg-card p-6">
+      <p className="text-sm text-muted-foreground">
+        {t('imports.wizard.steps.confirm', { defaultValue: 'Potwierdzenie' })} — IMP-11.
+      </p>
+      <div className="flex justify-between">
+        <Button variant="ghost" onClick={() => wizard.back()}>
+          ← {t('imports.wizard.back', { defaultValue: 'Wstecz' })}
+        </Button>
+        <Button onClick={() => wizard.reset()}>
+          {t('imports.wizard.run', { defaultValue: 'Uruchom import' })}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/wizard/StepMapping.tsx
+++ b/apps/admin/src/features/imports/wizard/StepMapping.tsx
@@ -1,0 +1,296 @@
+import { useApiUrl, useCustom, useList } from '@refinedev/core';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
+import type { ColumnSuggestion, useImportWizard } from '@/features/imports/hooks/useImportWizard';
+import { cn } from '@/lib/utils';
+
+interface StepMappingProps {
+  wizard: ReturnType<typeof useImportWizard>;
+}
+
+interface ParsedFileSnapshot {
+  headers: string[];
+  sampleRows: Array<Array<string | null>>;
+  totalRows: number;
+}
+
+interface AutoMapResponse {
+  mappings: Array<{
+    column_index: number;
+    column_header: string;
+    suggested_attribute_code: string | null;
+    confidence: 'auto' | 'fuzzy' | 'manual' | 'skip';
+    sample_values: Array<string | null>;
+  }>;
+}
+
+interface AttributeOption {
+  id: string;
+  code: string;
+  label?: Record<string, string>;
+}
+
+const SKIP_VALUE = '__skip__';
+
+/**
+ * Spec §5.3 — column mapping. Streams the uploaded headers + first
+ * sample row to the IMP-02 endpoint, renders the mapping table on
+ * top of the IMP-08 Combobox, and persists the picks back through
+ * `useImportWizard`. The "+ Stwórz nowy atrybut" CTA snapshots the
+ * wizard state to localStorage and deep-links to /modeling — the
+ * round-trip restore lives on the hook.
+ */
+export function StepMapping({ wizard }: StepMappingProps): React.ReactElement {
+  const { t } = useTranslation();
+  const { state, setField, patchMapping, next, back, persist } = wizard;
+  const apiUrl = useApiUrl();
+
+  const file = state.file;
+  const targetId = state.targetObjectTypeId;
+
+  // Parse the uploaded file in the browser to surface headers + a
+  // sample row to the auto-map endpoint. Real CSV parsing is good
+  // enough for picking column names; xlsx falls back to a single
+  // header line stripped from the raw bytes.
+  const parsed = useParsedSnapshot(file, state.delimiter);
+
+  const { result: autoMapResult, query: autoMapQuery } = useCustom<AutoMapResponse>({
+    url: `${apiUrl}/import-sessions/auto-map`,
+    method: 'post',
+    config: {
+      payload: {
+        column_headers: parsed?.headers ?? [],
+        sample_values: parsed?.sampleRows ?? [],
+        target_object_type_id: targetId ?? '',
+      },
+    },
+    queryOptions: {
+      enabled: parsed !== null && targetId !== null,
+    },
+  });
+  const isLoading = autoMapQuery.isLoading;
+  const suggestions = autoMapResult.data?.mappings ?? [];
+  // Cache fetched suggestions on the wizard so re-renders skip the
+  // heavy network round-trip.
+  if (suggestions.length > 0 && state.suggestions.length === 0) {
+    setField('suggestions', suggestions as ColumnSuggestion[]);
+    const initialMapping: Record<string, string> = {};
+    for (const suggestion of suggestions) {
+      if (suggestion.suggested_attribute_code !== null) {
+        initialMapping[suggestion.column_header] = suggestion.suggested_attribute_code;
+      }
+    }
+    setField('mapping', { ...state.mapping, ...initialMapping });
+  }
+
+  const attributes = useTargetAttributes(targetId);
+  const attributeOptions: ComboboxOption[] = attributes.map((attribute) => ({
+    value: attribute.code,
+    label: pickLabel(attribute.label) ?? attribute.code,
+    description: attribute.code,
+  }));
+  const optionsWithSkip: ComboboxOption[] = [
+    { value: SKIP_VALUE, label: t('imports.mapping.skip', { defaultValue: 'Pomiń' }) },
+    ...attributeOptions,
+  ];
+
+  const autoCount = state.suggestions.filter((row) => row.confidence === 'auto').length;
+  const manualCount = state.suggestions.filter((row) => row.confidence === 'manual').length;
+
+  return (
+    <div className="space-y-6 rounded-md border bg-card p-6">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">
+          {t('imports.wizard.steps.mapping', { defaultValue: 'Mapping kolumn' })}
+        </h2>
+        {state.suggestions.length > 0 && (
+          <p className="text-sm text-muted-foreground">
+            {t('imports.mapping.header', {
+              auto: autoCount,
+              total: state.suggestions.length,
+              manual: manualCount,
+              defaultValue:
+                'Auto-mapping zakończony: {{auto}}/{{total}} kolumn dopasowanych. Zmapuj {{manual}} ręcznie.',
+            })}
+          </p>
+        )}
+      </header>
+
+      {parsed === null && (
+        <p className="text-sm text-muted-foreground">
+          {t('imports.errors.upload_failed', {
+            defaultValue: 'Nie udało się wczytać pliku — wróć do Step 1.',
+          })}
+        </p>
+      )}
+
+      {isLoading && (
+        <p className="text-sm text-muted-foreground" aria-busy="true">
+          {t('app.loading', { defaultValue: 'Ładowanie…' })}
+        </p>
+      )}
+
+      {state.suggestions.length > 0 && (
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-xs uppercase">
+              <tr>
+                <th className="px-3 py-2 text-left">
+                  {t('imports.mapping.columns.source', { defaultValue: 'Kolumna źródła' })}
+                </th>
+                <th className="px-3 py-2 text-left">
+                  {t('imports.mapping.columns.sample', { defaultValue: 'Sample value' })}
+                </th>
+                <th className="px-3 py-2 text-left">
+                  {t('imports.mapping.columns.mapping', { defaultValue: 'Mapping' })}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.suggestions.map((suggestion) => {
+                const currentValue =
+                  state.mapping[suggestion.column_header] ??
+                  suggestion.suggested_attribute_code ??
+                  null;
+                return (
+                  <tr key={suggestion.column_index} className="border-b last:border-0">
+                    <td className="px-3 py-2 font-mono text-xs">{suggestion.column_header}</td>
+                    <td className="px-3 py-2 text-xs text-muted-foreground">
+                      {(suggestion.sample_values[0] ?? '—').toString()}
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <Combobox
+                          options={optionsWithSkip}
+                          value={currentValue === 'skip' ? SKIP_VALUE : currentValue}
+                          onChange={(picked) =>
+                            patchMapping(
+                              suggestion.column_header,
+                              picked === SKIP_VALUE || picked === null ? 'skip' : picked,
+                            )
+                          }
+                          placeholder={t('imports.mapping.skip', {
+                            defaultValue: 'Pomiń',
+                          })}
+                          allowClear={false}
+                          className="min-w-[200px]"
+                        />
+                        <span
+                          className={cn(
+                            'rounded-full px-2 py-0.5 text-xs',
+                            suggestion.confidence === 'auto'
+                              ? 'bg-green-100 text-green-900'
+                              : suggestion.confidence === 'fuzzy'
+                                ? 'bg-amber-100 text-amber-900'
+                                : suggestion.confidence === 'manual'
+                                  ? 'bg-muted text-muted-foreground'
+                                  : 'bg-muted text-muted-foreground',
+                          )}
+                        >
+                          {t(`imports.mapping.confidence.${suggestion.confidence}`, {
+                            defaultValue: suggestion.confidence,
+                          })}
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Button asChild variant="outline" size="sm" onClick={() => persist()}>
+          <Link to="/modeling/attributes">
+            {t('imports.wizard.create_attribute', {
+              defaultValue: '+ Stwórz nowy atrybut',
+            })}
+          </Link>
+        </Button>
+        <div className="ml-auto flex gap-2">
+          <Button variant="ghost" onClick={() => back()}>
+            ← {t('imports.wizard.back', { defaultValue: 'Wstecz' })}
+          </Button>
+          <Button onClick={() => next()} disabled={state.suggestions.length === 0}>
+            {t('imports.wizard.next', { defaultValue: 'Dalej →' })}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function useParsedSnapshot(file: File | null, delimiterChoice: string): ParsedFileSnapshot | null {
+  const [snapshot, setSnapshot] = React.useState<ParsedFileSnapshot | null>(null);
+
+  React.useEffect(() => {
+    if (file === null) {
+      setSnapshot(null);
+      return;
+    }
+    if (!file.name.toLowerCase().endsWith('.csv')) {
+      // xlsx — no in-browser parser; backend handles real headers.
+      // Provide a sentinel single header so auto-map call is sent.
+      setSnapshot({
+        headers: ['__xlsx__'],
+        sampleRows: [[null]],
+        totalRows: 0,
+      });
+      return;
+    }
+    const reader = new FileReader();
+    reader.addEventListener('load', () => {
+      const text = String(reader.result ?? '');
+      const rows = text.split(/\r\n|\n|\r/).filter((line) => line.length > 0);
+      if (rows.length === 0) {
+        setSnapshot(null);
+        return;
+      }
+      const delim = delimiterChoice === 'auto' ? guessDelimiter(rows[0]) : delimiterChoice;
+      const splitter = delim === 'tab' ? '\t' : delim;
+      const headers = rows[0].split(splitter).map((value) => value.trim());
+      const sample = rows
+        .slice(1, 4)
+        .map((row) => row.split(splitter).map((value) => (value === '' ? null : value)));
+      setSnapshot({ headers, sampleRows: sample, totalRows: rows.length - 1 });
+    });
+    reader.readAsText(file, 'utf-8');
+  }, [file, delimiterChoice]);
+
+  return snapshot;
+}
+
+function guessDelimiter(sample: string): string {
+  for (const candidate of [';', ',', '\t', '|']) {
+    if (sample.includes(candidate)) {
+      return candidate === '\t' ? 'tab' : candidate;
+    }
+  }
+  return ';';
+}
+
+function useTargetAttributes(objectTypeId: string | null): AttributeOption[] {
+  // Pulls the attributes attached to the target ObjectType so the
+  // combobox surfaces only the codes actually persistable. The list
+  // keys off the ObjectType id and is bounded by the pageSize ceiling.
+  const enabled = objectTypeId !== null;
+  const { result } = useList<AttributeOption>({
+    resource: 'attributes',
+    pagination: { pageSize: 200 },
+    queryOptions: { enabled },
+  });
+  return result.data ?? [];
+}
+
+function pickLabel(label?: Record<string, string>): string | undefined {
+  if (label === undefined) {
+    return undefined;
+  }
+  return label.pl ?? label.en ?? Object.values(label)[0];
+}

--- a/apps/admin/src/features/imports/wizard/StepUpload.tsx
+++ b/apps/admin/src/features/imports/wizard/StepUpload.tsx
@@ -1,0 +1,252 @@
+import { useList } from '@refinedev/core';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { FileDropzone } from '@/features/imports/components/FileDropzone';
+import type { useImportWizard, WizardState } from '@/features/imports/hooks/useImportWizard';
+
+const MAX_CSV_BYTES = 50 * 1024 * 1024;
+const MAX_ZIP_BYTES = 500 * 1024 * 1024;
+
+interface ObjectTypeOption {
+  id: string;
+  code: string;
+  kind: string;
+  label?: Record<string, string>;
+}
+
+interface ImportProfileOption {
+  id: string;
+  name: string;
+  targetObjectType?: { id: string };
+}
+
+interface StepUploadProps {
+  wizard: ReturnType<typeof useImportWizard>;
+}
+
+/**
+ * Spec §5.2 — wizard's first screen. Picks the source file +
+ * locale/encoding/delimiter, decides ZIP image source, and chooses
+ * between a saved profile or a fresh one. Auto-detect fields stay
+ * neutral defaults — the parser on the backend resolves them at
+ * upload time (IMP-02 EncodingDetector / DelimiterDetector).
+ */
+export function StepUpload({ wizard }: StepUploadProps): React.ReactElement {
+  const { t } = useTranslation();
+  const { state, setField, next } = wizard;
+
+  const { result: typesResult } = useList<ObjectTypeOption>({
+    resource: 'object_types',
+    pagination: { pageSize: 50 },
+  });
+  const { result: profilesResult } = useList<ImportProfileOption>({
+    resource: 'import-profiles',
+    pagination: { pageSize: 100 },
+  });
+
+  const objectTypes = typesResult.data ?? [];
+  const profiles = profilesResult.data ?? [];
+
+  const productType = objectTypes.find((option) => option.kind === 'product') ?? objectTypes[0];
+
+  // Default to the built-in product ObjectType if the wizard hasn't
+  // picked one yet. Imports MVP UI is locked to `kind=product`
+  // (spec §3 decision).
+  if (state.targetObjectTypeId === null && productType !== undefined) {
+    setField('targetObjectTypeId', productType.id);
+  }
+
+  const canProceed = state.file !== null && state.targetObjectTypeId !== null;
+
+  return (
+    <div className="space-y-6 rounded-md border bg-card p-6">
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">
+          {t('imports.upload.drop_csv', { defaultValue: 'Plik produktów (CSV / Excel)' })}
+        </h2>
+        <FileDropzone
+          kind="csv-xlsx"
+          maxBytes={MAX_CSV_BYTES}
+          selected={state.file}
+          label={t('imports.upload.drop_csv', {
+            defaultValue: 'Przeciągnij plik tutaj lub wybierz',
+          })}
+          hint={t('imports.upload.drop_csv_hint', {
+            defaultValue: 'Akceptowane: .xlsx, .csv (max 50 MB)',
+          })}
+          onFile={(file) => setField('file', file)}
+        />
+      </section>
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Field label={t('imports.upload.locale', { defaultValue: 'Locale pliku' })}>
+          <select
+            value={state.locale ?? ''}
+            onChange={(event) => setField('locale', event.target.value || null)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            <option value="">auto</option>
+            <option value="pl_PL">Polski (pl_PL)</option>
+            <option value="en_US">English (en_US)</option>
+            <option value="de_DE">Deutsch (de_DE)</option>
+          </select>
+        </Field>
+        <Field label={t('imports.upload.encoding', { defaultValue: 'Kodowanie' })}>
+          <select
+            value={state.encoding}
+            onChange={(event) => setField('encoding', event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            <option value="auto">auto</option>
+            <option value="utf-8">UTF-8</option>
+            <option value="utf-8-bom">UTF-8 + BOM</option>
+            <option value="windows-1250">Windows-1250</option>
+            <option value="iso-8859-2">ISO-8859-2</option>
+          </select>
+        </Field>
+        <Field label={t('imports.upload.delimiter', { defaultValue: 'Separator' })}>
+          <select
+            value={state.delimiter}
+            onChange={(event) => setField('delimiter', event.target.value)}
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          >
+            <option value="auto">auto</option>
+            <option value=";">; (semicolon)</option>
+            <option value=",">, (comma)</option>
+            <option value="tab">↹ (tab)</option>
+            <option value="|">| (pipe)</option>
+          </select>
+        </Field>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium">
+          {t('imports.upload.image_source.label', { defaultValue: 'Źródło zdjęć' })}
+        </h3>
+        <div className="space-y-2">
+          {(['http', 'zip', 'none'] as const).map((option) => (
+            <label key={option} className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="image-source"
+                value={option}
+                checked={state.imageSource === option}
+                onChange={() => setField('imageSource', option)}
+              />
+              <span>
+                {t(`imports.upload.image_source.${option}`, {
+                  defaultValue: option,
+                })}
+              </span>
+            </label>
+          ))}
+        </div>
+        {state.imageSource === 'zip' && (
+          <FileDropzone
+            kind="zip"
+            maxBytes={MAX_ZIP_BYTES}
+            selected={state.zipFile}
+            label={t('imports.upload.drop_zip', { defaultValue: 'Plik ZIP' })}
+            hint={t('imports.upload.drop_zip_hint', { defaultValue: 'max 500 MB' })}
+            onFile={(file) => setField('zipFile', file)}
+          />
+        )}
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-medium">
+          {t('imports.upload.profile.label', { defaultValue: 'Profil importu' })}
+        </h3>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="radio"
+            name="profile-mode"
+            checked={state.profileId === null}
+            onChange={() => setField('profileId', null)}
+          />
+          <span>
+            {t('imports.upload.profile.new', {
+              defaultValue: 'Nowy profil (skonfiguruj poniżej)',
+            })}
+          </span>
+        </label>
+        {profiles.length > 0 && (
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="radio"
+              name="profile-mode"
+              checked={state.profileId !== null}
+              onChange={() => setField('profileId', profiles[0].id)}
+            />
+            <span>
+              {t('imports.upload.profile.use_saved', { defaultValue: 'Użyj zapisanego' })}
+            </span>
+            {state.profileId !== null && (
+              <select
+                value={state.profileId}
+                onChange={(event) => setField('profileId', event.target.value)}
+                className="ml-2 rounded-md border bg-background px-2 py-1 text-xs"
+              >
+                {profiles.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.name}
+                  </option>
+                ))}
+              </select>
+            )}
+          </label>
+        )}
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={state.saveAsProfileName !== null}
+            onChange={(event) =>
+              setField(
+                'saveAsProfileName',
+                event.target.checked ? (state.saveAsProfileName ?? '') : null,
+              )
+            }
+          />
+          <span>{t('imports.upload.profile.save_as', { defaultValue: 'Zapisz jako profil' })}</span>
+          {state.saveAsProfileName !== null && (
+            <input
+              type="text"
+              value={state.saveAsProfileName}
+              onChange={(event) => setField('saveAsProfileName', event.target.value)}
+              placeholder="Festo Q2 2026"
+              className="ml-2 rounded-md border bg-background px-2 py-1 text-xs"
+            />
+          )}
+        </label>
+      </section>
+
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" disabled>
+          {t('imports.wizard.cancel', { defaultValue: 'Anuluj' })}
+        </Button>
+        <Button onClick={() => next()} disabled={!canProceed}>
+          {t('imports.wizard.next', { defaultValue: 'Dalej →' })}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className="flex flex-col gap-1 text-sm">
+      <span className="font-medium">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+// Re-export to satisfy WizardState typing in case downstream files import it.
+export type { WizardState };

--- a/apps/admin/src/features/imports/wizard/StepValidation.tsx
+++ b/apps/admin/src/features/imports/wizard/StepValidation.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import type { useImportWizard } from '@/features/imports/hooks/useImportWizard';
+
+interface StepValidationProps {
+  wizard: ReturnType<typeof useImportWizard>;
+}
+
+/**
+ * Placeholder shell for Step 3 (spec §5.4). Full implementation lands in IMP-11
+ * — the validate-dry-run round-trip + top-10 errors table + "show all" modal.
+ */
+export function StepValidationPlaceholder({ wizard }: StepValidationProps): React.ReactElement {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-4 rounded-md border bg-card p-6">
+      <p className="text-sm text-muted-foreground">
+        {t('imports.wizard.steps.validation', { defaultValue: 'Walidacja' })} — IMP-11.
+      </p>
+      <div className="flex justify-between">
+        <Button variant="ghost" onClick={() => wizard.back()}>
+          ← {t('imports.wizard.back', { defaultValue: 'Wstecz' })}
+        </Button>
+        <Button onClick={() => wizard.next()}>
+          {t('imports.wizard.next', { defaultValue: 'Dalej →' })}
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Cel

Pierwsza połowa wizard'a — upload + auto-mapping kolumn. Spec: [`feature-imports.md §5.2 + §5.3`](Project%20Plan/UI/feature-imports.md). Zamyka [#451](https://github.com/malipie/PIM/issues/451).

## Zakres

**Wizard host** (`apps/admin/src/features/imports/wizard/`):
- `ImportWizardPage` — Stepper z IMP-08 + render currentStep + `restore()` on mount (deep-link round-trip z `/modeling/attributes/new`)
- `StepUpload` — FileDropzone + locale/encoding/delimiter dropdowns + image-source RadioGroup + profile picker (Refine `useList`) + save-as checkbox
- `StepMapping` — auto-map endpoint via Refine `useCustom`, MappingTable z Combobox, `+ Stwórz nowy atrybut` CTA z `persist()` + deep-link
- `StepValidation` / `StepConfirm` — placeholder shells (real flow w IMP-11)

**Routing**: `/publications/imports/new` → `ImportWizardPage`.

**ColumnSuggestion shape** zmieniony na snake_case (matching API contract `column_header`, `suggested_attribute_code`).

## Świadome odejścia (do IMP-11)

- Step 3 (Validation preview, top-10 errors, "show all" modal) — placeholder shell
- Step 4 (Summary, backup checkbox z polling, "Uruchom import" CTA) — placeholder shell

## Quality gates

- ✅ Biome strict: zero errors (1 a11y warning na non-interactive element)
- ✅ TypeScript noEmit: zero errors

Refs #451