### PR TITLE
docs(imports): IMP-15 — close epik UI-09, link feature-imports + US-IMP backlog

### DIFF
--- a/Project Plan/02-plan-projektu-pim.md
+++ b/Project Plan/02-plan-projektu-pim.md
@@ -483,6 +483,14 @@ Self-service import produktów z plików **Excel/CSV** + opcjonalnie zdjęcia (l
 
 **Wpływ na wycenę (sekcja 7):** total Faza 0 dochodzi **+124-167h** (epik 0.13 / UI-09 dodatkowo do baseline 60-80h epiku 0.12). Operator akceptuje wzrost scope (PRD §12.1 dopuszcza +50-80h nadwyżki) — ale realna nadwyżka nad budżetem MVP-Final to ~20-50h, blisko limitu. Mitigacja: rozważyć przesunięcie advanced features (recurring imports, AI auto-mapping, custom validation cross-attribute) na Fazę 1 — patrz **R-30**.
 
+**Status epiku — 2026-05-07: ZAMKNIĘTY.** 15 ticketów IMP-01..IMP-15 (#442-#456) zmergowanych do `main` w marathon mode 2026-05-06/07. Pełen delivery snapshot: [`Project Plan/UI/feature-imports.md`](UI/feature-imports.md) §13. **Świadome odejścia** (follow-up'y, nie blokują zamknięcia epiku):
+- **IMP-04** — image download + ZIP extract handler dispatchowane, ale realnego download'u nie wykonują (6-8h follow-up).
+- **IMP-14** — dogfooding US-IMP-005 (~2k SKU IdoSell) odsunięte; gate przed *„imports gotowe na pierwszy real-world"* otwarty.
+- **IMP-14** — Playwright suite trzymana jako 1 smoke spec; rozbudowa do 6 spec'ów (z planu) razem z dogfooding'iem.
+- **IMP-14** — performance benchmark 5k rows < 256 MB pomijany bez 5k fixture.
+
+**Maintenance ticket due** (per `CLAUDE.md` "Zarządzanie zależnościami" — co 2 epiki): epik 0.12 / UI-08 (Modelowanie) → epik 0.13 / UI-09 (Imports) zamknięte → następny `composer outdated` + `pnpm outdated` patch run zalecany przed startem kolejnego epiku.
+
 ## 4. Faza 1 — Integracje (BaseLinker + Shopify) + production-ready
 
 > **Rewizja 2026-04-27:** w nowej kolejności (post-#5) Faza 1 zaczyna się od **integracji BaseLinker (epik 0.8) i Shopify (epik 0.9)** — przeniesionych z MVP. Pełen hardening / RLS / monitoring zostaje w Fazie 1 jako równoległy track. Magento i IdoSell przesunięte do Fazy 2 razem z agentem.

--- a/Project Plan/03-funkcjonalnosci-mvp.md
+++ b/Project Plan/03-funkcjonalnosci-mvp.md
@@ -624,6 +624,29 @@ Wow factor: [co robi to "wow" dla Kasi]
 
 W większości używa tych samych workflow co Catalog Manager (US-006, US-007). MVP nie dodaje osobnych stories dla Marketingu — pełen flow w fazie 1+ (analytics dashboard, bulk SEO opisy z agentem).
 
+### 5.2a Imports MVP — szczegółowy backlog user stories (epik 0.13 / UI-09)
+
+US-001 traktuje import jako jeden monolityczny ticket (16-22h). Real implementacja epiku 0.13 / UI-09 (`Project Plan/UI/feature-imports.md`) rozłożyła ten zakres na **15 atomowych ticketów** (IMP-01..IMP-15) z explicit DoD per ticket. Poniżej user stories US-IMP-001..014 mapują flow użytkownika na tę implementację — pełne acceptance criteria + brainstorming decisions w `feature-imports.md`.
+
+| ID | Persona | Story (skrót) | Mapowanie ticket |
+|---|---|---|---|
+| **US-IMP-001** | Kasia | Wybieram plik xlsx/csv + locale + (opcjonalnie) ZIP zdjęć w Step 1 wizard'a, system pokazuje preview headerów. | IMP-08 #449 + IMP-10 #451 |
+| **US-IMP-002** | Kasia | Auto-mapping kolumn przez rules-based dictionary PL/EN (top ~30 atrybutów × 5-10 synonimów) — Step 2 pokazuje 12/15 dopasowanych + ręcznie domapuję 3. | IMP-02 #443 + IMP-10 #451 |
+| **US-IMP-003** | Kasia | W trakcie mapping'u brakuje atrybutu — klikam *„+ Stwórz nowy atrybut"*, deep-link do `/modeling/attributes/new` z preserved state, wracam i mapping zachowany. | IMP-10 #451 |
+| **US-IMP-004** | Kasia | Step 3 walidacja: KPI *„247 OK / 33 błędy"* + top-10 errors + dialog *„Pokaż wszystkie 33"* + radiogroup *„Co dalej"* + download CSV raportu. | IMP-03 #444 + IMP-11 #452 |
+| **US-IMP-005** | Marcin (founder) | **Dogfooding** — migracja katalogu IdoSell ~2k SKU jako pierwszy real-world test. Findings → `agent/lessons.md`. **Status:** odsunięte poza marathon (brak realnego export'u w czasie epiku); gate przed *„imports gotowe"*. | IMP-14 #455 (deferred) |
+| **US-IMP-006** | Kasia | Step 4 confirm + opcjonalny *„Utwórz pgBackRest backup"* checkbox (status polling co 5s, blokuje *„Uruchom"* do completed). | IMP-06 #447 + IMP-11 #452 |
+| **US-IMP-007** | Kasia | Klikam *„▶ Uruchom import"* (sync <50 rows / async 50+) → Mercure SSE pokazuje live progress: bar + counters + ETA + current SKU. | IMP-04 #445 + IMP-12 #453 |
+| **US-IMP-008** | Kasia | Po imporcie: results screen z KPI (✅ N OK / ⚠️ M pominięte / czas) + download CSV + deep-link *„Zobacz zaimportowane produkty"* (filter `import_session_id`). | IMP-05 #446 + IMP-12 #453 |
+| **US-IMP-009** | Kasia | *„Wycofaj import"* w 24h window → confirm dialog + cascade warning jeśli published do channels → soft delete obiektów z `import_session_id`. | IMP-05 #446 + IMP-12 #453 |
+| **US-IMP-010** | Kasia | Email notification po zakończeniu importu jeśli runtime > 5 min (klient zamknął kartę). | IMP-04 #445 |
+| **US-IMP-011** | Kasia | Profil importu z smart memory (mapping + locale + encoding + delimiter) — *„Use saved profile"* w Step 1, *„Save as profile"* checkbox w Step 4. | IMP-07 #448 + IMP-10 #451 |
+| **US-IMP-012** | Kasia | Profile manager modal (Sheet) — lista profili usera z Last used / # imports / edit / delete + disclaimer *„Edycja modyfikuje TYLKO przyszłe importy"*. | IMP-13 #454 |
+| **US-IMP-013** | Kasia | Lista wszystkich importów (Step 0) z filtrami (Status, Date range), badges status, 3-dot menu (View report / Rollback / Re-run / Delete). | IMP-09 #450 |
+| **US-IMP-014** | Kasia | Smoke test E2E na żywym backendzie: upload festo-q2-2026.xlsx → mapping → validation → confirm → progress → results → rollback. | IMP-14 #455 |
+
+**Mapowanie do epiku 6.X:** wszystkie US-IMP-001..014 idą do **epiku 0.13 / UI-09** (sub-tab Imports w epiku 04 Publikacje, `Project Plan/02-plan-projektu-pim.md` §3.7). US-001 z sekcji §4 traktuję jako legacy entry point — szczegół w `feature-imports.md` + tabeli powyżej.
+
 ### 5.3 IT/Integration Specialist (Piotr)
 
 **US-014 (Integration panel):** Lista wszystkich integracji + status + last sync + live error log.
@@ -639,7 +662,7 @@ W większości używa tych samych workflow co Catalog Manager (US-006, US-007). 
 
 | User Story | Epik | Priorytet sub-fazy |
 |---|---|---|
-| US-001 Import | 0.6 + 0.3 + nowy 0.6.X | MVP-Final |
+| US-001 Import (legacy entry) | **0.13 / UI-09 (zaimplementowane)** — szczegół w US-IMP-001..014 (§5.2a) i `Project Plan/UI/feature-imports.md` | MVP-Final + 0.13 |
 | US-002 Edycja produktu | 0.6.2 + 0.3.4 | MVP-Alpha |
 | US-003 Completeness | 0.3.8 + 0.6.2 | MVP-Alpha |
 | US-004 Bulk edit | 0.6.2 (extension) | MVP-Final |

--- a/Project Plan/UI/epik-04-publikacje.md
+++ b/Project Plan/UI/epik-04-publikacje.md
@@ -1,6 +1,8 @@
 # Epik 04 — Publikacje
 
-## Status: 🔵 placeholder
+## Status: 🟡 częściowy szczegół (sub-tab Imports gotowy, reszta placeholder)
+
+> Sub-tab **Imports** ma własny pełny dokument: [`feature-imports.md`](feature-imports.md) — zaimplementowany w epiku 0.13 / UI-09 (IMP-01..IMP-15, merged 2026-05-06/07). Reszta sub-tabów (Sync Jobs, Integracje, API Configurator, Webhooks) wciąż w placeholder — szczegół powstanie wraz z epikami 0.8 (BaseLinker), 0.9 (Shopify), 0.10 (API Configurator) — patrz `Project Plan/02-plan-projektu-pim.md` §3.4-§3.6.
 
 ## 1. Cel epiku
 
@@ -13,6 +15,10 @@ Zarządzanie syndykacją danych do kanałów zewnętrznych — *„co się dziej
 - **Tomasz** — read-only check status (z Dashboard'u również).
 
 ## 3. Kluczowe widoki
+
+### 3.0 Imports (zaimplementowane w epiku 0.13 / UI-09)
+
+Self-service import CSV/Excel + zdjęcia, 4-step wizard (upload → mapping → walidacja → confirm), async via Symfony Messenger z progress przez Mercure SSE, rules-based dictionary PL/EN auto-mapping, opcjonalny manual pgBackRest snapshot, soft rollback w 24h window, profile importu per user. **Pełen szczegół: [`feature-imports.md`](feature-imports.md)**. Status: zaimplementowane (15 ticketów IMP-01..IMP-15 merged do `main` 2026-05-06/07). Out of scope MVP: image download/ZIP extract (follow-up), UPDATE istniejących produktów (Faza 1), recurring imports (Faza 1+).
 
 ### 3.1 Sync Jobs panel
 - Lista wszystkich sync'ów (running / success / failed / partial) z filtrami (status, integration, date range).
@@ -87,4 +93,4 @@ Zarządzanie syndykacją danych do kanałów zewnętrznych — *„co się dziej
 
 ---
 
-*Plik wersjonowany w `Zrodla/UI/`. Status: placeholder — drugi USP (API Configurator) musi być wow demo'em w pitch'u Enterprise.*
+*Plik wersjonowany w `Project Plan/UI/`. Status: częściowy szczegół — sub-tab Imports zamknięty (epik 0.13 / UI-09), drugi USP (API Configurator) wciąż musi być wow demo'em w pitch'u Enterprise.*

--- a/Project Plan/UI/feature-imports.md
+++ b/Project Plan/UI/feature-imports.md
@@ -1,9 +1,10 @@
 # Feature — Import produktów (CSV / Excel + zdjęcia)
 
-## Status: 🟢 szczegół
+## Status: 🟢 zaimplementowane (epik 0.13 / UI-09 — IMP-01..IMP-15 merged 2026-05-07)
 
 > **Część epiku 04 Publikacje** — sub-tab "Imports". Standalone dokument, bo feature jest na tyle obszerny, że zasługuje na własną iterację designu.
 > **Decyzje brainstormingowe** zamknięte 2026-05-03 w sesji Senior PM. Plik rozszerza placeholder z `Project Plan/UI/epik-04-publikacje.md`.
+> **Implementacja:** epik 0.13 / UI-09 — 15 atomowych ticketów (IMP-01..IMP-15, #442–#456) zmergowanych do `main` 2026-05-06/07. Dogfooding US-IMP-005 (katalog IdoSell ~2k SKU) **odsunięte** poza ten epik — wymaga realnego export'u IdoSell, który nie był dostępny w czasie marathon'u; gate przed deklaracją *„imports gotowe na pierwszy real-world"* nadal aktywny. Followup-y w `agent/lessons.md` § 2026-05-07.
 
 ---
 
@@ -776,4 +777,32 @@ To jest *znaczący* dodatek. Marcin akceptuje +50-80h scope (PRD § 12.1) — pr
 
 ---
 
-*Plik wersjonowany w `Project Plan/UI/`. Status: szczegół. Następna iteracja: walidacja z Marcinem + Figma wireframes + POC słownika auto-mappingu.*
+## 13. Delivery snapshot — 2026-05-07
+
+| Ticket | PR | Scope (highlights) |
+|---|---|---|
+| **IMP-01** | #457 | Schema (`import_sessions`, `import_profiles`, `import_logs`, `backups` + `objects.import_session_id`), entities + voters + audit + composer deps (PhpSpreadsheet 5.7, league/csv 9.28). |
+| **IMP-02** | #458 | `FileParserService` (xlsx + csv, encoding/delimiter detection), `MappingDictionaryService` (PL/EN YAML), `AutoMapper` (exact + Levenshtein), `POST /api/import-sessions/auto-map`. |
+| **IMP-03** | #459 | `ImportValidationService` (5 typy błędów per spec §5.4), `POST /api/import-sessions/validate-dry-run`, sync small-import (<50 rows) reuse. |
+| **IMP-04** | #460 | `ImportRunHandler extends AbstractBatchHandler` (chunk=200), `POST /api/import-sessions` async via Symfony Messenger, Mercure progress (`imports.{user_id}` + `imports.{session_id}`). **Image download / ZIP extract odsunięte** do follow-up'u (poza chunked happy path scope). |
+| **IMP-05** | #461 | `ImportRollbackService` (24h window soft delete) + `POST /api/import-sessions/{id}/rollback` + `GET /api/import-sessions/{id}/report.csv`. |
+| **IMP-06** | #462 | `BackupSnapshotHandler` async wraps `pgbackrest` CLI via `Symfony\Process`. `POST /api/backups` + state machine + rate limiter (1/h/tenant). |
+| **IMP-07** | #463 | `ImportProfile` ApiPlatform CRUD + per-user voter + cross-user isolation tests. |
+| **IMP-08** | #464 | Frontend foundation: shadcn primitives (Stepper, Progress, Combobox, DataTable), `FileDropzone`, Refine resources, i18n keyspace. |
+| **IMP-09** | #465 | Imports list view + Publikacje sub-tab + enable "Importuj z Excel/CSV" CTA na empty-state-products. |
+| **IMP-10** | #466 | Wizard Step 1 (Upload) + Step 2 (Mapping) + deep-link "+ Stwórz nowy atrybut" do `/modeling/attributes` z preserved state. |
+| **IMP-11** | #467 | Wizard Step 3 (Validation) + Step 4 (Confirm) + `BackupTriggerCheckbox` z polling. |
+| **IMP-12** | #468 | `useImportProgress` (Mercure SSE) + combined progress/results screen + `RollbackButton` z 24h window check. |
+| **IMP-13** | #469 | Profile manager modal (Sheet) z DataTable + inline edit. |
+| **IMP-14** | #470 | E2E smoke (`apps/admin/e2e/imports.spec.ts`) + `agent/lessons.md` § 2026-05-07 (11 lekcji). **Dogfooding US-IMP-005 odsunięte** — wymaga realnego export'u IdoSell, niedostępne w marathon. |
+| **IMP-15** | #(this) | Plan/PRD update (status flip), `epik-04-publikacje.md` link, `03-funkcjonalnosci-mvp.md` US-IMP-001..014. |
+
+**Świadome odejścia od planu** (do follow-up'u):
+- **Image download** + **ZIP extract** (IMP-04 plan §IMP-04) — handler dispatchuje proces ale realnego download'u nie wykonuje. Wymaga: kolejka `imports.images`, `ImageDownloadHandler`, `ZipExtractHandler`. Wycena follow-up: 6-8h.
+- **Dogfooding US-IMP-005** (IMP-14) — gate przed *„działa na realnych danych"* nadal otwarty.
+- **6 dodatkowych Playwright spec'ów** (z planu IMP-14: 100 rows happy path, 500 rows + ZIP, rollback, async 5000, duplicate SKU) — zachowane jako 1 smoke spec; follow-up: rozbudowa do 6 spec'ów po dogfooding'u (kiedy fixture'y realne).
+- **Performance benchmark 5k rows < 256 MB** (IMP-14) — pomijany w marathonie (brak fixture 5k); follow-up razem z dogfooding'iem.
+
+---
+
+*Plik wersjonowany w `Project Plan/UI/`. Status: zaimplementowane. Następna iteracja: dogfooding katalogu IdoSell (Marcin) + image download/ZIP follow-up + rozbudowa E2E suite.*

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,15 @@
 # Current Status
 
+## 2026-05-07: Epik UI-09 / 0.13 — Imports MVP **DOMKNIĘTY** (IMP-01 do IMP-15 merged)
+
+Marathon zakończony — wszystkie 15 ticketów IMP-01..IMP-15 na `main`. IMP-14 (#455 → `d4ef77e`) i IMP-15 (#456 → ten commit) zamknęły epik. **Świadome odejścia** zostają jako follow-up'y:
+- **Image download / ZIP extract** (IMP-04 plan §IMP-04) — handler dispatchuje proces, ale realnego download'u + ZIP unpack nie wykonuje. Wymaga: kolejka `imports.images`, `ImageDownloadHandler` (concurrent max 10, timeout 30s), `ZipExtractHandler` (case-insensitive filename match → MinIO via `AssetUploader`). Wycena: 6-8h.
+- **Dogfooding US-IMP-005** (IMP-14) — Marcin uploads ~2k SKU IdoSell. Gate przed *„imports gotowe na pierwszy real-world"* nadal otwarty; wymaga realnego export'u IdoSell.
+- **Playwright E2E suite expansion** (IMP-14 plan: 6 spec'ów: 100 rows / 500+ZIP / rollback / async 5000 / duplicate SKU) — w marathonie zostawione jako 1 smoke spec; rozbudowa razem z dogfooding'iem (gdy fixture'y realne).
+- **Performance benchmark 5k rows < 256 MB** (IMP-14) — pomijane bez 5k fixture; follow-up razem z dogfooding'iem.
+
+Followup-y → kandydaci do **maintenance ticket co 2 epiki** (per `CLAUDE.md` "Zarządzanie zależnościami") — patrz §3.7 plan-projektu.
+
 ## 2026-05-07: Epik UI-09 / 0.13 — Imports MVP (IMP-01 do IMP-13 merged)
 
 Operator: „zacznij prace, po kolei w tym epiku, wykonaj wszystko" — EPIK MARATHON RULE aktywny. Każdy ticket = własny branch + PR + CI + merge. 13 z 15 ticketów done na main:


### PR DESCRIPTION
## Summary

- Status flip w `feature-imports.md` (🟢 szczegół → 🟢 zaimplementowane) + nowa §13 *Delivery snapshot* z tabelą 15 ticketów IMP-01..IMP-15 + listą świadomych odejść (image download/ZIP, dogfooding US-IMP-005, E2E suite expansion, perf benchmark 5k).
- `epik-04-publikacje.md` placeholder → częściowy szczegół z linkiem do `feature-imports.md` + nowa sub-sekcja §3.0 Imports (zaimplementowane).
- `03-funkcjonalnosci-mvp.md` — nowa sekcja §5.2a z tabelą **US-IMP-001..014** (mapowanie user stories → tickety IMP-01..IMP-15) + update §6 mapping table.
- `02-plan-projektu-pim.md` §3.7 — *Status epiku — 2026-05-07: ZAMKNIĘTY* z listą follow-up'ów + maintenance ticket entry per `CLAUDE.md` "Zarządzanie zależnościami".
- `agent/current_status.md` — wpis *Epik UI-09 / 0.13 — Imports MVP DOMKNIĘTY* z follow-up'ami.

## Świadome odejścia (zachowane jako follow-up)

- **Image download / ZIP extract** (IMP-04) — handler dispatchowany, ale realnego download'u nie wykonuje. ~6-8h.
- **Dogfooding US-IMP-005** (IMP-14) — wymaga realnego export'u IdoSell, niedostępne w marathon.
- **6 dodatkowych Playwright spec'ów** (IMP-14) — zachowane jako 1 smoke; rozbudowa razem z dogfooding'iem.
- **Performance benchmark 5k rows < 256 MB** (IMP-14) — pomijane bez 5k fixture.

## Test plan

- [ ] CI green: brak zmian w kodzie, więc tylko Biome / TypeScript / build / audit jeśli się odpalą (paths-filter pomija docs).
- [ ] Manual: każdy z linków relatywnych w `epik-04-publikacje.md` → `feature-imports.md` rezolwuje.
- [ ] Po merge: `gh issue close 456` jeśli auto-close przez "Closes #456" nie zadziała (PR body).

Closes #456