### PR TITLE
feat(catalog): bulk attribute ops (VIEW-13)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-wizard/bulk-wizard.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/bulk-wizard.tsx
@@ -47,17 +47,83 @@ interface BulkActionResult {
   completed_at?: string;
 }
 
+type BulkMode =
+  | 'set_attribute'
+  | 'clear_attribute'
+  | 'append_value'
+  | 'remove_value'
+  | 'increment_numeric'
+  | 'multi_attribute_edit';
+
+const MODE_LABELS: Record<BulkMode, string> = {
+  set_attribute: 'Ustaw wartość',
+  clear_attribute: 'Wyczyść',
+  append_value: 'Dodaj do listy',
+  remove_value: 'Usuń z listy',
+  increment_numeric: 'Operacja arytm.',
+  multi_attribute_edit: 'Multi-atrybut',
+};
+
+interface MultiEdit {
+  id: string;
+  attr: string;
+  op: 'set' | 'clear';
+  value: string;
+}
+
+let multiEditCounter = 0;
+const nextEditId = (): string => `edit-${++multiEditCounter}`;
+
 export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizardProps) {
   const { t } = useTranslation();
   const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [mode, setMode] = useState<BulkMode>('set_attribute');
   const [attrCode, setAttrCode] = useState('');
   const [newValue, setNewValue] = useState('');
+  const [operator, setOperator] = useState<'+' | '-' | '*' | '/' | '%'>('*');
+  const [operand, setOperand] = useState('1.10');
+  const [edits, setEdits] = useState<MultiEdit[]>([
+    { id: nextEditId(), attr: '', op: 'set', value: '' },
+  ]);
   const [preview, setPreview] = useState<BulkActionPreview | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
   if (!open) return null;
 
-  const canAdvance = step === 1 ? attrCode.trim() !== '' && newValue.trim() !== '' : true;
+  const buildPayload = (): Record<string, unknown> => {
+    if (mode === 'multi_attribute_edit') {
+      return {
+        edits: edits
+          .filter((e) => e.attr.trim() !== '')
+          .map((e) => ({
+            attr: e.attr.trim(),
+            op: e.op,
+            ...(e.op === 'set' ? { value: e.value } : {}),
+          })),
+      };
+    }
+    if (mode === 'increment_numeric') {
+      return { attr: attrCode.trim(), operator, operand: Number(operand) };
+    }
+    if (mode === 'clear_attribute') {
+      return { attr: attrCode.trim() };
+    }
+    return { attr: attrCode.trim(), value: newValue };
+  };
+
+  const canAdvance = (() => {
+    if (step !== 1) return true;
+    if (mode === 'multi_attribute_edit') {
+      return edits.some((e) => e.attr.trim() !== '');
+    }
+    if (mode === 'clear_attribute') {
+      return attrCode.trim() !== '';
+    }
+    if (mode === 'increment_numeric') {
+      return attrCode.trim() !== '' && operand.trim() !== '' && !Number.isNaN(Number(operand));
+    }
+    return attrCode.trim() !== '' && newValue.trim() !== '';
+  })();
 
   const fetchPreview = async (): Promise<void> => {
     setIsLoading(true);
@@ -65,9 +131,9 @@ export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizard
       const response = await jsonFetch<BulkActionPreview>('/api/products/bulk-actions/preview', {
         method: 'POST',
         body: {
-          action: 'set_attribute',
+          action: mode,
           target_ids: selectedIds,
-          payload: { attr: attrCode, value: newValue },
+          payload: buildPayload(),
         },
       });
       setPreview(response);
@@ -81,16 +147,13 @@ export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizard
   const apply = async (): Promise<void> => {
     setIsLoading(true);
     try {
-      const response = await jsonFetch<BulkActionResult>(
-        '/api/products/bulk-actions/set_attribute',
-        {
-          method: 'POST',
-          body: {
-            target_ids: selectedIds,
-            payload: { attr: attrCode, value: newValue },
-          },
+      const response = await jsonFetch<BulkActionResult>(`/api/products/bulk-actions/${mode}`, {
+        method: 'POST',
+        body: {
+          target_ids: selectedIds,
+          payload: buildPayload(),
         },
-      );
+      });
       onApplied(response);
       toast.success(
         t('products.bulk_wizard.applied_success', {
@@ -194,35 +257,183 @@ export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizard
           {step === 1 && (
             <div className="space-y-4">
               <div>
-                <label
-                  htmlFor="bulk-attr-code"
-                  className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500"
-                >
-                  {t('products.bulk_wizard.attr_label', { defaultValue: 'Kod atrybutu' })}
-                </label>
-                <Input
-                  id="bulk-attr-code"
-                  value={attrCode}
-                  onChange={(e) => setAttrCode(e.target.value)}
-                  placeholder="brand, family, description_en …"
-                  className="mt-2"
-                />
+                <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500 mb-2">
+                  {t('products.bulk_wizard.mode_label', { defaultValue: 'Tryb operacji' })}
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  {(Object.keys(MODE_LABELS) as BulkMode[]).map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => setMode(m)}
+                      className={cn(
+                        'h-9 px-3 rounded-lg text-[12px] font-medium border',
+                        mode === m
+                          ? 'bg-zinc-900 text-white border-zinc-900'
+                          : 'bg-white text-zinc-700 border-zinc-200 hover:border-zinc-300',
+                      )}
+                    >
+                      {MODE_LABELS[m]}
+                    </button>
+                  ))}
+                </div>
               </div>
-              <div>
-                <label
-                  htmlFor="bulk-attr-value"
-                  className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500"
-                >
-                  {t('products.bulk_wizard.value_label', { defaultValue: 'Nowa wartość' })}
-                </label>
-                <Input
-                  id="bulk-attr-value"
-                  value={newValue}
-                  onChange={(e) => setNewValue(e.target.value)}
-                  placeholder="np. Festo"
-                  className="mt-2"
-                />
-              </div>
+              {mode !== 'multi_attribute_edit' && (
+                <div>
+                  <label
+                    htmlFor="bulk-attr-code"
+                    className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500"
+                  >
+                    {t('products.bulk_wizard.attr_label', { defaultValue: 'Kod atrybutu' })}
+                  </label>
+                  <Input
+                    id="bulk-attr-code"
+                    value={attrCode}
+                    onChange={(e) => setAttrCode(e.target.value)}
+                    placeholder="brand, family, description_en …"
+                    className="mt-2"
+                  />
+                </div>
+              )}
+              {(mode === 'set_attribute' || mode === 'append_value' || mode === 'remove_value') && (
+                <div>
+                  <label
+                    htmlFor="bulk-attr-value"
+                    className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500"
+                  >
+                    {mode === 'set_attribute'
+                      ? t('products.bulk_wizard.value_label', { defaultValue: 'Nowa wartość' })
+                      : mode === 'append_value'
+                        ? t('products.bulk_wizard.append_value_label', {
+                            defaultValue: 'Wartość do dodania',
+                          })
+                        : t('products.bulk_wizard.remove_value_label', {
+                            defaultValue: 'Wartość do usunięcia',
+                          })}
+                  </label>
+                  <Input
+                    id="bulk-attr-value"
+                    value={newValue}
+                    onChange={(e) => setNewValue(e.target.value)}
+                    placeholder="np. Festo"
+                    className="mt-2"
+                  />
+                </div>
+              )}
+              {mode === 'increment_numeric' && (
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label
+                      htmlFor="bulk-operator"
+                      className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500"
+                    >
+                      Operator
+                    </label>
+                    <select
+                      id="bulk-operator"
+                      value={operator}
+                      onChange={(e) => setOperator(e.target.value as '+' | '-' | '*' | '/' | '%')}
+                      className="mt-2 h-9 w-full rounded-lg border border-zinc-200 px-2 text-[13px] font-mono"
+                    >
+                      <option value="+">+ dodaj</option>
+                      <option value="-">- odejmij</option>
+                      <option value="*">* pomnóż</option>
+                      <option value="/">/ podziel</option>
+                      <option value="%">% modulo</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="bulk-operand"
+                      className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500"
+                    >
+                      Wartość
+                    </label>
+                    <Input
+                      id="bulk-operand"
+                      value={operand}
+                      onChange={(e) => setOperand(e.target.value)}
+                      placeholder="np. 1.10 (price *= 1.10)"
+                      className="mt-2 font-mono"
+                    />
+                  </div>
+                </div>
+              )}
+              {mode === 'multi_attribute_edit' && (
+                <div className="space-y-3">
+                  <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500">
+                    {t('products.bulk_wizard.multi_label', {
+                      defaultValue: 'Lista edycji (attr · op · value)',
+                    })}
+                  </div>
+                  {edits.map((edit) => (
+                    <div key={edit.id} className="flex gap-2 items-center">
+                      <Input
+                        value={edit.attr}
+                        onChange={(e) =>
+                          setEdits((arr) =>
+                            arr.map((row) =>
+                              row.id === edit.id ? { ...row, attr: e.target.value } : row,
+                            ),
+                          )
+                        }
+                        placeholder="attr code"
+                        className="flex-1"
+                      />
+                      <select
+                        value={edit.op}
+                        onChange={(e) =>
+                          setEdits((arr) =>
+                            arr.map((row) =>
+                              row.id === edit.id
+                                ? { ...row, op: e.target.value as 'set' | 'clear' }
+                                : row,
+                            ),
+                          )
+                        }
+                        className="h-9 w-24 rounded-lg border border-zinc-200 px-2 text-[13px]"
+                      >
+                        <option value="set">set</option>
+                        <option value="clear">clear</option>
+                      </select>
+                      {edit.op === 'set' && (
+                        <Input
+                          value={edit.value}
+                          onChange={(e) =>
+                            setEdits((arr) =>
+                              arr.map((row) =>
+                                row.id === edit.id ? { ...row, value: e.target.value } : row,
+                              ),
+                            )
+                          }
+                          placeholder="value"
+                          className="flex-1"
+                        />
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => setEdits((arr) => arr.filter((row) => row.id !== edit.id))}
+                        className="h-9 w-9 rounded-lg border border-zinc-200 text-zinc-500 hover:bg-zinc-50"
+                        aria-label="Remove edit row"
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setEdits((arr) => [
+                        ...arr,
+                        { id: nextEditId(), attr: '', op: 'set', value: '' },
+                      ])
+                    }
+                    className="h-8 px-3 rounded-lg border border-dashed border-zinc-300 text-[12px] font-medium text-zinc-600 hover:bg-zinc-50"
+                  >
+                    + Dodaj atrybut
+                  </button>
+                </div>
+              )}
             </div>
           )}
           {step === 2 && (

--- a/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-13 (#545) — `append_value` bulk action (multiselect-safe).
+ *
+ * Appends a value to a list attribute. If the attribute slot is null or
+ * scalar, it is promoted to `[old, new]` (dedup). If the value is
+ * already present, the row is skipped (no-op, info log).
+ */
+final class BulkAppendValueHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, string $attrCode, mixed $value): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $skipped = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$object instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $indexed = $object->getAttributesIndexed();
+                    $oldValue = $indexed[$attrCode] ?? null;
+                    $list = match (true) {
+                        \is_array($oldValue) => $oldValue,
+                        null === $oldValue => [],
+                        default => [$oldValue],
+                    };
+
+                    if (\in_array($value, $list, true)) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $oldValue,
+                            $oldValue,
+                            BulkLog::LEVEL_WARNING,
+                            'Value already present',
+                        ));
+                    } else {
+                        $list[] = $value;
+                        $indexed[$attrCode] = $list;
+                        $object->updateAttributeIndex($indexed);
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $oldValue,
+                            $list,
+                            BulkLog::LEVEL_INFO,
+                            null,
+                        ));
+                        ++$success;
+                    }
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, $skipped, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-13 (#545) — `clear_attribute` bulk action.
+ *
+ * Removes the attribute slot from `attributes_indexed` (unset). Used
+ * for resetting a field across N products. BulkLog records `old_value`
+ * for the 24h rollback path.
+ */
+final class BulkClearAttributeHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, string $attrCode): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$object instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $indexed = $object->getAttributesIndexed();
+                    $oldValue = $indexed[$attrCode] ?? null;
+                    unset($indexed[$attrCode]);
+                    $object->updateAttributeIndex($indexed);
+
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        $object->getId(),
+                        null,
+                        $oldValue,
+                        null,
+                        BulkLog::LEVEL_INFO,
+                        null,
+                    ));
+                    ++$success;
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, 0, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => 0, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-13 (#545) — `increment_numeric` bulk action.
+ *
+ * Applies an arithmetic operator (+ - * / %) to a numeric attribute
+ * across N products. Cmd+K killer use case (PRD §3.5): `price *= 1.10`.
+ * Skips rows where the current value is not numeric (warning log).
+ *
+ * Division-by-zero raises a per-row error log (no-op) rather than
+ * aborting the batch.
+ */
+final class BulkIncrementNumericHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, string $attrCode, string $operator, float $operand): array
+    {
+        if (!\in_array($operator, ['+', '-', '*', '/', '%'], true)) {
+            throw new BadRequestHttpException(\sprintf('Unsupported operator "%s".', $operator));
+        }
+
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $skipped = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$object instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $indexed = $object->getAttributesIndexed();
+                    $oldValue = $indexed[$attrCode] ?? null;
+
+                    if (!is_numeric($oldValue)) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $oldValue,
+                            $oldValue,
+                            BulkLog::LEVEL_WARNING,
+                            'Value is not numeric',
+                        ));
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $current = (float) $oldValue;
+                    $newValue = match ($operator) {
+                        '+' => $current + $operand,
+                        '-' => $current - $operand,
+                        '*' => $current * $operand,
+                        '/' => $this->safeDivide($current, $operand),
+                        '%' => $this->safeModulo($current, $operand),
+                    };
+
+                    if (null === $newValue) {
+                        ++$errors;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $oldValue,
+                            null,
+                            BulkLog::LEVEL_ERROR,
+                            'Division by zero',
+                        ));
+                    } else {
+                        $indexed[$attrCode] = $newValue;
+                        $object->updateAttributeIndex($indexed);
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $oldValue,
+                            $newValue,
+                            BulkLog::LEVEL_INFO,
+                            null,
+                        ));
+                        ++$success;
+                    }
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, $skipped, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+
+    private function safeDivide(float $a, float $b): ?float
+    {
+        if (0.0 === $b) {
+            return null;
+        }
+
+        return $a / $b;
+    }
+
+    private function safeModulo(float $a, float $b): ?float
+    {
+        if (0.0 === $b) {
+            return null;
+        }
+
+        return fmod($a, $b);
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-13 (#545) — `multi_attribute_edit` bulk action.
+ *
+ * Applies a list of (attr, op, value) tuples to each target in a single
+ * transaction per object. Each attribute change emits its own BulkLog
+ * (so rollback can replay individually). Supported ops: `set`, `clear`.
+ *
+ * Cmd+K killer use case (PRD §3.5): „skopiuj manufacturer do brand i
+ * ustaw enabled=true dla wszystkich z manufacturer IS NOT EMPTY".
+ */
+final class BulkMultiAttributeEditHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @param list<array{attr: string, op: string, value?: mixed}> $edits
+     *
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, array $edits): array
+    {
+        if ([] === $edits) {
+            throw new BadRequestHttpException('edits must be a non-empty list.');
+        }
+
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$object instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $indexed = $object->getAttributesIndexed();
+                    $rowChanged = false;
+                    foreach ($edits as $edit) {
+                        $code = $edit['attr'];
+                        $op = $edit['op'];
+                        $oldValue = $indexed[$code] ?? null;
+
+                        if ('set' === $op) {
+                            $newValue = $edit['value'] ?? null;
+                            $indexed[$code] = $newValue;
+                        } elseif ('clear' === $op) {
+                            $newValue = null;
+                            unset($indexed[$code]);
+                        } else {
+                            $this->em->persist(new BulkLog(
+                                $session->getId(),
+                                $object->getId(),
+                                null,
+                                $oldValue,
+                                $oldValue,
+                                BulkLog::LEVEL_ERROR,
+                                \sprintf('Unsupported edit op "%s" on attr "%s"', $op, $code),
+                            ));
+                            continue;
+                        }
+
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $oldValue,
+                            $newValue,
+                            BulkLog::LEVEL_INFO,
+                            $code,
+                        ));
+                        $rowChanged = true;
+                    }
+
+                    if ($rowChanged) {
+                        $object->updateAttributeIndex($indexed);
+                        ++$success;
+                    }
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, 0, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => 0, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-13 (#545) — `remove_value` bulk action (multiselect-safe).
+ *
+ * Removes a value from a list attribute. If the slot is scalar matching
+ * the value, it becomes null (unset). If the value is not present, the
+ * row is skipped (no-op, warning log).
+ */
+final class BulkRemoveValueHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, string $attrCode, mixed $value): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $skipped = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$object instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $indexed = $object->getAttributesIndexed();
+                    $oldValue = $indexed[$attrCode] ?? null;
+
+                    if (\is_array($oldValue)) {
+                        $idx = array_search($value, $oldValue, true);
+                        if (false === $idx) {
+                            ++$skipped;
+                            $this->em->persist(new BulkLog(
+                                $session->getId(),
+                                $object->getId(),
+                                null,
+                                $oldValue,
+                                $oldValue,
+                                BulkLog::LEVEL_WARNING,
+                                'Value not present',
+                            ));
+                        } else {
+                            $newList = array_values(array_filter(
+                                $oldValue,
+                                static fn ($v) => $v !== $value,
+                            ));
+                            $indexed[$attrCode] = $newList;
+                            $object->updateAttributeIndex($indexed);
+                            $this->em->persist(new BulkLog(
+                                $session->getId(),
+                                $object->getId(),
+                                null,
+                                $oldValue,
+                                $newList,
+                                BulkLog::LEVEL_INFO,
+                                null,
+                            ));
+                            ++$success;
+                        }
+                    } elseif ($oldValue === $value) {
+                        unset($indexed[$attrCode]);
+                        $object->updateAttributeIndex($indexed);
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $oldValue,
+                            null,
+                            BulkLog::LEVEL_INFO,
+                            null,
+                        ));
+                        ++$success;
+                    } else {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $oldValue,
+                            $oldValue,
+                            BulkLog::LEVEL_WARNING,
+                            'Value not present',
+                        ));
+                    }
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, $skipped, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace App\Catalog\Presentation\Controller;
 
+use App\Catalog\Application\Bulk\BulkAppendValueHandler;
+use App\Catalog\Application\Bulk\BulkClearAttributeHandler;
+use App\Catalog\Application\Bulk\BulkIncrementNumericHandler;
+use App\Catalog\Application\Bulk\BulkMultiAttributeEditHandler;
+use App\Catalog\Application\Bulk\BulkRemoveValueHandler;
 use App\Catalog\Application\Bulk\BulkSetAttributeHandler;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -41,6 +46,11 @@ final class BulkActionsController
         private readonly Security $security,
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly BulkSetAttributeHandler $setAttributeHandler,
+        private readonly BulkClearAttributeHandler $clearAttributeHandler,
+        private readonly BulkAppendValueHandler $appendValueHandler,
+        private readonly BulkRemoveValueHandler $removeValueHandler,
+        private readonly BulkIncrementNumericHandler $incrementNumericHandler,
+        private readonly BulkMultiAttributeEditHandler $multiAttributeEditHandler,
     ) {
     }
 
@@ -64,43 +74,134 @@ final class BulkActionsController
         $skipped = 0;
         $errors = 0;
 
-        if ('set_attribute' === $action) {
-            $attrCode = $payload['attr'] ?? null;
-            $newValue = $payload['value'] ?? null;
-            if (!\is_string($attrCode) || '' === $attrCode) {
-                throw new BadRequestHttpException('payload.attr is required.');
-            }
-            $sampleIds = \array_slice($targetIds, 0, 5);
-            foreach ($sampleIds as $id) {
-                try {
-                    $object = $this->catalogObjects->findById(Uuid::fromString($id));
-                    if (!$object instanceof CatalogObject) {
-                        ++$errors;
-                        continue;
-                    }
-                    $oldValue = $object->getAttributesIndexed()[$attrCode] ?? null;
-                    $sample[] = [
-                        'id' => $object->getId()->toRfc4122(),
-                        'sku' => $object->getCode(),
-                        'before' => $oldValue,
-                        'after' => $newValue,
-                    ];
-                } catch (Throwable) {
-                    ++$errors;
-                }
-            }
-
-            return new JsonResponse([
-                'action' => $action,
-                'target_count' => \count($targetIds),
-                'success_count' => \count($targetIds) - $skipped - $errors,
-                'skipped_count' => $skipped,
-                'error_count' => $errors,
-                'sample' => $sample,
-            ]);
+        if (!\in_array($action, [
+            'set_attribute',
+            'clear_attribute',
+            'append_value',
+            'remove_value',
+            'increment_numeric',
+            'multi_attribute_edit',
+        ], true)) {
+            throw new BadRequestHttpException(\sprintf('Unsupported bulk action "%s" in MVP.', $action));
         }
 
-        throw new BadRequestHttpException(\sprintf('Unsupported bulk action "%s" in MVP.', $action));
+        $sampleIds = \array_slice($targetIds, 0, 5);
+        foreach ($sampleIds as $id) {
+            try {
+                $object = $this->catalogObjects->findById(Uuid::fromString($id));
+                if (!$object instanceof CatalogObject) {
+                    ++$errors;
+                    continue;
+                }
+                [$before, $after] = $this->computePreviewDiff($action, $payload, $object);
+                $sample[] = [
+                    'id' => $object->getId()->toRfc4122(),
+                    'sku' => $object->getCode(),
+                    'before' => $before,
+                    'after' => $after,
+                ];
+            } catch (Throwable) {
+                ++$errors;
+            }
+        }
+
+        return new JsonResponse([
+            'action' => $action,
+            'target_count' => \count($targetIds),
+            'success_count' => \count($targetIds) - $skipped - $errors,
+            'skipped_count' => $skipped,
+            'error_count' => $errors,
+            'sample' => $sample,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{mixed, mixed}
+     */
+    private function computePreviewDiff(string $action, array $payload, CatalogObject $object): array
+    {
+        $indexed = $object->getAttributesIndexed();
+
+        if ('multi_attribute_edit' === $action) {
+            $edits = $payload['edits'] ?? [];
+            if (!\is_array($edits)) {
+                return [$indexed, $indexed];
+            }
+            $before = [];
+            $after = [];
+            foreach ($edits as $edit) {
+                if (!\is_array($edit) || !\is_string($edit['attr'] ?? null) || !\is_string($edit['op'] ?? null)) {
+                    continue;
+                }
+                $code = $edit['attr'];
+                $before[$code] = $indexed[$code] ?? null;
+                $after[$code] = 'clear' === $edit['op'] ? null : ($edit['value'] ?? null);
+            }
+
+            return [$before, $after];
+        }
+
+        $attrCode = $payload['attr'] ?? null;
+        if (!\is_string($attrCode) || '' === $attrCode) {
+            throw new BadRequestHttpException('payload.attr is required.');
+        }
+        $current = $indexed[$attrCode] ?? null;
+
+        return match ($action) {
+            'set_attribute' => [$current, $payload['value'] ?? null],
+            'clear_attribute' => [$current, null],
+            'append_value' => [$current, $this->previewAppend($current, $payload['value'] ?? null)],
+            'remove_value' => [$current, $this->previewRemove($current, $payload['value'] ?? null)],
+            'increment_numeric' => [$current, $this->previewIncrement(
+                $current,
+                \is_string($payload['operator'] ?? null) ? $payload['operator'] : '+',
+                is_numeric($payload['operand'] ?? null) ? (float) $payload['operand'] : 0.0,
+            )],
+            default => [$current, $current],
+        };
+    }
+
+    private function previewAppend(mixed $current, mixed $value): mixed
+    {
+        $list = match (true) {
+            \is_array($current) => $current,
+            null === $current => [],
+            default => [$current],
+        };
+        if (\in_array($value, $list, true)) {
+            return $list;
+        }
+        $list[] = $value;
+
+        return $list;
+    }
+
+    private function previewRemove(mixed $current, mixed $value): mixed
+    {
+        if (\is_array($current)) {
+            return array_values(array_filter($current, static fn ($v) => $v !== $value));
+        }
+
+        return $current === $value ? null : $current;
+    }
+
+    private function previewIncrement(mixed $current, string $operator, float $operand): mixed
+    {
+        if (!is_numeric($current)) {
+            return $current;
+        }
+        $base = (float) $current;
+
+        return match ($operator) {
+            '+' => $base + $operand,
+            '-' => $base - $operand,
+            '*' => $base * $operand,
+            '/' => 0.0 === $operand ? null : $base / $operand,
+            '%' => 0.0 === $operand ? null : fmod($base, $operand),
+            default => $base,
+        };
     }
 
     #[Route('/api/products/bulk-actions/{actionType}', name: 'pim_bulk_actions_apply', methods: ['POST'])]
@@ -136,8 +237,32 @@ final class BulkActionsController
         $result = match ($actionType) {
             'set_attribute' => $this->setAttributeHandler->handle(
                 $session,
-                \is_string($payload['attr'] ?? null) ? $payload['attr'] : '',
+                $this->requirePayloadAttr($payload),
                 $payload['value'] ?? null,
+            ),
+            'clear_attribute' => $this->clearAttributeHandler->handle(
+                $session,
+                $this->requirePayloadAttr($payload),
+            ),
+            'append_value' => $this->appendValueHandler->handle(
+                $session,
+                $this->requirePayloadAttr($payload),
+                $payload['value'] ?? null,
+            ),
+            'remove_value' => $this->removeValueHandler->handle(
+                $session,
+                $this->requirePayloadAttr($payload),
+                $payload['value'] ?? null,
+            ),
+            'increment_numeric' => $this->incrementNumericHandler->handle(
+                $session,
+                $this->requirePayloadAttr($payload),
+                \is_string($payload['operator'] ?? null) ? $payload['operator'] : '+',
+                is_numeric($payload['operand'] ?? null) ? (float) $payload['operand'] : 0.0,
+            ),
+            'multi_attribute_edit' => $this->multiAttributeEditHandler->handle(
+                $session,
+                $this->normaliseEdits($payload['edits'] ?? null),
             ),
             default => throw new NotFoundHttpException(\sprintf('Bulk action "%s" not implemented.', $actionType)),
         };
@@ -152,6 +277,50 @@ final class BulkActionsController
             'rollback_available_until' => $session->getRollbackAvailableUntil()?->format(DateTimeInterface::ATOM),
             'completed_at' => $session->getCompletedAt()?->format(DateTimeInterface::ATOM),
         ]);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function requirePayloadAttr(array $payload): string
+    {
+        $code = $payload['attr'] ?? null;
+        if (!\is_string($code) || '' === trim($code)) {
+            throw new BadRequestHttpException('payload.attr is required.');
+        }
+
+        return trim($code);
+    }
+
+    /**
+     * @return list<array{attr: string, op: string, value?: mixed}>
+     */
+    private function normaliseEdits(mixed $raw): array
+    {
+        if (!\is_array($raw)) {
+            throw new BadRequestHttpException('payload.edits must be a non-empty array.');
+        }
+        $out = [];
+        foreach ($raw as $edit) {
+            if (!\is_array($edit)) {
+                continue;
+            }
+            $code = $edit['attr'] ?? null;
+            $op = $edit['op'] ?? null;
+            if (!\is_string($code) || '' === $code || !\is_string($op)) {
+                continue;
+            }
+            $entry = ['attr' => $code, 'op' => $op];
+            if (\array_key_exists('value', $edit)) {
+                $entry['value'] = $edit['value'];
+            }
+            $out[] = $entry;
+        }
+        if ([] === $out) {
+            throw new BadRequestHttpException('payload.edits has no valid entries.');
+        }
+
+        return $out;
     }
 
     /**


### PR DESCRIPTION
## Summary
Five new bulk handlers extending the VIEW-12 wizard, each sharing the chunked flush+clear pattern (FrankenPHP worker memory rule, CHUNK_SIZE=200) and emitting BulkLog rows for the 24h rollback path:
- `BulkClearAttributeHandler` — unsets a slot in `attributes_indexed`
- `BulkAppendValueHandler` — dedup-appends to multiselect/list slots
- `BulkRemoveValueHandler` — removes a value (scalar→null, array→filtered)
- `BulkIncrementNumericHandler` — applies `+ - * / %` with safe divzero / modzero
- `BulkMultiAttributeEditHandler` — runs `set|clear` on N attributes per object in one transaction

`BulkActionsController.preview()` routes per-action diff computation (sample 5 + after value pre-computed deterministically); `apply()` dispatches to handlers via `match()`. Wizard Step 1 grows a **6-mode picker**; per-mode forms render conditionally:
- `increment_numeric` → operator dropdown + operand input (Cmd+K killer use case `price *= 1.10`)
- `multi_attribute_edit` → repeatable `[attr, op, value]` rows with stable IDs
- `set/append/remove` → value input
- `clear` → no value input

## Test plan
- [ ] Login → `/products` → select 3 produkty → Wizard → **Wybierz „Operacja arytm."** + `attr=price, *, 1.10` → preview → Apply → success toast
- [ ] Wizard → **„Multi-atrybut"** → 2 rows `[brand=Festo, enabled=true]` → preview shows both diffs → Apply
- [ ] Wizard → **„Wyczyść"** + `attr=description_en` → preview shows `before / null` → Apply
- [ ] Wycofaj toast (VIEW-17) revertuje każdą z 5 nowych operacji

Refs #545