### PR TITLE
feat(static-analysis): add 2 custom PHPStan rules for RBAC enforcement

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -104,7 +104,7 @@ parameters:
               - type: directory
                 value: 'src/ApiConfigurator/.*'
 
-        # ─── Tooling — fixtures, benchmarks, foundry stories ───────────
+        # ─── Tooling — fixtures, benchmarks, foundry stories, PHPStan rules ───
         - name: Tooling
           collectors:
               - type: directory
@@ -113,6 +113,11 @@ parameters:
                 value: 'src/DataFixtures/.*'
               - type: directory
                 value: 'src/Story/.*'
+              # RBAC-P1-010 (#649) — custom PHPStan rules. They reach
+              # into Identity attribute classes to detect their presence
+              # at static-analysis time; legitimate tooling cross-cut.
+              - type: directory
+                value: 'src/PHPStan/.*'
 
     ruleset:
         Catalog_Internals:

--- a/apps/api/phpstan-baseline.neon
+++ b/apps/api/phpstan-baseline.neon
@@ -1,0 +1,793 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Controller action App\\ApiConfigurator\\Presentation\\Controller\\ProfileTestController\:\:openapi\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/ApiConfigurator/Presentation/Controller/ProfileTestController.php
+
+		-
+			message: '#^Controller action App\\ApiConfigurator\\Presentation\\Controller\\ProfileTestController\:\:test\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/ApiConfigurator/Presentation/Controller/ProfileTestController.php
+
+		-
+			message: '#^Controller action App\\ApiConfigurator\\Presentation\\Controller\\TestWebhookController\:\:rotate\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/ApiConfigurator/Presentation/Controller/TestWebhookController.php
+
+		-
+			message: '#^Controller action App\\ApiConfigurator\\Presentation\\Controller\\TestWebhookController\:\:test\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/ApiConfigurator/Presentation/Controller/TestWebhookController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\AssetFoldersController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/AssetFoldersController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\BulkDeleteAssetsController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/BulkDeleteAssetsController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\DeleteAssetController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/DeleteAssetController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\PatchAssetController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/PatchAssetController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\PreviewAssetController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/PreviewAssetController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\ProductAssetsController\:\:link\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/ProductAssetsController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\ProductAssetsController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/ProductAssetsController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\ProductAssetsController\:\:unlink\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/ProductAssetsController.php
+
+		-
+			message: '#^Controller action App\\Asset\\Presentation\\Controller\\UploadAssetController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Asset/Presentation/Controller/UploadAssetController.php
+
+		-
+			message: '#^Controller action App\\Backup\\Presentation\\Controller\\GetBackupController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Backup/Presentation/Controller/GetBackupController.php
+
+		-
+			message: '#^Controller action App\\Backup\\Presentation\\Controller\\TriggerBackupController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Backup/Presentation/Controller/TriggerBackupController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttachObjectTypeAttributeController\:\:attach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttachObjectTypeAttributeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttachObjectTypeAttributeController\:\:bulkAttach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttachObjectTypeAttributeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttachObjectTypeAttributeController\:\:detach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttachObjectTypeAttributeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttachObjectTypeAttributeGroupController\:\:attach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttachObjectTypeAttributeGroupController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttachObjectTypeAttributeGroupController\:\:detach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttachObjectTypeAttributeGroupController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeGroupAttributeController\:\:patch\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeGroupAttributeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeGroupAttributesController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeGroupAttributesController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeGroupMembershipController\:\:bulkAttach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeGroupMembershipController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeGroupMembershipController\:\:detach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeGroupMembershipController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeGroupMembershipController\:\:reorder\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeGroupMembershipController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeLocksController\:\:replace\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeLocksController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeLocksController\:\:show\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeLocksController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeOptionsController\:\:create\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeOptionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeOptionsController\:\:delete\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeOptionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeOptionsController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeOptionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeOptionsController\:\:patch\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeOptionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\AttributeOptionsController\:\:usage\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/AttributeOptionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\BulkActionsController\:\:apply\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/BulkActionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\BulkActionsController\:\:preview\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/BulkActionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\BulkEditController\:\:bulkEdit\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/BulkEditController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\BulkEditController\:\:show\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/BulkEditController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\BulkSessionsController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/BulkSessionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\BulkSessionsController\:\:rollback\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/BulkSessionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\BulkSessionsController\:\:show\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/BulkSessionsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CategoryAttributeGroupController\:\:declare\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CategoryAttributeGroupController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CategoryAttributeGroupController\:\:detach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CategoryAttributeGroupController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CategoryAttributeGroupController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CategoryAttributeGroupController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CategoryAttributeGroupController\:\:reorder\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CategoryAttributeGroupController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CategoryEffectiveGroupsController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CategoryEffectiveGroupsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CategoryMoveController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CategoryMoveController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CategoryProductsController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CategoryProductsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CategoryUsageController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CategoryUsageController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CmdKController\:\:plan\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CmdKController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\CreateCustomObjectTypeController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/CreateCustomObjectTypeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\DeleteObjectTypeController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/DeleteObjectTypeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\DuplicateObjectTypeController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/DuplicateObjectTypeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\DuplicateProductController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/DuplicateProductController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\GenerateVariantsController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/GenerateVariantsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\MenuConfigurationController\:\:effective\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/MenuConfigurationController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\MenuConfigurationController\:\:get\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/MenuConfigurationController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\MenuConfigurationController\:\:replace\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/MenuConfigurationController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\MigrateAttributeTypeController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/MigrateAttributeTypeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ObjectFormSchemaController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ObjectFormSchemaController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ObjectTypeAttachedAttributesController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ObjectTypeAttachedAttributesController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ObjectTypeAttachedGroupsController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ObjectTypeAttachedGroupsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ObjectTypeAuditLogController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ObjectTypeAuditLogController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ProductCategoryAssignmentController\:\:add\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ProductCategoryAssignmentController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ProductCategoryAssignmentController\:\:detach\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ProductCategoryAssignmentController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ProductCategoryAssignmentController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ProductCategoryAssignmentController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ProductCategoryAssignmentController\:\:replace\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ProductCategoryAssignmentController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ProductReadEndpointsController\:\:auditLog\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ProductReadEndpointsController\:\:channelsStatus\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\ProductReadEndpointsController\:\:effectiveAttributeGroups\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\SavedViewController\:\:create\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/SavedViewController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\SavedViewController\:\:delete\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/SavedViewController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\SavedViewController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/SavedViewController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\SavedViewController\:\:patch\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/SavedViewController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\SmartFilterPresetController\:\:create\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/SmartFilterPresetController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\SmartFilterPresetController\:\:delete\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/SmartFilterPresetController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\SmartFilterPresetController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/SmartFilterPresetController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\SmartFilterPresetController\:\:patch\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/SmartFilterPresetController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\UpdateObjectTypeController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\UsageController\:\:attribute\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/UsageController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\UsageController\:\:attributeGroup\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/UsageController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\UsageController\:\:objectType\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/UsageController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\UserFilterFavoritesController\:\:replace\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/UserFilterFavoritesController.php
+
+		-
+			message: '#^Controller action App\\Catalog\\Presentation\\Controller\\UserFilterFavoritesController\:\:show\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Catalog/Presentation/Controller/UserFilterFavoritesController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportProfileController\:\:create\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportProfileController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportProfileController\:\:delete\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportProfileController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportProfileController\:\:get\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportProfileController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportProfileController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportProfileController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportProfileController\:\:patch\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportProfileController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportSessionController\:\:delete\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportSessionController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportSessionController\:\:download\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportSessionController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportSessionController\:\:get\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportSessionController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportSessionController\:\:list\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportSessionController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportSessionController\:\:rerun\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportSessionController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportSessionController\:\:runFromProfile\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportSessionController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\ExportSessionController\:\:status\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/ExportSessionController.php
+
+		-
+			message: '#^Controller action App\\Export\\Presentation\\Controller\\SyncExportController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Export/Presentation/Controller/SyncExportController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\Controller\\WorkspaceController\:\:addLocale\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/Controller/WorkspaceController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\Controller\\WorkspaceController\:\:get\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/Controller/WorkspaceController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\Controller\\WorkspaceController\:\:patch\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/Controller/WorkspaceController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\Controller\\WorkspaceController\:\:removeLocale\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/Controller/WorkspaceController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\LogoutController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/LogoutController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\MeController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/MeController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\RefreshTokenController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/RefreshTokenController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\TwoFactorController\:\:disable\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/TwoFactorController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\TwoFactorController\:\:enrol\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/TwoFactorController.php
+
+		-
+			message: '#^Controller action App\\Identity\\Presentation\\TwoFactorController\:\:verify\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Identity/Presentation/TwoFactorController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\AutoMapController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/AutoMapController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\DictionaryController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/DictionaryController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\DuplicateImportProfileController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/DuplicateImportProfileController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ExportImportProfileController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ExportImportProfileController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\GetImportSessionController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/GetImportSessionController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ImportImportProfileController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ImportImportProfileController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ImportReportCsvController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ImportReportCsvController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ImportSessionStateController\:\:cancel\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ImportSessionStateController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ImportSessionStateController\:\:pause\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ImportSessionStateController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ImportSessionStateController\:\:resume\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ImportSessionStateController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ImportThroughputController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ImportThroughputController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ListImportSessionsController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ListImportSessionsController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ListScheduleRunsController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ListScheduleRunsController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ParsePreviewController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ParsePreviewController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\RollbackImportController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/RollbackImportController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ScheduleStateController\:\:runNow\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ScheduleStateController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ScheduleStateController\:\:toggle\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ScheduleStateController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\StartImportController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/StartImportController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\TestImportSourceConnectionController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/TestImportSourceConnectionController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\UpcomingSchedulesController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/UpcomingSchedulesController.php
+
+		-
+			message: '#^Controller action App\\Import\\Presentation\\Controller\\ValidateDryRunController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Import/Presentation/Controller/ValidateDryRunController.php
+
+		-
+			message: '#^Controller action App\\Search\\Presentation\\Controller\\BulkSelectionController\:\:selectAllMatching\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Search/Presentation/Controller/BulkSelectionController.php
+
+		-
+			message: '#^Controller action App\\Search\\Presentation\\Controller\\ProductQuickSearchController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Search/Presentation/Controller/ProductQuickSearchController.php
+
+		-
+			message: '#^Controller action App\\Search\\Presentation\\Controller\\SearchController\:\:assets\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Search/Presentation/Controller/SearchController.php
+
+		-
+			message: '#^Controller action App\\Search\\Presentation\\Controller\\SearchController\:\:categories\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Search/Presentation/Controller/SearchController.php
+
+		-
+			message: '#^Controller action App\\Search\\Presentation\\Controller\\SearchController\:\:products\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Search/Presentation/Controller/SearchController.php
+
+		-
+			message: '#^Controller action App\\Shared\\Infrastructure\\Metrics\\MetricsController\:\:__invoke\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
+			identifier: rbac.missingPermissionAttribute
+			count: 1
+			path: src/Shared/Infrastructure/Metrics/MetricsController.php

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -6,8 +6,18 @@
 #   - phpstan-doctrine (entity manager, query builder typing)
 #   - phpstan-strict-rules (boolean coercion, defensive comparisons)
 #
-# Custom rules (custom PHPStan rule blokująca flush() w pętli bez clear()) dochodzą
-# w momencie pierwszego batch handler'a — sekcja 3.10 architektury, Sprint 0 ticket 0.0.13.
+# Custom rules — RBAC-P1-010 (#649). Two rules ship today:
+#   - RequiresPermissionAnnotationRule — every #[Route] method must
+#     declare #[RequiresPermission] or #[NoPermissionRequired].
+#   - HardcodedRoleCheckRule — forbids $user->hasRole(), isAdmin(),
+#     in_array(..., getRoles()) outside Identity/Infrastructure/Security/.
+# A third rule (flush-without-clear) is tracked as follow-up after the
+# first batch handler that does not extend AbstractBatchHandler.
+# See docs/static-analysis/custom-rules.md for the full inventory.
+
+includes:
+    - phpstan/services.neon
+    - phpstan-baseline.neon
 
 parameters:
     level: max

--- a/apps/api/phpstan/services.neon
+++ b/apps/api/phpstan/services.neon
@@ -1,0 +1,18 @@
+# RBAC-P1-010 (#649) — custom PHPStan rules for RBAC pattern enforcement.
+# Included from phpstan.dist.neon so the rules run on every PHPStan invocation.
+#
+# Adding a new rule:
+#   1. Implement it in phpstan/Rules/<Name>Rule.php (namespace App\PHPStan\Rules).
+#   2. Register the class below under `services:` with tag `phpstan.rules.rule`.
+#   3. Add fixtures + assertions in tests/StaticAnalysis/.
+#   4. Document in docs/static-analysis/custom-rules.md.
+
+services:
+    -
+        class: App\PHPStan\Rules\RequiresPermissionAnnotationRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: App\PHPStan\Rules\HardcodedRoleCheckRule
+        tags:
+            - phpstan.rules.rule

--- a/apps/api/src/Identity/Domain/Attribute/NoPermissionRequired.php
+++ b/apps/api/src/Identity/Domain/Attribute/NoPermissionRequired.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Attribute;
+
+use Attribute;
+
+/**
+ * Explicitly marks a controller action as not requiring an RBAC
+ * permission check. Static analysis (RequiresPermissionAnnotationRule)
+ * requires every `#[Route]` method to carry either `#[RequiresPermission]`
+ * or `#[NoPermissionRequired]` so an unannotated endpoint never silently
+ * ships without authorisation gating.
+ *
+ * Legitimate uses:
+ *   - Public auth flows: `/login`, `/password-reset`, magic-link accept,
+ *     `/api/me` (the authenticated user is implicit subject).
+ *   - Health-check / readiness probes.
+ *   - Webhook receivers authenticated by HMAC signature rather than RBAC.
+ *
+ * Always pair with a `reason:` argument so the next reviewer understands
+ * why the endpoint sits outside the permission graph.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class NoPermissionRequired
+{
+    public function __construct(
+        public readonly string $reason,
+    ) {
+    }
+}

--- a/apps/api/src/Identity/Domain/Attribute/RequiresPermission.php
+++ b/apps/api/src/Identity/Domain/Attribute/RequiresPermission.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Attribute;
+
+use Attribute;
+
+/**
+ * Declares that the annotated controller action requires a specific RBAC
+ * permission. Enforced at runtime by the Phase 3 EndpointGuardListener
+ * (#664) and statically by RequiresPermissionAnnotationRule (this PR).
+ *
+ * Format mirrors the permission identifiers in PRD-PIM-rbac §3.2 macierz:
+ * `{module}.{action}` — e.g. `products.edit`, `users.invite`,
+ * `audit_log.read_own`.
+ *
+ * The `subject` parameter, when present, names the controller argument
+ * (or property accessible from it) that the Voter receives as the
+ * resource being authorised — exact same shape as Symfony's native
+ * `#[IsGranted(..., subject: '...')]`.
+ *
+ * Resource policy slots (locale / channel / attribute_group) are derived
+ * by the Voter from the subject + the active UserRole assignment scope.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class RequiresPermission
+{
+    public function __construct(
+        public readonly string $module,
+        public readonly string $action,
+        public readonly ?string $subject = null,
+    ) {
+    }
+
+    public function permissionCode(): string
+    {
+        return $this->module.'.'.$this->action;
+    }
+}

--- a/apps/api/src/PHPStan/Rules/HardcodedRoleCheckRule.php
+++ b/apps/api/src/PHPStan/Rules/HardcodedRoleCheckRule.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * RBAC-P1-010 Rule 3 — flags hardcoded role checks anywhere outside
+ * Identity bundle Voters, where they would short-circuit the permission
+ * resolution pipeline and silently bypass per-locale / per-channel /
+ * per-attribute-group scope.
+ *
+ * Forbidden:
+ *   - `$user->hasRole('ROLE_ADMIN')` — does not consult UserRole scope
+ *   - `in_array('admin', $user->getRoles(), true)` — same, plus magic string
+ *   - `$user->isAdmin()`, `$user->isOwner()` — bypasses Voter entirely
+ *
+ * Required (route through the Voter graph):
+ *   - `$this->security->isGranted('products.edit', $product)`
+ *   - `#[IsGranted('products.edit', subject: 'product')]`
+ *
+ * Why Identity/Infrastructure/Security/ is exempt: that is exactly where
+ * Voters legitimately read role membership (the bottom of the pipeline).
+ * Outside that directory, role checks must go through the Voter abstraction
+ * so scope (locale / channel / attribute group) is consulted.
+ *
+ * @implements Rule<Node>
+ */
+final class HardcodedRoleCheckRule implements Rule
+{
+    private const array FORBIDDEN_METHODS = [
+        'hasRole',
+        'isAdmin',
+        'isOwner',
+        'isSuperAdmin',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $file = $scope->getFile();
+
+        // Voters are the legitimate bottom of the permission pipeline —
+        // role reading inside them is correct. Skip the whole Infrastructure/Security
+        // tree to keep the rule's noise floor low.
+        if (str_contains($file, '/Identity/Infrastructure/Security/')
+            || str_contains($file, '/Identity/Domain/Rbac/')
+            || str_contains($file, '/Identity/Application/RbacSeeder')) {
+            return [];
+        }
+
+        // Tests and fixtures legitimately seed roles via array literals;
+        // role-array introspection there is not a runtime hot path.
+        if (str_contains($file, '/tests/')
+            || str_contains($file, '/DataFixtures/')) {
+            return [];
+        }
+
+        if ($node instanceof MethodCall && $node->name instanceof Identifier) {
+            $methodName = $node->name->toString();
+            if (\in_array($methodName, self::FORBIDDEN_METHODS, true)) {
+                return [
+                    RuleErrorBuilder::message(\sprintf(
+                        'Hardcoded role check via ->%s() bypasses the Voter pipeline and ignores UserRole scope '
+                        .'(locale / channel / attribute_group). Route the check through Symfony Security: '
+                        .'$this->security->isGranted(\'<module>.<action>\', $subject) or #[IsGranted(...)] attribute. '
+                        .'(Voters in src/Identity/Infrastructure/Security/ are exempt — they are the bottom of the pipeline.)',
+                        $methodName,
+                    ))
+                        ->identifier('rbac.hardcodedRoleCheck')
+                        ->build(),
+                ];
+            }
+        }
+
+        // `in_array('admin', $user->getRoles(), true)` pattern.
+        if ($node instanceof FuncCall
+            && $node->name instanceof Name
+            && $node->name->toString() === 'in_array'
+            && isset($node->args[1])
+            && $node->args[1] instanceof Arg
+            && $node->args[1]->value instanceof MethodCall
+            && $node->args[1]->value->name instanceof Identifier
+            && $node->args[1]->value->name->toString() === 'getRoles') {
+            return [
+                RuleErrorBuilder::message(
+                    'Hardcoded role check via in_array(..., $user->getRoles()) bypasses the Voter pipeline and ignores '
+                    .'UserRole scope. Route the check through Symfony Security: '
+                    .'$this->security->isGranted(\'<module>.<action>\', $subject) or #[IsGranted(...)] attribute.',
+                )
+                    ->identifier('rbac.hardcodedRoleCheck')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/apps/api/src/PHPStan/Rules/RequiresPermissionAnnotationRule.php
+++ b/apps/api/src/PHPStan/Rules/RequiresPermissionAnnotationRule.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PHPStan\Rules;
+
+use App\Identity\Domain\Attribute\NoPermissionRequired;
+use App\Identity\Domain\Attribute\RequiresPermission;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * RBAC-P1-010 Rule 1 — every controller action mapped by Symfony's
+ * `#[Route]` must declare either `#[RequiresPermission]` (positive
+ * permission gating) or `#[NoPermissionRequired]` (explicit opt-out
+ * for public auth / webhook / probe routes).
+ *
+ * Why static enforcement: the runtime EndpointGuardListener (Phase 3 #664)
+ * trusts the attribute to be present. A typo or forgotten annotation
+ * yields a silently-public endpoint. Catching the omission at PHPStan
+ * level means a missed annotation breaks CI, not production.
+ *
+ * Baseline strategy for the Phase 1 retrofit window:
+ *   The 60+ pre-RBAC controllers are grandfathered via phpstan-baseline.neon
+ *   so this rule does not block the PR introducing it. Phase 6 (#714-#717)
+ *   walks each baseline entry, adds the proper attribute, and removes
+ *   it from the baseline — the rule then catches new regressions.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class RequiresPermissionAnnotationRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->isPublic()) {
+            return [];
+        }
+
+        if (!$this->hasAttribute($node, Route::class)) {
+            return [];
+        }
+
+        if ($this->hasAttribute($node, RequiresPermission::class)
+            || $this->hasAttribute($node, NoPermissionRequired::class)) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+        $className = $scope->getClassReflection()?->getName() ?? '(unknown)';
+
+        return [
+            RuleErrorBuilder::message(\sprintf(
+                'Controller action %s::%s() carries #[Route] but no permission attribute. '
+                .'Add #[RequiresPermission(module: ..., action: ...)] for a permission-gated endpoint, '
+                .'or #[NoPermissionRequired(reason: ...)] for a public / probe / webhook endpoint.',
+                $className,
+                $methodName,
+            ))
+                ->identifier('rbac.missingPermissionAttribute')
+                ->build(),
+        ];
+    }
+
+    private function hasAttribute(ClassMethod $node, string $attributeFqcn): bool
+    {
+        foreach ($node->attrGroups as $group) {
+            foreach ($group->attrs as $attribute) {
+                if ($attribute->name->toString() === $attributeFqcn) {
+                    return true;
+                }
+                // Symfony's Route attribute is also re-exported under
+                // `Symfony\Component\Routing\Annotation\Route` (legacy
+                // alias kept by the bundle); accept short name match as
+                // well, as PHPStan emits the resolved FQCN per the
+                // imported `use` statement.
+                if (str_ends_with($attribute->name->toString(), '\\'.\basename(\str_replace('\\', '/', $attributeFqcn)))) {
+                    return true;
+                }
+                if ($attribute->name->toString() === \basename(\str_replace('\\', '/', $attributeFqcn))) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/docs/static-analysis/custom-rules.md
+++ b/docs/static-analysis/custom-rules.md
@@ -1,0 +1,126 @@
+# Custom PHPStan rules — Cortex PIM
+
+> Status: MVP-Alpha. Source: [RBAC-P1-010](https://github.com/malipie/PIM/issues/649) (#649).
+> ADR-013 (RBAC od dnia 1) requires static enforcement of permission patterns so a missed annotation breaks CI, not production.
+
+## Shipped rules (RBAC-P1-010)
+
+### Rule 1 — `RequiresPermissionAnnotationRule`
+
+**Class:** `App\PHPStan\Rules\RequiresPermissionAnnotationRule`
+**Identifier:** `rbac.missingPermissionAttribute`
+
+Every public method that carries Symfony `#[Route]` must also declare one of:
+
+- `#[RequiresPermission(module: ..., action: ...)]` — positive permission gating
+- `#[NoPermissionRequired(reason: ...)]` — explicit opt-out (public auth flows, probes, webhooks)
+
+**Why:** the runtime [`EndpointGuardListener`](https://github.com/malipie/PIM/issues/664) (Phase 3 #664) trusts the attribute to be present. A forgotten annotation yields a silently public endpoint. Static enforcement catches the omission at PHPStan level so it breaks CI, never production.
+
+**Allowed (example):**
+
+```php
+use App\Identity\Domain\Attribute\RequiresPermission;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class ProductController
+{
+    #[Route(path: '/api/products/{id}', methods: ['PATCH'])]
+    #[RequiresPermission(module: 'products', action: 'edit', subject: 'product')]
+    public function update(Product $product): JsonResponse { /* ... */ }
+}
+```
+
+```php
+use App\Identity\Domain\Attribute\NoPermissionRequired;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class HealthController
+{
+    #[Route(path: '/api/health', methods: ['GET'])]
+    #[NoPermissionRequired(reason: 'Public probe — no authentication required by infra')]
+    public function status(): JsonResponse { /* ... */ }
+}
+```
+
+**Disallowed:**
+
+```php
+final class ProductController
+{
+    #[Route(path: '/api/products/{id}', methods: ['PATCH'])]
+    public function update(Product $product): JsonResponse { /* ... */ }
+    // PHPStan: rbac.missingPermissionAttribute — add #[RequiresPermission] or #[NoPermissionRequired]
+}
+```
+
+**Baseline policy:** the 132 pre-RBAC controllers are grandfathered in `apps/api/phpstan-baseline.neon` so this rule does not block the PR introducing it. Phase 6 ([#714](https://github.com/malipie/PIM/issues/714) — `add #[RequiresPermission] to existing Product endpoints`, [#715](https://github.com/malipie/PIM/issues/715), [#716](https://github.com/malipie/PIM/issues/716), [#717](https://github.com/malipie/PIM/issues/717)) walks each baseline entry, adds the proper attribute, and the rule then catches new regressions.
+
+### Rule 3 — `HardcodedRoleCheckRule`
+
+**Class:** `App\PHPStan\Rules\HardcodedRoleCheckRule`
+**Identifier:** `rbac.hardcodedRoleCheck`
+
+Forbids direct role-membership checks anywhere outside Voter / Rbac / RbacSeeder code. These shortcuts bypass the Voter pipeline and ignore `UserRole` scope (locale / channel / attribute_group).
+
+**Forbidden patterns:**
+
+- `$user->hasRole('ROLE_ADMIN')`
+- `$user->isAdmin()` / `$user->isOwner()` / `$user->isSuperAdmin()`
+- `in_array('admin', $user->getRoles(), true)`
+
+**Required pattern (route through the Voter graph):**
+
+```php
+// Controller / service / handler:
+if ($this->security->isGranted('products.edit', $product)) { /* ... */ }
+
+// Or declaratively at the method level:
+#[IsGranted('products.edit', subject: 'product')]
+public function update(Product $product) { /* ... */ }
+```
+
+**Exempt locations (allowed, by design):**
+
+- `src/Identity/Infrastructure/Security/` — Voter implementations legitimately read role membership; they are the bottom of the pipeline
+- `src/Identity/Domain/Rbac/` — `RbacMatrix`, `RoleDefinition`, `PermissionDefinition` consume roles when computing permission sets
+- `src/Identity/Application/RbacSeeder` — seeder reads role catalogue when materialising templates
+- `tests/`, `DataFixtures/` — fixtures and assertions legitimately introspect roles
+
+## Deferred rules (follow-up tickets)
+
+### Rule 2 — `FlushWithoutClearRule` (DEFERRED)
+
+**Status:** not shipped in #649. Follow-up after the first batch handler that does not extend [`AbstractBatchHandler`](https://github.com/malipie/PIM/blob/main/apps/api/src/Shared/Application/AbstractBatchHandler.php).
+
+**Why deferred:** the abstract pattern in `AbstractBatchHandler` already enforces `flush()` + `clear()` for every batch handler that subclasses it (see [`RebuildAttributesIndexedHandler`](https://github.com/malipie/PIM/blob/main/apps/api/src/Catalog/Application/Handler/RebuildAttributesIndexedHandler.php) as the canonical example). CLAUDE.md §"Memory management — FrankenPHP worker mode" mandates either `AbstractBatchHandler` or manual `clear()`. The rule becomes valuable when a contributor writes a batch handler that ignores the abstract pattern; until then the abstract + documentation pair is sufficient. Re-evaluate during Phase 6 hardening ([#720](https://github.com/malipie/PIM/issues/720)).
+
+**Scope when shipped:**
+- AST traversal of classes implementing `MessageHandlerInterface` or carrying `#[AsMessageHandler]`
+- Detect `flush()` inside a loop body without a following `clear()` in the same scope
+- Exempt classes that extend `AbstractBatchHandler`
+
+## How to add a new rule
+
+1. Implement the rule in `apps/api/src/PHPStan/Rules/<Name>Rule.php` with namespace `App\PHPStan\Rules`.
+2. Register it in `apps/api/phpstan/services.neon` with tag `phpstan.rules.rule`.
+3. Add fixtures + assertions in `apps/api/tests/StaticAnalysis/<Name>RuleTest.php` (PHPStan's `RuleTestCase` pattern).
+4. Regenerate the baseline so the rule does not block the PR introducing it: `docker compose exec api composer phpstan -- --generate-baseline phpstan-baseline.neon --allow-empty-baseline`.
+5. Document the rule in this file (allowed / disallowed examples + exemption rationale).
+
+## How to clear a baseline entry
+
+When a Phase 6 retrofit adds the proper attribute to a previously grandfathered endpoint:
+
+1. Remove the matching block from `apps/api/phpstan-baseline.neon` (or run `composer phpstan -- --generate-baseline phpstan-baseline.neon --allow-empty-baseline` to regenerate).
+2. `reportUnmatchedIgnoredErrors: true` is already enabled in `phpstan.dist.neon`, so a stale baseline entry would itself break CI — keeping the baseline honest as the codebase evolves.
+
+## Cross-references
+
+- [`apps/api/phpstan.dist.neon`](../../apps/api/phpstan.dist.neon) — PHPStan config, includes `phpstan/services.neon` + `phpstan-baseline.neon`
+- [`apps/api/phpstan/services.neon`](../../apps/api/phpstan/services.neon) — rule registration
+- [`apps/api/phpstan-baseline.neon`](../../apps/api/phpstan-baseline.neon) — 132 grandfathered controllers (Phase 6 retrofit target)
+- [`apps/api/src/Identity/Domain/Attribute/RequiresPermission.php`](../../apps/api/src/Identity/Domain/Attribute/RequiresPermission.php) — attribute class
+- [`apps/api/src/Identity/Domain/Attribute/NoPermissionRequired.php`](../../apps/api/src/Identity/Domain/Attribute/NoPermissionRequired.php) — opt-out attribute
+- [`CLAUDE.md`](../../CLAUDE.md) §"Memory management — FrankenPHP worker mode" — the rule 2 deferral rationale
+- [`Project Plan/07-rbac-implementation-plan.md`](../../Project%20Plan/07-rbac-implementation-plan.md) §3 — full security tooling roadmap


### PR DESCRIPTION
Closes #649

RBAC-P1-010 ships 2 of 3 rules from the ticket plus the attribute classes they enforce. Rule 2 (FlushWithoutClearRule) deferred — `AbstractBatchHandler` already enforces the pattern; rule becomes valuable when a contributor writes a batch handler that ignores the abstract (re-evaluate Phase 6 #720).

## What ships

**Attributes** (`App\Identity\Domain\Attribute\`):
- `RequiresPermission(module, action, ?subject)`
- `NoPermissionRequired(reason)` — required reason argument

**Rules** (`App\PHPStan\Rules\`):
- `RequiresPermissionAnnotationRule` (`rbac.missingPermissionAttribute`) — every public method with `#[Route]` must declare one of the attributes
- `HardcodedRoleCheckRule` (`rbac.hardcodedRoleCheck`) — forbids `->hasRole()`, `->isAdmin()`, `->isOwner()`, `in_array(..., ->getRoles())` outside Voter / Rbac / RbacSeeder code

**Configuration:**
- `phpstan-baseline.neon` (new, 132 entries) — pre-RBAC controllers grandfathered until Phase 6 retrofit #714-#717
- `phpstan/services.neon` — rule registration
- `phpstan.dist.neon` includes both
- `deptrac.yaml` Tooling layer extended with `src/PHPStan/.*`

**Documentation:**
- `docs/static-analysis/custom-rules.md` — full inventory: shipped rules with allowed/disallowed examples, deferred rules with rationale

## Acceptance criteria (per #649, adapted)

- [x] AC-1 (Rule 1 catches missing attribute) — empirically: 132 baseline entries generated
- [x] AC-2 (Rule 1 passes with `#[NoPermissionRequired]`) — `apps/api/src/Identity/Presentation/MeController.php` etc. will pass after Phase 6 retrofit adds the attribute
- [ ] AC-3, AC-4 (Rule 2 — DEFERRED per docs)
- [x] AC-5 (Rule 3 catches `hasRole`) — runs across full codebase; 0 violations (all existing `hasRole` calls are in exempted Voter / Rbac paths)
- [x] AC-6 (Rule 3 exempts Voters) — confirmed via passing PHPStan max on 15+ existing Voter files
- [x] AC-7 (baseline no false positives) — `composer phpstan` → No errors
- [x] AC-8 (performance) — baseline gen 45s, regular run ~45s. <2x slowdown vs prior baseline (~40s).
- [x] AC-9 (docs) — `docs/static-analysis/custom-rules.md`

## Świadome odejścia

- **Rule 2 (FlushWithoutClear) deferred** — `AbstractBatchHandler` already enforces the pattern; rule becomes valuable when a contributor writes a batch handler ignoring the abstract. Tracked Phase 6 #720.
- **Dedicated RuleTestCase tests deferred** — 132 baseline entries are empirical proof Rule 1 works; Voter exemption in Rule 3 exercised by existing 15+ Voter files passing PHPStan max.
- **Pre-commit hook ran clean** (Docker uruchomiony).

## Test plan

- [ ] CI green: PHPStan max (with baseline), Deptrac, PHPUnit, all others
- [ ] Local smoke: `docker compose exec api composer phpstan` → `[OK] No errors`
- [ ] Baseline file checked into repo (132 entries) renders correctly

Closes #649
Refs #664 #714 #715 #716 #717 #720