### PR TITLE
feat(admin): PCAT-06b — activate '+ Create test object' for products

### DIFF
--- a/apps/admin/src/features/catalog/categories/list.tsx
+++ b/apps/admin/src/features/catalog/categories/list.tsx
@@ -407,25 +407,42 @@ function CategoryDetailPanel({
             </span>
           </div>
           <span className="inline-flex items-center gap-1.5">
-            <button
-              type="button"
-              disabled
-              aria-disabled
-              className="inline-flex cursor-not-allowed items-center gap-1.5 text-[11.5px] font-medium text-violet-500"
-              title={t('categories.preview.create_test_object_mock_tooltip', {
-                defaultValue: 'Wymaga wizard tworzenia obiektu (Faza 1)',
-              })}
-            >
-              +{' '}
-              {t('categories.preview.create_test_object', {
-                defaultValue: 'Create test object',
-              })}
-            </button>
-            <MockBadge
-              tooltip={t('categories.preview.create_test_object_mock_tooltip', {
-                defaultValue: 'Wymaga wizard tworzenia obiektu (Faza 1)',
-              })}
-            />
+            {targetType === 'product' ? (
+              <Link
+                to={`/products/new?categories=${categoryId}&primary=${categoryId}`}
+                className="inline-flex items-center gap-1.5 text-[11.5px] font-medium text-violet-700 hover:text-violet-800 hover:underline"
+                title={t('categories.preview.create_test_object_active_tooltip', {
+                  defaultValue: 'Utwórz produkt pre-przypisany do tej kategorii',
+                })}
+              >
+                +{' '}
+                {t('categories.preview.create_test_object', {
+                  defaultValue: 'Create test object',
+                })}
+              </Link>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  disabled
+                  aria-disabled
+                  className="inline-flex cursor-not-allowed items-center gap-1.5 text-[11.5px] font-medium text-violet-500"
+                  title={t('categories.preview.create_test_object_mock_tooltip', {
+                    defaultValue: 'Wymaga wizard tworzenia obiektu (Faza 1)',
+                  })}
+                >
+                  +{' '}
+                  {t('categories.preview.create_test_object', {
+                    defaultValue: 'Create test object',
+                  })}
+                </button>
+                <MockBadge
+                  tooltip={t('categories.preview.create_test_object_mock_tooltip', {
+                    defaultValue: 'Wymaga wizard tworzenia obiektu (Faza 1)',
+                  })}
+                />
+              </>
+            )}
           </span>
         </div>
         <p className="mb-3 text-[12.5px] text-zinc-700">

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -12,7 +12,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 
 import type { Provenance } from '@/components/provenance-badge';
 import { Button } from '@/components/ui/button';
@@ -97,9 +97,29 @@ export interface ProductDetailPageProps {
 export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
   const isEditMode = mode === 'edit';
   const id = productId ?? '';
+
+  // PCAT-06b (#480): when entering create mode from a category panel
+  // ("+ Create test object"), the URL carries `?categories=<id>&primary=<id>`.
+  // After the product is POSTed we run a single PUT against
+  // /api/products/{newId}/categories so the fresh row lands with the
+  // assignment already in place.
+  const prePopulatedCategoryIds = useMemo<string[]>(() => {
+    if (mode !== 'create') return [];
+    const raw = searchParams.get('categories');
+    if (raw === null || raw === '') return [];
+    return raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s !== '');
+  }, [mode, searchParams]);
+  const prePopulatedPrimaryId = useMemo<string | null>(() => {
+    if (mode !== 'create') return null;
+    return searchParams.get('primary');
+  }, [mode, searchParams]);
 
   const { result, query } = useOne<CatalogObjectDto>({
     resource: 'products',
@@ -201,6 +221,35 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
           contentType: 'application/ld+json',
           body,
         });
+        // PCAT-06b: apply pre-populated category assignment if "+ Create
+        // test object" navigated us in with categories/primary in the URL.
+        if (prePopulatedCategoryIds.length > 0) {
+          try {
+            const validPrimary =
+              prePopulatedPrimaryId !== null &&
+              prePopulatedCategoryIds.includes(prePopulatedPrimaryId)
+                ? prePopulatedPrimaryId
+                : prePopulatedCategoryIds[0];
+            await jsonFetch(`/api/products/${created.id}/categories`, {
+              method: 'PUT',
+              contentType: 'application/json',
+              accept: 'application/json',
+              body: {
+                primaryCategoryId: validPrimary,
+                categoryIds: prePopulatedCategoryIds,
+              },
+            });
+          } catch {
+            // Non-fatal: product is created; operator can re-assign in the
+            // Kategorie tab. Toast surfaces the partial success.
+            toast.error(
+              t('products.detail.create.category_apply_failed', {
+                defaultValue:
+                  'Produkt utworzony, ale nie udało się przypisać kategorii — przypisz ręcznie w zakładce Kategorie.',
+              }),
+            );
+          }
+        }
         toast.success(
           t('products.detail.create.success', {
             defaultValue: 'Utworzono produkt {{code}}',


### PR DESCRIPTION
## Summary

Flips the disabled MOCK button on the modeling category panel into a working shortcut for product creation pre-populated with the selected category as primary. Closes the operator-facing loop opened in PCAT-05.

## Before

`apps/admin/src/features/catalog/categories/list.tsx#L410` rendered a `<button disabled>` with `MockBadge` and tooltip *"Wymaga wizard tworzenia obiektu (Faza 1)"*. The shortcut existed in design but couldn't work because no junction / no assignment API / no FE picker.

## After

For `targetType === 'product'`:
- Button is now a `<Link>` to `/products/new?categories={id}&primary={id}`
- `ProductDetailPage` in `mode='create'` parses those query params
- After the POST that creates the product, fires a single PUT against `/api/products/{newId}/categories` with `{primaryCategoryId, categoryIds: [...]}` so the fresh row lands with the assignment already wired
- Non-fatal failure: if PUT fails, product is already created — toast tells the operator to re-assign manually in the Kategorie tab. Avoids half-failed wizard state.

For other `targetType` values (`service`, `brand`, custom kinds): button stays disabled MOCK. Agent-driven create flow for custom kinds is Faza 2 scope.

## Test plan

- [x] TypeScript noEmit ✅
- [x] Biome strict ✅
- [x] Vite build smoke ✅
- [ ] Manual smoke on `pim.localhost`:
  1. Login → `/modeling/categories`
  2. Select a category in the tree, ensure Object Type filter is `Product`
  3. Look at the Effective preview card header → "+ Create test object" link visible (no MOCK badge)
  4. Click it → navigates to `/products/new?categories=…&primary=…`
  5. Fill SKU + any minimum field → click Save
  6. Lands on the new product detail page
  7. Click tab "Kategorie" → see the original category as a chip with ★ for primary
  8. Switch back to `/modeling/categories`, select the same category → "Produkty w tej kategorii" card now shows the new product
  9. DevTools Network: POST `/api/products` then PUT `/api/products/{id}/categories` both 2xx

## Out of scope

- Pre-populating the picker UI in the create form (the assignment is invisible until after save — fine for the "test object" quick-shortcut use case)
- Full agent-driven wizard for custom-kind objects (Faza 2)

Closes #480