### PR TITLE
chore(rbac): update Phase 1 progress (4/10 merged) + lessons learned

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,37 +1,40 @@
 # Current Status
 
-## 2026-05-18: 🚀 Epik 0.X Identity & RBAC startuje — Phase 1 Foundation w toku
+## 2026-05-18: 🚀 Epik 0.X Identity & RBAC — Phase 1 Foundation 4/10 done
 
 **Sub-faza:** MVP-Alpha, **epik 0.X Identity & RBAC** (ADR-013, milestones [#9](../../milestone/9)..[#15](../../milestone/15), 89 ticketów, ~330-445h).
 
 **Pre-work zamknięty (sesja 2026-05-17/18):**
 - PR [#729](../../pull/729) — 89 GitHub Issues utworzonych z `Project Plan/PRD/PRD-PIM-rbac.md` + 7 phase backlog files. 13 labels, 7 milestones, `tools/create-rbac-issues.py` (idempotent parser + gh wrapper) + `tools/rbac-issues-mapping.json`.
 
-**Phase 1 progress (2/10 done):**
+**Phase 1 progress (4/10 merged, 6 cascade-ready):**
 
 | Ticket | Issue | PR | Status | Co dostarczone |
 |---|---|---|---|---|
 | RBAC-P1-002 | #641 | [#730](../../pull/730) | ✅ Merged | ADR-013 (Project Plan/01-architektura-pim.md sekcja 13) — formalna decyzja pełen RBAC w MVP-Alpha |
-| RBAC-P1-003 | #642 | [#731](../../pull/731) | ✅ Merged | CLAUDE.md update — Priorytety implementacyjne (RBAC w MVP-Alpha), Epik 0.X breakdown z milestone linkami, 6 plików RBAC w *„Pliki, które utrzymujesz atomowo"* |
-| RBAC-P1-008 | [#647](../../issues/647) | — | 🟡 Plan posted | Brownfield audit completed (Identity bundle JEST brownfield: 5/9 entities + 15+ Voters + RbacSeeder już istnieją). Plan z adapted scope (5 missing entities, świadome odejścia od ticket spec) w komencie issue. Implementacja deferowana do dedykowanej sesji. |
-| RBAC-P1-001 | #640 | — | ⏸️ Not started | Security tooling (Infection / Semgrep / OWASP ZAP / TruffleHog) — wymaga dedykowanej sesji |
-| RBAC-P1-004 | #643 | — | ⏸️ Blocked | Schema 10 tables — wymaga #647 (entities) |
-| RBAC-P1-005 | #644 | — | ⏸️ Blocked | Delta migrations — wymaga #643 |
-| RBAC-P1-006 | #645 | — | ⏸️ Blocked | Permission seed — wymaga #643 |
-| RBAC-P1-007 | #646 | — | ⏸️ Blocked | Role templates — wymaga #645 |
-| RBAC-P1-009 | #648 | — | ⏸️ Blocked | Testcontainers — wymaga #640+#643+#647 |
-| RBAC-P1-010 | #649 | — | ⏸️ Blocked | PHPStan custom rules — wymaga #640 |
+| RBAC-P1-003 | #642 | [#731](../../pull/731) | ✅ Merged | CLAUDE.md — Priorytety implementacyjne (RBAC w MVP-Alpha), Epik 0.X breakdown z milestone linkami, 6 plików RBAC w *„Pliki, które utrzymujesz atomowo"* |
+| RBAC-P1-008 | #647 | [#733](../../pull/733) | ✅ Merged | 5 missing entities (SuperAdmin, UserRole, ApiToken, Invitation, UserTenantMembership) + 5 XML mappings + 5 repo interfaces + 5 Doctrine repos + migration Version20260518131500 + TenantAuditCommand whitelist (super_admins, user_role_assignments). SsoProvider deferred → Phase 2 #661. |
+| RBAC-P1-001 | #640 | [#734](../../pull/734) | ✅ Merged | Security tooling MVP scope: `.github/dependabot.yml` + `security-secrets.yml` (Gitleaks + TruffleHog) + Husky pre-commit z opt TruffleHog + Roave Security Advisories + `docs/security/tooling.md` + `.gitleaks.toml` allowlist. Infection / Semgrep / OWASP ZAP deferred do #720/#722/#724. |
+| RBAC-P1-004 | #643 | — | 🟢 **Cascade-ready** | Schema 10 tables — entities już istnieją; ticket scope to: dopisać sso_providers (Phase 2-coupled — może zostać do #661) + FK constraints na 5 nowych tabel (P1-008 odłożył do tego ticketu) + verify indexes per PRD §4.3 |
+| RBAC-P1-005 | #644 | — | ⏸️ Blocked by #643 | Delta migrations (attributes.integration_visible + role_attribute_permissions + audit_logs extensions) |
+| RBAC-P1-006 | #645 | — | ⏸️ Blocked by #643 | Seed atomic permissions fixtures (~50 entries) — RbacSeeder już częściowo gotowy |
+| RBAC-P1-007 | #646 | — | ⏸️ Blocked by #645 | Seed role templates (9 templates per tenant onboarding) |
+| RBAC-P1-009 | #648 | — | ⏸️ Blocked by #643 | Testcontainers Postgres setup for integration tests |
+| RBAC-P1-010 | #649 | — | 🟢 **Cascade-ready** | Custom PHPStan rules — RBAC pattern enforcement. P1-001 (PHPStan setup) ✓ already passed. |
 
-**Krytyczne odkrycia (z brownfield audit #647):**
-- **Identity bundle JEST brownfield, nie greenfield**: `apps/api/src/Identity/` ma już DDD layered structure z `Domain/Entity/`, `Domain/Repository/`, `Application/`, `Infrastructure/Doctrine/Repository/`, `Infrastructure/Security/`, `Presentation/`. 5 entities (User, Role, Permission, RefreshToken, TenantAgentConfig) + 15+ Voters + RbacSeeder + MeController + RefreshTokenController + TwoFactorController + TotpEnrolmentService + ByokKeyManager już istnieją.
-- **Doctrine używa XML mapping**, nie PHP attributes. Wszystkie XML w `apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/*.orm.xml`.
+**Krytyczne odkrycia (z brownfield audit #647 + zmergowane PR-y):**
+- **Identity bundle JEST brownfield, nie greenfield**: `apps/api/src/Identity/` ma już DDD layered structure z `Domain/Entity/`, `Domain/Repository/`, `Application/`, `Infrastructure/Doctrine/Repository/`, `Infrastructure/Security/`, `Presentation/`. Teraz po #733 mamy 10 entities (User, Role, Permission, RefreshToken, TenantAgentConfig + dodane: SuperAdmin, UserRole, ApiToken, Invitation, UserTenantMembership). SsoProvider DEFERRED → Phase 2 #661 (SSO Google/MS/SAML). 15+ Voters + RbacSeeder + MeController + RefreshTokenController + TwoFactorController + TotpEnrolmentService + ByokKeyManager już istnieją.
+- **Doctrine używa XML mapping**, nie PHP attributes. Wszystkie XML w `apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/*.orm.xml`. Doctrine 3.x `findBy()` zwraca `list<T>` → `array_values()` jest PHPStan-max-flagged no-op.
 - **Namespace = `App\Identity\`** (zgodny z `psr-4: {"App\\": "src/"}` w composer.json), NIE `Cortex\Identity\` jak sugerował ticket.
 - **Brak per-context Symfony bundles** — wszystkie bounded contexts (Catalog, Channel, Asset, Integration, Identity, …) są namespace'd pod `App\*` bez dedykowanego `IdentityBundle.php`. Autowiring działa przez `config/services.yaml` glob include.
 - **Lexik JWT bundle JUŻ registered** w `config/bundles.php` (Phase 2 #650 partially gotowe).
+- **TenantAuditCommand whitelist pattern** dla tabel które legitimately nie mają tenant_id (junction inherits via FK, lub platform-level) — patrz `apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php` `INFRA_TABLES` const.
+- **UserRole junction maps to `user_role_assignments` table** (nie `user_roles`) — separated od pre-existing M2M `User.assignedRoles` które używa `user_roles`. Consolidation deferred do #644 delta migrations.
+- **Security tooling stack po #734**: 13 + 2 nowe layers (Dependabot + Gitleaks + TruffleHog + Roave). 4 deferred: Infection (→ #720), Semgrep custom rules (→ #722), OWASP ZAP nightly (→ #724 post-staging), PHPStan custom RBAC rules (→ #649 explicit).
 
-**Następny krok:** dedykowana sesja P1-008 (~3-4h focused) z adapted scope = 5 missing entities (SuperAdmin, UserRole junction, ApiToken, Invitation, UserTenantMembership) — SsoProvider deferowany do Phase 2 #661. Każdy entity = POPO + XML mapping + Domain repo interface + Doctrine repo impl. Po #647 unblok #643 (migrations) → #644/645/646/647 cascade.
+**Następny krok:** cascade-ready **#643 (schema 10 tables, P1-004)** + **#649 (PHPStan RBAC rules, P1-010)** can start paralelnie. Po #643 unblok #644/645/646/648. Realistyczne timeline reszty Phase 1: ~30-40h dedicated work (8-12h #643 + 5-8h #644 + 4-6h #645 + 4-6h #646 + 4-6h #648 + 4-6h #649).
 
-**Aktywne blokery:** brak — czekam na decyzję operatora czy startujemy #647 jako kolejną sesję, czy idziemy paralelnie #640 (security tooling, no deps).
+**Aktywne blokery:** brak — wszystkie immediate-action tickety odblokowane lub w czasie cascade dependency.
 
 **Pełen plan epiku:** `Project Plan/07-rbac-implementation-plan.md` (v3.1) + `Project Plan/PRD/PRD-PIM-rbac.md` (v2.1).
 

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,39 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z RBAC Phase 1 marathon (P1-002/003/008/001 — 2026-05-18)
+
+### Patterns to Follow
+
+1. **Backlog ticketów może zakładać greenfield, gdy projekt jest brownfield — audit FIRST** — RBAC backlog (Project Plan/08..14) rozpisano z założeniem że Identity bundle dochodzi od zera. Reality: 5/9 entities + 15+ Voters + RbacSeeder + auth services już istnieją z poprzednich MVP-Alpha ticketów. **Wzór:** zanim implementujesz Phase 1 ticket, `find apps/api/src/{BundleName} -type f` + spot-check 1-2 plików → jeśli istnieje DDD layered struktura, brownfield. Adapt scope (5 missing entities zamiast 9 from scratch) i dokumentuj świadome odejścia w komencie issue PRZED `gh issue edit --add-label ready-to-implement`. Lekcja źródłowa: P1-008 #647 — full audit zaoszczędził ~3-4h pracy nad re-scaffoldingiem istniejącego kodu.
+
+2. **`gh pr merge N --squash --admin` autoryzowany dla Playwright flake gdy reszta CI green** — Quality (Frontend) na `main` failuje konsekwentnie (4 z ostatnich 5 runów na main). Confirmed źródła: `modeling-shell.spec.ts` + `exports.spec.ts:44` + `imports.spec.ts` (3 tests) + `modeling-object-types.spec.ts`. Verify-via: `gh run list --branch main --workflow quality-frontend.yml --limit 5`. Operator's pattern: merge z `--admin` gdy PHPStan / PHPUnit / Deptrac / Biome / TypeScript / composer audit / pnpm audit etc. PASS, tylko Playwright FAIL. Stosowane w #733 i #734 tej sesji.
+
+3. **Wzorce kopiowane 1:1 między entity classes** — pierwszy entity scaffolded (SuperAdmin) ustanowił template: POPO + Uuid::v7() + DateTimeImmutable + status string consts + `declare(strict_types=1)` + PHPDoc. Kolejne 4 (UserRole/ApiToken/Invitation/UserTenantMembership) tylko zmieniają fields + table name. XML mapping również 1:1 wzór `<id type=uuid>` + `<generator strategy=NONE>` + `<field type=...>` + `<unique-constraints>` + `<indexes>`. Doctrine repo impl 100% boilerplate: `extends ServiceEntityRepository implements Interface` + 4 metody. **Wzór:** scaffold pierwszy entity carefully, copy template dla pozostałych w tej samej PR.
+
+### Patterns to Avoid
+
+1. **NIE używaj `array_values()` na zwrotce z Doctrine `findBy()`** — Doctrine ORM 3.x zwraca `list<T>`, więc `array_values()` jest no-op flagged przez PHPStan max (`arrayValues.list`). Repo metody zwracające list-of-entities pisz po prostu jako `return $this->findBy(['field' => $value]);` — PHPDoc `@return list<T>` zostaje, ale call wrap usunięty. Zauważone w 4 z 5 Doctrine repo impls w #733; fix commit `6f5b70e`.
+
+2. **NIE używaj `--no-verify` przy commitcie chyba że Docker stack jest down** — pre-commit hook `lint-staged-php.sh` wymaga `pim-api` containera w docker compose. Gdy Docker daemon nie jest uruchomiony, hook fail'uje z `lint-staged PHP: stack is down and pim-api image is missing`. Pattern: zamiast bypass'ować `--no-verify`, **najpierw** uruchom `pnpm stack:up` (jeśli Docker Desktop chodzi) i retry. Bypass tylko gdy Docker Desktop sam jest down (GUI launch wymaga operator action) — wtedy explicit justification w commit body. CI server-side runs identical checks anyway.
+
+3. **NIE inline real-looking JWT/AWS keys w docs/** — Gitleaks regex flags real-looking secrets w komitach, włącznie z negative-test recipes w `docs/security/tooling.md`. Use `jwt encode` snippet generujący token at runtime (jak teraz w `docs/security/tooling.md:117`) zamiast wklejać hardcoded string. AWS-published placeholder `AKIAIOSFODNN7EXAMPLE` jest OK, ale wymaga `.gitleaks.toml` allowlist na pliku docs.
+
+### Toolchain quirks
+
+1. **PHPUnit Foundry `ResetDatabase` builds schema from entity metadata** — gdy dodajesz nową entity z XML mapping, Foundry's `ResetDatabase` w PHPUnit tworzy odpowiednie tabele automatycznie. Ale Playwright E2E używa `doctrine:fixtures:load` które wymaga FAKTYCZNYCH migrations. Pattern: dodając entities w PR, ZAWSZE dodaj Doctrine migration w tej samej PR — inaczej Playwright fail'uje z `relation "X" does not exist`. Migration można wygenerować przez `docker compose exec api bin/console doctrine:migrations:diff` (ale auto-generated czasem łapie stale schema drift z dev DB — review przed commit).
+
+2. **Dev DB może mieć tabele które CI nie ma** — w trakcie eksperymentów lokalnie tabele bywają tworzone via `doctrine:schema:update`. `migrations:diff` then nie generuje CREATE TABLE (bo DB ma tabelę). Sprawdź: `docker compose exec database psql -U pim -d pim -c "\dt"` przed `migrations:diff`. Jeśli dev DB ma „wyprzedzenie" w stosunku do migrations, użyj `pg_dump --schema-only -t <table>` jako baseline dla ręcznego migration file.
+
+3. **TenantAuditCommand whitelist pattern dla junction/platform-level tables** — `apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php` ma `INFRA_TABLES` const z tabelami które legitimately NIE mają tenant_id (junctions inherit via FK, lub platform-level tables jak `super_admins`). Test `tests/Integration/Maintenance/TenantAuditCommandTest.php` blokuje merge gdy nowa tabela bez tenant_id NIE jest na whitelist. Dodając junction lub platform table, **MUSISZ** dopisać do `INFRA_TABLES` z komentarzem wyjaśniającym scope inheritance. Egzemple: `user_roles` (M2M, scope via user), `super_admins` (platform-level), `bulk_logs` (via bulk_session), `export_logs` (via ExportSession).
+
+### Decyzje świadome (per ticket)
+
+- **P1-008 #647 (Identity entities)**: SsoProvider deferred do Phase 2 #661 (gdy SSO Google/MS/SAML auth ląduje); UserRole maps do `user_role_assignments` zamiast collidować z legacy `User.assignedRoles` M2M `user_roles`; FK constraints odłożone do P1-004 #643; bundle structure follows established DDD layered (NIE flat z ticket spec); namespace `App\Identity\` (NIE `Cortex\Identity\`); XML mapping (NIE PHP attributes).
+- **P1-001 #640 (Security tooling)**: Infection deferred (→ #720 lub follow-up — 2-3h config); Semgrep deferred (→ Phase 6 #722 dedicated); OWASP ZAP deferred (→ Phase 7 #724 post-staging); custom PHPStan RBAC rules deferred (→ Phase 1 #649 dedicated). Shipped 4 layers: Dependabot + Gitleaks + TruffleHog + Roave Security Advisories + comprehensive `docs/security/tooling.md`.
+- **CI Playwright merge z `--admin`**: pre-existing flake na main, NIE related do moich zmian (verified: `gh run list --branch main` shows same failures). Per CLAUDE.md lessons #4: "`gh pr merge N --squash --admin` jest authoryzowanym wzorem operatora dla tej infra flaki gdy reszta gates green".
+
+
 ## Lessons z mini-epik EXP-17..21 (świadome odejścia po maratonie #580-#595, 2026-05-15)
 
 ### Patterns to Follow


### PR DESCRIPTION
## Summary

Captures Phase 1 RBAC progress after session 2026-05-18: **4/10 tickets merged** (P1-001, P1-002, P1-003, P1-008). Updates `agent/current_status.md` with the cascade-readiness map and `agent/lessons.md` with the brownfield-audit pattern + PHPStan/Docker/Gitleaks gotchas surfaced this session.

## Why this matters

Next session/agent opening the repo needs to know:
1. **What's done** — 4 Phase 1 tickets across 5 merged PRs (#730, #731, #732, #733, #734)
2. **What's cascade-ready** — #643 (schema 10 tables) + #649 (PHPStan RBAC rules) can start in parallel; #644/#645/#646/#648 follow after #643
3. **The brownfield reality** — Identity bundle is NOT greenfield (existing User/Role/Permission/RefreshToken/TenantAgentConfig + 15+ Voters + RbacSeeder + auth services + Lexik JWT bundle); UserRole junction maps to `user_role_assignments` (not `user_roles`) to avoid collision
4. **The Doctrine 3.x pitfalls** — `findBy()` returns `list<T>`, so `array_values()` is a PHPStan max no-op; `TenantAuditCommand::INFRA_TABLES` must whitelist new junction/platform tables
5. **The Playwright flake protocol** — `gh pr merge N --squash --admin` is the operator-authorised pattern when PHP gates pass but Playwright fails on pre-existing infra issues (confirmed via `gh run list --branch main`)

## Files

- `agent/current_status.md` — Phase 1 progress table updated from "2/10 done" to "4/10 merged, 2 cascade-ready, 4 cascade-blocked"; krytyczne odkrycia expanded with TenantAuditCommand whitelist pattern + UserRole junction table name decision
- `agent/lessons.md` — new section *„Lessons z RBAC Phase 1 marathon (P1-002/003/008/001 — 2026-05-18)"*: 3 Patterns to Follow + 3 Patterns to Avoid + 3 Toolchain quirks + Decyzje świadome per ticket

## Test plan

- [ ] CI green (docs-only)
- [ ] Markdown renders correctly in GitHub UI
- [ ] Cross-references work (PR/issue/milestone links)