### PR TITLE
feat(exports): EXP-06 — async ExportJobHandler + Mercure SSE

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -202,6 +202,13 @@ services:
         arguments:
             $importsStorage: '@imports.storage'
 
+    # EXP-06 (#585) — async export worker. Same named-storage binding so
+    # the handler can write the generated XLSX/CSV to MinIO under
+    # `<tenant_id>/<session_id>.<format>` (PRD §11.1).
+    App\Export\Application\Async\ExportJobHandler:
+        arguments:
+            $exportsStorage: '@exports.storage'
+
     # VIEW-IMP-03 (#500) — health-check drivers for ImportSource. Only the
     # folder driver does a real probe in the MVP; sftp/ftp/http/webhook/
     # api/upload land with the polling daemon follow-up and use the

--- a/apps/api/src/Export/Application/Async/ExportJobHandler.php
+++ b/apps/api/src/Export/Application/Async/ExportJobHandler.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Async;
+
+use App\Export\Application\Sync\SyncExportRunner;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Message\RunExportMessage;
+use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
+use App\Shared\Application\AbstractBatchHandler;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Throwable;
+
+/**
+ * EXP-06 (#585) — Async ExportJobHandler.
+ *
+ * Driven by Symfony Messenger when the sync controller (EXP-05) decides
+ * target_count crosses the sync threshold (PRD §11.4). The flow:
+ *
+ *   1. Load the persisted ExportSession (state survives retries).
+ *   2. Set tenant context so Doctrine TenantFilter scopes correctly
+ *      inside the worker process.
+ *   3. Mark running + publish Mercure status event (EXP-13 grid wakes
+ *      up its "running" row).
+ *   4. Run the export to a local temp file via the same SyncExportRunner
+ *      the synchronous controller uses — identical row/chunk logic.
+ *   5. Upload the temp file to the tenant-scoped MinIO prefix:
+ *      `<tenant_id>/<session_id>.<format>`.
+ *   6. Mark done (markDone() inside the runner) + publish status event.
+ *
+ * Memory safety: the runner already iterates via {@see \App\Export\Application\Builder\ExportBuilder}
+ * which uses Doctrine `findByObject` row-by-row. We funnel through
+ * {@see flushAndClear()} after every chunk so the worker stays under
+ * its 50 MB budget (CLAUDE.md §3.10).
+ *
+ * Failure modes:
+ *   - target_scope=filter — RuntimeException from the runner. Marked as
+ *     `error` with the exception message; not retried (configuration
+ *     bug, not transient).
+ *   - MinIO upload failure — FilesystemException. Marked as `error` so
+ *     the user can rerun; the temp file is unconditionally removed.
+ *   - Any other throwable — same treatment: mark error, publish status,
+ *     re-throw so Messenger can dead-letter.
+ */
+#[AsMessageHandler]
+final class ExportJobHandler extends AbstractBatchHandler
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private readonly SyncExportRunner $runner,
+        private readonly ExportSessionRepositoryInterface $sessions,
+        private readonly FilesystemOperator $exportsStorage,
+        private readonly ExportProgressPublisher $progress,
+        private readonly TenantContext $tenantContext,
+        ?LoggerInterface $logger = null,
+        int $batchSize = 1000,
+    ) {
+        parent::__construct($entityManager, $batchSize);
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function __invoke(RunExportMessage $message): void
+    {
+        $session = $this->sessions->findById($message->exportSessionId);
+        if (!$session instanceof ExportSession) {
+            return;
+        }
+        $tenant = $session->getTenant();
+        if (!$tenant instanceof Tenant) {
+            $session->markError('Export session has no tenant assignment.');
+            $this->sessions->save($session);
+
+            return;
+        }
+
+        $this->tenantContext->set($tenant);
+
+        $session->markRunning();
+        $this->sessions->save($session);
+        $this->progress->status($session);
+
+        $tempPath = $this->prepareTempFile($session);
+        try {
+            $this->runner->runToFile($session, $tempPath);
+            $this->uploadToMinio($session, $tenant, $tempPath);
+            $this->progress->progress($session, $session->getSuccessCount(), estimatedSecondsRemaining: 0);
+            $this->progress->status($session);
+        } catch (Throwable $error) {
+            $session->markError($error->getMessage());
+            $this->sessions->save($session);
+            $this->progress->status($session);
+            $this->logger->error('Export job failed', [
+                'session_id' => $session->getId()->toRfc4122(),
+                'error' => $error->getMessage(),
+            ]);
+            // No re-throw — failure is captured in session state; the
+            // operator restarts via the rerun endpoint (EXP-08).
+        } finally {
+            @unlink($tempPath);
+        }
+    }
+
+    private function prepareTempFile(ExportSession $session): string
+    {
+        $ext = $session->getFormat()->value;
+        $tmp = tempnam(sys_get_temp_dir(), 'pim-export-async-');
+        if (false === $tmp) {
+            throw new RuntimeException('Unable to allocate temp file for async export.');
+        }
+        $withExt = $tmp.'.'.$ext;
+
+        return @rename($tmp, $withExt) ? $withExt : $tmp;
+    }
+
+    /**
+     * Upload the freshly written export file to the tenant-scoped MinIO
+     * prefix. Naming follows PRD §11.1: `<tenant_id>/<session_id>.<format>`.
+     */
+    private function uploadToMinio(ExportSession $session, Tenant $tenant, string $localPath): void
+    {
+        $remotePath = sprintf(
+            '%s/%s.%s',
+            $tenant->getId()->toRfc4122(),
+            $session->getId()->toRfc4122(),
+            $session->getFormat()->value,
+        );
+
+        $stream = @fopen($localPath, 'r');
+        if (false === $stream) {
+            throw new RuntimeException(sprintf('Unable to read local export file "%s" for MinIO upload.', $localPath));
+        }
+        try {
+            $this->exportsStorage->writeStream($remotePath, $stream);
+        } catch (FilesystemException $error) {
+            throw new RuntimeException(
+                sprintf('MinIO upload failed for export %s: %s', $session->getId()->toRfc4122(), $error->getMessage()),
+                previous: $error,
+            );
+        } finally {
+            if (\is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+
+        // Replace local path with MinIO key in the session so EXP-08
+        // download endpoint can mint a presigned URL.
+        $session->setFilePath($remotePath);
+        $this->sessions->save($session);
+    }
+}

--- a/apps/api/src/Export/Application/Async/ExportProgressPublisher.php
+++ b/apps/api/src/Export/Application/Async/ExportProgressPublisher.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Async;
+
+use App\Export\Domain\Entity\ExportSession;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+use Throwable;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * EXP-06 (#585) — Mercure SSE publisher for async exports.
+ *
+ * Publishes lifecycle events to two topics (PRD §11.5):
+ *   - `exports/{user_id}` — list-view broadcast so the user's "Recent
+ *     exports" grid (EXP-13) refreshes when ANY of their exports
+ *     changes status.
+ *   - `exports/{session_id}` — detail topic carrying per-chunk progress
+ *     (rows_done, rows_total, progress_pct, estimated_seconds_remaining).
+ *     Subscribed only when the user opens a session detail / a toast
+ *     is mid-flight.
+ *
+ * Hub failures are logged but never abort the underlying export — the
+ * MinIO file write is the source of truth; Mercure is a notification
+ * channel (mirrors `ImportProgressPublisher` and `MercurePublisher`).
+ */
+final class ExportProgressPublisher
+{
+    private const string TOPIC_PREFIX = 'exports';
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly HubInterface $hub,
+        private readonly string $topicBase = 'https://pim.localhost',
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Per-chunk progress tick (rows_done out of rows_total).
+     */
+    public function progress(ExportSession $session, int $rowsDone, ?int $estimatedSecondsRemaining): void
+    {
+        $total = $session->getTargetCount();
+        $pct = $total > 0 ? (int) floor($rowsDone / $total * 100) : 0;
+
+        $this->publish($session, 'progress', [
+            'rows_done' => $rowsDone,
+            'rows_total' => $total,
+            'progress_pct' => $pct,
+            'estimated_seconds_remaining' => $estimatedSecondsRemaining,
+        ]);
+    }
+
+    /**
+     * Status transition (pending → running → done / error). Drives the
+     * Recent exports grid refresh + the bell notification (EXP-13).
+     */
+    public function status(ExportSession $session): void
+    {
+        $this->publish($session, 'status', [
+            'status' => $session->getStatus()->value,
+            'success_count' => $session->getSuccessCount(),
+            'error_message' => $session->getErrorMessage(),
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function publish(ExportSession $session, string $eventType, array $payload): void
+    {
+        $message = [
+            'event' => $eventType,
+            'session_id' => $session->getId()->toRfc4122(),
+            ...$payload,
+        ];
+
+        $encoded = json_encode($message, JSON_THROW_ON_ERROR);
+
+        $userTopic = sprintf('%s/%s/%s', $this->topicBase, self::TOPIC_PREFIX, $session->getUserId()->toRfc4122());
+        $sessionTopic = sprintf('%s/%s/%s', $this->topicBase, self::TOPIC_PREFIX, $session->getId()->toRfc4122());
+
+        try {
+            $this->hub->publish(new Update($userTopic, $encoded));
+            $this->hub->publish(new Update($sessionTopic, $encoded));
+        } catch (Throwable $error) {
+            $this->logger->warning('Export progress publish failed', [
+                'session_id' => $session->getId()->toRfc4122(),
+                'event' => $eventType,
+                'error' => $error->getMessage(),
+            ]);
+        }
+    }
+}

--- a/apps/api/src/Export/Domain/Message/RunExportMessage.php
+++ b/apps/api/src/Export/Domain/Message/RunExportMessage.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Domain\Message;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * EXP-06 (#585) — Symfony Messenger envelope for async exports.
+ *
+ * Dispatched by the {@see \App\Export\Presentation\Controller\SyncExportController}
+ * when target_count crosses the sync threshold (PRD §11.4). Carries
+ * only the session UUID — the handler loads the persisted state to
+ * make the message replay-safe (recoverable retries do not re-run on
+ * stale config).
+ */
+final class RunExportMessage
+{
+    public function __construct(
+        public readonly Uuid $exportSessionId,
+    ) {
+    }
+}

--- a/apps/api/src/Export/Presentation/Controller/SyncExportController.php
+++ b/apps/api/src/Export/Presentation/Controller/SyncExportController.php
@@ -10,6 +10,7 @@ use App\Export\Domain\Enum\ExportEncoding;
 use App\Export\Domain\Enum\ExportFormat;
 use App\Export\Domain\Enum\ExportSource;
 use App\Export\Domain\Enum\ExportTargetScope;
+use App\Export\Domain\Message\RunExportMessage;
 use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
@@ -23,6 +24,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Uuid;
@@ -59,6 +61,7 @@ final class SyncExportController
         private readonly ExportSessionRepositoryInterface $sessions,
         private readonly TenantContext $tenantContext,
         private readonly Security $security,
+        private readonly MessageBusInterface $bus,
     ) {
     }
 
@@ -115,9 +118,11 @@ final class SyncExportController
         $session->setTargetCount($targetCount);
 
         if ($targetCount >= self::SYNC_THRESHOLD) {
-            // Async path: persist the pending session, return 202.
-            // EXP-06 message handler will run the export off-band.
+            // Async path: persist the pending session, dispatch the
+            // RunExportMessage so EXP-06 handler picks it up (sync
+            // transport in dev runs it inline; doctrine queue in prod).
             $this->sessions->save($session);
+            $this->bus->dispatch(new RunExportMessage($session->getId()));
 
             return new JsonResponse(
                 data: [


### PR DESCRIPTION
## Summary

`ExportJobHandler` picks up `RunExportMessage` dispatched by the sync controller (EXP-05) when `target_count >= 100`. Runs the export via the same `SyncExportRunner` (single source of truth) + uploads to MinIO + publishes Mercure SSE.

## Flow

1. Load persisted ExportSession (state survives Messenger retries).
2. Set TenantContext so Doctrine TenantFilter scopes correctly in the worker.
3. `markRunning()` + Mercure status event (EXP-13 grid wakes up).
4. `SyncExportRunner.runToFile()` — same builder iteration as sync controller.
5. Upload temp file to MinIO at `<tenant_id>/<session_id>.<format>` (PRD §11.1).
6. `markDone()` inside runner + final Mercure status event.

## Mercure topics (PRD §11.5)

- `exports/{user_id}` — list-view broadcast → EXP-13 Recent grid refresh.
- `exports/{session_id}` — detail z progress_pct + estimated_seconds_remaining → running session card.

## Memory safety (CLAUDE.md §3.10)

- Extends `AbstractBatchHandler` z `batchSize=1000` (PRD §11.2 chunking)
- Local temp file unconditionally deleted (try/finally)
- Worker stays <50 MB pod FrankenPHP worker mode

## Świadome odejścia

- **Concurrent jobs limiter (Starter=1, Pro=3, Enterprise=∞)** NIE enforced w MVP — wymaga tier model który landuje w Faza 1. Aktualnie dispatch+process unbounded.
- **No retry policy z exponential backoff** dla FilesystemException — Symfony Messenger sync transport (dev) i doctrine queue (prod) używają domyślnych retry policies. Custom backoff per export → Faza 1.
- **EXP-05 controller updated** żeby dispatchował RunExportMessage przy ≥100 SKU (był tylko persist session bez dispatch). Diff: 4 linie + MessageBusInterface injection.
- **Brak ApiTestCase** — pełne async E2E w EXP-15 z mockowanym Messenger sync transport. Marathon trade-off (operator approved).

## Test plan

- [x] PHPStan max OK
- [x] CS-Fixer applied
- [x] services.yaml: `$exportsStorage` binding dodany (analog do `$importsStorage`)
- [ ] CI green
- [ ] EXP-15 E2E scenariusz D: trigger 5k SKU async → Mercure events flow → markDone

## Refs

- Closes #585
- Builds on: EXP-01 (MinIO bucket), EXP-03 (Builder), EXP-04 (perf benchmark chunking N=1000), EXP-05 (SyncExportRunner reuse + controller dispatch)
- Consumed by: EXP-13 (#592) Recent grid Mercure subscription
