### PR TITLE
feat(infra): Prometheus + Alertmanager z FrankenPHP worker-memory alertem (PROD-04)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,9 @@
 # Subsequent overlays (kept in this same file for a single-source prod
 # topology):
 #   - PROD-02 (THIS FILE): PgBouncer in transaction mode in front of Postgres.
-#   - PROD-04: Prometheus scrape target + worker-memory alert rules.
+#   - PROD-04 (THIS FILE): Prometheus + Alertmanager scraping the existing
+#     /api/metrics endpoint with the FrankenPHP worker-memory alert
+#     CLAUDE.md §3.10 demands.
 #
 # PROD-02 detail:
 # Without PgBouncer, every FrankenPHP / messenger worker holds a long-lived
@@ -212,3 +214,81 @@ services:
       timeout: 3s
       retries: 5
       start_period: 15s
+
+  # ─── Prometheus (metrics scrape + alerting) ───────────────────────────────
+  #
+  # PROD-04. The Symfony API already exposes Prometheus-format metrics on
+  # /api/metrics (frankenphp_worker_memory_bytes, db_query_duration_seconds
+  # histogram). Prometheus scrapes through the edge Caddy → api routing,
+  # evaluates the alert rules in alerts.yml, and pushes firing groups to
+  # alertmanager below.
+  #
+  # The 256 MiB worker-memory ceiling lives in alerts.yml as
+  # FrankenphpWorkerMemoryHigh — CLAUDE.md §3.10 calls this out as the
+  # MUST-have monitoring before bulk operations ship to prod.
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.5"
+    depends_on:
+      api:
+        condition: service_healthy
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./docker/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+    expose:
+      - "9090"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:9090/-/healthy"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 30s
+
+  # ─── Alertmanager (routes Prometheus alerts to receivers) ─────────────────
+  #
+  # PROD-04. Minimal config that groups + dedupes alerts. ALERTMANAGER_WEBHOOK_URL
+  # in env points at the operator's choice of receiver (PagerDuty / Slack /
+  # Opsgenie / generic webhook). Default is example.invalid so an unconfigured
+  # deploy fails loudly during smoke instead of silently swallowing alerts.
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: "0.25"
+    environment:
+      ALERTMANAGER_WEBHOOK_URL: ${ALERTMANAGER_WEBHOOK_URL:-http://example.invalid/}
+    volumes:
+      - ./docker/prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager_data:/alertmanager
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+    expose:
+      - "9093"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:9093/-/healthy"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
+
+# Named volumes for monitoring state. Add to the prod overlay only — base
+# compose stays free of monitoring infrastructure (devs use Symfony's web
+# profiler instead of Prometheus locally).
+volumes:
+  prometheus_data:
+  alertmanager_data:

--- a/docker/prometheus/alertmanager.yml
+++ b/docker/prometheus/alertmanager.yml
@@ -1,0 +1,40 @@
+# Alertmanager routing config for the prod stack.
+#
+# PROD-04 — minimal config that groups + dedupes alerts and routes to
+# a single webhook receiver. The webhook URL is read from environment
+# (set via Compose secrets / .env on the prod host) so this file can
+# stay in version control without leaking the destination.
+#
+# Add real receivers (PagerDuty, Slack, Opsgenie) by extending the
+# `receivers:` block — Alertmanager docs:
+# https://prometheus.io/docs/alerting/latest/configuration/
+
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: default-webhook
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity = critical
+      receiver: default-webhook
+      repeat_interval: 1h
+
+receivers:
+  - name: default-webhook
+    webhook_configs:
+      - url: ${ALERTMANAGER_WEBHOOK_URL:-http://example.invalid/}
+        send_resolved: true
+
+inhibit_rules:
+  # Suppress the warning lane while the matching critical is firing —
+  # avoids paging twice for the same condition.
+  - source_matchers:
+      - severity = critical
+    target_matchers:
+      - severity = warning
+    equal: ["alertname"]

--- a/docker/prometheus/alerts.yml
+++ b/docker/prometheus/alerts.yml
@@ -1,0 +1,66 @@
+# Prometheus alert rules for the prod stack.
+#
+# PROD-04 — covers the architectural guard-rails CLAUDE.md §3.10 calls
+# out as MUST-have monitoring before bulk operations ship to prod.
+groups:
+  - name: pim-frankenphp-memory
+    interval: 30s
+    rules:
+      # Hard guard-rail per CLAUDE.md §3.10. Any worker crossing 256 MiB
+      # is a near-certain Doctrine Identity Map leak (or a missing
+      # EntityManager::clear() inside a long-running handler). Five
+      # consecutive minutes above threshold = real leak, not a noisy
+      # one-off scrape.
+      - alert: FrankenphpWorkerMemoryHigh
+        expr: max_over_time(frankenphp_worker_memory_bytes[5m]) > (256 * 1024 * 1024)
+        for: 5m
+        labels:
+          severity: critical
+          runbook: docs/runbook/disaster-recovery.md
+        annotations:
+          summary: "FrankenPHP worker memory above 256 MiB"
+          description: |
+            One or more FrankenPHP workers crossed the 256 MiB memory
+            ceiling for at least 5 minutes (current rolling max:
+            {{ $value | humanize1024 }}).
+
+            CLAUDE.md §3.10 flags this as a Doctrine Identity Map leak
+            indicator — Messenger handler is missing EntityManager::clear()
+            after flush() in a batch loop, or AbstractBatchHandler is not
+            being inherited.
+
+      # Early-warning lane. 192 MiB = 75% of the hard ceiling. Lower
+      # severity, longer window — gives an oncall heads-up before the
+      # critical alert fires.
+      - alert: FrankenphpWorkerMemoryRising
+        expr: max_over_time(frankenphp_worker_memory_bytes[15m]) > (192 * 1024 * 1024)
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "FrankenPHP worker memory trending toward the 256 MiB ceiling"
+          description: |
+            Rolling 15m max of frankenphp_worker_memory_bytes is above
+            75% of the hard ceiling for at least 15 minutes (current:
+            {{ $value | humanize1024 }}). Investigate before the
+            critical FrankenphpWorkerMemoryHigh alert fires.
+
+  - name: pim-db-latency
+    interval: 30s
+    rules:
+      # Slow-query smoke alarm. Backed by db_query_duration_seconds
+      # histogram emitted from QueryTimingMiddleware (audit MEDIUM-003).
+      # 0.5s p99 is generous for read paths; tighter thresholds belong
+      # in tier-specific alerts once we have per-route labels.
+      - alert: DbQueryP99Slow
+        expr: histogram_quantile(0.99, sum by (le) (rate(db_query_duration_seconds_bucket[5m]))) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Doctrine DBAL p99 query latency above 500 ms"
+          description: |
+            p99 of db_query_duration_seconds is above 500 ms over the
+            past 10 minutes. Check pg_stat_statements for the offender
+            and the PgBouncer admin console (port 6432) for connection
+            pool saturation.

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,42 @@
+# Prometheus scrape + alert config for the prod stack.
+#
+# PROD-04 — surfaces the FrankenPHP worker-memory ceiling that
+# CLAUDE.md §3.10 flags as the highest-risk class of regression
+# (Doctrine Identity Map drift inside a long-running worker → OOM).
+# Companion alert rules live in alerts.yml.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    stack: pim
+    env: prod
+
+rule_files:
+  - "/etc/prometheus/alerts.yml"
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: "pim-api"
+    metrics_path: /api/metrics
+    # Scraping the public Caddy hostname produces a fresh worker pick per
+    # scrape (random LB across the worker pool). The rolling-max alert
+    # rule in alerts.yml makes that randomness acceptable.
+    scheme: http
+    static_configs:
+      - targets: ["api:80"]
+        labels:
+          service: api
+          # The MetricsController also exposes db_query_duration_seconds —
+          # the same job covers both. Per-target relabeling is overkill at
+          # the single-API-service scale.
+          tier: web
+
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]


### PR DESCRIPTION
> **Stack:** based on #527 (PROD-02). Po merdze PROD-01 i PROD-02 → rebase tej PR na main.

## Cel

CLAUDE.md §3.10 wymaga Prometheus alertu na `frankenphp_worker_memory_bytes > 256MB` jako MUST-have monitoring przed shippowaniem bulk operacji do prod. `MetricsController` już eksponuje tę metrykę (i `db_query_duration_seconds` histogram z audit MEDIUM-003) na `/api/metrics` — ten PR dowozi consumerów.

## Co się zmienia

### `docker-compose.prod.yml`

| Service | Image | Rola |
|---|---|---|
| `prometheus` | `prom/prometheus:v2.55.1` | scrape `api:80/api/metrics` co 15s; ewaluacja rule files; push do alertmanager. 15-day retention + `--web.enable-lifecycle` (runtime rule reload) |
| `alertmanager` | `prom/alertmanager:v0.27.0` | group + dedupe + webhook receiver. `ALERTMANAGER_WEBHOOK_URL` env → operator's choice (PagerDuty/Slack/Opsgenie/generic). Default `example.invalid` żeby unconfigured deploy failował loudly podczas smoke |

### `docker/prometheus/`

- **`prometheus.yml`** — single scrape job `pim-api` celujący w `api:80`. Per-target labels `service: api`, `tier: web` na potrzeby query rozszerzeń.
- **`alerts.yml`** — trzy reguły:
  - **`FrankenphpWorkerMemoryHigh`** (critical) — `max_over_time(frankenphp_worker_memory_bytes[5m]) > 256 MiB` for 5m. Hard guard-rail per CLAUDE.md §3.10. Annotation linkuje do `docs/runbook/disaster-recovery.md` + tłumaczy „missing EntityManager::clear() w batch handlerze".
  - **`FrankenphpWorkerMemoryRising`** (warning) — 75% threshold (192 MiB) for 15m. Early-warning lane przed critical alertem.
  - **`DbQueryP99Slow`** (warning) — `histogram_quantile(0.99, sum by (le)(rate(db_query_duration_seconds_bucket[5m]))) > 0.5s` for 10m. Smoke alarm na slow queries; podpięty pod istniejący audit MEDIUM-003 histogram z `QueryTimingMiddleware`.
- **`alertmanager.yml`** — minimal grouping config + inhibition rule (critical suppress-uje warning na tym samym `alertname`).

## Notatki

- **Worker container nie jest scrape'owany** — workers to CLI processes bez HTTP endpointu. Memory bounded przez `--memory-limit=256M` z PROD-01 → self-recycle przed osiągnięciem threshold-a. Container-level RSS via cadvisor/node_exporter to follow-up.
- **Skala scrapów = single-API-service** — z multiple FrankenPHP workers per container, każdy scrape trafia w randomowego workera (LB). Alert `max_over_time` rolling window absorb-uje randomność.
- **Webhook URL** — `ALERTMANAGER_WEBHOOK_URL` musi być ustawiony na real prod hostie (przez `.env` lub Compose secrets). Default `example.invalid` jest celowy.

## Test plan

- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yml config --quiet` → exit 0
- [x] Rendered: prometheus + alertmanager services rendered z poprawnymi volume mountami i healthcheckami
- [x] Rendered: nowe volumes `pim_prometheus_data`, `pim_alertmanager_data` zarejestrowane
- [ ] Manual smoke (po pierwszym prod deployu):
  1. `docker compose ps prometheus alertmanager` → both `healthy`
  2. Curl `http://prometheus:9090/api/v1/targets` → `pim-api` job UP
  3. Promtool: `promtool check rules /etc/prometheus/alerts.yml` → 3 rules valid
  4. Force trigger: `kill -USR1 <api-pid>` (dump symbol table → memory spike) lub `php -r 'while (true) \$x[] = str_repeat(\"a\", 1024*1024);'` w api → po 5min FrankenphpWorkerMemoryHigh fires → webhook hit

## Świadome odejścia

- Brak Grafana — Prometheus UI sam w sobie wystarczy do oncall query/expression. Grafana dashboards = follow-up gdy będzie >5 metryk wartych panelu.
- Brak cAdvisor / node_exporter — container-level + host metrics w follow-up gdy operator zdecyduje o real prod hosting (k8s vs bare metal docker).
- Brak `pgbouncer_exporter` — PgBouncer admin console pokazuje pool state (`SHOW POOLS`) which is enough dla MVP ops triage.
- Brak Alertmanager + PagerDuty/Slack receiver — to per-deploy decyzja operatora (env var, nie hardcoded).

Refs: capacity-planning analiza z 2026-05-12 (PROD-01..05 marathon). CLAUDE.md §3.10 (memory management). Stack base: #527.