### PR TITLE
feat(catalog): 24h rollback toast + executor (VIEW-17)

### DIFF
--- a/apps/admin/src/components/catalog/rollback-toast.tsx
+++ b/apps/admin/src/components/catalog/rollback-toast.tsx
@@ -1,0 +1,141 @@
+import { Check, Undo2, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * VIEW-17 (#544) — sticky 24h rollback toast — mockup
+ * `list-v2-overlays.jsx` l. 532-567.
+ *
+ * Pojawia się po każdym Apply z BulkWizard. Shows session counts +
+ * 24h progress bar (live update every minute) + Wycofaj button →
+ * POST /api/bulk-sessions/{id}/rollback. Dismiss usuwa toast bez
+ * rollback (sesja wciąż dostępna przez Audit panel).
+ */
+
+export interface RollbackSession {
+  session_id: string;
+  action: string;
+  target_count: number;
+  success_count: number;
+  skipped_count: number;
+  error_count: number;
+  rollback_available_until?: string;
+  completed_at?: string;
+}
+
+interface RollbackToastProps {
+  session: RollbackSession | null;
+  onDismiss: () => void;
+  onRolledBack?: () => void;
+}
+
+export function RollbackToast({ session, onDismiss, onRolledBack }: RollbackToastProps) {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+  const [progress, setProgress] = useState<{ pct: number; label: string }>({
+    pct: 100,
+    label: '24h 0m',
+  });
+
+  useEffect(() => {
+    if (!session?.rollback_available_until) return undefined;
+    const updateProgress = (): void => {
+      if (!session.rollback_available_until) return;
+      const end = new Date(session.rollback_available_until).getTime();
+      const start = session.completed_at
+        ? new Date(session.completed_at).getTime()
+        : end - 24 * 3600_000;
+      const now = Date.now();
+      const totalMs = end - start;
+      const remainingMs = Math.max(0, end - now);
+      const pct = totalMs > 0 ? Math.round((remainingMs / totalMs) * 100) : 0;
+      const hours = Math.floor(remainingMs / 3600_000);
+      const minutes = Math.floor((remainingMs % 3600_000) / 60_000);
+      setProgress({ pct, label: `${hours}h ${minutes}m` });
+    };
+    updateProgress();
+    const handle = window.setInterval(updateProgress, 60_000);
+    return () => window.clearInterval(handle);
+  }, [session?.rollback_available_until, session?.completed_at]);
+
+  if (!session) return null;
+
+  const handleRollback = async (): Promise<void> => {
+    setIsLoading(true);
+    try {
+      const response = await jsonFetch<{ restored: number; rolled_back_at: string }>(
+        `/api/bulk-sessions/${session.session_id}/rollback`,
+        { method: 'POST' },
+      );
+      toast.success(
+        t('products.rollback_toast.rolled_back', {
+          count: response.restored,
+          defaultValue: `Wycofano ${response.restored} zmian`,
+        }),
+      );
+      onRolledBack?.();
+      onDismiss();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'rollback failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-6 left-6 z-40 w-[380px]">
+      <div className="rounded-2xl bg-zinc-900 text-white shadow-2xl overflow-hidden">
+        <div className="px-4 pt-3.5 pb-3 flex items-start gap-3">
+          <span className="h-8 w-8 rounded-xl bg-emerald-500/15 text-emerald-300 grid place-items-center mt-0.5">
+            <Check className="size-4" />
+          </span>
+          <div className="flex-1 leading-snug">
+            <div className="text-[13px] font-semibold tracking-tight">
+              {t('products.rollback_toast.applied', {
+                defaultValue: 'Zastosowano akcję zbiorczą',
+              })}
+            </div>
+            <div className="text-[12px] text-white/70 mt-0.5 font-mono">{session.action}</div>
+            <div className="text-[11px] text-white/50 mt-1 tabular-nums">
+              {session.success_count} zmienione · {session.skipped_count} pominięte ·{' '}
+              {session.error_count} błędów · sesja{' '}
+              <span className="font-mono">{session.session_id.slice(0, 8)}</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+            className="text-white/40 hover:text-white"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="px-4 pb-3 flex items-center gap-2">
+          <div className="flex-1 h-1 rounded-full bg-white/10 overflow-hidden">
+            <div className="h-full bg-white/60" style={{ width: `${progress.pct}%` }} />
+          </div>
+          <span className="font-mono text-[10.5px] text-white/60 tabular-nums">
+            {progress.label}
+          </span>
+        </div>
+        <div className="px-3 pb-3 flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void handleRollback()}
+            disabled={isLoading}
+            className="flex-1 h-8 rounded-lg bg-white/10 hover:bg-white/15 text-[12px] font-medium inline-flex items-center justify-center gap-1.5 disabled:opacity-50"
+          >
+            <Undo2 className="size-3.5 text-white/70" />
+            {isLoading
+              ? t('products.rollback_toast.rolling_back', { defaultValue: 'Wycofuję…' })
+              : t('products.rollback_toast.undo', { defaultValue: 'Wycofaj' })}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -7,12 +7,14 @@ import { Link } from 'react-router';
 import { AdvancedFilterBuilder } from '@/components/catalog/advanced-filter-builder';
 import { AdvancedFilterPanel } from '@/components/catalog/advanced-filter-panel';
 import { BulkBar } from '@/components/catalog/bulk-bar';
+import { BulkWizard } from '@/components/catalog/bulk-wizard/bulk-wizard';
 import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
 import { type ExcelColumn, ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
 import { FilterChipsBar } from '@/components/catalog/filter-chips-bar';
 import { FilterPill } from '@/components/catalog/filter-pill';
 import type { FilterValue } from '@/components/catalog/product-filter-chips';
 import { ProductsGrid, type ProductsGridRow } from '@/components/catalog/products-grid';
+import { type RollbackSession, RollbackToast } from '@/components/catalog/rollback-toast';
 import { SaveAsSmartPresetModal } from '@/components/catalog/save-as-smart-preset-modal';
 import { SaveViewModal } from '@/components/catalog/save-view-modal';
 import { SavedViewsRail } from '@/components/catalog/saved-views-rail';
@@ -102,6 +104,10 @@ export function ProductListPage() {
     capped: boolean;
   }>({ active: false, totalMatched: 0, capped: false });
   const [crossPageLoading, setCrossPageLoading] = useState(false);
+  // VIEW-12 (#543) — bulk wizard open/close.
+  // VIEW-17 (#544) — sticky 24h rollback toast for the last applied session.
+  const [bulkWizardOpen, setBulkWizardOpen] = useState(false);
+  const [lastBulkSession, setLastBulkSession] = useState<RollbackSession | null>(null);
   const [variantsMode, setVariantsMode] = useState<VariantsMode>('tree');
   const [viewMode, setViewMode] = useState<ProductsViewMode>(() => {
     if (typeof window === 'undefined') return 'grid';
@@ -922,6 +928,28 @@ export function ProductListPage() {
           setShowSelectedOnly(false);
         }}
         onApplied={onBulkApplied}
+      />
+
+      {bulkWizardOpen ? (
+        <BulkWizard
+          open={bulkWizardOpen}
+          selectedIds={Array.from(selected)}
+          onClose={() => setBulkWizardOpen(false)}
+          onApplied={(result) => {
+            setLastBulkSession(result);
+            setSelected(new Set());
+            setShowSelectedOnly(false);
+            void refetch();
+          }}
+        />
+      ) : null}
+
+      <RollbackToast
+        session={lastBulkSession}
+        onDismiss={() => setLastBulkSession(null)}
+        onRolledBack={() => {
+          void refetch();
+        }}
       />
 
       {showSaveViewModal ? (

--- a/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * VIEW-17 (#544) — 24h soft rollback executor.
+ *
+ * Iterates `bulk_logs` in reverse insertion order (Doctrine `iterate()`
+ * for memory safety per CLAUDE.md FrankenPHP rule), restoring `old_value`
+ * on each `attributes_indexed` slot. Marks the session as rolled back
+ * so the toast disappears + the rollback button greys out.
+ *
+ * Only logs with `level=info` are reversed — `error` rows were never
+ * applied, and `warning` rows are skip-with-report entries that already
+ * left the row untouched.
+ *
+ * Hard expiry: rollback past `rollback_available_until` raises 400.
+ */
+final class BulkRollbackHandler
+{
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    public function rollback(BulkSession $session): int
+    {
+        if (!$session->isRollbackAvailable()) {
+            throw new BadRequestHttpException('Rollback window expired or already used.');
+        }
+
+        $this->bulkContext->setBulk(true);
+        $restored = 0;
+        try {
+            $logs = $this->em->getRepository(BulkLog::class)
+                ->createQueryBuilder('l')
+                ->where('l.bulkSessionId = :session')
+                ->andWhere('l.level = :level')
+                ->setParameter('session', $session->getId())
+                ->setParameter('level', BulkLog::LEVEL_INFO)
+                ->orderBy('l.createdAt', 'DESC')
+                ->getQuery()
+                ->toIterable();
+
+            $chunk = 0;
+            foreach ($logs as $log) {
+                $object = $this->catalogObjects->findById($log->getObjectId());
+                if (!$object instanceof CatalogObject) {
+                    continue;
+                }
+
+                $indexed = $object->getAttributesIndexed();
+                // The accompanying handler stamps `null` attributeId for
+                // attribute-level changes that targeted `attributes_indexed`
+                // directly — recover the slot by walking the old/new value
+                // pair instead of needing the attribute UUID.
+                $action = $session->getActionType();
+                if ('set_attribute' === $action) {
+                    $payload = $session->getActionPayload();
+                    $attrCode = isset($payload['attr']) && \is_string($payload['attr']) ? $payload['attr'] : null;
+                    if (null !== $attrCode) {
+                        if (null === $log->getOldValue()) {
+                            unset($indexed[$attrCode]);
+                        } else {
+                            $indexed[$attrCode] = $log->getOldValue();
+                        }
+                        $object->updateAttributeIndex($indexed);
+                        ++$restored;
+                    }
+                }
+
+                ++$chunk;
+                if ($chunk >= 200) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunk = 0;
+                }
+            }
+
+            if ($chunk > 0) {
+                $this->em->flush();
+            }
+
+            // Reload session in case clear() detached it.
+            $sessionFresh = $this->em->find(BulkSession::class, $session->getId());
+            if ($sessionFresh instanceof BulkSession) {
+                $sessionFresh->markRolledBack();
+                $this->em->flush();
+            }
+
+            return $restored;
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/BulkSessionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkSessionsController.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\Bulk\BulkRollbackHandler;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-17 (#544) — bulk session rollback + diff viewer endpoints.
+ *
+ * `POST /api/bulk-sessions/{id}/rollback` invokes the executor; the
+ * toast in `RollbackToast` calls this when the operator clicks
+ * *„Wycofaj"*. `GET /api/bulk-sessions/{id}` returns session details
+ * + log entries for the session-viewer drawer.
+ */
+final class BulkSessionsController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly BulkRollbackHandler $rollbackHandler,
+    ) {
+    }
+
+    #[Route('/api/bulk-sessions/{id}', name: 'pim_bulk_session_show', requirements: ['id' => self::UUID_REGEX], methods: ['GET'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function show(string $id): JsonResponse
+    {
+        $session = $this->loadSession($id);
+
+        $logs = $this->em->getRepository(BulkLog::class)
+            ->createQueryBuilder('l')
+            ->where('l.bulkSessionId = :s')
+            ->setParameter('s', $session->getId())
+            ->orderBy('l.createdAt', 'DESC')
+            ->setMaxResults(1000)
+            ->getQuery()
+            ->getResult();
+
+        return new JsonResponse([
+            'id' => $session->getId()->toRfc4122(),
+            'action_type' => $session->getActionType(),
+            'target_count' => $session->getTargetCount(),
+            'success_count' => $session->getSuccessCount(),
+            'skipped_count' => $session->getSkippedCount(),
+            'error_count' => $session->getErrorCount(),
+            'started_at' => $session->getStartedAt()->format(DateTimeInterface::ATOM),
+            'completed_at' => $session->getCompletedAt()?->format(DateTimeInterface::ATOM),
+            'rollback_available_until' => $session->getRollbackAvailableUntil()?->format(DateTimeInterface::ATOM),
+            'rolled_back_at' => $session->getRolledBackAt()?->format(DateTimeInterface::ATOM),
+            'is_rollback_available' => $session->isRollbackAvailable(),
+            'source' => $session->getSource(),
+            'logs' => array_map(
+                static fn (BulkLog $l): array => [
+                    'object_id' => $l->getObjectId()->toRfc4122(),
+                    'old_value' => $l->getOldValue(),
+                    'new_value' => $l->getNewValue(),
+                    'level' => $l->getLevel(),
+                    'message' => $l->getMessage(),
+                ],
+                $logs,
+            ),
+        ]);
+    }
+
+    #[Route('/api/bulk-sessions/{id}/rollback', name: 'pim_bulk_session_rollback', requirements: ['id' => self::UUID_REGEX], methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function rollback(string $id): JsonResponse
+    {
+        $session = $this->loadSession($id);
+        $restored = $this->rollbackHandler->rollback($session);
+
+        return new JsonResponse([
+            'restored' => $restored,
+            'rolled_back_at' => $session->getRolledBackAt()?->format(DateTimeInterface::ATOM),
+        ], Response::HTTP_OK);
+    }
+
+    private function loadSession(string $id): BulkSession
+    {
+        $session = $this->em->getRepository(BulkSession::class)->find(Uuid::fromString($id));
+        if (!$session instanceof BulkSession) {
+            throw new NotFoundHttpException(\sprintf('Bulk session %s not found.', $id));
+        }
+
+        return $session;
+    }
+}


### PR DESCRIPTION
## Summary
- `BulkRollbackHandler` iterates `bulk_logs` in reverse insertion order via Doctrine `iterate()` (memory-safe per FrankenPHP rule), restores `old_value` per `attributes_indexed` slot, marks session `rolledBackAt`. Hard cap on `rollback_available_until` raises 400 when expired.
- `BulkSessionsController` exposes `GET /api/bulk-sessions/{id}` (session detail + last 1000 logs) and `POST /api/bulk-sessions/{id}/rollback`.
- `RollbackToast` (sticky bottom-left, mockup `list-v2-overlays.jsx` l. 532-567): session counts + 24h progress bar (live update every 60s) + *„Wycofaj"* button → POST rollback → success toast + refetch.
- Wired into `list.tsx` via `BulkWizard.onApplied` callback (sets `lastBulkSession`, toast appears immediately after bulk apply).

## Status
- VIEW-17 ticket 6/12 epiku UI-09 marathon.
- ships executor + toast + GET/POST endpoints, **wired end-to-end** for `set_attribute` flow from VIEW-12.
- Session viewer drawer (mockup `list-v2-overlays.jsx` l. 568-650 — pełen audit panel) deferred to follow-up VIEW-17.1 — toast pokrywa 90% real-time UX, drawer to historia.

## Test plan
- [ ] Login `admin@demo.localhost` → otwórz `/products` → zaznacz 3 produkty → Bulk Wizard `set_attribute` brand=Test → Apply
- [ ] Toast pojawia się bottom-left z 24h progress bar
- [ ] Kliknij *„Wycofaj"* → POST `/api/bulk-sessions/{id}/rollback` → 200 → success toast + dane revertują
- [ ] DevTools Network: brak errorów
- [ ] DevTools Console: brak czerwonych errorów

Refs #544