### PR TITLE
fix(catalog): seed Smart Filter Presets via AppFixtures (VIEW-09 follow-up)

### DIFF
--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -6,6 +6,7 @@ namespace App\DataFixtures;
 
 use App\Catalog\Application\BuiltInAssociationTypeSeeder;
 use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Application\BuiltInSmartFilterPresetsSeeder;
 use App\Catalog\Application\BuiltInSystemAttributesSeeder;
 use App\Catalog\Application\DefaultMenuSeeder;
 use App\Catalog\Application\DemoCatalogSeeder;
@@ -49,6 +50,7 @@ class AppFixtures extends Fixture
         private readonly ObjectTypeRepositoryInterface $objectTypeRepository,
         private readonly DemoCatalogSeeder $demoCatalogSeeder,
         private readonly DefaultMenuSeeder $defaultMenuSeeder,
+        private readonly BuiltInSmartFilterPresetsSeeder $smartFilterPresetsSeeder,
     ) {
     }
 
@@ -106,6 +108,12 @@ class AppFixtures extends Fixture
             // matching the legacy hard-coded sidebar minus Services).
             $this->defaultMenuSeeder->seed($tenant);
         }
+
+        // VIEW-09 (#535): 5 built-in Smart Filter Presets are system-shipped
+        // (`tenant_id IS NULL`), shared across every tenant. The migration
+        // inlines these on fresh schema, but fixtures-load purges the
+        // database first — re-seed here so the post-fixtures DB matches.
+        $this->smartFilterPresetsSeeder->seed();
 
         $admins = [
             'demo' => 'admin@demo.localhost',


### PR DESCRIPTION
## Summary

Po merge VIEW-09 (PR #536) smoke test na świeżym `pim:db:reset --force --with-fixtures` ujawnił że `/api/smart-filter-presets` zwraca **pustą tablicę** mimo migracji z inline seedem.

**Root cause:** `pim:db:reset` używa `doctrine:schema:create` (faster than `doctrine:migrations:migrate`) który omija INSERT-y w migracji, a `doctrine:fixtures:load` purguje DB przed seed. Inline seed w `Version20260513120000.up()` działa wyłącznie na pierwszy `migrate` w produkcji.

**Fix:** `AppFixtures.load()` woła `BuiltInSmartFilterPresetsSeeder->seed()` po per-tenant seederach. Seeder jest idempotent (sprawdza istniejące slug + is_built_in=true przed insert), więc bezpieczny na re-runy.

## Test plan

Lokalnie:
```bash
docker compose exec -T database psql -U pim -d postgres -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='pim' AND pid<>pg_backend_pid();"
docker compose exec -T api php bin/console pim:db:reset --force --with-fixtures
docker compose exec -T api php bin/console doctrine:query:sql "SELECT count(*) FROM smart_filter_presets"
# count: 5
```

Smoke test:
- [ ] Login admin@demo.localhost → /products → smart preset row pokazuje 5 built-in.

Refs #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)