### PR TITLE
fix(catalog): degrade saved-views fetch failures silently + log smell

### DIFF
--- a/apps/admin/src/components/catalog/saved-views-rail.tsx
+++ b/apps/admin/src/components/catalog/saved-views-rail.tsx
@@ -55,11 +55,24 @@ export function SavedViewsRail({
         // pagination shape change) the older `setViews(body.views)` left the
         // hook with `views = undefined` and the next `views.map(...)` blew up
         // the whole tree (white screen on /products, 2026-05-12).
-        if (!cancelled) setViews(body.views ?? []);
+        if (!cancelled) {
+          setViews(body.views ?? []);
+          setError(null);
+        }
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setError(err instanceof Error ? err.message : 'unknown');
+        // 2026-05-15 — operator saw `HTTP 200` errors from `jsonFetch`'s
+        // white-screen guard (PHP fatal-page disguised as JSON 200 or auth
+        // race where the cached response slipped past the JSON content-type
+        // check). The saved-views rail is non-critical UX — if the fetch
+        // can't return rows, degrade silently to "no views" instead of
+        // blocking the catalog page with a red alarm. Log the original
+        // failure so DevTools shows the smell for follow-up debugging.
+        // eslint-disable-next-line no-console
+        console.warn('saved-views fetch failed; degrading to empty list', err);
+        setViews([]);
+        setError(null);
       });
     return () => {
       cancelled = true;

--- a/apps/admin/src/lib/http.ts
+++ b/apps/admin/src/lib/http.ts
@@ -130,10 +130,15 @@ async function fetchInternal<T>(path: string, init: InternalJsonRequestInit): Pr
       contentType,
     );
   if (text && !expectsJson && typeof parsed === 'string') {
+    // Include a body snippet in the detail so DevTools shows what the
+    // server actually returned (HTML fatal page? auth refresh redirect?
+    // Vite index.html fallback?). 200 chars is enough to spot patterns
+    // without flooding the toast.
+    const snippet = parsed.length > 200 ? `${parsed.slice(0, 200)}…` : parsed;
     throw new HttpError(response.status, {
       type: 'about:blank',
       title: 'Unexpected response',
-      detail: `Server returned ${response.status} with ${contentType || 'no'} content-type when JSON was expected.`,
+      detail: `Server returned ${response.status} with ${contentType || 'no'} content-type when JSON was expected. Body starts with: ${snippet}`,
     });
   }
 


### PR DESCRIPTION
## Summary

Operator zgłosił **"Nie udało się pobrać widoków: HTTP 200"** czerwony alarm na liście produktów. Backend test (curl + DB query) potwierdza że `GET /api/saved-views?resource=products` zwraca poprawnie `{"views":[]}` z `application/json` na status 200 — endpoint działa.

Bez DevTools Network tab od operatora nie reproduce. Hipotezy:
- Stale FE bundle z poprzedniej sesji (browser cache miss po Vite HMR)
- Auth race (token refresh w trakcie initial mount)
- Browser extension / service worker intercepting `/api/...`

## Fix

Saved-views rail jest **non-critical UX** — catalog działa bez nich (to tylko shortcut tabs nad search). Czerwony alarm blokuje całą stronę bez powodu. Zmiana:

- `.catch()` setuje `views=[]` + `error=null` zamiast pokazywać błąd.
- `console.warn(...)` żeby DevTools nadal pokazywało smell — operator z Network tab może powiedzieć co naprawdę zwracał server.

## Bonus — body snippet w jsonFetch white-screen guard

`jsonFetch` HttpError.detail teraz dołącza pierwsze 200 znaków body przy "Unexpected response". Dzięki temu w przyszłości "HTTP 200" w toaście będzie też pokazywać `Body starts with: <HTML/text snippet>`, eliminacja zgadywania.

## Test plan

- [x] TypeScript noEmit OK
- [x] Biome strict OK
- [ ] CI green
- [ ] Smoke: hard reload /products → brak czerwonego alarmu, brak SavedViews ale layout intact
