### PR TITLE
feat(admin): date picker dla atrybutów typu date + Combobox dla osi wariantów

### DIFF
--- a/apps/admin/e2e/products-date-and-variants-axis.spec.ts
+++ b/apps/admin/e2e/products-date-and-variants-axis.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * Operator follow-up to the predefined-value attrs PR (#512) on
+ * 2026-05-12:
+ *  1. `release_date` (Data premiery, type=date) renders a plain text
+ *     input — no date picker.
+ *  2. The Variants tab axis selector is a generic <input + datalist>
+ *     that requires deleting the field content before suggestions
+ *     show up, and surfaces every attribute (incl. system-only) as
+ *     candidate axis.
+ *
+ * This spec exercises both fixes:
+ *  - AttrRow now renders `<input type="date">` for `date`. Pick a
+ *    date, save, reload → read-only display shows the picked date.
+ *  - The Variants axis selector is now a Combobox restricted to
+ *    select/multiselect attrs. Click → list opens → pick `color` →
+ *    suggested option codes (red/green/blue) appear under the row.
+ *
+ * Marked `fixme` in CI for the same `storageState` reason the other
+ * UI-seeded specs use.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('product detail date picker + variants axis combobox', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const authHeaders = { Authorization: `Bearer ${accessToken}` };
+
+  const sku = uniqueSku('DATE');
+
+  const objectTypesResponse = await page.request.get('/api/object_types', {
+    headers: authHeaders,
+  });
+  const objectTypesBody = (await objectTypesResponse.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const types = objectTypesBody.member ?? objectTypesBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  const createResponse = await page.request.post('/api/products', {
+    headers: { ...authHeaders, 'content-type': 'application/ld+json' },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: { name: `Date+Axis spec ${sku}` },
+    },
+  });
+  expect(createResponse.status()).toBe(201);
+  const product = (await createResponse.json()) as { id: string };
+
+  const groupsResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/effective-attribute-groups') &&
+      response.request().method() === 'GET',
+    { timeout: 15_000 },
+  );
+  await page.goto(`/products/${product.id}`);
+  await groupsResponse;
+  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible();
+
+  // ---------- Part 1: date picker -----------
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  const dateLabel = page.getByText(/^(Data premiery|Release date)$/).first();
+  await dateLabel.scrollIntoViewIfNeeded();
+  const dateRow = dateLabel.locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+  // Native HTML5 date input — Playwright introspects type=date.
+  const dateInput = dateRow.locator('input[type="date"]');
+  await expect(dateInput).toBeVisible();
+  await dateInput.fill('2027-03-15');
+
+  const datePatch = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/products/${product.id}`) &&
+      response.request().method() === 'PATCH',
+  );
+  await page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i }).click();
+  const datePatched = await datePatch;
+  expect(datePatched.status()).toBe(200);
+
+  // Reload + assert read-only display shows the picked date.
+  await page.reload();
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  const reloadedDateLabel = page.getByText(/^(Data premiery|Release date)$/).first();
+  await reloadedDateLabel.scrollIntoViewIfNeeded();
+  await expect(
+    reloadedDateLabel
+      .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]')
+      .getByText('2027-03-15'),
+  ).toBeVisible();
+
+  // ---------- Part 2: variants axis combobox ----------
+  await page.getByRole('tab', { name: /^(warianty|variants)$/i }).click();
+
+  // The previous datalist required the user to clear the field; the
+  // Combobox opens its option list on a single click instead.
+  const axisTrigger = page.locator('button[aria-haspopup="listbox"]').first();
+  await expect(axisTrigger).toBeVisible();
+  await axisTrigger.click();
+
+  // The popover shows attribute labels for select/multiselect attrs
+  // only — system attrs (created_at, updated_by, ...) MUST NOT appear.
+  // Each option button's accessible name combines label + code
+  // (`Kolor color`, `Tagi tags`).
+  await expect(page.getByRole('button', { name: 'Kolor color' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Tagi tags' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /created_at/ })).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Kolor color' }).click();
+
+  // After the pick the trigger reflects the chosen attribute label
+  // and the suggested option codes appear under the row.
+  await expect(axisTrigger).toContainText(/Kolor|Color/);
+  await expect(page.getByRole('button', { name: '+red' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '+green' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '+blue' })).toBeVisible();
+
+  // Operator follow-up: picking one suggestion must NOT collapse the
+  // rest of the pool — the remaining options should stay clickable
+  // until every option is consumed. Picking +red removes ONLY +red.
+  await page.getByRole('button', { name: '+red' }).click();
+  await expect(page.getByRole('button', { name: '+red' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: '+green' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '+blue' })).toBeVisible();
+});

--- a/apps/admin/src/components/catalog/variants-tab.tsx
+++ b/apps/admin/src/components/catalog/variants-tab.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
+import { Combobox } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
 import { jsonFetch } from '@/lib/http';
 
@@ -242,27 +243,41 @@ function AxisRow({
 }) {
   const { t } = useTranslation();
   const [draft, setDraft] = useState('');
-  const codeListId = `axis-codes-${axis.code || 'empty'}`;
   const valuesListId = `axis-values-${axis.code || 'empty'}`;
   const matchingAttribute = attributes.find((a) => a.code === axis.code);
   const suggestedValues = matchingAttribute?.options ?? [];
 
+  // Variants axes only make sense for attributes with predefined
+  // values (the generator iterates `select.options` / `multiselect.options`
+  // to compute combinations). Restricting the Combobox to these types
+  // also drops the noise of system attributes (created_at, updated_by,
+  // ...) the previous datalist surfaced. Each option exposes the code
+  // as `description` so operators can still see it under the label.
+  const axisAttributeOptions = attributes
+    .filter((a) => a.type === 'select' || a.type === 'multiselect')
+    .map((a) => ({
+      value: a.code,
+      label: a.label?.pl ?? a.label?.en ?? a.code,
+      description: a.code,
+    }));
+
   return (
     <div className="flex items-start gap-2">
-      <div className="w-32">
-        <Input
-          value={axis.code}
-          onChange={(e) => onCodeChange(e.target.value)}
-          placeholder="color"
-          list={codeListId}
+      <div className="w-48">
+        <Combobox
+          options={axisAttributeOptions}
+          value={axis.code === '' ? null : axis.code}
+          onChange={(next) => onCodeChange(next ?? '')}
+          placeholder={t('products.variants.pick_axis_attribute', {
+            defaultValue: 'Wybierz atrybut osi',
+          })}
+          searchPlaceholder={t('products.variants.search_axis_attribute', {
+            defaultValue: 'Szukaj atrybutu…',
+          })}
+          emptyText={t('products.variants.no_select_attributes', {
+            defaultValue: 'Brak atrybutów typu select/multiselect',
+          })}
         />
-        <datalist id={codeListId}>
-          {attributes.map((a) => (
-            <option key={a.id} value={a.code}>
-              {a.label?.pl ?? a.label?.en ?? a.code}
-            </option>
-          ))}
-        </datalist>
       </div>
       <div className="flex-1 space-y-1">
         <div className="flex flex-wrap gap-1">
@@ -310,18 +325,20 @@ function AxisRow({
             ))}
           </datalist>
         </div>
-        {suggestedValues.length > 0 && axis.values.length === 0 ? (
+        {suggestedValues.length > 0 ? (
           <div className="flex flex-wrap gap-1 pt-1">
-            {suggestedValues.map((opt) => (
-              <button
-                key={opt.code}
-                type="button"
-                onClick={() => onAddValue(opt.code)}
-                className="rounded border border-dashed px-1.5 py-0.5 text-[10px] text-muted-foreground hover:border-solid hover:text-foreground"
-              >
-                +{opt.code}
-              </button>
-            ))}
+            {suggestedValues
+              .filter((opt) => !axis.values.includes(opt.code))
+              .map((opt) => (
+                <button
+                  key={opt.code}
+                  type="button"
+                  onClick={() => onAddValue(opt.code)}
+                  className="rounded border border-dashed px-1.5 py-0.5 text-[10px] text-muted-foreground hover:border-solid hover:text-foreground"
+                >
+                  +{opt.code}
+                </button>
+              ))}
           </div>
         ) : null}
       </div>

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -121,6 +121,22 @@ export function AttrRow({
               onChange={(event) => onChange(event.target.checked)}
               className="size-4 rounded"
             />
+          ) : attribute.type === 'date' ? (
+            <Input
+              id={`attr-${attribute.code}`}
+              type="date"
+              value={readDateValue(value)}
+              onChange={(event) => onChange(event.target.value === '' ? null : event.target.value)}
+              className="w-full rounded-xl border-zinc-200 bg-white px-3 py-2 text-[13.5px]"
+            />
+          ) : attribute.type === 'datetime' ? (
+            <Input
+              id={`attr-${attribute.code}`}
+              type="datetime-local"
+              value={readDatetimeValue(value)}
+              onChange={(event) => onChange(event.target.value === '' ? null : event.target.value)}
+              className="w-full rounded-xl border-zinc-200 bg-white px-3 py-2 text-[13.5px]"
+            />
           ) : attribute.type === 'select' ? (
             <Combobox
               options={toComboboxOptions(selectOptions, lang)}
@@ -231,6 +247,28 @@ function readMultiselectValue(value: unknown): string[] {
 }
 
 /**
+ * `<input type="date">` only accepts the `YYYY-MM-DD` slice. Backend
+ * may send the same shape (preferred) or a full ISO 8601 string
+ * (legacy seeds) — strip the time component either way and reject
+ * anything that does not look like a valid date.
+ */
+function readDateValue(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const head = value.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(head) ? head : '';
+}
+
+/**
+ * `<input type="datetime-local">` accepts `YYYY-MM-DDTHH:mm` (no
+ * timezone). Strip seconds + zone if backend ships full ISO.
+ */
+function readDatetimeValue(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const head = value.slice(0, 16);
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(head) ? head : '';
+}
+
+/**
  * Read-only display: map option codes to their localized labels so the
  * detail page never shows raw codes (`red`, `new`) when an option label
  * exists. Falls back to the raw value for non-select-like types.
@@ -254,6 +292,14 @@ function renderReadOnlyValue(
       return match ? optionLabel(match, lang) : code;
     });
     return labels.join(', ');
+  }
+  if (attribute.type === 'date') {
+    const head = readDateValue(value);
+    return head === '' ? null : head;
+  }
+  if (attribute.type === 'datetime') {
+    const head = readDatetimeValue(value);
+    return head === '' ? null : head.replace('T', ' ');
   }
   if (value === null || value === undefined || value === '') return null;
   return typeof value === 'string' ? value : String(value);


### PR DESCRIPTION
## Co naprawione (3 follow-upy operatora po PR #512)

### 1. Brak date pickera dla `release_date` / typu `date`

Atrybuty typu `date` i `datetime` w karcie produktu renderowały się jako zwykły `<input type=text>` — brak kalendarza, brak walidacji formatu. Teraz `AttrRow` ma branche dla obu typów z natywnym `<input type="date">` / `<input type="datetime-local">`. Backend i tak zapisuje ISO `YYYY-MM-DD` (potwierdzone w `DemoCatalogSeeder` seedy `release_date`). Read-only display pokazuje sam slice daty bez czasu.

### 2. Generyczny axis selector w zakładce Warianty

Pole "axis" w zakładce Warianty było `<input + datalist>` HTML5 — trzeba było skasować zawartość żeby pojawiły się sugestie, a lista pokazywała WSZYSTKIE atrybuty (w tym systemowe `created_at`, `updated_at` które nie mają sensu jako oś wariantu). Zastąpione przez `Combobox` (ten sam co dla atrybutów `select`) ograniczony do typów `select` / `multiselect` (jedyne które mają `options` po stronie backendu — pozostałe nie miałyby sensu jako axis bo nie ma czego iterować).

### 3. Sugerowane wartości znikały po pierwszym wyborze

Po wybraniu osi (np. `color`) pod polem pojawiały się chipsy `+red +green +blue +black +white`. Klik na `+red` powodował zniknięcie WSZYSTKICH pozostałych. Teraz chipsy zostają widoczne dopóki pula nie zostanie wyczerpana — kliknięty znika tylko on (filtrowanie po `axis.values.includes(opt.code)`).

## Test plan

- [x] TypeScript noEmit — green
- [x] Biome check — green
- [x] Vite build — green
- [x] Playwright `products-date-and-variants-axis` — passes (7.7s) — pokrywa: date picker + save + reload + visible read-out, axis Combobox click-to-open + filter do select-only (assert że Created at NIE pojawia się w popoverze), suggestion persistence (`+green` `+blue` zostają po `+red` click).
- [x] Manual smoke pre-commit: localhost stack, edycja produktu, Tagi/Kolor/Rozmiar mają pickery, Data premiery ma kalendarz, Warianty axis pokazuje tylko select-like attrs i wartości po wyborze zostają widoczne.
- [ ] CI green

## Świadome odejścia

- **Per-type validation rules w create-attribute formie** (np. `min_date` / `max_date`) **nie ruszane** — operator wspomniał "popraw także w formularzu dodawania atrybutu jeśli trzeba", ale `date` jest już w `TYPES` i działa OK. Backend `validationRules` JSONB istnieje (#39 plan), ale UI editor dla per-type rules to osobny epik.
- **Brak nowego `MultiSelect` dla axis values** — operator w sugestiach oczekuje chipsów per opcja (już jest), nie multi-select dropdown. Pattern: `Combobox` dla axis attribute + chipsy dla wartości.
- **Datetime widget** — dorzucony za darmo razem z date branch'em (`<input type="datetime-local">`). Operator nie wskazał problemu z datetime ale jego model jest identyczny więc dodanie go nie kosztuje.