### PR TITLE
feat(admin): restore Excel view toggle on /products list

### DIFF
--- a/apps/admin/src/components/catalog/view-mode-toggle.tsx
+++ b/apps/admin/src/components/catalog/view-mode-toggle.tsx
@@ -1,0 +1,72 @@
+import { Grid3x3, Table2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+export type ProductsViewMode = 'grid' | 'excel';
+
+/**
+ * Restored after VIEW-05 (#412) dropped the table/excel toggle for
+ * mockup-perfection — operators kept reaching for batch inline-cell
+ * edit (UI-02.12 ExcelLikeGrid). Same segmented-control shape as
+ * {@link VariantsToggle} so the toolbar stays visually consistent.
+ *
+ * Persisted via localStorage in the parent (`pim.products.viewMode`)
+ * so the choice survives navigation. Default is `grid` — the
+ * pixel-perfect display the mockup ships.
+ */
+export function ViewModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: ProductsViewMode;
+  onChange: (next: ProductsViewMode) => void;
+}) {
+  const { t } = useTranslation();
+  const options: ReadonlyArray<{
+    value: ProductsViewMode;
+    label: string;
+    Icon: typeof Grid3x3;
+  }> = [
+    {
+      value: 'grid',
+      label: t('products.view_mode.grid', { defaultValue: 'Karty' }),
+      Icon: Grid3x3,
+    },
+    {
+      value: 'excel',
+      label: t('products.view_mode.excel', { defaultValue: 'Excel' }),
+      Icon: Table2,
+    },
+  ];
+
+  return (
+    <div
+      className="inline-flex h-11 items-center rounded-2xl bg-white p-1 shadow-sm"
+      role="tablist"
+      aria-label={t('products.view_mode.aria', { defaultValue: 'Tryb widoku' })}
+    >
+      {options.map(({ value, label, Icon }) => {
+        const active = mode === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => {
+              onChange(value);
+            }}
+            className={cn(
+              'inline-flex h-9 items-center gap-1.5 rounded-xl px-3 text-[12.5px] font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900',
+              active ? 'bg-zinc-900 text-white' : 'text-zinc-500 hover:text-zinc-700',
+            )}
+          >
+            <Icon className="size-3.5" />
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router';
 import { AdvancedFilterBuilder } from '@/components/catalog/advanced-filter-builder';
 import { BulkBar } from '@/components/catalog/bulk-bar';
 import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
+import { type ExcelColumn, ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
 import { FilterPill } from '@/components/catalog/filter-pill';
 import type { FilterValue } from '@/components/catalog/product-filter-chips';
 import { ProductsGrid, type ProductsGridRow } from '@/components/catalog/products-grid';
@@ -14,6 +15,7 @@ import { SaveViewModal } from '@/components/catalog/save-view-modal';
 import { SavedViewsRail } from '@/components/catalog/saved-views-rail';
 import type { SyncAggregate } from '@/components/catalog/sync-aggregate-icon';
 import { type VariantsMode, VariantsToggle } from '@/components/catalog/variants-toggle';
+import { type ProductsViewMode, ViewModeToggle } from '@/components/catalog/view-mode-toggle';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/components/ui/toast';
 import {
@@ -39,6 +41,30 @@ interface CatalogObjectListEntry {
 
 const PRODUCT_FACETS = ['enabled', 'status', 'brand', 'family'];
 
+/**
+ * Column set for Excel view (UI-02.12 restored). SKU + status + variant
+ * axis are read-only (system / derived). Name + brand commit through
+ * the attributes payload; enabled commits at the product root. Other
+ * columns are read-only because the value renderer flattens nested
+ * structures (categories, price, sync) that the inline editor cannot
+ * round-trip into a single PATCH.
+ *
+ * The intersection with `Record<string, unknown>` satisfies the
+ * `ExcelLikeGrid` generic constraint without modifying the shared
+ * `ProductsGridRow` interface (which has narrow per-key types).
+ */
+type ExcelProductRow = ProductsGridRow & Record<string, unknown>;
+
+const EXCEL_COLUMNS: ExcelColumn<ExcelProductRow>[] = [
+  { key: 'sku', label: 'SKU', type: 'text', width: 160, readOnly: true },
+  { key: 'name', label: 'Nazwa', type: 'text', width: 280 },
+  { key: 'brand', label: 'Marka', type: 'text', width: 160 },
+  { key: 'enabled', label: 'Aktywny', type: 'boolean', width: 100 },
+  { key: 'status', label: 'Status', type: 'text', width: 100, readOnly: true },
+  { key: 'completenessPct', label: 'Kompletność', type: 'number', width: 110, readOnly: true },
+  { key: 'variantAxis', label: 'Wariant', type: 'text', width: 120, readOnly: true },
+];
+
 const STATUS_VALUES: ReadonlyArray<{ value: string; label: string; sync: SyncAggregate }> = [
   { value: 'green', label: 'OK', sync: 'green' },
   { value: 'yellow', label: 'Niepełne', sync: 'yellow' },
@@ -55,6 +81,17 @@ export function ProductListPage() {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [showSelectedOnly, setShowSelectedOnly] = useState(false);
   const [variantsMode, setVariantsMode] = useState<VariantsMode>('tree');
+  const [viewMode, setViewMode] = useState<ProductsViewMode>(() => {
+    if (typeof window === 'undefined') return 'grid';
+    const stored = window.localStorage.getItem('pim.products.viewMode');
+    return stored === 'excel' ? 'excel' : 'grid';
+  });
+  const handleViewModeChange = (next: ProductsViewMode): void => {
+    setViewMode(next);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('pim.products.viewMode', next);
+    }
+  };
   const [activeViewSlug, setActiveViewSlug] = useState<string | null>(null);
   const [showSaveViewModal, setShowSaveViewModal] = useState(false);
   const [expandedMasters, setExpandedMasters] = useState<Set<string>>(new Set());
@@ -239,6 +276,39 @@ export function ProductListPage() {
       });
   };
 
+  const handleExcelCommit = async (
+    row: ProductsGridRow,
+    colKey: string,
+    value: unknown,
+  ): Promise<void> => {
+    // Two writeable surfaces in Excel mode:
+    //   - `enabled` is a top-level column on the product → PATCH at root
+    //   - everything else is an attribute → wrap in `attributes`
+    // Anything outside this set should not be reachable because
+    // EXCEL_COLUMNS marks unsupported keys as readOnly, but we guard
+    // defensively in case the column set changes.
+    try {
+      if (colKey === 'enabled') {
+        await jsonFetch(`/api/products/${row.id}`, {
+          method: 'PATCH',
+          body: { enabled: Boolean(value) },
+          contentType: 'application/merge-patch+json',
+        });
+      } else if (colKey === 'name' || colKey === 'brand') {
+        await jsonFetch(`/api/products/${row.id}`, {
+          method: 'PATCH',
+          body: { attributes: { [colKey]: value } },
+          contentType: 'application/merge-patch+json',
+        });
+      } else {
+        return;
+      }
+      await refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'unknown');
+    }
+  };
+
   const onBulkApplied = (): void => {
     setSelected(new Set());
     setShowSelectedOnly(false);
@@ -346,6 +416,8 @@ export function ProductListPage() {
 
         <VariantsToggle mode={variantsMode} onChange={setVariantsMode} />
 
+        <ViewModeToggle mode={viewMode} onChange={handleViewModeChange} />
+
         <Button
           type="button"
           variant="outline"
@@ -431,6 +503,16 @@ export function ProductListPage() {
 
       {showEmptyState ? (
         <EmptyStateProducts />
+      ) : viewMode === 'excel' ? (
+        <ExcelLikeGrid<ExcelProductRow>
+          rows={visible as ExcelProductRow[]}
+          columns={EXCEL_COLUMNS}
+          onCommit={(rowIdx, colKey, value) => {
+            const row = visible[rowIdx];
+            if (row === undefined) return;
+            void handleExcelCommit(row, colKey, value);
+          }}
+        />
       ) : (
         <ProductsGrid
           rows={visible}

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -579,6 +579,11 @@
       "expand": "Rozwiń warianty",
       "collapse": "Zwiń warianty"
     },
+    "view_mode": {
+      "aria": "Tryb widoku",
+      "grid": "Karty",
+      "excel": "Excel"
+    },
     "fields": {
       "sku": "SKU",
       "name": "Nazwa",


### PR DESCRIPTION
## Summary

VIEW-05 (PR #412) dropped the table/excel toggle from the products list for pixel-perfect mockup parity. Operator kept reaching for the batch inline-cell edit it provided (single-click cell editor, F2 quick-edit, drag-fill, clipboard TSV) — all from the existing **UI-02.12 ExcelLikeGrid component which has been sitting unused in the tree since**.

This PR re-wires it without re-opening VIEW-05's pixel decisions.

## What ships

- New [\`<ViewModeToggle>\`](apps/admin/src/components/catalog/view-mode-toggle.tsx) — two-pill segmented control matching \`<VariantsToggle>\` shape, sits next to it in the toolbar
- \`viewMode\` state in [\`ProductListPage\`](apps/admin/src/features/catalog/products/list.tsx) persisted via \`localStorage\` (\`pim.products.viewMode\`) — default \`grid\` (mockup parity), choice survives navigation
- Conditional render: \`<ProductsGrid>\` (default) or \`<ExcelLikeGrid>\` (excel mode), against the same \`visible\` row set
- Local \`ExcelProductRow = ProductsGridRow & Record<string, unknown>\` adapter to satisfy the grid's generic constraint without modifying the shared row interface
- Commit handler:
  - \`enabled\` → PATCH at product root (matches existing \`handleToggleEnabled\`)
  - \`name\` / \`brand\` → PATCH \`attributes\` payload
  - \`sku\` / \`status\` / \`completenessPct\` / \`variantAxis\` → read-only (system-derived or collapsed structures the inline editor can't round-trip)

## Why a separate \`<ViewModeToggle>\` (not extending VariantsToggle)

\`VariantsToggle\` is mode-specific (flat/tree); two unrelated booleans on one segmented control would conflate semantics. The new toggle is a pure 1:1 visual copy + new icon/label pair, so the toolbar reads as \"two independent dimensions\" — variants display + view mode — rather than a 4-way grid.

## Test plan

- [x] TypeScript noEmit ✅
- [x] Biome strict ✅ (3 pre-existing warnings, 1 info)
- [x] Vite build smoke ✅
- [ ] Manual smoke on \`pim.localhost\`:
  1. Login → \`/products\`
  2. Toolbar shows new \"Karty / Excel\" segmented control next to Płasko/Drzewo
  3. Click Excel → list re-renders as ExcelLikeGrid (same data, editable cells)
  4. Click Nazwa cell → inline editor; type → Enter → PATCH \`/api/products/{id}\` with \`{attributes: {name: \"…\"}}\`
  5. Toggle Aktywny boolean → PATCH with \`{enabled: …}\`
  6. Refresh page → toggle stays on Excel (localStorage)
  7. F2 quick-edit alias works
  8. SKU column shows read-only

## Out of scope

- E2E test for the new toggle (existing UI-02.25 spec covered the ExcelLikeGrid mechanics; new spec for the toggle alone is a small follow-up)
- Cell-level validation feedback (existing in ExcelLikeGrid as toast on failed PATCH)
- Drag-fill on the new column set (works through the unchanged ExcelLikeGrid internals — no new code)