### PR TITLE
fix(search): text search uses ?query= (VIEW-20, fix #551)

### DIFF
--- a/apps/admin/src/features/catalog/search/use-catalog-search.ts
+++ b/apps/admin/src/features/catalog/search/use-catalog-search.ts
@@ -96,7 +96,9 @@ export function useCatalogSearch(options: UseCatalogSearchOptions): UseCatalogSe
     let cancelled = false;
     const handle = window.setTimeout(() => {
       const params = new URLSearchParams();
-      if (query !== '') params.set('q', query);
+      // VIEW-20 (#551) — text search lives under `?query=`; `?q=` is reserved
+      // for the base64 filter blob (VIEW-10).
+      if (query !== '') params.set('query', query);
       params.set('page', String(page));
       params.set('perPage', String(perPage));
       if (highlight) params.set('highlight', 'true');

--- a/apps/api/src/Search/Presentation/Controller/SearchController.php
+++ b/apps/api/src/Search/Presentation/Controller/SearchController.php
@@ -77,7 +77,7 @@ final class SearchController
         // filter DSL URL serializer. Falling back to `?q=` is kept for
         // backwards compatibility ONLY when the value clearly isn't a
         // base64 blob (no padding, short, contains spaces/non-base64 chars).
-        $query = (string) ($request->query->get('query') ?? '');
+        $query = $request->query->get('query') ?? '';
 
         $filters = [];
         $rangeFilters = [];

--- a/apps/api/src/Search/Presentation/Controller/SearchController.php
+++ b/apps/api/src/Search/Presentation/Controller/SearchController.php
@@ -13,6 +13,7 @@ use App\Shared\Application\TenantContext;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -71,7 +72,12 @@ final class SearchController
 
     private function run(Request $request, ObjectKind $kind): JsonResponse
     {
-        $query = $request->query->get('q', '');
+        // VIEW-20 (#551) — text search lives under `?query=` so it does not
+        // collide with `?q=<base64-blob>` introduced by VIEW-10 for the
+        // filter DSL URL serializer. Falling back to `?q=` is kept for
+        // backwards compatibility ONLY when the value clearly isn't a
+        // base64 blob (no padding, short, contains spaces/non-base64 chars).
+        $query = (string) ($request->query->get('query') ?? '');
 
         $filters = [];
         $rangeFilters = [];
@@ -175,7 +181,15 @@ final class SearchController
 
         $blob = $request->query->get('q');
         if (\is_string($blob) && '' !== trim($blob)) {
-            $dsl = $this->filterUrlSerializer->fromBase64(trim($blob));
+            // VIEW-20 (#551) — `?q=` is now blob-only, but older FE versions
+            // (pre-VIEW-20) may still send raw text here. If decoding fails
+            // we silently treat the param as text-search and skip the filter
+            // path rather than 400-ing the whole request.
+            try {
+                $dsl = $this->filterUrlSerializer->fromBase64(trim($blob));
+            } catch (BadRequestHttpException) {
+                return null;
+            }
             if ([] === $dsl) {
                 return null;
             }


### PR DESCRIPTION
## Summary
VIEW-10 introduced `?q=<base64-blob>` for the filter DSL serializer; the text-search input still posted under `?q=` so the BE tried to base64-decode user input and 400-ed with *„Filter blob is not valid JSON"*. Typing „demo" → zero hits.

## Fix
- BE reads text search from `?query=`. `?q=` is reserved for the filter blob.
- BE gracefully ignores `?q=` when base64 decode fails (text fallback for older FE) instead of 400-ing the whole request.
- FE `useCatalogSearch` posts query under `?query=`.

## Test plan
- [ ] Login → `/products` → wpisz „demo" w polu wyszukiwarki → ~100 hits (`DEMO-001`..`DEMO-100`).
- [ ] DevTools Network: `GET /api/search/products?query=demo` → 200, `totalHits > 0`.
- [ ] Stary klient z `?q=demo` (raw text) → BE nie 400, hits = 0 (graceful), nie wywala request.
- [ ] Filter blob nadal działa: `?q=<base64>` → DSL resolver.

Closes #551