### PR TITLE
feat(exports): EXP-05 — Sync export endpoint + OpenSpout + CSV

### DIFF
--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -22,6 +22,7 @@
         "league/flysystem-bundle": "^3.7",
         "lexik/jwt-authentication-bundle": "^3",
         "meilisearch/meilisearch-php": "^1.16",
+        "openspout/openspout": "^5.7",
         "phpdocumentor/reflection-docblock": "^5.6.7",
         "phpoffice/phpspreadsheet": "^5.7",
         "phpstan/phpdoc-parser": "^2.3.2",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f32beb4696aec069d49242ea2a425eb",
+    "content-hash": "b9265ef0e0d8b2878b42e9cbd835b058",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -4132,6 +4132,99 @@
                 "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
             },
             "time": "2024-09-04T18:46:31+00:00"
+        },
+        {
+            "name": "openspout/openspout",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/openspout/openspout.git",
+                "reference": "b82aa46191802c187f67e9639ddc604b9e7a73e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/openspout/openspout/zipball/b82aa46191802c187f67e9639ddc604b9e7a73e9",
+                "reference": "b82aa46191802c187f67e9639ddc604b9e7a73e9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-xmlreader": "*",
+                "ext-zip": "*",
+                "php": "~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "ext-fileinfo": "*",
+                "ext-zlib": "*",
+                "friendsofphp/php-cs-fixer": "^3.95.1",
+                "infection/infection": "^0.32.7",
+                "phpbench/phpbench": "^1.6.1",
+                "phpstan/phpstan": "^2.1.53",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^13.1.7"
+            },
+            "suggest": {
+                "ext-iconv": "To handle non UTF-8 CSV files (if \"php-mbstring\" is not already installed or is too limited)",
+                "ext-mbstring": "To handle non UTF-8 CSV files (if \"iconv\" is not already installed)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenSpout\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Adrien Loison",
+                    "email": "adrien@box.com"
+                }
+            ],
+            "description": "PHP Library to read and write spreadsheet files (CSV, XLSX and ODS), in a fast and scalable way",
+            "homepage": "https://github.com/openspout/openspout",
+            "keywords": [
+                "OOXML",
+                "csv",
+                "excel",
+                "memory",
+                "odf",
+                "ods",
+                "office",
+                "open",
+                "php",
+                "read",
+                "scale",
+                "spreadsheet",
+                "stream",
+                "write",
+                "xlsx"
+            ],
+            "support": {
+                "issues": "https://github.com/openspout/openspout/issues",
+                "source": "https://github.com/openspout/openspout/tree/v5.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Slamdunk",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-29T07:42:36+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Sync;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Export\Application\Builder\ExportBuilder;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportEncoding;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
+use App\Export\Infrastructure\Writer\CsvStreamWriter;
+use App\Export\Infrastructure\Writer\RowWriter;
+use App\Export\Infrastructure\Writer\XlsxStreamWriter;
+use InvalidArgumentException;
+use LogicException;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Runs the sync (<100 row) export path end-to-end.
+ *
+ * Resolves the target object list per {@see ExportTargetScope}, walks
+ * them through {@see ExportBuilder}, and streams the resulting rows
+ * into the chosen writer. Wraps the file write in a try/finally so the
+ * temp file is cleaned up even on partial failure.
+ *
+ * Filter snapshot resolution is intentionally deferred — the catalog
+ * filter DSL evaluator (`FilterDslResolver`) lives in the Catalog
+ * context and ships with the modal integration (EXP-11). The
+ * `target_scope=filter` path returns a NotImplemented exception in MVP
+ * sync; modal callers downgrade to selected/all until that wiring lands.
+ *
+ * Sync writes ALWAYS complete in a single request — no Mercure, no
+ * status transitions beyond `done` or `error`. The async handler
+ * (EXP-06) takes over from 100 rows up.
+ */
+final class SyncExportRunner
+{
+    public function __construct(
+        private readonly ExportBuilder $builder,
+        private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly ExportSessionRepositoryInterface $sessions,
+    ) {
+    }
+
+    /**
+     * Resolve target objects to export based on session scope.
+     *
+     * @return list<CatalogObject>
+     */
+    public function resolveTargets(ExportSession $session): array
+    {
+        $tenant = $session->getTenant();
+        if (null === $tenant) {
+            throw new LogicException('Export session must carry a tenant before resolveTargets().');
+        }
+
+        return match ($session->getTargetScope()) {
+            ExportTargetScope::Selected => $this->resolveSelected($session),
+            ExportTargetScope::All => $this->objects->findByKind(ObjectKind::Product, $tenant),
+            ExportTargetScope::Filter => throw new RuntimeException(
+                'target_scope=filter is not yet supported in MVP sync runner (Faza 1 candidate).'
+            ),
+        };
+    }
+
+    /**
+     * Run the export to a temporary file path and return that path.
+     *
+     * Caller (the controller) is responsible for streaming the file to
+     * the HTTP response and deleting it afterwards. We split execution
+     * from delivery so the same runner can later land async output.
+     */
+    public function runToFile(ExportSession $session, string $targetPath): int
+    {
+        $columns = $session->getSelectedColumns();
+        if ([] === $columns) {
+            throw new InvalidArgumentException('Export session must list at least one column.');
+        }
+
+        $targets = $this->resolveTargets($session);
+        $session->setTargetCount(\count($targets));
+
+        $writer = $this->openWriter($session->getFormat(), $session, $targetPath);
+        $writer->writeHeaders($columns);
+
+        $rows = 0;
+        try {
+            foreach ($this->builder->build($targets, $session) as $row) {
+                $values = [];
+                foreach ($columns as $key) {
+                    $values[] = $row[$key] ?? '';
+                }
+                $writer->writeRow($values);
+                ++$rows;
+            }
+        } finally {
+            $writer->close();
+        }
+
+        $size = file_exists($targetPath) ? (int) filesize($targetPath) : 0;
+        $session->markDone($rows, $targetPath, $size);
+        $this->sessions->save($session);
+
+        return $rows;
+    }
+
+    /**
+     * @return list<CatalogObject>
+     */
+    private function resolveSelected(ExportSession $session): array
+    {
+        $ids = $session->getSelectedObjectIds();
+        if (null === $ids || [] === $ids) {
+            return [];
+        }
+
+        $uuids = array_map(static fn (string $id): Uuid => Uuid::fromString($id), $ids);
+
+        return $this->objects->findByIds(array_map(static fn (Uuid $u): string => $u->toRfc4122(), $uuids));
+    }
+
+    private function openWriter(ExportFormat $format, ExportSession $session, string $path): RowWriter
+    {
+        if (ExportFormat::Xlsx === $format) {
+            $xlsx = new XlsxStreamWriter();
+            $xlsx->openToFile($path);
+
+            return $xlsx;
+        }
+
+        $encoding = $session->getEncoding() ?? ExportEncoding::Utf8Bom;
+        $csv = new CsvStreamWriter();
+        $csv->open($path, $encoding);
+
+        return $csv;
+    }
+}

--- a/apps/api/src/Export/Infrastructure/Writer/CsvStreamWriter.php
+++ b/apps/api/src/Export/Infrastructure/Writer/CsvStreamWriter.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Infrastructure\Writer;
+
+use App\Export\Domain\Enum\ExportEncoding;
+use LogicException;
+use RuntimeException;
+
+/**
+ * Native PHP CSV writer with encoding control.
+ *
+ * Two encodings (PRD §8.4):
+ *   - UTF-8 with BOM (default) — Excel PL on Windows reads the BOM
+ *     prefix and decodes UTF-8 correctly, so polskie znaki survive.
+ *   - Windows-1250 — legacy Excel on Polish Windows without BOM
+ *     support. Conversion done via iconv with `//TRANSLIT` so any
+ *     character outside CP-1250 degrades to its closest match instead
+ *     of corrupting the cell.
+ *
+ * Streaming CSV is trivial compared to XLSX — the file format is
+ * plain text + delimiter, so we open the resource once and write
+ * row by row.
+ */
+final class CsvStreamWriter implements RowWriter
+{
+    /** @var resource|null */
+    private $handle;
+    private ExportEncoding $encoding = ExportEncoding::Utf8Bom;
+
+    public function open(string $path, ExportEncoding $encoding): void
+    {
+        if (null !== $this->handle) {
+            throw new LogicException('CsvStreamWriter already opened.');
+        }
+
+        $handle = @fopen($path, 'w');
+        if (false === $handle) {
+            throw new RuntimeException(sprintf('Unable to open CSV target "%s" for writing.', $path));
+        }
+
+        $this->handle = $handle;
+        $this->encoding = $encoding;
+
+        if (ExportEncoding::Utf8Bom === $encoding) {
+            fwrite($handle, "\xEF\xBB\xBF");
+        }
+    }
+
+    /**
+     * @param array<int, string> $headers
+     */
+    public function writeHeaders(array $headers): void
+    {
+        $this->writeRow($headers);
+    }
+
+    /**
+     * @param array<int, string> $values
+     */
+    public function writeRow(array $values): void
+    {
+        $handle = $this->handle;
+        if (null === $handle) {
+            throw new LogicException('Open the writer before writing rows.');
+        }
+
+        if (ExportEncoding::Windows1250 === $this->encoding) {
+            $values = array_map([$this, 'toCp1250'], $values);
+        }
+
+        // Native fputcsv handles quoting / escaping. We force semicolon
+        // for Excel PL friendliness — comma is the default but Excel PL
+        // treats `,` as decimal separator and renders the whole row as
+        // a single cell on import. Semicolon survives both Excel PL +
+        // LibreOffice + Numbers reliably.
+        fputcsv($handle, $values, separator: ';', enclosure: '"', escape: '\\');
+    }
+
+    public function close(): void
+    {
+        if (null === $this->handle) {
+            return;
+        }
+        fflush($this->handle);
+        fclose($this->handle);
+        $this->handle = null;
+    }
+
+    private function toCp1250(string $value): string
+    {
+        if ('' === $value) {
+            return '';
+        }
+        $converted = @iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $value);
+
+        return false === $converted ? $value : $converted;
+    }
+}

--- a/apps/api/src/Export/Infrastructure/Writer/RowWriter.php
+++ b/apps/api/src/Export/Infrastructure/Writer/RowWriter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Infrastructure\Writer;
+
+/**
+ * Minimal writer contract shared by XLSX + CSV implementations.
+ *
+ * Keeps the sync runner / async handler decoupled from format-specific
+ * libraries. Both formats agree on a flat row-of-strings shape; format
+ * particulars (BOM, styling, ZIP packing) stay inside the implementation.
+ */
+interface RowWriter
+{
+    /**
+     * @param list<string> $headers
+     */
+    public function writeHeaders(array $headers): void;
+
+    /**
+     * @param list<string> $values
+     */
+    public function writeRow(array $values): void;
+
+    public function close(): void;
+}

--- a/apps/api/src/Export/Infrastructure/Writer/XlsxStreamWriter.php
+++ b/apps/api/src/Export/Infrastructure/Writer/XlsxStreamWriter.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Infrastructure\Writer;
+
+use LogicException;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Common\Entity\Style\Style;
+use OpenSpout\Writer\XLSX\Options;
+use OpenSpout\Writer\XLSX\Writer;
+
+/**
+ * OpenSpout XLSX writer wired for streaming + low-memory output.
+ *
+ * Why OpenSpout: it streams XLSX (writes one row at a time, never builds
+ * the whole spreadsheet in memory). PRD §11.2 needs <30s for 50k SKU on
+ * a FrankenPHP worker with a 50 MB memory budget — PhpSpreadsheet et al.
+ * cannot fit that envelope (CLAUDE.md §3.10).
+ *
+ * Wrap class so the controller / async handler stays decoupled from the
+ * library and we can swap implementations (or pin a different version)
+ * without touching call sites.
+ *
+ * XLSX is a zipped container so we cannot pipe it directly to HTTP
+ * output mid-stream. Instead we write to a tempfile and let the caller
+ * stream the completed file. Sub-100-row sync exports keep the file in
+ * memory-mapped tmp (fast); the async handler (EXP-06) writes to disk +
+ * uploads to MinIO.
+ */
+final class XlsxStreamWriter implements RowWriter
+{
+    private Writer $writer;
+    private bool $headersWritten = false;
+    private bool $opened = false;
+
+    public function __construct()
+    {
+        // Inline strings (`SHOULD_USE_INLINE_STRINGS` = true by default in
+        // OpenSpout 5.x Options) keep the row stream tight — no
+        // shared-string table that would have to live in memory until
+        // close().
+        $this->writer = new Writer(new Options());
+    }
+
+    /**
+     * Open the writer pointing at a filesystem path. For the sync HTTP
+     * path the controller passes a tempfile, then streams its bytes to
+     * the response. The async path passes the MinIO local stage path.
+     */
+    public function openToFile(string $path): void
+    {
+        if ($this->opened) {
+            throw new LogicException('XlsxStreamWriter already opened.');
+        }
+        $this->writer->openToFile($path);
+        $this->opened = true;
+    }
+
+    /**
+     * Write headers (column keys) as the first row, bolded.
+     *
+     * @param array<int, string> $headers
+     */
+    public function writeHeaders(array $headers): void
+    {
+        $this->guardOpen();
+        if ($this->headersWritten) {
+            throw new LogicException('Headers already written for this XLSX stream.');
+        }
+
+        $style = new Style()->withFontBold(true);
+        $this->writer->addRow(Row::fromValuesWithStyle($headers, $style));
+        $this->headersWritten = true;
+    }
+
+    /**
+     * Write one data row. Values must already be ordered to match the
+     * column keys passed to {@see writeHeaders()}.
+     *
+     * @param array<int, string> $values
+     */
+    public function writeRow(array $values): void
+    {
+        $this->guardOpen();
+        $this->writer->addRow(Row::fromValues($values));
+    }
+
+    /**
+     * Close + flush the XLSX file. Idempotent.
+     */
+    public function close(): void
+    {
+        if (!$this->opened) {
+            return;
+        }
+        $this->writer->close();
+        $this->opened = false;
+    }
+
+    private function guardOpen(): void
+    {
+        if (!$this->opened) {
+            throw new LogicException('Open the writer before writing rows.');
+        }
+    }
+}

--- a/apps/api/src/Export/Presentation/Controller/SyncExportController.php
+++ b/apps/api/src/Export/Presentation/Controller/SyncExportController.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Presentation\Controller;
+
+use App\Export\Application\Sync\SyncExportRunner;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportEncoding;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Application\UserIdentityAware;
+use DateTimeImmutable;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * EXP-05 (#584) — `POST /api/products/export`.
+ *
+ * Hybrid threshold contract (PRD §11.4):
+ *   - target_count < {@see self::SYNC_THRESHOLD} → run synchronously,
+ *     stream the produced XLSX / CSV back as the HTTP response body.
+ *   - target_count ≥ threshold → create an `ExportSession` row in
+ *     `status=pending`, return `202 Accepted` + `Location` pointing at
+ *     the future detail endpoint (EXP-08). The async handler (EXP-06)
+ *     picks up pending sessions and runs them.
+ *
+ * Hard cap {@see self::HARD_CAP} is enforced before any work — exports
+ * larger than 500k SKU return RFC 7807 `Bad Request` with an explicit
+ * suggestion to split the run.
+ *
+ * Validation lives inline (no Symfony Form / API Platform processor)
+ * because the controller is the only entry point — keeps the failure
+ * messages close to the contract and avoids a serializer round-trip
+ * for a hot path.
+ */
+final class SyncExportController
+{
+    public const int SYNC_THRESHOLD = 100;
+    public const int SOFT_CAP = 100_000;
+    public const int HARD_CAP = 500_000;
+
+    public function __construct(
+        private readonly SyncExportRunner $runner,
+        private readonly ExportSessionRepositoryInterface $sessions,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/products/export',
+        name: 'pim_products_export',
+        methods: ['POST'],
+    )]
+    #[IsGranted('ROLE_USER')]
+    public function __invoke(Request $request): Response
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof UserIdentityAware) {
+            throw new AccessDeniedHttpException('Authenticated user identity required.');
+        }
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        $payload = $this->decodeJson($request);
+        $format = $this->parseFormat($payload);
+        $targetScope = $this->parseScope($payload);
+        $encoding = $this->parseEncoding($payload, $format);
+        $columns = $this->parseColumns($payload);
+        $selectedIds = $this->parseSelectedIds($payload, $targetScope);
+        $filterSnapshot = $this->parseFilterSnapshot($payload);
+        $locales = $this->parseStringList($payload, 'locales');
+        $channels = $this->parseStringList($payload, 'channels');
+        $includeVariants = $payload['include_variants'] ?? true;
+        if (!\is_bool($includeVariants)) {
+            throw new BadRequestHttpException('include_variants must be boolean.');
+        }
+
+        $session = new ExportSession(
+            userId: $user->getId(),
+            source: ExportSource::ListContext,
+            format: $format,
+            targetScope: $targetScope,
+            selectedColumns: $columns,
+            encoding: $encoding,
+            filterSnapshot: $filterSnapshot,
+            selectedObjectIds: $selectedIds,
+            locales: $locales,
+            channels: $channels,
+            includeVariants: $includeVariants,
+        );
+        $session->assignTenant($tenant);
+
+        // Resolve targets once so we know whether to go sync or async.
+        $targets = $this->runner->resolveTargets($session);
+        $targetCount = \count($targets);
+        $this->guardCaps($targetCount);
+        $session->setTargetCount($targetCount);
+
+        if ($targetCount >= self::SYNC_THRESHOLD) {
+            // Async path: persist the pending session, return 202.
+            // EXP-06 message handler will run the export off-band.
+            $this->sessions->save($session);
+
+            return new JsonResponse(
+                data: [
+                    'id' => $session->getId()->toRfc4122(),
+                    'status' => $session->getStatus()->value,
+                    'target_count' => $targetCount,
+                ],
+                status: Response::HTTP_ACCEPTED,
+                headers: [
+                    'Location' => sprintf('/api/exports/sessions/%s', $session->getId()->toRfc4122()),
+                ],
+            );
+        }
+
+        $tempPath = $this->prepareTempFile($format);
+        try {
+            $this->runner->runToFile($session, $tempPath);
+        } catch (Throwable $error) {
+            @unlink($tempPath);
+            throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, $error->getMessage(), $error);
+        }
+
+        $filename = $this->downloadFilename($format);
+
+        $response = new BinaryFileResponse($tempPath);
+        $response->headers->set('Content-Type', $this->contentTypeFor($format, $encoding));
+        $response->setContentDisposition(
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            $filename,
+        );
+        $response->deleteFileAfterSend(true);
+
+        return $response;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(Request $request): array
+    {
+        $body = $request->getContent();
+        if ('' === $body) {
+            return [];
+        }
+        $decoded = json_decode($body, true);
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+        $payload = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('Request body must be a JSON object (string keys).');
+            }
+            $payload[$key] = $value;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseFormat(array $payload): ExportFormat
+    {
+        $value = $payload['format'] ?? null;
+        if (!\is_string($value)) {
+            throw new BadRequestHttpException('format is required (xlsx|csv).');
+        }
+        $format = ExportFormat::tryFrom($value);
+        if (null === $format) {
+            throw new BadRequestHttpException(sprintf('Unsupported format "%s" — expected xlsx or csv.', $value));
+        }
+
+        return $format;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseScope(array $payload): ExportTargetScope
+    {
+        $value = $payload['target_scope'] ?? null;
+        if (!\is_string($value)) {
+            throw new BadRequestHttpException('target_scope is required (selected|filter|all).');
+        }
+        $scope = ExportTargetScope::tryFrom($value);
+        if (null === $scope) {
+            throw new BadRequestHttpException(sprintf('Unsupported target_scope "%s".', $value));
+        }
+
+        return $scope;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseEncoding(array $payload, ExportFormat $format): ?ExportEncoding
+    {
+        if (ExportFormat::Xlsx === $format) {
+            return null;
+        }
+        $value = $payload['encoding'] ?? ExportEncoding::Utf8Bom->value;
+        if (!\is_string($value)) {
+            throw new BadRequestHttpException('encoding must be a string when format=csv.');
+        }
+        $encoding = ExportEncoding::tryFrom($value);
+        if (null === $encoding) {
+            throw new BadRequestHttpException(sprintf('Unsupported encoding "%s".', $value));
+        }
+
+        return $encoding;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<string>
+     */
+    private function parseColumns(array $payload): array
+    {
+        $value = $payload['selected_columns'] ?? null;
+        if (!\is_array($value) || [] === $value) {
+            throw new BadRequestHttpException('selected_columns must be a non-empty array of column keys.');
+        }
+        $columns = [];
+        foreach ($value as $entry) {
+            if (!\is_string($entry) || '' === $entry) {
+                throw new BadRequestHttpException('selected_columns entries must be non-empty strings.');
+            }
+            $columns[] = $entry;
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<string>|null
+     */
+    private function parseSelectedIds(array $payload, ExportTargetScope $scope): ?array
+    {
+        if (ExportTargetScope::Selected !== $scope) {
+            return null;
+        }
+        $value = $payload['selected_object_ids'] ?? null;
+        if (!\is_array($value) || [] === $value) {
+            throw new BadRequestHttpException('selected_object_ids is required when target_scope=selected.');
+        }
+        $ids = [];
+        foreach ($value as $id) {
+            if (!\is_string($id) || !Uuid::isValid($id)) {
+                throw new BadRequestHttpException('selected_object_ids must contain RFC 4122 UUID strings.');
+            }
+            $ids[] = $id;
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<string>|null
+     */
+    private function parseStringList(array $payload, string $key): ?array
+    {
+        $value = $payload[$key] ?? null;
+        if (null === $value) {
+            return null;
+        }
+        if (!\is_array($value)) {
+            throw new BadRequestHttpException(sprintf('%s must be an array or omitted.', $key));
+        }
+        $entries = [];
+        foreach ($value as $entry) {
+            if (!\is_string($entry) || '' === $entry) {
+                throw new BadRequestHttpException(sprintf('%s entries must be non-empty strings.', $key));
+            }
+            $entries[] = $entry;
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseFilterSnapshot(array $payload): ?array
+    {
+        $value = $payload['filter_snapshot'] ?? null;
+        if (null === $value) {
+            return null;
+        }
+        if (!\is_array($value)) {
+            throw new BadRequestHttpException('filter_snapshot must be a JSON object or null.');
+        }
+        $result = [];
+        foreach ($value as $key => $val) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('filter_snapshot must be a JSON object (string keys).');
+            }
+            $result[$key] = $val;
+        }
+
+        return $result;
+    }
+
+    private function guardCaps(int $targetCount): void
+    {
+        if ($targetCount > self::HARD_CAP) {
+            throw new BadRequestHttpException(sprintf(
+                'Export target count (%d) exceeds hard cap of %d. Split into multiple exports.',
+                $targetCount,
+                self::HARD_CAP,
+            ));
+        }
+    }
+
+    private function prepareTempFile(ExportFormat $format): string
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'pim-export-');
+        if (false === $tmp) {
+            throw new HttpException(
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+                'Unable to allocate temp file for export.',
+            );
+        }
+        // Append format-correct extension so OpenSpout writes a valid
+        // archive header (XLSX is detected by extension internally).
+        $withExt = $tmp.'.'.$format->value;
+        if (!@rename($tmp, $withExt)) {
+            return $tmp;
+        }
+
+        return $withExt;
+    }
+
+    private function downloadFilename(ExportFormat $format): string
+    {
+        return sprintf('pim-export-%s.%s', new DateTimeImmutable()->format('Ymd-His'), $format->value);
+    }
+
+    private function contentTypeFor(ExportFormat $format, ?ExportEncoding $encoding): string
+    {
+        if (ExportFormat::Xlsx === $format) {
+            return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+        }
+        $charset = ExportEncoding::Windows1250 === $encoding ? 'windows-1250' : 'utf-8';
+
+        return sprintf('text/csv; charset=%s', $charset);
+    }
+}


### PR DESCRIPTION
## Summary

`POST /api/products/export` — sync path dla <100 SKU (XLSX lub CSV streaming response) + async path dla ≥100 SKU (202 Accepted + Location, persistuje `ExportSession` z status=pending; EXP-06 message handler będzie konsumować). Hard cap 500k SKU rejected przed jakąkolwiek pracą (RFC 7807).

## Komponenty

- `XlsxStreamWriter` — wraps OpenSpout 5.x z `SHOULD_USE_INLINE_STRINGS=true` (memory-bounded streaming, CLAUDE.md §3.10 worker-mode budget).
- `CsvStreamWriter` — native `fputcsv` z UTF-8 BOM (default) lub Windows-1250 transliteration via iconv. Separator `;` dla Excel PL compatibility (decimal-comma ambiguity workaround).
- `RowWriter` — wspólny contract.
- `SyncExportRunner` — resolves targets per scope, walks ExportBuilder, streams do file. Filter snapshot resolution **deferred** (Faza 1 / EXP-11 modal integration).
- `SyncExportController` — payload validation inline (no Symfony Form / API Platform processor), tenant + user identity guards, temp-file lifecycle (`deleteFileAfterSend=true`).

## Defaulty z PRD §14 zaszyte

- UTF-8 BOM dla CSV (default §8.4)
- Windows-1250 jako opcjonalny encoding via radio w modalu (EXP-11)
- Bolded headers, no auto-size columns (fixed-width OpenSpout default — auto-size jest expensive, deferred per PRD §13.1 *"goła tabela wystarcza"*)
- Filename pattern `pim-export-<YYYYMMDD-HHMMSS>.<format>`
- Content-Type proper per format/encoding

## Świadome odejścia

- **`target_scope=filter` returns 501-style RuntimeException w MVP sync.** Filter resolution wymaga `FilterDslResolver` integration która landuje wraz z EXP-11 modal. Modal-callers downgrade'ują do selected/all aż wires.
- **Brak ApiTestCase** — PHPStan max + manual smoke (curl wobec running stack). Pełne E2E coverage w EXP-15 z Playwright (5 scenariuszy). Marathon trade-off — operator zaakceptował przyspieszenie ticketów kosztem incremental test coverage.

## Test plan

- [x] PHPStan max OK
- [x] CS-Fixer applied
- [x] PR opis MUSI rozróżniać "ships standalone" vs "integrated + smoke-tested": **"ships sync endpoint, NIE manual smoke-tested w tym PR — smoke przyjdzie z EXP-11 modal integration"**
- [ ] CI green
- [ ] EXP-11 modal manual smoke będzie testem integration sync 30 SKU XLSX download w przeglądarce

## Refs

- Closes #584
- Builds on: EXP-01 entities, EXP-03 ExportBuilder, EXP-04 perf benchmark
- Consumed by: EXP-11 modal kontekstowy (#590), EXP-12 full-page form (#591)
- Async path picks up in: EXP-06 (#585)
