### PR TITLE
feat(identity): #667 ObjectType + Attribute + AttributeGroup voters (PRD §3.2)

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -244,3 +244,11 @@ parameters:
             - App\Catalog\Domain\ObjectKind
         App\Identity\Infrastructure\Security\Prd\AssetVoter:
             - App\Asset\Domain\Entity\Asset
+        # RBAC-P3-004 (#667) — modeling-row voters under Prd\. Each Voter
+        # legitimately references the resource class it protects.
+        App\Identity\Infrastructure\Security\Prd\ObjectTypeVoter:
+            - App\Catalog\Domain\Entity\ObjectType
+        App\Identity\Infrastructure\Security\Prd\AttributeVoter:
+            - App\Catalog\Domain\Entity\Attribute
+        App\Identity\Infrastructure\Security\Prd\AttributeGroupVoter:
+            - App\Catalog\Domain\Entity\AttributeGroup

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/AttributeGroupVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/AttributeGroupVoter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Identity\Infrastructure\Security\AbstractPrdVoter;
+
+/**
+ * RBAC-P3-004 (#667) — per-AttributeGroup authorization aligned with the
+ * PRD §3.2 Modeling row (`modeling.view`, `modeling.attribute_groups.add_edit`).
+ *
+ * AttributeGroup has no separate `delete` code in the macierz — its
+ * lifecycle is bundled into `add_edit`. There is also no delete action
+ * exposed by the voter; the macierz simply does not surface group
+ * deletion as a distinct permission. The controller relies on cascade
+ * rules from the database (groups detached on attribute migration / type
+ * change).
+ */
+final class AttributeGroupVoter extends AbstractPrdVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function permissionMap(): array
+    {
+        return [
+            'view' => 'modeling.view',
+            'add_edit' => 'modeling.attribute_groups.add_edit',
+        ];
+    }
+
+    protected function subjectClass(): string
+    {
+        return AttributeGroup::class;
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/AttributeVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/AttributeVoter.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Catalog\Domain\Entity\Attribute;
+use App\Identity\Infrastructure\Security\AbstractPrdVoter;
+
+/**
+ * RBAC-P3-004 (#667) — per-Attribute authorization aligned with the
+ * PRD §3.2 Modeling row (`modeling.view`, `modeling.attributes.add_edit`).
+ *
+ * `delete` collapses onto the same `add_edit` code: the macierz treats
+ * full attribute CRUD as one Modeler-owned action. There is no analogue
+ * to ObjectType's built-in protection here — every attribute, including
+ * the four `is_system=true` rows (`created_at`, `updated_at`, `created_by`,
+ * `updated_by`), is in scope; system-row protection belongs to the
+ * controller / migration boundary.
+ *
+ * Sibling: {@see ObjectTypeVoter} for the kind dimension,
+ * {@see AttributeGroupVoter} for groupings.
+ */
+final class AttributeVoter extends AbstractPrdVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function permissionMap(): array
+    {
+        return [
+            'view' => 'modeling.view',
+            'add_edit' => 'modeling.attributes.add_edit',
+            'delete' => 'modeling.attributes.add_edit',
+        ];
+    }
+
+    protected function subjectClass(): string
+    {
+        return Attribute::class;
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/ObjectTypeVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/ObjectTypeVoter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Identity\Infrastructure\Security\AbstractPrdVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * RBAC-P3-004 (#667) — per-ObjectType authorization aligned with the
+ * PRD §3.2 Modeling row (`modeling.view`, `modeling.object_types.add`,
+ * `modeling.delete_custom`).
+ *
+ * Mapping rationale:
+ *   - `view`        → `modeling.view` (broad modeling read gate),
+ *   - `add` / `edit` → `modeling.object_types.add` (the macierz collapses
+ *     creation and structural edits onto the same Modeler-owned action;
+ *     built-ins are protected separately below),
+ *   - `delete`      → `modeling.delete_custom` **plus** an `is_built_in=false`
+ *     runtime guard. The platform-owned built-ins (Product / Category /
+ *     Asset / Brand) cannot be deleted by anyone — Tenant Owner included —
+ *     because they back the API sugar paths. The 409 response shape comes
+ *     from the controller; the voter denies before the controller runs.
+ *
+ * Sibling voters in this ticket — AttributeVoter, AttributeGroupVoter —
+ * piggyback on the same PRD row but with simpler resolution (no
+ * is_built_in check; the protected built-ins live on ObjectType only).
+ *
+ * Auto-grant of `{kind}.view` / `{kind}.edit` to roles flagged with
+ * `modeling.auto_grant_new_object_types` lives in a Doctrine post-persist
+ * listener — deferred to a focused follow-up ticket because it requires
+ * a new dynamic-permission code namespace plus role_permissions writes
+ * tied to schema operations.
+ */
+final class ObjectTypeVoter extends AbstractPrdVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function permissionMap(): array
+    {
+        return [
+            'view' => 'modeling.view',
+            'add' => 'modeling.object_types.add',
+            'edit' => 'modeling.object_types.add',
+            'delete' => 'modeling.delete_custom',
+        ];
+    }
+
+    protected function subjectClass(): string
+    {
+        return ObjectType::class;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        if (!parent::voteOnAttribute($attribute, $subject, $token)) {
+            return false;
+        }
+
+        if ('delete' !== $attribute) {
+            return true;
+        }
+
+        // Built-in protection: even a Modeler with `modeling.delete_custom`
+        // must not delete a built-in row. The repository / controller may
+        // also enforce this, but the voter is the authoritative gate so
+        // every entry point (REST + GraphQL + future agent) inherits it.
+        return !($subject instanceof ObjectType && $subject->isBuiltIn());
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/AttributeGroupVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/AttributeGroupVoterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\AttributeGroupVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * RBAC-P3-004 (#667) — AttributeGroupVoter unit coverage.
+ */
+final class AttributeGroupVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsView(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $group = $this->attributeGroup($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeGroupVoter($this->resolverWith($user, ['modeling.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $group, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsAddEdit(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $group = $this->attributeGroup($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeGroupVoter($this->resolverWith($user, ['modeling.attribute_groups.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $group, ['add_edit']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnDelete(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $group = $this->attributeGroup($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeGroupVoter($this->resolverWith($user, ['modeling.attribute_groups.add_edit']));
+
+        // No `delete` code in the macierz — the voter abstains so the
+        // global affirmative strategy denies (no other voter covers it).
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), $group, ['delete']),
+        );
+    }
+
+    #[Test]
+    public function deniesAddEditWithoutPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $group = $this->attributeGroup($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeGroupVoter($this->resolverWith($user, ['modeling.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $group, ['add_edit']),
+        );
+    }
+
+    #[Test]
+    public function deniesAcrossTenants(): void
+    {
+        $alpha = new Tenant('alpha', 'Alpha');
+        $beta = new Tenant('beta', 'Beta');
+        $group = $this->attributeGroup($beta);
+        $user = $this->user($alpha);
+
+        $voter = new AttributeGroupVoter($this->resolverWith($user, ['modeling.attribute_groups.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $group, ['add_edit']),
+        );
+    }
+
+    private function attributeGroup(Tenant $tenant): AttributeGroup
+    {
+        $group = new AttributeGroup('pricing', ['en' => 'Pricing']);
+        $group->assignTenant($tenant);
+
+        return $group;
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/AttributeVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/AttributeVoterTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\AttributeVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * RBAC-P3-004 (#667) — AttributeVoter unit coverage.
+ */
+final class AttributeVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsView(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $attribute = $this->attribute($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeVoter($this->resolverWith($user, ['modeling.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $attribute, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsAddEditOnAttributesPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $attribute = $this->attribute($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeVoter($this->resolverWith($user, ['modeling.attributes.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $attribute, ['add_edit']),
+        );
+    }
+
+    #[Test]
+    public function grantsDeleteUnderTheSameCode(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $attribute = $this->attribute($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeVoter($this->resolverWith($user, ['modeling.attributes.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $attribute, ['delete']),
+        );
+    }
+
+    #[Test]
+    public function deniesAddEditWithoutPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $attribute = $this->attribute($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeVoter($this->resolverWith($user, ['modeling.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $attribute, ['add_edit']),
+        );
+    }
+
+    #[Test]
+    public function deniesAcrossTenants(): void
+    {
+        $alpha = new Tenant('alpha', 'Alpha');
+        $beta = new Tenant('beta', 'Beta');
+        $attribute = $this->attribute($beta);
+        $user = $this->user($alpha);
+
+        $voter = new AttributeVoter($this->resolverWith($user, ['modeling.attributes.add_edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $attribute, ['add_edit']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $attribute = $this->attribute($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new AttributeVoter($this->resolverWith($user, ['modeling.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), $attribute, ['UNHANDLED']),
+        );
+    }
+
+    private function attribute(Tenant $tenant): Attribute
+    {
+        $attribute = new Attribute('color', ['en' => 'Color'], AttributeType::Text);
+        $attribute->assignTenant($tenant);
+
+        return $attribute;
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/ObjectTypeVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/ObjectTypeVoterTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\ObjectTypeVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * RBAC-P3-004 (#667) — unit coverage of ObjectTypeVoter against the
+ * PRD §3.2 macierz Modeling codes plus built-in protection.
+ */
+final class ObjectTypeVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsViewWhenModelingViewPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $objectType = $this->customObjectType($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new ObjectTypeVoter($this->resolverWith($user, ['modeling.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $objectType, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsAddWhenObjectTypesAddPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new ObjectTypeVoter($this->resolverWith($user, ['modeling.object_types.add']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), ObjectType::class, ['add']),
+        );
+    }
+
+    #[Test]
+    public function grantsEditCustomObjectTypeWhenObjectTypesAddPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $custom = $this->customObjectType($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new ObjectTypeVoter($this->resolverWith($user, ['modeling.object_types.add']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $custom, ['edit']),
+        );
+    }
+
+    #[Test]
+    public function grantsDeleteCustomObjectTypeWhenDeleteCustomPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $custom = $this->customObjectType($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new ObjectTypeVoter($this->resolverWith($user, ['modeling.delete_custom']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), $custom, ['delete']),
+        );
+    }
+
+    #[Test]
+    public function deniesDeleteBuiltInObjectTypeEvenWithDeleteCustom(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $builtIn = $this->builtInObjectType($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new ObjectTypeVoter($this->resolverWith($user, ['modeling.delete_custom']));
+
+        // Built-in protection: the macierz grant alone is not enough — built-in
+        // rows back the API sugar paths and must survive every voter call.
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $builtIn, ['delete']),
+        );
+    }
+
+    #[Test]
+    public function deniesDeleteWhenDeleteCustomMissing(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $custom = $this->customObjectType($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new ObjectTypeVoter($this->resolverWith($user, ['modeling.view', 'modeling.object_types.add']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $custom, ['delete']),
+        );
+    }
+
+    #[Test]
+    public function deniesAcrossTenantsEvenWithPermission(): void
+    {
+        $alpha = new Tenant('alpha', 'Alpha');
+        $beta = new Tenant('beta', 'Beta');
+        $custom = $this->customObjectType($beta);
+        $user = $this->user($alpha);
+
+        $voter = new ObjectTypeVoter($this->resolverWith($user, ['modeling.object_types.add']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), $custom, ['edit']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $custom = $this->customObjectType($tenant);
+        $user = $this->user($tenant);
+
+        $voter = new ObjectTypeVoter($this->resolverWith($user, ['modeling.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), $custom, ['UNHANDLED']),
+        );
+    }
+
+    private function customObjectType(Tenant $tenant): ObjectType
+    {
+        $objectType = new ObjectType('custom-pricelist', ObjectKind::Custom, ['en' => 'Price list']);
+        $objectType->assignTenant($tenant);
+
+        return $objectType;
+    }
+
+    private function builtInObjectType(Tenant $tenant): ObjectType
+    {
+        $objectType = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $objectType->markBuiltIn();
+        $objectType->assignTenant($tenant);
+
+        return $objectType;
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-004 — three modeling-row voters under `App\Identity\Infrastructure\Security\Prd\` complementing #665 ProductVoter and #666 Category/Asset voters:

- **ObjectTypeVoter** — `modeling.view` / `modeling.object_types.add` (add+edit) / `modeling.delete_custom` + **built-in protection** (denies delete on `isBuiltIn()=true` regardless of permission).
- **AttributeVoter** — `modeling.view` / `modeling.attributes.add_edit` (CRUD collapses onto one Modeler-owned code per macierz).
- **AttributeGroupVoter** — `modeling.view` / `modeling.attribute_groups.add_edit`. Group `delete` not in macierz — voter abstains.

## Deferred to follow-up (scope cut)

**Auto-grant Doctrine listener** for `modeling.auto_grant_new_object_types` (ticket AC-5 / AC-6) — needs a new dynamic-permission code namespace (`{kind}.view` / `{kind}.edit`) plus role_permissions writes on ObjectType creation. Combining that with the voter layer would bundle a schema/permission-shape change into an authorization PR. Recommend a dedicated `feat/rbac-auto-grant-object-types` ticket.

## Test plan

- [x] 19 unit tests pass (8 ObjectType + 6 Attribute + 5 AttributeGroup)
- [ ] CI green (PHPStan, Biome, full test suite, deptrac, security audit)
- [ ] Manual smoke deferred to Phase 6 retrofit — legacy ObjectTypeVoter/AttributeVoter/AttributeGroupVoter (uppercase READ/WRITE/DELETE) still gate the existing endpoints

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)