### PR TITLE
feat(identity): #652 ApiToken auth — User principal + CLI mint command

### DIFF
--- a/apps/api/src/Identity/Infrastructure/Security/RbacApiTokenAuthenticator.php
+++ b/apps/api/src/Identity/Infrastructure/Security/RbacApiTokenAuthenticator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Identity\Infrastructure\Security;
 
 use App\Identity\Domain\Repository\ApiTokenRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Repository\TenantRepositoryInterface;
 use DateTimeImmutable;
@@ -49,6 +50,7 @@ final class RbacApiTokenAuthenticator extends AbstractAuthenticator
 
     public function __construct(
         private readonly ApiTokenRepositoryInterface $apiTokens,
+        private readonly UserRepositoryInterface $users,
         private readonly TenantRepositoryInterface $tenants,
         private readonly TenantContext $tenantContext,
     ) {
@@ -91,17 +93,31 @@ final class RbacApiTokenAuthenticator extends AbstractAuthenticator
         $apiToken->recordUsage($request->getClientIp(), new DateTimeImmutable());
         $this->apiTokens->save($apiToken);
 
-        $user = new RbacApiTokenUser(
-            apiTokenId: $apiToken->getId(),
-            userId: $apiToken->getUserId(),
-            tenantId: $managedTenant->getId(),
-            tokenLast4: $apiToken->getTokenLast4(),
-            scopes: $apiToken->getScopes(),
-        );
+        // The principal IS the User the token was minted for — auth via
+        // token is just an alternative to JWT (admin SPA uses JWT,
+        // integrations use ApiToken). MeController + Voters + any
+        // permission check thus see the same User entity regardless of
+        // which authenticator fired. Token-specific metadata (scopes,
+        // token_id, last4) is attached to the request via TenantContext
+        // + request attributes for downstream Voters (Phase 3 #664+).
+        $user = $this->users->findById($apiToken->getUserId());
+        if (null === $user) {
+            throw new CustomUserMessageAuthenticationException('User for API token not found.');
+        }
+        if (!$user->isActive()) {
+            throw new CustomUserMessageAuthenticationException('User for API token is disabled.');
+        }
+
+        // Stash token metadata on the request for Phase 3 Voters that
+        // need scope-aware decisions (scopes determine whether the token
+        // can POST vs read-only).
+        $request->attributes->set('_api_token_id', $apiToken->getId()->toRfc4122());
+        $request->attributes->set('_api_token_scopes', $apiToken->getScopes());
+        $request->attributes->set('_api_token_last4', $apiToken->getTokenLast4());
 
         return new SelfValidatingPassport(new UserBadge(
             $user->getUserIdentifier(),
-            static fn (): RbacApiTokenUser => $user,
+            static fn (): \App\Identity\Domain\Entity\User => $user,
         ));
     }
 

--- a/apps/api/src/Identity/Presentation/Command/CreateApiTokenCommand.php
+++ b/apps/api/src/Identity/Presentation/Command/CreateApiTokenCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Command;
+
+use App\Identity\Domain\Entity\ApiToken;
+use App\Identity\Domain\Repository\ApiTokenRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Identity\Infrastructure\Security\RbacApiTokenAuthenticator;
+use DateTimeImmutable;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use const DATE_ATOM;
+
+/**
+ * RBAC-P2-003 (#652) — mint an ApiToken for a User. Plaintext token
+ * printed to stdout exactly once; only the SHA-256 hash is persisted.
+ *
+ * Phase 5 #699/#700 add the Settings UI for token CRUD. This CLI command
+ * is the Phase 2 testability enabler (and the production fallback for
+ * tenant onboarding before the UI ships).
+ *
+ * Token format: cortex_<tenant_short>_<random32>. The `cortex_` prefix
+ * lets gitleaks / TruffleHog detect leaks in CI.
+ */
+#[AsCommand(
+    name: 'cortex:apitoken:create',
+    description: 'Mint an RBAC ApiToken dla User (plaintext printed once)',
+)]
+final class CreateApiTokenCommand extends Command
+{
+    public function __construct(
+        private readonly UserRepositoryInterface $users,
+        private readonly ApiTokenRepositoryInterface $apiTokens,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('email', InputArgument::REQUIRED, 'User email')
+            ->addArgument('name', InputArgument::REQUIRED, 'Token label (visible w Phase 5 UI)')
+            ->addOption('scope', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Scope codes (repeat for multiple)', ['read-only'])
+            ->addOption('ttl-days', null, InputOption::VALUE_REQUIRED, 'Days until expiry (omit for never)');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var string $email */
+        $email = $input->getArgument('email');
+        /** @var string $name */
+        $name = $input->getArgument('name');
+        /** @var list<string> $scopes */
+        $scopes = $input->getOption('scope');
+        $ttlDays = $input->getOption('ttl-days');
+
+        $user = $this->users->findByEmail($email);
+        if (null === $user) {
+            $io->error(\sprintf('User %s not found.', $email));
+
+            return Command::FAILURE;
+        }
+
+        $tenant = $user->getTenant();
+        $tenantShort = substr($tenant->getCode(), 0, 8);
+        $plaintext = RbacApiTokenAuthenticator::generatePlaintext($tenantShort);
+        $tokenHash = RbacApiTokenAuthenticator::hashFor($plaintext);
+        $last4 = RbacApiTokenAuthenticator::last4($plaintext);
+
+        $expiresAt = null;
+        if (null !== $ttlDays && '' !== $ttlDays) {
+            $expiresAt = new DateTimeImmutable(\sprintf('+%d days', (int) $ttlDays));
+        }
+
+        $token = new ApiToken(
+            tenantId: $tenant->getId(),
+            userId: $user->getId(),
+            name: $name,
+            tokenHash: $tokenHash,
+            tokenLast4: $last4,
+            scopes: $scopes,
+            expiresAt: $expiresAt,
+        );
+        $this->apiTokens->save($token);
+
+        $io->success(\sprintf('Token "%s" minted dla user %s (tenant %s)', $name, $email, $tenant->getCode()));
+        $io->section('Plaintext token — copy NOW; this is the only time it is shown');
+        $output->writeln($plaintext);
+        $io->newLine();
+        $io->note([
+            \sprintf('Token ID:    %s', $token->getId()->toRfc4122()),
+            \sprintf('Last 4:      ...%s', $last4),
+            \sprintf('Scopes:      %s', implode(', ', $scopes)),
+            \sprintf('Expires:     %s', null !== $expiresAt ? $expiresAt->format(DATE_ATOM) : 'never'),
+            'Authentication header: Authorization: Token '.$plaintext,
+        ]);
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
Closes #652 END-TO-END.

Refactor RbacApiTokenAuthenticator → loads User entity (consistent z JWT auth); MeController + Voters see same principal. Add cortex:apitoken:create CLI command (Phase 5 #699/#700 dorobi UI).

Smoke verified end-to-end on local stack.

Closes #652