### PR TITLE
feat(catalog): Produkty · Lista v2 — fundament UI + BE foundation (VIEW-09)

### DIFF
--- a/Project Plan/PRD/PRD-PIM-list-advanced.md
+++ b/Project Plan/PRD/PRD-PIM-list-advanced.md
@@ -1,0 +1,647 @@
+# PRD — Cortex PIM: Lista produktów (filtry, wyszukiwarka, akcje zbiorcze, Cmd+K)
+
+**Typ dokumentu:** Product Requirements Document — **Feature-level** w ramach produktu Cortex PIM
+**Klasa produktu:** PIM (Product Information Management) — agentic-first SaaS
+**Pozycjonowanie:** Alternatywa dla Akeneo / Pimcore / BaseLinker — operator cockpit + workflow-grade czystość + Cmd+K agent
+**Producent:** Marcin Lipiec (projekt prywatny; equity / model biznesowy poza zakresem tego dokumentu)
+**Data utworzenia:** 2026-05-13
+**Wersja dokumentu:** 1.0
+**Autor:** Marcin Lipiec (synteza brainstormingu 4-falowego 2026-05-11)
+**Status:** Draft — wymaga walidacji z first design partner przed Sprintem 1
+
+> **Nota o scope dokumentu.** To **feature-PRD** dla *jednego* obszaru produktu (lista produktów + filtry + search + bulk + Cmd+K). Pełen product-PRD dla Cortex PIM (pozycjonowanie, ICP, model biznesowy, multitenant SaaS, pricing) — patrz `Zrodla/PRD/PRD-PIM.md`. Sekcje 3, 4, 11, 12 niniejszego dokumentu zawierają wyciąg / odniesienia do master PRD; sekcje 5–10, 13–14 są feature-specific.
+>
+> Źródło prawdy detaliczne: [`Project Plan/UI/feature-list-advanced.md`](../UI/feature-list-advanced.md). Ten PRD agreguje, kwestionuje, eksponuje ryzyka.
+
+---
+
+## 1. Streszczenie wykonawcze (TL;DR)
+
+Lista produktów to *cockpit* Catalog Managera — 60% czasu pracy persony Kasi. Cortex PIM dostarcza dla tego ekranu trzy rzeczy, których konkurenci nie łączą w jednym narzędziu: (a) **gęstość BaseLinker** (15-20 kolumn, chip filtry, cross-page select), (b) **czystość Akeneo** (3-step bulk wizard z preview diff, completeness focus, pełne operatory filtrów), (c) **Cmd+K agent** jako natural language interface dla schema-ops + akcji zbiorczych — USP, którego ani Akeneo, ani Pimcore, ani BaseLinker nie ma natywnie. Pimcore-style developer overhead świadomie odrzucony — Kasia nie jest developerem.
+
+Feature obejmuje: 13 akcji zbiorczych z per-typ confirmation flow, soft rollback 24h przez `bulk_session_id`, URL-based filter persistence (shareable + refreshable), 5 built-in rule-based "smart filter" presetów (z **krytyczną notą** marketingową: w MVP to NIE są AI filtry), per-attribute lock skip-and-report, cascade impact summary dla destructive operations, BaseLinker-style cross-page selection.
+
+Backend impact: **+131–182h** ponad obecny budżet (rozłożone między epiki 0.4 / 0.5 / 0.6 / 0.7 / 0.11 — patrz §13). To 3-4× powyżej oryginalnego limitu PRD master §7. Świadoma decyzja właściciela („nie spieszę się, robimy dobrze") — eksponowana w §14 jako ryzyko scope creep R-30.
+
+**Jednozdaniowe pozycjonowanie feature'a:**
+*„Cockpit operatora z gęstością BaseLinker, dyscypliną workflow Akeneo, i jedynym na rynku Cmd+K agentem — wszystko z zachowaniem 24h rollback dla każdej zbiorczej zmiany."*
+
+---
+
+## 2. Wizja produktu i motywacja
+
+### 2.1 Dlaczego budujemy ten feature
+
+Lista produktów to **najczęściej odwiedzany ekran** w każdym PIM-ie — Kasia spędza tu 60% czasu pracy (5 h dziennie). Konkurencja rozwiązała każdy z trzech obszarów (gęstość / workflow / AI), ale żadna nie połączyła ich w jednym ekranie bez kompromisów:
+
+- **Pimcore** ma developer-grade kontrolę (ExtJS grid z 30+ konfigurowalnymi kolumnami, Object Class hierarchy, scripty), ale wymaga programisty do codziennej pracy. Kasia (32, bez backgroundu IT) nie da rady.
+- **Akeneo** ma fenomenalny 3-step bulk wizard z preview diff (signature feature, branża to skopiowała) i smart filter sidebar z pełnymi operatorami — ale to *workflow tool*, nie *cockpit*. Brak chip filtrów compact w toolbarze, brak select-all-matching w jednym kliknięciu, AI features tylko w paid Enterprise.
+- **BaseLinker** ma operator cockpit (gęstość, chipy, action bar inline, ~30 akcji per typ obiektu), ale nie ma natywnego rollback'u dla bulk, nie ma cross-locale completeness detection, nie ma preview diff przed Apply, i jest *integratorem multi-channel*, nie pełnoprawnym PIM-em.
+
+Cortex łączy trzy rzeczy w jednym ekranie: chip filtry compact + Advanced push-down panel z pełnymi operatorami + 3-step wizard z preview diff + 24h rollback per `bulk_session_id` + Cmd+K agent jako *„alternative input method"* (nie bypass — przechodzi przez ten sam wizard / preview / approval flow co manual).
+
+### 2.2 Dlaczego teraz (timing)
+
+Trzy zbiegające się czynniki w 2026:
+
+1. **Anthropic Claude Sonnet 4.5** (model dostępny od kwartałów, ceny spadły) — czyni Cmd+K agent technicznie realistycznym dla MVP (poprzednio koszt $0.10+/command był zaporowy; dziś $0.002–0.008).
+2. **Operator cockpit jako oczekiwanie rynku** — BaseLinker udowodnił w Polsce że e-commerce operatorzy chcą gęstego UI; Shopify Plus przejęło ten wzorzec; tradycyjny PIM (Akeneo workflow-first) zaczyna wyglądać archaicznie dla buyer person Marcina/Kasi.
+3. **API Platform 4 + Refine.dev 4 + shadcn/ui** — stack dojrzał wystarczająco żeby zbudować custom power UI w 95-130h (dominant cost feature'a) bez zaprzęgania zespołu Pimcore-grade.
+
+### 2.3 Wizja 3-letnia tego feature'a
+
+Lista produktów w Cortex za 3 lata to **referencyjny screen dla agentic-first PIM** — narzędzie, które ludzie pokazują jako *„Cmd+K w PIM-ie to to, co Linear zrobił dla project management"*. Konkretnie w 3-letnim horyzoncie:
+
+- **Cmd+K rozszerzony** z natural language filter queries (Faza 1), cross-channel inconsistency detection (Faza 1), LLM-driven bulk content generation (Faza 2).
+- **Real-time collaboration** na zaznaczeniach — Magda i Kasia widzą wzajemnie zaznaczone produkty + locks (Faza 2-3).
+- **AI quality dashboard** — completeness, consistency, freshness scoring per kanał z propozycjami fixów (Faza 2).
+- **Custom user-defined smart filter presets** zapisywane jako shared entities (Faza 1).
+
+### 2.4 North Star Metric (feature-level)
+
+**Średni czas wykonania zadania "zmodyfikuj 50 atrybutów Brand z Bosch na Festo"** — od momentu wejścia na listę do potwierdzenia Apply.
+
+- Pimcore: ~8-12 minut (search + selected + mass action + brak preview, ryzyko błędu = restart).
+- Akeneo: ~3-4 minuty (smart filter + select + wizard 3-step + preview + Apply).
+- BaseLinker: ~2-3 minuty (chip filter + select + inline bulk edit + simple confirm, ale brak preview = stres).
+- **Cortex target: ~90 sekund** (Cmd+K *„dla zaznaczonych ustaw brand na Festo"* + preview diff + Apply). Lub manual: chip filter + select + bulk action + wizard = ~2 min.
+
+Metryka mierzalna w MVP przez session replay (Hotjar / własny instrumentation) na cohorcie design partners.
+
+---
+
+## 3. Pozycjonowanie i różnicowanie (feature-level)
+
+> Master pozycjonowanie produktu Cortex PIM — patrz `Zrodla/PRD/PRD-PIM.md` §3. Poniżej tylko aspekty unikalne dla *tego* feature'a.
+
+### 3.1 Konkurencja bezpośrednia (per feature obszar lista/filtry/bulk)
+
+| Konkurent | Mocne strony (ten obszar) | Słabe strony (ten obszar) | Cena (orientacyjna) | Target |
+|-----------|----|---|---|---|
+| **Akeneo PIM** | 3-step bulk wizard z preview diff (signature); pełne operatory w Smart Filter sidebar; mass edit attributes wizard | Brak chip filtrów compact w toolbarze; brak operator-grade gęstości UI; brak Cmd+K; AI features (auto-translate, content gen) tylko w paid Enterprise (~€40k+/rok) | Free Community / Enterprise od €40k/rok | Mid-market i enterprise, workflow-first organizacje |
+| **Pimcore** | ExtJS grid z 30+ kolumn (ColumnConfigurator); Object Class hierarchy elastyczna; mass operations queue z scripts | Developer overhead — Kasia bez IT nie da rady; brak preview diff; brak natywnego bulk rollback (tylko audit log); brak Cmd+K | Open-source / Enterprise od ~€20k/rok | Enterprise z własnym zespołem dev |
+| **BaseLinker** | Operator cockpit — chip filtry compact, action bar inline, ~30 akcji per typ obiektu, cross-page selection toolbar; gęstość 15-20 kolumn | Brak natywnego rollback dla bulk; brak preview diff; brak cross-locale completeness; *integrator multi-channel*, nie pełnoprawny PIM; brak Cmd+K | Od ~399 PLN/miesiąc | Polskie e-commerce SMB, operatorzy multi-channel |
+| **Ergonode** | Workflow + completeness, similar do Akeneo ale lżejszy | Brak operator-grade gęstości; brak Cmd+K; mniejszy ecosystem | Cloud od €99/miesiąc | SMB e-commerce |
+| **Shopify Plus** (jako benchmark UX, nie PIM) | Bulk Editor inline, gęsty UI, real-time updates | Nie PIM (e-commerce platform z PIM-like features); zamknięty ekosystem | Od $2000/miesiąc | Mid-market e-commerce |
+
+### 3.2 Główna oś różnicowania feature'a
+
+**Cmd+K agent jako *„alternative input method"* dla bulk actions, NIE bypass.** Klient wpisuje *„dla zaznaczonych 30 ustaw kategorię na Pneumatyka"* → Anthropic parsuje intent → generuje tool call → **trafia w ten sam wizard 3-step preview diff** co manual flow → Apply przechodzi przez ten sam handler / audit / rollback. Spójność jest wartością — agent nie zwiększa ryzyka.
+
+Akeneo nie ma. Pimcore nie ma. BaseLinker nie ma. Wiosna 2026 — żaden komercyjny PIM tego nie zaoferował natywnie. To **jest** killer.
+
+### 3.3 Wspierające differentiatory
+
+1. **24h soft rollback per `bulk_session_id`** — analog do Cmd+Z dla bulk operations. Akeneo ma job history (z manual reverse, limited). BaseLinker / Pimcore — brak natywnego. To znacząca redukcja stresu Kasi (decyzja o bulk operation przestaje być terminal).
+2. **Hybrid filter UI** — chip compact w toolbarze (BaseLinker pattern) + Advanced push-down panel z grid/query mode (Magento + Akeneo pattern) + URL-based persistence (shareable). Klient wybiera tryb pracy: szybko (chipy), precyzyjnie (grid), power (query AND/OR).
+3. **Per-attribute lock z skip-and-report w bulk** — Kasia zabezpiecza ręcznie editowane pola (np. SEO description po manual copywritingu), bulk respektuje lock i raportuje *„247 selected, 230 updated, 17 skipped (locked)"*. Brak force override w MVP = świadoma decyzja, klient un-lock'uje ręcznie. Akeneo ma per-tenant attribute permissions (per-role), ale nie per-instance lock.
+4. **Cross-locale completeness mismatch jako quick filter preset** — *„description.pl filled AND description.en empty"* w jednym kliknięciu. Rule-based w MVP, ale **wystarcza** dla typowego pain point persony Magdy (i18n).
+
+### 3.4 Czego ten feature świadomie NIE robi lepiej
+
+- ❌ **Custom scripts mode** (BaseLinker power user feature) — defer do Fazy 3+ lub never. Kasia/Magda nie potrzebują, dla power user'ów (Marcin) Cmd+K wystarcza w 95% przypadków.
+- ❌ **Real-time AI semantic search** (*„znajdź mi produkty podobne do TST-001"*) — Faza 1+. MVP to strict prefix/exact + diacritic-insensitive po SKU/name/EAN/brand/tags. Wystarcza dla 90% queries Kasi.
+- ❌ **Cross-channel value inconsistency detection** (*„description na Shopify różni się od BaseLinker dla tego SKU"*) — Faza 1-2. Wymaga LLM semantic comparison, kosztuje compute, można poczekać.
+- ❌ **AI smart filters z prawdziwym LLM** — w MVP rule-based only (patrz §11 *Krytyczna nota marketingowa*). Brak wow-effect przy podstawowym poziomie, ale uczciwe komunikowanie zamiast misleading "AI-powered".
+- ❌ **Multi-user collaborative selection state** (*„Magda widzi że Kasia zaznaczyła te 30"*) — Faza 2-3. MVP solo only.
+- ❌ **Per-channel completeness scoring** — flat completeness w MVP (1 pasek 0-100%). Per-channel scoring → Faza 1 (wymaga rules per channel z epiku 04 Publikacje).
+- ❌ **Force override locked attribute przez super_admin** — w MVP nie ma. Klient un-lock'uje ręcznie. Faza 1 z confirm modal.
+- ❌ **Cmd+K NLP filter queries** (*„pokaż mi produkty z niespójnymi opisami"* jako natural language zamiast preset click) — Faza 1. MVP Cmd+K to schema-ops + bulk actions, nie filter intent.
+
+### 3.5 Killer use case
+
+**Scenariusz „Marcin migracja z IdoSell na nowy PIM"**: Marcin (dogfooding first user) importuje 5000 SKU z IdoSell. Po imporcie 60% produktów ma `brand` w polu `manufacturer` (niespójne mapowanie). Klasyczny PIM (Akeneo): otwórz, smart filter `manufacturer IS NOT EMPTY`, select all, bulk edit *„copy manufacturer → brand"*, czas ~10 min + ryzyko błędu bez Cmd+Z.
+
+Cortex flow: `⌘K` → *„dla wszystkich produktów z manufacturer IS NOT EMPTY skopiuj manufacturer do brand"* → agent parsuje, generuje plan, pokazuje preview diff *„3000 produktów: rozkład wartości manufacturer Festo (800), Bosch (650)... ; preview 5 sample rows: TST-001 manufacturer=Festo → brand=Festo"* → Apply → toast *„3000 produktów updated [Wycofaj 24h]"*. Czas ~90 sekund. **Bezstresowy** — bo Marcin wie, że ma 24h żeby cofnąć.
+
+Akeneo to zrobi w 8-10 minut (smart filter + wizard manual). BaseLinker to zrobi w 3-4 minuty (chip + inline bulk), ale bez preview = stres + ryzyko że brand=Festo set'nie się dla 200 produktów z manufacturer=Festo plus brand już Bosch (override bez preview). Pimcore — Marcin (bez IT skillsa Pimcore-grade) nie poradzi sobie w sensownym czasie.
+
+---
+
+## 4. ICP i persony (w kontekście tego feature'a)
+
+> Master ICP Cortex PIM — patrz `Zrodla/PRD/PRD-PIM.md` §4. Poniżej tylko zawężenie na *tego* feature'a.
+
+### 4.1 ICP — kogo szczególnie obchodzi ten feature
+
+- **Branże:** B2B e-commerce techniczny (Marcin profile — czujniki, pneumatyka, hydraulika), polski retail multi-channel (Kasia profile — Allegro + Shopify + BaseLinker). Mniej krytyczne dla: fashion, FMCG, single-channel butique.
+- **Skala asortymentu:** 1000–50 000 SKU (sweet spot). Poniżej 1000 — feature overkill, klient użyje Excel. Powyżej 50k — wymaga dodatkowych optymalizacji (lazy loading 200k+ jest planowany ale wymaga benchmarków Sprint 1).
+- **Częstotliwość bulk operations:** ≥5 bulk operations/tydzień. Klient z 1 bulk/miesiąc nie odczuje wartości 24h rollback / wizard preview.
+- **Dojrzałość digital:** Klient ma multi-locale (PL + EN minimum) lub multi-channel (≥2 kanały). Smart filter presets (cross-locale completeness) bez multi-locale = bez wartości.
+
+### 4.2 Persony użytkowników tego feature'a
+
+#### Kasia, 32 — Catalog Manager (PRIMARY)
+- **Kim jest:** Catalog Manager w polskim B2B e-commerce technicznym, 5 lat doświadczenia, używała wcześniej Magento admin + Excel + BaseLinker. Bez backgroundu IT, ale digital-savvy. Pracuje 8h dziennie w PIM, 60% czasu na liście produktów.
+- **Cele:** Znaleźć produkt w ≤10 sekund. Zmienić 50-500 produktów w ≤3 minuty z preview *„rozumiem co się stanie"*. Cofnąć błąd w ≤30 sekund bez czekania na IT.
+- **Frustracje dziś:** BaseLinker brak preview = stres przed Apply. Akeneo brak chip filtrów compact w toolbarze = za dużo klików dla typowych zadań. Excel zawsze fallback, ale brak audit / rollback / multi-user.
+- **Wskaźnik sukcesu:** Spadek liczby ticketów do IT *„cofnij moją bulk operation"* z N/miesiąc do 0. Spadek czasu na typowe zadanie (50 produktów brand change) z 10 min do 90 sek.
+
+#### Magda, 29 — Marketing / Content Manager (SECONDARY)
+- **Kim jest:** Marketing manager odpowiedzialny za content multi-locale (opisy PL+EN), kategoryzacja, kolekcje sezonowe, SEO. 5-10h/tydzień w PIM (głównie bulk content operations).
+- **Cele:** Bulk edit description dla 247 produktów Festo z preview diff (rozumie co się stanie). Cross-locale completeness check (gdzie PL filled ale EN empty). URL share z kolegą („otwórz to, zobacz dlaczego dropdown nie działa").
+- **Frustracje dziś:** Brak per-locale completeness w typowych PIM-ach (Akeneo Enterprise ma, ale ich budżet nie). Brak shareable URL z filter state — koleżanka musi tłumaczyć kroki *„kliknij to, potem to"*.
+- **Wskaźnik sukcesu:** Spadek czasu na *„dodaj EN description tam gdzie tylko PL"* z 2h do 30 min (cross-locale completeness filter + bulk wizard).
+
+#### Marcin — Founder / dogfooding (FIRST USER)
+- **Kim jest:** Founder Cortex PIM, prywatny e-commerce B2B (planowana migracja z IdoSell + Shopify). Hands-on, używa Cmd+K agresywnie, regression-testuje każdy nowy feature na własnym katalogu.
+- **Cele:** Każdy nowy feature ma „just work" na 5000 SKU realnym katalogu. Cmd+K musi być fast (< 3s) i precise (95%+ intent parsing accuracy na typowych queries).
+- **Frustracje dziś:** Generic PIM-y nie mają Cmd+K, więc co dzień klika 50 razy w UI dla zadań które naturalny język załatwia w 1 zdaniu.
+- **Wskaźnik sukcesu:** Codziennie 1-2h w Cortex, zero regression bugs po feature shippping (Marcin = manual QA).
+
+#### Tomasz — Owner / CEO (SPORADYCZNY)
+- **Kim jest:** Owner / CEO firmy klienta, audit + flagowe produkty edycja, 1-2h tygodniowo w PIM.
+- **Cele:** Self-service edycja flagowych produktów (5-10 SKU). Audit overview *„kto co zmienił w tym tygodniu"*. Saved View *„moje 10 produktów"*.
+- **Frustracje dziś:** Klasyczne PIM-y są workflow-tool dla teamu, nie owner-friendly. Tomasz chce wejść, znaleźć produkt, edit, wyjść.
+- **Wskaźnik sukcesu:** ≤30 sekund od loginu do edytowanego produktu.
+
+### 4.3 Decydent zakupowy vs. użytkownik
+
+- **Decydent zakupowy:** Tomasz (Owner/CEO) — podpisuje umowę, alokuje budżet, robi demo z konkurencją.
+- **Daily user:** Kasia (Catalog Manager) — używa 60% czasu pracy. **Jej** opinia decyduje o renewal w roku 2.
+- **Champion:** Magda (Marketing) — często pierwsza zauważa pain w bieżącym narzędziu, lobbuje za zmianą.
+
+Ten feature musi w demo wow-fować **Tomasza** (Cmd+K = magic moment) i potem w trial dostarczać codzienną wartość **Kasi** (chip filtry + preview diff + rollback = redukcja stresu).
+
+---
+
+## 5. Model danych (feature-level)
+
+> Master model danych Cortex PIM (ObjectType, Attribute, ObjectValue, attributes_indexed JSONB, ADR-006/009/010/011) — patrz `Zrodla/PRD/PRD-PIM.md` §5 i `Project Plan/01-architektura-pim.md`. Poniżej tylko delta wprowadzona przez ten feature.
+
+### 5.1 Nowe encje wprowadzane przez feature
+
+**`bulk_sessions`** — każda bulk operation tworzy session, służy jako anchor dla rollback w 24h window.
+
+```sql
+CREATE TABLE bulk_sessions (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    user_id UUID NOT NULL REFERENCES users(id),
+    action_type VARCHAR(64) NOT NULL,           -- set_attribute, delete, publish_channels, ...
+    target_object_ids UUID[] NOT NULL,
+    target_count INTEGER NOT NULL,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    skipped_count INTEGER NOT NULL DEFAULT 0,   -- locked attrs
+    error_count INTEGER NOT NULL DEFAULT 0,
+    action_payload JSONB NOT NULL,              -- attribute_id, new_value, channels, ...
+    rollback_available_until TIMESTAMPTZ,
+    rolled_back_at TIMESTAMPTZ,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    source VARCHAR(16) NOT NULL DEFAULT 'manual', -- manual, cmd_k_agent
+    cmd_k_command TEXT                          -- jeśli source=cmd_k_agent
+);
+```
+
+**`bulk_logs`** — per-produkt log starych wartości (rollback recipe).
+
+```sql
+CREATE TABLE bulk_logs (
+    id UUID PRIMARY KEY,
+    bulk_session_id UUID NOT NULL REFERENCES bulk_sessions(id) ON DELETE CASCADE,
+    object_id UUID NOT NULL REFERENCES objects(id),
+    attribute_id UUID REFERENCES attributes(id),   -- NULL dla destructive ops
+    old_value JSONB,
+    new_value JSONB,
+    level VARCHAR(8) NOT NULL,                     -- info, warning, error
+    message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_bulk_logs_session ON bulk_logs(bulk_session_id);
+CREATE INDEX idx_bulk_logs_object ON bulk_logs(object_id);
+```
+
+**`smart_filter_presets`** — rule-based filtry („AI smart filters" w marketingu, faktycznie SQL queries).
+
+```sql
+CREATE TABLE smart_filter_presets (
+    id UUID PRIMARY KEY,
+    tenant_id UUID,                          -- NULL = system-shipped global
+    user_id UUID REFERENCES users(id),       -- NULL = tenant-shared (Faza 1+)
+    name JSONB NOT NULL,                     -- {"pl": "Niespójne opisy", "en": "..."}
+    icon VARCHAR(16),
+    query JSONB NOT NULL,                    -- nasz filter DSL
+    is_built_in BOOLEAN NOT NULL DEFAULT false,
+    sort_order INTEGER DEFAULT 0
+);
+```
+
+5 built-in presetów seedowanych w MVP: *„Niespójne opisy (PL filled, EN empty)"*, *„Brakujące zdjęcia"*, *„Niepełne SEO"*, *„Czerwone (<50% complete)"*, *„Bez kategorii"*.
+
+**`user_filter_favorites`** — per-user top 10 atrybutów w *„Filtruj po atrybucie"* dropdown.
+
+```sql
+CREATE TABLE user_filter_favorites (
+    user_id UUID NOT NULL REFERENCES users(id),
+    attribute_id UUID NOT NULL REFERENCES attributes(id),
+    sort_order INTEGER NOT NULL,
+    PRIMARY KEY (user_id, attribute_id)
+);
+```
+
+### 5.2 Zmiany w istniejących encjach
+
+**`objects` table** — dwie nowe kolumny:
+
+```sql
+ALTER TABLE objects ADD COLUMN bulk_session_id UUID REFERENCES bulk_sessions(id);
+CREATE INDEX idx_objects_bulk_session ON objects(bulk_session_id) WHERE bulk_session_id IS NOT NULL;
+
+ALTER TABLE objects ADD COLUMN locked_attributes JSONB DEFAULT '[]'::JSONB;
+CREATE INDEX idx_objects_locked_attrs ON objects USING GIN(locked_attributes);
+```
+
+`bulk_session_id` — last bulk session that touched this object. `locked_attributes` — array of attribute_id zablokowanych w detail view (skip-and-report w bulk).
+
+### 5.3 Filter DSL — format JSONB query
+
+`smart_filter_presets.query` i URL filter params używają tego samego DSL:
+
+```json
+{
+  "operator": "AND",
+  "conditions": [
+    {"attribute": "brand", "op": "IS", "value": ["Festo", "Bosch"]},
+    {"attribute": "completeness_pct", "op": "<", "value": 50},
+    {
+      "operator": "OR",
+      "conditions": [
+        {"attribute": "stock", "op": ">=", "value": 10},
+        {"attribute": "date_created", "op": "BETWEEN", "value": ["2026-01-01", "2026-05-11"]}
+      ]
+    }
+  ]
+}
+```
+
+Płaski grid mode = `operator: AND` z prostą `conditions` listą. Query mode (power user) = zagnieżdżone OR/AND/NOT.
+
+URL serializer = lossy compression DSL → `?brand=Festo,Bosch&completeness=lt:50` (single level only). Power user query → URL z hashowanym blobem `?q=<base64-json>` lub Saved View.
+
+### 5.4 Audit / provenance
+
+- Każdy bulk write w `object_values` setuje `provenance = 'bulk'` (lub `'cmd_k_agent'` jeśli source z palette) z `provenance_meta.bulk_session_id` referencją.
+- AuditBundle log per ObjectValue change (Doctrine event listener) — z `user_id`, `timestamp`, `bulk_session_id` reference.
+- Rollback creates new audit entries (nie *„usuwa"* starych) — historia jest immutable.
+
+### 5.5 Walidacje per filter operator
+
+| Typ atrybutu | Walidacja operatora |
+|---|---|
+| `text`, `textarea`, `wysiwyg` | `=`, `≠`, `IS EMPTY`, `IS NOT EMPTY`, `STARTS WITH`, `ENDS WITH`, `CONTAINS`, `NOT CONTAINS` |
+| `number`, `metric` | `=`, `≠`, `>`, `<`, `>=`, `<=`, `BETWEEN`, `IS EMPTY`, `IS NOT EMPTY` |
+| `date`, `datetime` | `=`, `≠`, `>` (after), `<` (before), `BETWEEN`, `IS EMPTY`, `IS NOT EMPTY` |
+| `select` | `=`, `≠`, `IN`, `NOT IN`, `IS EMPTY`, `IS NOT EMPTY` |
+| `multiselect` | `CONTAINS`, `NOT CONTAINS`, `IS EMPTY`, `IS NOT EMPTY` |
+| `boolean` | `=` (TRUE/FALSE) |
+| `relation` | `=`, `≠`, `IN`, `NOT IN`, `IS EMPTY`, `IS NOT EMPTY` |
+| `asset` (image, file) | `IS EMPTY`, `IS NOT EMPTY` |
+
+Walidacja po stronie frontu (UI nie pokaże nieprawidłowych operatorów) + backend reject jako Problem Details (RFC 7807) gdy URL ręcznie modyfikowany.
+
+---
+
+## 6. Multikanałowość (kontekst feature'a)
+
+> Master strategia multikanałowa Cortex PIM — patrz `Zrodla/PRD/PRD-PIM.md` §6. Poniżej tylko wpływ na *ten* feature.
+
+### 6.1 Bulk publish / unpublish — semantyka per kanał
+
+- **`bulk publish to channels`** — `POST /api/products/bulk-actions/publish` z body `{target_ids[], channels[]}`. Sync workers per kanał (Shopify / BaseLinker / Allegro / IdoSell w Fazie 1+). Mercure SSE progress per kanał.
+- **`bulk unpublish from channels`** — j.w. dla unpublish. Rollback `bulk publish` triggeruje unpublish workers (per Fali 4: *„always unpublish wszystkie"*).
+- **Sales w międzyczasie** — produkt unpublish z Shopify gdy istnieje order = `partial` status w raporcie. Klient akceptuje *„buyer może zobaczyć product not found"*. System NIE blokuje rollback'u. Order historyczny retain product line item (Shopify default behavior).
+
+### 6.2 Scopable attributes w filter / bulk
+
+- Filter chip dla scopable atrybutu pokazuje channel: `[description.shopify CONTAINS "premium" ✕]`. Domyślnie filter w aktualnie wybranym channel sub-tab.
+- Bulk edit scopable attribute → wizard Step 1 pyta *„Apply do wszystkich kanałów / current channel only / wybranych kanałów?"*. Default: current channel.
+
+### 6.3 Per-channel completeness scoring — OUT OF MVP
+
+Decyzja świadoma: w MVP **flat completeness** (1 pasek 0-100% per produkt). Per-channel scoring (*„90% complete dla Shopify, 60% dla BaseLinker"*) → Faza 1. Wymaga rules per channel z epiku 04 Publikacje (które kanały *wymagają* których atrybutów). Bez tego MVP nie ma jak liczyć per-channel completeness.
+
+---
+
+## 7. DAM i media (kontekst feature'a)
+
+> Master DAM strategia — patrz `Zrodla/PRD/PRD-PIM.md` §7. Tu tylko aspekty list view.
+
+- **Filter `main_image IS EMPTY`** — preset *„Brakujące zdjęcia"* w smart filter presets.
+- **Thumbnail w kolumnie grid** — column `🖼` pokazuje 32×32 main_image. Lazy load (viewport-based) dla performance.
+- **Bulk delete cascade dla DAM** — `bulk delete` NIE usuwa assetów z DAM (zachowane w MinIO/S3, referencje product↔asset zerwane). Cascade impact modal informuje *„1820 zdjęć NIE zostanie usuniętych (zachowane w DAM)"*.
+- **Bulk replace main image / Bulk add to gallery** — OUT OF MVP (Faza 1).
+
+---
+
+## 8. Workflow i jakość danych (feature-level)
+
+### 8.1 Completeness w liście — flat formula
+
+- Kolumna `Compl.` w grid: progress bar 0-100% + procent.
+- Color coding: 🔴 <50% / 🟡 50-79% / 🟢 ≥80%.
+- Formula: `liczba wypełnionych atrybutów / total atrybutów w ObjectType (z weight 1 dla wszystkich w MVP)`.
+- Per-attribute weight — Faza 1 (atrybut SEO ma weight 5, atrybut technical_specs_pdf ma weight 1).
+- Per-locale completeness — `attributes_indexed.completeness_per_locale JSONB` z per-locale liczba (PL=80%, EN=20%). Używana w smart filter preset *„Niespójne opisy"* + tooltip pokazuje rozbicie po hover na pasku.
+
+### 8.2 Smart filter presets w MVP — rule-based
+
+| Preset | Query |
+|---|---|
+| 🌐 *„Niespójne opisy"* | `description.pl IS NOT EMPTY AND description.en IS EMPTY` |
+| 📷 *„Brakujące zdjęcia"* | `main_image IS EMPTY` |
+| 🔍 *„Niepełne SEO"* | `description IS NOT EMPTY AND meta_description IS EMPTY` |
+| 🔴 *„Czerwone (<50% complete)"* | `completeness_pct < 50` |
+| 📂 *„Bez kategorii"* | `category IS EMPTY` |
+
+Implementacja: server-side query against `attributes_indexed JSONB` z GIN index (z ADR-006).
+
+### 8.3 Per-attribute lock — provenance dla locked
+
+- Lock UX z epiku 02 §5.1 — 🔓 / 🔒 icon obok pola w detail view, click toggle.
+- Lock change → `objects.locked_attributes JSONB` update + audit entry z `lock_changed_at`, `lock_changed_by`, `lock_reason` (opcjonalny komentarz).
+- Bulk respect locks → handler checks `IF attribute_id IN object.locked_attributes THEN skip + log`.
+- Raport po bulk: *„247 selected, 230 updated, 17 skipped (locked) [pokaż SKUs]"*.
+
+### 8.4 Audit log per bulk operation
+
+- `bulk_sessions` + `bulk_logs` tabele jako primary audit dla bulk.
+- AuditBundle (epik 0.11.4) loguje też per-object change w `audit_logs` z `bulk_session_id` reference.
+- Retention: `bulk_logs` 7 dni hard delete (rollback window 24h + buffer). `audit_logs` długoterminowe (per tenant retention policy — Faza 1).
+
+---
+
+## 9. Importy, eksporty, integracje (kontekst feature'a)
+
+> Master strategia integracji Cortex PIM — patrz `Zrodla/PRD/PRD-PIM.md` §9 oraz [`feature-imports.md`](../UI/feature-imports.md). Tu tylko interakcja z list view.
+
+- **Import CTA z empty state** — link do `/imports` (epik 04 Publikacje sub-tab Imports).
+- **Bulk export** — *„Export selected to CSV/XLSX"* — OUT OF MVP. Faza 1 w epiku 04 Publikacje.
+- **Bulk publish to channels** — calls integration adapters (Shopify, BaseLinker — MVP+; Allegro, Magento, IdoSell — Faza 1+). Per-kanał Mercure SSE progress.
+- **Cmd+K integration intents** (*„opublikuj zaznaczone na Shopify"*) — mapped na `tool:bulk_publish` (MVP scope).
+
+---
+
+## 10. Strategia AI (feature-level)
+
+> Master AI strategia Cortex PIM (Anthropic, BYOK, limits) — patrz `Zrodla/PRD/PRD-PIM.md` §10 oraz `Project Plan/01-architektura-pim.md` §8.5. Tu tylko aspekty list view.
+
+### 10.1 Co JEST AI w MVP
+
+- ✅ **Cmd+K agent** — Anthropic Claude Sonnet 4.5 (domyślny). Parse user intent → generate tool call JSON → preview diff (z manual flow) → execute przez te same handlers.
+- ✅ **Schema-ops intents** (z epiku 08 Beta-Demo) — *„dodaj atrybut IP_class do rodziny Czujniki"* (Marcin osobiście).
+- ✅ **Bulk action intents** — *„dla zaznaczonych ustaw kategorię na Pneumatyka"*, *„podbij cenę o 10% dla zaznaczonych"*, *„wyłącz wszystkie zaznaczone"*, *„opublikuj zaznaczone na Shopify"*, *„dodaj do kategorii Promocja dla zaznaczonych"*, *„dla 30 zaznaczonych skopiuj manufacturer do brand"*.
+
+### 10.2 Co NIE JEST AI w MVP (mimo nazwy „smart filters")
+
+- ❌ **„AI smart filter" — Niespójne opisy** itd. — rule-based SQL query, **nie LLM**. Patrz §11 *Krytyczna nota marketingowa* poniżej.
+
+### 10.3 Co JEST AI w Fazie 1+
+
+- ⏳ **NLP filter queries w Cmd+K** — *„pokaż mi produkty z niespójnymi opisami"* jako natural language zamiast preset click.
+- ⏳ **Bulk translate** — *„przetłumacz description dla zaznaczonych z PL na EN"* (Faza 2, data-ops agent).
+- ⏳ **Bulk generate SEO** — *„wygeneruj opis SEO dla zaznaczonych z atrybutów"* (Faza 2).
+- ⏳ **Cross-channel inconsistency detection** — *„description na Shopify różni się od BaseLinker dla tego SKU"* (Faza 1-2, LLM semantic comparison).
+- ⏳ **AI quality dashboard** — completeness + consistency + freshness scoring per kanał z propozycjami fixów (Faza 2).
+- ⏳ **Real-time AI semantic search** — *„znajdź mi produkty podobne do TST-001"* (Faza 1+, embeddings).
+- ⏳ **`delete_bulk` przez Cmd+K** — Faza 1 (cautious — destructive bez full UI flow).
+
+### 10.4 AI a polityka danych klienta
+
+- **BYOK domyślnie** dla Pro/Enterprise — klient płaci swój Anthropic key, dane idą do *jego* organizacji Anthropic (data policy klienta vs Anthropic).
+- Marcin's key tylko dla testów + demo dla nowych design partners.
+- Limits z architektury §8.5: 50 tool calls/h/user, 10 tool calls/agent_run, $20/dzień/tenant, $300/miesiąc/tenant.
+
+### 10.5 AI cost per Cmd+K command
+
+- Input ~500-2000 tokens (current state + selection + filter context).
+- Output ~200-500 tokens (tool call JSON).
+- Claude Sonnet 4.5: ~$0.002-0.008 per command.
+- Przy 50 commands/dzień/user: $0.10-0.40/dzień. Typowy heavy user (Marcin profile): $3-12/miesiąc per user.
+
+---
+
+## 11. Architektura SaaS (feature-level)
+
+> Master architektura multitenant Cortex PIM (FrankenPHP worker, Doctrine TenantFilter, RLS w Fazie 1) — patrz `Zrodla/PRD/PRD-PIM.md` §11 oraz `Project Plan/01-architektura-pim.md`. Tu tylko aspekty feature'a.
+
+### 11.1 Multi-tenancy izolacja
+
+- Wszystkie nowe encje (`bulk_sessions`, `bulk_logs`, `smart_filter_presets`, `user_filter_favorites`) mają `tenant_id UUID NOT NULL` od dnia 1 (kontrakt CLAUDE.md).
+- Doctrine TenantFilter automatic clause `WHERE tenant_id = :current_tenant`.
+- `smart_filter_presets` ma `tenant_id NULLABLE` — `NULL` = system-shipped built-in (shared globally, immutable per tenant).
+- Postgres RLS aktywowany w Fazie 1 (sekcja 11.1a master architektury, plan 16-24h).
+
+### 11.2 Skala docelowa feature'a
+
+- **Filter query latency target:** p95 <300ms na 200k SKU. GIN index na `objects.attributes_indexed JSONB` (ADR-006) + Meilisearch dla quick search po SKU/name/EAN/brand/tags.
+- **Bulk operations:** async threshold >100 produktów (Symfony Messenger). Worker chunk size N=200 z `EntityManager::clear()` per chunk (memory management, CLAUDE.md FrankenPHP rule).
+- **Cmd+K response time target:** <3s end-to-end (input → Anthropic API → tool call generation → preview render).
+- **Selection state w memory client-side** — React state `selectedIds: string[]`. Limit cross-page selection 10k SKUs (UX warning powyżej; do uzgodnienia §14 open question).
+
+### 11.3 FrankenPHP worker mode — memory safety
+
+- `BulkEditAttributeHandler extends AbstractBatchHandler` — `EntityManager::clear()` per chunk N=200 (custom PHPStan rule blokuje flush-without-clear).
+- `BulkRollbackHandler` iteruje `bulk_logs` z Doctrine `iterate()` zamiast `findAll()` (memory-safe dla 10k+ entries).
+- Prometheus alert `frankenphp_worker_memory_bytes > 256MB` (z CLAUDE.md).
+
+### 11.4 Mercure SSE channels
+
+- `bulk-operations.{user_id}` — wszystkie bulk operations tego usera (live updates lista).
+- `bulk-operations.{session_id}` — pojedyncza operacja progress (subscribed gdy user otwiera detail).
+- `cmd-k.{user_id}` — Cmd+K agent stream response (token-by-token typing effect).
+
+### 11.5 Bezpieczeństwo i compliance
+
+- **MVP brak per-action gating** (decyzja Fali 3) — wszyscy userzy mogą bulk delete/publish. Audit log + 24h rollback wystarczą. Faza 1 → ADR-013 per-role permissions.
+- **Cmd+K agent rate limits** twarde (CLAUDE.md §8.5) — 50 tool calls/h/user, 10 tool calls/agent_run, $20/dzień/tenant, $300/miesiąc/tenant. Po przekroczeniu agent off do północy UTC.
+- **BYOK klucz tenanta** szyfrowany AES-256-GCM (z architektury §8.5).
+
+### 11.6 SLA per feature
+
+| Tier | Filter latency P95 | Bulk operations queue | Cmd+K availability |
+|------|--------------------|------------------------|--------------------|
+| Free / Trial | <500ms na 1k SKU | Sync only (limit 100 produktów) | Demo limit 10 commands/dzień |
+| Starter | <400ms na 10k SKU | Async, max 1 concurrent bulk job | 50 commands/h, BYOK opcjonalne |
+| Pro | <300ms na 50k SKU | Async, max 3 concurrent bulk jobs | 50 commands/h, BYOK obowiązkowe |
+| Enterprise | <300ms na 200k SKU + dedicated read replicas | Async, unlimited concurrent (kolejkowanie inteligentne) | Custom limits, BYOK + audit retention 12 miesięcy |
+
+---
+
+## 12. Model biznesowy i pricing (feature-level)
+
+> Master pricing Cortex PIM — patrz `Zrodla/PRD/PRD-PIM.md` §12. Tu tylko wpływ tego feature'a na pricing tiers.
+
+### 12.1 Co jest gated per tier
+
+| Tier | Smart filter presets | Saved Views per user | Cmd+K agent | Bulk concurrent jobs | Rollback retention |
+|------|-----------------------|----------------------|-------------|----------------------|--------------------|
+| Free / Trial | 5 built-in | 3 | 10 commands/dzień (demo) | 1 sync only, ≤100 produktów | 24h |
+| Starter | 5 built-in + 5 user-defined (Faza 1) | 10 | 50 commands/h, BYOK opc. | 1 concurrent async | 24h |
+| Pro | Unlimited user-defined | Unlimited | 50 commands/h, BYOK obow. | 3 concurrent async | 24h |
+| Enterprise | Unlimited + custom tenant-shared | Unlimited + role-based | Custom limits, BYOK + audit | Unlimited (smart queue) | Custom (7-30 dni) |
+
+### 12.2 Wpływ kosztowy AI na pricing
+
+- Cmd+K cost ~$0.002-0.008 per command. Heavy user (50 commands/dzień) = ~$3-12/miesiąc.
+- Margin assumption (Pro tier $99/miesiąc): Cmd+K cost <5% revenue per user. Margin OK do ~10 heavy users per tenant (10× $12 = $120 absorbed przez BYOK).
+- **BYOK obowiązkowe od Pro** — model unit economics nie domyka się bez tego dla heavy users.
+
+### 12.3 Open business questions (feature-related)
+
+- [ ] Czy Cmd+K w Trial 10 commands/dzień jest zbyt restrictive vs. demo wow-effect? Może 20 commands/Trial-okres total (cap globalny)?
+- [ ] Czy rollback 24h jest tier-gatable (7d na Enterprise) vs. universal („zaufanie do produktu" gest)?
+- [ ] Cmd+K bulk actions Faza 1+ cut (oszczędność ~12-16h MVP) — czy to akceptowalne, czy USP wymaga MVP shippping?
+
+---
+
+## 13. MVP scope i roadmap (feature-level)
+
+### 13.1 MVP — co MUSI być w pierwszym release feature'a
+
+**Wyszukiwarka i filtry:**
+- Quick search po SKU/name/EAN/brand/tags z Enter submit / debounce 800ms (brak typeahead — decyzja Fali 2).
+- *„Filtruj po atrybucie"* dropdown z favorite top 10 + link do full attribute modal.
+- Chip filter area z edit popover (click chip body) + ✕ kasuje.
+- Advanced filter panel push-down sticky-collapsible (Magento style) z grid mode (default).
+- Pełne operatory per typ atrybutu (Akeneo-grade) od dnia 1 — decyzja Fali 2.
+- 5 built-in smart filter presets (rule-based — patrz §11 *Krytyczna nota*).
+- URL-based filter persistence (shareable, refreshable).
+- Saved Views integration (entity z epiku 02 §9).
+
+**Akcje zbiorcze:**
+- 14 akcji: set/clear/append/remove attribute, multi-attr edit, increment numeric, toggle enabled, add/remove/move category, publish/unpublish channels, delete, duplicate.
+- 3-step wizard z preview diff (sample 5 + aggregate counter) dla edit/clear/append/remove/increment.
+- Inline toast + Undo 5s dla low-risk (toggle enabled, add/remove category).
+- Hard confirm typing N produktów dla destructive (delete).
+- Simple modal dla publish/unpublish/duplicate.
+- Cascade impact summary modal dla delete + change family (Faza 1).
+- 24h soft rollback per `bulk_session_id`.
+- Per-attribute lock skip-and-report (raport SKUs).
+- BaseLinker-style cross-page selection (toolbar wybór per-page vs select-all-matching).
+- Async via Symfony Messenger dla >100 produktów (Mercure SSE progress).
+
+**Cmd+K agent:**
+- Trigger ⌘K (Mac) / Ctrl+K (Win/Linux) + button toolbar.
+- Palette modal z input + kontekst sekcja (*„30 zaznaczone, filter: Brand=Festo"*) + podpowiedzi + ostatnie komendy.
+- Intent parsing przez Anthropic Claude Sonnet 4.5.
+- 6 MVP intents: `create_attribute` (schema-ops z epiku 08), `set_bulk_attribute`, `toggle_bulk_enabled`, `increment_bulk_numeric`, `add_remove_category`, `publish_bulk`.
+- Selection context naturalne (bez UI explicit chip — decyzja Fali 4).
+- Preview diff identyczny z manual flow (spójność).
+
+### 13.2 v1 (3-6 miesięcy po MVP) — Faza 1
+
+- Query mode w Advanced filter panel (AND/OR brackets — power user).
+- User-defined smart filter presets („Zapisz Saved View jako Smart Preset").
+- Cmd+K NLP filter queries (*„pokaż mi produkty z niespójnymi opisami"*).
+- Cmd+K `delete_bulk` intent (z full UI flow safeguards).
+- Per-channel completeness scoring (wymaga rules z epiku 04 Publikacje).
+- Force override locked attribute przez super_admin (z confirm modal).
+- Bulk replace main image / add to gallery.
+- Bulk export to CSV/XLSX (w epiku 04 Publikacje).
+- Find & replace text w description/name z regex (rules engine).
+- ADR-013 per-action role permissions.
+
+### 13.3 v2+ (Faza 2-3) — w roadmapie ale bez commit
+
+- Cmd+K `bulk_translate`, `bulk_generate_seo` (data-ops agent z LLM).
+- AI semantic search („produkty podobne do TST-001").
+- AI quality dashboard (cross-channel inconsistency, completeness, freshness).
+- Real-time collaborative selection state (multi-user lock visibility).
+- Custom scripts mode (BaseLinker-style power user) — kandydat lub never.
+- Change workflow state w bulk (Symfony Workflow z epiku 06).
+- Per-attribute weight w completeness formula.
+
+### 13.4 Pierwszy klient referencyjny / design partner
+
+- **Marcin (dogfooding)** — first user, 5000 SKU realny katalog (IdoSell + Shopify migracja). Zero-day feedback.
+- **Design partner #1** — szukany przed Sprintem 1 (PRD §13 ryzyko R-30). Profile: polski B2B techniczny e-commerce, 5-15k SKU, multi-locale (PL + EN), pain point z BaseLinker lub Akeneo. Free Cortex w zamian za 1h/tydzień feedback przez 3 miesiące.
+
+### 13.5 Czas do MVP
+
+- Backend impact: **+131-182h** ponad obecny budżet (3-4× scope creep vs. PRD master §7 limit).
+- Rozkład: epik 0.4 +14-20h, epik 0.5 +4-6h, epik 0.6 +95-130h (dominant), epik 0.7 +12-16h, epik 0.11 +6-10h.
+- Realna estymacja MVP feature'a w izolacji (założenie reszty epik 02 baseline gotowa): **6-10 tygodni** solo dev pace (Marcin).
+- Świadoma decyzja właściciela: *„nie spieszę się, robimy żeby było dobrze"* (cytat PRD master §12.1).
+
+---
+
+## 14. Ryzyka, sprzeczności, otwarte kwestie
+
+### 14.1 Zidentyfikowane ryzyka
+
+| Ryzyko | Prawdopodobieństwo | Wpływ | Mitygacja |
+|--------|--------------------|----|-----------|
+| **R-30 Scope creep feature'a** — +131-182h vs. PRD limit ~50-80h | Wysokie (już zaistniało) | Wysoki (opóźnienie całego MVP o 6-10 tyg.) | Cut Faza 1: Query mode (~12-16h) + Cmd+K bulk (~12-16h) + Increment numeric + multi-attr bulk edit (~8-10h). Decyzja przed Sprint 1. |
+| **R-31 Cmd+K accuracy <80%** intent parsing | Średnie | Średni (USP wow-effect zniweczony) | POC w Sprint 1 z mock agent (rule-based) + benchmark na 50 typowych queries Marcina przed Anthropic integration. |
+| **R-32 Anthropic API outage** podczas demo | Niskie | Wysoki (jeden incident = utracony lead) | Fallback do mock agent z disclaimer *„Cmd+K AI offline, użyj manual flow"*. BYOK redundancy (klient ma multi-region). |
+| **R-33 „AI smart filters" misleading marketing** — klient płaci za Pro tier oczekując prawdziwego AI | Średnie | Wysoki (refund + bad word-of-mouth) | **Krytyczna nota §11 obowiązkowa** w pitch deck, marketing copy, sales script. Slajd 4-5 pitch deck *„coming in Faza 1"* dla full AI smart filters. |
+| **R-34 Bulk rollback brak orderów sync** — `bulk publish` rollback gdy klient ma sprzedaż w międzyczasie | Wysokie | Średni (klient zaskoczony „partial" status) | UX expectation setting w hard confirm modal *„buyer może zobaczyć product not found w 12h window — akceptujesz?"*. Raport CSV z `partial` SKUs. |
+| **R-35 Cross-page selection 50k SKUs bulk operation** zalewa worker queue | Niskie | Wysoki (degradacja systemu, OOM workera) | UX warning *„>10k zaznaczonych — operacja zajmie 30+ minut"* + soft limit 10k (Pro tier) / 50k (Enterprise). |
+| **R-36 GIN index performance** na `attributes_indexed JSONB` przy 200k+ SKU | Średnie | Średni (filter latency >300ms target) | Benchmark Sprint 1 z syntetycznym 200k SKU dataset. Fallback: dedicated Meilisearch dla filter queries (poza quick search). |
+| **R-37 Filter URL params** edge cases z bogato zagnieżdżonymi query | Niskie | Niski (URL >2000 znaków, niektóre proxies tnie) | Hashowany blob `?q=<base64-json>` dla query mode + Saved View jako prawdziwy persistent. |
+| **R-38 Per-attribute lock locked-by stale** — user A lock'uje, opuszcza firmę, user B nie może bulk edit | Niskie | Niski | Faza 1: super_admin force override z confirm. MVP: workaround przez ręczny un-lock w detail view. |
+| **R-39 Cmd+K cost spike** — heavy user >$20/dzień limit po południu | Średnie | Niski (UX disruption) | Hard limit z architektury §8.5. Komunikat *„dzienny limit AI agenta wyczerpany, dostępny od jutra"*. |
+
+### 14.2 Otwarte kwestie (do uzupełnienia / walidacji)
+
+- [ ] **Bundle size feature'a** — Advanced filter panel + Cmd+K + bulk wizard razem ~150-200 KB. Czy code-split lazy load akceptowalne UX-owo (300ms delay na pierwsze otwarcie panel)?
+- [ ] **Operator pełne w Faza 1 czy MVP** — Marcin wybrał Akeneo-style pełne od dnia 1 (~10-14h). Czy *wszystkie* operatory per type w MVP, czy *core* (`=`, `≠`, `IS EMPTY`, `IS NOT EMPTY`) w MVP + reszta Faza 1?
+- [ ] **Query mode UX validation** — power user feature, ale UX nie trywialny. POC w Sprint 1? Użyć biblioteki `react-querybuilder` (MIT, ~50KB) czy build from scratch?
+- [ ] **Multi-channel filter** — *„description scopable na Shopify ma X"* — jak UX-owo? Default current channel sub-tab + override przez chip?
+- [ ] **Smart filter presets — user-defined w MVP?** — w MVP built-in only. Czy *„Zapisz Saved View jako Smart Preset"* (analog Saved Views ale dla filter previews) do MVP czy Faza 1?
+- [ ] **Cmd+K NLP filter — Faza 1 release** — kiedy *„pokaż mi produkty z niespójnymi opisami"* jako natural language (vs preset click)? Faza 1 z plate-ai integration?
+- [ ] **Bulk rollback dla `publish` — sales sync** — czy mamy `orders` table w bazie (sync z kanałów)? Jeśli nie, *„skip sold-since-publish"* niemożliwe → must accept *„best effort + raport"* approach. Decyzja: akceptujemy *„best effort + raport"* w MVP (z Fali 4).
+- [ ] **Select-all-matching limit** — 10k? 50k? 100k? UX warning vs. hard block?
+- [ ] **Search performance edge cases** — query z 5+ słowami: *„czujnik indukcyjny Festo 24V IP67"* — strict prefix nie zadziała. Klient potrzebuje *„at least one word matches"* — Meilisearch domyślnie tak działa, ale to nie jest prefix. Reconfirm semantic w Sprint 1 POC.
+- [ ] **Mobile UX** — z epiku 02 brak responsive, scroll horizontal. Cmd+K na mobile (touch device) — button w toolbar zamiast keyboard shortcut. Czy mobile MVP scope?
+- [ ] **Filter na archived value** (np. brand "Bosch" archived w Modelowaniu) — chip aktywny, ale value picker nie pokazuje. Czy to OK UX czy wymaga forced migration filter chip → new value?
+- [ ] **Cmd+K out-of-context queries** (klient w liście wpisuje *„dodaj użytkownika"*) — agent przekierowuje do Settings. Czy zachować selection state po cross-context navigation?
+- [ ] **Pricing Cmd+K w Trial** — 10 commands/dzień restrictive vs. 20 commands/Trial-okres total?
+
+### 14.3 Założenia, które trzeba zwalidować
+
+- **Założenie 1:** *„60% czasu Kasi na liście produktów"* — bazuje na heurystyce z konkurencji (Akeneo metryki). Walidacja: session replay Hotjar na design partner #1 w pierwszych 3 miesiącach trial.
+- **Założenie 2:** *„Cmd+K accuracy >90% na typowych queries"* — bazuje na Claude Sonnet 4.5 capability dla strukturyzowanych intents. Walidacja: POC w Sprint 1 z 50 typowymi queries Marcina, manual scoring.
+- **Założenie 3:** *„24h rollback wystarczy"* — bazuje na intuicji *„większość pomyłek user widzi w godzinach od popełnienia"*. Walidacja: monitoring rollback usage w pierwszych 6 miesiącach (jeśli >20% rollbacków odbywa się w 23-25h window → rozszerzyć do 48h).
+- **Założenie 4:** *„BYOK od Pro tier akceptowalne"* — bazuje na unit economics. Walidacja: rozmowy z 5 prospects czy BYOK to dealbreaker (zwłaszcza SMB tier).
+- **Założenie 5:** *„Filter URL share działa cross-team"* — założenie że Magda i Kasia mają shared sesje (zalogowane na tych samych URL). Walidacja: czy SSO Faza 3 wymaga zmiany filter persistence schema?
+- **Założenie 6:** *„Pełne operatory od dnia 1 = killer differentiator"* — bazuje na Akeneo feedback z forum. Walidacja: pytanie do design partners *„czy chcesz pełne operatory czy wystarczy `=` i `IS EMPTY`?"*. Jeśli >70% mówi *„wystarczy core"* — Faza 1 cut.
+- **Założenie 7:** *„Kasia/Magda nie chcą custom scripts mode"* — bazuje na profile persony. Walidacja: explicit pytanie design partners. Jeśli pojawi się popyt, Faza 2 kandydat.
+
+---
+
+## 15. Następne kroki
+
+1. **Walidacja konceptu z first design partner** — przed Sprintem 1. Profile: polski B2B techniczny e-commerce 5-15k SKU multi-locale. Pytania kluczowe: pełne operatory vs. core, Query mode konieczne czy luxury, Cmd+K wow vs. fluff, BYOK acceptable czy dealbreaker.
+2. **POC Cmd+K mock w Sprint 1** — rule-based intent parsing (regex + keyword matching) na 50 typowych queries Marcina. Benchmark accuracy. Decyzja: kontynuuj z Anthropic, lub wycofaj feature.
+3. **POC operator implementation w Sprint 1** — Akeneo-style pełne operatory per typ. Benchmark complexity (~10-14h) vs. wartość dla design partners.
+4. **POC GIN index performance** — syntetyczny 200k SKU dataset, benchmark filter latency p95. Jeśli >500ms → fallback Meilisearch dla filter queries.
+5. **Decyzja scope cuts przed Sprintem 1** — Marcin akceptuje +131-182h, ale możliwe:
+   - (a) Query mode AND/OR → Faza 1 (~12-16h oszczędność).
+   - (b) Cmd+K bulk actions → Faza 1 (~12-16h oszczędność, pozostaje schema-ops only z epiku 08).
+   - (c) Increment numeric + multi-attr bulk edit → Faza 1 (~8-10h oszczędność).
+   - Rekomendacja: cut (a) i (c), zachowaj (b) — Cmd+K bulk to USP wow-effect dla demo.
+6. **Aktualizacja `Project Plan/02-plan-projektu-pim.md`** — epik 0.4/0.5/0.6/0.7/0.11 estymacje + nowe ryzyko **R-30** (List feature scope creep).
+7. **Aktualizacja `Project Plan/03-funkcjonalnosci-mvp.md`** — dodać user stories US-LIST-001 do US-LIST-022 (z [`feature-list-advanced.md`](../UI/feature-list-advanced.md) §12).
+8. **Aktualizacja pitch deck** — wprowadzić *„coming in Faza 1"* note dla AI smart filters (krytyczna nota §11). Slajd 4 (USP Agentic) — Cmd+K + manual integration + 24h rollback jako triad differentiatorów.
+9. **Wireframes Figma** — przekazać external UX designer (PRD master §13.5) — priorytet: Advanced filter panel push-down + Cmd+K palette + bulk wizard Step 3 preview (sample 5 + aggregate).
+10. **Walidacja Cortex PIM master PRD spójność** — czy ten feature-PRD jest kompatybilny z roadmap master PRD § 13 (cuts mogą wymagać master update).
+
+---
+
+## 16. Załączniki i powiązane dokumenty
+
+- [`../UI/feature-list-advanced.md`](../UI/feature-list-advanced.md) — **źródło prawdy detaliczne** (wireframes ASCII, SQL schema, 22 user stories, business rules).
+- [`../UI/epik-02-produkty.md`](../UI/epik-02-produkty.md) — epik nadrzędny (lista produktów baseline, detail view, Saved Views, Excel-like editing).
+- [`../UI/feature-imports.md`](../UI/feature-imports.md) — wzorzec strukturalny (status 🟢 zaimplementowane IMP-01..IMP-15) + sąsiednie feature (importy CSV/XLS/XLSX).
+- [`../UI/00-plan-ui.md`](../UI/00-plan-ui.md) — master plan UI.
+- [`../../Zrodla/PRD/PRD-PIM.md`](../../Zrodla/PRD/PRD-PIM.md) — **master product PRD Cortex PIM** (pozycjonowanie globalne, ICP, multitenant SaaS, pricing, MVP scope całościowy).
+- [`../01-architektura-pim.md`](../01-architektura-pim.md) — architektura (ADR-006 hybrid attribute model, ADR-009 ObjectType, ADR-010 axis-driven variants, ADR-011 per-tenant locale fallback, sekcja 8.5 limits AI).
+- [`../02-plan-projektu-pim.md`](../02-plan-projektu-pim.md) — backlog i estymacje (do aktualizacji per §15 punkt 6).
+- [`../03-funkcjonalnosci-mvp.md`](../03-funkcjonalnosci-mvp.md) — user stories MVP (do aktualizacji per §15 punkt 7).
+- [`../../CLAUDE.md`](../../CLAUDE.md) — konstytucja projektu (memory management, single-origin Caddy, BYOK).
+
+---
+
+*Dokument wygenerowany 2026-05-13 jako synteza brainstormingu 4-falowego (2026-05-11) z [`feature-list-advanced.md`](../UI/feature-list-advanced.md). Status: Draft — wymaga walidacji z design partners (§15 punkt 1), decyzji o scope cuts (§15 punkt 5), i POC w Sprint 1 (§15 punkty 2-4) przed startem implementacji.*

--- a/Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-09-lista-fundament-ui.md
+++ b/Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-09-lista-fundament-ui.md
@@ -1,0 +1,590 @@
+# VIEW-09 — Lista produktów v2 · fundament UI (smart filter presets + push-down advanced filter panel grid mode + filter chips edit popover)
+
+## 1. Kontekst i cel widoku
+
+Widok `/products` po marathonie UI-02 (#336–#342) i VIEW-05 (PR #412) jest pixel-perfect z mockupem **v1** (`design_handoff_modelowania/produkty/list-view.jsx`). Mockup **v2** (`Zrodla/Front_Claude_Design/PIM-nowoczesny/Produkty v2.html`) wraz z PRD `Project Plan/PRD/PRD-PIM-list-advanced.md` definiuje cockpit operatora ICP Kasi (60% czasu pracy) — gęstość BaseLinker + workflow Akeneo + Cmd+K agent.
+
+VIEW-09 dostarcza **fundament UI** epiku UI-09: (a) pasek 5 built-in smart filter presets (PRD §8.2, rule-based — *NIE LLM*; PRD §11 krytyczna nota marketingowa) + user-defined CRUD; (b) push-down sticky-collapsible advanced filter panel w **grid mode only** (query mode → VIEW-09b); (c) filter chips area z edit popover (click chip body otwiera operator + value picker, ✕ kasuje, *„Wyczyść wszystkie"* + *„Skopiuj URL z filtrami"* buttony).
+
+Query mode AND/OR brackets, pełne operatory per typ, cross-page selection, bulk wizard, rollback, locki, Cmd+K — następne tickety epiku (VIEW-09b, VIEW-10..VIEW-19). VIEW-09 to baseline UI/UX i model danych pod resztę feature'a.
+
+## 2. Mockup / źródło designu
+
+- **Plik źródłowy (HTML wrapper)**: `Zrodla/Front_Claude_Design/PIM-nowoczesny/Produkty v2.html` (loader trzech JSX scriptów).
+- **Plik źródłowy (FE komponenty v2)**:
+  - `Zrodla/Front_Claude_Design/PIM-nowoczesny/produkty/list-view-v2.jsx` (694 LOC, główny widok)
+  - `Zrodla/Front_Claude_Design/PIM-nowoczesny/produkty/list-v2-overlays.jsx` (569 LOC — `AdvancedFilterPanel` + `BulkWizard` + `CmdKPalette` + `RollbackToast`)
+  - `Zrodla/Front_Claude_Design/PIM-nowoczesny/produkty/data.jsx` (156 LOC, schema reference dla SAVED_VIEWS + PRODUCTS + SMART_PRESETS)
+- **Pixel-perfect binding**: JSX prototyp v2 jest single source of truth dla layoutu, klas Tailwind, paddingów, copy, animacji. Adaptacje stack-specific (shadcn `<DropdownMenu>` zamiast hand-rolled, lucide-react zamiast inline SVG `IL2.*`) dozwolone, wizualny rezultat <2% pixel mismatch.
+- **PRD master**: `Project Plan/PRD/PRD-PIM-list-advanced.md` (1214 LOC, sekcje §1, §3, §5, §7.1, §7.2, §7.4, §8.2, §11, §13.1, §14.1).
+
+**Kluczowe linie mockupu (do referencji):**
+- `list-view-v2.jsx` l. 17-24: `SMART_PRESETS` 5 built-in tablica.
+- `list-view-v2.jsx` l. 49-69: `SavedViewsRail` (bez zmian — istnieje w `saved-views-rail.tsx`).
+- `list-view-v2.jsx` l. 71-107: `SmartFilterRow` — nowy fundament VIEW-09.
+- `list-view-v2.jsx` l. 109-151: `FilterChip` (upgrade z `FilterPill`).
+- `list-view-v2.jsx` l. 153-223: `Toolbar` — refactor existing.
+- `list-view-v2.jsx` l. 583-689: główna struktura widoku.
+- `list-v2-overlays.jsx` l. 9-19: `FILTER_OPS_BY_TYPE` mapa (full operatorzy → VIEW-10).
+- `list-v2-overlays.jsx` l. 21-38: `FILTER_ATTRS` baseline atrybutów z `star: true` (favorite top 10).
+- `list-v2-overlays.jsx` l. 40-146: `AdvancedFilterPanel` (grid mode w VIEW-09; query mode tab disabled).
+
+**Powiązane widoki niewchodzące w scope:**
+- `BulkWizard`, `CmdKPalette`, `RollbackToast` (overlays) → VIEW-12, VIEW-19, VIEW-17.
+- `SelectionToolbar` (`list-view-v2.jsx` l. 226-254) → VIEW-11.
+- `BulkBar` z 14 akcjami (l. 419-482) → fundament w VIEW-12, rozszerzenia w VIEW-13..VIEW-16.
+- Grid z 12 kolumnami (l. 260-396) — bez zmian, kolumna `lock` w VIEW-18.
+- `RollbackToast` → VIEW-17.
+
+**Klimas / inne nazwy w mockupie** to przykładowy tenant — nie używać w produkcyjnej kopii (feedback memory `feedback_view_scope_literal.md`).
+
+## 3. Zakres frontend (FE)
+
+### 3.1 Routing
+
+- `/products` (już istnieje, `apps/admin/src/app.tsx`). **Bez zmian** — VIEW-09 modyfikuje wnętrze widoku, nie route.
+- Auth gate: `<AuthedRoute>` (istnieje).
+- Lista pozostaje fullscreen-routed (nie Sheet/Dialog).
+
+### 3.2 Komponenty (lista płaska)
+
+#### Reuse (bez zmian)
+| Komponent | Plik | Cel w VIEW-09 |
+|---|---|---|
+| `SavedViewsRail` | `components/catalog/saved-views-rail.tsx` | Saved views rail pod headerem (bez zmian) |
+| `CompletenessBadge` | `components/catalog/completeness-badge.tsx` | Bez zmian (grid kolumna) |
+| `ProductsGrid` | `components/catalog/products-grid.tsx` | Bez zmian (kolumna lock → VIEW-18) |
+| `SaveViewModal` | `components/catalog/save-view-modal.tsx` | Reuse + dodanie ikoną picker dla Smart Preset |
+| `useCatalogSearch` | `features/catalog/search/use-catalog-search.ts` | Rozszerzenie o `smartPresetId` + filter DSL parametr |
+| `jsonFetch` | `lib/http.ts` | JWT-aware HTTP (defensive po hotfix #525) |
+| `ToastProvider` + `useToast` | `components/ui/toast.tsx` | Smart Preset save success toast |
+
+#### Nowe komponenty
+| Komponent | Plik | LOC | Props |
+|---|---|---|---|
+| `SmartFilterPresetsRow` | `components/catalog/smart-filter-presets-row.tsx` | ~140 | `{ activeId, presets, counts, onSelect, onCreate }` |
+| `SaveAsSmartPresetModal` | `components/catalog/save-as-smart-preset-modal.tsx` | ~100 | `{ open, onClose, currentFilters, onSaved }` |
+| `AdvancedFilterPanel` | `components/catalog/advanced-filter-panel.tsx` | ~280 | `{ open, mode, setMode, conditions, setConditions, onApply, onClose, onClear, onSaveAsView, onSaveAsPreset }` |
+| `FilterChip` | `components/catalog/filter-chip.tsx` | ~140 | `{ label, op, value, attrType, options, onChange, onRemove }` (zastępuje `FilterPill`) |
+| `FilterChipsBar` | `components/catalog/filter-chips-bar.tsx` | ~80 | `{ chips, onRemove, onClearAll, urlShareable }` |
+
+#### Modyfikacje
+| Plik | Zmiana |
+|---|---|
+| `features/catalog/products/list.tsx` | Topbar refactor: `SmartFilterPresetsRow` pod `SavedViewsRail` + toolbar bez 4 hardcoded `FilterPill` (zastąpione button *„Filtruj po atrybucie 3"* → otwiera Advanced panel) + `FilterChipsBar` pod toolbar + `AdvancedFilterPanel` renderowany conditionally |
+| `features/catalog/search/use-catalog-search.ts` | Dodaj `smartPresetId?: string` + `filterDsl?: FilterDsl` parametry; resolver po stronie BE |
+| `components/catalog/save-view-modal.tsx` | Dodaj `icon` picker (emoji set lub lucide IconPicker) — reuse w SaveAsSmartPresetModal |
+| `locales/pl.json` + `en.json` | ~40 nowych kluczy |
+| `app.tsx` | (Już zmounted ToastProvider w VIEW-05) — bez zmian |
+
+#### Usuwane
+| Plik | Powód |
+|---|---|
+| `components/catalog/advanced-filter-builder.tsx` (Sheet, 6KB) | Zastąpiony przez `advanced-filter-panel.tsx` (push-down sticky) |
+| `components/catalog/filter-pill.tsx` (3KB) | Zastąpiony przez `filter-chip.tsx` z edit popover |
+| `components/catalog/product-filter-chips.tsx` (2KB) | Zastąpiony przez `filter-chips-bar.tsx` |
+
+### 3.3 State management
+
+- `query: string` — quick search input value (debounce 800ms zgodnie z PRD §13.1, NIE 200ms jak teraz).
+- `conditions: FilterCondition[]` — array `{attr, op, value}` (płaski grid mode).
+- `activeSmartPresetId: string | null` — wybrany preset (clear gdy user edytuje conditions ręcznie).
+- `advancedOpen: boolean` — push-down panel open/closed (default closed; persisted w localStorage `products.advancedOpen`).
+- `chips: Chip[]` — derived state z `conditions` (1 chip = 1 condition).
+- `urlShareable: string` — derived URL z aktualnymi conditions.
+- `showSaveAsPresetModal: boolean` — modal trigger.
+
+**Mutacje + invalidacje:**
+- `GET /api/smart-filter-presets` (z `?counts=true` per preset) → `refetch()` po POST/DELETE.
+- `POST /api/smart-filter-presets` z `{name, icon, query: FilterDsl}` → toast success + refetch.
+- `DELETE /api/smart-filter-presets/{id}` → confirm + refetch.
+- `GET /api/search/products?smart_preset=<id>` lub `?filter=<filterDsl>` → useCatalogSearch refetch.
+
+**Cache:** Refine `useList` + `useCatalogSearch` query keys rozszerzone o `smartPresetId` + `filterDsl` hash.
+
+### 3.4 Struktura sekcji widoku (kolejność renderu)
+
+1. **Header** — breadcrumb-line *„Workspace · katalog"* + h1 *„Produkty"* 32px (lewa) + total SKU + last sync + Mercure live indicator (prawa). (Z VIEW-05 baseline, bez zmian).
+2. **Saved views rail** — poziomy rail z pillami (`SavedViewsRail`, bez zmian).
+3. **🆕 Smart filter presets row** — sticky pasek z 5 built-in + user-defined chipami.
+4. **Toolbar** — search flex-1 + button *„Filtruj po atrybucie [N]"* (otwiera Advanced panel) + segmented Płasko/Drzewo + Cmd+K button gradient violet (VIEW-19 implementacja, w VIEW-09 disabled z badge *„VIEW-19"*) + Import + Nowy produkt.
+5. **🆕 Filter chips bar** — *„Aktywne filtry"* label + chipy z edit popover + *„Wyczyść wszystkie"* + *„Skopiuj URL z filtrami"*.
+6. **🆕 Advanced filter panel** (conditional na `advancedOpen`) — push-down sticky, grid mode only.
+7. **ProductsGrid** — 12-col grid (bez zmian).
+8. **Pagination footer** — total + per page + paginator (bez zmian).
+9. **BulkBar** (sticky bottom-6, conditional, VIEW-12+ rozszerzenie z VIEW-05 placeholderów).
+
+### 3.4a Mapping element-po-elemencie z prototypu
+
+#### SmartFilterPresetsRow (mockup `list-view-v2.jsx` l. 71-107)
+
+Wrapper: `<div class="rounded-3xl bg-white soft-shadow border border-zinc-100 px-3 py-2.5 flex items-center gap-2">`.
+
+- Lewa sekcja (~120px): `<span class="h-7 w-7 rounded-xl bg-zinc-900 text-white grid place-items-center">` z `<Sparkles>` lucide ikoną (zamiast IL2.zap) + `<div class="leading-tight">` z `<div class="text-[11.5px] font-semibold tracking-tight">Smart filtry</div>` + `<div class="text-[10px] text-zinc-400 inline-flex items-center gap-1">` zawierające `<span class="font-mono px-1 rounded bg-zinc-100 text-zinc-500">reguły</span><span>· LLM od Fazy 1</span>` (**marketing-honest copy** — PRD §11 krytyczna nota).
+- Vertical separator: `<span class="h-7 w-px bg-zinc-100" />`.
+- Scrollable chip area (flex-1, `overflow-x-auto scrollbar-thin`):
+  - Per preset chip (5 built-in + N user-defined): `<button onClick={...} title={preset.rule} class="group shrink-0 inline-flex items-center gap-2 h-9 px-3 rounded-2xl text-[12.5px] font-medium transition border ${isActive ? 'bg-zinc-900 text-white border-zinc-900' : 'bg-zinc-50 text-zinc-700 border-zinc-100 hover:bg-white hover:border-zinc-200'}">` zawierający emoji icon + name + count `font-mono num`.
+- Prawa: `<button onClick={onCreate} class="shrink-0 inline-flex items-center gap-1.5 h-9 px-3 rounded-2xl text-[12px] text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50">` z `<Plus>` lucide + *„Własny preset"*.
+
+**5 built-in presets** (PRD §8.2, seedowane w migracji BE):
+
+| Slug | Icon | Name (PL) | Name (EN) | Query DSL |
+|---|---|---|---|---|
+| `inconsistent-translations` | 🌐 | Niespójne tłumaczenia | Inconsistent translations | `{op: "AND", conditions: [{attr: "description.pl", op: "IS NOT EMPTY"}, {attr: "description.en", op: "IS EMPTY"}]}` |
+| `missing-images` | 📷 | Brakujące zdjęcia | Missing images | `{attr: "main_image", op: "IS EMPTY"}` |
+| `weak-seo` | 🔍 | Niepełne SEO | Weak SEO | `{op: "AND", conditions: [{attr: "description", op: "IS NOT EMPTY"}, {attr: "meta_description", op: "IS EMPTY"}]}` |
+| `red-low-completeness` | 🔴 | Czerwone (<50%) | Red (<50%) | `{attr: "completeness_pct", op: "<", value: 50}` |
+| `no-category` | 📂 | Bez kategorii | No category | `{attr: "category", op: "IS EMPTY"}` |
+
+#### SaveAsSmartPresetModal
+
+shadcn `<Dialog>` z headerem *„Zapisz jako Smart Preset"* + body z `<Input>` (name) + `<EmojiPicker>` (icon, ~20 wybranych z lucide IconPicker) + read-only preview aktualnych conditions (DSL JSON pretty-printed) + footer Anuluj + Zapisz.
+
+**Walidacja:**
+- name min 3 znaki max 60.
+- conditions array nie może być pusty.
+- icon obowiązkowy.
+
+#### AdvancedFilterPanel (mockup `list-v2-overlays.jsx` l. 40-146)
+
+Wrapper: `<div class="rounded-3xl bg-white soft-shadow-lg border border-zinc-100 overflow-hidden fade-in">`.
+
+**Header** (`px-5 h-12 flex items-center gap-3 border-b border-zinc-100`):
+- Label: `<span class="text-[11px] uppercase tracking-wider font-semibold text-zinc-500">Filtr zaawansowany</span>`.
+- Mode toggle: `<div class="h-7 rounded-xl bg-zinc-100 inline-flex items-center p-0.5">`:
+  - Grid button (aktywny w VIEW-09): `bg-white text-zinc-900 soft-shadow`.
+  - Query button (disabled w VIEW-09 z badge *„VIEW-09b"* `bg-amber-100 text-amber-700 px-1 py-px rounded text-[9.5px]`).
+- ml-auto: count `<span class="text-[11.5px] text-zinc-400 num">{N} warunk{...}</span>` + *„Wyczyść"* button + ✕ close button.
+
+**Body grid mode** (`p-5`):
+- Lista conditions, każda jako `<div class="flex items-center gap-2">`:
+  - i === 0: `<span class="text-[11px] uppercase tracking-wider font-semibold text-zinc-400 w-12">Gdzie</span>`.
+  - i > 0: `<select>` z AND/OR (`h-9 w-12 text-[11px] uppercase tracking-wider font-semibold text-zinc-500 bg-zinc-50 rounded-lg px-1`).
+  - Attribute select `<select>` z optgroup *„Ulubione"* (star: true) + *„Wszystkie atrybuty"* (~min-w-[160px]).
+  - Type badge `<span class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-zinc-100 text-zinc-500">{type}</span>`.
+  - Operator select (min-w-[120px], font-mono) — w VIEW-09 hard-coded `["=", "≠", "IN", "NOT IN", "IS EMPTY", "IS NOT EMPTY"]`; pełne operatory per typ w VIEW-10.
+  - Value input (flex-1, conditional na non-empty op).
+  - Trash icon button (`h-9 w-9 hover:text-rose-600 hover:bg-rose-50 rounded-lg`).
+- `<button onClick={addCond} class="mt-3 text-[12.5px] text-zinc-500 hover:text-zinc-900 inline-flex items-center gap-1.5 h-8 px-2.5 rounded-lg hover:bg-zinc-100">` + `<Plus>` + *„Dodaj warunek"*.
+
+**Footer** (`px-5 h-12 flex items-center gap-3 border-t border-zinc-100 bg-zinc-50/50`):
+- Dopasuj AND/OR toggle: `<div class="h-6 rounded-lg bg-white border border-zinc-200 inline-flex items-center p-0.5">` z 2 buttonami *„Wszystkie (AND)"* (default) / *„Dowolne (OR)"*.
+- ml-auto: `<span class="text-[11.5px] text-zinc-400 inline-flex items-center gap-1.5">` z `<Link2>` lucide + *„URL zaktualizowany — udostępnij filtr"*.
+- *„Zapisz jako Saved View"* button (link do existing SaveViewModal).
+- *„Zapisz jako Smart Preset"* button (link do nowego SaveAsSmartPresetModal).
+- *„Zastosuj filtr"* button primary `h-9 px-4 rounded-xl bg-zinc-900 text-white text-[12.5px] font-medium hover:bg-zinc-800`.
+
+#### FilterChip (mockup `list-view-v2.jsx` l. 109-151)
+
+Single-chip button z popover:
+
+Wrapper: `<div class="relative inline-flex" ref={ref}>`.
+
+Button: `<button onClick={() => setOpen(o => !o)} class="h-9 pl-3 pr-1.5 rounded-2xl bg-zinc-900 text-white text-[12.5px] font-medium inline-flex items-center gap-1.5 hover:bg-zinc-800">`:
+- Label: `<span class="text-white/60">{label}</span>` (np. *„Marka"*).
+- Operator: `<span class="text-white/50 font-mono text-[11px]">{op}</span>` (np. *„IN"*).
+- Value: `<span class="font-medium">{value}</span>` (np. *„Festo, Bosch"*).
+- ✕: `<span onClick={(e) => { e.stopPropagation(); onRemove(); }} class="ml-1 h-5 w-5 rounded-full hover:bg-white/15 grid place-items-center text-white/70">` z SVG X.
+
+Popover (conditional `open`): `<div class="absolute top-11 left-0 z-30 min-w-[200px] bg-white rounded-2xl soft-shadow-lg border border-zinc-100 p-2 cmdk-pop">`:
+- Operator section: `<div class="text-[10.5px] uppercase tracking-wider font-semibold text-zinc-400 px-2 pb-1">Operator</div>` + flex-wrap buttons per op.
+- Value section: `<div class="text-[10.5px] uppercase tracking-wider font-semibold text-zinc-400 px-2 py-1 mt-1">Wartość</div>` + options list (`px-2 py-1.5 rounded-lg text-[12.5px] text-left hover:bg-zinc-50`).
+
+Click-outside hook: `useEffect` z `mousedown` listener.
+
+#### FilterChipsBar
+
+Wrapper: `<div class="flex items-center gap-2 flex-wrap">` (conditional na `chips.length > 0`).
+- Label: `<span class="text-[10.5px] uppercase tracking-wider font-semibold text-zinc-400">Aktywne filtry</span>`.
+- Chips: array `<FilterChip>`.
+- *„Wyczyść wszystkie"* underlined link button.
+- Vertical separator `<span class="text-zinc-300">·</span>`.
+- *„Skopiuj URL z filtrami"* button z `<Link2>` lucide → `navigator.clipboard.writeText(window.location.href)` + toast.
+
+#### Toolbar refactor (mockup l. 153-223)
+
+Layout: `<div class="flex items-center gap-2.5 flex-wrap">`:
+- **Search input** (flex-1 min-w-[280px] relative, `h-11`):
+  - `<Search>` icon absolute left.
+  - `<input type="search" placeholder="SKU, nazwa, EAN, brand, tagi…" class="w-full h-11 pl-10 pr-32 rounded-2xl bg-white soft-shadow text-[14px]">`.
+  - Hint right: `<span class="absolute right-3 top-1/2 -translate-y-1/2 inline-flex items-center gap-1.5 text-[10.5px] text-zinc-400">` z *„debounce 800ms"* + `<kbd>/</kbd>` (slash to focus shortcut).
+- **„Filtruj po atrybucie [N]"** button (zastępuje 4 hardcoded FilterPill): `<button onClick={toggleAdvanced} class="h-11 px-3.5 rounded-2xl ${advancedOpen ? 'bg-zinc-900 text-white border-zinc-900' : 'bg-white text-zinc-700 border-zinc-100 soft-shadow'}">` z `<SlidersHorizontal>` + label + count chip + `<ChevronDown>` rotate-180 gdy open.
+- **Segmented Płasko/Drzewo** (bez zmian z VIEW-05).
+- **Cmd+K button** (gradient violet — w VIEW-09 placeholder, render z `<Sparkles>` + label + `<kbd>⌘K</kbd>`, onClick `toast.info('Cmd+K — VIEW-19')`).
+- Vertical separator.
+- **Import** button (bez zmian, disabled placeholder z VIEW-05).
+- **Nowy produkt** button (bez zmian).
+
+### 3.5 i18n keys (~40 nowych)
+
+Dodaj do `apps/admin/src/locales/pl.json` i `en.json`:
+
+```
+products.smart_filters.label
+products.smart_filters.subtitle_rules
+products.smart_filters.subtitle_llm_phase_1
+products.smart_filters.custom_preset_button
+products.smart_filters.save_as_preset_title
+products.smart_filters.save_as_preset_name_placeholder
+products.smart_filters.save_as_preset_icon_label
+products.smart_filters.save_as_preset_save
+products.smart_filters.save_as_preset_cancel
+products.smart_filters.save_success
+products.smart_filters.delete_confirm
+
+products.smart_filters.builtin.inconsistent_translations
+products.smart_filters.builtin.missing_images
+products.smart_filters.builtin.weak_seo
+products.smart_filters.builtin.red_low_completeness
+products.smart_filters.builtin.no_category
+
+products.advanced_filter.title
+products.advanced_filter.mode_grid
+products.advanced_filter.mode_query
+products.advanced_filter.mode_query_phase_label
+products.advanced_filter.where_label
+products.advanced_filter.condition_count_one
+products.advanced_filter.condition_count_few
+products.advanced_filter.condition_count_other
+products.advanced_filter.clear
+products.advanced_filter.add_condition
+products.advanced_filter.match_label
+products.advanced_filter.match_all
+products.advanced_filter.match_any
+products.advanced_filter.url_updated
+products.advanced_filter.save_as_view
+products.advanced_filter.save_as_preset
+products.advanced_filter.apply
+
+products.filter_chips.active_label
+products.filter_chips.clear_all
+products.filter_chips.copy_url
+products.filter_chips.copy_url_success
+products.filter_chips.operator_label
+products.filter_chips.value_label
+
+products.toolbar.filter_by_attribute_button
+products.toolbar.search_placeholder
+products.toolbar.search_debounce_hint
+products.toolbar.cmdk_button
+products.toolbar.cmdk_phase_19_toast
+
+products.attribute_groups.favorites
+products.attribute_groups.all
+```
+
+Ban literałów w JSX — wszystko przez `t()`. Sprawdzone przez Biome rule + manual review.
+
+### 3.6 a11y
+
+- axe-core **0 violations serious/critical** na `/products`.
+- **SmartFilterPresetsRow**: `role="tablist"` + `role="tab" aria-selected={isActive}` per chip. ←/→ arrow keys move focus. Enter/Space apply.
+- **FilterChip**: shadcn `<Popover>` daje focus trap + aria-expanded + ESC close out-of-the-box. Button `aria-label="{label}: {value} (kliknij żeby edytować, ✕ żeby usunąć)"`.
+- **AdvancedFilterPanel**: `role="region" aria-label="Zaawansowany filtr"`. `<select>` z `aria-label` per atrybut/operator. Mode toggle `role="tablist"` + `role="tab"`. Query tab `aria-disabled="true"` + visible badge.
+- **SaveAsSmartPresetModal**: shadcn `<Dialog>` out-of-the-box focus trap. Input `aria-required="true"`. Icon picker grid `role="radiogroup"`.
+- **FilterChipsBar**: `role="region" aria-label="Aktywne filtry"`. *„Wyczyść wszystkie"* button `aria-label="Wyczyść wszystkie filtry"`. *„Skopiuj URL"* button `aria-label="Skopiuj URL ze stanem filtrów"`.
+- Focus ring: `focus-visible:ring-2 focus-visible:ring-zinc-900` na wszystkich interactive elements.
+- Color contrast: AA pass (zinc-900 na zinc-50, white na zinc-900, violet-700 na violet-50, amber-700 na amber-100 dla badge).
+
+### 3.7 Locales (multilingual fields)
+
+VIEW-09 nie pokazuje multilingual product fields (name/description w gridzie — z VIEW-05 baseline default locale). **Smart Preset name** jest multilingual w bazie (JSONB `{"pl": ..., "en": ...}` zgodnie z CLAUDE.md punkt 8). UI w MVP używa aktualnego user locale (FE `t()` z fallback do PL).
+
+### 3.8 Empty / loading / error states
+
+- **Smart presets empty (built-in tylko)**: 5 system-shipped widocznych zawsze (seedowane w migracji). Brak user-defined → brak chipów po built-in.
+- **Smart presets loading**: skeleton 3 chipy (`<div class="h-9 w-32 rounded-2xl bg-zinc-100 animate-pulse">`).
+- **Smart preset apply no results**: Grid pokazuje empty state *„Brak produktów pasujących do filtra"* + button *„Wyczyść filtr"*.
+- **Save preset error**: toast `toast.error('Nie udało się zapisać presetu — sprawdź połączenie')` + modal pozostaje otwarty.
+- **Advanced filter no conditions**: button *„Zastosuj filtr"* disabled + hint *„Dodaj warunek żeby filtrować"*.
+- **URL copy failure** (clipboard permission denied): toast `toast.error('Skopiuj URL ręcznie z paska adresu')`.
+
+## 4. Zakres backend (BE)
+
+### 4.1 Endpointy
+
+| Method | Path | Request | Response | Permissions | Filtry/sort/paginacja |
+|---|---|---|---|---|---|
+| GET | `/api/smart-filter-presets` | `?counts=true` (opcjonalne) | `{data: SmartFilterPreset[], counts?: {[id]: number}}` | authenticated user, all roles | TenantFilter + user filter (`tenant_shared OR own`); sort by `is_built_in DESC, sort_order ASC, created_at DESC`; brak paginacji (limit 50 max) |
+| POST | `/api/smart-filter-presets` | `{name: {pl, en}, icon: string, query: FilterDsl}` | `SmartFilterPreset` 201 | authenticated user | TenantAssignment + user_id auto-set |
+| PATCH | `/api/smart-filter-presets/{id}` | partial `{name?, icon?, query?, sort_order?}` | `SmartFilterPreset` 200 | owner only (built-in immutable, returns 403 z Problem Details) | — |
+| DELETE | `/api/smart-filter-presets/{id}` | — | 204 | owner only (built-in 403) | — |
+| GET | `/api/search/products` | extended: `?smart_preset=<slug-or-id>` lub `?filter=<base64-encoded-FilterDsl>` | unchanged | unchanged | resolver smart preset → FilterDsl → Meilisearch filter |
+
+**Errors w RFC 7807 Problem Details:**
+- 400 `validation_failed` (name <3 chars, icon empty, query invalid).
+- 403 `built_in_immutable` (PATCH/DELETE on built-in).
+- 404 `preset_not_found`.
+- 409 `name_duplicate` (per tenant + user).
+
+### 4.2 Encje / schema / migracje
+
+**Nowa encja** `App\Catalog\Domain\Entity\SmartFilterPreset` (wzorzec analogiczny do `SavedView`):
+
+```php
+namespace App\Catalog\Domain\Entity;
+
+class SmartFilterPreset implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;          // NULL = system-shipped
+    private ?Uuid $userId;                    // NULL = tenant-shared (Faza 1+); user-defined = owner
+    private string $slug;                     // unique per tenant
+    /** @var array{pl: string, en: string} */
+    private array $name;
+    private string $icon;                     // emoji string lub lucide icon name
+    /** @var array<string, mixed> */
+    private array $query;                     // FilterDsl JSONB
+    private bool $isBuiltIn = false;
+    private int $sortOrder = 0;
+    private DateTimeImmutable $createdAt;
+    private DateTimeImmutable $updatedAt;
+    // ... gettery + assignTenant() + setters z touch()
+}
+```
+
+**Migracja** `apps/api/migrations/Version20260513120000.php`:
+
+```sql
+CREATE TABLE smart_filter_presets (
+    id UUID PRIMARY KEY,
+    tenant_id UUID REFERENCES tenants(id) ON DELETE CASCADE, -- NULL = system
+    user_id UUID REFERENCES users(id) ON DELETE CASCADE,     -- NULL = tenant-shared
+    slug VARCHAR(64) NOT NULL,
+    name JSONB NOT NULL,                                      -- {pl, en}
+    icon VARCHAR(64) NOT NULL,
+    query JSONB NOT NULL,                                     -- FilterDsl
+    is_built_in BOOLEAN NOT NULL DEFAULT FALSE,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX uniq_smart_presets_slug ON smart_filter_presets (COALESCE(tenant_id, '00000000-0000-0000-0000-000000000000'::uuid), COALESCE(user_id, '00000000-0000-0000-0000-000000000000'::uuid), slug);
+CREATE INDEX idx_smart_presets_tenant ON smart_filter_presets (tenant_id) WHERE tenant_id IS NOT NULL;
+CREATE INDEX idx_smart_presets_user ON smart_filter_presets (user_id) WHERE user_id IS NOT NULL;
+CREATE INDEX idx_smart_presets_builtin ON smart_filter_presets (is_built_in) WHERE is_built_in = TRUE;
+```
+
+**Migracja + seed** w jednej `up()` — 5 built-in z `tenant_id=NULL, user_id=NULL, is_built_in=TRUE` (system-shipped global).
+
+**Down()** drop table + indeksy (reversible).
+
+### 4.3 Listenery / event subscribers
+
+- `TenantAssignmentListener` (istnieje) — auto-set `tenant_id` na prePersist gdy user-defined.
+- Brak nowych listenerów.
+
+### 4.4 Permissions / RBAC
+
+`SmartFilterPresetVoter extends Voter`:
+- `READ` — every authenticated user (system + own + tenant-shared).
+- `WRITE` (PATCH) — owner only (`getUserId() === currentUser`). Built-in returns false.
+- `DELETE` — owner only. Built-in returns false.
+
+**MVP brak per-role gating** (zgodnie z CLAUDE.md punkt 6 + PRD §11.5).
+
+Audit log: SmartFilterPreset create/update/delete loguje przez Doctrine event listener (z epik 0.11.4 AuditBundle, jeśli istnieje; w VIEW-09 jako TODO follow-up jeśli AuditBundle nie istnieje jeszcze).
+
+### 4.5 Provenance
+
+VIEW-09 nie pisze do `object_values` — N/A.
+
+### 4.6 Worker / async
+
+VIEW-09 nie odpala asynchronicznych jobów. Smart preset CRUD jest sync (low frequency operations).
+
+### 4.7 Real-time (Mercure)
+
+VIEW-09 nie używa Mercure. Smart preset add/remove jest re-fetched po POST/DELETE response.
+
+## 5. Sub-tasks (checklist)
+
+### Backend
+- [ ] Migracja `Version20260513120000.php` z CREATE TABLE + 5 built-in seed.
+- [ ] Encja `SmartFilterPreset.php` w `apps/api/src/Catalog/Domain/Entity/`.
+- [ ] Doctrine ORM XML mapping w `apps/api/config/doctrine/`.
+- [ ] Repository `SmartFilterPresetRepository.php`.
+- [ ] ApiResource declaration (REST + JSON-LD przez API Platform).
+- [ ] Custom controller `SmartFilterPresetCountsController.php` dla `?counts=true` (sub-query per preset).
+- [ ] Voter `SmartFilterPresetVoter.php` z READ/WRITE/DELETE.
+- [ ] FilterDsl resolver w `apps/api/src/Catalog/Application/Filter/FilterDslResolver.php` (basic version z 6 operatorami — pełne operatory → VIEW-10).
+- [ ] Rozszerzenie `SearchController` o `smart_preset` + `filter` query params.
+- [ ] PHPUnit unit testy: `SmartFilterPresetTest` (constructor + assignTenant + setters).
+- [ ] ApiTestCase integration testy: `SmartFilterPresetControllerTest` (401 + 403 built-in + 404 + 409 duplicate + happy path GET/POST/PATCH/DELETE + multi-tenancy isolation).
+- [ ] OpenAPI snapshot regen.
+
+### Frontend
+- [ ] `lib/filters/filter-dsl.ts` — TS types `FilterCondition`, `FilterDsl`, `FilterGroup`.
+- [ ] `lib/filters/url-serializer.ts` — basic flat conditions ↔ URLSearchParams (single level; nested → VIEW-09b).
+- [ ] `lib/filters/use-smart-presets.ts` — Refine `useList` hook z counts.
+- [ ] `components/catalog/smart-filter-presets-row.tsx` — nowy.
+- [ ] `components/catalog/save-as-smart-preset-modal.tsx` — nowy.
+- [ ] `components/catalog/advanced-filter-panel.tsx` — nowy (grid mode only).
+- [ ] `components/catalog/filter-chip.tsx` — nowy (zastępuje `filter-pill.tsx`).
+- [ ] `components/catalog/filter-chips-bar.tsx` — nowy.
+- [ ] `features/catalog/products/list.tsx` — refactor topbara.
+- [ ] `features/catalog/search/use-catalog-search.ts` — rozszerzenie o `smartPresetId` + `filterDsl`.
+- [ ] DELETE `components/catalog/advanced-filter-builder.tsx`.
+- [ ] DELETE `components/catalog/filter-pill.tsx`.
+- [ ] DELETE `components/catalog/product-filter-chips.tsx`.
+- [ ] `locales/pl.json` + `en.json` — ~40 kluczy.
+- [ ] Update `app.tsx` — confirm ToastProvider mounted (z VIEW-05).
+
+### E2E + Integration
+- [ ] `apps/admin/e2e/products-view-09.spec.ts`:
+  - Scenariusz 1 happy path: login → smart preset *„Czerwone <50%"* click → grid filtruje → URL update.
+  - Scenariusz 2 advanced filter: open panel → add condition `brand IN [Festo, Bosch]` → apply → chip pojawia się + URL update.
+  - Scenariusz 3 user-defined preset: open advanced panel → add 2 conditions → *„Zapisz jako Smart Preset"* → modal → save → chip pojawia się w row.
+  - Scenariusz 4 a11y axe-core.
+  - Scenariusz 5 URL share: copy URL with filters → open in new context → filter restored.
+
+### Testy non-functional
+- [ ] PHPStan max: 0 errors.
+- [ ] Biome strict: 0 errors.
+- [ ] TypeScript strict: 0 errors.
+- [ ] PHPUnit + ApiTestCase: nowe testy zielone + regression.
+- [ ] Playwright E2E: 5 scenariuszy zielone.
+- [ ] axe-core: 0 violations serious/critical.
+- [ ] Lighthouse a11y =100, performance ≥85.
+- [ ] Bundle size FE Δ <50KB gzip.
+- [ ] composer audit + pnpm audit: 0 high/critical.
+- [ ] OpenAPI snapshot zaktualizowany.
+
+### Dokumentacja
+- [ ] PR description z side-by-side mockup vs build screenshots.
+- [ ] PR description z lista świadomych odejść (Query mode disabled w VIEW-09, pełne operatory hold w VIEW-10).
+- [ ] PR description z linkami do follow-up VIEW-09b, VIEW-10..VIEW-19.
+- [ ] `agent/current_status.md` — sekcja VIEW-09.
+- [ ] `Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md` — update statusu (lista v2 fundament UI shipped).
+
+### Manual smoke (operator po merge)
+- [ ] Login `admin@demo.localhost / changeme` na `https://pim.localhost`.
+- [ ] `/products` → assert SmartFilterPresetsRow widoczny z 5 built-in chipami + counts.
+- [ ] Click *„🌐 Niespójne tłumaczenia"* → chip aktywny czarny + grid filtruje.
+- [ ] Click *„Filtruj po atrybucie"* → AdvancedFilterPanel push-down pojawia się.
+- [ ] Add condition: brand = Festo → Apply → chip *„Marka = Festo"* w FilterChipsBar.
+- [ ] Click chip body → popover z operator + value → zmień na *„IN Festo, Bosch"* → chip update.
+- [ ] Click ✕ na chipie → chip znika.
+- [ ] *„Skopiuj URL z filtrami"* → toast success → URL w schowku.
+- [ ] *„Zapisz jako Smart Preset"* w panel footer → modal → name + icon → save → toast + chip w row.
+- [ ] Delete user-defined preset (kebab w row) → confirm → chip znika.
+- [ ] Multi-tenant: tenant B widzi tylko własne + system-shipped, NIE user-defined tenanta A.
+- [ ] DevTools Network: GET `/api/smart-filter-presets?counts=true` < 200ms.
+- [ ] DevTools Console: brak czerwonych errorów.
+
+## 6. Acceptance criteria — funkcjonalne
+
+- [x] SmartFilterPresetsRow renderuje 5 built-in chipów (pixel-perfect z mockupem `list-view-v2.jsx` l. 71-107) + dynamicznie user-defined.
+- [x] Aktywny preset chip ma `bg-zinc-900 text-white`, nieaktywny `bg-zinc-50 text-zinc-700`.
+- [x] Click preset → grid filtruje + URL update + activeSmartPresetId state set.
+- [x] Click drugi raz aktywnego preset → toggle off → grid pokazuje wszystko.
+- [x] *„Własny preset"* button otwiera SaveAsSmartPresetModal (gdy `conditions.length > 0`) lub tooltip *„Najpierw dodaj warunek w Advanced filter"* (gdy puste).
+- [x] AdvancedFilterPanel push-down sticky pojawia się po click *„Filtruj po atrybucie [N]"*. Grid mode default. Query mode tab disabled z badge *„VIEW-09b"*.
+- [x] Add/remove conditions w grid mode (Akeneo style). Per condition: atrybut select + operator + value input + trash button.
+- [x] Apply filtr → chipy w FilterChipsBar + URL update + grid refetch.
+- [x] FilterChip body click otwiera popover (operator + value picker). ✕ kasuje chip.
+- [x] *„Wyczyść wszystkie"* link czyści wszystkie chipy + conditions.
+- [x] *„Skopiuj URL z filtrami"* button kopiuje URL do schowka + toast success.
+- [x] Save as Smart Preset modal: name (multilingual jeśli i18n active) + icon picker + read-only preview conditions → POST `/api/smart-filter-presets` → toast + chip pojawia się w row.
+- [x] Built-in preset PATCH/DELETE → 403 Problem Details + toast error.
+- [x] Multi-tenancy: user A nie widzi user-defined presets user B.
+- [x] i18n PL/EN togglue wszystkie nowe stringi.
+
+## 7. Acceptance criteria — non-functional (TWARDE GATES)
+
+- **Performance**:
+  - p95 `GET /api/smart-filter-presets?counts=true` < 200ms na seed 50k SKU (k6 raport w PR).
+  - p95 `POST /api/smart-filter-presets` < 100ms.
+  - p95 `GET /api/search/products?smart_preset=<id>` < 300ms na seed 50k SKU.
+- **N+1 query check**: `?counts=true` używa pojedynczego query z LATERAL JOIN lub batch count, NIE N+1. EXPLAIN ANALYZE w PR description.
+- **Indeksy**: wszystkie nowe WHERE kolumny pokryte indeksami (`tenant_id`, `user_id`, `is_built_in`, `slug` unique).
+- **Pagination**: smart_filter_presets list max 50 (hard limit per tenant).
+- **Memory (worker)**: N/A (sync handler).
+- **Bundle size FE**: Δ <50KB gzip (Vite build report w PR).
+- **Lighthouse**: performance ≥85, a11y =100, best-practices ≥90.
+- **PHPStan max**: 0 errors.
+- **Biome strict**: 0 errors.
+- **TypeScript strict**: 0 errors.
+- **PHPUnit coverage**: ≥80% nowej logiki domenowej (`SmartFilterPreset` + `FilterDslResolver`).
+- **ApiTestCase**: każdy nowy endpoint ma test 401 + 403 + 404 + 409 + walidacja + happy path + multi-tenancy isolation.
+- **Playwright E2E**: 5 scenariuszy zielone.
+- **axe-core**: 0 violations serious/critical na `/products`.
+- **composer audit + pnpm audit**: 0 high/critical.
+- **Multi-tenancy**: cross-tenant read test = 0 user-defined wyników (built-in widoczne).
+- **RBAC**: voter test dla owner + non-owner + built-in immutability.
+- **Audit log**: PATCH/DELETE pisze entry (jeśli AuditBundle istnieje; inaczej TODO follow-up).
+- **Provenance**: N/A.
+- **i18n coverage**: ~40 nowych kluczy obecnych w `pl.json` i `en.json`.
+- **OpenAPI snapshot**: `docs/api-spec/v0.json` zaktualizowany (`docker compose exec -T -e APP_ENV=dev -e APP_DEBUG=0 api bin/console api:openapi:export | python3 -m json.tool > docs/api-spec/v0.json`).
+
+## 8. Smoke-test scenariusze (manualne, dla operatora)
+
+1. Login `admin@demo.localhost / changeme` na `https://pim.localhost`.
+2. Nawigacja: sidebar → Produkty → `/products`.
+3. Assert SmartFilterPresetsRow widoczny pod SavedViewsRail z 5 built-in chipami: 🌐 Niespójne tłumaczenia, 📷 Brakujące zdjęcia, 🔍 Niepełne SEO, 🔴 Czerwone (<50%), 📂 Bez kategorii. Każdy z counter (server-side count).
+4. Click *„🔴 Czerwone (<50%)"* → chip czarny aktywny → grid filtruje do produktów z `completenessPct < 50` → URL update `?smart_preset=red-low-completeness`.
+5. Click *„Filtruj po atrybucie [0]"* button w toolbarze → AdvancedFilterPanel push-down rozszerza się pod toolbar.
+6. W panelu: dodaj condition: atrybut *„Marka"* + operator *„IN"* + value *„Festo, Bosch"*. Click *„Zastosuj filtr"*.
+7. Assert: panel zamyka się, w FilterChipsBar pojawia się chip *„Marka IN Festo, Bosch"*, URL update.
+8. Click chip body → popover z operator picker (`=`, `≠`, `IN`, `NOT IN`) + value picker (lista brandów). Zmień na *„NOT IN Bosch"*. Chip update.
+9. Click ✕ na chipie → chip znika + URL czyści.
+10. Click *„Filtruj po atrybucie"* → panel otwarty → click *„Wyczyść"* w header panel → wszystkie conditions usunięte.
+11. Dodaj 2 conditions → click *„Zapisz jako Smart Preset"* w footer panel → SaveAsSmartPresetModal otwiera się.
+12. Wpisz name *„Festo niski stock"* + wybierz icon ⚙️ → click Zapisz → toast success + chip *„⚙️ Festo niski stock"* pojawia się w SmartFilterPresetsRow.
+13. Click *„🔴 Czerwone (<50%)"* (built-in) → click kebab/right-click → assert opcja Delete jest ukryta lub disabled (built-in immutable).
+14. Click kebab przy user-defined *„⚙️ Festo niski stock"* → Delete → confirm modal → confirm → chip znika.
+15. Multi-tenancy: zaloguj jako inny tenant (jeśli dostępny w dev) → `/products` → assert built-in 5 widocznych, user-defined *„⚙️ Festo niski stock"* nie.
+16. *„Skopiuj URL z filtrami"* → toast success → paste URL w nowym tabie → assert filtry załadowane.
+17. DevTools Network: GET `/api/smart-filter-presets?counts=true` < 200ms, GET `/api/search/products?smart_preset=red-low-completeness` < 300ms.
+18. DevTools Console: brak czerwonych errorów.
+19. Lighthouse `/products` → a11y =100, performance ≥85.
+
+## 9. Edge cases / poza zakresem
+
+### Edge cases pokryte
+- Empty smart preset row (po deletecie wszystkich user-defined) → 5 built-in widocznych zawsze.
+- Smart preset apply gdy grid loading → spinner, nie zacina.
+- Save as preset gdy `conditions.length === 0` → button disabled z tooltipem.
+- Save as preset z duplicate name (per tenant + user) → 409 Problem Details + toast error.
+- Built-in preset PATCH/DELETE → 403 + toast error.
+- URL share z preset usunętym (stale URL) → fallback graceful: redirect do `/products` bez preset + toast info *„Preset nie istnieje"*.
+- AdvancedFilterPanel z 0 conditions → Apply button disabled z hint.
+- FilterChip popover click-outside → close.
+
+### Świadomie poza zakresem (deferred do follow-up VIEW-NN)
+1. **Query mode AND/OR brackets** → VIEW-09b. W VIEW-09 mode toggle widoczny ale Query tab disabled z badge *„VIEW-09b"*.
+2. **Pełne operatory per typ atrybutu (25 ops)** → VIEW-10. W VIEW-09 hardcoded 6 ops (`=`, `≠`, `IN`, `NOT IN`, `IS EMPTY`, `IS NOT EMPTY`).
+3. **URL hashed blob `?q=<base64>` dla query mode** → VIEW-09b.
+4. **Cross-page selection toolbar** → VIEW-11. W VIEW-09 selection state z VIEW-05 (single page only).
+5. **BulkBar 14 akcji + wizard** → VIEW-12+.
+6. **Cmd+K palette** → VIEW-19. W VIEW-09 button gradient violet jest placeholder z toast *„Cmd+K — VIEW-19"*.
+7. **Rollback toast + 24h cancel** → VIEW-17.
+8. **Per-attribute lock w gridzie kolumna `lock`** → VIEW-18.
+9. **Smart preset migration on schema change** (np. `completeness_pct` rename) → defer; ręczna naprawa przez admin.
+10. **AuditLog dla SmartFilterPreset CRUD** — TODO jeśli AuditBundle (epik 0.11.4) nie istnieje. W innym przypadku auto-loggowane.
+11. **react-querybuilder dla Advanced filter UI**: w VIEW-09 from scratch (prostsze, ~280 LOC). Decyzja library vs from scratch → VIEW-09b.
+
+### Edge cases pomijane (low-priority)
+- Mobile/tablet viewport <768px — admin desktop-first.
+- Concurrent edits Smart Preset (user A edytuje, user B widzi stary) → MVP last-write-wins, brak optymistic locking.
+- Smart preset z >100 conditions → not enforced (UI nie pozwoli przez UX, ale walidacja BE max 20 conditions per preset).
+- Tenant-shared user-defined presets (`user_id IS NULL, tenant_id IS NOT NULL`) → schema supports, MVP brak UI button *„Udostępnij tenancie"* (Faza 1).
+
+## 10. Powiązane ADR / dokumenty
+
+**Nowy ADR (po merge VIEW-09 lub razem):**
+- **ADR-015 — Filter DSL (JSONB) + URL serializer**: format flat conditions (VIEW-09) + nested AND/OR/NOT (VIEW-09b). Hashowany blob fallback. Resolver Meilisearch + Postgres `attributes_indexed @> ...`.
+
+**Aktualizacje istniejących dokumentów (commit razem z PR):**
+- `Project Plan/01-architektura-pim.md` — dodać sekcję dla Smart Filter Presets w §5 model danych (przeniesione z PRD §5.1).
+- `Project Plan/02-plan-projektu-pim.md` — checkbox VIEW-09 + estymacja 40h + ryzyko R-30 (PRD §14.1).
+- `agent/current_status.md` — sekcja *„2026-05-13: VIEW-09 marathon start"*.
+- `agent/lessons.md` — sekcja *„Lessons z VIEW-09"* po merge.
+- `Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md` — update statusu.
+- `docs/api-spec/v0.json` — regenerowane.
+
+**Memory updates:**
+- Brak nowych memories — feedback patterns z `feedback_view_scope_literal.md` + `feedback_pim_destructive_volume_ops.md` przestrzegane.
+
+**Brak nowego ADR-009 zmiany** — ObjectType pozostaje bez zmian (smart presets to feature meta, nie domain entity per kind).

--- a/Project Plan/UI/feature-list-advanced.md
+++ b/Project Plan/UI/feature-list-advanced.md
@@ -1,0 +1,1214 @@
+# Feature — Lista produktów: filtry, wyszukiwarka, akcje zbiorcze, Cmd+K
+
+## Status: 🟢 szczegół
+
+> **Część epiku 02 Produkty** — *„advanced layer"* nad podstawową listą produktów.
+> **Decyzje brainstormingowe** zamknięte 2026-05-11 w sesji Senior PM (4 fale, ~20 nowych decyzji ponad snapshot z 2026-04-30 w `epik-02-produkty.md` § 3).
+> Plik rozszerza i precyzuje `epik-02-produkty.md` w obszarach: § 4 (List view), § 9 (Sortowanie multi-column), § 11 (edge cases bulk actions).
+
+---
+
+## 1. Cel feature'a
+
+Operator (Kasia) potrzebuje listy produktów, która łączy **operator-grade gęstość informacji** (BaseLinker) z **workflow-grade czystością** (Akeneo) — *bez* Pimcore-style developer overhead. Lista jest jej *„cockpitem"* — 60% czasu pracy. Musi obsłużyć:
+
+1. **Szybkie odnajdywanie** — quick search po SKU/name/EAN/brand/tags + filtry chip-based z operatorami.
+2. **Zaawansowane wyszukiwanie** — Advanced filter panel z grid mode lub query mode (AND/OR).
+3. **Masowe modyfikacje** — 13 akcji bulk z confirmation flow per typ + cascade warning + 24h rollback.
+4. **Agentic interaction** — Cmd+K jako natural language interface dla schema-ops + bulk actions na zaznaczonych.
+5. **AI smart filters (MVP rule-based)** — *„cross-locale completeness mismatch"* jako quick filter preset.
+
+**Out of scope MVP:** AI semantic search, cross-channel value inconsistency detection (β/δ z killer feature), custom scripts mode (BaseLinker-style power user), per-channel completeness scoring, real-time collaboration na zaznaczeniach.
+
+**Marketing flag:** *„AI smart filters"* w MVP **nie jest AI** — to rule-based completeness check. Pełen AI w Fazie 1+ (semantic similarity, cross-channel value comparison). Patrz § 11 Flag.
+
+## 2. Persony
+
+| Persona | Rola w liście | Częstość |
+|---|---|---|
+| **Kasia, 32** (Catalog Manager) | Primary — 60% czasu pracy, codziennie 20-50 modyfikacji + 5-10 bulk operacji | Codziennie 8h |
+| **Magda, 29** (Marketing) | Secondary — bulk edit opisów SEO, kategoryzacja, kolekcje sezonowe | Tygodniowo 5-10h |
+| **Marcin (dogfooding)** | First user — IdoSell + Shopify migracja, regression test dla każdego nowego feature | Codziennie 1-2h |
+| **Tomasz** (Owner) | Sporadyczny — self-service edycja flagowych produktów, audit overview | Tygodniowo 1h |
+
+## 3. Brainstorming decisions snapshot (2026-05-11)
+
+Wszystkie 20 decyzji z 4 fal wywiadu, które kierują design'em. Ponad istniejący snapshot z `epik-02-produkty.md` § 3.
+
+### Fala 1 — Filozofia i fundament
+
+| Obszar | Decyzja |
+|---|---|
+| Filozofia listy | **Hybrid Akeneo + BaseLinker, bez Pimcore complexity** — operator cockpit (gęstość) + workflow workflow (completeness, preview diff) |
+| Drzewo kategorii w liście | **BRAK** — kategoria jako dropdown w filtrach. Tree view tylko w epiku 10 Categories |
+| Filter panel layout | **Magento/BaseLinker-style push-down** — rozsuwany w pionie (NIE prawy sidebar). Push'uje listę w dół |
+| Search/Filter separation | **Pimcore-style** — quick search bar + osobny *„Filtruj po atrybucie"* dropdown jako 2 różne UX-y |
+| Killer features | **Cmd+K agent + AI smart filters** — oba przez jeden shortcut (Cmd+K obsługuje action + filter intents) |
+
+### Fala 2 — Wyszukiwarka
+
+| Obszar | Decyzja |
+|---|---|
+| Quick search behavior | **NO typeahead** — search po Enter, full list filter. Bez Algolia/Spotlight dropdown |
+| Search po polach | **SKU + name + EAN + brand + tags** (typuję *„Festo"* → znajduje wszystkie Festo) |
+| Filtruj po atrybucie dropdown | **Favorite top 10** — user w settings wybiera, reszta w Advanced |
+| Operatory w MVP | **Pełne od dnia 1** — `=`, `≠`, `>`, `<`, `BETWEEN`, `IS EMPTY`, `IS NOT EMPTY`, `STARTS WITH`, `CONTAINS` (Akeneo style) |
+| Advanced filter panel layout | **Hybrid** — grid 3-4 kolumny atrybutów default + toggle do query mode (AND/OR brackets) |
+| Advanced panel zachowanie | **Sticky-collapsible** — manual toggle, klient sam decyduje czy panel zwija/rozwija |
+| Per-locale search | **Current locale only** — *„sensor"* nie znajdzie `name.pl=Czujnik`, klient musi przełączyć locale |
+| AI smart filters w MVP | **(γ) Completeness mismatch ONLY** — `description.pl filled AND description.en empty` jako preset filter. Rule-based, **bez LLM** |
+| AI smart filters Faza 1+ | Semantic comparison (β) + cross-channel inconsistency (δ) + AI quality dashboard (ε) |
+| Filter persistence | **URL-based** — `?brand=Festo&completeness=lt50`. Shareable + refreshable. Cross-tab nav = reset |
+
+### Fala 3 — Akcje zbiorcze
+
+| Obszar | Decyzja |
+|---|---|
+| Zestaw akcji MVP | **13 akcji rozszerzony** (b) — set/clear/append/remove attribute + multi-attr edit + increment numeric + toggle enabled + add/remove/move category + publish/unpublish + delete + duplicate |
+| Custom scripts mode | **Faza 3+ lub never** — defer |
+| Confirmation flow | **Per typ akcji** — wizard diff dla edit attribute, inline toast dla low-risk, hard confirm typing dla delete, simple modal dla publish/duplicate |
+| Cascade effects warning | **(a) Pełen impact summary modal** — *„cofnięcie publikacji z 3 kanałów + 144 variants + 89 cross-sell"* przed Confirm |
+| Bulk rollback | **24h per-session** — analog imports, dla wszystkich bulk operations |
+| Permission destructive | **Konsekwentnie brak gating** w MVP — audit log + rollback wystarczą. Spójne z Modelowaniem (Fali 1) |
+
+### Fala 4 — Edge cases + Cmd+K
+
+| Obszar | Decyzja |
+|---|---|
+| Rollback `bulk delete` | **(a2) Partial restore** — przywróć w PIM, klient ręcznie re-publish do kanałów |
+| Rollback `bulk publish` | **(b1) Always unpublish wszystkie** — buyer może zobaczyć *„product not found"* w międzyczasie. Klient akceptuje risk |
+| Cross-page selection | **BaseLinker style** — toolbar wybór: *„zaznacz na tej stronie"* vs *„zaznacz wszystkie wyniki"*. User decyduje świadomie |
+| Per-attribute lock w bulk | **Skip locked + raport** — *„247 selected, 230 updated, 17 skipped (locked)"*. Bez force override w MVP |
+| Cmd+K agent w MVP | **Schema-ops + bulk na zaznaczonych** — *„dla zaznaczonych 30 ustaw kategorię na Pneumatyka"*. NLP filter queries → Faza 2 |
+| Cmd+K selection state | **Naturalne, bez UI komunikacji** — agent czyta selection z React context, interpretuje *„dla zaznaczonych jeśli >0"* |
+| Bulk wizard preview | **(d) Hybrid** — sample 5 rows + aggregate counter na jednym screenie |
+
+---
+
+## 4. Mapping vs konkurencja per obszar
+
+| Obszar | Pimcore | Akeneo | BaseLinker | **Cortex (nasz)** |
+|---|---|---|---|---|
+| **Layout listy** | ExtJS grid z 30+ kolumn, ColumnConfigurator | Grid 8-12 kolumn + sidebar kategorii + smart filter sidebar po prawej | Gęsty grid 15-20 kolumn + sidebar kategorii + chip filtry + Action Bar | **Density BaseLinker + completeness Akeneo, bez drzewa kategorii w liście, push-down filter panel** |
+| **Quick search** | Quick search (full-text) + Advanced search per atrybut (Pimcore separation) | Single search across multiple fields (Akeneo unified) | Single keyword search + chip filters | **Pimcore-style separation** — quick search SKU/name/EAN/brand/tags + osobny *„Filtruj po atrybucie"* dropdown |
+| **Filter UI** | Column filter per nagłówek + sidebar Object Class filter z operatorami | Smart Filter sidebar po prawej z operatorami `IS`, `IS NOT`, `IS EMPTY`, `STARTS WITH` | Chip filtry compact w toolbar (~10-15 popularnych atrybutów) | **Chip filtry compact (BaseLinker) + Advanced push-down panel (Magento style) z grid/query modes** |
+| **Operatory** | Pełne (Akeneo-grade) | Pełne (`IS`, `IS NOT`, `IS EMPTY`, `STARTS WITH`, `CONTAINS`, `>=`, `<=`, `BETWEEN`) | Tylko `=` w chip, brak per-operator | **Pełne od dnia 1** — Akeneo-grade w grid mode + AND/OR query mode dla power users |
+| **AI features** | Brak (developer-tool, brak AI native) | Akeneo PIM AI (paid Enterprise — auto-translate, content generation) | Brak (klasyczna integracja, scripts mode jako power user) | **Cmd+K agent + completeness-mismatch rule-based filter** (MVP) → **AI semantic + AI quality dashboard** (Faza 1-2) |
+| **Cross-page selection** | Per-page select | Akeneo-style hybrid (per-page + *„Apply to filtered results"* z count) | Toolbar user choice — per-page vs select-all-matching | **BaseLinker style** — explicit toolbar choice |
+| **Bulk actions liczba** | ~10 generic (delete, copy, change parent, change class, mass operations queue) | ~15 (mass edit attributes wizard, classify, change status, workflow submit, export) | ~30 per typ obiektu (operator cockpit) | **13 w MVP** + custom scripts Faza 3+ |
+| **Confirm flow** | Context Menu actions + simple confirm | 3-step wizard z preview diff (Akeneo signature feature) | Simple modal z liczbą produktów | **Per typ akcji** — wizard diff dla destructive, inline toast dla low-risk |
+| **Rollback** | Audit log only (no native bulk rollback) | Job history + manual reverse (limited) | Brak natywnego rollback | **24h per-session rollback** dla wszystkich bulk operations + cascade handling |
+| **Permission** | Per-action role permissions | Per-action role permissions w Enterprise | Per-user permissions w admin | **Brak gating w MVP**, Faza 1 ADR-013 |
+| **Cmd+K / Command palette** | Brak | Brak | Brak | **Killer feature MVP** — schema-ops + bulk actions z natural language |
+| **Filter persistence** | Saved Views (JSON config) | Smart Views + URL params | LocalStorage per user | **URL-based only** — shareable + refreshable. Saved Views (z epiku 02) dla zachowania na dłużej |
+
+**Bottom line:** Cortex bierze gęstość operator UX z BaseLinker, czystość workflow + completeness focus z Akeneo, agentic-first Cmd+K jako *unique* USP którego żaden z trzech nie ma natywnie. Pimcore developer-grade complexity świadomie *odrzucamy* — Kasia nie jest developerem.
+
+---
+
+## 5. Layout główny — toolbar + filter panel + grid
+
+### 5.1 Layout bazowy (filter panel zwinięty)
+
+```
+┌─ Produkty ──────────────────────────────────────────────────────────────────┐
+│ [🔍 Szukaj SKU/name/EAN/brand/tags...]   [+ Filtruj po atrybucie ▼]  [Filtry ↓]│
+│                                                                              │
+│ Aktywne filtry: [Brand = Festo ✕] [Completeness < 50% ✕] [+ Add filter]    │
+│                                                                              │
+│ [Show variants:  ◉ As tree  ○ Flat]    [+ New Product]  [⋮ Imports]  [Cmd+K]│
+├──────────────────────────────────────────────────────────────────────────────┤
+│ ☐ │ 🖼 │ SKU       │ Name           │ Brand │ Compl. │Sync│ Channels │ Status │⋮│
+├──────────────────────────────────────────────────────────────────────────────┤
+│ ☐ │ ▶ │ TST-001   │ Czujnik X-200  │ Festo │ ▓▓▓░░ 60% │ 🟢 │🟢🟢🔴   │ ✓ │⋮ │
+│ ☐ │ 🖼 │ TBT-002  │ Taboret 3-noż. │ ProTec│ ▓▓▓▓▓ 100%│ 🟢 │🟢🟢🟢   │ ✓ │⋮ │
+│ ... 1245 rows ...                                                            │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ Showing 1-50 of 1247 products    Per page: [50 ▼]    [‹ Prev] [Next ›]      │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Toolbar sekcje (top-to-bottom):**
+1. **Quick search bar** + *„Filtruj po atrybucie"* dropdown + *„Filtry ↓"* toggle (rozsuwa Advanced panel).
+2. **Aktywne filtry** — chip area z X (kasuje filter).
+3. **Action bar** — variants toggle, New Product, Imports shortcut, Cmd+K shortcut.
+
+### 5.2 Layout z rozsuniętym Advanced filter panel (Magento-style push-down)
+
+```
+┌─ Produkty ──────────────────────────────────────────────────────────────────┐
+│ [🔍 Szukaj...]   [+ Filtruj po atrybucie ▼]  [Filtry ▲ (rozwinięte)]        │
+│                                                                              │
+│ Aktywne filtry: [Brand = Festo ✕] [Completeness < 50% ✕]                   │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ ╔══════════════════════════════════════════════════════════════════════╗   │
+│ ║ ZAAWANSOWANE FILTRY                              [⚙ Query mode] [×] ║   │
+│ ║                                                                       ║   │
+│ ║ Atrybut          Operator         Wartość                            ║   │
+│ ║ ─────────────────────────────────────────────────────────────────    ║   │
+│ ║ [Brand ▼]       [IS ▼]            [Festo ▼]                          ║   │
+│ ║ [Completeness ▼] [< ▼]            [50            ] %                 ║   │
+│ ║ [Stock ▼]       [>= ▼]            [10            ]                   ║   │
+│ ║ [Category ▼]    [IS NOT EMPTY ▼]                                     ║   │
+│ ║                                                                       ║   │
+│ ║ [+ Dodaj kolejny filtr]                                              ║   │
+│ ║                                                                       ║   │
+│ ║                       [Reset] [Zapisz jako Saved View] [Zastosuj]    ║   │
+│ ╚══════════════════════════════════════════════════════════════════════╝   │
+├──────────────────────────────────────────────────────────────────────────────┤
+│ Grid produktów (push'ed niżej, sticky-collapsible panel pozostaje rozwinięty)│
+│ ...                                                                          │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Panel zachowanie:**
+- **Sticky-collapsible** — klient klika *„Filtry ↓/▲"* manual toggle.
+- **Default state** — zwinięty.
+- **Po zapisaniu Saved View** — panel zostaje rozwinięty (user nadal w filter mode).
+- **Po Reset** — zwija się + chip area czysta.
+
+### 5.3 Layout z Query mode (AND/OR brackets dla power users)
+
+```
+┌─ Produkty ──────────────────────────────────────────────────────────────────┐
+│ ...                                                                          │
+│ ╔══════════════════════════════════════════════════════════════════════╗   │
+│ ║ ZAAWANSOWANE FILTRY — QUERY MODE                  [⚙ Grid mode] [×] ║   │
+│ ║                                                                       ║   │
+│ ║  ┌─ AND ─────────────────────────────────────────┐                   ║   │
+│ ║  │ Brand IS Festo                                │                   ║   │
+│ ║  │ ┌─ OR ────────────────────────────────────┐  │                   ║   │
+│ ║  │ │ Stock >= 10                             │  │                   ║   │
+│ ║  │ │ Completeness >= 80                      │  │                   ║   │
+│ ║  │ └─────────────────────────────────────────┘  │                   ║   │
+│ ║  │ Category IS NOT EMPTY                          │                  ║   │
+│ ║  └────────────────────────────────────────────────┘                  ║   │
+│ ║                                                                       ║   │
+│ ║  [+ AND condition]  [+ OR group]                                     ║   │
+│ ║                                                                       ║   │
+│ ║                       [Reset] [Zapisz jako Saved View] [Zastosuj]    ║   │
+│ ╚══════════════════════════════════════════════════════════════════════╝   │
+```
+
+**Toggle Grid ↔ Query:** klient może migrować filter z grid mode do query mode (zachowanie wartości). Migration tylko gdy grid → query daje uproszczenie (każdy grid filter = AND condition).
+
+### 5.4 Bulk actions toolbar (gdy >0 zaznaczonych)
+
+```
+┌─ Produkty ──────────────────────────────────────────────────────────────────┐
+│ ... (filter chips + grid header) ...                                         │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  ✓ 30 zaznaczone na tej stronie z 1247 wyników                              │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │  [Zaznacz wszystkie 1247 wyniki?]  [Wyczyść zaznaczenie]             │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+│                                                                              │
+│  [Bulk edit ▼]  [Zmień kategorię]  [Publish ▼]  [Duplicate]  [⚠ Usuń]      │
+│                                                                              │
+│  ☐ Show only selected (filter)                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  Grid (with selected rows highlighted)                                       │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**BaseLinker-style toolbar:**
+- *„30 zaznaczone na tej stronie z 1247 wyników"* — jasna informacja co user widzi vs co system ma.
+- *„Zaznacz wszystkie 1247 wyniki?"* — explicit upgrade do select-all-matching (BaseLinker pattern).
+- Bulk actions buttons inline (nie ukryte w dropdown chyba że >7).
+- *„Show only selected"* checkbox filter — zaznaczone produkty visible, reszta hidden.
+
+---
+
+## 6. Wyszukiwarka — szczegół
+
+### 6.1 Quick search behavior
+
+**Pole search:**
+- Top-left toolbar, max 360 px wide.
+- Placeholder: *„Szukaj SKU, nazwy, EAN, marki, tagów..."* (informuje user'a po jakich polach search'uje).
+- Submit po **Enter** lub po debounce 800 ms (gdy user przestaje pisać).
+- **Brak typeahead dropdown** (decyzja Fali 2).
+
+**Algorytm match w MVP:**
+- Strict prefix/exact (decyzja epiku 02).
+- Case-insensitive.
+- Diacritic-insensitive (Festo = fésto = FESTO).
+- Polish character handling — `ą`, `ć`, `ę`, `ł`, `ń`, `ó`, `ś`, `ź`, `ż` matchowane jako ich łacińskie equivalenty (`a`, `c`, `e`, `l`, `n`, `o`, `s`, `z`).
+
+**Search po polach:**
+```
+SKU starts_with(query)         OR
+name like(%query%)             OR
+EAN starts_with(query)         OR
+brand.name like(%query%)       OR
+tags contains(query)
+```
+
+Implementacja: Meilisearch index z `searchable_attributes: [sku, name, ean, brand_name, tags_concat]`. Latency <50ms na 200k SKU per architektury sekcji 6.2.
+
+**Search w current filter context:**
+- Active filters limit base set (np. *„Brand = Festo"*).
+- Search dalej zawęża w tym set'cie.
+- Counter visible: *„247 of 1247 matching"* po search.
+
+**Empty state:**
+- *„Brak wyników dla 'BSC123'"*.
+- Suggestion: *„Spróbuj wyłączyć filtry [Brand = Festo ✕]"* (gdy active filters).
+- Link: *„Pokaż wszystkie produkty"*.
+
+### 6.2 *„Filtruj po atrybucie"* dropdown
+
+**Wygląd dropdown:**
+
+```
+┌─ + Filtruj po atrybucie ─────────────────────────┐
+│ 🔍 Szukaj atrybutu...                            │
+├──────────────────────────────────────────────────┤
+│ ULUBIONE (Twoje top 10)                          │
+│ ├─ Brand                                          │
+│ ├─ Kategoria                                      │
+│ ├─ Completeness                                   │
+│ ├─ Status (enabled/disabled)                     │
+│ ├─ Cena                                           │
+│ ├─ Stock                                          │
+│ ├─ Provenance                                     │
+│ ├─ Sync status                                    │
+│ ├─ EAN                                            │
+│ └─ Date created                                   │
+├──────────────────────────────────────────────────┤
+│ INNE ATRYBUTY (klik → modal pełen filter builder)│
+│ ├─ Description PL                                 │
+│ ├─ Description EN                                 │
+│ ├─ IP Class                                       │
+│ ├─ Voltage                                        │
+│ ├─ ... ~200 atrybutów total                       │
+├──────────────────────────────────────────────────┤
+│ [⚙ Zarządzaj ulubionymi]                          │
+└──────────────────────────────────────────────────┘
+```
+
+**Po wyborze atrybutu** (np. *„Brand"*):
+- System inferuje typ z `Attribute.type`.
+- Dla `select` lub `relation`: dropdown z wartościami (`Festo`, `Bosch`, `SMC`, ...).
+- Dla `number`: input z operator picker (`=`, `≠`, `>`, `<`, `BETWEEN`).
+- Dla `text`: input z operator picker (`STARTS WITH`, `CONTAINS`, `IS EMPTY`, `IS NOT EMPTY`).
+- Dla `date`: date range picker.
+- Dla `boolean`: toggle.
+
+**Po wpisaniu wartości i Apply:**
+- Chip pojawia się w toolbar: `[Brand IS Festo ✕]`.
+- Klik na chip → otwiera popover z operator + value (edit).
+- Klik na ✕ → kasuje chip.
+
+**Ulubione settings:**
+- Default top 10 (z `Attribute.is_default_favorite=true`): Brand, Kategoria, Completeness, Status, Cena, Stock, Provenance, Sync, EAN, Date created.
+- User w settings (`/settings/list-filters`) wybiera własne top 10 z full list.
+- Persisted per user (analog do Saved Views z epiku 02).
+
+### 6.3 Operatory pełne (Akeneo-grade) od dnia 1
+
+| Typ atrybutu | Operatory dostępne |
+|---|---|
+| `text`, `textarea`, `wysiwyg` | `=`, `≠`, `IS EMPTY`, `IS NOT EMPTY`, `STARTS WITH`, `ENDS WITH`, `CONTAINS`, `NOT CONTAINS` |
+| `number`, `metric` | `=`, `≠`, `>`, `<`, `>=`, `<=`, `BETWEEN`, `IS EMPTY`, `IS NOT EMPTY` |
+| `date`, `datetime` | `=`, `≠`, `>` (after), `<` (before), `BETWEEN`, `IS EMPTY`, `IS NOT EMPTY` |
+| `select` | `=`, `≠`, `IN`, `NOT IN`, `IS EMPTY`, `IS NOT EMPTY` |
+| `multiselect` | `CONTAINS`, `NOT CONTAINS`, `IS EMPTY`, `IS NOT EMPTY` |
+| `boolean` | `=` (TRUE/FALSE) |
+| `relation` | `=`, `≠`, `IN`, `NOT IN`, `IS EMPTY`, `IS NOT EMPTY` |
+| `asset` (image, file) | `IS EMPTY`, `IS NOT EMPTY` |
+
+**Edge cases:**
+- **Localized attributes** (`description.pl` vs `description.en`) — operator applies do *current locale only* (z decyzji Fali 2).
+- **Scopable attributes** (`description.shopify` vs `description.baselinker`) — chip pokazuje channel: `[description.shopify CONTAINS "premium" ✕]`. Domyślnie filter w aktualnie wybranym channel sub-tab.
+- **JSONB values** — Postgres `@>` operator dla `CONTAINS`, `?` dla `IS NOT EMPTY`. GIN index z ADR-006.
+
+### 6.4 Per-locale search (current locale only)
+
+**Decyzja:** klient z `language=PL` szuka *„sensor"* (EN word) → **NIC nie znajduje** (jeśli `name.pl=Czujnik`).
+
+**UX consequence:**
+- W toolbar wskazuje aktualny locale: *„🔍 Szukaj... (PL)"*. Klient wie w jakim language szuka.
+- Locale picker (gdy klient ma tenant z >1 locales) — globalny w top bar, zmiana wpływa na search + grid display + filter values.
+- **Cross-locale search** (Faza 1 candidate) — checkbox *„Szukaj we wszystkich językach"* w toolbar dropdown.
+
+---
+
+## 7. Filtry — szczegół
+
+### 7.1 Aktywne filter chips area
+
+**Layout:**
+- Pod toolbar'em, max 1 linia (overflow → wrap do 2 linii).
+- Każdy chip: `[Attribute OP Value ✕]`.
+- Klik na chip body → otwiera popover z edit (operator + value).
+- Klik na ✕ → kasuje filter.
+- `+ Dodaj filtr` button na końcu (otwiera *„Filtruj po atrybucie"* dropdown).
+- *„Wyczyść wszystkie"* link gdy >2 chip'y.
+
+**Chip color coding:**
+- 🟣 Default chip (purple-100 bg, accent text) — *„Brand IS Festo"*.
+- 🔴 Special chip dla destructive filter (np. *„Marked for deletion"*) — light red bg.
+- 🟢 Special chip dla AI smart filter (np. *„AI: completeness mismatch"*) — light green bg z `✨` icon.
+
+### 7.2 Advanced filter panel (Magento push-down)
+
+**Grid mode (default):**
+
+```
+┌─ ZAAWANSOWANE FILTRY ───────────────────────────────  [⚙ Query mode] [×] ─┐
+│                                                                             │
+│  Atrybut              Operator             Wartość                          │
+│  ──────────────────────────────────────────────────────────────────────    │
+│  [Brand ▼]            [IS ▼]               [Festo ▼ (multi)]               │
+│  [Completeness ▼]     [< ▼]                [50           ] %               │
+│  [Stock ▼]            [>= ▼]               [10           ]                 │
+│  [Date created ▼]     [BETWEEN ▼]          [2026-01-01] – [2026-05-11]    │
+│  [Description.pl ▼]   [IS NOT EMPTY ▼]                                     │
+│                                                                             │
+│  [+ Dodaj kolejny filtr]                                                   │
+│                                                                             │
+│  Logika: WSZYSTKIE warunki (AND)                                            │
+│                                                                             │
+│  [Reset] [Zapisz jako Saved View] [Zastosuj filtry]                        │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Mechanika:**
+- Każdy row: attribute picker + operator picker + value input.
+- Wszystkie warunki łączone AND (najpopularniejszy use case).
+- Max 20 warunków (UX limit, dla większych przełącz na Query mode).
+- *„Reset"* czyści wszystko.
+- *„Zapisz jako Saved View"* — modal z nazwą (analog do epik 02 § 9.1).
+- *„Zastosuj filtry"* — apply, chip area refresh, grid filter, panel pozostaje rozwinięty (sticky).
+
+**Query mode (toggle dla power users):**
+
+Jak w wireframe § 5.3. Power user feature dla AND/OR brackets, NOT logic, nested conditions.
+
+**Migration grid ↔ query:**
+- Grid → Query: każdy grid row staje się AND condition. Lossless.
+- Query → Grid: tylko jeśli query *jest* płaską AND-chain. Jeśli ma OR/NOT/brackets → Grid mode blokowany z message *„Filter jest zbyt skomplikowany dla Grid mode. Pozostań w Query mode lub zresetuj."*.
+
+### 7.3 AI smart filter — Completeness mismatch (rule-based MVP)
+
+**Predefined filter preset** w toolbar:
+
+```
+┌─ + Filtruj po atrybucie ─────────────────────────┐
+│ ...                                               │
+├──────────────────────────────────────────────────┤
+│ ✨ SMART FILTERS                                  │
+│ ├─ Niespójne opisy (PL filled, EN empty)         │
+│ ├─ Niepełne SEO (description but no meta_desc)   │
+│ ├─ Brakujące zdjęcia (no main_image)              │
+│ ├─ ... (4-5 predefined presets w MVP)             │
+├──────────────────────────────────────────────────┤
+```
+
+**Mechanika MVP:**
+- Każdy preset = predefined query against `attributes_indexed JSONB`.
+- Klik → apply jako chip *„Niespójne opisy ✕"* w toolbar.
+- Implementacja: serwer-side, computed na bieżącym filter context.
+
+**Przykład preset query:**
+```sql
+-- "Niespójne opisy (PL filled, EN empty)"
+WHERE attributes_indexed->'description'->>'pl' IS NOT NULL
+  AND attributes_indexed->'description'->>'en' IS NULL
+```
+
+**Marketing positioning** (z flag § 11):
+- W UI: 🟢 chip `✨ AI Smart Filter` (badge dla wow-effect).
+- W pitch'u/sales: ❌ NIE *„AI smart filters"* — to brzmi misleading. Tak: *„Cross-locale completeness detection"* lub *„Rule-based quality filters"*.
+- Pełen *„AI smart filters"* z LLM semantic comparison → Faza 1-2 (β + δ + ε z killer feature listy).
+
+### 7.4 Filter persistence — URL-based
+
+**Format URL params:**
+
+```
+/products?
+  search=festo
+  &brand=Festo,Bosch         (multi-value: comma-separated)
+  &completeness=lt:50         (operator:value format)
+  &date_created=between:2026-01-01,2026-05-11
+  &description_pl=is_not_empty
+  &page=2
+  &per_page=50
+  &sort=completeness,asc&sort=sku,asc
+```
+
+**Mechanika:**
+- Każdy filter chip = URL param.
+- Każdy sort = URL param.
+- Pagination state = URL params.
+- Reload strony → filter zachowany.
+- Share link via Copy URL (epik 02 § 4.7 quick action) — kolega Magda otwiera, widzi te same produkty.
+- Cross-tab navigation (Produkty → Multimedia → Produkty) — URL reset, filter pusty. Klient używa Saved View dla zachowania długoterminowego.
+
+**Saved Views jako persisted filter sets** (z epik 02 § 9):
+- Klient klika *„Zapisz jako Saved View"* → nazwa → URL z filtrami saved jako entity `saved_views`.
+- *„Moje Saved Views"* dropdown w toolbar — kliknij view → URL się resetuje na zapisany.
+
+---
+
+## 8. Akcje zbiorcze — szczegół
+
+### 8.1 Pełna lista 13 akcji MVP
+
+| # | Akcja | Confirm UX | Typ ryzyka |
+|---|---|---|---|
+| 1 | **Set attribute value** (jeden atrybut, nowa wartość dla wszystkich) | Wizard 3-step z preview diff | Medium |
+| 2 | **Clear attribute** (wyczyść wartość) | Wizard 3-step z preview diff | Medium |
+| 3 | **Append to multi-value** (dodaj tag, kategorię do listy) | Wizard 3-step z preview diff | Low |
+| 4 | **Remove from multi-value** (usuń tag, kategorię) | Wizard 3-step z preview diff | Medium |
+| 5 | **Bulk edit multiple attributes** (zmień 3+ atrybuty naraz w 1 wizardzie) | Wizard 3-step z preview diff | Medium |
+| 6 | **Increment numeric** (+10%, +50 PLN, -5%) | Wizard 3-step z preview diff | Medium |
+| 7 | **Toggle enabled/disabled** | Inline toast + Undo 5s | Low |
+| 8 | **Add to category** | Inline toast + Undo 5s | Low |
+| 9 | **Remove from category** | Inline toast + Undo 5s | Low |
+| 10 | **Move to category** (replace existing) | Wizard z preview diff | Semi-destructive |
+| 11 | **Publish to channels** (multi-select kanałów) | Simple modal z opcjonalnym preview per kanał | Medium |
+| 12 | **Unpublish from channels** | Simple modal | Medium |
+| 13 | **Delete** | Hard confirm — typing liczby produktów | **Destructive** |
+| 14 | **Duplicate** | Simple modal z opcjami (z assetami / z relacjami / bez) | Low |
+
+(Razem 14 akcji — *„13 rozszerzony"* z Fali 3 plus duplicate z epiku 02.)
+
+**Out of MVP, Faza 1+:**
+- 15. Find & replace text w description/name z regex — Faza 2 (rules engine).
+- 16. Change workflow state (`draft → review → published`) — Faza 1 (po Symfony Workflow z epiku 06).
+- 17. Lock / unlock fields — Faza 1.
+- 18. Change family / ObjectType — Faza 1 (wymaga migration handler).
+- 19. Force resync — Faza 1.
+- 20. Bulk replace main image / Bulk add to gallery — Faza 1.
+- 21. Export to Excel / CSV — Faza 1 (w epiku 04 Publikacje).
+
+**Out of scope (Faza 3+ lub never):**
+- 22. Custom scripts mode (BaseLinker-style power user) — defer.
+
+### 8.2 Wizard 3-step (Akeneo-style) dla Set/Clear/Append/Remove/Increment attribute
+
+**Step 1: Wybór atrybutu i operacji**
+
+```
+┌─ Bulk edit — Step 1: Wybór atrybutu ─────────────────────────────────┐
+│  ●○○  Atrybut  Wartość  Preview & Apply                              │
+│                                                                       │
+│  Zaznaczone: 247 produktów                                            │
+│                                                                       │
+│  Atrybut:    [Brand ▼]   (search w dropdown gdy >20 atrybutów)       │
+│                                                                       │
+│  Operacja:                                                            │
+│    ◉ Ustaw wartość (zastąp wszystko)                                 │
+│    ○ Wyczyść wartość (set NULL)                                       │
+│    ○ Dodaj do listy (tylko multi-value)                              │
+│    ○ Usuń z listy (tylko multi-value)                                │
+│    ○ Inkrementuj (tylko number) — +/- wartość lub %                  │
+│                                                                       │
+│                                          [Anuluj]  [Dalej →]         │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+**Step 2: Wprowadzenie wartości**
+
+```
+┌─ Bulk edit — Step 2: Wartość ─────────────────────────────────────────┐
+│  ●●○  Atrybut  Wartość  Preview & Apply                              │
+│                                                                       │
+│  Atrybut: Brand                                                       │
+│  Operacja: Ustaw wartość (zastąp)                                     │
+│                                                                       │
+│  Nowa wartość:                                                        │
+│  [Festo ▼]   (dropdown z available brands w bazie)                   │
+│                                                                       │
+│  Opcje:                                                               │
+│  ☑ Respect attribute locks (pomiń produkty z lockowanym `brand`)     │
+│  ☐ Apply tylko gdy obecna wartość jest pusta (set if empty)          │
+│                                                                       │
+│                              [← Wstecz]  [Anuluj]  [Dalej →]         │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+**Step 3: Preview & Apply** — Hybrid (sample 5 + aggregate)
+
+```
+┌─ Bulk edit — Step 3: Preview ─────────────────────────────────────────┐
+│  ●●●  Atrybut  Wartość  Preview & Apply                              │
+│                                                                       │
+│  Operacja: Set `brand` = "Festo" dla 247 produktów                    │
+│                                                                       │
+│  ─── Statystyki ──────────────────────────────────────────           │
+│  ✓ 230 produktów zostanie zmienionych                                 │
+│  ⚠ 17 produktów pominiętych (locked `brand`)                          │
+│                                                                       │
+│  Rozkład obecnych wartości:                                           │
+│  ┌──────────────────────┬──────────────┐                            │
+│  │ Obecna wartość       │ Liczba prod. │                             │
+│  ├──────────────────────┼──────────────┤                            │
+│  │ Bosch                │ 89           │                             │
+│  │ SMC                  │ 67           │                             │
+│  │ (NULL / brak marki)  │ 54           │                             │
+│  │ Festo                │ 20           │ ← już są, no-op            │
+│  │ ... (inne)           │ 17           │                             │
+│  └──────────────────────┴──────────────┘                            │
+│                                                                       │
+│  ─── Sample (pierwsze 5 produktów) ──────────────────────────         │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │ SKU       │ Name           │ Przed → Po                     │   │
+│  ├─────────────────────────────────────────────────────────────┤   │
+│  │ BSC-001   │ Czujnik X-200  │ Bosch → Festo                 │   │
+│  │ BSC-002   │ Zawór Y-100    │ Bosch → Festo                 │   │
+│  │ BSC-003   │ Kabel KS-50    │ (brak) → Festo                │   │
+│  │ SMC-101   │ Zawór SMC-A    │ SMC → Festo                   │   │
+│  │ SMC-102   │ Pneumatyk B    │ SMC → Festo                   │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+│  [Pokaż wszystkie 247 produktów]                                     │
+│                                                                       │
+│                              [← Wstecz]  [Anuluj]  [▶ Zastosuj]      │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+**Po Apply:**
+- Async via Symfony Messenger jeśli >100 produktów (z PRD § 11.2).
+- Mercure SSE progress bar w toast bottom-right.
+- Po success: toast *„247 produktów zaktualizowanych [Wycofaj — 24h window]"*.
+- W tle: każdy produkt updated z `provenance=manual, bulk_session_id=X`.
+
+### 8.3 Cascade impact summary modal (dla destructive)
+
+**Bulk delete 247 produktów — modal:**
+
+```
+┌─ ⚠ Usuwasz 247 produktów ───────────────────────────────────────────┐
+│                                                                      │
+│  System wykrył następujące zależności:                              │
+│                                                                      │
+│  ─── 📤 Publikacja na kanałach ─────────────────────              │
+│  • 198 produktów było published do Shopify (cofnięta publikacja)    │
+│  • 220 produktów było published do BaseLinker (cofnięta)            │
+│  • 147 produktów było published do Allegro (cofnięta)               │
+│                                                                      │
+│  ─── 🔗 Variants i relacje ──────────────────────────                │
+│  • 12 produktów to master z variants (cascade: 144 variants usun.)  │
+│  • 89 produktów ma cross-sell relations (89 broken relations)       │
+│  • 23 produkty to variant — master pozostanie (broken variant ref)  │
+│                                                                      │
+│  ─── 📷 DAM (zdjęcia) ───────────────────────────────                │
+│  • 1820 zdjęć NIE zostanie usuniętych (zachowane w DAM)             │
+│  • Linki product↔asset zostaną zerwane                               │
+│                                                                      │
+│  ─── 📜 Workflow ────────────────────────────────────                │
+│  • 156 produktów w stanie `approved` (zostanie usunięte)            │
+│  • 78 produktów ma pending changes od agent (zostaną odrzucone)     │
+│                                                                      │
+│  ─── ↶ Rollback ─────────────────────────────────────                │
+│  • Rollback dostępny przez 24h (do 2026-05-12 14:30)                │
+│  • Partial restore: produkty w PIM, ale re-publikacja ręczna        │
+│                                                                      │
+│  Wpisz "247" aby potwierdzić:                                        │
+│  [_____________]                                                     │
+│                                                                      │
+│                                   [Anuluj]  [⚠ USUŃ 247 produktów]   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+**Apply tylko dla:**
+- `bulk delete` (z hard confirm typing).
+- `bulk change family` (semi-destructive — variant attribute migration).
+
+**NIE dla:**
+- `bulk set attribute` (preview diff w wizard wystarczy).
+- `bulk publish` (modal pokazuje per-channel impact, ale nie cascade).
+- `bulk toggle enabled` (inline toast).
+
+### 8.4 Rollback session i 24h window
+
+**Mechanika:**
+
+```sql
+-- Każda bulk operation tworzy session
+INSERT INTO bulk_sessions (id, tenant_id, user_id, action_type, target_count, ...)
+VALUES ('uuid-X', 'tenant-A', 'kasia', 'set_attribute', 247, ...);
+
+-- Każdy produkt updated z bulk_session_id
+UPDATE objects
+SET attributes_indexed = jsonb_set(...),
+    bulk_session_id = 'uuid-X',
+    updated_at = NOW()
+WHERE id IN (...);
+
+-- W tabeli bulk_logs zapisujemy stare wartości (dla rollback)
+INSERT INTO bulk_logs (bulk_session_id, object_id, attribute_id, old_value, new_value)
+VALUES ('uuid-X', 'prod-1', 'brand', '"Bosch"', '"Festo"'), ...;
+```
+
+**UI rollback:**
+- Toast po bulk operation: *„247 produktów zaktualizowanych. [Wycofaj — dostępne do jutra 14:30]"*.
+- Klik *„Wycofaj"* → confirm modal *„Cofnąć zmiany dla 247 produktów?"*.
+- Po confirm: system iteruje `bulk_logs`, przywraca old_value per produkt.
+- Async via Symfony Messenger (jeśli >100), progress bar.
+
+**Rollback specific edge cases:**
+
+**`bulk delete` rollback (partial restore):**
+- Soft delete → un-soft delete produktów w PIM.
+- **NIE** re-publish do kanałów automatycznie.
+- Toast po rollback: *„247 produktów przywrócono w PIM. Aby ponownie opublikować, użyj 'Publish to channels'."*.
+
+**`bulk publish to channels` rollback (always unpublish):**
+- Trigger unpublish workers per kanał.
+- 247 unpublish requests do Shopify / BaseLinker / Allegro.
+- Progress bar: *„Cofnięcie publikacji: 156/247 ukończone"*.
+- Po success: toast *„Publikacja cofnięta z 3 kanałów. 12 błędów (sprzedaż w międzyczasie / API timeout) — sprawdź raport."*.
+- **Buyer aspect** — produkty mogą sprzedawać się w międzyczasie (12h window). System NIE blokuje rollback'u — klient akceptuje *„buyer może zobaczyć 'product not found'"* per decyzja Fali 4.
+
+**Window expiration:**
+- Po 24h: `bulk_sessions.expires_at < NOW()` → rollback button disabled w UI.
+- Hard delete `bulk_logs` po 7 dniach (cleanup).
+
+### 8.5 Per-attribute lock — skip + raport
+
+**Mechanika:**
+- `Object.locked_attributes JSONB` — list of `attribute_id` zablokowanych ręcznie.
+- Bulk edit attribute → handler sprawdza per produkt: `IF attribute_id IN object.locked_attributes THEN skip`.
+- Raport po bulk:
+  - *„247 selected"*
+  - *„230 updated"*
+  - *„17 skipped (locked)"* — z list of SKUs jako sub-link.
+- **Bez force override w MVP** — klient ręcznie un-lock'uje w detail view per produkt, potem powtarza bulk.
+
+**Lock UX (z epiku 02 § 5.1):**
+- 🔓 / 🔒 icon obok pola w detail view.
+- Klik → toggle locked stan.
+- Provenance update: `lock_changed_at`, `lock_changed_by`.
+
+### 8.6 Cross-page selection (BaseLinker style)
+
+**Layout w toolbar gdy >0 selected:**
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  ✓ 30 zaznaczone na tej stronie z 1247 wyników                          │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │  [Zaznacz wszystkie 1247 wyniki?]    [Wyczyść zaznaczenie]       │  │
+│  └──────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**Mechanika:**
+- Default: selection per-page (zaznacz na current page).
+- Przy zmianie strony: selection per-page NIE persist (resetuje się przy navigation).
+- Toolbar shows *„30 zaznaczone na tej stronie z 1247 wyników"* — jasna informacja.
+- *„Zaznacz wszystkie 1247 wyniki?"* — upgrade do select-all-matching:
+  - Po klik: counter staje się *„1247 zaznaczone (cały filter set)"*.
+  - Bulk actions apply do całego filter set (nie tylko 30).
+  - *„Show only selected"* checkbox staje się no-op (filter już aktywny).
+- *„Wyczyść zaznaczenie"* — clear selection state.
+
+**Edge cases:**
+- Klient zaznacza 30 na page 1, zmienia stronę → selection resetuje się (per-page model).
+- Klient klika *„Zaznacz wszystkie 1247"* → selection persist cross-pages.
+- Klient z `select-all-matching=true` zmienia filter (np. dodaje *„Brand=Bosch"*) → automatyczny reset selection (filter change unieważnia *„zaznacz wszystkie"*).
+
+---
+
+## 9. Cmd+K agent integration (USP MVP)
+
+### 9.1 Trigger i layout
+
+**Trigger:**
+- Global keyboard shortcut: `⌘K` (Mac) / `Ctrl+K` (Win/Linux).
+- Button w toolbar listy (mobile-friendly fallback).
+- Available w każdym widoku admin (nie tylko liście produktów).
+
+**Layout palette (modal):**
+
+```
+┌─ ⌘K Cortex Agent ────────────────────────────────────────────────────┐
+│                                                                       │
+│  ⌘K [Co chcesz zrobić?                                           ]   │
+│                                                                       │
+│  ─── KONTEKST ────────────────────────────────────────────────       │
+│  📌 30 produktów zaznaczone (filter: Brand=Festo)                    │
+│                                                                       │
+│  ─── PODPOWIEDZI ─────────────────────────────────────────────       │
+│  💡 "ustaw kategorię na Pneumatyka dla zaznaczonych"                 │
+│  💡 "wyczyść tag promo dla zaznaczonych"                             │
+│  💡 "podbij cenę o 10% dla zaznaczonych"                             │
+│  💡 "dodaj nowy atrybut waga_opakowania (number, kg) do rodziny"    │
+│                                                                       │
+│  ─── OSTATNIE KOMENDY ────────────────────────────────────────       │
+│  🕐 "dodaj atrybut IP_class do rodziny Czujniki"  (wczoraj 14:30)   │
+│  🕐 "ustaw enabled=false dla wszystkich Bosch"   (2 dni temu)       │
+│                                                                       │
+│                                                  [Esc do zamknięcia] │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+### 9.2 Selection context — naturalne, bez UI komunikacji
+
+**Per decyzji Fali 4:** agent czyta selection state z React context, interpretuje *„dla zaznaczonych jeśli >0"*.
+
+**Mechanika:**
+- React state: `selectedIds: string[]`, `selectionMode: 'per-page' | 'all-matching'`, `filterContext: FilterQuery`.
+- Agent prompt input:
+  ```
+  Current selection: 30 products from page 1 (per-page mode)
+  Active filters: brand=Festo, completeness<50
+  Total matching filter: 247 products
+  User selected SKUs: [BSC-001, BSC-002, ...]
+  
+  User command: "ustaw kategorię na Pneumatyka dla zaznaczonych"
+  ```
+- Agent interpretuje *„dla zaznaczonych"* jako 30 zaznaczonych. Jeśli user pominie *„zaznaczonych"* — agent pyta clarification *„Czy ustawić dla 30 zaznaczonych, dla 247 z filtrem, czy dla wszystkich w katalogu?"*.
+
+**UI nie pokazuje explicit selection chip w palette** (decyzja Fali 4 — naturalne). Ale palette **ma sekcję KONTEKST** (wireframe wyżej) która informuje user'a co agent widzi. To kompromis — bez explicit *„dla zaznaczonych"* hint, ale z transparency co agent rozumie.
+
+### 9.3 Scope Cmd+K w MVP — schema-ops + bulk actions
+
+**Akceptowane intents w MVP (z epiku 08 § MVP Beta-Demo + tej decyzji):**
+
+| Intent | Przykład command | Mapped tool | Status |
+|---|---|---|---|
+| `create_attribute` | *„dodaj atrybut IP_class do rodziny Czujniki"* | `tool:create_attribute` | MVP (z epiku 08) |
+| `set_bulk_attribute` | *„ustaw kategorię na Pneumatyka dla zaznaczonych"* | `tool:bulk_edit_attribute` | **MVP (ten dokument)** |
+| `toggle_bulk_enabled` | *„wyłącz wszystkie zaznaczone"* | `tool:bulk_toggle_enabled` | MVP |
+| `increment_bulk_numeric` | *„podbij cenę o 10% dla zaznaczonych"* | `tool:bulk_increment_numeric` | MVP |
+| `add_remove_category` | *„dodaj do kategorii Promocja dla zaznaczonych"* | `tool:bulk_add_to_category` | MVP |
+| `publish_bulk` | *„opublikuj zaznaczone na Shopify"* | `tool:bulk_publish` | MVP |
+
+**Faza 1+:**
+
+| Intent | Przykład command | Status |
+|---|---|---|
+| `filter_products` | *„pokaż mi produkty z niespójnymi opisami"* | Faza 1 (NLP filter) |
+| `delete_bulk` | *„usuń wszystkie zaznaczone"* | Faza 1 (cautious — destructive bez full UI flow) |
+| `bulk_translate` | *„przetłumacz description dla zaznaczonych z PL na EN"* | Faza 2 (data-ops agent) |
+| `bulk_generate_seo` | *„wygeneruj opis SEO dla zaznaczonych z atrybutów"* | Faza 2 |
+
+### 9.4 Approval flow dla agent w bulk actions
+
+**Każda bulk action z Cmd+K przechodzi przez ten sam flow co manual:**
+
+1. User wpisuje *„ustaw kategorię na Pneumatyka dla zaznaczonych"*.
+2. Agent (Claude) parsuje intent, generuje plan:
+   - Tool call: `bulk_edit_attribute`
+   - Args: `{attribute: "category", value: "Pneumatyka", target_ids: [30 selected SKUs]}`
+3. **Preview** — agent pokazuje **bulk wizard Step 3 preview diff** (jak w manual flow § 8.2).
+4. User klika *„Zastosuj"* → identyczne handler'y backend, identyczny rollback flow.
+
+**Spójność:** Cmd+K NIE jest *„bypass"* dla normalnego flow — jest *„alternative input method"*. Wszystkie security/preview/rollback gates działają.
+
+### 9.5 Anthropic koszt + BYOK
+
+**Per command:**
+- ~500-2000 tokens input (current state + selection + filter context).
+- ~200-500 tokens output (tool call JSON).
+- Claude Sonnet 4.5 cost: ~$0.002-0.008 per command.
+
+**Limits z architektury § 8.5:**
+- 50 tool calls/h/user.
+- $20/dzień/tenant.
+- BYOK domyślnie — klient płaci swój Anthropic key (Pro/Enterprise), Marcin's key tylko dla testów + demo.
+
+---
+
+## 10. Edge cases — szczegółowo
+
+### 10.1 Variants w bulk operations
+
+**Z epiku 02 § 11.1:**
+- **Bulk action na master w tree mode** — confirm modal: *„Apply to master only / master + all variants / variants only?"*.
+- **Default:** *„master + variants"* (cascade).
+- **Bulk delete master** — blokuje jeśli master ma >0 active variants. Confirm: *„Delete master + N variants?"*.
+- **Bulk change family** dla master — propagacja do variants automatyczna. Variants z `level=variant` atrybutami które nie istnieją w nowej family → warning.
+
+### 10.2 Excel-like editing edge cases
+
+**Z epiku 02 § 11.2:**
+- Paste do read-only kolumny (Family, Categories) — alert *„Read-only column. Use detail view to edit."*.
+- Paste niewłaściwego typu (text → number column) — inline validation, błąd per komórka, skip invalid rows.
+- Paste do localizable column — wkleja do *current locale tab* (czyli jakiego klient widzi). NIE w wszystkich locales.
+- Paste do scopable column — j.w. dla aktualnego channel sub-tab.
+- Drag-fill na różnych typach komórek — działa tylko gdy wszystkie komórki w drag są tego samego typu.
+
+### 10.3 Filter chip edge cases
+
+- **Filter na removed attribute** (Adam usunął atrybut z Modelowania) — chip pokazuje *„Atrybut nie istnieje. [Usuń filter]"*.
+- **Filter na archived value** (np. brand "Bosch" archived w Modelowaniu) — chip aktywny, ale value picker nie pokazuje. Klient może edit chip, value zostaje historyczny.
+- **Conflicting filters** — *„Brand IS Festo AND Brand IS Bosch"* → empty result. UI ostrzega: *„Brak wyników. Filtry są sprzeczne."*.
+
+### 10.4 Search edge cases
+
+- **Empty search** — pokazuje wszystko (default).
+- **Search w current filter context** — search zawęża aktualnie filtrowany zestaw, nie całość.
+- **Search > 200 wyników** — pokazuje top 50 (paginacja standardowa) + warning *„200+ matches, refine your search"*.
+- **Search po locked attribute** — pokazuje matches niezależnie od lock state (lock dotyczy edit, nie visibility).
+
+### 10.5 Bulk publish channels + sales w międzyczasie
+
+**Scenario:** Klient publish 247 produktów na Shopify o 14:30. 3 produkty (SKU A, B, C) sprzedały się w ciągu 12h. Klient o 02:30 (next day) klika *„Wycofaj publikację"*.
+
+**System behavior (per Fali 4):**
+- Trigger unpublish workers per kanał (Shopify, BaseLinker, Allegro).
+- Per produkt: `DELETE` request do Shopify Admin API.
+- **Shopify response dla SKU sprzedanych** — sukces unpublish (product removed from storefront). Order #ABC123 zawiera SKU A jako *„archived line item"*. Buyer email już wysłany przy purchase, kopia produktu w order. Order pozostaje OK.
+- **Result toast** *„Cofnięcie publikacji: 244/247 sukcesów. 3 błędy (sprawdź raport)."*.
+- **Raport:**
+  ```
+  SKU,channel,status,note
+  A,shopify,partial,"Product unpublished. Existing order #ABC123 retains line item."
+  B,shopify,partial,"Product unpublished. Existing order #ABC457 retains line item."
+  C,shopify,partial,"Product unpublished. Existing order #ABC998 retains line item."
+  ```
+
+**Komunikacja w UI:**
+- Toast po rollback z linkiem do raportu.
+- W raporcie *„partial"* status to NIE *„błąd"* — to *„informacja: produkt cofnięty, ale order historyczny pozostaje"*.
+- Klient akceptuje (decyzja Fali 4).
+
+### 10.6 Cmd+K agent — out of context queries
+
+**Scenario:** Klient w liście Produkty wpisuje w Cmd+K *„dodaj nowego użytkownika"* (Settings activity, nie list activity).
+
+**Behavior:**
+- Agent rozpoznaje że nie jest list/schema-ops intent.
+- Response: *„Ta akcja jest w zakładce Ustawienia → Users. Czy przekierować?"*.
+- Confirm → navigacja do Settings + zachowanie selection state? Pewnie nie zachowanie (user-context resetuje się przy nawigacji).
+
+**Scenario:** Klient wpisuje *„usuń wszystkie produkty"* bez zaznaczenia.
+
+**Behavior:**
+- Agent ostrzega *„Brak zaznaczenia. Czy chcesz usunąć WSZYSTKIE 1247 produktów z bieżącego filtra? [Tak] [Nie]"*.
+- Po confirm → hard confirm modal (typing liczby) jak manual flow.
+- Spójność: destructive bulk zawsze przez hard confirm, niezależnie czy z Cmd+K czy manual.
+
+---
+
+## 11. ⚠️ Krytyczna nota — AI smart filters w MVP NIE jest AI
+
+**Co marketing/sales materials NIE mogą używać dla MVP:**
+- ❌ *„AI-powered smart filters"*
+- ❌ *„AI quality check"*
+- ❌ *„Semantic search"*
+- ❌ *„LLM-driven product analysis"*
+
+**Co MOŻE używać dla MVP:**
+- ✅ *„Cross-locale completeness detection"*
+- ✅ *„Rule-based smart filters"*
+- ✅ *„Predefined quality filters"*
+- ✅ *„Quick filter presets"*
+
+**Background:** Marcin w Fali 1 wybrał (δ) *„AI smart filters"* jako killer feature. W Fali 2 wybrał (γ) *„completeness mismatch only"* jako MVP scope — co jest **rule-based SQL query**, nie AI. Pełen AI (β semantic + δ cross-channel inconsistency + ε quality dashboard) → Faza 1-2.
+
+**Konsekwencja dla pitch deck (cortex-pim-pitch-deck-v1):**
+- Slajd 4 (USP #1 Agentic-first) — *jest* AI killer (Cmd+K agent z Anthropic).
+- Slajd 5 (USP #2 API Configurator) — *jest* differentiator (nie AI).
+- *„AI smart filters"* — **nie wymieniać w pitch jako USP MVP**. Wymienić jako *„coming in Faza 1"* gdy klient zapyta o roadmap.
+
+---
+
+## 12. User stories
+
+### 12.1 Wyszukiwarka + filtry
+
+| ID | Persona | Story |
+|---|---|---|
+| US-LIST-001 | Kasia | Wpisuje *„BSC"* w quick search → znajduje produkty zaczynające się od `BSC` w SKU lub name |
+| US-LIST-002 | Kasia | Wpisuje *„Festo"* w quick search → znajduje wszystkie produkty z `brand=Festo` (bez explicit filter chip) |
+| US-LIST-003 | Magda | Klika *„+ Filtruj po atrybucie"* → wybiera `Description PL` z dropdown → operator `IS EMPTY` → chip w toolbar |
+| US-LIST-004 | Kasia | Otwiera Advanced filter panel (push-down) → konfiguruje 4 filtry w grid mode → klika *„Zapisz jako Saved View"* (*„Festo niski completeness"*) |
+| US-LIST-005 | Tomasz | Otwiera Saved View Kasi przez URL share → widzi te same produkty + filtry |
+| US-LIST-006 | Magda | Toggle do Query mode w Advanced panel → buduje query *„Brand IS Festo AND (Stock >= 10 OR Completeness >= 80)"* |
+| US-LIST-007 | Kasia | Klika preset *„✨ Niespójne opisy (PL filled, EN empty)"* → chip w toolbar, lista filtrowana |
+| US-LIST-008 | Kasia | Filter URL `/products?brand=Festo` → reload strony → filter zachowany |
+| US-LIST-009 | Kasia | W settings (`/settings/list-filters`) wybiera 10 ulubionych atrybutów z full list |
+
+### 12.2 Akcje zbiorcze
+
+| ID | Persona | Story |
+|---|---|---|
+| US-LIST-010 | Kasia | Zaznacza 30 produktów na page 1 → klika *„Zaznacz wszystkie 1247 wyniki?"* → bulk delete z hard confirm typing *„1247"* |
+| US-LIST-011 | Magda | Bulk edit `description.pl` dla 247 produktów Festo → wizard 3-step → preview diff z sample 5 + aggregate counter → Apply |
+| US-LIST-012 | Kasia | Bulk publish 50 produktów na Shopify + BaseLinker → simple modal → async progress z Mercure SSE |
+| US-LIST-013 | Marcin (dogfooding) | Omyłkowo bulk delete 1000 produktów → toast z *„[Wycofaj — dostępne do jutra 14:30]"* → klika → partial restore w PIM (bez re-publish) |
+| US-LIST-014 | Magda | Bulk publish 247 produktów na Shopify, 3 sprzedały się w 12h, klika *„Wycofaj"* → unpublish 244 sukces + 3 partial z linkiem do raportu |
+| US-LIST-015 | Kasia | Bulk edit attribute `description.pl` z 17 produktów lockowanymi → wizard pokazuje *„17 skipped (locked)"* w preview |
+| US-LIST-016 | Kasia | Increment numeric `price *= 1.1` dla 50 produktów → wizard pokazuje rozkład *„avg before: 245.50, avg after: 270.05"* |
+| US-LIST-017 | Magda | Bulk duplicate 20 produktów z opcjami *„z assetami / bez relacji"* → 20 nowych produktów stworzonych z `provenance=duplicate, source_id=X` |
+| US-LIST-018 | Kasia | Bulk delete master + 12 variants (cascade) → cascade impact modal pokazuje *„12 master + 144 variants do usunięcia"* |
+
+### 12.3 Cmd+K agent
+
+| ID | Persona | Story |
+|---|---|---|
+| US-LIST-019 | Kasia | Cmd+K → *„dla zaznaczonych 30 ustaw kategorię na Pneumatyka"* → agent generuje tool call → preview diff → Apply |
+| US-LIST-020 | Magda | Cmd+K → *„podbij cenę o 10% dla zaznaczonych"* → agent generuje increment numeric tool call → preview rozkład → Apply |
+| US-LIST-021 | Kasia | Cmd+K bez zaznaczenia → *„usuń wszystkie produkty z brand Bosch"* → agent ostrzega *„Brak zaznaczenia. Usunąć wszystkie 89 produktów z bieżącego filtra Bosch?"* → confirm → hard confirm typing *„89"* |
+| US-LIST-022 | Marcin (dogfooding) | Cmd+K → *„dodaj atrybut waga_opakowania (number, kg) do rodziny Elektronika"* → schema-ops tool call (z epiku 08) → modelowanie update |
+
+---
+
+## 13. Business rules
+
+### 13.1 Performance
+
+- **Filter query latency** — Postgres GIN index z ADR-006 + Meilisearch dla quick search. Target: p95 <300ms na 200k SKU.
+- **Bulk operations async threshold** — >100 produktów → async via Symfony Messenger. <100 → sync z spinner.
+- **Cmd+K response time** — Anthropic Claude Sonnet 4.5, target: <3s end-to-end (input + reasoning + tool call).
+- **Filter chip render** — debounce 200ms (nie re-fetch przy każdym keystroke).
+
+### 13.2 Permission rules (MVP brak gating)
+
+- Wszyscy user'zy mogą:
+  - Wyszukiwać i filtrować bez ograniczeń.
+  - Bulk edit/delete/publish bez explicit role check.
+- Audit log każdej akcji (Doctrine AuditBundle z epiku 0.11.4):
+  - User_id, timestamp, action, target_ids[], old_values, new_values.
+  - Rollback path zachowany przez 7 dni (potem hard delete logs).
+
+### 13.3 Concurrency rules
+
+- **Same user, multiple bulk ops** — allow + warn *„Już jeden bulk job w toku"*. Drugi w queue.
+- **Different users on same products** — allow concurrent edits. Last-write-wins. Audit log shows order.
+- **Bulk + manual edit race** — pesimistic locking per object_id przy bulk handler write. Manual edit czeka.
+
+### 13.4 Saved Views integration
+
+- Filter z Advanced panel → *„Zapisz jako Saved View"* → entity `saved_views` (z epiku 02 § 9).
+- Saved Views = solo only (per user, z epiku 02).
+- URL share z Saved View name → odbiorca widzi filter, ale nie ma save'd entity. Może *„Zapisz jako swoją Saved View"*.
+
+---
+
+## 14. Dependency na backend
+
+### 14.1 Encje + tabele (delta vs aktualnego planu)
+
+```sql
+-- Sesje bulk operations (analog do import_sessions z feature-imports.md)
+CREATE TABLE bulk_sessions (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    user_id UUID NOT NULL REFERENCES users(id),
+    action_type VARCHAR(64) NOT NULL,   -- set_attribute, delete, publish_channels, etc.
+    target_object_ids UUID[] NOT NULL,
+    target_count INTEGER NOT NULL,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    skipped_count INTEGER NOT NULL DEFAULT 0,  -- locked attrs
+    error_count INTEGER NOT NULL DEFAULT 0,
+    action_payload JSONB NOT NULL,        -- attribute_id, new_value, channels, etc.
+    rollback_available_until TIMESTAMPTZ,
+    rolled_back_at TIMESTAMPTZ,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    source VARCHAR(16) NOT NULL DEFAULT 'manual', -- manual, cmd_k_agent
+    cmd_k_command TEXT  -- jeśli source=cmd_k_agent, oryginał command
+);
+
+-- Logi per produkt w bulk (dla rollback)
+CREATE TABLE bulk_logs (
+    id UUID PRIMARY KEY,
+    bulk_session_id UUID NOT NULL REFERENCES bulk_sessions(id) ON DELETE CASCADE,
+    object_id UUID NOT NULL REFERENCES objects(id),
+    attribute_id UUID REFERENCES attributes(id),  -- NULL dla destructive ops
+    old_value JSONB,
+    new_value JSONB,
+    level VARCHAR(8) NOT NULL,  -- info, warning, error
+    message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_bulk_logs_session ON bulk_logs(bulk_session_id);
+CREATE INDEX idx_bulk_logs_object ON bulk_logs(object_id);
+
+-- Update: objects
+ALTER TABLE objects ADD COLUMN bulk_session_id UUID REFERENCES bulk_sessions(id);
+CREATE INDEX idx_objects_bulk_session ON objects(bulk_session_id) WHERE bulk_session_id IS NOT NULL;
+ALTER TABLE objects ADD COLUMN locked_attributes JSONB DEFAULT '[]'::JSONB;
+CREATE INDEX idx_objects_locked_attrs ON objects USING GIN(locked_attributes);
+
+-- Saved filter presets (rule-based AI smart filters)
+CREATE TABLE smart_filter_presets (
+    id UUID PRIMARY KEY,
+    tenant_id UUID,                       -- NULL = global preset (system-shipped)
+    user_id UUID REFERENCES users(id),    -- NULL = tenant-shared (Faza 1+)
+    name JSONB NOT NULL,                  -- {"pl": "Niespójne opisy", "en": "Inconsistent descriptions"}
+    icon VARCHAR(16),
+    query JSONB NOT NULL,                 -- filter query w naszym DSL
+    is_built_in BOOLEAN NOT NULL DEFAULT false,
+    sort_order INTEGER DEFAULT 0
+);
+
+-- Seed: 4-5 built-in presets dla MVP
+INSERT INTO smart_filter_presets (id, name, icon, query, is_built_in)
+VALUES
+  ('uuid-1', '{"pl":"Niespójne opisy"}', '🌐', '{"description.pl":"IS_NOT_EMPTY","description.en":"IS_EMPTY"}', true),
+  ('uuid-2', '{"pl":"Brakujące zdjęcia"}', '📷', '{"main_image":"IS_EMPTY"}', true),
+  ('uuid-3', '{"pl":"Niepełne SEO"}', '🔍', '{"description":"IS_NOT_EMPTY","meta_description":"IS_EMPTY"}', true),
+  ('uuid-4', '{"pl":"Czerwone (<50% complete)"}', '🔴', '{"completeness_pct":{"op":"<","value":50}}', true),
+  ('uuid-5', '{"pl":"Bez kategorii"}', '📂', '{"category":"IS_EMPTY"}', true);
+
+-- User favorite filter attributes (top 10 dropdown)
+CREATE TABLE user_filter_favorites (
+    user_id UUID NOT NULL REFERENCES users(id),
+    attribute_id UUID NOT NULL REFERENCES attributes(id),
+    sort_order INTEGER NOT NULL,
+    PRIMARY KEY (user_id, attribute_id)
+);
+
+-- Default top 10 dla każdego nowego user'a (seed via listener po user create)
+```
+
+### 14.2 API endpoints
+
+| Endpoint | Metoda | Cel |
+|---|---|---|
+| `/api/products/search` | GET | Quick search z params `q`, `filters`, `sort`, `page` |
+| `/api/products/filter-presets` | GET | Lista smart filter presets (built-in + user) |
+| `/api/products/filter-presets/{id}/apply` | POST | Apply preset → returns matching product IDs |
+| `/api/products/bulk-actions/edit-attribute` | POST | Body: `{target_ids[], attribute_id, operation, value, respect_locks}` |
+| `/api/products/bulk-actions/delete` | POST | Hard confirm required (count in body) |
+| `/api/products/bulk-actions/publish` | POST | Body: `{target_ids[], channels[]}` |
+| `/api/products/bulk-actions/unpublish` | POST | j.w. |
+| `/api/products/bulk-actions/duplicate` | POST | Body: `{target_ids[], with_assets, with_relations}` |
+| `/api/bulk-sessions` | GET | Lista user's bulk sessions z filters |
+| `/api/bulk-sessions/{id}` | GET | Status + counts + logs |
+| `/api/bulk-sessions/{id}/rollback` | POST | Trigger rollback (within 24h) |
+| `/api/bulk-sessions/{id}/report.csv` | GET | Download raport CSV |
+| `/api/user/filter-favorites` | GET/PUT | CRUD user's top 10 atrybutów |
+| `/api/cmd-k/parse` | POST | Body: `{command, context}` — Anthropic call, returns tool call JSON + preview |
+| `/api/cmd-k/execute` | POST | Body: `{tool_call_json}` — execute pre-validated tool call |
+
+### 14.3 Symfony Messenger handlers
+
+- `BulkEditAttributeHandler` extends `AbstractBatchHandler` (`EntityManager::clear()` per chunk N=200).
+- `BulkDeleteHandler` — soft delete + cascade unpublish channels (Faza 1+).
+- `BulkPublishHandler` — per-channel sync workers + Mercure progress.
+- `BulkRollbackHandler` — iteruje `bulk_logs`, restore old values, audit entries.
+- `CmdKAgentHandler` — Anthropic API call + tool dispatch.
+
+### 14.4 Mercure SSE channels
+
+- `bulk-operations.{user_id}` — wszystkie bulk operations tego usera (lista live updates).
+- `bulk-operations.{session_id}` — pojedyncza operacja progress (subscribed gdy user otwiera detail).
+
+### 14.5 Doctrine listeners
+
+- `ProductCompletenessIndexListener` — przy `Object` postUpdate, recompute completeness + per-locale checks. Update `attributes_indexed.completeness_per_locale JSONB`.
+- `BulkSessionAuditListener` — przy każdy `Object` change w bulk, log do `bulk_logs`.
+- `FilterFavoriteSeedListener` — przy user creation, seed default top 10 atrybutów.
+
+---
+
+## 15. Komponenty Refine + shadcn
+
+### 15.1 Refine resources
+
+- `Refine.Resource("products")` — extends z epiku 02.
+- `Refine.Resource("bulk-sessions")` — list, show, rollback action.
+- `Refine.Resource("smart-filter-presets")` — list, apply action.
+- Custom hooks:
+  - `useFilterUrlState()` — URL-based filter persistence (params ↔ filter state sync).
+  - `useBulkOperation(actionType)` — generic bulk handler z async + progress.
+  - `useSelectionState()` — per-page vs all-matching selection model.
+  - `useCmdKAgent()` — Cmd+K trigger + Anthropic call wrapper.
+
+### 15.2 shadcn components
+
+- `Tabs`, `Form`, `Input`, `Select`, `Combobox`, `Switch`, `Button`, `Badge`, `Tooltip`, `Card`, `Dialog`, `Sheet`, `Popover`, `DropdownMenu`, `Progress`, `Toast` (sonner), `Skeleton`.
+- Plus `Command` (shadcn-cmdk wrapper) dla Cmd+K palette.
+
+### 15.3 Custom components
+
+| Komponent | Rola |
+|---|---|
+| `ProductListPage` | Root z layoutem toolbar + filter panel + grid |
+| `ListToolbar` | Search bar + Filtruj dropdown + Filtry toggle + action bar |
+| `QuickSearchInput` | Z debounce 800ms + Enter submit, Meilisearch backend |
+| `FilterByAttributeDropdown` | Favorite top 10 + *„Inne atrybuty"* link do modal |
+| `OperatorPicker` | Per-type operator dropdown (`=`, `≠`, `STARTS WITH`, etc.) |
+| `FilterChipArea` | Aktywne chip filters z edit popover + ✕ kasuje |
+| `AdvancedFilterPanel` | Push-down sticky-collapsible, hybrid grid/query mode |
+| `FilterGridMode` | Grid 3-4 kolumny attr+op+value |
+| `FilterQueryMode` | AND/OR brackets builder |
+| `SmartFilterPresetsList` | Sekcja w *„Filtruj"* dropdown z built-in presets |
+| `BulkSelectionToolbar` | BaseLinker style — *„30 zaznaczone z 1247"* + upgrade button |
+| `BulkActionsToolbar` | Sticky-bottom z 13 akcjami |
+| `BulkEditWizard` | 3-step z preview diff |
+| `BulkPreviewDiff` | Sample 5 + aggregate counter |
+| `CascadeImpactModal` | Pełen impact summary (channels + variants + relations + DAM + workflow) |
+| `HardConfirmModal` | Typing N produktów dla destructive |
+| `BulkProgressToast` | Mercure SSE progress + cancel |
+| `BulkRollbackToast` | Z 24h window countdown + undo button |
+| `CmdKPalette` | Modal z input + kontekst sekcja + podpowiedzi |
+| `CmdKContextSection` | Pokazuje *„30 zaznaczone, filter: Brand=Festo"* w palette |
+| `CmdKSuggestions` | Predefined + last-used commands |
+| `LockedAttributesBadge` | 🔒 / 🔓 icon w detail view obok pola |
+| `FilterUrlSerializer` | Helpers do URL ↔ filter state ↔ Saved View |
+
+---
+
+## 16. Open questions
+
+- [ ] **Bundle size** — Advanced filter panel + Cmd+K + bulk wizard razem ~150-200 KB. Code-split per feature (lazy load Advanced panel + Cmd+K).
+- [ ] **Operator pełne w Faza 1 czy MVP** — Marcin wybrał Akeneo-style pełne od dnia 1 (β). Implementacja: ~10-14h. Czy *wszystkie* operatory per type w MVP, czy *core* (`=`, `≠`, `IS EMPTY`, `IS NOT EMPTY`) w MVP + reszta Faza 1?
+- [ ] **Query mode UX validation** — power user feature, ale UX nie trywialny. POC w Sprint? Może użyć biblioteki (react-querybuilder, MIT, ~50 KB)?
+- [ ] **Multi-channel filter** — *„description scopable na Shopify ma X"* — jak UX-owo? Default current channel sub-tab + override przez chip?
+- [ ] **Smart filter presets — user-defined?** — w MVP built-in only. Faza 1: user może *„Zapisz Saved View jako Smart Preset"* (analog Saved Views ale dla filter previews).
+- [ ] **Cmd+K NLP filter — Faza 1 release** — kiedy *„pokaż mi produkty z niespójnymi opisami"* jako natural language (vs preset click)? Faza 1 z plate-ai integration?
+- [ ] **Bulk rollback dla `publish` — sales sync** — czy mamy `orders` table w bazie (sync z kanałów)? Jeśli nie, *„skip sold-since-publish"* niemożliwe → must accept *„best effort + raport"* approach.
+- [ ] **Per-attribute lock force override** — w MVP brak. Faza 1: super_admin może force override z confirmation?
+- [ ] **Select-all-matching limit** — jeśli filter result = 50000 produktów, klient klika *„Zaznacz wszystkie"* → bulk operation na 50k rows. Limit: 10k? 100k? Niewskazane?
+- [ ] **Search performance edge cases** — query z 5+ słowami: *„czujnik indukcyjny Festo 24V IP67"* — strict prefix nie zadziała. Klient potrzebuje *„at least one word matches"* — Meilisearch domyślnie tak działa, ale to nie jest prefix. Reconfirm semantic.
+- [ ] **Mobile UX** — z PRD § 4.4 epiku 02 brak responsive, scroll horizontal. Cmd+K na mobile (touch device) — button w toolbar zamiast keyboard shortcut.
+
+---
+
+## 17. Wpływ na backend roadmap
+
+Feature wpływa na:
+
+- **Epik 0.4 (API Platform)** — dochodzą endpointy: `/products/search`, `/products/bulk-actions/*`, `/bulk-sessions/*`, `/cmd-k/*`, `/user/filter-favorites`. **Estymacja: +14-20h** ponad obecny scope.
+- **Epik 0.5 (Search Meilisearch)** — search po 5 polach (SKU+name+EAN+brand+tags) + diacritic-insensitive. **Estymacja: +4-6h**.
+- **Epik 0.6 (Admin UI)** — Advanced filter panel + bulk wizard + cascade modal + Cmd+K + smart filter presets. **Estymacja: +95-130h** (dominant cost).
+- **Epik 0.7 (Agent layer)** — Cmd+K rozszerzenie z schema-ops (epik 08 MVP demo) na bulk actions na zaznaczonych. **Estymacja: +12-16h** ponad obecny Beta-Demo scope.
+- **Epik 0.11 (Hardening)** — bulk_sessions encja, rollback worker, audit integration. **Estymacja: +6-10h**.
+
+**Total impact na Fazę 0:** **+131-182h**.
+
+Aktualny budżet z PRD ~310-440h (po MVP-Beta-Demo + ADR-009/010/011/012 + epik 02 + epik 08 + feature-imports). Po dodaniu tego feature'a: **~440-620h**.
+
+**Marcin akceptuje +50-80h scope (PRD § 12.1).** Po tej iteracji jesteśmy **~3-4× ponad limit**. To jest **świadoma decyzja** Marcina (*„nie spieszę się, robimy żeby było dobrze"*), ale trzeba to flag'ować w PRD § 7 wycena update.
+
+**Drivery scope'u:**
+- Advanced filter panel (grid + query mode) z operatorami pełnymi: ~30-40h.
+- Bulk actions toolbar + 13 akcji handlers: ~40-50h.
+- Bulk wizard 3-step z preview diff: ~16-22h.
+- Cascade impact modal + hard confirm + rollback: ~12-16h.
+- Cmd+K agent integration (rozszerzenie Beta-Demo): ~12-16h.
+- Smart filter presets (rule-based): ~6-8h.
+- URL-based filter persistence: ~4-6h.
+- Cross-page selection BaseLinker-style: ~4-6h.
+- Per-attribute lock UX w bulk: ~4-6h.
+
+---
+
+## 18. Co dalej
+
+1. **Walidacja koncepcji** z Marcinem — czy Advanced filter panel hybrid (grid + query) UX-owo działa, czy POC w Sprint 1.
+2. **POC operatory pełne od dnia 1** — Akeneo-grade implementacja w Sprint 1 z benchmark complexity vs `=` only.
+3. **Wireframes w Figma** — przekazać external UX designer'owi (PRD § 13.5).
+4. **POC Cmd+K w liście** — sprint 1 zbudować Cmd+K palette z mock agent (rules-based intent parsing) zanim Anthropic integration.
+5. **Decyzja scope: cuts** — Marcin akceptuje +131-182h, ale można rozważyć:
+   - (a) Query mode AND/OR — Faza 1 (oszczędność ~12-16h MVP).
+   - (b) Cmd+K bulk actions — Faza 1 (oszczędność ~12-16h MVP). Pozostaje schema-ops only w MVP (epik 08).
+   - (c) Increment numeric + multi-attr bulk edit — Faza 1 (oszczędność ~8-10h MVP).
+6. **Aktualizacja `Project Plan/02-plan-projektu-pim.md`** epik 0.4/0.5/0.6/0.7/0.11 estymacji + nowe ryzyko *„R-30 List feature scope creep"*.
+7. **Aktualizacja `Project Plan/03-funkcjonalnosci-mvp.md`** — dodać user stories US-LIST-001 do US-LIST-022.
+8. **Update `epik-02-produkty.md`** — add link do tego dokumentu w § 4 List view + § 11 edge cases.
+
+---
+
+*Plik wersjonowany w `Project Plan/UI/`. Status: szczegół. Następna iteracja: walidacja z Marcinem + Figma wireframes + POC operatory + POC Cmd+K mock.*

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,40 @@
 # Current Status
 
+## 2026-05-13: EPIK UI-09 marathon START — Lista produktów v2 (cockpit operatora wg PRD-PIM-list-advanced)
+
+**Sub-faza:** MVP-Alpha → epik UI-09 (rozbudowa listy produktów do cockpit operatora wg PRD `Project Plan/PRD/PRD-PIM-list-advanced.md`).
+
+**Plan epiku:** `~/.claude/plans/w-folderze-users-mlipieclocal-dev-pim-zr-iridescent-zephyr.md` (zatwierdzony 2026-05-13).
+
+**Scope:** 12 ticketów VIEW-09..VIEW-19 + VIEW-09b, pełen scope MVP wg decyzji operatora 2026-05-13:
+- Query mode AND/OR brackets — pełen edytor (VIEW-09b, nie cut).
+- `increment_numeric` + `multi_attribute_edit` — keep w MVP (VIEW-13).
+- Smart filter presets user-defined — w MVP (VIEW-09).
+
+**Realna estymacja:** ~357h pełen scope (vs PRD §13.5 baseline 131-182h). Solo dev pace 9-13 tygodni.
+
+**Tryb:** EPIK MARATHON RULE z CLAUDE.md aktywny — żadnych przerw, każdy ticket = własny branch + PR + CI + merge.
+
+**Pipeline kolejność:**
+1. VIEW-09 — fundament UI (smart presets + push-down filter panel + chips edit popover) ← **W TRAKCIE**
+2. VIEW-10 — pełne operatory per typ + URL DSL
+3. VIEW-09b — Query mode AND/OR brackets
+4. VIEW-11 — cross-page selection toolbar
+5. VIEW-12 — bulk wizard fundament + sessions + Messenger
+6. VIEW-17 — 24h rollback (przed kolejnymi bulk akcjami)
+7. VIEW-13 — bulk attribute ops (clear/append/remove + increment + multi-attr)
+8. VIEW-14 — bulk taxonomy
+9. VIEW-15 — bulk channels + cascade
+10. VIEW-16 — bulk destructive (delete + duplicate)
+11. VIEW-18 — per-attribute lock
+12. VIEW-19 — Cmd+K palette + Anthropic + 6 MVP intents
+
+**Aktualny ticket:** VIEW-09 (`Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-09-lista-fundament-ui.md`, ~40h estymacja).
+
+**Blockers / decisions cross-context:** brak na tym etapie. Wszystkie scope decyzje potwierdzone przez operatora (Query mode pełen, increment+multi keep, user-defined presets w MVP).
+
+---
+
 ## 2026-05-13: PR #534 — białe okno na „Generuj warianty" (HOTFIX)
 
 **Branch:** `fix/variants-generation-perf` (merged, branch deleted)

--- a/apps/admin/e2e/products-view-09.spec.ts
+++ b/apps/admin/e2e/products-view-09.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * VIEW-09 (#535) — Smart Filter Presets row + Advanced Filter Panel +
+ * Filter Chips Bar pixel-perfect smoke tests.
+ *
+ * Covers:
+ *   1. List page surfaces 5 built-in smart filter presets (migration seed).
+ *   2. Clicking a preset chip flips it to the active (dark) state.
+ *   3. "Filtruj zaawansowane" toggle opens the push-down panel.
+ *   4. Adding a condition + Apply spawns a chip in the chips bar.
+ *   5. axe-core scan finds 0 serious/critical violations on the page.
+ *
+ * Marked `fixme` in CI for the storageState reason the other UI-seeded
+ * specs use — VIEW-09 inherits the auth rate-limiter quota.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: VIEW-09 reuses the shared auth quota.';
+
+test.describe('VIEW-09 smart filter presets + advanced filter panel', () => {
+  test.beforeEach(async ({ page }) => {
+    test.fixme(!!process.env.CI, CI_BLOCKED);
+    test.setTimeout(90_000);
+    await loginAsAdmin(page);
+    await page.goto('/products');
+  });
+
+  test('renders the five built-in smart presets', async ({ page }) => {
+    const presetsRow = page.getByRole('tablist', { name: /smart filtry/i });
+    await expect(presetsRow).toBeVisible();
+
+    for (const name of [
+      /niespójne tłumaczenia|inconsistent translations/i,
+      /brakujące zdjęcia|missing images/i,
+      /niepełne seo|weak seo/i,
+      /czerwone|red/i,
+      /bez kategorii|no category/i,
+    ]) {
+      const tab = presetsRow.getByRole('tab', { name });
+      await expect(tab).toBeVisible();
+    }
+  });
+
+  test('clicking a preset chip flips its aria-selected state', async ({ page }) => {
+    const presetsRow = page.getByRole('tablist', { name: /smart filtry/i });
+    const redTab = presetsRow.getByRole('tab', { name: /czerwone|red/i });
+
+    await expect(redTab).toHaveAttribute('aria-selected', 'false');
+    await redTab.click();
+    await expect(redTab).toHaveAttribute('aria-selected', 'true');
+
+    // Toggle off — clicking the active chip clears the selection.
+    await redTab.click();
+    await expect(redTab).toHaveAttribute('aria-selected', 'false');
+  });
+
+  test('advanced filter panel toggles open + accepts a condition', async ({ page }) => {
+    const toggle = page.getByRole('button', { name: /filtruj zaawansowane/i });
+    await toggle.click();
+
+    const panel = page.getByRole('region', { name: /filtr zaawansowany/i });
+    // VIEW-09 panel renders as <section aria-label>; Playwright maps both.
+    await expect(panel.or(page.locator('section[aria-label*="Filtr"]'))).toBeVisible();
+
+    // Push the "Dodaj warunek" button → a condition row appears with the
+    // default attribute (Marka) and the operator dropdown.
+    const addBtn = page.getByRole('button', { name: /dodaj warunek/i });
+    await addBtn.click();
+    await expect(page.getByLabel('Atrybut').first()).toBeVisible();
+    await expect(page.getByLabel('Operator').first()).toBeVisible();
+
+    // Type a value and Apply — chip lands in the chips bar.
+    const valueInput = page.getByPlaceholder(/wpisz wartość/i).first();
+    await valueInput.fill('Festo');
+    const applyBtn = page.getByRole('button', { name: /zastosuj filtr/i });
+    await applyBtn.click();
+
+    // FilterChipsBar exposes the chips under the active-filters region.
+    const chipsRegion = page.locator('section[aria-label*="Aktywne filtry"]');
+    await expect(chipsRegion).toBeVisible();
+    await expect(chipsRegion.getByText('Festo', { exact: false })).toBeVisible();
+  });
+});

--- a/apps/admin/src/components/catalog/advanced-filter-panel.tsx
+++ b/apps/admin/src/components/catalog/advanced-filter-panel.tsx
@@ -1,0 +1,375 @@
+import { Link2, Plus, Trash2, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  CORE_OPERATORS,
+  FILTER_OPERATORS_BY_TYPE,
+  type FilterCondition,
+  type FilterOperator,
+} from '@/lib/filters/filter-dsl';
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-09 (#535) — push-down sticky-collapsible advanced filter panel.
+ * Replaces Sheet-based `AdvancedFilterBuilder` (UI-02.9 / #299).
+ *
+ * Grid mode only in VIEW-09 (Query mode tab disabled — lands in VIEW-09b).
+ * Full operator set per attribute type → VIEW-10 (currently hardcoded
+ * CORE_OPERATORS as fallback).
+ *
+ * Pixel-perfect Tailwind mirror of mockup `list-v2-overlays.jsx` l. 40-146.
+ */
+
+type PanelAttr = {
+  code: string;
+  name: string;
+  type: keyof typeof FILTER_OPERATORS_BY_TYPE;
+  star?: boolean;
+};
+
+const FIRST_PANEL_ATTR: PanelAttr = {
+  code: 'brand',
+  name: 'Marka',
+  type: 'relation',
+  star: true,
+};
+
+const PANEL_ATTRS: ReadonlyArray<PanelAttr> = [
+  FIRST_PANEL_ATTR,
+  { code: 'family', name: 'Rodzina', type: 'relation', star: true },
+  { code: 'category', name: 'Kategoria', type: 'relation', star: true },
+  { code: 'completeness_pct', name: 'Completeness %', type: 'number', star: true },
+  { code: 'enabled', name: 'Aktywny', type: 'boolean', star: true },
+  { code: 'price', name: 'Cena bazowa', type: 'metric', star: true },
+  { code: 'stock', name: 'Stan magazynowy', type: 'number' },
+  { code: 'main_image', name: 'Główne zdjęcie', type: 'asset' },
+  { code: 'description.pl', name: 'Opis · PL', type: 'text' },
+  { code: 'description.en', name: 'Opis · EN', type: 'text' },
+  { code: 'meta_description', name: 'Meta description', type: 'text' },
+  { code: 'tags', name: 'Tagi', type: 'multiselect' },
+];
+
+interface AdvancedFilterPanelProps {
+  open: boolean;
+  conditions: FilterCondition[];
+  setConditions: (conditions: FilterCondition[]) => void;
+  matchOperator: 'AND' | 'OR';
+  setMatchOperator: (op: 'AND' | 'OR') => void;
+  onApply: () => void;
+  onClose: () => void;
+  onClear: () => void;
+  onSaveAsView?: () => void;
+  onSaveAsPreset?: () => void;
+  resultCount?: number;
+}
+
+export function AdvancedFilterPanel({
+  open,
+  conditions,
+  setConditions,
+  matchOperator,
+  setMatchOperator,
+  onApply,
+  onClose,
+  onClear,
+  onSaveAsView,
+  onSaveAsPreset,
+  resultCount,
+}: AdvancedFilterPanelProps) {
+  const { t } = useTranslation();
+  if (!open) return null;
+
+  const updateCondition = (idx: number, patch: Partial<FilterCondition>): void => {
+    setConditions(conditions.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
+  };
+  const removeCondition = (idx: number): void => {
+    setConditions(conditions.filter((_, i) => i !== idx));
+  };
+  const addCondition = (): void => {
+    const defaultAttr = PANEL_ATTRS[0];
+    if (!defaultAttr) return;
+    setConditions([...conditions, { attr: defaultAttr.code, op: '=', value: '' }]);
+  };
+
+  return (
+    <section
+      aria-label={t('products.advanced_filter.title', { defaultValue: 'Filtr zaawansowany' })}
+      className="rounded-3xl bg-white shadow-md border border-zinc-100 overflow-hidden"
+    >
+      {/* Header */}
+      <div className="px-5 h-12 flex items-center gap-3 border-b border-zinc-100">
+        <span className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500">
+          {t('products.advanced_filter.title', { defaultValue: 'Filtr zaawansowany' })}
+        </span>
+        {/* Mode toggle — Grid active in VIEW-09, Query disabled with badge */}
+        <div role="tablist" className="h-7 rounded-xl bg-zinc-100 inline-flex items-center p-0.5">
+          <button
+            type="button"
+            role="tab"
+            aria-selected="true"
+            className="h-6 px-2.5 rounded-lg text-[11.5px] font-medium bg-white text-zinc-900 shadow-sm"
+          >
+            {t('products.advanced_filter.mode_grid', { defaultValue: 'Grid' })}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-disabled="true"
+            disabled
+            className="h-6 px-2.5 rounded-lg text-[11.5px] font-medium text-zinc-400 inline-flex items-center gap-1 cursor-not-allowed"
+          >
+            {t('products.advanced_filter.mode_query', { defaultValue: 'Query' })}
+            <span className="text-[9.5px] uppercase tracking-wider px-1 py-px rounded bg-amber-100 text-amber-700">
+              {t('products.advanced_filter.mode_query_phase_label', { defaultValue: 'VIEW-09b' })}
+            </span>
+          </button>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <span className="text-[11.5px] text-zinc-400 tabular-nums">
+            {t('products.advanced_filter.condition_count', {
+              count: conditions.length,
+              defaultValue: `${conditions.length} warunków`,
+            })}
+          </span>
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-[12px] text-zinc-500 hover:text-zinc-900 px-2 h-7 rounded-lg hover:bg-zinc-100"
+          >
+            {t('products.advanced_filter.clear', { defaultValue: 'Wyczyść' })}
+          </button>
+          <button
+            type="button"
+            aria-label={t('app.close', { defaultValue: 'Close' })}
+            onClick={onClose}
+            className="h-7 w-7 grid place-items-center rounded-lg text-zinc-400 hover:bg-zinc-100"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Body — grid mode */}
+      <div className="p-5">
+        <div className="space-y-2">
+          {conditions.map((cond, idx) => {
+            const attrMeta = PANEL_ATTRS.find((a) => a.code === cond.attr) ?? FIRST_PANEL_ATTR;
+            const ops = FILTER_OPERATORS_BY_TYPE[attrMeta.type] ?? CORE_OPERATORS;
+            const isEmpty = cond.op === 'IS EMPTY' || cond.op === 'IS NOT EMPTY';
+
+            return (
+              // Index-based key is acceptable here: the editor mutates
+              // conditions in-place by index, so a stable identity would
+              // require a synthetic id field on every condition. The
+              // surrounding controls already key off the index too.
+              // biome-ignore lint/suspicious/noArrayIndexKey: see comment
+              <div key={`cond-${idx}`} className="flex items-center gap-2">
+                {idx === 0 ? (
+                  <span className="text-[11px] uppercase tracking-wider font-semibold text-zinc-400 w-12">
+                    {t('products.advanced_filter.where_label', { defaultValue: 'Gdzie' })}
+                  </span>
+                ) : (
+                  <select
+                    value={matchOperator}
+                    onChange={(e) => setMatchOperator(e.target.value as 'AND' | 'OR')}
+                    aria-label="Conjunction"
+                    className="h-9 w-12 text-[11px] uppercase tracking-wider font-semibold text-zinc-500 bg-zinc-50 rounded-lg px-1 outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 border-0"
+                  >
+                    <option value="AND">AND</option>
+                    <option value="OR">OR</option>
+                  </select>
+                )}
+
+                <select
+                  value={cond.attr}
+                  onChange={(e) => {
+                    const nextAttr =
+                      PANEL_ATTRS.find((a) => a.code === e.target.value) ?? FIRST_PANEL_ATTR;
+                    const nextOps = FILTER_OPERATORS_BY_TYPE[nextAttr.type] ?? CORE_OPERATORS;
+                    updateCondition(idx, {
+                      attr: e.target.value,
+                      op: nextOps[0] ?? '=',
+                      value: '',
+                    });
+                  }}
+                  aria-label="Atrybut"
+                  className="h-9 px-2.5 text-[12.5px] bg-white border border-zinc-200 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 min-w-[160px]"
+                >
+                  <optgroup
+                    label={t('products.attribute_groups.favorites', { defaultValue: 'Ulubione' })}
+                  >
+                    {PANEL_ATTRS.filter((a) => a.star).map((a) => (
+                      <option key={a.code} value={a.code}>
+                        {a.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                  <optgroup
+                    label={t('products.attribute_groups.all', {
+                      defaultValue: 'Wszystkie atrybuty',
+                    })}
+                  >
+                    {PANEL_ATTRS.filter((a) => !a.star).map((a) => (
+                      <option key={a.code} value={a.code}>
+                        {a.name}
+                      </option>
+                    ))}
+                  </optgroup>
+                </select>
+
+                <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-zinc-100 text-zinc-500">
+                  {attrMeta.type}
+                </span>
+
+                <select
+                  value={cond.op}
+                  onChange={(e) => updateCondition(idx, { op: e.target.value as FilterOperator })}
+                  aria-label="Operator"
+                  className="h-9 px-2.5 text-[12.5px] bg-white border border-zinc-200 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 font-mono min-w-[120px]"
+                >
+                  {ops.map((o) => (
+                    <option key={o} value={o}>
+                      {o}
+                    </option>
+                  ))}
+                </select>
+
+                {!isEmpty && (
+                  <Input
+                    value={
+                      typeof cond.value === 'string' || typeof cond.value === 'number'
+                        ? String(cond.value)
+                        : Array.isArray(cond.value)
+                          ? cond.value.join(', ')
+                          : ''
+                    }
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const next =
+                        cond.op === 'IN' || cond.op === 'NOT IN'
+                          ? raw
+                              .split(',')
+                              .map((s) => s.trim())
+                              .filter(Boolean)
+                          : attrMeta.type === 'number' || attrMeta.type === 'metric'
+                            ? raw === ''
+                              ? ''
+                              : Number(raw)
+                            : raw;
+                      updateCondition(idx, { value: next });
+                    }}
+                    placeholder={
+                      attrMeta.type === 'number' || attrMeta.type === 'metric'
+                        ? 'wartość'
+                        : 'wpisz wartość'
+                    }
+                    className="h-9 flex-1 text-[12.5px]"
+                  />
+                )}
+                {isEmpty && <div className="flex-1" />}
+
+                <button
+                  type="button"
+                  onClick={() => removeCondition(idx)}
+                  aria-label="Usuń warunek"
+                  className="h-9 w-9 grid place-items-center text-zinc-400 hover:text-rose-600 hover:bg-rose-50 rounded-lg"
+                >
+                  <Trash2 className="size-4" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          onClick={addCondition}
+          className="mt-3 text-[12.5px] text-zinc-500 hover:text-zinc-900 inline-flex items-center gap-1.5 h-8 px-2.5 rounded-lg hover:bg-zinc-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+        >
+          <Plus className="size-3.5" />
+          {t('products.advanced_filter.add_condition', { defaultValue: 'Dodaj warunek' })}
+        </button>
+      </div>
+
+      {/* Footer */}
+      <div className="px-5 h-12 flex items-center gap-3 border-t border-zinc-100 bg-zinc-50/50">
+        <div className="inline-flex items-center gap-2 text-[11.5px] text-zinc-500">
+          <span>{t('products.advanced_filter.match_label', { defaultValue: 'Dopasuj:' })}</span>
+          <div className="h-6 rounded-lg bg-white border border-zinc-200 inline-flex items-center p-0.5">
+            <button
+              type="button"
+              onClick={() => setMatchOperator('AND')}
+              className={cn(
+                'h-5 px-2 rounded-md text-[11px]',
+                matchOperator === 'AND' ? 'bg-zinc-900 text-white font-medium' : 'text-zinc-500',
+              )}
+            >
+              {t('products.advanced_filter.match_all', { defaultValue: 'Wszystkie (AND)' })}
+            </button>
+            <button
+              type="button"
+              onClick={() => setMatchOperator('OR')}
+              className={cn(
+                'h-5 px-2 rounded-md text-[11px]',
+                matchOperator === 'OR' ? 'bg-zinc-900 text-white font-medium' : 'text-zinc-500',
+              )}
+            >
+              {t('products.advanced_filter.match_any', { defaultValue: 'Dowolne (OR)' })}
+            </button>
+          </div>
+        </div>
+
+        {conditions.length > 0 && (
+          <span className="text-[11.5px] text-zinc-400 inline-flex items-center gap-1.5">
+            <Link2 className="size-3.5" />
+            <span>
+              {t('products.advanced_filter.url_updated', { defaultValue: 'URL zaktualizowany' })}
+              {resultCount !== undefined && (
+                <span className="ml-1 tabular-nums">— {resultCount} wyników</span>
+              )}
+            </span>
+          </span>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          {onSaveAsView && (
+            <Button
+              variant="ghost"
+              type="button"
+              onClick={onSaveAsView}
+              className="h-9 text-[12.5px]"
+            >
+              {t('products.advanced_filter.save_as_view', {
+                defaultValue: 'Zapisz jako Saved View',
+              })}
+            </Button>
+          )}
+          {onSaveAsPreset && (
+            <Button
+              variant="ghost"
+              type="button"
+              onClick={onSaveAsPreset}
+              disabled={conditions.length === 0}
+              className="h-9 text-[12.5px]"
+            >
+              {t('products.advanced_filter.save_as_preset', {
+                defaultValue: 'Zapisz jako Smart Preset',
+              })}
+            </Button>
+          )}
+          <Button
+            type="button"
+            onClick={onApply}
+            disabled={conditions.length === 0}
+            className="h-9 px-4 rounded-xl bg-zinc-900 text-white text-[12.5px] font-medium hover:bg-zinc-800"
+          >
+            {t('products.advanced_filter.apply', { defaultValue: 'Zastosuj filtr' })}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/admin/src/components/catalog/filter-chips-bar.tsx
+++ b/apps/admin/src/components/catalog/filter-chips-bar.tsx
@@ -1,0 +1,131 @@
+import { Link2, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { toast } from '@/components/ui/toast';
+import type { FilterCondition } from '@/lib/filters/filter-dsl';
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-09 (#535) — Filter chips area pod toolbar.
+ *
+ * Mockup `list-view-v2.jsx` l. 206-219. Każdy chip pokazuje
+ * `Label op value` w czarnym pillu z ✕ kasującym condition.
+ *
+ * Edycja operator + value przez popover docelowo dostarcza
+ * `FilterChip` z popoverem; w VIEW-09 redagowanie idzie przez
+ * Advanced filter panel (jeden flow), chip body click otwiera panel
+ * (callback `onEditChip`). Inline popover edit → VIEW-09b.
+ */
+
+interface FilterChipsBarProps {
+  chips: FilterCondition[];
+  attrLabelMap: Record<string, string>;
+  onRemove: (index: number) => void;
+  onClearAll: () => void;
+  onEditChip?: (index: number) => void;
+}
+
+export function FilterChipsBar({
+  chips,
+  attrLabelMap,
+  onRemove,
+  onClearAll,
+  onEditChip,
+}: FilterChipsBarProps) {
+  const { t } = useTranslation();
+  if (chips.length === 0) return null;
+
+  const copyUrl = (): void => {
+    if (typeof window === 'undefined' || !navigator?.clipboard) return;
+    void navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        toast.success(
+          t('products.filter_chips.copy_url_success', {
+            defaultValue: 'URL z filtrami skopiowany',
+          }),
+        );
+      })
+      .catch(() => {
+        toast.error(
+          t('products.filter_chips.copy_url_error', {
+            defaultValue: 'Nie udało się skopiować URL — zaznacz pasek adresu ręcznie',
+          }),
+        );
+      });
+  };
+
+  return (
+    <section
+      aria-label={t('products.filter_chips.active_label', { defaultValue: 'Aktywne filtry' })}
+      className="flex items-center gap-2 flex-wrap"
+    >
+      <span className="text-[10.5px] uppercase tracking-wider font-semibold text-zinc-400">
+        {t('products.filter_chips.active_label', { defaultValue: 'Aktywne filtry' })}
+      </span>
+      {chips.map((chip, i) => {
+        const label = attrLabelMap[chip.attr] ?? chip.attr;
+        const valueDisplay = formatValue(chip);
+        const chipKey = `${chip.attr}-${chip.op}-${i}`;
+        return (
+          <span
+            key={chipKey}
+            className={cn(
+              'h-9 pl-3 pr-1.5 rounded-2xl bg-zinc-900 text-white text-[12.5px] font-medium inline-flex items-center gap-1.5',
+              !onEditChip && 'cursor-default',
+            )}
+          >
+            <button
+              type="button"
+              onClick={() => onEditChip?.(i)}
+              className="inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 rounded"
+              aria-label={`Edytuj ${label}`}
+            >
+              <span className="text-white/60">{label}</span>
+              <span className="text-white/50 font-mono text-[11px]">{chip.op}</span>
+              {valueDisplay && <span className="font-medium">{valueDisplay}</span>}
+            </button>
+            <button
+              type="button"
+              aria-label={`Usuń ${label}`}
+              onClick={() => {
+                onRemove(i);
+              }}
+              className="ml-1 h-5 w-5 rounded-full hover:bg-white/15 grid place-items-center text-white/70 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+            >
+              <X className="size-3" />
+            </button>
+          </span>
+        );
+      })}
+      <button
+        type="button"
+        onClick={onClearAll}
+        className="text-[12px] text-zinc-500 hover:text-zinc-900 underline underline-offset-2 ml-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 rounded"
+      >
+        {t('products.filter_chips.clear_all', { defaultValue: 'Wyczyść wszystkie' })}
+      </button>
+      <span className="text-zinc-300">·</span>
+      <button
+        type="button"
+        onClick={copyUrl}
+        aria-label={t('products.filter_chips.copy_url', {
+          defaultValue: 'Skopiuj URL z filtrami',
+        })}
+        className="text-[12px] text-zinc-500 hover:text-zinc-900 inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 rounded"
+      >
+        <Link2 className="size-3.5" />
+        <span>
+          {t('products.filter_chips.copy_url', { defaultValue: 'Skopiuj URL z filtrami' })}
+        </span>
+      </button>
+    </section>
+  );
+}
+
+function formatValue(chip: FilterCondition): string {
+  if (chip.op === 'IS EMPTY' || chip.op === 'IS NOT EMPTY') return '';
+  if (Array.isArray(chip.value)) return chip.value.join(', ');
+  if (chip.value === undefined || chip.value === null) return '';
+  return String(chip.value);
+}

--- a/apps/admin/src/components/catalog/save-as-smart-preset-modal.tsx
+++ b/apps/admin/src/components/catalog/save-as-smart-preset-modal.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import type { FilterDsl } from '@/lib/filters/filter-dsl';
+import type { SmartFilterPreset } from '@/lib/filters/use-smart-presets';
+import { cn } from '@/lib/utils';
+
+const ICON_CHOICES = ['🔧', '⚙️', '⚡', '🛠️', '🏷️', '📦', '🔍', '🌟', '🚀', '🎯', '💡', '📊'];
+
+interface SaveAsSmartPresetModalProps {
+  query: FilterDsl | null;
+  onClose: () => void;
+  onSaved: (preset: SmartFilterPreset) => void;
+  create: (input: {
+    name: { pl: string; en: string };
+    icon: string;
+    query: FilterDsl;
+  }) => Promise<SmartFilterPreset>;
+}
+
+/**
+ * VIEW-09 (#535) — modal "Zapisz jako Smart Preset" wywoływany z
+ * Advanced filter panel footer + SmartFilterPresetsRow "Własny preset"
+ * button.
+ *
+ * Wymaga niepustego DSL — modal nie pozwoli zapisać presetu bez
+ * conditions (Apply button disabled). Nazwa multilingual {pl, en}
+ * zgodnie z CLAUDE.md punkt 8. Icon picker z 12 emoji presetów (lucide
+ * IconPicker do Fazy 1).
+ */
+export function SaveAsSmartPresetModal({
+  query,
+  onClose,
+  onSaved,
+  create,
+}: SaveAsSmartPresetModalProps) {
+  const { t } = useTranslation();
+  const [namePl, setNamePl] = useState('');
+  const [nameEn, setNameEn] = useState('');
+  const [icon, setIcon] = useState(ICON_CHOICES[0] ?? '🔧');
+  const [isPending, setIsPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSubmit =
+    query !== null && namePl.trim().length >= 3 && nameEn.trim().length >= 3 && icon !== '';
+
+  const handleSubmit = async (event: React.FormEvent): Promise<void> => {
+    event.preventDefault();
+    if (!canSubmit || query === null) return;
+    setIsPending(true);
+    setError(null);
+    try {
+      const preset = await create({
+        name: { pl: namePl.trim(), en: nameEn.trim() },
+        icon,
+        query,
+      });
+      onSaved(preset);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'unknown');
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <Sheet
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <SheetContent side="right" className="w-[460px] p-6">
+        <SheetTitle>
+          {t('products.smart_filters.save_as_preset_title', {
+            defaultValue: 'Zapisz jako Smart Preset',
+          })}
+        </SheetTitle>
+        <form onSubmit={(e) => void handleSubmit(e)} className="mt-4 space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="smart-preset-name-pl" className="text-sm font-medium">
+              {t('products.smart_filters.name_pl', { defaultValue: 'Nazwa (PL)' })}
+              <span className="ml-1 text-rose-600">*</span>
+            </label>
+            <Input
+              id="smart-preset-name-pl"
+              value={namePl}
+              onChange={(e) => setNamePl(e.target.value)}
+              minLength={3}
+              maxLength={60}
+              placeholder={t('products.smart_filters.save_as_preset_name_placeholder', {
+                defaultValue: 'np. Festo niski stock',
+              })}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="smart-preset-name-en" className="text-sm font-medium">
+              {t('products.smart_filters.name_en', { defaultValue: 'Nazwa (EN)' })}
+              <span className="ml-1 text-rose-600">*</span>
+            </label>
+            <Input
+              id="smart-preset-name-en"
+              value={nameEn}
+              onChange={(e) => setNameEn(e.target.value)}
+              minLength={3}
+              maxLength={60}
+              placeholder="e.g. Festo low stock"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <span className="text-sm font-medium">
+              {t('products.smart_filters.save_as_preset_icon_label', { defaultValue: 'Ikona' })}
+              <span className="ml-1 text-rose-600">*</span>
+            </span>
+            <fieldset className="grid grid-cols-6 gap-2 border-0 p-0">
+              <legend className="sr-only">Icon</legend>
+              {ICON_CHOICES.map((choice) => (
+                <label
+                  key={choice}
+                  className={cn(
+                    'h-10 w-10 rounded-xl border text-[18px] grid place-items-center cursor-pointer focus-within:ring-2 focus-within:ring-zinc-900',
+                    icon === choice
+                      ? 'bg-zinc-900 text-white border-zinc-900'
+                      : 'bg-white text-zinc-700 border-zinc-200 hover:border-zinc-300',
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="smart-preset-icon"
+                    value={choice}
+                    checked={icon === choice}
+                    onChange={() => setIcon(choice)}
+                    className="sr-only"
+                  />
+                  <span aria-hidden="true">{choice}</span>
+                </label>
+              ))}
+            </fieldset>
+          </div>
+
+          <div className="rounded-md border bg-muted/40 p-3 text-xs">
+            <div className="mb-1 font-medium">
+              {t('products.smart_filters.preview_title', { defaultValue: 'Warunki presetu:' })}
+            </div>
+            {query === null ? (
+              <p className="text-muted-foreground">
+                {t('products.smart_filters.preview_empty', {
+                  defaultValue: 'Brak warunków. Dodaj filtr w panelu zaawansowanym.',
+                })}
+              </p>
+            ) : (
+              <pre className="font-mono whitespace-pre-wrap text-zinc-600">
+                {JSON.stringify(query, null, 2)}
+              </pre>
+            )}
+          </div>
+
+          {error !== null ? <p className="text-sm text-rose-600">{error}</p> : null}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" type="button" onClick={onClose} disabled={isPending}>
+              {t('products.smart_filters.save_as_preset_cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button type="submit" disabled={!canSubmit || isPending}>
+              {isPending
+                ? t('products.smart_filters.submitting', { defaultValue: 'Zapisuję…' })
+                : t('products.smart_filters.save_as_preset_save', { defaultValue: 'Zapisz' })}
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/admin/src/components/catalog/smart-filter-presets-row.tsx
+++ b/apps/admin/src/components/catalog/smart-filter-presets-row.tsx
@@ -1,0 +1,144 @@
+import { Plus, Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { SmartFilterPreset } from '@/lib/filters/use-smart-presets';
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-09 (#535) — Smart Filter Presets row (mockup `list-view-v2.jsx`
+ * l. 71-107).
+ *
+ * Pixel-perfect Tailwind tokens mirror the prototype. Note PRD §11
+ * krytyczna nota marketingowa — copy explicit nazywa to "reguły"
+ * (nie "AI-powered") i wskazuje "LLM od Fazy 1" jako rzetelny vector
+ * roadmap, nie obietnicę.
+ */
+
+const BUILT_IN_LABEL_KEY: Record<string, string> = {
+  'inconsistent-translations': 'products.smart_filters.builtin.inconsistent_translations',
+  'missing-images': 'products.smart_filters.builtin.missing_images',
+  'weak-seo': 'products.smart_filters.builtin.weak_seo',
+  'red-low-completeness': 'products.smart_filters.builtin.red_low_completeness',
+  'no-category': 'products.smart_filters.builtin.no_category',
+};
+
+interface SmartFilterPresetsRowProps {
+  presets: SmartFilterPreset[];
+  activeId: string | null;
+  onSelect: (preset: SmartFilterPreset | null) => void;
+  onCreate: () => void;
+  isLoading?: boolean;
+}
+
+export function SmartFilterPresetsRow({
+  presets,
+  activeId,
+  onSelect,
+  onCreate,
+  isLoading = false,
+}: SmartFilterPresetsRowProps) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language.startsWith('en') ? 'en' : 'pl';
+
+  return (
+    <div
+      role="tablist"
+      aria-label={t('products.smart_filters.label', { defaultValue: 'Smart filtry' })}
+      className="rounded-3xl bg-white shadow-sm border border-zinc-100 px-3 py-2.5 flex items-center gap-2"
+    >
+      <div className="px-2 flex items-center gap-1.5 shrink-0">
+        <span
+          className="h-7 w-7 rounded-xl bg-zinc-900 text-white grid place-items-center"
+          aria-hidden="true"
+        >
+          <Sparkles className="size-3.5" />
+        </span>
+        <div className="leading-tight">
+          <div className="text-[11.5px] font-semibold tracking-tight">
+            {t('products.smart_filters.label', { defaultValue: 'Smart filtry' })}
+          </div>
+          <div className="text-[10px] text-zinc-400 inline-flex items-center gap-1">
+            <span className="font-mono px-1 rounded bg-zinc-100 text-zinc-500">
+              {t('products.smart_filters.subtitle_rules', { defaultValue: 'reguły' })}
+            </span>
+            <span>
+              ·{' '}
+              {t('products.smart_filters.subtitle_llm_phase_1', { defaultValue: 'LLM od Fazy 1' })}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <span className="h-7 w-px bg-zinc-100 shrink-0" />
+
+      <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-thin flex-1 min-w-0">
+        {isLoading && (
+          <>
+            <SkeletonChip />
+            <SkeletonChip />
+            <SkeletonChip />
+          </>
+        )}
+        {!isLoading &&
+          presets.map((preset) => {
+            const isActive = activeId === preset.id;
+            const labelKey = BUILT_IN_LABEL_KEY[preset.slug];
+            const fallbackLabel = preset.name[lang] ?? preset.name.pl;
+            const label = labelKey ? t(labelKey, { defaultValue: fallbackLabel }) : fallbackLabel;
+            return (
+              <button
+                key={preset.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => {
+                  onSelect(isActive ? null : preset);
+                }}
+                className={cn(
+                  'group shrink-0 inline-flex items-center gap-2 h-9 px-3 rounded-2xl text-[12.5px] font-medium transition border focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900',
+                  isActive
+                    ? 'bg-zinc-900 text-white border-zinc-900'
+                    : 'bg-zinc-50 text-zinc-700 border-zinc-100 hover:bg-white hover:border-zinc-200',
+                )}
+              >
+                <span className="text-[14px] leading-none" aria-hidden="true">
+                  {preset.icon}
+                </span>
+                <span>{label}</span>
+                {preset.count !== undefined && (
+                  <span
+                    className={cn(
+                      'text-[10.5px] tabular-nums font-mono',
+                      isActive ? 'text-white/60' : 'text-zinc-400',
+                    )}
+                  >
+                    {preset.count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+      </div>
+
+      <button
+        type="button"
+        onClick={onCreate}
+        className="shrink-0 inline-flex items-center gap-1.5 h-9 px-3 rounded-2xl text-[12px] text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+        aria-label={t('products.smart_filters.custom_preset_button', {
+          defaultValue: 'Własny preset',
+        })}
+      >
+        <Plus className="size-3.5" />
+        <span>
+          {t('products.smart_filters.custom_preset_button', { defaultValue: 'Własny preset' })}
+        </span>
+      </button>
+    </div>
+  );
+}
+
+function SkeletonChip() {
+  return (
+    <span className="h-9 w-32 rounded-2xl bg-zinc-100 animate-pulse shrink-0" aria-hidden="true" />
+  );
+}

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -5,14 +5,18 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import { AdvancedFilterBuilder } from '@/components/catalog/advanced-filter-builder';
+import { AdvancedFilterPanel } from '@/components/catalog/advanced-filter-panel';
 import { BulkBar } from '@/components/catalog/bulk-bar';
 import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
 import { type ExcelColumn, ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
+import { FilterChipsBar } from '@/components/catalog/filter-chips-bar';
 import { FilterPill } from '@/components/catalog/filter-pill';
 import type { FilterValue } from '@/components/catalog/product-filter-chips';
 import { ProductsGrid, type ProductsGridRow } from '@/components/catalog/products-grid';
+import { SaveAsSmartPresetModal } from '@/components/catalog/save-as-smart-preset-modal';
 import { SaveViewModal } from '@/components/catalog/save-view-modal';
 import { SavedViewsRail } from '@/components/catalog/saved-views-rail';
+import { SmartFilterPresetsRow } from '@/components/catalog/smart-filter-presets-row';
 import type { SyncAggregate } from '@/components/catalog/sync-aggregate-icon';
 import { type VariantsMode, VariantsToggle } from '@/components/catalog/variants-toggle';
 import { type ProductsViewMode, ViewModeToggle } from '@/components/catalog/view-mode-toggle';
@@ -23,6 +27,12 @@ import {
   useCatalogSearch,
 } from '@/features/catalog/search/use-catalog-search';
 import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
+import {
+  conditionsToDsl,
+  dslToFlatConditions,
+  type FilterCondition,
+} from '@/lib/filters/filter-dsl';
+import { type SmartFilterPreset, useSmartPresets } from '@/lib/filters/use-smart-presets';
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -96,6 +106,19 @@ export function ProductListPage() {
   const [activeViewSlug, setActiveViewSlug] = useState<string | null>(null);
   const [showSaveViewModal, setShowSaveViewModal] = useState(false);
   const [expandedMasters, setExpandedMasters] = useState<Set<string>>(new Set());
+  // VIEW-09: smart presets + push-down advanced filter panel + filter chips bar.
+  // The legacy FilterPill + AdvancedFilterBuilder Sheet stay in place so this
+  // ticket adds without breaking. VIEW-10 unifies the two flows.
+  const {
+    presets: smartPresets,
+    isLoading: smartPresetsLoading,
+    create: createSmartPreset,
+  } = useSmartPresets({ withCounts: true });
+  const [activeSmartPresetId, setActiveSmartPresetId] = useState<string | null>(null);
+  const [advancedPanelOpen, setAdvancedPanelOpen] = useState(false);
+  const [panelConditions, setPanelConditions] = useState<FilterCondition[]>([]);
+  const [matchOperator, setMatchOperator] = useState<'AND' | 'OR'>('AND');
+  const [showSaveAsPresetModal, setShowSaveAsPresetModal] = useState(false);
 
   const { searchFilters, rangeFilters } = useMemo(() => {
     const sf: Record<string, string | string[]> = { ...filters };
@@ -282,6 +305,129 @@ export function ProductListPage() {
     });
   };
 
+  /**
+   * VIEW-09: map known FilterCondition shapes onto the existing
+   * `filters` (searchFilters) + `rangeFilters` plumbing so apply-preset
+   * actually filters the list for the simplest cases.
+   *
+   * Coverage in VIEW-09 (FE resolver):
+   *   - `attr=brand`, `=`, single string  → filters.brand = value
+   *   - `attr=brand`, `IN`, array         → filters.brand = array
+   *   - `attr=completeness_pct`, `<`, n   → rangeFilters.completenessPct.lte = n - 1
+   *   - `attr=completeness_pct`, `<=`, n  → rangeFilters.completenessPct.lte = n
+   *   - `attr=completeness_pct`, `>=`, n  → rangeFilters.completenessPct.gte = n
+   *   - `attr=enabled`, `=`, bool         → filters.enabled = 'true'/'false'
+   *
+   * Conditions outside this shape (IS EMPTY, locale-scoped, asset,
+   * relation joins) are surfaced as an unobtrusive toast and skipped.
+   * Full DSL → search resolver lands in VIEW-10.
+   */
+  const applyConditionsToFilters = (
+    conditions: FilterCondition[],
+  ): {
+    matched: number;
+    skipped: number;
+  } => {
+    const nextFilters: Record<string, string | string[]> = {};
+    const nextAdvanced: Record<string, FilterValue> = {};
+    let matched = 0;
+    let skipped = 0;
+
+    for (const cond of conditions) {
+      const value = cond.value;
+      const op = cond.op;
+      const attr = cond.attr;
+
+      if (attr === 'brand' || attr === 'family') {
+        if (op === '=' && typeof value === 'string') {
+          nextFilters[attr] = value;
+          matched += 1;
+          continue;
+        }
+        if (op === 'IN' && Array.isArray(value)) {
+          nextFilters[attr] = value.map(String);
+          matched += 1;
+          continue;
+        }
+      }
+
+      if (attr === 'enabled' && op === '=' && typeof value === 'boolean') {
+        nextFilters.enabled = String(value);
+        matched += 1;
+        continue;
+      }
+
+      if (attr === 'completeness_pct') {
+        if ((op === '<' || op === '<=') && typeof value === 'number') {
+          const lte = op === '<' ? value - 1 : value;
+          nextAdvanced.completeness = { ...(nextAdvanced.completeness as object), lte };
+          matched += 1;
+          continue;
+        }
+        if ((op === '>' || op === '>=') && typeof value === 'number') {
+          const gte = op === '>' ? value + 1 : value;
+          nextAdvanced.completeness = { ...(nextAdvanced.completeness as object), gte };
+          matched += 1;
+          continue;
+        }
+      }
+
+      skipped += 1;
+    }
+
+    setFilters(nextFilters);
+    setAdvancedFilters(nextAdvanced);
+    return { matched, skipped };
+  };
+
+  const handleApplySmartPreset = (preset: SmartFilterPreset | null): void => {
+    if (preset === null) {
+      setActiveSmartPresetId(null);
+      setPanelConditions([]);
+      applyConditionsToFilters([]);
+      return;
+    }
+
+    setActiveSmartPresetId(preset.id);
+    const conditions = dslToFlatConditions(preset.query);
+    if (conditions === null) {
+      toast.info(
+        t('products.smart_filters.nested_unsupported', {
+          defaultValue: 'Preset zawiera zagnieżdżone grupy AND/OR (Query mode w VIEW-09b).',
+        }),
+      );
+      setPanelConditions([]);
+      return;
+    }
+
+    setPanelConditions(conditions);
+    const { matched, skipped } = applyConditionsToFilters(conditions);
+    if (skipped > 0) {
+      toast.info(
+        t('products.smart_filters.partial_apply', {
+          matched,
+          skipped,
+          defaultValue: `Zastosowano ${matched} warunków, ${skipped} pominiętych (czeka na BE resolver w VIEW-10).`,
+        }),
+      );
+    }
+  };
+
+  const handleApplyAdvancedPanel = (): void => {
+    setAdvancedPanelOpen(false);
+    setActiveSmartPresetId(null);
+    const { matched, skipped } = applyConditionsToFilters(panelConditions);
+    if (skipped > 0) {
+      toast.info(
+        t('products.advanced_filter.partial_apply', {
+          matched,
+          skipped,
+          defaultValue: `Zastosowano ${matched} warunków, ${skipped} pominiętych (czeka na BE resolver w VIEW-10).`,
+        }),
+      );
+    }
+  };
+
   const handleApplySavedView = (view: { slug: string; config: Record<string, unknown> }): void => {
     setActiveViewSlug(view.slug);
     const cfg = view.config;
@@ -390,6 +536,25 @@ export function ProductListPage() {
         currentTotal={totalHits}
       />
 
+      <SmartFilterPresetsRow
+        presets={smartPresets}
+        activeId={activeSmartPresetId}
+        onSelect={handleApplySmartPreset}
+        onCreate={() => {
+          if (panelConditions.length === 0) {
+            toast.info(
+              t('products.smart_filters.create_requires_conditions', {
+                defaultValue: 'Najpierw dodaj warunek w panelu zaawansowanym.',
+              }),
+            );
+            setAdvancedPanelOpen(true);
+            return;
+          }
+          setShowSaveAsPresetModal(true);
+        }}
+        isLoading={smartPresetsLoading}
+      />
+
       <div className="flex flex-wrap items-center gap-3">
         <div className="relative flex-1 min-w-[280px]">
           <Search
@@ -443,6 +608,24 @@ export function ProductListPage() {
           }}
         />
 
+        <Button
+          type="button"
+          variant={advancedPanelOpen ? 'default' : 'outline'}
+          onClick={() => setAdvancedPanelOpen((prev) => !prev)}
+          className="h-11 rounded-2xl"
+          aria-expanded={advancedPanelOpen}
+          aria-controls="advanced-filter-panel"
+        >
+          {t('products.toolbar.filter_by_attribute_button', {
+            defaultValue: 'Filtruj zaawansowane',
+          })}
+          {panelConditions.length > 0 && (
+            <span className="ml-1.5 rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10px] text-zinc-700">
+              {panelConditions.length}
+            </span>
+          )}
+        </Button>
+
         <VariantsToggle mode={variantsMode} onChange={setVariantsMode} />
 
         <ViewModeToggle mode={viewMode} onChange={handleViewModeChange} />
@@ -468,6 +651,60 @@ export function ProductListPage() {
           </Link>
         </Button>
       </div>
+
+      <div id="advanced-filter-panel">
+        <AdvancedFilterPanel
+          open={advancedPanelOpen}
+          conditions={panelConditions}
+          setConditions={setPanelConditions}
+          matchOperator={matchOperator}
+          setMatchOperator={setMatchOperator}
+          onApply={handleApplyAdvancedPanel}
+          onClose={() => setAdvancedPanelOpen(false)}
+          onClear={() => {
+            setPanelConditions([]);
+            applyConditionsToFilters([]);
+            setActiveSmartPresetId(null);
+          }}
+          onSaveAsView={() => {
+            setShowSaveViewModal(true);
+          }}
+          onSaveAsPreset={() => {
+            setShowSaveAsPresetModal(true);
+          }}
+          resultCount={totalHits}
+        />
+      </div>
+
+      <FilterChipsBar
+        chips={panelConditions}
+        attrLabelMap={{
+          brand: t('products.toolbar.filter_brand', { defaultValue: 'Marka' }),
+          family: t('products.toolbar.filter_family', { defaultValue: 'Rodzina' }),
+          category: t('products.fields.categories', { defaultValue: 'Kategoria' }),
+          completeness_pct: t('products.fields.completeness', { defaultValue: 'Compl.' }),
+          enabled: t('products.fields.enabled', { defaultValue: 'Aktywny' }),
+          price: t('products.fields.price', { defaultValue: 'Cena' }),
+          'description.pl': t('products.fields.description_pl', { defaultValue: 'Opis · PL' }),
+          'description.en': t('products.fields.description_en', { defaultValue: 'Opis · EN' }),
+          main_image: t('products.fields.main_image', { defaultValue: 'Główne zdjęcie' }),
+          meta_description: t('products.fields.meta_description', {
+            defaultValue: 'Meta description',
+          }),
+        }}
+        onRemove={(idx) => {
+          const next = panelConditions.filter((_, i) => i !== idx);
+          setPanelConditions(next);
+          applyConditionsToFilters(next);
+          if (next.length === 0) setActiveSmartPresetId(null);
+        }}
+        onClearAll={() => {
+          setPanelConditions([]);
+          applyConditionsToFilters([]);
+          setActiveSmartPresetId(null);
+        }}
+        onEditChip={() => setAdvancedPanelOpen(true)}
+      />
 
       <div className="flex flex-wrap items-center gap-2 text-[12px] text-zinc-500">
         <span className="tabular-nums">
@@ -578,6 +815,22 @@ export function ProductListPage() {
           }}
           onSaved={(slug) => {
             setActiveViewSlug(slug);
+          }}
+        />
+      ) : null}
+
+      {showSaveAsPresetModal ? (
+        <SaveAsSmartPresetModal
+          query={conditionsToDsl(panelConditions, matchOperator)}
+          create={createSmartPreset}
+          onClose={() => setShowSaveAsPresetModal(false)}
+          onSaved={(preset) => {
+            toast.success(
+              t('products.smart_filters.save_success', {
+                defaultValue: 'Smart Preset zapisany',
+              }),
+            );
+            setActiveSmartPresetId(preset.id);
           }}
         />
       ) : null}

--- a/apps/admin/src/lib/filters/filter-dsl.ts
+++ b/apps/admin/src/lib/filters/filter-dsl.ts
@@ -1,0 +1,112 @@
+/**
+ * VIEW-09 (#535) — Filter DSL shared between Smart Filter Presets,
+ * Advanced Filter Panel, and URL serializer.
+ *
+ * Flat (single-level) form:
+ *   { attr: 'brand', op: 'IN', value: ['Festo', 'Bosch'] }
+ *
+ * Grouped form (one level of grouping in VIEW-09; nested AND/OR/NOT
+ * lands in VIEW-09b without schema changes):
+ *   { operator: 'AND', conditions: [
+ *     { attr: 'description.pl', op: 'IS NOT EMPTY' },
+ *     { attr: 'description.en', op: 'IS EMPTY' },
+ *   ]}
+ *
+ * Backend resolver mirrors this exactly — see FilterDslResolver.php.
+ * URL serializer compresses single-level conditions into shareable
+ * params (see `url-serializer.ts`); query mode falls back to a
+ * base64 blob landing in VIEW-09b.
+ */
+
+export type FilterOperator =
+  | '='
+  | '!='
+  | '≠'
+  | 'IS EMPTY'
+  | 'IS NOT EMPTY'
+  | '<'
+  | '>'
+  | '<='
+  | '>='
+  | 'IN'
+  | 'NOT IN';
+
+export type FilterConditionValue = string | number | boolean | Array<string | number> | null;
+
+export interface FilterCondition {
+  attr: string;
+  op: FilterOperator;
+  value?: FilterConditionValue;
+}
+
+export interface FilterGroup {
+  operator: 'AND' | 'OR';
+  conditions: Array<FilterCondition | FilterGroup>;
+}
+
+export type FilterDsl = FilterCondition | FilterGroup;
+
+/**
+ * Pełna lista operatorów per typ atrybutu w VIEW-10. VIEW-09 hardcoded
+ * obsługuje 6 wspólnych operatorów ({@link CORE_OPERATORS}).
+ */
+export const CORE_OPERATORS: readonly FilterOperator[] = [
+  '=',
+  '≠',
+  'IN',
+  'NOT IN',
+  'IS EMPTY',
+  'IS NOT EMPTY',
+] as const;
+
+export const FILTER_OPERATORS_BY_TYPE: Record<string, readonly FilterOperator[]> = {
+  text: ['=', '≠', 'IS EMPTY', 'IS NOT EMPTY'],
+  number: ['=', '≠', '<', '>', '<=', '>=', 'IS EMPTY', 'IS NOT EMPTY'],
+  metric: ['=', '≠', '<', '>', '<=', '>=', 'IS EMPTY', 'IS NOT EMPTY'],
+  select: ['=', '≠', 'IN', 'NOT IN', 'IS EMPTY', 'IS NOT EMPTY'],
+  multiselect: ['IS EMPTY', 'IS NOT EMPTY'],
+  boolean: ['='],
+  relation: ['=', '≠', 'IN', 'NOT IN', 'IS EMPTY', 'IS NOT EMPTY'],
+  asset: ['IS EMPTY', 'IS NOT EMPTY'],
+};
+
+/**
+ * True when DSL is a grouped form (operator + conditions).
+ */
+export function isFilterGroup(dsl: FilterDsl): dsl is FilterGroup {
+  return 'operator' in dsl && 'conditions' in dsl;
+}
+
+/**
+ * Convert a flat condition list to a top-level AND group, or unwrap a
+ * single condition. Used by the Advanced filter panel grid mode where
+ * the editor manages a flat array, but the API/saved preset expects a
+ * group.
+ */
+export function conditionsToDsl(
+  conditions: FilterCondition[],
+  operator: 'AND' | 'OR' = 'AND',
+): FilterDsl | null {
+  const first = conditions[0];
+  if (first === undefined) return null;
+  if (conditions.length === 1) return first;
+  return { operator, conditions };
+}
+
+/**
+ * Inverse of {@link conditionsToDsl}: flatten the top-level group into a
+ * flat condition list when possible (drops grouping). Returns `null`
+ * when DSL contains nested groups — the grid mode editor cannot
+ * represent them (VIEW-09b query mode handles those).
+ */
+export function dslToFlatConditions(dsl: FilterDsl | null): FilterCondition[] | null {
+  if (!dsl) return [];
+  if (!isFilterGroup(dsl)) return [dsl];
+
+  const flat: FilterCondition[] = [];
+  for (const cond of dsl.conditions) {
+    if (isFilterGroup(cond)) return null; // nested → query mode required
+    flat.push(cond);
+  }
+  return flat;
+}

--- a/apps/admin/src/lib/filters/use-smart-presets.ts
+++ b/apps/admin/src/lib/filters/use-smart-presets.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+
+import { jsonFetch } from '@/lib/http';
+
+import type { FilterDsl } from './filter-dsl';
+
+/**
+ * VIEW-09 (#535) — Smart Filter Presets client. CRUD + counts.
+ *
+ * Counts are server-side aggregates against the current tenant's
+ * `catalog_objects` table (FilterDslResolver compiles DSL → SQL).
+ * The endpoint is single-batched (no N+1), so passing `withCounts=true`
+ * is cheap.
+ */
+
+export interface SmartFilterPreset {
+  id: string;
+  slug: string;
+  name: { pl: string; en: string };
+  icon: string;
+  query: FilterDsl;
+  is_built_in: boolean;
+  is_system: boolean;
+  sort_order: number;
+  count?: number;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ListResponse {
+  data: SmartFilterPreset[];
+}
+
+export interface UseSmartPresetsOptions {
+  withCounts?: boolean;
+}
+
+export interface UseSmartPresetsResult {
+  presets: SmartFilterPreset[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+  create: (input: {
+    name: { pl: string; en: string };
+    icon: string;
+    query: FilterDsl;
+  }) => Promise<SmartFilterPreset>;
+  remove: (id: string) => Promise<void>;
+}
+
+export function useSmartPresets({
+  withCounts = true,
+}: UseSmartPresetsOptions = {}): UseSmartPresetsResult {
+  const [presets, setPresets] = useState<SmartFilterPreset[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const load = async (): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (withCounts) params.set('counts', 'true');
+      const url = `/api/smart-filter-presets${params.toString() ? `?${params.toString()}` : ''}`;
+      const body = await jsonFetch<ListResponse>(url);
+      setPresets(body.data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [withCounts]);
+
+  const create: UseSmartPresetsResult['create'] = async (input) => {
+    const created = await jsonFetch<SmartFilterPreset>('/api/smart-filter-presets', {
+      method: 'POST',
+      body: input,
+    });
+    await load();
+    return created;
+  };
+
+  const remove: UseSmartPresetsResult['remove'] = async (id) => {
+    await jsonFetch<unknown>(`/api/smart-filter-presets/${id}`, { method: 'DELETE' });
+    await load();
+  };
+
+  return {
+    presets,
+    isLoading,
+    error,
+    refetch: load,
+    create,
+    remove,
+  };
+}

--- a/apps/api/migrations/Version20260513120000.php
+++ b/apps/api/migrations/Version20260513120000.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * VIEW-09 (#535) — `smart_filter_presets` table for rule-based filter
+ * presets surfaced in the products list smart filter row. System-shipped
+ * built-ins (`tenant_id IS NULL`, `user_id IS NULL`, `is_built_in=true`)
+ * are immutable per tenant; user-defined presets are owner-scoped.
+ *
+ * Five built-in presets seeded inline so the smart filter row works on
+ * a clean tenant without app-bootstrap fixtures. Slugs are stable: tools
+ * and tests reference them by slug, not UUID.
+ */
+final class Version20260513120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'VIEW-09 smart_filter_presets table + 5 built-in seed (#535).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE smart_filter_presets (
+              id UUID NOT NULL,
+              tenant_id UUID NULL,
+              user_id UUID NULL,
+              slug VARCHAR(64) NOT NULL,
+              name JSONB NOT NULL,
+              icon VARCHAR(64) NOT NULL,
+              query JSONB NOT NULL,
+              is_built_in BOOLEAN NOT NULL DEFAULT false,
+              sort_order INTEGER NOT NULL DEFAULT 0,
+              created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+              PRIMARY KEY (id)
+            )
+            SQL);
+
+        // Unique slug per (tenant_id, user_id) — system-shipped (both NULL)
+        // collides on slug across the whole table thanks to COALESCE.
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX smart_filter_presets_slug_uniq
+              ON smart_filter_presets (
+                COALESCE(tenant_id, '00000000-0000-0000-0000-000000000000'::uuid),
+                COALESCE(user_id,   '00000000-0000-0000-0000-000000000000'::uuid),
+                slug
+              )
+            SQL);
+
+        $this->addSql('CREATE INDEX smart_filter_presets_tenant_idx ON smart_filter_presets (tenant_id) WHERE tenant_id IS NOT NULL');
+        $this->addSql('CREATE INDEX smart_filter_presets_user_idx ON smart_filter_presets (user_id) WHERE user_id IS NOT NULL');
+        $this->addSql('CREATE INDEX smart_filter_presets_builtin_idx ON smart_filter_presets (is_built_in) WHERE is_built_in = true');
+
+        // Seed 5 built-in presets (PRD §8.2 rule-based, marketing-honest).
+        $now = '2026-05-13 00:00:00';
+        $seed = [
+            [
+                'id' => '019089d0-0000-7000-8000-000000000001',
+                'slug' => 'inconsistent-translations',
+                'name' => ['pl' => 'Niespójne tłumaczenia', 'en' => 'Inconsistent translations'],
+                'icon' => '🌐',
+                'query' => [
+                    'operator' => 'AND',
+                    'conditions' => [
+                        ['attr' => 'description.pl', 'op' => 'IS NOT EMPTY'],
+                        ['attr' => 'description.en', 'op' => 'IS EMPTY'],
+                    ],
+                ],
+                'sort_order' => 10,
+            ],
+            [
+                'id' => '019089d0-0000-7000-8000-000000000002',
+                'slug' => 'missing-images',
+                'name' => ['pl' => 'Brakujące zdjęcia', 'en' => 'Missing images'],
+                'icon' => '📷',
+                'query' => ['attr' => 'main_image', 'op' => 'IS EMPTY'],
+                'sort_order' => 20,
+            ],
+            [
+                'id' => '019089d0-0000-7000-8000-000000000003',
+                'slug' => 'weak-seo',
+                'name' => ['pl' => 'Niepełne SEO', 'en' => 'Weak SEO'],
+                'icon' => '🔍',
+                'query' => [
+                    'operator' => 'AND',
+                    'conditions' => [
+                        ['attr' => 'description', 'op' => 'IS NOT EMPTY'],
+                        ['attr' => 'meta_description', 'op' => 'IS EMPTY'],
+                    ],
+                ],
+                'sort_order' => 30,
+            ],
+            [
+                'id' => '019089d0-0000-7000-8000-000000000004',
+                'slug' => 'red-low-completeness',
+                'name' => ['pl' => 'Czerwone (<50%)', 'en' => 'Red (<50%)'],
+                'icon' => '🔴',
+                'query' => ['attr' => 'completeness_pct', 'op' => '<', 'value' => 50],
+                'sort_order' => 40,
+            ],
+            [
+                'id' => '019089d0-0000-7000-8000-000000000005',
+                'slug' => 'no-category',
+                'name' => ['pl' => 'Bez kategorii', 'en' => 'No category'],
+                'icon' => '📂',
+                'query' => ['attr' => 'category', 'op' => 'IS EMPTY'],
+                'sort_order' => 50,
+            ],
+        ];
+
+        foreach ($seed as $row) {
+            $this->addSql(
+                'INSERT INTO smart_filter_presets (id, tenant_id, user_id, slug, name, icon, query, is_built_in, sort_order, created_at, updated_at) '
+                . 'VALUES (:id, NULL, NULL, :slug, CAST(:name AS JSONB), :icon, CAST(:query AS JSONB), true, :sort_order, :now, :now)',
+                [
+                    'id' => $row['id'],
+                    'slug' => $row['slug'],
+                    'name' => json_encode($row['name'], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+                    'icon' => $row['icon'],
+                    'query' => json_encode($row['query'], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
+                    'sort_order' => $row['sort_order'],
+                    'now' => $now,
+                ]
+            );
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS smart_filter_presets_builtin_idx');
+        $this->addSql('DROP INDEX IF EXISTS smart_filter_presets_user_idx');
+        $this->addSql('DROP INDEX IF EXISTS smart_filter_presets_tenant_idx');
+        $this->addSql('DROP INDEX IF EXISTS smart_filter_presets_slug_uniq');
+        $this->addSql('DROP TABLE IF EXISTS smart_filter_presets');
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInSmartFilterPresetsSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInSmartFilterPresetsSeeder.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\Entity\SmartFilterPreset;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-09 (#535) — seeds the five system-shipped Smart Filter Presets.
+ *
+ * The migration {@see \DoctrineMigrations\Version20260513120000} inlines
+ * these rows on production-style boot. Tests use `doctrine:schema:create`
+ * (faster than running 41 migrations) so the seed has to be replayed
+ * explicitly — that lives here so production and test code converge on
+ * the same definitions.
+ *
+ * Built-in presets are tenant-less (`tenant_id IS NULL`) and immutable;
+ * the upsert logic skips them when they already exist.
+ */
+final class BuiltInSmartFilterPresetsSeeder
+{
+    /**
+     * @return list<array{id: string, slug: string, name: array{pl: string, en: string}, icon: string, query: array<string, mixed>, sort_order: int}>
+     */
+    public static function definitions(): array
+    {
+        return [
+            [
+                'id' => '019089d0-0000-7000-8000-000000000001',
+                'slug' => 'inconsistent-translations',
+                'name' => ['pl' => 'Niespójne tłumaczenia', 'en' => 'Inconsistent translations'],
+                'icon' => '🌐',
+                'query' => [
+                    'operator' => 'AND',
+                    'conditions' => [
+                        ['attr' => 'description.pl', 'op' => 'IS NOT EMPTY'],
+                        ['attr' => 'description.en', 'op' => 'IS EMPTY'],
+                    ],
+                ],
+                'sort_order' => 10,
+            ],
+            [
+                'id' => '019089d0-0000-7000-8000-000000000002',
+                'slug' => 'missing-images',
+                'name' => ['pl' => 'Brakujące zdjęcia', 'en' => 'Missing images'],
+                'icon' => '📷',
+                'query' => ['attr' => 'main_image', 'op' => 'IS EMPTY'],
+                'sort_order' => 20,
+            ],
+            [
+                'id' => '019089d0-0000-7000-8000-000000000003',
+                'slug' => 'weak-seo',
+                'name' => ['pl' => 'Niepełne SEO', 'en' => 'Weak SEO'],
+                'icon' => '🔍',
+                'query' => [
+                    'operator' => 'AND',
+                    'conditions' => [
+                        ['attr' => 'description', 'op' => 'IS NOT EMPTY'],
+                        ['attr' => 'meta_description', 'op' => 'IS EMPTY'],
+                    ],
+                ],
+                'sort_order' => 30,
+            ],
+            [
+                'id' => '019089d0-0000-7000-8000-000000000004',
+                'slug' => 'red-low-completeness',
+                'name' => ['pl' => 'Czerwone (<50%)', 'en' => 'Red (<50%)'],
+                'icon' => '🔴',
+                'query' => ['attr' => 'completeness_pct', 'op' => '<', 'value' => 50],
+                'sort_order' => 40,
+            ],
+            [
+                'id' => '019089d0-0000-7000-8000-000000000005',
+                'slug' => 'no-category',
+                'name' => ['pl' => 'Bez kategorii', 'en' => 'No category'],
+                'icon' => '📂',
+                'query' => ['attr' => 'category', 'op' => 'IS EMPTY'],
+                'sort_order' => 50,
+            ],
+        ];
+    }
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Idempotent seed: skips slugs that already exist (lookup keyed on
+     * `is_built_in=true` + slug).
+     */
+    public function seed(): void
+    {
+        $repo = $this->em->getRepository(SmartFilterPreset::class);
+
+        foreach (self::definitions() as $def) {
+            $existing = $repo->findOneBy(['slug' => $def['slug'], 'isBuiltIn' => true]);
+            if (null !== $existing) {
+                continue;
+            }
+
+            $preset = new SmartFilterPreset(
+                slug: $def['slug'],
+                name: $def['name'],
+                icon: $def['icon'],
+                query: $def['query'],
+                userId: null,
+                isBuiltIn: true,
+                sortOrder: $def['sort_order'],
+                id: Uuid::fromString($def['id']),
+            );
+
+            $this->em->persist($preset);
+        }
+
+        $this->em->flush();
+    }
+}

--- a/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Filter;
+
+use RuntimeException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Throwable;
+
+/**
+ * VIEW-09 (#535) — Filter DSL resolver.
+ *
+ * Flat (single-level) JSONB shape:
+ *   {"attr": "brand", "op": "IN", "value": ["Festo", "Bosch"]}
+ *
+ * Composite (one level of grouping in VIEW-09; nested AND/OR/NOT lands in VIEW-09b):
+ *   {"operator": "AND", "conditions": [
+ *     {"attr": "description.pl", "op": "IS NOT EMPTY"},
+ *     {"attr": "description.en", "op": "IS EMPTY"}
+ *   ]}
+ *
+ * Supported operators in VIEW-09 (basic 6, full 25 → VIEW-10):
+ *   `=` | `!=` (alias `≠`) | `IS EMPTY` | `IS NOT EMPTY` | `<` | `IN`
+ *
+ * Reserved attribute paths:
+ *   - `main_image`        — checks `attributes_indexed->>'main_image'` (object_value asset).
+ *   - `category`          — checks `EXISTS (SELECT 1 FROM object_categories WHERE object_id=...)`.
+ *   - `description`       — locale-agnostic; `EXISTS` over any locale.
+ *   - `description.pl`    — locale-scoped (per-locale JSONB path).
+ *   - `description.en`    — same.
+ *   - `meta_description`  — single-value attribute.
+ *   - `completeness_pct`  — column on catalog_objects, NOT JSONB.
+ *
+ * Custom attribute codes (brand, family, ip_class, voltage…) hit
+ * `attributes_indexed->>'{code}'` — GIN-indexed per ADR-006.
+ */
+final class FilterDslResolver
+{
+    private const array SUPPORTED_OPS_V09 = ['=', '!=', '≠', 'IS EMPTY', 'IS NOT EMPTY', '<', '>', '<=', '>=', 'IN', 'NOT IN'];
+    private const array LOGICAL_OPS = ['AND', 'OR'];
+
+    /**
+     * Reserved attribute paths that map to columns/joins instead of
+     * `attributes_indexed` JSONB lookups.
+     *
+     * @var array<string, string>
+     */
+    private const array COLUMN_MAP = [
+        'completeness_pct' => 'co.completeness_pct',
+        'enabled' => 'co.enabled',
+        'sku' => 'co.sku',
+    ];
+
+    /**
+     * Validate DSL structure. Throws BadRequestHttpException with a
+     * clear message on first violation.
+     *
+     * @param array<string, mixed> $dsl
+     */
+    public function validate(array $dsl): void
+    {
+        if (isset($dsl['operator']) && isset($dsl['conditions'])) {
+            $this->validateGroup($dsl, depth: 0);
+
+            return;
+        }
+
+        if (!isset($dsl['attr']) || !isset($dsl['op'])) {
+            throw new BadRequestHttpException('FilterDsl must be either a condition {attr, op, value?} or group {operator, conditions[]}.');
+        }
+
+        $this->validateCondition($dsl);
+    }
+
+    /**
+     * Convert DSL to a PostgreSQL `WHERE`-fragment SQL string usable
+     * inside the bulk count query (`SELECT COUNT(*) FROM catalog_objects co WHERE ... AND ({sql})`).
+     *
+     * Returns `null` when the DSL targets attributes not yet indexed
+     * (graceful degradation; count = 0 surfaced to the user).
+     *
+     * **NOTE — VIEW-09 scope**: builds *parameter-free* SQL by inlining
+     * literal values escaped via `pg_escape_literal` semantics. Future
+     * VIEW-10 will switch to PDO-bound parameters for safety; for VIEW-09
+     * the DSL flow is admin-only (curated dropdown values) and the
+     * controller's `executeQuery` is wrapped in try/catch.
+     *
+     * @param array<string, mixed> $dsl
+     */
+    public function toCountSql(array $dsl): ?string
+    {
+        try {
+            return $this->compile($dsl, depth: 0);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $dsl
+     */
+    private function compile(array $dsl, int $depth): string
+    {
+        if ($depth > 3) {
+            throw new RuntimeException('FilterDsl nesting too deep (>3).');
+        }
+
+        if (isset($dsl['operator']) && isset($dsl['conditions'])) {
+            /** @var array{operator: string, conditions: list<array<string, mixed>>} $group */
+            $group = $dsl;
+            $operator = strtoupper($group['operator']);
+            if (!\in_array($operator, self::LOGICAL_OPS, true)) {
+                throw new RuntimeException('Unsupported logical operator: '.$group['operator']);
+            }
+
+            $parts = [];
+            foreach ($group['conditions'] as $condition) {
+                $parts[] = '('.$this->compile($condition, $depth + 1).')';
+            }
+            if ([] === $parts) {
+                return '1=1';
+            }
+
+            return implode(' '.$operator.' ', $parts);
+        }
+
+        return $this->compileCondition($dsl);
+    }
+
+    /**
+     * @param array<string, mixed> $cond
+     */
+    private function compileCondition(array $cond): string
+    {
+        $attrRaw = $cond['attr'] ?? null;
+        $opRaw = $cond['op'] ?? null;
+        if (!\is_string($attrRaw) || !\is_string($opRaw)) {
+            throw new RuntimeException('Condition attr/op must be strings.');
+        }
+        $attr = $attrRaw;
+        $op = $opRaw;
+        $value = $cond['value'] ?? null;
+
+        if ('' === $attr || '' === $op) {
+            throw new RuntimeException('Condition missing attr or op.');
+        }
+
+        $left = $this->resolveLeftExpression($attr);
+
+        switch (strtoupper($op)) {
+            case 'IS EMPTY':
+                return $left.' IS NULL';
+
+            case 'IS NOT EMPTY':
+                return $left.' IS NOT NULL';
+
+            case '=':
+                return $left.' = '.$this->literal($value);
+
+            case '!=':
+            case '≠':
+                return $left.' <> '.$this->literal($value);
+
+            case '<':
+                return $left.' < '.$this->numericLiteral($value);
+
+            case '>':
+                return $left.' > '.$this->numericLiteral($value);
+
+            case '<=':
+                return $left.' <= '.$this->numericLiteral($value);
+
+            case '>=':
+                return $left.' >= '.$this->numericLiteral($value);
+
+            case 'IN':
+                return $left.' IN ('.$this->literalList($value).')';
+
+            case 'NOT IN':
+                return $left.' NOT IN ('.$this->literalList($value).')';
+
+            default:
+                throw new RuntimeException('Operator not supported in VIEW-09: '.$op);
+        }
+    }
+
+    private function resolveLeftExpression(string $attr): string
+    {
+        if (isset(self::COLUMN_MAP[$attr])) {
+            return self::COLUMN_MAP[$attr];
+        }
+
+        // Locale-scoped path e.g. `description.pl`.
+        if (str_contains($attr, '.')) {
+            [$base, $locale] = explode('.', $attr, 2);
+            $baseEsc = $this->safeIdent($base);
+            $localeEsc = $this->safeIdent($locale);
+
+            return "NULLIF((co.attributes_indexed->'$baseEsc'->>'$localeEsc'), '')";
+        }
+
+        // Standard JSONB lookup with NULLIF to coerce empty strings to NULL.
+        $attrEsc = $this->safeIdent($attr);
+
+        return "NULLIF((co.attributes_indexed->>'$attrEsc'), '')";
+    }
+
+    private function safeIdent(string $ident): string
+    {
+        // Identifiers come from controlled UI dropdowns; allow safe chars only.
+        if (1 !== preg_match('/^[a-zA-Z0-9_\-]+$/', $ident)) {
+            throw new RuntimeException('Invalid identifier: '.$ident);
+        }
+
+        return $ident;
+    }
+
+    private function literal(mixed $value): string
+    {
+        if (\is_int($value) || \is_float($value)) {
+            return (string) $value;
+        }
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (\is_string($value)) {
+            return "'".str_replace("'", "''", $value)."'";
+        }
+        throw new RuntimeException('Unsupported literal type.');
+    }
+
+    private function numericLiteral(mixed $value): string
+    {
+        if (\is_int($value) || \is_float($value)) {
+            return (string) $value;
+        }
+        if (\is_string($value) && is_numeric($value)) {
+            return $value;
+        }
+        throw new RuntimeException('Numeric value required.');
+    }
+
+    private function literalList(mixed $value): string
+    {
+        if (!\is_array($value) || [] === $value) {
+            throw new RuntimeException('IN/NOT IN requires a non-empty array value.');
+        }
+
+        return implode(', ', array_map($this->literal(...), $value));
+    }
+
+    /**
+     * @param array<string, mixed> $group
+     */
+    private function validateGroup(array $group, int $depth): void
+    {
+        if ($depth > 3) {
+            throw new BadRequestHttpException('FilterDsl nesting too deep (max 3 levels).');
+        }
+        $operatorRaw = $group['operator'] ?? null;
+        if (!\is_string($operatorRaw) || !\in_array(strtoupper($operatorRaw), self::LOGICAL_OPS, true)) {
+            throw new BadRequestHttpException('Group operator must be AND or OR.');
+        }
+        if (!isset($group['conditions']) || !\is_array($group['conditions'])) {
+            throw new BadRequestHttpException('Group must contain a conditions array.');
+        }
+        if (\count($group['conditions']) > 20) {
+            throw new BadRequestHttpException('A filter group cannot contain more than 20 conditions.');
+        }
+
+        foreach ($group['conditions'] as $cond) {
+            if (!\is_array($cond)) {
+                throw new BadRequestHttpException('Each condition must be an object.');
+            }
+            /** @var array<string, mixed> $cond */
+            if (isset($cond['operator']) && isset($cond['conditions'])) {
+                $this->validateGroup($cond, $depth + 1);
+            } else {
+                $this->validateCondition($cond);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $cond
+     */
+    private function validateCondition(array $cond): void
+    {
+        $attr = $cond['attr'] ?? null;
+        $op = $cond['op'] ?? null;
+
+        if (!\is_string($attr) || '' === trim($attr)) {
+            throw new BadRequestHttpException('Condition `attr` must be a non-empty string.');
+        }
+        if (!\is_string($op) || '' === trim($op)) {
+            throw new BadRequestHttpException('Condition `op` must be a non-empty string.');
+        }
+        if (!\in_array(strtoupper($op), array_map(strtoupper(...), self::SUPPORTED_OPS_V09), true)) {
+            throw new BadRequestHttpException(\sprintf(
+                'Operator "%s" not supported in VIEW-09. Use one of: %s. (Full operator set lands in VIEW-10.)',
+                $op,
+                implode(', ', self::SUPPORTED_OPS_V09),
+            ));
+        }
+
+        // Validate identifier safety upfront.
+        try {
+            $this->resolveLeftExpression($attr);
+        } catch (RuntimeException $e) {
+            throw new BadRequestHttpException($e->getMessage());
+        }
+
+        $opUpper = strtoupper($op);
+        $emptyOp = \in_array($opUpper, ['IS EMPTY', 'IS NOT EMPTY'], true);
+        $listOp = \in_array($opUpper, ['IN', 'NOT IN'], true);
+
+        if (!$emptyOp && !\array_key_exists('value', $cond)) {
+            throw new BadRequestHttpException(\sprintf('Operator "%s" requires a value.', $op));
+        }
+        if ($listOp && !\is_array($cond['value'] ?? null)) {
+            throw new BadRequestHttpException(\sprintf('Operator "%s" requires an array value.', $op));
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
@@ -84,7 +84,7 @@ final class FilterDslResolver
      * literal values escaped via `pg_escape_literal` semantics. Future
      * VIEW-10 will switch to PDO-bound parameters for safety; for VIEW-09
      * the DSL flow is admin-only (curated dropdown values) and the
-     * controller's `executeQuery` is wrapped in try/catch.
+     * controller-side execution is wrapped in try/catch.
      *
      * @param array<string, mixed> $dsl
      */

--- a/apps/api/src/Catalog/Domain/Entity/SmartFilterPreset.php
+++ b/apps/api/src/Catalog/Domain/Entity/SmartFilterPreset.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Entity;
+
+use App\Shared\Application\SystemShipped;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-09 (#535) — rule-based smart filter preset surfaced in the
+ * products list smart filter row.
+ *
+ * Two ownership axes:
+ *   - `(tenant_id IS NULL, user_id IS NULL, is_built_in=true)` — system
+ *     shipped, immutable, visible to every tenant.
+ *   - `(tenant_id=current, user_id=current)` — user-defined, owner can
+ *     PATCH/DELETE.
+ *   - `(tenant_id=current, user_id IS NULL)` — tenant-shared lane,
+ *     reserved for Faza 1+ "share to team" UX (schema supports it now).
+ *
+ * The `query` JSONB is a flat filter DSL in MVP (VIEW-09 / VIEW-10);
+ * nested AND/OR/NOT lands in VIEW-09b without schema change.
+ *
+ * Marketing nota PRD §11 — "smart" tutaj znaczy *rule-based*, nie LLM.
+ * Nie używaj "AI-powered" / "AI smart filter" w copy ani docstringach.
+ */
+class SmartFilterPreset implements TenantScoped, SystemShipped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+    private ?Uuid $userId;
+    private string $slug;
+
+    /** @var array{pl: string, en: string} */
+    private array $name;
+
+    private string $icon;
+
+    /** @var array<string, mixed> */
+    private array $query;
+
+    private bool $isBuiltIn;
+    private int $sortOrder;
+    private DateTimeImmutable $createdAt;
+    private DateTimeImmutable $updatedAt;
+
+    /**
+     * @param array{pl: string, en: string} $name
+     * @param array<string, mixed>          $query
+     */
+    public function __construct(
+        string $slug,
+        array $name,
+        string $icon,
+        array $query,
+        ?Uuid $userId = null,
+        bool $isBuiltIn = false,
+        int $sortOrder = 0,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->slug = $slug;
+        $this->name = $name;
+        $this->icon = $icon;
+        $this->query = $query;
+        $this->userId = $userId;
+        $this->isBuiltIn = $isBuiltIn;
+        $this->sortOrder = $sortOrder;
+        $this->createdAt = new DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist for
+     *           user-defined presets; system-shipped rows silently skip
+     *           the assignment so they stay tenant-less
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        if ($this->isBuiltIn) {
+            // Built-in presets are system-shipped (tenant_id IS NULL) by
+            // contract — silently ignore listener assignments so the
+            // shared TenantAssignmentListener does not need a per-entity
+            // exception list.
+            return;
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getUserId(): ?Uuid
+    {
+        return $this->userId;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function changeSlug(string $slug): void
+    {
+        $this->guardMutable();
+        $this->slug = $slug;
+        $this->touch();
+    }
+
+    /**
+     * @return array{pl: string, en: string}
+     */
+    public function getName(): array
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param array{pl: string, en: string} $name
+     */
+    public function rename(array $name): void
+    {
+        $this->guardMutable();
+        $this->name = $name;
+        $this->touch();
+    }
+
+    public function getIcon(): string
+    {
+        return $this->icon;
+    }
+
+    public function changeIcon(string $icon): void
+    {
+        $this->guardMutable();
+        $this->icon = $icon;
+        $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getQuery(): array
+    {
+        return $this->query;
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     */
+    public function updateQuery(array $query): void
+    {
+        $this->guardMutable();
+        $this->query = $query;
+        $this->touch();
+    }
+
+    public function isBuiltIn(): bool
+    {
+        return $this->isBuiltIn;
+    }
+
+    public function getSortOrder(): int
+    {
+        return $this->sortOrder;
+    }
+
+    public function reorder(int $sortOrder): void
+    {
+        $this->guardMutable();
+        $this->sortOrder = $sortOrder;
+        $this->touch();
+    }
+
+    public function isSystem(): bool
+    {
+        return null === $this->userId && null === $this->tenant;
+    }
+
+    public function isTenantShared(): bool
+    {
+        return null === $this->userId && null !== $this->tenant;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function isOwnedBy(Uuid $userId): bool
+    {
+        return null !== $this->userId && $this->userId->equals($userId);
+    }
+
+    private function guardMutable(): void
+    {
+        if ($this->isBuiltIn) {
+            throw new LogicException('Built-in smart filter presets are immutable.');
+        }
+    }
+
+    private function touch(): void
+    {
+        $this->updatedAt = new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/SmartFilterPreset.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/SmartFilterPreset.orm.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Catalog\Domain\Entity\SmartFilterPreset"
+            table="smart_filter_presets">
+
+        <indexes>
+            <index name="smart_filter_presets_tenant_idx" columns="tenant_id"/>
+            <index name="smart_filter_presets_user_idx" columns="user_id"/>
+            <index name="smart_filter_presets_builtin_idx" columns="is_built_in"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="true" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="userId" type="uuid" column="user_id" nullable="true"/>
+        <field name="slug" type="string" length="64"/>
+
+        <field name="name" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="icon" type="string" length="64"/>
+
+        <field name="query" type="json" column="query">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+        <field name="isBuiltIn" type="boolean" column="is_built_in">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+
+        <field name="sortOrder" type="integer" column="sort_order">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Catalog/Presentation/Controller/SmartFilterPresetController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/SmartFilterPresetController.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\Filter\FilterDslResolver;
+use App\Catalog\Domain\Entity\SmartFilterPreset;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Application\TenantContext;
+use DateTimeInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-09 (#535) — `SmartFilterPreset` CRUD endpoints.
+ *
+ * Read scope:
+ *  - system-shipped (tenant_id IS NULL) — visible to every authenticated user.
+ *  - tenant-shared (user_id IS NULL, tenant_id matches) — Faza 1+ lane.
+ *  - user-owned (user_id matches current user) — visible to owner only.
+ *
+ * Write scope (PATCH / DELETE):
+ *  - built-in (is_built_in=true) → 403 Conflict, immutable per CLAUDE.md ADR.
+ *  - user-owned → owner only.
+ *  - cross-user attempt → 404 (information hiding, not 403).
+ *
+ * Marketing nota PRD §11 — "smart" tutaj znaczy *rule-based*, nie LLM.
+ */
+final class SmartFilterPresetController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+    private const int MAX_USER_PRESETS = 50;
+    private const int MAX_NAME_LEN = 60;
+    private const int MIN_NAME_LEN = 3;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly Connection $connection,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+        private readonly FilterDslResolver $filterDslResolver,
+    ) {
+    }
+
+    #[Route('/api/smart-filter-presets', name: 'pim_smart_filter_presets_list', methods: ['GET'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function list(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        $user = $this->security->getUser();
+        $userId = $user instanceof User ? $user->getId() : null;
+
+        $withCounts = $request->query->getBoolean('counts', false);
+
+        $qb = $this->em->getRepository(SmartFilterPreset::class)
+            ->createQueryBuilder('p')
+            ->orderBy('p.isBuiltIn', 'DESC')
+            ->addOrderBy('p.sortOrder', 'ASC')
+            ->addOrderBy('p.createdAt', 'DESC')
+            ->setMaxResults(self::MAX_USER_PRESETS + 5); // 5 built-in + N user
+
+        // Visible to user: system-shipped (tenant NULL) OR own user-defined.
+        if (null !== $tenant && null !== $userId) {
+            $qb->andWhere('p.tenant IS NULL OR (p.tenant = :tenant AND (p.userId = :user OR p.userId IS NULL))')
+                ->setParameter('tenant', $tenant)
+                ->setParameter('user', $userId);
+        } else {
+            $qb->andWhere('p.tenant IS NULL');
+        }
+
+        /** @var list<SmartFilterPreset> $presets */
+        $presets = $qb->getQuery()->getResult();
+
+        $counts = $withCounts ? $this->resolveCounts($presets) : null;
+
+        return new JsonResponse([
+            'data' => array_map(
+                fn (SmartFilterPreset $p): array => $this->serialize($p, $counts[$p->getId()->toRfc4122()] ?? null),
+                $presets,
+            ),
+        ]);
+    }
+
+    #[Route('/api/smart-filter-presets', name: 'pim_smart_filter_presets_create', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function create(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new BadRequestHttpException('User identity required.');
+        }
+        $userId = $user->getId();
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        $name = $this->parseName($body['name'] ?? null);
+        $icon = $this->parseIcon($body['icon'] ?? null);
+        $query = $this->parseQuery($body['query'] ?? null);
+        $sortOrderRaw = $body['sort_order'] ?? 100;
+        $sortOrder = is_numeric($sortOrderRaw) ? (int) $sortOrderRaw : 100;
+
+        $slug = $this->generateUniqueSlug($name['pl'], $tenant->getId(), $userId);
+
+        $preset = new SmartFilterPreset(
+            slug: $slug,
+            name: $name,
+            icon: $icon,
+            query: $query,
+            userId: $userId,
+            isBuiltIn: false,
+            sortOrder: $sortOrder,
+        );
+
+        $this->em->persist($preset);
+        $this->em->flush();
+
+        return new JsonResponse($this->serialize($preset), Response::HTTP_CREATED);
+    }
+
+    #[Route('/api/smart-filter-presets/{id}', name: 'pim_smart_filter_presets_patch', requirements: ['id' => self::UUID_REGEX], methods: ['PATCH'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function patch(string $id, Request $request): JsonResponse
+    {
+        $preset = $this->mustFindOwned($id);
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        if (\array_key_exists('name', $body)) {
+            $preset->rename($this->parseName($body['name']));
+        }
+        if (\array_key_exists('icon', $body)) {
+            $preset->changeIcon($this->parseIcon($body['icon']));
+        }
+        if (\array_key_exists('query', $body)) {
+            $preset->updateQuery($this->parseQuery($body['query']));
+        }
+        if (\array_key_exists('sort_order', $body) && is_numeric($body['sort_order'])) {
+            $preset->reorder((int) $body['sort_order']);
+        }
+
+        $this->em->flush();
+
+        return new JsonResponse($this->serialize($preset));
+    }
+
+    #[Route('/api/smart-filter-presets/{id}', name: 'pim_smart_filter_presets_delete', requirements: ['id' => self::UUID_REGEX], methods: ['DELETE'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function delete(string $id): Response
+    {
+        $preset = $this->mustFindOwned($id);
+        $this->em->remove($preset);
+        $this->em->flush();
+
+        return new Response('', Response::HTTP_NO_CONTENT);
+    }
+
+    private function mustFindOwned(string $id): SmartFilterPreset
+    {
+        $preset = $this->em->getRepository(SmartFilterPreset::class)->find(Uuid::fromString($id));
+        if (!$preset instanceof SmartFilterPreset) {
+            throw new NotFoundHttpException(\sprintf('Smart filter preset %s not found.', $id));
+        }
+
+        if ($preset->isBuiltIn()) {
+            throw new AccessDeniedHttpException('Built-in smart filter presets are immutable.');
+        }
+
+        $user = $this->security->getUser();
+        $userId = $user instanceof User ? $user->getId() : null;
+        $tenant = $this->tenantContext->get();
+
+        $sameTenant = null !== $tenant && null !== $preset->getTenant()
+            && $preset->getTenant()->getId()->equals($tenant->getId());
+
+        if (!$sameTenant) {
+            // Cross-tenant — pretend not found (information hiding).
+            throw new NotFoundHttpException(\sprintf('Smart filter preset %s not found.', $id));
+        }
+
+        if (null !== $userId && !$preset->isOwnedBy($userId)) {
+            throw new NotFoundHttpException(\sprintf('Smart filter preset %s not found.', $id));
+        }
+
+        return $preset;
+    }
+
+    /**
+     * @return array{pl: string, en: string}
+     */
+    private function parseName(mixed $raw): array
+    {
+        if (!\is_array($raw)) {
+            throw new BadRequestHttpException('name must be an object {pl, en}.');
+        }
+        $pl = $raw['pl'] ?? null;
+        $en = $raw['en'] ?? null;
+        if (!\is_string($pl) || !\is_string($en)) {
+            throw new BadRequestHttpException('name must include both pl and en strings.');
+        }
+        $pl = trim($pl);
+        $en = trim($en);
+        if (\strlen($pl) < self::MIN_NAME_LEN || \strlen($en) < self::MIN_NAME_LEN) {
+            throw new BadRequestHttpException(\sprintf('name must be at least %d characters in each locale.', self::MIN_NAME_LEN));
+        }
+        if (mb_strlen($pl) > self::MAX_NAME_LEN || mb_strlen($en) > self::MAX_NAME_LEN) {
+            throw new BadRequestHttpException(\sprintf('name must be at most %d characters in each locale.', self::MAX_NAME_LEN));
+        }
+
+        return ['pl' => $pl, 'en' => $en];
+    }
+
+    private function parseIcon(mixed $raw): string
+    {
+        if (!\is_string($raw) || '' === trim($raw)) {
+            throw new BadRequestHttpException('icon is required (emoji string or lucide icon name).');
+        }
+        $icon = trim($raw);
+        if (mb_strlen($icon) > 64) {
+            throw new BadRequestHttpException('icon must be at most 64 characters.');
+        }
+
+        return $icon;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseQuery(mixed $raw): array
+    {
+        if (!\is_array($raw)) {
+            throw new BadRequestHttpException('query must be a FilterDsl object.');
+        }
+        /* @var array<string, mixed> $raw */
+        $this->filterDslResolver->validate($raw);
+
+        return $raw;
+    }
+
+    private function generateUniqueSlug(string $name, Uuid $tenantId, Uuid $userId): string
+    {
+        $base = $this->slugify($name);
+        if ('' === $base) {
+            $base = 'preset';
+        }
+        $candidate = $base;
+        $counter = 1;
+        $repo = $this->em->getRepository(SmartFilterPreset::class);
+        while (null !== $repo->findOneBy([
+            'tenant' => $tenantId,
+            'userId' => $userId,
+            'slug' => $candidate,
+        ])) {
+            ++$counter;
+            $candidate = $base.'-'.$counter;
+            if ($counter > 9999) {
+                throw new ConflictHttpException(\sprintf('Cannot allocate a slug for "%s".', $name));
+            }
+        }
+
+        return $candidate;
+    }
+
+    private function slugify(string $name): string
+    {
+        $lower = mb_strtolower($name);
+        // Replace Polish diacritics + non-alnum with hyphen.
+        $map = ['ą' => 'a', 'ć' => 'c', 'ę' => 'e', 'ł' => 'l', 'ń' => 'n', 'ó' => 'o', 'ś' => 's', 'ź' => 'z', 'ż' => 'z'];
+        $ascii = strtr($lower, $map);
+        $slug = preg_replace('/[^a-z0-9]+/u', '-', $ascii) ?? '';
+
+        return trim($slug, '-');
+    }
+
+    /**
+     * Single batched COUNT query for all presets (no N+1). Returns
+     * `[presetId.toRfc4122 => count]`. Counts only run against the
+     * current tenant scope — system-shipped presets are surfaced with
+     * the same count for every viewer (cheap, cache-friendly).
+     *
+     * @param list<SmartFilterPreset> $presets
+     *
+     * @return array<string, int>
+     */
+    private function resolveCounts(array $presets): array
+    {
+        if ([] === $presets) {
+            return [];
+        }
+
+        $tenant = $this->tenantContext->get();
+        $tenantId = $tenant?->getId()->toRfc4122();
+        if (null === $tenantId) {
+            return [];
+        }
+
+        $counts = [];
+        foreach ($presets as $preset) {
+            $sql = $this->filterDslResolver->toCountSql($preset->getQuery());
+            if (null === $sql) {
+                $counts[$preset->getId()->toRfc4122()] = 0;
+                continue;
+            }
+            try {
+                $result = $this->connection->executeQuery(
+                    'SELECT COUNT(*) FROM catalog_objects WHERE tenant_id = :tenant AND kind = :kind AND ('.$sql.')',
+                    ['tenant' => $tenantId, 'kind' => 'product'],
+                )->fetchOne();
+                $counts[$preset->getId()->toRfc4122()] = is_numeric($result) ? (int) $result : 0;
+            } catch (Throwable) {
+                // Fallback: 0 count rather than fail the whole list endpoint.
+                $counts[$preset->getId()->toRfc4122()] = 0;
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialize(SmartFilterPreset $preset, ?int $count = null): array
+    {
+        $payload = [
+            'id' => $preset->getId()->toRfc4122(),
+            'slug' => $preset->getSlug(),
+            'name' => $preset->getName(),
+            'icon' => $preset->getIcon(),
+            'query' => $preset->getQuery(),
+            'is_built_in' => $preset->isBuiltIn(),
+            'is_system' => $preset->isSystem(),
+            'sort_order' => $preset->getSortOrder(),
+            'created_at' => $preset->getCreatedAt()->format(DateTimeInterface::ATOM),
+            'updated_at' => $preset->getUpdatedAt()->format(DateTimeInterface::ATOM),
+        ];
+
+        if (null !== $count) {
+            $payload['count'] = $count;
+        }
+
+        return $payload;
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/SmartFilterPresetController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/SmartFilterPresetController.php
@@ -6,8 +6,8 @@ namespace App\Catalog\Presentation\Controller;
 
 use App\Catalog\Application\Filter\FilterDslResolver;
 use App\Catalog\Domain\Entity\SmartFilterPreset;
-use App\Identity\Domain\Entity\User;
 use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
 use DateTimeInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -61,7 +61,7 @@ final class SmartFilterPresetController
     {
         $tenant = $this->tenantContext->get();
         $user = $this->security->getUser();
-        $userId = $user instanceof User ? $user->getId() : null;
+        $userId = $user instanceof UserIdentityAware ? $user->getId() : null;
 
         $withCounts = $request->query->getBoolean('counts', false);
 
@@ -103,7 +103,7 @@ final class SmartFilterPresetController
             throw new BadRequestHttpException('No tenant context.');
         }
         $user = $this->security->getUser();
-        if (!$user instanceof User) {
+        if (!$user instanceof UserIdentityAware) {
             throw new BadRequestHttpException('User identity required.');
         }
         $userId = $user->getId();
@@ -185,7 +185,7 @@ final class SmartFilterPresetController
         }
 
         $user = $this->security->getUser();
-        $userId = $user instanceof User ? $user->getId() : null;
+        $userId = $user instanceof UserIdentityAware ? $user->getId() : null;
         $tenant = $this->tenantContext->get();
 
         $sameTenant = null !== $tenant && null !== $preset->getTenant()
@@ -249,10 +249,11 @@ final class SmartFilterPresetController
         if (!\is_array($raw)) {
             throw new BadRequestHttpException('query must be a FilterDsl object.');
         }
-        /* @var array<string, mixed> $raw */
-        $this->filterDslResolver->validate($raw);
+        /** @var array<string, mixed> $typed */
+        $typed = $raw;
+        $this->filterDslResolver->validate($typed);
 
-        return $raw;
+        return $typed;
     }
 
     private function generateUniqueSlug(string $name, Uuid $tenantId, Uuid $userId): string
@@ -320,6 +321,7 @@ final class SmartFilterPresetController
                 continue;
             }
             try {
+                // tenant-safe: explicit tenant_id filter
                 $result = $this->connection->executeQuery(
                     'SELECT COUNT(*) FROM catalog_objects WHERE tenant_id = :tenant AND kind = :kind AND ('.$sql.')',
                     ['tenant' => $tenantId, 'kind' => 'product'],

--- a/apps/api/src/Identity/Domain/Entity/User.php
+++ b/apps/api/src/Identity/Domain/Entity/User.php
@@ -6,6 +6,7 @@ namespace App\Identity\Domain\Entity;
 
 use App\Identity\Contracts\Event\UserAuthenticated;
 use App\Shared\Application\TenantAware;
+use App\Shared\Application\UserIdentityAware;
 use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
@@ -28,7 +29,7 @@ use Symfony\Component\Uid\Uuid;
  * The TenantAware interface lets CurrentTenantProvider read the tenant from
  * the security token's user without coupling Identity to Catalog.
  */
-class User extends AggregateRoot implements UserInterface, PasswordAuthenticatedUserInterface, TenantAware
+class User extends AggregateRoot implements UserInterface, PasswordAuthenticatedUserInterface, TenantAware, UserIdentityAware
 {
     public const string STATUS_ACTIVE = 'active';
     public const string STATUS_DISABLED = 'disabled';

--- a/apps/api/src/Shared/Application/SystemShipped.php
+++ b/apps/api/src/Shared/Application/SystemShipped.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+/**
+ * Marker for entities that may exist as system-shipped rows
+ * (`tenant_id IS NULL`) alongside tenant-owned ones.
+ *
+ * The shared {@see \App\Shared\Infrastructure\Doctrine\EventListener\TenantAssignmentListener}
+ * checks {@see self::isSystem()} before resolving the current tenant —
+ * system rows stay tenant-less without forcing a `TenantContext` set in
+ * boot/test code paths that do not otherwise need one (seeders, fixtures).
+ *
+ * Entities implementing this contract still implement {@see TenantScoped}
+ * because their tenant-owned siblings need tenant scoping; the system
+ * lane is just opted-out at the listener layer.
+ */
+interface SystemShipped
+{
+    public function isSystem(): bool;
+}

--- a/apps/api/src/Shared/Application/UserIdentityAware.php
+++ b/apps/api/src/Shared/Application/UserIdentityAware.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Marker for security principals that expose a stable UUID identity.
+ *
+ * Cross-bounded-context code (Catalog, Channel, Asset…) needs to record
+ * `user_id` on owned rows (`saved_views.user_id`, `smart_filter_presets.user_id`,
+ * future `bulk_sessions.user_id` etc.) without depending on the concrete
+ * `Identity\Domain\Entity\User` class — Deptrac enforces the boundary.
+ *
+ * Implemented by `App\Identity\Domain\Entity\User`. Machine principals
+ * (`ApiKeyPrincipal`) do **not** implement this — controllers should treat
+ * api-key paths as bot-owned (write a NULL user_id) or reject them at the
+ * permission layer.
+ */
+interface UserIdentityAware extends UserInterface
+{
+    public function getId(): Uuid;
+}

--- a/apps/api/src/Shared/Infrastructure/Doctrine/EventListener/TenantAssignmentListener.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/EventListener/TenantAssignmentListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Doctrine\EventListener;
 
+use App\Shared\Application\SystemShipped;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\TenantScoped;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
@@ -45,6 +46,13 @@ final readonly class TenantAssignmentListener
         }
 
         if (null !== $entity->getTenant()) {
+            return;
+        }
+
+        // System-shipped rows stay tenant-less by design (built-in
+        // ObjectTypes are still per-tenant, but SmartFilterPreset and
+        // future global catalogs use the SystemShipped lane).
+        if ($entity instanceof SystemShipped && $entity->isSystem()) {
             return;
         }
 

--- a/apps/api/src/Shared/Infrastructure/Doctrine/Filter/TenantFilter.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Filter/TenantFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Doctrine\Filter;
 
+use App\Shared\Application\SystemShipped;
 use App\Shared\Application\TenantScoped;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Filter\SQLFilter;
@@ -49,6 +50,18 @@ final class TenantFilter extends SQLFilter
 
         if ('' === $value || 'NULL' === $value) {
             return '';
+        }
+
+        // Entities with a SystemShipped lane (built-ins shared across
+        // tenants via `tenant_id IS NULL`) must surface those rows to
+        // every tenant alongside the tenant's own entries.
+        if (is_subclass_of($targetEntity->getName(), SystemShipped::class, true)) {
+            return \sprintf(
+                '(%s.tenant_id = %s OR %s.tenant_id IS NULL)',
+                $targetTableAlias,
+                $value,
+                $targetTableAlias,
+            );
         }
 
         return \sprintf('%s.tenant_id = %s', $targetTableAlias, $value);

--- a/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
@@ -106,6 +106,11 @@ final class TenantAuditCommand extends Command
      */
     private const array NULLABLE_TENANT_TABLES = [
         'roles',
+        // VIEW-09 (#535) — system-shipped Smart Filter Presets are
+        // shared across every tenant via `tenant_id IS NULL` (built-in
+        // rows). User-defined presets fill the column. See
+        // `App\Shared\Application\SystemShipped` marker contract.
+        'smart_filter_presets',
     ];
 
     public function __construct(

--- a/apps/api/tests/Api/Catalog/SmartFilterPresetsApiTest.php
+++ b/apps/api/tests/Api/Catalog/SmartFilterPresetsApiTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInSmartFilterPresetsSeeder;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * VIEW-09 (#535) — SmartFilterPreset CRUD endpoints.
+ *
+ * Coverage:
+ *   - 401 anonymous denied.
+ *   - GET lists 5 system-shipped built-ins after migration.
+ *   - POST creates a user-defined preset with auto-generated slug.
+ *   - POST 400 on malformed name / invalid query DSL.
+ *   - PATCH updates owner's preset, 403 on built-in, 404 on random UUID.
+ *   - DELETE removes owner's preset, 403 on built-in.
+ *   - Multi-tenant isolation: tenant B sees only built-ins + own user-defined.
+ */
+final class SmartFilterPresetsApiTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // doctrine:schema:create skips migration seed; replay built-ins
+        // using a direct EntityManager instance to bypass test-container
+        // service inlining (Symfony optimisation when no referrer).
+        new BuiltInSmartFilterPresetsSeeder($this->em())->seed();
+    }
+
+    #[Test]
+    public function anonymousRequestIsRejected(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/api/smart-filter-presets');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function listReturnsFiveBuiltInPresets(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/smart-filter-presets');
+        self::assertResponseStatusCodeSame(200);
+
+        $body = $response->toArray();
+        self::assertArrayHasKey('data', $body);
+        $data = $body['data'];
+        \assert(\is_array($data));
+
+        $slugs = [];
+        foreach ($data as $row) {
+            \assert(\is_array($row));
+            $slug = $row['slug'] ?? null;
+            \assert(\is_string($slug));
+            $slugs[] = $slug;
+        }
+
+        self::assertContains('inconsistent-translations', $slugs);
+        self::assertContains('missing-images', $slugs);
+        self::assertContains('weak-seo', $slugs);
+        self::assertContains('red-low-completeness', $slugs);
+        self::assertContains('no-category', $slugs);
+
+        foreach ($data as $row) {
+            \assert(\is_array($row));
+            if ('red-low-completeness' === ($row['slug'] ?? null)) {
+                self::assertTrue($row['is_built_in']);
+                self::assertTrue($row['is_system']);
+                self::assertSame('🔴', $row['icon']);
+                self::assertEqualsCanonicalizing(['pl' => 'Czerwone (<50%)', 'en' => 'Red (<50%)'], $row['name']);
+            }
+        }
+    }
+
+    #[Test]
+    public function createUserDefinedPresetAutoSlug(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/smart-filter-presets', [
+            'json' => [
+                'name' => ['pl' => 'Festo niski stock', 'en' => 'Festo low stock'],
+                'icon' => '⚙️',
+                'query' => ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $body = $response->toArray();
+
+        self::assertFalse($body['is_built_in']);
+        self::assertFalse($body['is_system']);
+        self::assertSame('festo-niski-stock', $body['slug']);
+        self::assertSame(['pl' => 'Festo niski stock', 'en' => 'Festo low stock'], $body['name']);
+    }
+
+    #[Test]
+    public function createRejectsMalformedName(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/smart-filter-presets', [
+            'json' => [
+                'name' => ['pl' => 'A', 'en' => 'B'], // too short (<3 chars)
+                'icon' => '⚙️',
+                'query' => ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    #[Test]
+    public function createRejectsInvalidQueryDsl(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/smart-filter-presets', [
+            'json' => [
+                'name' => ['pl' => 'Niespójne brak', 'en' => 'Bad query'],
+                'icon' => '⚠️',
+                'query' => ['attr' => 'brand', 'op' => 'STARTS WITH', 'value' => 'F'],
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    #[Test]
+    public function patchUpdatesOwnPreset(): void
+    {
+        $client = $this->authenticatedClient();
+        $created = $client->request('POST', '/api/smart-filter-presets', [
+            'json' => [
+                'name' => ['pl' => 'Test preset', 'en' => 'Test preset'],
+                'icon' => '🔧',
+                'query' => ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            ],
+        ])->toArray();
+
+        $createdId = $created['id'];
+        \assert(\is_string($createdId));
+
+        $response = $client->request('PATCH', '/api/smart-filter-presets/'.$createdId, [
+            'json' => [
+                'name' => ['pl' => 'Zaktualizowany', 'en' => 'Updated preset'],
+                'icon' => '⚡',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(200);
+        $body = $response->toArray();
+
+        self::assertSame(['pl' => 'Zaktualizowany', 'en' => 'Updated preset'], $body['name']);
+        self::assertSame('⚡', $body['icon']);
+    }
+
+    #[Test]
+    public function patchBuiltInPresetForbidden(): void
+    {
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/smart-filter-presets')->toArray();
+        $data = $body['data'];
+        \assert(\is_array($data));
+
+        $redId = null;
+        foreach ($data as $row) {
+            \assert(\is_array($row));
+            if ('red-low-completeness' === ($row['slug'] ?? null)) {
+                $rowId = $row['id'] ?? null;
+                \assert(\is_string($rowId));
+                $redId = $rowId;
+                break;
+            }
+        }
+        self::assertNotNull($redId);
+
+        $client->request('PATCH', '/api/smart-filter-presets/'.$redId, [
+            'json' => ['icon' => '🟢'],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    #[Test]
+    public function deleteBuiltInPresetForbidden(): void
+    {
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/smart-filter-presets')->toArray();
+        $data = $body['data'];
+        \assert(\is_array($data) && [] !== $data);
+        $first = $data[0];
+        \assert(\is_array($first));
+        $presetId = $first['id'] ?? null;
+        \assert(\is_string($presetId));
+
+        $client->request('DELETE', '/api/smart-filter-presets/'.$presetId);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    #[Test]
+    public function deleteOwnPresetReturnsNoContent(): void
+    {
+        $client = $this->authenticatedClient();
+        $created = $client->request('POST', '/api/smart-filter-presets', [
+            'json' => [
+                'name' => ['pl' => 'Do skasowania', 'en' => 'To delete'],
+                'icon' => '🗑️',
+                'query' => ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            ],
+        ])->toArray();
+        $createdId = $created['id'];
+        \assert(\is_string($createdId));
+
+        $client->request('DELETE', '/api/smart-filter-presets/'.$createdId);
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $body = $client->request('GET', '/api/smart-filter-presets')->toArray();
+        $data = $body['data'];
+        \assert(\is_array($data));
+        $slugs = [];
+        foreach ($data as $row) {
+            \assert(\is_array($row));
+            $slug = $row['slug'] ?? null;
+            \assert(\is_string($slug));
+            $slugs[] = $slug;
+        }
+        self::assertNotContains('do-skasowania', $slugs);
+    }
+
+    #[Test]
+    public function patchReturnsNotFoundForRandomUuid(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/smart-filter-presets/01234567-0123-7000-8000-000000000999', [
+            'json' => ['icon' => '🟢'],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
+    public function multiTenantIsolationHidesOtherTenantsUserPresets(): void
+    {
+        // Tenant A: admin creates a user-defined preset.
+        $clientA = $this->authenticatedClient();
+        $clientA->request('POST', '/api/smart-filter-presets', [
+            'json' => [
+                'name' => ['pl' => 'Tylko tenant A', 'en' => 'Tenant A only'],
+                'icon' => '🅰️',
+                'query' => ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        // Tenant B: seed a second tenant + user, sign JWT, verify isolation.
+        $em = $this->em();
+        $tenantB = new Tenant('demo-b', 'Demo Tenant B');
+        $em->persist($tenantB);
+        $em->flush();
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stubB = new User($tenantB, 'admin-b@demo.localhost', '', ['ROLE_USER']);
+        $adminB = new User($tenantB, 'admin-b@demo.localhost', $hasher->hashPassword($stubB, 'changeme'), ['ROLE_USER']);
+        $em->persist($adminB);
+        $em->flush();
+
+        $userBRepo = self::getContainer()->get(UserRepositoryInterface::class);
+        $userB = $userBRepo->findByEmail('admin-b@demo.localhost');
+        self::assertNotNull($userB);
+        $jwtManager = self::getContainer()->get(JWTTokenManagerInterface::class);
+        $jwtB = $jwtManager->create($userB);
+
+        $clientB = static::createClient();
+        $clientB->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwtB]]);
+
+        $bodyB = $clientB->request('GET', '/api/smart-filter-presets')->toArray();
+        $data = $bodyB['data'];
+        \assert(\is_array($data));
+        $slugsB = [];
+        foreach ($data as $row) {
+            \assert(\is_array($row));
+            $slug = $row['slug'] ?? null;
+            \assert(\is_string($slug));
+            $slugsB[] = $slug;
+        }
+
+        self::assertContains('red-low-completeness', $slugsB);
+        self::assertNotContains('tylko-tenant-a', $slugsB);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/FilterDslResolverTest.php
+++ b/apps/api/tests/Unit/Catalog/FilterDslResolverTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Application\Filter\FilterDslResolver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * VIEW-09 (#535) — FilterDslResolver covers:
+ *   - validation rejects unsupported operators / malformed DSL.
+ *   - validation accepts the 5 built-in preset DSLs verbatim.
+ *   - toCountSql compiles flat + grouped conditions to safe SQL.
+ *   - identifier safety (no SQL injection via attribute name).
+ */
+final class FilterDslResolverTest extends TestCase
+{
+    private FilterDslResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new FilterDslResolver();
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>}>
+     */
+    public static function builtInPresetDslProvider(): iterable
+    {
+        yield 'inconsistent-translations' => [[
+            'operator' => 'AND',
+            'conditions' => [
+                ['attr' => 'description.pl', 'op' => 'IS NOT EMPTY'],
+                ['attr' => 'description.en', 'op' => 'IS EMPTY'],
+            ],
+        ]];
+        yield 'missing-images' => [['attr' => 'main_image', 'op' => 'IS EMPTY']];
+        yield 'weak-seo' => [[
+            'operator' => 'AND',
+            'conditions' => [
+                ['attr' => 'description', 'op' => 'IS NOT EMPTY'],
+                ['attr' => 'meta_description', 'op' => 'IS EMPTY'],
+            ],
+        ]];
+        yield 'red-low-completeness' => [['attr' => 'completeness_pct', 'op' => '<', 'value' => 50]];
+        yield 'no-category' => [['attr' => 'category', 'op' => 'IS EMPTY']];
+    }
+
+    /**
+     * @param array<string, mixed> $dsl
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('builtInPresetDslProvider')]
+    public function testValidateAcceptsBuiltInPresets(array $dsl): void
+    {
+        $this->resolver->validate($dsl);
+        $sql = $this->resolver->toCountSql($dsl);
+
+        self::assertNotNull($sql, 'built-in DSL must compile to SQL fragment');
+        self::assertIsString($sql);
+    }
+
+    public function testValidateRejectsUnsupportedOperator(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessageMatches('/Operator "STARTS WITH" not supported/');
+
+        $this->resolver->validate(['attr' => 'brand', 'op' => 'STARTS WITH', 'value' => 'Fest']);
+    }
+
+    public function testValidateRejectsMalformedGroup(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->resolver->validate(['operator' => 'XOR', 'conditions' => []]);
+    }
+
+    public function testValidateRejectsConditionMissingValue(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessageMatches('/requires a value/');
+
+        $this->resolver->validate(['attr' => 'brand', 'op' => '=']);
+    }
+
+    public function testValidateRejectsInWithoutArrayValue(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessageMatches('/requires an array value/');
+
+        $this->resolver->validate(['attr' => 'brand', 'op' => 'IN', 'value' => 'Festo']);
+    }
+
+    public function testValidateRejectsUnsafeIdentifier(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->resolver->validate(['attr' => "brand'; DROP TABLE--", 'op' => '=', 'value' => 'x']);
+    }
+
+    public function testValidateRejectsDeeplyNestedGroup(): void
+    {
+        // 5 nested groups → depth 4 throws (max depth = 3 per PRD §13.2).
+        $deeplyNested = [
+            'operator' => 'AND',
+            'conditions' => [[
+                'operator' => 'OR',
+                'conditions' => [[
+                    'operator' => 'AND',
+                    'conditions' => [[
+                        'operator' => 'OR',
+                        'conditions' => [[
+                            'operator' => 'AND',
+                            'conditions' => [['attr' => 'brand', 'op' => '=', 'value' => 'Festo']],
+                        ]],
+                    ]],
+                ]],
+            ]],
+        ];
+
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessageMatches('/nesting too deep/');
+        $this->resolver->validate($deeplyNested);
+    }
+
+    public function testToCountSqlEmitsNullCheckForIsEmpty(): void
+    {
+        $sql = $this->resolver->toCountSql(['attr' => 'main_image', 'op' => 'IS EMPTY']);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString("attributes_indexed->>'main_image'", $sql);
+        self::assertStringContainsString('IS NULL', $sql);
+    }
+
+    public function testToCountSqlEmitsLocaleScopedJsonPath(): void
+    {
+        $sql = $this->resolver->toCountSql([
+            'operator' => 'AND',
+            'conditions' => [
+                ['attr' => 'description.pl', 'op' => 'IS NOT EMPTY'],
+                ['attr' => 'description.en', 'op' => 'IS EMPTY'],
+            ],
+        ]);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString("'description'->>'pl'", $sql);
+        self::assertStringContainsString("'description'->>'en'", $sql);
+        self::assertStringContainsString(' AND ', $sql);
+    }
+
+    public function testToCountSqlEmitsColumnReferenceForReservedNames(): void
+    {
+        $sql = $this->resolver->toCountSql(['attr' => 'completeness_pct', 'op' => '<', 'value' => 50]);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString('co.completeness_pct < 50', $sql);
+    }
+
+    public function testToCountSqlEscapesStringLiteralsSafely(): void
+    {
+        $sql = $this->resolver->toCountSql(['attr' => 'brand', 'op' => '=', 'value' => "O'Reilly"]);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString("'O''Reilly'", $sql);
+        self::assertStringNotContainsString("'O'Reilly'", $sql); // not bare single-quote
+    }
+
+    public function testToCountSqlReturnsNullForCompilationFailure(): void
+    {
+        // Suppress validation: pass directly to compile via toCountSql.
+        $sql = $this->resolver->toCountSql(['attr' => "brand'; DROP", 'op' => '=', 'value' => 'x']);
+        self::assertNull($sql, 'unsafe identifier must return null SQL, not throw');
+    }
+
+    public function testToCountSqlHandlesInList(): void
+    {
+        $sql = $this->resolver->toCountSql(['attr' => 'brand', 'op' => 'IN', 'value' => ['Festo', 'Bosch']]);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString("IN ('Festo', 'Bosch')", $sql);
+    }
+
+    public function testToCountSqlHandlesNotInList(): void
+    {
+        $sql = $this->resolver->toCountSql(['attr' => 'brand', 'op' => 'NOT IN', 'value' => ['Bosch']]);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString("NOT IN ('Bosch')", $sql);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/SmartFilterPresetTest.php
+++ b/apps/api/tests/Unit/Catalog/SmartFilterPresetTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Domain\Entity\SmartFilterPreset;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-09 (#535) — invariants for SmartFilterPreset entity:
+ *   - built-in presets cannot be mutated or assigned to a tenant.
+ *   - user-defined presets can be renamed / re-iconed / re-queried.
+ *   - ownership check (isOwnedBy) is identity-aware.
+ */
+final class SmartFilterPresetTest extends TestCase
+{
+    public function testConstructDefaultsToTimestampsAndSortOrderZero(): void
+    {
+        $preset = new SmartFilterPreset(
+            slug: 'my-festo-low',
+            name: ['pl' => 'Festo niski stock', 'en' => 'Festo low stock'],
+            icon: '⚙️',
+            query: ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            userId: Uuid::v7(),
+        );
+
+        self::assertFalse($preset->isBuiltIn());
+        self::assertSame(0, $preset->getSortOrder());
+        self::assertEquals($preset->getCreatedAt(), $preset->getUpdatedAt());
+        self::assertFalse($preset->isSystem());
+    }
+
+    public function testBuiltInPresetIsSystemAndImmutable(): void
+    {
+        $preset = new SmartFilterPreset(
+            slug: 'red-low-completeness',
+            name: ['pl' => 'Czerwone (<50%)', 'en' => 'Red (<50%)'],
+            icon: '🔴',
+            query: ['attr' => 'completeness_pct', 'op' => '<', 'value' => 50],
+            userId: null,
+            isBuiltIn: true,
+        );
+
+        self::assertTrue($preset->isBuiltIn());
+        self::assertTrue($preset->isSystem());
+        self::assertFalse($preset->isTenantShared());
+
+        $this->expectException(LogicException::class);
+        $preset->rename(['pl' => 'X', 'en' => 'X']);
+    }
+
+    public function testBuiltInPresetSilentlyIgnoresTenantAssignment(): void
+    {
+        // The shared TenantAssignmentListener fires for every TenantScoped
+        // entity; built-in presets stay system-shipped (tenant_id NULL)
+        // by silently dropping the assignment instead of throwing — so a
+        // single listener works for both lanes.
+        $preset = new SmartFilterPreset(
+            slug: 'red',
+            name: ['pl' => 'X', 'en' => 'X'],
+            icon: '🔴',
+            query: ['attr' => 'completeness_pct', 'op' => '<', 'value' => 50],
+            userId: null,
+            isBuiltIn: true,
+        );
+        $tenant = new Tenant('demo', 'Demo');
+
+        $preset->assignTenant($tenant);
+
+        self::assertNull($preset->getTenant());
+        self::assertTrue($preset->isSystem());
+    }
+
+    public function testUserDefinedPresetMutators(): void
+    {
+        $userId = Uuid::v7();
+        $preset = new SmartFilterPreset(
+            slug: 'my-preset',
+            name: ['pl' => 'Mój preset', 'en' => 'My preset'],
+            icon: '🛠️',
+            query: ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            userId: $userId,
+        );
+
+        $createdAt = $preset->getCreatedAt();
+        usleep(1_500); // ensure updatedAt clock tick on systems with µs resolution
+
+        $preset->rename(['pl' => 'Nowy', 'en' => 'New']);
+        $preset->changeIcon('⚡');
+        $preset->updateQuery(['attr' => 'family', 'op' => '=', 'value' => 'Czujniki']);
+        $preset->reorder(42);
+        $preset->changeSlug('renamed');
+
+        self::assertSame(['pl' => 'Nowy', 'en' => 'New'], $preset->getName());
+        self::assertSame('⚡', $preset->getIcon());
+        self::assertSame('renamed', $preset->getSlug());
+        self::assertSame(42, $preset->getSortOrder());
+        self::assertSame($createdAt, $preset->getCreatedAt());
+        self::assertGreaterThanOrEqual($createdAt, $preset->getUpdatedAt());
+    }
+
+    public function testOwnershipIsIdentityAware(): void
+    {
+        $owner = Uuid::v7();
+        $other = Uuid::v7();
+        $preset = new SmartFilterPreset(
+            slug: 'mine',
+            name: ['pl' => 'Mój', 'en' => 'Mine'],
+            icon: '🔧',
+            query: ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            userId: $owner,
+        );
+
+        self::assertTrue($preset->isOwnedBy($owner));
+        self::assertFalse($preset->isOwnedBy($other));
+    }
+
+    public function testTenantSharedPresetHasTenantWithoutUser(): void
+    {
+        $preset = new SmartFilterPreset(
+            slug: 'shared',
+            name: ['pl' => 'Shared', 'en' => 'Shared'],
+            icon: '👥',
+            query: ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+            userId: null,
+            isBuiltIn: false,
+        );
+        $tenant = new Tenant('demo', 'Demo');
+        $preset->assignTenant($tenant);
+
+        self::assertFalse($preset->isSystem());
+        self::assertTrue($preset->isTenantShared());
+        self::assertNull($preset->getUserId());
+    }
+}


### PR DESCRIPTION
## Summary

Pierwszy ticket epiku **UI-09** (Lista produktów v2 — cockpit operatora wg PRD-PIM-list-advanced). Dostarcza fundament UI + BE foundation pod kolejne 11 ticketów (~317h pozostałych).

VIEW-09 zamyka 3 obszary:

- **5 built-in Smart Filter Presets** w pasku pod SavedViewsRail. Seed inline w migracji + idempotent runtime seeder dla testów. User-defined CRUD endpoint + tenant-isolation + built-in immutability.
- **Push-down Advanced Filter Panel** (Magento style) zastępuje Sheet-based AdvancedFilterBuilder. Grid mode w VIEW-09; Query mode tab widoczny ale disabled z badge `VIEW-09b`.
- **FilterChipsBar** pod toolbar z chip body click → otwiera panel + ✕ remove + *„Wyczyść wszystkie"* + *„Skopiuj URL z filtrami"*.

Plus: nowy **SystemShipped** marker interface (rozszerza TenantScoped o tenant-less lane dla shared built-in rows), TenantFilter + TenantAssignmentListener support, ~270 LOC FilterDslResolver z 11 operatorami i identifier safety.

## Backend

| Plik | Cel |
|---|---|
| `apps/api/migrations/Version20260513120000.php` | CREATE TABLE `smart_filter_presets` + 5 built-in seed inline |
| `apps/api/src/Catalog/Domain/Entity/SmartFilterPreset.php` | Encja: TenantScoped + SystemShipped, built-in immutability + ownership invariants |
| `apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/SmartFilterPreset.orm.xml` | Doctrine XML mapping (JSONB name + query) |
| `apps/api/src/Catalog/Presentation/Controller/SmartFilterPresetController.php` | GET/POST/PATCH/DELETE z owner-only writes + built-in 403 + cross-tenant 404 + N+1-free counts resolver |
| `apps/api/src/Catalog/Application/Filter/FilterDslResolver.php` | DSL → SQL fragment z 11 ops (`=`, `≠`, `IS EMPTY`, `IS NOT EMPTY`, `<`, `>`, `<=`, `>=`, `IN`, `NOT IN`) + flat / 3-level grouped + safe identifier check |
| `apps/api/src/Catalog/Application/BuiltInSmartFilterPresetsSeeder.php` | Idempotent runtime seed dla testów (mirror migracji) |
| `apps/api/src/Shared/Application/SystemShipped.php` | Marker interface dla entities z system-shipped lane |
| `apps/api/src/Shared/Infrastructure/Doctrine/Filter/TenantFilter.php` | `tenant_id IS NULL` allow-list dla SystemShipped subclasses |
| `apps/api/src/Shared/Infrastructure/Doctrine/EventListener/TenantAssignmentListener.php` | Skip system-shipped entities w prePersist |

## Frontend

| Plik | Cel |
|---|---|
| `apps/admin/src/components/catalog/smart-filter-presets-row.tsx` | Pasek 5 built-in + user-defined z counter + „Własny preset" button |
| `apps/admin/src/components/catalog/advanced-filter-panel.tsx` | Push-down sticky panel z mode toggle (Grid active, Query disabled z badge) |
| `apps/admin/src/components/catalog/filter-chips-bar.tsx` | Aktywne filtry pod toolbar z chip body click + ✕ + Skopiuj URL |
| `apps/admin/src/components/catalog/save-as-smart-preset-modal.tsx` | Multilingual name + emoji picker + JSON preview |
| `apps/admin/src/lib/filters/filter-dsl.ts` | TS types `FilterCondition` / `FilterGroup` / `FilterDsl` + helpery `conditionsToDsl` / `dslToFlatConditions` |
| `apps/admin/src/lib/filters/use-smart-presets.ts` | Refine-style CRUD hook (list/create/remove + refetch) |
| `apps/admin/src/features/catalog/products/list.tsx` | Refactor topbara: nowe komponenty integrowane, legacy FilterPill + Sheet zachowane (VIEW-10 unifikuje) |
| `apps/admin/e2e/products-view-09.spec.ts` | 3 scenariusze Playwright |

## Quality gates

- **PHPStan max**: 0 errors.
- **Biome strict**: 0 errors.
- **TypeScript strict**: 0 errors.
- **PHPUnit**: 35 testów VIEW-09 zielone (24 unit + 11 API integration: 401 / 400 / 403 built-in immutable / 404 / happy path / multi-tenancy isolation).
- **composer audit**: 0 high/critical.
- **pnpm audit**: regression OK.
- **Vite build**: 20.96s, chunk size ostrzeżenia pre-existing.
- **OpenAPI snapshot**: bez zmian (vanilla Symfony routes nie są w API Platform OpenAPI).

## Świadome odejścia

Dokumentowane w `Project Plan/UI/Wdrozenie_grafiki/ticket-VIEW-09-lista-fundament-ui.md` sekcja 9:

1. **Query mode AND/OR brackets** → VIEW-09b (mode toggle widoczny ale Query tab disabled z badge).
2. **Pełne operatory per typ (25 ops)** → VIEW-10 (hardcoded 11 ops w VIEW-09 ze stałą `CORE_OPERATORS`).
3. **BE smart_preset/filter param w SearchController** → VIEW-10 (FE applyConditionsToFilters resolver pokrywa 6 znanych shape'ów; reszta surfaced jako toast info *„partial apply"*).
4. **Inline FilterChip popover** (operator + value picker) → VIEW-10 (chip body click w VIEW-09 otwiera Advanced panel zamiast inline popover).
5. **Cross-page selection toolbar** → VIEW-11.
6. **BulkBar 14 akcji + wizard** → VIEW-12+.
7. **Cmd+K palette** → VIEW-19.
8. **Rollback toast + 24h cancel** → VIEW-17.
9. **Per-attribute lock kolumna** → VIEW-18.
10. **axe-core E2E scan** → follow-up (pakiet `@axe-core/playwright` nie zainstalowany).
11. **i18n keys (~40 nowych)** → defaultValue fallback w MVP, klucze do `pl.json/en.json` w follow-up.
12. **AdvancedFilterBuilder Sheet + FilterPill nie usuwane** — VIEW-09 dodaje obok, VIEW-10 unifikuje.

## Test plan

- [ ] Login `admin@demo.localhost / changeme` na `https://pim.localhost`.
- [ ] Goto `/products` → assert pasek z 5 built-in chipami: 🌐 Niespójne tłumaczenia, 📷 Brakujące zdjęcia, 🔍 Niepełne SEO, 🔴 Czerwone, 📂 Bez kategorii. Każdy z counter (z BE).
- [ ] Click `🔴 Czerwone (<50%)` → chip czarny aktywny → grid filtruje produkty z completeness <50% (FE resolver mapuje `completeness_pct < 50` → `rangeFilters.completeness.lte = 49`).
- [ ] Click drugi raz aktywnego preset → toggle off → grid pokazuje wszystko.
- [ ] Click `Filtruj zaawansowane` button → push-down panel pojawia się.
- [ ] Dodaj condition: brand IN Festo, Bosch → Apply → chip w FilterChipsBar.
- [ ] Click chip body → panel otwiera się.
- [ ] Click ✕ na chipie → chip znika + filter clears.
- [ ] *„Skopiuj URL z filtrami"* → toast success.
- [ ] Z conditions niepustymi: click *„Własny preset"* → SaveAsSmartPresetModal otwiera się → wpisz nazwę PL+EN + wybierz icon → Zapisz → toast + chip w row.
- [ ] Multi-tenant: zaloguj jako inny tenant (jeśli dostępny) → assert built-in 5 widocznych, user-defined nie.
- [ ] DevTools Network: GET `/api/smart-filter-presets?counts=true` < 200ms.
- [ ] DevTools Console: brak czerwonych errorów.

## Plan epiku UI-09 (kontekst)

Plan kompletny w `~/.claude/plans/w-folderze-users-mlipieclocal-dev-pim-zr-iridescent-zephyr.md`. 12 ticketów `VIEW-09..VIEW-19` + `VIEW-09b`. Pełen scope decyzji operatora 2026-05-13: ~357h.

Kolejność:
1. **VIEW-09** ← *this PR*
2. VIEW-10 — pełne operatory + URL DSL serializer + BE `smart_preset` w search
3. VIEW-09b — Query mode AND/OR brackets
4. VIEW-11 — cross-page selection toolbar
5. VIEW-12 — bulk wizard fundament + `bulk_sessions` + Messenger
6. VIEW-17 — 24h rollback
7. VIEW-13..VIEW-16 — bulk attribute / taxonomy / channels / destructive
8. VIEW-18 — per-attribute lock
9. VIEW-19 — Cmd+K + Anthropic + 6 MVP intents

Refs `Project Plan/PRD/PRD-PIM-list-advanced.md` §1, §3, §5, §7, §8.2, §11, §13.1, §14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
