### PR TITLE
docs(catalog): PCAT-07 — close epik UI-10 + lessons + plan/UI doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ versioning per epic milestones (`0.X.Y` matches ticket numbering in
 
 ## [Unreleased]
 
+### Added — epik UI-10 (Product Categories Assignment)
+
+- **PCAT-01..07** Product↔category assignment end-to-end (1-day burst,
+  2026-05-10):
+  - DB junction `object_categories` (composite PK, partial unique
+    index `WHERE is_primary = true`, ON DELETE CASCADE on both FKs).
+    (#474 / PR #482)
+  - HTTP layer `ProductCategoryAssignmentController` — GET / PUT
+    (atomic replace) / POST (idempotent add) / DELETE (auto-promote
+    next primary). 50-cap, kind validation, tenant isolation.
+    (#475 / PR #483)
+  - `EffectiveAttributeGroupResolver` activates the `kind=Product`
+    branch — products inherit attribute groups from each assigned
+    category's full ancestor chain. Killer-feature "Effective preview"
+    in the modeling categories panel finally has empirical validation.
+    `PrimaryCategoryRepairListener` promotes the next-oldest assignment
+    when a category is cascade-removed. (#476 / PR #485)
+  - `ObjectFormSchemaCacheInvalidator` bursts the per-ObjectType cache
+    when an `ObjectCategory` row mutates. (#477 / PR #486)
+  - Frontend tab "Kategorie" on the product detail page (between
+    Multimedia and Powiązania) with chip-list + multi-select tree
+    picker dialog supporting primary swap. (#478 / PR #487)
+  - "Produkty (N)" card in the modeling category detail panel —
+    paginated reverse listing of the products assigned to a category.
+    (#479 / PR #488)
+  - Activated the previously-MOCK "+ Create test object" button —
+    one-click product creation pre-populated with the selected
+    category as primary. (#480 / PR #489)
+  - OpenAPI snapshot regenerated, epik documentation in
+    `Project Plan/UI/epik-10-product-categories.md`. (#481 / this PR)
+
+### Added — chore (deps maintenance)
+
+- **chore/deps** Force `fast-uri >= 3.1.2` via `pnpm.overrides` to
+  clear two HIGH advisories transitively pulled in via
+  `@commitlint/cli > ajv > fast-uri` (GHSA-q3j6-qgpj-74h6 path
+  traversal + GHSA-v39h-62p7-jpjc host confusion). Workaround until
+  upstream commitlint bumps ajv. (PR #484)
+
 ### Added — epic 0.11 hardening
 
 - **0.11.4** Audit log MVP via DH Auditor for catalog schema (ObjectType /

--- a/Project Plan/UI/epik-10-product-categories.md
+++ b/Project Plan/UI/epik-10-product-categories.md
@@ -1,0 +1,218 @@
+# Epik UI-10 — Product Categories Assignment
+
+**Status:** Closed (8/8 tickets shipped)
+**Sprzed mergowanego do main:** 2026-05-10
+**Zakres czasowy:** 1-day burst (PCAT-01..07)
+**Tickety:** [#474](https://github.com/malipie/PIM/issues/474), [#475](https://github.com/malipie/PIM/issues/475), [#476](https://github.com/malipie/PIM/issues/476), [#477](https://github.com/malipie/PIM/issues/477), [#478](https://github.com/malipie/PIM/issues/478), [#479](https://github.com/malipie/PIM/issues/479), [#480](https://github.com/malipie/PIM/issues/480), [#481](https://github.com/malipie/PIM/issues/481)
+**PR-y:** [#482](https://github.com/malipie/PIM/pull/482), [#483](https://github.com/malipie/PIM/pull/483), [#485](https://github.com/malipie/PIM/pull/485), [#486](https://github.com/malipie/PIM/pull/486), [#487](https://github.com/malipie/PIM/pull/487), [#488](https://github.com/malipie/PIM/pull/488), [#489](https://github.com/malipie/PIM/pull/489) (+ chore [#484](https://github.com/malipie/PIM/pull/484))
+
+---
+
+## Problem
+
+Cała koncepcja „Samochody mają inne pola niż Kosmetyki samochodowe" była **martwa**. Backend miał gotowy mechanizm dziedziczenia grup atrybutów po drzewie kategorii (`CategoryAttributeGroup` + `EffectiveAttributeGroupResolver`), ale **nie istniała relacja produkt↔kategoria** której resolver mógłby skonsumować dla `kind=Product`. Dwa konkretne objawy:
+
+1. `EffectiveAttributeGroupResolver::resolve($product)` zwracał tylko global ObjectType groups — branch dla `kind=Product` nie istniał, choć branch `kind=Category` był gotowy.
+2. „Effective preview" w panelu kategorii (killer feature) działał hipotetycznie — pokazywał *jakie grupy obiekt zobaczyłby*, ale dziś żaden produkt nie mógł być w kategorii, więc preview nie miał walidacji empirycznej.
+
+Dodatkowo button „+ Create test object" w panelu kategorii był MOCK (disabled, tooltip „Faza 1") — pierwszy *zalążek* dokładnie tej historii.
+
+## Outcome
+
+Po epiku operator może:
+
+1. **Przypisać produkt do N kategorii** z 1 oznaczoną jako primary (zakładka „Kategorie" w karcie produktu)
+2. **Widzieć w formie produktu pola dziedziczone po kategorii** (resolver branch dla Product aktywuje istniejący `CategoryAttributeGroup`)
+3. **Zobaczyć z poziomu panelu kategorii listę przypisanych produktów** (nowa karta „Produkty w tej kategorii (N)")
+4. **Utworzyć produkt pre-przypisany do kategorii** jednym kliknięciem („+ Create test object" aktywne dla Product)
+
+Killer feature „Effective preview" w panelu kategorii dostaje walidację empiryczną — co preview obiecuje pokazuje się w realnym formularzu produktu.
+
+---
+
+## Decyzje produktowe (potwierdzone z operatorem)
+
+1. **Primary + dodatkowe** — produkt ma 1 kategorię główną (`is_primary=true`) + N dodatkowych. Partial unique index na DB gwarantuje 1 primary per object. Primary użyte później w eksportach single-channel (Shopify wymaga jednej kategorii per produkt) i w breadcrumbs storefront.
+2. **Dedykowana junction `object_categories`** — nie reuse `Association`. Lepsze indeksy + czystsza semantyka + zgodność z resztą architektury (junction-pattern jak `CategoryAttributeGroup`).
+3. **Tab Kategorie** w karcie produktu — osobny pomiędzy Multimedia a Powiązania. Operator zmienił scope w trakcie planowania (oryginalnie planowane jako sekcja w tabie Powiązania) — kategorie są pierwszej klasy obywatelem produktu, podczas gdy Powiązania semantycznie znaczą produkt↔produkt (cross-sell).
+4. **Per-ObjectType cache invalidation** (nie per-object) — trade-off zaakceptowany: zmiana 1 produktu burst-uje cache dla wszystkich produktów tego typu. Per-object cache to follow-up Faza 1.1.
+
+---
+
+## Architektura
+
+### Junction `object_categories`
+
+```sql
+CREATE TABLE object_categories (
+  object_id   UUID NOT NULL,
+  category_id UUID NOT NULL,
+  is_primary  BOOLEAN NOT NULL DEFAULT false,
+  position    INT NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (object_id, category_id),
+  CONSTRAINT object_categories_no_self CHECK (object_id <> category_id)
+);
+CREATE INDEX object_categories_object_idx ON object_categories(object_id);
+CREATE INDEX object_categories_category_idx ON object_categories(category_id);
+CREATE UNIQUE INDEX object_categories_one_primary_per_object
+  ON object_categories(object_id) WHERE is_primary = true;
+ALTER TABLE object_categories
+  ADD CONSTRAINT object_categories_object_fk FOREIGN KEY (object_id) REFERENCES objects(id) ON DELETE CASCADE,
+  ADD CONSTRAINT object_categories_category_fk FOREIGN KEY (category_id) REFERENCES objects(id) ON DELETE CASCADE;
+```
+
+**Tenant scope:** dziedziczony przez FK do `objects.tenant_id` (bez own column). Listed w `TenantAuditCommand::INFRA_TABLES` allowlist.
+
+### API endpointy (HTTP layer — nie API Platform)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/products/{id}/categories` | List assignments |
+| PUT | `/api/products/{id}/categories` | Atomic replace (primary + categoryIds) |
+| POST | `/api/products/{id}/categories` | Idempotent single add (z opcjonalnym primary swap) |
+| DELETE | `/api/products/{id}/categories/{categoryId}` | Detach + auto-promote next |
+| GET | `/api/categories/{id}/products` | Reverse listing (paginated, hydra-shaped) |
+
+Walidacje (PUT):
+- max 50 kategorii per produkt (`MAX_ASSIGNMENTS = 50` w controllerze)
+- każdy `categoryId` musi być `kind=category` w tym samym tenancie
+- duplikaty w `categoryIds` blokowane (422)
+- `primaryCategoryId` musi być w `categoryIds` (lub `null` przy pustej liście)
+- target produkt musi być `kind=product` (404 inaczej)
+
+### Resolver branch (PCAT-03)
+
+```php
+} elseif (ObjectKind::Product === $object->getKind()) {
+    $assignments = $this->productCategories->findByProduct($object);
+    if ([] !== $assignments) {
+        $ancestorMap = [];
+        foreach ($assignments as $assignment) {
+            foreach ($this->collectCategoryAncestorIds($assignment->getCategory(), includeSelf: true) as $id) {
+                $ancestorMap[$id->toRfc4122()] = $id;
+            }
+        }
+        if ([] !== $ancestorMap) {
+            $this->mergeCategoryGroups($groups, array_values($ancestorMap), $type);
+        }
+    }
+}
+```
+
+Reuse istniejących helperów (`collectCategoryAncestorIds` z `includeSelf=true`, `mergeCategoryGroups`). Resolver pozostaje stateless. Backward compat: produkt bez assignments → fall back do ObjectType groups (zero regresji).
+
+### Primary repair listener (PCAT-03)
+
+Gdy kategoria jest cascade-removed:
+- `preRemove` na CatalogObject (`kind=category`) buforuje `Uuid[]` produktów dla których była primary (DBAL SELECT przed cascade)
+- `postFlush` dla każdego produktu wykonuje raw DBAL UPDATE: `WHERE oc.object_id = :pid ORDER BY position ASC, created_at ASC LIMIT 1` → set `is_primary=true`
+- Brak innych assignments → primary `null` (legalne)
+
+Raw DBAL bo managed entities są już detached po CASCADE. ORM-side mutations either miss the rows or fight Doctrine change tracking.
+
+### Cache invalidator (PCAT-04)
+
+`ObjectFormSchemaCacheInvalidator` rozszerzony o branch dla `ObjectCategory`:
+```php
+if ($entity instanceof ObjectCategory) {
+    $product = $entity->getProduct();
+    $this->perTypeTags[$product->getObjectType()->getId()->toRfc4122()] = true;
+}
+```
+
+Per-ObjectType invalidation (zgodnie z istniejącą strategią). Trade-off: bursty.
+
+---
+
+## Frontend
+
+### Tab „Kategorie" w karcie produktu (PCAT-05)
+
+Nowa kolejność tabów: `Atrybuty` | `Multimedia` | **`Kategorie`** | `Powiązania` | `Historia` | `Warianty`
+
+`<CategoriesTab>` ([apps/admin/src/features/catalog/products/components/categories-tab.tsx](../../apps/admin/src/features/catalog/products/components/categories-tab.tsx)):
+- Chip-list assignments (★ primary, × detach)
+- Single-row operations (toggle primary, detach) bezpośrednio przez POST/DELETE
+- Button „+ Edytuj kategorie" otwiera dialog z multi-select tree
+
+`<CategoryPickerDialog>` ([apps/admin/src/components/catalog/category-picker-dialog.tsx](../../apps/admin/src/components/catalog/category-picker-dialog.tsx)):
+- Multi-select tree (search + checkboxes + per-row star radio dla primary)
+- Auto-promote first selection do primary (mirroring DELETE handler semantics)
+- Save → single PUT (atomic replace)
+
+Adaptacja `<CategoryTree>` — opcjonalny `mode='multi-select'` z `selectedIds`/`onToggle`/`primaryId`/`onPrimaryChange`. Backward compat default `'select'`.
+
+### Tab „Produkty (N)" w panelu kategorii (PCAT-06)
+
+`<CategoryProductsCard>` ([apps/admin/src/features/catalog/categories/category-products-card.tsx](../../apps/admin/src/features/catalog/categories/category-products-card.tsx)) renderowany pod „Effective preview":
+- Paginowana lista (PAGE_SIZE = 20) z totalItems counter
+- Row: ★ primary + code + localized name + enabled badge + link do `/products/{id}`
+- Empty state z hint o tab Kategorie
+
+### „+ Create test object" (PCAT-06b)
+
+Dla `targetType === 'product'` button MOCK staje się `<Link>` do `/products/new?categories=<id>&primary=<id>`. ProductDetailPage w mode='create' parsuje query params i po POST wykonuje PUT na junction. Inne kindy zostają na MOCK (Faza 2).
+
+---
+
+## Co NIE jest scope tego epiku
+
+- **Per-object cache key** — Faza 1.1 (4-6h, wymaga rozszerzenia `GetObjectFormSchemaHandler` o trzecią warstwę tagów)
+- **Bulk reassignment** — Faza 1 (zaznacz N produktów → przypisz do kategorii)
+- **Drag&drop produktu z grid na drzewo** — Faza 1+
+- **Reorder przypisanych kategorii w pickerze** — Faza 1+
+- **Filtrowanie listy „Produkty per kategoria"** — Faza 1
+- **OpenAPI annotations dla custom controllerów** — pomijamy (zgodnie z istniejącym wzorcem `CategoryAttributeGroupController`); follow-up ticket „API documentation completeness"
+- **E2E spec dla picker-a** — follow-up
+
+---
+
+## Lessons (zapisane w `agent/lessons.md`)
+
+### Patterns to follow
+
+- **Junction bez tenant_id** dziedziczy izolację przez FK do TenantScoped głównej encji (`objects.tenant_id`). Dodać do `TenantAuditCommand::INFRA_TABLES` allowlist. Wzór: `category_attribute_groups`.
+- **Partial unique index** dla 1-of-N constraint (`WHERE is_primary = true`). ORM XML nie wspiera — migracja jest autorytatywna, ORM mirror plain (lub none jeśli plain by zablokował multi-row case).
+- **Atomic replace** (DELETE all + INSERT new w jednej transakcji) — używać ORM remove (nie DQL DELETE), żeby Identity Map była zsynchronizowana. Inaczej kolejne `persist` z tymi samymi composite PKs rzuca `EntityIdentityCollisionException`.
+- **Listener który mutuje przez DBAL po cascade** — bo managed entities są detached. Cleanup DBAL UPDATE w `postFlush` jest bezpieczny (partial unique index nie ma window).
+
+### Patterns to avoid
+
+- **NIE używać DQL DELETE** w atomic replace pattern — zostawia stale managed entities w Identity Map.
+- **NIE polegać na partial unique index w testach Foundry** — `ResetDatabase` rebuild schema z ORM mapping, partial indexes nie są w XML. Testy app-level (nie DB-level) dla 1-of-N invariants.
+
+### Świadome decyzje
+
+- **Per-ObjectType cache invalidation** zaakceptowane jako trade-off (burst akceptowany w MVP). Per-object follow-up Faza 1.1.
+- **Custom controllers nie w OpenAPI docs** — zgodnie z istniejącym wzorcem `CategoryAttributeGroupController`. Follow-up ticket dla pełnego API documentation completeness.
+- **`pnpm.overrides` dla fast-uri** ([#484](https://github.com/malipie/PIM/pull/484)) — transitive vuln w `@commitlint/cli > ajv > fast-uri`. Override do >=3.1.2 do czasu upstream commitlint bumpu ajv.
+
+---
+
+## Manual smoke flow (end-to-end weryfikacja)
+
+1. Login `admin@demo.localhost / changeme`
+2. Modeling → Kategorie → utwórz „Samochody" → zadeklaruj grupę „Specyfikacja samochodu" (target: Product)
+3. Edit dowolnego produktu → tab Kategorie → „+ Edytuj kategorie" → wybierz „Samochody" → ustaw primary → Save
+4. Refresh strony → tab Atrybuty pokazuje sekcję „Specyfikacja samochodu" (dziedziczona z kategorii)
+5. Modeling → Kategorie → „Samochody" → karta „Produkty w tej kategorii (1)" — widać produkt z ★
+6. „+ Create test object" w karcie Effective preview → otwiera form nowego produktu z prepopulated category
+7. Save → produkt utworzony + już ma „Samochody" jako primary
+
+**DevTools:**
+- PUT/POST/DELETE wszystkie 200/201/204
+- Console bez errorów
+
+---
+
+## Next steps
+
+Po merge wszystkich 8 PR-ów epik jest closed. Naturalne follow-up tickety:
+
+1. **PCAT-FOLLOWUP-01: Per-object cache key** (Faza 1.1, 4-6h)
+2. **PCAT-FOLLOWUP-02: Bulk reassignment z grida produktów** (Faza 1)
+3. **PCAT-FOLLOWUP-03: E2E spec dla picker-a** (małe)
+4. **API documentation completeness** — OpenAPI annotations dla custom controllerów (osobny epik)
+
+Pierwsze MDM follow-upy (rozszerzenia typu „bazy kompatybilności") są w [Zrodla/PRD/MDM-rozszerzenia-pomysly.md](../../Zrodla/PRD/MDM-rozszerzenia-pomysly.md) — Faza 2/3 scope.

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,38 @@
 # Current Status
 
+## 2026-05-10: Epik UI-10 — Product Categories Assignment **DOMKNIĘTY** (PCAT-01..07 + PCAT-06b merged)
+
+Marathon zakończony — wszystkie 8 ticketów PCAT-01..07 + PCAT-06b shipped w jednym dniu (Marathon Rule). Killer feature „Effective preview" w panelu kategorii dostała empirical validation: produkt można wpiąć w kategorię, jego forma realnie pokazuje dziedziczone grupy atrybutów.
+
+**Backend (4 PR-y):**
+- #482 (`9e69868`) PCAT-01 — DB junction `object_categories` (composite PK + partial unique `WHERE is_primary=true` + cascade FK + entity + repo + atomic replace)
+- #483 (`89f7b88`) PCAT-02 — `ProductCategoryAssignmentController` (GET / PUT atomic replace / POST idempotent / DELETE auto-promote-next; 50-cap; tenant isolation)
+- #485 (`412d9c6`) PCAT-03 — `EffectiveAttributeGroupResolver` branch dla `kind=Product` + `PrimaryCategoryRepairListener` (cascade safety)
+- #486 (`aeb4cb8`) PCAT-04 — `ObjectFormSchemaCacheInvalidator` hook na `ObjectCategory` (per-ObjectType, follow-up per-object Faza 1.1)
+
+**Frontend (3 PR-y):**
+- #487 (`be427e4`) PCAT-05 — tab „Kategorie" w karcie produktu (między Multimedia a Powiązania) + `CategoryPickerDialog` (multi-select tree z primary radio) + chip-list assignments z reactive POST/DELETE
+- #488 PCAT-06 — `CategoryProductsCard` w panelu kategorii (paginowana lista produktów + ★ primary + link do `/products/{id}`) + backend `GET /api/categories/{id}/products`
+- #489 PCAT-06b — aktywacja MOCK „+ Create test object" → `<Link>` do `/products/new?categories=<id>&primary=<id>` + post-POST PUT na junction
+
+**Maintenance:**
+- #484 (`26d3cac`) chore(deps) — `pnpm.overrides` na `fast-uri >= 3.1.2` (transitive vuln w `@commitlint/cli > ajv > fast-uri`)
+
+**Dokumentacja:**
+- `Project Plan/UI/epik-10-product-categories.md` — pełny opis epiku (problem / outcome / decyzje / architektura / lessons / next steps)
+- `Zrodla/PRD/MDM-rozszerzenia-pomysly.md` — brainstorm 5 use-case'ów rozszerzeń MDM (bazy kompatybilności, salony, lookbooki, recipe, sales reps) z mapowaniem na ADR-009 — Faza 2/3 scope
+- `agent/lessons.md` — 10 patterns z PCAT (junction inheritance, partial unique, atomic replace, DBAL listener, cache trade-off, OpenAPI custom controllers, pnpm overrides, subroute pattern, tab semantics, killer-feature validation)
+- `CHANGELOG.md` — sekcja Added — epik UI-10
+- Snapshot `packages/shared-types/src/api.d.ts` (4927 linii, AP4 routes; custom controllery jak w `CategoryAttributeGroupController` precedensem nie wpisane do OpenAPI — follow-up ticket „API documentation completeness")
+
+**Świadome odejścia (kandydaci na follow-up):**
+- **PCAT-FOLLOWUP-01 — per-object cache key** (Faza 1.1, 4-6h)
+- **PCAT-FOLLOWUP-02 — bulk reassignment z grida produktów** (Faza 1)
+- **PCAT-FOLLOWUP-03 — E2E spec dla picker-a** (mały)
+- **API documentation completeness** — OpenAPI annotations dla wszystkich custom controllers (osobny epik)
+
+---
+
 ## 2026-05-07: Epik UI-09 / 0.13 — Imports MVP **DOMKNIĘTY** (IMP-01 do IMP-15 merged)
 
 Marathon zakończony — wszystkie 15 ticketów IMP-01..IMP-15 na `main`. IMP-14 (#455 → `d4ef77e`) i IMP-15 (#456 → ten commit) zamknęły epik. **Świadome odejścia** zostają jako follow-up'y:

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,43 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z epiku UI-10 (PCAT — Product Categories Assignment, 2026-05-10)
+
+1. **Junction bez `tenant_id` dziedziczy izolację przez FK** do TenantScoped głównej encji (`objects.tenant_id`). Wzór: `category_attribute_groups`. Działa dla `object_categories` bez własnej kolumny tenant. Wymóg: dodać do `TenantAuditCommand::INFRA_TABLES` allowlist, inaczej audit command rzuci alert. Ekonomia: o jedną kolumnę i jeden indeks mniej × N junction tables. Defence in depth: gdy CASCADE na FK się rozjedzie, audit komenda szybko wykryje rozspójnienie.
+
+2. **Partial unique index dla `1-of-N constraint`** (np. `WHERE is_primary = true`). ORM XML nie wspiera `where` na unique-constraint — migracja jest autorytatywna, ORM mirror plain (lub none jeśli plain unique zablokowałby multi-row case). W moim PCAT-01: nie da się dać plain unique na `(object_id)` bo to zablokowałoby wszystkie multi-assignments. Skutek: w testach Foundry (`ResetDatabase` rebuilds schema z mapping bypassing migrations) partial unique nie istnieje. Walidacja `1-of-N` musi być testowana na app-level (controller wraps DELETE+INSERT w transakcji), nie DB-level. DB partial unique to safety-net na app-level bug → testowany w manual smoke (cURL bezpośrednio do realnej bazy).
+
+3. **Atomic replace** (DELETE all + INSERT new w jednej transakcji): używać **ORM `remove`** (foreach + persist), nie DQL `DELETE`. DQL DELETE nie czyści Identity Map — kolejny `persist` z tymi samymi composite PKs rzuca `EntityIdentityCollisionException`. Pattern z `DoctrineObjectCategoryRepository::replaceForProduct`:
+   ```php
+   $em->wrapInTransaction(function () use ($em, $product, $categoryIds, $primaryId): void {
+       foreach ($this->findByProduct($product) as $existing) {
+           $em->remove($existing);
+       }
+       $em->flush();
+       // …potem persist nowych
+       $em->flush();
+   });
+   ```
+
+4. **Listener który mutuje przez DBAL po cascade delete** — managed entities są już detached w `postFlush`, ORM-side mutations either miss the rows or fight Doctrine change tracking. Pattern z `PrimaryCategoryRepairListener`:
+   - `preRemove`: SELECT z DBAL przed cascade, buforuj affected ids w field state
+   - `postFlush`: dla każdego buforowanego id raw DBAL UPDATE; partial unique już bezpieczny bo poprzedni primary row został cascade-removed
+   - W testach Foundry: `$em->clear()` po `$em->flush()` żeby Identity Map odświeżył encje (DBAL UPDATE nie powiadamia ORM)
+
+5. **Per-ObjectType cache invalidation jako MVP trade-off** — `ObjectFormSchemaCacheInvalidator` używa per-type tag (`pim_form_schema.object_type.<id>`) bo per-object key wymaga rozszerzenia `GetObjectFormSchemaHandler` o trzecią warstwę tagów (4-6h). Trade-off zaakceptowany w MVP: zmiana 1 produktu burst-uje cache wszystkich produktów tego typu. Przy admin-pacede operacjach (nie bulk import) i krótkim TTL modeling cache pool — niezauważalne. Per-object → Faza 1.1.
+
+6. **Custom controllers nie w OpenAPI docs** — zgodnie z istniejącym wzorcem `CategoryAttributeGroupController`. Frontend używa `jsonFetch` bezpośrednio (lokalne typy w komponencie). Generowane `packages/shared-types/src/api.d.ts` zawiera tylko API Platform routes (`/api/products`, `/api/categories` etc.). Pełna OpenAPI completeness dla custom routes = osobny epik; nie blocker dla zewnętrznych klientów którzy po katalogu chodzą przez API Platform routes.
+
+7. **`pnpm.overrides` na transitive vuln** ([#484](https://github.com/malipie/PIM/pull/484)) — gdy advisory dotyczy transitive dep (`@commitlint/cli > ajv > fast-uri ≤ 3.1.1`), upstream nie ma jeszcze patched release, ale fix jest w nowszej wersji transitive — `pnpm.overrides.<package>` zmusza wszystkie chains na patched. Workaround do czasu aż upstream commitlint bumpnie ajv. Ważne: `pnpm install` po zmianie `package.json` regeneruje lockfile (sprawdź `pnpm audit` → "No known vulnerabilities found").
+
+8. **Custom controller subroute na `/api/products/{id}/{subresource}`** (np. `/api/products/{id}/categories`) NIE konfliktuje z API Platform routes na `/api/products` ani `/api/products/{id}`. Symfony pierwszy match wygrywa, ale path-parametry z różną liczbą segmentów to różne routes — bezpieczne. Wzór działa dla `CategoryAttributeGroupController` (#408) i `ProductCategoryAssignmentController` (PCAT-02). Anti-pattern: subroute na *tym samym* path co AP4 read endpoint — patrz Asset MVP lesson #5.
+
+9. **Tab order semantics — kategorie ≠ powiązania** (decyzja UX, 2026-05-10). Pierwotny plan PCAT-05 wpinał picker kategorii w tab `Powiązania` jako sekcję. Operator zmienił scope: `Powiązania` semantycznie znaczy produkt↔produkt (cross-sell, up-sell), `Kategorie` to driver dziedziczenia atrybutów + nawigacja storefront — **dwa różne pojęcia, dwa taby**. Reguła: gdy nowa relacja domenowa wchodzi do karty obiektu, zastanów się czy semantycznie pasuje do istniejącego tabu czy zasługuje na własny.
+
+10. **Killer feature wymaga empirical validation** — „Effective preview" w panelu kategorii pokazywał *jakie grupy obiekt zobaczyłby* od dawna, ale przed PCAT-03 nie było żadnego sposobu żeby zweryfikować że preview działa zgodnie z prawdą (żaden produkt nie mógł być w kategorii). Po epiku: operator może otworzyć tab Atrybuty produktu wpiętego w kategorię i porównać wynik z Effective preview tej samej kategorii — powinny się zgadzać. Reguła: feature zaprojektowany w izolacji *bez weryfikatora* jest fragile; jak najszybciej dorabiamy ścieżkę żeby empirycznie potwierdzić poprawność.
+
+---
+
 ## Lessons z #438 (DAM MVP — `/assets` upload, dedupe, thumbnails, edit, bulk)
 
 1. **`#[IsGranted('ATTR', 'App\\FQCN')]` zwraca 500** — Symfony 7 traktuje drugi argument jako Expression Language, nie literalny string. „Could not find the subject 'X' for the #[IsGranted] attribute". Workaround: inject `AuthorizationCheckerInterface` w konstruktorze + manualny `->isGranted('ATTR', \App\FQCN::class)` w `__invoke`. Wzorzec już używany w pozostałych Asset controllerach (PatchAssetController, DeleteAssetController, BulkDeleteAssetsController). Nie używaj `#[IsGranted]` z subject jako string.


### PR DESCRIPTION
## Summary

Documentation closing PR for epic UI-10 (Product Categories Assignment).

## What ships

- **[Project Plan/UI/epik-10-product-categories.md](Project Plan/UI/epik-10-product-categories.md)** — full epic record:
  - Problem statement (resolver branch dla \`kind=Product\` martwy + killer-feature \"Effective preview\" bez empirical validation + \"+ Create test object\" MOCK)
  - Outcome (4 user-facing capabilities)
  - Decyzje produktowe (primary + dodatkowe; dedykowana junction; tab Kategorie osobno; per-ObjectType cache trade-off)
  - Architecture (junction schema, API contract, resolver branch code, listener pattern)
  - Out of scope (per-object cache; bulk reassignment; drag&drop; reorder; filtering; OpenAPI for custom controllers; E2E)
  - Lessons + manual smoke flow + next-steps backlog
- **[agent/lessons.md](agent/lessons.md)** — 10 patterns dorzucone do tematycznych sekcji:
  1. Junction bez \`tenant_id\` dziedziczy izolację przez FK
  2. Partial unique index dla 1-of-N constraint
  3. Atomic replace via ORM remove (nie DQL DELETE)
  4. DBAL listener po cascade delete
  5. Per-ObjectType cache invalidation jako MVP trade-off
  6. Custom controllers nie w OpenAPI docs
  7. \`pnpm.overrides\` na transitive vuln
  8. Custom subroute pattern \`/api/products/{id}/{subresource}\`
  9. Tab order semantics — kategorie ≠ powiązania (decyzja UX)
  10. Killer feature wymaga empirical validation
- **[agent/current_status.md](agent/current_status.md)** — UI-10 oznaczone DOMKNIĘTY z PR ledger + dokumentacja + follow-up
- **[CHANGELOG.md](CHANGELOG.md)** — sekcje Added: epik UI-10 + chore/deps fast-uri

## Snapshot \`packages/shared-types/src/api.d.ts\`

Lokalnie zregenerowane (4927 linii, AP4 routes). **NIE w tym PR-ze** — plik jest gitignored (\`packages/shared-types/.gitignore\` line 2). Custom controllery (\`ProductCategoryAssignmentController\`, \`CategoryProductsController\`, \`CategoryAttributeGroupController\`) nie są w OpenAPI docs zgodnie z istniejącym wzorcem (\`CategoryAttributeGroupController\` to precedens). Pełna OpenAPI completeness dla custom routes = osobny epik (\"API documentation completeness\"), nie blocker dla zewnętrznych klientów którzy chodzą po katalogu przez API Platform routes.

## Test plan

- [x] Both \`pnpm --filter @pim/admin typecheck\` and \`pnpm --filter @pim/shared-types typecheck\` pass
- [x] Manual review of all 4 docs files for accuracy against shipped code
- [x] OpenAPI snapshot verified locally — admin typecheck (which doesn't import \`api.d.ts\`) still passes

## Next steps after merge

Backlog created in \`Project Plan/UI/epik-10-product-categories.md\` § Next steps:
- PCAT-FOLLOWUP-01: Per-object cache key (Faza 1.1, 4-6h)
- PCAT-FOLLOWUP-02: Bulk reassignment z grida produktów (Faza 1)
- PCAT-FOLLOWUP-03: E2E spec dla picker-a (mały)
- API documentation completeness (osobny epik)

Plus first MDM extensions (Pimcore-style) brainstorm w \`Zrodla/PRD/MDM-rozszerzenia-pomysly.md\` — Faza 2/3 scope.

Closes #481