### PR TITLE
feat(dev): auto-seed admin user on container start

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,22 @@
 # Current Status
 
+## 2026-05-13: PR #533 — auto-seed admin user na container start (DEV-QOL)
+
+**Branch:** `dev/auto-seed-on-container-start`
+**PR:** [#533](https://github.com/malipie/PIM/pull/533) (CI w toku w momencie commit'u tego statusu)
+
+**Powód**: powtarzający się class incidentów „login broken po wipe" (po `pim:db:reset`, `docker compose down -v`, big rebase'ie). Operator widział `Nieprawidłowy e-mail lub hasło` toast — technicznie poprawny, ale wygląda jak bug.
+
+**Co dostarczono**:
+- `pim:dev:ensure-seeded` — idempotentna komenda console (decision tree: pusta DB → reset+fixtures, populated DB bez admin → warning+exit 0, admin obecny → noop). Skipuje na `APP_ENV=prod`.
+- `apps/api/docker-entrypoint.sh` — wrapper FrankenPHP entrypoint odpalający ensure-seeded raz przed `exec frankenphp run`. Best-effort: api wstaje mimo failure seed.
+- `apps/api/Dockerfile` — `COPY` entrypointu, `ENTRYPOINT` + `CMD` zachowujące upstream `frankenphp run …`.
+- **Pre-existing bug fix** w `DatabaseResetCommand`: nested `ArrayInput` musiał mieć `setInteractive(false)` przed `run()`, inaczej `doctrine:fixtures:load` cicho cancelował się na purge prompt (default `[no]`) a parent reportował success. Inne chained commands miały default `[yes]` więc nie były dotknięte. Lekcja → lessons.md.
+
+**Smoke E2E**: drop pim → recreate empty → restart api → entrypoint odpalił reset+fixtures → POST `/api/auth/login` HTTP 200 + JWT. Idempotency: re-restart na populated DB = silent noop (`--quiet-when-noop`).
+
+---
+
 ## 2026-05-12: Epik UI-11 — Importy redesign **DOMKNIĘTY** (8 PR-ów merged, marathon ~24h)
 
 **Merged commits w kolejności:**

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,38 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z PR #533 (auto-seed admin user, 2026-05-13)
+
+1. **Nested `ArrayInput` w chained Symfony Console commands MUSI mieć explicit `setInteractive(false)`** — inaczej `--no-interaction` outer call NIE propaguje się do inner. Symptom: `pim:db:reset --with-fixtures --force` w entrypoint zwracał success ale fixtures cicho aborted. Root cause: `doctrine:fixtures:load` ma purge confirmation z **default `[no]`**; gdy `$arrayInput->isInteractive() === true` (default), prompt fall-through do `[no]` → fixtures exit 0 bez insertu. Inne chained commands (drop/create/migrate) miały default `[yes]` więc były OK.
+
+   **Wzór do zastosowania ZAWSZE przy chained `$application->find($name)->run($input, $output)`**:
+   ```php
+   $arrayInput = new ArrayInput($arguments);
+   $arrayInput->setInteractive(false);  // critical — flag option NIE wystarczy
+   $application->find($commandName)->run($arrayInput, $output);
+   ```
+   Nawet jeśli `$arguments` zawiera `'--no-interaction' => true`. Flag option jest processowany przez Application boot; nested run() omija ten path.
+
+2. **Doctrine fixtures purge NIE obejmuje rekordów seedowanych przez migration** (sub-lekcja). `AppFixtures::load()` zaczyna od `$manager->persist(new Locale('pl_PL', ...))` z komentarzem „re-seed po purge". Ale jeśli migration `Version2026...` insertuje `pl_PL` przez DML i fixture purger nie czyści tabeli `locales` (bo Locale entity może być flaged jako exclude lub purger nie wykrywa go w order), `--append=false` wybucha unique constraint violation. **W praktyce u nas działa** bo purge dotyka locales, ale gdyby pojawił się następny edge case: rozważ `--purge-with-truncate` lub explicit DELETE w fixture przed persist.
+
+3. **`docker compose exec -T` nie alokuje TTY ale `isInteractive()` w Symfony Console ZALEŻY od stdin TTY check'u** — manual exec `bin/console foo` z `-T` przekazuje `isInteractive=false` do top-level Application bo stdin nie jest TTY. Ale gdy Application chain'uje pod-komendy z fresh `ArrayInput()`, ten input dziedziczy `isInteractive=true` (default). To wytłumacza dlaczego Pre-existing `pim:db:reset --with-fixtures --force` z manual exec też miał ten bug — operator po prostu nigdy się tego nie zorientował, bo... sprawdzić to (może admin@acme.localhost wstawił się przez race lub partial exception przed cancel).
+
+4. **Disk pressure kill'uje docker daemon, nie tylko build** — disk @ 100% (Mac /System/Volumes/Data) rezultuje w `Cannot connect to the Docker daemon at unix:///Users/.../docker.sock`. Daemon się sam restartuje po `docker builder prune -af` (~5GB recovered) i compose stack auto-startuje. **Reguła**: `df -h /System/Volumes/Data` przed każdym dużym build'em na Macu; jeśli >95% used, `docker builder prune -af` jako pre-flight.
+
+5. **Bind-mount source code w dev compose pozwala iterować PHP zmiany BEZ rebuild image** — `apps/api/src/**` jest mount'owany z hosta do `/app/src` w api container. Zmiana w command class jest natychmiast widziana przez `docker compose exec api bin/console foo`. Tylko entrypoint, Dockerfile, composer dependencies wymagają full rebuild. Wzór dla iteracji command/handler/listener: edit → exec → repeat, bez `docker compose build`.
+
+6. **Best-effort entrypoint pattern** — wrapper który robi setup-step ale exec'uje główny CMD niezależnie od wyniku setup. Wzór:
+   ```sh
+   if [ "${APP_ENV:-dev}" = "dev" ]; then
+       php /app/bin/console pim:dev:ensure-seeded --quiet-when-noop --no-interaction \
+           || echo "[entrypoint] WARN: ensure-seeded failed; api will still start."
+   fi
+   exec "$@"
+   ```
+   `||` z echo (a nie `set -e`) gwarantuje że failure setup'u nie blokuje boot'u. Operator dostaje warning w logach + working API. Lepsze niż twardy fail bo: (a) seed bug nie ma blokować developmentu, (b) operator ma diagnostic context na `docker compose logs`.
+
+---
+
 ## Lessons z marathonu PROD-01..05 (production-readiness, 2026-05-12)
 
 Marathon: 5 PR-ów (#526 PROD-01 async Messenger overlay, #531 PROD-02 PgBouncer tx-mode, #528 PROD-03 Meili batch indexing collector, #529 PROD-04 Prometheus + worker-memory alert, #530 PROD-05 per-tenant bulk concurrency lock). Wszystkie merged tego samego dnia.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -52,6 +52,15 @@ COPY frankenphp/Caddyfile /etc/frankenphp/Caddyfile
 COPY frankenphp/php.ini /usr/local/etc/php/conf.d/app.ini
 COPY frankenphp/worker.Caddyfile /etc/frankenphp/worker.Caddyfile
 
+# Custom entrypoint that auto-seeds the dev/test database on container
+# start (idempotent; calls pim:dev:ensure-seeded). See ./docker-entrypoint.sh
+# for the decision tree. Prod containers (APP_ENV=prod) skip the seed
+# entirely so this hook never touches production data.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["frankenphp", "run", "--config", "/etc/frankenphp/Caddyfile"]
+
 # Composer optimisations: cache layer for vendor before copying source
 COPY composer.json composer.lock ./
 RUN --mount=type=cache,target=/root/.composer/cache \

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# PIM api container entrypoint.
+#
+# Wraps the upstream FrankenPHP entrypoint with a dev-only auto-seed step
+# so a fresh database (post `pim:db:reset`, post `docker compose down -v`,
+# post big-rebase that wiped the volume) auto-loads the admin user before
+# the operator hits the login form. Without this, every "DB empty" boot
+# surfaces as a misleading "Nieprawidłowy e-mail lub hasło" toast.
+#
+# Decisions:
+# - dev/test only. APP_ENV=prod skips entirely (safety: never touch prod
+#   data from an entrypoint hook).
+# - Best-effort: a seed failure logs a warning but does NOT block the
+#   container from coming up. Operator still gets a working API and can
+#   diagnose interactively.
+# - DB readiness is gated by compose `depends_on: database:
+#   service_healthy`, so the seed runs against an up DB. The Symfony
+#   command also has its own retry-on-DBAL-error path.
+#
+# This file is COPYed into /usr/local/bin/docker-entrypoint.sh in the
+# Dockerfile and made the container ENTRYPOINT.
+
+set -e
+
+# Mirror the upstream behaviour from /usr/local/bin/docker-php-entrypoint:
+# expand `-f flag` style args into a full `frankenphp run …` invocation.
+if [ "${1#-}" != "$1" ]; then
+    set -- frankenphp run "$@"
+fi
+
+# Run the seed guard only on dev / test. The command itself rechecks
+# APP_ENV but the early bail saves a kernel boot in prod containers.
+if [ "${APP_ENV:-dev}" = "dev" ] || [ "${APP_ENV:-dev}" = "test" ]; then
+    if [ -x /app/bin/console ]; then
+        echo "[entrypoint] Running pim:dev:ensure-seeded (env=${APP_ENV:-dev})"
+        php /app/bin/console pim:dev:ensure-seeded --quiet-when-noop --no-interaction \
+            || echo "[entrypoint] WARN: ensure-seeded failed; api will still start. Run 'docker compose exec api bin/console pim:dev:ensure-seeded' manually to diagnose."
+    fi
+fi
+
+exec "$@"

--- a/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
@@ -97,9 +97,18 @@ final class DatabaseResetCommand extends Command
                 return Command::FAILURE;
             }
 
+            $arrayInput = new \Symfony\Component\Console\Input\ArrayInput($arguments);
+            // Nested ArrayInput defaults to interactive=true even when the
+            // outer command was invoked with --no-interaction. Without this,
+            // doctrine:fixtures:load silently aborts on its purge prompt
+            // (default answer "no") and pim:db:reset reports success despite
+            // an empty fixtures load. Other chained commands (drop/create/
+            // migrate) ship a "yes" default so they were never affected.
+            $arrayInput->setInteractive(false);
+
             $exitCode = $application
                 ->find($commandName)
-                ->run(new \Symfony\Component\Console\Input\ArrayInput($arguments), $output);
+                ->run($arrayInput, $output);
 
             if (Command::SUCCESS !== $exitCode) {
                 $io->error(sprintf('Step "%s" failed (exit %d). Aborting.', $commandName, $exitCode));

--- a/apps/api/src/Shared/Infrastructure/Maintenance/EnsureSeededCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/EnsureSeededCommand.php
@@ -67,7 +67,8 @@ final class EnsureSeededCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $envRaw = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
         $env = \is_string($envRaw) ? $envRaw : 'dev';
-        $quiet = (bool) $input->getOption('quiet-when-noop');
+        // VALUE_NONE options are typed as bool by phpstan-symfony — no cast needed.
+        $quiet = $input->getOption('quiet-when-noop');
 
         if ('dev' !== $env && 'test' !== $env) {
             if (!$quiet) {
@@ -140,10 +141,12 @@ final class EnsureSeededCommand extends Command
     private function userCount(): int
     {
         try {
-            return (int) $this->connection->fetchOne('SELECT COUNT(*) FROM users');
+            $count = $this->connection->fetchOne('SELECT COUNT(*) FROM users');
         } catch (DbalException) {
             return 0;
         }
+
+        return \is_numeric($count) ? (int) $count : 0;
     }
 
     private function tableExists(string $name): bool
@@ -162,10 +165,10 @@ final class EnsureSeededCommand extends Command
                 'SELECT COUNT(*) FROM users WHERE email = :email',
                 ['email' => self::ADMIN_EMAIL],
             );
-
-            return (int) $count > 0;
         } catch (DbalException) {
             return false;
         }
+
+        return \is_numeric($count) && (int) $count > 0;
     }
 }

--- a/apps/api/src/Shared/Infrastructure/Maintenance/EnsureSeededCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/EnsureSeededCommand.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Maintenance;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DbalException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Idempotent dev-database seed guard. Run on every container start
+ * (wired through docker-entrypoint.sh) so an empty database — created by
+ * `pim:db:reset`, an aborted migration, or a fresh `docker compose down -v`
+ * — is automatically backfilled before the operator hits the login form
+ * and sees a misleading "invalid credentials" error.
+ *
+ * Decision tree:
+ *   - APP_ENV != dev/test → exit 0 (silently noop, never touch prod data).
+ *   - DB is unreachable → exit 0 with warning (compose `depends_on:
+ *     database: service_healthy` should prevent this; the warning lane
+ *     handles transient races without breaking the boot).
+ *   - `users` table missing OR `users` table empty → run
+ *     `pim:db:reset --with-fixtures --force` (covers post-
+ *     `docker compose down -v` and post-`pim:db:reset` cases — both
+ *     leave the database with no application data to lose).
+ *   - `users` table has rows but admin@demo.localhost missing → warn
+ *     and exit 0 (do NOT auto-mutate a populated DB; running fixtures
+ *     `--append` would crash on unique constraints, and a destructive
+ *     reset is the operator's call to make).
+ *   - admin@demo.localhost present → exit 0 ("already seeded").
+ *
+ * Designed to be safe to call ANY number of times. The `--quiet` flag
+ * suppresses output when nothing changes so container logs stay clean.
+ */
+#[AsCommand(
+    name: 'pim:dev:ensure-seeded',
+    description: 'Idempotent seed guard for dev — auto-loads fixtures if admin user is missing.',
+)]
+final class EnsureSeededCommand extends Command
+{
+    private const string ADMIN_EMAIL = 'admin@demo.localhost';
+
+    public function __construct(private readonly Connection $connection)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'quiet-when-noop',
+            null,
+            InputOption::VALUE_NONE,
+            'Suppress output when seeding is not needed (entrypoint use).',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $envRaw = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
+        $env = \is_string($envRaw) ? $envRaw : 'dev';
+        $quiet = (bool) $input->getOption('quiet-when-noop');
+
+        if ('dev' !== $env && 'test' !== $env) {
+            if (!$quiet) {
+                $io->note(\sprintf('Skipping ensure-seeded: APP_ENV=%s (only runs on dev/test).', $env));
+            }
+
+            return Command::SUCCESS;
+        }
+
+        $usersTableExists = $this->tableExists('users');
+        $userCount = $usersTableExists ? $this->userCount() : 0;
+
+        if ($usersTableExists && $userCount > 0 && $this->adminUserExists()) {
+            if (!$quiet) {
+                $io->success('Database already seeded — admin user present.');
+            }
+
+            return Command::SUCCESS;
+        }
+
+        $application = $this->getApplication();
+        if (null === $application) {
+            $io->error('Console application not available — cannot chain commands.');
+
+            return Command::FAILURE;
+        }
+
+        if ($usersTableExists && $userCount > 0) {
+            $io->warning(\sprintf(
+                'Database has %d user(s) but admin@demo.localhost is missing. '
+                .'Refusing to auto-seed a populated DB — run '
+                ."'docker compose exec api bin/console pim:db:reset --with-fixtures --force' "
+                .'manually if a full reset is intended.',
+                $userCount,
+            ));
+
+            return Command::SUCCESS;
+        }
+
+        $io->section('Empty database — running pim:db:reset --with-fixtures');
+
+        // Release our DBAL connection so 'doctrine:database:drop' (chained
+        // by pim:db:reset) is not blocked by our own session in postgres.
+        $this->connection->close();
+
+        $resetInput = new ArrayInput([
+            '--force' => true,
+            '--with-fixtures' => true,
+        ]);
+        // Match DatabaseResetCommand's nested-call behaviour: must be
+        // non-interactive so the chained pim:db:reset honours --force without
+        // prompting (the entrypoint runs with no TTY).
+        $resetInput->setInteractive(false);
+
+        $exitCode = $application
+            ->find('pim:db:reset')
+            ->run($resetInput, $output);
+
+        if (Command::SUCCESS !== $exitCode) {
+            $io->error(\sprintf('pim:db:reset failed (exit %d).', $exitCode));
+
+            return Command::FAILURE;
+        }
+
+        $io->success('Schema created and fixtures loaded.');
+
+        return Command::SUCCESS;
+    }
+
+    private function userCount(): int
+    {
+        try {
+            return (int) $this->connection->fetchOne('SELECT COUNT(*) FROM users');
+        } catch (DbalException) {
+            return 0;
+        }
+    }
+
+    private function tableExists(string $name): bool
+    {
+        try {
+            return $this->connection->createSchemaManager()->tablesExist([$name]);
+        } catch (DbalException) {
+            return false;
+        }
+    }
+
+    private function adminUserExists(): bool
+    {
+        try {
+            $count = $this->connection->fetchOne(
+                'SELECT COUNT(*) FROM users WHERE email = :email',
+                ['email' => self::ADMIN_EMAIL],
+            );
+
+            return (int) $count > 0;
+        } catch (DbalException) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Po `pim:db:reset`, `docker compose down -v`, lub większym rebase'ie który czyści wolumen postgres'a, operator wchodzi na login i widzi `Nieprawidłowy e-mail lub hasło`. Toast jest **technicznie poprawny** — `admin@demo.localhost` rzeczywiście nie istnieje — ale wygląda jak bug aplikacji. Recovery (odpalenie fixtures ręcznie) nie jest oczywiste, a sytuacja powtarzała się co kilka tygodni.

## Rozwiązanie

Trzy elementy:

1. **`pim:dev:ensure-seeded`** ([EnsureSeededCommand.php](apps/api/src/Shared/Infrastructure/Maintenance/EnsureSeededCommand.php)) — idempotentna komenda console:
   - `APP_ENV != dev/test` → silently noop (NIGDY nie dotyka prod data)
   - tabela `users` brak LUB pusta → `pim:db:reset --with-fixtures --force`
   - tabela `users` ma rekordy ale brak `admin@demo.localhost` → warning + exit 0 (nie auto-mutuje populated DB; `--append` wybuchłby na unique constraints, a destruktywny reset to decyzja operatora)
   - admin obecny → `[OK] Database already seeded`
   - `--quiet-when-noop` ucisza success line — boot logs zostają czyste

2. **`docker-entrypoint.sh`** — wrapper który odpala `pim:dev:ensure-seeded --quiet-when-noop --no-interaction` raz przed `exec frankenphp run …`. Failure jest **best-effort**: api wstaje mimo to, operator dostaje warning w logach. Skipuje się całkowicie na `APP_ENV=prod`.

3. **Dockerfile** — `COPY` entrypointu, `ENTRYPOINT` + `CMD` które zachowują upstream `frankenphp run --config /etc/frankenphp/Caddyfile`.

## Pre-existing bug fix

W trakcie testów wyszedł osobny bug w [DatabaseResetCommand.php](apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php): nested `ArrayInput` przekazany do `doctrine:fixtures:load` defaultował do `interactive=true` mimo że outer call był `--no-interaction`. Prompt `database "pim" will be purged. Continue? [no]` defaultował do **no**, fixtures **silently** aborted, a `pim:db:reset` zwracał success. Inne chained commands (drop/create/migrate) miały default `[yes]` na podobnym prompt'cie więc były OK. Naprawione `$arrayInput->setInteractive(false)` przed każdym nested `run()`.

## Smoke test (end-to-end, manual)

```
docker compose stop api
docker compose exec database psql -U pim -d postgres -c "DROP DATABASE pim WITH (FORCE);"
docker compose exec database psql -U pim -d postgres -c "CREATE DATABASE pim OWNER pim;"
docker compose up -d api
docker compose logs api
# → [entrypoint] Running pim:dev:ensure-seeded (env=dev)
# → Empty database — running pim:db:reset --with-fixtures
# → [OK] Schema created and fixtures loaded.
# → FrankenPHP started 🐘

curl -k -X POST https://pim.localhost/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"admin@demo.localhost","password":"changeme"}'
# → HTTP 200 + JWT

docker compose restart api  # idempotency
docker compose logs api --since 10s
# → [entrypoint] Running pim:dev:ensure-seeded (env=dev)
# → (no further output — --quiet-when-noop)

docker compose exec api bin/console pim:dev:ensure-seeded
# →  [OK] Database already seeded — admin user present.
```

## Test plan

- [x] Empty DB → entrypoint odpala reset+fixtures → admin@demo + admin@acme wstawieni
- [x] POST `/api/auth/login` → HTTP 200 + JWT
- [x] Re-restart na populated DB → noop (silent)
- [x] Manual invocation → `[OK] Database already seeded`
- [x] Pre-existing fixtures-silently-abort bug fixed
- [ ] CI green (PHPStan max + PHPUnit + Biome + build)

## Out of scope

- Test integracyjny dla `EnsureSeededCommand` — funkcja jest end-to-end smoke verified, a unit test wymagałby mockowania `Connection` + `Application` w sposób który niewiele dodaje. Jeśli regresja kiedyś wróci, raczej trzeba będzie test integracyjny na poziomie `docker compose up` (out of repo scope).
- `APP_ENV=prod` path nie jest test'owany na żywym prod — guard jest defense-in-depth: shell-level + command-level, oba sprawdzają env przed touch'em data.