### PR TITLE
fix(import): re-merge tenant + attributes after batch flushAndClear

### DIFF
--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -166,7 +166,25 @@ final class ImportRunHandler extends AbstractBatchHandler
 
                 if ($this->shouldFlush($processed)) {
                     $this->flushAndClear();
+                    // After clear() every previously-loaded entity is
+                    // detached. The catalog-side lookups in the next
+                    // iteration (Attribute references on ObjectValue,
+                    // Tenant stamped by TenantAssignmentListener) would
+                    // throw "Multiple non-persisted new entities" on the
+                    // next flush — re-merge by reloading the session and
+                    // its tenant, replaying the attribute lookup, and
+                    // resetting TenantContext so the listener pulls the
+                    // managed reference.
                     $session = $this->refreshSession($session);
+                    $tenant = $session->getTenant();
+                    if (!$tenant instanceof Tenant) {
+                        throw new RuntimeException(\sprintf(
+                            'Import session "%s" lost its tenant assignment mid-run.',
+                            $session->getId()->toRfc4122(),
+                        ));
+                    }
+                    $this->tenantContext->set($tenant);
+                    $attributesByCode = $this->validator->loadAttributesByCode($tenant, $columnMapping);
                     $this->progressPublisher->progress($session, $processed, $sku);
                 }
             }


### PR DESCRIPTION
## Summary

Operator zgłosił HTTP 500 na kroku Confirm w wizard dla 390-wierszowego XLSX:

```
Handling "App\Import\Domain\Message\ImportRunMessage" failed:
Multiple non-persisted new entities were found through the given
association graph:
 * ObjectValue#tenant → Proxies\__CG__\App\Shared\Domain\Tenant@XXX
 * ObjectValue#attribute → App\Catalog\Domain\Entity\Attribute@YYY
 * (and more attributes per row)
```

`ImportRunHandler::run()` ładuje `$tenant` (z sesji) i `$attributesByCode` (z `ImportValidationService::loadAttributesByCode()`) raz przed pętlą wierszy. Na granicy batch=200 woła `flushAndClear()` z `AbstractBatchHandler` — `EntityManager::clear()` detachuje cały identity map. Cached `Tenant` i `Attribute` w pętli pozostają w pamięci PHP, ale Doctrine widzi je jako "new" przy następnym persist `ObjectValue` (które odnosi się do nich przez `ManyToOne`).

Mały plik <200 wierszy nigdy nie krzyżował granicy batch i działał. Magento XLSX (390 wierszy) trafiał w drugi batch (201-390) i zakańczał na 500.

## Backend

- `apps/api/src/Import/Application/Handler/ImportRunHandler.php` — po `flushAndClear()` ten sam wzorzec re-merge jak dla `$session`:
  - reload session przez `refreshSession()` (już było),
  - pull świeży managed `$tenant` z reloaded session,
  - re-set `TenantContext` żeby `TenantAssignmentListener` używał managed reference,
  - re-run `loadAttributesByCode()` do odbudowy mapy `$attributesByCode`.

`$columnMapping` to `array<string,string>` (czysty array), nie wymaga refresh.

## Frontend

N/A.

## Quality gates

- PHPStan max: 0 errors.
- PHPUnit `ImportRun*` (unit): 1/1 zielone.
- PHPUnit `ImportApi*` (Api): 2/2 zielone.

## Test plan

- [ ] Login `admin@demo.localhost / changeme` → `/integrations/imports/new`.
- [ ] Upload `magento-2021-10-19-start-5381-end-5439.xlsx` (390 wierszy).
- [ ] Wizard 1-4, commit. Response 202 (lub 200 dla sync path), brak 500.
- [ ] W zakładce *Sesje* sesja kończy się statusem `Sukces`.
- [ ] `/products` listing pokazuje ~390 nowych produktów.
- [ ] DevTools Console — brak czerwonych errorów.
- [ ] FrankenPHP worker log — brak `Multiple non-persisted new entities`.

## Świadome odejścia

- Nie dodaję dodatkowego testu E2E ImportApiTest dla >200-wierszowego pliku w tym PR — istniejące testy używają małych CSV i przejście granicy 200 wierszy wymagałoby fixture z 200+ wierszami danych testowych. Follow-up: dorzucić regression test gdy będziemy mieli k6 benchmark dla importu (planowane w VIEW-IMP-AUDIT).
- Nie zmieniam `batchSize=200` — to świadomie wybrana wartość z memory contract (R-25, 256 MiB worker ceiling). Fix jest w re-merge, nie w omijaniu batchowania.

🤖 Generated with [Claude Code](https://claude.com/claude-code)