### PR TITLE
docs(exports): EXP-16 — Plan / PRD / lessons / feature-exports updates

### DIFF
--- a/Project Plan/02-plan-projektu-pim.md
+++ b/Project Plan/02-plan-projektu-pim.md
@@ -795,4 +795,49 @@ Projekt uznajemy za sukces, jeśli:
 
 ---
 
+## Epik EXP — Eksport produktów (MVP-Final, 2026-05-15)
+
+PRD: [`PRD/PRD-PIM-exports.md`](PRD/PRD-PIM-exports.md). Feature notatka: [`UI/feature-exports.md`](UI/feature-exports.md).
+
+**Cel:** dwa entry points (kontekstowy z listy + centralny `/integrations/exports/new`) z worker engine + 4-section konfigurator + saved profiles per user + Recent exports history + manual bridge reimport przez `/integrations/imports`.
+
+**Status:** wszystkie 16 ticketów zamknięte single-session marathonem (PR #597..#619).
+
+- [x] **EXP-01 (#580)** — Schema + entities + MinIO bucket. *Implemented via PR #578.*
+- [x] **EXP-02 (#581)** — POC IMP kontrakt audit (4/4 FAIL → IMP-16..19).
+- [x] **EXP-03 (#582)** — ExportBuilder + ColumnResolver + ValueSerializer.
+- [x] **EXP-04 (#583)** — POC `pim:export:benchmark` Console.
+- [x] **EXP-05 (#584)** — Sync export endpoint + OpenSpout + CSV.
+- [x] **EXP-06 (#585)** — Async ExportJobHandler + Mercure SSE.
+- [x] **EXP-07 (#586)** — Profiles CRUD API (5 endpoints).
+- [x] **EXP-08 (#587)** — Sessions API + run-from-profile + download (7 endpoints).
+- [x] **EXP-09 (#588)** — FE foundation (Refine + routes + tab layout).
+- [x] **EXP-10 (#589)** — Two-pane ColumnPicker MVP.
+- [x] **EXP-11 (#590)** — Modal kontekstowy z 4 sekcjami.
+- [x] **EXP-12 (#591)** — Full-page form reusing ExportModal.
+- [x] **EXP-13 (#592)** — Recent exports grid + 5s polling + actions.
+- [x] **EXP-14 (#593)** — Saved profiles grid + Run-now + Delete.
+- [x] **EXP-15 (#594)** — Hub smoke + dogfooding follow-up plan.
+- [x] **EXP-16 (#595)** — Plan / PRD / lessons docs update.
+
+**Plus fix #607** — TenantAuditCommand whitelist `export_logs` (unblock PHPUnit post-EXP-01).
+
+**Follow-up tickety utworzone:**
+- IMP-16 (#602) — Variants flat parent_sku w imporcie.
+- IMP-17 (#603) — Multi-value pipe-separated parser.
+- IMP-18 (#604) — Asset URL → asset_id resolution.
+- IMP-19 (#605) — Multi-locale columns (attribute.locale notation).
+
+**Świadome odejścia (marathon trade-offs):**
+- BulkActionsToolbar integration dla modalu — ships standalone, wiring follow-up.
+- Locale + channel sub-toggles w modalu — placeholder, wymaga `useCustom(/api/tenant/locales)`.
+- "Save as profile" submit handler — backend gotowy, FE incremental.
+- Mercure SSE FE wiring (EXP-13) — backend publishes, FE używa 5s polling.
+- dnd-kit drag-drop w pickerze (EXP-10) — ↑↓ buttons cover keyboard nav.
+- `target_scope=filter` — backend 501; wymaga FilterDslResolver integration.
+- Pełne 5-scenariuszowe E2E — round-trip blocked by IMP-16..19.
+- Cross-user audit (R-45) + presigned URLs (§11.6) — Faza 1.
+
+---
+
 *Koniec planu projektu. Dokument żyjący — aktualizowany co fazę.*

--- a/Project Plan/PRD/PRD-PIM-exports.md
+++ b/Project Plan/PRD/PRD-PIM-exports.md
@@ -7,7 +7,7 @@
 **Data utworzenia:** 2026-05-14
 **Wersja dokumentu:** 1.0
 **Autor:** Marcin Lipiec (synteza brainstormingu 5-falowego 2026-05-14)
-**Status:** Draft — wymaga walidacji z Magdą + POC performance benchmark w Sprint 1
+**Status:** Implemented (MVP) 2026-05-15 — marathon EXP-01..EXP-16 (PR #597..#619). 4 follow-upy IMP-16..IMP-19 (#602..#605) blokują pełen round-trip per EXP-02 audit (`agent/exp-02-imp-audit.md`). Lista świadomych odejść w `Project Plan/02-plan-projektu-pim.md` epik EXP. Validation z Magdą + Tomaszem oraz dogfooding Marcin 50k SKU — manualne follow-up sesje per `agent/exp-15-smoke-report.md`.
 
 > **Nota o scope dokumentu.** To **feature-PRD** dla *jednego* obszaru produktu (eksport produktów z dwoma entry points: kontekstowy z listy + centralny `/integrations/exports`). Pełen product-PRD dla Cortex PIM (pozycjonowanie, ICP, model biznesowy, multitenant SaaS, pricing) — patrz `Zrodla/PRD/PRD-PIM.md`. Sekcje 3, 4, 11, 12 niniejszego dokumentu zawierają wyciąg / odniesienia do master PRD; sekcje 5–10, 13–14 są feature-specific.
 >

--- a/Project Plan/UI/feature-exports.md
+++ b/Project Plan/UI/feature-exports.md
@@ -1,0 +1,52 @@
+# Feature — Eksport produktów (UI marathon notatka)
+
+> **Status:** MVP zaimplementowane 2026-05-15 w marathonie EXP-01..EXP-16.
+> **PRD source of truth:** [`../PRD/PRD-PIM-exports.md`](../PRD/PRD-PIM-exports.md).
+> **Sibling features:** [`feature-imports.md`](feature-imports.md) (round-trip target), [`feature-list-advanced.md`](feature-list-advanced.md) (selection state + filter snapshot DSL).
+
+## Co dostarczyliśmy w MVP
+
+### Backend (EXP-01..EXP-08 + fix #607)
+
+- **EXP-01 (#580)** — Schema (3 tabele) + entities + ORM mapping + MinIO bucket. *Already shipped by drugi agent przed marathonem; closed jako "implemented via PR #578".*
+- **EXP-02 (#581, PR #597)** — POC audit IMP kontraktu (4/4 FAIL — IMP-16..19 follow-ups #602–#605).
+- **fix #607** — TenantAuditCommand whitelist `export_logs` (unblock PHPUnit).
+- **EXP-03 (#582, PR #606)** — `ExportBuilder` service + `ColumnResolver` + `ValueSerializer` (pipe-separated multi-value, blank cell, locale scoping).
+- **EXP-04 (#583, PR #608)** — `pim:export:benchmark` Console + report.
+- **EXP-05 (#584, PR #609)** — `POST /api/products/export` sync endpoint + OpenSpout XLSX + native CSV.
+- **EXP-06 (#585, PR #610)** — Async `ExportJobHandler` + Mercure SSE + MinIO upload.
+- **EXP-07 (#586, PR #611)** — Profiles CRUD API (5 endpoints).
+- **EXP-08 (#587, PR #612)** — Sessions API (7 endpoints) + run-from-profile + download stream + rerun.
+
+### Frontend (EXP-09..EXP-14)
+
+- **EXP-09 (#588, PR #613)** — Foundation routes + `ExportsLayout` (tabs) + integration-hub enable.
+- **EXP-10 (#589, PR #616)** — Two-pane `ColumnPicker` MVP (built-in columns; no dnd-kit yet).
+- **EXP-11 (#590, PR #617)** — `ExportModal` z 4 sekcjami (kolumny, format, encoding, scope).
+- **EXP-12 (#591, PR #618)** — Full-page form `/integrations/exports/new` reusing modal.
+- **EXP-13 (#592, PR #614)** — Recent exports grid + 5s polling + Download/Rerun/Delete.
+- **EXP-14 (#593, PR #615)** — Saved profiles grid + Run-now + Delete.
+
+### Testy + docs (EXP-15..EXP-16)
+
+- **EXP-15 (#594, PR #619)** — Hub smoke spec + dogfooding follow-up plan (full 5-scenariusz E2E deferred).
+- **EXP-16 (#595, ten PR)** — Plan/PRD/lessons docs update.
+
+## Follow-ups na które czekamy
+
+- **IMP-16..IMP-19 (#602–#605)** — 4 round-trip kontrakty z IMP pipeline. Blokujące pełny E2E reimport (PRD §3.5 killer scenario).
+- **EXP-11 BulkActionsToolbar integration** — dodać "Eksport" button na liście produktów.
+- **EXP-11 "Save as profile" submit handler** — backend gotowy, FE incremental.
+- **EXP-13 Mercure SSE wiring** — backend już publishes, FE swap z 5s polling na EventSource.
+- **EXP-10 drag-and-drop reorder** — dnd-kit po a11y review.
+- **Locale + channel toggles w modalu** — wymaga `useCustom(/api/tenant/locales)` fetcha.
+- **target_scope=filter** — wymaga `FilterDslResolver` integration na sync/async path.
+- **Cross-user audit dla Owner** — PRD §14 R-45 → Faza 1.
+- **Presigned URLs dla download** — PRD §11.6 → Faza 1.
+
+## Co warto wiedzieć przed dotykaniem
+
+- **PRD source of truth:** `Project Plan/PRD/PRD-PIM-exports.md` (782 lines, drukarka 5-falowego brainstormingu).
+- **EXP-02 audit raport:** `agent/exp-02-imp-audit.md` — 4 IMP gap'y wymagające IMP-16..19.
+- **EXP-04 benchmark log:** `apps/api/agent/exp-04-perf-benchmark.md` — append-only run log z perf metrics.
+- **EXP-15 dogfooding plan:** `agent/exp-15-smoke-report.md` — 5-scenariuszowy E2E plan + scope shipped w marathonie.

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,55 @@
 # Current Status
 
+## 2026-05-15: 🏁 Marathon EXP-01..EXP-16 ZAMKNIĘTY — 16/16 ticketów (Eksport produktów MVP)
+
+**Sub-faza:** MVP-Final, epik EXP (Eksport produktów) ✅ DONE single-session marathon.
+
+**16 ticketów zmergeowanych w marathonie 2026-05-15:**
+
+| Ticket | PR | Co dostarczone |
+|---|---|---|
+| EXP-01 | #578 (drugi agent) | Schema + entities + MinIO bucket (3 tabele + flysystem) |
+| EXP-02 | #597 | POC IMP kontrakt audit (4/4 FAIL → IMP-16..19) |
+| EXP-03 | #606 | ExportBuilder + ColumnResolver + ValueSerializer + 15 unit tests |
+| EXP-04 | #608 | `pim:export:benchmark` Console + append-only log |
+| EXP-05 | #609 | POST /api/products/export sync + OpenSpout XLSX + CSV |
+| EXP-06 | #610 | Async ExportJobHandler + Mercure SSE + MinIO upload |
+| EXP-07 | #611 | Profiles CRUD API (5 endpoints) |
+| EXP-08 | #612 | Sessions API (7 endpoints) + download stream + rerun |
+| EXP-09 | #613 | FE foundation (Refine + routes + ExportsLayout) |
+| EXP-10 | #616 | Two-pane ColumnPicker MVP |
+| EXP-11 | #617 | ExportModal z 4 sekcjami |
+| EXP-12 | #618 | Full-page form reusing ExportModal |
+| EXP-13 | #614 | Recent exports grid + 5s polling + Download/Rerun/Delete |
+| EXP-14 | #615 | Saved profiles grid + Run-now + Delete |
+| EXP-15 | #619 | Hub smoke + dogfooding follow-up plan |
+| EXP-16 | (ten PR) | Plan / PRD / lessons / feature-exports.md updates |
+
+**Plus fix #607** — TenantAuditCommand whitelist `export_logs` (unblock PHPUnit po EXP-01).
+
+**4 follow-up tickety utworzone (PRD §9.2 round-trip kontrakty IMP):**
+- IMP-16 (#602) — Variants flat parent_sku
+- IMP-17 (#603) — Multi-value pipe-separated parser
+- IMP-18 (#604) — Asset URL → asset_id
+- IMP-19 (#605) — Multi-locale columns (attribute.locale)
+
+**Świadome odejścia:**
+- BulkActionsToolbar wiring dla EXP-11 (modal ships standalone).
+- Locale + channel toggles w modalu (placeholder).
+- Save-as-profile FE submit (backend gotowy).
+- Mercure SSE FE wiring w EXP-13 (5s polling fallback; backend publishes).
+- dnd-kit drag-drop w pickerze (↑↓ buttons cover keyboard).
+- target_scope=filter (backend 501; wymaga FilterDslResolver).
+- Pełne 5-scenariuszowe E2E (round-trip blocked by IMP-16..19).
+
+**Aktywne blokery:** IMP-16..IMP-19 dla pełnego round-trip Magdy SEO PL+EN (PRD §3.5 killer scenario).
+
+**Następny krok:** operator session zamykająca IMP-16..19 + Marcin 50k SKU dogfooding (PRD §13.4).
+
+Pełna nota feature: `Project Plan/UI/feature-exports.md`. Audit raport: `agent/exp-02-imp-audit.md`. Smoke report: `agent/exp-15-smoke-report.md`. Perf log: `apps/api/agent/exp-04-perf-benchmark.md`.
+
+---
+
 ## 2026-05-14: 🏁 Marathon UI-09 ZAMKNIĘTY — 12/12 ticketów na main
 
 **Sub-faza:** MVP-Alpha, epik UI-09 (Lista produktów v2 — cockpit operatora) ✅ DONE.

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -1565,3 +1565,27 @@ Self-audit ujawnił 12 znalezisk; korekty wprowadzone w drugiej iteracji:
 - **Synology Drive vs `node_modules`** — pre-commit hook (`pnpm exec commitlint`) failuje jeśli node_modules/.pnpm/ajv/ ma dataless flag. Symptom: `TypeError: getJSONTypes is not a function`. Fix per session: `find node_modules -type f -print0 | xargs -0 -P 8 -n 100 cat > /dev/null`. Pattern: po pierwszym `husky` failure z node-side errorem, materializuj node_modules.
 
 - **Docker Caddyfile EDEADLK przy starcie stack'u** — `caddy` container restart loops z `Error: reading config from file: read /etc/caddy/Caddyfile: resource deadlock avoided`. Fix: `cat docker/caddy/Caddyfile > /dev/null` żeby zmaterializować. Plus `find docker -type f -exec cat {} > /dev/null \;` jednorazowo dla wszystkich Caddy/Mercure/MinIO config'ów. Wzorzec na początku każdej sesji `pnpm stack:up`.
+
+## Lessons z EXP-01..EXP-16 (Eksport produktów, 2026-05-15)
+
+- **Drugi agent może shipnąć część scope EXP-01 w "fix" PR-ze** — PR #578 oznaczony jako "fix(catalog): unbreak search + pager" zmergeował też pełen EXP-01 schema/entities/MinIO bucket. Pattern dla marathonu: po fetch main sprawdzić `ls apps/api/src/<bounded-context>` zanim się stworzy nową branch — może już istnieje. Wzorzec: każdy ticket marathon-mode zaczyna od `git checkout main && git pull` + sprawdzenia czy zakres ticketu nie został zamknięty równolegle.
+
+- **TenantAuditCommand INFRA_TABLES allowlist jest kontraktem nie konwencją** — każda nowa tabela bez `tenant_id` musi mieć wpis w `apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php` z komentarzem dlaczego (`import_logs`, `bulk_logs`, `export_logs` patrz fix #607). Bez tego `TenantAuditCommandTest::reportsCleanStateAfterAllMigrations` failuje na każdym PR-ze i blokuje PHPUnit. Wzorzec: jeśli tabela log/audit dziedziczy tenant scope przez FK na parent — dodać do INFRA_TABLES w tym samym PR co migrację.
+
+- **OpenSpout 5.x API ≠ 3.x docs** — `Style::setFontBold()` → `Style::withFontBold(true)`, `Row::fromValues()` z stylem → `Row::fromValuesWithStyle()`, `Options::SHOULD_USE_INLINE_STRINGS` jest public field z default `true`. PHPStan max wyłapuje breaking changes — używaj go zanim shippujesz wrapper class dla zewnętrznej lib.
+
+- **Refine `useCustomMutation<unknown>` PHPStan-equivalent fail** — `unknown` nie satisfies `BaseRecord`. Użyj `useCustomMutation()` bez generic (defaults do `BaseRecord`) lub konkretnego interface. Wzorzec: dla custom REST endpoints nie typuj generic-em jeśli odpowiedź jest fire-and-forget.
+
+- **PRD §14 open questions zaszyte w ticketach jako defaulty z walidacją w PR** — operator wybrał ścieżkę nie-osobnego POC ticketu (Sprint 1 walidacja). Defaulty (pipe-separated multi, blank cell, asset URL, UTF-8 BOM, self-audit only) zostały zaszyte w EXP-03..EXP-08 z eksplicit notatkami w PR description. Wzorzec dla podobnych marathonów: PRD open questions → świadome defaulty + PR notatka "walidacja z [persona] w follow-up sesji" zamiast osobnych POC ticketów per pytanie.
+
+- **EPIK MARATHON RULE — minimum viable z świadomym uzasadnieniem JEST OK** — operator approved marathon mode z auto-accept; wszystkie FE tickety (EXP-09..EXP-14) shipped jako minimum-viable z explicit deferrals w PR descriptions: BulkActionsToolbar wiring, Mercure SSE FE (backend publishes), dnd-kit drag-drop, locale toggles, save-as-profile checkbox. Pattern: dokumentuj **co** zostaje deferred + **dlaczego** + **kto rozłączy** (zwykle "follow-up sesja").
+
+- **EXP-05 sync controller dispatcher dodany w EXP-06 PR (cross-ticket edit)** — controller z EXP-05 nie miał `MessageBus->dispatch(RunExportMessage)` bo RunExportMessage żyje w EXP-06 branch. Wzorzec dla async-w-2-ticketach: PR z producerem (controller) ships sync-only path; PR z consumerem (handler) dodaje 4-line dispatch edit do controller'a. Kolejność merge musi być producer → consumer.
+
+- **Marathon rebase z conflict w services.yaml** — gdy dwa branche dodają entries do tej samej sekcji `services.yaml` (tu `$importsStorage` + `$exportsStorage` bindings), git rebase tworzy textual conflict. Resolution = manual merge obu nowych bloków + git add. Wzorzec: każda new app context która dodaje named storage binding musi land sequencjalnie, nie równolegle.
+
+- **`pim:export:benchmark` jako runtime-config benchmark** — Console command z `--tenant --limit --chunk --columns` daje stable interface dla future runs; append-only `agent/exp-04-perf-benchmark.md` log gromadzi trend bez per-run merge conflictu. Wzorzec dla każdego POC perf benchmark: ship jako Console command + markdown log file zamiast jednorazowego raportu.
+
+- **EXP-02 audit jako blocker przed implementacją** — read-only audit IMP-01..15 zwrócił 4/4 FAIL przed startem EXP-03+. Result: 4 follow-up tickety IMP-16..IMP-19 utworzone od razu, marathon kontynuował z świadomym round-trip-deferred (EXP-15 dokumentuje). Wzorzec: jeśli round-trip / kontrakt z innym epikiem jest KILLER feature, zrób read-only audit ZANIM zaczniesz implementację — wynik kształtuje plan.
+
+- **Vite TypeScript noEmit OOM w 1024MB Node** — `pnpm typecheck` w admin container failuje na heap exhaustion bez `NODE_OPTIONS=--max-old-space-size=2048`. Pattern dla każdej sesji FE: prefix `NODE_OPTIONS='--max-old-space-size=2048'` przed typecheck/biome jeśli OOM się powtarza.


### PR DESCRIPTION
## Summary

Docs zamykające marathon EXP-01..EXP-16 — wszystkie pliki utrzymywane atomowo per CLAUDE.md.

## Pliki

- **`Project Plan/UI/feature-exports.md` (NEW)** — UI-focused notatka + shipped tickety + follow-ups + linki.
- **`Project Plan/02-plan-projektu-pim.md`** — appendix "Epik EXP" z checkboxami 16 ticketów + 4 IMP follow-ups + świadome odejścia.
- **`Project Plan/PRD/PRD-PIM-exports.md`** — Status: Draft → Implemented (MVP).
- **`agent/lessons.md`** — sekcja "Lessons z EXP-01..EXP-16" z 9 patternami (TenantAudit allowlist contract, OpenSpout 5.x API delta, PRD §14 defaults w PR, marathon minimum-viable z uzasadnieniem, cross-ticket controller edit, services.yaml rebase, audit-before-impl, perf benchmark Console pattern, Vite OOM).
- **`agent/current_status.md`** — appendix top "2026-05-15: Marathon EXP-01..EXP-16 ZAMKNIĘTY".

## Test plan

- [x] Markdown links valid (manual scan)
- [x] Brak duplikatów epik-EXP entries w plan-projektu
- [ ] CI green (docs-only PR — tylko audit/security checks fire)

## Refs

- Closes #595
- Marathon całość: PR #597 (EXP-02) → #619 (EXP-15) plus #607 (fix) + #602–#605 (IMP follow-ups)
