### PR TITLE
fix(admin): hotfix white-screen on /products (defensive nullish on jsonFetch)

### DIFF
--- a/apps/admin/src/components/catalog/saved-views-rail.tsx
+++ b/apps/admin/src/components/catalog/saved-views-rail.tsx
@@ -48,9 +48,14 @@ export function SavedViewsRail({
 
   useEffect(() => {
     let cancelled = false;
-    jsonFetch<{ views: SavedView[] }>(`/api/saved-views?resource=${encodeURIComponent(resource)}`)
+    jsonFetch<{ views?: SavedView[] }>(`/api/saved-views?resource=${encodeURIComponent(resource)}`)
       .then((body) => {
-        if (!cancelled) setViews(body.views);
+        // Defensive: jsonFetch's generic is a runtime hint, not a guarantee.
+        // If the backend ever omits `views` (auth race during refresh, future
+        // pagination shape change) the older `setViews(body.views)` left the
+        // hook with `views = undefined` and the next `views.map(...)` blew up
+        // the whole tree (white screen on /products, 2026-05-12).
+        if (!cancelled) setViews(body.views ?? []);
       })
       .catch((err: unknown) => {
         if (cancelled) return;

--- a/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
+++ b/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
@@ -57,10 +57,12 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
         const arr = Array.isArray(list) ? list : [];
         setVariants(arr);
       }),
-      jsonFetch<{ groups: GroupMeta[] }>(
+      jsonFetch<{ groups?: GroupMeta[] }>(
         `/api/products/${productId}/effective-attribute-groups`,
       ).then((body) => {
-        if (!cancelled) setGroups(body.groups);
+        // Defensive — see saved-views-rail comment. Empty groups is a
+        // valid state (product whose ObjectType has no attached groups).
+        if (!cancelled) setGroups(body.groups ?? []);
       }),
     ]).catch(() => undefined);
     return () => {


### PR DESCRIPTION
## Hotfix — biały ekran na /products

Operator zgłosił po marathonie 2026-05-12: po zalogowaniu i kliku w Products → biały ekran. Stack trace: `Cannot read properties of undefined (reading 'map')` w `SavedViewsRail`.

## Root cause

\`\`\`ts
jsonFetch<{ views: SavedView[] }>(...)
  .then((body) => setViews(body.views));
\`\`\`

Generic `<{ views: SavedView[] }>` to **runtime hint**, nie gwarancja. Kiedy backend ominął klucz `views` (legitimate state przy auth race, pustej odpowiedzi, zmianie pagination shape) — `body.views = undefined` → `setViews(undefined)` → `views.map(...)` crashuje cały tree → biały ekran.

`tsconfig strict` (HARD-04) tego nie złapie — jsonFetch param `T = unknown`, assertion to call-site, runtime nigdy nie re-validuje shape.

## Fix

Defensive `?? []` po narrow:

\`\`\`ts
jsonFetch<{ views?: SavedView[] }>(...)
  .then((body) => setViews(body.views ?? []));
\`\`\`

Plus prophylactic fix tego samego patternu w `variants-tab-host.tsx` — `setGroups(body.groups ?? [])`.

## Test plan

- [x] PHPStan/typecheck/lint — green
- [x] Probe Playwright: po fixie /products renderuje (bodylen 3073), zero pageerrors. Przed: bodylen 0, throw w SavedViewsRail.
- [ ] CI green
- [ ] Smoke: operator weryfikuje /products + /dashboard po merge

## Lekcja (do dorzucenia w lessons.md)

`jsonFetch<T>` runtime hint nie jest type-safe. Dla każdej setState po jsonFetch z list-shape: `?? []` ZAWSZE. Dla object-shape: typed `?: T` + null-check przy konsumpcji.