### PR TITLE
fix(security): PUBLIC_ACCESS dla invitations/accept + password-reset

### DIFF
--- a/apps/api/config/packages/security.yaml
+++ b/apps/api/config/packages/security.yaml
@@ -69,6 +69,12 @@ security:
         # must be reachable without an access token because the typical
         # caller has just had its access token expire.
         - { path: ^/api/auth/refresh, roles: PUBLIC_ACCESS }
+        # RBAC-P2-008 (#657) / P2-009 (#658) — magic-link accept + password
+        # reset confirm are open by design: the token IS the auth factor.
+        # /api/invitations/{token}/accept matches the path below; the
+        # token character class is enforced at the controller route level.
+        - { path: '^/api/invitations/[a-f0-9]+/accept$', roles: PUBLIC_ACCESS }
+        - { path: '^/api/auth/password-reset/(request|confirm)$', roles: PUBLIC_ACCESS }
         - { path: ^/api/docs, roles: PUBLIC_ACCESS }
         - { path: ^/api/contexts, roles: PUBLIC_ACCESS }
         - { path: ^/api/metrics$, roles: PUBLIC_ACCESS }


### PR DESCRIPTION
Closes runtime gap dla #657 + #658 — security.yaml access_control teraz pozwala na public access dla invitation accept + password reset endpoints (token = auth factor). #[NoPermissionRequired] attr jest tylko static-analysis hint (Phase 6 enforcement); firewall nadal wymaga PUBLIC_ACCESS rule.

Smoke verified end-to-end:
- Magic link: create → accept → login as new user ✅
- Password reset: request → confirm → login z new password ✅

Refs #657 #658