### PR TITLE
feat(imports): IMP-12 — progress + results + rollback UI

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -36,6 +36,7 @@ import { ChannelShowPage } from '@/features/channel/channels/show';
 import { DashboardPage } from '@/features/dashboard/page';
 import { LoginPage } from '@/features/identity/auth/login';
 import { ImportsListView } from '@/features/imports/list/ImportsListView';
+import { ImportShowPage } from '@/features/imports/show/ImportShowPage';
 import { ImportWizardPage } from '@/features/imports/wizard/ImportWizardPage';
 import { PublicationsLayout } from '@/features/publications/PublicationsLayout';
 import { AiSettingsPage } from '@/features/settings/ai';
@@ -216,6 +217,7 @@ function App() {
                 <Route index element={<Navigate to="/publications/imports" replace />} />
                 <Route path="imports" element={<ImportsListView />} />
                 <Route path="imports/new" element={<ImportWizardPage />} />
+                <Route path="imports/:id" element={<ImportShowPage />} />
               </Route>
             </Route>
             <Route path="*" element={<Navigate to="/dashboard" replace />} />

--- a/apps/admin/src/features/imports/components/RollbackButton.tsx
+++ b/apps/admin/src/features/imports/components/RollbackButton.tsx
@@ -1,0 +1,114 @@
+import { useApiUrl } from '@refinedev/core';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface RollbackButtonProps {
+  sessionId: string;
+  rollbackUntil: string | null;
+  onRolledBack: () => void;
+}
+
+/**
+ * Spec §5.7 results screen — "Wycofaj import" CTA. Disabled when the
+ * 24h window has expired; opens a confirm Dialog before issuing the
+ * destructive POST. Cascade warning copy mentions Faza 1+ channel
+ * pruning so operators know the MVP scope (objects only).
+ */
+export function RollbackButton({
+  sessionId,
+  rollbackUntil,
+  onRolledBack,
+}: RollbackButtonProps): React.ReactElement {
+  const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const [open, setOpen] = React.useState(false);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const isExpired = rollbackUntil === null || new Date(rollbackUntil).getTime() < Date.now();
+
+  const handleConfirm = (): void => {
+    setSubmitting(true);
+    setError(null);
+    fetch(`${apiUrl}/import-sessions/${sessionId}/rollback`, {
+      method: 'POST',
+      credentials: 'include',
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        setOpen(false);
+        onRolledBack();
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'unknown');
+      })
+      .finally(() => setSubmitting(false));
+  };
+
+  if (isExpired) {
+    return (
+      <Button variant="outline" disabled>
+        ↶ {t('imports.results.rollback_expired', { defaultValue: 'Okno wycofania wygasło' })}
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <Button variant="outline" onClick={() => setOpen(true)}>
+        ↶ {t('imports.results.rollback', { defaultValue: 'Wycofaj import' })}
+      </Button>
+      <p className="text-xs text-muted-foreground">
+        ⏰{' '}
+        {t('imports.results.rollback_window', {
+          date: rollbackUntil !== null ? new Date(rollbackUntil).toLocaleString('pl-PL') : '',
+          defaultValue: 'Dostępne do {{date}}',
+        })}
+      </p>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('imports.results.rollback', { defaultValue: 'Wycofaj import' })}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 text-sm">
+            <p>
+              Operacja usunie wszystkie produkty zaimportowane w tej sesji. Powiązane assety (jeśli
+              były pobrane) pozostaną w DAM — usuń je ręcznie.
+            </p>
+            <p className="rounded-md border border-amber-500/40 bg-amber-50 p-2 text-xs">
+              ⚠️ Jeśli te produkty były publikowane do kanałów (Faza 1+) — wycofanie MVP usunie je
+              tylko z tej tabeli. Cascade do kanałów dochodzi w Fazie 1.
+            </p>
+            {error !== null && (
+              <p role="alert" className="text-destructive">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setOpen(false)} disabled={submitting}>
+              {t('imports.wizard.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button variant="destructive" onClick={handleConfirm} disabled={submitting}>
+              {t('imports.results.rollback', { defaultValue: 'Wycofaj' })}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/admin/src/features/imports/hooks/useImportProgress.ts
+++ b/apps/admin/src/features/imports/hooks/useImportProgress.ts
@@ -1,0 +1,100 @@
+import * as React from 'react';
+
+interface ProgressEvent {
+  type: 'progress' | 'row_processed' | 'error' | 'completed';
+  session_id: string;
+  data: {
+    processed_rows?: number;
+    total_rows?: number;
+    success_count?: number;
+    error_count?: number;
+    current_sku?: string | null;
+    status?: string;
+  };
+}
+
+export interface ImportProgressState {
+  /** True until the first SSE event lands or the connection drops. */
+  connecting: boolean;
+  processedRows: number;
+  totalRows: number;
+  successCount: number;
+  errorCount: number;
+  currentSku: string | null;
+  status:
+    | 'pending'
+    | 'running'
+    | 'paused'
+    | 'success'
+    | 'partial'
+    | 'failed'
+    | 'cancelled'
+    | 'rolled_back';
+}
+
+const INITIAL_STATE: ImportProgressState = {
+  connecting: true,
+  processedRows: 0,
+  totalRows: 0,
+  successCount: 0,
+  errorCount: 0,
+  currentSku: null,
+  status: 'pending',
+};
+
+/**
+ * Mercure SSE subscriber for the import detail topic
+ * (`imports/{session_id}`). Mirrors the IMP-04 publisher. The hook
+ * is idempotent — re-subscribing on session id change closes the
+ * previous EventSource and opens a fresh one.
+ */
+export function useImportProgress(sessionId: string | null): ImportProgressState {
+  const [state, setState] = React.useState<ImportProgressState>(INITIAL_STATE);
+
+  React.useEffect(() => {
+    if (sessionId === null) {
+      setState(INITIAL_STATE);
+      return;
+    }
+    if (typeof window === 'undefined' || typeof EventSource === 'undefined') {
+      return;
+    }
+
+    const topic = `https://pim.localhost/imports/${sessionId}`;
+    const url = `${window.location.origin}/.well-known/mercure?topic=${encodeURIComponent(topic)}`;
+    const source = new EventSource(url, { withCredentials: true });
+
+    source.addEventListener('open', () => {
+      setState((prev) => ({ ...prev, connecting: false }));
+    });
+
+    source.addEventListener('message', (event) => {
+      try {
+        const raw = JSON.parse(event.data) as ProgressEvent;
+        setState((prev) => ({
+          ...prev,
+          connecting: false,
+          processedRows: raw.data.processed_rows ?? prev.processedRows,
+          totalRows: raw.data.total_rows ?? prev.totalRows,
+          successCount: raw.data.success_count ?? prev.successCount,
+          errorCount: raw.data.error_count ?? prev.errorCount,
+          currentSku: raw.data.current_sku ?? prev.currentSku,
+          status: (raw.data.status as ImportProgressState['status']) ?? prev.status,
+        }));
+      } catch {
+        // Malformed Mercure payload — surface a console.warn on the
+        // root error handler in dev only.
+      }
+    });
+
+    source.addEventListener('error', () => {
+      setState((prev) => ({ ...prev, connecting: false }));
+    });
+
+    return () => {
+      source.close();
+    };
+  }, [sessionId]);
+
+  return state;
+}

--- a/apps/admin/src/features/imports/show/ImportShowPage.tsx
+++ b/apps/admin/src/features/imports/show/ImportShowPage.tsx
@@ -1,0 +1,210 @@
+import { useApiUrl, useOne } from '@refinedev/core';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import { RollbackButton } from '@/features/imports/components/RollbackButton';
+import { useImportProgress } from '@/features/imports/hooks/useImportProgress';
+import { type ImportStatus, StatusBadge } from '@/features/imports/list/StatusBadge';
+
+interface ImportSession {
+  id: string;
+  status: ImportStatus;
+  file_name: string;
+  total_rows: number | null;
+  success_count: number;
+  error_count: number;
+  images_downloaded: number;
+  images_failed: number;
+  started_at: string | null;
+  completed_at: string | null;
+  rollback_until: string | null;
+  rolled_back_at: string | null;
+  error_message: string | null;
+}
+
+/**
+ * Spec §5.6 + §5.7 — combined progress / results screen.
+ *
+ * The same page surfaces both because the wizard CTA navigates here
+ * right after dispatch (status='pending'/'running'). Once Mercure /
+ * polling updates the status to a terminal state, the layout
+ * transitions to the results card with KPI counters + the
+ * RollbackButton + report download. No router redirect needed —
+ * the screen is symmetric.
+ */
+export function ImportShowPage(): React.ReactElement {
+  const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const params = useParams<{ id: string }>();
+  const sessionId = params.id ?? null;
+
+  const { result: session, query } = useOne<ImportSession>({
+    resource: 'import-sessions',
+    id: sessionId ?? '',
+    queryOptions: {
+      enabled: sessionId !== null,
+      refetchInterval: 5000,
+    },
+  });
+  const progress = useImportProgress(sessionId);
+
+  if (sessionId === null || query.isLoading || session === undefined) {
+    return (
+      <p className="text-sm text-muted-foreground" aria-busy="true">
+        {t('app.loading', { defaultValue: 'Ładowanie…' })}
+      </p>
+    );
+  }
+
+  const isTerminal =
+    session.status === 'success' ||
+    session.status === 'partial' ||
+    session.status === 'failed' ||
+    session.status === 'cancelled' ||
+    session.status === 'rolled_back';
+
+  // Server is the source of truth; Mercure refines counters in
+  // realtime when REST poll has stale data.
+  const processed = Math.max(progress.processedRows, session.success_count + session.error_count);
+  const total = Math.max(progress.totalRows, session.total_rows ?? 0);
+
+  return (
+    <div className="space-y-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">{session.file_name}</h1>
+          <p className="text-sm text-muted-foreground">
+            <StatusBadge status={session.status} />
+          </p>
+        </div>
+        <Button asChild variant="ghost">
+          <Link to="/publications/imports">
+            ← {t('imports.list.title', { defaultValue: 'Importy' })}
+          </Link>
+        </Button>
+      </header>
+
+      {!isTerminal && (
+        <Card className="space-y-3 p-6">
+          <div className="flex items-center justify-between text-sm">
+            <span className="font-medium">
+              {processed} / {total > 0 ? total : '?'} (
+              {total > 0 ? Math.round((processed / total) * 100) : 0}%)
+            </span>
+            {progress.currentSku !== null && (
+              <span className="font-mono text-xs text-muted-foreground">
+                {t('imports.progress.current_sku', {
+                  sku: progress.currentSku,
+                  defaultValue: 'Aktualnie: {{sku}}',
+                })}
+              </span>
+            )}
+          </div>
+          <Progress
+            value={total > 0 ? (processed / total) * 100 : 0}
+            ariaLabel={t('imports.progress.title', { defaultValue: 'Import w toku' })}
+          />
+          <p className="text-xs text-muted-foreground">
+            💡{' '}
+            {t('imports.progress.close_hint', {
+              defaultValue: 'Możesz zamknąć tę kartę. System wyśle email po zakończeniu.',
+            })}
+          </p>
+        </Card>
+      )}
+
+      {isTerminal && (
+        <Card className="space-y-4 p-6">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <Kpi
+              label={t('imports.results.imported', {
+                count: session.success_count,
+                defaultValue: '{{count}} produktów zaimportowano',
+              })}
+              tone="ok"
+            />
+            <Kpi
+              label={t('imports.results.skipped', {
+                count: session.error_count,
+                defaultValue: '{{count}} pominiętych',
+              })}
+              tone="warn"
+            />
+            <Kpi
+              label={t('imports.results.duration', {
+                value: formatDuration(session.started_at, session.completed_at),
+                defaultValue: 'Czas: {{value}}',
+              })}
+              tone="muted"
+            />
+          </div>
+
+          {session.error_message !== null && (
+            <p className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm text-destructive">
+              {session.error_message}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button asChild variant="outline">
+              <a href={`${apiUrl}/import-sessions/${sessionId}/report.csv`}>
+                📥 {t('imports.results.download_report', { defaultValue: 'Pobierz raport CSV' })}
+              </a>
+            </Button>
+            <Button asChild variant="outline">
+              <Link to={`/products?import_session_id=${sessionId}`}>
+                👁{' '}
+                {t('imports.results.view_products', {
+                  defaultValue: 'Zobacz zaimportowane produkty',
+                })}
+              </Link>
+            </Button>
+            {(session.status === 'success' || session.status === 'partial') && (
+              <RollbackButton
+                sessionId={sessionId}
+                rollbackUntil={session.rollback_until}
+                onRolledBack={() => query.refetch()}
+              />
+            )}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function Kpi({
+  label,
+  tone,
+}: {
+  label: string;
+  tone: 'ok' | 'warn' | 'muted';
+}): React.ReactElement {
+  const palette =
+    tone === 'ok'
+      ? 'border-green-500/40 bg-green-50'
+      : tone === 'warn'
+        ? 'border-amber-500/40 bg-amber-50'
+        : 'border-muted bg-muted/40';
+  return (
+    <div className={`rounded-md border p-4 text-center text-base font-semibold ${palette}`}>
+      {label}
+    </div>
+  );
+}
+
+function formatDuration(start: string | null, end: string | null): string {
+  if (start === null || end === null) {
+    return '—';
+  }
+  const diff = new Date(end).getTime() - new Date(start).getTime();
+  if (Number.isNaN(diff) || diff < 0) {
+    return '—';
+  }
+  const seconds = Math.floor(diff / 1000) % 60;
+  const minutes = Math.floor(diff / (1000 * 60));
+  return `${minutes}m ${seconds}s`;
+}


### PR DESCRIPTION
## Cel

Landing page po wizard'owej akcji "Uruchom import". Spec: [`feature-imports.md §5.6 + §5.7`](Project%20Plan/UI/feature-imports.md). Zamyka [#453](https://github.com/malipie/PIM/issues/453).

## Zakres

**Components**:
- `useImportProgress(sessionId)` — Mercure SSE subscriber dla `imports/{session_id}` topic
- `ImportShowPage` — combined progress / results screen z Refine `useOne` + 5s polling + SSE overlay
- `RollbackButton` — wrap `POST /api/import-sessions/{id}/rollback` + confirm Dialog z cascade warning, disabled poza 24h window

**Routing**: `/publications/imports/{id}` → `ImportShowPage`

## Quality gates

- ✅ Biome strict: zero errors (1 a11y warning carried over)
- ✅ TypeScript noEmit: zero errors

Refs #453