### PR TITLE
fix(exports): resilient catalog fetch — Promise.allSettled + per-endpoint logs

### DIFF
--- a/apps/admin/src/features/exports/components/use-export-column-catalog.ts
+++ b/apps/admin/src/features/exports/components/use-export-column-catalog.ts
@@ -69,38 +69,61 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
     setError(null);
 
     void (async () => {
-      try {
-        const [attrsResponse, groupsResponse, workspaceResponse] = await Promise.all([
-          jsonFetch<AttributeRow[] | { member?: AttributeRow[] }>(
-            '/api/attributes?itemsPerPage=500',
-          ),
-          jsonFetch<AttributeGroupRow[] | { member?: AttributeGroupRow[] }>(
-            '/api/attribute_groups?itemsPerPage=100',
-          ),
-          jsonFetch<WorkspaceRow>('/api/workspaces/current'),
-        ]);
+      // Promise.allSettled — partial failures are OK. Attribute catalog
+      // is the critical one (the rest are nice-to-have for grouping +
+      // locale fan-out). The hook only flips `error` if attributes
+      // themselves cannot load; groups + workspace silently fall back to
+      // their defaults so the modal still ships a useful picker.
+      const [attrsResult, groupsResult, workspaceResult] = await Promise.allSettled([
+        jsonFetch<AttributeRow[] | { member?: AttributeRow[] }>('/api/attributes?itemsPerPage=500'),
+        jsonFetch<AttributeGroupRow[] | { member?: AttributeGroupRow[] }>(
+          '/api/attribute_groups?itemsPerPage=100',
+        ),
+        jsonFetch<WorkspaceRow>('/api/workspaces/current'),
+      ]);
 
-        if (cancelled) return;
+      if (cancelled) return;
 
-        const attrsList = Array.isArray(attrsResponse)
-          ? attrsResponse
-          : (attrsResponse.member ?? []);
-        const groupsList = Array.isArray(groupsResponse)
-          ? groupsResponse
-          : (groupsResponse.member ?? []);
-
-        setAttrs(attrsList);
-        setAttrGroups(groupsList);
-        setWorkspace(workspaceResponse);
-      } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof Error ? err : new Error(String(err)));
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
+      if (attrsResult.status === 'fulfilled') {
+        const value = attrsResult.value;
+        const list = Array.isArray(value) ? value : (value.member ?? []);
+        setAttrs(list);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn('export-column-catalog: attributes fetch failed', attrsResult.reason);
+        setAttrs([]);
+        setError(
+          attrsResult.reason instanceof Error
+            ? attrsResult.reason
+            : new Error(String(attrsResult.reason)),
+        );
       }
+
+      if (groupsResult.status === 'fulfilled') {
+        const value = groupsResult.value;
+        const list = Array.isArray(value) ? value : (value.member ?? []);
+        setAttrGroups(list);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'export-column-catalog: attribute_groups fetch failed (degrading to "Inne" bucket)',
+          groupsResult.reason,
+        );
+        setAttrGroups([]);
+      }
+
+      if (workspaceResult.status === 'fulfilled') {
+        setWorkspace(workspaceResult.value);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'export-column-catalog: workspace fetch failed (using default locales pl/en)',
+          workspaceResult.reason,
+        );
+        setWorkspace(null);
+      }
+
+      setIsLoading(false);
     })();
 
     return () => {


### PR DESCRIPTION
## Summary

Operator: "Kolumny (nie udało się załadować atrybutów — pokazuję tylko wbudowane kolumny)" — błąd w modal eksportu (lista) + integracje→eksporty.

Backend test (curl + Bearer) potwierdza że wszystkie 3 endpointy zwracają 200 z poprawnym JSON. Hipoteza: `Promise.all` killing wszystko gdy jeden z trzech zfailuje (np. 401 race podczas mount).

## Fix

- `Promise.allSettled` zamiast `Promise.all` — partial failures OK
- Per-endpoint `console.warn` z reason — DevTools pokaże który konkretnie endpoint pada
- **Attributes** = critical → error flipuje UI
- **Attribute_groups** failure → orphan-only "Inne atrybuty", silent
- **Workspace** failure → fallback `['pl', 'en']`, silent

## Test plan

- [x] TypeScript noEmit OK
- [x] Biome strict OK (auto-fixed)
- [ ] CI green
- [ ] Smoke: hard reload → modal otwiera się — jeśli błąd dalej, DevTools Console pokaże nazwę failed endpointu

## Refs

- Refs #589 (EXP-10 dynamic catalog hardening)
