### PR TITLE
feat(catalog): predefined-value attrs render as Combobox/MultiSelect w karcie produktu

### DIFF
--- a/apps/admin/e2e/products-select-multiselect-attrs.spec.ts
+++ b/apps/admin/e2e/products-select-multiselect-attrs.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * Operator report (2026-05-12): "atrybuty z predefiniowanymi
+ * wartościami (Tagi, Kolor, Rozmiar) muszą się wyświetlać jako
+ * select / multiselect w karcie produktu — aktualnie muszę wpisywać
+ * wartości z palca". Spec exercises the full round-trip:
+ *
+ *  1. Seed a product on the built-in Product ObjectType (which already
+ *     has `color` and `tags` attached via the demo seeder).
+ *  2. Open the detail page, switch to edit mode.
+ *  3. Assert that the Kolor row renders the searchable Combobox and
+ *     that the Tagi row renders the chip-style MultiSelect — not a
+ *     plain `<input>` (the regression catch).
+ *  4. Pick one option in each, save, reload.
+ *  5. Assert the picker remembers the selections and the read-only
+ *     read-out shows the localized labels (e.g. "Nowość"), never the
+ *     raw codes (`new`).
+ *
+ * Marked `fixme` in CI for the same `storageState` reason the other
+ * UI-seeded specs use; locally (cold rate-limiter) it is the smoke
+ * gate operators rely on.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('product detail renders Combobox/MultiSelect for select-like attributes', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const authHeaders = { Authorization: `Bearer ${accessToken}` };
+
+  const sku = uniqueSku('SEL');
+
+  const objectTypesResponse = await page.request.get('/api/object_types', {
+    headers: authHeaders,
+  });
+  const objectTypesBody = (await objectTypesResponse.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const types = objectTypesBody.member ?? objectTypesBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  const createResponse = await page.request.post('/api/products', {
+    headers: { ...authHeaders, 'content-type': 'application/ld+json' },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: { name: `Select-Multi spec ${sku}` },
+    },
+  });
+  expect(createResponse.status()).toBe(201);
+  const product = (await createResponse.json()) as { id: string };
+
+  // Wait for the effective groups call to settle on initial mount.
+  // The endpoint also ships `options` for select/multiselect attributes
+  // which is the backend half of this PR.
+  const groupsResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/effective-attribute-groups') &&
+      response.request().method() === 'GET',
+    { timeout: 15_000 },
+  );
+  await page.goto(`/products/${product.id}`);
+  await groupsResponse;
+  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible();
+
+  // Synthetic "default" group is appended last by the controller, so
+  // expand-all is needed even though the detail page expands all groups
+  // by default. Scroll the page bottom to mount the synthetic card.
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  const kolorLabel = page.getByText(/^(Kolor|Color)$/).first();
+  await kolorLabel.scrollIntoViewIfNeeded();
+  await expect(kolorLabel).toBeVisible();
+
+  // Single-select (Kolor): Combobox button shows the "Wybierz…"
+  // placeholder until a value is chosen. Locate by aria-haspopup so
+  // the selector stays stable after a value has been picked.
+  const kolorRow = kolorLabel.locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+  const kolorTrigger = kolorRow.locator('button[aria-haspopup="listbox"]');
+  await expect(kolorTrigger).toBeVisible();
+  await kolorTrigger.click();
+  await page.getByRole('button', { name: /^(Czerwony|Red)$/ }).click();
+  await expect(kolorTrigger).toContainText(/Czerwony|Red/);
+
+  // Multiselect (Tagi): trigger is a div role=button hosting chips.
+  const tagiLabel = page.getByText(/^(Tagi|Tags)$/).first();
+  await tagiLabel.scrollIntoViewIfNeeded();
+  const tagiRow = tagiLabel.locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+  const tagiTrigger = tagiRow.locator('[role="button"][aria-haspopup="listbox"]');
+  await expect(tagiTrigger).toBeVisible();
+  await tagiTrigger.click();
+  await page.getByRole('button', { name: /^(Nowość|New)$/ }).click();
+  // Close popover by clicking the trigger again; chip stays inside.
+  await tagiTrigger.click();
+  await expect(tagiTrigger).toContainText(/Nowość|New/);
+
+  // Save → backend persists `{attributes: {color: "red", tags: ["new"]}}`.
+  const patchResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/products/') && response.request().method() === 'PATCH',
+  );
+  await page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i }).click();
+  const patched = await patchResponse;
+  expect(patched.status()).toBe(200);
+
+  // Reload + assert read-only display now shows localized option
+  // labels (not raw codes) — this is the round-trip the read path
+  // was missing entirely before the fix.
+  await page.reload();
+  const reloadedKolorLabel = page.getByText(/^(Kolor|Color)$/).first();
+  await reloadedKolorLabel.scrollIntoViewIfNeeded();
+  await expect(
+    reloadedKolorLabel
+      .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]')
+      .getByText(/^(Czerwony|Red)$/),
+  ).toBeVisible();
+  const reloadedTagiLabel = page.getByText(/^(Tagi|Tags)$/).first();
+  await reloadedTagiLabel.scrollIntoViewIfNeeded();
+  await expect(
+    reloadedTagiLabel
+      .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]')
+      .getByText(/^(Nowość|New)$/),
+  ).toBeVisible();
+});

--- a/apps/admin/src/components/ui/multi-select.tsx
+++ b/apps/admin/src/components/ui/multi-select.tsx
@@ -1,0 +1,212 @@
+import { Check, X } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface MultiSelectOption {
+  value: string;
+  label: string;
+  color?: string | null;
+  deprecated?: boolean;
+}
+
+interface MultiSelectProps {
+  options: MultiSelectOption[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Lightweight popover multi-select. Renders selected entries as removable
+ * chips inside the trigger and a search-filtered checkbox list in the
+ * popover. Used by the product detail page for `multiselect` attributes
+ * (Tagi etc.) where operators were previously typing option codes by hand.
+ *
+ * Stays headless of `cmdk` / `@radix-ui/react-popover` to mirror
+ * `Combobox` and avoid extra deps.
+ */
+export function MultiSelect({
+  options,
+  value,
+  onChange,
+  placeholder = 'Wybierz…',
+  searchPlaceholder = 'Szukaj…',
+  emptyText = 'Brak wyników',
+  disabled,
+  className,
+}: MultiSelectProps): React.ReactElement {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  const filtered = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if ('' === q) {
+      return options;
+    }
+    return options.filter(
+      (option) => option.label.toLowerCase().includes(q) || option.value.toLowerCase().includes(q),
+    );
+  }, [options, query]);
+
+  const selectedSet = React.useMemo(() => new Set(value), [value]);
+  const selected = options.filter((option) => selectedSet.has(option.value));
+
+  const toggle = (optionValue: string): void => {
+    if (selectedSet.has(optionValue)) {
+      onChange(value.filter((v) => v !== optionValue));
+    } else {
+      onChange([...value, optionValue]);
+    }
+  };
+
+  const removeChip = (optionValue: string, event: React.MouseEvent): void => {
+    event.stopPropagation();
+    onChange(value.filter((v) => v !== optionValue));
+  };
+
+  // The trigger has to host real <button> chips for "remove" actions, so
+  // it cannot itself be a <button> (no nested interactives). Use a div
+  // with role=button + keyboard handlers so a11y is preserved.
+  const handleTriggerKey = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (disabled) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      setOpen((prev) => !prev);
+    } else if (event.key === 'Escape' && open) {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  return (
+    <div ref={wrapperRef} className={cn('relative inline-block w-full', className)}>
+      {/* biome-ignore lint/a11y/useSemanticElements: chips inside contain real <button>s for "remove", so the trigger cannot itself be a <button>. */}
+      <div
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        onClick={() => !disabled && setOpen((prev) => !prev)}
+        onKeyDown={handleTriggerKey}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-disabled={disabled}
+        className={cn(
+          'flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border border-input bg-background px-2 py-1.5 text-sm shadow-sm transition-colors',
+          'hover:bg-accent/40',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
+      >
+        {selected.length === 0 ? (
+          <span className="px-1 text-muted-foreground">{placeholder}</span>
+        ) : (
+          selected.map((option) => (
+            <span
+              key={option.value}
+              className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs"
+            >
+              {option.color ? (
+                <span
+                  aria-hidden
+                  className="size-2 rounded-full"
+                  style={{ backgroundColor: option.color }}
+                />
+              ) : null}
+              <span>{option.label}</span>
+              {!disabled && (
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={`Usuń ${option.label}`}
+                  onClick={(event) => removeChip(option.value, event)}
+                  className="ml-0.5 inline-flex size-3.5 cursor-pointer items-center justify-center rounded-full text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+                >
+                  <X className="size-3" />
+                </button>
+              )}
+            </span>
+          ))
+        )}
+        <span aria-hidden className="ml-auto text-muted-foreground">
+          ▾
+        </span>
+      </div>
+
+      {open && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border border-input bg-popover shadow-md">
+          <div className="border-b border-input p-2">
+            <input
+              ref={(node) => {
+                node?.focus();
+              }}
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={searchPlaceholder}
+              className="w-full rounded-md border border-transparent bg-transparent px-2 py-1 text-sm focus:border-input focus:outline-none"
+            />
+          </div>
+          <div className="max-h-60 overflow-auto py-1">
+            {filtered.length === 0 ? (
+              <div className="px-3 py-2 text-sm text-muted-foreground">{emptyText}</div>
+            ) : (
+              filtered.map((option) => {
+                const isSelected = selectedSet.has(option.value);
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => toggle(option.value)}
+                    className={cn(
+                      'flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent',
+                      option.deprecated && 'text-muted-foreground line-through',
+                    )}
+                    aria-pressed={isSelected}
+                  >
+                    <span
+                      className={cn(
+                        'flex size-4 items-center justify-center rounded border',
+                        isSelected
+                          ? 'border-primary bg-primary text-primary-foreground'
+                          : 'border-input',
+                      )}
+                      aria-hidden
+                    >
+                      {isSelected ? <Check className="size-3" /> : null}
+                    </span>
+                    {option.color ? (
+                      <span
+                        aria-hidden
+                        className="size-2.5 rounded-full"
+                        style={{ backgroundColor: option.color }}
+                      />
+                    ) : null}
+                    <span className="flex-1">{option.label}</span>
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -2,11 +2,13 @@ import { Copy, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { WysiwygEditor } from '@/components/catalog/wysiwyg-editor';
 import { type Provenance, ProvenanceBadge } from '@/components/provenance-badge';
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
+import { MultiSelect, type MultiSelectOption } from '@/components/ui/multi-select';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
-import type { AttributeMeta, ProductLocale } from './types';
+import type { AttributeMeta, AttributeOptionMeta, ProductLocale } from './types';
 
 export interface AttrRowProps {
   attribute: AttributeMeta;
@@ -49,6 +51,8 @@ export function AttrRow({
   const editable = isEditing && !isLocked;
   const stringValue = typeof value === 'string' ? value : value == null ? '' : String(value);
   const localeChip = isLocaleScoped(attribute) ? locale : null;
+  const isSelectLike = attribute.type === 'select' || attribute.type === 'multiselect';
+  const selectOptions = isSelectLike ? (attribute.options ?? []) : [];
 
   return (
     <div
@@ -117,6 +121,26 @@ export function AttrRow({
               onChange={(event) => onChange(event.target.checked)}
               className="size-4 rounded"
             />
+          ) : attribute.type === 'select' ? (
+            <Combobox
+              options={toComboboxOptions(selectOptions, lang)}
+              value={typeof value === 'string' && value !== '' ? value : null}
+              onChange={(next) => onChange(next)}
+              placeholder={t('products.detail.field.select_placeholder', {
+                defaultValue: 'Wybierz…',
+              })}
+              className="rounded-xl text-[13.5px]"
+            />
+          ) : attribute.type === 'multiselect' ? (
+            <MultiSelect
+              options={toMultiSelectOptions(selectOptions, lang)}
+              value={readMultiselectValue(value)}
+              onChange={(next) => onChange(next)}
+              placeholder={t('products.detail.field.multiselect_placeholder', {
+                defaultValue: 'Wybierz…',
+              })}
+              className="rounded-xl text-[13.5px]"
+            />
           ) : (
             <Input
               id={`attr-${attribute.code}`}
@@ -135,12 +159,10 @@ export function AttrRow({
               isLocked ? 'cursor-default text-zinc-700' : 'text-ink',
             )}
           >
-            {stringValue === '' ? (
+            {renderReadOnlyValue(attribute, value, selectOptions, lang) ?? (
               <span className="italic text-zinc-400">
                 {t('products.detail.field.empty', { defaultValue: '—' })}
               </span>
-            ) : (
-              stringValue
             )}
           </div>
         )}
@@ -178,4 +200,61 @@ function isLocaleScoped(attribute: AttributeMeta): boolean {
   // benefit from a locale chip in the row label.
   if (/_pl$|_en$|_de$|_cs$/i.test(attribute.code)) return true;
   return attribute.type === 'richtext' || attribute.type === 'textarea';
+}
+
+function optionLabel(option: AttributeOptionMeta, lang: 'pl' | 'en'): string {
+  return option.label[lang] ?? option.label.en ?? option.label.pl ?? option.code;
+}
+
+function toComboboxOptions(options: AttributeOptionMeta[], lang: 'pl' | 'en'): ComboboxOption[] {
+  return options.map((o) => ({
+    value: o.code,
+    label: optionLabel(o, lang),
+  }));
+}
+
+function toMultiSelectOptions(
+  options: AttributeOptionMeta[],
+  lang: 'pl' | 'en',
+): MultiSelectOption[] {
+  return options.map((o) => ({
+    value: o.code,
+    label: optionLabel(o, lang),
+    color: o.color ?? null,
+    deprecated: o.is_deprecated === true,
+  }));
+}
+
+function readMultiselectValue(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+/**
+ * Read-only display: map option codes to their localized labels so the
+ * detail page never shows raw codes (`red`, `new`) when an option label
+ * exists. Falls back to the raw value for non-select-like types.
+ */
+function renderReadOnlyValue(
+  attribute: AttributeMeta,
+  value: unknown,
+  options: AttributeOptionMeta[],
+  lang: 'pl' | 'en',
+): string | null {
+  if (attribute.type === 'select') {
+    if (typeof value !== 'string' || value === '') return null;
+    const match = options.find((o) => o.code === value);
+    return match ? optionLabel(match, lang) : value;
+  }
+  if (attribute.type === 'multiselect') {
+    const codes = readMultiselectValue(value);
+    if (codes.length === 0) return null;
+    const labels = codes.map((code) => {
+      const match = options.find((o) => o.code === code);
+      return match ? optionLabel(match, lang) : code;
+    });
+    return labels.join(', ');
+  }
+  if (value === null || value === undefined || value === '') return null;
+  return typeof value === 'string' ? value : String(value);
 }

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -33,6 +33,20 @@ export interface CatalogObjectDto {
   objectType?: { id?: string; code?: string; name?: { pl?: string; en?: string } } | null;
 }
 
+/**
+ * One choice for a `select` / `multiselect` Attribute. Backend ships this
+ * shape via `effective-attribute-groups` so the detail page can render a
+ * proper picker instead of a free-text input — see
+ * `App\Catalog\Presentation\Controller\ProductReadEndpointsController::serializeAttribute`.
+ */
+export interface AttributeOptionMeta {
+  code: string;
+  label: { pl?: string; en?: string };
+  color?: string | null;
+  is_default?: boolean;
+  is_deprecated?: boolean;
+}
+
 export interface AttributeMeta {
   id: string;
   code: string;
@@ -42,6 +56,13 @@ export interface AttributeMeta {
   position: number;
   is_required_in_group: boolean;
   visible_when?: unknown;
+  /**
+   * Populated by the backend only for `select` / `multiselect` types
+   * (`AttributeType::usesOptions()`). Other types omit the field
+   * entirely; treat `undefined` as "no predefined values, use a free
+   * input".
+   */
+  options?: AttributeOptionMeta[];
 }
 
 export interface GroupMeta {

--- a/apps/api/src/Catalog/Domain/Repository/AttributeOptionRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/AttributeOptionRepositoryInterface.php
@@ -17,6 +17,18 @@ interface AttributeOptionRepositoryInterface
      */
     public function findByAttribute(Attribute $attribute): array;
 
+    /**
+     * Bulk variant of {@see findByAttribute}. Returns every option whose
+     * parent Attribute is in `$attributes`, sorted by attribute then by
+     * position. Used by the product detail / variants tab eager loader so
+     * select-like attributes ship their options in one round-trip.
+     *
+     * @param list<Attribute> $attributes
+     *
+     * @return list<AttributeOption>
+     */
+    public function findByAttributes(array $attributes): array;
+
     public function save(AttributeOption $attributeOption): void;
 
     public function remove(AttributeOption $attributeOption): void;

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineAttributeOptionRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineAttributeOptionRepository.php
@@ -36,6 +36,28 @@ class DoctrineAttributeOptionRepository extends ServiceEntityRepository implemen
         return $rows;
     }
 
+    /**
+     * @param list<Attribute> $attributes
+     *
+     * @return list<AttributeOption>
+     */
+    public function findByAttributes(array $attributes): array
+    {
+        if ([] === $attributes) {
+            return [];
+        }
+        /** @var list<AttributeOption> $rows */
+        $rows = $this->createQueryBuilder('o')
+            ->andWhere('o.attribute IN (:attributes)')
+            ->setParameter('attributes', $attributes)
+            ->orderBy('IDENTITY(o.attribute)', 'ASC')
+            ->addOrderBy('o.position', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
     public function findById(\Symfony\Component\Uid\Uuid $id): ?AttributeOption
     {
         return parent::find($id->toRfc4122());

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Catalog\Presentation\Controller;
 
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
@@ -62,6 +65,7 @@ final class ProductReadEndpointsController
         private readonly EffectiveAttributeGroupResolver $resolver,
         private readonly Connection $connection,
         private readonly ObjectTypeAttributeRepositoryInterface $objectTypeAttributes,
+        private readonly AttributeOptionRepositoryInterface $attributeOptions,
     ) {
     }
 
@@ -151,6 +155,29 @@ final class ProductReadEndpointsController
         $groups = $this->resolver->resolve($product);
         $byGroup = $this->resolver->loadGroupAttributes($groups);
 
+        // Pre-pass: collect every select / multiselect Attribute reachable
+        // from this product so we can ship its `AttributeOption` list in the
+        // same response. Without this the detail page renders a free-text
+        // input for predefined-value attributes and operators have to type
+        // option codes by hand instead of picking them.
+        /** @var array<string, Attribute> $optionsAttrs */
+        $optionsAttrs = [];
+        foreach ($groups as $group) {
+            foreach ($byGroup[$group->getId()->toRfc4122()] ?? [] as $j) {
+                $a = $j->getAttribute();
+                if ($a->getType()->usesOptions()) {
+                    $optionsAttrs[$a->getId()->toRfc4122()] = $a;
+                }
+            }
+        }
+        foreach ($this->objectTypeAttributes->findByObjectType($product->getObjectType()) as $junction) {
+            $a = $junction->getAttribute();
+            if ($a->getType()->usesOptions()) {
+                $optionsAttrs[$a->getId()->toRfc4122()] = $a;
+            }
+        }
+        $optionsByAttributeId = $this->loadOptionsByAttributeId(array_values($optionsAttrs));
+
         // Track every Attribute UUID already exposed via a real group so
         // the synthetic "default" bucket below never duplicates them.
         $seenAttributeIds = [];
@@ -162,16 +189,13 @@ final class ProductReadEndpointsController
             foreach ($junctions as $j) {
                 $attribute = $j->getAttribute();
                 $seenAttributeIds[$attribute->getId()->toRfc4122()] = true;
-                $attributes[] = [
-                    'id' => $attribute->getId()->toRfc4122(),
-                    'code' => $attribute->getCode(),
-                    'type' => $attribute->getType()->value,
-                    'label' => $attribute->getLabel(),
-                    'is_system' => $attribute->isSystem(),
-                    'position' => $j->getPosition(),
-                    'is_required_in_group' => $j->isRequiredInGroup(),
-                    'visible_when' => $j->getVisibleWhen(),
-                ];
+                $attributes[] = $this->serializeAttribute(
+                    $attribute,
+                    $j->getPosition(),
+                    $j->isRequiredInGroup(),
+                    $j->getVisibleWhen(),
+                    $optionsByAttributeId,
+                );
             }
             $effective[] = [
                 'id' => $group->getId()->toRfc4122(),
@@ -206,16 +230,13 @@ final class ProductReadEndpointsController
                 continue;
             }
             $seenAttributeIds[$key] = true;
-            $defaultAttributes[] = [
-                'id' => $key,
-                'code' => $attribute->getCode(),
-                'type' => $attribute->getType()->value,
-                'label' => $attribute->getLabel(),
-                'is_system' => $attribute->isSystem(),
-                'position' => $junction->getSortOrder(),
-                'is_required_in_group' => $junction->isRequiredForCompleteness(),
-                'visible_when' => null,
-            ];
+            $defaultAttributes[] = $this->serializeAttribute(
+                $attribute,
+                $junction->getSortOrder(),
+                $junction->isRequiredForCompleteness(),
+                null,
+                $optionsByAttributeId,
+            );
         }
 
         if ([] !== $defaultAttributes) {
@@ -246,5 +267,58 @@ final class ProductReadEndpointsController
         }
 
         return $product;
+    }
+
+    /**
+     * @param list<Attribute> $attributes
+     *
+     * @return array<string, list<array{code: string, label: array<string, string>, color: ?string, is_default: bool, is_deprecated: bool}>>
+     */
+    private function loadOptionsByAttributeId(array $attributes): array
+    {
+        $byId = [];
+        foreach ($this->attributeOptions->findByAttributes($attributes) as $option) {
+            $byId[$option->getAttribute()->getId()->toRfc4122()][] = [
+                'code' => $option->getCode(),
+                'label' => $option->getLabel(),
+                'color' => $option->getColor(),
+                'is_default' => $option->isDefault(),
+                'is_deprecated' => $option->isDeprecated(),
+            ];
+        }
+
+        return $byId;
+    }
+
+    /**
+     * @param array<string, list<array{code: string, label: array<string, string>, color: ?string, is_default: bool, is_deprecated: bool}>> $optionsByAttributeId
+     *
+     * @return array<string, mixed>
+     */
+    private function serializeAttribute(
+        Attribute $attribute,
+        int $position,
+        bool $isRequiredInGroup,
+        mixed $visibleWhen,
+        array $optionsByAttributeId,
+    ): array {
+        $payload = [
+            'id' => $attribute->getId()->toRfc4122(),
+            'code' => $attribute->getCode(),
+            'type' => $attribute->getType()->value,
+            'label' => $attribute->getLabel(),
+            'is_system' => $attribute->isSystem(),
+            'position' => $position,
+            'is_required_in_group' => $isRequiredInGroup,
+            'visible_when' => $visibleWhen,
+        ];
+
+        // Only ship `options` for select-like types — other types ignore
+        // the field, and we want the payload to stay tight.
+        if ($attribute->getType()->usesOptions()) {
+            $payload['options'] = $optionsByAttributeId[$attribute->getId()->toRfc4122()] ?? [];
+        }
+
+        return $payload;
     }
 }

--- a/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
@@ -8,6 +8,7 @@ use App\Catalog\Application\BuiltInSystemAttributesSeeder;
 use App\Catalog\Application\ObjectTypeService;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
@@ -202,5 +203,108 @@ final class EffectiveAttributeGroupsApiTest extends CatalogApiTestCase
         }
 
         self::assertSame(1, $occurrences, 'Attribute exposed in a real group must not also appear in the synthetic default group.');
+    }
+
+    #[Test]
+    public function shipsAttributeOptionsForSelectAndMultiselectAttributes(): void
+    {
+        $client = $this->authenticatedClient();
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $productType = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $colorAttr = new Attribute('color_view07', ['pl' => 'Kolor', 'en' => 'Color'], AttributeType::Select);
+        $tagsAttr = new Attribute('tags_view07', ['pl' => 'Tagi', 'en' => 'Tags'], AttributeType::Multiselect);
+        $textAttr = new Attribute('notes_view07', ['pl' => 'Notatki', 'en' => 'Notes'], AttributeType::Text);
+        $em = $this->em();
+        $em->persist($colorAttr);
+        $em->persist($tagsAttr);
+        $em->persist($textAttr);
+        $em->flush();
+
+        $em->persist(new AttributeOption(
+            attribute: $colorAttr,
+            code: 'red',
+            label: ['pl' => 'Czerwony', 'en' => 'Red'],
+            position: 0,
+            color: '#EF4444',
+            isDefault: true,
+        ));
+        $em->persist(new AttributeOption(
+            attribute: $colorAttr,
+            code: 'blue',
+            label: ['pl' => 'Niebieski', 'en' => 'Blue'],
+            position: 1,
+            color: '#3B82F6',
+        ));
+        $em->persist(new AttributeOption(
+            attribute: $tagsAttr,
+            code: 'new',
+            label: ['pl' => 'Nowość', 'en' => 'New'],
+            position: 0,
+        ));
+        $em->flush();
+
+        $service = self::getContainer()->get(ObjectTypeService::class);
+        $service->assignAttribute($productType, $colorAttr, required: false, sortOrder: 0);
+        $service->assignAttribute($productType, $tagsAttr, required: false, sortOrder: 1);
+        $service->assignAttribute($productType, $textAttr, required: false, sortOrder: 2);
+
+        $tenantContext->clear();
+
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'V071-OPTIONS',
+                'objectTypeId' => $productType->getId()->toRfc4122(),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+        $id = $created['id'] ?? null;
+        \assert(\is_string($id));
+
+        $response = $client->request('GET', '/api/products/'.$id.'/effective-attribute-groups');
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+
+        $byCode = [];
+        foreach (($body['groups'] ?? []) as $group) {
+            \assert(\is_array($group));
+            foreach (($group['attributes'] ?? []) as $attr) {
+                \assert(\is_array($attr));
+                $code = $attr['code'] ?? null;
+                if (\is_string($code)) {
+                    $byCode[$code] = $attr;
+                }
+            }
+        }
+
+        self::assertArrayHasKey('color_view07', $byCode);
+        self::assertArrayHasKey('options', $byCode['color_view07']);
+        $colorOptions = $byCode['color_view07']['options'];
+        \assert(\is_array($colorOptions));
+        self::assertCount(2, $colorOptions);
+        self::assertSame('red', $colorOptions[0]['code']);
+        self::assertSame('Czerwony', $colorOptions[0]['label']['pl'] ?? null);
+        self::assertSame('Red', $colorOptions[0]['label']['en'] ?? null);
+        self::assertSame('#EF4444', $colorOptions[0]['color']);
+        self::assertTrue($colorOptions[0]['is_default']);
+        self::assertFalse($colorOptions[0]['is_deprecated']);
+        self::assertSame('blue', $colorOptions[1]['code']);
+
+        self::assertArrayHasKey('tags_view07', $byCode);
+        self::assertArrayHasKey('options', $byCode['tags_view07']);
+        self::assertCount(1, $byCode['tags_view07']['options']);
+
+        // text attribute MUST NOT carry an `options` key — option-less
+        // types ignore the field and we want the payload tight.
+        self::assertArrayHasKey('notes_view07', $byCode);
+        self::assertArrayNotHasKey('options', $byCode['notes_view07']);
     }
 }

--- a/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
@@ -273,10 +273,15 @@ final class EffectiveAttributeGroupsApiTest extends CatalogApiTestCase
         self::assertResponseIsSuccessful();
         $body = $response->toArray();
 
+        $groups = $body['groups'] ?? [];
+        \assert(\is_array($groups));
+        /** @var array<string, array<string, mixed>> $byCode */
         $byCode = [];
-        foreach (($body['groups'] ?? []) as $group) {
+        foreach ($groups as $group) {
             \assert(\is_array($group));
-            foreach (($group['attributes'] ?? []) as $attr) {
+            $attributes = $group['attributes'] ?? [];
+            \assert(\is_array($attributes));
+            foreach ($attributes as $attr) {
                 \assert(\is_array($attr));
                 $code = $attr['code'] ?? null;
                 if (\is_string($code)) {
@@ -290,17 +295,25 @@ final class EffectiveAttributeGroupsApiTest extends CatalogApiTestCase
         $colorOptions = $byCode['color_view07']['options'];
         \assert(\is_array($colorOptions));
         self::assertCount(2, $colorOptions);
-        self::assertSame('red', $colorOptions[0]['code']);
-        self::assertSame('Czerwony', $colorOptions[0]['label']['pl'] ?? null);
-        self::assertSame('Red', $colorOptions[0]['label']['en'] ?? null);
-        self::assertSame('#EF4444', $colorOptions[0]['color']);
-        self::assertTrue($colorOptions[0]['is_default']);
-        self::assertFalse($colorOptions[0]['is_deprecated']);
-        self::assertSame('blue', $colorOptions[1]['code']);
+        $firstColor = $colorOptions[0];
+        \assert(\is_array($firstColor));
+        self::assertSame('red', $firstColor['code']);
+        $firstLabel = $firstColor['label'] ?? null;
+        \assert(\is_array($firstLabel));
+        self::assertSame('Czerwony', $firstLabel['pl'] ?? null);
+        self::assertSame('Red', $firstLabel['en'] ?? null);
+        self::assertSame('#EF4444', $firstColor['color']);
+        self::assertTrue($firstColor['is_default']);
+        self::assertFalse($firstColor['is_deprecated']);
+        $secondColor = $colorOptions[1];
+        \assert(\is_array($secondColor));
+        self::assertSame('blue', $secondColor['code']);
 
         self::assertArrayHasKey('tags_view07', $byCode);
         self::assertArrayHasKey('options', $byCode['tags_view07']);
-        self::assertCount(1, $byCode['tags_view07']['options']);
+        $tagsOptions = $byCode['tags_view07']['options'];
+        \assert(\is_array($tagsOptions));
+        self::assertCount(1, $tagsOptions);
 
         // text attribute MUST NOT carry an `options` key — option-less
         // types ignore the field and we want the payload tight.


### PR DESCRIPTION
## Co naprawione

Operator zgłosił 2026-05-12: w widoku produktu atrybuty z predefiniowanymi wartościami (Tagi multiselect, Kolor select, Rozmiar select) renderują się jako zwykły `<input type=text>` — trzeba wpisywać kody opcji z palca zamiast wybierać z listy. Naprawione end-to-end.

## Backend

- Nowy `AttributeOptionRepositoryInterface::findByAttributes(array $attributes): list<AttributeOption>` + Doctrine impl z bulk `IN` query (uniknięcie N+1).
- `ProductReadEndpointsController::effectiveAttributeGroups()` w preprocessing zbiera wszystkie select/multiselect attrs (`AttributeType::usesOptions()`) i jednym round-tripem ładuje ich opcje. Helper `serializeAttribute(...)` warunkowo dorzuca pole `options` do payloadu attrybutu — typy bez predefiniowanych wartości pomijają je całkowicie (payload tight).
- ApiTestCase `EffectiveAttributeGroupsApiTest::shipsAttributeOptionsForSelectAndMultiselectAttributes` pokrywa: kolor (5 opcji z color/is_default), tagi (1 opcja), text (brak `options` w payloadzie).

## Frontend

- `AttributeMeta` w `apps/admin/src/features/catalog/products/components/types.ts` dostaje `options?: AttributeOptionMeta[]` (typ z label localized + color + is_default + is_deprecated).
- Nowy `apps/admin/src/components/ui/multi-select.tsx` — popover z checkbox-listą + chips w triggerze, zachowuje się jak [`Combobox`](apps/admin/src/components/ui/combobox.tsx) ale dla wielu wyborów.
- `AttrRow` ([`apps/admin/src/features/catalog/products/components/attr-row.tsx`](apps/admin/src/features/catalog/products/components/attr-row.tsx)) dostaje dwa nowe branche:
  - `attribute.type === 'select'` → `<Combobox />` (search + clear)
  - `attribute.type === 'multiselect'` → `<MultiSelect />` (chips + checkbox popover)
- Read-only display teraz mapuje code → localized label. Operator widzi "Czerwony" / "Nowość", nigdy raw `red` / `new`.

## Test plan

- [x] PHPStan max — green (`docker compose exec api vendor/bin/phpstan analyse src/Catalog`)
- [x] PHP CS Fixer — green (auto-applied via lint-staged)
- [x] PHPUnit `EffectiveAttributeGroupsApiTest` — 4/4 passes (16 assertions w samym new test-cie)
- [x] TypeScript noEmit — green
- [x] Biome check — green
- [x] Vite build — green
- [x] Playwright `products-select-multiselect-attrs` — passes (12.4s) — covers: create product, edit mode, click Combobox dla Kolor + wybór "Czerwony", click MultiSelect dla Tagi + wybór "Nowość", save, reload, assert że read-only display pokazuje localized labels.
- [x] Manual smoke: localhost stack, product detail dla seeded produktu — Kolor/Rozmiar/Tagi pokazują pickery, edit + save działa, reload odzyskuje selekcję
- [ ] CI green

## Świadome odejścia

- **Tylko `select` / `multiselect`** — to jedyne typy z `usesOptions() === true` (per `AttributeType::usesOptions()`). Tagi w mowie operatora to multiselect z opcjami. Inne typy (text, number, boolean, date, asset, relation, price, metric, wysiwyg, datetime, reference) nie mają predefiniowanych wartości — bez zmian.
- **Trigger MultiSelect to `<div role="button">`** zamiast `<button>` bo wewnątrz są nested real `<button>`-y do chip removal. `biome-ignore` z uzasadnieniem na `useSemanticElements`. Keyboard a11y: Enter/Space/Escape obsłużone w `handleTriggerKey`.
- **Bulk fetch zamiast N+1** — założenie że produktów z 50+ select attrs nie ma w MVP, więc jedna `IN` query jest tańsza niż osobne round-tripy per attr. Jeśli kiedyś będzie 200+ attrs, opcje można scopować per-group.
- **Brak unit testu dla `MultiSelect`** — admin nie ma vitest, Playwright pokrywa pełen happy-path round-trip.
- **`/api/object_types/{id}/effective-attribute-groups` (create mode)** — endpoint nie istnieje (zwraca 404), więc create mode nie ładuje grup ani options. To pre-existing problem; PR fixuje tylko edit mode (zgodnie z bugiem operatora). Follow-up: dodać symetryczny endpoint dla ObjectType jeśli operator zgłosi.