### PR TITLE
fix(exports): wire Eksport button in BulkBar to ExportModal

### DIFF
--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -40,6 +40,12 @@ interface BulkBarProps {
   onOpenDeleteModal?: () => void;
   onOpenDuplicateModal?: () => void;
   onOpenCmdK?: () => void;
+  /**
+   * EXP-11 follow-up — opens ExportModal pre-filled z target_scope=selected
+   * + selected_object_ids = selectedIds. Backend `POST /api/products/export`
+   * sync <100 SKU → BinaryFileResponse, ≥100 → async session.
+   */
+  onOpenExportModal?: () => void;
 }
 
 /**
@@ -61,6 +67,7 @@ export function BulkBar({
   onOpenDeleteModal,
   onOpenDuplicateModal,
   onOpenCmdK,
+  onOpenExportModal,
 }: BulkBarProps) {
   const { t } = useTranslation();
   const [isPending, setIsPending] = useState(false);
@@ -143,7 +150,7 @@ export function BulkBar({
         </button>
         <button
           type="button"
-          onClick={placeholder('VIEW-05.4')}
+          onClick={onOpenExportModal ?? placeholder('VIEW-05.4')}
           className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
         >
           <Download className="size-3.5" aria-hidden="true" />

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -40,6 +40,11 @@ const BulkPublishModal = lazy(() =>
 const BulkWizard = lazy(() =>
   import('@/components/catalog/bulk-wizard/bulk-wizard').then((m) => ({ default: m.BulkWizard })),
 );
+// EXP-11 follow-up — modal eksportu z bulk toolbar. Lazy load żeby
+// nie ważył initial bundle (modal renderuje się tylko po user action).
+const ExportModal = lazy(() =>
+  import('@/features/exports/wizard/ExportModal').then((m) => ({ default: m.ExportModal })),
+);
 
 import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
 import { type ExcelColumn, ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
@@ -183,6 +188,8 @@ export function ProductListPage() {
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const [bulkDuplicateOpen, setBulkDuplicateOpen] = useState(false);
   const [cmdKOpen, setCmdKOpen] = useState(false);
+  // EXP-11 follow-up — export modal otwierany przez Eksport button w BulkBar.
+  const [exportModalOpen, setExportModalOpen] = useState(false);
   const [lastBulkSession, setLastBulkSession] = useState<RollbackSession | null>(null);
 
   useEffect(() => {
@@ -825,7 +832,18 @@ export function ProductListPage() {
         onOpenDeleteModal={() => setBulkDeleteOpen(true)}
         onOpenDuplicateModal={() => setBulkDuplicateOpen(true)}
         onOpenCmdK={() => setCmdKOpen(true)}
+        onOpenExportModal={() => setExportModalOpen(true)}
       />
+
+      <Suspense fallback={null}>
+        {exportModalOpen ? (
+          <ExportModal
+            open={exportModalOpen}
+            onOpenChange={setExportModalOpen}
+            selectedObjectIds={Array.from(selected)}
+          />
+        ) : null}
+      </Suspense>
 
       <Suspense fallback={null}>
         {bulkWizardOpen ? (


### PR DESCRIPTION
## Summary

Operator zgłosił że po zaznaczeniu produktów na liście Eksport button w bulk toolbar nie działa — wciąż jest placeholderem z VIEW-05.4. EXP-11 marathon shippował modal standalone, ale BulkActionsToolbar integration była deferred do follow-up. Ten fix podłącza modal do bulk toolbar.

## Zmiana

- `BulkBarProps` — nowy opcjonalny `onOpenExportModal?: () => void`.
- Eksport button: `onClick={onOpenExportModal ?? placeholder('VIEW-05.4')}` — callback działa gdy parent przekaże, placeholder zostaje dla back-compat.
- `ProductListPage`:
  - `[exportModalOpen, setExportModalOpen]` state.
  - Lazy-loaded `<ExportModal>` w Suspense wrapper.
  - `onOpenExportModal={() => setExportModalOpen(true)}` na BulkBar.
  - `selectedObjectIds={Array.from(selected)}` przekazane do modalu.

Modal otwiera się z `target_scope=selected` — UX zgodny z PRD §3.5 (Magda 247 Festo → toolbar Eksport → modal → submit).

## Bug 1 ("zniknęły Smart Filtry")

Po analizie kodu i screenshot operatora: **prawdopodobnie crop screenshot**, nie faktyczny bug. `SmartFilterPresetsRow` w `apps/admin/src/components/catalog/smart-filter-presets-row.tsx` renderuje header (Smart filtry + reguły badge) jako `shrink-0` po lewej, a chips presets w `flex-1 overflow-x-auto` po prawej. API zwraca 5 built-in presets (potwierdzone curl + DB query). Operator's screenshot kończy się ok. 1500px szerokości — chips obszar jest off-screen po prawej.

**Jeśli operator faktycznie nie widzi chips** w przeglądarce z viewport ≥1920px: prosi o DevTools Network tab (czy `/api/smart-filter-presets?counts=true` zwraca 5 items) + Console (czy są runtime errory). Wtedy będę miał concrete bug do diagnose.

## Test plan

- [x] TypeScript noEmit OK
- [x] Biome strict OK (no fixes)
- [ ] CI green
- [ ] Smoke: login → /products → zaznacz 2 produkty → Eksport button w toolbar → modal opens z scope=selected → submit → download

## Refs

- Refs #590 (EXP-11 BulkActionsToolbar integration follow-up)
- Operator reported bug podczas marathonu EXP-01..EXP-16 review
