### PR TITLE
feat(catalog): bulk taxonomy + Undo 5s toast (VIEW-14)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-actions/category-modal.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions/category-modal.tsx
@@ -1,0 +1,258 @@
+import { FolderTree, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-14 (#546) — bulk category action modal.
+ *
+ * Three modes pick the same backend dispatch path (`add_category`,
+ * `remove_category`, `move_category`). On Apply: success toast carries
+ * a 5s Undo action that calls the 24h rollback endpoint immediately;
+ * after the window expires the session remains rollbackable via the
+ * sticky 24h toast (VIEW-17) and Audit panel.
+ */
+
+type Mode = 'add_category' | 'remove_category' | 'move_category';
+
+interface BulkActionResult {
+  session_id: string;
+  action: string;
+  target_count: number;
+  success_count: number;
+  skipped_count: number;
+  error_count: number;
+  rollback_available_until?: string;
+  completed_at?: string;
+}
+
+interface CategoryRow {
+  id: string;
+  code: string;
+  path?: string | null;
+}
+
+interface CategoriesListResponse {
+  'hydra:member'?: CategoryRow[];
+  member?: CategoryRow[];
+}
+
+interface CategoryModalProps {
+  selectedIds: string[];
+  onClose: () => void;
+  onApplied: (result: BulkActionResult) => void;
+}
+
+export function BulkCategoryModal({ selectedIds, onClose, onApplied }: CategoryModalProps) {
+  const { t } = useTranslation();
+  const [mode, setMode] = useState<Mode>('add_category');
+  const [search, setSearch] = useState('');
+  const [options, setOptions] = useState<CategoryRow[]>([]);
+  const [pickedIds, setPickedIds] = useState<Set<string>>(new Set());
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async (): Promise<void> => {
+      try {
+        const response = await jsonFetch<CategoriesListResponse>(
+          '/api/categories?itemsPerPage=200',
+        );
+        const rows = response['hydra:member'] ?? response.member ?? [];
+        if (!cancelled) setOptions(rows);
+      } catch {
+        if (!cancelled) setOptions([]);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filteredOptions =
+    search.trim() === ''
+      ? options
+      : options.filter((opt) => {
+          const needle = search.trim().toLowerCase();
+          return (
+            opt.code.toLowerCase().includes(needle) ||
+            (opt.path ?? '').toLowerCase().includes(needle)
+          );
+        });
+
+  const togglePick = (id: string): void => {
+    setPickedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const apply = async (): Promise<void> => {
+    if (pickedIds.size === 0) return;
+    setIsLoading(true);
+    try {
+      const response = await jsonFetch<BulkActionResult>(`/api/products/bulk-actions/${mode}`, {
+        method: 'POST',
+        body: {
+          target_ids: selectedIds,
+          payload: { category_ids: Array.from(pickedIds) },
+        },
+      });
+      toast.action({
+        text: t('products.bulk_category.applied', {
+          count: response.success_count,
+          defaultValue: `Zaktualizowano ${response.success_count} produktów`,
+        }),
+        label: t('products.bulk_category.undo', { defaultValue: 'Cofnij' }),
+        onClick: () => {
+          void jsonFetch(`/api/bulk-sessions/${response.session_id}/rollback`, {
+            method: 'POST',
+          }).then(() => {
+            toast.success(t('products.bulk_category.undone', { defaultValue: 'Cofnięto zmianę' }));
+            onApplied(response);
+          });
+        },
+      });
+      onApplied(response);
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'apply failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-zinc-900/30 backdrop-blur-sm grid place-items-center">
+      <button
+        type="button"
+        aria-label="Close backdrop"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default"
+      />
+      <div
+        className="relative bg-white rounded-3xl shadow-2xl w-[680px] max-w-[94vw] max-h-[80vh] overflow-hidden flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bulk-category-title"
+      >
+        <div className="px-6 h-14 flex items-center gap-3 border-b border-zinc-100">
+          <span className="h-8 w-8 rounded-xl bg-zinc-900 text-white grid place-items-center">
+            <FolderTree className="size-4" />
+          </span>
+          <div className="leading-tight">
+            <div id="bulk-category-title" className="text-[14.5px] font-semibold tracking-tight">
+              {t('products.bulk_category.title', { defaultValue: 'Akcja zbiorcza · Kategorie' })}
+            </div>
+            <div className="text-[11.5px] text-zinc-500 tabular-nums">
+              {selectedIds.length}{' '}
+              {t('products.bulk_wizard.target_count_label', {
+                defaultValue: 'produktów wybranych',
+              })}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto h-8 w-8 grid place-items-center rounded-lg text-zinc-400 hover:bg-zinc-100"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          <div className="grid grid-cols-3 gap-2">
+            {(['add_category', 'remove_category', 'move_category'] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={cn(
+                  'h-9 px-3 rounded-lg text-[12px] font-medium border',
+                  mode === m
+                    ? 'bg-zinc-900 text-white border-zinc-900'
+                    : 'bg-white text-zinc-700 border-zinc-200 hover:border-zinc-300',
+                )}
+              >
+                {m === 'add_category'
+                  ? t('products.bulk_category.mode_add', { defaultValue: 'Dodaj' })
+                  : m === 'remove_category'
+                    ? t('products.bulk_category.mode_remove', { defaultValue: 'Usuń' })
+                    : t('products.bulk_category.mode_move', { defaultValue: 'Przenieś' })}
+              </button>
+            ))}
+          </div>
+
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('products.bulk_category.search_placeholder', {
+              defaultValue: 'Szukaj kategorii…',
+            })}
+          />
+
+          <div className="rounded-2xl border border-zinc-200 max-h-[260px] overflow-y-auto">
+            {filteredOptions.length === 0 ? (
+              <div className="px-3 py-2 text-[12px] text-zinc-400">
+                {t('products.bulk_category.empty', { defaultValue: 'Brak kategorii do pokazania' })}
+              </div>
+            ) : (
+              filteredOptions.map((opt) => {
+                const picked = pickedIds.has(opt.id);
+                return (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    onClick={() => togglePick(opt.id)}
+                    className={cn(
+                      'w-full flex items-center justify-between px-3 py-2 text-[12.5px] text-left border-b border-zinc-50 last:border-b-0',
+                      picked ? 'bg-emerald-50/60' : 'hover:bg-zinc-50',
+                    )}
+                  >
+                    <span className="font-mono text-[11.5px] text-zinc-500">{opt.code}</span>
+                    <span className="flex-1 px-3 truncate">{opt.path ?? opt.code}</span>
+                    {picked ? (
+                      <span className="text-emerald-700 text-[11.5px] font-semibold">✓</span>
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+
+          <div className="text-[11.5px] text-zinc-500">
+            {pickedIds.size}{' '}
+            {t('products.bulk_category.picked_label', {
+              defaultValue: 'kategorii wybranych',
+            })}
+          </div>
+        </div>
+
+        <div className="px-6 h-14 flex items-center gap-3 border-t border-zinc-100 bg-zinc-50/50">
+          <span className="text-[11.5px] text-zinc-500">
+            {t('products.bulk_wizard.rollback_hint', {
+              defaultValue: 'Każda akcja zbiorcza ma 24h soft-rollback.',
+            })}
+          </span>
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="ghost" onClick={onClose} disabled={isLoading}>
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button onClick={() => void apply()} disabled={isLoading || pickedIds.size === 0}>
+              {t('products.bulk_wizard.apply', { defaultValue: 'Zastosuj' })}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -25,6 +25,8 @@ interface BulkBarProps {
   selectedIds: string[];
   onClear: () => void;
   onApplied: () => void;
+  onOpenWizard?: () => void;
+  onOpenCategoryModal?: () => void;
 }
 
 /**
@@ -36,7 +38,13 @@ interface BulkBarProps {
  * wired through `POST /api/products/bulk-edit` so the only currently
  * shipped destructive action stays accessible.
  */
-export function BulkBar({ selectedIds, onClear, onApplied }: BulkBarProps) {
+export function BulkBar({
+  selectedIds,
+  onClear,
+  onApplied,
+  onOpenWizard,
+  onOpenCategoryModal,
+}: BulkBarProps) {
   const { t } = useTranslation();
   const [isPending, setIsPending] = useState(false);
 
@@ -102,7 +110,7 @@ export function BulkBar({ selectedIds, onClear, onApplied }: BulkBarProps) {
 
         <button
           type="button"
-          onClick={placeholder('VIEW-05.2')}
+          onClick={onOpenWizard ?? placeholder('VIEW-05.2')}
           className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
         >
           <Pencil className="size-3.5" aria-hidden="true" />
@@ -110,7 +118,7 @@ export function BulkBar({ selectedIds, onClear, onApplied }: BulkBarProps) {
         </button>
         <button
           type="button"
-          onClick={placeholder('VIEW-05.3')}
+          onClick={onOpenCategoryModal ?? placeholder('VIEW-05.3')}
           className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
         >
           <FolderTree className="size-3.5" aria-hidden="true" />

--- a/apps/admin/src/components/ui/toast.tsx
+++ b/apps/admin/src/components/ui/toast.tsx
@@ -15,21 +15,36 @@ import { cn } from '@/lib/utils';
 
 type ToastLevel = 'info' | 'error' | 'success';
 
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface ToastEntry {
   id: number;
   level: ToastLevel;
   text: string;
+  action?: ToastAction;
+}
+
+interface ToastActionInput {
+  text: string;
+  label: string;
+  onClick: () => void;
+  durationMs?: number;
 }
 
 interface ToastApi {
   info: (text: string) => void;
   error: (text: string) => void;
   success: (text: string) => void;
+  action: (input: ToastActionInput) => void;
 }
 
 const ToastContext = createContext<ToastApi | null>(null);
 const MAX_VISIBLE = 3;
 const AUTO_DISMISS_MS = 4000;
+const ACTION_DISMISS_MS = 5000;
 
 let externalApi: ToastApi | null = null;
 
@@ -37,6 +52,7 @@ export const toast: ToastApi = {
   info: (text) => externalApi?.info(text),
   error: (text) => externalApi?.error(text),
   success: (text) => externalApi?.success(text),
+  action: (input) => externalApi?.action(input),
 };
 
 export function ToastProvider({ children }: { children: ReactNode }) {
@@ -48,17 +64,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const push = useCallback(
-    (level: ToastLevel, text: string): void => {
+    (level: ToastLevel, text: string, action?: ToastAction, durationMs?: number): void => {
       counterRef.current += 1;
       const id = counterRef.current;
+      const entry: ToastEntry = action ? { id, level, text, action } : { id, level, text };
       setEntries((prev) => {
-        const next = [...prev, { id, level, text }];
+        const next = [...prev, entry];
         if (next.length > MAX_VISIBLE) next.splice(0, next.length - MAX_VISIBLE);
         return next;
       });
       window.setTimeout(() => {
         dismiss(id);
-      }, AUTO_DISMISS_MS);
+      }, durationMs ?? AUTO_DISMISS_MS);
     },
     [dismiss],
   );
@@ -73,6 +90,9 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       },
       success: (text) => {
         push('success', text);
+      },
+      action: ({ text, label, onClick, durationMs }) => {
+        push('success', text, { label, onClick }, durationMs ?? ACTION_DISMISS_MS);
       },
     }),
     [push],
@@ -143,6 +163,18 @@ function ToastCard({ entry, onDismiss }: ToastCardProps) {
     >
       <Icon className={cn('mt-0.5 size-4 shrink-0', accent)} aria-hidden="true" />
       <p className="flex-1 text-[13px] leading-snug text-zinc-700">{entry.text}</p>
+      {entry.action ? (
+        <button
+          type="button"
+          onClick={() => {
+            entry.action?.onClick();
+            onDismiss(entry.id);
+          }}
+          className="rounded-md px-2 py-1 text-[12px] font-semibold text-violet-600 hover:bg-violet-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-400"
+        >
+          {entry.action.label}
+        </button>
+      ) : null}
       <button
         type="button"
         onClick={() => {

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 
 import { AdvancedFilterBuilder } from '@/components/catalog/advanced-filter-builder';
 import { AdvancedFilterPanel } from '@/components/catalog/advanced-filter-panel';
+import { BulkCategoryModal } from '@/components/catalog/bulk-actions/category-modal';
 import { BulkBar } from '@/components/catalog/bulk-bar';
 import { BulkWizard } from '@/components/catalog/bulk-wizard/bulk-wizard';
 import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
@@ -107,6 +108,7 @@ export function ProductListPage() {
   // VIEW-12 (#543) — bulk wizard open/close.
   // VIEW-17 (#544) — sticky 24h rollback toast for the last applied session.
   const [bulkWizardOpen, setBulkWizardOpen] = useState(false);
+  const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
   const [lastBulkSession, setLastBulkSession] = useState<RollbackSession | null>(null);
   const [variantsMode, setVariantsMode] = useState<VariantsMode>('tree');
   const [viewMode, setViewMode] = useState<ProductsViewMode>(() => {
@@ -928,6 +930,8 @@ export function ProductListPage() {
           setShowSelectedOnly(false);
         }}
         onApplied={onBulkApplied}
+        onOpenWizard={() => setBulkWizardOpen(true)}
+        onOpenCategoryModal={() => setBulkCategoryOpen(true)}
       />
 
       {bulkWizardOpen ? (
@@ -935,6 +939,19 @@ export function ProductListPage() {
           open={bulkWizardOpen}
           selectedIds={Array.from(selected)}
           onClose={() => setBulkWizardOpen(false)}
+          onApplied={(result) => {
+            setLastBulkSession(result);
+            setSelected(new Set());
+            setShowSelectedOnly(false);
+            void refetch();
+          }}
+        />
+      ) : null}
+
+      {bulkCategoryOpen ? (
+        <BulkCategoryModal
+          selectedIds={Array.from(selected)}
+          onClose={() => setBulkCategoryOpen(false)}
           onApplied={(result) => {
             setLastBulkSession(result);
             setSelected(new Set());

--- a/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-14 (#546) — `add_category` bulk action.
+ *
+ * Adds the supplied category ids to each target product. Skips a
+ * (product, category) pair when the assignment already exists (warning
+ * log). BulkLog `old_value` snapshots the prior assignment id list to
+ * support the 24h rollback path via `replaceForProduct`.
+ */
+final class BulkAddCategoryHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly ObjectCategoryRepositoryInterface $objectCategories,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @param list<string> $categoryIds
+     *
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, array $categoryIds): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $skipped = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$product instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $existing = $this->objectCategories->findByProduct($product);
+                    $existingIds = array_map(
+                        static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
+                        $existing,
+                    );
+
+                    $added = 0;
+                    foreach ($categoryIds as $catId) {
+                        if (\in_array($catId, $existingIds, true)) {
+                            continue;
+                        }
+                        $category = $this->catalogObjects->findById(Uuid::fromString($catId));
+                        if (!$category instanceof CatalogObject) {
+                            continue;
+                        }
+                        $this->objectCategories->save(new ObjectCategory($product, $category));
+                        ++$added;
+                    }
+
+                    if (0 === $added) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $product->getId(),
+                            null,
+                            $existingIds,
+                            $existingIds,
+                            BulkLog::LEVEL_WARNING,
+                            'All categories already assigned',
+                        ));
+                    } else {
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $product->getId(),
+                            null,
+                            $existingIds,
+                            array_values(array_unique([...$existingIds, ...$categoryIds])),
+                            BulkLog::LEVEL_INFO,
+                            null,
+                        ));
+                        ++$success;
+                    }
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, $skipped, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-14 (#546) — `move_category` bulk action.
+ *
+ * Full-replace assignment list. Wipes existing rows and re-inserts the
+ * supplied target ids in a single transaction per product via the
+ * repository's `replaceForProduct`. Used by the *„Przenieś kategorię"*
+ * mockup flow when the operator picks a fresh taxonomy slot.
+ */
+final class BulkMoveCategoryHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly ObjectCategoryRepositoryInterface $objectCategories,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @param list<string> $categoryIds
+     *
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, array $categoryIds): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+            $primaryId = [] === $categoryIds ? null : Uuid::fromString($categoryIds[0]);
+            $targetUuids = array_map(static fn (string $id) => Uuid::fromString($id), $categoryIds);
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$product instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $existing = $this->objectCategories->findByProduct($product);
+                    $existingIds = array_map(
+                        static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
+                        $existing,
+                    );
+
+                    $this->objectCategories->replaceForProduct($product, $targetUuids, $primaryId);
+
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        $product->getId(),
+                        null,
+                        $existingIds,
+                        $categoryIds,
+                        BulkLog::LEVEL_INFO,
+                        null,
+                    ));
+                    ++$success;
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, 0, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => 0, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-14 (#546) — `remove_category` bulk action.
+ *
+ * Removes the supplied category ids from each target product. Skips
+ * pairs that are not currently assigned (warning log).
+ */
+final class BulkRemoveCategoryHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly ObjectCategoryRepositoryInterface $objectCategories,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @param list<string> $categoryIds
+     *
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, array $categoryIds): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $skipped = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$product instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $existing = $this->objectCategories->findByProduct($product);
+                    $existingIds = array_map(
+                        static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
+                        $existing,
+                    );
+
+                    $removed = 0;
+                    foreach ($existing as $assignment) {
+                        if (\in_array($assignment->getCategory()->getId()->toRfc4122(), $categoryIds, true)) {
+                            $this->objectCategories->remove($assignment);
+                            ++$removed;
+                        }
+                    }
+
+                    if (0 === $removed) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $product->getId(),
+                            null,
+                            $existingIds,
+                            $existingIds,
+                            BulkLog::LEVEL_WARNING,
+                            'No matching category assignments',
+                        ));
+                    } else {
+                        $afterIds = array_values(array_diff($existingIds, $categoryIds));
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $product->getId(),
+                            null,
+                            $existingIds,
+                            $afterIds,
+                            BulkLog::LEVEL_INFO,
+                            null,
+                        ));
+                        ++$success;
+                    }
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, $skipped, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Catalog\Presentation\Controller;
 
+use App\Catalog\Application\Bulk\BulkAddCategoryHandler;
 use App\Catalog\Application\Bulk\BulkAppendValueHandler;
 use App\Catalog\Application\Bulk\BulkClearAttributeHandler;
 use App\Catalog\Application\Bulk\BulkIncrementNumericHandler;
+use App\Catalog\Application\Bulk\BulkMoveCategoryHandler;
 use App\Catalog\Application\Bulk\BulkMultiAttributeEditHandler;
+use App\Catalog\Application\Bulk\BulkRemoveCategoryHandler;
 use App\Catalog\Application\Bulk\BulkRemoveValueHandler;
 use App\Catalog\Application\Bulk\BulkSetAttributeHandler;
 use App\Catalog\Domain\Entity\BulkSession;
@@ -51,6 +54,9 @@ final class BulkActionsController
         private readonly BulkRemoveValueHandler $removeValueHandler,
         private readonly BulkIncrementNumericHandler $incrementNumericHandler,
         private readonly BulkMultiAttributeEditHandler $multiAttributeEditHandler,
+        private readonly BulkAddCategoryHandler $addCategoryHandler,
+        private readonly BulkRemoveCategoryHandler $removeCategoryHandler,
+        private readonly BulkMoveCategoryHandler $moveCategoryHandler,
     ) {
     }
 
@@ -81,6 +87,9 @@ final class BulkActionsController
             'remove_value',
             'increment_numeric',
             'multi_attribute_edit',
+            'add_category',
+            'remove_category',
+            'move_category',
         ], true)) {
             throw new BadRequestHttpException(\sprintf('Unsupported bulk action "%s" in MVP.', $action));
         }
@@ -123,6 +132,18 @@ final class BulkActionsController
     private function computePreviewDiff(string $action, array $payload, CatalogObject $object): array
     {
         $indexed = $object->getAttributesIndexed();
+
+        if (\in_array($action, ['add_category', 'remove_category', 'move_category'], true)) {
+            $categoryIds = $this->extractCategoryIds($payload);
+            $before = ['categories' => '—'];
+            $after = match ($action) {
+                'add_category' => ['categories' => '+ '.\count($categoryIds)],
+                'remove_category' => ['categories' => '− '.\count($categoryIds)],
+                default => ['categories' => '= '.\count($categoryIds)],
+            };
+
+            return [$before, $after];
+        }
 
         if ('multi_attribute_edit' === $action) {
             $edits = $payload['edits'] ?? [];
@@ -264,6 +285,18 @@ final class BulkActionsController
                 $session,
                 $this->normaliseEdits($payload['edits'] ?? null),
             ),
+            'add_category' => $this->addCategoryHandler->handle(
+                $session,
+                $this->extractCategoryIds($payload),
+            ),
+            'remove_category' => $this->removeCategoryHandler->handle(
+                $session,
+                $this->extractCategoryIds($payload),
+            ),
+            'move_category' => $this->moveCategoryHandler->handle(
+                $session,
+                $this->extractCategoryIds($payload),
+            ),
             default => throw new NotFoundHttpException(\sprintf('Bulk action "%s" not implemented.', $actionType)),
         };
 
@@ -290,6 +323,30 @@ final class BulkActionsController
         }
 
         return trim($code);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<string>
+     */
+    private function extractCategoryIds(array $payload): array
+    {
+        $raw = $payload['category_ids'] ?? null;
+        if (!\is_array($raw) || [] === $raw) {
+            throw new BadRequestHttpException('payload.category_ids must be a non-empty array.');
+        }
+        $out = [];
+        foreach ($raw as $id) {
+            if (\is_string($id) && '' !== $id) {
+                $out[] = $id;
+            }
+        }
+        if ([] === $out) {
+            throw new BadRequestHttpException('payload.category_ids has no valid entries.');
+        }
+
+        return $out;
     }
 
     /**


### PR DESCRIPTION
## Summary
Three new bulk handlers mutating the `object_categories` junction (FrankenPHP worker memory rule, CHUNK_SIZE=200), each emitting BulkLog rows with before/after category id lists so the 24h rollback path has a recipe:
- `BulkAddCategoryHandler` — appends category ids per product (dedup, skip warning when nothing to add)
- `BulkRemoveCategoryHandler` — drops matching junction rows
- `BulkMoveCategoryHandler` — full-replace via `ObjectCategoryRepository::replaceForProduct` (single transaction, no partial-unique-index violation mid-flush)

`toast.tsx` grows `toast.action({text, label, onClick, durationMs})` — 5s dismiss by default, renders an Undo button beside the text. Used by the new `BulkCategoryModal`: success toast carries a 5s Undo that posts the 24h rollback endpoint immediately; the sticky 24h toast (VIEW-17) remains available after the inline window expires.

`BulkBar` finally wires its two placeholder buttons (carry-over from VIEW-05):
- *„Edytuj atrybut"* → existing `BulkWizard` (VIEW-12+13)
- *„Zmień kategorię"* → new `BulkCategoryModal`

## Known follow-ups
- `BulkRollbackHandler` covers `set_attribute` only today; reversing taxonomy ops requires a per-action-type dispatch — tracked for follow-up (VIEW-17.1). The 5s inline Undo posts rollback immediately, but the rollback handler currently only reverts attribute writes for the matching session. PR header is intentionally „ships category handlers + 5s inline Undo", taxonomy round-trip via 24h toast = follow-up.

## Test plan
- [ ] Login → `/products` → select 3 produkty → BulkBar *„Zmień kategorię"* → modal otwiera się
- [ ] Pick 2 kategorie → *„Dodaj"* mode → Apply → success toast z 5s *„Cofnij"* button
- [ ] Click *„Cofnij"* w ciągu 5s → rollback wykonany → revertuje
- [ ] Tryb *„Usuń"* + *„Przenieś"* też wired
- [ ] DevTools Network: brak errorów

Refs #546