### PR TITLE
fix(exports): scroll the modal body so Eksportuj stays in viewport

### DIFF
--- a/apps/admin/src/features/exports/wizard/ExportModal.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportModal.tsx
@@ -241,13 +241,13 @@ export function ExportModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl">
+      <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col">
         <DialogHeader>
           <DialogTitle>
             {t('exports.modal.title', { defaultValue: 'Eksportuj produkty' })}
           </DialogTitle>
         </DialogHeader>
-        <div className="space-y-6">
+        <div className="-mx-6 flex-1 space-y-6 overflow-y-auto px-6">
           {/* Section 1 — Kolumny */}
           <section>
             <h3 className="mb-2 text-sm font-medium">


### PR DESCRIPTION
## Summary
Regression od EXP-18 (#635) — sekcja \"Zapisz jako profil\" zwiększyła wysokość modalu poza viewport. `DialogContent` nie miał `max-h` ani `overflow`, więc DialogFooter (Anuluj / Eksportuj) zniknął pod ekranem bez możliwości scrollowania (zgłoszone na screenshotcie 2026-05-15).

Fix:
- `DialogContent`: dodane `flex max-h-[90vh] flex-col` — caps wysokość + flex column.
- Inner content stack: `flex-1 overflow-y-auto -mx-6 px-6` — header/footer trzymają natural height, cztery sekcje scrollują wewnątrz.
- `-mx-6 px-6` pozwala scrollbarowi sięgać krawędzi modalu zachowując padding sekcji.

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` — green
- [ ] Manual smoke (po merge):
  1. Login → `/catalog/products` → zaznacz produkt → BulkBar \"Eksport\".
  2. Modal otwarty: sekcje Kolumny / Format / Co eksportujesz / Zapisz jako profil → scroll w środku.
  3. Footer z \"Anuluj\" + \"Eksportuj\" zawsze widoczny niezależnie od wysokości okna.
  4. Test na mniejszym viewporcie (~600px height) — scroll działa, footer nie znika.