### PR TITLE
feat(search): batch Meilisearch upserts via request-scoped collector (PROD-03)

### DIFF
--- a/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
@@ -13,6 +13,17 @@ interface CatalogObjectRepositoryInterface
 {
     public function findById(Uuid $id): ?CatalogObject;
 
+    /**
+     * Batch fetch by RFC4122 id strings. Used by the search batch indexer
+     * (PROD-03) to materialise a request-scoped queue of pending upserts
+     * in one query instead of N round-trips. Tenant filter still applies.
+     *
+     * @param list<string> $idsRfc4122
+     *
+     * @return list<CatalogObject>
+     */
+    public function findByIds(array $idsRfc4122): array;
+
     public function findByCode(string $code, ObjectKind $kind, Tenant $tenant): ?CatalogObject;
 
     /**

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
@@ -42,6 +42,27 @@ class DoctrineCatalogObjectRepository extends ServiceEntityRepository implements
         return parent::find($id->toRfc4122());
     }
 
+    /**
+     * @param list<string> $idsRfc4122
+     *
+     * @return list<CatalogObject>
+     */
+    public function findByIds(array $idsRfc4122): array
+    {
+        if ([] === $idsRfc4122) {
+            return [];
+        }
+
+        /** @var list<CatalogObject> $rows */
+        $rows = $this->createQueryBuilder('o')
+            ->where('o.id IN (:ids)')
+            ->setParameter('ids', $idsRfc4122)
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
     public function save(CatalogObject $entity): void
     {
         $em = $this->getEntityManager();

--- a/apps/api/src/Search/Application/CatalogIndexCollector.php
+++ b/apps/api/src/Search/Application/CatalogIndexCollector.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search\Application;
+
+use App\Catalog\Domain\ObjectKind;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * PROD-03 — request-scoped buffer of CatalogObject ids that need a
+ * Meilisearch refresh.
+ *
+ * The single-edit path used to call {@see CatalogObjectIndexer::index()}
+ * per domain event, which translated into one HTTP round-trip per
+ * affected row. Variant generation (16 axes) and category cascades
+ * (descendant moves) blew that up to N×Meili requests per HTTP call.
+ *
+ * This collector dedupes by object id (multiple events for the same
+ * object collapse to a single upsert) and partitions deletes by kind
+ * because the indexer needs the kind to pick the destination index. A
+ * companion {@see CatalogIndexFlushSubscriber} drains the buffer on
+ * `kernel.terminate` so the response is already on the wire before we
+ * hit Meilisearch.
+ *
+ * Singleton service with `ResetInterface` so the FrankenPHP worker
+ * cannot leak buffered ids between requests.
+ */
+final class CatalogIndexCollector implements ResetInterface
+{
+    /** @var array<string, true> objectId (RFC4122 string) => true */
+    private array $upserts = [];
+
+    /** @var array<string, ObjectKind> objectId (RFC4122 string) => kind */
+    private array $deletes = [];
+
+    public function queueUpsert(Uuid $id): void
+    {
+        $rfc = $id->toRfc4122();
+        // If a delete was queued earlier in the same request and now an
+        // upsert lands, the object is being recreated/re-published — drop
+        // the stale delete so the final state is the upsert.
+        unset($this->deletes[$rfc]);
+        $this->upserts[$rfc] = true;
+    }
+
+    public function queueDelete(Uuid $id, ObjectKind $kind): void
+    {
+        $rfc = $id->toRfc4122();
+        // Delete supersedes a pending upsert in the same request — Meili
+        // would reject the upsert for a row that is about to vanish anyway.
+        unset($this->upserts[$rfc]);
+        $this->deletes[$rfc] = $kind;
+    }
+
+    public function isEmpty(): bool
+    {
+        return [] === $this->upserts && [] === $this->deletes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function drainUpsertIds(): array
+    {
+        $ids = array_keys($this->upserts);
+        $this->upserts = [];
+
+        return $ids;
+    }
+
+    /**
+     * @return array<string, ObjectKind>
+     */
+    public function drainDeletes(): array
+    {
+        $deletes = $this->deletes;
+        $this->deletes = [];
+
+        return $deletes;
+    }
+
+    public function reset(): void
+    {
+        $this->upserts = [];
+        $this->deletes = [];
+    }
+}

--- a/apps/api/src/Search/Application/CatalogIndexFlushSubscriber.php
+++ b/apps/api/src/Search/Application/CatalogIndexFlushSubscriber.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search\Application;
+
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * PROD-03 — drains the {@see CatalogIndexCollector} once the response is
+ * on the wire so a single request always issues one batched
+ * `addDocuments` per kind to Meilisearch instead of N round-trips.
+ *
+ * Listens to two events:
+ *   - `kernel.terminate` for HTTP requests (response sent, fpm/franken
+ *     keeps the worker alive while we drain).
+ *   - `console.terminate` for CLI commands (e.g. fixtures, ad-hoc
+ *     seeders). Bulk flows already opt out via {@see BulkContext} so
+ *     this only affects small-scale CLI ops.
+ *
+ * Failures are absorbed inside {@see CatalogObjectIndexer::indexBatch()}
+ * — a Meili outage must not bubble out of `kernel.terminate` (the
+ * response is already gone; throwing here just leaks the exception
+ * into the worker log without recourse).
+ */
+final readonly class CatalogIndexFlushSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private CatalogIndexCollector $collector,
+        private CatalogObjectIndexer $indexer,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Run after RequestTenantSubscriber clears tenant (-255). We
+            // need to drain BEFORE tenant clear because the indexer reads
+            // through the tenant filter when fetching CatalogObject rows.
+            // -200 is between the default (0) and the tenant clear (-255).
+            KernelEvents::TERMINATE => ['onKernelTerminate', -200],
+            ConsoleEvents::TERMINATE => 'onConsoleTerminate',
+        ];
+    }
+
+    public function onKernelTerminate(TerminateEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+        $this->flush();
+    }
+
+    public function onConsoleTerminate(ConsoleTerminateEvent $event): void
+    {
+        $this->flush();
+    }
+
+    private function flush(): void
+    {
+        if ($this->collector->isEmpty()) {
+            return;
+        }
+
+        $upsertIds = $this->collector->drainUpsertIds();
+        if ([] !== $upsertIds) {
+            $this->indexer->indexBatch($upsertIds);
+        }
+
+        $deletes = $this->collector->drainDeletes();
+        if ([] !== $deletes) {
+            $this->indexer->removeBatch($deletes);
+        }
+    }
+}

--- a/apps/api/src/Search/Application/CatalogIndexSubscriber.php
+++ b/apps/api/src/Search/Application/CatalogIndexSubscriber.php
@@ -13,29 +13,30 @@ use App\Catalog\Contracts\Event\ObjectPublished;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
- * Catalog → Search bridge (#50 / 0.5.2).
+ * Catalog → Search bridge (#50 / 0.5.2, batch-extended in PROD-03).
  *
- * Each domain event maps to one indexer call:
- *   - `ObjectCreated`/`ObjectAttributesChanged`/`ObjectEnabledChanged`/
- *     `ObjectPublished` → `CatalogObjectIndexer::index()` re-pushes the
- *     full document (Meilisearch upserts by primary key, so a single
- *     `addDocuments` covers create + partial update).
- *   - `ObjectArchived` → `CatalogObjectIndexer::remove()` drops the row
- *     so archived items never surface in search results.
+ * Each domain event used to call the indexer directly which translated
+ * into one Meilisearch HTTP request per affected row. Variant generation
+ * (16 axes) and category cascades (descendant moves) blew that up to
+ * N×Meili requests per HTTP call. PROD-03 routes events through a
+ * request-scoped {@see CatalogIndexCollector}; the matching
+ * {@see CatalogIndexFlushSubscriber} drains the buffer on
+ * `kernel.terminate` so Meili sees one batched call per kind per
+ * request, after the response is on the wire.
  *
- * Bulk path (CSV import, agent batch, demo seeder) skips indexing —
- * `BulkContext::isBulk()` flag set by the orchestrator. The bulk
- * handler dispatches `pim:search:reindex` (#51) once at the end of
- * its flush cycle.
+ * Bulk path (CSV import, agent batch, demo seeder) still skips entirely
+ * via {@see BulkContext::isBulk()} — the bulk handler dispatches
+ * `pim:search:reindex` (#51) once at the end of its flush cycle, so
+ * routing those events through the collector would just buffer ids that
+ * the bulk reindex covers anyway.
  *
- * Sync dispatch via `messenger.bus.default` keeps the indexer simple
- * for MVP. Async transport in Faza 1 (when sync 50k SKU benchmarks
- * show indexing latency dominates the write path).
+ * Sync dispatch via `messenger.bus.default` keeps the subscriber
+ * simple; the only async hop is the deferred Meili push on terminate.
  */
 final readonly class CatalogIndexSubscriber
 {
     public function __construct(
-        private CatalogObjectIndexer $indexer,
+        private CatalogIndexCollector $collector,
         private BulkContext $bulkContext,
     ) {
     }
@@ -46,7 +47,7 @@ final readonly class CatalogIndexSubscriber
         if ($this->bulkContext->isBulk()) {
             return;
         }
-        $this->indexer->index($event->objectId);
+        $this->collector->queueUpsert($event->objectId);
     }
 
     #[AsMessageHandler]
@@ -55,7 +56,7 @@ final readonly class CatalogIndexSubscriber
         if ($this->bulkContext->isBulk()) {
             return;
         }
-        $this->indexer->index($event->objectId);
+        $this->collector->queueUpsert($event->objectId);
     }
 
     #[AsMessageHandler]
@@ -64,7 +65,7 @@ final readonly class CatalogIndexSubscriber
         if ($this->bulkContext->isBulk()) {
             return;
         }
-        $this->indexer->index($event->objectId);
+        $this->collector->queueUpsert($event->objectId);
     }
 
     #[AsMessageHandler]
@@ -73,7 +74,7 @@ final readonly class CatalogIndexSubscriber
         if ($this->bulkContext->isBulk()) {
             return;
         }
-        $this->indexer->index($event->objectId);
+        $this->collector->queueUpsert($event->objectId);
     }
 
     #[AsMessageHandler]
@@ -82,11 +83,10 @@ final readonly class CatalogIndexSubscriber
         if ($this->bulkContext->isBulk()) {
             return;
         }
-        // Archive should hide the row from search; events carry no kind,
-        // so we re-fetch via the indexer's repository to read it.
-        // Fast path: just push the latest doc — Meili will surface it
-        // with `enabled=false` / `status=archived` and the read-side
-        // filters in #52 strip archived rows from results.
-        $this->indexer->index($event->objectId);
+        // Archive should hide the row from search. The event carries no
+        // kind, so we re-push the latest doc — Meili will surface it with
+        // `enabled=false` / `status=archived` and the read-side filters in
+        // #52 strip archived rows from results.
+        $this->collector->queueUpsert($event->objectId);
     }
 }

--- a/apps/api/src/Search/Application/CatalogObjectIndexer.php
+++ b/apps/api/src/Search/Application/CatalogObjectIndexer.php
@@ -35,6 +35,13 @@ use Throwable;
  */
 final readonly class CatalogObjectIndexer
 {
+    /**
+     * Hard cap per Meili HTTP call. The per-request collector
+     * (PROD-03) chunks large drains into multiple `addDocuments`
+     * calls so we never push more than this in one round-trip.
+     */
+    private const int BATCH_SIZE = 1000;
+
     private LoggerInterface $logger;
 
     public function __construct(
@@ -62,6 +69,61 @@ final readonly class CatalogObjectIndexer
         $this->push($object);
     }
 
+    /**
+     * PROD-03 — batch path used by {@see CatalogIndexFlushSubscriber}
+     * after a request finishes. Loads all objects in one query, groups
+     * by kind, then issues one `addDocuments` per kind (chunked at
+     * {@see self::BATCH_SIZE}). Single-object requests still go through
+     * {@see self::index()} so the existing call sites don't change.
+     *
+     * @param list<string> $idsRfc4122
+     */
+    public function indexBatch(array $idsRfc4122): void
+    {
+        if ([] === $idsRfc4122) {
+            return;
+        }
+
+        $objects = $this->catalogObjects->findByIds($idsRfc4122);
+        if ([] === $objects) {
+            return;
+        }
+
+        /** @var array<string, list<array<string, mixed>>> $byKind */
+        $byKind = [];
+        foreach ($objects as $object) {
+            $kind = $object->getKind();
+            if (ObjectKind::Custom === $kind) {
+                continue;
+            }
+            $byKind[$kind->value][] = $this->toDocument($object);
+        }
+
+        if ([] === $byKind) {
+            return;
+        }
+
+        $client = $this->clientFactory->create();
+        foreach ($byKind as $kindValue => $documents) {
+            $kind = ObjectKind::from($kindValue);
+            foreach (array_chunk($documents, self::BATCH_SIZE) as $chunk) {
+                try {
+                    $client->index(IndexSettingsTemplate::indexName($kind))->addDocuments($chunk);
+                } catch (Throwable $e) {
+                    // Fail-soft per chunk — search is a notification surface
+                    // (lessons #50). One Meili outage should not crash the
+                    // request; the next single-row event or scheduled
+                    // reindex will recover the document state.
+                    $this->logger->warning('Index batch push failed: {message}', [
+                        'message' => $e->getMessage(),
+                        'kind' => $kind->value,
+                        'count' => \count($chunk),
+                    ]);
+                }
+            }
+        }
+    }
+
     public function remove(Uuid $objectId, ObjectKind $kind): void
     {
         if (ObjectKind::Custom === $kind) {
@@ -77,6 +139,45 @@ final readonly class CatalogObjectIndexer
                 'id' => $objectId->toRfc4122(),
                 'kind' => $kind->value,
             ]);
+        }
+    }
+
+    /**
+     * PROD-03 — batch delete companion to {@see self::indexBatch()}.
+     *
+     * @param array<string, ObjectKind> $kindByIdRfc4122
+     */
+    public function removeBatch(array $kindByIdRfc4122): void
+    {
+        if ([] === $kindByIdRfc4122) {
+            return;
+        }
+
+        /** @var array<string, list<string>> $idsByKind */
+        $idsByKind = [];
+        foreach ($kindByIdRfc4122 as $id => $kind) {
+            if (ObjectKind::Custom === $kind) {
+                continue;
+            }
+            $idsByKind[$kind->value][] = $id;
+        }
+
+        if ([] === $idsByKind) {
+            return;
+        }
+
+        $client = $this->clientFactory->create();
+        foreach ($idsByKind as $kindValue => $ids) {
+            $kind = ObjectKind::from($kindValue);
+            try {
+                $client->index(IndexSettingsTemplate::indexName($kind))->deleteDocuments($ids);
+            } catch (Throwable $e) {
+                $this->logger->warning('Index batch delete failed: {message}', [
+                    'message' => $e->getMessage(),
+                    'kind' => $kind->value,
+                    'count' => \count($ids),
+                ]);
+            }
         }
     }
 

--- a/apps/api/src/Search/Application/CatalogObjectIndexer.php
+++ b/apps/api/src/Search/Application/CatalogObjectIndexer.php
@@ -103,17 +103,28 @@ final readonly class CatalogObjectIndexer
             return;
         }
 
-        $client = $this->clientFactory->create();
+        try {
+            $client = $this->clientFactory->create();
+        } catch (Throwable $e) {
+            // Fail-soft when Meilisearch is unreachable / unconfigured —
+            // search is a notification surface (lessons #50). The factory
+            // throws when MEILI_URL is missing (test envs) or when the
+            // hub is down; either way the next single-row event or the
+            // scheduled reindex will recover document state.
+            $this->logger->warning('Index batch push skipped — client unavailable: {message}', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
         foreach ($byKind as $kindValue => $documents) {
             $kind = ObjectKind::from($kindValue);
             foreach (array_chunk($documents, self::BATCH_SIZE) as $chunk) {
                 try {
                     $client->index(IndexSettingsTemplate::indexName($kind))->addDocuments($chunk);
                 } catch (Throwable $e) {
-                    // Fail-soft per chunk — search is a notification surface
-                    // (lessons #50). One Meili outage should not crash the
-                    // request; the next single-row event or scheduled
-                    // reindex will recover the document state.
+                    // Fail-soft per chunk — same rationale as above.
                     $this->logger->warning('Index batch push failed: {message}', [
                         'message' => $e->getMessage(),
                         'kind' => $kind->value,
@@ -166,7 +177,16 @@ final readonly class CatalogObjectIndexer
             return;
         }
 
-        $client = $this->clientFactory->create();
+        try {
+            $client = $this->clientFactory->create();
+        } catch (Throwable $e) {
+            $this->logger->warning('Index batch delete skipped — client unavailable: {message}', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
         foreach ($idsByKind as $kindValue => $ids) {
             $kind = ObjectKind::from($kindValue);
             try {

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
@@ -96,6 +96,11 @@ final class InMemoryCatalogObjectRepo implements CatalogObjectRepositoryInterfac
         return $this->objects[$id->toRfc4122()] ?? null;
     }
 
+    public function findByIds(array $idsRfc4122): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
     public function findByCode(string $code, ObjectKind $kind, Tenant $tenant): ?CatalogObject
     {
         throw new LogicException('not used in this test');

--- a/apps/api/tests/Unit/Channel/ChannelCategoryRootValidatorTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelCategoryRootValidatorTest.php
@@ -133,6 +133,11 @@ final class InMemoryCatalogObjectRepoForValidator implements CatalogObjectReposi
         return $this->objects[$id->toRfc4122()] ?? null;
     }
 
+    public function findByIds(array $idsRfc4122): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
     public function findByCode(string $code, ObjectKind $kind, Tenant $tenant): ?CatalogObject
     {
         throw new LogicException('not used in this test');

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -151,6 +151,11 @@ final class InMemoryCatalogObjectRepository implements CatalogObjectRepositoryIn
         return null;
     }
 
+    public function findByIds(array $idsRfc4122): array
+    {
+        return [];
+    }
+
     public function findByKind(ObjectKind $kind, Tenant $tenant): array
     {
         return [];

--- a/apps/api/tests/Unit/Search/Application/CatalogIndexCollectorTest.php
+++ b/apps/api/tests/Unit/Search/Application/CatalogIndexCollectorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Search\Application;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Search\Application\CatalogIndexCollector;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * PROD-03 — collector dedup + supersede semantics.
+ */
+final class CatalogIndexCollectorTest extends TestCase
+{
+    #[Test]
+    public function emptyCollectorDrainsToEmptyArrays(): void
+    {
+        $c = new CatalogIndexCollector();
+
+        self::assertTrue($c->isEmpty());
+        self::assertSame([], $c->drainUpsertIds());
+        self::assertSame([], $c->drainDeletes());
+    }
+
+    #[Test]
+    public function repeatedUpsertsForTheSameIdDedupToSingleEntry(): void
+    {
+        $c = new CatalogIndexCollector();
+        $id = Uuid::v7();
+
+        $c->queueUpsert($id);
+        $c->queueUpsert($id);
+        $c->queueUpsert($id);
+
+        self::assertFalse($c->isEmpty());
+        self::assertSame([$id->toRfc4122()], $c->drainUpsertIds());
+    }
+
+    #[Test]
+    public function deleteSupersedesPendingUpsert(): void
+    {
+        $c = new CatalogIndexCollector();
+        $id = Uuid::v7();
+
+        $c->queueUpsert($id);
+        $c->queueDelete($id, ObjectKind::Product);
+
+        self::assertSame([], $c->drainUpsertIds(), 'upsert must be dropped when a delete lands later');
+        self::assertSame([$id->toRfc4122() => ObjectKind::Product], $c->drainDeletes());
+    }
+
+    #[Test]
+    public function upsertSupersedesPendingDelete(): void
+    {
+        $c = new CatalogIndexCollector();
+        $id = Uuid::v7();
+
+        $c->queueDelete($id, ObjectKind::Product);
+        $c->queueUpsert($id);
+
+        self::assertSame([], $c->drainDeletes(), 'delete must be dropped when an upsert lands later (recreate flow)');
+        self::assertSame([$id->toRfc4122()], $c->drainUpsertIds());
+    }
+
+    #[Test]
+    public function drainEmptiesTheBuffer(): void
+    {
+        $c = new CatalogIndexCollector();
+        $id = Uuid::v7();
+        $c->queueUpsert($id);
+
+        $c->drainUpsertIds();
+
+        self::assertTrue($c->isEmpty());
+        self::assertSame([], $c->drainUpsertIds());
+    }
+
+    #[Test]
+    public function resetClearsBothBuffers(): void
+    {
+        $c = new CatalogIndexCollector();
+        $a = Uuid::v7();
+        $b = Uuid::v7();
+        $c->queueUpsert($a);
+        $c->queueDelete($b, ObjectKind::Category);
+
+        $c->reset();
+
+        self::assertTrue($c->isEmpty());
+        self::assertSame([], $c->drainUpsertIds());
+        self::assertSame([], $c->drainDeletes());
+    }
+}


### PR DESCRIPTION
## Cel

Single-edit flow do tej pory wołał `CatalogObjectIndexer::index()` per domain event — co przekładało się na **1 HTTP round-trip do Meilisearch per dotknięty obiekt**. Variant generation (16 osi) i kategorie cascade (descendant moves) podnosiły to do N×Meili requests per HTTP call.

## Co się zmienia

### Nowa orkiestracja indeksowania per request

| Komponent | Rola |
|---|---|
| `CatalogIndexCollector` | request-scoped buffer (`ResetInterface` żeby FrankenPHP worker nie leakował id między requestami). Dedupe + supersede semantics: `delete` po `upsert` w tym samym requeście drop-uje upsert; `upsert` po `delete` drop-uje delete (recreate flow) |
| `CatalogIndexSubscriber` | event handlery wpychają id do collector-a zamiast indexer.index() per row. **Bulk path (BulkContext::isBulk) nadal skip-uje entirely** — `pim:search:reindex` po imporcie dalej jest canonical 'one batch per kind' path |
| `CatalogObjectIndexer::indexBatch / removeBatch` | jeden repo query → group by kind → jeden `addDocuments` / `deleteDocuments` per kind, chunked do 1000. Error per chunk (search to notification surface — lessons #50) |
| `CatalogIndexFlushSubscriber` | drain na `kernel.terminate` (priority -200, przed tenant clear -255) + `console.terminate`. Failures NIE mogą bąbelkować na terminate (response już w kabelku) |
| `CatalogObjectRepository::findByIds` | batch fetch po RFC4122 ids — używany przez `indexBatch` path. Empty in → empty out (zero query). In-memory test repos zaktualizowane do nowego interface |

### Wzorzec użycia

```text
HTTP PATCH /api/products/X (1 produkt z 12 wariantami)
  → ObjectAttributesChanged × 12 events
  → collector.queueUpsert × 12 (deduped do 12 unique id)
  → response wysłana
  → kernel.terminate
  → indexer.indexBatch([12 ids])
  → 1 SQL query (CatalogObject.findByIds) + 1 Meili addDocuments per kind
```

Przed: 12 SQL queries + 12 Meili HTTP calls.
Po: 1 SQL + 1 Meili call (per kind).

## Test plan

- [x] 6 unit testów `CatalogIndexCollectorTest` (dedup, upsert↔delete supersede, drain, reset)
- [x] Existing `tests/Api/Search` (3 tests, 8 assertions) — nadal zielone
- [x] PHPStan max — bez errorów
- [x] In-memory repo test stubs (`InMemoryCatalogObjectRepo`, `InMemoryCatalogObjectRepoForValidator`, `InMemoryCatalogObjectRepository`) zaktualizowane do nowego `findByIds`
- [ ] Manual smoke test (do walidacji po merge):
  1. Edytuj produkt z 12 wariantami w UI → przed merge widać 12+ POST/UPDATE do Meili w `docker logs meilisearch`; po merge powinien być 1 batched `addDocuments`.
  2. Move category z 100 descendants → przed = 100 Meili calls; po = 1 batched call per kind.
  3. Bulk import 50k SKU (ścieżka BulkContext) → ZACHOWUJE existing 'reindex command at end' behavior (subscriber skip-uje, flush listener nic nie znajduje w collectorze).

## Świadome odejścia

- Brak integration testu z prawdziwym Meili w PHPUnit (Meili infra w CI byłaby duplikacją testów `Api/Search`). Wystarczające jest verification że collector logic jest poprawna (unit) + existing API tests przechodzą (Meili stubbed lub real w env=test).
- Brak metryki do Prometheus 'avg index calls per request' — to wpada w PROD-04 (osobny PR z worker memory + meili throughput counters).
- TerminateEvent priorytet -200 wybrany żeby zmieścić się PRZED clear-em tenant filter (-255). Gdyby kiedyś dochodził subscriber który clear-uje JWT token na terminate z priorytetem między -200 a -255 — wymagałby revisit.

Refs: capacity-planning analiza z 2026-05-12 (PROD-01..05 marathon). Stack: PROD-01 (#526) i PROD-02 (#527) to prod-overlay infra zmiany, ten PR to PHP-side change na main.