### PR TITLE
feat(identity): #670 AuditLogVoter (PRD §3.2 audit row)

### DIFF
--- a/apps/api/src/Identity/Infrastructure/Security/Prd/AuditLogVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/AuditLogVoter.php
@@ -35,6 +35,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  * the entity replaces it. Voter does not implement query filtering;
  * that is the responsibility of {@see \App\Identity\Application\Policy\OwnershipPolicy}
  * (RBAC-P3-010 #673) plus the service layer once AuditLog lands.
+ *
+ * @extends Voter<string, object|string>
  */
 final class AuditLogVoter extends Voter
 {

--- a/apps/api/src/Identity/Infrastructure/Security/Prd/AuditLogVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/Prd/AuditLogVoter.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security\Prd;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * RBAC-P3-007 (#670) — audit log read authorization aligned with the
+ * PRD §3.2 macierz row.
+ *
+ * Three actions split the macierz:
+ *
+ *   - `view_own`                    — every authenticated user; service
+ *                                     layer scopes the query to
+ *                                     `WHERE user_id = current_user`,
+ *   - `view_cross_user`             — Owner / Admin / Approver / Viewer
+ *                                     scope (tenant-wide audit view),
+ *   - `view_platform_cross_tenant`  — Super Admin only, no tenant filter.
+ *
+ * Permission codes:
+ *
+ *   - `audit.view_own`              — granted to every tenant-level role
+ *                                     in the macierz,
+ *   - `audit.view_cross_user`       — tenant-wide,
+ *   - `platform.audit.view_all`     — platform-scope, Super Admin only.
+ *
+ * Subject: the AuditLog entity ships with the audit log listener
+ * (RBAC-P3-013 #676). Until then the voter operates on the placeholder
+ * string `'audit_log'` — controller-side calls pass that literal until
+ * the entity replaces it. Voter does not implement query filtering;
+ * that is the responsibility of {@see \App\Identity\Application\Policy\OwnershipPolicy}
+ * (RBAC-P3-010 #673) plus the service layer once AuditLog lands.
+ */
+final class AuditLogVoter extends Voter
+{
+    public const string SUBJECT_PLACEHOLDER = 'audit_log';
+
+    private const array ATTRIBUTES = [
+        'view_own' => 'audit.view_own',
+        'view_cross_user' => 'audit.view_cross_user',
+        'view_platform_cross_tenant' => 'platform.audit.view_all',
+    ];
+
+    public function __construct(private readonly PermissionResolverInterface $resolver)
+    {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        if (!\array_key_exists($attribute, self::ATTRIBUTES)) {
+            return false;
+        }
+
+        if (\is_string($subject)) {
+            return self::SUBJECT_PLACEHOLDER === $subject
+                || str_contains($subject, '\\AuditLog');
+        }
+
+        if (\is_object($subject)) {
+            return str_contains($subject::class, 'AuditLog');
+        }
+
+        return false;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        $code = self::ATTRIBUTES[$attribute] ?? null;
+        if (null === $code) {
+            return false;
+        }
+
+        return $this->resolver->resolve($user)->has($code);
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/Prd/AuditLogVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/Prd/AuditLogVoterTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security\Prd;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\Prd\AuditLogVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * RBAC-P3-007 (#670) — AuditLogVoter unit coverage of the
+ * own / cross-user / cross-tenant three-tier split.
+ */
+final class AuditLogVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsViewOwnForEveryTenantUser(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new AuditLogVoter($this->resolverWith($user, ['audit.view_own']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), AuditLogVoter::SUBJECT_PLACEHOLDER, ['view_own']),
+        );
+    }
+
+    #[Test]
+    public function deniesCrossUserWithoutPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new AuditLogVoter($this->resolverWith($user, ['audit.view_own']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), AuditLogVoter::SUBJECT_PLACEHOLDER, ['view_cross_user']),
+        );
+    }
+
+    #[Test]
+    public function grantsCrossUserWithPermission(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new AuditLogVoter($this->resolverWith($user, ['audit.view_own', 'audit.view_cross_user']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), AuditLogVoter::SUBJECT_PLACEHOLDER, ['view_cross_user']),
+        );
+    }
+
+    #[Test]
+    public function deniesPlatformCrossTenantWithoutSuperAdmin(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        // Even tenant-level cross-user permission must not grant access to
+        // platform-scope audit visibility — that is Super Admin's privilege.
+        $voter = new AuditLogVoter($this->resolverWith($user, ['audit.view_cross_user']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), AuditLogVoter::SUBJECT_PLACEHOLDER, ['view_platform_cross_tenant']),
+        );
+    }
+
+    #[Test]
+    public function grantsPlatformCrossTenantWithSuperAdminCode(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new AuditLogVoter($this->resolverWith($user, ['platform.audit.view_all']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), AuditLogVoter::SUBJECT_PLACEHOLDER, ['view_platform_cross_tenant']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new AuditLogVoter($this->resolverWith($user, ['audit.view_own']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), AuditLogVoter::SUBJECT_PLACEHOLDER, ['UNKNOWN']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnsupportedSubject(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new AuditLogVoter($this->resolverWith($user, ['audit.view_own']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), 'something_else', ['view_own']),
+        );
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-007 — `AuditLogVoter` with the three-tier read split (own / cross-user / platform-cross-tenant) under `App\Identity\Infrastructure\Security\Prd\`:

- `view_own` → `audit.view_own` (everyone)
- `view_cross_user` → `audit.view_cross_user` (Owner / Admin / Approver / Viewer)
- `view_platform_cross_tenant` → `platform.audit.view_all` (Super Admin only)

Cross-tenant escalation guard verified: tenant-level `audit.view_cross_user` does NOT grant platform-scope visibility.

Subject is placeholder string `'audit_log'` until the AuditLog entity lands with #676. Query scoping (own filter, cross-user filter, no-filter for platform) belongs to the service layer once the entity exists — voter only decides whether access is allowed.

## Test plan

- [x] 7 unit tests pass
- [x] Deptrac green
- [ ] CI green (PHPStan, Biome, full test suite, security audit, Playwright)

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)