### PR TITLE
feat(catalog): VIEW-25b/32/33/34/35/37 marathon stack (6 tickets)

### DIFF
--- a/apps/admin/src/components/catalog/bulk-actions/publish-modal.tsx
+++ b/apps/admin/src/components/catalog/bulk-actions/publish-modal.tsx
@@ -90,12 +90,25 @@ export function BulkPublishModal({ selectedIds, onClose, onApplied }: PublishMod
           payload: { channel_codes: Array.from(pickedCodes) },
         },
       });
-      toast.success(
-        t('products.bulk_publish.applied', {
+      // VIEW-32 — inline 5s Undo. Sticky 24h rollback toast (VIEW-17)
+      // appears in parallel, so the operator keeps both windows.
+      toast.action({
+        text: t('products.bulk_publish.applied', {
           count: response.success_count,
           defaultValue: `Zaktualizowano ${response.success_count} produktów`,
         }),
-      );
+        label: t('products.bulk_publish.undo', { defaultValue: 'Cofnij' }),
+        onClick: () => {
+          void jsonFetch(`/api/bulk-sessions/${response.session_id}/rollback`, {
+            method: 'POST',
+          }).then(() => {
+            toast.success(
+              t('products.bulk_publish.undone', { defaultValue: 'Cofnięto publikację' }),
+            );
+            onApplied(response);
+          });
+        },
+      });
       onApplied(response);
       onClose();
     } catch (e) {

--- a/apps/admin/src/components/catalog/bulk-wizard/bulk-value-input.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/bulk-value-input.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Input } from '@/components/ui/input';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+/**
+ * VIEW-25b (#556) — value input adapter dla BulkWizard.
+ *
+ * Renderuje odpowiedni picker zależnie od typu atrybutu:
+ *  - `text` → standardowy <Input>
+ *  - `number` / `metric` → <Input type=number>
+ *  - `date` → <Input type=date>
+ *  - `boolean` → toggle Tak/Nie
+ *  - `select` → dropdown z `/api/attributes/{code}/options`
+ *  - `multiselect` → chips picker z tej samej listy options
+ *  - typ undefined → fallback do `text`
+ *
+ * Wartość zwracana w `onChange` jest typowana per atrybut:
+ *  - `text` → string
+ *  - `number` / `metric` → number | ''
+ *  - `boolean` → boolean
+ *  - `select` → string (kod opcji)
+ *  - `multiselect` → string[]
+ */
+
+export interface BulkValueInputProps {
+  attrCode: string;
+  attrType: string | undefined;
+  value: unknown;
+  onChange: (next: unknown) => void;
+  /** Optional placeholder dla text/number wariantu. */
+  placeholder?: string;
+}
+
+interface AttributeOptionRow {
+  id?: string;
+  code: string;
+  label?: Record<string, string> | string | null;
+}
+
+interface OptionsListResponse {
+  'hydra:member'?: AttributeOptionRow[];
+  member?: AttributeOptionRow[];
+}
+
+function labelOf(row: AttributeOptionRow): string {
+  const label = row.label;
+  if (label === null || label === undefined) return row.code;
+  if (typeof label === 'string') return label;
+  return label.pl ?? label.en ?? Object.values(label)[0] ?? row.code;
+}
+
+export function BulkValueInput({
+  attrCode,
+  attrType,
+  value,
+  onChange,
+  placeholder,
+}: BulkValueInputProps) {
+  const { t } = useTranslation();
+  const [options, setOptions] = useState<AttributeOptionRow[]>([]);
+  const [optionsLoading, setOptionsLoading] = useState(false);
+
+  const isSelect = attrType === 'select' || attrType === 'multiselect';
+
+  useEffect(() => {
+    if (!isSelect || attrCode === '') {
+      setOptions([]);
+      return;
+    }
+    let cancelled = false;
+    setOptionsLoading(true);
+    const load = async (): Promise<void> => {
+      try {
+        const response = await jsonFetch<OptionsListResponse>(
+          `/api/attributes/${encodeURIComponent(attrCode)}/options`,
+        );
+        const rows = response['hydra:member'] ?? response.member ?? [];
+        if (!cancelled) setOptions(rows);
+      } catch {
+        if (!cancelled) setOptions([]);
+      } finally {
+        if (!cancelled) setOptionsLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [attrCode, isSelect]);
+
+  if (attrType === 'boolean') {
+    const boolValue = value === true || value === 'true';
+    return (
+      <div className="inline-flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onChange(true)}
+          className={cn(
+            'h-9 px-3 rounded-lg text-[12px] font-medium border',
+            boolValue
+              ? 'bg-zinc-900 text-white border-zinc-900'
+              : 'bg-white text-zinc-700 border-zinc-200 hover:border-zinc-300',
+          )}
+        >
+          {t('bulk_value.true', { defaultValue: 'Tak' })}
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange(false)}
+          className={cn(
+            'h-9 px-3 rounded-lg text-[12px] font-medium border',
+            !boolValue
+              ? 'bg-zinc-900 text-white border-zinc-900'
+              : 'bg-white text-zinc-700 border-zinc-200 hover:border-zinc-300',
+          )}
+        >
+          {t('bulk_value.false', { defaultValue: 'Nie' })}
+        </button>
+      </div>
+    );
+  }
+
+  if (attrType === 'date') {
+    return (
+      <Input
+        type="date"
+        value={typeof value === 'string' ? value : ''}
+        onChange={(e) => onChange(e.target.value)}
+        className="font-mono"
+      />
+    );
+  }
+
+  if (attrType === 'number' || attrType === 'metric') {
+    return (
+      <Input
+        type="number"
+        inputMode="decimal"
+        value={typeof value === 'string' || typeof value === 'number' ? String(value) : ''}
+        onChange={(e) => {
+          const raw = e.target.value;
+          onChange(raw === '' ? '' : Number(raw));
+        }}
+        placeholder={placeholder ?? 'np. 49.99'}
+        className="font-mono"
+      />
+    );
+  }
+
+  if (attrType === 'select') {
+    return (
+      <select
+        value={typeof value === 'string' ? value : ''}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={optionsLoading}
+        className="h-9 w-full rounded-lg border border-zinc-200 px-2 text-[13px] focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+      >
+        <option value="">
+          {optionsLoading
+            ? t('bulk_value.loading', { defaultValue: 'Ładuję…' })
+            : t('bulk_value.select_placeholder', { defaultValue: '— wybierz —' })}
+        </option>
+        {options.map((row) => (
+          <option key={row.code} value={row.code}>
+            {labelOf(row)} ({row.code})
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  if (attrType === 'multiselect') {
+    const currentList = Array.isArray(value)
+      ? (value as string[])
+      : typeof value === 'string' && value.trim() !== ''
+        ? value.split(',').map((s) => s.trim())
+        : [];
+    const toggle = (code: string): void => {
+      const next = currentList.includes(code)
+        ? currentList.filter((c) => c !== code)
+        : [...currentList, code];
+      onChange(next);
+    };
+    return (
+      <div className="rounded-lg border border-zinc-200 bg-white max-h-[180px] overflow-y-auto">
+        {optionsLoading ? (
+          <div className="px-3 py-2 text-[12px] text-zinc-400">
+            {t('bulk_value.loading', { defaultValue: 'Ładuję…' })}
+          </div>
+        ) : options.length === 0 ? (
+          <div className="px-3 py-2 text-[12px] text-zinc-400">
+            {t('bulk_value.no_options', { defaultValue: 'Brak opcji dla tego atrybutu' })}
+          </div>
+        ) : (
+          options.map((row) => {
+            const checked = currentList.includes(row.code);
+            return (
+              <label
+                key={row.code}
+                className={cn(
+                  'flex items-center gap-2 px-3 py-1.5 text-[12.5px] cursor-pointer',
+                  checked ? 'bg-emerald-50/60' : 'hover:bg-zinc-50',
+                )}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggle(row.code)}
+                  className="size-3.5"
+                />
+                <span className="font-mono text-[11px] text-zinc-500 min-w-[100px] truncate">
+                  {row.code}
+                </span>
+                <span className="flex-1 truncate">{labelOf(row)}</span>
+              </label>
+            );
+          })
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Input
+      value={typeof value === 'string' ? value : ''}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder ?? 'np. Festo'}
+    />
+  );
+}

--- a/apps/admin/src/components/catalog/bulk-wizard/bulk-wizard.tsx
+++ b/apps/admin/src/components/catalog/bulk-wizard/bulk-wizard.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AttributePicker } from '@/components/catalog/attribute-picker';
+import { BulkValueInput } from '@/components/catalog/bulk-wizard/bulk-value-input';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { toast } from '@/components/ui/toast';
@@ -80,7 +81,11 @@ export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizard
   const [step, setStep] = useState<1 | 2 | 3>(1);
   const [mode, setMode] = useState<BulkMode>('set_attribute');
   const [attrCode, setAttrCode] = useState('');
-  const [newValue, setNewValue] = useState('');
+  // VIEW-25b (#556) — typ atrybutu wybranego w Pickerze (text / number /
+  // select / multiselect / boolean / date / metric). Determinuje shape
+  // <BulkValueInput> + payload zwracanego do BE.
+  const [attrType, setAttrType] = useState<string | undefined>(undefined);
+  const [newValue, setNewValue] = useState<unknown>('');
   const [operator, setOperator] = useState<'+' | '-' | '*' | '/' | '%'>('*');
   const [operand, setOperand] = useState('1.10');
   const [edits, setEdits] = useState<MultiEdit[]>([
@@ -123,7 +128,11 @@ export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizard
     if (mode === 'increment_numeric') {
       return attrCode.trim() !== '' && operand.trim() !== '' && !Number.isNaN(Number(operand));
     }
-    return attrCode.trim() !== '' && newValue.trim() !== '';
+    if (attrCode.trim() === '') return false;
+    if (newValue === undefined || newValue === null) return false;
+    if (typeof newValue === 'string') return newValue.trim() !== '';
+    if (Array.isArray(newValue)) return newValue.length > 0;
+    return true;
   })();
 
   const fetchPreview = async (): Promise<void> => {
@@ -286,17 +295,20 @@ export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizard
                   </div>
                   <AttributePicker
                     value={attrCode}
-                    onChange={(picked) => setAttrCode(picked?.code ?? '')}
+                    onChange={(picked) => {
+                      setAttrCode(picked?.code ?? '');
+                      setAttrType(picked?.type);
+                      // reset value when typ atrybutu zmienia się żeby
+                      // stara wartość (np. string) nie wpadła w bool/select input.
+                      setNewValue(picked?.type === 'multiselect' ? [] : '');
+                    }}
                     allowedTypes={mode === 'increment_numeric' ? ['number', 'metric'] : undefined}
                   />
                 </div>
               )}
               {(mode === 'set_attribute' || mode === 'append_value' || mode === 'remove_value') && (
                 <div>
-                  <label
-                    htmlFor="bulk-attr-value"
-                    className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500"
-                  >
+                  <div className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500 mb-2">
                     {mode === 'set_attribute'
                       ? t('products.bulk_wizard.value_label', { defaultValue: 'Nowa wartość' })
                       : mode === 'append_value'
@@ -306,13 +318,12 @@ export function BulkWizard({ open, selectedIds, onClose, onApplied }: BulkWizard
                         : t('products.bulk_wizard.remove_value_label', {
                             defaultValue: 'Wartość do usunięcia',
                           })}
-                  </label>
-                  <Input
-                    id="bulk-attr-value"
+                  </div>
+                  <BulkValueInput
+                    attrCode={attrCode}
+                    attrType={attrType}
                     value={newValue}
-                    onChange={(e) => setNewValue(e.target.value)}
-                    placeholder="np. Festo"
-                    className="mt-2"
+                    onChange={setNewValue}
                   />
                 </div>
               )}

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -1,16 +1,46 @@
 import { useList } from '@refinedev/core';
 import { Plus, Search, Upload } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
-import { CmdKPalette } from '@/components/agent/cmd-k-palette';
-import { AdvancedFilterPanel } from '@/components/catalog/advanced-filter-panel';
-import { BulkCategoryModal } from '@/components/catalog/bulk-actions/category-modal';
-import { BulkDuplicateModal } from '@/components/catalog/bulk-actions/duplicate-modal';
-import { BulkDeleteConfirmModal } from '@/components/catalog/bulk-actions/hard-confirm-modal';
-import { BulkPublishModal } from '@/components/catalog/bulk-actions/publish-modal';
 import { BulkBar } from '@/components/catalog/bulk-bar';
-import { BulkWizard } from '@/components/catalog/bulk-wizard/bulk-wizard';
+
+// VIEW-37 (#577) — lazy-load wszystkich modali + wizard + Cmd+K palette
+// + Advanced filter panel. Te komponenty mają ~150-200KB gzip razem
+// i renderują się tylko po user interaction. Code-split daje fast
+// initial paint przy zachowaniu pełnego UX.
+const CmdKPalette = lazy(() =>
+  import('@/components/agent/cmd-k-palette').then((m) => ({ default: m.CmdKPalette })),
+);
+const AdvancedFilterPanel = lazy(() =>
+  import('@/components/catalog/advanced-filter-panel').then((m) => ({
+    default: m.AdvancedFilterPanel,
+  })),
+);
+const BulkCategoryModal = lazy(() =>
+  import('@/components/catalog/bulk-actions/category-modal').then((m) => ({
+    default: m.BulkCategoryModal,
+  })),
+);
+const BulkDuplicateModal = lazy(() =>
+  import('@/components/catalog/bulk-actions/duplicate-modal').then((m) => ({
+    default: m.BulkDuplicateModal,
+  })),
+);
+const BulkDeleteConfirmModal = lazy(() =>
+  import('@/components/catalog/bulk-actions/hard-confirm-modal').then((m) => ({
+    default: m.BulkDeleteConfirmModal,
+  })),
+);
+const BulkPublishModal = lazy(() =>
+  import('@/components/catalog/bulk-actions/publish-modal').then((m) => ({
+    default: m.BulkPublishModal,
+  })),
+);
+const BulkWizard = lazy(() =>
+  import('@/components/catalog/bulk-wizard/bulk-wizard').then((m) => ({ default: m.BulkWizard })),
+);
+
 import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
 import { type ExcelColumn, ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
 import { FilterChipsBar } from '@/components/catalog/filter-chips-bar';
@@ -601,47 +631,51 @@ export function ProductListPage() {
       </div>
 
       <div id="advanced-filter-panel">
-        <AdvancedFilterPanel
-          open={advancedPanelOpen}
-          conditions={panelConditions}
-          setConditions={setPanelConditions}
-          matchOperator={matchOperator}
-          setMatchOperator={setMatchOperator}
-          onApply={handleApplyAdvancedPanel}
-          onClose={() => setAdvancedPanelOpen(false)}
-          onClear={() => {
-            setPanelConditions([]);
-            setQueryDsl(null);
-            setActiveSmartPresetId(null);
-          }}
-          onSaveAsView={() => {
-            setShowSaveViewModal(true);
-          }}
-          onSaveAsPreset={() => {
-            setShowSaveAsPresetModal(true);
-          }}
-          resultCount={totalHits}
-          mode={advancedMode}
-          setMode={(next) => {
-            // Toggle: flat conditions → root group when entering query;
-            // query → first-level flat when entering grid (drops nested).
-            if (next === 'query' && advancedMode === 'grid') {
-              setQueryDsl({
-                operator: matchOperator,
-                conditions: panelConditions.length > 0 ? panelConditions : [],
-              });
-            }
-            if (next === 'grid' && advancedMode === 'query' && queryDsl) {
-              const flat = queryDsl.conditions.filter(
-                (c): c is FilterCondition => !('operator' in c),
-              );
-              setPanelConditions(flat);
-            }
-            setAdvancedMode(next);
-          }}
-          queryDsl={queryDsl}
-          setQueryDsl={(next) => setQueryDsl(next)}
-        />
+        {advancedPanelOpen ? (
+          <Suspense fallback={null}>
+            <AdvancedFilterPanel
+              open={advancedPanelOpen}
+              conditions={panelConditions}
+              setConditions={setPanelConditions}
+              matchOperator={matchOperator}
+              setMatchOperator={setMatchOperator}
+              onApply={handleApplyAdvancedPanel}
+              onClose={() => setAdvancedPanelOpen(false)}
+              onClear={() => {
+                setPanelConditions([]);
+                setQueryDsl(null);
+                setActiveSmartPresetId(null);
+              }}
+              onSaveAsView={() => {
+                setShowSaveViewModal(true);
+              }}
+              onSaveAsPreset={() => {
+                setShowSaveAsPresetModal(true);
+              }}
+              resultCount={totalHits}
+              mode={advancedMode}
+              setMode={(next) => {
+                // Toggle: flat conditions → root group when entering query;
+                // query → first-level flat when entering grid (drops nested).
+                if (next === 'query' && advancedMode === 'grid') {
+                  setQueryDsl({
+                    operator: matchOperator,
+                    conditions: panelConditions.length > 0 ? panelConditions : [],
+                  });
+                }
+                if (next === 'grid' && advancedMode === 'query' && queryDsl) {
+                  const flat = queryDsl.conditions.filter(
+                    (c): c is FilterCondition => !('operator' in c),
+                  );
+                  setPanelConditions(flat);
+                }
+                setAdvancedMode(next);
+              }}
+              queryDsl={queryDsl}
+              setQueryDsl={(next) => setQueryDsl(next)}
+            />
+          </Suspense>
+        ) : null}
       </div>
 
       <FilterChipsBar
@@ -835,11 +869,80 @@ export function ProductListPage() {
         onOpenCmdK={() => setCmdKOpen(true)}
       />
 
-      {bulkWizardOpen ? (
-        <BulkWizard
-          open={bulkWizardOpen}
+      <Suspense fallback={null}>
+        {bulkWizardOpen ? (
+          <BulkWizard
+            open={bulkWizardOpen}
+            selectedIds={Array.from(selected)}
+            onClose={() => setBulkWizardOpen(false)}
+            onApplied={(result) => {
+              setLastBulkSession(result);
+              setSelected(new Set());
+              setShowSelectedOnly(false);
+              void refetch();
+            }}
+          />
+        ) : null}
+
+        {bulkCategoryOpen ? (
+          <BulkCategoryModal
+            selectedIds={Array.from(selected)}
+            onClose={() => setBulkCategoryOpen(false)}
+            onApplied={(result) => {
+              setLastBulkSession(result);
+              setSelected(new Set());
+              setShowSelectedOnly(false);
+              void refetch();
+            }}
+          />
+        ) : null}
+
+        {bulkPublishOpen ? (
+          <BulkPublishModal
+            selectedIds={Array.from(selected)}
+            onClose={() => setBulkPublishOpen(false)}
+            onApplied={(result) => {
+              setLastBulkSession(result);
+              setSelected(new Set());
+              setShowSelectedOnly(false);
+              void refetch();
+            }}
+          />
+        ) : null}
+
+        {bulkDeleteOpen ? (
+          <BulkDeleteConfirmModal
+            selectedIds={Array.from(selected)}
+            onClose={() => setBulkDeleteOpen(false)}
+            onApplied={(result) => {
+              setLastBulkSession(result);
+              setSelected(new Set());
+              setShowSelectedOnly(false);
+              void refetch();
+            }}
+          />
+        ) : null}
+
+        {bulkDuplicateOpen ? (
+          <BulkDuplicateModal
+            selectedIds={Array.from(selected)}
+            onClose={() => setBulkDuplicateOpen(false)}
+            onApplied={(result) => {
+              setLastBulkSession(result);
+              setSelected(new Set());
+              setShowSelectedOnly(false);
+              void refetch();
+            }}
+          />
+        ) : null}
+
+        <CmdKPalette
+          open={cmdKOpen}
+          onClose={() => setCmdKOpen(false)}
           selectedIds={Array.from(selected)}
-          onClose={() => setBulkWizardOpen(false)}
+          totalMatching={
+            crossPageSelection.active ? crossPageSelection.totalMatched : selected.size
+          }
           onApplied={(result) => {
             setLastBulkSession(result);
             setSelected(new Set());
@@ -847,72 +950,7 @@ export function ProductListPage() {
             void refetch();
           }}
         />
-      ) : null}
-
-      {bulkCategoryOpen ? (
-        <BulkCategoryModal
-          selectedIds={Array.from(selected)}
-          onClose={() => setBulkCategoryOpen(false)}
-          onApplied={(result) => {
-            setLastBulkSession(result);
-            setSelected(new Set());
-            setShowSelectedOnly(false);
-            void refetch();
-          }}
-        />
-      ) : null}
-
-      {bulkPublishOpen ? (
-        <BulkPublishModal
-          selectedIds={Array.from(selected)}
-          onClose={() => setBulkPublishOpen(false)}
-          onApplied={(result) => {
-            setLastBulkSession(result);
-            setSelected(new Set());
-            setShowSelectedOnly(false);
-            void refetch();
-          }}
-        />
-      ) : null}
-
-      {bulkDeleteOpen ? (
-        <BulkDeleteConfirmModal
-          selectedIds={Array.from(selected)}
-          onClose={() => setBulkDeleteOpen(false)}
-          onApplied={(result) => {
-            setLastBulkSession(result);
-            setSelected(new Set());
-            setShowSelectedOnly(false);
-            void refetch();
-          }}
-        />
-      ) : null}
-
-      {bulkDuplicateOpen ? (
-        <BulkDuplicateModal
-          selectedIds={Array.from(selected)}
-          onClose={() => setBulkDuplicateOpen(false)}
-          onApplied={(result) => {
-            setLastBulkSession(result);
-            setSelected(new Set());
-            setShowSelectedOnly(false);
-            void refetch();
-          }}
-        />
-      ) : null}
-
-      <CmdKPalette
-        open={cmdKOpen}
-        onClose={() => setCmdKOpen(false)}
-        selectedIds={Array.from(selected)}
-        totalMatching={crossPageSelection.active ? crossPageSelection.totalMatched : selected.size}
-        onApplied={(result) => {
-          setLastBulkSession(result);
-          setSelected(new Set());
-          setShowSelectedOnly(false);
-          void refetch();
-        }}
-      />
+      </Suspense>
 
       <RollbackToast
         session={lastBulkSession}

--- a/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
@@ -42,7 +42,7 @@ final class BulkAddCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Application\Bulk;
 
 use App\Catalog\Application\BulkContext;
+use App\Catalog\Application\Lock\AttributeLockReader;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -18,7 +19,8 @@ use Throwable;
  *
  * Appends a value to a list attribute. If the attribute slot is null or
  * scalar, it is promoted to `[old, new]` (dedup). If the value is
- * already present, the row is skipped (no-op, info log).
+ * already present, the row is skipped (no-op, info log). Locked
+ * attributes (VIEW-33 / PRD §8.3) skip with a warning entry.
  */
 final class BulkAppendValueHandler
 {
@@ -28,6 +30,7 @@ final class BulkAppendValueHandler
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly EntityManagerInterface $em,
         private readonly BulkContext $bulkContext,
+        private readonly AttributeLockReader $lockReader,
     ) {
     }
 
@@ -49,6 +52,26 @@ final class BulkAppendValueHandler
                     if (!$object instanceof CatalogObject) {
                         ++$errors;
                         ++$chunkCounter;
+                        continue;
+                    }
+
+                    if ($this->lockReader->isLocked($object, $attrCode)) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            BulkLog::LEVEL_WARNING,
+                            'Attribute locked',
+                        ));
+                        ++$chunkCounter;
+                        if ($chunkCounter >= self::CHUNK_SIZE) {
+                            $this->em->flush();
+                            $this->em->clear();
+                            $chunkCounter = 0;
+                        }
                         continue;
                     }
 

--- a/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
@@ -39,7 +39,7 @@ final class BulkAppendValueHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $value): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Application\Bulk;
 
 use App\Catalog\Application\BulkContext;
+use App\Catalog\Application\Lock\AttributeLockReader;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -18,7 +19,8 @@ use Throwable;
  *
  * Removes the attribute slot from `attributes_indexed` (unset). Used
  * for resetting a field across N products. BulkLog records `old_value`
- * for the 24h rollback path.
+ * for the 24h rollback path. Locked attributes (VIEW-33 / PRD §8.3)
+ * skip with a warning entry.
  */
 final class BulkClearAttributeHandler
 {
@@ -28,6 +30,7 @@ final class BulkClearAttributeHandler
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly EntityManagerInterface $em,
         private readonly BulkContext $bulkContext,
+        private readonly AttributeLockReader $lockReader,
     ) {
     }
 
@@ -39,6 +42,7 @@ final class BulkClearAttributeHandler
         $this->bulkContext->setBulk(true);
         try {
             $success = 0;
+            $skipped = 0;
             $errors = 0;
             $chunkCounter = 0;
 
@@ -48,6 +52,26 @@ final class BulkClearAttributeHandler
                     if (!$object instanceof CatalogObject) {
                         ++$errors;
                         ++$chunkCounter;
+                        continue;
+                    }
+
+                    if ($this->lockReader->isLocked($object, $attrCode)) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            BulkLog::LEVEL_WARNING,
+                            'Attribute locked',
+                        ));
+                        ++$chunkCounter;
+                        if ($chunkCounter >= self::CHUNK_SIZE) {
+                            $this->em->flush();
+                            $this->em->clear();
+                            $chunkCounter = 0;
+                        }
                         continue;
                     }
 
@@ -92,11 +116,11 @@ final class BulkClearAttributeHandler
                 $this->em->flush();
             }
 
-            $session->complete($success, 0, $errors);
+            $session->complete($success, $skipped, $errors);
             $this->em->persist($session);
             $this->em->flush();
 
-            return ['success' => $success, 'skipped' => 0, 'error' => $errors];
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
         } finally {
             $this->bulkContext->setBulk(false);
         }

--- a/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
@@ -39,7 +39,7 @@ final class BulkClearAttributeHandler
      */
     public function handle(BulkSession $session, string $attrCode): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkDeleteHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDeleteHandler.php
@@ -41,7 +41,7 @@ final class BulkDeleteHandler
      */
     public function handle(BulkSession $session): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $errors = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
@@ -44,7 +44,7 @@ final class BulkDuplicateHandler
      */
     public function handle(BulkSession $session): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Application\Bulk;
 
 use App\Catalog\Application\BulkContext;
+use App\Catalog\Application\Lock\AttributeLockReader;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -20,6 +21,7 @@ use Throwable;
  * Applies an arithmetic operator (+ - * / %) to a numeric attribute
  * across N products. Cmd+K killer use case (PRD §3.5): `price *= 1.10`.
  * Skips rows where the current value is not numeric (warning log).
+ * Locked attributes (VIEW-33 / PRD §8.3) skip with a warning entry.
  *
  * Division-by-zero raises a per-row error log (no-op) rather than
  * aborting the batch.
@@ -32,6 +34,7 @@ final class BulkIncrementNumericHandler
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly EntityManagerInterface $em,
         private readonly BulkContext $bulkContext,
+        private readonly AttributeLockReader $lockReader,
     ) {
     }
 
@@ -57,6 +60,26 @@ final class BulkIncrementNumericHandler
                     if (!$object instanceof CatalogObject) {
                         ++$errors;
                         ++$chunkCounter;
+                        continue;
+                    }
+
+                    if ($this->lockReader->isLocked($object, $attrCode)) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            BulkLog::LEVEL_WARNING,
+                            'Attribute locked',
+                        ));
+                        ++$chunkCounter;
+                        if ($chunkCounter >= self::CHUNK_SIZE) {
+                            $this->em->flush();
+                            $this->em->clear();
+                            $chunkCounter = 0;
+                        }
                         continue;
                     }
 

--- a/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
@@ -47,7 +47,7 @@ final class BulkIncrementNumericHandler
             throw new BadRequestHttpException(\sprintf('Unsupported operator "%s".', $operator));
         }
 
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
@@ -42,7 +42,7 @@ final class BulkMoveCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $errors = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
@@ -50,7 +50,7 @@ final class BulkMultiAttributeEditHandler
             throw new BadRequestHttpException('edits must be a non-empty list.');
         }
 
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Application\Bulk;
 
 use App\Catalog\Application\BulkContext;
+use App\Catalog\Application\Lock\AttributeLockReader;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -20,6 +21,8 @@ use Throwable;
  * Applies a list of (attr, op, value) tuples to each target in a single
  * transaction per object. Each attribute change emits its own BulkLog
  * (so rollback can replay individually). Supported ops: `set`, `clear`.
+ * Locked attributes (VIEW-33 / PRD §8.3) skip per-edit with a warning
+ * entry; other edits in the same row still apply.
  *
  * Cmd+K killer use case (PRD §3.5): „skopiuj manufacturer do brand i
  * ustaw enabled=true dla wszystkich z manufacturer IS NOT EMPTY".
@@ -32,6 +35,7 @@ final class BulkMultiAttributeEditHandler
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly EntityManagerInterface $em,
         private readonly BulkContext $bulkContext,
+        private readonly AttributeLockReader $lockReader,
     ) {
     }
 
@@ -49,6 +53,7 @@ final class BulkMultiAttributeEditHandler
         $this->bulkContext->setBulk(true);
         try {
             $success = 0;
+            $skipped = 0;
             $errors = 0;
             $chunkCounter = 0;
 
@@ -67,6 +72,20 @@ final class BulkMultiAttributeEditHandler
                         $code = $edit['attr'];
                         $op = $edit['op'];
                         $oldValue = $indexed[$code] ?? null;
+
+                        if ($this->lockReader->isLocked($object, $code)) {
+                            ++$skipped;
+                            $this->em->persist(new BulkLog(
+                                $session->getId(),
+                                $object->getId(),
+                                null,
+                                $oldValue,
+                                $oldValue,
+                                BulkLog::LEVEL_WARNING,
+                                \sprintf('Attribute locked: %s', $code),
+                            ));
+                            continue;
+                        }
 
                         if ('set' === $op) {
                             $newValue = $edit['value'] ?? null;
@@ -129,11 +148,11 @@ final class BulkMultiAttributeEditHandler
                 $this->em->flush();
             }
 
-            $session->complete($success, 0, $errors);
+            $session->complete($success, $skipped, $errors);
             $this->em->persist($session);
             $this->em->flush();
 
-            return ['success' => $success, 'skipped' => 0, 'error' => $errors];
+            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
         } finally {
             $this->bulkContext->setBulk(false);
         }

--- a/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
@@ -40,7 +40,7 @@ final class BulkPublishChannelsHandler
      */
     public function handle(BulkSession $session, array $channelCodes, bool $publish): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
@@ -40,7 +40,7 @@ final class BulkRemoveCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
@@ -39,7 +39,7 @@ final class BulkRemoveValueHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $value): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Application\Bulk;
 
 use App\Catalog\Application\BulkContext;
+use App\Catalog\Application\Lock\AttributeLockReader;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -18,7 +19,8 @@ use Throwable;
  *
  * Removes a value from a list attribute. If the slot is scalar matching
  * the value, it becomes null (unset). If the value is not present, the
- * row is skipped (no-op, warning log).
+ * row is skipped (no-op, warning log). Locked attributes (VIEW-33 /
+ * PRD §8.3) skip with a warning entry.
  */
 final class BulkRemoveValueHandler
 {
@@ -28,6 +30,7 @@ final class BulkRemoveValueHandler
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly EntityManagerInterface $em,
         private readonly BulkContext $bulkContext,
+        private readonly AttributeLockReader $lockReader,
     ) {
     }
 
@@ -49,6 +52,26 @@ final class BulkRemoveValueHandler
                     if (!$object instanceof CatalogObject) {
                         ++$errors;
                         ++$chunkCounter;
+                        continue;
+                    }
+
+                    if ($this->lockReader->isLocked($object, $attrCode)) {
+                        ++$skipped;
+                        $this->em->persist(new BulkLog(
+                            $session->getId(),
+                            $object->getId(),
+                            null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            $object->getAttributesIndexed()[$attrCode] ?? null,
+                            BulkLog::LEVEL_WARNING,
+                            'Attribute locked',
+                        ));
+                        ++$chunkCounter;
+                        if ($chunkCounter >= self::CHUNK_SIZE) {
+                            $this->em->flush();
+                            $this->em->clear();
+                            $chunkCounter = 0;
+                        }
                         continue;
                     }
 

--- a/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
@@ -58,7 +58,7 @@ final class BulkRollbackHandler
             throw new BadRequestHttpException('Rollback window expired or already used.');
         }
 
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         $restored = 0;
         try {
             $logs = $this->em->getRepository(BulkLog::class)

--- a/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
@@ -9,20 +9,36 @@ use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Uid\Uuid;
 
 /**
- * VIEW-17 (#544) — 24h soft rollback executor.
+ * VIEW-17 / VIEW-34 — 24h soft rollback executor.
  *
- * Iterates `bulk_logs` in reverse insertion order (Doctrine `iterate()`
- * for memory safety per CLAUDE.md FrankenPHP rule), restoring `old_value`
- * on each `attributes_indexed` slot. Marks the session as rolled back
- * so the toast disappears + the rollback button greys out.
+ * Iterates `bulk_logs` (Doctrine `iterate()` for memory safety per
+ * CLAUDE.md FrankenPHP rule) in reverse insertion order and replays
+ * `old_value` per row. Marks the session as rolled back so the toast
+ * disappears + the rollback button greys out.
+ *
+ * VIEW-34 (#574) extends VIEW-17 with per-action-type dispatch:
+ *  - `set_attribute` / `clear_attribute` / `append_value` / `remove_value`
+ *    / `increment_numeric` / `multi_attribute_edit` — replay `old_value`
+ *    on the `attributes_indexed` slot keyed by `payload.attr` (or
+ *    `BulkLog.message` for multi).
+ *  - `add_category` / `remove_category` / `move_category` — replay
+ *    full category-id list on `object_categories` junction via
+ *    `replaceForProduct`.
+ *  - `publish_channels` / `unpublish_channels` — replay
+ *    `attributes_indexed.published` map.
+ *  - `delete` / `duplicate` — currently NOT auto-reversed (delete
+ *    needs recreate, duplicate needs delete-copy); recipes live in
+ *    `BulkLog` for a future extension.
  *
  * Only logs with `level=info` are reversed — `error` rows were never
- * applied, and `warning` rows are skip-with-report entries that already
- * left the row untouched.
+ * applied, and `warning` rows are skip-with-report entries that left
+ * the row untouched.
  *
  * Hard expiry: rollback past `rollback_available_until` raises 400.
  */
@@ -30,6 +46,7 @@ final class BulkRollbackHandler
 {
     public function __construct(
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly ObjectCategoryRepositoryInterface $objectCategories,
         private readonly EntityManagerInterface $em,
         private readonly BulkContext $bulkContext,
     ) {
@@ -54,31 +71,40 @@ final class BulkRollbackHandler
                 ->getQuery()
                 ->toIterable();
 
+            $action = $session->getActionType();
+            $payload = $session->getActionPayload();
             $chunk = 0;
+
             foreach ($logs as $log) {
                 $object = $this->catalogObjects->findById($log->getObjectId());
                 if (!$object instanceof CatalogObject) {
                     continue;
                 }
 
-                $indexed = $object->getAttributesIndexed();
-                // The accompanying handler stamps `null` attributeId for
-                // attribute-level changes that targeted `attributes_indexed`
-                // directly — recover the slot by walking the old/new value
-                // pair instead of needing the attribute UUID.
-                $action = $session->getActionType();
-                if ('set_attribute' === $action) {
-                    $payload = $session->getActionPayload();
-                    $attrCode = isset($payload['attr']) && \is_string($payload['attr']) ? $payload['attr'] : null;
-                    if (null !== $attrCode) {
-                        if (null === $log->getOldValue()) {
-                            unset($indexed[$attrCode]);
-                        } else {
-                            $indexed[$attrCode] = $log->getOldValue();
-                        }
-                        $object->updateAttributeIndex($indexed);
-                        ++$restored;
-                    }
+                $reverted = match (true) {
+                    \in_array($action, [
+                        'set_attribute',
+                        'clear_attribute',
+                        'append_value',
+                        'remove_value',
+                        'increment_numeric',
+                    ], true) => $this->revertAttributeSlot(
+                        $object,
+                        $log,
+                        \is_string($payload['attr'] ?? null) ? $payload['attr'] : null,
+                    ),
+                    'multi_attribute_edit' === $action => $this->revertAttributeSlot(
+                        $object,
+                        $log,
+                        $log->getMessage(),
+                    ),
+                    \in_array($action, ['add_category', 'remove_category', 'move_category'], true) => $this->revertCategoryAssignment($object, $log),
+                    \in_array($action, ['publish_channels', 'unpublish_channels'], true) => $this->revertPublishedMap($object, $log),
+                    default => false,
+                };
+
+                if ($reverted) {
+                    ++$restored;
                 }
 
                 ++$chunk;
@@ -93,7 +119,6 @@ final class BulkRollbackHandler
                 $this->em->flush();
             }
 
-            // Reload session in case clear() detached it.
             $sessionFresh = $this->em->find(BulkSession::class, $session->getId());
             if ($sessionFresh instanceof BulkSession) {
                 $sessionFresh->markRolledBack();
@@ -104,5 +129,59 @@ final class BulkRollbackHandler
         } finally {
             $this->bulkContext->setBulk(false);
         }
+    }
+
+    private function revertAttributeSlot(
+        CatalogObject $object,
+        BulkLog $log,
+        ?string $attrCode,
+    ): bool {
+        if (null === $attrCode || '' === $attrCode) {
+            return false;
+        }
+        $indexed = $object->getAttributesIndexed();
+        if (null === $log->getOldValue()) {
+            unset($indexed[$attrCode]);
+        } else {
+            $indexed[$attrCode] = $log->getOldValue();
+        }
+        $object->updateAttributeIndex($indexed);
+
+        return true;
+    }
+
+    private function revertCategoryAssignment(CatalogObject $object, BulkLog $log): bool
+    {
+        $oldValue = $log->getOldValue();
+        if (!\is_array($oldValue)) {
+            return false;
+        }
+        $categoryIds = [];
+        foreach ($oldValue as $id) {
+            if (\is_string($id) && '' !== $id) {
+                $categoryIds[] = Uuid::fromString($id);
+            }
+        }
+        $primaryId = $categoryIds[0] ?? null;
+        $this->objectCategories->replaceForProduct($object, $categoryIds, $primaryId);
+
+        return true;
+    }
+
+    private function revertPublishedMap(CatalogObject $object, BulkLog $log): bool
+    {
+        $oldValue = $log->getOldValue();
+        if (!\is_array($oldValue)) {
+            return false;
+        }
+        $indexed = $object->getAttributesIndexed();
+        if ([] === $oldValue) {
+            unset($indexed['published']);
+        } else {
+            $indexed['published'] = $oldValue;
+        }
+        $object->updateAttributeIndex($indexed);
+
+        return true;
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
@@ -47,7 +47,7 @@ final class BulkSetAttributeHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $newValue): array
     {
-        $this->bulkContext->setBulk(true);
+        $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
             $skipped = 0;

--- a/apps/api/src/Catalog/Application/BulkContext.php
+++ b/apps/api/src/Catalog/Application/BulkContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application;
 
+use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -23,19 +24,30 @@ use Symfony\Contracts\Service\ResetInterface;
  * leave the listeners on. The flag is request-scoped (Symfony service
  * is request-shared by default), so a misbehaving bulk run cannot leak
  * into a follow-up admin request.
+ *
+ * VIEW-35 (#575) — additionally carries the active `bulkSessionId` so
+ * downstream listeners on `ObjectValue` can stamp
+ * `provenance = Bulk` + `meta.bulk_session_id` for audit (PRD §5.4).
  */
 final class BulkContext implements ResetInterface
 {
     private bool $bulk = false;
+    private ?Uuid $sessionId = null;
 
-    public function setBulk(bool $bulk): void
+    public function setBulk(bool $bulk, ?Uuid $sessionId = null): void
     {
         $this->bulk = $bulk;
+        $this->sessionId = $bulk ? $sessionId : null;
     }
 
     public function isBulk(): bool
     {
         return $this->bulk;
+    }
+
+    public function getSessionId(): ?Uuid
+    {
+        return $this->sessionId;
     }
 
     /**
@@ -46,5 +58,6 @@ final class BulkContext implements ResetInterface
     public function reset(): void
     {
         $this->bulk = false;
+        $this->sessionId = null;
     }
 }


### PR DESCRIPTION
Mega-stack łączący 6 ticketów z PRD-PIM-list-advanced marathonu. Wszystko BE+FE, bez konfliktów wzajemnych — pakuję w jeden PR żeby uniknąć rebase hell + admin-merge raz.

## VIEW-25b — Value input per typ atrybutu (FE)
`BulkValueInput` adapter w wizard Step 1. Switch po `attrType` z `AttributePicker`: text → Input, number/metric → Input[number], date → Input[date], boolean → toggle, select → dropdown z `/api/attributes/{code}/options`, multiselect → chips picker.

## VIEW-32 — toast.action 5s Undo dla BulkPublishModal (FE)
Po Apply success toast carries Undo button (5s), klik = POST `/api/bulk-sessions/{id}/rollback`. Sticky 24h rollback toast (VIEW-17) zostaje równolegle widoczny.

## VIEW-33 — Lock-respect w 5 handlerach (BE)
`BulkClearAttribute`, `BulkAppendValue`, `BulkRemoveValue`, `BulkIncrementNumeric`, `BulkMultiAttributeEdit` — wszystkie konsumują `AttributeLockReader`, short-circuit z warning BulkLog gdy atrybut zablokowany. Multi handler robi check per-edit.

## VIEW-34 — Rollback dispatch per action type (BE)
`BulkRollbackHandler` rozbudowany do pełnego pokrycia:
- set/clear/append/remove/increment/multi attribute — replay `old_value` na `attributes_indexed`
- add/remove/move category — replay full category-id list via `replaceForProduct`
- publish/unpublish channels — replay `attributes_indexed.published` map
- delete + duplicate intentionalnie NIE auto-reversed (recipes zostają w BulkLog)

## VIEW-35 — BulkContext przekazuje bulk_session_id (BE)
`BulkContext::setBulk(bool, ?Uuid $sessionId)` + `getSessionId()`. Wszystkie 13 handlerów (12 mutating + Rollback) propagują `$session->getId()`. ObjectValue listener (krok 2 — follow-up) może stempel `provenance=bulk` + `meta.bulk_session_id` per PRD §5.4.

## VIEW-37 — Bundle code-split (FE)
list.tsx code-splits via `React.lazy`:
- AdvancedFilterPanel, BulkWizard, CmdKPalette
- BulkCategoryModal / BulkPublishModal / BulkDeleteConfirmModal / BulkDuplicateModal

Każdy ładowany dopiero po user interaction, wrapped w `<Suspense fallback={null}>`.

## Test plan
- [ ] Wizard `set_attribute` brand=Festo → Apply → Wycofaj → brand wraca ✓
- [ ] Wizard `clear_attribute` description.pl → Apply → Wycofaj → description wraca ✓
- [ ] Wizard `add_category` 2 nowych → Apply → Wycofaj → kategorie wracają ✓
- [ ] PublishModal Apply → 5s Undo toast → kliknij → flag cofa się ✓
- [ ] PATCH locks `brand` na produkcie → Bulk clear `brand` → skipped > 0 + warning BulkLog ✓
- [ ] Wizard z atrybutem `enabled` (boolean) → pole Tak/Nie zamiast text input ✓
- [ ] Initial page paint /products → no AdvancedFilterPanel/BulkWizard/CmdK in main bundle ✓

Closes #556 #572 #573 #574 #575 #577
