### PR TITLE
chore(deps): switch Dependabot to weekly to avoid first-run flood

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,11 @@ updates:
   - package-ecosystem: composer
     directory: /apps/api
     schedule:
-      interval: daily
+      # Weekly to avoid first-run backlog flood. Patch updates are
+      # frequent enough that weekly catches them within the
+      # CLAUDE.md "Maintenance ticket co 2 epiki" cadence.
+      interval: weekly
+      day: monday
       time: "06:00"
       timezone: Europe/Warsaw
     open-pull-requests-limit: 10
@@ -81,7 +85,11 @@ updates:
   - package-ecosystem: npm
     directory: /apps/admin
     schedule:
-      interval: daily
+      # Weekly to avoid first-run backlog flood. Patch updates are
+      # frequent enough that weekly catches them within the
+      # CLAUDE.md "Maintenance ticket co 2 epiki" cadence.
+      interval: weekly
+      day: monday
       time: "06:00"
       timezone: Europe/Warsaw
     open-pull-requests-limit: 10


### PR DESCRIPTION
Daily schedule + first activation = 31 PRs in 30 min. Weekly Monday catches updates within the CLAUDE.md 'Maintenance ticket co 2 epiki' cadence without burying real review work.

Existing 31 PRs triaged:
- 15 patches → auto-merge enabled via `gh pr merge --auto` (per CLAUDE.md 'automerge tylko patch')
- 8 minor + 8 major → left for manual review

Refs #640