### PR TITLE
feat(catalog): pager + page size selector (VIEW-26, #557)

### DIFF
--- a/apps/admin/src/components/catalog/pagination-bar.tsx
+++ b/apps/admin/src/components/catalog/pagination-bar.tsx
@@ -1,0 +1,165 @@
+import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-26 (#557) — pager + page size selector dla listy produktów.
+ *
+ * Wyświetla:
+ *  - dropdown „Wyświetl: [20|50|100|200]"
+ *  - tekst „Strona N z M · K produktów"
+ *  - buttony « ‹ 1 2 3 4 5 › » (z `aria-current` na aktywnej)
+ *
+ * Hoist'owany przez parent, który zarządza `page`/`pageSize` w state
+ * (URL + localStorage init). Pager NIE robi własnej persystencji.
+ */
+
+export const PAGE_SIZE_OPTIONS = [20, 50, 100, 200] as const;
+export type PageSize = (typeof PAGE_SIZE_OPTIONS)[number];
+
+interface PaginationBarProps {
+  page: number;
+  pageSize: PageSize;
+  totalItems: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: PageSize) => void;
+  className?: string;
+}
+
+const WINDOW_SIZE = 5; // ile numerowanych przycisków wokół aktywnej strony
+
+export function PaginationBar({
+  page,
+  pageSize,
+  totalItems,
+  onPageChange,
+  onPageSizeChange,
+  className,
+}: PaginationBarProps) {
+  const { t } = useTranslation();
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  const current = Math.min(Math.max(1, page), totalPages);
+
+  if (totalItems === 0) return null;
+
+  const windowStart = Math.max(1, current - Math.floor(WINDOW_SIZE / 2));
+  const windowEnd = Math.min(totalPages, windowStart + WINDOW_SIZE - 1);
+  const adjustedStart = Math.max(1, windowEnd - WINDOW_SIZE + 1);
+  const pageNumbers: number[] = [];
+  for (let i = adjustedStart; i <= windowEnd; i++) {
+    pageNumbers.push(i);
+  }
+
+  const goto = (target: number): void => {
+    const clamped = Math.min(Math.max(1, target), totalPages);
+    if (clamped !== current) onPageChange(clamped);
+  };
+
+  return (
+    <nav
+      aria-label={t('pagination.aria_label', { defaultValue: 'Stronicowanie' })}
+      className={cn(
+        'flex items-center justify-between gap-3 rounded-2xl border border-zinc-100 bg-white px-4 py-2.5 shadow-sm',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 text-[12.5px] text-zinc-600">
+        <label htmlFor="page-size-select" className="text-zinc-500">
+          {t('pagination.page_size_label', { defaultValue: 'Wyświetl:' })}
+        </label>
+        <select
+          id="page-size-select"
+          value={pageSize}
+          onChange={(e) => onPageSizeChange(Number(e.target.value) as PageSize)}
+          className="h-8 px-2 rounded-lg border border-zinc-200 text-[12.5px] font-medium tabular-nums focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+        >
+          {PAGE_SIZE_OPTIONS.map((size) => (
+            <option key={size} value={size}>
+              {size}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="text-[12px] text-zinc-500 tabular-nums">
+        {t('pagination.page_indicator', {
+          page: current,
+          totalPages,
+          totalItems,
+          defaultValue: `Strona ${current} z ${totalPages} · ${totalItems} produktów`,
+        })}
+      </div>
+
+      <div className="flex items-center gap-1">
+        <PageButton
+          aria-label={t('pagination.first', { defaultValue: 'Pierwsza strona' })}
+          onClick={() => goto(1)}
+          disabled={current === 1}
+        >
+          <ChevronsLeft className="size-3.5" aria-hidden="true" />
+        </PageButton>
+        <PageButton
+          aria-label={t('pagination.previous', { defaultValue: 'Poprzednia strona' })}
+          onClick={() => goto(current - 1)}
+          disabled={current === 1}
+        >
+          <ChevronLeft className="size-3.5" aria-hidden="true" />
+        </PageButton>
+        {pageNumbers.map((num) => (
+          <PageButton
+            key={num}
+            onClick={() => goto(num)}
+            aria-current={num === current ? 'page' : undefined}
+            active={num === current}
+          >
+            <span className="tabular-nums text-[12px]">{num}</span>
+          </PageButton>
+        ))}
+        <PageButton
+          aria-label={t('pagination.next', { defaultValue: 'Następna strona' })}
+          onClick={() => goto(current + 1)}
+          disabled={current === totalPages}
+        >
+          <ChevronRight className="size-3.5" aria-hidden="true" />
+        </PageButton>
+        <PageButton
+          aria-label={t('pagination.last', { defaultValue: 'Ostatnia strona' })}
+          onClick={() => goto(totalPages)}
+          disabled={current === totalPages}
+        >
+          <ChevronsRight className="size-3.5" aria-hidden="true" />
+        </PageButton>
+      </div>
+    </nav>
+  );
+}
+
+interface PageButtonProps {
+  children: React.ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  active?: boolean;
+  'aria-label'?: string;
+  'aria-current'?: 'page' | undefined;
+}
+
+function PageButton({ children, onClick, disabled, active, ...rest }: PageButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      {...rest}
+      className={cn(
+        'h-8 min-w-[32px] px-2 rounded-lg text-[12px] font-medium transition grid place-items-center border',
+        active
+          ? 'bg-zinc-900 text-white border-zinc-900'
+          : 'bg-white text-zinc-700 border-zinc-200 hover:border-zinc-400',
+        disabled && 'opacity-40 cursor-not-allowed hover:border-zinc-200',
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -16,6 +16,11 @@ import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
 import { type ExcelColumn, ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
 import { FilterChipsBar } from '@/components/catalog/filter-chips-bar';
 import { FilterPill } from '@/components/catalog/filter-pill';
+import {
+  PAGE_SIZE_OPTIONS,
+  type PageSize,
+  PaginationBar,
+} from '@/components/catalog/pagination-bar';
 import type { FilterValue } from '@/components/catalog/product-filter-chips';
 import { ProductsGrid, type ProductsGridRow } from '@/components/catalog/products-grid';
 import { type RollbackSession, RollbackToast } from '@/components/catalog/rollback-toast';
@@ -92,10 +97,50 @@ const STATUS_VALUES: ReadonlyArray<{ value: string; label: string; sync: SyncAgg
 
 const CHANNEL_VALUES: ReadonlyArray<string> = ['Shopify', 'BaseLinker', 'Allegro'];
 
+function readInitialPageSize(): PageSize {
+  if (typeof window === 'undefined') return 50;
+  const urlParam = new URLSearchParams(window.location.search).get('pageSize');
+  const parsedUrl = urlParam !== null ? Number(urlParam) : Number.NaN;
+  if (PAGE_SIZE_OPTIONS.includes(parsedUrl as PageSize)) {
+    return parsedUrl as PageSize;
+  }
+  const stored = window.localStorage.getItem('pim.products.pageSize');
+  const parsedStored = stored !== null ? Number(stored) : Number.NaN;
+  if (PAGE_SIZE_OPTIONS.includes(parsedStored as PageSize)) {
+    return parsedStored as PageSize;
+  }
+  return 50;
+}
+
+function readInitialPage(): number {
+  if (typeof window === 'undefined') return 1;
+  const urlParam = new URLSearchParams(window.location.search).get('page');
+  const parsed = urlParam !== null ? Number(urlParam) : Number.NaN;
+  return Number.isFinite(parsed) && parsed >= 1 ? parsed : 1;
+}
+
 export function ProductListPage() {
   const { t } = useTranslation();
   const [query, setQuery] = useState('');
   const [filters, setFilters] = useState<Record<string, string | string[]>>({});
+  // VIEW-26 (#557) — pager + page size selector. Init kolejność:
+  // URL `?page=` + `?pageSize=` → localStorage → default 50.
+  const [page, setPage] = useState<number>(() => readInitialPage());
+  const [pageSize, setPageSize] = useState<PageSize>(() => readInitialPageSize());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem('pim.products.pageSize', String(pageSize));
+  }, [pageSize]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    params.set('page', String(page));
+    params.set('pageSize', String(pageSize));
+    const url = `${window.location.pathname}?${params.toString()}${window.location.hash}`;
+    window.history.replaceState(null, '', url);
+  }, [page, pageSize]);
   const [advancedFilters, setAdvancedFilters] = useState<Record<string, FilterValue>>({});
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [showSelectedOnly, setShowSelectedOnly] = useState(false);
@@ -217,6 +262,14 @@ export function ProductListPage() {
     }
   }, [activePreset, panelConditions, matchOperator, advancedMode, queryDsl]);
 
+  // VIEW-26 (#557) — reset pagera do strony 1 gdy filter/query/preset
+  // się zmienia, żeby operator nie wylądował na page 5 po zmianie
+  // filtra który ma tylko 2 strony wyników.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — `setPage` is stable, page tracked elsewhere
+  useEffect(() => {
+    setPage(1);
+  }, [query, filters, activeSmartPresetId, filterBlob, variantsMode]);
+
   const { result: searchResult, isLoading: isSearchLoading } = useCatalogSearch({
     kind: 'products',
     query,
@@ -225,7 +278,8 @@ export function ProductListPage() {
     smartPresetId: activePreset?.slug ?? activePreset?.id,
     filterBlob,
     facets: PRODUCT_FACETS,
-    perPage: 30,
+    page,
+    perPage: pageSize,
   });
 
   // Tree mode (#514): only fetch master products. Without this filter
@@ -940,6 +994,17 @@ export function ProductListPage() {
           alwaysShowChevronOnMasters={variantsMode === 'tree' && !isSearchActive}
         />
       )}
+
+      <PaginationBar
+        page={page}
+        pageSize={pageSize}
+        totalItems={totalHits}
+        onPageChange={setPage}
+        onPageSizeChange={(next) => {
+          setPageSize(next);
+          setPage(1);
+        }}
+      />
 
       <BulkBar
         selectedIds={Array.from(selected)}

--- a/apps/api/src/Search/Presentation/Controller/SearchController.php
+++ b/apps/api/src/Search/Presentation/Controller/SearchController.php
@@ -111,7 +111,9 @@ final class SearchController
         ));
 
         $page = max(1, (int) ($request->query->get('page') ?? 1));
-        $perPage = min(100, max(1, (int) ($request->query->get('perPage') ?? 30)));
+        // VIEW-26 (#557) — page size selector wykładnia 20/50/100/200,
+        // więc cap podniesiony ze 100 do 200.
+        $perPage = min(200, max(1, (int) ($request->query->get('perPage') ?? 30)));
         $highlight = filter_var($request->query->get('highlight'), FILTER_VALIDATE_BOOLEAN);
         // VIEW-11 (#542) — count-only shortcut for cross-page selection
         // toolbar. Skips hit hydration + facet aggregation; Meilisearch


### PR DESCRIPTION
PaginationBar component (4 page sizes 20/50/100/200, default 50) + numbered page buttons z window of 5 + first/prev/next/last. Init z URL → localStorage → 50.

## BE
- `SearchController::run()` perPage cap **100 → 200** żeby zgrać się z nowym maksimum.

## FE
- `<PaginationBar>` (~150 LOC) — selector + tekst „Strona N z M · K produktów" + buttons.
- `list.tsx`:
  - `readInitialPage()` / `readInitialPageSize()` — URL `?page` / `?pageSize` → localStorage → default 50.
  - `useEffect` persist `pageSize` → localStorage.
  - `useEffect` mirrors `?page=…&pageSize=…` w URL via `window.history.replaceState` (deep link friendly).
  - `useEffect` resetuje page=1 przy zmianie query/filters/preset/filterBlob/variantsMode (operator nie ląduje na page 5 dla 2-stronicowego filtra).
  - `<PaginationBar>` renderowany między gridem a BulkBar.

## Test plan
- Login → `/products` → pager pokazuje się, domyślnie pageSize=50
- Zmień pageSize na 200 → 200 rows, reload → wybór 200 zachowany (localStorage)
- Klik strona 3 → URL `?page=3&pageSize=200` → DevTools Network `?page=3&perPage=200`
- Filtr → page resetuje się do 1
- Cross-page selection (VIEW-11): zaznacz 3 na page 1 → page 2 → counter 3 zachowany

Closes #557
