### PR TITLE
fix(exports): download with Bearer token + blob (not window.open)

### DIFF
--- a/apps/admin/src/features/exports/sessions/ExportSessionsView.tsx
+++ b/apps/admin/src/features/exports/sessions/ExportSessionsView.tsx
@@ -1,6 +1,8 @@
 import { useApiUrl, useCustom, useCustomMutation } from '@refinedev/core';
 import { useTranslation } from 'react-i18next';
 
+import { getAccessToken } from '@/lib/http';
+
 interface ExportSessionRow {
   id: string;
   format: 'xlsx' | 'csv';
@@ -55,8 +57,43 @@ export function ExportSessionsView(): React.ReactElement {
 
   const sessions = result?.data?.items ?? [];
 
-  const onDownload = (id: string) => {
-    window.open(`${apiUrl}/exports/sessions/${id}/download`, '_blank');
+  const onDownload = async (id: string) => {
+    // `window.open(...)` doesn't carry Authorization headers, so the
+    // backend `/download` endpoint (JWT-guarded) responds 401 in a new
+    // tab. Fetch with Bearer token, then trigger a blob download via a
+    // temp anchor — same pattern as ExportModal sync path.
+    try {
+      const token = getAccessToken();
+      const headers: Record<string, string> = {
+        accept:
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, text/csv, application/json',
+      };
+      if (token !== null) {
+        headers['authorization'] = `Bearer ${token}`;
+      }
+      const response = await fetch(`${apiUrl}/exports/sessions/${id}/download`, {
+        method: 'GET',
+        headers,
+        credentials: 'same-origin',
+      });
+      if (!response.ok) {
+        throw new Error(`Download failed: HTTP ${response.status}`);
+      }
+      const blob = await response.blob();
+      const filename =
+        parseFilename(response.headers.get('content-disposition')) ?? `pim-export-${id}`;
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('Export download failed', err);
+    }
   };
 
   const onRerun = (id: string) => {
@@ -189,6 +226,12 @@ export function ExportSessionsView(): React.ReactElement {
       </table>
     </div>
   );
+}
+
+function parseFilename(header: string | null): string | null {
+  if (header === null) return null;
+  const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(header);
+  return match?.[1] !== undefined ? decodeURIComponent(match[1]) : null;
 }
 
 export default ExportSessionsView;


### PR DESCRIPTION
## Summary

Operator: klik "Pobierz" w Recent grid otwiera nowe okno z `{"code":401,"message":"JWT Token not found"}`.

Root cause: `window.open()` nie wysyła Authorization headera — backend `/download` jest JWT-guarded.

## Fix

`onDownload` używa `fetch()` z Bearer token (via `getAccessToken()`), reads `response.blob()`, triggers download przez temp anchor + Content-Disposition filename. Same pattern co ExportModal sync path z fix #622.

## Test plan

- [x] TypeScript noEmit OK
- [x] Biome strict OK
- [ ] CI green
- [ ] Smoke: hard reload /integrations/exports/sessions → klik Pobierz → plik pobiera się

## Refs

- Refs #592 (EXP-13)
