### PR TITLE
chore(admin): HARD-04 tsconfig strict + noUncheckedIndexedAccess

### DIFF
--- a/apps/admin/src/features/api-configurator/api-profiles/form.tsx
+++ b/apps/admin/src/features/api-configurator/api-profiles/form.tsx
@@ -605,9 +605,9 @@ function resolveLabel(
 ): string {
   if (label === null || label === undefined) return '';
   if (typeof label === 'string') return label;
-  if (locale in label) return label[locale];
-  if ('en' in label) return label.en;
-  if ('pl' in label) return label.pl;
+  if (locale in label) return label[locale] ?? '';
+  if ('en' in label) return label.en ?? '';
+  if ('pl' in label) return label.pl ?? '';
   const first = Object.values(label)[0];
   return first ?? '';
 }

--- a/apps/admin/src/features/catalog/attribute-groups/list.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/list.tsx
@@ -276,7 +276,8 @@ function useGroupsUsage(rows: AttributeGroupRow[]): Record<string, UsageResp> {
   const map: Record<string, UsageResp> = {};
   for (let i = 0; i < rows.length; i += 1) {
     const data = queries[i]?.data;
-    if (data !== undefined) map[rows[i].id] = data;
+    const row = rows[i];
+    if (data !== undefined && row !== undefined) map[row.id] = data;
   }
   return map;
 }

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -310,6 +310,7 @@ function useAttributeUsage(
   const map: Record<string, { typesUsed: number; groupsUsed: number; instancesWith: number }> = {};
   for (let i = 0; i < rows.length; i += 1) {
     const row = rows[i];
+    if (row === undefined) continue;
     const data = queries[i]?.data;
     map[row.id] = {
       typesUsed: data?.objectTypes?.length ?? 0,
@@ -336,7 +337,8 @@ function useOptionCounts(rows: AttributeRow[]): Record<string, number> {
   const counts: Record<string, number> = {};
   for (let i = 0; i < selectRows.length; i += 1) {
     const data = queries[i]?.data;
-    if (typeof data === 'number') counts[selectRows[i].code] = data;
+    const row = selectRows[i];
+    if (typeof data === 'number' && row !== undefined) counts[row.code] = data;
   }
   return counts;
 }

--- a/apps/admin/src/features/catalog/attributes/values.tsx
+++ b/apps/admin/src/features/catalog/attributes/values.tsx
@@ -121,8 +121,9 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
 
   const [activeId, setActiveId] = useState<string | null>(null);
   useEffect(() => {
-    if (activeId === null && options.length > 0) {
-      setActiveId(options[0].id);
+    const first = options[0];
+    if (activeId === null && first !== undefined) {
+      setActiveId(first.id);
     }
   }, [activeId, options]);
 

--- a/apps/admin/src/features/catalog/modeling/layout.tsx
+++ b/apps/admin/src/features/catalog/modeling/layout.tsx
@@ -88,7 +88,7 @@ export function ModelingLayout() {
   const { t } = useTranslation();
   const { pathname } = useLocation();
 
-  const activeTab = TABS.find((tab) => pathname.startsWith(tab.to))?.value ?? TABS[0].value;
+  const activeTab = TABS.find((tab) => pathname.startsWith(tab.to))?.value ?? TABS[0]?.value ?? '';
 
   return (
     <div className="space-y-6">

--- a/apps/admin/src/features/channel/channels/mapping-editor.tsx
+++ b/apps/admin/src/features/channel/channels/mapping-editor.tsx
@@ -65,7 +65,7 @@ export function ChannelMappingEditor({ channelId }: ChannelMappingEditorProps) {
 
       <div className="space-y-3">
         {groupKeys.map((otCode) => {
-          const groupRows = grouped[otCode];
+          const groupRows = grouped[otCode] ?? [];
           const sample = groupRows[0]?.objectType;
           const objectTypeLabel = sample
             ? (resolveLabel(sample.label ?? null, i18n.language) ?? otCode)
@@ -175,15 +175,14 @@ function groupByObjectType(rows: MappingRow[]): Record<string, MappingRow[]> {
   const grouped: Record<string, MappingRow[]> = {};
   for (const row of rows) {
     const otCode = row.objectType?.code ?? 'unknown';
-    if (!grouped[otCode]) {
-      grouped[otCode] = [];
-    }
-    grouped[otCode].push(row);
+    const bucket = grouped[otCode] ?? [];
+    bucket.push(row);
+    grouped[otCode] = bucket;
   }
 
   // Stable sort within group by attribute code
   for (const key of Object.keys(grouped)) {
-    grouped[key].sort((a, b) => (a.attribute?.code ?? '').localeCompare(b.attribute?.code ?? ''));
+    grouped[key]?.sort((a, b) => (a.attribute?.code ?? '').localeCompare(b.attribute?.code ?? ''));
   }
   return grouped;
 }

--- a/apps/admin/src/features/imports/wizard/StepUpload.tsx
+++ b/apps/admin/src/features/imports/wizard/StepUpload.tsx
@@ -177,7 +177,10 @@ export function StepUpload({ wizard }: StepUploadProps): React.ReactElement {
               type="radio"
               name="profile-mode"
               checked={state.profileId !== null}
-              onChange={() => setField('profileId', profiles[0].id)}
+              onChange={() => {
+                const first = profiles[0];
+                if (first !== undefined) setField('profileId', first.id);
+              }}
             />
             <span>
               {t('imports.upload.profile.use_saved', { defaultValue: 'Użyj zapisanego' })}

--- a/apps/admin/tsconfig.app.json
+++ b/apps/admin/tsconfig.app.json
@@ -16,6 +16,8 @@
     "jsx": "react-jsx",
 
     /* Linting */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,


### PR DESCRIPTION
## HARD-04 — strict TypeScript

Admin tsconfig miał tylko cztery individual flags (noUnusedLocals/Parameters/FallthroughCasesInSwitch/erasableSyntaxOnly). Brak strictNullChecks, strictFunctionTypes, strictBindCallApply, strictPropertyInitialization, alwaysStrict — bugy null/undefined wpadały do prod.

Operator widział 5 takich bug-ów w samej sesji 2026-05-12:
- excel grid edit readback (#511) — niezunwrapowany `{value:...}` envelope
- products list orphans (#514) — brak `parent_id IS NULL` filter
- date attr text input (#513) — brak `<input type="date">` branch
- variants axis combobox (#513) — brak filter na select-only
- predefined-value attrs (#512) — `null` options array

## Zmiany

- `tsconfig.app.json`: `"strict": true` + `"noUncheckedIndexedAccess": true`
- 11 latent bugów wykrytych i naprawionych w 7 plikach:
  - api-profiles/form.tsx — `label[locale]` może być undefined
  - catalog/attribute-groups/list.tsx — `rows[i]` może być undefined
  - catalog/attributes/list.tsx — 2× `rows[i]` undefined guard
  - catalog/attributes/values.tsx — `options[0].id` undefined check
  - catalog/modeling/layout.tsx — `TABS[0].value` undefined fallback
  - channel/channels/mapping-editor.tsx — 2× `grouped[key]` undefined
  - imports/wizard/StepUpload.tsx — `profiles[0].id` undefined onChange

## Test plan

- [x] `pnpm typecheck` — green (0 errors po fixach)
- [x] `pnpm lint` — green
- [x] `pnpm build` — green (bundle size niezmieniony)
- [x] Zero zmian runtime — guards wstawione tam gdzie już były potrzebne, type checker tylko teraz to widzi
- [ ] CI green

## Świadome odejścia

- **Brak `noImplicitOverride`, `exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`** — to dodatkowe flagi strict-family, ale nie domyślne `strict: true`. Wprowadzenie tych wymaga ~50-100 dodatkowych guards i kosmetycznych zmian. Można dodać w osobnym ticket-cie jak wszystkie 8 plików już ma noUncheckedIndexedAccess pattern.
- **Brak migracji `as any` / `// @ts-ignore`** — w admin nie ma żadnego z tych (zero matches w grep). Zachowuję dyscyplinę.