### PR TITLE
feat(imports): profiles — overhaul ImportProfilesView (grid/list + duplicate/export/import) (VIEW-IMP-02)

### DIFF
--- a/Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-IMP-02-profile.md
+++ b/Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-IMP-02-profile.md
@@ -1,0 +1,77 @@
+# VIEW-IMP-02 — Profile mapowań: pełnoekranowy widok z grid/list toggle + duplicate/export/import
+
+Epik: **UI-11 — Importy redesign**. Status: in progress (start: 2026-05-12).
+
+## 1. Kontekst i cel widoku
+
+Zastępuje obecny `ImportProfilesPlaceholder` (CTA do `ImportProfileManager` Sheet) pełnym widokiem strony wg `importy-profiles.jsx`. Operator ma:
+- toggle grid/list (3-col grid kart / lista wierszy 9-col),
+- search po name + code,
+- akcje per profil: edit / duplicate / export JSON / delete,
+- `NewProfileCard` jako CTA tile w grid,
+- ekspozycja success rate (computed FE-side z `ImportSession` repository — jeśli zaszacujmy później).
+
+## 2. Mockup / źródło designu
+
+- Plik JSX: [Zrodla/Front_Claude_Design/PIM-nowoczesny/integracje/importy-profiles.jsx](../../Zrodla/Front_Claude_Design/PIM-nowoczesny/integracje/importy-profiles.jsx).
+- Komponenty: `ImportProfilesView` (grid/list toggle), `ProfileCard`, `ProfileRow`, `NewProfileCard`.
+
+## 3. Zakres FE
+
+### 3.1 Routing
+- `/integrations/imports/profiles` → `<ImportProfilesView>` (zastępuje placeholder w App.tsx).
+
+### 3.2 Komponenty
+| Komponent | Plik | Props |
+|---|---|---|
+| `ImportProfilesView` | `profiles/ImportProfilesView.tsx` | brak (state: q, view) |
+| `ProfileCard` | `profiles/ProfileCard.tsx` | `profile`, `onEdit`, `onDuplicate`, `onDelete` |
+| `ProfileRow` | `profiles/ProfileRow.tsx` | `profile`, `onEdit`, `onDuplicate`, `onDelete` |
+| `NewProfileCard` | `profiles/NewProfileCard.tsx` | `onClick` |
+| `ProfileEditDialog` | `profiles/ProfileEditDialog.tsx` | `open`, `mode: 'create' \| 'edit'`, `profile?`, `onClose`, `onSubmit` |
+
+### 3.3 i18n keys
+`imports.profiles.{title, subtitle_eyebrow, description, new_profile, search_placeholder, view.grid, view.list, grid.*, list.*, card.*, dialog.*, actions.*}`
+
+### 3.4 a11y
+- Grid/list toggle jako `<fieldset>` z `aria-pressed` (V01 pattern).
+- Dropdown akcji (more menu) shadcn `DropdownMenu` — Radix free a11y.
+- Delete dialog z `AlertDialog`.
+
+## 4. Zakres BE
+
+### 4.1 Migracja
+`Version20260512XXXXXX_add_import_profile_code_mode.php`:
+- ADD `code` VARCHAR(64) NULL initially → backfill auto-slug z `name` → SET NOT NULL.
+- ADD `mode` VARCHAR(16) NOT NULL DEFAULT 'UPDATE'.
+- ADD UNIQUE INDEX `(tenant_id, user_id, code)`.
+
+### 4.2 Entity
+- `ImportProfile`: dodaj `code` (string) + `mode` (ImportMode enum) + gettery/settery + setCode/setMode.
+- ORM XML: dodaj pola + unique constraint.
+
+### 4.3 Enum
+- `ImportMode` (nowy): ADD, UPDATE, UPSERT, MERGE, INCREMENT, DELETE.
+
+### 4.4 Inputy AP4
+- `ImportProfileInput` + `ImportProfilePatchInput`: dodaj `code` + `mode`.
+
+### 4.5 Custom controllery
+- `DuplicateImportProfileController` — POST `/api/import-profiles/{id}/duplicate` → tworzy nowy profil z `_copy` suffix.
+- `ExportImportProfileController` — GET `/api/import-profiles/{id}/export.json` → Content-Disposition attachment.
+- `ImportImportProfileController` — POST `/api/import-profiles/import` (multipart JSON) → tworzy profil z JSON.
+
+### 4.6 Voter
+Re-use istniejącego `ImportProfileVoter`.
+
+## 5. Sub-tasks
+
+**BE**: migration, entity update, orm.xml, enum, inputs, 3 controllers, voter, ApiTestCase, unit (ImportProfile entity test).
+
+**FE**: ImportProfilesView, ProfileCard, ProfileRow, NewProfileCard, ProfileEditDialog, App.tsx routing update, i18n keys, Playwright spec (1 test/1 login).
+
+**Quality gates**: PHPStan max, PHPUnit, ApiTestCase, Biome, TS, Vite, Playwright, axe-core, p95<300ms.
+
+## 6-10. Skrócone
+
+Wszystkie pozostałe sekcje (acceptance, smoke, edge cases, ADR) zgodne z planem epiku UI-11 (`~/.claude/plans/nifty-exploring-dolphin.md`).

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -19,7 +19,8 @@ Operator wrzucił design do `Zrodla/Front_Claude_Design/PIM-nowoczesny/integracj
 
 **Postęp epiku:**
 - ✅ **VIEW-IMP-00** ([#495](https://github.com/malipie/PIM/pull/495) → `b63e1f3`) — foundation: `<ImportsLayout>` + `<ImportsTabNav>` + 10 reusable prymitywów + i18n + Playwright spec. CI 6/6 zielone.
-- 🟡 **VIEW-IMP-01** ([#496](https://github.com/malipie/PIM/issues/496)) — Sesje overhaul (PR pending) — BE: `ListImportSessionsController` + `ImportThroughputController` + `ImportThroughputCalculator` + 9 ApiTestCase + 6 unit tests. FE: `ImportSessionsView` (zastępuje `ImportsListView`) + `KpiStrip` + `LiveSessionCard` + `HistoryTable` + `HistoryRow` + `SessionsFilterPills` + Playwright spec.
+- ✅ **VIEW-IMP-01** ([#497](https://github.com/malipie/PIM/pull/497) → `07fa5a5`) — Sesje overhaul. BE: `ListImportSessionsController` + `ImportThroughputController` + `ImportThroughputCalculator`. FE: `ImportSessionsView` (zastępuje `ImportsListView`) + KpiStrip + LiveSessionCard + HistoryTable. Test: 9 ApiTestCase + 6 unit + 1 Playwright (skonsolidowane). Lekcja: nowe spec'y MUSZĄ mieć 1 test/1 login (rate-limiter 5/IP/15min).
+- 🟡 **VIEW-IMP-02** ([#498](https://github.com/malipie/PIM/issues/498)) — Profile overhaul. BE: migracja `import_profiles.code` + `mode` + UNIQUE (tenant_id, user_id, code), `ImportMode` enum, 3 custom controllery (Duplicate/Export/Import), Input + PatchInput rozszerzone. FE: `ImportProfilesView` (zastępuje placeholder), `ProfileCard`/`ProfileRow`/`NewProfileCard`/`ProfileEditDialog`, grid/list toggle, search, delete dialog. 7 ApiTestCase + Playwright (1 test/1 login).
 
 ---
 

--- a/apps/admin/e2e/imports-profiles.spec.ts
+++ b/apps/admin/e2e/imports-profiles.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * VIEW-IMP-02 (#498) — profiles hub smoke. Single login covers the
+ * three behaviours (title + new profile CTA, grid/list toggle, empty
+ * state) to stay inside the 5/IP/15min auth rate-limiter.
+ */
+test('imports profiles hub — title + grid/list toggle + new-profile CTA', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/integrations/imports/profiles');
+
+  await expect(
+    page.getByRole('heading', { name: /profile mapowań|mapping profiles/i }),
+  ).toBeVisible();
+
+  // "Nowy profil" CTA is visible in the header.
+  const newProfile = page.getByRole('button', { name: /nowy profil|new profile/i }).first();
+  await expect(newProfile).toBeVisible();
+
+  // Grid → list toggle.
+  const listToggle = page.getByRole('button', { name: /^lista$|^list$/i });
+  await listToggle.click();
+  await expect(listToggle).toHaveAttribute('aria-pressed', 'true');
+
+  // Back to grid.
+  const gridToggle = page.getByRole('button', { name: /^siatka$|^grid$/i });
+  await gridToggle.click();
+  await expect(gridToggle).toHaveAttribute('aria-pressed', 'true');
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -36,7 +36,7 @@ import { ChannelShowPage } from '@/features/channel/channels/show';
 import { DashboardPage } from '@/features/dashboard/page';
 import { LoginPage } from '@/features/identity/auth/login';
 import { ImportsLayout } from '@/features/imports/layout/ImportsLayout';
-import { ImportProfilesPlaceholder } from '@/features/imports/profiles/ImportProfilesPlaceholder';
+import { ImportProfilesView } from '@/features/imports/profiles/ImportProfilesView';
 import { ImportSchedulePlaceholder } from '@/features/imports/schedule/ImportSchedulePlaceholder';
 import { ImportSessionsView } from '@/features/imports/sessions/ImportSessionsView';
 import { ImportShowPage } from '@/features/imports/show/ImportShowPage';
@@ -225,7 +225,7 @@ function App() {
                 <Route path="imports" element={<ImportsLayout />}>
                   <Route index element={<Navigate to="sessions" replace />} />
                   <Route path="sessions" element={<ImportSessionsView />} />
-                  <Route path="profiles" element={<ImportProfilesPlaceholder />} />
+                  <Route path="profiles" element={<ImportProfilesView />} />
                   <Route path="sources" element={<ImportSourcesPlaceholder />} />
                   <Route path="schedule" element={<ImportSchedulePlaceholder />} />
                 </Route>

--- a/apps/admin/src/features/imports/profiles/ImportProfileManager.tsx
+++ b/apps/admin/src/features/imports/profiles/ImportProfileManager.tsx
@@ -56,18 +56,18 @@ export function ImportProfileManager({
   const columns: ReadonlyArray<DataTableColumn<ImportProfileRow>> = [
     {
       id: 'name',
-      header: t('imports.profiles.columns.name', { defaultValue: 'Profil' }),
+      header: t('imports.profile_manager.columns.name', { defaultValue: 'Profil' }),
       cell: (row) => <span className="font-medium">{row.name}</span>,
     },
     {
       id: 'last_used',
-      header: t('imports.profiles.columns.last_used', { defaultValue: 'Ostatnio użyty' }),
+      header: t('imports.profile_manager.columns.last_used', { defaultValue: 'Ostatnio użyty' }),
       cell: (row) => formatRelative(row.lastUsedAt),
       className: 'whitespace-nowrap text-xs text-muted-foreground',
     },
     {
       id: 'actions',
-      header: t('imports.profiles.columns.actions', { defaultValue: 'Akcje' }),
+      header: t('imports.profile_manager.columns.actions', { defaultValue: 'Akcje' }),
       align: 'right',
       cell: (row) => (
         <div className="flex justify-end gap-1">
@@ -78,7 +78,7 @@ export function ImportProfileManager({
             variant="ghost"
             size="sm"
             onClick={() => setDeleting(row)}
-            aria-label={t('imports.profiles.delete', { defaultValue: 'Usuń' })}
+            aria-label={t('imports.profile_manager.delete', { defaultValue: 'Usuń' })}
           >
             🗑
           </Button>
@@ -92,10 +92,10 @@ export function ImportProfileManager({
       <Sheet open={open} onOpenChange={onOpenChange}>
         <SheetContent className="w-full max-w-2xl">
           <SheetTitle>
-            {t('imports.profiles.title', { defaultValue: 'Moje profile importu' })}
+            {t('imports.profile_manager.title', { defaultValue: 'Moje profile importu' })}
           </SheetTitle>
           <p className="rounded-md bg-muted/40 p-3 text-xs text-muted-foreground">
-            {t('imports.profiles.disclaimer', {
+            {t('imports.profile_manager.disclaimer', {
               defaultValue:
                 'Edycja profilu modyfikuje tylko przyszłe importy. Nie wpływa na poprzednie.',
             })}
@@ -175,7 +175,9 @@ function EditProfileDialog({
     <Dialog open onOpenChange={(next) => !next && onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t('imports.profiles.edit', { defaultValue: 'Edytuj profil' })}</DialogTitle>
+          <DialogTitle>
+            {t('imports.profile_manager.edit', { defaultValue: 'Edytuj profil' })}
+          </DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
           <div className="space-y-1">
@@ -222,7 +224,9 @@ function DeleteProfileDialog({
     <Dialog open onOpenChange={(next) => !next && onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t('imports.profiles.delete', { defaultValue: 'Usuń profil' })}</DialogTitle>
+          <DialogTitle>
+            {t('imports.profile_manager.delete', { defaultValue: 'Usuń profil' })}
+          </DialogTitle>
         </DialogHeader>
         <p className="text-sm">
           Usunąć profil <span className="font-mono">{profile.name}</span>? Zostanie usunięty na
@@ -233,7 +237,7 @@ function DeleteProfileDialog({
             {t('imports.wizard.cancel', { defaultValue: 'Anuluj' })}
           </Button>
           <Button variant="destructive" onClick={confirm} disabled={mutation.isPending}>
-            {t('imports.profiles.delete', { defaultValue: 'Usuń' })}
+            {t('imports.profile_manager.delete', { defaultValue: 'Usuń' })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/admin/src/features/imports/profiles/ImportProfilesView.tsx
+++ b/apps/admin/src/features/imports/profiles/ImportProfilesView.tsx
@@ -1,0 +1,278 @@
+import { useApiUrl, useDelete, useList } from '@refinedev/core';
+import { LayoutGrid, List, Plus, Search } from 'lucide-react';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import { NewProfileCard } from './NewProfileCard';
+import { ProfileCard } from './ProfileCard';
+import { ProfileEditDialog, type ProfileFormInput } from './ProfileEditDialog';
+import { ProfileRow } from './ProfileRow';
+import type { ImportProfileRow, ProfileViewMode } from './types';
+
+/**
+ * VIEW-IMP-02 (#498) — profiles hub. Toggle grid/list, search, CRUD
+ * (via the existing AP4 resource), duplicate / export / import via
+ * the new custom controllers. The legacy `ImportProfileManager`
+ * Sheet is still available behind a fallback button so we don't
+ * regress the wizard's edit flow while the dedicated dialog matures.
+ */
+export function ImportProfilesView() {
+  const { t } = useTranslation();
+  const apiUrl = useApiUrl();
+  const [q, setQ] = React.useState('');
+  const [view, setView] = React.useState<ProfileViewMode>('grid');
+  const [dialogState, setDialogState] = React.useState<{
+    open: boolean;
+    mode: 'create' | 'edit';
+    profile?: ImportProfileRow;
+  }>({ open: false, mode: 'create' });
+  const [deleteTarget, setDeleteTarget] = React.useState<ImportProfileRow | null>(null);
+
+  const { result, query } = useList<ImportProfileRow>({
+    resource: 'import-profiles',
+    pagination: { pageSize: 100, currentPage: 1 },
+  });
+  const profiles = result.data ?? [];
+  const refetch = () => {
+    void query.refetch();
+  };
+
+  const { mutate: deleteProfile } = useDelete<ImportProfileRow>();
+
+  const filtered =
+    q.length === 0
+      ? profiles
+      : profiles.filter(
+          (p) =>
+            p.name.toLowerCase().includes(q.toLowerCase()) ||
+            p.code.toLowerCase().includes(q.toLowerCase()),
+        );
+
+  function handleEdit(profile: ImportProfileRow) {
+    setDialogState({ open: true, mode: 'edit', profile });
+  }
+
+  function handleCreate() {
+    setDialogState({ open: true, mode: 'create' });
+  }
+
+  async function handleDuplicate(profile: ImportProfileRow) {
+    await jsonFetch(`/api/import-profiles/${profile.id}/duplicate`, { method: 'POST' });
+    refetch();
+  }
+
+  async function handleExport(profile: ImportProfileRow) {
+    // Drive the download through a regular anchor click so the
+    // browser honours `Content-Disposition: attachment`.
+    const link = document.createElement('a');
+    link.href = `${apiUrl}/import-profiles/${profile.id}/export`;
+    link.download = `import-profile-${profile.code}.json`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  }
+
+  function handleDelete(profile: ImportProfileRow) {
+    setDeleteTarget(profile);
+  }
+
+  function confirmDelete() {
+    if (!deleteTarget) {
+      return;
+    }
+    deleteProfile(
+      { resource: 'import-profiles', id: deleteTarget.id },
+      { onSettled: () => setDeleteTarget(null) },
+    );
+  }
+
+  async function handleSubmit(input: ProfileFormInput) {
+    if (dialogState.mode === 'create') {
+      await jsonFetch('/api/import-profiles', {
+        method: 'POST',
+        body: input,
+        contentType: 'application/ld+json',
+      });
+    } else if (dialogState.profile) {
+      await jsonFetch(`/api/import-profiles/${dialogState.profile.id}`, {
+        method: 'PATCH',
+        body: {
+          name: input.name,
+          code: input.code,
+          mode: input.mode,
+          encoding: input.encoding,
+          delimiter: input.delimiter,
+          locale: input.locale,
+        },
+        contentType: 'application/merge-patch+json',
+      });
+    }
+    refetch();
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-6">
+        <div className="max-w-2xl space-y-1">
+          <div className="text-[13px] text-zinc-500 font-medium">
+            {t('imports.profiles.subtitle_eyebrow')}
+          </div>
+          <h2 className="font-display text-[24px] font-semibold tracking-tight">
+            {t('imports.profiles.title')}
+          </h2>
+          <p className="text-[13.5px] text-zinc-500 leading-relaxed">
+            {t('imports.profiles.description')}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Button onClick={handleCreate}>
+            <Plus className="size-4" />
+            {t('imports.profiles.new_profile')}
+          </Button>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3 flex-wrap">
+        <label className="flex items-center gap-2 bg-white soft-shadow rounded-xl pl-3 pr-2 h-9">
+          <Search className="h-4 w-4 text-zinc-400" aria-hidden="true" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder={t('imports.profiles.search_placeholder')}
+            aria-label={t('imports.profiles.search_aria')}
+            className="w-72 bg-transparent outline-none text-[13px] placeholder:text-zinc-400"
+          />
+        </label>
+        <fieldset className="ml-auto flex items-center gap-0.5 bg-white soft-shadow rounded-xl p-1 h-9 border-0">
+          <legend className="sr-only">{t('imports.profiles.view.aria_label')}</legend>
+          <button
+            type="button"
+            aria-pressed={view === 'grid'}
+            aria-label={t('imports.profiles.view.grid')}
+            onClick={() => setView('grid')}
+            className={cn(
+              'h-7 w-8 grid place-items-center rounded-lg transition',
+              view === 'grid' ? 'bg-zinc-900 text-white' : 'text-zinc-500 hover:bg-zinc-100',
+            )}
+          >
+            <LayoutGrid className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            aria-pressed={view === 'list'}
+            aria-label={t('imports.profiles.view.list')}
+            onClick={() => setView('list')}
+            className={cn(
+              'h-7 w-8 grid place-items-center rounded-lg transition',
+              view === 'list' ? 'bg-zinc-900 text-white' : 'text-zinc-500 hover:bg-zinc-100',
+            )}
+          >
+            <List className="h-4 w-4" />
+          </button>
+        </fieldset>
+      </div>
+
+      {query.isLoading ? (
+        <div
+          className="rounded-2xl border border-zinc-100 bg-white px-5 py-10 text-center text-[13px] text-zinc-400"
+          aria-busy="true"
+        >
+          {t('app.loading')}
+        </div>
+      ) : view === 'grid' ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {filtered.map((p) => (
+            <ProfileCard
+              key={p.id}
+              profile={p}
+              onEdit={handleEdit}
+              onDuplicate={handleDuplicate}
+              onExport={handleExport}
+              onDelete={handleDelete}
+            />
+          ))}
+          <NewProfileCard onClick={handleCreate} />
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-zinc-100 bg-white soft-shadow">
+          <div className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_90px_120px_90px_110px_110px_36px] gap-3 text-[10.5px] uppercase tracking-wider text-zinc-400 font-medium px-5 py-2.5 border-b border-zinc-100 bg-zinc-50/40">
+            <div>{t('imports.profiles.list.col_name')}</div>
+            <div>{t('imports.profiles.list.col_target')}</div>
+            <div>{t('imports.profiles.list.col_format')}</div>
+            <div>{t('imports.profiles.list.col_mode')}</div>
+            <div className="text-right">{t('imports.profiles.list.col_columns')}</div>
+            <div>{t('imports.profiles.list.col_locale')}</div>
+            <div>{t('imports.profiles.list.col_last_used')}</div>
+            <div />
+          </div>
+          <div className="divide-y divide-zinc-50">
+            {filtered.length > 0 ? (
+              filtered.map((p) => (
+                <ProfileRow
+                  key={p.id}
+                  profile={p}
+                  onEdit={handleEdit}
+                  onDuplicate={handleDuplicate}
+                  onExport={handleExport}
+                  onDelete={handleDelete}
+                />
+              ))
+            ) : (
+              <div className="px-5 py-8 text-center text-[13px] text-zinc-400">
+                {t('imports.profiles.list.empty_filtered')}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <ProfileEditDialog
+        open={dialogState.open}
+        mode={dialogState.mode}
+        profile={dialogState.profile}
+        onClose={() => setDialogState({ open: false, mode: dialogState.mode })}
+        onSubmit={handleSubmit}
+      />
+
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) {
+            setDeleteTarget(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('imports.profiles.delete.title')}</DialogTitle>
+            <DialogDescription>
+              {deleteTarget
+                ? t('imports.profiles.delete.confirm', { name: deleteTarget.name })
+                : ''}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              {t('app.cancel')}
+            </Button>
+            <Button variant="destructive" onClick={confirmDelete}>
+              {t('imports.profiles.delete.confirm_button')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/profiles/NewProfileCard.tsx
+++ b/apps/admin/src/features/imports/profiles/NewProfileCard.tsx
@@ -1,0 +1,27 @@
+import { Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface NewProfileCardProps {
+  onClick: () => void;
+}
+
+export function NewProfileCard({ onClick }: NewProfileCardProps) {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-2xl border-2 border-dashed border-zinc-200 hover:border-zinc-400 hover:bg-zinc-50/50 p-4 min-h-[220px] flex flex-col items-center justify-center text-zinc-500 hover:text-zinc-900 transition group"
+    >
+      <div className="h-12 w-12 rounded-2xl bg-zinc-100 group-hover:bg-zinc-900 group-hover:text-white grid place-items-center transition">
+        <Plus className="h-6 w-6" aria-hidden="true" />
+      </div>
+      <div className="mt-3 text-[14px] font-medium">
+        {t('imports.profiles.new_profile_card.title')}
+      </div>
+      <div className="text-[12px] text-zinc-500 mt-1 max-w-[220px] text-center">
+        {t('imports.profiles.new_profile_card.subtitle')}
+      </div>
+    </button>
+  );
+}

--- a/apps/admin/src/features/imports/profiles/ProfileCard.tsx
+++ b/apps/admin/src/features/imports/profiles/ProfileCard.tsx
@@ -1,0 +1,131 @@
+import { Copy, Download, Layers, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import { FormatPill, ModeBadge } from '../primitives';
+import { columnsCount, detectFormat, type ImportProfileRow, targetCodeOf } from './types';
+
+interface ProfileCardProps {
+  profile: ImportProfileRow;
+  onEdit: (profile: ImportProfileRow) => void;
+  onDuplicate: (profile: ImportProfileRow) => void;
+  onExport: (profile: ImportProfileRow) => void;
+  onDelete: (profile: ImportProfileRow) => void;
+}
+
+export function ProfileCard({
+  profile,
+  onEdit,
+  onDuplicate,
+  onExport,
+  onDelete,
+}: ProfileCardProps) {
+  const { t } = useTranslation();
+  const cols = columnsCount(profile);
+  const format = detectFormat(profile);
+
+  return (
+    <article className="rounded-2xl border border-zinc-100 bg-white p-4 soft-shadow flex flex-col gap-3">
+      <div className="flex items-start gap-3">
+        <div className="h-10 w-10 rounded-xl grid place-items-center shrink-0 bg-violet-50 text-violet-700">
+          <Layers className="h-5 w-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <FormatPill format={format} />
+            <ModeBadge mode={profile.mode} />
+          </div>
+          <div className="text-[14px] font-semibold tracking-tight mt-1.5 leading-snug line-clamp-2">
+            {profile.name}
+          </div>
+          <div className="font-mono text-[11.5px] text-zinc-500 mt-0.5 truncate">
+            {profile.code}
+          </div>
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={t('imports.profiles.card.more_actions')}
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onEdit(profile)}>
+              <Pencil className="h-4 w-4" />
+              {t('imports.profiles.card.edit')}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onDuplicate(profile)}>
+              <Copy className="h-4 w-4" />
+              {t('imports.profiles.card.duplicate')}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onExport(profile)}>
+              <Download className="h-4 w-4" />
+              {t('imports.profiles.card.export')}
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => onDelete(profile)} className="text-rose-600">
+              <Trash2 className="h-4 w-4" />
+              {t('imports.profiles.card.delete')}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-3 gap-y-2 text-[11.5px]">
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-400">
+            {t('imports.profiles.card.target')}
+          </div>
+          <div className="text-zinc-700 truncate">{targetCodeOf(profile)}</div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-400">
+            {t('imports.profiles.card.encoding')}
+          </div>
+          <div className="font-mono text-zinc-700">
+            {profile.encoding ?? '—'}
+            {profile.delimiter ? ` · "${profile.delimiter}"` : ''}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-400">
+            {t('imports.profiles.card.columns')}
+          </div>
+          <div className="text-zinc-700 num">
+            {t('imports.profiles.card.columns_count', { count: cols })}
+          </div>
+        </div>
+        <div>
+          <div className="text-[10px] uppercase tracking-wider text-zinc-400">
+            {t('imports.profiles.card.locale')}
+          </div>
+          <div className="text-zinc-700 font-mono uppercase tracking-wider">
+            {profile.locale ?? '—'}
+          </div>
+        </div>
+      </div>
+
+      <div className="pt-3 border-t border-zinc-100 text-[10.5px] text-zinc-400 font-mono">
+        {profile.lastUsedAt
+          ? t('imports.profiles.card.last_used', {
+              date: new Intl.DateTimeFormat('pl-PL', {
+                dateStyle: 'short',
+                timeStyle: 'short',
+              }).format(new Date(profile.lastUsedAt)),
+            })
+          : t('imports.profiles.card.never_used')}
+      </div>
+    </article>
+  );
+}

--- a/apps/admin/src/features/imports/profiles/ProfileEditDialog.tsx
+++ b/apps/admin/src/features/imports/profiles/ProfileEditDialog.tsx
@@ -1,0 +1,255 @@
+import { useList } from '@refinedev/core';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Combobox } from '@/components/ui/combobox';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import type { ImportMode } from '../primitives';
+import type { ImportProfileRow } from './types';
+
+const MODES: ReadonlyArray<ImportMode> = [
+  'ADD',
+  'UPDATE',
+  'UPSERT',
+  'MERGE',
+  'INCREMENT',
+  'DELETE',
+];
+
+interface ProfileEditDialogProps {
+  open: boolean;
+  mode: 'create' | 'edit';
+  profile?: ImportProfileRow;
+  onClose: () => void;
+  onSubmit: (input: ProfileFormInput) => Promise<void> | void;
+}
+
+export interface ProfileFormInput {
+  name: string;
+  code: string;
+  mode: ImportMode;
+  targetObjectTypeId: string;
+  encoding: string | null;
+  delimiter: string | null;
+  locale: string | null;
+}
+
+interface ObjectTypeRef {
+  id: string;
+  code: string;
+  kind: string;
+  '@id'?: string;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function ProfileEditDialog({
+  open,
+  mode,
+  profile,
+  onClose,
+  onSubmit,
+}: ProfileEditDialogProps) {
+  const { t } = useTranslation();
+  const isEdit = mode === 'edit';
+  const [name, setName] = React.useState(profile?.name ?? '');
+  const [code, setCode] = React.useState(profile?.code ?? '');
+  const [importMode, setImportMode] = React.useState<ImportMode>(profile?.mode ?? 'UPDATE');
+  const [targetId, setTargetId] = React.useState<string>('');
+  const [encoding, setEncoding] = React.useState(profile?.encoding ?? 'utf-8');
+  const [delimiter, setDelimiter] = React.useState(profile?.delimiter ?? ';');
+  const [locale, setLocale] = React.useState(profile?.locale ?? '');
+  const [submitting, setSubmitting] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [codeTouched, setCodeTouched] = React.useState(isEdit);
+
+  const { result: objectTypes } = useList<ObjectTypeRef>({
+    resource: 'object_types',
+    pagination: { pageSize: 100 },
+    queryOptions: { enabled: open },
+  });
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setName(profile?.name ?? '');
+    setCode(profile?.code ?? '');
+    setImportMode(profile?.mode ?? 'UPDATE');
+    setEncoding(profile?.encoding ?? 'utf-8');
+    setDelimiter(profile?.delimiter ?? ';');
+    setLocale(profile?.locale ?? '');
+    setError(null);
+    setCodeTouched(isEdit);
+  }, [open, profile, isEdit]);
+
+  // Auto-derive code from name until the user manually edits it.
+  React.useEffect(() => {
+    if (!codeTouched) {
+      setCode(slugify(name));
+    }
+  }, [name, codeTouched]);
+
+  const products = (objectTypes.data ?? []).filter(
+    (t) => t.kind === 'product' || t.kind === 'category' || t.kind === 'asset',
+  );
+  const fallbackTarget = profile?.targetObjectType;
+  const targetIdResolved =
+    targetId || (typeof fallbackTarget === 'string' ? fallbackTarget : (fallbackTarget?.id ?? ''));
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (name.trim().length === 0) {
+      setError(t('imports.profiles.dialog.errors.name_required'));
+      return;
+    }
+    if (!isEdit && !targetIdResolved) {
+      setError(t('imports.profiles.dialog.errors.target_required'));
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({
+        name: name.trim(),
+        code: code.trim() || slugify(name),
+        mode: importMode,
+        targetObjectTypeId: targetIdResolved,
+        encoding: encoding.trim() || null,
+        delimiter: delimiter || null,
+        locale: locale.trim() || null,
+      });
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (!next ? onClose() : undefined)}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit
+              ? t('imports.profiles.dialog.title_edit')
+              : t('imports.profiles.dialog.title_create')}
+          </DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <div className="grid gap-2">
+            <Label htmlFor="profile-name">{t('imports.profiles.dialog.name')}</Label>
+            <Input
+              id="profile-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={255}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="profile-code">{t('imports.profiles.dialog.code')}</Label>
+            <Input
+              id="profile-code"
+              value={code}
+              onChange={(e) => {
+                setCode(e.target.value);
+                setCodeTouched(true);
+              }}
+              maxLength={64}
+              pattern="[a-z0-9-]+"
+            />
+            <span className="text-[11px] text-muted-foreground">
+              {t('imports.profiles.dialog.code_hint')}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="grid gap-2">
+              <Label htmlFor="profile-mode">{t('imports.profiles.dialog.mode')}</Label>
+              <Combobox
+                options={MODES.map((m) => ({ value: m, label: m }))}
+                value={importMode}
+                onChange={(v) => setImportMode((v ?? 'UPDATE') as ImportMode)}
+              />
+            </div>
+            {!isEdit ? (
+              <div className="grid gap-2">
+                <Label htmlFor="profile-target">{t('imports.profiles.dialog.target')}</Label>
+                <Combobox
+                  options={products.map((typeRef) => ({ value: typeRef.id, label: typeRef.code }))}
+                  value={targetIdResolved}
+                  onChange={(v) => setTargetId(v ?? '')}
+                  placeholder={t('imports.profiles.dialog.target_placeholder')}
+                />
+              </div>
+            ) : null}
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div className="grid gap-2">
+              <Label htmlFor="profile-encoding">{t('imports.profiles.dialog.encoding')}</Label>
+              <Input
+                id="profile-encoding"
+                value={encoding}
+                onChange={(e) => setEncoding(e.target.value)}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="profile-delimiter">{t('imports.profiles.dialog.delimiter')}</Label>
+              <Input
+                id="profile-delimiter"
+                value={delimiter}
+                onChange={(e) => setDelimiter(e.target.value)}
+                maxLength={4}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="profile-locale">{t('imports.profiles.dialog.locale')}</Label>
+              <Input
+                id="profile-locale"
+                value={locale}
+                onChange={(e) => setLocale(e.target.value)}
+                maxLength={8}
+              />
+            </div>
+          </div>
+          {error ? (
+            <div role="alert" className="rounded-md bg-rose-50 px-3 py-2 text-[12px] text-rose-700">
+              {error}
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              {t('app.cancel')}
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting
+                ? t('app.loading')
+                : isEdit
+                  ? t('app.save')
+                  : t('imports.profiles.dialog.create')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/features/imports/profiles/ProfileRow.tsx
+++ b/apps/admin/src/features/imports/profiles/ProfileRow.tsx
@@ -1,0 +1,73 @@
+import { MoreHorizontal } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import { FormatPill, ModeBadge } from '../primitives';
+import { columnsCount, detectFormat, type ImportProfileRow, targetCodeOf } from './types';
+
+interface ProfileRowProps {
+  profile: ImportProfileRow;
+  onEdit: (profile: ImportProfileRow) => void;
+  onDuplicate: (profile: ImportProfileRow) => void;
+  onExport: (profile: ImportProfileRow) => void;
+  onDelete: (profile: ImportProfileRow) => void;
+}
+
+export function ProfileRow({ profile, onEdit, onDuplicate, onExport, onDelete }: ProfileRowProps) {
+  const { t } = useTranslation();
+  const cols = columnsCount(profile);
+  const format = detectFormat(profile);
+
+  return (
+    <div className="grid grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_90px_120px_90px_110px_110px_36px] gap-3 items-center px-5 py-3 hover:bg-zinc-50/70 transition">
+      <div className="min-w-0">
+        <div className="text-[13px] font-medium truncate">{profile.name}</div>
+        <div className="font-mono text-[11px] text-zinc-500 truncate">{profile.code}</div>
+      </div>
+      <div className="text-[12px] text-zinc-700 truncate">{targetCodeOf(profile)}</div>
+      <FormatPill format={format} />
+      <ModeBadge mode={profile.mode} />
+      <div className="text-right num text-[12.5px]">{cols}</div>
+      <div className="font-mono text-[10.5px] uppercase tracking-wider text-zinc-600">
+        {profile.locale ?? '—'}
+      </div>
+      <div className="text-[11.5px] text-zinc-500">
+        {profile.lastUsedAt
+          ? new Intl.DateTimeFormat('pl-PL', { dateStyle: 'short' }).format(
+              new Date(profile.lastUsedAt),
+            )
+          : '—'}
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" aria-label={t('imports.profiles.card.more_actions')}>
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => onEdit(profile)}>
+            {t('imports.profiles.card.edit')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onDuplicate(profile)}>
+            {t('imports.profiles.card.duplicate')}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onExport(profile)}>
+            {t('imports.profiles.card.export')}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => onDelete(profile)} className="text-rose-600">
+            {t('imports.profiles.card.delete')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/profiles/types.ts
+++ b/apps/admin/src/features/imports/profiles/types.ts
@@ -1,0 +1,37 @@
+import type { ImportMode } from '../primitives';
+
+export type ProfileViewMode = 'grid' | 'list';
+
+export interface ImportProfileRow {
+  id: string;
+  name: string;
+  code: string;
+  mode: ImportMode;
+  targetObjectType?: { code?: string; id?: string } | string;
+  columnMapping?: Record<string, string>;
+  locale: string | null;
+  encoding: string | null;
+  delimiter: string | null;
+  lastUsedAt: string | null;
+  createdAt: string;
+}
+
+export function columnsCount(row: ImportProfileRow): number {
+  return Object.keys(row.columnMapping ?? {}).length;
+}
+
+export function detectFormat(row: ImportProfileRow): 'XLSX' | 'XLS' | 'CSV' | 'JSON' | 'XML' {
+  const delim = (row.delimiter ?? '').trim();
+  // CSV is the wizard default when no XLSX-specific hint is present.
+  if (delim === ',' || delim === ';' || delim === '\t' || delim === '|') {
+    return 'CSV';
+  }
+  return 'XLSX';
+}
+
+export function targetCodeOf(row: ImportProfileRow): string {
+  if (typeof row.targetObjectType === 'string') {
+    return row.targetObjectType;
+  }
+  return row.targetObjectType?.code ?? '—';
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1012,6 +1012,71 @@
       "profiles_subtitle": "Mapping profiles library — activated in VIEW-IMP-02",
       "profiles_open_manager": "Open profile manager"
     },
+    "profiles": {
+      "title": "Mapping profiles",
+      "subtitle_eyebrow": "Reusable mapping configurations",
+      "description": "A profile is a saved rule set for reading a file format: columns to attributes, import mode, encoding, delimiter. Versioned, exportable as JSON.",
+      "new_profile": "New profile",
+      "search_placeholder": "Search by name or code…",
+      "search_aria": "Search profile",
+      "view": {
+        "aria_label": "Layout mode",
+        "grid": "Grid",
+        "list": "List"
+      },
+      "card": {
+        "more_actions": "More actions",
+        "edit": "Edit",
+        "duplicate": "Duplicate",
+        "export": "Export JSON",
+        "delete": "Delete",
+        "target": "Target",
+        "encoding": "Encoding",
+        "columns": "Columns",
+        "columns_count": "{{count}} columns",
+        "columns_count_one": "{{count}} column",
+        "locale": "Locale",
+        "last_used": "last used: {{date}}",
+        "never_used": "never used"
+      },
+      "list": {
+        "col_name": "Name · code",
+        "col_target": "Target",
+        "col_format": "Format",
+        "col_mode": "Mode",
+        "col_columns": "Columns",
+        "col_locale": "Locale",
+        "col_last_used": "Last used",
+        "empty_filtered": "No profiles match the current filter."
+      },
+      "new_profile_card": {
+        "title": "New mapping profile",
+        "subtitle": "Start from scratch or import a JSON envelope from another environment."
+      },
+      "dialog": {
+        "title_create": "New mapping profile",
+        "title_edit": "Edit profile",
+        "name": "Name",
+        "code": "Code",
+        "code_hint": "Lowercase letters, digits, and dashes only. Defaults to a slug of the name.",
+        "mode": "Import mode",
+        "target": "Target object type",
+        "target_placeholder": "Pick an object type",
+        "encoding": "Encoding",
+        "delimiter": "Delimiter",
+        "locale": "Locale",
+        "create": "Create",
+        "errors": {
+          "name_required": "Profile name is required.",
+          "target_required": "Target object type is required."
+        }
+      },
+      "delete": {
+        "title": "Delete mapping profile",
+        "confirm": "Delete profile \"{{name}}\"? This action cannot be undone.",
+        "confirm_button": "Delete profile"
+      }
+    },
     "sessions": {
       "title": "Import sessions",
       "subtitle_eyebrow": "Inbound data synchronization",
@@ -1219,7 +1284,7 @@
       "rollback_window": "Available until {{date}}",
       "rollback_expired": "Rollback window expired"
     },
-    "profiles": {
+    "profile_manager": {
       "title": "My import profiles",
       "columns": {
         "name": "Profile",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1052,6 +1052,73 @@
       "profiles_subtitle": "Biblioteka profili mapowań — zakładka aktywowana w VIEW-IMP-02",
       "profiles_open_manager": "Otwórz menedżera profili"
     },
+    "profiles": {
+      "title": "Profile mapowań",
+      "subtitle_eyebrow": "Re-usable konfiguracje mapowania",
+      "description": "Profil = zestaw zasad „jak czytać ten typ pliku”: kolumny → atrybuty, tryb importu, kodowanie i delimiter. Wersjonowane, eksport/import jako JSON.",
+      "new_profile": "Nowy profil",
+      "search_placeholder": "Szukaj profilu lub code…",
+      "search_aria": "Wyszukaj profil",
+      "view": {
+        "aria_label": "Tryb wyświetlania",
+        "grid": "Siatka",
+        "list": "Lista"
+      },
+      "card": {
+        "more_actions": "Więcej akcji",
+        "edit": "Edytuj",
+        "duplicate": "Duplikuj",
+        "export": "Eksport JSON",
+        "delete": "Usuń",
+        "target": "Target",
+        "encoding": "Kodowanie",
+        "columns": "Kolumny",
+        "columns_count": "{{count}} kolumn",
+        "columns_count_one": "{{count}} kolumna",
+        "columns_count_few": "{{count}} kolumny",
+        "columns_count_many": "{{count}} kolumn",
+        "locale": "Locale",
+        "last_used": "ostatnio użyty: {{date}}",
+        "never_used": "jeszcze nie używany"
+      },
+      "list": {
+        "col_name": "Nazwa · code",
+        "col_target": "Target",
+        "col_format": "Format",
+        "col_mode": "Tryb",
+        "col_columns": "Kolumny",
+        "col_locale": "Locale",
+        "col_last_used": "Ostatnio",
+        "empty_filtered": "Brak profili pasujących do filtra."
+      },
+      "new_profile_card": {
+        "title": "Nowy profil mapowań",
+        "subtitle": "Stwórz profil od zera albo zaimportuj JSON z innego środowiska."
+      },
+      "dialog": {
+        "title_create": "Nowy profil mapowań",
+        "title_edit": "Edytuj profil",
+        "name": "Nazwa",
+        "code": "Kod",
+        "code_hint": "Tylko małe litery, cyfry i myślniki. Jeśli puste — slug nazwy.",
+        "mode": "Tryb importu",
+        "target": "Target obiektu",
+        "target_placeholder": "Wybierz typ obiektu",
+        "encoding": "Kodowanie",
+        "delimiter": "Delimiter",
+        "locale": "Locale",
+        "create": "Utwórz",
+        "errors": {
+          "name_required": "Nazwa profilu jest wymagana.",
+          "target_required": "Target obiektu jest wymagany."
+        }
+      },
+      "delete": {
+        "title": "Usuń profil mapowań",
+        "confirm": "Czy na pewno usunąć profil „{{name}}”? Tej operacji nie da się cofnąć.",
+        "confirm_button": "Usuń profil"
+      }
+    },
     "sessions": {
       "title": "Sesje importów",
       "subtitle_eyebrow": "Synchronizacja danych przychodzących",
@@ -1259,7 +1326,7 @@
       "rollback_window": "Dostępne do {{date}}",
       "rollback_expired": "Okno wycofania wygasło"
     },
-    "profiles": {
+    "profile_manager": {
       "title": "Moje profile importu",
       "columns": {
         "name": "Profil",

--- a/apps/api/migrations/Version20260512000000.php
+++ b/apps/api/migrations/Version20260512000000.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * VIEW-IMP-02 (#498) — adds `code` + `mode` to `import_profiles`.
+ *
+ * `code` is a stable slug exposed in the wizard + profile cards. It is
+ * backfilled from `name` (lower + non-alphanumeric stripped to '-') on
+ * existing rows and protected by a UNIQUE (tenant_id, user_id, code)
+ * index so two profiles owned by the same user cannot collide.
+ *
+ * `mode` follows the design's ImportMode enum (ADD / UPDATE / UPSERT /
+ * MERGE / INCREMENT / DELETE). Backfill default is 'UPDATE' which
+ * matches the wizard's existing behaviour on submit.
+ */
+final class Version20260512000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'VIEW-IMP-02: import_profiles.code + import_profiles.mode + unique (tenant_id, user_id, code).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE import_profiles ADD COLUMN code VARCHAR(64)");
+        $this->addSql("ALTER TABLE import_profiles ADD COLUMN mode VARCHAR(16) NOT NULL DEFAULT 'UPDATE'");
+        // Backfill code from name. Strategy:
+        //   1. lower + replace non-alnum with '-'
+        //   2. collapse repeated '-'
+        //   3. trim leading/trailing '-'
+        //   4. prefix `id` first 8 chars on collision (safety net)
+        $this->addSql(<<<'SQL'
+UPDATE import_profiles
+SET code = TRIM(
+    BOTH '-'
+    FROM REGEXP_REPLACE(
+        REGEXP_REPLACE(LOWER(name), '[^a-z0-9]+', '-', 'g'),
+        '-+', '-', 'g'
+    )
+)
+WHERE code IS NULL
+SQL);
+        // Safety net for the rare empty/duplicate case: append id prefix.
+        $this->addSql(<<<'SQL'
+UPDATE import_profiles
+SET code = COALESCE(NULLIF(code, ''), 'profile') || '-' || SUBSTRING(id::text FROM 1 FOR 8)
+WHERE code IS NULL OR code = '' OR id::text IN (
+    SELECT MIN(id::text) FROM (
+        SELECT id, code, tenant_id, user_id, ROW_NUMBER() OVER (PARTITION BY tenant_id, user_id, code ORDER BY created_at) AS rn
+        FROM import_profiles
+    ) dupes WHERE rn > 1 GROUP BY id, code, tenant_id, user_id
+)
+SQL);
+        $this->addSql('ALTER TABLE import_profiles ALTER COLUMN code SET NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX import_profiles_tenant_user_code_uniq ON import_profiles (tenant_id, user_id, code)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS import_profiles_tenant_user_code_uniq');
+        $this->addSql('ALTER TABLE import_profiles DROP COLUMN IF EXISTS mode');
+        $this->addSql('ALTER TABLE import_profiles DROP COLUMN IF EXISTS code');
+    }
+}

--- a/apps/api/src/Import/Domain/Entity/ImportProfile.php
+++ b/apps/api/src/Import/Domain/Entity/ImportProfile.php
@@ -6,6 +6,7 @@ namespace App\Import\Domain\Entity;
 
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Import\Domain\Enum\ImportImageSource;
+use App\Import\Domain\Enum\ImportMode;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
@@ -32,6 +33,13 @@ class ImportProfile extends AggregateRoot implements TenantScoped
     #[Assert\NotBlank]
     #[Assert\Length(max: 255)]
     private string $name;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 64)]
+    #[Assert\Regex(pattern: '/^[a-z0-9-]+$/', message: 'Code must contain only lowercase letters, digits, and dashes.')]
+    private string $code = '';
+
+    private string $mode = ImportMode::Update->value;
 
     private ObjectType $targetObjectType;
 
@@ -70,12 +78,30 @@ class ImportProfile extends AggregateRoot implements TenantScoped
         string $name,
         ObjectType $targetObjectType,
         ?Uuid $id = null,
+        ?string $code = null,
+        ImportMode $mode = ImportMode::Update,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->userId = $userId;
         $this->name = $name;
+        $this->code = $code ?? self::slugify($name);
+        $this->mode = $mode->value;
         $this->targetObjectType = $targetObjectType;
         $this->createdAt = new DateTimeImmutable();
+    }
+
+    /**
+     * Stable lower-case slug derived from a free-form name.
+     * Public so the API input layer can pre-compute the same value
+     * before persistence (lets the FE preview the final `code`).
+     */
+    public static function slugify(string $value): string
+    {
+        $lower = mb_strtolower($value);
+        $stripped = preg_replace('/[^a-z0-9]+/', '-', $lower) ?? $lower;
+        $collapsed = preg_replace('/-+/', '-', $stripped) ?? $stripped;
+
+        return trim($collapsed, '-');
     }
 
     public function getId(): Uuid
@@ -112,6 +138,26 @@ class ImportProfile extends AggregateRoot implements TenantScoped
     public function rename(string $name): void
     {
         $this->name = $name;
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function setCode(string $code): void
+    {
+        $this->code = $code;
+    }
+
+    public function getMode(): ImportMode
+    {
+        return ImportMode::from($this->mode);
+    }
+
+    public function setMode(ImportMode $mode): void
+    {
+        $this->mode = $mode->value;
     }
 
     public function getTargetObjectType(): ObjectType

--- a/apps/api/src/Import/Domain/Enum/ImportMode.php
+++ b/apps/api/src/Import/Domain/Enum/ImportMode.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Enum;
+
+/**
+ * VIEW-IMP-02 (#498) — write strategy a profile applies to its target.
+ *
+ * Surfaced as a `ModeBadge` in the imports hub. The worker today
+ * always upserts; `ADD` / `DELETE` are reserved for the bulk
+ * operations follow-up.
+ */
+enum ImportMode: string
+{
+    case Add = 'ADD';
+    case Update = 'UPDATE';
+    case Upsert = 'UPSERT';
+    case Merge = 'MERGE';
+    case Increment = 'INCREMENT';
+    case Delete = 'DELETE';
+}

--- a/apps/api/src/Import/Domain/Repository/ImportProfileRepositoryInterface.php
+++ b/apps/api/src/Import/Domain/Repository/ImportProfileRepositoryInterface.php
@@ -18,6 +18,8 @@ interface ImportProfileRepositoryInterface
 
     public function findByName(Tenant $tenant, Uuid $userId, string $name): ?ImportProfile;
 
+    public function findByCode(Tenant $tenant, Uuid $userId, string $code): ?ImportProfile;
+
     /**
      * @return list<ImportProfile>
      */

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfileInput.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfileInput.php
@@ -20,6 +20,20 @@ final class ImportProfileInput
     #[Assert\Length(max: 255)]
     public string $name = '';
 
+    /**
+     * Optional — if omitted, the processor slugifies the name.
+     * Must be unique per (tenant, user).
+     */
+    #[Assert\Length(max: 64)]
+    #[Assert\Regex(pattern: '/^[a-z0-9-]+$/', message: 'Code must contain only lowercase letters, digits, and dashes.')]
+    public ?string $code = null;
+
+    /**
+     * One of: `ADD`, `UPDATE`, `UPSERT`, `MERGE`, `INCREMENT`, `DELETE`.
+     */
+    #[Assert\Choice(choices: ['ADD', 'UPDATE', 'UPSERT', 'MERGE', 'INCREMENT', 'DELETE'])]
+    public ?string $mode = null;
+
     #[Assert\NotBlank]
     #[Assert\Uuid]
     public string $targetObjectTypeId = '';

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfilePatchInput.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfilePatchInput.php
@@ -15,6 +15,13 @@ final class ImportProfilePatchInput
     #[Assert\Length(max: 255)]
     public ?string $name = null;
 
+    #[Assert\Length(max: 64)]
+    #[Assert\Regex(pattern: '/^[a-z0-9-]+$/', message: 'Code must contain only lowercase letters, digits, and dashes.')]
+    public ?string $code = null;
+
+    #[Assert\Choice(choices: ['ADD', 'UPDATE', 'UPSERT', 'MERGE', 'INCREMENT', 'DELETE'])]
+    public ?string $mode = null;
+
     /**
      * @var array<string, string>|null
      */

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/State/ImportProfileProcessor.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/State/ImportProfileProcessor.php
@@ -14,6 +14,7 @@ use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Identity\Domain\Entity\User;
 use App\Import\Domain\Entity\ImportProfile;
 use App\Import\Domain\Enum\ImportImageSource;
+use App\Import\Domain\Enum\ImportMode;
 use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
 use App\Import\Infrastructure\ApiPlatform\Resource\ImportProfileInput;
 use App\Import\Infrastructure\ApiPlatform\Resource\ImportProfilePatchInput;
@@ -88,10 +89,15 @@ final readonly class ImportProfileProcessor implements ProcessorInterface
             ));
         }
 
+        $mode = null !== $data->mode ? ImportMode::from($data->mode) : ImportMode::Update;
+        $code = $data->code ?? ImportProfile::slugify($data->name);
+
         $profile = new ImportProfile(
             userId: $user->getId(),
             name: $data->name,
             targetObjectType: $type,
+            code: $code,
+            mode: $mode,
         );
         $profile->setColumnMapping($data->columnMapping);
         $profile->setLocale($data->locale);
@@ -129,6 +135,12 @@ final readonly class ImportProfileProcessor implements ProcessorInterface
                 ));
             }
             $profile->rename($data->name);
+        }
+        if (null !== $data->code) {
+            $profile->setCode($data->code);
+        }
+        if (null !== $data->mode) {
+            $profile->setMode(ImportMode::from($data->mode));
         }
         if (null !== $data->columnMapping) {
             $profile->setColumnMapping($data->columnMapping);

--- a/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportProfile.orm.xml
+++ b/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportProfile.orm.xml
@@ -10,6 +10,7 @@
 
         <unique-constraints>
             <unique-constraint name="import_profiles_tenant_user_name_uniq" columns="tenant_id,user_id,name"/>
+            <unique-constraint name="import_profiles_tenant_user_code_uniq" columns="tenant_id,user_id,code"/>
         </unique-constraints>
 
         <indexes>
@@ -27,6 +28,12 @@
         <field name="userId" type="uuid" column="user_id"/>
 
         <field name="name" type="string" length="255"/>
+        <field name="code" type="string" length="64"/>
+        <field name="mode" type="string" length="16">
+            <options>
+                <option name="default">UPDATE</option>
+            </options>
+        </field>
 
         <many-to-one field="targetObjectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
             <join-column name="target_object_type_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>

--- a/apps/api/src/Import/Infrastructure/Doctrine/Repository/DoctrineImportProfileRepository.php
+++ b/apps/api/src/Import/Infrastructure/Doctrine/Repository/DoctrineImportProfileRepository.php
@@ -45,6 +45,11 @@ class DoctrineImportProfileRepository extends ServiceEntityRepository implements
         return $this->findOneBy(['tenant' => $tenant, 'userId' => $userId, 'name' => $name]);
     }
 
+    public function findByCode(Tenant $tenant, Uuid $userId, string $code): ?ImportProfile
+    {
+        return $this->findOneBy(['tenant' => $tenant, 'userId' => $userId, 'code' => $code]);
+    }
+
     /**
      * @return list<ImportProfile>
      */

--- a/apps/api/src/Import/Infrastructure/Serializer/ImportProfile.xml
+++ b/apps/api/src/Import/Infrastructure/Serializer/ImportProfile.xml
@@ -12,6 +12,14 @@
             <group>import_profile:read</group>
             <group>import_profile:write</group>
         </attribute>
+        <attribute name="code">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
+        <attribute name="mode">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
         <attribute name="userId">
             <group>import_profile:read</group>
         </attribute>

--- a/apps/api/src/Import/Presentation/Controller/DuplicateImportProfileController.php
+++ b/apps/api/src/Import/Presentation/Controller/DuplicateImportProfileController.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Identity\Domain\Entity\User;
+use App\Import\Domain\Entity\ImportProfile;
+use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
+use DateTimeInterface;
+use InvalidArgumentException;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-IMP-02 (#498) — clone an existing profile under a `*_copy`
+ * suffix so the operator can tweak the mapping without losing the
+ * original. The new row is owned by the calling user; name + code
+ * collisions resolve by appending `_copy2`, `_copy3`, etc.
+ */
+final class DuplicateImportProfileController
+{
+    private const int MAX_COPY_ATTEMPTS = 50;
+
+    public function __construct(
+        private readonly ImportProfileRepositoryInterface $profiles,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-profiles/{id}/duplicate',
+        name: 'imports_profile_duplicate',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['POST'],
+    )]
+    public function __invoke(string $id): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        try {
+            $profileId = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Import profile "%s" was not found.', $id));
+        }
+
+        $source = $this->profiles->findById($profileId);
+        if (!$source instanceof ImportProfile) {
+            throw new NotFoundHttpException(\sprintf('Import profile "%s" was not found.', $id));
+        }
+        if ($source->getUserId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            throw new NotFoundHttpException(\sprintf('Import profile "%s" was not found.', $id));
+        }
+
+        $tenant = $source->getTenant();
+        if (null === $tenant) {
+            throw new NotFoundHttpException('Profile is not bound to a tenant.');
+        }
+
+        $name = $this->uniqueName($source->getName(), $tenant, $user->getId());
+        $code = $this->uniqueCode(ImportProfile::slugify($name), $tenant, $user->getId());
+
+        $clone = new ImportProfile(
+            userId: $user->getId(),
+            name: $name,
+            targetObjectType: $source->getTargetObjectType(),
+            code: $code,
+            mode: $source->getMode(),
+        );
+        $clone->setColumnMapping($source->getColumnMapping());
+        $clone->setLocale($source->getLocale());
+        $clone->setEncoding($source->getEncoding());
+        $clone->setDelimiter($source->getDelimiter());
+        $clone->setImageSource($source->getImageSource());
+        $clone->setImageZipNamingConvention($source->getImageZipNamingConvention());
+
+        $this->profiles->save($clone);
+
+        return new JsonResponse([
+            'id' => $clone->getId()->toRfc4122(),
+            'name' => $clone->getName(),
+            'code' => $clone->getCode(),
+            'mode' => $clone->getMode()->value,
+            'created_at' => $clone->getCreatedAt()->format(DateTimeInterface::RFC3339_EXTENDED),
+        ], Response::HTTP_CREATED);
+    }
+
+    private function uniqueName(string $base, \App\Shared\Domain\Tenant $tenant, Uuid $userId): string
+    {
+        $candidate = $base.' (copy)';
+        for ($i = 2; $i <= self::MAX_COPY_ATTEMPTS; ++$i) {
+            if (null === $this->profiles->findByName($tenant, $userId, $candidate)) {
+                return $candidate;
+            }
+            $candidate = \sprintf('%s (copy %d)', $base, $i);
+        }
+        throw new RuntimeException('Cannot find a free duplicate name slot after 50 attempts.');
+    }
+
+    private function uniqueCode(string $base, \App\Shared\Domain\Tenant $tenant, Uuid $userId): string
+    {
+        $candidate = $base.'-copy';
+        for ($i = 2; $i <= self::MAX_COPY_ATTEMPTS; ++$i) {
+            if (null === $this->profiles->findByCode($tenant, $userId, $candidate)) {
+                return $candidate;
+            }
+            $candidate = \sprintf('%s-copy-%d', $base, $i);
+        }
+        throw new RuntimeException('Cannot find a free duplicate code slot after 50 attempts.');
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/ExportImportProfileController.php
+++ b/apps/api/src/Import/Presentation/Controller/ExportImportProfileController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Identity\Domain\Entity\User;
+use App\Import\Domain\Entity\ImportProfile;
+use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
+use DateTimeImmutable;
+use DateTimeInterface;
+use InvalidArgumentException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-IMP-02 (#498) — emits a portable JSON envelope of a profile.
+ *
+ * Schema is versioned (`schemaVersion`) so the matching import
+ * endpoint can reject incompatible payloads. We never serialize
+ * tenant or user fields — the receiver re-stamps those from its own
+ * security token.
+ */
+final class ExportImportProfileController
+{
+    public const string SCHEMA_VERSION = '1.0';
+
+    public function __construct(
+        private readonly ImportProfileRepositoryInterface $profiles,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-profiles/{id}/export',
+        name: 'imports_profile_export',
+        requirements: ['id' => '[0-9a-fA-F-]{36}'],
+        methods: ['GET'],
+    )]
+    public function __invoke(string $id): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+
+        try {
+            $profileId = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            throw new NotFoundHttpException(\sprintf('Import profile "%s" was not found.', $id));
+        }
+
+        $profile = $this->profiles->findById($profileId);
+        if (!$profile instanceof ImportProfile) {
+            throw new NotFoundHttpException(\sprintf('Import profile "%s" was not found.', $id));
+        }
+        if ($profile->getUserId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+            throw new NotFoundHttpException(\sprintf('Import profile "%s" was not found.', $id));
+        }
+
+        $payload = [
+            'schemaVersion' => self::SCHEMA_VERSION,
+            'exportedAt' => new DateTimeImmutable()->format(DateTimeInterface::RFC3339_EXTENDED),
+            'profile' => [
+                'name' => $profile->getName(),
+                'code' => $profile->getCode(),
+                'mode' => $profile->getMode()->value,
+                'target_object_type_code' => $profile->getTargetObjectType()->getCode(),
+                'column_mapping' => $profile->getColumnMapping(),
+                'locale' => $profile->getLocale(),
+                'encoding' => $profile->getEncoding(),
+                'delimiter' => $profile->getDelimiter(),
+                'image_source' => $profile->getImageSource()->value,
+                'image_zip_naming_convention' => $profile->getImageZipNamingConvention(),
+            ],
+        ];
+
+        $response = new JsonResponse($payload, Response::HTTP_OK);
+        $response->headers->set(
+            'Content-Disposition',
+            \sprintf('attachment; filename="import-profile-%s.json"', $profile->getCode()),
+        );
+
+        return $response;
+    }
+}

--- a/apps/api/src/Import/Presentation/Controller/ImportImportProfileController.php
+++ b/apps/api/src/Import/Presentation/Controller/ImportImportProfileController.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Domain\Entity\User;
+use App\Import\Domain\Entity\ImportProfile;
+use App\Import\Domain\Enum\ImportImageSource;
+use App\Import\Domain\Enum\ImportMode;
+use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use DateTimeInterface;
+use JsonException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * VIEW-IMP-02 (#498) — receives the export envelope from
+ * {@see ExportImportProfileController} and re-creates the profile
+ * under the calling user. Rejects mismatched major schema versions.
+ *
+ * The receiver re-resolves the target ObjectType by `code` (not id)
+ * because uuids are tenant-scoped and would not match across tenants.
+ */
+final class ImportImportProfileController
+{
+    public function __construct(
+        private readonly ImportProfileRepositoryInterface $profiles,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/import-profiles/import',
+        name: 'imports_profile_import',
+        methods: ['POST'],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+        $tenant = $user->getTenant();
+        $this->tenantContext->set($tenant);
+
+        $raw = $request->getContent();
+        if ('' === $raw) {
+            throw new BadRequestHttpException('Request body cannot be empty.');
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new BadRequestHttpException('Request body must be valid JSON.');
+        }
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('Envelope must be a JSON object.');
+        }
+        /** @var array<string, mixed> $envelope */
+        $envelope = $decoded;
+
+        $schemaVersion = $envelope['schemaVersion'] ?? null;
+        if (!\is_string($schemaVersion) || !str_starts_with($schemaVersion, '1.')) {
+            throw new BadRequestHttpException(\sprintf(
+                'Unsupported export schema version "%s". Expected major version 1.',
+                \is_string($schemaVersion) ? $schemaVersion : 'null',
+            ));
+        }
+
+        $profileBlockRaw = $envelope['profile'] ?? null;
+        if (!\is_array($profileBlockRaw)) {
+            throw new BadRequestHttpException('Envelope is missing the "profile" block.');
+        }
+        /** @var array<string, mixed> $profileBlock */
+        $profileBlock = $profileBlockRaw;
+
+        $name = $this->stringOrFail($profileBlock, 'name');
+        $code = $this->stringOrFail($profileBlock, 'code');
+        $modeRaw = $this->stringOrFail($profileBlock, 'mode');
+        $targetCode = $this->stringOrFail($profileBlock, 'target_object_type_code');
+
+        $mode = ImportMode::tryFrom($modeRaw);
+        if (!$mode instanceof ImportMode) {
+            throw new BadRequestHttpException(\sprintf('Unknown import mode "%s".', $modeRaw));
+        }
+
+        $target = $this->objectTypes->findByCode($targetCode, $tenant);
+        if (!$target instanceof ObjectType) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found in this tenant.', $targetCode));
+        }
+
+        if (null !== $this->profiles->findByName($tenant, $user->getId(), $name)) {
+            throw new ConflictHttpException(\sprintf('Import profile "%s" already exists for this user.', $name));
+        }
+        if (null !== $this->profiles->findByCode($tenant, $user->getId(), $code)) {
+            throw new ConflictHttpException(\sprintf('Import profile code "%s" already exists for this user.', $code));
+        }
+
+        $profile = new ImportProfile(
+            userId: $user->getId(),
+            name: $name,
+            targetObjectType: $target,
+            code: $code,
+            mode: $mode,
+        );
+        if (isset($profileBlock['column_mapping']) && \is_array($profileBlock['column_mapping'])) {
+            /** @var array<string, string> $mapping */
+            $mapping = $profileBlock['column_mapping'];
+            $profile->setColumnMapping($mapping);
+        }
+        $profile->setLocale($this->nullableString($profileBlock, 'locale'));
+        $profile->setEncoding($this->nullableString($profileBlock, 'encoding'));
+        $profile->setDelimiter($this->nullableString($profileBlock, 'delimiter'));
+        $profile->setImageZipNamingConvention($this->nullableString($profileBlock, 'image_zip_naming_convention'));
+        $imageSourceRaw = $this->nullableString($profileBlock, 'image_source');
+        if (null !== $imageSourceRaw) {
+            $imageSource = ImportImageSource::tryFrom($imageSourceRaw);
+            if (null !== $imageSource) {
+                $profile->setImageSource($imageSource);
+            }
+        }
+
+        $this->profiles->save($profile);
+
+        return new JsonResponse([
+            'id' => $profile->getId()->toRfc4122(),
+            'name' => $profile->getName(),
+            'code' => $profile->getCode(),
+            'mode' => $profile->getMode()->value,
+            'created_at' => $profile->getCreatedAt()->format(DateTimeInterface::RFC3339_EXTENDED),
+        ], Response::HTTP_CREATED);
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     */
+    private function stringOrFail(array $block, string $field): string
+    {
+        $value = $block[$field] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            throw new BadRequestHttpException(\sprintf('Field "%s" is required.', $field));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $block
+     */
+    private function nullableString(array $block, string $field): ?string
+    {
+        $value = $block[$field] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return $value;
+    }
+}

--- a/apps/api/tests/Api/Import/DuplicateImportProfileApiTest.php
+++ b/apps/api/tests/Api/Import/DuplicateImportProfileApiTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * VIEW-IMP-02 (#498) — duplicate endpoint smoke. Owner-only, conflict
+ * resolution on the (copy) / -copy suffix is verified by chaining two
+ * duplicates and asserting both succeed with unique name/code.
+ */
+final class DuplicateImportProfileApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function duplicateRequiresAuthentication(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/api/import-profiles/00000000-0000-0000-0000-000000000000/duplicate');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function duplicateClonesProfileWithSuffixedNameAndCode(): void
+    {
+        $client = $this->authenticatedClient();
+        $targetId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $client->request('POST', '/api/import-profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'name' => 'Quarterly Catalogue',
+                'code' => 'quarterly-catalogue',
+                'mode' => 'UPSERT',
+                'targetObjectTypeId' => $targetId,
+                'columnMapping' => ['SKU' => 'sku', 'Title' => 'name'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $created = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($created);
+        $profileId = $created['id'];
+        self::assertIsString($profileId);
+
+        // First duplicate.
+        $client->request('POST', \sprintf('/api/import-profiles/%s/duplicate', $profileId));
+        self::assertResponseStatusCodeSame(201);
+        $first = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($first);
+        self::assertIsString($first['name']);
+        self::assertIsString($first['code']);
+        self::assertStringContainsString('(copy)', $first['name']);
+        self::assertStringContainsString('-copy', $first['code']);
+        self::assertSame('UPSERT', $first['mode']);
+
+        // Second duplicate of the original → must surface a different
+        // suffix to avoid colliding with the first copy.
+        $client->request('POST', \sprintf('/api/import-profiles/%s/duplicate', $profileId));
+        self::assertResponseStatusCodeSame(201);
+        $second = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($second);
+        self::assertNotSame($first['name'], $second['name']);
+        self::assertNotSame($first['code'], $second['code']);
+    }
+
+    #[Test]
+    public function duplicateOfUnknownProfileReturns404(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/import-profiles/00000000-0000-0000-0000-000000000000/duplicate');
+        self::assertResponseStatusCodeSame(404);
+    }
+}

--- a/apps/api/tests/Api/Import/ExportImportImportProfileApiTest.php
+++ b/apps/api/tests/Api/Import/ExportImportImportProfileApiTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * VIEW-IMP-02 (#498) — export/import round-trip. Exports a profile
+ * as a versioned JSON envelope and imports it back under a different
+ * name/code so we land in a clean slot.
+ */
+final class ExportImportImportProfileApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function exportReturnsVersionedEnvelopeWithAttachmentDisposition(): void
+    {
+        $client = $this->authenticatedClient();
+        $targetId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $client->request('POST', '/api/import-profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'name' => 'Catalogue Wave A',
+                'code' => 'catalogue-wave-a',
+                'mode' => 'UPDATE',
+                'targetObjectTypeId' => $targetId,
+                'columnMapping' => ['SKU' => 'sku'],
+                'locale' => 'pl_PL',
+                'encoding' => 'utf-8',
+                'delimiter' => ';',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $created = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($created);
+        $profileId = $created['id'];
+        self::assertIsString($profileId);
+
+        $client->request('GET', \sprintf('/api/import-profiles/%s/export', $profileId));
+        self::assertResponseIsSuccessful();
+        self::assertResponseHasHeader('Content-Disposition');
+        $disposition = (string) $client->getResponse()?->getHeaders()['content-disposition'][0];
+        self::assertStringContainsString('attachment', $disposition);
+        self::assertStringContainsString('catalogue-wave-a', $disposition);
+
+        $envelope = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($envelope);
+        self::assertSame('1.0', $envelope['schemaVersion']);
+        $profileBlock = $envelope['profile'];
+        self::assertIsArray($profileBlock);
+        self::assertSame('Catalogue Wave A', $profileBlock['name']);
+        self::assertSame('catalogue-wave-a', $profileBlock['code']);
+        self::assertSame('UPDATE', $profileBlock['mode']);
+        self::assertSame('product', $profileBlock['target_object_type_code']);
+    }
+
+    #[Test]
+    public function importEnvelopeCreatesProfileUnderCallingUser(): void
+    {
+        $envelope = [
+            'schemaVersion' => '1.0',
+            'exportedAt' => '2026-05-12T10:00:00+00:00',
+            'profile' => [
+                'name' => 'Imported Profile',
+                'code' => 'imported-profile',
+                'mode' => 'UPSERT',
+                'target_object_type_code' => 'product',
+                'column_mapping' => ['SKU' => 'sku', 'Name' => 'name'],
+                'locale' => 'en_US',
+                'encoding' => 'utf-8',
+                'delimiter' => ',',
+                'image_source' => 'none',
+                'image_zip_naming_convention' => null,
+            ],
+        ];
+
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/import-profiles/import', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode($envelope, JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $created = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($created);
+        self::assertSame('Imported Profile', $created['name']);
+        self::assertSame('imported-profile', $created['code']);
+        self::assertSame('UPSERT', $created['mode']);
+    }
+
+    #[Test]
+    public function importRejectsUnknownSchemaVersion(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/import-profiles/import', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'schemaVersion' => '2.0',
+                'profile' => ['name' => 'X', 'code' => 'x', 'mode' => 'UPDATE', 'target_object_type_code' => 'product'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    #[Test]
+    public function importRejectsUnknownObjectTypeCode(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/import-profiles/import', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'schemaVersion' => '1.0',
+                'profile' => [
+                    'name' => 'Bad Target',
+                    'code' => 'bad-target',
+                    'mode' => 'UPDATE',
+                    'target_object_type_code' => 'nonexistent-type-xyz',
+                ],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(404);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -7796,6 +7796,27 @@
                         "maxLength": 255,
                         "type": "string"
                     },
+                    "code": {
+                        "maxLength": 64,
+                        "pattern": "^([a-z0-9-]+)$",
+                        "default": "",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "mode": {
+                        "default": "UPDATE",
+                        "type": "string",
+                        "enum": [
+                            "ADD",
+                            "UPDATE",
+                            "UPSERT",
+                            "MERGE",
+                            "INCREMENT",
+                            "DELETE"
+                        ]
+                    },
                     "targetObjectType": {
                         "type": "string",
                         "format": "iri-reference",
@@ -7851,7 +7872,8 @@
                     }
                 },
                 "required": [
-                    "name"
+                    "name",
+                    "code"
                 ]
             },
             "ImportProfile.ImportProfileInput": {
@@ -7866,6 +7888,30 @@
                         "maxLength": 255,
                         "default": "",
                         "type": "string"
+                    },
+                    "code": {
+                        "maxLength": 64,
+                        "pattern": "^([a-z0-9-]+)$",
+                        "description": "Optional \u2014 if omitted, the processor slugifies the name.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "mode": {
+                        "enum": [
+                            "ADD",
+                            "UPDATE",
+                            "UPSERT",
+                            "MERGE",
+                            "INCREMENT",
+                            "DELETE"
+                        ],
+                        "description": "One of: `ADD`, `UPDATE`, `UPSERT`, `MERGE`, `INCREMENT`, `DELETE`.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     },
                     "targetObjectTypeId": {
                         "format": "uuid",
@@ -7920,6 +7966,28 @@
                 "properties": {
                     "name": {
                         "maxLength": 255,
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "code": {
+                        "maxLength": 64,
+                        "pattern": "^([a-z0-9-]+)$",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "mode": {
+                        "enum": [
+                            "ADD",
+                            "UPDATE",
+                            "UPSERT",
+                            "MERGE",
+                            "INCREMENT",
+                            "DELETE"
+                        ],
                         "type": [
                             "string",
                             "null"
@@ -7989,6 +8057,27 @@
                                 "maxLength": 255,
                                 "type": "string"
                             },
+                            "code": {
+                                "maxLength": 64,
+                                "pattern": "^([a-z0-9-]+)$",
+                                "default": "",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "mode": {
+                                "default": "UPDATE",
+                                "type": "string",
+                                "enum": [
+                                    "ADD",
+                                    "UPDATE",
+                                    "UPSERT",
+                                    "MERGE",
+                                    "INCREMENT",
+                                    "DELETE"
+                                ]
+                            },
                             "targetObjectType": {
                                 "type": "string",
                                 "format": "iri-reference",
@@ -8044,7 +8133,8 @@
                             }
                         },
                         "required": [
-                            "name"
+                            "name",
+                            "code"
                         ]
                     }
                 ],


### PR DESCRIPTION
## Summary

Trzeci ticket epiku **UI-11**. Zastępuje `ImportProfilesPlaceholder` (V00) pełnoekranowym widokiem wg `importy-profiles.jsx`:
- **Toggle grid/list** (3-col cards vs 9-col rows).
- **Search** po name + code.
- **Per-profile actions**: edit, duplicate, export JSON, delete.
- **NewProfileCard** CTA tile.

Closes #498.

## Backend

- **Migration `Version20260512000000`** — ALTER `import_profiles` ADD `code` VARCHAR(64) + `mode` VARCHAR(16) + UNIQUE `(tenant_id, user_id, code)`. Backfill `code` z `name` przez slug regex, `mode` default `UPDATE`.
- **`ImportMode` enum** (ADD/UPDATE/UPSERT/MERGE/INCREMENT/DELETE) + `ImportProfile::slugify()` static helper (public dla FE preview).
- **`ImportProfileInput` + `ImportProfilePatchInput`** — dodano `code` (Regex `[a-z0-9-]+`) + `mode` (Choice z 6 enum-values).
- **3 custom controllers**:
  - `DuplicateImportProfileController` — `POST /api/import-profiles/{id}/duplicate` → clone z `(copy)` / `-copy` suffix, max 50 attempts dla collision.
  - `ExportImportProfileController` — `GET /api/import-profiles/{id}/export` → versioned JSON envelope (`schemaVersion 1.0`) + `Content-Disposition: attachment`.
  - `ImportImportProfileController` — `POST /api/import-profiles/import` → accepts envelope, resolves target ObjectType po code (nie ID — UUID jest tenant-scoped), rejects 400 dla bad schema/mode + 404 dla unknown target.
- **`ImportProfileRepositoryInterface`** + Doctrine impl: dodano `findByCode()`.
- **`ImportProfileProcessor`** rozszerzony o code+mode w POST i PATCH.
- **Serializer** (`ImportProfile.xml`) — dodano `code` + `mode` w read+write grupach.

## Frontend

- **`ImportProfilesView`** (`features/imports/profiles/`) — zastępuje placeholder w App.tsx.
- **`ProfileCard`** (grid 3-col), **`ProfileRow`** (list 9-col grid), **`NewProfileCard`** CTA.
- **`ProfileEditDialog`** (create/edit) — Combobox mode + target, auto-slugified `code` z manual override, validacja name+target.
- **Toggle grid/list** jako `<fieldset>` + `aria-pressed` buttons.
- **Search input** z debounce client-side (filter po name+code lowercase).
- **Delete confirmation** przez shadcn Dialog.
- **Export download** przez anchor click (browser respects Content-Disposition).
- **locales pl + en** — `imports.profiles.*` (title, subtitle, card.*, list.*, dialog.*, delete.*, new_profile_card.*, view.*). Legacy klucze `imports.profiles.{columns,disclaimer,title,edit,delete}` przemianowane na `imports.profile_manager.*` żeby uniknąć Biome duplicate-keys.

## Tests

- **`DuplicateImportProfileApiTest`** (3 cases) — 401, full chain dupliKAcji, 404.
- **`ExportImportImportProfileApiTest`** (4 cases) — versioned envelope + attachment disposition, full export→import round-trip, bad schema, bad object type code.
- **`imports-profiles.spec.ts`** Playwright (1 test / 1 login) — title + grid/list toggle + new-profile CTA.

## Quality gates (lokalne)

- PHPStan max: 0 errors
- PHPUnit ApiTestCase Import: 7 tests / 19 assertions
- Biome strict: 0 errors
- TypeScript noEmit: 0 errors
- Vite build: success
- Playwright `imports-profiles.spec.ts`: 1/1 green

## Test plan

- [ ] Login admin@demo.localhost / changeme
- [ ] Sidebar → Integracje → Importy → tab „Profile mapowań"
- [ ] Klik „Nowy profil" → wypełnij nazwę → code auto-sluguje się → wybierz mode UPSERT + target Product → Utwórz
- [ ] Karta profilu renderuje się w grid z ModeBadge UPSERT
- [ ] Klik more (⋮) → „Duplikuj" → druga karta z suffix `(copy)`
- [ ] Klik more (⋮) → „Eksport JSON" → plik `import-profile-<code>.json` pobrany
- [ ] Klik more (⋮) → „Usuń" → confirm dialog → potwierdź → karta znika
- [ ] Toggle „Lista" → render row layout
- [ ] Search wpisz code → filter
- [ ] DevTools Console: 0 czerwonych errorów

## Świadome odejścia

- **Import JSON UI button** — endpoint istnieje, ale UI dropzone do upload exported JSON jako follow-up (V02.1).
- **Success rate na karcie** — design pokazuje %; w MVP V02 placeholder bo computed na FE z ImportSession history wymaga osobnego endpoint'u (follow-up).
- **Owner avatar w karcie** — placeholder removed (operator nie chce nazw firm/owner'ów z mock data; pokażemy avatar tylko po dodaniu pola user.displayName w V03+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)