### PR TITLE
feat(admin): PCAT-05 — Kategorie tab + CategoryPickerDialog

### DIFF
--- a/apps/admin/src/components/catalog/category-picker-dialog.tsx
+++ b/apps/admin/src/components/catalog/category-picker-dialog.tsx
@@ -1,0 +1,270 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { FolderTree, Search } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { buildCategoryTree, CategoryTree } from '@/components/modeling/category-tree';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { HttpError, jsonFetch } from '@/lib/http';
+
+interface CategoryRow {
+  id: string;
+  code: string;
+  path?: string | null;
+  attributesIndexed?: Record<string, unknown> | null;
+}
+
+interface CategoriesListResponse {
+  'hydra:member'?: CategoryRow[];
+  member?: CategoryRow[];
+}
+
+export interface CurrentAssignment {
+  categoryId: string;
+  isPrimary: boolean;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  productId: string;
+  /** Current assignments — used to seed the picker state when the dialog opens. */
+  currentAssignments: CurrentAssignment[];
+  /** Called after a successful PUT so the caller can refresh the chip list + effective groups. */
+  onSaved: () => void;
+}
+
+/**
+ * PCAT-05 (#478) — multi-select category picker for the product's
+ * "Kategorie" tab. Loads the full category tree (capped at 200 rows
+ * for the picker — typical mid-market catalogue is well under that),
+ * lets the operator toggle an arbitrary subset, and pin one as
+ * primary via a star button. Save dispatches a single
+ * `PUT /api/products/{id}/categories` (atomic replace) so the partial
+ * unique index never sees a transient state.
+ *
+ * Validation:
+ *   - if at least one category is selected, exactly one must be primary
+ *   - the picker auto-promotes the first selection to primary when no
+ *     primary was set yet, mirroring the controller's promote-next
+ *     semantics on DELETE
+ */
+export function CategoryPickerDialog({
+  open,
+  onOpenChange,
+  productId,
+  currentAssignments,
+  onSaved,
+}: Props) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [primaryId, setPrimaryId] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed every time the dialog opens so reopening discards a
+  // half-edited state from the previous open.
+  useEffect(() => {
+    if (!open) return;
+    const ids = new Set<string>();
+    let primary: string | null = null;
+    for (const assignment of currentAssignments) {
+      ids.add(assignment.categoryId);
+      if (assignment.isPrimary) {
+        primary = assignment.categoryId;
+      }
+    }
+    setSelected(ids);
+    setPrimaryId(primary);
+    setSearch('');
+    setError(null);
+  }, [open, currentAssignments]);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['categories', 'picker'],
+    queryFn: async () => {
+      // Refine convention: itemsPerPage with a generous cap; the picker
+      // is for admin-paced selection, not infinite-scroll.
+      return jsonFetch<CategoriesListResponse>('/api/categories?itemsPerPage=200');
+    },
+    enabled: open,
+    staleTime: 60_000,
+  });
+
+  const rows = useMemo<CategoryRow[]>(() => {
+    if (!data) return [];
+    return data['hydra:member'] ?? data.member ?? [];
+  }, [data]);
+
+  const filteredRows = useMemo(() => {
+    if (search.trim() === '') return rows;
+    const needle = search.trim().toLowerCase();
+    return rows.filter((row) => {
+      if (row.code.toLowerCase().includes(needle)) return true;
+      const name = row.attributesIndexed?.name;
+      if (typeof name === 'string' && name.toLowerCase().includes(needle)) return true;
+      if (name && typeof name === 'object') {
+        const map = name as Record<string, string>;
+        for (const value of Object.values(map)) {
+          if (typeof value === 'string' && value.toLowerCase().includes(needle)) return true;
+        }
+      }
+      return false;
+    });
+  }, [rows, search]);
+
+  const tree = useMemo(
+    () =>
+      buildCategoryTree(
+        filteredRows.map((row) => ({
+          id: row.id,
+          code: row.code,
+          path: row.path ?? null,
+          attributesIndexed: row.attributesIndexed ?? undefined,
+        })),
+      ),
+    [filteredRows],
+  );
+
+  const handleToggle = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+        // If the primary was deselected, drop the primary flag
+        if (primaryId === id) setPrimaryId(null);
+      } else {
+        next.add(id);
+        // Auto-promote the first selection to primary if none was set
+        if (primaryId === null) setPrimaryId(id);
+      }
+      return next;
+    });
+  };
+
+  const handlePrimaryChange = (id: string) => {
+    if (!selected.has(id)) return;
+    setPrimaryId(id);
+  };
+
+  const canSave = selected.size === 0 || (primaryId !== null && selected.has(primaryId));
+
+  const handleSave = async () => {
+    if (!canSave || isSaving) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      const categoryIds = Array.from(selected);
+      const primary = selected.size === 0 ? null : primaryId;
+      await jsonFetch(`/api/products/${productId}/categories`, {
+        method: 'PUT',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: { primaryCategoryId: primary, categoryIds },
+      });
+      // Burst the affected cache keys so the chip list, the effective
+      // schema, and any product-level reads pick up the change.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['products', productId, 'categories'] }),
+        queryClient.invalidateQueries({
+          queryKey: ['products', productId, 'effective-attribute-groups'],
+        }),
+        queryClient.invalidateQueries({ queryKey: ['products', productId] }),
+      ]);
+      onSaved();
+      onOpenChange(false);
+    } catch (e) {
+      setError(
+        e instanceof HttpError && e.body && typeof e.body === 'object' && 'detail' in e.body
+          ? String((e.body as { detail: unknown }).detail)
+          : t('categories.picker.error_generic', { defaultValue: 'Nie udało się zapisać' }),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <header className="mb-3 flex items-center gap-2">
+          <FolderTree className="size-4 text-violet-600" />
+          <h2 className="text-base font-semibold">
+            {t('categories.picker.title', { defaultValue: 'Wybierz kategorie' })}
+          </h2>
+        </header>
+
+        <div className="relative mb-3">
+          <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-zinc-400" />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('categories.picker.search_placeholder', {
+              defaultValue: 'Szukaj kategorii…',
+            })}
+            className="w-full rounded-xl border border-zinc-200 bg-white py-2 pl-9 pr-3 text-[13px] focus:border-violet-300 focus:outline-none"
+          />
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto rounded-xl border border-zinc-100 bg-white p-3">
+          {isLoading ? (
+            <p className="px-2 py-4 text-center text-[12.5px] text-zinc-500">
+              {t('app.loading', { defaultValue: 'Ładowanie…' })}
+            </p>
+          ) : tree.length === 0 ? (
+            <p className="px-2 py-4 text-center text-[12.5px] text-zinc-500">
+              {t('categories.picker.empty', { defaultValue: 'Brak wyników.' })}
+            </p>
+          ) : (
+            <CategoryTree
+              nodes={tree}
+              onSelect={() => undefined}
+              mode="multi-select"
+              selectedIds={selected}
+              onToggle={handleToggle}
+              primaryId={primaryId}
+              onPrimaryChange={handlePrimaryChange}
+              initialExpanded={new Set(tree.map((n) => n.id))}
+            />
+          )}
+        </div>
+
+        {!canSave ? (
+          <p className="mt-3 text-[11.5px] text-amber-600">
+            {t('categories.picker.no_primary_warning', {
+              defaultValue: 'Zaznacz kategorię główną (⭐) żeby zapisać.',
+            })}
+          </p>
+        ) : null}
+
+        {error !== null ? (
+          <p className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-[12.5px] text-red-700">{error}</p>
+        ) : null}
+
+        <footer className="mt-4 flex items-center justify-between">
+          <span className="text-[11.5px] text-zinc-500">
+            {t('categories.picker.selected_count', {
+              defaultValue: 'Wybrano: {{count}}',
+              count: selected.size,
+            })}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={isSaving}>
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button onClick={() => void handleSave()} disabled={!canSave || isSaving}>
+              {isSaving
+                ? t('categories.picker.saving', { defaultValue: 'Zapisywanie…' })
+                : t('categories.picker.save', { defaultValue: 'Zapisz' })}
+            </Button>
+          </div>
+        </footer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/components/modeling/category-tree.tsx
+++ b/apps/admin/src/components/modeling/category-tree.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, FolderTree } from 'lucide-react';
+import { ChevronRight, FolderTree, Star } from 'lucide-react';
 import { useState } from 'react';
 
 import { cn } from '@/lib/utils';
@@ -15,6 +15,8 @@ export interface CategoryTreeNode {
   children: CategoryTreeNode[];
 }
 
+type CategoryTreeMode = 'select' | 'multi-select';
+
 interface Props {
   nodes: CategoryTreeNode[];
   selectedId?: string;
@@ -23,6 +25,21 @@ interface Props {
   disabledIds?: Set<string>;
   /** Pre-expanded node ids — derived from URL search param in the list page. */
   initialExpanded?: Set<string>;
+  /**
+   * PCAT-05 (#478) — switches the tree to multi-select mode for the
+   * category picker on the product form. In `'multi-select'`:
+   *   - `selectedIds` controls the checkbox state (toggle via `onToggle`)
+   *   - `primaryId` highlights one row with a ⭐ radio (toggle via
+   *     `onPrimaryChange`); only enabled when the row is selected
+   *   - `onSelect` is still called on row click but consumers typically
+   *     wire it to `onToggle`
+   * Default `'select'` keeps the modeling/Move usage unchanged.
+   */
+  mode?: CategoryTreeMode;
+  selectedIds?: Set<string>;
+  onToggle?: (id: string) => void;
+  primaryId?: string | null;
+  onPrimaryChange?: (id: string) => void;
 }
 
 /**
@@ -37,10 +54,21 @@ interface Props {
  *   - Optional emoji glyph + bold name + tabular instance count.
  *   - Up to 3 group color dots as a per-row indicator + "+N" overflow.
  */
-export function CategoryTree({ nodes, selectedId, onSelect, disabledIds, initialExpanded }: Props) {
+export function CategoryTree({
+  nodes,
+  selectedId,
+  onSelect,
+  disabledIds,
+  initialExpanded,
+  mode = 'select',
+  selectedIds,
+  onToggle: onToggleSelection,
+  primaryId,
+  onPrimaryChange,
+}: Props) {
   const [expanded, setExpanded] = useState<Set<string>>(() => initialExpanded ?? new Set());
 
-  const toggle = (id: string) => {
+  const toggleExpand = (id: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -59,7 +87,12 @@ export function CategoryTree({ nodes, selectedId, onSelect, disabledIds, initial
           onSelect={onSelect}
           disabledIds={disabledIds}
           expanded={expanded}
-          onToggle={toggle}
+          onToggleExpand={toggleExpand}
+          mode={mode}
+          selectedIds={selectedIds}
+          onToggleSelection={onToggleSelection}
+          primaryId={primaryId ?? null}
+          onPrimaryChange={onPrimaryChange}
         />
       ))}
     </ul>
@@ -72,84 +105,167 @@ function CategoryTreeRow({
   onSelect,
   disabledIds,
   expanded,
-  onToggle,
+  onToggleExpand,
+  mode,
+  selectedIds,
+  onToggleSelection,
+  primaryId,
+  onPrimaryChange,
 }: {
   node: CategoryTreeNode;
   selectedId?: string;
   onSelect: (id: string) => void;
   disabledIds?: Set<string>;
   expanded: Set<string>;
-  onToggle: (id: string) => void;
+  onToggleExpand: (id: string) => void;
+  mode: CategoryTreeMode;
+  selectedIds?: Set<string>;
+  onToggleSelection?: (id: string) => void;
+  primaryId: string | null;
+  onPrimaryChange?: (id: string) => void;
 }) {
   const hasChildren = node.children.length > 0;
   const isExpanded = expanded.has(node.id);
-  const isSelected = selectedId === node.id;
+  const isMulti = mode === 'multi-select';
+  const isChecked = isMulti ? (selectedIds?.has(node.id) ?? false) : false;
+  const isPrimary = isMulti ? primaryId === node.id : false;
+  const isSelected = isMulti ? isChecked : selectedId === node.id;
   const isDisabled = disabledIds?.has(node.id) ?? false;
   const groupColors = node.groupColors ?? [];
 
+  const handleRowClick = () => {
+    if (isDisabled) return;
+    if (isMulti) {
+      onToggleSelection?.(node.id);
+      return;
+    }
+    onSelect(node.id);
+  };
+
+  const rowVisualClass = isMulti
+    ? isChecked
+      ? 'bg-violet-50/60 hover:bg-violet-50'
+      : 'hover:bg-zinc-100/70'
+    : isSelected
+      ? 'bg-zinc-900 text-white'
+      : 'hover:bg-zinc-100/70';
+
   return (
     <li>
-      <button
-        type="button"
-        disabled={isDisabled}
-        onClick={() => onSelect(node.id)}
+      <div
         className={cn(
           'flex w-full items-center gap-1.5 rounded-xl px-2 py-1.5 text-left transition-colors',
-          isSelected ? 'bg-zinc-900 text-white' : 'hover:bg-zinc-100/70',
+          rowVisualClass,
           isDisabled && 'cursor-not-allowed opacity-50',
         )}
         style={{ paddingLeft: `${8 + node.depth * 16}px` }}
       >
+        {isMulti ? (
+          <input
+            type="checkbox"
+            checked={isChecked}
+            disabled={isDisabled}
+            onChange={() => onToggleSelection?.(node.id)}
+            className="size-3.5 cursor-pointer accent-violet-600"
+            aria-label={`Wybierz kategorię ${node.label}`}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : null}
         {hasChildren ? (
-          <ChevronRight
-            className={cn(
-              'size-3.5 transition-transform',
-              isSelected ? 'text-white/70' : 'text-zinc-400',
-            )}
-            style={{ transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
-            aria-hidden
+          <button
+            type="button"
             onClick={(e) => {
               e.stopPropagation();
-              onToggle(node.id);
+              onToggleExpand(node.id);
             }}
-          />
+            className="grid size-5 place-items-center"
+            aria-label={isExpanded ? 'Zwiń' : 'Rozwiń'}
+          >
+            <ChevronRight
+              className={cn(
+                'size-3.5 transition-transform',
+                isSelected && !isMulti ? 'text-white/70' : 'text-zinc-400',
+              )}
+              style={{ transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)' }}
+              aria-hidden
+            />
+          </button>
         ) : (
           <span className="grid size-5 place-items-center text-zinc-300">
             <FolderTree className="size-3" />
           </span>
         )}
-        <span className="text-[14px]">{node.icon ?? '📁'}</span>
-        <span className="text-[13px] font-medium">{node.label}</span>
-        {node.instanceCount !== undefined ? (
-          <span
+        <button
+          type="button"
+          disabled={isDisabled}
+          onClick={handleRowClick}
+          className="flex flex-1 items-center gap-1.5 text-left"
+        >
+          <span className="text-[14px]">{node.icon ?? '📁'}</span>
+          <span className="text-[13px] font-medium">{node.label}</span>
+          {node.instanceCount !== undefined ? (
+            <span
+              className={cn(
+                'ml-1 font-mono text-[10.5px] tabular-nums',
+                isSelected && !isMulti ? 'text-white/50' : 'text-zinc-400',
+              )}
+            >
+              {node.instanceCount}
+            </span>
+          ) : null}
+          {groupColors.length > 0 && !isMulti ? (
+            <span className="ml-auto inline-flex items-center gap-0.5">
+              {groupColors.slice(0, 3).map((color) => (
+                <span
+                  key={color}
+                  className="size-2 rounded-full"
+                  style={{ background: color }}
+                  aria-hidden
+                />
+              ))}
+              {groupColors.length > 3 ? (
+                <span
+                  className={cn(
+                    'ml-0.5 text-[10px]',
+                    isSelected ? 'text-white/50' : 'text-zinc-400',
+                  )}
+                >
+                  +{groupColors.length - 3}
+                </span>
+              ) : null}
+            </span>
+          ) : null}
+        </button>
+        {isMulti ? (
+          <button
+            type="button"
+            disabled={!isChecked}
+            onClick={(e) => {
+              e.stopPropagation();
+              if (isChecked) onPrimaryChange?.(node.id);
+            }}
             className={cn(
-              'ml-1 font-mono text-[10.5px] tabular-nums',
-              isSelected ? 'text-white/50' : 'text-zinc-400',
+              'ml-auto grid size-6 place-items-center rounded-lg transition-colors',
+              isPrimary
+                ? 'bg-amber-100 text-amber-700'
+                : isChecked
+                  ? 'text-zinc-400 hover:bg-amber-50 hover:text-amber-600'
+                  : 'cursor-not-allowed text-zinc-200',
             )}
+            aria-label={isPrimary ? 'Kategoria główna' : 'Ustaw jako główną'}
+            aria-pressed={isPrimary}
+            title={
+              !isChecked
+                ? 'Najpierw zaznacz kategorię'
+                : isPrimary
+                  ? 'Kategoria główna'
+                  : 'Ustaw jako główną'
+            }
           >
-            {node.instanceCount}
-          </span>
+            <Star className={cn('size-3.5', isPrimary ? 'fill-amber-500' : '')} />
+          </button>
         ) : null}
-        {groupColors.length > 0 ? (
-          <span className="ml-auto inline-flex items-center gap-0.5">
-            {groupColors.slice(0, 3).map((color) => (
-              <span
-                key={color}
-                className="size-2 rounded-full"
-                style={{ background: color }}
-                aria-hidden
-              />
-            ))}
-            {groupColors.length > 3 ? (
-              <span
-                className={cn('ml-0.5 text-[10px]', isSelected ? 'text-white/50' : 'text-zinc-400')}
-              >
-                +{groupColors.length - 3}
-              </span>
-            ) : null}
-          </span>
-        ) : null}
-      </button>
+      </div>
       {hasChildren && isExpanded ? (
         <ul className="space-y-1">
           {node.children.map((child) => (
@@ -160,7 +276,12 @@ function CategoryTreeRow({
               onSelect={onSelect}
               disabledIds={disabledIds}
               expanded={expanded}
-              onToggle={onToggle}
+              onToggleExpand={onToggleExpand}
+              mode={mode}
+              selectedIds={selectedIds}
+              onToggleSelection={onToggleSelection}
+              primaryId={primaryId}
+              onPrimaryChange={onPrimaryChange}
             />
           ))}
         </ul>

--- a/apps/admin/src/features/catalog/products/components/categories-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/categories-tab.tsx
@@ -1,0 +1,229 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { FolderTree, Star, X } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import {
+  CategoryPickerDialog,
+  type CurrentAssignment,
+} from '@/components/catalog/category-picker-dialog';
+import { Button } from '@/components/ui/button';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+interface AssignmentRow {
+  categoryId: string;
+  code: string;
+  isPrimary: boolean;
+  position: number;
+}
+
+interface ListResponse {
+  productId: string;
+  primaryCategoryId: string | null;
+  assignments: AssignmentRow[];
+}
+
+interface Props {
+  productId: string;
+}
+
+/**
+ * PCAT-05 (#478) — "Kategorie" tab on the product detail page.
+ *
+ * Shows the current assignments as chips (label + ⭐ for primary + ×
+ * to detach), plus an "Edytuj kategorie" button that opens
+ * {@link CategoryPickerDialog} for full multi-select editing. Single-row
+ * operations (toggle primary, detach) hit POST/DELETE directly so the
+ * UI stays reactive without re-opening the dialog.
+ *
+ * Empty state explains the link to attribute inheritance — operator
+ * needs to know that picking a category is what activates the
+ * category-driven group set on the form (PCAT-03).
+ */
+export function CategoriesTab({ productId }: Props) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [busyCategoryId, setBusyCategoryId] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['products', productId, 'categories'],
+    queryFn: async () =>
+      jsonFetch<ListResponse>(`/api/products/${productId}/categories`, {
+        accept: 'application/json',
+      }),
+    enabled: productId !== '',
+  });
+
+  const assignments = data?.assignments ?? [];
+  const currentAssignments: CurrentAssignment[] = assignments.map((a) => ({
+    categoryId: a.categoryId,
+    isPrimary: a.isPrimary,
+  }));
+
+  const refresh = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['products', productId, 'categories'] }),
+      queryClient.invalidateQueries({
+        queryKey: ['products', productId, 'effective-attribute-groups'],
+      }),
+      queryClient.invalidateQueries({ queryKey: ['products', productId] }),
+    ]);
+  };
+
+  const handleDetach = async (categoryId: string) => {
+    if (busyCategoryId !== null) return;
+    setBusyCategoryId(categoryId);
+    try {
+      await jsonFetch(`/api/products/${productId}/categories/${categoryId}`, {
+        method: 'DELETE',
+        accept: 'application/json',
+      });
+      await refresh();
+    } catch {
+      // intentionally swallow — caller will see stale state, error
+      // banner is reserved for picker-driven failures
+    } finally {
+      setBusyCategoryId(null);
+    }
+  };
+
+  const handlePromote = async (categoryId: string) => {
+    if (busyCategoryId !== null) return;
+    setBusyCategoryId(categoryId);
+    try {
+      await jsonFetch(`/api/products/${productId}/categories`, {
+        method: 'POST',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: { categoryId, isPrimary: true },
+      });
+      await refresh();
+    } catch {
+      // see comment above
+    } finally {
+      setBusyCategoryId(null);
+    }
+  };
+
+  return (
+    <section className="space-y-4">
+      <header className="flex items-center justify-between">
+        <div>
+          <h3 className="text-[13.5px] font-semibold text-ink">
+            {t('products.detail.categories.title', { defaultValue: 'Kategorie' })}
+          </h3>
+          <p className="mt-0.5 text-[11.5px] text-muted-foreground">
+            {t('products.detail.categories.subtitle', {
+              defaultValue: 'Przypisanie do kategorii decyduje o dziedziczonych polach formularza.',
+            })}
+          </p>
+        </div>
+        <Button onClick={() => setPickerOpen(true)} size="sm">
+          {assignments.length === 0
+            ? t('products.detail.categories.add_button', { defaultValue: '+ Przypisz kategorie' })
+            : t('products.detail.categories.edit_button', {
+                defaultValue: '+ Edytuj kategorie',
+              })}
+        </Button>
+      </header>
+
+      {isLoading ? (
+        <p className="text-[12.5px] text-muted-foreground">
+          {t('app.loading', { defaultValue: 'Ładowanie…' })}
+        </p>
+      ) : assignments.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-line bg-surface p-6 text-center">
+          <FolderTree className="mx-auto size-6 text-zinc-400" />
+          <p className="mt-2 text-[13px] font-medium text-ink">
+            {t('products.detail.categories.empty', {
+              defaultValue: 'Brak przypisanych kategorii',
+            })}
+          </p>
+          <p className="mt-1 text-[11.5px] text-muted-foreground">
+            {t('products.detail.categories.empty_hint', {
+              defaultValue:
+                'Dodaj kategorię aby aktywować dziedziczenie dodatkowych pól formularza.',
+            })}
+          </p>
+        </div>
+      ) : (
+        <ul className="flex flex-wrap gap-2">
+          {assignments.map((assignment) => {
+            const isPrimary = assignment.isPrimary;
+            const isBusy = busyCategoryId === assignment.categoryId;
+            return (
+              <li
+                key={assignment.categoryId}
+                className={cn(
+                  'group inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[12.5px] transition-colors',
+                  isPrimary
+                    ? 'border-amber-200 bg-amber-50 text-amber-900'
+                    : 'border-zinc-200 bg-white text-ink hover:bg-zinc-50',
+                  isBusy && 'opacity-50',
+                )}
+              >
+                <button
+                  type="button"
+                  onClick={() => void handlePromote(assignment.categoryId)}
+                  disabled={isPrimary || isBusy}
+                  className={cn(
+                    'grid size-5 place-items-center rounded-full',
+                    isPrimary
+                      ? 'cursor-default text-amber-600'
+                      : 'text-zinc-400 hover:bg-amber-100 hover:text-amber-700',
+                  )}
+                  aria-label={
+                    isPrimary
+                      ? t('products.detail.categories.is_primary', {
+                          defaultValue: 'Kategoria główna',
+                        })
+                      : t('products.detail.categories.set_primary', {
+                          defaultValue: 'Ustaw jako główną',
+                        })
+                  }
+                  aria-pressed={isPrimary}
+                  title={
+                    isPrimary
+                      ? t('products.detail.categories.is_primary', {
+                          defaultValue: 'Kategoria główna',
+                        })
+                      : t('products.detail.categories.set_primary', {
+                          defaultValue: 'Ustaw jako główną',
+                        })
+                  }
+                >
+                  <Star className={cn('size-3.5', isPrimary && 'fill-amber-500')} />
+                </button>
+                <span className="font-medium">{assignment.code}</span>
+                <button
+                  type="button"
+                  onClick={() => void handleDetach(assignment.categoryId)}
+                  disabled={isBusy}
+                  className="grid size-5 place-items-center rounded-full text-zinc-400 hover:bg-red-100 hover:text-red-600"
+                  aria-label={t('products.detail.categories.detach', {
+                    defaultValue: 'Odepnij kategorię',
+                  })}
+                  title={t('products.detail.categories.detach', {
+                    defaultValue: 'Odepnij kategorię',
+                  })}
+                >
+                  <X className="size-3.5" />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <CategoryPickerDialog
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        productId={productId}
+        currentAssignments={currentAssignments}
+        onSaved={() => undefined}
+      />
+    </section>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -33,6 +33,7 @@ import { useDefaultObjectType } from '../use-default-object-type';
 import { AgentSuggestionsCard } from './agent-suggestions-card';
 import { AttrGroupCard } from './attr-group-card';
 import { AttrRow } from './attr-row';
+import { CategoriesTab } from './categories-tab';
 import { CompletenessRing } from './completeness-ring';
 import { DuplicateButton } from './duplicate-button';
 import { EffectiveModelCard } from './effective-model-card';
@@ -51,7 +52,14 @@ import type {
 import { VariantsListCard } from './variants-list-card';
 import { VariantsTabHost } from './variants-tab-host';
 
-const TABS = ['attributes', 'multimedia', 'relations', 'history', 'variants'] as const;
+const TABS = [
+  'attributes',
+  'multimedia',
+  'categories',
+  'relations',
+  'history',
+  'variants',
+] as const;
 type TabKey = (typeof TABS)[number];
 
 const GROUP_ICONS: Record<string, string> = {
@@ -657,6 +665,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
 const TAB_DEFAULT_LABELS: Record<TabKey, string> = {
   attributes: 'Atrybuty',
   multimedia: 'Multimedia',
+  categories: 'Kategorie',
   relations: 'Powiązania',
   history: 'Historia',
   variants: 'Warianty',
@@ -669,6 +678,7 @@ function tabBadge(
 ): number | null {
   if (tab === 'attributes') return groups.length === 0 ? null : groups.length;
   if (tab === 'multimedia') return null;
+  if (tab === 'categories') return null;
   if (tab === 'relations') return null;
   if (tab === 'history') return null;
   if (tab === 'variants') {
@@ -728,6 +738,7 @@ function resolveProvenance(
 
 function OtherTabs({ activeTab, productId }: { activeTab: TabKey; productId: string }) {
   if (activeTab === 'multimedia') return <ProductMultimediaTab productId={productId} />;
+  if (activeTab === 'categories') return <CategoriesTab productId={productId} />;
   if (activeTab === 'relations') return <RelationsStub />;
   if (activeTab === 'history') return <HistoryStub />;
   if (activeTab === 'variants') return <VariantsTabHost productId={productId} />;

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -408,6 +408,16 @@
     },
     "actions": {
       "view": "Podgląd"
+    },
+    "picker": {
+      "title": "Wybierz kategorie",
+      "search_placeholder": "Szukaj kategorii…",
+      "empty": "Brak wyników.",
+      "save": "Zapisz",
+      "saving": "Zapisywanie…",
+      "selected_count": "Wybrano: {{count}}",
+      "no_primary_warning": "Zaznacz kategorię główną (⭐) żeby zapisać.",
+      "error_generic": "Nie udało się zapisać"
     }
   },
   "object_types": {
@@ -691,9 +701,21 @@
         "aria": "Zakładki produktu",
         "attributes": "Atrybuty",
         "multimedia": "Multimedia",
+        "categories": "Kategorie",
         "relations": "Powiązania",
         "history": "Historia",
         "variants": "Warianty"
+      },
+      "categories": {
+        "title": "Kategorie",
+        "subtitle": "Przypisanie do kategorii decyduje o dziedziczonych polach formularza.",
+        "add_button": "+ Przypisz kategorie",
+        "edit_button": "+ Edytuj kategorie",
+        "empty": "Brak przypisanych kategorii",
+        "empty_hint": "Dodaj kategorię aby aktywować dziedziczenie dodatkowych pól formularza.",
+        "is_primary": "Kategoria główna",
+        "set_primary": "Ustaw jako główną",
+        "detach": "Odepnij kategorię"
       },
       "locale": {
         "label": "Język",


### PR DESCRIPTION
## Summary

Frontend half of the UI-10 epic (PCAT-05). Adds a dedicated **"Kategorie" tab** between Multimedia and Powiązania on the product detail page, plus a multi-select tree picker dialog. Closes the loop the rest of the epic builds toward.

## Why a separate tab (not a section in Powiązania)

Original plan tucked categories under the existing Powiązania (Relations) tab. Operator changed scope on 2026-05-10: kategorie are first-class on a product (they drive attribute inheritance and storefront navigation), while Powiązania semantically means product↔product (cross-sell / up-sell). Mixing the two confuses both concepts, so kategorie gets its own tab.

New tab order: `Atrybuty` | `Multimedia` | **`Kategorie`** | `Powiązania` | `Historia` | `Warianty`. Powiązania stays a mock for now (cross-sell / up-sell follow-up).

## What ships

- **`<CategoriesTab>`** ([categories-tab.tsx](apps/admin/src/features/catalog/products/components/categories-tab.tsx)) — chip-list of current assignments (★ marks primary, × detaches), button "Edytuj kategorie" opens the picker
- **`<CategoryPickerDialog>`** ([category-picker-dialog.tsx](apps/admin/src/components/catalog/category-picker-dialog.tsx)) — multi-select tree (search + checkboxes + per-row star radio for primary), saves via single `PUT /api/products/{id}/categories`
- **`category-tree.tsx`** got an optional `mode='multi-select'` with `selectedIds` / `onToggle` / `primaryId` / `onPrimaryChange`. Backward compatible — existing modeling/Move usages stay on the default `'select'` mode unchanged.
- **i18n**: new keys under `products.detail.categories.*` and `categories.picker.*` (PL).

## How it ties to the epic

After PCAT-03 + PCAT-04 merge:
1. Operator opens product detail → tab "Kategorie" → picker → assigns to "Samochody"
2. `EffectiveAttributeGroupResolver` (PCAT-03) walks the assigned category's ancestor chain
3. Cache invalidator (PCAT-04) bursts the form-schema cache for that ObjectType
4. Operator switches to tab "Atrybuty" → sees the inherited "Specyfikacja samochodu" group
5. Same picture matches the "Effective preview" card in `/modeling/categories?selected=…` — killer feature finally has empirical validation

## Test plan

- [x] TypeScript noEmit ✅
- [x] Biome strict ✅ (0 errors, 3 pre-existing warnings)
- [x] Vite build smoke ✅ (746ms, no new warnings)
- [ ] **Manual smoke on `pim.localhost`** (requires PCAT-02 ✅ already merged + PCAT-03 #485 + PCAT-04 #486 merged):
  1. Login as `admin@demo.localhost / changeme`
  2. Open any product → click tab "Kategorie"
  3. Click "+ Przypisz kategorie" → picker opens with full tree
  4. Search filter narrows visible nodes
  5. Check 2 categories → first auto-promotes to ★ primary
  6. Click ★ on the second → primary swaps
  7. Save → dialog closes, chip list shows both with ★ on the right one
  8. DevTools Network: PUT `/api/products/{id}/categories` returns 200
  9. DevTools Console: no red errors
  10. After PCAT-03 merged: refresh page → tab Atrybuty shows additional groups inherited from the assigned categories
- [ ] E2E (`apps/admin/e2e/cat-prod-05-picker.spec.ts`) — deferred to follow-up; existing Playwright suite stays green (PCAT-05 doesn't touch other flows)

## A11y

- Star button has `aria-label`, `aria-pressed`, `title`
- Detach button has `aria-label`, `title`
- Tree checkbox has `aria-label` referencing the category name
- Dialog uses shadcn Dialog primitives (focus trap + Esc behaviour built in)

## Out of scope

- Drag&drop reorder of assigned categories (Faza 1+)
- Bulk assign N products to a category from the products grid (Faza 1+)
- Cross-sell / Up-sell wiring in Powiązania tab (separate ticket)
- E2E spec — follow-up

Closes #478