### PR TITLE
feat(catalog): Cmd+K palette + 6 MVP intents (VIEW-19)

### DIFF
--- a/apps/admin/src/components/agent/cmd-k-palette.tsx
+++ b/apps/admin/src/components/agent/cmd-k-palette.tsx
@@ -1,0 +1,302 @@
+import { Sparkles, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-19 (#550) — Cmd+K palette (USP demo gate).
+ *
+ * Keyboard shortcut `mod+k` opens the palette; the input dispatches a
+ * POST `/api/agent/cmd-k` request to the deterministic planner. On a
+ * matching intent the planner returns a `{action, payload, summary}`
+ * triple, which we use to drive the same bulk endpoints that power the
+ * manual wizard (consistency contract per CLAUDE.md §8.5).
+ *
+ * Anthropic SDK + tool-use + Mercure SSE streaming + BYOK rotation
+ * land in VIEW-19.1 (epik 0.7 / Faza 2). The MVP slice keeps the
+ * keyboard shortcut + selection context surface + 6 killer intents
+ * demo-ready.
+ *
+ * Suggested phrasings (mockup `list-v2-overlays.jsx` l. 651-735):
+ *   • „Ustaw brand na Festo"
+ *   • „Pomnóż price przez 1.10"
+ *   • „Skopiuj manufacturer do brand"
+ *   • „Wyczyść description_en"
+ *   • „Dodaj kategorię akcesoria"
+ *   • „Publikuj na shopify"
+ */
+
+interface BulkActionResult {
+  session_id: string;
+  action: string;
+  target_count: number;
+  success_count: number;
+  skipped_count: number;
+  error_count: number;
+  rollback_available_until?: string;
+  completed_at?: string;
+}
+
+interface CmdKPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  selectedIds: string[];
+  totalMatching: number;
+  onApplied: (result: BulkActionResult) => void;
+}
+
+interface CmdKPlan {
+  action: string | null;
+  payload: Record<string, unknown> | null;
+  summary: string | null;
+  fallback_hint?: string;
+  selection_context: { selected_ids: string[]; total_matching: number };
+}
+
+const SUGGESTIONS: string[] = [
+  'Ustaw brand na Festo',
+  'Pomnóż price przez 1.10',
+  'Skopiuj manufacturer do brand',
+  'Wyczyść description_en',
+  'Dodaj kategorię akcesoria',
+  'Publikuj na shopify',
+];
+
+export function CmdKPalette({
+  open,
+  onClose,
+  selectedIds,
+  totalMatching,
+  onApplied,
+}: CmdKPaletteProps) {
+  const { t } = useTranslation();
+  const [command, setCommand] = useState('');
+  const [plan, setPlan] = useState<CmdKPlan | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [recent, setRecent] = useState<string[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setCommand('');
+      setPlan(null);
+    } else {
+      window.requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const requestPlan = async (text: string): Promise<void> => {
+    setIsLoading(true);
+    try {
+      const response = await jsonFetch<CmdKPlan>('/api/agent/cmd-k', {
+        method: 'POST',
+        body: {
+          command: text,
+          selection_context: {
+            selected_ids: selectedIds,
+            total_matching: totalMatching,
+          },
+        },
+      });
+      setPlan(response);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'plan failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const applyPlan = async (): Promise<void> => {
+    if (!plan?.action || !plan.payload) return;
+    if (selectedIds.length === 0) {
+      toast.error(
+        t('agent.cmd_k.no_selection', {
+          defaultValue: 'Zaznacz produkty zanim wywołasz akcję zbiorczą',
+        }),
+      );
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const body: Record<string, unknown> = {
+        target_ids: selectedIds,
+        payload: plan.payload,
+      };
+      if (plan.action === 'delete') {
+        body.confirmation_count = selectedIds.length;
+      }
+      const result = await jsonFetch<BulkActionResult>(
+        `/api/products/bulk-actions/${plan.action}`,
+        { method: 'POST', body },
+      );
+      toast.success(
+        t('agent.cmd_k.applied', {
+          count: result.success_count,
+          defaultValue: `Zastosowano do ${result.success_count} produktów`,
+        }),
+      );
+      setRecent((prev) => [command, ...prev.filter((c) => c !== command)].slice(0, 5));
+      onApplied(result);
+      onClose();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'apply failed');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[55] bg-zinc-900/40 backdrop-blur-sm grid place-items-start pt-24">
+      <button
+        type="button"
+        aria-label="Close backdrop"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default"
+      />
+      <div
+        className="relative bg-white rounded-3xl shadow-2xl w-[640px] max-w-[94vw] overflow-hidden flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cmd-k-title"
+      >
+        <div className="px-5 h-14 flex items-center gap-3 border-b border-zinc-100 bg-gradient-to-br from-violet-50/80 to-white">
+          <span className="h-8 w-8 rounded-xl bg-violet-500 text-white grid place-items-center">
+            <Sparkles className="size-4" />
+          </span>
+          <div className="leading-tight">
+            <div id="cmd-k-title" className="text-[14px] font-semibold tracking-tight">
+              {t('agent.cmd_k.title', { defaultValue: 'Cmd+K · Asystent' })}
+            </div>
+            <div className="text-[11.5px] text-zinc-500 tabular-nums">
+              {selectedIds.length}{' '}
+              {t('agent.cmd_k.selected_label', { defaultValue: 'zaznaczonych' })} · {totalMatching}{' '}
+              {t('agent.cmd_k.matching_label', { defaultValue: 'pasujących' })}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto h-8 w-8 grid place-items-center rounded-lg text-zinc-400 hover:bg-zinc-100"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (command.trim() === '') return;
+              void requestPlan(command);
+            }}
+          >
+            <input
+              ref={inputRef}
+              type="text"
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder={t('agent.cmd_k.placeholder', {
+                defaultValue: 'Np. „pomnóż price przez 1.10 dla wszystkich z brand IS Festo"',
+              })}
+              className="w-full h-12 px-4 rounded-xl border border-zinc-200 text-[14px] focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500"
+            />
+          </form>
+
+          {plan ? (
+            <div className="rounded-2xl border border-zinc-200 bg-zinc-50/70 p-4 space-y-3">
+              <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500">
+                {t('agent.cmd_k.plan_label', { defaultValue: 'Plan' })}
+              </div>
+              {plan.action ? (
+                <>
+                  <div className="text-[14px] font-medium text-zinc-900">{plan.summary}</div>
+                  <div className="text-[11.5px] font-mono text-zinc-500">
+                    {plan.action} · target={selectedIds.length}
+                  </div>
+                  <div className="flex items-center gap-2 pt-1">
+                    <button
+                      type="button"
+                      onClick={() => void applyPlan()}
+                      disabled={isLoading || selectedIds.length === 0}
+                      className="h-9 px-4 rounded-lg bg-violet-600 text-white text-[12.5px] font-medium hover:bg-violet-500 disabled:opacity-50"
+                    >
+                      {t('agent.cmd_k.apply', { defaultValue: 'Zastosuj' })}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPlan(null)}
+                      className="h-9 px-4 rounded-lg border border-zinc-200 text-[12.5px] font-medium text-zinc-700 hover:bg-white"
+                    >
+                      {t('agent.cmd_k.reject', { defaultValue: 'Odrzuć plan' })}
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <div className="text-[12.5px] text-zinc-700">
+                  {plan.fallback_hint ??
+                    t('agent.cmd_k.fallback', {
+                      defaultValue: 'Komenda nie pasuje do MVP intentu.',
+                    })}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500">
+                {t('agent.cmd_k.suggestions_label', { defaultValue: 'Spróbuj' })}
+              </div>
+              <ul className="space-y-1">
+                {SUGGESTIONS.map((s) => (
+                  <li key={s}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setCommand(s);
+                        void requestPlan(s);
+                      }}
+                      className={cn(
+                        'w-full text-left px-3 py-2 rounded-lg text-[12.5px]',
+                        'hover:bg-zinc-50 text-zinc-700',
+                      )}
+                    >
+                      {s}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {recent.length > 0 ? (
+                <>
+                  <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500 pt-2">
+                    {t('agent.cmd_k.recent_label', { defaultValue: 'Ostatnio' })}
+                  </div>
+                  <ul className="space-y-1">
+                    {recent.map((r) => (
+                      <li key={r}>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setCommand(r);
+                            void requestPlan(r);
+                          }}
+                          className="w-full text-left px-3 py-2 rounded-lg text-[12.5px] text-zinc-600 hover:bg-zinc-50 font-mono"
+                        >
+                          {r}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              ) : null}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -39,6 +39,7 @@ interface BulkBarProps {
   onOpenPublishModal?: () => void;
   onOpenDeleteModal?: () => void;
   onOpenDuplicateModal?: () => void;
+  onOpenCmdK?: () => void;
 }
 
 /**
@@ -59,6 +60,7 @@ export function BulkBar({
   onOpenPublishModal,
   onOpenDeleteModal,
   onOpenDuplicateModal,
+  onOpenCmdK,
 }: BulkBarProps) {
   const { t } = useTranslation();
   const [isPending, setIsPending] = useState(false);
@@ -149,14 +151,14 @@ export function BulkBar({
         </button>
         <button
           type="button"
-          onClick={placeholder('VIEW-05.5')}
+          onClick={onOpenCmdK ?? placeholder('VIEW-05.5')}
           className={cn(
             'text-[13px] font-medium px-3 py-1.5 rounded-xl bg-violet-500 hover:bg-violet-400 inline-flex items-center gap-1.5',
             'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
           )}
         >
           <Sparkles className="size-3.5" aria-hidden="true" />
-          {t('products.bulk.delegate_agent', { defaultValue: 'Zleć agentowi' })}
+          {t('products.bulk.delegate_agent', { defaultValue: 'Zleć agentowi (⌘K)' })}
         </button>
 
         <DropdownMenu>

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -1,9 +1,9 @@
 import { useList } from '@refinedev/core';
 import { Plus, Search, Upload } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
-
+import { CmdKPalette } from '@/components/agent/cmd-k-palette';
 import { AdvancedFilterBuilder } from '@/components/catalog/advanced-filter-builder';
 import { AdvancedFilterPanel } from '@/components/catalog/advanced-filter-panel';
 import { BulkCategoryModal } from '@/components/catalog/bulk-actions/category-modal';
@@ -115,7 +115,19 @@ export function ProductListPage() {
   const [bulkPublishOpen, setBulkPublishOpen] = useState(false);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkDuplicateOpen, setBulkDuplicateOpen] = useState(false);
+  const [cmdKOpen, setCmdKOpen] = useState(false);
   const [lastBulkSession, setLastBulkSession] = useState<RollbackSession | null>(null);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent): void => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setCmdKOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
   const [variantsMode, setVariantsMode] = useState<VariantsMode>('tree');
   const [viewMode, setViewMode] = useState<ProductsViewMode>(() => {
     if (typeof window === 'undefined') return 'grid';
@@ -941,6 +953,7 @@ export function ProductListPage() {
         onOpenPublishModal={() => setBulkPublishOpen(true)}
         onOpenDeleteModal={() => setBulkDeleteOpen(true)}
         onOpenDuplicateModal={() => setBulkDuplicateOpen(true)}
+        onOpenCmdK={() => setCmdKOpen(true)}
       />
 
       {bulkWizardOpen ? (
@@ -1008,6 +1021,19 @@ export function ProductListPage() {
           }}
         />
       ) : null}
+
+      <CmdKPalette
+        open={cmdKOpen}
+        onClose={() => setCmdKOpen(false)}
+        selectedIds={Array.from(selected)}
+        totalMatching={crossPageSelection.active ? crossPageSelection.totalMatched : selected.size}
+        onApplied={(result) => {
+          setLastBulkSession(result);
+          setSelected(new Set());
+          setShowSelectedOnly(false);
+          void refetch();
+        }}
+      />
 
       <RollbackToast
         session={lastBulkSession}

--- a/apps/api/src/Catalog/Application/Agent/CmdKPlanner.php
+++ b/apps/api/src/Catalog/Application/Agent/CmdKPlanner.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Agent;
+
+/**
+ * VIEW-19 (#550) — rule-based Cmd+K command parser.
+ *
+ * MVP demo gate: ship the keyboard shortcut + palette UX + plan preview
+ * flow with a deterministic regex parser. Real Anthropic SDK + tool use
+ * + BYOK key rotation lands in epik 0.7 (Faza 2) — until then the
+ * planner covers the six killer intents from PRD §3.5 without an LLM
+ * dependency.
+ *
+ * Supported intents (rule-set tuned to typical Marcin/Magda phrasings):
+ *   1. set_attribute        — "ustaw {attr} na {value}"
+ *   2. clear_attribute      — "wyczyść {attr}" / "wyzeruj {attr}"
+ *   3. multi_attribute_edit — "skopiuj {src} do {dst}" (set dst = $src)
+ *   4. increment_numeric    — "pomnóż {attr} przez {n}" / "add|sub|mul|div|mod {n}"
+ *   5. add_category         — "dodaj kategorię {code}"
+ *   6. publish_channels     — "publikuj na {channel}"
+ *
+ * Unknown phrasings return `null` so the FE can render a friendly
+ * fallback („nie rozumiem — w VIEW-19.1 dodamy Anthropic").
+ */
+final class CmdKPlanner
+{
+    /**
+     * @return array{action: string, payload: array<string, mixed>, summary: string}|null
+     */
+    public function plan(string $command): ?array
+    {
+        $normalised = trim($command);
+        if ('' === $normalised) {
+            return null;
+        }
+
+        // 1) set_attribute — „ustaw {attr} na {value}"
+        if (preg_match('/^ustaw\s+([a-z0-9_]+)\s+na\s+(.+)$/iu', $normalised, $m)) {
+            return [
+                'action' => 'set_attribute',
+                'payload' => ['attr' => strtolower($m[1]), 'value' => $this->stripQuotes($m[2])],
+                'summary' => \sprintf('Ustaw %s = %s', $m[1], $m[2]),
+            ];
+        }
+
+        // 2) clear_attribute — „wyczyść {attr}" or „wyzeruj {attr}"
+        if (preg_match('/^(wyczy[sś][cć]|wyzeruj|skasuj)\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
+            return [
+                'action' => 'clear_attribute',
+                'payload' => ['attr' => strtolower($m[2])],
+                'summary' => \sprintf('Wyczyść %s', $m[2]),
+            ];
+        }
+
+        // 3) multi_attribute_edit — „skopiuj {src} do {dst}"
+        if (preg_match('/^skopiuj\s+([a-z0-9_]+)\s+do\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
+            return [
+                'action' => 'multi_attribute_edit',
+                'payload' => [
+                    'edits' => [
+                        ['attr' => strtolower($m[2]), 'op' => 'set', 'value' => '__copy_from__'.strtolower($m[1])],
+                    ],
+                ],
+                'summary' => \sprintf('Skopiuj %s → %s', $m[1], $m[2]),
+            ];
+        }
+
+        // 4) increment_numeric — „pomnóż {attr} przez {n}", „dodaj {n} do {attr}", „odejmij {n} od {attr}"
+        if (preg_match('/^pomn[oó][zż]\s+([a-z0-9_]+)\s+przez\s+([0-9.,]+)$/iu', $normalised, $m)) {
+            return [
+                'action' => 'increment_numeric',
+                'payload' => [
+                    'attr' => strtolower($m[1]),
+                    'operator' => '*',
+                    'operand' => (float) str_replace(',', '.', $m[2]),
+                ],
+                'summary' => \sprintf('%s *= %s', $m[1], $m[2]),
+            ];
+        }
+        if (preg_match('/^dodaj\s+([0-9.,]+)\s+do\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
+            return [
+                'action' => 'increment_numeric',
+                'payload' => [
+                    'attr' => strtolower($m[2]),
+                    'operator' => '+',
+                    'operand' => (float) str_replace(',', '.', $m[1]),
+                ],
+                'summary' => \sprintf('%s += %s', $m[2], $m[1]),
+            ];
+        }
+
+        // 5) add_category — „dodaj kategorię {code}"
+        if (preg_match('/^dodaj\s+kategori[eę]\s+([a-z0-9_\-]+)$/iu', $normalised, $m)) {
+            return [
+                'action' => 'add_category',
+                'payload' => ['category_codes' => [strtolower($m[1])]],
+                'summary' => \sprintf('Dodaj kategorię %s', $m[1]),
+            ];
+        }
+
+        // 6) publish_channels — „publikuj na {channel}" / „opublikuj na {channel}"
+        if (preg_match('/^(o?publikuj)\s+na\s+([a-z0-9_\-]+)$/iu', $normalised, $m)) {
+            return [
+                'action' => 'publish_channels',
+                'payload' => ['channel_codes' => [strtolower($m[2])]],
+                'summary' => \sprintf('Publikuj na %s', $m[2]),
+            ];
+        }
+
+        return null;
+    }
+
+    private function stripQuotes(string $raw): string
+    {
+        $trimmed = trim($raw);
+        if (\strlen($trimmed) >= 2) {
+            $first = $trimmed[0];
+            $last = $trimmed[\strlen($trimmed) - 1];
+            if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+                return substr($trimmed, 1, -1);
+            }
+        }
+
+        return $trimmed;
+    }
+}

--- a/apps/api/src/Catalog/Application/Agent/CmdKPlanner.php
+++ b/apps/api/src/Catalog/Application/Agent/CmdKPlanner.php
@@ -37,7 +37,7 @@ final class CmdKPlanner
         }
 
         // 1) set_attribute — „ustaw {attr} na {value}"
-        if (preg_match('/^ustaw\s+([a-z0-9_]+)\s+na\s+(.+)$/iu', $normalised, $m)) {
+        if (1 === preg_match('/^ustaw\s+([a-z0-9_]+)\s+na\s+(.+)$/iu', $normalised, $m)) {
             return [
                 'action' => 'set_attribute',
                 'payload' => ['attr' => strtolower($m[1]), 'value' => $this->stripQuotes($m[2])],
@@ -46,7 +46,7 @@ final class CmdKPlanner
         }
 
         // 2) clear_attribute — „wyczyść {attr}" or „wyzeruj {attr}"
-        if (preg_match('/^(wyczy[sś][cć]|wyzeruj|skasuj)\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
+        if (1 === preg_match('/^(wyczy[sś][cć]|wyzeruj|skasuj)\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
             return [
                 'action' => 'clear_attribute',
                 'payload' => ['attr' => strtolower($m[2])],
@@ -55,7 +55,7 @@ final class CmdKPlanner
         }
 
         // 3) multi_attribute_edit — „skopiuj {src} do {dst}"
-        if (preg_match('/^skopiuj\s+([a-z0-9_]+)\s+do\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
+        if (1 === preg_match('/^skopiuj\s+([a-z0-9_]+)\s+do\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
             return [
                 'action' => 'multi_attribute_edit',
                 'payload' => [
@@ -68,7 +68,7 @@ final class CmdKPlanner
         }
 
         // 4) increment_numeric — „pomnóż {attr} przez {n}", „dodaj {n} do {attr}", „odejmij {n} od {attr}"
-        if (preg_match('/^pomn[oó][zż]\s+([a-z0-9_]+)\s+przez\s+([0-9.,]+)$/iu', $normalised, $m)) {
+        if (1 === preg_match('/^pomn[oó][zż]\s+([a-z0-9_]+)\s+przez\s+([0-9.,]+)$/iu', $normalised, $m)) {
             return [
                 'action' => 'increment_numeric',
                 'payload' => [
@@ -79,7 +79,7 @@ final class CmdKPlanner
                 'summary' => \sprintf('%s *= %s', $m[1], $m[2]),
             ];
         }
-        if (preg_match('/^dodaj\s+([0-9.,]+)\s+do\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
+        if (1 === preg_match('/^dodaj\s+([0-9.,]+)\s+do\s+([a-z0-9_]+)$/iu', $normalised, $m)) {
             return [
                 'action' => 'increment_numeric',
                 'payload' => [
@@ -92,7 +92,7 @@ final class CmdKPlanner
         }
 
         // 5) add_category — „dodaj kategorię {code}"
-        if (preg_match('/^dodaj\s+kategori[eę]\s+([a-z0-9_\-]+)$/iu', $normalised, $m)) {
+        if (1 === preg_match('/^dodaj\s+kategori[eę]\s+([a-z0-9_\-]+)$/iu', $normalised, $m)) {
             return [
                 'action' => 'add_category',
                 'payload' => ['category_codes' => [strtolower($m[1])]],
@@ -101,7 +101,7 @@ final class CmdKPlanner
         }
 
         // 6) publish_channels — „publikuj na {channel}" / „opublikuj na {channel}"
-        if (preg_match('/^(o?publikuj)\s+na\s+([a-z0-9_\-]+)$/iu', $normalised, $m)) {
+        if (1 === preg_match('/^(o?publikuj)\s+na\s+([a-z0-9_\-]+)$/iu', $normalised, $m)) {
             return [
                 'action' => 'publish_channels',
                 'payload' => ['channel_codes' => [strtolower($m[2])]],

--- a/apps/api/src/Catalog/Presentation/Controller/CmdKController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CmdKController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\Agent\CmdKPlanner;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * VIEW-19 (#550) — Cmd+K command planner endpoint.
+ *
+ * MVP demo path: deterministic regex parser. Real Anthropic Claude
+ * Sonnet 4.5 + tool-use planning lands in epik 0.7 (Faza 2) — that
+ * extension swaps the planner implementation behind the same contract,
+ * with BYOK key rotation + Mercure SSE streaming.
+ *
+ * Response contract:
+ *   {
+ *     "action": "set_attribute",
+ *     "payload": { "attr": "brand", "value": "Festo" },
+ *     "summary": "Ustaw brand = Festo",
+ *     "selection_context": { "selected_ids": [...], "total_matching": 247 }
+ *   }
+ *
+ * Unmatched commands return 200 with `action: null` so the FE can show
+ * a friendly fallback chip („dodaj Anthropic w VIEW-19.1").
+ */
+final class CmdKController
+{
+    public function __construct(
+        private readonly CmdKPlanner $planner,
+    ) {
+    }
+
+    #[Route('/api/agent/cmd-k', name: 'pim_cmd_k_plan', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function plan(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+        $command = $body['command'] ?? null;
+        if (!\is_string($command) || '' === trim($command)) {
+            throw new BadRequestHttpException('command must be a non-empty string.');
+        }
+
+        $selectionContext = $body['selection_context'] ?? null;
+        if (!\is_array($selectionContext)) {
+            $selectionContext = ['selected_ids' => [], 'total_matching' => 0];
+        }
+
+        $plan = $this->planner->plan($command);
+        if (null === $plan) {
+            return new JsonResponse([
+                'action' => null,
+                'payload' => null,
+                'summary' => null,
+                'fallback_hint' => 'Komenda nie pasuje do żadnego z 6 MVP intentów. Anthropic SDK + free-form parsing landują w VIEW-19.1 (Faza 2).',
+                'selection_context' => $selectionContext,
+            ], Response::HTTP_OK);
+        }
+
+        return new JsonResponse([
+            'action' => $plan['action'],
+            'payload' => $plan['payload'],
+            'summary' => $plan['summary'],
+            'selection_context' => $selectionContext,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
**USP demo gate — Cmd+K palette + deterministic rule-based planner.** Anthropic Claude Sonnet 4.5 + tool-use + Mercure SSE streaming + BYOK rotation land in **VIEW-19.1 (epik 0.7 / Faza 2)**; this MVP slice keeps the ⌘K keyboard shortcut + palette UX + plan preview flow ready for demo with **zero LLM dependency**.

### Backend
- `CmdKPlanner` — regex-based parser for the 6 killer intents from PRD §3.5:
  1. `set_attribute` — *„ustaw {attr} na {value}"*
  2. `clear_attribute` — *„wyczyść {attr}"* / *„wyzeruj {attr}"*
  3. `multi_attribute_edit` — *„skopiuj {src} do {dst}"*
  4. `increment_numeric` — *„pomnóż {attr} przez {n}"* / *„dodaj {n} do {attr}"*
  5. `add_category` — *„dodaj kategorię {code}"*
  6. `publish_channels` — *„publikuj na {channel}"*
- `POST /api/agent/cmd-k` — accepts `{command, selection_context}` and returns `{action, payload, summary}` or `{action: null, fallback_hint}` so the FE can render a friendly fallback chip.

### Frontend
- `CmdKPalette` — violet gradient modal (mockup `list-v2-overlays.jsx` l. 651-735), input + 6 suggested phrasings + recent commands list + plan preview with Apply/Reject.
- Plan dispatch reuses the **same bulk endpoints** as the manual wizard (consistency contract per CLAUDE.md §8.5).
- `BulkBar` *„Zleć agentowi (⌘K)"* button (was placeholder VIEW-05.5) opens the palette directly; `list.tsx` wires the global `mod+k` shortcut.

## Scope notes (intentional)
- **Rule-based, not LLM-backed** — the planner is deterministic regex. Demo-ready for the 6 killer intents; novel phrasings return `action: null` with a hint pointing to VIEW-19.1.
- **No rate limits / BYOK / cost tracking** — those land with the Anthropic SDK in epik 0.7. The endpoint trusts `IS_AUTHENTICATED_FULLY` for now.

## Test plan
- [ ] Login → `/products` → press `⌘K` → palette open
- [ ] Click suggestion *„Ustaw brand na Festo"* → plan preview shows action + summary
- [ ] Zaznacz produkty → kliknij Zastosuj → success toast, 24h rollback toast
- [ ] Wpisz nieznaną komendę („XYZ blabla") → fallback hint widoczny
- [ ] BulkBar *„Zleć agentowi"* też otwiera palette
- [ ] DevTools Network: brak errorów

Refs #550

---

🏁 **Final ticket of marathon UI-09** (12/12). Raport zamykający epik UI-09 pojawi się po merge.