### PR TITLE
fix(lint): unblock Dependabot phpstan 2.1.55 bump (2 pre-existing errors)

### DIFF
--- a/apps/api/config/reference.php
+++ b/apps/api/config/reference.php
@@ -1859,8 +1859,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type MercureConfig = array{
  *     hubs?: array<string, array{ // Default: []
- *         url?: scalar|Param|null, // URL of the hub's publish endpoint
- *         public_url?: scalar|Param|null, // URL of the hub's public endpoint // Default: null
+ *         url?: scalar|Param|null, // URL of the hub's publish endpoint // Default: null
+ *         public_url?: scalar|Param|null, // URL of the hub's public endpoint
  *         jwt?: string|array{ // JSON Web Token configuration.
  *             value?: scalar|Param|null, // JSON Web Token to use to publish to this hub.
  *             provider?: scalar|Param|null, // The ID of a service to call to provide the JSON Web Token.

--- a/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
@@ -180,15 +180,17 @@ final class TenantAuditCommand extends Command
             $hasIndex = $this->columnHasIndex($table, 'tenant_id');
             $indexSeverity = $hasIndex ? self::SEVERITY_OK : self::SEVERITY_WARN;
 
-            $worst = self::SEVERITY_OK;
-            foreach ([$nullableSeverity, $indexSeverity] as $candidate) {
-                if (self::SEVERITY_FAIL === $candidate) {
-                    $worst = self::SEVERITY_FAIL;
-                    break;
-                }
-                if (self::SEVERITY_WARN === $candidate && self::SEVERITY_OK === $worst) {
-                    $worst = self::SEVERITY_WARN;
-                }
+            // Worst severity from the two candidate checks. PHPStan
+            // narrows $nullableSeverity to 'OK'|'FAIL' (line ~165) and
+            // $indexSeverity to 'OK'|'WARN' (line ~181), so we only test
+            // the values each variable can actually hold. FAIL beats
+            // WARN beats OK.
+            if (self::SEVERITY_FAIL === $nullableSeverity) {
+                $worst = self::SEVERITY_FAIL;
+            } elseif (self::SEVERITY_WARN === $indexSeverity) {
+                $worst = self::SEVERITY_WARN;
+            } else {
+                $worst = self::SEVERITY_OK;
             }
 
             $rows[] = [

--- a/apps/api/tests/Integration/Identity/ByokKeyManagerTest.php
+++ b/apps/api/tests/Integration/Identity/ByokKeyManagerTest.php
@@ -96,7 +96,9 @@ final class ByokKeyManagerTest extends KernelTestCase
         \assert(\is_string($first));
 
         $manager->setKey($tenant, 'sk-ant-rotated-key');
-        $second = $this->repo()->findForTenant($tenant)?->getAnthropicApiKeyEncrypted();
+        $config = $this->repo()->findForTenant($tenant);
+        \assert(null !== $config);
+        $second = $config->getAnthropicApiKeyEncrypted();
 
         self::assertNotSame($first, $second, 'Ciphertext must change on rotation.');
         self::assertSame('sk-ant-rotated-key', $manager->resolveKey($tenant));


### PR DESCRIPTION
Background-agent Dependabot triage surfaced 2 actual PHPStan errors in main that current pin (2.1.51) misses, but 2.1.55+ catches. Fix both so PRs #740 / #743 (phpstan + phpstan-strict-rules bumps) can finally merge.

## Fixes

1. **`TenantAuditCommand.php:189`** — refactor loop-based 'worst severity' computation to flat if/elif using each variable's actual narrowed type (`$nullableSeverity` is OK|FAIL, `$indexSeverity` is OK|WARN). No behaviour change.
2. **`ByokKeyManagerTest.php:99`** — replace nullsafe `?->` with explicit `\assert(null !== $config)` + `->` access. The row was just persisted; nullsafe was dead code.

## Test plan
- [x] PHPStan max passes locally (no errors)
- [ ] CI green
- [ ] After merge: Dependabot PRs #740 + #743 can merge

Refs #740 #743