### PR TITLE
feat(catalog): objects.bulk_session_id denormalized + handler wiring (VIEW-28, #559)

### DIFF
--- a/apps/api/migrations/Version20260514160000.php
+++ b/apps/api/migrations/Version20260514160000.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * VIEW-28 (#559) — `objects.bulk_session_id` denormalized column (PRD §5.2).
+ *
+ * Last bulk session that touched the row. Cache speeds up the "show me
+ * everything bulk_a8f3c2 changed" queries from the VIEW-17 audit panel
+ * and the future R-36 benchmark. `ON DELETE SET NULL` (not CASCADE)
+ * because deleting an old bulk session must NOT cascade into product
+ * rows.
+ *
+ * Partial index `WHERE bulk_session_id IS NOT NULL` keeps the index
+ * small — most rows in steady state have NULL (never touched by bulk).
+ */
+final class Version20260514160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'VIEW-28 objects.bulk_session_id denormalized cache column (#559).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE objects ADD COLUMN bulk_session_id UUID NULL
+            SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE objects
+              ADD CONSTRAINT fk_objects_bulk_session
+              FOREIGN KEY (bulk_session_id) REFERENCES bulk_sessions(id)
+              ON DELETE SET NULL
+            SQL);
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_objects_bulk_session
+              ON objects (bulk_session_id)
+              WHERE bulk_session_id IS NOT NULL
+            SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_objects_bulk_session');
+        $this->addSql('ALTER TABLE objects DROP CONSTRAINT IF EXISTS fk_objects_bulk_session');
+        $this->addSql('ALTER TABLE objects DROP COLUMN IF EXISTS bulk_session_id');
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
@@ -89,6 +89,7 @@ final class BulkAddCategoryHandler
                             'All categories already assigned',
                         ));
                     } else {
+                        $product->markTouchedByBulkSession($session->getId());
                         $this->em->persist(new BulkLog(
                             $session->getId(),
                             $product->getId(),

--- a/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
@@ -75,6 +75,7 @@ final class BulkAppendValueHandler
                         $list[] = $value;
                         $indexed[$attrCode] = $list;
                         $object->updateAttributeIndex($indexed);
+                        $object->markTouchedByBulkSession($session->getId());
                         $this->em->persist(new BulkLog(
                             $session->getId(),
                             $object->getId(),

--- a/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
@@ -55,6 +55,7 @@ final class BulkClearAttributeHandler
                     $oldValue = $indexed[$attrCode] ?? null;
                     unset($indexed[$attrCode]);
                     $object->updateAttributeIndex($indexed);
+                    $object->markTouchedByBulkSession($session->getId());
 
                     $this->em->persist(new BulkLog(
                         $session->getId(),

--- a/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
@@ -83,6 +83,7 @@ final class BulkDuplicateHandler
 
                     $copy = new CatalogObject($source->getObjectType(), $newCode);
                     $this->catalogObjects->save($copy);
+                    $copy->markTouchedByBulkSession($session->getId());
 
                     foreach ($this->values->findByObject($source) as $sourceValue) {
                         $cloned = new ObjectValue(

--- a/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
@@ -101,6 +101,7 @@ final class BulkIncrementNumericHandler
                     } else {
                         $indexed[$attrCode] = $newValue;
                         $object->updateAttributeIndex($indexed);
+                        $object->markTouchedByBulkSession($session->getId());
                         $this->em->persist(new BulkLog(
                             $session->getId(),
                             $object->getId(),

--- a/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
@@ -66,6 +66,7 @@ final class BulkMoveCategoryHandler
                     );
 
                     $this->objectCategories->replaceForProduct($product, $targetUuids, $primaryId);
+                    $product->markTouchedByBulkSession($session->getId());
 
                     $this->em->persist(new BulkLog(
                         $session->getId(),

--- a/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
@@ -101,6 +101,7 @@ final class BulkMultiAttributeEditHandler
 
                     if ($rowChanged) {
                         $object->updateAttributeIndex($indexed);
+                        $object->markTouchedByBulkSession($session->getId());
                         ++$success;
                     }
                 } catch (Throwable $e) {

--- a/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
@@ -84,6 +84,7 @@ final class BulkPublishChannelsHandler
                     } else {
                         $indexed['published'] = $publishedRaw;
                         $product->updateAttributeIndex($indexed);
+                        $product->markTouchedByBulkSession($session->getId());
                         $this->em->persist(new BulkLog(
                             $session->getId(),
                             $product->getId(),

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
@@ -82,6 +82,7 @@ final class BulkRemoveCategoryHandler
                             'No matching category assignments',
                         ));
                     } else {
+                        $product->markTouchedByBulkSession($session->getId());
                         $afterIds = array_values(array_diff($existingIds, $categoryIds));
                         $this->em->persist(new BulkLog(
                             $session->getId(),

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
@@ -75,6 +75,7 @@ final class BulkRemoveValueHandler
                             ));
                             $indexed[$attrCode] = $newList;
                             $object->updateAttributeIndex($indexed);
+                            $object->markTouchedByBulkSession($session->getId());
                             $this->em->persist(new BulkLog(
                                 $session->getId(),
                                 $object->getId(),
@@ -89,6 +90,7 @@ final class BulkRemoveValueHandler
                     } elseif ($oldValue === $value) {
                         unset($indexed[$attrCode]);
                         $object->updateAttributeIndex($indexed);
+                        $object->markTouchedByBulkSession($session->getId());
                         $this->em->persist(new BulkLog(
                             $session->getId(),
                             $object->getId(),

--- a/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
@@ -101,6 +101,7 @@ final class BulkSetAttributeHandler
                     $indexed = $object->getAttributesIndexed();
                     $indexed[$attrCode] = $newValue;
                     $object->updateAttributeIndex($indexed);
+                    $object->markTouchedByBulkSession($session->getId());
 
                     $this->em->persist(new BulkLog(
                         $session->getId(),

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -122,6 +122,14 @@ class CatalogObject extends AggregateRoot implements TenantScoped
      */
     private ?Uuid $importSessionId = null;
 
+    /**
+     * VIEW-28 (#559) — denormalized cache of the last BulkSession id
+     * that mutated this row. Set by bulk handlers after a successful
+     * write; reset to NULL on hard delete of the parent BulkSession
+     * (`ON DELETE SET NULL` in the FK).
+     */
+    private ?Uuid $lastBulkSessionId = null;
+
     private DateTimeImmutable $createdAt;
     private DateTimeImmutable $updatedAt;
 
@@ -379,6 +387,22 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     public function assignImportSession(?Uuid $sessionId): void
     {
         $this->importSessionId = $sessionId;
+    }
+
+    public function getLastBulkSessionId(): ?Uuid
+    {
+        return $this->lastBulkSessionId;
+    }
+
+    /**
+     * VIEW-28 (#559) — bulk handlers call this immediately after writing
+     * to flag the row as touched by the given session. Also bumps
+     * `updatedAt` so listeners and audit pipelines see a fresh edit.
+     */
+    public function markTouchedByBulkSession(Uuid $sessionId): void
+    {
+        $this->lastBulkSessionId = $sessionId;
+        $this->touch();
     }
 
     private function touch(): void

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -86,6 +86,16 @@
         </field>
         <field name="importSessionId" type="uuid" column="import_session_id" nullable="true"/>
 
+        <!--
+            VIEW-28 (#559) — denormalized cache of the last BulkSession id
+            that touched this row. NULL by default; bulk handlers set it
+            after a successful mutation. Partial index defined in the
+            migration (skips NULL rows to keep the index lean).
+            ON DELETE SET NULL on FK so dropping an expired bulk_session
+            does not cascade into products.
+        -->
+        <field name="lastBulkSessionId" type="uuid" column="bulk_session_id" nullable="true"/>
+
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
         <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
 


### PR DESCRIPTION
PRD §5.2 — denormalizowana kolumna „last bulk session that touched the row". Speedup dla query *„pokaż produkty dotknięte przez session X"* — bez denormalizacji wymagało `JOIN bulk_logs`. P2 PERF.

## Migration `Version20260514160000`
- `ALTER TABLE objects ADD COLUMN bulk_session_id UUID NULL`
- FK `ON DELETE SET NULL` (delete session ≠ delete row — odwrotnie niż CASCADE).
- Partial index `WHERE bulk_session_id IS NOT NULL` (steady state most rows NULL — index small).

## `CatalogObject`
- `private ?Uuid $lastBulkSessionId`
- `getLastBulkSessionId(): ?Uuid` + `markTouchedByBulkSession(Uuid): void`
- XML mapping `<field bulk_session_id nullable="true">`

## Handler wiring (11 handlers)
Idempotent call per object mutate:
- ✅ `BulkSetAttribute` / `Clear` / `Append` / `Remove` / `Increment` / `Multi` — po `updateAttributeIndex`
- ✅ `BulkAddCategory` / `RemoveCategory` / `MoveCategory` — po junction mutate
- ✅ `BulkPublishChannels` — po `updateAttributeIndex` (soft `published` flag)
- ✅ `BulkDuplicate` — kopia marked (NIE source — source bez zmian)
- ⏭️ `BulkDelete` (no-op — row znika), `BulkRollback` (osobna semantyka, deferred) skipped intencjonalnie.

## Test plan
- `SELECT COUNT(*) FROM objects WHERE bulk_session_id IS NOT NULL` rośnie po każdym bulk action
- `SELECT bulk_session_id FROM objects WHERE id = ?` zwraca ID ostatniej sesji
- `DELETE FROM bulk_sessions WHERE id = ?` zerowuje `objects.bulk_session_id` (ON DELETE SET NULL)

Closes #559
