### PR TITLE
chore(rbac): Phase 2 marathon status (9/14 done) + lessons learned

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,58 @@
 # Current Status
 
+## 2026-05-18 (cd.): ⚡ Phase 2 RBAC marathon — 9/14 merged + 5 plans posted
+
+**Sub-faza:** MVP-Alpha, epik 0.X Identity & RBAC, **Phase 2 (Backend Auth)** w toku. Milestone [#10](../../milestone/10) — 9/14 done w jednej sesji marathon po Phase 1 close.
+
+**Phase 2 — co zrobione:**
+
+| Ticket | Issue | PR | Status | Co dostarczone |
+|---|---|---|---|---|
+| RBAC-P2-001 Lexik JWT | #650 | — | ✅ Closed-as-DONE | Brownfield audit: bundle JUŻ registered + JWT keypair + lexik_jwt_authentication.yaml + login firewall + RefreshTokenController + LoginSuccessHandler. Świadome odejście: klucze NIE w Symfony Secrets Vault — pozostaje passphrase + env vars (Phase 7 #724 pentest prep). |
+| RBAC-P2-002 email+password | #651 | — | ✅ Closed-as-DONE | json_login authenticator + rate limiter (5/15min) + AuthenticationFailureListener. Świadome odejście: User.failed_login_attempts column → Phase 5 #694. |
+| RBAC-P2-003 ApiToken auth | #652 | [#778](../../pull/778) | ✅ Merged | RbacApiTokenAuthenticator + RbacApiTokenUser. Header `Authorization: Token cortex_<tenant>_<random32>`. SHA-256 hash lookup. Świadome odejście: POST /api/api-tokens endpoint → Phase 5 #699/#700. |
+| RBAC-P2-004 TenantContext + TenantFilter | #653 | — | ✅ Closed-as-DONE | Brownfield audit: TenantContext + CurrentTenantProvider + TenantFilter + TenantFilterConfigurator + TenantContextRebindingMiddleware JUŻ istnieją. AC-3 (Super Admin bypass) → Phase 3 #677. |
+| RBAC-P2-005 Postgres RLS | #654 | [#779](../../pull/779) | ✅ Merged | Version20260518170000: RLS enabled na 5 RBAC tabelach (api_tokens, invitations, user_role_assignments, user_tenant_memberships, audit_logs) + tenant_isolation + super_admin_bypass policies + RlsContextListener. **Bundled hotfix**: P1-005 #771 GIN-on-json mismatch — special_flags ALTER do jsonb (was deterministic Playwright fail on every Phase 2 PR). |
+| RBAC-P2-006 PermissionResolver | #655 | [#777](../../pull/777) | ✅ Merged | PermissionSet VO + PermissionResolver service (single JOIN query). pim.permissions_cache TagAware pool (5min TTL). Świadome odejścia: PermissionInvalidationListener → Phase 3 #664, Mercure publish → Phase 4 #687, benchmark → Phase 6 #720. |
+| RBAC-P2-007 /api/me | #656 | — | ✅ Closed-as-DONE | Brownfield audit: MeController + firewall. Świadome odejście: permissions list w response → Phase 3 #664 (after PermissionResolver wire). |
+| RBAC-P2-008 Magic link invite | #657 | — | 🟡 Plan posted | Task-level plan w komencie issue. ~4-5h impl. Invitation entity + repo gotowe z P1-008. |
+| RBAC-P2-009 Password reset | #658 | — | 🟡 Plan posted | Task-level plan w komencie issue. ~3-4h impl, mirror pattern z #657. |
+| RBAC-P2-010 MFA email TOTP | #659 | — | ✅ Closed-as-DONE | Brownfield audit: TotpEnrolmentService + TwoFactorController + spomky-labs/otphp + User.totpBackupCodes JUŻ shipped. RFC 6238 standard. |
+| RBAC-P2-011 MFA Google Authenticator | #660 | — | ✅ Closed-as-DONE | Same implementation jak #659 — RFC 6238 TOTP secret compatible z Google Authenticator (no separate code needed). |
+| RBAC-P2-012/013/014 SSO Google/MS/SAML | #661 #662 #663 | — | 🟡 Plans posted | Comprehensive task-level plan posted on each (shared substrate + per-provider sections). ~18-26h total — dedicated session(s). SsoProvider entity DEFERRED z P1-008 ląduje tutaj. Library choices: league/oauth2-google, stevenmaguire/oauth2-microsoft, onelogin/php-saml. |
+
+**Bonus deliverables w sesji:**
+- **GIN-on-json hotfix** (P1-005 audit_logs.special_flags) — bundled w #779. Unblocks Playwright CI deterministically (was failing every Phase 2 PR).
+- **Stale ignoreErrors cleanup attempt** — initially dropped Import/Domain/Entity/* paths w #777, then RESTORED after CI fail revealed they were active patterns (local PHPStan cache had stale state).
+- **Dropping stale Import paths bonus** — applied to all 3 merged Phase 2 PRs.
+
+**Krytyczne odkrycia (przez background-agent triage 31 Dependabot PR-ów):**
+- **GIN-on-json deterministic Playwright fail** — opisane wyżej + naprawione w #779
+- **2 actual PHPStan errors w MAIN** — wykryte przez phpstan 2.1.55+ (current pin 2.1.51): `TenantAuditCommand.php:189` (`'OK' === 'OK'` tautology) + `tests/Integration/Identity/ByokKeyManagerTest.php:99` (nullsafe na non-nullable TenantAgentConfig). Worth follow-up lint-fix ticket przed PHPStan bump.
+- **Symfony 7.4 LTS pin violations** w 3 Dependabot patches (#750 api-platform/symfony, #744 api-platform/doctrine-orm, #742 doctrine/orm) — transitively pulled Symfony 8.x major. Composer.json potrzebuje constraint `"symfony/*": "~7.4"` lub Dependabot `ignore` rule. **Worth follow-up infra ticket.**
+- **Pnpm workspace lockfile bug** — Dependabot updates apps/admin/package.json but root pnpm-lock.yaml nie regeneruje. 4 Dependabot patches stuck (#762, #761, #760, #755). Either `versioning-strategy: increase-if-necessary` w dependabot.yml, lub manual pnpm install push.
+
+**Background agent (Dependabot triage) wynik:**
+- 5 patches merged (#751 symfony/mime, #747 symfony/console, #749 symfony/serializer, #756 vite, #739 symfony/rate-limiter)
+- 11 minor/major labelled needs-manual-review
+- 9 patches reclassified do needs-manual-review (real CI failures, nie flake)
+- 7 GitHub Actions majors skipped per instructions
+
+**Phase 2 metrics:**
+- 9/14 tickets DONE (64%)
+- 5/14 deferred z comprehensive task-level plans (#657, #658, #661, #662, #663)
+- 3 PR-y zmergeowane (#777, #778, #779)
+- 1 hotfix bundled (#779 GIN→jsonb)
+- 0 nowych regression (Playwright fix unblocks future CI)
+
+**Następny krok:** **Phase 3 (Permission Engine)** — milestone [#11](../../milestone/11), 14 ticketów #664-#677, ~80-100h. PermissionResolver (#777) i RbacApiTokenAuthenticator (#778) gotowe substraty. Pierwsze cascade-ready: #664 (#[RequiresPermission] guard + listener), #665 (ProductVoter), #671 (3-state attribute permissions enforcement).
+
+**Phase 2 reszta:** #657 (magic link, ~4-5h) + #658 (password reset, ~3-4h) + #661/#662/#663 (SSO, ~18-26h total) — dedicated session(s).
+
+**Aktywne blokery:** brak.
+
+---
+
 ## 2026-05-18: 🏁 Phase 1 RBAC ZAMKNIĘTY — 10/10 ticketów merged (single-session marathon)
 
 **Sub-faza:** MVP-Alpha, **epik 0.X Identity & RBAC** (ADR-013, milestones [#9](../../milestone/9)..[#15](../../milestone/15), 89 ticketów, ~330-445h). **Phase 1 (Foundation) DONE.**

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,49 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z RBAC Phase 2 marathon (9/14 done + 5 plans — 2026-05-18 cd. same day)
+
+### Patterns to Follow
+
+1. **Brownfield close-as-DONE pattern dla pre-existing infra** — Phase 2 miał 6 ticketów których scope już shipped pre-RBAC (Sprint-0 + epic 0.X early work). Wzór: audit existing files, post audit comment z 1:1 mapping table (Wymaganie → Status → Plik), close issue. 6× w Phase 2 (#650, #651, #653, #656, #659, #660). Total time savings: ~30-40h vs naive re-implementation.
+
+2. **Background-agent triage for cross-cutting concerns** — Dependabot's 31-PR backlog was a distraction from RBAC marathon. Spawn parallel general-purpose agent z explicit narrow scope ("triage Dependabot PRs ONLY, do not touch feat/rbac-*"). Agent reported 5 merged + 11 needs-review + 9 real-CI-fails reclassified + 7 skipped, plus surfaced 3 high-value findings I'd have missed (GIN/json mismatch, 2 PHPStan errors in main, Symfony 7.4 LTS pin violations). Wzór: when triage volume blocks main work, delegate to agent with strict scope boundaries.
+
+3. **Bundle hotfix w naturalnym sąsiadującym migration** — P1-005 GIN-on-json bug found by background agent. Bundling fix w #779 RLS migration (same Phase 2 work, same transaction window) zamiast osobny hotfix PR = atomic rollout + reduces commit noise. Wzór: when fixing a stale bug, prefer bundling z related ongoing work over standalone PR.
+
+4. **`gh issue comment --body-file /tmp/x.md`** dla multi-line plans z Polish special chars — zsh globbing breaks `--body "$(cat <<EOF...)"` z markdown bullets + `*` glyphs + Polish quotes. Write plan to /tmp file first, pass --body-file. Pattern: always use --body-file for posts >10 lines.
+
+### Patterns to Avoid
+
+1. **NIE usuwaj ignoreErrors paths bez testowania w fresh-cache CI** — `reportUnmatchedIgnoredErrors: true` flagged Import/Domain/Entity paths as "stale". Locally PHPStan said "no errors" (cached state). CI z fresh cache: 6 errors fired. Lesson: PHPStan cache locally != fresh CI run. Test via `docker compose exec api composer phpstan -- --no-cache` before assuming ignore is stale. Reverted w follow-up commit on each PR.
+
+2. **NIE używaj Doctrine `JSON` type gdy potrzebujesz GIN index** — Doctrine `json` maps to Postgres `json` column type. Postgres `json` does NOT support GIN; `jsonb` does. P1-005 migration created GIN on `json` column — succeeded under permissive `doctrine:schema:update`, failed under strict `doctrine:migrations:migrate` (Playwright). Lesson: any column queried via GIN MUST be raw `JSONB NOT NULL` w migration SQL (not Doctrine `json` type). Bundled hotfix w #779 (P2-005).
+
+3. **NIE rozdrabniaj substantive new services na rushed implementations w marathon tail** — Magic link / password reset / SSO are 5-30h chunks. Plowing through them at session end leads to half-baked quality. Wzór: post comprehensive task-level plan comment, mark as "deferred to focused session", move on. Phase 2 tail: 5 plans posted on #657/#658/#661/#662/#663 — clean handoff without compromised code.
+
+### Toolchain quirks
+
+1. **`gh issue comment` z Polish quotes (`„"`) crashes zsh globbing** — use `--body-file` z temp file. Affects every multi-line Polish-language comment.
+
+2. **Dependabot lockfile bug** — root pnpm-lock.yaml does NOT auto-regenerate when Dependabot updates apps/admin/package.json (workspaces config). 4 Dependabot patches stuck in "lockfile out of sync" state requiring manual `pnpm install --filter @pim/admin --lockfile-only` push. **Configuration fix**: investigate dependabot.yml `versioning-strategy: increase-if-necessary` or set root manifest.
+
+3. **Doctrine `JSON` vs `JSONB`** — Doctrine 3.x `type="json"` maps to Postgres `json` (not `jsonb`). Use `<field name="x" type="json"/>` in XML for entity mapping but explicit `JSONB` in migration SQL. Mismatch fails on operations requiring jsonb (GIN, `@>` operator, jsonb_set).
+
+### Decyzje świadome (per ticket Phase 2)
+
+- **P2-001 #650** (Lexik JWT): closed-as-DONE. Świadome: JWT keys w passphrase + env vars zamiast Symfony Secrets Vault — Phase 7 #724 pentest prep handles vault migration.
+- **P2-002 #651** (email+password): closed-as-DONE. Świadome: User.failed_login_attempts column → Phase 5 #694 (deactivate/reactivate user flow handles lockout column).
+- **P2-003 #652** (ApiToken auth): merged via #778. Świadome: POST /api/api-tokens endpoint → Phase 5 #699/#700 (Settings UI). Async last_used_at via Messenger → Phase 6 #720 (after profiling shows >5ms overhead).
+- **P2-004 #653** (TenantContext + TenantFilter): closed-as-DONE. Świadome: Super Admin bypass mode → Phase 3 #677 break-glass.
+- **P2-005 #654** (Postgres RLS): merged via #779. Świadome: RLS rollout to 30+ remaining tenant-scoped tables → Phase 6 #720. Performance benchmark → Phase 6 #720. Bundled hotfix dla #771 GIN/json mismatch.
+- **P2-006 #655** (PermissionResolver): merged via #777. Świadome: PermissionInvalidationListener → Phase 3 #664. Mercure publish → Phase 4 #687. Benchmark → Phase 6 #720.
+- **P2-007 #656** (/api/me): closed-as-DONE. Świadome: permissions list w response → Phase 3 #664 (po PermissionResolver wire). attribute_restrictions → Phase 3 #671.
+- **P2-008 #657** (Magic link): plan-only. ~4-5h impl deferred.
+- **P2-009 #658** (Password reset): plan-only. ~3-4h impl deferred, mirror #657.
+- **P2-010 #659** (MFA email TOTP): closed-as-DONE. RFC 6238 via spomky-labs/otphp + TotpEnrolmentService już shipped.
+- **P2-011 #660** (MFA Google Authenticator): closed-as-DONE. Same RFC 6238 implementation jak #659; Google Authenticator jest klientem standardu, nie wymaga separate code.
+- **P2-012/013/014 #661/#662/#663** (SSO Google/MS/SAML): plan-only. ~18-26h total, dedicated session. SsoProvider entity DEFERRED z P1-008 ląduje tutaj. Library choices: league/oauth2-google, stevenmaguire/oauth2-microsoft, onelogin/php-saml.
+
 ## Lessons z RBAC Phase 1 FULL marathon (10/10 — 2026-05-18 single session)
 
 ### Patterns to Follow


### PR DESCRIPTION
Phase 2 Backend Auth — 9/14 ticketów closed w jednej sesji marathon.

## Summary

- **6 closed-as-DONE via brownfield audit**: Lexik JWT (#650), email+password (#651), TenantContext+TenantFilter (#653), /api/me (#656), MFA email TOTP (#659), MFA Google Auth (#660). Wszystkie miały scope shipped pre-RBAC w Sprint-0/epic 0.X early work.
- **3 implementation merged**: #777 PermissionResolver + PermissionSet, #778 RbacApiTokenAuthenticator, #779 Postgres RLS + audit_logs GIN/json hotfix
- **5 deferred z task-level plans** (posted on each issue): #657 magic link (~4-5h), #658 password reset (~3-4h), #661/#662/#663 SSO (~18-26h total)

## Background-agent results (Dependabot triage)

- 5 patches merged
- 11 minor/major labelled `needs-manual-review`
- 9 reclassified (real CI fails, nie flake)
- 7 skipped (GitHub Actions majors)
- **3 high-value findings surfaced**:
  1. GIN-on-json bug (P1-005 audit_logs) — fixed in #779 bundled hotfix
  2. 2 actual PHPStan errors in main (caught by 2.1.55+; current pin 2.1.51): TenantAuditCommand:189 + ByokKeyManagerTest:99
  3. Symfony 7.4 LTS pin violations w 3 Dependabot composer patches

## Phase 3 ready

Milestone #11, 14 ticketów (#664-#677), ~80-100h. PermissionResolver + RbacApiTokenAuthenticator gotowe substraty dla Voters + endpoint guards.

Refs Phase 2 tickets (#650-#663)