### PR TITLE
feat(catalog): per-attribute lock skip-and-report (VIEW-18)

### DIFF
--- a/apps/admin/src/components/catalog/detail/attribute-lock-toggle.tsx
+++ b/apps/admin/src/components/catalog/detail/attribute-lock-toggle.tsx
@@ -1,0 +1,82 @@
+import { Lock, Unlock } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-18 (#549) — per-attribute lock toggle.
+ *
+ * Renders a small icon button next to the attribute label in the detail
+ * view. Toggling posts the full replacement list to
+ * `PATCH /api/products/{id}/locks` (PUT/PATCH share the route). Bulk
+ * actions read the same JSONB slot via `AttributeLockReader` and
+ * skip+report locked attrs.
+ */
+
+interface AttributeLockToggleProps {
+  productId: string;
+  attrCode: string;
+  initialLocked: boolean;
+  currentLocks: string[];
+  onChanged?: (locks: string[]) => void;
+}
+
+export function AttributeLockToggle({
+  productId,
+  attrCode,
+  initialLocked,
+  currentLocks,
+  onChanged,
+}: AttributeLockToggleProps) {
+  const { t } = useTranslation();
+  const [locked, setLocked] = useState(initialLocked);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const toggle = async (): Promise<void> => {
+    setIsLoading(true);
+    const nextLocks = locked
+      ? currentLocks.filter((code) => code !== attrCode)
+      : Array.from(new Set([...currentLocks, attrCode]));
+    try {
+      const response = await jsonFetch<{ locked_attributes: string[] }>(
+        `/api/products/${productId}/locks`,
+        {
+          method: 'PATCH',
+          body: { locked_attributes: nextLocks },
+        },
+      );
+      setLocked(response.locked_attributes.includes(attrCode));
+      onChanged?.(response.locked_attributes);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'lock toggle failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const Icon = locked ? Lock : Unlock;
+  return (
+    <button
+      type="button"
+      onClick={() => void toggle()}
+      disabled={isLoading}
+      aria-pressed={locked}
+      aria-label={
+        locked
+          ? t('products.attr_lock.unlock', { defaultValue: 'Odblokuj atrybut' })
+          : t('products.attr_lock.lock', { defaultValue: 'Zablokuj atrybut' })
+      }
+      className={cn(
+        'h-6 w-6 grid place-items-center rounded-md transition disabled:opacity-50',
+        locked
+          ? 'text-amber-600 bg-amber-50 hover:bg-amber-100'
+          : 'text-zinc-400 hover:bg-zinc-100',
+      )}
+    >
+      <Icon className="size-3.5" aria-hidden="true" />
+    </button>
+  );
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Application\Bulk;
 
 use App\Catalog\Application\BulkContext;
+use App\Catalog\Application\Lock\AttributeLockReader;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -33,6 +34,7 @@ final class BulkSetAttributeHandler
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly EntityManagerInterface $em,
         private readonly BulkContext $bulkContext,
+        private readonly AttributeLockReader $lockReader,
     ) {
     }
 
@@ -67,6 +69,26 @@ final class BulkSetAttributeHandler
                             'Object not found',
                         ));
                         ++$chunkCounter;
+                        continue;
+                    }
+
+                    if ($this->lockReader->isLocked($object, $attrCode)) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            BulkLog::LEVEL_WARNING,
+                            'Attribute locked',
+                        ));
+                        ++$chunkCounter;
+                        if ($chunkCounter >= self::CHUNK_SIZE) {
+                            $this->em->flush();
+                            $this->em->clear();
+                            $chunkCounter = 0;
+                        }
                         continue;
                     }
 

--- a/apps/api/src/Catalog/Application/Lock/AttributeLockReader.php
+++ b/apps/api/src/Catalog/Application/Lock/AttributeLockReader.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Lock;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+
+/**
+ * VIEW-18 (#549) — read locked attribute codes for a catalog object.
+ *
+ * Storage: `attributes_indexed['__locks']` JSONB array of attribute
+ * codes. The double-underscore prefix marks it as a meta-slot so the
+ * value never collides with a real attribute called `locks`. Avoids a
+ * dedicated migration in MVP — the existing GIN index covers the slot.
+ */
+final class AttributeLockReader
+{
+    public const string LOCKS_META_KEY = '__locks';
+
+    /**
+     * @return list<string>
+     */
+    public function getLockedCodes(CatalogObject $object): array
+    {
+        $indexed = $object->getAttributesIndexed();
+        $raw = $indexed[self::LOCKS_META_KEY] ?? null;
+        if (!\is_array($raw)) {
+            return [];
+        }
+        $out = [];
+        foreach ($raw as $code) {
+            if (\is_string($code) && '' !== $code) {
+                $out[] = $code;
+            }
+        }
+
+        return $out;
+    }
+
+    public function isLocked(CatalogObject $object, string $attrCode): bool
+    {
+        return \in_array($attrCode, $this->getLockedCodes($object), true);
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/AttributeLocksController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttributeLocksController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\Lock\AttributeLockReader;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * VIEW-18 (#549) — per-attribute lock endpoints.
+ *
+ * `GET /api/products/{id}/locks` returns the current list of locked
+ * attribute codes. `PATCH /api/products/{id}/locks` replaces the full
+ * list (idempotent, no merge — the FE toggle ships the final intent).
+ *
+ * Storage lives under `attributes_indexed['__locks']` so this controller
+ * stays migration-free. Bulk handlers consult `AttributeLockReader`
+ * before mutating any locked slot.
+ */
+final class AttributeLocksController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly AttributeLockReader $lockReader,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    #[Route('/api/products/{id}/locks', name: 'pim_products_locks_show', requirements: ['id' => self::UUID_REGEX], methods: ['GET'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function show(string $id): JsonResponse
+    {
+        $product = $this->loadProduct($id);
+
+        return new JsonResponse(['locked_attributes' => $this->lockReader->getLockedCodes($product)]);
+    }
+
+    #[Route('/api/products/{id}/locks', name: 'pim_products_locks_replace', requirements: ['id' => self::UUID_REGEX], methods: ['PATCH', 'PUT'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function replace(string $id, Request $request): JsonResponse
+    {
+        $product = $this->loadProduct($id);
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+        $raw = $body['locked_attributes'] ?? null;
+        if (!\is_array($raw)) {
+            throw new BadRequestHttpException('locked_attributes must be an array.');
+        }
+        $codes = [];
+        foreach ($raw as $code) {
+            if (\is_string($code) && '' !== $code) {
+                $codes[] = $code;
+            }
+        }
+
+        $indexed = $product->getAttributesIndexed();
+        if ([] === $codes) {
+            unset($indexed[AttributeLockReader::LOCKS_META_KEY]);
+        } else {
+            $indexed[AttributeLockReader::LOCKS_META_KEY] = array_values(array_unique($codes));
+        }
+        $product->updateAttributeIndex($indexed);
+        $this->em->flush();
+
+        return new JsonResponse(['locked_attributes' => $this->lockReader->getLockedCodes($product)]);
+    }
+
+    private function loadProduct(string $id): CatalogObject
+    {
+        $product = $this->catalogObjects->findById(Uuid::fromString($id));
+        if (!$product instanceof CatalogObject) {
+            throw new NotFoundHttpException(\sprintf('Product %s not found.', $id));
+        }
+
+        return $product;
+    }
+}


### PR DESCRIPTION
## Summary
`AttributeLockReader` reads locked attribute codes from `attributes_indexed['__locks']` — a meta-slot prefixed with double-underscore to keep this ticket migration-free while still being covered by the existing GIN index. Bulk handlers consult the reader before mutating any single attribute slot; locked rows skip with a warning `BulkLog` entry and increment the wizard's skipped counter (already rendered by VIEW-12 Step 3).

`AttributeLocksController` exposes:
- `GET /api/products/{id}/locks` → `{ locked_attributes: string[] }`
- `PATCH /api/products/{id}/locks { locked_attributes: string[] }` (replace semantics — the FE toggle ships the final intent).

`BulkSetAttributeHandler` is the first handler wired through the reader. `AttributeLockToggle` renders 🔓/🔒 next to the attribute label in the detail view; toggle posts the full replacement list and surfaces errors via the toast.

## Known follow-ups (intentional)
- Remaining attribute-touching handlers (`clear_attribute`, `append_value`, `remove_value`, `increment_numeric`, `multi_attribute_edit`) read the same slot in follow-up VIEW-18.1.
- Wizard Step 1 *„17 produktów ma zablokowany atrybut"* count requires the pre-flight scan — also VIEW-18.1.

## Test plan
- [ ] PATCH `/api/products/{id}/locks` z `{ locked_attributes: ["brand"] }` → 200 → `attributes_indexed.__locks === ["brand"]`
- [ ] Bulk wizard *„Ustaw atrybut brand"* na produkty zawierające zablokowany → skipped_count > 0 + BulkLog z `LEVEL_WARNING / "Attribute locked"`
- [ ] AttributeLockToggle w detail view toggluje stan + persystuje przez refresh
- [ ] DevTools Network 200, brak errorów

Refs #549