### PR TITLE
fix(catalog): BulkBar fixed bottom (VIEW-24, fix #555)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -108,7 +108,7 @@ export function BulkBar({
   };
 
   return (
-    <div className="sticky bottom-6 z-30 flex justify-center pointer-events-none">
+    <div className="fixed bottom-6 left-0 right-0 z-40 flex justify-center pointer-events-none">
       <section
         aria-label={t('products.bulk.aria_region', { defaultValue: 'Akcje masowe' })}
         className="pointer-events-auto bg-zinc-900 text-white rounded-3xl shadow-xl px-6 py-3 flex items-center gap-5 animate-in fade-in slide-in-from-bottom-2 duration-200"


### PR DESCRIPTION
Operator widział BulkBar gdzieś w górnej części listy zamiast przyklejonego do dołu. Stary `sticky bottom-6` pozycjonował go względem rodzica który nie ma zdefiniowanej max-height — scroll listy powodował znikanie poza viewport.

Fix: pozycja `fixed bottom-6 left-0 right-0 z-40`. List page już ma `pb-24` → ostatni row nie chowa się pod toolbar-em.

## Test plan
- Zaznacz produkty → BulkBar pojawia się przyklejony do dołu ekranu
- Scroll listy → BulkBar zostaje na dole, widoczny przez cały czas
- Ostatni row listy nie chowa się pod toolbar-em (pb-24)

Closes #555
