### PR TITLE
feat(exports): EXP-09 — FE foundation (Exports hub MVP)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -167,6 +167,24 @@ const ImportWizardPage = lazyPage(
   () => import('@/features/imports/wizard/ImportWizardPage'),
   'ImportWizardPage',
 );
+// EXP-09 (#588) — Exports hub MVP. Placeholder views for sessions/profiles
+// + new flow; real grids land with EXP-13/EXP-14, column picker EXP-10.
+const ExportsLayout = lazyPage(
+  () => import('@/features/exports/layout/ExportsLayout'),
+  'ExportsLayout',
+);
+const ExportSessionsView = lazyPage(
+  () => import('@/features/exports/sessions/ExportSessionsView'),
+  'ExportSessionsView',
+);
+const ExportProfilesView = lazyPage(
+  () => import('@/features/exports/profiles/ExportProfilesView'),
+  'ExportProfilesView',
+);
+const ExportNewPage = lazyPage(
+  () => import('@/features/exports/wizard/ExportNewPage'),
+  'ExportNewPage',
+);
 const IntegrationsLayout = lazyPage(
   () => import('@/features/integration-hub/IntegrationsLayout'),
   'IntegrationsLayout',
@@ -279,6 +297,19 @@ function App() {
             {
               name: 'import-schedules',
               list: '/integrations/imports/schedule',
+            },
+            // EXP-09 (#588) — Refine resource registrations for the
+            // Exports hub. List endpoints land with EXP-13 (sessions
+            // grid) and EXP-14 (profiles grid).
+            {
+              name: 'export-sessions',
+              list: '/integrations/exports/sessions',
+              show: '/integrations/exports/sessions/:id',
+              create: '/integrations/exports/new',
+            },
+            {
+              name: 'export-profiles',
+              list: '/integrations/exports/profiles',
             },
           ]}
           options={{
@@ -396,6 +427,15 @@ function App() {
                   </Route>
                   <Route path="imports/new" element={<ImportWizardPage />} />
                   <Route path="imports/:id" element={<ImportShowPage />} />
+                  {/* EXP-09 (#588) — Exports hub MVP. Tabs sessions/profiles
+                      + standalone /new full-page form. Mirrors imports layout
+                      depth so deep-links survive into Faza 1. */}
+                  <Route path="exports" element={<ExportsLayout />}>
+                    <Route index element={<Navigate to="sessions" replace />} />
+                    <Route path="sessions" element={<ExportSessionsView />} />
+                    <Route path="profiles" element={<ExportProfilesView />} />
+                  </Route>
+                  <Route path="exports/new" element={<ExportNewPage />} />
                   <Route path="api-configurator" element={<ApiProfilesListPage />} />
                   <Route path="api-configurator/create" element={<ApiProfileCreatePage />} />
                   <Route path="api-configurator/:id/edit" element={<ApiProfileEditPage />} />

--- a/apps/admin/src/features/exports/layout/ExportsLayout.tsx
+++ b/apps/admin/src/features/exports/layout/ExportsLayout.tsx
@@ -1,0 +1,99 @@
+import { useTranslation } from 'react-i18next';
+import { NavLink, Outlet, useLocation } from 'react-router';
+
+interface TabDef {
+  value: string;
+  to: string;
+  labelKey: string;
+}
+
+const TABS: readonly TabDef[] = [
+  {
+    value: 'sessions',
+    to: '/integrations/exports/sessions',
+    labelKey: 'exports.tabs.sessions',
+  },
+  {
+    value: 'profiles',
+    to: '/integrations/exports/profiles',
+    labelKey: 'exports.tabs.profiles',
+  },
+] as const;
+
+const DEFAULT_TAB = 'sessions';
+
+function activeTabFor(pathname: string): string {
+  const match = TABS.find((tab) => pathname.startsWith(tab.to));
+  return match?.value ?? DEFAULT_TAB;
+}
+
+/**
+ * EXP-09 (#588) — Exports hub layout (analog do ImportsLayout VIEW-IMP-00).
+ *
+ * Two tabs in MVP:
+ *   - Recent exports (lista sesji per user, EXP-13)
+ *   - Saved profiles (CRUD profili per user, EXP-14)
+ *
+ * "New export" lives at `/integrations/exports/new` as a stand-alone
+ * full-page form (EXP-12). It's reachable from the tab strip via a CTA
+ * button rather than another tab so the hub stays clean (PRD §13.1).
+ */
+export function ExportsLayout(): React.ReactElement {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+  const activeTab = activeTabFor(pathname);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="display text-[28px] font-semibold tracking-tight">
+          {t('exports.section_title', { defaultValue: 'Eksporty' })}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t('exports.section_subtitle', {
+            defaultValue:
+              'Eksportuj produkty do XLSX / CSV — z modalem z listy lub z dedykowanej formy.',
+          })}
+        </p>
+      </header>
+      <div
+        className="flex items-center justify-between gap-4 border-b"
+        role="tablist"
+        aria-label={t('exports.tabs.aria_label', { defaultValue: 'Zakładki eksportu' })}
+      >
+        <div className="flex gap-1">
+          {TABS.map((tab) => {
+            const isActive = activeTab === tab.value;
+            return (
+              <NavLink
+                key={tab.value}
+                to={tab.to}
+                role="tab"
+                aria-selected={isActive}
+                className={({ isActive: navActive }) =>
+                  [
+                    'inline-flex items-center border-b-2 px-3 py-2 text-sm font-medium transition-colors',
+                    navActive || isActive
+                      ? 'border-foreground text-foreground'
+                      : 'border-transparent text-muted-foreground hover:border-muted-foreground/40 hover:text-foreground',
+                  ].join(' ')
+                }
+              >
+                {t(tab.labelKey)}
+              </NavLink>
+            );
+          })}
+        </div>
+        <NavLink
+          to="/integrations/exports/new"
+          className="inline-flex items-center rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          {t('exports.tabs.new_cta', { defaultValue: 'Nowy eksport' })}
+        </NavLink>
+      </div>
+      <Outlet />
+    </div>
+  );
+}
+
+export default ExportsLayout;

--- a/apps/admin/src/features/exports/profiles/ExportProfilesView.tsx
+++ b/apps/admin/src/features/exports/profiles/ExportProfilesView.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * EXP-09 (#588) — placeholder Saved profiles view.
+ *
+ * Real grid (Name | Created | Last run | Run count | Actions) + Run-now
+ * dispatch lands with EXP-14 (#593). Stub keeps the route reachable.
+ */
+export function ExportProfilesView(): React.ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-md border border-dashed bg-muted/30 p-8 text-center">
+      <h2 className="text-lg font-medium">
+        {t('exports.profiles.empty_title', { defaultValue: 'Brak zapisanych profili eksportu' })}
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {t('exports.profiles.empty_subtitle', {
+          defaultValue:
+            'Saved profiles CRUD (EXP-14) landuje wkrótce. Profile zapisujesz checkboxem w modalu Eksport (EXP-11).',
+        })}
+      </p>
+    </div>
+  );
+}
+
+export default ExportProfilesView;

--- a/apps/admin/src/features/exports/sessions/ExportSessionsView.tsx
+++ b/apps/admin/src/features/exports/sessions/ExportSessionsView.tsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * EXP-09 (#588) — placeholder Recent exports view.
+ *
+ * Real grid (Date | User | Format | Rows | Status | Actions) + Mercure
+ * SSE wiring (`exports/{user_id}` topic) lands with EXP-13 (#592). This
+ * stub keeps the route reachable so the layout works end-to-end and the
+ * sidebar link does not 404.
+ */
+export function ExportSessionsView(): React.ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-md border border-dashed bg-muted/30 p-8 text-center">
+      <h2 className="text-lg font-medium">
+        {t('exports.sessions.empty_title', { defaultValue: 'Nie masz jeszcze eksportów' })}
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {t('exports.sessions.empty_subtitle', {
+          defaultValue:
+            'Recent exports grid + live status (EXP-13) wiąże się po zakończeniu marathonu. Otwórz [Nowy eksport →] aby przetestować flow.',
+        })}
+      </p>
+    </div>
+  );
+}
+
+export default ExportSessionsView;

--- a/apps/admin/src/features/exports/wizard/ExportNewPage.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportNewPage.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+/**
+ * EXP-09 (#588) — placeholder full-page export form.
+ *
+ * Real shared-sections form (column picker + locale/channel toggles +
+ * format + scope + filter picker) lands with EXP-12 (#591). The
+ * column picker itself lands with EXP-10 (#589).
+ *
+ * Until then this stub renders a friendly explainer so the route + the
+ * tab CTA do not 404. Marathon mode trade-off documented in the
+ * companion PR.
+ */
+export function ExportNewPage(): React.ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-4">
+      <header className="space-y-1">
+        <h1 className="display text-[28px] font-semibold tracking-tight">
+          {t('exports.new.title', { defaultValue: 'Nowy eksport' })}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t('exports.new.subtitle', {
+            defaultValue:
+              'Pełna forma (column picker + filtry + scope) landuje w EXP-10..EXP-12. Backend (POST /api/products/export) działa już teraz — wywołasz go z modalu na liście produktów po wdrożeniu EXP-11.',
+          })}
+        </p>
+      </header>
+      <div className="rounded-md border border-dashed bg-muted/30 p-6 text-sm">
+        <p className="font-medium">Backend dostępny:</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5 text-muted-foreground">
+          <li>
+            <code>POST /api/products/export</code> — sync &lt;100 SKU, async &gt;=100 SKU
+          </li>
+          <li>
+            <code>GET /api/exports/sessions</code> — historia (Recent grid w EXP-13)
+          </li>
+          <li>
+            <code>GET /api/exports/profiles</code> — zapisane profile (Saved grid w EXP-14)
+          </li>
+        </ul>
+      </div>
+      <Link
+        to="/integrations/exports"
+        className="inline-flex items-center text-sm text-primary hover:underline"
+      >
+        ← {t('exports.new.back_to_hub', { defaultValue: 'Wróć do eksportów' })}
+      </Link>
+    </div>
+  );
+}
+
+export default ExportNewPage;

--- a/apps/admin/src/features/integration-hub/IntegrationsLayout.tsx
+++ b/apps/admin/src/features/integration-hub/IntegrationsLayout.tsx
@@ -13,12 +13,8 @@ interface TabDef {
 
 const TABS: readonly TabDef[] = [
   { to: '/integrations/imports', labelKey: 'integrations.tabs.imports', enabled: true },
-  {
-    to: '/integrations/exports',
-    labelKey: 'integrations.tabs.exports',
-    enabled: false,
-    comingSoonKey: 'integrations.coming_soon',
-  },
+  // EXP-09 (#588) — Exports hub enabled. Grids + modal land in EXP-13/14.
+  { to: '/integrations/exports', labelKey: 'integrations.tabs.exports', enabled: true },
   {
     to: '/integrations/connectors',
     labelKey: 'integrations.tabs.connectors',


### PR DESCRIPTION
## Summary

Frontend foundation dla Exports hub. Routing + Refine resources + tab layout pod `/integrations/exports`.

## Komponenty

- `ExportsLayout` — sessions/profiles tab strip + "Nowy eksport" CTA (analog `ImportsLayout`).
- `ExportSessionsView` — placeholder dla Recent exports grid (EXP-13 #592).
- `ExportProfilesView` — placeholder dla Saved profiles grid (EXP-14 #593).
- `ExportNewPage` — placeholder dla full-page form (EXP-12 #591 + EXP-10 ColumnPicker #589 + EXP-11 modal sections #590).

## Integration

- `/integrations/exports` tab w IntegrationsLayout: enabled (był disabled)
- Refine resources: `export-sessions`, `export-profiles`
- Routes pod `<Route path="exports">` mirror imports pattern
- i18n inline `defaultValue:` (przed catalog growth)

## Świadome odejścia

- Stubs minimalne — pełne UX w EXP-10..EXP-14
- Sidebar primary nav unchanged — integracje access via existing menu

## Test plan

- [x] Biome strict OK (auto-fixed format issues)
- [x] TypeScript noEmit OK (`pnpm typecheck` z increased Node heap)
- [ ] CI green

## Refs

- Closes #588
- Routes prepared for: EXP-10 picker, EXP-11 modal, EXP-12 form, EXP-13 sessions grid, EXP-14 profiles grid
