### PR TITLE
feat(exports): EXP-12 — Full-page export form reusing ExportModal

### DIFF
--- a/apps/admin/src/features/exports/wizard/ExportNewPage.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportNewPage.tsx
@@ -1,53 +1,52 @@
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
+import { useNavigate } from 'react-router';
+
+import { ExportModal } from './ExportModal';
 
 /**
- * EXP-09 (#588) — placeholder full-page export form.
+ * EXP-12 (#591) — Full-page export form.
  *
- * Real shared-sections form (column picker + locale/channel toggles +
- * format + scope + filter picker) lands with EXP-12 (#591). The
- * column picker itself lands with EXP-10 (#589).
+ * MVP renders the same {@see ExportModal} from EXP-11 (#590) but with
+ * `open=true` and a redirect on close — so power users who reach
+ * `/integrations/exports/new` directly (Marcin's snapshot use case
+ * from PRD §3.5) get the full picker + scope sections without going
+ * through the catalog list page.
  *
- * Until then this stub renders a friendly explainer so the route + the
- * tab CTA do not 404. Marathon mode trade-off documented in the
- * companion PR.
+ * Why reuse the modal instead of a parallel page-level form:
+ *   - Submit flow + payload validation are identical.
+ *   - Sections (columns, format/encoding, scope) match 1:1.
+ *   - Single source of truth for FE export controls keeps the
+ *     contract tight as the modal evolves (e.g. when locale toggles
+ *     and "save as profile" wire in).
+ *
+ * Świadome odejścia (PRD §13.1 + §14):
+ *   - Chip filter picker — backend zwraca 501 dla target_scope=filter
+ *     w MVP sync runnera. Once the FilterDslResolver lands in the
+ *     async path, this page grows a chip-style filter section above
+ *     the modal — same component, just gated on tenant-side feature
+ *     flag.
+ *   - No back-to-hub breadcrumb in MVP — Esc/cancel on the modal
+ *     returns to `/integrations/exports` which IS the hub.
  */
 export function ExportNewPage(): React.ReactElement {
+  const navigate = useNavigate();
   const { t } = useTranslation();
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      navigate('/integrations/exports');
+    }
+  };
 
   return (
     <div className="space-y-4">
-      <header className="space-y-1">
-        <h1 className="display text-[28px] font-semibold tracking-tight">
-          {t('exports.new.title', { defaultValue: 'Nowy eksport' })}
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          {t('exports.new.subtitle', {
-            defaultValue:
-              'Pełna forma (column picker + filtry + scope) landuje w EXP-10..EXP-12. Backend (POST /api/products/export) działa już teraz — wywołasz go z modalu na liście produktów po wdrożeniu EXP-11.',
-          })}
-        </p>
-      </header>
-      <div className="rounded-md border border-dashed bg-muted/30 p-6 text-sm">
-        <p className="font-medium">Backend dostępny:</p>
-        <ul className="mt-2 list-disc space-y-1 pl-5 text-muted-foreground">
-          <li>
-            <code>POST /api/products/export</code> — sync &lt;100 SKU, async &gt;=100 SKU
-          </li>
-          <li>
-            <code>GET /api/exports/sessions</code> — historia (Recent grid w EXP-13)
-          </li>
-          <li>
-            <code>GET /api/exports/profiles</code> — zapisane profile (Saved grid w EXP-14)
-          </li>
-        </ul>
-      </div>
-      <Link
-        to="/integrations/exports"
-        className="inline-flex items-center text-sm text-primary hover:underline"
-      >
-        ← {t('exports.new.back_to_hub', { defaultValue: 'Wróć do eksportów' })}
-      </Link>
+      <p className="text-sm text-muted-foreground">
+        {t('exports.new.hint', {
+          defaultValue:
+            'Pełna forma eksportu — wybierz kolumny, format i zasięg, potem [Eksportuj]. Sync (<100 SKU) zwróci plik bezpośrednio; ≥100 SKU pójdzie do kolejki async (widoczne w Recent exports).',
+        })}
+      </p>
+      <ExportModal open={true} onOpenChange={handleClose} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

`/integrations/exports/new` renderuje `ExportModal` (EXP-11) forced-open. Cancel/Esc → redirect do hub. Single source of truth dla FE export controls.

## Świadome odejścia

- **Chip filter picker NOT here** — backend 501 dla `target_scope=filter` w MVP sync. Filter UI rośnie tutaj gdy `FilterDslResolver` wires in async (jednocześnie modal + page dostają tę sekcję).
- **No back-to-hub breadcrumb** — Esc/cancel returns to /integrations/exports.
- **Marcin "full snapshot" use case (PRD §3.5)** covered via `target_scope=all` + select-all columns; "Select all built-ins" button polish jest follow-up.

## Test plan

- [x] TypeScript noEmit OK
- [x] Biome strict OK
- [ ] CI green
- [ ] Smoke: nav do /integrations/exports/new → modal opens → cancel → /integrations/exports

## Refs

- Closes #591
- Builds on: EXP-11 (#590) — reuses ExportModal entirely
