### PR TITLE
feat(catalog): PCAT-06 — Produkty (N) card in modeling category panel

### DIFF
--- a/apps/admin/src/features/catalog/categories/category-products-card.tsx
+++ b/apps/admin/src/features/catalog/categories/category-products-card.tsx
@@ -1,0 +1,190 @@
+import { useQuery } from '@tanstack/react-query';
+import { ChevronLeft, ChevronRight, FolderTree, Star } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { Card } from '@/components/ui/card';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+interface ProductRow {
+  id: string;
+  code: string;
+  enabled: boolean;
+  status: string;
+  attributesIndexed: Record<string, unknown> | null;
+  isPrimary: boolean;
+  position: number;
+}
+
+interface ListResponse {
+  'hydra:totalItems'?: number;
+  'hydra:member'?: ProductRow[];
+}
+
+interface Props {
+  categoryId: string;
+}
+
+const PAGE_SIZE = 20;
+
+/**
+ * PCAT-06 (#479) — "Produkty (N)" section in the modeling category
+ * detail panel. Lists products assigned to the selected category with
+ * basic pagination. Each row links to `/products/{id}` for fast hop
+ * to the picker (PCAT-05) when the operator wants to change the
+ * assignment.
+ *
+ * Lives below the Effective preview card so the killer-feature reads
+ * "here's what an object would see, and here are the actual N objects
+ * already there".
+ */
+export function CategoryProductsCard({ categoryId }: Props) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language === 'pl' ? 'pl' : 'en';
+  const [page, setPage] = useState(1);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['categories', categoryId, 'products', page],
+    queryFn: async () =>
+      jsonFetch<ListResponse>(
+        `/api/categories/${categoryId}/products?page=${page}&itemsPerPage=${PAGE_SIZE}`,
+        { accept: 'application/json' },
+      ),
+    enabled: categoryId !== '',
+    staleTime: 30_000,
+  });
+
+  const total = data?.['hydra:totalItems'] ?? 0;
+  const members = data?.['hydra:member'] ?? [];
+  const lastPage = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <Card className="border border-zinc-200 p-6">
+      <header className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-zinc-500">
+            {t('categories.products_card.title', { defaultValue: 'Produkty w tej kategorii' })}
+          </span>
+          <span className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10.5px] text-zinc-600">
+            {total}
+          </span>
+        </div>
+      </header>
+
+      {isLoading ? (
+        <p className="px-1 py-3 text-[12.5px] text-zinc-500">
+          {t('app.loading', { defaultValue: 'Ładowanie…' })}
+        </p>
+      ) : total === 0 ? (
+        <div className="rounded-xl border border-dashed border-zinc-200 bg-zinc-50 p-6 text-center">
+          <FolderTree className="mx-auto size-6 text-zinc-400" />
+          <p className="mt-2 text-[12.5px] text-zinc-600">
+            {t('categories.products_card.empty', {
+              defaultValue: 'Brak produktów w tej kategorii.',
+            })}
+          </p>
+          <p className="mt-1 text-[11px] text-zinc-500">
+            {t('categories.products_card.empty_hint', {
+              defaultValue:
+                'Otwórz kartę produktu i przypisz go do kategorii w zakładce „Kategorie".',
+            })}
+          </p>
+        </div>
+      ) : (
+        <>
+          <ul className="divide-y divide-zinc-100 rounded-xl border border-zinc-100 bg-white">
+            {members.map((row) => (
+              <li key={row.id} className="flex items-center gap-3 px-3 py-2">
+                <Link
+                  to={`/products/${row.id}`}
+                  className="flex flex-1 items-center gap-3 text-left hover:underline"
+                >
+                  {row.isPrimary ? (
+                    <span
+                      className="grid size-5 place-items-center rounded-full bg-amber-100 text-amber-700"
+                      title={t('categories.products_card.is_primary', {
+                        defaultValue: 'Kategoria główna',
+                      })}
+                    >
+                      <Star className="size-3 fill-amber-500" />
+                    </span>
+                  ) : (
+                    <span className="size-5" aria-hidden />
+                  )}
+                  <span className="font-mono text-[12px] text-zinc-500">{row.code}</span>
+                  <span className="flex-1 text-[12.5px] text-ink">
+                    {productName(row.attributesIndexed, lang) ?? row.code}
+                  </span>
+                  <span
+                    className={cn(
+                      'rounded px-2 py-0.5 text-[10.5px] font-medium',
+                      row.enabled ? 'bg-emerald-50 text-emerald-700' : 'bg-zinc-100 text-zinc-500',
+                    )}
+                  >
+                    {row.enabled
+                      ? t('categories.products_card.enabled', { defaultValue: 'aktywny' })
+                      : t('categories.products_card.disabled', { defaultValue: 'nieaktywny' })}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+          {lastPage > 1 ? (
+            <footer className="mt-3 flex items-center justify-between text-[11.5px] text-zinc-500">
+              <span>
+                {t('categories.products_card.page_indicator', {
+                  defaultValue: 'Strona {{page}} z {{total}}',
+                  page,
+                  total: lastPage,
+                })}
+              </span>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page === 1}
+                  className="grid size-6 place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-30"
+                  aria-label={t('app.previous', { defaultValue: 'Poprzednia' })}
+                >
+                  <ChevronLeft className="size-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.min(lastPage, p + 1))}
+                  disabled={page === lastPage}
+                  className="grid size-6 place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-30"
+                  aria-label={t('app.next', { defaultValue: 'Następna' })}
+                >
+                  <ChevronRight className="size-3.5" />
+                </button>
+              </div>
+            </footer>
+          ) : null}
+        </>
+      )}
+    </Card>
+  );
+}
+
+function productName(
+  attrs: Record<string, unknown> | null | undefined,
+  lang: 'pl' | 'en',
+): string | null {
+  if (!attrs) return null;
+  const name = attrs.name;
+  if (typeof name === 'string') return name;
+  if (typeof name === 'object' && name !== null) {
+    const map = name as Record<string, unknown>;
+    const direct = map[lang];
+    if (typeof direct === 'string') return direct;
+    if (typeof map.value === 'object' && map.value !== null) {
+      const v = (map.value as Record<string, unknown>)[lang];
+      if (typeof v === 'string') return v;
+    }
+    if (typeof map.pl === 'string') return map.pl;
+    if (typeof map.en === 'string') return map.en;
+  }
+  return null;
+}

--- a/apps/admin/src/features/catalog/categories/list.tsx
+++ b/apps/admin/src/features/catalog/categories/list.tsx
@@ -21,6 +21,8 @@ import { MockBadge } from '@/components/ui/mock-badge';
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
+import { CategoryProductsCard } from './category-products-card';
+
 interface CategoryEntry {
   id: string;
   code: string;
@@ -472,6 +474,8 @@ function CategoryDetailPanel({
           })}
         </p>
       </Card>
+
+      <CategoryProductsCard categoryId={categoryId} />
 
       <p className="text-xs text-muted-foreground">
         <Link to={`/modeling/categories/${categoryId}`} className="underline">

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -418,6 +418,15 @@
       "selected_count": "Wybrano: {{count}}",
       "no_primary_warning": "Zaznacz kategorię główną (⭐) żeby zapisać.",
       "error_generic": "Nie udało się zapisać"
+    },
+    "products_card": {
+      "title": "Produkty w tej kategorii",
+      "empty": "Brak produktów w tej kategorii.",
+      "empty_hint": "Otwórz kartę produktu i przypisz go do kategorii w zakładce „Kategorie\".",
+      "is_primary": "Kategoria główna",
+      "enabled": "aktywny",
+      "disabled": "nieaktywny",
+      "page_indicator": "Strona {{page}} z {{total}}"
     }
   },
   "object_types": {

--- a/apps/api/src/Catalog/Presentation/Controller/CategoryProductsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CategoryProductsController.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * PCAT-06 (#479) — `GET /api/categories/{id}/products`
+ *
+ * Reverse-listing of the product↔category junction (epic UI-10): given a
+ * category, return the products assigned to it (paginated, hydra-shaped
+ * so Refine can consume it via the standard data provider).
+ *
+ * Server-side filter joins `object_categories` on `object_id`; only
+ * `kind=product` rows are returned (categories or assets cascading
+ * through the same junction would be a domain bug, but we filter
+ * defensively). TenantFilter on the parent fetch returns 404 for
+ * cross-tenant categories before we touch the DBAL query.
+ */
+final class CategoryProductsController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    private const int MAX_ITEMS_PER_PAGE = 200;
+    private const int DEFAULT_ITEMS_PER_PAGE = 30;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly Connection $connection,
+    ) {
+    }
+
+    #[Route(
+        '/api/categories/{id}/products',
+        name: 'pim_categories_products',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function __invoke(string $id, Request $request): JsonResponse
+    {
+        $category = $this->catalogObjects->findById(Uuid::fromString($id));
+        if (null === $category) {
+            throw new NotFoundHttpException(\sprintf('Category "%s" was not found.', $id));
+        }
+        if (ObjectKind::Category !== $category->getKind()) {
+            throw new UnprocessableEntityHttpException(\sprintf('Object "%s" is not a category.', $id));
+        }
+
+        $page = max(1, (int) $request->query->get('page', '1'));
+        $itemsPerPage = (int) $request->query->get('itemsPerPage', (string) self::DEFAULT_ITEMS_PER_PAGE);
+        if ($itemsPerPage < 1) {
+            $itemsPerPage = self::DEFAULT_ITEMS_PER_PAGE;
+        }
+        if ($itemsPerPage > self::MAX_ITEMS_PER_PAGE) {
+            $itemsPerPage = self::MAX_ITEMS_PER_PAGE;
+        }
+        $offset = ($page - 1) * $itemsPerPage;
+
+        $thisId = $category->getId()->toRfc4122();
+
+        $totalItems = self::toInt($this->connection->fetchOne(
+            'SELECT COUNT(*) FROM object_categories oc'
+            .' INNER JOIN objects o ON o.id = oc.object_id'
+            ." WHERE oc.category_id = CAST(:id AS uuid) AND o.kind = 'product'",
+            ['id' => $thisId],
+        ));
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT o.id AS id, o.code AS code, o.enabled AS enabled, o.status AS status,'
+            .' o.attributes_indexed AS attributes_indexed,'
+            .' oc.is_primary AS is_primary, oc.position AS position'
+            .' FROM object_categories oc'
+            .' INNER JOIN objects o ON o.id = oc.object_id'
+            ." WHERE oc.category_id = CAST(:id AS uuid) AND o.kind = 'product'"
+            .' ORDER BY o.id DESC'
+            .' LIMIT :limit OFFSET :offset',
+            ['id' => $thisId, 'limit' => $itemsPerPage, 'offset' => $offset],
+        );
+
+        $members = [];
+        foreach ($rows as $row) {
+            $rowId = self::asString($row['id'] ?? null);
+            $rowCode = self::asString($row['code'] ?? null);
+            $rowStatus = self::asString($row['status'] ?? null);
+            $members[] = [
+                '@id' => '/api/products/'.$rowId,
+                '@type' => 'Product',
+                'id' => $rowId,
+                'code' => $rowCode,
+                'enabled' => self::toBool($row['enabled']),
+                'status' => $rowStatus,
+                'attributesIndexed' => $this->decodeJson($row['attributes_indexed']),
+                'isPrimary' => self::toBool($row['is_primary']),
+                'position' => self::toInt($row['position']),
+            ];
+        }
+
+        $base = '/api/categories/'.$thisId.'/products';
+        $view = [
+            '@id' => $base.'?page='.$page.'&itemsPerPage='.$itemsPerPage,
+            '@type' => 'hydra:PartialCollectionView',
+            'hydra:first' => $base.'?page=1&itemsPerPage='.$itemsPerPage,
+        ];
+        $lastPage = $totalItems === 0 ? 1 : (int) ceil($totalItems / $itemsPerPage);
+        $view['hydra:last'] = $base.'?page='.$lastPage.'&itemsPerPage='.$itemsPerPage;
+        if ($page < $lastPage) {
+            $view['hydra:next'] = $base.'?page='.($page + 1).'&itemsPerPage='.$itemsPerPage;
+        }
+        if ($page > 1) {
+            $view['hydra:previous'] = $base.'?page='.($page - 1).'&itemsPerPage='.$itemsPerPage;
+        }
+
+        return new JsonResponse([
+            '@context' => '/api/contexts/Product',
+            '@id' => $base,
+            '@type' => 'hydra:Collection',
+            'hydra:totalItems' => $totalItems,
+            'hydra:member' => $members,
+            'hydra:view' => $view,
+        ]);
+    }
+
+    private function decodeJson(mixed $value): mixed
+    {
+        if (!\is_string($value) || '' === $value) {
+            return [];
+        }
+        $decoded = json_decode($value, true);
+
+        return \is_array($decoded) ? $decoded : [];
+    }
+
+    private static function toInt(mixed $value): int
+    {
+        if (\is_int($value)) {
+            return $value;
+        }
+        if (\is_string($value) && '' !== $value) {
+            return (int) $value;
+        }
+
+        return 0;
+    }
+
+    private static function asString(mixed $value): string
+    {
+        if (\is_string($value)) {
+            return $value;
+        }
+        if (\is_int($value)) {
+            return (string) $value;
+        }
+
+        return '';
+    }
+
+    private static function toBool(mixed $value): bool
+    {
+        if (\is_bool($value)) {
+            return $value;
+        }
+        if (\is_int($value)) {
+            return 1 === $value;
+        }
+        if (\is_string($value)) {
+            return 't' === $value || 'true' === $value || '1' === $value;
+        }
+
+        return false;
+    }
+}

--- a/apps/api/tests/Api/Catalog/CategoryProductsApiTest.php
+++ b/apps/api/tests/Api/Catalog/CategoryProductsApiTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Catalog\Domain\ObjectKind;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * PCAT-06 (#479) — coverage for `GET /api/categories/{id}/products`.
+ */
+final class CategoryProductsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function listsAssignedProductsWithPagination(): void
+    {
+        $client = $this->authenticatedClient();
+        $categoryId = $this->createCategory($client, 'cat_list');
+
+        $first = $this->createProduct($client, 'sku_a');
+        $second = $this->createProduct($client, 'sku_b');
+
+        $this->assign($client, $first, $categoryId, true);
+        $this->assign($client, $second, $categoryId, false);
+
+        $response = $client->request('GET', "/api/categories/{$categoryId}/products");
+        self::assertResponseStatusCodeSame(200);
+
+        $body = $response->toArray();
+        self::assertSame(2, $body['hydra:totalItems'] ?? null);
+        $members = $body['hydra:member'] ?? null;
+        \assert(\is_array($members));
+        self::assertCount(2, $members);
+
+        // Sanity check: each member carries the assignment-level metadata.
+        foreach ($members as $row) {
+            \assert(\is_array($row));
+            self::assertArrayHasKey('isPrimary', $row);
+            self::assertArrayHasKey('code', $row);
+        }
+    }
+
+    #[Test]
+    public function emptyResponseForCategoryWithoutAssignments(): void
+    {
+        $client = $this->authenticatedClient();
+        $categoryId = $this->createCategory($client, 'cat_empty');
+
+        $response = $client->request('GET', "/api/categories/{$categoryId}/products");
+        self::assertResponseStatusCodeSame(200);
+
+        $body = $response->toArray();
+        self::assertSame(0, $body['hydra:totalItems'] ?? null);
+        self::assertSame([], $body['hydra:member'] ?? null);
+    }
+
+    #[Test]
+    public function respectsItemsPerPageCap(): void
+    {
+        $client = $this->authenticatedClient();
+        $categoryId = $this->createCategory($client, 'cat_cap');
+
+        // Create 3 products, request 1 per page → assert hydra:totalItems=3
+        // and members count is 1. The cap (200) is asserted via the
+        // controller default; here we exercise the small-page path.
+        $a = $this->createProduct($client, 'cap_a');
+        $b = $this->createProduct($client, 'cap_b');
+        $c = $this->createProduct($client, 'cap_c');
+        foreach ([$a, $b, $c] as $p) {
+            $this->assign($client, $p, $categoryId, false);
+        }
+
+        $response = $client->request(
+            'GET',
+            "/api/categories/{$categoryId}/products?page=1&itemsPerPage=1",
+        );
+        self::assertResponseStatusCodeSame(200);
+
+        $body = $response->toArray();
+        self::assertSame(3, $body['hydra:totalItems'] ?? null);
+        $members = $body['hydra:member'] ?? null;
+        \assert(\is_array($members));
+        self::assertCount(1, $members);
+    }
+
+    #[Test]
+    public function nonCategoryIdReturns422(): void
+    {
+        $client = $this->authenticatedClient();
+        $productId = $this->createProduct($client, 'sku_kindcheck');
+
+        $client->request('GET', "/api/categories/{$productId}/products");
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function unauthorizedReturns401(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/api/categories/00000000-0000-7000-8000-000000000000/products');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    private function createProduct(Client $client, string $code): string
+    {
+        $response = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => $code,
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $id = $response->toArray()['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    private function createCategory(Client $client, string $code): string
+    {
+        $response = $client->request('POST', '/api/categories', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => $code,
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $id = $response->toArray()['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    private function assign(Client $client, string $productId, string $categoryId, bool $primary): void
+    {
+        $client->request('POST', "/api/products/{$productId}/categories", [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'categoryId' => $categoryId,
+                'isPrimary' => $primary,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Reverse-listing half of UI-10 (PCAT-06). Adds a "Produkty w tej kategorii (N)" card to the modeling category detail panel, plus the backend endpoint that powers it.

The killer-feature flow now reads end-to-end:
1. Operator opens `/modeling/categories?selected=…`
2. Sees declared groups + inherited groups + **Effective preview** ("what an object would see")
3. Sees **Produkty w tej kategorii (N)** ("the N actual objects already there") ← PCAT-06

Each row has ★ for the primary assignment + click → `/products/{id}` for fast hop into the picker (PCAT-05).

## Backend

`GET /api/categories/{id}/products?page=1&itemsPerPage=30`

- DBAL paginated query joining `object_categories` on `object_id`
- Hydra-shaped response (Refine-compatible: `hydra:member`, `hydra:totalItems`, `hydra:view` with first/last/next/previous)
- Server-side filter on `kind='product'` (defensive even though junction is product-only)
- Page size capped at 200, default 30
- Tenant scope via `findById` on category — cross-tenant returns 404
- Non-category id returns 422

## Frontend

`CategoryProductsCard` renders below the existing `Effective preview` card:
- Empty state explains the link to the assignment flow ("przypisz w zakładce Kategorie")
- Row: ★ if primary + code + localized name (`attributesIndexed.name.pl/en`) + enabled/disabled badge + link to product detail
- Pagination footer (prev/next + "Strona X z Y") only when total > page size

## Test plan

- [x] `bin/phpunit tests/Api/Catalog/CategoryProductsApiTest.php` — 5 scenarios:
  - lists assigned products with pagination
  - empty response for category without assignments
  - respects itemsPerPage cap (page 1 of 3 returns 1 member)
  - non-category id returns 422
  - unauthorized returns 401
- [x] PHPStan max ✅
- [x] PHP-CS-Fixer ✅
- [x] TypeScript noEmit ✅
- [x] Biome strict (formatter applied)
- [x] Vite build smoke ✅
- [ ] Manual smoke on `pim.localhost`:
  1. Login → `/modeling/categories` → select a category
  2. Scroll past the Effective preview card → see "Produkty w tej kategorii (0)" empty state
  3. Open any product → tab Kategorie (PCAT-05 #487) → assign to the category
  4. Refresh modeling category panel → counter shows (1), row visible with the product code
  5. Click row → opens `/products/{id}` correctly
  6. DevTools Network: GET `/api/categories/{id}/products` returns 200 with hydra shape
  7. DevTools Console: no red errors

## Out of scope

- Bulk move/unassign from the list (Faza 1)
- Filter by status / enabled (Faza 1)
- Sort other than `o.id DESC` (UUID v7 monotonic = chronological newest first by default)

Closes #479