### PR TITLE
fix(admin): DeclareAttributeGroupDialog — read both member shapes

### DIFF
--- a/apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx
@@ -71,11 +71,14 @@ export function DeclareAttributeGroupDialog({
   const { data: groups = [] } = useQuery<AttributeGroupRow[]>({
     queryKey: ['attribute_groups', 'picker'],
     queryFn: async () => {
-      const data = await jsonFetch<{ 'hydra:member'?: AttributeGroupRow[] }>(
-        '/api/attribute_groups?itemsPerPage=200',
-        { accept: 'application/ld+json' },
-      );
-      return data['hydra:member'] ?? [];
+      // AP4 hydra collection: newer responses use the unprefixed `member`
+      // field, older surface still ships `hydra:member`. Read both so the
+      // dialog stays correct across the upgrade window.
+      const data = await jsonFetch<{
+        'hydra:member'?: AttributeGroupRow[];
+        member?: AttributeGroupRow[];
+      }>('/api/attribute_groups?itemsPerPage=200', { accept: 'application/ld+json' });
+      return data.member ?? data['hydra:member'] ?? [];
     },
     enabled: open,
     staleTime: 30_000,


### PR DESCRIPTION
## Summary

Pre-existing bug in the modeling categories panel — \"Declare attribute group\" dialog showed \"Brak wyników.\" even when the tenant had seeded attribute groups (audit + custom).

## Root cause

AP4 hydra collections now ship the **unprefixed** \`member\` field; older surface still included \`hydra:member\`. The dialog (UI-08 VIEW-04, [declare-attribute-group-dialog.tsx#L74-L82](apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx#L74)) only read \`data['hydra:member']\` → always \`undefined\` after the AP4 bump → \`?? []\` → empty list.

Verified raw response from \`/api/attribute_groups?itemsPerPage=200\`:
\`\`\`json
{
  \"@type\": \"Collection\",
  \"totalItems\": 2,
  \"member\": [{ \"id\": \"…\", \"code\": \"audit\" }, { \"id\": \"…\", \"code\": \"wymiary\" }]
}
\`\`\`

## Fix

Read both shapes (\`data.member ?? data['hydra:member'] ?? []\`) — pattern already used in \`variants-tab-host.tsx:55\` and \`variants-list-card.tsx:49\` for the same reason.

## Test plan

- [x] TypeScript noEmit ✅
- [x] Biome strict ✅ (3 pre-existing warnings, 1 info)
- [ ] Manual smoke on \`pim.localhost\`: open Modelowanie → Kategorie → wybierz kategorię → \"+ Declare group\" → assert lista grup jest widoczna (nie \"Brak wyników\")

## Discovered during

Operator was validating PCAT-05/06 manual smoke and reported \"nie wyświetlają się grupy atrybutów do przypisania do kategorii\". Quick triage: AP4 response shape mismatch.

## Out of scope

- Same potential issue elsewhere — grepped \`hydra:member\` and only this one + the VariantsList* (already fixed) consume it. Other AP4 reads go through Refine's data provider which handles both.