### PR TITLE
feat(identity): #668 UserVoter + RoleVoter (PRD §3.2 Settings codes)

### DIFF
--- a/apps/api/src/Identity/Infrastructure/Security/Prd/RoleVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/RoleVoter.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Infrastructure\Security\AbstractPrdVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * RBAC-P3-005 (#668) — per-Role authorization aligned with the
+ * PRD §3.2 macierz Settings → Roles single-permission row
+ * (`settings.roles.manage`).
+ *
+ * Every action (view / add / edit / delete) maps to the same Tenant
+ * Owner / Administrator permission, matching the UserVoter pattern.
+ *
+ * Tenant boundary: AbstractPrdVoter's default tenant compare skips when
+ * the subject's tenant is null (a global / built-in row). For Role that
+ * default is unsafe — null-tenant means "seeded platform-owned template
+ * like super_admin / viewer", which tenant-scoped `settings.roles.manage`
+ * must not mutate. This voter overrides the comparison to deny outright
+ * when `Role::isGlobal()` is true while the caller is tenant-scoped.
+ *
+ * Built-in / system role protection (e.g. blocking delete of the seeded
+ * `tenant_owner` template inside a tenant) is enforced at the service
+ * layer where the 409 message belongs — Role entity has no `is_system`
+ * column today, so adding a runtime check here would require a schema
+ * change that belongs to its own ticket.
+ */
+final class RoleVoter extends AbstractPrdVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function permissionMap(): array
+    {
+        return [
+            'view' => 'settings.roles.manage',
+            'add' => 'settings.roles.manage',
+            'edit' => 'settings.roles.manage',
+            'delete' => 'settings.roles.manage',
+        ];
+    }
+
+    protected function subjectClass(): string
+    {
+        return Role::class;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        if (!parent::voteOnAttribute($attribute, $subject, $token)) {
+            return false;
+        }
+
+        // Global / platform-owned roles (null tenant) cannot be mutated by
+        // any tenant-scoped principal — the macierz code is tenant-scoped.
+        return !($subject instanceof Role && $subject->isGlobal());
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/UserVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/UserVoter.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Identity\Domain\Entity\User;
+use App\Identity\Infrastructure\Security\AbstractPrdVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * RBAC-P3-005 (#668) — per-User authorization aligned with the
+ * PRD §3.2 macierz Settings → Users single-permission row
+ * (`settings.users.manage`).
+ *
+ * Macierz collapses every CRUD-style user operation onto one Tenant
+ * Owner / Administrator permission. The voter maps each operational
+ * action (view / invite / edit / deactivate / reactivate / change_roles)
+ * to the same code and adds one runtime invariant:
+ *
+ *   - **self-modification protection** — a user is allowed to update
+ *     their own profile but never their own role set, because that
+ *     would be a privilege-escalation path through a single API call.
+ *     The voter denies `change_roles` whenever the subject matches the
+ *     authenticated user, regardless of the `settings.users.manage`
+ *     permission.
+ *
+ * Deferred to a follow-up (documented in PR description):
+ *   - Last-admin protection (`deactivate` / `change_roles` on the only
+ *     remaining user holding `settings.users.manage`) — requires a query
+ *     against the role membership graph and is more naturally enforced
+ *     at the service layer, where a 409 with the explanation message
+ *     belongs.
+ *   - Owner uniqueness (`change_roles` assigning `tenant_owner` while
+ *     it is already held) — same reasoning.
+ *
+ * Both runtime invariants stack on top of this voter once their support
+ * services land; until then the broad gate + self-modification carry
+ * the authorization layer.
+ */
+final class UserVoter extends AbstractPrdVoter
+{
+    /**
+     * @return array<string, string>
+     */
+    protected function permissionMap(): array
+    {
+        return [
+            'view' => 'settings.users.manage',
+            'invite' => 'settings.users.manage',
+            'edit' => 'settings.users.manage',
+            'deactivate' => 'settings.users.manage',
+            'reactivate' => 'settings.users.manage',
+            'change_roles' => 'settings.users.manage',
+        ];
+    }
+
+    protected function subjectClass(): string
+    {
+        return User::class;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        if (!parent::voteOnAttribute($attribute, $subject, $token)) {
+            return false;
+        }
+
+        if ('change_roles' !== $attribute) {
+            return true;
+        }
+
+        $current = $token->getUser();
+        if (!$current instanceof User || !$subject instanceof User) {
+            return true;
+        }
+
+        // Self-modification block — granted upstream by the macierz, but
+        // we deny here so neither REST nor GraphQL nor a future agent
+        // can be coerced into escalating a session through "edit my own
+        // role".
+        return $current->getId()->toRfc4122() !== $subject->getId()->toRfc4122();
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/RoleVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/RoleVoterTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\RoleVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * RBAC-P3-005 (#668) — RoleVoter unit coverage including the
+ * null-tenant (global) role denial.
+ */
+final class RoleVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsViewWhenManagePermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $role = $this->tenantRole($tenant);
+        $current = $this->user($tenant);
+
+        $voter = new RoleVoter($this->resolverWith($current, ['settings.roles.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), $role, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsAddOnClassLevelSubject(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+
+        $voter = new RoleVoter($this->resolverWith($current, ['settings.roles.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), Role::class, ['add']),
+        );
+    }
+
+    #[Test]
+    public function deniesEditOnGlobalRoleEvenWithPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $globalRole = new Role('super_admin', 'Super Admin', null);
+        $current = $this->user($tenant);
+
+        $voter = new RoleVoter($this->resolverWith($current, ['settings.roles.manage']));
+
+        // Tenant-scoped principals cannot mutate platform-owned global roles.
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($current), $globalRole, ['edit']),
+        );
+    }
+
+    #[Test]
+    public function deniesAcrossTenants(): void
+    {
+        $alpha = new Tenant('alpha', 'Alpha');
+        $beta = new Tenant('beta', 'Beta');
+        $role = $this->tenantRole($beta);
+        $current = $this->user($alpha);
+
+        $voter = new RoleVoter($this->resolverWith($current, ['settings.roles.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($current), $role, ['edit']),
+        );
+    }
+
+    #[Test]
+    public function deniesEverythingWithoutPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $role = $this->tenantRole($tenant);
+        $current = $this->user($tenant);
+
+        $voter = new RoleVoter($this->resolverWith($current, []));
+
+        foreach (['view', 'add', 'edit', 'delete'] as $action) {
+            self::assertSame(
+                VoterInterface::ACCESS_DENIED,
+                $voter->vote($this->token($current), $role, [$action]),
+                "Expected denial for action {$action}",
+            );
+        }
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $role = $this->tenantRole($tenant);
+        $current = $this->user($tenant);
+
+        $voter = new RoleVoter($this->resolverWith($current, ['settings.roles.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($current), $role, ['UNKNOWN']),
+        );
+    }
+
+    private function tenantRole(Tenant $tenant): Role
+    {
+        return new Role('catalog_manager', 'Catalog Manager', $tenant);
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/UserVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/UserVoterTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\UserVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-005 (#668) — UserVoter unit coverage including the
+ * self-modification guard against the `change_roles` action.
+ */
+final class UserVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsViewWhenManagePermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $target = $this->user($tenant, 'target@alpha.localhost');
+        $current = $this->user($tenant, 'admin@alpha.localhost');
+
+        $voter = new UserVoter($this->resolverWith($current, ['settings.users.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), $target, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsInviteOnClassLevelSubject(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant, 'admin@alpha.localhost');
+
+        $voter = new UserVoter($this->resolverWith($current, ['settings.users.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), User::class, ['invite']),
+        );
+    }
+
+    #[Test]
+    public function deniesAcrossTenants(): void
+    {
+        $alpha = new Tenant('alpha', 'Alpha');
+        $beta = new Tenant('beta', 'Beta');
+        $target = $this->user($beta, 'someone@beta.localhost');
+        $current = $this->user($alpha, 'admin@alpha.localhost');
+
+        $voter = new UserVoter($this->resolverWith($current, ['settings.users.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($current), $target, ['edit']),
+        );
+    }
+
+    #[Test]
+    public function deniesChangeRolesOnSelfEvenWithPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant, 'admin@alpha.localhost');
+
+        $voter = new UserVoter($this->resolverWith($current, ['settings.users.manage']));
+
+        // Even Tenant Owner cannot grant themselves new roles in one PATCH —
+        // protects against privilege escalation through single-call edit.
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($current), $current, ['change_roles']),
+        );
+    }
+
+    #[Test]
+    public function grantsEditSelfWithoutRoleChange(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant, 'admin@alpha.localhost');
+
+        $voter = new UserVoter($this->resolverWith($current, ['settings.users.manage']));
+
+        // Profile edit on self is fine — only the role-change action is
+        // self-modification-locked.
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), $current, ['edit']),
+        );
+    }
+
+    #[Test]
+    public function grantsChangeRolesOnOtherUser(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $target = $this->user($tenant, 'colleague@alpha.localhost');
+        $current = $this->user($tenant, 'admin@alpha.localhost');
+
+        $voter = new UserVoter($this->resolverWith($current, ['settings.users.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), $target, ['change_roles']),
+        );
+    }
+
+    #[Test]
+    public function deniesAllActionsWithoutPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $target = $this->user($tenant, 'colleague@alpha.localhost');
+        $current = $this->user($tenant, 'employee@alpha.localhost');
+
+        $voter = new UserVoter($this->resolverWith($current, []));
+
+        foreach (['view', 'invite', 'edit', 'deactivate', 'reactivate', 'change_roles'] as $action) {
+            self::assertSame(
+                VoterInterface::ACCESS_DENIED,
+                $voter->vote($this->token($current), $target, [$action]),
+                "Expected denial for action {$action}",
+            );
+        }
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant, 'admin@alpha.localhost');
+
+        $voter = new UserVoter($this->resolverWith($current, ['settings.users.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($current), $current, ['UNKNOWN']),
+        );
+    }
+
+    private function user(Tenant $tenant, string $email): User
+    {
+        return new User($tenant, $email, 'placeholder', ['ROLE_USER'], Uuid::v7());
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-005 — Settings-row voters under `App\Identity\Infrastructure\Security\Prd\`:

- **UserVoter** — all 6 actions → `settings.users.manage`. Self-`change_roles` denied regardless of permission.
- **RoleVoter** — all 4 actions → `settings.roles.manage`. Mutation of global / null-tenant rows denied (seeded platform templates protected).

## Deferred (scope cut, documented in code)

- Last-admin protection on User.deactivate / change_roles → service-layer (409 with explanation).
- Tenant Owner uniqueness on User.change_roles → same.
- System / built-in role protection on Role.delete → needs `is_system` column on `roles` table (own ticket).

## Test plan

- [x] 14 unit tests pass (8 UserVoter + 6 RoleVoter)
- [x] Deptrac green (both voters live in Identity_Internals, no cross-BC)
- [ ] CI green (PHPStan, Biome, full test suite, security audit, Playwright)

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)