### PR TITLE
feat(import): per-tenant bulk operation concurrency lock (PROD-05)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -45,6 +45,7 @@ RUN apk add --no-cache \
         opcache \
         pcntl \
         pdo_pgsql \
+        redis \
         zip
 
 COPY frankenphp/Caddyfile /etc/frankenphp/Caddyfile

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -15,6 +15,8 @@ use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
 use App\Import\Domain\ReservedMappingTarget;
 use App\Import\Domain\ValueObject\ValidationError;
 use App\Shared\Application\AbstractBatchHandler;
+use App\Shared\Application\BulkOperationInProgressException;
+use App\Shared\Application\BulkOperationLock;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
@@ -23,6 +25,7 @@ use League\Flysystem\FilesystemOperator;
 use LogicException;
 use RuntimeException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Throwable;
 
 use const PATHINFO_EXTENSION;
@@ -54,6 +57,7 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly ImportProgressPublisher $progressPublisher,
         private readonly TenantContext $tenantContext,
         private readonly FilesystemOperator $importsStorage,
+        private readonly BulkOperationLock $bulkLock,
         int $batchSize = 200,
     ) {
         parent::__construct($entityManager, $batchSize);
@@ -75,7 +79,19 @@ final class ImportRunHandler extends AbstractBatchHandler
         }
 
         $this->tenantContext->set($tenant);
-        $this->run($session);
+
+        try {
+            $this->run($session);
+        } catch (BulkOperationInProgressException $exception) {
+            // PROD-05 — Messenger entry point: re-throw as recoverable so
+            // the queue retries with backoff instead of dead-lettering.
+            // The synchronous controller path in StartImportController
+            // catches the same domain exception and returns HTTP 409.
+            throw new RecoverableMessageHandlingException(
+                $exception->getMessage().' Will retry.',
+                previous: $exception,
+            );
+        }
     }
 
     /**
@@ -93,11 +109,23 @@ final class ImportRunHandler extends AbstractBatchHandler
             return;
         }
 
+        // PROD-05 — at-most-one bulk job per tenant. Non-blocking acquire;
+        // on collision raise a domain exception so the caller decides
+        // (controller -> 409 Conflict, async handler -> recoverable
+        // retry). ImportSession status stays `pending` so the operator
+        // sees the job is waiting, not dropped.
+        $lock = $this->bulkLock->acquire($tenant);
+        if (null === $lock) {
+            throw new BulkOperationInProgressException($tenant);
+        }
+
         try {
             $session->markRunning();
             $this->sessions->save($session);
         } catch (LogicException $exception) {
             // Already running / paused / failed — bail without state churn.
+            $lock->release();
+
             return;
         }
 
@@ -206,6 +234,7 @@ final class ImportRunHandler extends AbstractBatchHandler
             if (null !== $sourcePath && file_exists($sourcePath)) {
                 @unlink($sourcePath);
             }
+            $lock->release();
         }
     }
 

--- a/apps/api/src/Import/Presentation/Controller/StartImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/StartImportController.php
@@ -13,6 +13,7 @@ use App\Import\Domain\Entity\ImportSession;
 use App\Import\Domain\Message\ImportRunMessage;
 use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
 use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Shared\Application\BulkOperationInProgressException;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use DateTimeInterface;
@@ -26,6 +27,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -137,7 +139,15 @@ final class StartImportController
         if ($session->getFileSizeBytes() <= self::SYNC_THRESHOLD_ROWS * 1024) {
             $reload = $this->sessions->findById($session->getId());
             if ($reload instanceof ImportSession) {
-                $this->runHandler->run($reload);
+                try {
+                    $this->runHandler->run($reload);
+                } catch (BulkOperationInProgressException $exception) {
+                    // PROD-05 — translate the domain collision into a 409
+                    // so the operator sees a clear conflict response. The
+                    // ImportSession row stays `pending`; user can retry
+                    // once the in-flight bulk job releases the lock.
+                    throw new ConflictHttpException($exception->getMessage(), $exception);
+                }
                 $reload = $this->sessions->findById($session->getId()) ?? $reload;
 
                 return new JsonResponse(

--- a/apps/api/src/Shared/Application/BulkOperationInProgressException.php
+++ b/apps/api/src/Shared/Application/BulkOperationInProgressException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+use App\Shared\Domain\Tenant;
+use RuntimeException;
+
+/**
+ * PROD-05 — thrown by code paths gated by {@see BulkOperationLock} when
+ * the tenant already has an in-flight bulk job. Callers translate this
+ * into the right surface: the synchronous controller path returns HTTP
+ * 409, the async Messenger handler re-throws as
+ * `RecoverableMessageHandlingException` so the queue retries with the
+ * configured backoff.
+ */
+final class BulkOperationInProgressException extends RuntimeException
+{
+    public function __construct(public readonly Tenant $tenant)
+    {
+        parent::__construct(\sprintf(
+            'Tenant "%s" already has a bulk operation in progress.',
+            $tenant->getId()->toRfc4122(),
+        ));
+    }
+}

--- a/apps/api/src/Shared/Application/BulkOperationLock.php
+++ b/apps/api/src/Shared/Application/BulkOperationLock.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+
+/**
+ * PROD-05 — at-most-one bulk operation per tenant.
+ *
+ * Bulk handlers (import, attributes_indexed rebuild, snapshot) hold the
+ * Postgres connection pool, the Meilisearch index, and the FrankenPHP
+ * worker memory budget for the duration of a job. Two concurrent bulk
+ * jobs from the same tenant — same operator clicking import twice, two
+ * operators within the same org — multiply that footprint with no
+ * matching benefit and create races on the per-row `attributes_indexed`
+ * write path.
+ *
+ * Implementation: Symfony Lock keyed `bulk-op:{tenantId}`. Non-blocking
+ * acquire so a contending handler returns immediately and the caller
+ * decides whether to retry (Messenger {@see RecoverableMessageHandlingException})
+ * or surface a domain-specific status (`ImportSession::pause`).
+ *
+ * TTL is set to 1h: long enough for the largest realistic single-tenant
+ * import (5k SKU at 50 ms/row ≈ 4 min, with headroom for outliers); short
+ * enough that a crashed worker frees the lock before it blocks the
+ * tenant's next operation past the operator's patience.
+ *
+ * Backend swaps via {@see LOCK_DSN} env: `flock` for single-container dev,
+ * `redis://redis:6379` in prod so the lock is shared across the API
+ * pool + Messenger worker pool. Configured in docker-compose.prod.yml
+ * (PROD-05 overlay extension).
+ */
+final readonly class BulkOperationLock
+{
+    /**
+     * Auto-release after 1h to recover from a crashed worker that did
+     * not run its `finally { release() }` block. {@see LockInterface}'s
+     * heartbeat extends the TTL while the holder process is alive.
+     */
+    private const float TTL_SECONDS = 3600.0;
+
+    public function __construct(
+        private LockFactory $lockFactory,
+    ) {
+    }
+
+    /**
+     * @return LockInterface|null null when another worker already holds
+     *                            the lock for this tenant; never blocks
+     */
+    public function acquire(Tenant $tenant): ?LockInterface
+    {
+        $lock = $this->lockFactory->createLock(
+            self::keyFor($tenant),
+            ttl: self::TTL_SECONDS,
+            autoRelease: true,
+        );
+
+        if (false === $lock->acquire(blocking: false)) {
+            return null;
+        }
+
+        return $lock;
+    }
+
+    public static function keyFor(Tenant $tenant): string
+    {
+        return 'bulk-op:'.$tenant->getId()->toRfc4122();
+    }
+}

--- a/apps/api/tests/Unit/Shared/Application/BulkOperationLockTest.php
+++ b/apps/api/tests/Unit/Shared/Application/BulkOperationLockTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Application;
+
+use App\Shared\Application\BulkOperationLock;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
+
+/**
+ * PROD-05 — confirms the per-tenant lock acquires once, blocks the
+ * second attempt, and releases cleanly so the next call succeeds.
+ *
+ * In-memory store is used here so the test does not depend on a real
+ * Redis or Postgres advisory store; the real-store behaviour is
+ * exercised by the integration suite via the actual messenger handler
+ * roundtrip.
+ */
+final class BulkOperationLockTest extends TestCase
+{
+    #[Test]
+    public function acquireSucceedsOnceAndBlocksConcurrentSecondAttempt(): void
+    {
+        $factory = new LockFactory(new InMemoryStore());
+        $lockService = new BulkOperationLock($factory);
+        $tenant = new Tenant('demo', 'Demo');
+
+        $first = $lockService->acquire($tenant);
+        self::assertNotNull($first, 'first acquire must succeed');
+
+        $second = $lockService->acquire($tenant);
+        self::assertNull($second, 'second acquire on the same tenant must fail (non-blocking)');
+
+        $first->release();
+
+        $third = $lockService->acquire($tenant);
+        self::assertNotNull($third, 'after release the next acquire must succeed');
+        $third->release();
+    }
+
+    #[Test]
+    public function differentTenantsHoldIndependentLocks(): void
+    {
+        $factory = new LockFactory(new InMemoryStore());
+        $lockService = new BulkOperationLock($factory);
+
+        $tenantA = new Tenant('a', 'Tenant A');
+        $tenantB = new Tenant('b', 'Tenant B');
+
+        $lockA = $lockService->acquire($tenantA);
+        $lockB = $lockService->acquire($tenantB);
+
+        self::assertNotNull($lockA);
+        self::assertNotNull($lockB, 'different tenants must not contend on the same key');
+
+        $lockA->release();
+        $lockB->release();
+    }
+
+    #[Test]
+    public function keyForReturnsStableTenantScopedKey(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $key = BulkOperationLock::keyFor($tenant);
+
+        self::assertStringStartsWith('bulk-op:', $key);
+        self::assertSame($key, BulkOperationLock::keyFor($tenant), 'key must be deterministic');
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -63,6 +63,11 @@ services:
       # PROD-02: re-route the web tier through PgBouncer (port 6432) so the
       # process pool multiplexes onto a small backend connection pool.
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@pgbouncer:6432/${POSTGRES_DB:-app}?serverVersion=16&charset=utf8&application_name=pim_api
+      # PROD-05: shared lock store across the api + worker pools. The base
+      # file uses 'flock', which only works inside a single container — a
+      # Messenger worker container would never see a lock acquired by the
+      # api container. Redis is already part of the base stack.
+      LOCK_DSN: redis://redis:6379
 
   # ─── Symfony Messenger worker pool ────────────────────────────────────────
   #
@@ -102,6 +107,9 @@ services:
       # application_name shows up in pg_stat_activity for triage.
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@pgbouncer:6432/${POSTGRES_DB:-app}?serverVersion=16&charset=utf8&application_name=pim_api
       MESSENGER_TRANSPORT_DSN: doctrine://default?queue_name=async&auto_setup=0
+      # PROD-05: same shared lock store as the api container so the
+      # worker sees locks acquired by inline imports and vice-versa.
+      LOCK_DSN: redis://redis:6379
       MERCURE_URL: http://mercure/.well-known/mercure
       MERCURE_PUBLIC_URL: ${MERCURE_PUBLIC_URL:-https://pim.localhost/.well-known/mercure}
       MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:-!ChangeMercureKeyAtLeast256BitsLong!}


### PR DESCRIPTION
> **Stack:** based on #529 (PROD-04). Po merdze PROD-01..04 → rebase tej PR na main.

## Cel

Dwa równoległe bulk importy dla jednego tenanta podwajają footprint connection pool, contendują na per-row `attributes_indexed` write path i myślą operatora (która sesja jest „prawdziwa"?). Fix: at-most-one bulk job per tenant via Symfony Lock keyed `bulk-op:{tenantId}`.

## Co się zmienia

### Shared building blocks

| Plik | Rola |
|---|---|
| `App\Shared\Application\BulkOperationLock` | non-blocking acquire + 1h TTL (auto-release safety net dla crashed workers). Zwraca `LockInterface` żeby handler kontrolował release timing |
| `App\Shared\Application\BulkOperationInProgressException` | domain collision exception. Caller decyduje translation (HTTP 409 vs Messenger recoverable retry) |

### Wiring — `ImportRunHandler`

```php
public function run(ImportSession $session): void {
    $lock = $this->bulkLock->acquire($tenant);
    if (null === $lock) {
        throw new BulkOperationInProgressException($tenant);
    }
    try { /* ...existing run logic... */ }
    finally { $lock->release(); }
}
```

Dwie ścieżki tłumaczenia exception:
- **`ImportRunHandler::__invoke()`** (async messenger) → wraps w `RecoverableMessageHandlingException` → Messenger retries z backoff zamiast dead-letteringować
- **`StartImportController` inline (<50 row sync path)** → `ConflictHttpException` (HTTP 409) → operator widzi conflict natychmiast zamiast 500

### Infra (`docker-compose.prod.yml`)

- `LOCK_DSN: redis://redis:6379` na api + worker — base file używa `flock` które działa tylko w jednym kontenerze; worker container nigdy nie zobaczyłby locka acquired przez api
- `apps/api/Dockerfile`: `install-php-extensions redis` (jeden line dodatkowy, image rebuild required)

## Test plan

- [x] 3 unit testy `BulkOperationLockTest` (acquire/conflict/release/different-tenant-independence/key-stability) — `LockFactory + InMemoryStore` żeby unit nie wymagał Redis
- [x] PHPStan max — clean
- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yml config --quiet` → exit 0
- [x] Rendered: `LOCK_DSN: redis://redis:6379` na api **i** worker
- [ ] Manual smoke (do walidacji po pierwszym prod deploy):
  1. Trigger import z UI dla tenanta X (long-running, ≥10 min)
  2. W innym tabie trigger import dla tenanta X — powinien zwrócić HTTP 409 z `BulkOperationInProgressException::message`
  3. Trigger import dla tenanta Y (other tenant) — powinien start normalnie, niezależnie od X

## Świadome odejścia

- **Nie locking `RebuildAttributesIndexedHandler`** — message nie nosi tenant id i rebuild to downstream tail jednego importu, więc lockowanie samego importu pokrywa concurrency intent. Follow-up jeśli pojawi się nowy non-import dispatch path.
- **Nie locking `BackupSnapshotHandler`** — backup to per-system op (nie per-tenant), więc per-tenant lock semantics nie applies.
- **Brak migracji `lock_keys` table** — używamy redis store zamiast DBAL (PgBouncer transaction mode jest niekompatybilny z `pg_advisory_lock` które używa Symfony PostgresqlStore).
- **TTL = 1h hardcoded** w `BulkOperationLock::TTL_SECONDS`. Jeśli kiedyś ktoś będzie miał import >1h to lock wygasa i drugi może wskoczyć. Operator alert na metryce „import duration > 30 min" to follow-up.

Refs: capacity-planning analiza z 2026-05-12 (PROD-01..05 marathon). Stack base: #529.