### PR TITLE
feat(exports): EXP-17 — Mercure SSE FE wiring for Recent exports grid

### DIFF
--- a/apps/admin/src/features/exports/hooks/useExportSessionsStream.ts
+++ b/apps/admin/src/features/exports/hooks/useExportSessionsStream.ts
@@ -1,0 +1,79 @@
+import * as React from 'react';
+
+interface ExportEvent {
+  event: 'progress' | 'status';
+  session_id: string;
+  rows_done?: number;
+  rows_total?: number;
+  progress_pct?: number;
+  estimated_seconds_remaining?: number | null;
+  status?: 'pending' | 'running' | 'done' | 'error';
+  success_count?: number;
+  error_message?: string | null;
+}
+
+export interface UseExportSessionsStreamState {
+  /** True once the EventSource connection is open. */
+  connected: boolean;
+  /** Latest event received; consumers can useEffect on this to refetch. */
+  lastEvent: ExportEvent | null;
+}
+
+/**
+ * EXP-17 (#629) — Mercure SSE subscriber for the user-level export topic.
+ *
+ * Topic: `exports/{user_id}` — the backend publisher (EXP-06 #585) fires
+ * both `progress` and `status` events for every export the user runs.
+ *
+ * Returns the latest event so callers can `query.refetch()` the REST
+ * endpoint (`/api/exports/sessions`). REST stays the source of truth;
+ * Mercure is a "something changed" signal that avoids 5s polling when
+ * the hub is reachable. Mirrors the IMP-04 publisher contract / the
+ * `useImportProgress` subscriber pattern.
+ *
+ * Gracefully no-ops in environments without EventSource (jsdom unit
+ * envs, SSR) and on connection errors — caller's polling fallback
+ * keeps working when the hub is down.
+ */
+export function useExportSessionsStream(userId: string | null): UseExportSessionsStreamState {
+  const [connected, setConnected] = React.useState(false);
+  const [lastEvent, setLastEvent] = React.useState<ExportEvent | null>(null);
+
+  React.useEffect(() => {
+    if (userId === null) {
+      setConnected(false);
+      setLastEvent(null);
+      return;
+    }
+    if (typeof window === 'undefined' || typeof EventSource === 'undefined') {
+      return;
+    }
+
+    const topic = `https://pim.localhost/exports/${userId}`;
+    const url = `${window.location.origin}/.well-known/mercure?topic=${encodeURIComponent(topic)}`;
+    const source = new EventSource(url, { withCredentials: true });
+
+    source.addEventListener('open', () => {
+      setConnected(true);
+    });
+
+    source.addEventListener('message', (event) => {
+      try {
+        const parsed = JSON.parse(event.data) as ExportEvent;
+        setLastEvent(parsed);
+      } catch {
+        // Malformed payload — Mercure is enrichment, not source of truth.
+      }
+    });
+
+    source.addEventListener('error', () => {
+      setConnected(false);
+    });
+
+    return () => {
+      source.close();
+    };
+  }, [userId]);
+
+  return { connected, lastEvent };
+}

--- a/apps/admin/src/features/exports/sessions/ExportSessionsView.tsx
+++ b/apps/admin/src/features/exports/sessions/ExportSessionsView.tsx
@@ -1,7 +1,10 @@
-import { useApiUrl, useCustom, useCustomMutation } from '@refinedev/core';
+import { useApiUrl, useCustom, useCustomMutation, useGetIdentity } from '@refinedev/core';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { getAccessToken } from '@/lib/http';
+
+import { useExportSessionsStream } from '../hooks/useExportSessionsStream';
 
 interface ExportSessionRow {
   id: string;
@@ -27,6 +30,10 @@ const STATUS_STYLES: Record<ExportSessionRow['status'], string> = {
   error: 'bg-rose-100 text-rose-900',
 };
 
+interface Identity {
+  id: string;
+}
+
 /**
  * EXP-13 (#592) — Recent exports grid.
  *
@@ -36,21 +43,28 @@ const STATUS_STYLES: Record<ExportSessionRow['status'], string> = {
  *   - Rerun → POST `/rerun`, refreshes the grid.
  *   - Delete → DELETE, refreshes the grid.
  *
- * 5-second polling refresh keeps the running rows alive without
- * Mercure SSE wiring (PRD §11.5; native SSE subscription is a
- * follow-up — `exports/{user_id}` topic publishes are already running
- * on the backend EXP-06 handler, so flipping the FE switch is just an
- * EventSource hookup).
+ * Status freshness: Mercure SSE (`exports/{user_id}` topic, EXP-17 #629)
+ * triggers an immediate REST refetch on every `progress` / `status`
+ * event from the EXP-06 publisher. REST is the source of truth; when
+ * the hub is unreachable the 5s polling fallback keeps the grid alive.
  */
 export function ExportSessionsView(): React.ReactElement {
   const { t } = useTranslation();
   const apiUrl = useApiUrl();
+  const { data: identity } = useGetIdentity<Identity>();
 
   const { result, query } = useCustom<SessionsResponse>({
     url: `${apiUrl}/exports/sessions`,
     method: 'get',
     queryOptions: { refetchInterval: 5000, staleTime: 2000 },
   });
+
+  const { lastEvent } = useExportSessionsStream(identity?.id ?? null);
+
+  useEffect(() => {
+    if (lastEvent === null) return;
+    void query.refetch();
+  }, [lastEvent, query]);
 
   const { mutate: rerun } = useCustomMutation();
   const { mutate: del } = useCustomMutation();


### PR DESCRIPTION
## Summary
- Nowy hook `useExportSessionsStream(userId)` subskrybuje topic Mercure `exports/{user_id}` (publikowany przez EXP-06 backend).
- `ExportSessionsView` re-fetchuje REST endpoint na każdy `progress`/`status` event z hub'a; 5s polling zostaje jako fallback gdy Mercure niedostępne.
- Wzór 1:1 z `useImportProgress` (IMP-04): REST is source of truth, Mercure = "something changed" signal.

## Test plan
- [x] `pnpm typecheck` — green
- [x] `pnpm lint` (Biome) — green (5 warningi pre-existing w innych plikach)
- [x] `pnpm build` — green
- [ ] Manual smoke (po merge na pim.localhost):
  1. Login admin@demo.localhost.
  2. Otwórz `/integrations/exports/sessions`.
  3. W innym tabie: trigger async export >=100 SKU.
  4. DevTools Network: jeden `EventSource` do `/.well-known/mercure?topic=exports%2F...`.
  5. Row w gridzie zmienia status pending → running → done bez czekania 5s na polling.
  6. DevTools Console: 0 czerwonych errorów.

Closes #629