### PR TITLE
feat(identity): #666 CategoryVoter + AssetVoter (PRD §3.2 codes)

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -237,3 +237,10 @@ parameters:
         App\Identity\Infrastructure\Security\ProductVoter:
             - App\Catalog\Domain\Entity\CatalogObject
             - App\Catalog\Domain\ObjectKind
+        # RBAC-P3-003 (#666) — sibling voters under Prd\, same reasoning:
+        # voters legitimately reference the resource class they protect.
+        App\Identity\Infrastructure\Security\Prd\CategoryVoter:
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\ObjectKind
+        App\Identity\Infrastructure\Security\Prd\AssetVoter:
+            - App\Asset\Domain\Entity\Asset

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/AssetVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/AssetVoter.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Asset\Domain\Entity\Asset;
+use App\Identity\Infrastructure\Security\AbstractPrdVoter;
+
+/**
+ * RBAC-P3-003 (#666) — per-asset authorization aligned with the
+ * PRD §3.2 macierz permission codes for the multimedia row
+ * (`multimedia.view`, `multimedia.add_edit_own`,
+ * `multimedia.add_edit_any`, `multimedia.delete`).
+ *
+ * Subject: per ADR-009 Asset carries storage details on its own table
+ * while user-defined metadata lives on a paired `CatalogObject(kind=asset)`
+ * — see the Asset entity PHPDoc. This voter handles the storage entity
+ * directly because all asset CRUD endpoints route through it.
+ *
+ * Scope split per the Phase 3 ticket plan:
+ *   - this voter handles the **broad PRD §3.2 gate** only;
+ *   - the own-vs-any ownership semantics land in
+ *     {@see \App\Identity\Application\Policy\OwnershipPolicy} (RBAC-P3-010,
+ *     #673) — the resource currently has no `uploaded_by` column, so the
+ *     ownership policy is introduced together with the schema change in
+ *     that ticket. Until then the voter affirms whichever of
+ *     `multimedia.add_edit_own` / `multimedia.add_edit_any` the caller's
+ *     role carries; the ownership check stacks on top once #673 lands.
+ *
+ * The legacy {@see \App\Identity\Infrastructure\Security\AssetVoter}
+ * still covers the uppercase `READ`/`WRITE`/`DELETE` attribute style used
+ * by Asset.xml + Asset controllers; both run side-by-side until the
+ * Phase 6 retrofit migrates the surface over.
+ */
+final class AssetVoter extends AbstractPrdVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function permissionMap(): array
+    {
+        return [
+            'view' => 'multimedia.view',
+            'add_edit_own' => 'multimedia.add_edit_own',
+            'add_edit_any' => 'multimedia.add_edit_any',
+            'delete' => 'multimedia.delete',
+        ];
+    }
+
+    protected function subjectClass(): string
+    {
+        return Asset::class;
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/CategoryVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/CategoryVoter.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Identity\Infrastructure\Security\AbstractPrdVoter;
+
+/**
+ * RBAC-P3-003 (#666) — per-category authorization aligned with the
+ * PRD §3.2 macierz permission codes (`categories.view`,
+ * `categories.add_edit`, `categories.delete`).
+ *
+ * Subject discrimination: per ADR-009 the unified {@see CatalogObject}
+ * entity carries every kind; this voter accepts only `kind=Category`
+ * instances. The product voter (#665) covers `kind=Product`, the asset
+ * voter (sibling in this ticket) covers `kind=Asset`. Class-level
+ * subjects pass through because collection scope is enforced by Doctrine
+ * filters.
+ *
+ * The legacy {@see \App\Identity\Infrastructure\Security\CatalogObjectVoter}
+ * still serves the `READ`/`WRITE`/`DELETE` uppercase-attribute style used
+ * by the legacy XML ApiResource configs; this voter introduces the
+ * PRD-aligned lowercase actions and runs alongside until the Phase 6
+ * retrofit (RBAC-P6 backlog) swaps the API surface over.
+ */
+final class CategoryVoter extends AbstractPrdVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function permissionMap(): array
+    {
+        return [
+            'view' => 'categories.view',
+            'add_edit' => 'categories.add_edit',
+            'delete' => 'categories.delete',
+        ];
+    }
+
+    protected function subjectClass(): string
+    {
+        return CatalogObject::class;
+    }
+
+    protected function acceptsSubject(mixed $subject): bool
+    {
+        if (\is_string($subject)) {
+            return CatalogObject::class === $subject;
+        }
+
+        if (!$subject instanceof CatalogObject) {
+            return false;
+        }
+
+        return ObjectKind::Category === $subject->getKind();
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/AssetVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/AssetVoterTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Asset\Domain\Entity\Asset;
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\AssetVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * RBAC-P3-003 (#666) — unit coverage of AssetVoter against the
+ * PRD §3.2 macierz `multimedia.*` codes.
+ *
+ * Scope assertions:
+ *   - broad PRD §3.2 gate works for every action (view, add_edit_own,
+ *     add_edit_any, delete);
+ *   - cross-tenant subject denies even when permission is present;
+ *   - own-vs-any ownership semantics are NOT exercised here — they
+ *     plug in via OwnershipPolicy (RBAC-P3-010, #673) once the schema
+ *     carries an `uploaded_by` column.
+ */
+final class AssetVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsViewWhenPermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $asset = $this->asset($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $asset, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsAddEditOwnWhenPermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $asset = $this->asset($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.add_edit_own']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $asset, ['add_edit_own']),
+        );
+    }
+
+    #[Test]
+    public function grantsAddEditAnyWhenPermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $asset = $this->asset($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.add_edit_any']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $asset, ['add_edit_any']),
+        );
+    }
+
+    #[Test]
+    public function deniesAddEditAnyWhenOnlyOwnGranted(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $asset = $this->asset($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.view', 'multimedia.add_edit_own']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $asset, ['add_edit_any']),
+        );
+    }
+
+    #[Test]
+    public function deniesDeleteWhenPermissionMissing(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $asset = $this->asset($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.view', 'multimedia.add_edit_any']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $asset, ['delete']),
+        );
+    }
+
+    #[Test]
+    public function deniesAcrossTenantsEvenWithPermission(): void
+    {
+        $alpha = new Tenant('alpha', 'Alpha');
+        $beta = new Tenant('beta', 'Beta');
+        $asset = $this->asset($beta);
+        $user = $this->user($alpha);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.delete']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $asset, ['delete']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $asset = $this->asset($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), $asset, ['UNHANDLED_ATTRIBUTE']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnNonAssetSubject(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), new stdClass(), ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsClassLevelOnAddEditAny(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new AssetVoter($this->resolverWith($user, ['multimedia.add_edit_any']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), Asset::class, ['add_edit_any']),
+        );
+    }
+
+    #[Test]
+    public function deniesAnonymous(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $asset = $this->asset($tenant);
+
+        $voter = new AssetVoter($this->createStub(PermissionResolverInterface::class));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(new NullToken(), $asset, ['view']),
+        );
+    }
+
+    private function asset(Tenant $tenant): Asset
+    {
+        $asset = new Asset(
+            code: 'asset-'.$tenant->getCode(),
+            originalFilename: 'sample.jpg',
+            mimeType: 'image/jpeg',
+            size: 1024,
+            storagePath: 'tenants/'.$tenant->getCode().'/sample.jpg',
+        );
+        $asset->assignTenant($tenant);
+
+        return $asset;
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/CategoryVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/CategoryVoterTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\CategoryVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * RBAC-P3-003 (#666) — unit coverage of CategoryVoter against the
+ * PRD §3.2 macierz codes (`categories.*`).
+ */
+final class CategoryVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsViewWhenPermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $category = $this->category($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new CategoryVoter($this->resolverWith($user, ['categories.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $category, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsAddEditWhenPermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $category = $this->category($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new CategoryVoter($this->resolverWith($user, ['categories.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $category, ['add_edit']),
+        );
+    }
+
+    #[Test]
+    public function deniesDeleteWhenPermissionMissing(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $category = $this->category($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new CategoryVoter($this->resolverWith($user, ['categories.view', 'categories.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $category, ['delete']),
+        );
+    }
+
+    #[Test]
+    public function deniesAcrossTenantsEvenWithPermission(): void
+    {
+        $alpha = new Tenant('alpha', 'Alpha');
+        $beta = new Tenant('beta', 'Beta');
+        $category = $this->category($beta);
+        $user = $this->user($alpha);
+
+        $voter = new CategoryVoter($this->resolverWith($user, ['categories.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $category, ['add_edit']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $category = $this->category($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new CategoryVoter($this->resolverWith($user, ['categories.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), $category, ['UNHANDLED_ATTRIBUTE']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnNonCategoryCatalogObject(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $product = $this->catalogObject($tenant, ObjectKind::Product);
+        $user = $this->user($tenant);
+
+        $voter = new CategoryVoter($this->resolverWith($user, ['categories.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), $product, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsClassLevelOnAddEdit(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new CategoryVoter($this->resolverWith($user, ['categories.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), CatalogObject::class, ['add_edit']),
+        );
+    }
+
+    #[Test]
+    public function deniesAnonymous(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $category = $this->category($tenant);
+
+        $voter = new CategoryVoter($this->createStub(PermissionResolverInterface::class));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(new NullToken(), $category, ['view']),
+        );
+    }
+
+    private function category(Tenant $tenant): CatalogObject
+    {
+        return $this->catalogObject($tenant, ObjectKind::Category);
+    }
+
+    private function catalogObject(Tenant $tenant, ObjectKind $kind): CatalogObject
+    {
+        $type = new ObjectType($kind->value, $kind, ['en' => ucfirst($kind->value)]);
+        $object = new CatalogObject($type, 'CODE-'.$kind->value);
+        $object->assignTenant($tenant);
+
+        return $object;
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-003 — two PRD §3.2-aligned voters under `App\Identity\Infrastructure\Security\Prd\`, sibling to ProductVoter (#665):

- **CategoryVoter** — `CatalogObject(kind=Category)` → `categories.view` / `categories.add_edit` / `categories.delete`. Kind discriminator keeps Product/Asset voters scoped.
- **AssetVoter** — `Asset` entity (storage-side per ADR-009) → `multimedia.view` / `multimedia.add_edit_own` / `multimedia.add_edit_any` / `multimedia.delete`. Broad-gate only — own-vs-any ownership stacks on top via OwnershipPolicy (#673) once the schema carries `uploaded_by`.

Legacy `AssetVoter` / `CatalogObjectVoter` (uppercase `READ`/`WRITE`/`DELETE`) still serves XML ApiResource configs unchanged. Phase 6 retrofits the surface.

## Test plan

- [x] 18 unit tests pass (10 AssetVoter + 8 CategoryVoter)
- [x] Full `tests/Unit/Identity/Security` suite green (47 tests)
- [ ] CI green (PHPStan, Biome, full test suite, deptrac, security audit)
- [ ] Manual smoke deferred to Phase 6 retrofit — current voter wiring (legacy uppercase attributes via Asset.xml / CatalogObject.xml) untouched; new PRD voters await an endpoint switch to `view`/`add_edit`/`delete` attribute strings

## Risk

- `Prd\` subnamespace chosen over replacing legacy to avoid breaking `is_granted('READ', $asset)` calls scattered across Asset controllers + Asset.xml ApiPlatform config. Both voter families coexist until Phase 6 retrofit.
- Asset ownership semantics deferred to #673 (schema change + listener + policy in one focused ticket per backlog).

Closes #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)