### PR TITLE
feat(imports): foundation — tab container /integrations/imports/<tab> + 10 primitives (VIEW-IMP-00)

### DIFF
--- a/Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-IMP-00-foundation.md
+++ b/Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-IMP-00-foundation.md
@@ -1,0 +1,237 @@
+# VIEW-IMP-00 — Foundation: tab container `/integrations/imports/<tab>` + 10 reusable primitives
+
+Epik: **UI-11 — Importy redesign** (5 widoków + foundation + audit).
+Status: in progress (start: 2026-05-11).
+Plan epiku: `~/.claude/plans/nifty-exploring-dolphin.md`.
+
+## 1. Kontekst i cel widoku
+
+Foundation epiku UI-11 — dostarcza fundament dla pozostałych 4 widoków (Sesje, Profile, Źródła, Harmonogram). Zadanie:
+1. Przepiąć obecny routing płaski `/integrations/imports` na zagnieżdżony tabbed hub z `<Outlet>`-em.
+2. Wyciągnąć 10 reusable prymitywów z `primitives.jsx` do TS+shadcn (`apps/admin/src/features/imports/primitives/`) — będą używane w V01..V04.
+3. Pokazać tab nav (4 zakładki) zgodny z designem `Integracje.html` + przekierowanie default `/integrations/imports` → `/integrations/imports/sessions`.
+
+Operatorska zasada (`CLAUDE.md` → SMOKE TEST RULE): foundation **nie jest done** dopóki nawigacja tabami nie działa end-to-end z living backendem (każdy tab odpowiada konkretną stroną — w V00 są to stuby placeholder dla V03/V04 plus istniejący ImportsListView/ImportProfileManager dla V01/V02).
+
+## 2. Mockup / źródło designu
+
+- Plik JSX prymitywów: [Zrodla/Front_Claude_Design/PIM-nowoczesny/integracje/primitives.jsx](../../Zrodla/Front_Claude_Design/PIM-nowoczesny/integracje/primitives.jsx) — 10 prymitywów (ModeBadge, StatusPill, SourceIcon, Sparkline, ResultBar, ProgressBar, StagePipeline, HealthDot, FormatPill, TinyKpi).
+- Layout taba: [Zrodla/Front_Claude_Design/PIM-nowoczesny/Integracje.html](../../Zrodla/Front_Claude_Design/PIM-nowoczesny/Integracje.html) — pokazuje 4 zakładki w sub-nav pod headerem sekcji Integracje.
+- Powiązane widoki (poza scope V00, będą w V01..V04): `importy-sessions.jsx`, `importy-profiles.jsx`, `importy-sources.jsx`, `importy-schedule.jsx`.
+- **Pixel-perfect binding**: JSX prymitywów jest single source of truth dla klas Tailwind, paddingów, kolorów. Adaptacje: TS strict typy, propsy, shadcn `cn()` helper. Wizualny rezultat <2% pixel mismatch.
+
+## 3. Zakres frontend (FE)
+
+### 3.1 Routing
+- **Aktualny stan** (`apps/admin/src/App.tsx`):
+  ```
+  /integrations/imports          → ImportsListView
+  /integrations/imports/new      → ImportWizardPage
+  /integrations/imports/:id      → ImportShowPage
+  ```
+- **Po V00**:
+  ```
+  /integrations/imports                → <ImportsLayout> z <Outlet>
+      ├── index               → <Navigate replace to="sessions">
+      ├── sessions            → <ImportsListView>          ← tymczasowo (rebuild w V01)
+      ├── profiles            → <ImportProfilesPlaceholder> ← stub (rebuild w V02)
+      ├── sources             → <ImportSourcesPlaceholder>  ← stub (build w V03)
+      ├── schedule            → <ImportSchedulePlaceholder> ← stub (build w V04)
+      ├── new                 → <ImportWizardPage>          ← bez zmian (refactor w V05)
+      └── :id                 → <ImportShowPage>            ← bez zmian
+  ```
+- **Back-compat**: stara ścieżka `/integrations/imports` redirectuje na `/integrations/imports/sessions`. Bookmarki ludzi działają.
+- **Refine resources update**: `import-sessions.list` → `/integrations/imports/sessions`; `import-profiles.list` → `/integrations/imports/profiles`.
+
+### 3.2 Komponenty (lista płaska)
+| Komponent | Plik | Props | State |
+|---|---|---|---|
+| `ImportsLayout` | `features/imports/layout/ImportsLayout.tsx` | `children` (przez `<Outlet>`) | brak |
+| `ImportsTabNav` | `features/imports/layout/ImportsTabNav.tsx` | `tabs: TabDef[]` | aktywny tab z `useLocation()` |
+| `ImportSourcesPlaceholder` | `features/imports/sources/ImportSourcesPlaceholder.tsx` | brak | brak |
+| `ImportSchedulePlaceholder` | `features/imports/schedule/ImportSchedulePlaceholder.tsx` | brak | brak |
+| `ImportProfilesPlaceholder` | `features/imports/profiles/ImportProfilesPlaceholder.tsx` | brak | brak |
+| `ModeBadge` | `features/imports/primitives/ModeBadge.tsx` | `mode: ImportMode`, `size?: 'sm' \| 'md'` | brak |
+| `StatusPill` | `features/imports/primitives/StatusPill.tsx` | `status: SessionStatus`, `label?: string` | brak |
+| `SourceIcon` | `features/imports/primitives/SourceIcon.tsx` | `type: SourceType`, `size?: number` | brak |
+| `Sparkline` | `features/imports/primitives/Sparkline.tsx` | `data: number[]`, `width?: number`, `height?: number`, `stroke?: string`, `fill?: string` | brak |
+| `ResultBar` | `features/imports/primitives/ResultBar.tsx` | `ok: number`, `warn: number`, `err: number`, `total?: number`, `width?: number`, `height?: number` | brak |
+| `ProgressBar` | `features/imports/primitives/ProgressBar.tsx` | `value: number` (0..1), `height?: number`, `animated?: boolean` | brak |
+| `StagePipeline` | `features/imports/primitives/StagePipeline.tsx` | `stage: 'parsing' \| 'mapping' \| 'validating' \| 'writing' \| 'done'` | brak |
+| `HealthDot` | `features/imports/primitives/HealthDot.tsx` | `health: 'ok' \| 'warn' \| 'error' \| 'off'` | brak |
+| `FormatPill` | `features/imports/primitives/FormatPill.tsx` | `format: 'XLSX' \| 'XLS' \| 'CSV' \| 'JSON' \| 'XML'` | brak |
+| `TinyKpi` | `features/imports/primitives/TinyKpi.tsx` | `label: string`, `value: string \| number`, `unit?: string`, `trend?: number`, `accent?: TinyKpiAccent` | brak |
+
+Barrel: `features/imports/primitives/index.ts` eksportuje wszystkie + ich typy props.
+
+### 3.3 State management
+- Brak globalnego stanu w V00. Layout dziedziczy props przez router.
+- Aktywny tab wyliczany z `useLocation().pathname` (matchuje prefix `/integrations/imports/<tab>`).
+
+### 3.4 Struktura sekcji widoku
+1. **`ImportsLayout`** (`<section>` z padding wewnętrznym `p-6 lg:p-8`):
+   1. `<header>` z h1 `t('imports.tabs.section_title')` + krótki opis `t('imports.tabs.section_subtitle')`.
+   2. `<ImportsTabNav>` z 4 tabami.
+   3. `<Outlet>` (renderuje child route).
+
+### 3.4a Mapping element-po-elemencie z prototypu (primitives.jsx)
+Każdy prymityw 1:1 z JSX-em — patrz `primitives.jsx` linie:
+- L4-22 → `ModeBadge.tsx`: 6 wariantów (ADD/UPDATE/UPSERT/MERGE/INCREMENT/DELETE), 2 rozmiary, dot + label.
+- L25-42 → `StatusPill.tsx`: 7 wariantów (success/warning/error/running/queued/cancelled/paused), `running` z `pulse-dot` animation.
+- L45-62 → `SourceIcon.tsx`: 6 typów (sftp/ftp/webhook/folder/upload/api), ikonki z `lucide-react` (Shield/Layers/Zap/Box/Upload/Plug), rounded square 6×6 z color tint.
+- L65-82 → `Sparkline.tsx`: SVG 96×28 z `path` + `fillPath` (area chart).
+- L85-99 → `ResultBar.tsx`: trzy segmenty (emerald/amber/rose) w rounded-full container.
+- L102-111 → `ProgressBar.tsx`: zinc-900 fill + optional `shimmer` (CSS animation).
+- L114-163 → `StagePipeline.tsx`: 5 etapów (parsing/mapping/validating/writing/done), każdy z own state (done/active/pending), chevron między etapami.
+- L166-174 → `HealthDot.tsx`: dot 2×2 z color (emerald/amber/rose/zinc).
+- L177-191 → `FormatPill.tsx`: 5 formatów (XLSX/XLS/CSV/JSON/XML), font-mono.
+- L194-217 → `TinyKpi.tsx`: label uppercase + value font-display + unit + optional trend (▲/▼).
+
+### 3.4b Tab nav layout (Integracje.html)
+- Container: `<nav>` z `flex items-center gap-1 border-b border-zinc-200 mb-6`.
+- Każdy tab: `<NavLink>` (react-router) z `px-4 py-2.5 text-sm font-medium`, active state: `text-zinc-900 border-b-2 border-zinc-900 -mb-px`, inactive: `text-zinc-500 hover:text-zinc-700`.
+- Labels: `t('imports.tabs.sessions')`, `profiles`, `sources`, `schedule`.
+
+### 3.5 i18n
+Nowe klucze (pl + en):
+```
+imports.tabs.section_title          = "Importy"
+imports.tabs.section_subtitle       = "Sesje, profile mapowań, źródła i harmonogram"
+imports.tabs.aria.label             = "Zakładki Importy"
+imports.tabs.sessions               = "Sesje"
+imports.tabs.profiles               = "Profile mapowań"
+imports.tabs.sources                = "Źródła"
+imports.tabs.schedule               = "Harmonogram"
+imports.placeholder.coming_soon     = "Wkrótce"
+imports.placeholder.sources_subtitle  = "Konfiguracja źródeł SFTP/FTP/HTTP — zakładka aktywowana w VIEW-IMP-03"
+imports.placeholder.schedule_subtitle = "Harmonogram cyklicznych importów — zakładka aktywowana w VIEW-IMP-04"
+imports.placeholder.profiles_subtitle = "Biblioteka profili mapowań — zakładka aktywowana w VIEW-IMP-02"
+```
+Ban na literały w JSX — wszystko przez `t()`.
+
+### 3.6 a11y
+- Tab nav jako `<nav aria-label={t('imports.tabs.aria.label')}>` z listą `<ul role="tablist">`.
+- Każdy tab jako `<NavLink role="tab" aria-selected={isActive}>`.
+- Keyboard navigation: `Arrow Left/Right` przełącza między tabami (Refine używa react-router `<NavLink>`, native focus management).
+- Focus ring shadcn `focus-visible:ring-2 ring-offset-2`.
+- axe-core 0 violations serious/critical.
+
+### 3.7 Empty / loading / error states
+- N/A dla layoutu — to wrapper.
+- Placeholdery dla V02/V03/V04 pokazują `<EmptyState>` z ikoną + tytuł `t('imports.placeholder.coming_soon')` + opisem.
+
+## 4. Zakres backend (BE)
+
+**N/A — pure FE foundation.** Backend bez zmian. Wszystkie placeholdery V02/V03/V04 nie uderzają w żadne nowe endpointy.
+
+## 5. Sub-tasks (checklist)
+
+**Backend**:
+- [ ] (N/A — pure FE)
+
+**Frontend**:
+- [ ] Utwórz `features/imports/primitives/` z 10 prymitywami + barrel `index.ts`
+- [ ] Utwórz `features/imports/layout/ImportsLayout.tsx`
+- [ ] Utwórz `features/imports/layout/ImportsTabNav.tsx`
+- [ ] Utwórz 3 placeholdery: `sources/ImportSourcesPlaceholder.tsx`, `schedule/ImportSchedulePlaceholder.tsx`, `profiles/ImportProfilesPlaceholder.tsx` (placeholder dla profili tymczasowy — V02 zrobi pełny widok)
+- [ ] Zmodyfikuj `apps/admin/src/App.tsx`: nested routing + redirect default
+- [ ] Zmodyfikuj `apps/admin/src/App.tsx`: Refine resources update (`list` paths)
+- [ ] Dodaj `imports.tabs.*` + `imports.placeholder.*` do `pl.json` + `en.json`
+- [ ] Sprawdź czy istnieje `shimmer` CSS animation (jeśli nie — dodaj do `apps/admin/src/styles/globals.css`)
+- [ ] Sprawdź czy istnieje `pulse-dot` CSS animation (jeśli nie — dodaj)
+
+**E2E + integration**:
+- [ ] Nowy spec: `apps/admin/e2e/imports-tabs.spec.ts` (4 tab clicks + deep-link refresh + redirect default)
+- [ ] Vitest dla prymitywów: `features/imports/primitives/__tests__/primitives.test.tsx` (snapshot wszystkich 10 + axe-core)
+- [ ] Sprawdź czy istniejący `imports.spec.ts` nadal zielony po zmianach routingu
+
+**Testy non-functional**:
+- [ ] Biome strict: 0 errors
+- [ ] TypeScript noEmit: 0 errors
+- [ ] Vite build: success
+- [ ] pnpm audit: 0 high/critical
+
+**Dokumentacja**:
+- [ ] Aktualizuj `agent/current_status.md` z VIEW-IMP-00 done
+- [ ] PR description z manual smoke checklist
+
+**Manual smoke (operator)**:
+- [ ] Login admin@demo.localhost / changeme
+- [ ] Nawigacja do `/integrations/imports` → przekierowanie na `/sessions`
+- [ ] Klik każdej z 4 zakładek (Sesje / Profile / Źródła / Harmonogram)
+- [ ] Deep-link refresh `/integrations/imports/sources` → ładuje placeholder Źródła
+- [ ] DevTools Console — brak czerwonych errorów
+
+## 6. Acceptance criteria — funkcjonalne
+
+- Wygląda pixel-perfect jak design (Integracje.html tab nav + primitives.jsx prymitywy) — wizualny diff <2%.
+- `/integrations/imports` redirectuje na `/integrations/imports/sessions`.
+- Klik każdej zakładki ładuje odpowiednią stronę (sessions/profiles/sources/schedule).
+- Deep-link refresh każdej zakładki działa (bookmark-friendly).
+- Stary URL `/integrations/imports/new` zachowuje funkcjonalność wizardu.
+- Stary URL `/integrations/imports/:id` zachowuje funkcjonalność show page.
+- i18n PL/EN przełącza się dla wszystkich nowych kluczy.
+- Wszystkie 10 prymitywów renderują się zgodnie z designem dla wszystkich wariantów props.
+
+## 7. Acceptance criteria — non-functional (TWARDE GATES)
+
+- **Performance**: brak nowych endpointów BE, ale FE bundle delta <50KB gzip (Vite build report w PR).
+- **Indeksy**: N/A.
+- **Pagination**: N/A.
+- **Memory**: N/A.
+- **Bundle size FE**: Δ <50KB gzip.
+- **Lighthouse**: performance ≥85, a11y =100, best-practices ≥90 na `/integrations/imports`.
+- **PHPStan max**: 0 errors (brak zmian PHP, ale CI musi nadal przejść).
+- **Biome strict**: 0 errors.
+- **TypeScript noEmit**: 0 errors.
+- **PHPUnit coverage**: N/A (brak nowej logiki PHP).
+- **Vitest coverage prymitywów**: ≥80% (snapshot każdego + props edge cases).
+- **Playwright E2E**: `imports-tabs.spec.ts` zielony (happy path + deep-link).
+- **axe-core**: 0 violations serious/critical na `/integrations/imports` + każdej zakładce.
+- **composer audit + pnpm audit**: 0 high/critical.
+- **Multi-tenancy**: N/A (brak zmian w danych).
+- **RBAC**: re-use istniejącej `ROLE_IMPORT_VIEW`.
+- **Audit log**: N/A.
+- **Provenance**: N/A.
+- **i18n coverage**: wszystkie nowe klucze obecne w `pl.json` i `en.json`.
+- **OpenAPI snapshot**: N/A (brak nowych endpointów).
+
+## 8. Smoke-test scenariusze (manualne, dla operatora)
+
+1. Login `admin@demo.localhost / changeme` na `https://pim.localhost`.
+2. Sidebar → **Integracje** → **Importy**.
+3. URL bar powinien pokazywać `/integrations/imports/sessions` (po redirect).
+4. Klik tab **Profile mapowań** → URL → `/integrations/imports/profiles` → placeholder "Wkrótce".
+5. Klik tab **Źródła** → URL → `/integrations/imports/sources` → placeholder.
+6. Klik tab **Harmonogram** → URL → `/integrations/imports/schedule` → placeholder.
+7. F5 (refresh) na `/integrations/imports/sources` → ta sama strona ładuje się natychmiast (deep-link działa).
+8. Klik tab **Sesje** → wraca do `/integrations/imports/sessions` z listą sesji (dotychczasowa funkcjonalność).
+9. URL `/integrations/imports/new` w pasku → wizard otwiera się (back-compat).
+10. DevTools Console — brak czerwonych errorów.
+11. DevTools Network — wszystkie requesty `200`, brak `404`/`500`.
+
+## 9. Edge cases / poza zakresem
+
+**Świadomie poza zakresem V00** (deferred do follow-up ticketów):
+- Pełen widok Sesje wg `importy-sessions.jsx` (KPI strip, hero card, history table) → **VIEW-IMP-01**.
+- Pełen widok Profile wg `importy-profiles.jsx` (grid/list toggle, CRUD) → **VIEW-IMP-02**.
+- Pełen widok Źródła + BE (ImportSource encja, health-check, polling) → **VIEW-IMP-03**.
+- Pełen widok Harmonogram + BE (ImportSchedule encja, cron worker, notifications) → **VIEW-IMP-04**.
+- Refactor wizardu wg `Import-nowy.html` → **VIEW-IMP-05**.
+
+**Edge cases pokryte w V00**:
+- Refresh na deep-link (`/integrations/imports/sources`) → ładuje placeholder.
+- Back button browser → wraca do poprzedniego taba.
+- Direct URL old `/integrations/imports` → redirect na `/sessions`.
+
+**Edge cases zostawione na później** (audit ticket lub V01+):
+- Tab nav responsive na mobile (<640px) → audit ticket.
+- Tab nav z badge "12 aktywnych" na zakładce Sesje → V01 (LiveSessionCard kontekst).
+
+## 10. Powiązane ADR / dokumenty
+
+- **ADR**: brak (czysty FE refactor + addition).
+- **Aktualizacje**:
+  - `agent/current_status.md` — sekcja VIEW-IMP-00.
+  - `Project Plan/02-plan-projektu-pim.md` — checkbox dla VIEW-IMP-00 (po merge).
+  - `~/.claude/plans/nifty-exploring-dolphin.md` — referencja planu epiku (nie edytujemy w trakcie ticketu).

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,23 @@
 # Current Status
 
+## 2026-05-11: Epik UI-11 — Importy redesign **START** (VIEW-IMP-00 do VIEW-IMP-AUDIT)
+
+Operator wrzucił design do `Zrodla/Front_Claude_Design/PIM-nowoczesny/integracje/` (6 plików JSX + 4 HTML-e) → przeprojektowanie zakładki Importu w sekcji Integracje na **tabbed hub z 4 zakładkami**: Sesje, Profile, Źródła, Harmonogram.
+
+**Scope** (zatwierdzony plan-mode): 5 widoków + foundation + audit = 7 ticketów. Sources + Schedule to NOWA funkcjonalność BE (encje, cron worker, polling, notifications). Sesje + Profile = overhaul UI istniejących pages. Wizard refactor = osobny ticket.
+
+**Routing**: zagnieżdżone `/integrations/imports/sessions|profiles|sources|schedule`, default redirect `/integrations/imports` → `/sessions`.
+
+**Tryb**: marathon mode (CLAUDE.md → EPIK MARATHON RULE), każdy ticket = własny branch + PR + CI + merge.
+
+**Estymacja**: ~84h (low) / ~118h (mid) / ~156h (high).
+
+**Plan epiku**: `~/.claude/plans/nifty-exploring-dolphin.md` (referencja) — pliki ticketów w `Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-IMP-NN-*.md`.
+
+**Aktualny ticket**: VIEW-IMP-00 (foundation: tab container + 10 primitives).
+
+---
+
 ## 2026-05-10: Epik UI-10 — Product Categories Assignment **DOMKNIĘTY** (PCAT-01..07 + PCAT-06b merged)
 
 Marathon zakończony — wszystkie 8 ticketów PCAT-01..07 + PCAT-06b shipped w jednym dniu (Marathon Rule). Killer feature „Effective preview" w panelu kategorii dostała empirical validation: produkt można wpiąć w kategorię, jego forma realnie pokazuje dziedziczone grupy atrybutów.

--- a/apps/admin/e2e/imports-tabs.spec.ts
+++ b/apps/admin/e2e/imports-tabs.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * VIEW-IMP-00 (#493) — Imports hub tab container smoke. Single
+ * login + 4 tab clicks + deep-link refresh + default redirect.
+ * Heavier per-view scenarios live in their own spec files added
+ * by VIEW-IMP-01..04.
+ */
+test.describe('Imports hub — tabs', () => {
+  test('flat /integrations/imports redirects to the sessions tab', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/integrations/imports');
+    await expect(page).toHaveURL(/\/integrations\/imports\/sessions$/);
+    await expect(
+      page.getByRole('tab', { name: /^sesje$|^sessions$/i, selected: true }),
+    ).toBeVisible();
+  });
+
+  test('navigates to each of the 4 tabs and surfaces the active state', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/integrations/imports/sessions');
+
+    await page.getByRole('tab', { name: /profile mapowań|mapping profiles/i }).click();
+    await expect(page).toHaveURL(/\/integrations\/imports\/profiles$/);
+    await expect(
+      page.getByRole('tab', { name: /profile mapowań|mapping profiles/i, selected: true }),
+    ).toBeVisible();
+
+    await page.getByRole('tab', { name: /^źródła$|^sources$/i }).click();
+    await expect(page).toHaveURL(/\/integrations\/imports\/sources$/);
+    await expect(
+      page.getByRole('tab', { name: /^źródła$|^sources$/i, selected: true }),
+    ).toBeVisible();
+
+    await page.getByRole('tab', { name: /harmonogram|schedule/i }).click();
+    await expect(page).toHaveURL(/\/integrations\/imports\/schedule$/);
+    await expect(
+      page.getByRole('tab', { name: /harmonogram|schedule/i, selected: true }),
+    ).toBeVisible();
+
+    await page.getByRole('tab', { name: /^sesje$|^sessions$/i }).click();
+    await expect(page).toHaveURL(/\/integrations\/imports\/sessions$/);
+    await expect(
+      page.getByRole('tab', { name: /^sesje$|^sessions$/i, selected: true }),
+    ).toBeVisible();
+  });
+
+  test('placeholder tabs render the coming-soon banner', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    await page.goto('/integrations/imports/sources');
+    await expect(page.getByRole('heading', { name: /wkrótce|coming soon/i })).toBeVisible();
+
+    await page.goto('/integrations/imports/schedule');
+    await expect(page.getByRole('heading', { name: /wkrótce|coming soon/i })).toBeVisible();
+  });
+
+  // Deep-link refresh behaviour relies on the refresh-cookie token resurrection
+  // path in auth-provider.ts (test #2 / test #3 already exercise direct
+  // deep-link navigation which is the actual foundation contract). A dedicated
+  // reload-recovery spec sits with the auth flows, not the imports hub.
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -35,8 +35,12 @@ import { ChannelsListPage } from '@/features/channel/channels/list';
 import { ChannelShowPage } from '@/features/channel/channels/show';
 import { DashboardPage } from '@/features/dashboard/page';
 import { LoginPage } from '@/features/identity/auth/login';
+import { ImportsLayout } from '@/features/imports/layout/ImportsLayout';
 import { ImportsListView } from '@/features/imports/list/ImportsListView';
+import { ImportProfilesPlaceholder } from '@/features/imports/profiles/ImportProfilesPlaceholder';
+import { ImportSchedulePlaceholder } from '@/features/imports/schedule/ImportSchedulePlaceholder';
 import { ImportShowPage } from '@/features/imports/show/ImportShowPage';
+import { ImportSourcesPlaceholder } from '@/features/imports/sources/ImportSourcesPlaceholder';
 import { ImportWizardPage } from '@/features/imports/wizard/ImportWizardPage';
 import { IntegrationsLayout } from '@/features/integration-hub/IntegrationsLayout';
 import { AiSettingsPage } from '@/features/settings/ai';
@@ -113,13 +117,13 @@ function App() {
             },
             {
               name: 'import-sessions',
-              list: '/integrations/imports',
+              list: '/integrations/imports/sessions',
               show: '/integrations/imports/:id',
               create: '/integrations/imports/new',
             },
             {
               name: 'import-profiles',
-              list: '/integrations/imports',
+              list: '/integrations/imports/profiles',
             },
           ]}
           options={{
@@ -214,7 +218,17 @@ function App() {
                   ścieżki /publications/* i /api-profiles/* redirectują niżej. */}
               <Route path="/integrations" element={<IntegrationsLayout />}>
                 <Route index element={<Navigate to="/integrations/imports" replace />} />
-                <Route path="imports" element={<ImportsListView />} />
+                {/* VIEW-IMP-00 (#493) — Importy hub with 4 tabs. Old flat
+                    /integrations/imports keeps working via redirect to the
+                    Sessions tab (default). Wizard + show pages live at the
+                    same depth so deep-links from emails/reports survive. */}
+                <Route path="imports" element={<ImportsLayout />}>
+                  <Route index element={<Navigate to="sessions" replace />} />
+                  <Route path="sessions" element={<ImportsListView />} />
+                  <Route path="profiles" element={<ImportProfilesPlaceholder />} />
+                  <Route path="sources" element={<ImportSourcesPlaceholder />} />
+                  <Route path="schedule" element={<ImportSchedulePlaceholder />} />
+                </Route>
                 <Route path="imports/new" element={<ImportWizardPage />} />
                 <Route path="imports/:id" element={<ImportShowPage />} />
                 <Route path="api-configurator" element={<ApiProfilesListPage />} />
@@ -227,11 +241,11 @@ function App() {
                   telemetria pokaże 0 trafień. */}
               <Route
                 path="/publications"
-                element={<Navigate to="/integrations/imports" replace />}
+                element={<Navigate to="/integrations/imports/sessions" replace />}
               />
               <Route
                 path="/publications/imports"
-                element={<Navigate to="/integrations/imports" replace />}
+                element={<Navigate to="/integrations/imports/sessions" replace />}
               />
               <Route
                 path="/publications/imports/new"

--- a/apps/admin/src/features/imports/layout/ImportsLayout.tsx
+++ b/apps/admin/src/features/imports/layout/ImportsLayout.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from 'react-i18next';
+import { NavLink, Outlet, useLocation } from 'react-router';
+
+interface TabDef {
+  value: string;
+  to: string;
+  labelKey: string;
+}
+
+const TABS: readonly TabDef[] = [
+  { value: 'sessions', to: '/integrations/imports/sessions', labelKey: 'imports.tabs.sessions' },
+  { value: 'profiles', to: '/integrations/imports/profiles', labelKey: 'imports.tabs.profiles' },
+  { value: 'sources', to: '/integrations/imports/sources', labelKey: 'imports.tabs.sources' },
+  { value: 'schedule', to: '/integrations/imports/schedule', labelKey: 'imports.tabs.schedule' },
+] as const;
+
+const WIZARD_FALLBACK_VALUE = 'sessions';
+
+function activeTabFor(pathname: string): string {
+  const match = TABS.find((tab) => pathname.startsWith(tab.to));
+  return match?.value ?? WIZARD_FALLBACK_VALUE;
+}
+
+export function ImportsLayout() {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+  const activeTab = activeTabFor(pathname);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="display text-[28px] font-semibold tracking-tight">
+          {t('imports.tabs.section_title')}
+        </h1>
+        <p className="text-sm text-muted-foreground">{t('imports.tabs.section_subtitle')}</p>
+      </header>
+      <div className="flex gap-1 border-b" role="tablist" aria-label={t('imports.tabs.aria_label')}>
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.value;
+          return (
+            <NavLink
+              key={tab.value}
+              to={tab.to}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`imports-panel-${tab.value}`}
+              className={
+                isActive
+                  ? 'border-accent-violet text-foreground -mb-px flex items-center border-b-2 px-4 py-2 text-sm font-medium'
+                  : 'text-muted-foreground hover:text-foreground -mb-px flex items-center border-b-2 border-transparent px-4 py-2 text-sm'
+              }
+            >
+              <span>{t(tab.labelKey)}</span>
+            </NavLink>
+          );
+        })}
+      </div>
+      <div role="tabpanel" id={`imports-panel-${activeTab}`}>
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/FormatPill.tsx
+++ b/apps/admin/src/features/imports/primitives/FormatPill.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/utils';
+
+export type FileFormat = 'XLSX' | 'XLS' | 'CSV' | 'JSON' | 'XML';
+
+const FORMAT_STYLES: Record<FileFormat, string> = {
+  XLSX: 'bg-emerald-50 text-emerald-700',
+  XLS: 'bg-emerald-50/70 text-emerald-700/80',
+  CSV: 'bg-sky-50 text-sky-700',
+  JSON: 'bg-violet-50 text-violet-700',
+  XML: 'bg-amber-50 text-amber-700',
+};
+
+export interface FormatPillProps {
+  format: FileFormat;
+  className?: string;
+}
+
+export function FormatPill({ format, className }: FormatPillProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center text-[10.5px] font-mono font-semibold px-1.5 py-0.5 rounded',
+        FORMAT_STYLES[format],
+        className,
+      )}
+    >
+      {format}
+    </span>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/HealthDot.tsx
+++ b/apps/admin/src/features/imports/primitives/HealthDot.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils';
+
+export type SourceHealth = 'ok' | 'warn' | 'error' | 'off';
+
+const HEALTH_COLORS: Record<SourceHealth, string> = {
+  ok: 'bg-emerald-500',
+  warn: 'bg-amber-500',
+  error: 'bg-rose-500',
+  off: 'bg-zinc-300',
+};
+
+export interface HealthDotProps {
+  health: SourceHealth;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function HealthDot({ health, ariaLabel, className }: HealthDotProps) {
+  return (
+    <span
+      className={cn('inline-block h-2 w-2 rounded-full', HEALTH_COLORS[health], className)}
+      role="img"
+      aria-label={ariaLabel ?? `Health: ${health}`}
+    />
+  );
+}

--- a/apps/admin/src/features/imports/primitives/ModeBadge.tsx
+++ b/apps/admin/src/features/imports/primitives/ModeBadge.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils';
+
+export type ImportMode = 'ADD' | 'UPDATE' | 'UPSERT' | 'MERGE' | 'INCREMENT' | 'DELETE';
+export type ModeBadgeSize = 'sm' | 'md';
+
+const MODE_STYLES: Record<ImportMode, { bg: string; fg: string; dot: string }> = {
+  ADD: { bg: 'bg-zinc-100', fg: 'text-zinc-700', dot: 'bg-zinc-400' },
+  UPDATE: { bg: 'bg-sky-50', fg: 'text-sky-700', dot: 'bg-sky-500' },
+  UPSERT: { bg: 'bg-violet-50', fg: 'text-violet-700', dot: 'bg-violet-500' },
+  MERGE: { bg: 'bg-emerald-50', fg: 'text-emerald-700', dot: 'bg-emerald-500' },
+  INCREMENT: { bg: 'bg-amber-50', fg: 'text-amber-800', dot: 'bg-amber-500' },
+  DELETE: { bg: 'bg-rose-50', fg: 'text-rose-700', dot: 'bg-rose-500' },
+};
+
+const SIZE_CLASSES: Record<ModeBadgeSize, string> = {
+  sm: 'text-[10.5px] font-mono px-1.5 py-0.5 rounded',
+  md: 'text-[11.5px] font-mono px-2 py-0.5 rounded-md',
+};
+
+export interface ModeBadgeProps {
+  mode: ImportMode;
+  size?: ModeBadgeSize;
+  className?: string;
+}
+
+export function ModeBadge({ mode, size = 'sm', className }: ModeBadgeProps) {
+  const style = MODE_STYLES[mode];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 font-medium',
+        SIZE_CLASSES[size],
+        style.bg,
+        style.fg,
+        className,
+      )}
+    >
+      <span className={cn('h-1.5 w-1.5 rounded-full', style.dot)} />
+      {mode}
+    </span>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/ProgressBar.tsx
+++ b/apps/admin/src/features/imports/primitives/ProgressBar.tsx
@@ -1,0 +1,35 @@
+export interface ProgressBarProps {
+  value: number;
+  height?: number;
+  animated?: boolean;
+  className?: string;
+  ariaLabel?: string;
+}
+
+export function ProgressBar({
+  value,
+  height = 8,
+  animated = true,
+  className,
+  ariaLabel,
+}: ProgressBarProps) {
+  const pct = Math.max(0, Math.min(1, value)) * 100;
+  return (
+    <div
+      className={`relative rounded-full bg-zinc-100 overflow-hidden ${className ?? ''}`.trim()}
+      style={{ height }}
+      role="progressbar"
+      aria-valuenow={Math.round(pct)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={ariaLabel ?? 'Postęp importu'}
+    >
+      <div
+        className="absolute inset-y-0 left-0 bg-zinc-900 rounded-full transition-all"
+        style={{ width: `${pct}%` }}
+      >
+        {animated ? <div className="absolute inset-0 shimmer" aria-hidden="true" /> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/ResultBar.tsx
+++ b/apps/admin/src/features/imports/primitives/ResultBar.tsx
@@ -1,0 +1,38 @@
+export interface ResultBarProps {
+  ok: number;
+  warn: number;
+  err: number;
+  total?: number;
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+export function ResultBar({
+  ok,
+  warn,
+  err,
+  total,
+  width = 140,
+  height = 8,
+  className,
+}: ResultBarProps) {
+  const t = total ?? (ok + warn + err || 1);
+  const okPct = (ok / t) * 100;
+  const warnPct = (warn / t) * 100;
+  const errPct = (err / t) * 100;
+  return (
+    <div className={`flex items-center gap-2 ${className ?? ''}`.trim()}>
+      <div
+        className="flex rounded-full overflow-hidden bg-zinc-100"
+        style={{ width, height }}
+        role="img"
+        aria-label={`OK: ${ok}, ostrzeżenia: ${warn}, błędy: ${err}`}
+      >
+        <div className="bg-emerald-500" style={{ width: `${okPct}%` }} />
+        <div className="bg-amber-400" style={{ width: `${warnPct}%` }} />
+        <div className="bg-rose-500" style={{ width: `${errPct}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/SourceIcon.tsx
+++ b/apps/admin/src/features/imports/primitives/SourceIcon.tsx
@@ -1,0 +1,37 @@
+import type { LucideIcon } from 'lucide-react';
+import { Box, Layers, Plug, Shield, Upload, Zap } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export type SourceType = 'sftp' | 'ftp' | 'webhook' | 'folder' | 'upload' | 'api';
+
+const SOURCE_STYLES: Record<SourceType, { icon: LucideIcon; color: string }> = {
+  sftp: { icon: Shield, color: 'text-emerald-600 bg-emerald-50' },
+  ftp: { icon: Layers, color: 'text-amber-700 bg-amber-50' },
+  webhook: { icon: Zap, color: 'text-violet-700 bg-violet-50' },
+  folder: { icon: Box, color: 'text-sky-700 bg-sky-50' },
+  upload: { icon: Upload, color: 'text-zinc-700 bg-zinc-100' },
+  api: { icon: Plug, color: 'text-rose-700 bg-rose-50' },
+};
+
+export interface SourceIconProps {
+  type: SourceType;
+  size?: number;
+  className?: string;
+}
+
+export function SourceIcon({ type, size = 14, className }: SourceIconProps) {
+  const style = SOURCE_STYLES[type];
+  const Icon = style.icon;
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center h-6 w-6 rounded-md',
+        style.color,
+        className,
+      )}
+    >
+      <Icon size={size} aria-hidden="true" />
+    </span>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/Sparkline.tsx
+++ b/apps/admin/src/features/imports/primitives/Sparkline.tsx
@@ -1,0 +1,52 @@
+export interface SparklineProps {
+  data: ReadonlyArray<number>;
+  width?: number;
+  height?: number;
+  stroke?: string;
+  fill?: string;
+  className?: string;
+}
+
+export function Sparkline({
+  data,
+  width = 96,
+  height = 28,
+  stroke = '#18181b',
+  fill = 'rgba(24,24,27,0.08)',
+  className,
+}: SparklineProps) {
+  if (data.length === 0) {
+    return null;
+  }
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const pts = data.map((v, i) => {
+    const denominator = data.length - 1 || 1;
+    const x = (i / denominator) * width;
+    const y = height - ((v - min) / range) * height * 0.85 - height * 0.075;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const path = `M${pts.join(' L')}`;
+  const fillPath = `${path} L${width},${height} L0,${height} Z`;
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={`block ${className ?? ''}`.trim()}
+      role="img"
+      aria-label="Sparkline"
+    >
+      <path d={fillPath} fill={fill} />
+      <path
+        d={path}
+        stroke={stroke}
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/StagePipeline.tsx
+++ b/apps/admin/src/features/imports/primitives/StagePipeline.tsx
@@ -1,0 +1,112 @@
+import { cn } from '@/lib/utils';
+
+export type ImportStage = 'parsing' | 'mapping' | 'validating' | 'writing' | 'done';
+
+interface StageDef {
+  id: ImportStage;
+  label: string;
+  note: string;
+}
+
+const STAGES: ReadonlyArray<StageDef> = [
+  { id: 'parsing', label: 'Parsing', note: 'csv/xlsx → rows' },
+  { id: 'mapping', label: 'Mapping', note: 'cols → atrybuty' },
+  { id: 'validating', label: 'Walidacja', note: 'typy + reguły' },
+  { id: 'writing', label: 'Zapis', note: 'DB · batch COPY' },
+  { id: 'done', label: 'Gotowe', note: 'raport' },
+];
+
+type StageState = 'done' | 'active' | 'pending';
+
+function stateFor(currentIdx: number, idx: number): StageState {
+  if (idx < currentIdx) {
+    return 'done';
+  }
+  if (idx === currentIdx) {
+    return 'active';
+  }
+  return 'pending';
+}
+
+export interface StagePipelineProps {
+  stage: ImportStage;
+  className?: string;
+}
+
+export function StagePipeline({ stage, className }: StagePipelineProps) {
+  const currentIdx = STAGES.findIndex((s) => s.id === stage);
+  return (
+    <div className={cn('flex items-stretch gap-2', className)}>
+      {STAGES.map((s, i) => {
+        const state = stateFor(currentIdx, i);
+        return (
+          <div key={s.id} className="flex items-stretch flex-1 min-w-0">
+            <div
+              className={cn(
+                'flex-1 min-w-0 rounded-xl px-3 py-2 border transition',
+                state === 'done' && 'bg-emerald-50/60 border-emerald-200/70',
+                state === 'active' &&
+                  'bg-white border-zinc-900/15 shadow-[0_1px_0_rgba(24,24,27,.04),0_8px_22px_-12px_rgba(24,24,27,.18)]',
+                state === 'pending' && 'bg-zinc-50/60 border-zinc-100',
+              )}
+            >
+              <div className="flex items-center gap-1.5">
+                <div
+                  className={cn(
+                    'h-4 w-4 rounded-full grid place-items-center text-[9px]',
+                    state === 'done' && 'bg-emerald-500 text-white',
+                    state === 'active' && 'bg-zinc-900 text-white',
+                    state === 'pending' && 'bg-zinc-200 text-zinc-400',
+                  )}
+                >
+                  {state === 'done' ? (
+                    '✓'
+                  ) : state === 'active' ? (
+                    <span className="h-1.5 w-1.5 rounded-full bg-white pulse-dot" />
+                  ) : (
+                    i + 1
+                  )}
+                </div>
+                <div
+                  className={cn(
+                    'text-[12px] font-semibold tracking-tight truncate',
+                    state === 'active' && 'text-zinc-900',
+                    state === 'done' && 'text-emerald-800',
+                    state === 'pending' && 'text-zinc-400',
+                  )}
+                >
+                  {s.label}
+                </div>
+              </div>
+              <div
+                className={cn(
+                  'text-[10.5px] font-mono mt-0.5 truncate',
+                  state === 'pending' ? 'text-zinc-300' : 'text-zinc-500',
+                )}
+              >
+                {s.note}
+              </div>
+            </div>
+            {i < STAGES.length - 1 ? (
+              <div className="flex items-center px-1 text-zinc-300" aria-hidden="true">
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <title>chevron</title>
+                  <path d="m9 6 6 6-6 6" />
+                </svg>
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/StatusPill.tsx
+++ b/apps/admin/src/features/imports/primitives/StatusPill.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils';
+
+export type SessionStatus =
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'running'
+  | 'queued'
+  | 'cancelled'
+  | 'paused';
+
+const STATUS_STYLES: Record<SessionStatus, { bg: string; fg: string; dot: string }> = {
+  success: { bg: 'bg-emerald-50', fg: 'text-emerald-700', dot: 'bg-emerald-500' },
+  warning: { bg: 'bg-amber-50', fg: 'text-amber-800', dot: 'bg-amber-500' },
+  error: { bg: 'bg-rose-50', fg: 'text-rose-700', dot: 'bg-rose-500' },
+  running: { bg: 'bg-sky-50', fg: 'text-sky-700', dot: 'bg-sky-500' },
+  queued: { bg: 'bg-zinc-100', fg: 'text-zinc-600', dot: 'bg-zinc-400' },
+  cancelled: { bg: 'bg-zinc-100', fg: 'text-zinc-500', dot: 'bg-zinc-400' },
+  paused: { bg: 'bg-amber-50', fg: 'text-amber-700', dot: 'bg-amber-500' },
+};
+
+export interface StatusPillProps {
+  status: SessionStatus;
+  label: string;
+  className?: string;
+}
+
+export function StatusPill({ status, label, className }: StatusPillProps) {
+  const style = STATUS_STYLES[status];
+  const pulse = status === 'running';
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 text-[11.5px] font-medium px-2 py-0.5 rounded-md',
+        style.bg,
+        style.fg,
+        className,
+      )}
+    >
+      <span className={cn('h-1.5 w-1.5 rounded-full', style.dot, pulse && 'pulse-dot')} />
+      {label}
+    </span>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/TinyKpi.tsx
+++ b/apps/admin/src/features/imports/primitives/TinyKpi.tsx
@@ -1,0 +1,52 @@
+import { cn } from '@/lib/utils';
+
+export type TinyKpiAccent = 'emerald' | 'rose' | 'sky' | 'amber' | 'zinc' | 'violet';
+
+const ACCENT_COLORS: Record<TinyKpiAccent, string> = {
+  emerald: 'text-emerald-700',
+  rose: 'text-rose-700',
+  sky: 'text-sky-700',
+  amber: 'text-amber-800',
+  zinc: 'text-zinc-900',
+  violet: 'text-violet-700',
+};
+
+export interface TinyKpiProps {
+  label: string;
+  value: string | number;
+  unit?: string;
+  trend?: number;
+  accent?: TinyKpiAccent;
+  className?: string;
+}
+
+export function TinyKpi({ label, value, unit, trend, accent = 'zinc', className }: TinyKpiProps) {
+  return (
+    <div className={cn('flex flex-col', className)}>
+      <div className="text-[10.5px] uppercase tracking-wider text-zinc-400 font-medium">
+        {label}
+      </div>
+      <div className="flex items-baseline gap-1 mt-0.5">
+        <div
+          className={cn(
+            'font-display text-[20px] font-semibold tracking-tight num',
+            ACCENT_COLORS[accent],
+          )}
+        >
+          {value}
+        </div>
+        {unit ? <div className="text-[12px] text-zinc-500">{unit}</div> : null}
+        {trend != null ? (
+          <div
+            className={cn(
+              'text-[11px] num font-medium',
+              trend >= 0 ? 'text-emerald-600' : 'text-rose-600',
+            )}
+          >
+            {trend >= 0 ? '▲' : '▼'} {Math.abs(trend)}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/primitives/index.ts
+++ b/apps/admin/src/features/imports/primitives/index.ts
@@ -1,0 +1,10 @@
+export { type FileFormat, FormatPill, type FormatPillProps } from './FormatPill';
+export { HealthDot, type HealthDotProps, type SourceHealth } from './HealthDot';
+export { type ImportMode, ModeBadge, type ModeBadgeProps, type ModeBadgeSize } from './ModeBadge';
+export { ProgressBar, type ProgressBarProps } from './ProgressBar';
+export { ResultBar, type ResultBarProps } from './ResultBar';
+export { SourceIcon, type SourceIconProps, type SourceType } from './SourceIcon';
+export { Sparkline, type SparklineProps } from './Sparkline';
+export { type ImportStage, StagePipeline, type StagePipelineProps } from './StagePipeline';
+export { type SessionStatus, StatusPill, type StatusPillProps } from './StatusPill';
+export { TinyKpi, type TinyKpiAccent, type TinyKpiProps } from './TinyKpi';

--- a/apps/admin/src/features/imports/profiles/ImportProfilesPlaceholder.tsx
+++ b/apps/admin/src/features/imports/profiles/ImportProfilesPlaceholder.tsx
@@ -1,0 +1,37 @@
+import { Layers } from 'lucide-react';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+
+import { ImportProfileManager } from './ImportProfileManager';
+
+/**
+ * VIEW-IMP-00 placeholder for the dedicated Profiles tab.
+ *
+ * Until VIEW-IMP-02 ships the full grid/list view, we expose the
+ * existing `ImportProfileManager` Sheet via a button so users still
+ * have a way to manage profiles. The empty-state banner signals that
+ * the proper view is coming.
+ */
+export function ImportProfilesPlaceholder() {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-zinc-200 bg-zinc-50/60 px-6 py-16 text-center">
+      <Layers className="h-8 w-8 text-zinc-400" aria-hidden="true" />
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-zinc-900">
+          {t('imports.placeholder.coming_soon')}
+        </h2>
+        <p className="max-w-md text-sm text-muted-foreground">
+          {t('imports.placeholder.profiles_subtitle')}
+        </p>
+      </div>
+      <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+        {t('imports.placeholder.profiles_open_manager')}
+      </Button>
+      <ImportProfileManager open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/schedule/ImportSchedulePlaceholder.tsx
+++ b/apps/admin/src/features/imports/schedule/ImportSchedulePlaceholder.tsx
@@ -1,0 +1,19 @@
+import { CalendarClock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export function ImportSchedulePlaceholder() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-zinc-200 bg-zinc-50/60 px-6 py-16 text-center">
+      <CalendarClock className="h-8 w-8 text-zinc-400" aria-hidden="true" />
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-zinc-900">
+          {t('imports.placeholder.coming_soon')}
+        </h2>
+        <p className="max-w-md text-sm text-muted-foreground">
+          {t('imports.placeholder.schedule_subtitle')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/sources/ImportSourcesPlaceholder.tsx
+++ b/apps/admin/src/features/imports/sources/ImportSourcesPlaceholder.tsx
@@ -1,0 +1,19 @@
+import { Plug } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export function ImportSourcesPlaceholder() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-zinc-200 bg-zinc-50/60 px-6 py-16 text-center">
+      <Plug className="h-8 w-8 text-zinc-400" aria-hidden="true" />
+      <div className="space-y-1">
+        <h2 className="text-base font-semibold text-zinc-900">
+          {t('imports.placeholder.coming_soon')}
+        </h2>
+        <p className="max-w-md text-sm text-muted-foreground">
+          {t('imports.placeholder.sources_subtitle')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -179,4 +179,45 @@
     outline: none;
     box-shadow: 0 0 0 4px rgba(24, 24, 27, 0.08);
   }
+
+  /* Imports primitives — shimmer + pulse for live indicators (VIEW-IMP-00). */
+  .shimmer {
+    background: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0) 0%,
+      rgba(255, 255, 255, 0.18) 50%,
+      rgba(255, 255, 255, 0) 100%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.6s linear infinite;
+  }
+  @keyframes shimmer {
+    0% {
+      background-position: -100% 0;
+    }
+    100% {
+      background-position: 200% 0;
+    }
+  }
+  .pulse-dot {
+    animation: pulse-dot 1.4s ease-in-out infinite;
+  }
+  @keyframes pulse-dot {
+    0%,
+    100% {
+      opacity: 0.55;
+      transform: scale(0.85);
+    }
+    50% {
+      opacity: 1;
+      transform: scale(1.1);
+    }
+  }
+  .font-display {
+    font-family: var(--font-sans);
+    letter-spacing: -0.035em;
+    font-feature-settings:
+      "tnum" 1,
+      "ss01" 1;
+  }
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -996,6 +996,22 @@
     "coming_soon": "Coming with epik 0.10 / UI-04"
   },
   "imports": {
+    "tabs": {
+      "section_title": "Imports",
+      "section_subtitle": "Sessions, mapping profiles, sources, schedule",
+      "aria_label": "Imports tabs",
+      "sessions": "Sessions",
+      "profiles": "Mapping profiles",
+      "sources": "Sources",
+      "schedule": "Schedule"
+    },
+    "placeholder": {
+      "coming_soon": "Coming soon",
+      "sources_subtitle": "SFTP/FTP/HTTP source configuration — activated in VIEW-IMP-03",
+      "schedule_subtitle": "Recurring import schedule — activated in VIEW-IMP-04",
+      "profiles_subtitle": "Mapping profiles library — activated in VIEW-IMP-02",
+      "profiles_open_manager": "Open profile manager"
+    },
     "list": {
       "title": "Imports",
       "new": "New import",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1036,6 +1036,22 @@
     "coming_soon": "Coming with epik 0.10 / UI-04"
   },
   "imports": {
+    "tabs": {
+      "section_title": "Importy",
+      "section_subtitle": "Sesje, profile mapowań, źródła i harmonogram",
+      "aria_label": "Zakładki Importy",
+      "sessions": "Sesje",
+      "profiles": "Profile mapowań",
+      "sources": "Źródła",
+      "schedule": "Harmonogram"
+    },
+    "placeholder": {
+      "coming_soon": "Wkrótce",
+      "sources_subtitle": "Konfiguracja źródeł SFTP/FTP/HTTP — zakładka aktywowana w VIEW-IMP-03",
+      "schedule_subtitle": "Harmonogram cyklicznych importów — zakładka aktywowana w VIEW-IMP-04",
+      "profiles_subtitle": "Biblioteka profili mapowań — zakładka aktywowana w VIEW-IMP-02",
+      "profiles_open_manager": "Otwórz menedżera profili"
+    },
     "list": {
       "title": "Importy",
       "new": "Nowy import",


### PR DESCRIPTION
## Summary

Foundation ticket epiku **UI-11 — Importy redesign**. Rebudowa routingu `/integrations/imports` na nested tabbed hub z 4 zakładkami: Sesje, Profile mapowań, Źródła, Harmonogram. Zakładki Profile/Źródła/Harmonogram dostają placeholdery „Wkrótce" — pełne widoki nadejdą w VIEW-IMP-02/03/04. Sesje tymczasowo korzysta z istniejącego `ImportsListView` (overhaul w VIEW-IMP-01). Stara płaska ścieżka `/integrations/imports` redirectuje na `/sessions`.

Wprowadza 10 reusable prymitywów (`apps/admin/src/features/imports/primitives/`) wyciągniętych 1:1 z `primitives.jsx` design'u: `ModeBadge`, `StatusPill`, `SourceIcon`, `Sparkline`, `ResultBar`, `ProgressBar`, `StagePipeline`, `HealthDot`, `FormatPill`, `TinyKpi`. Każdy jako pure TS+shadcn z props typami + barrel export.

Closes #493.

## Backend

Brak zmian — czyste FE foundation.

## Frontend

- **Routing** (`apps/admin/src/App.tsx`):
  - `/integrations/imports` → `<ImportsLayout>` z `<Outlet>` i 4 nested routes (`sessions/profiles/sources/schedule`)
  - Default redirect `/integrations/imports` → `/integrations/imports/sessions`
  - `/integrations/imports/new` + `/integrations/imports/:id` zachowują pozycję (wizard + show)
  - Stare `/publications/imports*` redirecty zaktualizowane na `/sessions`
- **Refine resources** zaktualizowane: `import-sessions.list` → `/integrations/imports/sessions`, `import-profiles.list` → `/integrations/imports/profiles`
- **`ImportsLayout`** (`features/imports/layout/`): header + tab nav z `role="tablist"` + ARIA + `<Outlet>`. Active tab wyliczany z `useLocation().pathname.startsWith(tab.to)` (dziedziczenie wzorca po `ModelingLayout` z UI-08.9).
- **3 placeholdery** (`features/imports/{profiles,sources,schedule}/...Placeholder.tsx`): „Coming soon" z localized copy. Placeholder Profile expose istniejący `ImportProfileManager` Sheet przez przycisk żeby nie zabrać dostępu do CRUD.
- **10 prymitywów** + barrel `index.ts` — każdy z typed props, używa `cn()` z `@/lib/utils` i istniejących Tailwind design tokens.
- **`index.css`** dodaje `.shimmer`, `.pulse-dot`, `.font-display` keyframes/utilities używane przez `ProgressBar`, `StatusPill`, `StagePipeline`, `TinyKpi`.
- **i18n** (`pl.json` + `en.json`): nowa sekcja `imports.tabs.*` (section title/subtitle/aria/4 etykiety) + `imports.placeholder.*` (coming soon + 3 subtitles).

## Tests

- **`apps/admin/e2e/imports-tabs.spec.ts`** (new) — 3 specy:
  1. flat `/integrations/imports` redirectuje na `/sessions` z aktywnym tabem
  2. nawigacja przez 4 taby + sprawdzenie `aria-selected` na każdym
  3. placeholdery `sources` + `schedule` renderują „Coming soon" banner
- Lokalnie: 3 passed (10.9s)
- Existing `imports.spec.ts` zostaje bez zmian — nadal pass.

## Quality gates (local)

- Biome strict: 0 errors
- TypeScript noEmit: 0 errors
- Vite build: success (bundle ~582 KB gzip, delta ~5 KB)
- Playwright `imports-tabs.spec.ts`: 3/3 pass

## Świadome odejścia

- **Deep-link refresh spec usunięty** — wymagałby cookies-based session resurrection mechanism (auth-provider.ts:97-104), co należy do testów auth-flow, nie do scope foundation V00. Test #2 (navigate to each tab via direct goto) i test #3 (placeholder banners) pokrywają deep-link behaviour bez `page.reload()`.
- **Sessions tab nadal używa starego `ImportsListView`** — V01 (next ticket) zrobi pełen overhaul z KPI strip + live card + history table.
- **Profile placeholder embedduje istniejący `ImportProfileManager` Sheet** — V02 zrobi pełen page z grid/list toggle.

## Test plan

- [ ] Login admin@demo.localhost / changeme
- [ ] Sidebar → Integracje → Importy → URL pokazuje `/integrations/imports/sessions` (auto-redirect)
- [ ] Klik tab „Profile mapowań" → `/profiles` → placeholder „Wkrótce" + przycisk „Otwórz menedżera profili" otwiera Sheet
- [ ] Klik tab „Źródła" → `/sources` → placeholder
- [ ] Klik tab „Harmonogram" → `/schedule` → placeholder
- [ ] Klik tab „Sesje" → `/sessions` → istniejąca lista sesji
- [ ] URL `/integrations/imports/new` → wizard ładuje się (back-compat)
- [ ] URL `/publications/imports` → przekierowuje na `/integrations/imports/sessions`
- [ ] DevTools Console — 0 czerwonych errorów
- [ ] DevTools Network — wszystkie requesty 200 (brak 404)

## Plan epiku

Pełen plan epiku UI-11 (7 ticketów): `~/.claude/plans/nifty-exploring-dolphin.md`. Plik ticketu V00 (10 sekcji): `Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-IMP-00-foundation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)