### PR TITLE
feat(exports): EXP-20 — target_scope=filter + FilterDslResolver integration

### DIFF
--- a/apps/admin/src/features/exports/wizard/ExportModal.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportModal.tsx
@@ -23,6 +23,13 @@ interface ExportModalProps {
   onOpenChange: (open: boolean) => void;
   /** SKU IDs preselected from the catalog list. Triggers `target_scope=selected`. */
   selectedObjectIds?: readonly string[];
+  /**
+   * Pre-parsed FilterDSL snapshot to pass through `target_scope=filter`.
+   * When provided, the "Cały filter" radio becomes enabled and the
+   * snapshot is forwarded to the export endpoint. Set by `ExportNewPage`
+   * after parsing the user's JSON input.
+   */
+  filterSnapshot?: Record<string, unknown> | null;
 }
 
 /**
@@ -46,14 +53,20 @@ interface ExportModalProps {
  *   - Locale + channel sub-toggles — wymaga `/api/tenant/locales`
  *     + per-attribute scope dropdown. Single-locale tenant MVP
  *     nie używa.
- *   - target_scope=filter z modalu — modal nie ma kontekstu filtra
- *     listy; pełna ścieżka filtrowa działa w `/integrations/exports/new`
- *     (EXP-20).
+ *
+ * Filter scope:
+ *   - Modal-from-list (no `filterSnapshot` prop): "Cały filter" radio
+ *     is disabled with a hint to use the full-page form.
+ *   - Full-page form (`ExportNewPage` passes `filterSnapshot`): radio
+ *     is enabled, and the snapshot rides through the export payload.
+ *   - Backend SQL resolution lives in `SyncExportRunner::resolveFilter`
+ *     (EXP-20 #632) via `FilterDslResolver::toCountSql`.
  */
 export function ExportModal({
   open,
   onOpenChange,
   selectedObjectIds = [],
+  filterSnapshot = null,
 }: ExportModalProps): React.ReactElement {
   const { t } = useTranslation();
   const apiUrl = useApiUrl();
@@ -61,7 +74,8 @@ export function ExportModal({
   const [columns, setColumns] = useState<string[]>(['sku', 'parent_sku', 'status']);
   const [format, setFormat] = useState<ExportFormat>('xlsx');
   const [encoding, setEncoding] = useState<ExportEncoding>('utf8_bom');
-  const initialScope: TargetScope = selectedObjectIds.length > 0 ? 'selected' : 'all';
+  const initialScope: TargetScope =
+    selectedObjectIds.length > 0 ? 'selected' : filterSnapshot !== null ? 'filter' : 'all';
   const [targetScope, setTargetScope] = useState<TargetScope>(initialScope);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -105,6 +119,9 @@ export function ExportModal({
     if (targetScope === 'selected') {
       payload['selected_object_ids'] = selectedObjectIds;
     }
+    if (targetScope === 'filter' && filterSnapshot !== null) {
+      payload['filter_snapshot'] = filterSnapshot;
+    }
 
     try {
       // Raw fetch — sync response is XLSX/CSV binary (NOT JSON), so
@@ -134,6 +151,9 @@ export function ExportModal({
         };
         if (format === 'csv') {
           profileConfig['encoding'] = encoding;
+        }
+        if (targetScope === 'filter' && filterSnapshot !== null) {
+          profileConfig['filter_snapshot'] = filterSnapshot;
         }
         const profileResponse = await fetch(`${apiUrl}/exports/profiles`, {
           method: 'POST',
@@ -325,6 +345,32 @@ export function ExportModal({
                   count: selectedObjectIds.length,
                   defaultValue: `Zaznaczone (${selectedObjectIds.length})`,
                 })}
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="radio"
+                  name="scope"
+                  className="size-4"
+                  checked={targetScope === 'filter'}
+                  onChange={() => setTargetScope('filter')}
+                  disabled={filterSnapshot === null}
+                  title={
+                    filterSnapshot === null
+                      ? t('exports.modal.scope_filter_disabled', {
+                          defaultValue:
+                            'Filtr dostępny tylko z formularza /integrations/exports/new.',
+                        })
+                      : undefined
+                  }
+                />
+                {t('exports.modal.scope_filter', { defaultValue: 'Cały filter' })}
+                {filterSnapshot === null && (
+                  <span className="ml-1 text-xs text-muted-foreground">
+                    {t('exports.modal.scope_filter_hint', {
+                      defaultValue: '(użyj /integrations/exports/new)',
+                    })}
+                  </span>
+                )}
               </label>
               <label className="flex items-center gap-2">
                 <input

--- a/apps/admin/src/features/exports/wizard/ExportNewPage.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportNewPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
@@ -6,29 +7,62 @@ import { ExportModal } from './ExportModal';
 /**
  * EXP-12 (#591) — Full-page export form.
  *
- * MVP renders the same {@see ExportModal} from EXP-11 (#590) but with
- * `open=true` and a redirect on close — so power users who reach
- * `/integrations/exports/new` directly (Marcin's snapshot use case
- * from PRD §3.5) get the full picker + scope sections without going
- * through the catalog list page.
+ * Renders the same {@see ExportModal} from EXP-11 (#590) so submit flow,
+ * payload validation, and sections (columns, format/encoding, scope,
+ * save-as-profile) stay 1:1 with the modal-from-list path.
  *
- * Why reuse the modal instead of a parallel page-level form:
- *   - Submit flow + payload validation are identical.
- *   - Sections (columns, format/encoding, scope, save-as-profile)
- *     match 1:1.
- *   - Single source of truth for FE export controls keeps the
- *     contract tight as the modal evolves.
+ * EXP-20 (#632) — adds a Filter section above the modal. When the user
+ * pastes a valid FilterDSL snapshot (PRD §5.5, e.g.
+ * `{"attr":"brand","op":"IN","value":["Festo"]}`), the JSON is parsed
+ * client-side and forwarded as `filterSnapshot` to the modal. The
+ * modal then enables the "Cały filter" radio and rides the snapshot
+ * through `POST /api/products/export`, where `SyncExportRunner` compiles
+ * it via `FilterDslResolver::toCountSql` into tenant-scoped SQL.
  *
- * Świadome odejścia (PRD §13.1 + §14):
- *   - Chip filter picker dla target_scope=filter — gated on EXP-20
- *     FilterDslResolver integration. Modal sam z listy nie ma
- *     kontekstu filtra, ta strona dorośnie do tego po EXP-20.
- *   - No back-to-hub breadcrumb in MVP — Esc/cancel on the modal
- *     returns to `/integrations/exports` which IS the hub.
+ * Świadome odejście: chip-style filter builder (PRD §13.2) — deferred
+ * to a follow-up; the raw textarea is the minimal viable surface for
+ * Marcin's snapshot use case and reuses the catalog filter operators
+ * verbatim.
  */
 export function ExportNewPage(): React.ReactElement {
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  const [filterJson, setFilterJson] = useState('');
+  const [filterSnapshot, setFilterSnapshot] = useState<Record<string, unknown> | null>(null);
+  const [filterError, setFilterError] = useState<string | null>(null);
+
+  const onFilterChange = (raw: string) => {
+    setFilterJson(raw);
+    const trimmed = raw.trim();
+    if (trimmed === '') {
+      setFilterSnapshot(null);
+      setFilterError(null);
+      return;
+    }
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        setFilterSnapshot(null);
+        setFilterError(
+          t('exports.new.filter_error_object', {
+            defaultValue:
+              'Filtr musi być obiektem JSON (np. {"attr":"brand","op":"IN","value":["Festo"]}).',
+          }),
+        );
+        return;
+      }
+      setFilterSnapshot(parsed as Record<string, unknown>);
+      setFilterError(null);
+    } catch (err) {
+      setFilterSnapshot(null);
+      setFilterError(
+        err instanceof Error
+          ? err.message
+          : t('exports.new.filter_error_parse', { defaultValue: 'Nieprawidłowy JSON.' }),
+      );
+    }
+  };
 
   const handleClose = (open: boolean) => {
     if (!open) {
@@ -44,7 +78,46 @@ export function ExportNewPage(): React.ReactElement {
             'Pełna forma eksportu — wybierz kolumny, format i zasięg, potem [Eksportuj]. Sync (<100 SKU) zwróci plik bezpośrednio; ≥100 SKU pójdzie do kolejki async (widoczne w Recent exports).',
         })}
       </p>
-      <ExportModal open={true} onOpenChange={handleClose} />
+
+      <details className="rounded-md border bg-card">
+        <summary className="cursor-pointer px-3 py-2 text-sm font-medium">
+          {t('exports.new.filter_summary', {
+            defaultValue: 'Filtr (opcjonalny — odblokowuje scope „Cały filter")',
+          })}
+        </summary>
+        <div className="space-y-2 border-t p-3">
+          <label className="block text-xs text-muted-foreground" htmlFor="export-filter-dsl">
+            {t('exports.new.filter_label', {
+              defaultValue:
+                'Wklej FilterDSL jako JSON (np. {"attr":"brand","op":"IN","value":["Festo"]}). Operator-set z PRD §5.5.',
+            })}
+          </label>
+          <textarea
+            id="export-filter-dsl"
+            value={filterJson}
+            onChange={(e) => onFilterChange(e.target.value)}
+            rows={4}
+            placeholder='{"attr":"brand","op":"IN","value":["Festo","Bosch"]}'
+            className="w-full rounded border border-input bg-background px-2 py-1.5 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+            aria-invalid={filterError !== null}
+            aria-describedby={filterError !== null ? 'filter-error' : undefined}
+          />
+          {filterError !== null && (
+            <p id="filter-error" className="text-xs text-rose-700" role="alert">
+              {filterError}
+            </p>
+          )}
+          {filterSnapshot !== null && filterError === null && (
+            <p className="text-xs text-emerald-700">
+              {t('exports.new.filter_ok', {
+                defaultValue: 'Filtr OK — wybierz „Cały filter" w sekcji Co eksportujesz.',
+              })}
+            </p>
+          )}
+        </div>
+      </details>
+
+      <ExportModal open={true} onOpenChange={handleClose} filterSnapshot={filterSnapshot} />
     </div>
   );
 }

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Export\Application\Sync;
 
+use App\Catalog\Application\Filter\FilterDslResolver;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
@@ -16,10 +17,13 @@ use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
 use App\Export\Infrastructure\Writer\CsvStreamWriter;
 use App\Export\Infrastructure\Writer\RowWriter;
 use App\Export\Infrastructure\Writer\XlsxStreamWriter;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
 use Symfony\Component\Uid\Uuid;
+use Throwable;
 
 /**
  * Runs the sync (<100 row) export path end-to-end.
@@ -29,11 +33,12 @@ use Symfony\Component\Uid\Uuid;
  * into the chosen writer. Wraps the file write in a try/finally so the
  * temp file is cleaned up even on partial failure.
  *
- * Filter snapshot resolution is intentionally deferred — the catalog
- * filter DSL evaluator (`FilterDslResolver`) lives in the Catalog
- * context and ships with the modal integration (EXP-11). The
- * `target_scope=filter` path returns a NotImplemented exception in MVP
- * sync; modal callers downgrade to selected/all until that wiring lands.
+ * Filter scope (EXP-20 #632) compiles the session's `filter_snapshot`
+ * via {@see FilterDslResolver::toCountSql()} into a tenant-scoped
+ * SQL WHERE clause, fetches the matching `catalog_objects` IDs, and
+ * loads the full entities through the repository — mirrors the
+ * SmartFilterPresetController::resolveCounts pattern so we get the
+ * same operator coverage (PRD §5.5) without re-implementing the DSL.
  *
  * Sync writes ALWAYS complete in a single request — no Mercure, no
  * status transitions beyond `done` or `error`. The async handler
@@ -45,6 +50,8 @@ final class SyncExportRunner
         private readonly ExportBuilder $builder,
         private readonly CatalogObjectRepositoryInterface $objects,
         private readonly ExportSessionRepositoryInterface $sessions,
+        private readonly FilterDslResolver $filterDsl,
+        private readonly Connection $connection,
     ) {
     }
 
@@ -63,9 +70,7 @@ final class SyncExportRunner
         return match ($session->getTargetScope()) {
             ExportTargetScope::Selected => $this->resolveSelected($session),
             ExportTargetScope::All => $this->objects->findByKind(ObjectKind::Product, $tenant),
-            ExportTargetScope::Filter => throw new RuntimeException(
-                'target_scope=filter is not yet supported in MVP sync runner (Faza 1 candidate).'
-            ),
+            ExportTargetScope::Filter => $this->resolveFilter($session, $tenant),
         };
     }
 
@@ -108,6 +113,51 @@ final class SyncExportRunner
         $this->sessions->save($session);
 
         return $rows;
+    }
+
+    /**
+     * Compile the session's filter DSL into tenant-scoped SQL, fetch the
+     * matching catalog_objects IDs, and load the full entities through
+     * the repository.
+     *
+     * @return list<CatalogObject>
+     */
+    private function resolveFilter(ExportSession $session, Tenant $tenant): array
+    {
+        $dsl = $session->getFilterSnapshot();
+        if (null === $dsl || [] === $dsl) {
+            return [];
+        }
+
+        $whereClause = $this->filterDsl->toCountSql($dsl);
+        if (null === $whereClause) {
+            throw new RuntimeException('Invalid filter DSL in export session snapshot.');
+        }
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        $sql = 'SELECT id FROM catalog_objects '
+            .'WHERE tenant_id = :tenant AND kind = :kind AND deleted_at IS NULL AND ('.$whereClause.')';
+
+        try {
+            $rows = $this->connection->fetchAllAssociative(
+                $sql,
+                ['tenant' => $tenantId, 'kind' => ObjectKind::Product->value],
+            );
+        } catch (Throwable $error) {
+            throw new RuntimeException('Filter scope SQL execution failed: '.$error->getMessage(), previous: $error);
+        }
+
+        $ids = [];
+        foreach ($rows as $row) {
+            if (isset($row['id']) && \is_string($row['id'])) {
+                $ids[] = $row['id'];
+            }
+        }
+        if ([] === $ids) {
+            return [];
+        }
+
+        return $this->objects->findByIds($ids);
     }
 
     /**


### PR DESCRIPTION
## Summary
- **Backend**: `SyncExportRunner::resolveFilter` kompiluje `ExportSession.filter_snapshot` (DSL per PRD §5.5) przez `FilterDslResolver::toCountSql` na tenant-scoped SQL, fetchuje matching IDs z `catalog_objects` i ładuje encje przez repo. Wzór 1:1 z `SmartFilterPresetController::resolveCounts` — full operator set bez re-implementacji DSL.
- **Frontend**: `ExportNewPage` dostaje collapsible filter section z JSON textarea. Valid DSL → parsed `filterSnapshot` prop na modal → enable \"Cały filter\" radio + forward w POST oraz save-as-profile config.
- **Modal-from-list**: \"Cały filter\" radio disabled z inline hint (modal nie ma kontekstu filtra listy).
- Async path automatycznie pokryty — `ExportJobHandler` deleguje do tego samego `SyncExportRunner::runToFile`.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` — green
- [x] `phpstan analyse --memory-limit=2G` — green (level max)
- [x] `phpunit tests/Unit/Export tests/Unit/Catalog` — 348/348 green
- [ ] Manual smoke:
  1. Login → `/integrations/exports/new`.
  2. Rozwiń sekcję Filtr → wklej `{\"attr\":\"brand\",\"op\":\"IN\",\"value\":[\"Festo\",\"Bosch\"]}` → status \"Filtr OK\".
  3. Sekcja \"Co eksportujesz\" → radio \"Cały filter\" odblokowane → zaznacz.
  4. Submit → plik zawiera tylko produkty Festo/Bosch.
  5. Sessions grid → \"Powtórz\" → ten sam set (filterSnapshot replay).

Closes #632