### PR TITLE
fix(catalog): products list tree mode hides variants behind master chevron

### DIFF
--- a/apps/admin/e2e/products-list-tree-masters.spec.ts
+++ b/apps/admin/e2e/products-list-tree-masters.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * Operator report (2026-05-12): generating ~16 variants for one product
+ * filled the products list page entirely with that master's variants
+ * and pushed every other product (including the master itself) off
+ * the visible page. Tree mode looked broken because the variants were
+ * orphaned (parent not in the same Refine page) and rendered flat at
+ * the top.
+ *
+ * Fix: tree mode now sends `?parent_id=null` so the list only fetches
+ * masters; variants load lazily on chevron expand. Spec covers:
+ *   1. Seed a master + 5 variants via API.
+ *   2. Open /products in tree mode (default).
+ *   3. Assert master row is visible AND variant SKUs are NOT in the
+ *      list (they would have been before the fix).
+ *   4. Click the master's expand chevron → variants land inline.
+ *
+ * Marked `fixme` in CI for the same `storageState` reason the other
+ * UI-seeded specs use.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('products list tree mode hides variants until expand', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const authHeaders = { Authorization: `Bearer ${accessToken}` };
+
+  const sku = uniqueSku('TREE');
+
+  const objectTypesResponse = await page.request.get('/api/object_types', {
+    headers: authHeaders,
+  });
+  const objectTypesBody = (await objectTypesResponse.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const types = objectTypesBody.member ?? objectTypesBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  // Master.
+  const masterResponse = await page.request.post('/api/products', {
+    headers: { ...authHeaders, 'content-type': 'application/ld+json' },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: { name: `Tree-mode spec ${sku}` },
+    },
+  });
+  expect(masterResponse.status()).toBe(201);
+  const master = (await masterResponse.json()) as { id: string };
+
+  // 5 variants under the master.
+  const variantSkus: string[] = [];
+  for (const suffix of ['red', 'green', 'blue', 'black', 'white']) {
+    const variantSku = `${sku}-${suffix}`;
+    variantSkus.push(variantSku);
+    const variantResponse = await page.request.post('/api/products', {
+      headers: { ...authHeaders, 'content-type': 'application/ld+json' },
+      data: {
+        code: variantSku,
+        objectTypeId: productType.id,
+        parentId: master.id,
+        attributes: { name: `Tree-mode spec ${sku} ${suffix}` },
+      },
+    });
+    expect(variantResponse.status()).toBe(201);
+  }
+
+  await page.goto('/products');
+
+  // Tree mode is the default. The master must be visible and every
+  // variant SKU must be absent from the page until expand. SKU cells
+  // wrap on two lines for long codes, so match by `text=` substring
+  // rather than exact accessible name.
+  await expect(page.getByText(sku).first()).toBeVisible({ timeout: 15_000 });
+  for (const variantSku of variantSkus) {
+    await expect(page.getByText(variantSku)).toHaveCount(0);
+  }
+
+  // Find the master row and click its expand chevron. ProductsGrid
+  // is a CSS grid (no native <tr>); rows expose `data-testid` keyed
+  // by SKU and the chevron is the first <button> in the row.
+  const masterRow = page.locator(`[data-testid="products-grid-row-${sku}"]`);
+  await expect(masterRow).toBeVisible();
+  await masterRow.locator('button').first().click();
+
+  // Variants now load lazily and appear inline.
+  for (const variantSku of variantSkus) {
+    await expect(page.getByText(variantSku).first()).toBeVisible({ timeout: 10_000 });
+  }
+});

--- a/apps/admin/src/components/catalog/products-grid.tsx
+++ b/apps/admin/src/components/catalog/products-grid.tsx
@@ -35,6 +35,14 @@ interface ProductsGridProps {
   onToggleEnabled: (id: string, next: boolean) => void;
   onChangedRow: () => void;
   isLoading: boolean;
+  /**
+   * When true the chevron is rendered on every master row even when
+   * the inline `variantsByMasterCount` does not know whether the row
+   * has variants yet — the parent list lazy-loads variants on click
+   * (#514). Without this the chevron only shows in flat mode where
+   * variants live in the same Refine page as the master.
+   */
+  alwaysShowChevronOnMasters?: boolean;
 }
 
 const GRID_TPL =
@@ -84,6 +92,7 @@ export function ProductsGrid({
   onToggleEnabled,
   onChangedRow,
   isLoading,
+  alwaysShowChevronOnMasters = false,
 }: ProductsGridProps) {
   const { t } = useTranslation();
   const masterIds = rows.filter((r) => r.parentId === null).map((r) => r.id);
@@ -139,6 +148,7 @@ export function ProductsGrid({
               isExpanded={expandedMasters.has(row.id)}
               onToggleExpand={onToggleExpand}
               variantsCount={variantsByMasterCount.get(row.id) ?? 0}
+              forceExpandable={alwaysShowChevronOnMasters && row.parentId === null}
               onToggleEnabled={onToggleEnabled}
               onChangedRow={onChangedRow}
             />
@@ -187,6 +197,7 @@ interface RowViewProps {
   isExpanded: boolean;
   onToggleExpand: (id: string) => void;
   variantsCount: number;
+  forceExpandable?: boolean;
   onToggleEnabled: (id: string, next: boolean) => void;
   onChangedRow: () => void;
 }
@@ -198,12 +209,13 @@ function ProductsGridRowView({
   isExpanded,
   onToggleExpand,
   variantsCount,
+  forceExpandable = false,
   onToggleEnabled,
   onChangedRow,
 }: RowViewProps) {
   const { t } = useTranslation();
   const variant = isVariant(row);
-  const hasVariants = !variant && variantsCount > 0;
+  const hasVariants = !variant && (variantsCount > 0 || forceExpandable);
   const style: CSSProperties = { gridTemplateColumns: GRID_TPL };
 
   return (

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -128,13 +128,51 @@ export function ProductListPage() {
     perPage: 30,
   });
 
+  // Tree mode (#514): only fetch master products. Without this filter
+  // a single page (default 30) can fill up entirely with variants of
+  // one freshly generated master, pushing every other product —
+  // including the master itself — off the visible page. Variants
+  // load lazily on chevron expand below. Flat mode keeps the full
+  // mixed-row listing.
+  const masterFilter = useMemo(
+    () =>
+      variantsMode === 'tree'
+        ? [{ field: 'parent_id', operator: 'eq' as const, value: 'null' }]
+        : [],
+    [variantsMode],
+  );
+
   const { result, query: listQuery } = useList<CatalogObjectListEntry>({
     resource: 'products',
+    filters: masterFilter,
     queryOptions: { enabled: !isSearchActive },
   });
   const refetch = listQuery.refetch;
   const products = result.data;
   const isListLoading = listQuery.isLoading;
+
+  // Lazy-loaded variants per expanded master. Populated on toggleExpand
+  // by a single call to /api/products?parent_id={masterId}.
+  const [variantsByMasterId, setVariantsByMasterId] = useState<Record<string, ProductsGridRow[]>>(
+    {},
+  );
+
+  const fetchVariantsForMaster = async (masterId: string): Promise<void> => {
+    if (variantsByMasterId[masterId] !== undefined) return;
+    try {
+      const body = await jsonFetch<{
+        member?: CatalogObjectListEntry[];
+        'hydra:member'?: CatalogObjectListEntry[];
+      }>(`/api/products?parent_id=${masterId}&itemsPerPage=200`);
+      const list = body.member ?? body['hydra:member'] ?? [];
+      setVariantsByMasterId((prev) => ({
+        ...prev,
+        [masterId]: list.map(catalogObjectToRow),
+      }));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'unknown');
+    }
+  };
 
   const baseRows = useMemo<ProductsGridRow[]>(() => {
     if (isSearchActive) {
@@ -161,33 +199,20 @@ export function ProductListPage() {
 
   const visible = useMemo<ProductsGridRow[]>(() => {
     if (variantsMode === 'flat') return filteredRows;
-    const byId = new Map(filteredRows.map((r) => [r.id, r]));
-    const masters: ProductsGridRow[] = [];
-    const variantsByMaster = new Map<string, ProductsGridRow[]>();
-    const orphans: ProductsGridRow[] = [];
-    for (const row of filteredRows) {
-      if (row.parentId === null) {
-        masters.push(row);
-        continue;
-      }
-      if (byId.has(row.parentId)) {
-        const list = variantsByMaster.get(row.parentId) ?? [];
-        list.push(row);
-        variantsByMaster.set(row.parentId, list);
-      } else {
-        orphans.push(row);
-      }
-    }
+    // In tree mode `filteredRows` only contains masters (the API
+    // filter takes care of that). Variants come from the lazy-loaded
+    // `variantsByMasterId` map and are spliced in below each expanded
+    // master.
     const out: ProductsGridRow[] = [];
-    for (const master of masters) {
-      out.push(master);
-      if (expandedMasters.has(master.id)) {
-        out.push(...(variantsByMaster.get(master.id) ?? []));
+    for (const row of filteredRows) {
+      if (row.parentId !== null) continue;
+      out.push(row);
+      if (expandedMasters.has(row.id)) {
+        out.push(...(variantsByMasterId[row.id] ?? []));
       }
     }
-    out.push(...orphans);
     return out;
-  }, [filteredRows, variantsMode, expandedMasters]);
+  }, [filteredRows, variantsMode, expandedMasters, variantsByMasterId]);
 
   const toggleExpand = (masterId: string): void => {
     setExpandedMasters((prev) => {
@@ -196,6 +221,9 @@ export function ProductListPage() {
       else next.add(masterId);
       return next;
     });
+    if (variantsMode === 'tree' && !expandedMasters.has(masterId)) {
+      void fetchVariantsForMaster(masterId);
+    }
   };
 
   const isLoading = isSearchActive ? isSearchLoading : isListLoading;
@@ -528,6 +556,7 @@ export function ProductListPage() {
             void refetch();
           }}
           isLoading={isLoading}
+          alwaysShowChevronOnMasters={variantsMode === 'tree' && !isSearchActive}
         />
       )}
 

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/ParentIdFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/ParentIdFilter.php
@@ -12,6 +12,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * `?parent_id=<uuid>` — exact match on `CatalogObject.parent_id`.
+ * `?parent_id=null` — masters-only (rows whose parent IS NULL).
  *
  * Drives the `<VariantsListCard />` (VIEW-07 #420) which lists variants
  * of a master product (`/api/products?parent_id={master_id}`). Without
@@ -19,14 +20,22 @@ use Symfony\Component\Uid\Uuid;
  * cursor page — UI naïvely rendered DEMO-099/DEMO-098/... as „variants
  * of DEMO-100", which is a lie. Issue #429.
  *
- * Empty / non-UUID values are skipped — the filter is a no-op when the
- * param is absent or malformed (returning an unfiltered list is a less
- * surprising fallback than a 500). Tenant scoping still applies via
- * `TenantFilter` so cross-tenant lookups are impossible.
+ * The literal-string `null` value supports the products list tree mode
+ * (#514): with many variants of one master a single page of /api/products
+ * fills entirely with variants and pushes other masters off-screen.
+ * Sending `?parent_id=null` returns only masters and the UI lazy-loads
+ * variants on chevron expand.
+ *
+ * Empty / non-UUID values (other than `null`) are skipped — the filter
+ * is a no-op when the param is absent or malformed (returning an
+ * unfiltered list is a less surprising fallback than a 500). Tenant
+ * scoping still applies via `TenantFilter` so cross-tenant lookups are
+ * impossible.
  */
 final class ParentIdFilter implements FilterInterface
 {
     private const string PARAMETER = 'parent_id';
+    private const string NULL_TOKEN = 'null';
 
     public function apply(
         QueryBuilder $queryBuilder,
@@ -41,12 +50,22 @@ final class ParentIdFilter implements FilterInterface
         }
 
         $value = $filters[self::PARAMETER] ?? null;
-        if (!\is_string($value) || !Uuid::isValid($value)) {
+        if (!\is_string($value)) {
             return;
         }
 
         $alias = $queryBuilder->getRootAliases()[0] ?? null;
         if (null === $alias) {
+            return;
+        }
+
+        if (self::NULL_TOKEN === $value) {
+            $queryBuilder->andWhere(\sprintf('%s.parent IS NULL', $alias));
+
+            return;
+        }
+
+        if (!Uuid::isValid($value)) {
             return;
         }
 
@@ -68,7 +87,7 @@ final class ParentIdFilter implements FilterInterface
                 'property' => 'parent',
                 'type' => 'string',
                 'required' => false,
-                'description' => 'Exact match on parent_id — returns rows whose parent points at the given UUID (variants of a master product, children of a category).',
+                'description' => 'Exact match on parent_id — returns rows whose parent points at the given UUID (variants of a master product, children of a category). Pass the literal string `null` to return masters only (rows whose parent IS NULL).',
                 'strategy' => 'exact',
             ],
         ];

--- a/apps/api/tests/Api/Catalog/CatalogFiltersApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogFiltersApiTest.php
@@ -82,6 +82,42 @@ final class CatalogFiltersApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function parentIdFilterNullReturnsMastersOnly(): void
+    {
+        // 1 master + 2 variants — the masters-only filter must hide
+        // the variants and surface the master so the products list
+        // tree mode (#514) can paginate masters without losing them
+        // to a variant-heavy page.
+        $em = $this->em();
+        $tenant = $this->tenant();
+        $context = self::getContainer()->get(TenantContext::class);
+        $context->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $repo = self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+        $master = new CatalogObject($type, 'MASTERS-ONLY-MASTER');
+        $repo->save($master);
+        foreach (['MASTERS-ONLY-V1', 'MASTERS-ONLY-V2'] as $code) {
+            $variant = new CatalogObject($type, $code);
+            $variant->assignParent($master);
+            $repo->save($variant);
+        }
+        $em->flush();
+        $em->clear();
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/products?parent_id=null')->toArray();
+
+        $codes = $this->codesFrom($body);
+        self::assertContains('MASTERS-ONLY-MASTER', $codes);
+        self::assertNotContains('MASTERS-ONLY-V1', $codes);
+        self::assertNotContains('MASTERS-ONLY-V2', $codes);
+    }
+
+    #[Test]
     public function parentIdFilterIgnoresInvalidUuid(): void
     {
         $this->seedProducts(['INVALID-PARENT-A', 'INVALID-PARENT-B']);

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -2132,7 +2132,7 @@
                     {
                         "name": "parent_id",
                         "in": "query",
-                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category).",
+                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category). Pass the literal string `null` to return masters only (rows whose parent IS NULL).",
                         "required": false,
                         "deprecated": false,
                         "schema": {
@@ -2435,7 +2435,7 @@
                     {
                         "name": "parent_id",
                         "in": "query",
-                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category).",
+                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category). Pass the literal string `null` to return masters only (rows whose parent IS NULL).",
                         "required": false,
                         "deprecated": false,
                         "schema": {
@@ -3048,7 +3048,7 @@
                     {
                         "name": "parent_id",
                         "in": "query",
-                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category).",
+                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category). Pass the literal string `null` to return masters only (rows whose parent IS NULL).",
                         "required": false,
                         "deprecated": false,
                         "schema": {


### PR DESCRIPTION
## Co naprawione

Operator wygenerował ~16 wariantów dla jednego produktu i lista produktów się "wykrzaczyła":
- Wszystkie 16+ wariantów zajęło stronę 30 wyników w `/api/products` Refine paginacji
- Master + inne produkty wypadły poza widok
- Tryb Drzewo próbował grupować warianty pod masterem inline, ale skoro master nie był w tym samym slice'ie strony, warianty stały się "sierotami" i renderowały się płasko na górze

## Backend

- `ParentIdFilter` akceptuje teraz literał `null` jako wartość → emituje `parent IS NULL`. Istniejąca semantyka UUID zachowana.
- ApiTestCase `parentIdFilterNullReturnsMastersOnly` weryfikuje filtr (master visible, warianty hidden).

## Frontend

- Lista produktów w trybie Drzewo wysyła `?parent_id=null` → strona pokazuje TYLKO masterów. Warianty znikają z głównej listy.
- Nowy lazy-fetch `/api/products?parent_id={masterId}&itemsPerPage=200` ładuje warianty na klik chevronu i rendeuje je inline pod masterem. Cache po stronie React-state — re-expand jest darmowy.
- `ProductsGrid` dostaje prop `alwaysShowChevronOnMasters`: w tree mode chevron renderuje się na każdym masterze (nawet gdy lokalny count = 0, bo warianty są dopiero lazy-loaded).
- Tryb Płasko zachowuje stare mixed listing dla operatorów którzy chcą widzieć wszystko naraz.

## Test plan

- [x] PHPStan max — green
- [x] PHPUnit `parentIdFilter*` — 3/3 pass (11 assertions)
- [x] TypeScript noEmit — green
- [x] Biome check — green
- [x] Vite build — green
- [x] Playwright `products-list-tree-masters` — passes (6.3s) — pokrywa: API seed master + 5 wariantów, otwarcie /products w tree mode, asercja że warianty NIE są na liście, klik chevronu, asercja że warianty pojawiają się inline po lazy fetch.
- [x] Manual smoke pre-commit: po wygenerowaniu wariantów lista pokazuje master + inne produkty (nie tylko warianty jednego), chevron rozwija warianty inline.
- [ ] CI green

## Świadome odejścia

- **Brak variant count badge**: backend nie ma tanio dostępnej liczby wariantów per master (wymaga GROUP BY subquery lub denorm column). W tree mode chevron pokazuje się na każdym masterze, lazy fetch ujawnia rzeczywistą zawartość. Badge "+N wariantów" pojawi się gdy backend dorzuci `variantsCount` do payloadu listy (osobny ticket).
- **Search/filter active mode bypass**: gdy operator ma aktywny search lub filter, używamy Meilisearch path (nie REST), więc tree filter nie aplikuje się — i nie powinien, bo Meilisearch zwraca cross-strefowo i sterowanie tree mode tam to inny scope.
- **Excel mode w tree** też dostaje masters-only filter (przez wspólny `useList`). Jeśli operator chce edytować warianty inline w Excel — przełącza na Płasko.