### PR TITLE
chore(deps): force fast-uri >= 3.1.2 to clear pnpm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "turbo": "^2.3.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "fast-uri": ">=3.1.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: '>=3.1.2'
+
 importers:
 
   .:
@@ -1482,8 +1485,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3525,7 +3528,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3711,7 +3714,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Adds `pnpm.overrides` to force every transitive consumer of `fast-uri` onto the patched line (≥ 3.1.2). Closes a long-standing red ❌ on every PR's `pnpm audit` job.

## Why this CI was red

Two HIGH severity advisories in `fast-uri ≤ 3.1.1`:

1. [GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6) — path traversal via percent-encoded dot segments
2. [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — host confusion via percent-encoded authority delimiters

Dep chain (transitive):
```
pim → @commitlint/cli → @commitlint/load → @commitlint/config-validator → ajv → fast-uri
```

`@commitlint` hasn't bumped its ajv pin yet, so direct dep upgrades don't propagate. `pnpm.overrides` is the canonical workaround — patches every transitive resolution path.

## Test plan

- [x] `pnpm install` regenerates lockfile cleanly
- [x] `pnpm audit --audit-level=high` returns "No known vulnerabilities found"
- [x] Husky / lint-staged still works (verified by passing pre-commit hook on this PR)
- [x] No runtime impact — `fast-uri` is dev-only (commitlint validation), never bundled into admin/api

## Why no specific issue

Per `CLAUDE.md` "Maintenance ticket co 2 epiki (1-2h) — composer outdated, pnpm outdated, patch-only updates" rule. Bundled into this PR rather than waiting for the formal maintenance ticket because every open PR is currently showing a red ❌ next to `pnpm audit` and operator wants clean CI before continuing the PCAT epic.