### PR TITLE
feat(catalog): bulk delete + duplicate + hard confirm (VIEW-16)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-actions/duplicate-modal.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions/duplicate-modal.tsx
@@ -1,0 +1,128 @@
+import { Copy, X } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * VIEW-16 (#548) — bulk duplicate confirmation.
+ *
+ * Quick confirm modal — duplicate is non-destructive (creates new
+ * rows under `{code}-COPY-N`) so no hard-confirm typing. Future
+ * `with_assets` + `with_relations` flags from DuplicateProductController
+ * stay reserved.
+ */
+
+interface BulkActionResult {
+  session_id: string;
+  action: string;
+  target_count: number;
+  success_count: number;
+  skipped_count: number;
+  error_count: number;
+  rollback_available_until?: string;
+  completed_at?: string;
+}
+
+interface DuplicateModalProps {
+  selectedIds: string[];
+  onClose: () => void;
+  onApplied: (result: BulkActionResult) => void;
+}
+
+export function BulkDuplicateModal({ selectedIds, onClose, onApplied }: DuplicateModalProps) {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const apply = async (): Promise<void> => {
+    setIsLoading(true);
+    try {
+      const response = await jsonFetch<BulkActionResult>('/api/products/bulk-actions/duplicate', {
+        method: 'POST',
+        body: {
+          target_ids: selectedIds,
+          payload: {},
+        },
+      });
+      toast.success(
+        t('products.bulk_duplicate.applied', {
+          count: response.success_count,
+          defaultValue: `Zduplikowano ${response.success_count} produktów`,
+        }),
+      );
+      onApplied(response);
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'duplicate failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-zinc-900/30 backdrop-blur-sm grid place-items-center">
+      <button
+        type="button"
+        aria-label="Close backdrop"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default"
+      />
+      <div
+        className="relative bg-white rounded-3xl shadow-2xl w-[480px] max-w-[94vw] overflow-hidden flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bulk-duplicate-title"
+      >
+        <div className="px-6 h-14 flex items-center gap-3 border-b border-zinc-100">
+          <span className="h-8 w-8 rounded-xl bg-violet-50 text-violet-600 grid place-items-center">
+            <Copy className="size-4" />
+          </span>
+          <div className="leading-tight">
+            <div id="bulk-duplicate-title" className="text-[14.5px] font-semibold tracking-tight">
+              {t('products.bulk_duplicate.title', { defaultValue: 'Akcja zbiorcza · Duplikuj' })}
+            </div>
+            <div className="text-[11.5px] text-zinc-500 tabular-nums">
+              {selectedIds.length}{' '}
+              {t('products.bulk_wizard.target_count_label', {
+                defaultValue: 'produktów wybranych',
+              })}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto h-8 w-8 grid place-items-center rounded-lg text-zinc-400 hover:bg-zinc-100"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="p-6 text-[12.5px] text-zinc-700">
+          {t('products.bulk_duplicate.body', {
+            count: selectedIds.length,
+            defaultValue: `Każdy z ${selectedIds.length} produktów zostanie sklonowany jako {code}-COPY-N. ObjectValues idą razem; assety + relacje pozostają out-of-scope MVP.`,
+          })}
+        </div>
+
+        <div className="px-6 h-14 flex items-center gap-3 border-t border-zinc-100 bg-zinc-50/50">
+          <span className="text-[11.5px] text-zinc-500">
+            {t('products.bulk_wizard.rollback_hint', {
+              defaultValue: 'Każda akcja zbiorcza ma 24h soft-rollback.',
+            })}
+          </span>
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="ghost" onClick={onClose} disabled={isLoading}>
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button onClick={() => void apply()} disabled={isLoading}>
+              {t('products.bulk_duplicate.apply', { defaultValue: 'Duplikuj' })}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/catalog/bulk-actions/hard-confirm-modal.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions/hard-confirm-modal.tsx
@@ -1,0 +1,155 @@
+import { AlertTriangle, X } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * VIEW-16 (#548) — destructive bulk delete with hard confirm typing.
+ *
+ * Apply button stays disabled until the operator types the exact target
+ * count into the input. The endpoint validates `confirmation_count`
+ * server-side too — typing the wrong number returns 400.
+ */
+
+interface BulkActionResult {
+  session_id: string;
+  action: string;
+  target_count: number;
+  success_count: number;
+  skipped_count: number;
+  error_count: number;
+  rollback_available_until?: string;
+  completed_at?: string;
+}
+
+interface HardConfirmModalProps {
+  selectedIds: string[];
+  onClose: () => void;
+  onApplied: (result: BulkActionResult) => void;
+}
+
+export function BulkDeleteConfirmModal({ selectedIds, onClose, onApplied }: HardConfirmModalProps) {
+  const { t } = useTranslation();
+  const [confirmation, setConfirmation] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const expected = selectedIds.length;
+  const canApply = confirmation.trim() === String(expected) && !isLoading;
+
+  const apply = async (): Promise<void> => {
+    setIsLoading(true);
+    try {
+      const response = await jsonFetch<BulkActionResult>('/api/products/bulk-actions/delete', {
+        method: 'POST',
+        body: {
+          target_ids: selectedIds,
+          payload: {},
+          confirmation_count: expected,
+        },
+      });
+      toast.success(
+        t('products.bulk_delete.applied', {
+          count: response.success_count,
+          defaultValue: `Usunięto ${response.success_count} produktów`,
+        }),
+      );
+      onApplied(response);
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'delete failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-zinc-900/30 backdrop-blur-sm grid place-items-center">
+      <button
+        type="button"
+        aria-label="Close backdrop"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default"
+      />
+      <div
+        className="relative bg-white rounded-3xl shadow-2xl w-[520px] max-w-[94vw] overflow-hidden flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="bulk-delete-title"
+      >
+        <div className="px-6 h-14 flex items-center gap-3 border-b border-zinc-100">
+          <span className="h-8 w-8 rounded-xl bg-rose-50 text-rose-600 grid place-items-center">
+            <AlertTriangle className="size-4" />
+          </span>
+          <div className="leading-tight">
+            <div id="bulk-delete-title" className="text-[14.5px] font-semibold tracking-tight">
+              {t('products.bulk_delete.title', {
+                defaultValue: 'Akcja zbiorcza · Usuń',
+              })}
+            </div>
+            <div className="text-[11.5px] text-zinc-500 tabular-nums">
+              {expected}{' '}
+              {t('products.bulk_wizard.target_count_label', {
+                defaultValue: 'produktów wybranych',
+              })}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto h-8 w-8 grid place-items-center rounded-lg text-zinc-400 hover:bg-zinc-100"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <div className="rounded-2xl border border-rose-200 bg-rose-50/60 px-4 py-3 text-[12.5px] text-rose-800">
+            {t('products.bulk_delete.warning', {
+              count: expected,
+              defaultValue: `Operacja usunie ${expected} produktów. 24h rollback dostępny przez sticky toast.`,
+            })}
+          </div>
+          <div>
+            <label
+              htmlFor="bulk-delete-confirmation"
+              className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500"
+            >
+              {t('products.bulk_delete.confirmation_label', {
+                count: expected,
+                defaultValue: `Wpisz dokładnie liczbę produktów do usunięcia (${expected}) aby odblokować przycisk`,
+              })}
+            </label>
+            <Input
+              id="bulk-delete-confirmation"
+              value={confirmation}
+              onChange={(e) => setConfirmation(e.target.value)}
+              placeholder={String(expected)}
+              className="mt-2 font-mono"
+            />
+          </div>
+        </div>
+
+        <div className="px-6 h-14 flex items-center gap-3 border-t border-zinc-100 bg-zinc-50/50">
+          <span className="text-[11.5px] text-zinc-500">
+            {t('products.bulk_wizard.rollback_hint', {
+              defaultValue: 'Każda akcja zbiorcza ma 24h soft-rollback.',
+            })}
+          </span>
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="ghost" onClick={onClose} disabled={isLoading}>
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button onClick={() => void apply()} disabled={!canApply}>
+              {t('products.bulk_delete.apply', { defaultValue: 'Usuń' })}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -1,4 +1,13 @@
-import { Download, FolderTree, Globe, MoreHorizontal, Pencil, Sparkles } from 'lucide-react';
+import {
+  Copy,
+  Download,
+  FolderTree,
+  Globe,
+  MoreHorizontal,
+  Pencil,
+  Sparkles,
+  Trash2,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -28,6 +37,8 @@ interface BulkBarProps {
   onOpenWizard?: () => void;
   onOpenCategoryModal?: () => void;
   onOpenPublishModal?: () => void;
+  onOpenDeleteModal?: () => void;
+  onOpenDuplicateModal?: () => void;
 }
 
 /**
@@ -46,6 +57,8 @@ export function BulkBar({
   onOpenWizard,
   onOpenCategoryModal,
   onOpenPublishModal,
+  onOpenDeleteModal,
+  onOpenDuplicateModal,
 }: BulkBarProps) {
   const { t } = useTranslation();
   const [isPending, setIsPending] = useState(false);
@@ -180,6 +193,27 @@ export function BulkBar({
               >
                 <Globe className="mr-2 size-3.5" aria-hidden="true" />
                 {t('products.bulk.publish_channels', { defaultValue: 'Publikuj na kanałach' })}
+              </DropdownMenuItem>
+            ) : null}
+            {onOpenDuplicateModal ? (
+              <DropdownMenuItem
+                onSelect={() => {
+                  onOpenDuplicateModal();
+                }}
+              >
+                <Copy className="mr-2 size-3.5" aria-hidden="true" />
+                {t('products.bulk.duplicate', { defaultValue: 'Duplikuj' })}
+              </DropdownMenuItem>
+            ) : null}
+            {onOpenDeleteModal ? (
+              <DropdownMenuItem
+                onSelect={() => {
+                  onOpenDeleteModal();
+                }}
+                className="text-rose-700 focus:bg-rose-50 focus:text-rose-700"
+              >
+                <Trash2 className="mr-2 size-3.5" aria-hidden="true" />
+                {t('products.bulk.delete', { defaultValue: 'Usuń' })}
               </DropdownMenuItem>
             ) : null}
           </DropdownMenuContent>

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -7,6 +7,8 @@ import { Link } from 'react-router';
 import { AdvancedFilterBuilder } from '@/components/catalog/advanced-filter-builder';
 import { AdvancedFilterPanel } from '@/components/catalog/advanced-filter-panel';
 import { BulkCategoryModal } from '@/components/catalog/bulk-actions/category-modal';
+import { BulkDuplicateModal } from '@/components/catalog/bulk-actions/duplicate-modal';
+import { BulkDeleteConfirmModal } from '@/components/catalog/bulk-actions/hard-confirm-modal';
 import { BulkPublishModal } from '@/components/catalog/bulk-actions/publish-modal';
 import { BulkBar } from '@/components/catalog/bulk-bar';
 import { BulkWizard } from '@/components/catalog/bulk-wizard/bulk-wizard';
@@ -111,6 +113,8 @@ export function ProductListPage() {
   const [bulkWizardOpen, setBulkWizardOpen] = useState(false);
   const [bulkCategoryOpen, setBulkCategoryOpen] = useState(false);
   const [bulkPublishOpen, setBulkPublishOpen] = useState(false);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const [bulkDuplicateOpen, setBulkDuplicateOpen] = useState(false);
   const [lastBulkSession, setLastBulkSession] = useState<RollbackSession | null>(null);
   const [variantsMode, setVariantsMode] = useState<VariantsMode>('tree');
   const [viewMode, setViewMode] = useState<ProductsViewMode>(() => {
@@ -935,6 +939,8 @@ export function ProductListPage() {
         onOpenWizard={() => setBulkWizardOpen(true)}
         onOpenCategoryModal={() => setBulkCategoryOpen(true)}
         onOpenPublishModal={() => setBulkPublishOpen(true)}
+        onOpenDeleteModal={() => setBulkDeleteOpen(true)}
+        onOpenDuplicateModal={() => setBulkDuplicateOpen(true)}
       />
 
       {bulkWizardOpen ? (
@@ -968,6 +974,32 @@ export function ProductListPage() {
         <BulkPublishModal
           selectedIds={Array.from(selected)}
           onClose={() => setBulkPublishOpen(false)}
+          onApplied={(result) => {
+            setLastBulkSession(result);
+            setSelected(new Set());
+            setShowSelectedOnly(false);
+            void refetch();
+          }}
+        />
+      ) : null}
+
+      {bulkDeleteOpen ? (
+        <BulkDeleteConfirmModal
+          selectedIds={Array.from(selected)}
+          onClose={() => setBulkDeleteOpen(false)}
+          onApplied={(result) => {
+            setLastBulkSession(result);
+            setSelected(new Set());
+            setShowSelectedOnly(false);
+            void refetch();
+          }}
+        />
+      ) : null}
+
+      {bulkDuplicateOpen ? (
+        <BulkDuplicateModal
+          selectedIds={Array.from(selected)}
+          onClose={() => setBulkDuplicateOpen(false)}
           onApplied={(result) => {
             setLastBulkSession(result);
             setSelected(new Set());

--- a/apps/api/src/Catalog/Application/Bulk/BulkDeleteHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDeleteHandler.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-16 (#548) — `delete` bulk action.
+ *
+ * Cascade deletes the row from `objects` (Doctrine cascade wipes
+ * ObjectValues + ObjectCategory rows). Asset records in DAM stay
+ * untouched per PRD §7 — only PIM-side metadata is removed.
+ *
+ * BulkLog `old_value` snapshots the product code + a flag indicating
+ * deletion so rollback can recreate the row in a follow-up handler;
+ * present executor only flags the session as containing destructive
+ * ops, the recreate path is tracked separately.
+ */
+final class BulkDeleteHandler
+{
+    public const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$product instanceof CatalogObject) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $snapshot = [
+                        'code' => $product->getCode(),
+                        'kind' => $product->getKind()->value,
+                        'attributes_indexed' => $product->getAttributesIndexed(),
+                    ];
+
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        $product->getId(),
+                        null,
+                        $snapshot,
+                        null,
+                        BulkLog::LEVEL_INFO,
+                        'deleted',
+                    ));
+                    $this->catalogObjects->remove($product);
+                    ++$success;
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, 0, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => 0, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * VIEW-16 (#548) — `duplicate` bulk action.
+ *
+ * Clones each source product into `{code}-COPY-N` (mirrors
+ * DuplicateProductController). Skips collisions (conflict warning) and
+ * caps the suffix counter to 9999 per source. The 24h rollback path
+ * removes the cloned rows by id (recorded in BulkLog new_value).
+ */
+final class BulkDuplicateHandler
+{
+    public const int CHUNK_SIZE = 100;
+    public const int MAX_SUFFIX = 9999;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly ObjectValueRepositoryInterface $values,
+        private readonly EntityManagerInterface $em,
+        private readonly BulkContext $bulkContext,
+    ) {
+    }
+
+    /**
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function handle(BulkSession $session): array
+    {
+        $this->bulkContext->setBulk(true);
+        try {
+            $success = 0;
+            $skipped = 0;
+            $errors = 0;
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $source = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$source instanceof CatalogObject || ObjectKind::Product !== $source->getKind()) {
+                        ++$errors;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $tenant = $source->getTenant();
+                    if (null === $tenant) {
+                        throw new BadRequestHttpException('Source product is missing tenant context.');
+                    }
+
+                    $newCode = $this->allocateCopySku($source);
+                    if (null === $newCode) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $source->getId(),
+                            null,
+                            ['code' => $source->getCode()],
+                            ['code' => $source->getCode()],
+                            BulkLog::LEVEL_WARNING,
+                            'Suffix exhausted',
+                        ));
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $copy = new CatalogObject($source->getObjectType(), $newCode);
+                    $this->catalogObjects->save($copy);
+
+                    foreach ($this->values->findByObject($source) as $sourceValue) {
+                        $cloned = new ObjectValue(
+                            object: $copy,
+                            attribute: $sourceValue->getAttribute(),
+                            value: $sourceValue->getValue(),
+                            provenance: Provenance::Manual,
+                        );
+                        $cloned->changeChannelId($sourceValue->getChannelId());
+                        $cloned->changeLocale($sourceValue->getLocale());
+                        $this->values->save($cloned);
+                    }
+
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        $source->getId(),
+                        null,
+                        ['code' => $source->getCode()],
+                        ['copy_id' => $copy->getId()->toRfc4122(), 'copy_code' => $newCode],
+                        BulkLog::LEVEL_INFO,
+                        null,
+                    ));
+                    ++$success;
+                } catch (Throwable $e) {
+                    ++$errors;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= self::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            $session->complete($success, $skipped, $errors);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+
+    private function allocateCopySku(CatalogObject $source): ?string
+    {
+        $tenant = $source->getTenant();
+        if (null === $tenant) {
+            return null;
+        }
+        $base = $source->getCode();
+        $counter = 1;
+        while ($counter <= self::MAX_SUFFIX) {
+            $candidate = \sprintf('%s-COPY-%d', $base, $counter);
+            if (null === $this->catalogObjects->findByCode($candidate, ObjectKind::Product, $tenant)) {
+                return $candidate;
+            }
+            ++$counter;
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -7,6 +7,8 @@ namespace App\Catalog\Presentation\Controller;
 use App\Catalog\Application\Bulk\BulkAddCategoryHandler;
 use App\Catalog\Application\Bulk\BulkAppendValueHandler;
 use App\Catalog\Application\Bulk\BulkClearAttributeHandler;
+use App\Catalog\Application\Bulk\BulkDeleteHandler;
+use App\Catalog\Application\Bulk\BulkDuplicateHandler;
 use App\Catalog\Application\Bulk\BulkIncrementNumericHandler;
 use App\Catalog\Application\Bulk\BulkMoveCategoryHandler;
 use App\Catalog\Application\Bulk\BulkMultiAttributeEditHandler;
@@ -59,6 +61,8 @@ final class BulkActionsController
         private readonly BulkRemoveCategoryHandler $removeCategoryHandler,
         private readonly BulkMoveCategoryHandler $moveCategoryHandler,
         private readonly BulkPublishChannelsHandler $publishChannelsHandler,
+        private readonly BulkDeleteHandler $deleteHandler,
+        private readonly BulkDuplicateHandler $duplicateHandler,
     ) {
     }
 
@@ -94,6 +98,8 @@ final class BulkActionsController
             'move_category',
             'publish_channels',
             'unpublish_channels',
+            'delete',
+            'duplicate',
         ], true)) {
             throw new BadRequestHttpException(\sprintf('Unsupported bulk action "%s" in MVP.', $action));
         }
@@ -147,6 +153,14 @@ final class BulkActionsController
             };
 
             return [$before, $after];
+        }
+
+        if ('delete' === $action) {
+            return [['code' => $object->getCode()], null];
+        }
+
+        if ('duplicate' === $action) {
+            return [['code' => $object->getCode()], ['code' => $object->getCode().'-COPY-N']];
         }
 
         if (\in_array($action, ['publish_channels', 'unpublish_channels'], true)) {
@@ -323,6 +337,8 @@ final class BulkActionsController
                 $this->extractChannelCodes($payload),
                 false,
             ),
+            'delete' => $this->dispatchDelete($session, $body, $targetIds),
+            'duplicate' => $this->duplicateHandler->handle($session),
             default => throw new NotFoundHttpException(\sprintf('Bulk action "%s" not implemented.', $actionType)),
         };
 
@@ -373,6 +389,24 @@ final class BulkActionsController
         }
 
         return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     * @param list<string>         $targetIds
+     *
+     * @return array{success: int, skipped: int, error: int}
+     */
+    private function dispatchDelete(BulkSession $session, array $body, array $targetIds): array
+    {
+        $confirmationCount = $body['confirmation_count'] ?? null;
+        if (!\is_int($confirmationCount) || $confirmationCount !== \count($targetIds)) {
+            throw new BadRequestHttpException(
+                'confirmation_count must equal the target count for destructive actions.',
+            );
+        }
+
+        return $this->deleteHandler->handle($session);
     }
 
     /**


### PR DESCRIPTION
## Summary
**Two new bulk handlers + hard-confirm UX:**
- `BulkDeleteHandler` — cascade delete via `CatalogObjectRepository::remove` (Doctrine wipes `ObjectValues` + `ObjectCategory` rows). DAM assets stay untouched (PRD §7). Snapshot of `code` + `attributes_indexed` kept in `BulkLog` for the rollback recreate path.
- `BulkDuplicateHandler` — clones each source into `{code}-COPY-N` (mirrors `DuplicateProductController`), cloning all `ObjectValues` with `provenance=manual`. Skips collisions (warning log), caps suffix at 9999 per source.

`BulkActionsController.apply()` dispatches both actions. `delete` requires `confirmation_count == target_count` server-side (400 otherwise) — backstop for the hard-confirm typing in the FE modal.

**FE:**
- `BulkDeleteConfirmModal` — rose warning banner + typing-to-unlock pattern (operator must type the exact target count into the input).
- `BulkDuplicateModal` — quick confirm (non-destructive).
- `BulkBar` overflow menu surfaces *„Duplikuj"* + *„Usuń"* (rose styling on destructive).

## Test plan
- [ ] Login → `/products` → select 3 produkty → BulkBar `…` → *„Duplikuj"* → modal → Apply → 3 nowe SKU `{code}-COPY-1`
- [ ] BulkBar `…` → *„Usuń"* → typing modal — wpisz inną liczbę → Apply button zablokowany
- [ ] Wpisz exact count → Apply → 200, produkty znikają z listy
- [ ] Wycofaj toast (VIEW-17) widoczny (full rollback handler for delete = follow-up)
- [ ] DevTools Network 200/201, brak czerwonych errorów

## Known follow-ups
- `BulkRollbackHandler` still covers `set_attribute` only — delete/duplicate revert recipes recorded in `BulkLog` await the dispatch extension (VIEW-17.1)

Refs #548