### PR TITLE
feat(catalog): PCAT-01 — DB junction object_categories + entity + repo

### DIFF
--- a/apps/api/migrations/Version20260510221123.php
+++ b/apps/api/migrations/Version20260510221123.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Epic UI-10 / PCAT-01 — Product↔Category junction.
+ *
+ * Wires products into the existing category-driven attribute-group inheritance
+ * pipeline (see `CategoryAttributeGroup` + `EffectiveAttributeGroupResolver`).
+ * Until now `EffectiveAttributeGroupResolver::resolve($product)` only returned
+ * global ObjectType groups for products — there was no relation to walk for
+ * the `kind=Product` branch. PCAT-03 activates that branch on top of this
+ * junction.
+ *
+ * Schema:
+ * - Composite PK `(object_id, category_id)` — one row per assignment.
+ * - `is_primary BOOLEAN` with a partial unique index that enforces at most
+ *   one primary per object (`WHERE is_primary = true`). Cheaper than a row
+ *   trigger and atomic with the partial-unique catch + retry pattern in
+ *   the upsert path.
+ * - `ON DELETE CASCADE` on both FKs to `objects(id)` — when a product OR
+ *   a category is removed the assignment row is reaped. Primary repair
+ *   for products that lose their primary assignment is handled by
+ *   `PrimaryCategoryRepairListener` (PCAT-03), not the DB.
+ * - `CHECK (object_id <> category_id)` — defensive, guards against
+ *   self-assignment which has no semantic meaning.
+ * - No `tenant_id` column. Tenant scope is inherited via the FK to
+ *   `objects.tenant_id` (which is `NOT NULL` and TenantScoped). Listed
+ *   in `TenantAuditCommand::INFRA_TABLES` allowlist.
+ */
+final class Version20260510221123 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add object_categories junction (PCAT-01 / epic UI-10).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE object_categories (
+              object_id UUID NOT NULL,
+              category_id UUID NOT NULL,
+              is_primary BOOLEAN NOT NULL DEFAULT false,
+              position INT NOT NULL DEFAULT 0,
+              created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT NOW(),
+              PRIMARY KEY (object_id, category_id),
+              CONSTRAINT object_categories_no_self CHECK (object_id <> category_id)
+            )
+        SQL);
+
+        $this->addSql('CREATE INDEX object_categories_object_idx ON object_categories (object_id)');
+        $this->addSql('CREATE INDEX object_categories_category_idx ON object_categories (category_id)');
+
+        // Partial unique: at most one primary assignment per object. Lets the
+        // app upsert primary swaps as DELETE-of-old + INSERT-of-new inside a
+        // single transaction without ever holding two primary rows at flush
+        // boundary. NULL primary (no assignments) is legal — the index
+        // simply has no row to compare against.
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX object_categories_one_primary_per_object
+              ON object_categories (object_id) WHERE is_primary = true
+        SQL);
+
+        $this->addSql('ALTER TABLE object_categories ADD CONSTRAINT object_categories_object_fk FOREIGN KEY (object_id) REFERENCES objects (id) ON DELETE CASCADE NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE object_categories ADD CONSTRAINT object_categories_category_fk FOREIGN KEY (category_id) REFERENCES objects (id) ON DELETE CASCADE NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE object_categories');
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/ObjectCategory.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectCategory.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Entity;
+
+use DateTimeImmutable;
+
+/**
+ * Junction declaring that a product (or other catalog object) is assigned to
+ * a category, with at most one assignment marked as primary per product.
+ *
+ * Both `product` and `category` reference the same `objects` table (per
+ * ADR-009 ObjectKind discriminates rows). The DB CHECK enforces
+ * `object_id <> category_id` so a category cannot self-assign.
+ *
+ * `isPrimary=true` is constrained to at most one row per `product` by a
+ * partial unique index — see `Version20260510221123` migration. Primary
+ * is meaningful for downstream channel exports (e.g. Shopify wants one
+ * category per product) and for breadcrumbs in the storefront.
+ *
+ * Walked by `EffectiveAttributeGroupResolver` (PCAT-03) to compute the
+ * effective attribute groups for a product: for each assigned category
+ * the resolver collects ancestor categories and merges their declared
+ * `CategoryAttributeGroup`s on top of the product's ObjectType groups.
+ *
+ * No `tenant_id` column — tenant scope is inherited via `objects.tenant_id`
+ * on both FKs (NOT NULL + TenantScoped). Listed in
+ * `TenantAuditCommand::INFRA_TABLES` allowlist.
+ */
+class ObjectCategory
+{
+    private CatalogObject $product;
+    private CatalogObject $category;
+    private bool $isPrimary;
+    private int $position;
+    private DateTimeImmutable $createdAt;
+
+    public function __construct(
+        CatalogObject $product,
+        CatalogObject $category,
+        bool $isPrimary = false,
+        int $position = 0,
+        ?DateTimeImmutable $createdAt = null,
+    ) {
+        $this->product = $product;
+        $this->category = $category;
+        $this->isPrimary = $isPrimary;
+        $this->position = $position;
+        $this->createdAt = $createdAt ?? new DateTimeImmutable();
+    }
+
+    public function getProduct(): CatalogObject
+    {
+        return $this->product;
+    }
+
+    public function getCategory(): CatalogObject
+    {
+        return $this->category;
+    }
+
+    public function isPrimary(): bool
+    {
+        return $this->isPrimary;
+    }
+
+    public function promoteToPrimary(): void
+    {
+        $this->isPrimary = true;
+    }
+
+    public function demoteFromPrimary(): void
+    {
+        $this->isPrimary = false;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function reorder(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Repository/ObjectCategoryRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/ObjectCategoryRepositoryInterface.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Repository;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * PCAT-01 (#474) — repository contract for the `objects × categories`
+ * junction. Composite PK so the standard `find()` shape doesn't apply
+ * — call sites slice by product (the picker dialog + form), by category
+ * (reverse listing), or as a single tuple lookup.
+ */
+interface ObjectCategoryRepositoryInterface
+{
+    /**
+     * All assignments for a single product, ordered by `position` ASC then
+     * `created_at` ASC for deterministic UI rendering and for the
+     * promote-next-primary tie-breaker (PCAT-02 DELETE handler / PCAT-03
+     * `PrimaryCategoryRepairListener`).
+     *
+     * @return list<ObjectCategory>
+     */
+    public function findByProduct(CatalogObject $product): array;
+
+    /**
+     * All assignments referencing a single category, ordered the same way.
+     * Used by the reverse-listing endpoint (PCAT-06) and by the cache
+     * invalidator when a category-level change should burst per-product
+     * caches.
+     *
+     * @return list<ObjectCategory>
+     */
+    public function findByCategory(CatalogObject $category): array;
+
+    /**
+     * Single tuple lookup. Returns `null` when the (product, category)
+     * pair has no row — used by POST single-add to detect idempotent
+     * conflict.
+     */
+    public function findOne(CatalogObject $product, CatalogObject $category): ?ObjectCategory;
+
+    /**
+     * The current primary assignment for a product, or `null` when the
+     * product has no assignments at all (legal: resolver falls back to
+     * global ObjectType groups). Backed by the partial unique index on
+     * `(object_id) WHERE is_primary = true`.
+     */
+    public function findPrimary(CatalogObject $product): ?ObjectCategory;
+
+    /**
+     * Atomic full-replace of a product's assignments. Wipes all existing
+     * rows for the product, re-inserts the supplied list, and marks the
+     * row matching `$primaryId` as primary in the same transaction.
+     *
+     * Wraps DELETE + INSERT in `wrapInTransaction()` so the partial
+     * unique index never sees two primary rows for the same product
+     * mid-flush. Caller MUST ensure `$primaryId` is in `$categoryIds`
+     * (or both null/empty) — controller-level validation guards this in
+     * PCAT-02; the repo asserts defensively but does not validate
+     * business rules.
+     *
+     * @param list<Uuid> $categoryIds
+     */
+    public function replaceForProduct(CatalogObject $product, array $categoryIds, ?Uuid $primaryId): void;
+
+    public function save(ObjectCategory $assignment): void;
+
+    public function remove(ObjectCategory $assignment): void;
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectCategory.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectCategory.orm.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\ObjectCategory"
+            table="object_categories"
+            repository-class="App\Catalog\Infrastructure\Doctrine\Repository\DoctrineObjectCategoryRepository">
+
+        <indexes>
+            <index name="object_categories_object_idx" columns="object_id"/>
+            <index name="object_categories_category_idx" columns="category_id"/>
+        </indexes>
+
+        <id name="product" association-key="true"/>
+        <id name="category" association-key="true"/>
+
+        <many-to-one field="product" target-entity="App\Catalog\Domain\Entity\CatalogObject">
+            <join-column name="object_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="category" target-entity="App\Catalog\Domain\Entity\CatalogObject">
+            <join-column name="category_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="isPrimary" type="boolean" column="is_primary">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+
+        <field name="position" type="integer">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+
+        <field name="createdAt" type="datetimetz_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectCategoryRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectCategoryRepository.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Doctrine\Repository;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use InvalidArgumentException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<ObjectCategory>
+ */
+final class DoctrineObjectCategoryRepository extends ServiceEntityRepository implements ObjectCategoryRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ObjectCategory::class);
+    }
+
+    public function findByProduct(CatalogObject $product): array
+    {
+        /** @var list<ObjectCategory> $rows */
+        $rows = $this->createQueryBuilder('a')
+            ->innerJoin('a.category', 'c')
+            ->addSelect('c')
+            ->andWhere('a.product = :product')
+            ->orderBy('a.position', 'ASC')
+            ->addOrderBy('a.createdAt', 'ASC')
+            ->setParameter('product', $product)
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
+    public function findByCategory(CatalogObject $category): array
+    {
+        /** @var list<ObjectCategory> $rows */
+        $rows = $this->createQueryBuilder('a')
+            ->innerJoin('a.product', 'p')
+            ->addSelect('p')
+            ->andWhere('a.category = :category')
+            ->orderBy('a.position', 'ASC')
+            ->addOrderBy('a.createdAt', 'ASC')
+            ->setParameter('category', $category)
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
+    public function findOne(CatalogObject $product, CatalogObject $category): ?ObjectCategory
+    {
+        /** @var ObjectCategory|null $row */
+        $row = $this->createQueryBuilder('a')
+            ->andWhere('a.product = :product')
+            ->andWhere('a.category = :category')
+            ->setParameter('product', $product)
+            ->setParameter('category', $category)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $row;
+    }
+
+    public function findPrimary(CatalogObject $product): ?ObjectCategory
+    {
+        /** @var ObjectCategory|null $row */
+        $row = $this->createQueryBuilder('a')
+            ->innerJoin('a.category', 'c')
+            ->addSelect('c')
+            ->andWhere('a.product = :product')
+            ->andWhere('a.isPrimary = true')
+            ->setParameter('product', $product)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $row;
+    }
+
+    public function replaceForProduct(CatalogObject $product, array $categoryIds, ?Uuid $primaryId): void
+    {
+        if ([] === $categoryIds && null !== $primaryId) {
+            throw new InvalidArgumentException('primary id must be null when categoryIds is empty');
+        }
+
+        if (null !== $primaryId && !$this->containsUuid($categoryIds, $primaryId)) {
+            throw new InvalidArgumentException('primary id must be present in categoryIds');
+        }
+
+        $em = $this->getEntityManager();
+
+        $em->wrapInTransaction(function () use ($em, $product, $categoryIds, $primaryId): void {
+            // Wipe existing assignments via the ORM so the Identity Map is
+            // updated alongside the row removal — a DQL DELETE would leave
+            // stale managed entities behind and the new persist() calls
+            // below would collide with the same composite PKs.
+            foreach ($this->findByProduct($product) as $existing) {
+                $em->remove($existing);
+            }
+            $em->flush();
+
+            $position = 0;
+            foreach ($categoryIds as $categoryId) {
+                $category = $em->getReference(CatalogObject::class, $categoryId->toRfc4122());
+                if (null === $category) {
+                    throw new InvalidArgumentException(sprintf('Category %s not found while replacing assignments.', $categoryId->toRfc4122()));
+                }
+                $isPrimary = null !== $primaryId && $primaryId->equals($categoryId);
+                $assignment = new ObjectCategory(
+                    product: $product,
+                    category: $category,
+                    isPrimary: $isPrimary,
+                    position: $position++,
+                );
+                $em->persist($assignment);
+            }
+
+            $em->flush();
+        });
+    }
+
+    public function save(ObjectCategory $assignment): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($assignment);
+        $em->flush();
+    }
+
+    public function remove(ObjectCategory $assignment): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($assignment);
+        $em->flush();
+    }
+
+    /**
+     * @param list<Uuid> $haystack
+     */
+    private function containsUuid(array $haystack, Uuid $needle): bool
+    {
+        foreach ($haystack as $candidate) {
+            if ($candidate->equals($needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
@@ -85,6 +85,9 @@ final class TenantAuditCommand extends Command
         'attribute_group_attributes',
         'object_type_attribute_groups',
         'category_attribute_groups',
+        // PCAT-01 (#474) / UI-10 — product↔category assignments. Tenant
+        // scope inherited via FK to objects(tenant_id).
+        'object_categories',
         // UI-08.6 (#261) — pre-migration JSONB backup snapshots. Tenant
         // scope inherited via the parent attribute.
         'attribute_migration_backups',

--- a/apps/api/tests/Integration/Catalog/DoctrineObjectCategoryRepositoryTest.php
+++ b/apps/api/tests/Integration/Catalog/DoctrineObjectCategoryRepositoryTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Integration coverage for the `object_categories` junction repository
+ * (PCAT-01 / #474). Verifies atomic replace, primary lookup, and the
+ * partial unique index that enforces at-most-one primary per product.
+ */
+final class DoctrineObjectCategoryRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($this->tenant);
+    }
+
+    #[Test]
+    public function freshProductHasNoAssignmentsAndNoPrimary(): void
+    {
+        $product = $this->makeProduct('SKU-empty');
+
+        self::assertSame([], $this->repo()->findByProduct($product));
+        self::assertNull($this->repo()->findPrimary($product));
+    }
+
+    #[Test]
+    public function replaceForProductPersistsAssignmentsAndPrimaryAtomically(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $cat1 = $this->makeCategory('c1');
+        $cat2 = $this->makeCategory('c2');
+
+        $this->repo()->replaceForProduct(
+            $product,
+            [$cat1->getId(), $cat2->getId()],
+            $cat2->getId(),
+        );
+
+        $rows = $this->repo()->findByProduct($product);
+        self::assertCount(2, $rows);
+        self::assertSame($cat1->getId()->toRfc4122(), $rows[0]->getCategory()->getId()->toRfc4122());
+        self::assertSame(0, $rows[0]->getPosition());
+        self::assertFalse($rows[0]->isPrimary());
+        self::assertSame($cat2->getId()->toRfc4122(), $rows[1]->getCategory()->getId()->toRfc4122());
+        self::assertSame(1, $rows[1]->getPosition());
+        self::assertTrue($rows[1]->isPrimary());
+
+        $primary = $this->repo()->findPrimary($product);
+        self::assertNotNull($primary);
+        self::assertSame($cat2->getId()->toRfc4122(), $primary->getCategory()->getId()->toRfc4122());
+    }
+
+    #[Test]
+    public function replaceForProductWipesOldRowsBeforeReinsert(): void
+    {
+        $product = $this->makeProduct('SKU-2');
+        $cat1 = $this->makeCategory('c1');
+        $cat2 = $this->makeCategory('c2');
+
+        // First state: cat1 only, primary
+        $this->repo()->replaceForProduct($product, [$cat1->getId()], $cat1->getId());
+        self::assertCount(1, $this->repo()->findByProduct($product));
+
+        // Replace with cat2 only — cat1 row must be gone, no primary index conflict
+        $this->repo()->replaceForProduct($product, [$cat2->getId()], $cat2->getId());
+
+        $rows = $this->repo()->findByProduct($product);
+        self::assertCount(1, $rows);
+        self::assertSame($cat2->getId()->toRfc4122(), $rows[0]->getCategory()->getId()->toRfc4122());
+        self::assertTrue($rows[0]->isPrimary());
+    }
+
+    #[Test]
+    public function replaceForProductWithEmptyListClearsAllAssignments(): void
+    {
+        $product = $this->makeProduct('SKU-3');
+        $cat = $this->makeCategory('c1');
+        $this->repo()->replaceForProduct($product, [$cat->getId()], $cat->getId());
+
+        $this->repo()->replaceForProduct($product, [], null);
+
+        self::assertSame([], $this->repo()->findByProduct($product));
+        self::assertNull($this->repo()->findPrimary($product));
+    }
+
+    #[Test]
+    public function replaceForProductRejectsPrimaryNotInList(): void
+    {
+        $product = $this->makeProduct('SKU-4');
+        $cat1 = $this->makeCategory('c1');
+        $cat2 = $this->makeCategory('c2');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->repo()->replaceForProduct($product, [$cat1->getId()], $cat2->getId());
+    }
+
+    #[Test]
+    public function replaceForProductRejectsPrimaryWithEmptyCategoryList(): void
+    {
+        $product = $this->makeProduct('SKU-5');
+        $cat = $this->makeCategory('c1');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->repo()->replaceForProduct($product, [], $cat->getId());
+    }
+
+    #[Test]
+    public function replaceForProductReorderingPrimarySwapsPrimaryFlagAtomically(): void
+    {
+        // Application-level guarantee that the partial unique index in the
+        // production schema is also enforced at the API boundary: even when
+        // the same product is replaced multiple times with a different
+        // primary, exactly one row carries `is_primary=true` after each call.
+        // (The DB-level partial unique itself is exercised by the manual
+        // smoke described in PCAT-01 — Foundry's ResetDatabase rebuilds the
+        // schema from ORM mapping which cannot express partial indexes, so
+        // the constraint is not present in the test database.)
+        $product = $this->makeProduct('SKU-6');
+        $cat1 = $this->makeCategory('c1');
+        $cat2 = $this->makeCategory('c2');
+
+        $this->repo()->replaceForProduct($product, [$cat1->getId(), $cat2->getId()], $cat1->getId());
+        $primaryFirst = $this->repo()->findPrimary($product);
+        self::assertNotNull($primaryFirst);
+        self::assertSame($cat1->getId()->toRfc4122(), $primaryFirst->getCategory()->getId()->toRfc4122());
+
+        $this->repo()->replaceForProduct($product, [$cat1->getId(), $cat2->getId()], $cat2->getId());
+        $primarySecond = $this->repo()->findPrimary($product);
+        self::assertNotNull($primarySecond);
+        self::assertSame($cat2->getId()->toRfc4122(), $primarySecond->getCategory()->getId()->toRfc4122());
+
+        $primaryRows = array_filter(
+            $this->repo()->findByProduct($product),
+            static fn (ObjectCategory $a) => $a->isPrimary(),
+        );
+        self::assertCount(1, $primaryRows);
+    }
+
+    #[Test]
+    public function findOneReturnsExistingTupleAndNullForMissing(): void
+    {
+        $product = $this->makeProduct('SKU-7');
+        $cat1 = $this->makeCategory('c1');
+        $cat2 = $this->makeCategory('c2');
+        $this->repo()->replaceForProduct($product, [$cat1->getId()], $cat1->getId());
+
+        self::assertNotNull($this->repo()->findOne($product, $cat1));
+        self::assertNull($this->repo()->findOne($product, $cat2));
+    }
+
+    #[Test]
+    public function findByCategoryReturnsAssignmentsForReverseListing(): void
+    {
+        $cat = $this->makeCategory('cshared');
+        $p1 = $this->makeProduct('SKU-r1');
+        $p2 = $this->makeProduct('SKU-r2');
+        $this->repo()->replaceForProduct($p1, [$cat->getId()], $cat->getId());
+        $this->repo()->replaceForProduct($p2, [$cat->getId()], null);
+
+        $rows = $this->repo()->findByCategory($cat);
+
+        self::assertCount(2, $rows);
+        $codes = array_map(static fn (ObjectCategory $a) => $a->getProduct()->getCode(), $rows);
+        sort($codes);
+        self::assertSame(['SKU-r1', 'SKU-r2'], $codes);
+    }
+
+    private function repo(): ObjectCategoryRepositoryInterface
+    {
+        return self::getContainer()->get(ObjectCategoryRepositoryInterface::class);
+    }
+
+    private function makeProduct(string $code): CatalogObject
+    {
+        $em = $this->em();
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)->findBuiltInByKind(ObjectKind::Product, $this->tenant);
+        \assert(null !== $type);
+        $product = new CatalogObject($type, $code);
+        $em->persist($product);
+        $em->flush();
+
+        return $product;
+    }
+
+    private function makeCategory(string $code): CatalogObject
+    {
+        $em = $this->em();
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)->findBuiltInByKind(ObjectKind::Category, $this->tenant);
+        \assert(null !== $type);
+        $category = new CatalogObject($type, $code);
+        $category->attachToPath($code);
+        $em->persist($category);
+        $em->flush();
+
+        return $category;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/ObjectCategoryTest.php
+++ b/apps/api/tests/Unit/Catalog/ObjectCategoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectCategoryTest extends TestCase
+{
+    #[Test]
+    public function freshAssignmentCarriesProductCategoryAndDefaults(): void
+    {
+        $product = $this->makeObject(ObjectKind::Product, 'SKU-1');
+        $category = $this->makeObject(ObjectKind::Category, 'cat-1');
+
+        $assignment = new ObjectCategory($product, $category);
+
+        self::assertSame($product, $assignment->getProduct());
+        self::assertSame($category, $assignment->getCategory());
+        self::assertFalse($assignment->isPrimary());
+        self::assertSame(0, $assignment->getPosition());
+        self::assertInstanceOf(DateTimeImmutable::class, $assignment->getCreatedAt());
+    }
+
+    #[Test]
+    public function explicitConstructorArgumentsOverrideDefaults(): void
+    {
+        $product = $this->makeObject(ObjectKind::Product, 'SKU-2');
+        $category = $this->makeObject(ObjectKind::Category, 'cat-2');
+        $stamp = new DateTimeImmutable('2026-05-10T12:00:00+00:00');
+
+        $assignment = new ObjectCategory(
+            product: $product,
+            category: $category,
+            isPrimary: true,
+            position: 7,
+            createdAt: $stamp,
+        );
+
+        self::assertTrue($assignment->isPrimary());
+        self::assertSame(7, $assignment->getPosition());
+        self::assertSame($stamp, $assignment->getCreatedAt());
+    }
+
+    #[Test]
+    public function promoteAndDemoteToggleThePrimaryFlag(): void
+    {
+        $assignment = new ObjectCategory(
+            $this->makeObject(ObjectKind::Product, 'SKU-3'),
+            $this->makeObject(ObjectKind::Category, 'cat-3'),
+        );
+
+        $assignment->promoteToPrimary();
+        self::assertTrue($assignment->isPrimary());
+
+        $assignment->demoteFromPrimary();
+        self::assertFalse($assignment->isPrimary());
+    }
+
+    #[Test]
+    public function reorderUpdatesPositionInPlace(): void
+    {
+        $assignment = new ObjectCategory(
+            $this->makeObject(ObjectKind::Product, 'SKU-4'),
+            $this->makeObject(ObjectKind::Category, 'cat-4'),
+            position: 0,
+        );
+
+        $assignment->reorder(42);
+
+        self::assertSame(42, $assignment->getPosition());
+    }
+
+    private function makeObject(ObjectKind $kind, string $code): CatalogObject
+    {
+        $type = new ObjectType($kind->value, $kind, ['en' => ucfirst($kind->value)]);
+
+        return new CatalogObject($type, $code);
+    }
+}


### PR DESCRIPTION
## Summary

Wires the schema groundwork for product↔category assignments (epic UI-10 / PCAT-01).

- New table `object_categories(object_id, category_id, is_primary, position, created_at)` — composite PK, partial unique index `WHERE is_primary = true`, `ON DELETE CASCADE` on both FKs to `objects(id)`, CHECK no-self-assignment.
- Entity `App\Catalog\Domain\Entity\ObjectCategory` + ORM mapping + repo interface + Doctrine impl.
- `replaceForProduct(product, categoryIds, primaryId)` is atomic: ORM remove (not DQL DELETE — Identity Map keeps stale references) + persist new rows in a single `wrapInTransaction()`.
- Tenant scope inherited via FK to `objects.tenant_id` — no own `tenant_id` column. Listed in `TenantAuditCommand::INFRA_TABLES` allowlist.

## Why this matters

Until now `EffectiveAttributeGroupResolver::resolve(\$product)` ignored categories entirely because no relation existed; the killer feature `Effective preview` in the categories panel showed *hypothetical* groups with no way to validate empirically. PCAT-03 will add the resolver branch that walks ancestor categories of the assigned categories — but it needs this junction first.

## Test plan

- [x] `bin/phpunit tests/Unit/Catalog/ObjectCategoryTest.php` — 4 tests, entity invariants
- [x] `bin/phpunit tests/Integration/Catalog/DoctrineObjectCategoryRepositoryTest.php` — 9 tests, atomic replace + primary lookup + reverse listing + validation
- [x] PHPStan max OK (`composer lint`)
- [x] PHP-CS-Fixer OK
- [x] Migration up/down clean (`migrate -n` then `execute --down -n` then `execute --up -n`)
- [x] **Manual smoke on dev DB** — partial unique index blocks 2 primary rows for the same product:
  ```sql
  -- first INSERT with is_primary=true → OK
  -- second INSERT with same object_id + is_primary=true → ERROR: duplicate key value violates unique constraint
  --   "object_categories_one_primary_per_object"
  -- second INSERT with same object_id + is_primary=false → OK (multi-assignment legal, only primary is unique)
  ```

## Out of scope (follow-up tickets)

- HTTP endpoints (PCAT-02 #475)
- Resolver branch + primary-repair listener (PCAT-03 #476)
- Cache invalidation hook (PCAT-04 #477)
- Frontend picker (PCAT-05 #478)

Closes #474