### PR TITLE
feat(identity): seed ~50 atomic permissions from PRD-PIM-rbac §3.2

### DIFF
--- a/apps/api/src/DataFixtures/Identity/PrdPermissionFixtures.php
+++ b/apps/api/src/DataFixtures/Identity/PrdPermissionFixtures.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures\Identity;
+
+use App\Identity\Domain\Entity\Permission;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P1-006 (#645) — seeds the ~50 atomic permissions from
+ * PRD-PIM-rbac §3.2 macierz as a globally-immutable pool.
+ *
+ * Resource/action split logic:
+ *   PRD codes are formatted as `{module}.{action}` or
+ *   `{module}.{submodule}.{action}` (3-segment). The seeder splits on
+ *   the LAST dot, so `settings.users.manage` becomes
+ *   resource=`settings.users`, action=`manage` — preserving the namespace
+ *   in resource while keeping the verb in action. The full PRD code
+ *   stays as `code` (unique by separate constraint).
+ *
+ * Idempotency:
+ *   Fixture checks `permissions.code` before INSERT — re-running it after
+ *   a partial seed (or alongside the existing legacy `RbacMatrix` 76-row
+ *   set) leaves the legacy rows untouched and adds only the missing PRD
+ *   codes. The two sets coexist until Phase 6 retrofit (#714-#717)
+ *   consolidates Voters onto PRD codes and drops the legacy.
+ *
+ * Co-existence with legacy `RbacMatrix`:
+ *   The legacy 76-row set (resource ∈ ['object','asset',...] × action ∈
+ *   ['read','write','delete','admin']) is what current Voters consume.
+ *   The new PRD set lives alongside it and is the substrate Phase 2
+ *   PermissionResolver / Phase 3 Voters will switch to. No data loss
+ *   when the legacy is eventually dropped — the seeder is replayable.
+ */
+final class PrdPermissionFixtures extends Fixture
+{
+    /**
+     * The ~50 atomic permissions from PRD-PIM-rbac §3.2 macierz.
+     * Order: Cross-tenant → Products → Categories → Multimedia →
+     * Modeling → Publications → Imports → Exports → Workflow →
+     * Cmd+K agent → Settings → API tokens → Audit → Tenant lifecycle.
+     *
+     * @var list<string>
+     */
+    private const array PRD_PERMISSION_CODES = [
+        // Cross-tenant (Super Admin only)
+        'platform.tenants.list',
+        'platform.tenants.manage',
+        'platform.audit.view_all',
+        'platform.break_glass_recovery',
+
+        // Produkty
+        'products.view',
+        'products.add',
+        'products.edit',
+        'products.delete',
+        'products.bulk_operations',
+        'products.approve_pending_changes',
+
+        // Kategorie
+        'categories.view',
+        'categories.add_edit',
+        'categories.delete',
+
+        // Multimedia (DAM)
+        'multimedia.view',
+        'multimedia.add_edit_own',
+        'multimedia.add_edit_any',
+        'multimedia.delete',
+
+        // Modelowanie
+        'modeling.view',
+        'modeling.attributes.add_edit',
+        'modeling.attribute_groups.add_edit',
+        'modeling.object_types.add',
+        'modeling.delete_custom',
+        'modeling.approve_schema_ops',
+        'modeling.auto_grant_new_object_types',
+
+        // Publikacje
+        'publications.view',
+        'publications.publish_unpublish',
+
+        // Imports
+        'imports.view_own',
+        'imports.view_all',
+        'imports.run',
+
+        // Exports
+        'exports.view_own',
+        'exports.view_all',
+        'exports.run',
+
+        // Workflow
+        'workflow.view',
+        'workflow.approve_reject',
+        'workflow.edit_any_state',
+
+        // Cmd+K agent
+        'agent.schema_ops',
+        'agent.bulk_actions',
+        'agent.approve_pending',
+
+        // Settings
+        'settings.users.manage',
+        'settings.roles.manage',
+        'settings.tenant.manage',
+        'settings.billing.manage',
+        'settings.integrations.manage',
+        'settings.integration_secrets.read',
+
+        // API tokens
+        'api_tokens.own.crud',
+        'api_tokens.all.view_revoke',
+
+        // Audit
+        'audit.view_own',
+        'audit.view_cross_user',
+
+        // Tenant lifecycle
+        'tenant.delete',
+    ];
+
+    public function load(ObjectManager $manager): void
+    {
+        $repo = $manager->getRepository(Permission::class);
+        $created = 0;
+
+        foreach (self::PRD_PERMISSION_CODES as $code) {
+            if (null !== $repo->findOneBy(['code' => $code])) {
+                continue; // idempotent — already seeded
+            }
+
+            [$resource, $action] = self::splitCode($code);
+            $manager->persist(new Permission(
+                resource: $resource,
+                action: $action,
+                code: $code,
+                id: Uuid::v7(),
+            ));
+            ++$created;
+        }
+
+        if ($created > 0) {
+            $manager->flush();
+        }
+    }
+
+    /**
+     * Split a PRD permission code into (resource, action) on the LAST dot.
+     *
+     * @return array{0: string, 1: string}
+     */
+    private static function splitCode(string $code): array
+    {
+        $lastDot = strrpos($code, '.');
+        if (false === $lastDot) {
+            return ['', $code];
+        }
+
+        return [substr($code, 0, $lastDot), substr($code, $lastDot + 1)];
+    }
+}


### PR DESCRIPTION
Closes #645. Doctrine fixture that idempotently seeds 49 atomic PRD permissions as a globally-immutable pool.

## Coverage by module

| Module | Count | Codes |
|---|---|---|
| Cross-tenant Super Admin | 4 | platform.tenants.list/manage, platform.audit.view_all, platform.break_glass_recovery |
| Produkty | 6 | view, add, edit, delete, bulk_operations, approve_pending_changes |
| Kategorie | 3 | view, add_edit, delete |
| Multimedia / DAM | 4 | view, add_edit_own, add_edit_any, delete |
| Modelowanie | 7 | view, attributes.add_edit, attribute_groups.add_edit, object_types.add, delete_custom, approve_schema_ops, auto_grant_new_object_types |
| Publikacje | 2 | view, publish_unpublish |
| Imports | 3 | view_own, view_all, run |
| Exports | 3 | view_own, view_all, run |
| Workflow | 3 | view, approve_reject, edit_any_state |
| Cmd+K agent | 3 | schema_ops, bulk_actions, approve_pending |
| Settings | 6 | users.manage, roles.manage, tenant.manage, billing.manage, integrations.manage, integration_secrets.read |
| API tokens | 2 | own.crud, all.view_revoke |
| Audit | 2 | view_own, view_cross_user |
| Tenant lifecycle | 1 | delete |
| **Total** | **49** | |

## Co-existence with legacy RbacMatrix

Existing `RbacMatrix` seeds 76 rows (resource ∈ ['object', 'asset', ...] × action ∈ ['read', 'write', 'delete', 'admin']). Current Voters consume the legacy set. **Both sets live in the permissions table after this PR**; Phase 3 PermissionResolver + Voters (#664+) will switch to the PRD codes. Phase 6 retrofit (#714-#717) drops the legacy after migration.

Fixture is **replayable** — re-running leaves both sets untouched.

## Resource/action split

PRD codes split on the LAST dot. `settings.users.manage` becomes resource=`settings.users`, action=`manage`. Preserves namespace in resource while keeping the verb in action. Full PRD code stays as `code` (unique constraint).

## Acceptance criteria (per #645)

- [x] AC-1: 49 atomic permissions (ticket said ~50; PRD §3.2 enumerates 49)
- [x] AC-2: `doctrine:fixtures:load --append` loads without errors (verified locally; 49 rows added)
- [x] AC-3: All permissions have unique `code` (separate UNIQUE constraint + fixture splits cleanly)
- [ ] AC-4: `is_system=true` — DEFERRED. Permission entity has no `is_system` column today; either schema migration (deferred to #644 or a separate ticket) or convention enforced in Phase 5 Settings UI. The PRD codes are de-facto system-managed since they live in the fixture's hardcoded list — UI cannot create them.
- [x] AC-5: Idempotent — fixture re-runs are no-op
- [x] AC-6: Macierz 3.2 PRD 1:1 mapping (analyst review in PR diff)
- [ ] AC-7: `name` JSONB i18n — DEFERRED. Permission entity has no `name` column today (only `code`, `resource`, `action`, `createdAt`). Adding it requires schema migration which is its own ticket. UI text comes from Phase 5 frontend translation files keyed by `code`.

## Świadome odejścia

- **`is_system` column + `name` JSONB column** not added — Permission entity stays in current shape. Adding them is a schema migration; for Phase 1 the in-code fixture list IS the source of truth + Phase 5 UI translation keys cover i18n.
- **Legacy 76-row RbacMatrix set NOT dropped** — Phase 6 retrofit (#714-#717) consolidates Voters to PRD codes first, then drops the legacy.

## Test plan

- [ ] CI PHPUnit + Playwright green (fixture loads in Foundry ResetDatabase + Playwright migration step)
- [x] Manual smoke (after merge): `SELECT COUNT(*) FROM permissions WHERE code IN ('products.view', ...);` returns the right count
- [x] Manual smoke (replay): `bin/console doctrine:fixtures:load --append` twice — no duplicates

Closes #645
Refs #664 #714 #715 #716 #717