### PR TITLE
feat(catalog): bulk channels publish/unpublish + cascade (VIEW-15)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-actions/publish-modal.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions/publish-modal.tsx
@@ -1,0 +1,235 @@
+import { Globe, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-15 (#547) — bulk channel publish modal.
+ *
+ * Two modes (`publish_channels` / `unpublish_channels`) share the picker
+ * UX. Cascade impact banner surfaces variant + cross-sell counts so the
+ * operator sees the blast radius before confirming. Backend writes the
+ * soft `attributes_indexed.published[channel_code]` flag — real
+ * integration adapter calls (Shopify, BaseLinker) land in epik 0.6/0.9.
+ */
+
+type Mode = 'publish_channels' | 'unpublish_channels';
+
+interface BulkActionResult {
+  session_id: string;
+  action: string;
+  target_count: number;
+  success_count: number;
+  skipped_count: number;
+  error_count: number;
+  rollback_available_until?: string;
+  completed_at?: string;
+}
+
+interface ChannelRow {
+  code: string;
+  name?: string | null;
+}
+
+interface ChannelsListResponse {
+  'hydra:member'?: ChannelRow[];
+  member?: ChannelRow[];
+}
+
+interface PublishModalProps {
+  selectedIds: string[];
+  onClose: () => void;
+  onApplied: (result: BulkActionResult) => void;
+}
+
+export function BulkPublishModal({ selectedIds, onClose, onApplied }: PublishModalProps) {
+  const { t } = useTranslation();
+  const [mode, setMode] = useState<Mode>('publish_channels');
+  const [channels, setChannels] = useState<ChannelRow[]>([]);
+  const [pickedCodes, setPickedCodes] = useState<Set<string>>(new Set());
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async (): Promise<void> => {
+      try {
+        const response = await jsonFetch<ChannelsListResponse>('/api/channels?itemsPerPage=100');
+        const rows = response['hydra:member'] ?? response.member ?? [];
+        if (!cancelled) setChannels(rows);
+      } catch {
+        if (!cancelled) setChannels([]);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const togglePick = (code: string): void => {
+    setPickedCodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
+  };
+
+  const apply = async (): Promise<void> => {
+    if (pickedCodes.size === 0) return;
+    setIsLoading(true);
+    try {
+      const response = await jsonFetch<BulkActionResult>(`/api/products/bulk-actions/${mode}`, {
+        method: 'POST',
+        body: {
+          target_ids: selectedIds,
+          payload: { channel_codes: Array.from(pickedCodes) },
+        },
+      });
+      toast.success(
+        t('products.bulk_publish.applied', {
+          count: response.success_count,
+          defaultValue: `Zaktualizowano ${response.success_count} produktów`,
+        }),
+      );
+      onApplied(response);
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'apply failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-zinc-900/30 backdrop-blur-sm grid place-items-center">
+      <button
+        type="button"
+        aria-label="Close backdrop"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default"
+      />
+      <div
+        className="relative bg-white rounded-3xl shadow-2xl w-[680px] max-w-[94vw] max-h-[80vh] overflow-hidden flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bulk-publish-title"
+      >
+        <div className="px-6 h-14 flex items-center gap-3 border-b border-zinc-100">
+          <span className="h-8 w-8 rounded-xl bg-zinc-900 text-white grid place-items-center">
+            <Globe className="size-4" />
+          </span>
+          <div className="leading-tight">
+            <div id="bulk-publish-title" className="text-[14.5px] font-semibold tracking-tight">
+              {t('products.bulk_publish.title', { defaultValue: 'Akcja zbiorcza · Kanały' })}
+            </div>
+            <div className="text-[11.5px] text-zinc-500 tabular-nums">
+              {selectedIds.length}{' '}
+              {t('products.bulk_wizard.target_count_label', {
+                defaultValue: 'produktów wybranych',
+              })}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto h-8 w-8 grid place-items-center rounded-lg text-zinc-400 hover:bg-zinc-100"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          <div className="grid grid-cols-2 gap-2">
+            {(['publish_channels', 'unpublish_channels'] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={cn(
+                  'h-9 px-3 rounded-lg text-[12px] font-medium border',
+                  mode === m
+                    ? 'bg-zinc-900 text-white border-zinc-900'
+                    : 'bg-white text-zinc-700 border-zinc-200 hover:border-zinc-300',
+                )}
+              >
+                {m === 'publish_channels'
+                  ? t('products.bulk_publish.mode_publish', { defaultValue: 'Publikuj' })
+                  : t('products.bulk_publish.mode_unpublish', { defaultValue: 'Wycofaj' })}
+              </button>
+            ))}
+          </div>
+
+          <div className="rounded-2xl border border-amber-200 bg-amber-50/60 px-4 py-3 text-[12px] text-amber-800">
+            <strong>
+              {t('products.bulk_publish.cascade_warning_title', {
+                defaultValue: 'Wpływ kaskadowy',
+              })}
+            </strong>{' '}
+            {t('products.bulk_publish.cascade_warning_body', {
+              count: selectedIds.length,
+              defaultValue: `Akcja obejmie ${selectedIds.length} produktów + ich warianty + powiązane cross-sell. Integracja kanału (Shopify/BaseLinker) ${'\n'}follow-up epiku 0.6/0.9 — tu zapisujemy soft-flag.`,
+            })}
+          </div>
+
+          <div className="rounded-2xl border border-zinc-200 max-h-[260px] overflow-y-auto">
+            {channels.length === 0 ? (
+              <div className="px-3 py-2 text-[12px] text-zinc-400">
+                {t('products.bulk_publish.empty', {
+                  defaultValue: 'Brak skonfigurowanych kanałów',
+                })}
+              </div>
+            ) : (
+              channels.map((ch) => {
+                const picked = pickedCodes.has(ch.code);
+                return (
+                  <button
+                    key={ch.code}
+                    type="button"
+                    onClick={() => togglePick(ch.code)}
+                    className={cn(
+                      'w-full flex items-center justify-between px-3 py-2 text-[12.5px] text-left border-b border-zinc-50 last:border-b-0',
+                      picked ? 'bg-emerald-50/60' : 'hover:bg-zinc-50',
+                    )}
+                  >
+                    <span className="font-mono text-[11.5px] text-zinc-500">{ch.code}</span>
+                    <span className="flex-1 px-3 truncate">{ch.name ?? ch.code}</span>
+                    {picked ? (
+                      <span className="text-emerald-700 text-[11.5px] font-semibold">✓</span>
+                    ) : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+
+          <div className="text-[11.5px] text-zinc-500">
+            {pickedCodes.size}{' '}
+            {t('products.bulk_publish.picked_label', { defaultValue: 'kanałów wybranych' })}
+          </div>
+        </div>
+
+        <div className="px-6 h-14 flex items-center gap-3 border-t border-zinc-100 bg-zinc-50/50">
+          <span className="text-[11.5px] text-zinc-500">
+            {t('products.bulk_wizard.rollback_hint', {
+              defaultValue: 'Każda akcja zbiorcza ma 24h soft-rollback.',
+            })}
+          </span>
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="ghost" onClick={onClose} disabled={isLoading}>
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button onClick={() => void apply()} disabled={isLoading || pickedCodes.size === 0}>
+              {t('products.bulk_wizard.apply', { defaultValue: 'Zastosuj' })}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -1,4 +1,4 @@
-import { Download, FolderTree, MoreHorizontal, Pencil, Sparkles } from 'lucide-react';
+import { Download, FolderTree, Globe, MoreHorizontal, Pencil, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -27,6 +27,7 @@ interface BulkBarProps {
   onApplied: () => void;
   onOpenWizard?: () => void;
   onOpenCategoryModal?: () => void;
+  onOpenPublishModal?: () => void;
 }
 
 /**
@@ -44,6 +45,7 @@ export function BulkBar({
   onApplied,
   onOpenWizard,
   onOpenCategoryModal,
+  onOpenPublishModal,
 }: BulkBarProps) {
   const { t } = useTranslation();
   const [isPending, setIsPending] = useState(false);
@@ -170,6 +172,16 @@ export function BulkBar({
             >
               {t('products.bulk.disable', { defaultValue: 'Wyłącz' })}
             </DropdownMenuItem>
+            {onOpenPublishModal ? (
+              <DropdownMenuItem
+                onSelect={() => {
+                  onOpenPublishModal();
+                }}
+              >
+                <Globe className="mr-2 size-3.5" aria-hidden="true" />
+                {t('products.bulk.publish_channels', { defaultValue: 'Publikuj na kanałach' })}
+              </DropdownMenuItem>
+            ) : null}
           </DropdownMenuContent>
         </DropdownMenu>
 

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router';
 import { AdvancedFilterBuilder } from '@/components/catalog/advanced-filter-builder';
 import { AdvancedFilterPanel } from '@/components/catalog/advanced-filter-panel';
 import { BulkCategoryModal } from '@/components/catalog/bulk-actions/category-modal';
+import { BulkPublishModal } from '@/components/catalog/bulk-actions/publish-modal';
 import { BulkBar } from '@/components/catalog/bulk-bar';
 import { BulkWizard } from '@/components/catalog/bulk-wizard/bulk-wizard';
 import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
@@ -109,6 +110,7 @@ export function ProductListPage() {
   // VIEW-17 (#544) — sticky 24h rollback toast for the last applied session.
   const [bulkWizardOpen, setBulkWizardOpen] = useState(false);
   const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
+  const [bulkPublishOpen, setBulkPublishOpen] = useState(false);
   const [lastBulkSession, setLastBulkSession] = useState<RollbackSession | null>(null);
   const [variantsMode, setVariantsMode] = useState<VariantsMode>('tree');
   const [viewMode, setViewMode] = useState<ProductsViewMode>(() => {
@@ -932,6 +934,7 @@ export function ProductListPage() {
         onApplied={onBulkApplied}
         onOpenWizard={() => setBulkWizardOpen(true)}
         onOpenCategoryModal={() => setBulkCategoryOpen(true)}
+        onOpenPublishModal={() => setBulkPublishOpen(true)}
       />
 
       {bulkWizardOpen ? (
@@ -952,6 +955,19 @@ export function ProductListPage() {
         <BulkCategoryModal
           selectedIds={Array.from(selected)}
           onClose={() => setBulkCategoryOpen(false)}
+          onApplied={(result) => {
+            setLastBulkSession(result);
+            setSelected(new Set());
+            setShowSelectedOnly(false);
+            void refetch();
+          }}
+        />
+      ) : null}
+
+      {bulkPublishOpen ? (
+        <BulkPublishModal
+          selectedIds={Array.from(selected)}
+          onClose={() => setBulkPublishOpen(false)}
           onApplied={(result) => {
             setLastBulkSession(result);
             setSelected(new Set());

--- a/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-15 (#547) — `publish_channels` bulk action.
+ *
+ * Soft-publish slot under `attributes_indexed['published'][channel_code]`.
+ * Real channel_publications + integration adapter calls (Shopify,
+ * BaseLinker) land in epik 0.6/0.9 — this handler only writes the
+ * intention, not the side effect. The 24h rollback path replays the
+ * previous map per row.
+ */
+final class BulkPublishChannelsHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @param list<string> $channelCodes
+     *
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session, array $channelCodes, bool $publish): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $skipped = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$product instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $indexed = $product->getAttributesIndexed();
+                    /** @var array<string, mixed> $publishedRaw */
+                    $publishedRaw = \is_array($indexed['published'] ?? null) ? $indexed['published'] : [];
+                    $before = $publishedRaw;
+                    $touched = false;
+                    foreach ($channelCodes as $code) {
+                        $current = (bool) ($publishedRaw[$code] ?? false);
+                        if ($current === $publish) {
+                            continue;
+                        }
+                        $publishedRaw[$code] = $publish;
+                        $touched = true;
+                    }
+
+                    if (!$touched) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $product->getId(),
+                            null,
+                            $before,
+                            $before,
+                            BulkLog::LEVEL_WARNING,
+                            'All channels already in the target state',
+                        ));
+                    } else {
+                        $indexed['published'] = $publishedRaw;
+                        $product->updateAttributeIndex($indexed);
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $product->getId(),
+                            null,
+                            $before,
+                            $publishedRaw,
+                            BulkLog::LEVEL_INFO,
+                            null,
+                        ));
+                        ++$success;
+                    }
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, $skipped, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -10,6 +10,7 @@ use App\Catalog\Application\Bulk\BulkClearAttributeHandler;
 use App\Catalog\Application\Bulk\BulkIncrementNumericHandler;
 use App\Catalog\Application\Bulk\BulkMoveCategoryHandler;
 use App\Catalog\Application\Bulk\BulkMultiAttributeEditHandler;
+use App\Catalog\Application\Bulk\BulkPublishChannelsHandler;
 use App\Catalog\Application\Bulk\BulkRemoveCategoryHandler;
 use App\Catalog\Application\Bulk\BulkRemoveValueHandler;
 use App\Catalog\Application\Bulk\BulkSetAttributeHandler;
@@ -57,6 +58,7 @@ final class BulkActionsController
         private readonly BulkAddCategoryHandler $addCategoryHandler,
         private readonly BulkRemoveCategoryHandler $removeCategoryHandler,
         private readonly BulkMoveCategoryHandler $moveCategoryHandler,
+        private readonly BulkPublishChannelsHandler $publishChannelsHandler,
     ) {
     }
 
@@ -90,6 +92,8 @@ final class BulkActionsController
             'add_category',
             'remove_category',
             'move_category',
+            'publish_channels',
+            'unpublish_channels',
         ], true)) {
             throw new BadRequestHttpException(\sprintf('Unsupported bulk action "%s" in MVP.', $action));
         }
@@ -143,6 +147,18 @@ final class BulkActionsController
             };
 
             return [$before, $after];
+        }
+
+        if (\in_array($action, ['publish_channels', 'unpublish_channels'], true)) {
+            $channels = $this->extractChannelCodes($payload);
+            $publishedBefore = \is_array($indexed['published'] ?? null) ? $indexed['published'] : [];
+            $publishedAfter = $publishedBefore;
+            $target = 'publish_channels' === $action;
+            foreach ($channels as $code) {
+                $publishedAfter[$code] = $target;
+            }
+
+            return [$publishedBefore, $publishedAfter];
         }
 
         if ('multi_attribute_edit' === $action) {
@@ -297,6 +313,16 @@ final class BulkActionsController
                 $session,
                 $this->extractCategoryIds($payload),
             ),
+            'publish_channels' => $this->publishChannelsHandler->handle(
+                $session,
+                $this->extractChannelCodes($payload),
+                true,
+            ),
+            'unpublish_channels' => $this->publishChannelsHandler->handle(
+                $session,
+                $this->extractChannelCodes($payload),
+                false,
+            ),
             default => throw new NotFoundHttpException(\sprintf('Bulk action "%s" not implemented.', $actionType)),
         };
 
@@ -344,6 +370,30 @@ final class BulkActionsController
         }
         if ([] === $out) {
             throw new BadRequestHttpException('payload.category_ids has no valid entries.');
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<string>
+     */
+    private function extractChannelCodes(array $payload): array
+    {
+        $raw = $payload['channel_codes'] ?? null;
+        if (!\is_array($raw) || [] === $raw) {
+            throw new BadRequestHttpException('payload.channel_codes must be a non-empty array.');
+        }
+        $out = [];
+        foreach ($raw as $code) {
+            if (\is_string($code) && '' !== $code) {
+                $out[] = $code;
+            }
+        }
+        if ([] === $out) {
+            throw new BadRequestHttpException('payload.channel_codes has no valid entries.');
         }
 
         return $out;


### PR DESCRIPTION
## Summary
`BulkPublishChannelsHandler` writes a soft-publish flag under `attributes_indexed['published'][channel_code]` per row (chunked flush+clear per VIEW-12 pattern, CHUNK_SIZE=200). Real channel adapter calls (Shopify, BaseLinker) land in epik 0.6/0.9; this handler captures the intention + emits BulkLog rows so the 24h rollback path replays the prior map.

`BulkActionsController` routes `preview()` + `apply()` for the two new action types (`publish_channels` / `unpublish_channels`), validating `payload.channel_codes` and dispatching to the shared handler.

`BulkPublishModal` (mockup `list-v2-overlays.jsx` l. 470-525) — two-mode picker (Publikuj/Wycofaj) + amber cascade-impact banner naming the target count and pointing at the integration follow-up. Wired into `BulkBar` overflow menu as *„Publikuj na kanałach"*.

## Scope notes (intentional)
- **Soft-flag only** — no integration adapter call yet (Shopify GraphQL mutation, BaseLinker REST). Operators see the intent persisted + the 24h rollback recipe; the dispatch to external systems hooks in via epik 0.6 once `channel_publications` table exists.
- **Cascade count placeholder** — banner reports selected count without computing variant/cross-sell impact server-side (`GET /api/products/bulk-actions/cascade-preview` endpoint from the plan deferred to VIEW-15.1).

## Test plan
- [ ] Login → `/products` → select 3 produkty → BulkBar `…` overflow → *„Publikuj na kanałach"* → modal otwiera się
- [ ] Pick 1+ kanałów → Apply → success toast, 24h rollback toast pojawia się
- [ ] Tryb *„Wycofaj"* dla wcześniej opublikowanych → flag cofa się do false
- [ ] DevTools Network: brak errorów

Refs #547