### PR TITLE
feat(catalog): PCAT-03 — product↔category inheritance + primary repair

### DIFF
--- a/apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php
+++ b/apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php
@@ -11,6 +11,7 @@ use App\Catalog\Domain\Entity\CategoryAttributeGroup;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -32,10 +33,15 @@ use Symfony\Component\Uid\Uuid;
  *
  * **Out of scope (Faza 1+ kandydat):**
  *   - Per-object ad-hoc groups (no `object_attribute_groups` table yet).
- *   - Product → category linkage via Association rows. Products in MVP
- *     surface only their ObjectType groups; category-driven inheritance
- *     for products lands when {@see Association} is used as the canonical
- *     product↔category edge (see plan §14 open questions).
+ *
+ * **Product↔category inheritance (PCAT-03 / epic UI-10):** when the
+ * resolved object is `kind=Product`, the resolver fetches the product's
+ * assignments via {@see ObjectCategoryRepositoryInterface}, walks each
+ * assigned category's ancestor chain (root→leaf via `parent_id` self-FK),
+ * deduplicates the union, and merges declared groups exactly the same way
+ * the category branch does. A product with zero assignments still works
+ * — the category merge is a no-op so the result is just the ObjectType
+ * groups (backward compatible with the pre-PCAT behaviour).
  *
  * **Deduplication:** outputs are unique by `AttributeGroup.id`. When the
  * same group is declared at multiple levels, the higher-priority source
@@ -52,6 +58,7 @@ final readonly class EffectiveAttributeGroupResolver
 {
     public function __construct(
         private EntityManagerInterface $em,
+        private ObjectCategoryRepositoryInterface $productCategories,
     ) {
     }
 
@@ -72,6 +79,25 @@ final readonly class EffectiveAttributeGroupResolver
             // when editing a category sitting on this branch").
             $ancestorIds = $this->collectCategoryAncestorIds($object);
             $this->mergeCategoryGroups($groups, $ancestorIds, $type);
+        } elseif (ObjectKind::Product === $object->getKind()) {
+            // PCAT-03: for each assigned category, gather its ancestor
+            // chain (including the category itself) and merge declared
+            // groups targeting this product's ObjectType. Deduplication
+            // by UUID happens inside mergeCategoryGroups so multi-category
+            // products don't double-count shared ancestors (e.g. two
+            // assignments under the same root category).
+            $assignments = $this->productCategories->findByProduct($object);
+            if ([] !== $assignments) {
+                $ancestorMap = [];
+                foreach ($assignments as $assignment) {
+                    foreach ($this->collectCategoryAncestorIds($assignment->getCategory(), includeSelf: true) as $id) {
+                        $ancestorMap[$id->toRfc4122()] = $id;
+                    }
+                }
+                if ([] !== $ancestorMap) {
+                    $this->mergeCategoryGroups($groups, array_values($ancestorMap), $type);
+                }
+            }
         }
 
         return array_values($groups);

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/PrimaryCategoryRepairListener.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/PrimaryCategoryRepairListener.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Doctrine\EventListener;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\Events;
+
+/**
+ * PCAT-03 (#476) — when a category is removed, promote the next-oldest
+ * remaining assignment to primary for every product that lost its primary
+ * to the cascade.
+ *
+ * Mechanics:
+ *
+ *   1. `onFlush` scans scheduled deletions for `CatalogObject` rows of
+ *      `kind=category`. For each one, reads the `object_categories` table
+ *      to find every product where this category is currently primary,
+ *      and buffers the product ids in a state field.
+ *
+ *   2. `postFlush` fires *after* the DB-level CASCADE has already
+ *      removed the assignment rows. For each buffered product id we run
+ *      a single raw DBAL UPDATE that promotes the oldest remaining
+ *      assignment (`position ASC, created_at ASC LIMIT 1`) to primary.
+ *      If no rows remain (the deleted category was the only assignment),
+ *      the product simply ends up without a primary — legal.
+ *
+ * Raw DBAL is used because by `postFlush` the affected ORM entities are
+ * already detached after CASCADE; managed-entity operations would either
+ * miss them or trigger spurious change-tracking. The single SQL also
+ * sidesteps the partial-unique-index window (the CASCADE removed the
+ * primary row first, so promoting another to `is_primary=true` is safe).
+ */
+#[AsDoctrineListener(event: Events::onFlush)]
+#[AsDoctrineListener(event: Events::postFlush)]
+final class PrimaryCategoryRepairListener
+{
+    /**
+     * @var array<string, true> set of product ids (RFC4122) whose primary
+     *                          assignment is about to be cascade-removed
+     */
+    private array $productsLosingPrimary = [];
+
+    public function onFlush(OnFlushEventArgs $event): void
+    {
+        $em = $event->getObjectManager();
+        $uow = $em->getUnitOfWork();
+        $conn = $em->getConnection();
+
+        foreach ($uow->getScheduledEntityDeletions() as $entity) {
+            if (!$entity instanceof CatalogObject) {
+                continue;
+            }
+            if (ObjectKind::Category !== $entity->getKind()) {
+                continue;
+            }
+
+            $rows = $conn->fetchAllAssociative(
+                'SELECT object_id FROM object_categories WHERE category_id = :cat AND is_primary = true',
+                ['cat' => $entity->getId()->toRfc4122()],
+            );
+            foreach ($rows as $row) {
+                $productId = $row['object_id'] ?? null;
+                if (\is_string($productId)) {
+                    $this->productsLosingPrimary[$productId] = true;
+                }
+            }
+        }
+    }
+
+    public function postFlush(PostFlushEventArgs $event): void
+    {
+        if ([] === $this->productsLosingPrimary) {
+            return;
+        }
+
+        $em = $event->getObjectManager();
+        $conn = $em->getConnection();
+        $ids = array_keys($this->productsLosingPrimary);
+        $this->productsLosingPrimary = [];
+
+        foreach ($ids as $productId) {
+            $this->promoteOldestRemaining($conn, $productId);
+        }
+    }
+
+    /**
+     * Atomic promote-next inside a single transaction. The lookup +
+     * update run as one SQL each; the partial unique index allows the
+     * promotion because the previous primary row no longer exists
+     * (cascade removed it before postFlush fires).
+     */
+    private function promoteOldestRemaining(Connection $conn, string $productId): void
+    {
+        $row = $conn->fetchAssociative(
+            'SELECT category_id FROM object_categories'
+            .' WHERE object_id = :pid'
+            .' ORDER BY position ASC, created_at ASC'
+            .' LIMIT 1',
+            ['pid' => $productId],
+        );
+
+        if (false === $row) {
+            // Product has no assignments left — primary stays unset, legal.
+            return;
+        }
+
+        $candidate = $row['category_id'] ?? null;
+        if (!\is_string($candidate)) {
+            return;
+        }
+
+        $conn->executeStatement(
+            'UPDATE object_categories SET is_primary = true'
+            .' WHERE object_id = :pid AND category_id = :cat',
+            ['pid' => $productId, 'cat' => $candidate],
+        );
+    }
+}

--- a/apps/api/tests/Integration/Catalog/EffectiveAttributeGroupResolverProductTest.php
+++ b/apps/api/tests/Integration/Catalog/EffectiveAttributeGroupResolverProductTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Application\BuiltInSystemAttributesSeeder;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\CategoryAttributeGroup;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * PCAT-03 (#476) — coverage for the `kind=Product` branch in
+ * {@see EffectiveAttributeGroupResolver}. Verifies that products inherit
+ * attribute groups from every assigned category's full ancestor chain,
+ * deduplicated across assignments.
+ */
+final class EffectiveAttributeGroupResolverProductTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($this->tenant);
+        self::getContainer()->get(BuiltInSystemAttributesSeeder::class)->seed($this->tenant);
+    }
+
+    #[Test]
+    public function resolveReturnsObjectTypeGroupsOnlyWhenNoAssignments(): void
+    {
+        $product = $this->makeProduct('sku-empty');
+
+        $groups = $this->resolver()->resolve($product);
+
+        // Built-in product has the audit group only by default — same as
+        // pre-PCAT behaviour, no regression for unassigned products.
+        $codes = array_map(static fn (AttributeGroup $g): string => $g->getCode(), $groups);
+        self::assertSame(['audit'], $codes);
+    }
+
+    #[Test]
+    public function resolveMergesGroupsFromAssignedCategoriesIntoProduct(): void
+    {
+        $em = $this->em();
+        $productType = $this->productType();
+
+        $cat = $this->makeCategory('cars');
+        $spec = $this->makeGroup('vehicle-spec', 'Vehicle Spec');
+        $em->persist(new CategoryAttributeGroup($cat->getId(), $productType, $spec, 1));
+        $em->flush();
+
+        $product = $this->makeProduct('sku-car-1');
+        $this->assign($product, [$cat->getId()], $cat->getId());
+
+        $groups = $this->resolver()->resolve($product);
+
+        $codes = array_map(static fn (AttributeGroup $g): string => $g->getCode(), $groups);
+        self::assertContains('audit', $codes);
+        self::assertContains('vehicle-spec', $codes);
+    }
+
+    #[Test]
+    public function resolveIncludesAncestorGroupsForEachAssignedCategory(): void
+    {
+        $em = $this->em();
+        $productType = $this->productType();
+
+        $root = $this->makeCategory('root', 'root');
+        $branch = $this->makeCategory('branch', 'root.branch', parent: $root);
+        $leaf = $this->makeCategory('leaf', 'root.branch.leaf', parent: $branch);
+
+        $rootGroup = $this->makeGroup('root-group', 'Root');
+        $branchGroup = $this->makeGroup('branch-group', 'Branch');
+        $leafGroup = $this->makeGroup('leaf-group', 'Leaf');
+
+        $em->persist(new CategoryAttributeGroup($root->getId(), $productType, $rootGroup, 1));
+        $em->persist(new CategoryAttributeGroup($branch->getId(), $productType, $branchGroup, 1));
+        $em->persist(new CategoryAttributeGroup($leaf->getId(), $productType, $leafGroup, 1));
+        $em->flush();
+
+        $product = $this->makeProduct('sku-deep');
+        // Assign the leaf only — ancestors must still contribute.
+        $this->assign($product, [$leaf->getId()], $leaf->getId());
+
+        $groups = $this->resolver()->resolve($product);
+        $codes = array_map(static fn (AttributeGroup $g): string => $g->getCode(), $groups);
+
+        self::assertContains('root-group', $codes);
+        self::assertContains('branch-group', $codes);
+        self::assertContains('leaf-group', $codes);
+    }
+
+    #[Test]
+    public function resolveDeduplicatesGroupsAcrossOverlappingAssignments(): void
+    {
+        $em = $this->em();
+        $productType = $this->productType();
+
+        // Two sibling categories under the same root. Each declares its
+        // own group, plus the shared root declares a shared group. A
+        // product assigned to BOTH siblings must see the root group only
+        // once (dedup by AttributeGroup id).
+        $root = $this->makeCategory('shared-root', 'shared');
+        $left = $this->makeCategory('left', 'shared.left', parent: $root);
+        $right = $this->makeCategory('right', 'shared.right', parent: $root);
+
+        $shared = $this->makeGroup('shared-group', 'Shared');
+        $leftGroup = $this->makeGroup('left-group', 'Left');
+        $rightGroup = $this->makeGroup('right-group', 'Right');
+
+        $em->persist(new CategoryAttributeGroup($root->getId(), $productType, $shared, 1));
+        $em->persist(new CategoryAttributeGroup($left->getId(), $productType, $leftGroup, 1));
+        $em->persist(new CategoryAttributeGroup($right->getId(), $productType, $rightGroup, 1));
+        $em->flush();
+
+        $product = $this->makeProduct('sku-multi');
+        $this->assign($product, [$left->getId(), $right->getId()], $left->getId());
+
+        $groups = $this->resolver()->resolve($product);
+        $codes = array_map(static fn (AttributeGroup $g): string => $g->getCode(), $groups);
+
+        self::assertContains('shared-group', $codes);
+        self::assertContains('left-group', $codes);
+        self::assertContains('right-group', $codes);
+        // Each code appears at most once even though the root is in both
+        // ancestor chains.
+        self::assertSame(\count($codes), \count(array_unique($codes)));
+    }
+
+    #[Test]
+    public function resolveEmitsObjectTypeGroupsBeforeCategoryGroups(): void
+    {
+        $em = $this->em();
+        $productType = $this->productType();
+
+        $cat = $this->makeCategory('ordercat');
+        $catGroup = $this->makeGroup('cat-group', 'Cat');
+        $em->persist(new CategoryAttributeGroup($cat->getId(), $productType, $catGroup, 1));
+        $em->flush();
+
+        $product = $this->makeProduct('sku-order');
+        $this->assign($product, [$cat->getId()], $cat->getId());
+
+        $groups = $this->resolver()->resolve($product);
+        $codes = array_map(static fn (AttributeGroup $g): string => $g->getCode(), $groups);
+
+        $auditIdx = array_search('audit', $codes, true);
+        $catIdx = array_search('cat-group', $codes, true);
+        self::assertNotFalse($auditIdx);
+        self::assertNotFalse($catIdx);
+        self::assertLessThan($catIdx, $auditIdx, 'ObjectType-global groups must precede category-derived groups.');
+    }
+
+    /**
+     * @param list<\Symfony\Component\Uid\Uuid> $categoryIds
+     */
+    private function assign(CatalogObject $product, array $categoryIds, ?\Symfony\Component\Uid\Uuid $primaryId = null): void
+    {
+        self::getContainer()->get(ObjectCategoryRepositoryInterface::class)
+            ->replaceForProduct($product, $categoryIds, $primaryId);
+    }
+
+    private function productType(): \App\Catalog\Domain\Entity\ObjectType
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)->findBuiltInByKind(ObjectKind::Product, $this->tenant);
+        \assert(null !== $type);
+
+        return $type;
+    }
+
+    private function resolver(): EffectiveAttributeGroupResolver
+    {
+        return self::getContainer()->get(EffectiveAttributeGroupResolver::class);
+    }
+
+    private function makeProduct(string $code): CatalogObject
+    {
+        $em = $this->em();
+        $product = new CatalogObject($this->productType(), $code);
+        $em->persist($product);
+        $em->flush();
+
+        return $product;
+    }
+
+    private function makeCategory(string $code, ?string $path = null, ?CatalogObject $parent = null): CatalogObject
+    {
+        $em = $this->em();
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)->findBuiltInByKind(ObjectKind::Category, $this->tenant);
+        \assert(null !== $type);
+        $category = new CatalogObject($type, $code);
+        $category->attachToPath($path ?? $code);
+        if (null !== $parent) {
+            $category->assignParent($parent);
+        }
+        $em->persist($category);
+        $em->flush();
+
+        return $category;
+    }
+
+    private function makeGroup(string $code, string $label): AttributeGroup
+    {
+        $em = $this->em();
+        $group = new AttributeGroup($code, ['en' => $label]);
+        $em->persist($group);
+        $attribute = new Attribute($code.'_field', ['en' => $label.' field'], AttributeType::Text);
+        $em->persist($attribute);
+        $em->flush();
+        $em->persist(new AttributeGroupAttribute($group, $attribute, 1));
+        $em->flush();
+
+        return $group;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}

--- a/apps/api/tests/Integration/Catalog/PrimaryCategoryRepairListenerTest.php
+++ b/apps/api/tests/Integration/Catalog/PrimaryCategoryRepairListenerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * PCAT-03 (#476) — when a category is removed, its primary assignment
+ * cascades away. The listener must promote the next-oldest remaining
+ * assignment to primary so the product never stays in a "had assignments
+ * but no primary" state.
+ */
+final class PrimaryCategoryRepairListenerTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($this->tenant);
+    }
+
+    #[Test]
+    public function removingPrimaryCategoryPromotesOldestRemainingAssignment(): void
+    {
+        $product = $this->makeProduct('sku-promote');
+        $primary = $this->makeCategory('primary-cat');
+        $alt1 = $this->makeCategory('alt-1');
+        $alt2 = $this->makeCategory('alt-2');
+
+        // Order matters for the promote-next tie-breaker (position ASC,
+        // created_at ASC). replaceForProduct assigns positions in the
+        // order of the categoryIds list, so alt-1 is the oldest non-primary.
+        $this->repo()->replaceForProduct(
+            $product,
+            [$primary->getId(), $alt1->getId(), $alt2->getId()],
+            $primary->getId(),
+        );
+
+        $this->em()->remove($primary);
+        $this->em()->flush();
+        // Listener uses raw DBAL UPDATE in postFlush (managed entities are
+        // already detached after cascade). Clear the Identity Map so
+        // subsequent reads hydrate from the freshly-mutated DB rows
+        // instead of the stale cached entities.
+        $this->em()->clear();
+
+        $newPrimary = $this->repo()->findPrimary($product);
+        self::assertNotNull($newPrimary);
+        self::assertSame('alt-1', $newPrimary->getCategory()->getCode());
+
+        // Sanity: still exactly one primary across all remaining rows.
+        $primaryCount = 0;
+        foreach ($this->repo()->findByProduct($product) as $assignment) {
+            if ($assignment->isPrimary()) {
+                ++$primaryCount;
+            }
+        }
+        self::assertSame(1, $primaryCount);
+    }
+
+    #[Test]
+    public function removingOnlyPrimaryLeavesProductWithoutPrimary(): void
+    {
+        $product = $this->makeProduct('sku-only');
+        $only = $this->makeCategory('only-cat');
+
+        $this->repo()->replaceForProduct($product, [$only->getId()], $only->getId());
+
+        $this->em()->remove($only);
+        $this->em()->flush();
+        $this->em()->clear();
+
+        self::assertNull($this->repo()->findPrimary($product));
+        self::assertSame([], $this->repo()->findByProduct($product));
+    }
+
+    #[Test]
+    public function removingNonPrimaryCategoryDoesNotTouchExistingPrimary(): void
+    {
+        $product = $this->makeProduct('sku-untouched');
+        $primary = $this->makeCategory('keep-primary');
+        $extra = $this->makeCategory('to-remove');
+
+        $this->repo()->replaceForProduct(
+            $product,
+            [$primary->getId(), $extra->getId()],
+            $primary->getId(),
+        );
+
+        $this->em()->remove($extra);
+        $this->em()->flush();
+        $this->em()->clear();
+
+        $current = $this->repo()->findPrimary($product);
+        self::assertNotNull($current);
+        self::assertSame('keep-primary', $current->getCategory()->getCode());
+    }
+
+    private function repo(): ObjectCategoryRepositoryInterface
+    {
+        return self::getContainer()->get(ObjectCategoryRepositoryInterface::class);
+    }
+
+    private function makeProduct(string $code): CatalogObject
+    {
+        $em = $this->em();
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)->findBuiltInByKind(ObjectKind::Product, $this->tenant);
+        \assert(null !== $type);
+        $product = new CatalogObject($type, $code);
+        $em->persist($product);
+        $em->flush();
+
+        return $product;
+    }
+
+    private function makeCategory(string $code): CatalogObject
+    {
+        $em = $this->em();
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)->findBuiltInByKind(ObjectKind::Category, $this->tenant);
+        \assert(null !== $type);
+        $category = new CatalogObject($type, $code);
+        $category->attachToPath(str_replace('-', '_', $code));
+        $em->persist($category);
+        $em->flush();
+
+        return $category;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}


### PR DESCRIPTION
## Summary

Activates the killer feature in the modeling UI (epic UI-10 / PCAT-03).

`EffectiveAttributeGroupResolver` gets a `kind=Product` branch mirroring the existing `kind=Category` logic: for each assigned category, walk the ancestor chain (root→leaf via `parent_id`) and merge declared `CategoryAttributeGroup` rows targeting the product's ObjectType. Deduplication by AttributeGroup id ensures multi-category products with overlapping ancestor paths don't double-count.

`PrimaryCategoryRepairListener` handles the cascade-delete edge case: when a category is removed, every product that had it as primary gets the next-oldest remaining assignment promoted (`position ASC, created_at ASC`).

## Why this matters

Before this PR: `Effective preview` card in `categories/list.tsx#L399` rendered hypothetical groups — the resolver returned them for an *imagined* product placed under the category, but no real product could actually be placed there. Empirical validation impossible.

After this PR + PCAT-05 (FE picker): operator assigns a product to a category in the form, then opens the same category's `Effective preview` and sees the *exact same group set* in both places. Designer's promise meets runtime.

## Backward compatibility

Products without assignments → resolver returns ObjectType groups only (the pre-PCAT shape). The existing `EffectiveAttributeGroupResolverTest` suite stays green untouched (5/5).

## Implementation notes

- Resolver injection: added `ObjectCategoryRepositoryInterface` to constructor (still `final readonly`)
- Listener: raw DBAL `UPDATE` in `postFlush` because managed entities are already detached after CASCADE; ORM-side mutations would either miss the rows or fight Doctrine change-tracking
- Promote-next ordering matches the controller's DELETE handler in PCAT-02 (`position ASC, created_at ASC`) — single source of truth for primary tie-breaking

## Test plan

- [x] `bin/phpunit tests/Integration/Catalog/EffectiveAttributeGroupResolverProductTest.php` — 5 scenarios (empty assignments fallback, merge from categories, ancestor inheritance, deduplication across overlapping assignments, ordering global-first)
- [x] `bin/phpunit tests/Integration/Catalog/PrimaryCategoryRepairListenerTest.php` — 3 scenarios (promote oldest remaining, leave null when no assignments left, ignore non-primary deletes)
- [x] `bin/phpunit tests/Integration/Catalog/EffectiveAttributeGroupResolverTest.php` — 5/5 still green (no regression)
- [x] PHPStan max ✅
- [x] PHP-CS-Fixer ✅
- [ ] Manual smoke once PCAT-02 (#483) and PCAT-05 (#478) merge: assign product to category in UI → product form shows inherited group → cascade-delete category → product gets next assignment promoted

## Out of scope

- Cache invalidation hook on `ObjectCategory` mutations → PCAT-04 (#477)
- Frontend picker → PCAT-05 (#478)

Closes #476