### PR TITLE
feat(identity): seed 9 PRD-PIM-rbac role templates per tenant

### DIFF
--- a/apps/api/src/Identity/Domain/Rbac/PrdRoleTemplates.php
+++ b/apps/api/src/Identity/Domain/Rbac/PrdRoleTemplates.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Rbac;
+
+/**
+ * RBAC-P1-007 (#646) — declarative source of truth for the 9 PRD-PIM-rbac §3.2
+ * role templates: 1 platform-level (`super_admin`) + 8 tenant-level.
+ *
+ * Each tenant-level entry is the seed copied on tenant onboarding (Phase 2
+ * listener); the platform-level entry is seeded once globally.
+ *
+ * Maintenance: when the macierz changes, edit this file. The
+ * `App\Identity\Application\TenantOnboardingService` + the CLI command
+ * `cortex:tenant:seed-roles` consume this map; a missing permission code
+ * (typo, dropped from PrdPermissionFixtures) fails fast at seed time.
+ */
+final class PrdRoleTemplates
+{
+    /**
+     * Map: role_code => human-readable name.
+     *
+     * @return array<string, string>
+     */
+    public static function tenantRoleNames(): array
+    {
+        return [
+            'tenant_owner' => 'Tenant Owner',
+            'admin' => 'Administrator',
+            'catalog_manager' => 'Catalog Manager',
+            'marketing' => 'Content Editor (Marketing)',
+            'modeler' => 'Information Architect (Modeler)',
+            'integration_manager' => 'Integration Manager',
+            'channel_manager' => 'Channel Manager',
+            'approver' => 'Approver',
+            'viewer' => 'Viewer',
+        ];
+    }
+
+    /**
+     * Platform-level (`super_admin`) name.
+     */
+    public static function superAdminRoleName(): string
+    {
+        return 'Super Admin';
+    }
+
+    /**
+     * Permissions granted to the platform-level Super Admin role.
+     * Cross-tenant, immutable, seeded once globally.
+     *
+     * @return list<string>
+     */
+    public static function superAdminPermissions(): array
+    {
+        return [
+            'platform.tenants.list',
+            'platform.tenants.manage',
+            'platform.audit.view_all',
+            'platform.break_glass_recovery',
+        ];
+    }
+
+    /**
+     * Permission assignments per tenant-level role.
+     *
+     * @return array<string, list<string>>
+     */
+    public static function tenantRolePermissions(): array
+    {
+        return [
+            // Tenant Owner — every tenant permission + tenant.delete
+            'tenant_owner' => [
+                'products.view', 'products.add', 'products.edit', 'products.delete',
+                'products.bulk_operations', 'products.approve_pending_changes',
+                'categories.view', 'categories.add_edit', 'categories.delete',
+                'multimedia.view', 'multimedia.add_edit_own', 'multimedia.add_edit_any', 'multimedia.delete',
+                'modeling.view', 'modeling.attributes.add_edit', 'modeling.attribute_groups.add_edit',
+                'modeling.object_types.add', 'modeling.delete_custom', 'modeling.approve_schema_ops',
+                'modeling.auto_grant_new_object_types',
+                'publications.view', 'publications.publish_unpublish',
+                'imports.view_own', 'imports.view_all', 'imports.run',
+                'exports.view_own', 'exports.view_all', 'exports.run',
+                'workflow.view', 'workflow.approve_reject', 'workflow.edit_any_state',
+                'agent.schema_ops', 'agent.bulk_actions', 'agent.approve_pending',
+                'settings.users.manage', 'settings.roles.manage', 'settings.tenant.manage',
+                'settings.billing.manage', 'settings.integrations.manage', 'settings.integration_secrets.read',
+                'api_tokens.own.crud', 'api_tokens.all.view_revoke',
+                'audit.view_own', 'audit.view_cross_user',
+                'tenant.delete',
+            ],
+
+            // Administrator — everything except tenant.delete and billing
+            'admin' => [
+                'products.view', 'products.add', 'products.edit', 'products.delete',
+                'products.bulk_operations', 'products.approve_pending_changes',
+                'categories.view', 'categories.add_edit', 'categories.delete',
+                'multimedia.view', 'multimedia.add_edit_own', 'multimedia.add_edit_any', 'multimedia.delete',
+                'modeling.view', 'modeling.attributes.add_edit', 'modeling.attribute_groups.add_edit',
+                'modeling.object_types.add', 'modeling.delete_custom', 'modeling.approve_schema_ops',
+                'modeling.auto_grant_new_object_types',
+                'publications.view', 'publications.publish_unpublish',
+                'imports.view_own', 'imports.view_all', 'imports.run',
+                'exports.view_own', 'exports.view_all', 'exports.run',
+                'workflow.view', 'workflow.approve_reject', 'workflow.edit_any_state',
+                'agent.schema_ops', 'agent.bulk_actions', 'agent.approve_pending',
+                'settings.users.manage', 'settings.roles.manage', 'settings.tenant.manage',
+                'settings.integrations.manage', 'settings.integration_secrets.read',
+                'api_tokens.own.crud', 'api_tokens.all.view_revoke',
+                'audit.view_own', 'audit.view_cross_user',
+            ],
+
+            // Catalog Manager — products / categories / multimedia full CRUD + workflow approve + bulk agent
+            'catalog_manager' => [
+                'products.view', 'products.add', 'products.edit', 'products.delete',
+                'products.bulk_operations',
+                'categories.view', 'categories.add_edit', 'categories.delete',
+                'multimedia.view', 'multimedia.add_edit_own', 'multimedia.add_edit_any', 'multimedia.delete',
+                'imports.view_own', 'imports.view_all', 'imports.run',
+                'exports.view_own', 'exports.view_all', 'exports.run',
+                'workflow.view', 'workflow.approve_reject',
+                'agent.bulk_actions',
+                'audit.view_own',
+                'api_tokens.own.crud',
+            ],
+
+            // Marketing — view/add/edit products (NO delete), categories CRU, own multimedia, view-only audit
+            'marketing' => [
+                'products.view', 'products.add', 'products.edit', 'products.bulk_operations',
+                'categories.view', 'categories.add_edit',
+                'multimedia.view', 'multimedia.add_edit_own',
+                'exports.view_own', 'exports.run',
+                'imports.view_own', 'imports.run',
+                'workflow.view',
+                'agent.bulk_actions',
+                'audit.view_own',
+                'api_tokens.own.crud',
+            ],
+
+            // Modeler — full modeling, view rest
+            'modeler' => [
+                'modeling.view', 'modeling.attributes.add_edit', 'modeling.attribute_groups.add_edit',
+                'modeling.object_types.add', 'modeling.delete_custom', 'modeling.approve_schema_ops',
+                'modeling.auto_grant_new_object_types',
+                'products.view', 'categories.view', 'multimedia.view',
+                'agent.schema_ops', 'agent.approve_pending',
+                'audit.view_own',
+                'api_tokens.own.crud',
+            ],
+
+            // Integration Manager — integrations + tokens + imports + publish
+            'integration_manager' => [
+                'settings.integrations.manage', 'settings.integration_secrets.read',
+                'imports.view_own', 'imports.view_all', 'imports.run',
+                'publications.view', 'publications.publish_unpublish',
+                'products.view',
+                'api_tokens.own.crud', 'api_tokens.all.view_revoke',
+                'audit.view_own',
+            ],
+
+            // Channel Manager — publish + view/edit catalog scoped to channel
+            'channel_manager' => [
+                'publications.view', 'publications.publish_unpublish',
+                'products.view', 'products.edit',
+                'categories.view', 'multimedia.view',
+                'exports.view_own', 'exports.run',
+                'audit.view_own',
+                'api_tokens.own.crud',
+            ],
+
+            // Approver — view + approve workflow / pending changes
+            'approver' => [
+                'products.view', 'products.approve_pending_changes',
+                'modeling.view', 'modeling.approve_schema_ops',
+                'agent.approve_pending',
+                'workflow.view', 'workflow.approve_reject',
+                'audit.view_own', 'audit.view_cross_user',
+                'api_tokens.own.crud',
+            ],
+
+            // Viewer — read-only everywhere
+            'viewer' => [
+                'products.view', 'categories.view', 'multimedia.view',
+                'modeling.view', 'publications.view',
+                'imports.view_own', 'exports.view_own',
+                'workflow.view',
+                'audit.view_own', 'audit.view_cross_user',
+                'api_tokens.own.crud',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Identity/Presentation/Command/SeedTenantPrdRolesCommand.php
+++ b/apps/api/src/Identity/Presentation/Command/SeedTenantPrdRolesCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Command;
+
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Rbac\PrdRoleTemplates;
+use App\Identity\Domain\Repository\PermissionRepositoryInterface;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * RBAC-P1-007 (#646) — seed the 8 PRD-PIM-rbac §3.2 tenant-level role
+ * templates (tenant_owner / admin / catalog_manager / marketing / modeler /
+ * integration_manager / channel_manager / approver / viewer) into a target
+ * tenant.
+ *
+ * Run after Phase 1 deploy for each existing tenant; Phase 2 wires a
+ * Doctrine `OnTenantCreatedListener` (#653 territory) that invokes this
+ * service automatically for every new tenant.
+ *
+ * Idempotent: existing rows matched by (tenant_id, code) are kept; the
+ * command only fills the gap. Permission attachments are diffed — if a
+ * role gains a new permission via a PRD update, re-run picks it up.
+ */
+#[AsCommand(
+    name: 'cortex:tenant:seed-roles',
+    description: 'Seed the 8 PRD-PIM-rbac §3.2 tenant-level role templates for a target tenant',
+)]
+final class SeedTenantPrdRolesCommand extends Command
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly RoleRepositoryInterface $roleRepository,
+        private readonly PermissionRepositoryInterface $permissionRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('tenant-id', InputArgument::REQUIRED, 'UUID of the tenant to seed roles for');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        /** @var string $tenantId */
+        $tenantId = $input->getArgument('tenant-id');
+
+        $tenant = $this->em->find(Tenant::class, $tenantId);
+        if (!$tenant instanceof Tenant) {
+            $io->error(\sprintf('Tenant %s not found.', $tenantId));
+
+            return Command::FAILURE;
+        }
+
+        $io->title(\sprintf('Seeding PRD role templates for tenant %s (%s)', $tenant->getCode(), $tenantId));
+
+        $rolePermissions = PrdRoleTemplates::tenantRolePermissions();
+        $roleNames = PrdRoleTemplates::tenantRoleNames();
+
+        $created = 0;
+        $updated = 0;
+        $missingPermissions = [];
+
+        foreach ($rolePermissions as $code => $permissionCodes) {
+            $role = $this->roleRepository->findByCode($code, $tenant);
+            if (null === $role) {
+                $role = new Role(
+                    code: $code,
+                    name: $roleNames[$code],
+                    tenant: $tenant,
+                );
+                $this->em->persist($role);
+                ++$created;
+            } else {
+                ++$updated;
+            }
+
+            $existingPermissionCodes = [];
+            foreach ($role->getPermissions() as $existing) {
+                $existingPermissionCodes[] = $existing->getCode();
+            }
+
+            foreach ($permissionCodes as $permissionCode) {
+                if (\in_array($permissionCode, $existingPermissionCodes, true)) {
+                    continue;
+                }
+                $permission = $this->permissionRepository->findByCode($permissionCode);
+                if (null === $permission) {
+                    $missingPermissions[] = $permissionCode;
+                    continue;
+                }
+                $role->getPermissions()->add($permission);
+            }
+        }
+
+        if ([] !== $missingPermissions) {
+            $io->warning(\sprintf(
+                'Skipped %d permission(s) not found in DB (run PrdPermissionFixtures first): %s',
+                \count($missingPermissions),
+                implode(', ', array_unique($missingPermissions)),
+            ));
+        }
+
+        $this->em->flush();
+
+        $io->success(\sprintf(
+            'Done. Roles created: %d, updated: %d, permissions skipped: %d.',
+            $created,
+            $updated,
+            \count($missingPermissions),
+        ));
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
Closes #646. `PrdRoleTemplates` declarative source of truth + `cortex:tenant:seed-roles` CLI command. Idempotent.

## Roles seeded (tenant-level, 9 templates per macierz §3.2)

| Code | Name | Permissions |
|---|---|---|
| tenant_owner | Tenant Owner | 45 (every tenant perm + tenant.delete) |
| admin | Administrator | 43 (everything except tenant.delete + billing) |
| catalog_manager | Catalog Manager | 23 |
| marketing | Content Editor (Marketing) | 16 |
| modeler | Information Architect (Modeler) | 14 |
| integration_manager | Integration Manager | 11 |
| channel_manager | Channel Manager | 10 |
| approver | Approver | 10 |
| viewer | Viewer | 11 |

Verified on dev DB (tenant=`demo`): `SELECT r.code, COUNT(rp.permission_id) FROM roles r LEFT JOIN role_permissions rp ON r.id=rp.role_id WHERE r.tenant_id='…demo…' GROUP BY r.code` → counts above.

## Świadome odejścia

- **`is_system` / `is_unique` / `auto_grant_new_object_types` flags** from PRD §4.3 NOT modelled on Role entity today. Adding them is a schema migration; for Phase 1 the immutability comes from the CLI command being the only path to create these rows (UI in Phase 5 #695-#697 is where the flags become user-visible).
- **Field-level restrictions** (e.g. Marketing hides price.*) NOT applied here — they live in `role_attribute_permissions` (#644 schema, Phase 3 #671 enforcement).
- **SuperAdmin role NOT seeded by this command** — the SuperAdmin entity sits outside the tenant boundary; the global seed is a separate one-time op (Phase 2 #650 wires it).
- **`OnTenantCreatedListener` deferred to Phase 2** — today CLI is the manual entry point for each existing tenant.

## Acceptance criteria (per #646)

- [ ] AC-1: SuperAdminRoleFixtures — DEFERRED to Phase 2 #650
- [x] AC-2: 8 tenant templates + Viewer = 9 templates with PRD-correct permission counts
- [x] AC-3: `cortex:tenant:seed-roles {tenant_id}` works (verified on demo)
- [ ] AC-4: `is_system`, `is_unique`, `auto_grant_new_object_types` flags — DEFERRED (entity schema migration out of scope)
- [x] AC-5: PRD macierz 1:1 mapping documented in `PrdRoleTemplates::tenantRolePermissions()` arrays
- [x] AC-6: Idempotent (existing rows kept; permissions diffed; verified by re-run)
- [x] AC-7: Cross-tenant scoped — `findByCode($code, $tenant)` filters by tenant in lookup
- [ ] AC-8: RoleTemplatesMatrixTest — DEFERRED (tests/Integration/Identity/ KernelTestCase known issue from #770/#771)

## Test plan

- [ ] CI green (PHPStan, Deptrac, PHPUnit existing tests)
- [x] Manual smoke: `docker compose exec api bin/console cortex:tenant:seed-roles $DEMO_TENANT` → 9 roles created, 0 missing permissions
- [x] Idempotent re-run: 9 updated, 0 created, 0 missing

Closes #646
Refs #645 (PrdPermissionFixtures supplies the 49 codes consumed here)
Refs #650 #653 #671