### PR TITLE
feat(catalog): PCAT-04 — invalidate form-schema cache on ObjectCategory mutation

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/ObjectFormSchemaCacheInvalidator.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/ObjectFormSchemaCacheInvalidator.php
@@ -8,6 +8,7 @@ use App\Catalog\Application\Query\GetObjectFormSchema\GetObjectFormSchemaHandler
 use App\Catalog\Application\Query\Usage\UsageQueryService;
 use App\Catalog\Domain\Entity\AttributeGroupAttribute;
 use App\Catalog\Domain\Entity\CategoryAttributeGroup;
+use App\Catalog\Domain\Entity\ObjectCategory;
 use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\PostFlushEventArgs;
@@ -37,6 +38,13 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
  *   - AttributeGroupAttribute change → invalidate the global tag (a
  *     change to a group's member set ripples to every schema that
  *     includes that group; the per-type tags are insufficient).
+ *   - ObjectCategory change (PCAT-04) → invalidate the per-type tag
+ *     for the affected product's ObjectType. PCAT-03 made products
+ *     inherit category-declared groups, so toggling an assignment
+ *     changes the resolved schema for every product of that type.
+ *     Trade-off accepted: we burst the cache for *all* products of
+ *     the type, not just the one that changed (per-object cache key
+ *     is a Faza 1.1 follow-up).
  *
  * Defers actual invalidation to `postFlush` so a single transaction
  * touching N rows triggers one cache invalidation per affected tag set.
@@ -120,6 +128,18 @@ final class ObjectFormSchemaCacheInvalidator
             // this group must rebuild. Global flush is the simplest
             // correct invalidation in MVP.
             $this->globalInvalidate = true;
+
+            return;
+        }
+
+        if ($entity instanceof ObjectCategory) {
+            // PCAT-04: assigning/detaching a category from a product
+            // shifts the resolved group set for that product (PCAT-03
+            // resolver branch). Invalidate the per-type tag — bursts
+            // cache for all products of the type, but per-object
+            // granularity is a Faza 1.1 follow-up.
+            $product = $entity->getProduct();
+            $this->perTypeTags[$product->getObjectType()->getId()->toRfc4122()] = true;
         }
     }
 }


### PR DESCRIPTION
## Summary

Hooks `ObjectCategory` (epic UI-10 / PCAT-01 junction) into `ObjectFormSchemaCacheInvalidator` so the modeling cache pool is correctly invalidated when product↔category assignments change.

## Why this matters

Without this hook:
- Operator assigns product → category in the picker (PCAT-05)
- Resolver (PCAT-03) correctly computes the new effective group set
- But the form-schema cache from a previous read still serves the stale shape
- → Operator sees the old form fields, has to hard-refresh

The invalidator already handled the three pre-existing junctions (`ObjectTypeAttributeGroup`, `CategoryAttributeGroup`, `AttributeGroupAttribute`). This PR adds the fourth: `ObjectCategory`.

## Strategy

Per-ObjectType invalidation (consistent with the existing branches):
```php
if ($entity instanceof ObjectCategory) {
    $this->perTypeTags[$entity->getProduct()->getObjectType()->getId()->toRfc4122()] = true;
}
```

**Trade-off accepted:** assigning a single product to a category invalidates the form-schema cache for *all* products of that type. Per-object cache key is a Faza 1.1 follow-up (4-6h, requires extending `GetObjectFormSchemaHandler` with a third tag layer).

In MVP this is fine: form-schema cache is admin-side only, picker writes are operator-paced (not bulk import), and the modeling cache pool TTL is short.

## Test plan

- [x] PHPStan max ✅
- [x] PHP-CS-Fixer ✅
- [ ] **Manual smoke** (requires PCAT-02 #483 + PCAT-03 #485 merged):
  ```bash
  # 1. Login + grab IDs
  TOKEN=\$(curl -sk -X POST https://pim.localhost/api/auth -H 'Content-Type: application/json' \\
    -d '{"email":"admin@demo.localhost","password":"changeme"}' | jq -r .token)
  PRODUCT_ID=…  CATEGORY_ID=…

  # 2. First fetch — populates form-schema cache
  curl -sk https://pim.localhost/api/products/\$PRODUCT_ID/effective-attribute-groups \\
    -H "Authorization: Bearer \$TOKEN" | jq '.effectiveGroups | length'  # → N

  # 3. Confirm cache populated
  docker compose exec redis redis-cli KEYS 'pim_form_schema*'

  # 4. Assign product to category with declared groups
  curl -sk -X PUT https://pim.localhost/api/products/\$PRODUCT_ID/categories \\
    -H "Authorization: Bearer \$TOKEN" -H 'Content-Type: application/json' \\
    -d "{\"primaryCategoryId\":\"\$CATEGORY_ID\",\"categoryIds\":[\"\$CATEGORY_ID\"]}"

  # 5. Confirm cache invalidated for the affected type
  docker compose exec redis redis-cli KEYS 'pim_form_schema*'  # → entries for that ObjectType gone

  # 6. Refetch — fresh resolve sees inherited groups
  curl -sk https://pim.localhost/api/products/\$PRODUCT_ID/effective-attribute-groups \\
    -H "Authorization: Bearer \$TOKEN" | jq '.effectiveGroups | length'  # → N + inherited count
  ```
- [ ] No automated PHP test in this PR — full integration scenario requires PCAT-03 (resolver branch) merged so the resolver actually returns different content after invalidation. Will be covered by E2E in PCAT-05/06.

## Out of scope

- Per-object cache key (Faza 1.1)
- Frontend integration (PCAT-05 #478)

Closes #477