### PR TITLE
fix(maintenance): pim:db:reset runs audit:schema:update before fixtures

### DIFF
--- a/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
@@ -74,6 +74,14 @@ final class DatabaseResetCommand extends Command
             ['doctrine:database:drop', ['--force' => true, '--if-exists' => true]],
             ['doctrine:database:create', ['--if-not-exists' => true]],
             ['doctrine:migrations:migrate', ['--no-interaction' => true, '--allow-no-migration' => true]],
+            // dh_auditor creates *_audit tables outside the regular Doctrine
+            // migrations pipeline. Without this step, INSERTs into audited
+            // entities (ImportSession, ImportProfile, Channel, Asset, …)
+            // trip a "relation does not exist" inside the auditor listener,
+            // rollback the surrounding transaction, and the operator sees a
+            // bare 500 with a foreign-key violation when the parent rows
+            // were never actually committed.
+            ['audit:schema:update', ['--force' => true]],
         ];
 
         if ($loadFixtures) {


### PR DESCRIPTION
## Problem

Operator zgłosił HTTP 500 podczas próby importu CSV w wizardzie po marathon UI-11. Root cause:

```
SQLSTATE[23503]: Foreign key violation: 7
ERROR: insert or update on table "objects" violates foreign key constraint "objects_import_session_fk"
DETAIL: Key (import_session_id)=(...) is not present in table "import_sessions".
```

Misleading bo wskazuje na FK, ale prawdziwa przyczyna to **brak audit tables** dla `ImportSession` + `ImportProfile` (dh_auditor enabled w `config/packages/dh_auditor.yaml` ale tabele `import_sessions_audit` / `import_profiles_audit` nigdy nie zostały utworzone w dev DB).

## Mechanizm

`pim:db:reset` woła kolejno `doctrine:database:drop` → `create` → `migrations:migrate` → `fixtures:load`. Brak kroku dla `audit:schema:update` (dh_auditor tworzy `*_audit` tabele poza standardowym Doctrine migrations pipeline).

Po `pim:db:reset` audit tables nie istnieją. Próba persist'a na audited encji rzuca `relation "<entity>_audit" does not exist` w auditor listenerze → rolluje wszystkie INSERT-y w obecnej transakcji → import_sessions row NIE jest commitowany → kolejny INSERT objects.import_session_id fail z FK violation pointing at missing parent.

Operator widzi tylko końcowy FK error, traci 30 minut na diagnostykę.

## Fix

Dodaję krok `audit:schema:update --force` do `pim:db:reset`, między migrations i fixtures load. Każdy reset dev DB tworzy też 20 audit tables (api_keys_audit, attributes_audit, channels_audit, import_sessions_audit, …).

Pliki:
- `apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php` — single new step + comment z root cause.

## Quality gates

- PHPStan max: 0 errors
- Manual smoke: `pim:db:reset --force --with-fixtures` → audit tables created → POST /api/import-sessions z 2-row CSV → HTTP 200, status=success.

## Test plan

- [ ] `docker compose exec api php bin/console pim:db:reset --force --with-fixtures`
- [ ] `docker compose exec database psql -U pim -d pim -c '\dt *_audit'` — pokazuje 20 tabel
- [ ] Login + POST /api/import-sessions → HTTP 200 (nie 500)

## Lekcja

Dopisuje do agent/lessons.md (osobny commit lub follow-up): **dh_auditor schema migration jest poza Doctrine migrations**. Każdy reset dev DB MUSI też wykonać `audit:schema:update` inaczej FK violations rolluja parent INSERT'y w nieoczywisty sposób.

Refs UI-11 marathon — operator smoke test fail po merge of #507.

🤖 Generated with Claude Code