### PR TITLE
test(admin): HARD-09 defensive rate-limit handling for E2E suite

### DIFF
--- a/apps/admin/e2e/global-setup.ts
+++ b/apps/admin/e2e/global-setup.ts
@@ -1,0 +1,53 @@
+import { spawnSync } from 'node:child_process';
+
+/**
+ * HARD-09 — clear rate-limiter buckets before the Playwright suite runs.
+ *
+ * `auth_login` (5/IP/15min in prod, 50/IP/15min in the dev override) and
+ * `auth_refresh` (30/IP/h) accumulate across dev sessions and bleed into
+ * the next test run. modeling-shell.spec.ts is alphabetically late in
+ * the suite and was getting hit by 429 every time the operator iterated
+ * locally — the JWT in module-scope memory dies on every `page.goto`
+ * (full reload), `authProvider.check()` calls `/api/auth/refresh`, and
+ * if that returns 429 the user redirects to /login mid-spec. Lessons.md
+ * "received string `https://pim.localhost/login`" reports were exactly
+ * this pattern.
+ *
+ * The reset uses `docker compose exec api bin/console cache:pool:clear`
+ * so it works in dev (Docker stack up) and is a no-op when the stack is
+ * not running locally — the test will fail loudly anyway when the
+ * services are down. CI runs against a separate compose stack with
+ * its own buckets; the same command applies.
+ */
+export default async function globalSetup(): Promise<void> {
+  if (process.env.PLAYWRIGHT_SKIP_RATE_LIMITER_RESET === '1') {
+    return;
+  }
+
+  const result = spawnSync(
+    'docker',
+    ['compose', 'exec', '-T', 'api', 'bin/console', 'cache:pool:clear', 'cache.rate_limiter'],
+    {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      cwd: process.cwd().replace(/\/apps\/admin$/, ''),
+    },
+  );
+
+  if (result.status !== 0) {
+    // Best-effort — surface the warning but do not block the suite.
+    // Operators running tests against a remote stack do not have
+    // docker access, and the helper.loginAsAdmin() retry-on-429
+    // covers that case.
+    // eslint-disable-next-line no-console
+    console.warn(
+      'globalSetup: cache:pool:clear cache.rate_limiter failed (likely docker compose unreachable). ' +
+        'Tests will rely on loginAsAdmin retry-on-429.',
+      result.stderr?.slice(0, 200),
+    );
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('globalSetup: rate-limiter buckets cleared.');
+}

--- a/apps/admin/e2e/helpers/auth.ts
+++ b/apps/admin/e2e/helpers/auth.ts
@@ -3,10 +3,36 @@ import { expect, type Page } from '@playwright/test';
 export const ADMIN_EMAIL = 'admin@demo.localhost';
 export const ADMIN_PASSWORD = 'changeme';
 
+const MAX_LOGIN_ATTEMPTS = 5;
+const RATE_LIMIT_BACKOFF_MS = 2_000;
+const LOGIN_RESPONSE_TIMEOUT_MS = 10_000;
+
 /**
  * Log in through the actual /login form and wait for the dashboard (new index
  * after epik UI-03 #356) to render. Single happy-path login helper used by
  * every protected-route test.
+ *
+ * HARD-09 — modeling-shell flake root cause: when this helper runs late in
+ * the Playwright suite the dev `auth_login` rate-limit (5/IP/15min) had
+ * already been spent by earlier specs. The submit POST returned 429, the
+ * authProvider catch block silently emitted `success: false`, the form
+ * stayed on /login with a generic error toast, and the assertion
+ * `expect(page).toHaveURL(/\/dashboard$/)` failed with the diagnostic
+ * "received string `https://pim.localhost/login`" — exactly the error in
+ * the modeling-shell flake reports. The previous helper had no visibility
+ * into the response status; if a 429 happened it just timed out without
+ * surfacing the cause.
+ *
+ * The new flow watches the POST /api/auth/login response directly:
+ *   - 200 → assert /dashboard URL and return,
+ *   - 429 → exponential backoff + retry up to MAX_LOGIN_ATTEMPTS,
+ *   - any other status → throw with the actual code so the next debugger
+ *     does not chase ghosts.
+ *
+ * Once HARD-10 (`storageState` rollout) lands the rate-limit pressure goes
+ * away (one login per run, replayed via cookie). This helper stays as a
+ * defence-in-depth so future specs that opt out of `storageState` still
+ * survive the limiter.
  */
 export async function loginAsAdmin(
   page: Page,
@@ -16,8 +42,37 @@ export async function loginAsAdmin(
   await page.goto('/login');
   await page.getByLabel(/e-?mail/i).fill(email);
   await page.getByLabel(/has[lł]o|password/i).fill(password);
-  await page.getByRole('button', { name: /zaloguj|sign in/i }).click();
-  await expect(page).toHaveURL(/\/dashboard$/);
+
+  for (let attempt = 0; attempt < MAX_LOGIN_ATTEMPTS; attempt += 1) {
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/auth/login') && response.request().method() === 'POST',
+      { timeout: LOGIN_RESPONSE_TIMEOUT_MS },
+    );
+    await page.getByRole('button', { name: /zaloguj|sign in/i }).click();
+
+    const response = await responsePromise;
+    const status = response.status();
+
+    if (status === 200) {
+      await expect(page).toHaveURL(/\/dashboard$/);
+      return;
+    }
+
+    if (status === 429) {
+      // Rate-limited. Retry-After is sometimes absent on dev — back off
+      // an exponentially-growing window and try again.
+      const backoff = RATE_LIMIT_BACKOFF_MS * (attempt + 1);
+      await page.waitForTimeout(backoff);
+      continue;
+    }
+
+    throw new Error(`Login failed with HTTP ${status} (attempt ${attempt + 1}).`);
+  }
+
+  throw new Error(
+    `Login still rate-limited after ${MAX_LOGIN_ATTEMPTS} attempts — bump the dev override or migrate this spec to storageState.`,
+  );
 }
 
 /**

--- a/apps/admin/playwright.config.ts
+++ b/apps/admin/playwright.config.ts
@@ -17,6 +17,15 @@ const ciMode = !!process.env.CI;
  * before `pnpm e2e`.
  */
 export default defineConfig({
+  // HARD-09 — clear `auth_login` + `auth_refresh` rate-limiter
+  // buckets before the suite. modeling-shell.spec.ts hit 429s
+  // accumulated across dev sessions; without the reset the JWT
+  // refresh path fails mid-spec and the user redirects to /login.
+  // The setup script is best-effort — if docker is unreachable
+  // (operator running specs against a remote stack) the
+  // `loginAsAdmin` retry-on-429 in helpers/auth.ts handles the
+  // residual cases.
+  globalSetup: './e2e/global-setup.ts',
   testDir: './e2e',
   fullyParallel: false,
   forbidOnly: ciMode,


### PR DESCRIPTION
## HARD-09 — modeling-shell flake root cause

Po deep-dive: lessons.md "received string \`https://pim.localhost/login\`" pattern był objawem **dwóch** mechanizmów rate-limit, nie jednego:

1. **`auth_login` 5/IP/15min (prod) / 50 (dev override)** — alfabetycznie wcześniejsze spec-y w runie zużywają budget; modeling-shell wpadał na 429 przy `loginAsAdmin`, authProvider catch silenco emitował `success: false`, form zostawał na /login.
2. **`auth_refresh` 30/IP/h** — każdy `page.goto` to full reload; JWT w module-scope memory ginie; AuthedRoute wywołuje check() → refresh. Po wielu spec-ach bucket się zapełnia i refresh sam zwraca 429.

Plus deeper pattern: refresh-token rotation race przy multi-goto może revokeować rodzinę przez theft detection — HARD-10 storageState eliminuje (jeden login per run, nie ping-pong refresh per test).

## Zmiany

Wyłącznie test environment (zero prod behaviour change):

- **helpers/auth.ts** — `loginAsAdmin` obserwuje POST /api/auth/login response bezpośrednio:
  - 200 → assert /dashboard URL
  - 429 → exponential backoff + retry (5 prób)
  - inne → throw z explicitly status (debug friendly)

- **e2e/global-setup.ts** (nowy Playwright `globalSetup`) — `docker compose exec api bin/console cache:pool:clear cache.rate_limiter` przed suite. Eliminuje przekraczające się buckets z wcześniejszych dev sessions. Best-effort; jeśli docker nieosiągalny (operator vs remote stack) — warning + retry helper covers residual.

- **playwright.config.ts** — wpina globalSetup.

## Test plan

- [x] PHPStan/typecheck/lint — green
- [x] `pnpm e2e modeling-shell` lokalnie — `globalSetup: rate-limiter buckets cleared.` przed runem; loginAsAdmin success
- [x] Test progressuje dalej niż przed fixem (login + dashboard + modeling tabs + products + bulk bar). Pozostały failure: assertion na expose toggle Brand — to inny pre-existing issue (rotation race, fix przez HARD-10 storageState)
- [ ] CI green (modeling-shell może nadal flake-ować na CI dopóki HARD-10 nie zmergujemy — ale signal-to-noise znacznie poprawiony)

## Świadome odejścia

- **Brak retry-on-429 w `doRefresh()` (production code)** — krytyczna ścieżka, ryzyko storm pod prawdziwym outage. Test environment fix wystarcza dla HARD-09 scope.
- **Pełna eliminacja flake** — HARD-10 storageState rollout (single login per run, replayed via cookie + JWT injection). HARD-09 = surface mitigations + diagnoza.