### PR TITLE
feat(identity): real email send for #657 + #658 (Mailpit dev)

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -107,3 +107,7 @@ MERCURE_JWT_SECRET="!ChangeThisMercureHubJWTSecretKey!"
 # postgresql+advisory://db_user:db_password@localhost/db_name
 LOCK_DSN=flock
 ###< symfony/lock ###
+
+###> symfony/mailer ###
+MAILER_DSN=null://null
+###< symfony/mailer ###

--- a/apps/api/.env.dev
+++ b/apps/api/.env.dev
@@ -8,3 +8,6 @@ APP_SECRET=e65fa14762532539948ae4ce3d479159
 # `doctrine://default?queue_name=async` so the FrankenPHP workers
 # drain the queue.
 MESSENGER_TRANSPORT_DSN=sync://
+
+# RBAC Mailer dev: SMTP → Mailpit container (UI at https://mail.pim.localhost)
+MAILER_DSN=smtp://mailpit:1025

--- a/apps/api/compose.override.yaml
+++ b/apps/api/compose.override.yaml
@@ -5,3 +5,14 @@ services:
     ports:
       - "80"
 ###< symfony/mercure-bundle ###
+
+###> symfony/mailer ###
+  mailer:
+    image: axllent/mailpit
+    ports:
+      - "1025"
+      - "8025"
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+###< symfony/mailer ###

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -34,6 +34,7 @@
         "symfony/expression-language": "7.4.*",
         "symfony/flex": "^2.10",
         "symfony/framework-bundle": "7.4.*",
+        "symfony/mailer": "7.4.*",
         "symfony/mercure-bundle": "^0.4.2",
         "symfony/messenger": "7.4.*",
         "symfony/mime": "7.4.*",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87a5391b7436da1afa7fef550fa2df99",
+    "content-hash": "35d17fa77ed18d6c49f9bb38d8c36cae",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2882,6 +2882,73 @@
                 }
             ],
             "time": "2025-10-31T18:51:33+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.2",
+                "vimeo/psalm": "^5.12"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-06T22:45:56+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -6326,16 +6393,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.8",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f57b899fa736fd71121168ef268f23c206083f0a"
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f57b899fa736fd71121168ef268f23c206083f0a",
-                "reference": "f57b899fa736fd71121168ef268f23c206083f0a",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
                 "shasum": ""
             },
             "require": {
@@ -6387,7 +6454,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.8"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -6407,20 +6474,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:54:39+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
                 "shasum": ""
             },
             "require": {
@@ -6434,7 +6501,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6467,7 +6534,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -6479,11 +6546,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-01-05T13:30:16+00:00"
         },
         {
             "name": "symfony/expression-language",
@@ -7474,6 +7545,90 @@
                 }
             ],
             "time": "2026-03-31T07:11:17+00:00"
+        },
+        {
+            "name": "symfony/mailer",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.2",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^7.2|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/mime": "<6.4",
+                "symfony/twig-bridge": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/twig-bridge": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/mercure",

--- a/apps/api/config/packages/mailer.yaml
+++ b/apps/api/config/packages/mailer.yaml
@@ -1,0 +1,3 @@
+framework:
+    mailer:
+        dsn: '%env(MAILER_DSN)%'

--- a/apps/api/config/reference.php
+++ b/apps/api/config/reference.php
@@ -576,7 +576,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         }>,
  *     },
  *     mailer?: bool|array{ // Mailer configuration
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
  *         dsn?: scalar|Param|null, // Default: null
  *         transports?: array<string, scalar|Param|null>,

--- a/apps/api/src/Identity/Application/InvitationService.php
+++ b/apps/api/src/Identity/Application/InvitationService.php
@@ -15,7 +15,12 @@ use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -53,6 +58,9 @@ final class InvitationService
         private readonly RoleRepositoryInterface $roles,
         private readonly MagicLinkTokenHasher $tokenHasher,
         private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly MailerInterface $mailer,
+        private readonly LoggerInterface $logger,
+        private readonly string $appBaseUrl = 'https://pim.localhost',
     ) {
     }
 
@@ -88,6 +96,32 @@ final class InvitationService
         );
 
         $this->invitations->save($invitation);
+
+        // Send invitation email (Mailpit catches in dev — see https://mail.pim.localhost).
+        // Failure to send is logged but does NOT block the create flow — the
+        // operator can re-send via Phase 5 UI, and the dev-mode token return
+        // covers test scenarios.
+        try {
+            $email = new TemplatedEmail()
+                ->from(new Address('noreply@pim.localhost', 'Cortex PIM'))
+                ->to(new Address($email))
+                ->subject(\sprintf('Zaproszenie do %s — Cortex PIM', $tenant->getName()))
+                ->htmlTemplate('email/invitation.html.twig')
+                ->context([
+                    'recipient_email' => $email,
+                    'tenant_name' => $tenant->getName(),
+                    'invited_by_email' => $invitedBy->getEmail(),
+                    'role_name' => $role->getName(),
+                    'accept_url' => \sprintf('%s/invitations/%s/accept', $this->appBaseUrl, $plaintext),
+                    'expires_at' => $expiresAt,
+                ]);
+            $this->mailer->send($email);
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->warning('Invitation email failed to send', [
+                'invitation_id' => $invitation->getId()->toRfc4122(),
+                'reason' => $e->getMessage(),
+            ]);
+        }
 
         return ['invitation' => $invitation, 'token' => $plaintext];
     }

--- a/apps/api/src/Identity/Application/PasswordResetService.php
+++ b/apps/api/src/Identity/Application/PasswordResetService.php
@@ -11,7 +11,12 @@ use App\Identity\Domain\Repository\UserRepositoryInterface;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Symfony\Bridge\Twig\Mime\TemplatedEmail;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
@@ -41,6 +46,9 @@ final class PasswordResetService
         private readonly UserRepositoryInterface $users,
         private readonly MagicLinkTokenHasher $tokenHasher,
         private readonly UserPasswordHasherInterface $passwordHasher,
+        private readonly MailerInterface $mailer,
+        private readonly LoggerInterface $logger,
+        private readonly string $appBaseUrl = 'https://pim.localhost',
     ) {
     }
 
@@ -67,6 +75,28 @@ final class PasswordResetService
             tokenHash: $tokenHash,
         );
         $this->tokens->save($token);
+
+        // Send reset email (Mailpit catches in dev). Failure is logged but
+        // does NOT block the request flow — account-enumeration prevention
+        // requires the response to be identical regardless of email
+        // existence + mail delivery success.
+        try {
+            $message = new TemplatedEmail()
+                ->from(new Address('noreply@pim.localhost', 'Cortex PIM'))
+                ->to(new Address($email))
+                ->subject('Reset hasła — Cortex PIM')
+                ->htmlTemplate('email/password-reset.html.twig')
+                ->context([
+                    'recipient_email' => $email,
+                    'confirm_url' => \sprintf('%s/password-reset/%s', $this->appBaseUrl, $plaintext),
+                ]);
+            $this->mailer->send($message);
+        } catch (TransportExceptionInterface $e) {
+            $this->logger->warning('Password reset email failed to send', [
+                'token_id' => $token->getId()->toRfc4122(),
+                'reason' => $e->getMessage(),
+            ]);
+        }
 
         return $plaintext;
     }

--- a/apps/api/symfony.lock
+++ b/apps/api/symfony.lock
@@ -218,6 +218,18 @@
             "config/packages/lock.yaml"
         ]
     },
+    "symfony/mailer": {
+        "version": "7.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "4.3",
+            "ref": "09051cfde49476e3c12cd3a0e44289ace1c75a4f"
+        },
+        "files": [
+            "config/packages/mailer.yaml"
+        ]
+    },
     "symfony/mercure-bundle": {
         "version": "0.4",
         "recipe": {

--- a/apps/api/templates/email/invitation.html.twig
+++ b/apps/api/templates/email/invitation.html.twig
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{ tenant_name }} — Zaproszenie</title>
+</head>
+<body style="font-family: -apple-system, system-ui, sans-serif; max-width: 560px; margin: 0 auto; padding: 32px; color: #1a1a1a;">
+    <h1 style="font-size: 20px;">Zaproszenie do {{ tenant_name }}</h1>
+
+    <p>Hej {{ recipient_email }},</p>
+
+    <p>
+        <strong>{{ invited_by_email }}</strong> zaprasza Cię do dołączenia do
+        organizacji <strong>{{ tenant_name }}</strong> w Cortex PIM jako
+        <strong>{{ role_name }}</strong>.
+    </p>
+
+    <p>Kliknij w link poniżej żeby zaakceptować zaproszenie i ustawić hasło:</p>
+
+    <p>
+        <a href="{{ accept_url }}" style="display: inline-block; background: #0070f3; color: white; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 600;">
+            Akceptuj zaproszenie
+        </a>
+    </p>
+
+    <p style="color: #6b7280; font-size: 14px;">
+        Link wygasa <strong>{{ expires_at|date('Y-m-d H:i') }}</strong> (7 dni od wystawienia).
+        Jeśli nie poprosiłeś o to zaproszenie, zignoruj ten email.
+    </p>
+
+    <hr style="border: 0; border-top: 1px solid #e5e7eb; margin: 32px 0;">
+
+    <p style="color: #9ca3af; font-size: 12px;">
+        Cortex PIM • {{ tenant_name }}
+    </p>
+</body>
+</html>

--- a/apps/api/templates/email/password-reset.html.twig
+++ b/apps/api/templates/email/password-reset.html.twig
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Reset hasła — Cortex PIM</title>
+</head>
+<body style="font-family: -apple-system, system-ui, sans-serif; max-width: 560px; margin: 0 auto; padding: 32px; color: #1a1a1a;">
+    <h1 style="font-size: 20px;">Reset hasła</h1>
+
+    <p>Hej,</p>
+
+    <p>
+        Otrzymaliśmy prośbę resetu hasła dla konta <strong>{{ recipient_email }}</strong> w
+        Cortex PIM. Kliknij link poniżej żeby ustawić nowe hasło:
+    </p>
+
+    <p>
+        <a href="{{ confirm_url }}" style="display: inline-block; background: #0070f3; color: white; padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 600;">
+            Resetuj hasło
+        </a>
+    </p>
+
+    <p style="color: #6b7280; font-size: 14px;">
+        Link wygasa za <strong>1 godzinę</strong>.
+        Jeśli nie prosiłeś o reset hasła, zignoruj ten email — Twoje konto pozostaje
+        bezpieczne (token nie aktywuje się sam).
+    </p>
+
+    <hr style="border: 0; border-top: 1px solid #e5e7eb; margin: 32px 0;">
+
+    <p style="color: #9ca3af; font-size: 12px;">
+        Cortex PIM
+    </p>
+</body>
+</html>


### PR DESCRIPTION
Symfony Mailer + Twig templates → real HTML email send. Mailpit catches w dev (UI https://mail.pim.localhost). Smoke verified end-to-end. Refs #657 #658