### PR TITLE
fix(deps): update pnpm-lock for slate-react 0.124.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,7 +91,7 @@ importers:
         version: 49.0.0(@udecode/plate@49.0.0(@types/react@19.2.14)(immer@10.2.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)(use-sync-external-store@1.6.0(react@19.2.5)))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@udecode/plate-serializer-html':
         specifier: ^21.5.1
-        version: 21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-hyperscript@0.100.0(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+        version: 21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-hyperscript@0.100.0(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -138,8 +138,8 @@ importers:
         specifier: ^0.100.0
         version: 0.100.0(slate@0.124.1)
       slate-react:
-        specifier: ^0.124.0
-        version: 0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+        specifier: ^0.124.2
+        version: 0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -2123,8 +2123,8 @@ packages:
       slate: '>=0.114.0'
       slate-dom: '>=0.110.2'
 
-  slate-react@0.124.0:
-    resolution: {integrity: sha512-NLN6ME64ChOgJtiVTKwISS1sI/Y8/qN1cwmDTZM9AQJCl+jR3XNCvDsKNrW0kJU+1G3NgIGaYoVWhgIVEIL+Aw==}
+  slate-react@0.124.2:
+    resolution: {integrity: sha512-2B6ZZX5qKYeISNaQ9cDuvvp0tWydnHUPuGxyVJZfjD+W00X34dGaAF/5ZyVMZt/O//sf0Glbgd7+NBHRWjiA7Q==}
     peerDependencies:
       react: '>=18.2.0'
       react-dom: '>=18.2.0'
@@ -3235,19 +3235,19 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@udecode/plate-common@21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
+  '@udecode/plate-common@21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
     dependencies:
-      '@udecode/plate-core': 21.5.1(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
-      '@udecode/plate-utils': 21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+      '@udecode/plate-core': 21.5.1(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+      '@udecode/plate-utils': 21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
       '@udecode/slate': 21.4.1(slate-history@0.113.1(slate@0.124.1))(slate@0.124.1)
-      '@udecode/slate-react': 21.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+      '@udecode/slate-react': 21.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
       '@udecode/slate-utils': 21.4.1(slate-history@0.113.1(slate@0.124.1))(slate@0.124.1)
       '@udecode/utils': 19.7.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       slate: 0.124.1
       slate-history: 0.113.1(slate@0.124.1)
-      slate-react: 0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+      slate-react: 0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3264,10 +3264,10 @@ snapshots:
       - react-native
       - scheduler
 
-  '@udecode/plate-core@21.5.1(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
+  '@udecode/plate-core@21.5.1(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
     dependencies:
       '@udecode/slate': 21.4.1(slate-history@0.113.1(slate@0.124.1))(slate@0.124.1)
-      '@udecode/slate-react': 21.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+      '@udecode/slate-react': 21.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
       '@udecode/utils': 19.7.1
       '@udecode/zustood': 1.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(zustand@3.7.2(react@19.2.5))
       clsx: 1.2.1
@@ -3279,7 +3279,7 @@ snapshots:
       react-hotkeys-hook: 4.6.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       slate: 0.124.1
       slate-history: 0.113.1(slate@0.124.1)
-      slate-react: 0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+      slate-react: 0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
       use-deep-compare: 1.3.0(react@19.2.5)
       zustand: 3.7.2(react@19.2.5)
     transitivePeerDependencies:
@@ -3363,16 +3363,16 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@udecode/plate-serializer-html@21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-hyperscript@0.100.0(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
+  '@udecode/plate-serializer-html@21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-hyperscript@0.100.0(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
     dependencies:
-      '@udecode/plate-common': 21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+      '@udecode/plate-common': 21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
       html-entities: 2.6.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       slate: 0.124.1
       slate-history: 0.113.1(slate@0.124.1)
       slate-hyperscript: 0.100.0(slate@0.124.1)
-      slate-react: 0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+      slate-react: 0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3389,19 +3389,19 @@ snapshots:
       - react-native
       - scheduler
 
-  '@udecode/plate-utils@21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
+  '@udecode/plate-utils@21.5.1(@types/react@19.2.14)(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.5)
-      '@udecode/plate-core': 21.5.1(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+      '@udecode/plate-core': 21.5.1(jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.14)(react@19.2.5))(optics-ts@2.4.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(scheduler@0.27.0)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
       '@udecode/slate': 21.4.1(slate-history@0.113.1(slate@0.124.1))(slate@0.124.1)
-      '@udecode/slate-react': 21.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
+      '@udecode/slate-react': 21.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)
       '@udecode/slate-utils': 21.4.1(slate-history@0.113.1(slate@0.124.1))(slate@0.124.1)
       '@udecode/utils': 19.7.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       slate: 0.124.1
       slate-history: 0.113.1(slate@0.124.1)
-      slate-react: 0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+      slate-react: 0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -3471,7 +3471,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@udecode/slate-react@21.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
+  '@udecode/slate-react@21.4.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-history@0.113.1(slate@0.124.1))(slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1))(slate@0.124.1)':
     dependencies:
       '@udecode/slate': 21.4.1(slate-history@0.113.1(slate@0.124.1))(slate@0.124.1)
       '@udecode/utils': 19.7.1
@@ -3479,7 +3479,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       slate: 0.124.1
       slate-history: 0.113.1(slate@0.124.1)
-      slate-react: 0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
+      slate-react: 0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)
 
   '@udecode/slate-utils@21.4.1(slate-history@0.113.1(slate@0.124.1))(slate@0.124.1)':
     dependencies:
@@ -4244,7 +4244,7 @@ snapshots:
       slate-dom: 0.124.1(slate@0.124.1)
       tiny-invariant: 1.3.1
 
-  slate-react@0.124.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1):
+  slate-react@0.124.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1):
     dependencies:
       '@juggle/resize-observer': 3.4.0
       direction: 1.0.4


### PR DESCRIPTION
PR #764 (slate-react Dependabot bump) merged with a stale lockfile — Playwright CI fails on every PR since with `ERR_PNPM_OUTDATED_LOCKFILE`. This regenerates the lockfile.

Unblocks the 5 RBAC Phase 1 PRs currently in flight (#770, #771, #772, #773, #774).

Refs #764