### PR TITLE
fix(catalog,import): unblock long-running bulk + import operations

### DIFF
--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -682,7 +682,15 @@ export function ProductListPage() {
           void (async () => {
             setCrossPageLoading(true);
             try {
-              const body: Record<string, unknown> = {};
+              const body: Record<string, unknown> = {
+                // Mirror the list view's variant-tree gate so the
+                // server-side selection excludes variants when the
+                // grid is hiding them. Without this the badge shows
+                // "4495 zaznaczonych" against a 2395-row list because
+                // Meili returns master+variant docs that the list
+                // (`parent_id=null` filter on Refine useList) hid.
+                variants_mode: variantsMode,
+              };
               if (activePreset !== undefined) {
                 body.smart_preset = activePreset.slug ?? activePreset.id;
               } else if (filterBlob !== undefined) {

--- a/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
@@ -44,6 +44,12 @@ final class BulkAddCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -126,6 +132,20 @@ final class BulkAddCategoryHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
@@ -41,6 +41,12 @@ final class BulkAppendValueHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $value): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -135,6 +141,20 @@ final class BulkAppendValueHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
@@ -41,6 +41,12 @@ final class BulkClearAttributeHandler
      */
     public function handle(BulkSession $session, string $attrCode): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -116,6 +122,20 @@ final class BulkClearAttributeHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkDeleteHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDeleteHandler.php
@@ -44,6 +44,12 @@ final class BulkDeleteHandler
      */
     public function handle(BulkSession $session): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -99,6 +105,20 @@ final class BulkDeleteHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, 0, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
@@ -46,6 +46,12 @@ final class BulkDuplicateHandler
      */
     public function handle(BulkSession $session): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -132,6 +138,20 @@ final class BulkDuplicateHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
@@ -45,6 +45,12 @@ final class BulkIncrementNumericHandler
      */
     public function handle(BulkSession $session, string $attrCode, string $operator, float $operand): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's 30s HTTP
+        // timeout — without disabling it the handler is killed mid-loop,
+        // the session stays incomplete, and the operator sees 200 + zero
+        // rows touched.
+        set_time_limit(0);
+
         if (!\in_array($operator, ['+', '-', '*', '/', '%'], true)) {
             throw new BadRequestHttpException(\sprintf('Unsupported operator "%s".', $operator));
         }
@@ -161,6 +167,20 @@ final class BulkIncrementNumericHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
@@ -44,6 +44,12 @@ final class BulkMoveCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -103,6 +109,20 @@ final class BulkMoveCategoryHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, 0, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
@@ -48,6 +48,12 @@ final class BulkMultiAttributeEditHandler
      */
     public function handle(BulkSession $session, array $edits): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's 30s HTTP
+        // timeout — without disabling it the handler is killed mid-loop,
+        // the session stays incomplete, and the operator sees 200 + zero
+        // rows touched.
+        set_time_limit(0);
+
         if ([] === $edits) {
             throw new BadRequestHttpException('edits must be a non-empty list.');
         }
@@ -148,6 +154,20 @@ final class BulkMultiAttributeEditHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
@@ -42,6 +42,12 @@ final class BulkPublishChannelsHandler
      */
     public function handle(BulkSession $session, array $channelCodes, bool $publish): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -121,6 +127,20 @@ final class BulkPublishChannelsHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
@@ -42,6 +42,12 @@ final class BulkRemoveCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -120,6 +126,20 @@ final class BulkRemoveCategoryHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
@@ -41,6 +41,12 @@ final class BulkRemoveValueHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $value): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -161,6 +167,20 @@ final class BulkRemoveValueHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRollbackHandler.php
@@ -56,6 +56,12 @@ final class BulkRollbackHandler
 
     public function rollback(BulkSession $session): int
     {
+        // Long bulk rollbacks (reversing 2k+ products) routinely exceed
+        // PHP's 30s HTTP timeout — without disabling it the handler is
+        // killed mid-loop, the session stays incomplete, and the
+        // operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         if (!$session->isRollbackAvailable()) {
             throw new BadRequestHttpException('Rollback window expired or already used.');
         }

--- a/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
@@ -49,6 +49,12 @@ final class BulkSetAttributeHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $newValue): array
     {
+        // Long bulk runs (2k+ products) routinely exceed PHP's
+        // 30s HTTP timeout — without disabling it the handler
+        // is killed mid-loop, the session stays incomplete, and
+        // the operator sees 200 + zero rows touched.
+        set_time_limit(0);
+
         $this->bulkContext->setBulk(true, $session->getId());
         try {
             $success = 0;
@@ -139,6 +145,20 @@ final class BulkSetAttributeHandler
 
             if ($chunkCounter > 0) {
                 $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+
+            // local instance and its Tenant proxy. The final persist
+
+            // below would otherwise raise EntityNotFoundException on
+
+            // flush trying to resolve the stale proxy.
+
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
             }
 
             $session->complete($success, $skipped, $errors);

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -101,6 +101,15 @@ final class ImportRunHandler extends AbstractBatchHandler
      */
     public function run(ImportSession $session): void
     {
+        // Streaming + per-row Doctrine flushes scale with file size.
+        // A 100-row XLSX easily exceeds FrankenPHP's default 30s HTTP
+        // budget (max_execution_time is 0 in CLI but the worker resets
+        // it to 30 for each request). Without this opt-out the import
+        // handler gets killed mid-loop, the response still returns 200
+        // because the headers were already flushed, but the session
+        // stays `pending` forever and 0 import_logs are written.
+        set_time_limit(0);
+
         $tenant = $session->getTenant();
         if (!$tenant instanceof Tenant) {
             $session->markFailed('Import session has no tenant assignment.');

--- a/apps/api/src/Search/Application/IndexSettingsTemplate.php
+++ b/apps/api/src/Search/Application/IndexSettingsTemplate.php
@@ -41,6 +41,11 @@ final class IndexSettingsTemplate
     private const array PRODUCT_RESERVED_FILTERABLE = [
         'tenantId', 'kind', 'status', 'enabled', 'objectTypeId',
         'completeness_pct', 'sync_status_aggregate', 'category',
+        // `parentId` exposed so the variant-tree view (only masters) can
+        // mirror its `parent_id IS NULL` filter on cross-page selection
+        // through Meili (`BulkSelectionController` reads `variants_mode`
+        // from the body and emits the matching filter).
+        'parentId',
     ];
 
     public function __construct(
@@ -76,6 +81,14 @@ final class IndexSettingsTemplate
                 'sortableAttributes' => ['createdAt', 'updatedAt', 'name', 'price'],
                 'displayedAttributes' => ['*'],
                 'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
+                // Meili's default `maxTotalHits` (1000) caps cross-page
+                // selection at the first page and silently truncates the
+                // result. Operator's "Zaznacz wszystkie pasujące" loop
+                // page-by-page tops out at 1000 even though tenants
+                // routinely run 5–10× that. Raised to match the bulk
+                // selection HARD_CAP (10 000) — `BulkSelectionController`
+                // already enforces that as the absolute ceiling.
+                'pagination' => ['maxTotalHits' => 10_000],
             ],
             ObjectKind::Category => [
                 'searchableAttributes' => ['code', 'name', 'path', 'seo_title'],

--- a/apps/api/src/Search/Presentation/Controller/BulkSelectionController.php
+++ b/apps/api/src/Search/Presentation/Controller/BulkSelectionController.php
@@ -58,6 +58,19 @@ final class BulkSelectionController
         $query = \is_string($body['q'] ?? null) ? trim($body['q']) : '';
         $customFilterExpression = $this->resolveCustomFilter($body);
 
+        // Mirror the list view's variant-tree gate: when the operator
+        // sees only masters (`variants_mode=tree`, default in the FE),
+        // selecting "all matching" must not pull variants in — otherwise
+        // the badge count exceeds the visible row count and bulk actions
+        // run on rows the operator can't see.
+        $variantsMode = \is_string($body['variants_mode'] ?? null) ? $body['variants_mode'] : 'tree';
+        if ('tree' === $variantsMode) {
+            $masterClause = 'parentId IS NULL';
+            $customFilterExpression = null === $customFilterExpression
+                ? $masterClause
+                : '('.$customFilterExpression.') AND '.$masterClause;
+        }
+
         $limit = isset($body['limit']) && is_numeric($body['limit'])
             ? min(self::HARD_CAP, max(1, (int) $body['limit']))
             : self::HARD_CAP;

--- a/apps/api/src/Shared/Application/BulkOperationLock.php
+++ b/apps/api/src/Shared/Application/BulkOperationLock.php
@@ -61,10 +61,46 @@ final readonly class BulkOperationLock
         );
 
         if (false === $lock->acquire(blocking: false)) {
-            return null;
+            // Flock-backed locks survive a PHP fatal that bypasses
+            // `finally { release() }`. The OS releases the file lock
+            // on process exit, but FrankenPHP's worker mode keeps the
+            // same process alive across requests, so a request that
+            // hit `max_execution_time` (e.g. a 30s bulk handler with
+            // no `set_time_limit(0)` opt-out) holds the flock until
+            // the worker is recycled. Pre-`set_time_limit` runs left
+            // stale locks that blocked the next bulk action for the
+            // full 1h TTL. As a safety net: when the lock file is
+            // older than the TTL, treat it as abandoned, unlink, and
+            // retry once. New holders rotate the file on acquire so
+            // a healthy concurrent holder won't trip this branch.
+            $this->forceClearStaleLockFile($tenant);
+            // PHPStan can't see past the first `acquire()` call here
+            // because `LockInterface::acquire(blocking: false)` is
+            // typed as a closed boolean. Suppressed manually — at
+            // runtime the second call can succeed once the stale
+            // file got unlinked above.
+            // @phpstan-ignore booleanNot.alwaysTrue
+            if (!$lock->acquire(blocking: false)) {
+                return null;
+            }
         }
 
         return $lock;
+    }
+
+    private function forceClearStaleLockFile(Tenant $tenant): void
+    {
+        $matches = glob(sys_get_temp_dir().'/sf.'.self::keyFor($tenant).'.*.lock');
+        if (!\is_array($matches)) {
+            return;
+        }
+        $threshold = time() - (int) self::TTL_SECONDS;
+        foreach ($matches as $path) {
+            $mtime = @filemtime($path);
+            if (false !== $mtime && $mtime < $threshold) {
+                @unlink($path);
+            }
+        }
     }
 
     public static function keyFor(Tenant $tenant): string

--- a/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/DatabaseResetCommand.php
@@ -97,6 +97,23 @@ final class DatabaseResetCommand extends Command
             $steps[] = ['pim:search:reindex', ['--kind' => 'all', '--purge' => true]];
         }
 
+        // Wipe stale BulkOperationLock flock files (`sf.bulk-op-{tenant}.lock`)
+        // sitting in /tmp from previous tenant generations. The tenant
+        // UUID rotates on every fixture reload, so the old lock file
+        // never matches the new tenant — but a worker that crashed
+        // mid-bulk-run still leaves the lock present for the same
+        // tenant ID, blocking subsequent runs for up to the 1h TTL.
+        // Resetting the DB is the right point to flush that state.
+        $lockDir = sys_get_temp_dir();
+        $matches = glob($lockDir.'/sf.bulk-op-*.lock');
+        $stale = \is_array($matches) ? $matches : [];
+        foreach ($stale as $lockPath) {
+            @unlink($lockPath);
+        }
+        if ([] !== $stale) {
+            $io->writeln(sprintf('  cleared %d stale bulk-op lock file(s)', \count($stale)));
+        }
+
         foreach ($steps as [$commandName, $arguments]) {
             $io->section(sprintf('→ %s', $commandName));
             $application = $this->getApplication();


### PR DESCRIPTION
## Summary

Round-trip dogfood (import 100-SKU XLSX → bulk add_category on 2395 products) surfaced five interlocking blockers. Each one left the operator with a `200` response while the server-side state never changed.

- **`set_time_limit(0)`** at the entry of `ImportRunHandler` and every bulk handler. Without it, FrankenPHP's 30s HTTP budget kills the loop after the headers have flushed → `status:200, success_count:0`.
- **Reload `BulkSession` after `em->clear()`** in the 12 non-rollback bulk handlers. The final `complete() + persist()` was being run against the detached entity whose `Tenant` proxy threw `EntityNotFoundException` (visible as HTTP 500 on `bulk-actions/add_category` with 1000+ products).
- **Meili `maxTotalHits` 1000 → 10000** on the product index; `parentId` added to reserved filterable list so the tree-mode gate compiles. Pre-fix `select-all-matching` was silently capped at 1000.
- **`BulkSelectionController` honours `variants_mode`** — adds `parentId IS NULL` when the FE list shows only masters. Eliminates the impossible "4495 zaznaczonych / 2395 wyników" mismatch.
- **`BulkOperationLock` self-heals stale flock files** (file older than the 1h TTL → unlink + retry). `pim:db:reset --with-fixtures` also wipes `/tmp/sf.bulk-op-*.lock` so a tenant rotation doesn't leave abandoned locks behind.

## Test plan

- [x] PHPStan max — 0 errors
- [x] Manual round-trip on dev seed:
  - Import 100-row XLSX → status `partial` (2195/2295) with no timeout
  - Tree-mode "Zaznacz wszystkie pasujące" → 2395 (= grid total)
  - Flat-mode "Zaznacz wszystkie pasujące" → 2395 (no variants in this seed)
  - Bulk `add_category` on 2395 products → 200, session `complete_at` set, all rows touched
- [ ] FE manual smoke after merge: tree-mode select all → bulk delete → verify count