### PR TITLE
fix(maintenance): whitelist export_logs in tenant audit skip list

### DIFF
--- a/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
@@ -103,6 +103,10 @@ final class TenantAuditCommand extends Command
         // VIEW-27 (#558) — per-user attribute favorites junction. Tenant
         // scope inherited via users.tenant_id (FK CASCADE on user delete).
         'user_filter_favorites',
+        // EXP-01 (#580) — per-job export trace. Tenant scope inherited
+        // via the parent ExportSession (FK CASCADE on delete); pairs
+        // with the same pattern used by import_logs and bulk_logs.
+        'export_logs',
     ];
 
     /**


### PR DESCRIPTION
## Summary

Naprawia czerwone PHPUnit na main od merge'a PR #578 (EXP-01) — `TenantAuditCommandTest::reportsCleanStateAfterAllMigrations` failowało bo `export_logs` nie był w whitelist tabel które dziedziczą tenant scope przez parent.

## Root cause

PR #578 dodał `export_logs` table bez `tenant_id` (intentionally — komentarz w `ExportLog` entity: *"Not tenant-scoped on its own — tenant isolation flows through the parent ExportSession"*). To OK design, ale `TenantAuditCommand` nie wiedział o tym → audit zwracał FAIL → test failował na każdym PR mergowanym do main.

Identyczny wzorzec już używany przez `import_logs` (#442) i `bulk_logs` (#558).

## Fix

Jedna linijka — dodaję `export_logs` do `INFRA_TABLES` w `TenantAuditCommand.php` z komentarzem dokumentującym intencję.

## Test plan

- [x] `vendor/bin/phpunit --filter=TenantAuditCommandTest` lokalnie zielony (2 tests, 10 assertions)
- [ ] CI green
- [ ] Merge unblocks dalsze PR-y EXP marathon (EXP-04 wzwyż)

## Refs

- Refs #580 EXP-01
- Related pattern: import_logs (#442), bulk_logs (#558)