### PR TITLE
feat(imports): IMP-11 — wizard Step 3 (Validation) + Step 4 (Confirm)

### DIFF
--- a/apps/admin/src/features/imports/components/BackupTriggerCheckbox.tsx
+++ b/apps/admin/src/features/imports/components/BackupTriggerCheckbox.tsx
@@ -1,0 +1,145 @@
+import { useApiUrl, useCustom } from '@refinedev/core';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Progress } from '@/components/ui/progress';
+import { cn } from '@/lib/utils';
+
+interface BackupTriggerCheckboxProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  /**
+   * Pushed up to the parent so Step 4 can disable the "Uruchom import"
+   * CTA while the backup is still running.
+   */
+  onStatusChange?: (status: 'idle' | 'pending' | 'running' | 'completed' | 'failed') => void;
+}
+
+interface BackupStatusResponse {
+  id: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  error_message: string | null;
+}
+
+/**
+ * Spec §5.5 — wizard Step 4 backup checkbox.
+ *
+ * On check the checkbox `POST`s `/api/backups`, then polls the status
+ * endpoint every 5 s until the row reaches a terminal state. The
+ * IMP-06 in-memory rate limiter caps abuse at 1/h/tenant.
+ */
+export function BackupTriggerCheckbox({
+  checked,
+  onChange,
+  onStatusChange,
+}: BackupTriggerCheckboxProps): React.ReactElement {
+  const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const [backupId, setBackupId] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const { result } = useCustom<BackupStatusResponse>({
+    url: `${apiUrl}/backups/${backupId ?? ''}`,
+    method: 'get',
+    queryOptions: {
+      enabled: backupId !== null,
+      refetchInterval: 5000,
+    },
+  });
+  const status = result.data?.status ?? 'idle';
+
+  React.useEffect(() => {
+    onStatusChange?.(status);
+  }, [status, onStatusChange]);
+
+  const handleToggle = (next: boolean): void => {
+    onChange(next);
+    if (!next) {
+      setBackupId(null);
+      setError(null);
+      return;
+    }
+    fetch(`${apiUrl}/backups`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ triggered_by_action: 'pre_import' }),
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        return (await res.json()) as { id: string };
+      })
+      .then((data) => setBackupId(data.id))
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'unknown');
+        onChange(false);
+      });
+  };
+
+  return (
+    <div className="space-y-2 rounded-md border bg-muted/20 p-4">
+      <label className="flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(event) => handleToggle(event.target.checked)}
+          className="mt-1"
+        />
+        <span className="space-y-1">
+          <span className="font-medium">
+            {t('imports.confirm.backup.label', {
+              defaultValue: 'Utwórz pełen backup bazy danych (pgBackRest)',
+            })}
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            💡{' '}
+            {t('imports.confirm.backup.hint_recommended', {
+              defaultValue: 'Zalecane dla importów >1000 produktów',
+            })}
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            ⏱{' '}
+            {t('imports.confirm.backup.hint_duration', {
+              defaultValue: 'Backup zajmie 5–30 minut',
+            })}
+          </span>
+          <span className="block text-xs text-muted-foreground">
+            {t('imports.confirm.backup.hint_rollback', {
+              defaultValue: 'Bez backupu: dostępny soft rollback przez 24h',
+            })}
+          </span>
+        </span>
+      </label>
+
+      {checked && backupId !== null && (
+        <div className="space-y-1">
+          <Progress
+            value={status === 'completed' ? 100 : status === 'running' ? 50 : 10}
+            ariaLabel="Backup progress"
+          />
+          <p
+            className={cn(
+              'text-xs',
+              status === 'completed' && 'text-green-700',
+              status === 'failed' && 'text-destructive',
+              (status === 'pending' || status === 'running') && 'text-muted-foreground',
+            )}
+          >
+            {status === 'pending' && '🔄 Oczekuje…'}
+            {status === 'running' && '🔄 Backup w toku…'}
+            {status === 'completed' && '✅ Backup gotowy'}
+            {status === 'failed' && `❌ ${result.data?.error_message ?? 'Błąd'}`}
+          </p>
+        </div>
+      )}
+
+      {error !== null && (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/wizard/StepConfirm.tsx
+++ b/apps/admin/src/features/imports/wizard/StepConfirm.tsx
@@ -1,6 +1,11 @@
+import { useApiUrl } from '@refinedev/core';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 
 import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { BackupTriggerCheckbox } from '@/features/imports/components/BackupTriggerCheckbox';
 import type { useImportWizard } from '@/features/imports/hooks/useImportWizard';
 
 interface StepConfirmProps {
@@ -8,24 +13,138 @@ interface StepConfirmProps {
 }
 
 /**
- * Placeholder shell for Step 4 (spec §5.5). Full summary card + backup
- * trigger + "Uruchom import" CTA arrive in IMP-11.
+ * Spec §5.5 — Step 4 confirm. Renders the summary card, optional
+ * pgBackRest trigger (IMP-06), email notification toggle, and the
+ * "Uruchom import" CTA. The CTA is gated on the backup being either
+ * `idle` (operator opted out) or `completed` so the backend always
+ * runs on a snapshot when the user asked for one.
  */
 export function StepConfirmPlaceholder({ wizard }: StepConfirmProps): React.ReactElement {
   const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const navigate = useNavigate();
+  const { state, setField } = wizard;
+
+  const [backupStatus, setBackupStatus] = React.useState<
+    'idle' | 'pending' | 'running' | 'completed' | 'failed'
+  >('idle');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
+
+  const canRun =
+    state.file !== null &&
+    state.targetObjectTypeId !== null &&
+    !submitting &&
+    (state.doBackup === false || backupStatus === 'completed' || backupStatus === 'idle');
+
+  const handleRun = (): void => {
+    if (state.file === null || state.targetObjectTypeId === null) {
+      return;
+    }
+    setSubmitting(true);
+    setSubmitError(null);
+
+    const formData = new FormData();
+    formData.set('file', state.file);
+    formData.set('target_object_type_id', state.targetObjectTypeId);
+    formData.set('mapping', JSON.stringify(state.mapping));
+    formData.set('encoding', state.encoding);
+    formData.set('delimiter', state.delimiter);
+    formData.set('do_backup', state.doBackup ? '1' : '0');
+
+    fetch(`${apiUrl}/import-sessions`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    })
+      .then(async (res) => {
+        if (!res.ok && res.status !== 202) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        return (await res.json()) as { id: string };
+      })
+      .then((data) => {
+        wizard.reset();
+        navigate(`/publications/imports/${data.id}`);
+      })
+      .catch((err: unknown) => {
+        setSubmitError(err instanceof Error ? err.message : 'unknown');
+        setSubmitting(false);
+      });
+  };
+
   return (
-    <div className="space-y-4 rounded-md border bg-card p-6">
-      <p className="text-sm text-muted-foreground">
-        {t('imports.wizard.steps.confirm', { defaultValue: 'Potwierdzenie' })} — IMP-11.
+    <div className="space-y-6 rounded-md border bg-card p-6">
+      <header>
+        <h2 className="text-lg font-semibold">
+          {t('imports.confirm.summary', { defaultValue: 'Podsumowanie' })}
+        </h2>
+      </header>
+
+      <Card className="space-y-2 p-4 text-sm">
+        <SummaryRow label="Plik" value={state.file?.name ?? '—'} />
+        <SummaryRow label="Locale" value={state.locale ?? 'auto'} />
+        <SummaryRow label="Encoding" value={state.encoding} />
+        <SummaryRow label="Delimiter" value={state.delimiter} />
+        <SummaryRow label="Mapowanie" value={`${Object.keys(state.mapping).length} kolumn`} />
+        <SummaryRow label="Zdjęcia" value={state.imageSource} />
+        {state.validation !== null && (
+          <SummaryRow
+            label="Do importu"
+            value={`${state.validation.successCount} OK (+ ${state.validation.errorCount} pominiętych)`}
+          />
+        )}
+      </Card>
+
+      <BackupTriggerCheckbox
+        checked={state.doBackup}
+        onChange={(next) => setField('doBackup', next)}
+        onStatusChange={setBackupStatus}
+      />
+
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          checked={state.emailNotification}
+          onChange={(event) => setField('emailNotification', event.target.checked)}
+        />
+        <span>
+          {t('imports.confirm.email', {
+            defaultValue: 'Wyślij email po zakończeniu (>5 min runtime)',
+          })}
+        </span>
+      </label>
+
+      <p className="rounded-md border border-amber-500/40 bg-amber-50 px-3 py-2 text-xs">
+        ⚠️{' '}
+        {t('imports.confirm.warning', {
+          defaultValue: 'Akcja jest finalna. Możesz wycofać import w 24h.',
+        })}
       </p>
+
+      {submitError !== null && (
+        <p role="alert" className="text-sm text-destructive">
+          {submitError}
+        </p>
+      )}
+
       <div className="flex justify-between">
         <Button variant="ghost" onClick={() => wizard.back()}>
           ← {t('imports.wizard.back', { defaultValue: 'Wstecz' })}
         </Button>
-        <Button onClick={() => wizard.reset()}>
-          {t('imports.wizard.run', { defaultValue: 'Uruchom import' })}
+        <Button onClick={handleRun} disabled={!canRun}>
+          ▶ {t('imports.wizard.run', { defaultValue: 'Uruchom import' })}
         </Button>
       </div>
+    </div>
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }): React.ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono text-xs">{value}</span>
     </div>
   );
 }

--- a/apps/admin/src/features/imports/wizard/StepValidation.tsx
+++ b/apps/admin/src/features/imports/wizard/StepValidation.tsx
@@ -1,31 +1,318 @@
+import { useApiUrl } from '@refinedev/core';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
-import type { useImportWizard } from '@/features/imports/hooks/useImportWizard';
+import { Card } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import type { useImportWizard, ValidationFinding } from '@/features/imports/hooks/useImportWizard';
+import { cn } from '@/lib/utils';
 
 interface StepValidationProps {
   wizard: ReturnType<typeof useImportWizard>;
 }
 
+interface DryRunResponse {
+  total_rows: number;
+  success_count: number;
+  error_count: number;
+  top_errors: ApiError[];
+  all_errors: ApiError[];
+}
+
+interface ApiError {
+  row_number: number;
+  sku: string | null;
+  error_type: string;
+  level: 'info' | 'warning' | 'error';
+  message: string;
+  column_name: string | null;
+  column_value: string | null;
+}
+
 /**
- * Placeholder shell for Step 3 (spec §5.4). Full implementation lands in IMP-11
- * — the validate-dry-run round-trip + top-10 errors table + "show all" modal.
+ * Spec §5.4 — wizard Step 3 dry-run preview. Calls validate-dry-run
+ * with the uploaded file + the mapping picked on Step 2 and renders
+ * the IMP-03 response: two KPI cards + top-10 errors + a "show all"
+ * modal that streams the full list. The decision RadioGroup just
+ * forwards control to Step 4 — the back-to-mapping branch routes
+ * the wizard to step index 1.
  */
 export function StepValidationPlaceholder({ wizard }: StepValidationProps): React.ReactElement {
   const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const [showAll, setShowAll] = React.useState(false);
+  const [response, setResponse] = React.useState<DryRunResponse | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [decision, setDecision] = React.useState<'import_ok' | 'back_to_mapping'>('import_ok');
+
+  const file = wizard.state.file;
+  const targetId = wizard.state.targetObjectTypeId;
+  const mapping = wizard.state.mapping;
+  const setValidation = wizard.setField;
+  const encoding = wizard.state.encoding;
+  const delimiter = wizard.state.delimiter;
+
+  React.useEffect(() => {
+    if (file === null || targetId === null) {
+      return;
+    }
+    let cancelled = false;
+    const formData = new FormData();
+    formData.set('file', file);
+    formData.set('target_object_type_id', targetId);
+    formData.set('mapping', JSON.stringify(mapping));
+    formData.set('encoding', encoding);
+    formData.set('delimiter', delimiter);
+
+    setLoading(true);
+    setError(null);
+    fetch(`${apiUrl}/import-sessions/validate-dry-run`, {
+      method: 'POST',
+      credentials: 'include',
+      body: formData,
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        return (await res.json()) as DryRunResponse;
+      })
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+        setResponse(data);
+        setValidation('validation', {
+          totalRows: data.total_rows,
+          successCount: data.success_count,
+          errorCount: data.error_count,
+          topErrors: data.top_errors.map(toFinding),
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        setError(err instanceof Error ? err.message : 'unknown');
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiUrl, file, targetId, mapping, encoding, delimiter, setValidation]);
+
+  const handleNext = (): void => {
+    if (decision === 'back_to_mapping') {
+      wizard.back();
+      return;
+    }
+    wizard.next();
+  };
+
   return (
-    <div className="space-y-4 rounded-md border bg-card p-6">
-      <p className="text-sm text-muted-foreground">
-        {t('imports.wizard.steps.validation', { defaultValue: 'Walidacja' })} — IMP-11.
-      </p>
+    <div className="space-y-6 rounded-md border bg-card p-6">
+      <header className="space-y-1">
+        <h2 className="text-lg font-semibold">
+          {t('imports.wizard.steps.validation', { defaultValue: 'Walidacja' })}
+        </h2>
+      </header>
+
+      {loading && (
+        <p className="text-sm text-muted-foreground" aria-busy="true">
+          {t('app.loading', { defaultValue: 'Ładowanie…' })}
+        </p>
+      )}
+
+      {error !== null && (
+        <p role="alert" className="text-sm text-destructive">
+          {t('imports.errors.upload_failed', {
+            defaultValue: 'Walidacja nie powiodła się.',
+          })}
+          : {error}
+        </p>
+      )}
+
+      {response !== null && (
+        <>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <Kpi
+              label={t('imports.validation.ok', {
+                count: response.success_count,
+                defaultValue: '{{count}} produktów OK',
+              })}
+              tone="ok"
+            />
+            <Kpi
+              label={t('imports.validation.errors', {
+                count: response.error_count,
+                defaultValue: '{{count}} błędów / ostrzeżeń',
+              })}
+              tone="warn"
+            />
+          </div>
+
+          {response.top_errors.length > 0 && (
+            <ErrorTable
+              errors={response.top_errors}
+              onShowAll={() => setShowAll(true)}
+              showAllLabel={t('imports.validation.show_all', {
+                count: response.error_count,
+                defaultValue: 'Pokaż wszystkie {{count}} błędy',
+              })}
+            />
+          )}
+
+          <fieldset className="space-y-2">
+            <legend className="text-sm font-medium">
+              {t('imports.validation.decide.label', { defaultValue: 'Co dalej?' })}
+            </legend>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="decision"
+                checked={decision === 'import_ok'}
+                onChange={() => setDecision('import_ok')}
+              />
+              <span>
+                {t('imports.validation.decide.import_ok', {
+                  defaultValue: 'Zaimportuj OK, pomiń błędne',
+                })}
+              </span>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="radio"
+                name="decision"
+                checked={decision === 'back_to_mapping'}
+                onChange={() => setDecision('back_to_mapping')}
+              />
+              <span>
+                {t('imports.validation.decide.back_to_mapping', {
+                  defaultValue: 'Wróć do mappingu, popraw błędy',
+                })}
+              </span>
+            </label>
+          </fieldset>
+        </>
+      )}
+
       <div className="flex justify-between">
         <Button variant="ghost" onClick={() => wizard.back()}>
           ← {t('imports.wizard.back', { defaultValue: 'Wstecz' })}
         </Button>
-        <Button onClick={() => wizard.next()}>
+        <Button onClick={handleNext} disabled={response === null}>
           {t('imports.wizard.next', { defaultValue: 'Dalej →' })}
         </Button>
       </div>
+
+      {showAll && response !== null && (
+        <Dialog open={showAll} onOpenChange={setShowAll}>
+          <DialogContent className="max-w-3xl">
+            <DialogHeader>
+              <DialogTitle>
+                {t('imports.validation.show_all', {
+                  count: response.error_count,
+                  defaultValue: 'Wszystkie błędy',
+                })}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="max-h-[60vh] overflow-auto">
+              <ErrorTable errors={response.all_errors} />
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   );
+}
+
+function Kpi({ label, tone }: { label: string; tone: 'ok' | 'warn' }): React.ReactElement {
+  return (
+    <Card
+      className={cn(
+        'p-4 text-center text-lg font-semibold',
+        tone === 'ok' ? 'border-green-500/40 bg-green-50' : 'border-amber-500/40 bg-amber-50',
+      )}
+    >
+      {label}
+    </Card>
+  );
+}
+
+function ErrorTable({
+  errors,
+  onShowAll,
+  showAllLabel,
+}: {
+  errors: ApiError[];
+  onShowAll?: () => void;
+  showAllLabel?: string;
+}): React.ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full text-sm">
+          <thead className="border-b bg-muted/40 text-xs uppercase">
+            <tr>
+              <th className="px-3 py-2 text-left">
+                {t('imports.validation.errors_table.row', { defaultValue: 'Wiersz' })}
+              </th>
+              <th className="px-3 py-2 text-left">
+                {t('imports.validation.errors_table.sku', { defaultValue: 'SKU' })}
+              </th>
+              <th className="px-3 py-2 text-left">
+                {t('imports.validation.errors_table.type', { defaultValue: 'Typ błędu' })}
+              </th>
+              <th className="px-3 py-2 text-left">
+                {t('imports.validation.errors_table.message', { defaultValue: 'Komunikat' })}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {errors.map((row) => (
+              <tr
+                key={`${row.row_number}-${row.error_type}-${row.column_name ?? ''}`}
+                className="border-b last:border-0"
+              >
+                <td className="px-3 py-2 font-mono text-xs">{row.row_number}</td>
+                <td className="px-3 py-2 font-mono text-xs">{row.sku ?? '—'}</td>
+                <td className="px-3 py-2 text-xs">
+                  {t(`imports.validation.error_types.${row.error_type}`, {
+                    defaultValue: row.error_type,
+                  })}
+                </td>
+                <td className="px-3 py-2 text-xs text-muted-foreground">{row.message}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {onShowAll !== undefined && showAllLabel !== undefined && (
+        <Button variant="link" size="sm" onClick={onShowAll} className="mt-2">
+          {showAllLabel}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function toFinding(error: ApiError): ValidationFinding {
+  return {
+    rowNumber: error.row_number,
+    sku: error.sku,
+    errorType: error.error_type,
+    level: error.level,
+    message: error.message,
+    columnName: error.column_name,
+    columnValue: error.column_value,
+  };
 }


### PR DESCRIPTION
## Cel

Druga połowa wizard'a — validation preview + confirm + backup. Spec: [`feature-imports.md §5.4 + §5.5`](Project%20Plan/UI/feature-imports.md). Zamyka [#452](https://github.com/malipie/PIM/issues/452).

## Zakres

**Step 3 — StepValidation**:
- Multipart fetch `/api/import-sessions/validate-dry-run` z file + mapping z Step 2
- KPI Cards (success_count + error_count), top-10 errors table, "show all" Dialog modal
- Decision RadioGroup: import_ok / back_to_mapping

**Step 4 — StepConfirm**:
- Summary card (file, locale, encoding, delimiter, mapping count, validation preview)
- `BackupTriggerCheckbox` (nowy) — POST `/api/backups` + poll `/api/backups/{id}` co 5s + Progress bar
- "Uruchom import" CTA gated na backup completion (operator opt-in/out)
- Email notification toggle + warning copy
- Run handler: multipart POST `/api/import-sessions` → navigate `/publications/imports/{id}`

## Quality gates

- ✅ Biome strict: zero errors (1 a11y warning carried over)
- ✅ TypeScript noEmit: zero errors

Refs #452