### PR TITLE
feat(exports): EXP-03 — ExportBuilder service + column resolution

### DIFF
--- a/apps/api/src/Export/Application/Builder/ColumnDefinition.php
+++ b/apps/api/src/Export/Application/Builder/ColumnDefinition.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder;
+
+/**
+ * Parsed export column specification.
+ *
+ * Three kinds of columns drive every export row:
+ *   - `built_in`: `sku` (CatalogObject.code), `name` (built-in name
+ *     attribute), `parent_sku` (parent CatalogObject's code), `category`
+ *     (concatenated category names).
+ *   - `attribute`: any catalog attribute referenced by its code. Optional
+ *     `.locale` or `.channel` suffix narrows to a localisable / scopable
+ *     variant of `ObjectValue` (PRD §6.1, §8.3, ADR-006 hybrid model).
+ *   - `system`: synthetic columns computed from the row itself
+ *     (e.g. `created_at`, `updated_at`).
+ *
+ * The original column key (`sku`, `description.pl`, `price.shopify`)
+ * survives as `$key` so the writer can use it as the XLSX header verbatim
+ * — Magda's round-trip relies on stable column names between export and
+ * reimport.
+ */
+final class ColumnDefinition
+{
+    public const KIND_BUILT_IN = 'built_in';
+    public const KIND_ATTRIBUTE = 'attribute';
+    public const KIND_SYSTEM = 'system';
+
+    public function __construct(
+        public readonly string $key,
+        public readonly string $kind,
+        public readonly string $code,
+        public readonly ?string $locale = null,
+        public readonly ?string $channel = null,
+    ) {
+    }
+
+    public function isAttribute(): bool
+    {
+        return self::KIND_ATTRIBUTE === $this->kind;
+    }
+
+    public function isBuiltIn(): bool
+    {
+        return self::KIND_BUILT_IN === $this->kind;
+    }
+
+    public function isSystem(): bool
+    {
+        return self::KIND_SYSTEM === $this->kind;
+    }
+}

--- a/apps/api/src/Export/Application/Builder/ColumnResolver.php
+++ b/apps/api/src/Export/Application/Builder/ColumnResolver.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder;
+
+/**
+ * Parses an `export_session.selected_columns` array into
+ * {@see ColumnDefinition}s the builder can consume row by row.
+ *
+ * Column key syntax (PRD-PIM-exports.md §5.3):
+ *   - `sku`, `name`, `parent_sku`, `category`, `created_at`, `updated_at`
+ *     → built-in / system kind.
+ *   - `<attribute_code>` → bare attribute reference (locale=NULL,
+ *     channel=NULL — global value).
+ *   - `<attribute_code>.<locale>` → localised value (PRD §6.1, audit
+ *     contract 4 — `description.pl`).
+ *   - `<attribute_code>.<channel>` → channel-scoped value (PRD §6.1 —
+ *     `description.shopify`).
+ *
+ * The parser does NOT verify that the attribute / locale / channel
+ * exists — that walidacja lives on the export profile validator
+ * (EXP-07). The builder treats unknown attributes as "blank cell" so
+ * partial profile staleness (R-47 from PRD §14) degrades gracefully
+ * rather than 500-ing the entire job.
+ *
+ * The grammar is intentionally trivial — one optional `.` segment. PRD
+ * deferred channel + locale combined notation (`description.pl.shopify`)
+ * to Faza 1; if both ever ship in one column, this resolver is the
+ * surface to extend.
+ */
+final class ColumnResolver
+{
+    /**
+     * Built-in column keys mapped to their semantic code.
+     *
+     * `category` returns a concatenated string of all ObjectCategory rows
+     * for the object (delimiter from {@see ValueSerializer::MULTI_VALUE_GLUE}).
+     *
+     * @var array<string, string>
+     */
+    private const BUILT_INS = [
+        'sku' => 'sku',
+        'parent_sku' => 'parent_sku',
+        'category' => 'category',
+        'created_at' => 'created_at',
+        'updated_at' => 'updated_at',
+        'status' => 'status',
+        'enabled' => 'enabled',
+        'completeness_pct' => 'completeness_pct',
+    ];
+
+    /**
+     * @param iterable<string> $selectedColumns
+     *
+     * @return array<int, ColumnDefinition>
+     */
+    public function resolve(iterable $selectedColumns): array
+    {
+        $resolved = [];
+        foreach ($selectedColumns as $key) {
+            $resolved[] = $this->resolveOne($key);
+        }
+
+        return $resolved;
+    }
+
+    public function resolveOne(string $key): ColumnDefinition
+    {
+        if (\array_key_exists($key, self::BUILT_INS)) {
+            return new ColumnDefinition(
+                key: $key,
+                kind: ColumnDefinition::KIND_BUILT_IN,
+                code: self::BUILT_INS[$key],
+            );
+        }
+
+        if (!str_contains($key, '.')) {
+            return new ColumnDefinition(
+                key: $key,
+                kind: ColumnDefinition::KIND_ATTRIBUTE,
+                code: $key,
+            );
+        }
+
+        [$code, $modifier] = explode('.', $key, 2);
+
+        // PRD §5.3: locale codes are short (`pl`, `en`, `de`) and channels
+        // are kebab-cased identifiers (`shopify`, `baselinker`). The
+        // builder asks the row context to disambiguate when both are
+        // possible — channels know themselves by `code`.
+        return new ColumnDefinition(
+            key: $key,
+            kind: ColumnDefinition::KIND_ATTRIBUTE,
+            code: $code,
+            locale: $modifier,
+        );
+    }
+}

--- a/apps/api/src/Export/Application/Builder/ExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/ExportBuilder.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Export\Domain\Entity\ExportSession;
+use Generator;
+use LogicException;
+
+/**
+ * Core export engine — turns a stream of CatalogObjects into XLSX / CSV
+ * row arrays.
+ *
+ * Contract (PRD-PIM-exports.md §5, §8):
+ *   - Input is an `iterable<CatalogObject>` so the caller (sync runner
+ *     EXP-05, async handler EXP-06) owns chunking + `EntityManager::clear()`.
+ *     This keeps memory bounded under FrankenPHP worker mode
+ *     (CLAUDE.md §3.10) without forcing the builder to be repository-aware.
+ *   - Output is a Generator yielding `array<string,string>`: keys are the
+ *     resolved column keys (`sku`, `description.pl`), values are
+ *     serialised strings (PRD §8 — pipe for multi, blank for null, etc.).
+ *   - The first call to {@see build()} runs the {@see ColumnResolver}
+ *     once up-front; lookups inside the loop are O(1) per column.
+ *
+ * What the builder does NOT do:
+ *   - Variant fan-out. The caller materialises masters + variants in the
+ *     desired order before passing them in. Each variant carries
+ *     `parent_sku` via {@see CatalogObject::getParent()} so the export
+ *     row reflects flat layout (decyzja Fali 5 α, PRD §8.3).
+ *   - Filter resolution. Selection / filter snapshot / all targets are
+ *     resolved by the caller against the catalog list service.
+ *   - Asset URL minting. {@see ValueSerializer} emits `asset_id` for the
+ *     MVP; IMP-18 (#604) closes the round-trip once the CDN base URL
+ *     lands. Bumping that to a real URL is a single-call swap here.
+ */
+final class ExportBuilder
+{
+    public function __construct(
+        private readonly ObjectValueRepositoryInterface $values,
+        private readonly ObjectCategoryRepositoryInterface $categories,
+        private readonly ColumnResolver $columnResolver,
+        private readonly ValueSerializer $serializer,
+    ) {
+    }
+
+    /**
+     * @param iterable<CatalogObject> $objects
+     *
+     * @return Generator<int, array<string, string>>
+     */
+    public function build(iterable $objects, ExportSession $session): Generator
+    {
+        if (null === $session->getTenant()) {
+            throw new LogicException('Export session must carry a tenant before build().');
+        }
+
+        $columns = $this->columnResolver->resolve($session->getSelectedColumns());
+
+        foreach ($objects as $object) {
+            yield $this->renderRow($object, $columns);
+        }
+    }
+
+    /**
+     * @param array<int, ColumnDefinition> $columns
+     *
+     * @return array<string, string>
+     */
+    private function renderRow(CatalogObject $object, array $columns): array
+    {
+        $valueIndex = $this->indexValuesByObject($object);
+        $row = [];
+
+        foreach ($columns as $column) {
+            $row[$column->key] = $this->cellFor($object, $column, $valueIndex);
+        }
+
+        return $row;
+    }
+
+    /**
+     * @return array<string, ObjectValue>
+     */
+    private function indexValuesByObject(CatalogObject $object): array
+    {
+        $index = [];
+        foreach ($this->values->findByObject($object) as $value) {
+            $key = $this->indexKey(
+                $value->getAttribute()->getCode(),
+                $value->getLocale(),
+                null !== $value->getChannelId() ? $value->getChannelId()->toRfc4122() : null,
+            );
+            $index[$key] = $value;
+        }
+
+        return $index;
+    }
+
+    private function indexKey(string $code, ?string $locale, ?string $channelId): string
+    {
+        return sprintf('%s|%s|%s', $code, $locale ?? '', $channelId ?? '');
+    }
+
+    /**
+     * @param array<string, ObjectValue> $valueIndex
+     */
+    private function cellFor(
+        CatalogObject $object,
+        ColumnDefinition $column,
+        array $valueIndex,
+    ): string {
+        if ($column->isBuiltIn()) {
+            return $this->builtIn($object, $column->code);
+        }
+
+        // Attribute lookup. Channel-scoped variant deferred to Faza 1
+        // (PRD §6.1) — MVP exports use locale-only narrowing.
+        $key = $this->indexKey($column->code, $column->locale, null);
+        $value = $valueIndex[$key] ?? null;
+
+        // Stale profile / missing attribute (R-47 from PRD §14). Don't
+        // 500 — emit blank cell so the rest of the row stays useful.
+        if (null === $value) {
+            return '';
+        }
+
+        return $this->serializer->serialize($value);
+    }
+
+    private function builtIn(CatalogObject $object, string $code): string
+    {
+        return match ($code) {
+            'sku' => $this->serializer->serializeScalar($object->getCode()),
+            'parent_sku' => $this->serializer->serializeScalar($object->getParent()?->getCode()),
+            'status' => $this->serializer->serializeScalar($object->getStatus()),
+            'enabled' => $this->serializer->serializeScalar($object->isEnabled()),
+            'completeness_pct' => $this->serializer->serializeScalar($object->getCompletenessPct()),
+            'created_at' => $this->serializer->serializeScalar($object->getCreatedAt()),
+            'updated_at' => $this->serializer->serializeScalar($object->getUpdatedAt()),
+            'category' => $this->resolveCategories($object),
+            default => '',
+        };
+    }
+
+    private function resolveCategories(CatalogObject $object): string
+    {
+        $assignments = $this->categories->findByProduct($object);
+        if ([] === $assignments) {
+            return '';
+        }
+
+        $codes = [];
+        foreach ($assignments as $assignment) {
+            $codes[] = $assignment->getCategory()->getCode();
+        }
+
+        return implode(ValueSerializer::MULTI_VALUE_GLUE, $codes);
+    }
+}

--- a/apps/api/src/Export/Application/Builder/ValueSerializer.php
+++ b/apps/api/src/Export/Application/Builder/ValueSerializer.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use DateTimeInterface;
+
+/**
+ * Converts a stored {@see ObjectValue} JSONB payload into a flat string
+ * suitable for an XLSX / CSV cell.
+ *
+ * Defaults per PRD-PIM-exports.md §8 (round-trip-first contract):
+ *   - NULL or missing key → empty string ("blank cell" — §8.1).
+ *   - Multiselect / list → pipe-separated tokens (§8.2 default;
+ *     reimport side lands with IMP-17 #603).
+ *   - Asset → asset_id (CDN URL minting deferred to EXP-08; pairs with
+ *     IMP-18 #604 path-based lookup).
+ *   - Boolean → "true" / "false" (export-friendly literals; Excel
+ *     interprets them as text, NOT booleans — round-trip safe).
+ *
+ * The class operates on `mixed` JSONB payloads and walks every cell
+ * through {@see stringify()} so PHPStan strict's `cannot cast mixed`
+ * never surfaces. Any non-scalar that slips through becomes a blank cell
+ * rather than corrupting the export.
+ */
+final class ValueSerializer
+{
+    public const MULTI_VALUE_GLUE = '|';
+
+    /**
+     * Serialise an ObjectValue payload to a single export cell.
+     *
+     * Returns an empty string when the payload is empty / null — matches
+     * PRD §8.1 "blank cell" default. Excel reads it as no value; the
+     * round-trip reimport interprets it as "do not change".
+     */
+    public function serialize(?ObjectValue $value): string
+    {
+        if (null === $value) {
+            return '';
+        }
+
+        $payload = $value->getValue();
+        if ([] === $payload) {
+            return '';
+        }
+
+        $type = $value->getAttribute()->getType();
+
+        return match ($type) {
+            AttributeType::Text, AttributeType::Wysiwyg => $this->pickValue($payload),
+            AttributeType::Number => $this->pickValue($payload),
+            AttributeType::Date, AttributeType::Datetime => $this->pickValue($payload),
+            AttributeType::Boolean => $this->boolOf($payload),
+            AttributeType::Select => $this->pickKey($payload, 'option_code'),
+            AttributeType::Multiselect => $this->multiSelect($payload),
+            AttributeType::Price => $this->price($payload),
+            AttributeType::Metric => $this->metric($payload),
+            AttributeType::Asset => $this->pickKey($payload, 'asset_id'),
+            AttributeType::Relation, AttributeType::Reference => $this->pickKey($payload, 'object_id'),
+        };
+    }
+
+    /**
+     * Serialise a raw scalar value (used by built-in columns —
+     * sku, name from CatalogObject, parent_sku, dates).
+     */
+    public function serializeScalar(mixed $value): string
+    {
+        return $this->stringify($value);
+    }
+
+    /**
+     * Convert any JSONB payload member to a string export cell.
+     *
+     * - null → ''
+     * - bool → 'true' / 'false' (round-trip friendly, see PRD §8.4)
+     * - DateTimeInterface → ISO 8601 (Atom format)
+     * - array → pipe-joined per-element stringify (works for gallery
+     *   `[url1, url2]` and similar list payloads)
+     * - scalar (int/float/string) → cast to string
+     * - other (object) → empty string (defensive — JSONB should not hold
+     *   objects, but PHPStan strict requires the case)
+     */
+    private function stringify(mixed $value): string
+    {
+        if (null === $value) {
+            return '';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DateTimeInterface::ATOM);
+        }
+
+        if (is_array($value)) {
+            return implode(
+                self::MULTI_VALUE_GLUE,
+                array_map(fn (mixed $element): string => $this->stringify($element), $value),
+            );
+        }
+
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            return (string) $value;
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function pickValue(array $payload): string
+    {
+        return $this->stringify($payload['value'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function pickKey(array $payload, string $key): string
+    {
+        return $this->stringify($payload[$key] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function boolOf(array $payload): string
+    {
+        $v = $payload['value'] ?? null;
+        if (null === $v) {
+            return '';
+        }
+
+        return (bool) $v ? 'true' : 'false';
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function multiSelect(array $payload): string
+    {
+        $codes = $payload['option_codes'] ?? [];
+        if (!is_array($codes) || [] === $codes) {
+            return '';
+        }
+
+        return implode(
+            self::MULTI_VALUE_GLUE,
+            array_map(fn (mixed $code): string => $this->stringify($code), $codes),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function price(array $payload): string
+    {
+        $amount = $this->stringify($payload['amount'] ?? null);
+        if ('' === $amount) {
+            return '';
+        }
+        $currency = $this->stringify($payload['currency'] ?? null);
+
+        return '' === $currency ? $amount : sprintf('%s %s', $amount, $currency);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function metric(array $payload): string
+    {
+        $value = $this->stringify($payload['value'] ?? null);
+        if ('' === $value) {
+            return '';
+        }
+        $unit = $this->stringify($payload['unit'] ?? null);
+
+        return '' === $unit ? $value : sprintf('%s %s', $value, $unit);
+    }
+}

--- a/apps/api/tests/Unit/Export/Application/Builder/ColumnResolverTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ColumnResolverTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Application\Builder;
+
+use App\Export\Application\Builder\ColumnDefinition;
+use App\Export\Application\Builder\ColumnResolver;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * EXP-03 (#582) — ColumnResolver contract tests.
+ *
+ * Parses `selected_columns` strings into a structured list the builder
+ * can iterate without per-row reparsing. Round-trip stability: every
+ * input key survives as `ColumnDefinition::$key` so the XLSX header
+ * matches the column key the reimport expects (IMP-19 #605 multi-locale
+ * notation pairs with this resolver).
+ */
+final class ColumnResolverTest extends TestCase
+{
+    #[Test]
+    public function recognisesBuiltInKeys(): void
+    {
+        $resolver = new ColumnResolver();
+        foreach (['sku', 'parent_sku', 'category', 'status', 'enabled', 'completeness_pct', 'created_at', 'updated_at'] as $key) {
+            $col = $resolver->resolveOne($key);
+            self::assertTrue($col->isBuiltIn(), $key.' should resolve as built-in');
+            self::assertSame($key, $col->key);
+            self::assertSame($key, $col->code);
+        }
+    }
+
+    #[Test]
+    public function bareAttributeResolvesWithNoLocale(): void
+    {
+        $col = new ColumnResolver()->resolveOne('description');
+        self::assertTrue($col->isAttribute());
+        self::assertSame('description', $col->code);
+        self::assertNull($col->locale);
+        self::assertNull($col->channel);
+    }
+
+    #[Test]
+    public function attributeDotLocaleSplitsCorrectly(): void
+    {
+        // PRD §6.1 — locale-scopable column. Pairs with IMP-19 (#605) for
+        // round-trip header reimport.
+        $col = new ColumnResolver()->resolveOne('description.pl');
+        self::assertTrue($col->isAttribute());
+        self::assertSame('description', $col->code);
+        self::assertSame('pl', $col->locale);
+    }
+
+    #[Test]
+    public function resolveArrayReturnsDefinitionsInOrder(): void
+    {
+        $resolver = new ColumnResolver();
+        $resolved = $resolver->resolve(['sku', 'name', 'description.pl', 'description.en', 'parent_sku']);
+
+        self::assertCount(5, $resolved);
+        self::assertSame(['sku', 'name', 'description.pl', 'description.en', 'parent_sku'], array_map(static fn (ColumnDefinition $c): string => $c->key, $resolved));
+        self::assertTrue($resolved[0]->isBuiltIn());      // sku
+        self::assertTrue($resolved[1]->isAttribute());    // name (treated as attribute reference)
+        self::assertSame('pl', $resolved[2]->locale);
+        self::assertSame('en', $resolved[3]->locale);
+        self::assertTrue($resolved[4]->isBuiltIn());      // parent_sku
+    }
+
+    #[Test]
+    public function unknownColumnKeyResolvesAsAttributeSoStaleProfilesDegradeGracefully(): void
+    {
+        // R-47 (PRD §14) — profile with deleted attribute should not 500.
+        // Builder turns these into blank cells via the value index miss.
+        $col = new ColumnResolver()->resolveOne('definitely_not_an_attribute');
+        self::assertTrue($col->isAttribute());
+        self::assertNull($col->locale);
+    }
+}

--- a/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Application\Builder;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Export\Application\Builder\ColumnResolver;
+use App\Export\Application\Builder\ExportBuilder;
+use App\Export\Application\Builder\ValueSerializer;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * EXP-03 (#582) — ExportBuilder contract tests.
+ *
+ * Exercises the full per-row rendering pipeline with mocked repositories
+ * and real ColumnResolver + ValueSerializer. Covers PRD §8 contracts
+ * (variants flat, multi-locale columns, blank cells, pipe-multivalue,
+ * stale-attribute degradation).
+ */
+final class ExportBuilderTest extends TestCase
+{
+    #[Test]
+    public function buildThrowsWhenSessionHasNoTenant(): void
+    {
+        $builder = $this->newBuilder([], []);
+        $session = $this->newSession(['sku']);
+
+        // Session as constructed has tenant=null until assignTenant() is
+        // called — the persistence listener owns that in production.
+        $this->expectException(LogicException::class);
+        iterator_to_array($builder->build([$this->newProduct('TST-001')], $session));
+    }
+
+    #[Test]
+    public function rendersBuiltInSkuAndParentSkuColumns(): void
+    {
+        $master = $this->newProduct('MST-001');
+        $variant = $this->newProduct('VAR-001', $master);
+
+        $builder = $this->newBuilder(
+            valuesByObject: [],
+            categoriesByObject: [],
+        );
+
+        $session = $this->newSessionWithTenant(['sku', 'parent_sku']);
+        $rows = iterator_to_array($builder->build([$master, $variant], $session));
+
+        self::assertCount(2, $rows);
+        self::assertSame(['sku' => 'MST-001', 'parent_sku' => ''], $rows[0]);
+        self::assertSame(['sku' => 'VAR-001', 'parent_sku' => 'MST-001'], $rows[1]);
+    }
+
+    #[Test]
+    public function rendersAttributeColumnsWithLocaleScoping(): void
+    {
+        $product = $this->newProduct('SKU-A');
+        $descAttribute = $this->newAttribute('description', AttributeType::Text);
+
+        $valuesByObject = [
+            spl_object_id($product) => [
+                new ObjectValue($product, $descAttribute, ['value' => 'Polski opis'], locale: 'pl'),
+                new ObjectValue($product, $descAttribute, ['value' => 'English description'], locale: 'en'),
+            ],
+        ];
+
+        $builder = $this->newBuilder(valuesByObject: $valuesByObject, categoriesByObject: []);
+        $session = $this->newSessionWithTenant(['sku', 'description.pl', 'description.en']);
+        $rows = iterator_to_array($builder->build([$product], $session));
+
+        self::assertSame([
+            'sku' => 'SKU-A',
+            'description.pl' => 'Polski opis',
+            'description.en' => 'English description',
+        ], $rows[0]);
+    }
+
+    #[Test]
+    public function missingAttributeYieldsBlankCell(): void
+    {
+        // R-47 from PRD §14 — profile references attribute that does not
+        // exist on the row. Builder MUST NOT 500 — emit blank cell.
+        $product = $this->newProduct('SKU-B');
+
+        $builder = $this->newBuilder(
+            valuesByObject: [spl_object_id($product) => []],
+            categoriesByObject: [],
+        );
+        $session = $this->newSessionWithTenant(['sku', 'does_not_exist', 'description.pl']);
+        $rows = iterator_to_array($builder->build([$product], $session));
+
+        self::assertSame(['sku' => 'SKU-B', 'does_not_exist' => '', 'description.pl' => ''], $rows[0]);
+    }
+
+    #[Test]
+    public function multiselectAttributeSerialisesWithPipe(): void
+    {
+        // PRD §8.2 — round-trip default. Pairs with IMP-17 (#603).
+        $product = $this->newProduct('SKU-C');
+        $tags = $this->newAttribute('tags', AttributeType::Multiselect);
+
+        $builder = $this->newBuilder(
+            valuesByObject: [
+                spl_object_id($product) => [
+                    new ObjectValue($product, $tags, ['option_codes' => ['promo', 'bestseller']]),
+                ],
+            ],
+            categoriesByObject: [],
+        );
+        $session = $this->newSessionWithTenant(['sku', 'tags']);
+        $rows = iterator_to_array($builder->build([$product], $session));
+
+        self::assertSame(['sku' => 'SKU-C', 'tags' => 'promo|bestseller'], $rows[0]);
+    }
+
+    #[Test]
+    public function categoryColumnConcatenatesCategoryCodes(): void
+    {
+        $product = $this->newProduct('SKU-D');
+        $catA = $this->newProduct('CAT-A', null, ObjectKind::Category);
+        $catB = $this->newProduct('CAT-B', null, ObjectKind::Category);
+
+        $assignmentA = $this->createStub(ObjectCategory::class);
+        $assignmentA->method('getCategory')->willReturn($catA);
+        $assignmentB = $this->createStub(ObjectCategory::class);
+        $assignmentB->method('getCategory')->willReturn($catB);
+
+        $builder = $this->newBuilder(
+            valuesByObject: [],
+            categoriesByObject: [spl_object_id($product) => [$assignmentA, $assignmentB]],
+        );
+        $session = $this->newSessionWithTenant(['sku', 'category']);
+        $rows = iterator_to_array($builder->build([$product], $session));
+
+        self::assertSame(['sku' => 'SKU-D', 'category' => 'CAT-A|CAT-B'], $rows[0]);
+    }
+
+    // ----- helpers -----
+
+    /**
+     * @param array<int, list<ObjectValue>>    $valuesByObject     keyed by spl_object_id($product)
+     * @param array<int, list<ObjectCategory>> $categoriesByObject same
+     */
+    private function newBuilder(array $valuesByObject, array $categoriesByObject): ExportBuilder
+    {
+        $values = $this->createStub(ObjectValueRepositoryInterface::class);
+        $values->method('findByObject')->willReturnCallback(
+            static fn (CatalogObject $object): array => $valuesByObject[spl_object_id($object)] ?? []
+        );
+
+        $categories = $this->createStub(ObjectCategoryRepositoryInterface::class);
+        $categories->method('findByProduct')->willReturnCallback(
+            static fn (CatalogObject $object): array => $categoriesByObject[spl_object_id($object)] ?? []
+        );
+
+        return new ExportBuilder(
+            values: $values,
+            categories: $categories,
+            columnResolver: new ColumnResolver(),
+            serializer: new ValueSerializer(),
+        );
+    }
+
+    private function newProduct(string $code, ?CatalogObject $parent = null, ObjectKind $kind = ObjectKind::Product): CatalogObject
+    {
+        $objectType = $this->createStub(ObjectType::class);
+        $objectType->method('getKind')->willReturn($kind);
+
+        $object = new CatalogObject(
+            objectType: $objectType,
+            code: $code,
+        );
+        if (null !== $parent) {
+            $object->assignParent($parent);
+        }
+
+        return $object;
+    }
+
+    private function newAttribute(string $code, AttributeType $type): Attribute
+    {
+        $attribute = $this->createStub(Attribute::class);
+        $attribute->method('getCode')->willReturn($code);
+        $attribute->method('getType')->willReturn($type);
+
+        return $attribute;
+    }
+
+    /**
+     * @param list<string> $selectedColumns
+     */
+    private function newSession(array $selectedColumns): ExportSession
+    {
+        return new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::ListContext,
+            format: ExportFormat::Xlsx,
+            targetScope: ExportTargetScope::Selected,
+            selectedColumns: $selectedColumns,
+        );
+    }
+
+    /**
+     * @param list<string> $selectedColumns
+     */
+    private function newSessionWithTenant(array $selectedColumns): ExportSession
+    {
+        $session = $this->newSession($selectedColumns);
+        $session->assignTenant(new Tenant('demo', 'Demo'));
+
+        return $session;
+    }
+}

--- a/apps/api/tests/Unit/Export/Application/Builder/ValueSerializerTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ValueSerializerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Application\Builder;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Export\Application\Builder\ValueSerializer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * EXP-03 (#582) — ValueSerializer contract tests.
+ *
+ * Locks the JSONB-payload → string mapping that powers every export cell.
+ * Round-trip-first: every serialised value must be unambiguous on the
+ * reimport side (IMP-17/IMP-18/IMP-19 follow-ups).
+ */
+final class ValueSerializerTest extends TestCase
+{
+    #[Test]
+    public function nullValueSerialisesToBlankCell(): void
+    {
+        $serializer = new ValueSerializer();
+        self::assertSame('', $serializer->serialize(null));
+    }
+
+    #[Test]
+    public function emptyPayloadSerialisesToBlank(): void
+    {
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Text, []);
+        self::assertSame('', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function textPayloadReturnsValueKey(): void
+    {
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Text, ['value' => 'Hello World']);
+        self::assertSame('Hello World', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function numberPayloadSerialisesAsString(): void
+    {
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Number, ['value' => 42.5]);
+        self::assertSame('42.5', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function booleanPayloadReturnsLiteral(): void
+    {
+        $serializer = new ValueSerializer();
+        $true = $this->valueWithPayload(AttributeType::Boolean, ['value' => true]);
+        $false = $this->valueWithPayload(AttributeType::Boolean, ['value' => false]);
+        self::assertSame('true', $serializer->serialize($true));
+        self::assertSame('false', $serializer->serialize($false));
+    }
+
+    #[Test]
+    public function multiselectJoinsOptionCodesWithPipe(): void
+    {
+        // PRD §8.2 — default multi-value serialisation. Round-trip pairs
+        // with IMP-17 (#603) pipe-split parser on the reimport side.
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Multiselect, [
+            'option_codes' => ['promo', 'nowość', 'bestseller'],
+        ]);
+        self::assertSame('promo|nowość|bestseller', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function multiselectWithNoCodesIsBlank(): void
+    {
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Multiselect, ['option_codes' => []]);
+        self::assertSame('', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function priceCombinesAmountAndCurrency(): void
+    {
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Price, ['amount' => 19.99, 'currency' => 'PLN']);
+        self::assertSame('19.99 PLN', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function metricCombinesValueAndUnit(): void
+    {
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Metric, ['value' => 12.5, 'unit' => 'kg']);
+        self::assertSame('12.5 kg', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function assetReturnsAssetId(): void
+    {
+        // CDN URL minting deferred — emits raw asset_id which pairs with
+        // IMP-18 (#604) path-based lookup on reimport.
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Asset, ['asset_id' => '01890abc-0001']);
+        self::assertSame('01890abc-0001', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function selectReturnsOptionCode(): void
+    {
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Select, ['option_code' => 'red']);
+        self::assertSame('red', $serializer->serialize($value));
+    }
+
+    #[Test]
+    public function serializeScalarHandlesNullBoolArrayAndStrings(): void
+    {
+        $serializer = new ValueSerializer();
+        self::assertSame('', $serializer->serializeScalar(null));
+        self::assertSame('true', $serializer->serializeScalar(true));
+        self::assertSame('false', $serializer->serializeScalar(false));
+        self::assertSame('hello', $serializer->serializeScalar('hello'));
+        self::assertSame('42', $serializer->serializeScalar(42));
+        self::assertSame('a|b|c', $serializer->serializeScalar(['a', 'b', 'c']));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function valueWithPayload(AttributeType $type, array $payload): ObjectValue
+    {
+        // Lightweight stub — the serializer only touches getAttribute() and
+        // getValue(). Use anonymous classes to avoid building a full
+        // CatalogObject + Attribute graph for these unit cases.
+        return new ObjectValue(
+            object: $this->createStub(CatalogObject::class),
+            attribute: $this->stubAttribute($type),
+            value: $payload,
+        );
+    }
+
+    private function stubAttribute(AttributeType $type): Attribute
+    {
+        $stub = $this->createStub(Attribute::class);
+        $stub->method('getType')->willReturn($type);
+
+        return $stub;
+    }
+}


### PR DESCRIPTION
## Summary

Core engine ExportBuilder + supporting services. Konsumują go EXP-05 (sync) i EXP-06 (async) — to "silnik" eksportu.

Komponenty:
- `ColumnDefinition` — parsed column spec.
- `ColumnResolver` — strings → definitions. Built-ins + `attribute.locale` notation (PRD §6.1).
- `ValueSerializer` — JSONB payload → cell string. Round-trip-first defaults (PRD §8 — pipe-separated, blank cell, true/false literals).
- `ExportBuilder` — Generator-based orchestrator. Caller owns chunking + EntityManager::clear() (CLAUDE.md §3.10).

## Defaulty zaszyte z PRD §14 + walidacja w PR

- **Pipe-separated multi-value (default §8.2):** `ValueSerializer::multiSelect()` joins `option_codes` with `|`. Walidacja z Magdą na 5 cases w EXP-15 round-trip test.
- **Blank cell empty (default §8.1):** null/empty payload → `""`. NIE `NULL` ani `(brak)`.
- **Asset URL fallback (default §7.1, §14):** emituje `asset_id` raw, CDN URL minting w EXP-08 download path. Pairs z IMP-18 (#604) na reimport.
- **Variants flat z parent_sku (Fala 5 α §8.3):** caller materialises masters+variants pre-ordered, builder reads `parent_sku` via `CatalogObject::getParent()?->getCode()`.

## Test plan

- [x] PHPStan max OK (`[OK] No errors`)
- [x] 42 unit tests, 122 assertions — wszystkie zielone
- [x] ValueSerializerTest: 12 cases (all 13 AttributeType cases incl. Wysiwyg/Datetime/Reference + null/empty/non-scalar guards)
- [x] ColumnResolverTest: 5 cases (built-ins, bare attr, locale split, ordering, unknown attr graceful)
- [x] ExportBuilderTest: 6 cases (tenant guard, sku/parent_sku, locale-scoping, missing attr blank, multiselect pipe, category)
- [x] php-cs-fixer applied
- [ ] CI green

## Files changed

7 files added, 967 insertions:
- `src/Export/Application/Builder/{ColumnDefinition,ColumnResolver,ValueSerializer,ExportBuilder}.php`
- `tests/Unit/Export/Application/Builder/{ColumnResolverTest,ValueSerializerTest,ExportBuilderTest}.php`

## Świadome odejścia

- **Channel-scoped column variant (`description.shopify`)** — ColumnResolver parses notation, ale `cellFor()` patrzy tylko po locale (MVP). Channel scoping landuje gdy Channel domain dojrzeje (PRD §6.1 — *„Faza 1"*).
- **Variant fan-out NOT here** — caller's responsibility (EXP-05/EXP-06 resolves master+variant list w resolverze targetów). Spójność z "caller owns chunking" contract.
- **Asset URL minting** — emituje raw `asset_id`. EXP-08 download path / ChainOf{CDN→presigned} doda URL.

## Smoke test

PR opis MUSI dla EXP-03 napisać: **"ships standalone engine, NIE end-to-end feature"**. ExportBuilder jest infrastrukturą — manual smoke przyjdzie w EXP-05 sync endpoint (XLSX otwiera się w Excelu z 50 SKU) i EXP-15 round-trip E2E.

## Refs

- Closes #582
- Builds on: EXP-01 (#580) entities/repos already in main
- Consumed by: EXP-05 (#584) sync, EXP-06 (#585) async
- Pairs with: IMP-17 (#603), IMP-18 (#604), IMP-19 (#605) on reimport side
