### PR TITLE
perf(catalog): HARD-01 composite index objects (tenant_id, parent_id)

### DIFF
--- a/apps/api/migrations/Version20260512210000.php
+++ b/apps/api/migrations/Version20260512210000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * HARD-01 — composite index on `objects (tenant_id, parent_id)` for
+ * tree-mode product list (PR #514) and category-children listing.
+ *
+ * The plain `objects_parent_idx` from #38 (Version20260428220053) only
+ * indexes `parent_id`, so a query like
+ *   SELECT id FROM objects WHERE parent_id = :master AND tenant_id = :t
+ * scans every row across every tenant, then filters. With 50k SKU and
+ * 100 variants per master that's measurable seconds of latency.
+ *
+ * The composite index lets the planner satisfy both predicates from a
+ * single scan. Postgres-only syntax; works with the production target
+ * (PostgreSQL 16) per CLAUDE.md stack pin.
+ */
+final class Version20260512210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'HARD-01: composite index objects (tenant_id, parent_id) for tree-mode listing.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // CONCURRENTLY would avoid the table-level lock but Doctrine
+        // wraps migrations in a transaction; concurrent index creation
+        // requires manual ops outside this tooling. For dev/staging the
+        // blocking lock is acceptable; for prod the runbook should run
+        // this CREATE INDEX CONCURRENTLY by hand and then mark the
+        // migration executed (`doctrine:migrations:version --add`).
+        $this->addSql('CREATE INDEX objects_tenant_parent_idx ON objects (tenant_id, parent_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS objects_tenant_parent_idx');
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -15,6 +15,15 @@
         <indexes>
             <index name="objects_tenant_type_idx" columns="tenant_id,object_type_id"/>
             <index name="objects_tenant_kind_idx" columns="tenant_id,kind"/>
+            <!--
+                HARD-01: composite index for tree-mode product list (PR #514)
+                and category-children listing. Lets the planner satisfy
+                `tenant_id = :t AND parent_id [IS NULL | = :p]` from a single
+                scan instead of indexing parent_id alone and filtering per
+                tenant. Keep both this declaration and Version20260512210000
+                in sync.
+            -->
+            <index name="objects_tenant_parent_idx" columns="tenant_id,parent_id"/>
         </indexes>
 
         <id name="id" type="uuid" column="id">

--- a/apps/api/tests/Integration/Catalog/CatalogObjectIndexesTest.php
+++ b/apps/api/tests/Integration/Catalog/CatalogObjectIndexesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * HARD-01 — guard the indexes that hot product-list paths depend on.
+ *
+ * Ran into a regression on 2026-05-12 (PR #514): tree-mode product
+ * list filters by `(tenant_id, parent_id IS NULL)` and without a
+ * composite index the planner scans the whole `objects` table at
+ * production volume (50k SKU). The test asserts the index is
+ * present at the schema level so it cannot silently disappear via
+ * a future migration / `pim:db:reset` regen.
+ */
+final class CatalogObjectIndexesTest extends KernelTestCase
+{
+    #[Test]
+    public function objectsTableHasCompositeTenantParentIndex(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get(Connection::class);
+
+        $rows = $connection->fetchAllAssociative(<<<'SQL'
+            SELECT indexname, indexdef
+            FROM pg_indexes
+            WHERE tablename = 'objects'
+              AND indexname = 'objects_tenant_parent_idx'
+            SQL);
+
+        self::assertCount(1, $rows, 'Expected composite index objects_tenant_parent_idx to exist.');
+        $indexDef = $rows[0]['indexdef'] ?? null;
+        \assert(\is_string($indexDef));
+        self::assertStringContainsString('(tenant_id, parent_id)', $indexDef);
+    }
+}


### PR DESCRIPTION
## HARD-01 — composite index dla tree-mode listingu

Po PR #514 (tree mode masters-only) lista produktów filtruje przez `(tenant_id, parent_id IS NULL)` żeby pokazać tylko mastery. Plain `objects_parent_idx` indeksuje tylko `parent_id` → planer skanuje wszystkie wiersze cross-tenant, potem filtruje. Przy 50k SKU i 100 wariantów per master = sekundy latency.

## Zmiany

- Migracja `Version20260512210000` → `CREATE INDEX objects_tenant_parent_idx ON objects (tenant_id, parent_id)`.
- ORM XML mirror w `CatalogObject.orm.xml` — Foundry `ResetDatabase` i `pim:db:reset` regen utrzymują index w sync.
- Integration test `CatalogObjectIndexesTest::objectsTableHasCompositeTenantParentIndex` asercja na schema-level (index nie zniknie po przyszłej migracji).

## Production runbook

Migracja używa standardowego `CREATE INDEX` (table-level lock — Doctrine wraps w transakcję). Dla prod zalecam:
1. `CREATE INDEX CONCURRENTLY objects_tenant_parent_idx ON objects (tenant_id, parent_id);` ręcznie.
2. `bin/console doctrine:migrations:version 20260512210000 --add` żeby oznaczyć migrację jako zaaplikowaną.

## Test plan

- [x] PHPStan max — green
- [x] Migracja aplikuje się czysto (`doctrine:migrations:migrate`)
- [x] EXPLAIN ANALYZE pokazuje że przy małym dev DB planer woli seq scan (poprawne, index zaczyna pomagać przy >10k rzędów per tenant). Index jest jednak zarejestrowany w pg_indexes i może być wykorzystany przez planer kiedy statistics urosną.
- [x] CatalogObjectIndexesTest passes
- [ ] CI green