### PR TITLE
fix(catalog): HARD-07 tenant-safe raw SQL lint + MoveCategory tenant_id fix

### DIFF
--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - "apps/api/**"
       - "docs/api-spec/**"
+      - "scripts/lint-raw-sql.sh"
       - ".github/workflows/quality-php.yml"
   push:
     branches: [main]
     paths:
       - "apps/api/**"
       - "docs/api-spec/**"
+      - "scripts/lint-raw-sql.sh"
       - ".github/workflows/quality-php.yml"
 
 concurrency:
@@ -103,6 +105,21 @@ jobs:
 
       - name: Deptrac analyse
         run: vendor/bin/deptrac analyse --no-progress --no-cache
+
+  raw-sql-lint:
+    # HARD-07 — guard-rail for raw SQL bypassing TenantFilter.
+    # Cheap shell job; runs before composer install so failures
+    # surface in seconds without burning CI minutes.
+    name: Raw SQL tenant-safe lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Lint raw SQL escape hatches
+        run: bash scripts/lint-raw-sql.sh
 
   php-cs-fixer:
     name: PHP-CS-Fixer (dry-run)

--- a/apps/api/src/Benchmark/BulkImportBenchmarkCommand.php
+++ b/apps/api/src/Benchmark/BulkImportBenchmarkCommand.php
@@ -204,6 +204,11 @@ final class BulkImportBenchmarkCommand extends Command
         $output->writeln(\sprintf('pim_benchmark_peak_memory_bytes %d', $peakMemory));
 
         if (!$keep) {
+            // tenant-safe: infrastructure (admin-only benchmark CLI).
+            // The command runs cross-tenant by design — it cleans up
+            // its own seeded rows by code prefix and is gated behind
+            // direct shell access; the deleted set never includes
+            // operator data because $skuPrefix is generated per-run.
             $deleted = (int) $this->entityManager->getConnection()->executeStatement(
                 "DELETE FROM objects WHERE kind = 'product' AND code LIKE :prefix",
                 ['prefix' => $skuPrefix.'%'],

--- a/apps/api/src/Catalog/Application/Command/DeleteAttributeGroup/DeleteAttributeGroupHandler.php
+++ b/apps/api/src/Catalog/Application/Command/DeleteAttributeGroup/DeleteAttributeGroupHandler.php
@@ -62,6 +62,12 @@ final readonly class DeleteAttributeGroupHandler
             ));
         }
 
+        // tenant-safe: junction inherits tenant via FK chain (the
+        // attribute_group_id is tenant-scoped via the parent group
+        // entity loaded through TenantFilter on line 25).
+        // The two COUNT queries above (lines 45-52) read the same
+        // junctions and are tenant-safe for the same reason.
+        //
         // Cascade-clear the AttributeGroupAttribute junction rows. ON
         // DELETE CASCADE is set on the FK, but Doctrine's UoW does not
         // know about M:N junction rows that aren't mapped as a

--- a/apps/api/src/Catalog/Application/Migration/AttributeMigrationExecutor.php
+++ b/apps/api/src/Catalog/Application/Migration/AttributeMigrationExecutor.php
@@ -34,6 +34,12 @@ use Throwable;
  * Tenant scope: queries narrow by `attribute_id`, which is already
  * tenant-scoped via the attribute row. Cross-tenant access is blocked
  * upstream (controller resolves attribute through TenantFilter).
+ *
+ * tenant-safe: every executeStatement below filters by id (per-row PK
+ * lookups for attributes / object_values) or by attribute_id (joined
+ * with the attribute row that came through TenantFilter). The
+ * INSERT into attribute_migration_backups carries attribute_id as
+ * the natural tenant anchor.
  */
 final readonly class AttributeMigrationExecutor
 {

--- a/apps/api/src/Catalog/Application/ProductAssetLinkerService.php
+++ b/apps/api/src/Catalog/Application/ProductAssetLinkerService.php
@@ -40,6 +40,9 @@ final readonly class ProductAssetLinkerService implements ProductAssetLinker
         $nextPosition = is_numeric($rawPosition) ? (int) $rawPosition : 0;
 
         foreach ($assetIds as $assetId) {
+            // tenant-safe: junction table inherits tenant via FK chain
+            // — both asset_id and product_id are tenant-scoped UUIDs
+            // resolved by callers through TenantFilter-aware repositories.
             $this->connection->executeStatement(
                 <<<'SQL'
                     INSERT INTO product_assets (asset_id, product_id, position, created_at)
@@ -57,6 +60,8 @@ final readonly class ProductAssetLinkerService implements ProductAssetLinker
 
     public function unlinkAssetFromProduct(Uuid $productId, Uuid $assetId): void
     {
+        // tenant-safe: junction table inherits tenant via FK chain
+        // (product_id + asset_id are tenant-scoped UUIDs).
         $this->connection->executeStatement(
             'DELETE FROM product_assets WHERE product_id = :productId AND asset_id = :assetId',
             [

--- a/apps/api/src/Catalog/Application/Service/MoveCategoryService.php
+++ b/apps/api/src/Catalog/Application/Service/MoveCategoryService.php
@@ -140,7 +140,10 @@ final class MoveCategoryService
 
         $this->connection()->beginTransaction();
         try {
-            // Rewrite the moving node first.
+            // tenant-safe: WHERE id = :id is selective enough — id is a
+            // tenant-scoped UUID we just resolved through
+            // CatalogObjectRepositoryInterface (TenantFilter applied), so
+            // it can only match a row in the current tenant.
             $this->connection()->executeStatement(
                 'UPDATE objects SET path = CAST(:newPath AS ltree), parent_id = :parentId, updated_at = NOW() WHERE id = CAST(:id AS uuid)',
                 [
@@ -153,17 +156,31 @@ final class MoveCategoryService
                 ],
             );
 
+            // tenant-safe: explicit tenant_id filter. Without it the
+            // ltree subtree match (`path <@ :oldPath`) would touch rows
+            // in other tenants that happen to share the same ltree
+            // namespace — every tenant has its own root nodes and ltree
+            // labels are not unique across tenants. The category's
+            // tenant_id is read from the aggregate we already loaded
+            // through TenantFilter.
+            //
             // Rewrite descendants — strict descendants only (excluding self,
             // which we just rewrote). LTREE `subpath(path, oldDepth)` strips
             // the old prefix; concatenation with `newPath ||` re-anchors it
             // under the new parent path.
             $oldDepth = $this->ltreeDepth($oldPath);
+            $tenant = $category->getTenant();
+            \assert(null !== $tenant);
             $affected = $this->connection()->executeStatement(
                 'UPDATE objects SET path = CAST(:newPath AS ltree) || subpath(path, :oldDepth), updated_at = NOW()'
-                .' WHERE kind = :kind AND path <@ CAST(:oldPath AS ltree) AND id <> CAST(:id AS uuid)',
+                .' WHERE tenant_id = CAST(:tenantId AS uuid)'
+                .'   AND kind = :kind'
+                .'   AND path <@ CAST(:oldPath AS ltree)'
+                .'   AND id <> CAST(:id AS uuid)',
                 [
                     'newPath' => $newPath,
                     'oldDepth' => $oldDepth,
+                    'tenantId' => $tenant->getId()->toRfc4122(),
                     'kind' => ObjectKind::Category->value,
                     'oldPath' => $oldPath,
                     'id' => $category->getId()->toRfc4122(),

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/CategoryPathBuilder.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/CategoryPathBuilder.php
@@ -70,6 +70,11 @@ final class CategoryPathBuilder
             return;
         }
 
+        // tenant-safe: per-row UPDATE keyed by primary key. The id
+        // belongs to an entity Doctrine just persisted under the
+        // current TenantContext (TenantAssignmentListener stamped
+        // tenant_id on prePersist), so it is necessarily the
+        // current tenant's row.
         $em = $event->getObjectManager();
         $em->getConnection()->executeStatement(
             'UPDATE objects SET path = CAST(:path AS ltree) WHERE id = CAST(:id AS uuid) AND path IS NULL',

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/PostgresExtensionLoader.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/PostgresExtensionLoader.php
@@ -41,6 +41,9 @@ final class PostgresExtensionLoader
         // and the only correct answer once we cannot trust the DB to be
         // the same between two boots in the same process.
         try {
+            // tenant-safe: infrastructure DDL — CREATE EXTENSION
+            // operates on the database cluster, no row data is read
+            // or written.
             $this->connection->executeStatement('CREATE EXTENSION IF NOT EXISTS ltree');
         } catch (Throwable) {
             // Best-effort: if the extension cannot be created (no

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/PrimaryCategoryRepairListener.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/PrimaryCategoryRepairListener.php
@@ -36,6 +36,14 @@ use Doctrine\ORM\Events;
  * miss them or trigger spurious change-tracking. The single SQL also
  * sidesteps the partial-unique-index window (the CASCADE removed the
  * primary row first, so promoting another to `is_primary=true` is safe).
+ *
+ * tenant-safe: object_categories is a junction table whose tenant
+ * isolation comes from the FK chain (object_id + category_id are both
+ * tenant-scoped CatalogObject ids). The buffered productIds collected
+ * in onFlush originate from a CatalogObject that already passed
+ * TenantFilter on its own load; the `category_id` queried in
+ * onFlush is the deletion target which Doctrine resolved through
+ * the same filter.
  */
 #[AsDoctrineListener(event: Events::onFlush)]
 #[AsDoctrineListener(event: Events::postFlush)]

--- a/apps/api/src/Catalog/Presentation/Controller/AttachObjectTypeAttributeGroupController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttachObjectTypeAttributeGroupController.php
@@ -93,6 +93,11 @@ final class AttachObjectTypeAttributeGroupController
             );
         }
 
+        // tenant-safe: junction table inherits tenant via FK chain.
+        // Both $id (ObjectType) and $groupId (AttributeGroup) were
+        // resolved through TenantFilter-aware repositories above
+        // (lines 50, 87) — they cannot reference rows from other
+        // tenants by the time we reach the DELETE.
         $this->connection->executeStatement(
             'DELETE FROM object_type_attribute_groups WHERE object_type_id = ? AND attribute_group_id = ?',
             [$id, $groupId],

--- a/apps/api/src/Import/Application/Service/ImportRollbackService.php
+++ b/apps/api/src/Import/Application/Service/ImportRollbackService.php
@@ -25,6 +25,13 @@ use Doctrine\ORM\EntityManagerInterface;
  * Linked Asset rows stay untouched on purpose (spec §7.7: "klient
  * ręcznie usuwa w DAM"). The 24h window guard lives on the entity;
  * this service just orchestrates the DBAL DELETE.
+ *
+ * tenant-safe: import_session_id is the natural tenant anchor.
+ * The ImportSession entity is loaded through TenantFilter via the
+ * repository; objects/values created by that import inherit the
+ * same tenant on the FK chain (every CatalogObject has tenant_id
+ * stamped on prePersist). Filtering by import_session_id therefore
+ * cannot reach rows from other tenants.
  */
 final readonly class ImportRollbackService
 {

--- a/apps/api/src/Shared/Infrastructure/Maintenance/AuditLogCleanupCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/AuditLogCleanupCommand.php
@@ -20,6 +20,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * itself. Per-table DELETE keeps locks scoped — one slow table does
  * not stall the others. Dry-run reports row counts without touching
  * data so the cron can stay loud.
+ *
+ * tenant-safe: infrastructure (cron-driven retention policy across
+ * every `*_audit` table). The audit tables are deliberately
+ * cross-tenant — the retention horizon applies platform-wide and
+ * tenant_id is not even present on the bundle's audit schema.
  */
 #[AsCommand(
     name: 'pim:audit:cleanup',

--- a/scripts/lint-raw-sql.sh
+++ b/scripts/lint-raw-sql.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# HARD-07 — guard-rail for raw SQL bypassing TenantFilter.
+#
+# Doctrine TenantFilter only kicks in for ORM-mediated queries; calls to
+# Connection::executeQuery / executeStatement / createNativeQuery skip
+# it entirely. Without an explicit `tenant_id` predicate (or a documented
+# infrastructure exemption) such a call is a cross-tenant data leak
+# waiting to happen. This script:
+#
+#   1. lists every PHP file under apps/api/src/ that uses one of the
+#      escape hatches above (`grep -rln`),
+#   2. fails the build if any of those files lacks a `tenant-safe:`
+#      comment marker. Authors must justify each escape inline so the
+#      next reader understands why the absence of TenantFilter is okay.
+#
+# Marker format (free-form text after the colon — checked verbatim):
+#
+#     // tenant-safe: <one-line reason>
+#
+# Reasons in current use:
+#   - "infrastructure (admin-only ...)" — DDL / cross-tenant tooling
+#   - "junction inherits tenant via FK chain" — junction table queried
+#     by tenant-scoped parent ids
+#   - "per-row UPDATE keyed by primary key" — id resolved through
+#     TenantFilter-aware repository
+#   - "explicit tenant_id filter" — WHERE clause includes tenant_id
+#
+# Exit non-zero with the offender list so CI surfaces every file at
+# once instead of bisecting one PR at a time.
+
+set -eu
+
+ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="${ROOT}/apps/api/src"
+PATTERN='executeQuery|executeStatement|createNativeQuery'
+
+if [ ! -d "$SRC" ]; then
+    echo "lint-raw-sql: source dir $SRC not found" >&2
+    exit 1
+fi
+
+# `grep -rln` returns 0 (matches found), 1 (no matches), or 2 (error).
+# We treat "no matches" as a green run.
+files=$(grep -rln -E "$PATTERN" "$SRC" --include='*.php' || true)
+
+if [ -z "$files" ]; then
+    echo "lint-raw-sql: no raw SQL escape hatches found — clean."
+    exit 0
+fi
+
+offenders=""
+total=0
+for f in $files; do
+    total=$((total + 1))
+    if ! grep -q 'tenant-safe:' "$f"; then
+        offenders="$offenders\n  $f"
+    fi
+done
+
+if [ -n "$offenders" ]; then
+    echo "lint-raw-sql: $total file(s) use raw SQL; the following lack a tenant-safe: marker:" >&2
+    printf "$offenders\n" >&2
+    cat >&2 <<'TXT'
+
+Each offender must add an inline comment justifying why TenantFilter is
+not needed:
+
+  // tenant-safe: <reason>
+
+Reasons in current use:
+  - infrastructure (admin-only DDL / cron / benchmark CLI)
+  - junction inherits tenant via FK chain
+  - per-row UPDATE keyed by primary key (id from tenant-scoped repo)
+  - explicit tenant_id filter in WHERE
+TXT
+    exit 1
+fi
+
+echo "lint-raw-sql: $total file(s) use raw SQL — every one carries a tenant-safe: marker. Clean."
+exit 0


### PR DESCRIPTION
## HARD-07 — guard-rail dla raw SQL bypassujących TenantFilter

Audyt 2026-05-12 znalazł 11 plików z `executeQuery/executeStatement/createNativeQuery` w `apps/api/src`. **Jeden był prawdziwym bugiem leak data**.

## Realny bug fix — MoveCategoryService

Drugi `UPDATE objects SET path` w `MoveCategoryService::move()` używał `WHERE kind = :kind AND path <@ :oldPath AND id <> :id` — **bez `tenant_id`**. Dwóch tenantów których ltree namespace się przecinają (każdy tenant ma własne roots, labels nie są unique cross-tenant) mogłoby się nawzajem updatować przy move kategorii. Naprawione: filtr `tenant_id = :tenantId` z aggregate-a.

## Guard-rail CI

`scripts/lint-raw-sql.sh` — greppuje 3 escape hatches w `apps/api/src`, fail-uje gdy hit nie ma inline komentarza `// tenant-safe: <reason>`. Wpięty do `Quality (PHP)` workflow jako osobny job (cheap shell, runs przed composer install).

## Markery dorzucone (10 pozostałych plików)

Cztery kategorie:
- **infrastructure** (3): BulkImportBenchmarkCommand, PostgresExtensionLoader, AuditLogCleanupCommand
- **junction inherits tenant via FK chain** (4): ProductAssetLinkerService, DeleteAttributeGroupHandler, PrimaryCategoryRepairListener, AttachObjectTypeAttributeGroupController
- **per-row UPDATE keyed by primary key** (2): CategoryPathBuilder, AttributeMigrationExecutor
- **import_session_id naturalny tenant anchor** (1): ImportRollbackService

## Test plan

- [x] PHPStan max — green
- [x] PHPUnit `CategoryMove` — 4/4 pass (tenant_id filter nic nie zepsuł)
- [x] `scripts/lint-raw-sql.sh` lokalnie — `11 file(s) use raw SQL — every one carries a tenant-safe: marker. Clean.`
- [x] Test negatywny: ręczne usunięcie markera z dowolnego pliku → script fail z listą offenderów ✓
- [ ] CI green

## Świadome odejścia

- **Brak refactoru raw SQL na Doctrine ORM gdzie to możliwe** — kompromis: część raw SQL jest świadomy (perf — bulk UPDATE z ltree, junctions M:N bez collection mapping). Marker pełni rolę "świadomy + uzasadniony".
- **Marker `tenant-safe:` to free-form text** — script tylko sprawdza jego obecność, nie parsuje uzasadnienia. Treść zostaje na ludzkim review w PR.
- **Brak coverage dla każdej z 4 kategorii uzasadnień jako osobny test** — uzasadnienia weryfikuje human reviewer per PR.