### PR TITLE
feat(identity): #669 ApiTokenVoter + IntegrationVoter (PRD §3.2)

### DIFF
--- a/apps/api/src/Identity/Infrastructure/Security/Prd/ApiTokenVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/ApiTokenVoter.php
@@ -37,6 +37,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  * fit — this voter implements its own check directly. Cross-tenant
  * tokens never authorise even with `all.view_revoke`, because that code
  * is tenant-scoped.
+ *
+ * @extends Voter<string, ApiToken|class-string<ApiToken>>
  */
 final class ApiTokenVoter extends Voter
 {

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/ApiTokenVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/ApiTokenVoter.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\ApiToken;
+use App\Identity\Domain\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * RBAC-P3-006 (#669) — per-ApiToken authorization aligned with the
+ * PRD §3.2 macierz row.
+ *
+ * The macierz splits API-token operations onto two codes:
+ *
+ *   - `api_tokens.own.crud`         — caller manages tokens **they own**,
+ *   - `api_tokens.all.view_revoke`  — caller manages tokens across the
+ *                                     tenant (Owner / Admin / Integration
+ *                                     Manager).
+ *
+ * Action → permission resolution:
+ *   - `create`                     → needs `api_tokens.own.crud`. Class-
+ *                                    level subject (`ApiToken` FQCN), no
+ *                                    ownership compare.
+ *   - `view`, `revoke` (instance)  → granted when EITHER the caller owns
+ *                                    the token AND has `own.crud`, OR
+ *                                    the caller has `all.view_revoke`.
+ *   - `view_all`, `revoke_all`     → needs `api_tokens.all.view_revoke`.
+ *                                    Used for the cross-tenant management
+ *                                    list endpoint.
+ *
+ * Subject: {@see ApiToken} carries `tenantId` / `userId` as Uuids (not a
+ * Tenant entity), so AbstractPrdVoter's default tenant compare doesn't
+ * fit — this voter implements its own check directly. Cross-tenant
+ * tokens never authorise even with `all.view_revoke`, because that code
+ * is tenant-scoped.
+ */
+final class ApiTokenVoter extends Voter
+{
+    private const array INSTANCE_ATTRIBUTES = ['view', 'revoke'];
+    private const array CLASS_ATTRIBUTES = ['create', 'view_all', 'revoke_all'];
+
+    public function __construct(private readonly PermissionResolverInterface $resolver)
+    {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        if (!\in_array($attribute, [...self::INSTANCE_ATTRIBUTES, ...self::CLASS_ATTRIBUTES], true)) {
+            return false;
+        }
+
+        if (\is_string($subject)) {
+            return ApiToken::class === $subject;
+        }
+
+        return $subject instanceof ApiToken;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        $permissions = $this->resolver->resolve($user);
+        $hasOwnCrud = $permissions->has('api_tokens.own.crud');
+        $hasAllViewRevoke = $permissions->has('api_tokens.all.view_revoke');
+
+        return match ($attribute) {
+            'create' => $hasOwnCrud,
+            'view_all', 'revoke_all' => $hasAllViewRevoke,
+            'view', 'revoke' => $this->canActOnToken($subject, $user, $hasOwnCrud, $hasAllViewRevoke),
+            default => false,
+        };
+    }
+
+    private function canActOnToken(
+        mixed $subject,
+        User $user,
+        bool $hasOwnCrud,
+        bool $hasAllViewRevoke,
+    ): bool {
+        if (!$subject instanceof ApiToken) {
+            return false;
+        }
+
+        if ($subject->getTenantId()->toRfc4122() !== $user->getTenant()->getId()->toRfc4122()) {
+            return false;
+        }
+
+        if ($hasAllViewRevoke) {
+            return true;
+        }
+
+        return $hasOwnCrud
+            && $subject->getUserId()->toRfc4122() === $user->getId()->toRfc4122();
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/IntegrationVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/IntegrationVoter.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * RBAC-P3-006 (#669) — authorization for the Integration management
+ * surface aligned with the PRD §3.2 macierz row.
+ *
+ * Two codes split the macierz:
+ *   - `settings.integrations.manage`        — read + configure + manage
+ *                                             webhooks,
+ *   - `settings.integration_secrets.read`   — separate read access to
+ *                                             `access_token` /
+ *                                             `webhook_secret` payloads.
+ *                                             Even Owner needs this to
+ *                                             see the secret bodies.
+ *
+ * Action → permission resolution:
+ *   - `view`             → `settings.integrations.manage`,
+ *   - `manage_config`    → `settings.integrations.manage`,
+ *   - `manage_webhooks`  → `settings.integrations.manage`,
+ *   - `read_secrets`     → `settings.integration_secrets.read`.
+ *
+ * Subject: the Integration BC is forward-compatible (per ADR-0013 / Deptrac
+ * configuration — `src/Integration/*` is empty in MVP). The voter accepts
+ * either the canonical placeholder string `"integration"` or a future
+ * Integration entity once the BC fills in. Phase 6 retrofit tightens the
+ * subject contract when concrete adapters land.
+ *
+ * Last-used IP redaction (per ticket discussion) is a serializer concern
+ * (RBAC-P3-012 #675), not a voter concern — this voter only decides
+ * whether the action is allowed, not which fields the response carries.
+ */
+final class IntegrationVoter extends Voter
+{
+    public const string SUBJECT_PLACEHOLDER = 'integration';
+
+    private const array ATTRIBUTES = [
+        'view' => 'settings.integrations.manage',
+        'manage_config' => 'settings.integrations.manage',
+        'manage_webhooks' => 'settings.integrations.manage',
+        'read_secrets' => 'settings.integration_secrets.read',
+    ];
+
+    public function __construct(private readonly PermissionResolverInterface $resolver)
+    {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        if (!\array_key_exists($attribute, self::ATTRIBUTES)) {
+            return false;
+        }
+
+        if (\is_string($subject)) {
+            return self::SUBJECT_PLACEHOLDER === $subject
+                || str_contains($subject, '\\Integration\\');
+        }
+
+        if (\is_object($subject)) {
+            return str_contains($subject::class, '\\Integration\\');
+        }
+
+        return false;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        $code = self::ATTRIBUTES[$attribute] ?? null;
+        if (null === $code) {
+            return false;
+        }
+
+        return $this->resolver->resolve($user)->has($code);
+    }
+}

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/IntegrationVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/IntegrationVoter.php
@@ -37,6 +37,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  * Last-used IP redaction (per ticket discussion) is a serializer concern
  * (RBAC-P3-012 #675), not a voter concern — this voter only decides
  * whether the action is allowed, not which fields the response carries.
+ *
+ * @extends Voter<string, object|string>
  */
 final class IntegrationVoter extends Voter
 {

--- a/apps/api/tests/Unit/Identity/Security/Prd/ApiTokenVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/ApiTokenVoterTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\ApiToken;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\ApiTokenVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-006 (#669) — ApiTokenVoter unit coverage of the
+ * own / cross-user split (`api_tokens.own.crud` vs
+ * `api_tokens.all.view_revoke`).
+ */
+final class ApiTokenVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsCreateWithOwnCrud(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.own.crud']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), ApiToken::class, ['create']),
+        );
+    }
+
+    #[Test]
+    public function grantsViewOwnToken(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+        $ownToken = $this->apiToken($tenant->getId(), $current->getId());
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.own.crud']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), $ownToken, ['view']),
+        );
+    }
+
+    #[Test]
+    public function deniesViewOtherUserTokenWithOnlyOwnCrud(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+        $someoneElse = Uuid::v7();
+        $otherToken = $this->apiToken($tenant->getId(), $someoneElse);
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.own.crud']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($current), $otherToken, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsViewOtherUserTokenWithAllViewRevoke(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+        $someoneElse = Uuid::v7();
+        $otherToken = $this->apiToken($tenant->getId(), $someoneElse);
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.all.view_revoke']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), $otherToken, ['view']),
+        );
+    }
+
+    #[Test]
+    public function deniesAcrossTenantsEvenWithAllViewRevoke(): void
+    {
+        $alpha = new Tenant('alpha', 'Alpha');
+        $beta = new Tenant('beta', 'Beta');
+        $current = $this->user($alpha);
+        $crossTenantToken = $this->apiToken($beta->getId(), Uuid::v7());
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.all.view_revoke']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($current), $crossTenantToken, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsRevokeOwnTokenWithOwnCrud(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+        $ownToken = $this->apiToken($tenant->getId(), $current->getId());
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.own.crud']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), $ownToken, ['revoke']),
+        );
+    }
+
+    #[Test]
+    public function grantsViewAllWithAllViewRevoke(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.all.view_revoke']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($current), ApiToken::class, ['view_all']),
+        );
+    }
+
+    #[Test]
+    public function deniesViewAllWithOnlyOwnCrud(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.own.crud']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($current), ApiToken::class, ['view_all']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $current = $this->user($tenant);
+
+        $voter = new ApiTokenVoter($this->resolverWith($current, ['api_tokens.own.crud']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($current), ApiToken::class, ['UNKNOWN']),
+        );
+    }
+
+    private function apiToken(Uuid $tenantId, Uuid $userId): ApiToken
+    {
+        return new ApiToken(
+            tenantId: $tenantId,
+            userId: $userId,
+            name: 'integration-test',
+            tokenHash: 'hash',
+            tokenLast4: '1234',
+            scopes: ['read-only'],
+        );
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder', ['ROLE_USER'], Uuid::v7());
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/IntegrationVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/IntegrationVoterTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\IntegrationVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * RBAC-P3-006 (#669) — IntegrationVoter unit coverage of the
+ * manage vs secrets split.
+ */
+final class IntegrationVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsViewWithManagePermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new IntegrationVoter($this->resolverWith($user, ['settings.integrations.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), IntegrationVoter::SUBJECT_PLACEHOLDER, ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsManageConfigWithManagePermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new IntegrationVoter($this->resolverWith($user, ['settings.integrations.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), IntegrationVoter::SUBJECT_PLACEHOLDER, ['manage_config']),
+        );
+    }
+
+    #[Test]
+    public function deniesReadSecretsWithoutSecretsPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        // Even with the broad manage gate, the secrets layer requires the
+        // dedicated code — Phase 6 ensures no surface bypass.
+        $voter = new IntegrationVoter($this->resolverWith($user, ['settings.integrations.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), IntegrationVoter::SUBJECT_PLACEHOLDER, ['read_secrets']),
+        );
+    }
+
+    #[Test]
+    public function grantsReadSecretsWhenBothPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new IntegrationVoter($this->resolverWith($user, [
+            'settings.integrations.manage',
+            'settings.integration_secrets.read',
+        ]));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), IntegrationVoter::SUBJECT_PLACEHOLDER, ['read_secrets']),
+        );
+    }
+
+    #[Test]
+    public function deniesEverythingWithoutPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new IntegrationVoter($this->resolverWith($user, []));
+
+        foreach (['view', 'manage_config', 'manage_webhooks', 'read_secrets'] as $action) {
+            self::assertSame(
+                VoterInterface::ACCESS_DENIED,
+                $voter->vote($this->token($user), IntegrationVoter::SUBJECT_PLACEHOLDER, [$action]),
+                "Expected denial for action {$action}",
+            );
+        }
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new IntegrationVoter($this->resolverWith($user, ['settings.integrations.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), IntegrationVoter::SUBJECT_PLACEHOLDER, ['UNKNOWN']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnsupportedSubject(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new IntegrationVoter($this->resolverWith($user, ['settings.integrations.manage']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), 'something_else', ['view']),
+        );
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-006 — two voters under `App\Identity\Infrastructure\Security\Prd\`:

- **ApiTokenVoter** — direct Voter (not AbstractPrdVoter) because macierz splits across two codes: `api_tokens.own.crud` for own-token CRUD, `api_tokens.all.view_revoke` for cross-user view/revoke. Cross-tenant tokens denied regardless of permission (tenant-scoped code, no escape).
- **IntegrationVoter** — `settings.integrations.manage` covers view + manage_config + manage_webhooks; `settings.integration_secrets.read` gates the dedicated secret-body access. Subject is placeholder string `'integration'` until the Integration BC fills in (forward-compatible per Deptrac).

## Test plan

- [x] 16 unit tests pass (9 ApiTokenVoter + 7 IntegrationVoter)
- [x] Deptrac green (no cross-BC)
- [ ] CI green (PHPStan, Biome, full test suite, security audit, Playwright)

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)