### PR TITLE
fix(doctrine): disable per-query backtrace collection in worker mode

### DIFF
--- a/apps/api/config/packages/doctrine.yaml
+++ b/apps/api/config/packages/doctrine.yaml
@@ -20,7 +20,17 @@ doctrine:
         # either here or in the DATABASE_URL env var (see .env file)
         #server_version: '16'
 
-        profiling_collect_backtrace: '%kernel.debug%'
+        # Backtrace collection is the dev default but is incompatible with
+        # FrankenPHP worker mode + long-running handlers: every executed
+        # query holds a full stack trace in BacktraceDebugDataHolder for
+        # the lifetime of the worker. A 60-row XLSX import dispatched
+        # through the in-band sync transport fires ~10 queries per row
+        # (ObjectType / Category / attribute lookups, object + value
+        # inserts, audit log writes) and pushes a single worker past the
+        # 256 MiB ceiling. Symfony's web profiler still records query
+        # counts and SQL strings through the regular data collector — we
+        # only drop the per-query backtrace.
+        profiling_collect_backtrace: false
         use_savepoints: true
 
         # Disable query logging globally — sekcja 3.10 architektury and ticket


### PR DESCRIPTION
## Summary

Operator zgłosił po marathonie UI-11: duży XLSX (84.7 KiB, 60 wierszy) wisi w stanie *pending* po przejściu wszystkich kroków wizardu. Mniejszy CSV (76 B) przeszedł bez problemu. Diagnoza pokazała w logach FrankenPHP:

```
PHP Fatal error: Allowed memory size of 268435456 bytes exhausted
(tried to allocate 20480 bytes) in
/app/vendor/doctrine/doctrine-bundle/src/Middleware/BacktraceDebugDataHolder.php
on line 43
```

`profiling_collect_backtrace: '%kernel.debug%'` (dev default) sprawia, że DoctrineBundle wpina pełen stack trace do każdego wykonanego SQL. W worker mode (FrankenPHP) ten kolektor żyje przez cały czas życia workera; ImportRunHandler na 60-wierszowym XLSX wysyła ~10 queries/wiersz (attribute / category / object lookups + INSERTy + dh_auditor) i przebija sufit 256 MiB zanim handler zdąży flushnąć.

CSV poniżej 50 KiB nie był dotknięty, bo `StartImportController` puszcza go inline przez request thread (próg `SYNC_THRESHOLD_ROWS * 1024`), gdzie limit pamięci jest większy a profilera krócej żyje. Pliki większe szły async transportem (w dev aliasowanym na `sync://`) i handler odpalał się in-band z workera — gdzie kumulował pamięć.

## Backend

- `apps/api/config/packages/doctrine.yaml` — `profiling_collect_backtrace: false` na stałe. Symfony web profiler dalej widzi liczbę queriy, SQL strings, parametry i czasy (osobny data collector) — tracimy tylko stack trace per query.
- Produkcja nie była dotknięta: `kernel.debug=false` resolwował parametr do `false`.

## Frontend

N/A.

## Quality gates

- PHPStan max: zielony lokalnie.
- Cache warmup w dev: OK.
- Manual smoke: po fixu + restarcie API workera operator powinien móc ponownie wgrać `magento-2021-10-19-start-5381-end-5439.xlsx` przez wizard i zobaczyć status `success` (sesja wcześniej wisząca `019e1ae2-684a-7711-9e0a-bf166393f228` została w bazie ręcznie oznaczona jako `failed` z notatką "Worker memory exhausted (pre-fix); please retry the upload.").

## Test plan

- [ ] Login `admin@demo.localhost / changeme` → przejście do `/integrations/imports/new`.
- [ ] Upload `magento-2021-10-19-start-5381-end-5439.xlsx` (84.7 KiB).
- [ ] Wizard kroki 1-4, klik commit.
- [ ] Po przeładowaniu w zakładce *Sesje* import jest widoczny ze statusem `Sukces`.
- [ ] DevTools Console — brak czerwonych errorów.
- [ ] FrankenPHP log brak `PHP Fatal error: Allowed memory size`.

## Świadome odejścia

- Nie podnoszę globalnego `memory_limit` w PHP — to maskuje root cause i pamięć rośnie liniowo z czasem życia workera; backtrace per query był jedynym kolektorem skalującym z lifetime workera, reszta resetuje się przy nowym requeście.
- Nie zmieniam routing async → sync ani threshold w `StartImportController` — fix problemu *pamięci*, nie *ścieżki dispatch*. Async path jest poprawny dla MVP i jutro (gdy pojedzie z prawdziwym async transportem) zachowa się tak samo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)