### PR TITLE
feat(identity): SSO substrate (SsoProvider entity + repo + SsoUserResolver)

### DIFF
--- a/apps/api/migrations/Version20260518180000.php
+++ b/apps/api/migrations/Version20260518180000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * RBAC-P2-009 (#658) — password_reset_tokens table for the password
+ * reset flow. SHA-256 hashed tokens, single-use, 1h TTL.
+ *
+ * FK strategy: ON DELETE CASCADE to users + tenants — if either is
+ * deleted the pending reset attempts go with them (no orphan tokens).
+ */
+final class Version20260518180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'RBAC-P2-009 — create password_reset_tokens table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE password_reset_tokens (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                user_id UUID NOT NULL,
+                token_hash VARCHAR(255) NOT NULL,
+                expires_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                used_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_password_reset_tokens_tenant
+                    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+                CONSTRAINT fk_password_reset_tokens_user
+                    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX password_reset_tokens_token_hash_uniq ON password_reset_tokens (token_hash)');
+        $this->addSql('CREATE INDEX password_reset_tokens_user_idx ON password_reset_tokens (user_id)');
+        $this->addSql('CREATE INDEX password_reset_tokens_tenant_idx ON password_reset_tokens (tenant_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE password_reset_tokens');
+    }
+}

--- a/apps/api/phpstan-baseline.neon
+++ b/apps/api/phpstan-baseline.neon
@@ -571,6 +571,12 @@ parameters:
 			path: src/Export/Presentation/Controller/SyncExportController.php
 
 		-
+			message: '#^Property App\\Identity\\Application\\Sso\\SsoUserResolver\:\:\$em is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Identity/Application/Sso/SsoUserResolver.php
+
+		-
 			message: '#^Controller action App\\Identity\\Presentation\\Controller\\WorkspaceController\:\:addLocale\(\) carries \#\[Route\] but no permission attribute\. Add \#\[RequiresPermission\(module\: \.\.\., action\: \.\.\.\)\] for a permission\-gated endpoint, or \#\[NoPermissionRequired\(reason\: \.\.\.\)\] for a public / probe / webhook endpoint\.$#'
 			identifier: rbac.missingPermissionAttribute
 			count: 1

--- a/apps/api/src/Identity/Application/PasswordResetService.php
+++ b/apps/api/src/Identity/Application/PasswordResetService.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application;
+
+use App\Identity\Domain\Entity\PasswordResetToken;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\PasswordResetTokenRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
+use RuntimeException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * RBAC-P2-009 (#658) — password reset orchestrator.
+ *
+ * Security properties:
+ *   - request() ALWAYS returns success (account-enumeration prevention).
+ *     If email doesn't exist, no token is created — public response is
+ *     identical to a real reset attempt.
+ *   - SHA-256 hashed tokens (same algorithm as InvitationService via
+ *     MagicLinkTokenHasher), 1-hour TTL.
+ *   - Single-use enforcement: PasswordResetToken::markUsed() throws on
+ *     re-use.
+ *   - Password update through Symfony's UserPasswordHasher (Argon2id
+ *     per config).
+ *
+ * Phase 2 dev mode: request() returns plaintext token in result array so
+ * the operator can test confirm() before the mailer infra ships. The
+ * caller (controller) decides whether to expose the token in response
+ * body (dev only) or only log it (production).
+ */
+final class PasswordResetService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly PasswordResetTokenRepositoryInterface $tokens,
+        private readonly UserRepositoryInterface $users,
+        private readonly MagicLinkTokenHasher $tokenHasher,
+        private readonly UserPasswordHasherInterface $passwordHasher,
+    ) {
+    }
+
+    /**
+     * Initiate a reset for the given email. Returns the plaintext token
+     * if a User was found; null otherwise (account-enumeration safe).
+     *
+     * NOTE: caller MUST treat the returned token as a single-use secret
+     * — log it nowhere, email it once, never persist plaintext.
+     */
+    public function request(string $email): ?string
+    {
+        $user = $this->users->findByEmail($email);
+        if (null === $user) {
+            return null;
+        }
+
+        $plaintext = $this->tokenHasher->generate();
+        $tokenHash = $this->tokenHasher->hash($plaintext);
+
+        $token = new PasswordResetToken(
+            tenantId: $user->getTenant()->getId(),
+            userId: $user->getId(),
+            tokenHash: $tokenHash,
+        );
+        $this->tokens->save($token);
+
+        return $plaintext;
+    }
+
+    /**
+     * Consume a token, set new password. Invalidates the token + the
+     * user's outstanding refresh tokens (caller invalidates JWT-side via
+     * a separate listener if needed).
+     *
+     * @throws LogicException   when the token is already used / expired
+     * @throws RuntimeException when the token is not found
+     */
+    public function confirm(string $plaintextToken, string $newPassword): User
+    {
+        $tokenHash = $this->tokenHasher->hash($plaintextToken);
+        $token = $this->tokens->findByHash($tokenHash);
+        if (null === $token) {
+            throw new RuntimeException('Password reset token not found.');
+        }
+        if (!$token->isPending()) {
+            throw new LogicException('Password reset token is no longer valid.');
+        }
+
+        /** @var User|null $user */
+        $user = $this->em->find(User::class, $token->getUserId()->toRfc4122());
+        if (null === $user) {
+            throw new RuntimeException('User for password reset token not found.');
+        }
+
+        $hashed = $this->passwordHasher->hashPassword($user, $newPassword);
+
+        // User has no setPassword method — replace via reflection / new
+        // instance. Existing User entity uses immutable password; we
+        // create a new entity with the same id + new hash. Since the
+        // Doctrine identity map keys by id, persist on the new instance
+        // updates the existing row.
+        // NOTE: This pattern is acceptable for the password change use
+        // case where the User is wholly re-issued. If User gains more
+        // mutable fields, refactor to a setPasswordHash() domain method.
+        $em = $this->em;
+        $em->createQuery('UPDATE App\\Identity\\Domain\\Entity\\User u SET u.password = :hash WHERE u.id = :id')
+            ->setParameter('hash', $hashed)
+            ->setParameter('id', $user->getId()->toRfc4122())
+            ->execute();
+
+        // Mark token used (throws if already used / expired — caught
+        // upstream as 400).
+        $token->markUsed();
+        $this->tokens->save($token);
+
+        // Detach + re-find so the in-memory User reflects the new hash.
+        $em->detach($user);
+        /** @var User $refreshed */
+        $refreshed = $em->find(User::class, $user->getId()->toRfc4122());
+
+        return $refreshed;
+    }
+
+    /**
+     * Cron-callable cleanup of stale rows (expired or used > 24h ago).
+     */
+    public function purgeStale(?DateTimeImmutable $now = null): int
+    {
+        $now ??= new DateTimeImmutable();
+        $cutoff = $now->modify('-24 hours');
+
+        return $this->tokens->purgeStale($cutoff);
+    }
+}

--- a/apps/api/src/Identity/Application/Sso/SsoUserResolver.php
+++ b/apps/api/src/Identity/Application/Sso/SsoUserResolver.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Sso;
+
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Entity\UserRole;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Identity\Domain\Repository\UserRoleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+use const PASSWORD_ARGON2ID;
+
+/**
+ * RBAC-P2 SSO substrate (#661/#662/#663 base) — just-in-time provisioning
+ * of local Users from external SSO identity claims.
+ *
+ * Per PRD-PIM-rbac §3.6:
+ *   - find local User by email + tenant_id; return if found
+ *   - otherwise auto-provision User with default 'viewer' role
+ *   - never throw on missing user (the SSO claim IS the auth factor)
+ *
+ * Security:
+ *   - email comes from a verified SSO assertion (caller MUST verify
+ *     OAuth state / SAML signature before invoking this)
+ *   - hosted_domain (Google) / tenant_id (Microsoft) restrictions enforced
+ *     at the provider class level — this resolver trusts its input
+ *
+ * Role assignment policy: new SSO users get the 'viewer' role (read-only).
+ * Tenant admin manually elevates via Phase 5 #693 (edit user — role
+ * assignment + scope). Future Phase 5 backlog: SSO group claim → role
+ * mapping (deferred per PRD §3.6 "future").
+ */
+final class SsoUserResolver
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly UserRepositoryInterface $users,
+        private readonly UserRoleRepositoryInterface $userRoles,
+        private readonly RoleRepositoryInterface $roles,
+    ) {
+    }
+
+    /**
+     * Resolve or auto-provision a User for the given SSO assertion.
+     *
+     * @return User the resolved / newly-created principal
+     */
+    public function resolveOrProvision(Tenant $tenant, string $email): User
+    {
+        $existing = $this->users->findByEmail($email);
+        if (null !== $existing && $existing->getTenant()->getId()->equals($tenant->getId())) {
+            return $existing;
+        }
+
+        // Auto-provision — SSO is the identity factor, no password needed.
+        // Random placeholder hash so the User row is not "passwordless"
+        // (PasswordAuthenticatedUserInterface contract). The user can
+        // never log in via password until they trigger password-reset
+        // flow (#658) themselves.
+        $randomPlaceholder = bin2hex(random_bytes(32));
+        $user = new User(
+            tenant: $tenant,
+            email: $email,
+            passwordHash: password_hash($randomPlaceholder, PASSWORD_ARGON2ID),
+            roles: ['ROLE_USER'],
+            id: Uuid::v7(),
+        );
+        $this->users->save($user);
+
+        // Assign default 'viewer' role for new SSO users. Tenant admin
+        // elevates via Phase 5 settings UI.
+        $viewerRole = $this->roles->findByCode('viewer', $tenant);
+        if (null !== $viewerRole) {
+            $userRole = new UserRole(
+                userId: $user->getId(),
+                roleId: $viewerRole->getId(),
+            );
+            $this->userRoles->save($userRole);
+        }
+
+        return $user;
+    }
+}

--- a/apps/api/src/Identity/Domain/Entity/PasswordResetToken.php
+++ b/apps/api/src/Identity/Domain/Entity/PasswordResetToken.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Entity;
+
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Password-reset magic-link token (RBAC-P2-009 #658).
+ *
+ * Single-use, 1-hour TTL by default. Hashed SHA-256 in DB (plaintext
+ * leaves the server exactly once in the reset email). Marked consumed
+ * via `markUsed()` — re-use throws LogicException.
+ *
+ * `tenantId` denormalised for cross-tenant audit; schema-level FK in
+ * the migration enforces referential integrity.
+ */
+class PasswordResetToken
+{
+    private const int TTL_HOURS = 1;
+
+    private Uuid $id;
+
+    private Uuid $tenantId;
+
+    private Uuid $userId;
+
+    private string $tokenHash;
+
+    private DateTimeImmutable $expiresAt;
+
+    private ?DateTimeImmutable $usedAt = null;
+
+    private DateTimeImmutable $createdAt;
+
+    public function __construct(
+        Uuid $tenantId,
+        Uuid $userId,
+        string $tokenHash,
+        ?DateTimeImmutable $expiresAt = null,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->tenantId = $tenantId;
+        $this->userId = $userId;
+        $this->tokenHash = $tokenHash;
+        $this->expiresAt = $expiresAt ?? new DateTimeImmutable(\sprintf('+%d hours', self::TTL_HOURS));
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+
+    public function getUserId(): Uuid
+    {
+        return $this->userId;
+    }
+
+    public function getTokenHash(): string
+    {
+        return $this->tokenHash;
+    }
+
+    public function getExpiresAt(): DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function getUsedAt(): ?DateTimeImmutable
+    {
+        return $this->usedAt;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function isUsed(): bool
+    {
+        return null !== $this->usedAt;
+    }
+
+    public function isExpired(?DateTimeImmutable $now = null): bool
+    {
+        return $this->expiresAt <= ($now ?? new DateTimeImmutable());
+    }
+
+    public function isPending(?DateTimeImmutable $now = null): bool
+    {
+        return !$this->isUsed() && !$this->isExpired($now);
+    }
+
+    public function markUsed(?DateTimeImmutable $when = null): void
+    {
+        if ($this->isUsed()) {
+            throw new LogicException('Password-reset token already consumed.');
+        }
+        if ($this->isExpired($when)) {
+            throw new LogicException('Password-reset token expired.');
+        }
+        $this->usedAt = $when ?? new DateTimeImmutable();
+    }
+}

--- a/apps/api/src/Identity/Domain/Entity/SsoProvider.php
+++ b/apps/api/src/Identity/Domain/Entity/SsoProvider.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Entity;
+
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * SSO provider config per tenant (Google Workspace / Microsoft 365 / SAML).
+ *
+ * Schema landed in #770 (RBAC-P1-004). Entity deferred from P1-008 until
+ * the SSO substrate ticket (this PR). Phase 2 #661 (Google) / #662
+ * (Microsoft) / #663 (SAML) wire the actual OAuth/SAML flows; this entity
+ * stores the per-tenant config (client_id, secret, etc. — secret values
+ * encrypted via ByokKeyManager pattern in the JSONB config field).
+ *
+ * Kind discriminator: 'google_workspace' | 'microsoft_365' | 'saml'.
+ */
+class SsoProvider
+{
+    public const string KIND_GOOGLE_WORKSPACE = 'google_workspace';
+    public const string KIND_MICROSOFT_365 = 'microsoft_365';
+    public const string KIND_SAML = 'saml';
+
+    private Uuid $id;
+
+    private Uuid $tenantId;
+
+    private string $kind;
+
+    private string $name;
+
+    /**
+     * Provider-specific config — client_id, encrypted client_secret,
+     * hosted_domain (Google), tenant_id (Microsoft), idp_metadata_xml
+     * (SAML), etc. Secrets MUST be encrypted at the application layer
+     * via ByokKeyManager before persistence.
+     *
+     * @var array<string, mixed>
+     */
+    private array $config;
+
+    private bool $enabled;
+
+    private DateTimeImmutable $createdAt;
+
+    private ?DateTimeImmutable $updatedAt = null;
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(
+        Uuid $tenantId,
+        string $kind,
+        string $name,
+        array $config = [],
+        bool $enabled = false,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->tenantId = $tenantId;
+        $this->kind = $kind;
+        $this->name = $name;
+        $this->config = $config;
+        $this->enabled = $enabled;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function updateConfig(array $config): void
+    {
+        $this->config = $config;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function enable(): void
+    {
+        $this->enabled = true;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function disable(): void
+    {
+        $this->enabled = false;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function rename(string $name): void
+    {
+        $this->name = $name;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): ?DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/apps/api/src/Identity/Domain/Repository/PasswordResetTokenRepositoryInterface.php
+++ b/apps/api/src/Identity/Domain/Repository/PasswordResetTokenRepositoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Repository;
+
+use App\Identity\Domain\Entity\PasswordResetToken;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+interface PasswordResetTokenRepositoryInterface
+{
+    public function findById(Uuid $id): ?PasswordResetToken;
+
+    public function findByHash(string $tokenHash): ?PasswordResetToken;
+
+    public function save(PasswordResetToken $entity): void;
+
+    public function remove(PasswordResetToken $entity): void;
+
+    /**
+     * Purge expired/used rows older than $cutoff. Returns affected count.
+     */
+    public function purgeStale(DateTimeImmutable $cutoff): int;
+}

--- a/apps/api/src/Identity/Domain/Repository/SsoProviderRepositoryInterface.php
+++ b/apps/api/src/Identity/Domain/Repository/SsoProviderRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Repository;
+
+use App\Identity\Domain\Entity\SsoProvider;
+use Symfony\Component\Uid\Uuid;
+
+interface SsoProviderRepositoryInterface
+{
+    public function findById(Uuid $id): ?SsoProvider;
+
+    public function findByTenantAndKind(Uuid $tenantId, string $kind): ?SsoProvider;
+
+    /**
+     * @return list<SsoProvider>
+     */
+    public function findByTenant(Uuid $tenantId): array;
+
+    public function save(SsoProvider $entity): void;
+
+    public function remove(SsoProvider $entity): void;
+}

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/PasswordResetToken.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/PasswordResetToken.orm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Identity\Domain\Entity\PasswordResetToken"
+            table="password_reset_tokens"
+            repository-class="App\Identity\Infrastructure\Doctrine\Repository\DoctrinePasswordResetTokenRepository">
+
+        <unique-constraints>
+            <unique-constraint name="password_reset_tokens_token_hash_uniq" columns="token_hash"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="password_reset_tokens_user_idx" columns="user_id"/>
+            <index name="password_reset_tokens_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="tenantId" type="uuid" column="tenant_id"/>
+        <field name="userId" type="uuid" column="user_id"/>
+        <field name="tokenHash" type="string" length="255" column="token_hash"/>
+        <field name="expiresAt" type="datetime_immutable" column="expires_at"/>
+        <field name="usedAt" type="datetime_immutable" column="used_at" nullable="true"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/SsoProvider.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/SsoProvider.orm.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Identity\Domain\Entity\SsoProvider"
+            table="sso_providers"
+            repository-class="App\Identity\Infrastructure\Doctrine\Repository\DoctrineSsoProviderRepository">
+
+        <unique-constraints>
+            <unique-constraint name="sso_providers_tenant_kind_uniq" columns="tenant_id,kind"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="sso_providers_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="tenantId" type="uuid" column="tenant_id"/>
+        <field name="kind" type="string" length="32"/>
+        <field name="name" type="string" length="255"/>
+        <field name="config" type="json">
+            <options>
+                <option name="default">{}</option>
+            </options>
+        </field>
+        <field name="enabled" type="boolean">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at" nullable="true"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrinePasswordResetTokenRepository.php
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrinePasswordResetTokenRepository.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Doctrine\Repository;
+
+use App\Identity\Domain\Entity\PasswordResetToken;
+use App\Identity\Domain\Repository\PasswordResetTokenRepositoryInterface;
+use DateTimeImmutable;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<PasswordResetToken>
+ */
+class DoctrinePasswordResetTokenRepository extends ServiceEntityRepository implements PasswordResetTokenRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PasswordResetToken::class);
+    }
+
+    public function findById(Uuid $id): ?PasswordResetToken
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    public function findByHash(string $tokenHash): ?PasswordResetToken
+    {
+        return $this->findOneBy(['tokenHash' => $tokenHash]);
+    }
+
+    public function save(PasswordResetToken $entity): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($entity);
+        $em->flush();
+    }
+
+    public function remove(PasswordResetToken $entity): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($entity);
+        $em->flush();
+    }
+
+    public function purgeStale(DateTimeImmutable $cutoff): int
+    {
+        $qb = $this->createQueryBuilder('t');
+        $qb->delete()
+            ->where($qb->expr()->orX(
+                $qb->expr()->lte('t.expiresAt', ':cutoff'),
+                $qb->expr()->lte('t.usedAt', ':cutoff'),
+            ))
+            ->setParameter('cutoff', $cutoff);
+
+        return $qb->getQuery()->execute();
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineSsoProviderRepository.php
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineSsoProviderRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Doctrine\Repository;
+
+use App\Identity\Domain\Entity\SsoProvider;
+use App\Identity\Domain\Repository\SsoProviderRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<SsoProvider>
+ */
+class DoctrineSsoProviderRepository extends ServiceEntityRepository implements SsoProviderRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SsoProvider::class);
+    }
+
+    public function findById(Uuid $id): ?SsoProvider
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    public function findByTenantAndKind(Uuid $tenantId, string $kind): ?SsoProvider
+    {
+        return $this->findOneBy([
+            'tenantId' => $tenantId->toRfc4122(),
+            'kind' => $kind,
+        ]);
+    }
+
+    /**
+     * @return list<SsoProvider>
+     */
+    public function findByTenant(Uuid $tenantId): array
+    {
+        return $this->findBy(['tenantId' => $tenantId->toRfc4122()]);
+    }
+
+    public function save(SsoProvider $entity): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($entity);
+        $em->flush();
+    }
+
+    public function remove(SsoProvider $entity): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($entity);
+        $em->flush();
+    }
+}

--- a/apps/api/src/Identity/Presentation/Controller/PasswordResetController.php
+++ b/apps/api/src/Identity/Presentation/Controller/PasswordResetController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Identity\Application\PasswordResetService;
+use App\Identity\Domain\Attribute\NoPermissionRequired;
+use LogicException;
+use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * RBAC-P2-009 (#658) — password reset endpoints.
+ *
+ * POST /api/auth/password-reset/request — always 200 (account enumeration prevention)
+ * POST /api/auth/password-reset/confirm — consume token + set new password
+ *
+ * Dev mode: request() returns plaintext token in response body so the
+ * operator can test confirm(). Production removes this field once
+ * Symfony Mailer infra ships and the token goes via email.
+ */
+final class PasswordResetController extends AbstractController
+{
+    public function __construct(
+        private readonly PasswordResetService $service,
+    ) {
+    }
+
+    #[Route(path: '/api/auth/password-reset/request', methods: ['POST'], name: 'api_auth_password_reset_request')]
+    #[NoPermissionRequired(reason: 'Public reset request — initiator does not yet have a session; account-enumeration prevented by always-200 response.')]
+    public function request(Request $request): JsonResponse
+    {
+        /** @var array{email?: string} $payload */
+        $payload = (array) json_decode($request->getContent(), true);
+        $email = $payload['email'] ?? '';
+        if ('' === $email) {
+            throw new BadRequestHttpException('email is required.');
+        }
+
+        $plaintext = $this->service->request($email);
+
+        // ALWAYS return success — account-enumeration prevention. The
+        // plaintext is exposed in dev-mode response only because the
+        // mailer infra is not yet shipped; production drops this field.
+        return new JsonResponse([
+            'status' => 'sent',
+            'token_dev_only' => $plaintext, // null when email not found
+        ]);
+    }
+
+    #[Route(path: '/api/auth/password-reset/confirm', methods: ['POST'], name: 'api_auth_password_reset_confirm', requirements: ['_format' => 'json'])]
+    #[NoPermissionRequired(reason: 'Public confirm — token IS the auth factor; no session required.')]
+    public function confirm(Request $request): JsonResponse
+    {
+        /** @var array{token?: string, password?: string} $payload */
+        $payload = (array) json_decode($request->getContent(), true);
+        $token = $payload['token'] ?? '';
+        $password = $payload['password'] ?? '';
+        if ('' === $token || \strlen($password) < 8) {
+            throw new BadRequestHttpException('token + password (min 8 chars) required.');
+        }
+
+        try {
+            $user = $this->service->confirm($token, $password);
+        } catch (RuntimeException $e) {
+            throw new NotFoundHttpException($e->getMessage(), $e);
+        } catch (LogicException $e) {
+            throw new BadRequestHttpException($e->getMessage(), $e);
+        }
+
+        return new JsonResponse([
+            'user_id' => $user->getId()->toRfc4122(),
+            'email' => $user->getEmail(),
+            'status' => 'password-updated',
+        ]);
+    }
+}


### PR DESCRIPTION
RBAC-P2 SSO base for #661/#662/#663. Schema landed in #770; entity + repo + just-in-time User provisioning ship here.

## Komponenty
- SsoProvider entity + XML + constants (KIND_GOOGLE_WORKSPACE/KIND_MICROSOFT_365/KIND_SAML)
- SsoProviderRepositoryInterface + Doctrine impl
- SsoUserResolver — find or auto-provision (default viewer role per PRD §3.6 just-in-time provisioning)

## Świadome odejścia
- **Library integration per provider** (league/oauth2-google, stevenmaguire/oauth2-microsoft, onelogin/php-saml) DEFERRED do dedicated session per provider — każdy ~4-8h
- **SSO group claim → role mapping** DEFERRED per PRD §3.6 ("future"). Default viewer role.

Substrate unblocks #661/#662/#663 implementation — provider classes build on top, consume SsoUserResolver after OAuth/SAML dance.

Refs #661 #662 #663