### PR TITLE
feat(identity): #671 AttributePermissionPolicy (PRD §3.5 3-state)

### DIFF
--- a/apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php
+++ b/apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\AttributePermission;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-008 (#671) — 3-state attribute permission resolution per
+ * PRD §3.5.
+ *
+ * **Resolution chain (per role, then merged most-permissive):**
+ *
+ *   0. **Broad gate first** (decyzja designerska A) — the caller must
+ *      hold either `products.view` or `products.edit` in the macierz.
+ *      If neither, every per-attribute grant is inactive and the policy
+ *      returns `Restricted` immediately.
+ *
+ *   1. **Per-attribute override** —
+ *      `role_attribute_permissions(role_id, attribute_id)`. First entry
+ *      wins for that role.
+ *
+ *   2. **Per-group override** —
+ *      `role_attribute_group_permissions(role_id, attribute_group_id)`.
+ *      The attribute can belong to multiple groups via
+ *      `attribute_group_attributes`; the most-permissive group entry
+ *      among them is taken.
+ *
+ *   3. **Role default** — `roles.default_attribute_permission` falls
+ *      back to one of the three values (defaults to `edit` per schema).
+ *
+ * **Multi-role merging:** the user can carry multiple roles (both via
+ * `user_role_assignments` and the legacy `user_roles` M2M). The policy
+ * resolves per role and returns `max(rank)` — most-permissive role
+ * wins. This matches PermissionResolver's union semantics for broad
+ * permissions.
+ *
+ * **Tenant scope:** roles are tenant-scoped through `roles.tenant_id`;
+ * `user_roles` / `user_role_assignments` carry the link from a
+ * tenant-scoped user to a tenant-scoped role. No additional tenant
+ * compare is needed here — the role IDs we collect are already inside
+ * the caller's tenant.
+ *
+ * **Cache:** not wired in this ticket. The three SELECTs are indexed
+ * (primary key on the junction tables, FK index on roles.id), so a
+ * single resolve runs in O(roles) cheap lookups. Cache + invalidation
+ * listeners land in a follow-up once profiling shows the call path is
+ * hot enough to amortise the invalidation complexity (Phase 6 #720
+ * benchmark ticket).
+ *
+ * **`integration_visible` flag:** independent semantics, lives in the
+ * serializer (RBAC-P3-012 #675). This policy resolves only the per-role
+ * 3-state values — the serializer composes them with the integration
+ * flag for the final response shape.
+ */
+final readonly class AttributePermissionPolicy
+{
+    public function __construct(
+        private Connection $connection,
+        private PermissionResolverInterface $resolver,
+    ) {
+    }
+
+    public function resolvePermission(User $user, Uuid $attributeId): AttributePermission
+    {
+        // Step 0 — broad gate first (PRD §3.5 decyzja designerska A).
+        $permissions = $this->resolver->resolve($user);
+        if (!$permissions->has('products.view') && !$permissions->has('products.edit')) {
+            return AttributePermission::Restricted;
+        }
+
+        $roleIds = $this->collectRoleIds($user->getId());
+        if ([] === $roleIds) {
+            return AttributePermission::Restricted;
+        }
+
+        $best = AttributePermission::Restricted;
+        foreach ($roleIds as $roleId) {
+            $resolved = $this->resolveForRole($roleId, $attributeId);
+            if ($resolved->rank() > $best->rank()) {
+                $best = $resolved;
+            }
+            if (AttributePermission::Edit === $best) {
+                // Most-permissive already reached — short-circuit. Saves
+                // the remaining per-role queries on Owner/Admin users
+                // that carry several roles.
+                return $best;
+            }
+        }
+
+        return $best;
+    }
+
+    public function canEditAttribute(User $user, Uuid $attributeId): bool
+    {
+        return $this->resolvePermission($user, $attributeId)->canEdit();
+    }
+
+    public function canViewAttribute(User $user, Uuid $attributeId): bool
+    {
+        return $this->resolvePermission($user, $attributeId)->canView();
+    }
+
+    /**
+     * @return list<string> role UUIDs (RFC4122 strings) accessible to the
+     *                      user via either `user_role_assignments` or the
+     *                      legacy `user_roles` M2M, deduplicated
+     */
+    private function collectRoleIds(Uuid $userId): array
+    {
+        $sql = <<<'SQL'
+            SELECT DISTINCT role_id::text AS role_id
+              FROM user_role_assignments
+             WHERE user_id = :user_id
+            UNION
+            SELECT DISTINCT role_id::text AS role_id
+              FROM user_roles
+             WHERE user_id = :user_id
+            SQL;
+
+        /** @var list<array{role_id: string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, ['user_id' => $userId->toRfc4122()]);
+
+        return array_map(static fn (array $row): string => $row['role_id'], $rows);
+    }
+
+    private function resolveForRole(string $roleId, Uuid $attributeId): AttributePermission
+    {
+        // 1. Per-attribute override — direct lookup, primary-key indexed.
+        $perAttr = $this->connection->fetchOne(
+            'SELECT permission FROM role_attribute_permissions WHERE role_id = :role_id AND attribute_id = :attribute_id',
+            ['role_id' => $roleId, 'attribute_id' => $attributeId->toRfc4122()],
+        );
+        if (false !== $perAttr && \is_string($perAttr)) {
+            return AttributePermission::from($perAttr);
+        }
+
+        // 2. Per-group override — attribute may belong to multiple groups;
+        //    take the most-permissive group grant for this role.
+        $perGroup = $this->connection->fetchOne(
+            <<<'SQL'
+                SELECT rgp.permission
+                  FROM role_attribute_group_permissions rgp
+                  JOIN attribute_group_attributes aga ON aga.attribute_group_id = rgp.attribute_group_id
+                 WHERE rgp.role_id = :role_id
+                   AND aga.attribute_id = :attribute_id
+                 ORDER BY CASE rgp.permission
+                              WHEN 'edit' THEN 2
+                              WHEN 'view' THEN 1
+                              ELSE 0
+                          END DESC
+                 LIMIT 1
+                SQL,
+            ['role_id' => $roleId, 'attribute_id' => $attributeId->toRfc4122()],
+        );
+        if (false !== $perGroup && \is_string($perGroup)) {
+            return AttributePermission::from($perGroup);
+        }
+
+        // 3. Role default — column defaults to 'edit' for tenant-level
+        //    roles, 'view' for viewer, 'restricted' for explicit setups.
+        $default = $this->connection->fetchOne(
+            'SELECT default_attribute_permission FROM roles WHERE id = :role_id',
+            ['role_id' => $roleId],
+        );
+        if (false !== $default && \is_string($default)) {
+            return AttributePermission::from($default);
+        }
+
+        return AttributePermission::Restricted;
+    }
+}

--- a/apps/api/src/Identity/Domain/Rbac/AttributePermission.php
+++ b/apps/api/src/Identity/Domain/Rbac/AttributePermission.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Rbac;
+
+/**
+ * RBAC-P3-008 (#671) — 3-state attribute permission per PRD §3.5.
+ *
+ * Each entry on `role_attribute_permissions(role_id, attribute_id)` /
+ * `role_attribute_group_permissions(role_id, attribute_group_id)` carries
+ * one of three values, and `roles.default_attribute_permission` falls
+ * back to one of the three when no override matches.
+ *
+ *   - `restricted` — attribute is hidden from the response and rejects
+ *                    edits (full removal in the serializer + 403 on PATCH),
+ *   - `view`       — value visible, edits rejected (`{value, editable:
+ *                    false, reason: "view_only"}` shape per §3.5),
+ *   - `edit`       — full read + write.
+ *
+ * The {@see rank()} method orders the values from least- to most-permissive
+ * so {@see \App\Identity\Application\Policy\AttributePermissionPolicy} can
+ * merge multiple roles by taking the maximum.
+ */
+enum AttributePermission: string
+{
+    case Restricted = 'restricted';
+    case View = 'view';
+    case Edit = 'edit';
+
+    public function rank(): int
+    {
+        return match ($this) {
+            self::Restricted => 0,
+            self::View => 1,
+            self::Edit => 2,
+        };
+    }
+
+    public function canView(): bool
+    {
+        return self::Restricted !== $this;
+    }
+
+    public function canEdit(): bool
+    {
+        return self::Edit === $this;
+    }
+}

--- a/apps/api/tests/Unit/Identity/Application/Policy/AttributePermissionPolicyTest.php
+++ b/apps/api/tests/Unit/Identity/Application/Policy/AttributePermissionPolicyTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Application\Policy\AttributePermissionPolicy;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\AttributePermission;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-008 (#671) — unit coverage of AttributePermissionPolicy
+ * resolution priority per PRD §3.5.
+ *
+ * Connection-level interactions are stubbed so each test exercises a
+ * single branch of the resolution chain: broad gate / per-attribute /
+ * per-group / role-default / multi-role merge.
+ */
+final class AttributePermissionPolicyTest extends TestCase
+{
+    private const string ROLE_ID = '01931700-0000-7000-8000-000000000001';
+    private const string ROLE_ID_SECOND = '01931700-0000-7000-8000-000000000002';
+
+    #[Test]
+    public function returnsRestrictedWhenBroadGateMissing(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, []);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::never())->method('fetchAllAssociative');
+        $connection->expects(self::never())->method('fetchOne');
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertSame(AttributePermission::Restricted, $policy->resolvePermission($user, $attrId));
+    }
+
+    #[Test]
+    public function perAttributeOverrideWinsOverGroupAndDefault(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, ['products.view']);
+        $connection = $this->stubConnection(
+            roleIds: [self::ROLE_ID],
+            perAttribute: AttributePermission::Edit->value,
+        );
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertSame(AttributePermission::Edit, $policy->resolvePermission($user, $attrId));
+    }
+
+    #[Test]
+    public function perGroupOverrideWinsWhenAttributeOverrideAbsent(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, ['products.view']);
+        $connection = $this->stubConnection(
+            roleIds: [self::ROLE_ID],
+            perGroup: AttributePermission::View->value,
+        );
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertSame(AttributePermission::View, $policy->resolvePermission($user, $attrId));
+    }
+
+    #[Test]
+    public function fallsBackToRoleDefault(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, ['products.view']);
+        $connection = $this->stubConnection(
+            roleIds: [self::ROLE_ID],
+            roleDefault: AttributePermission::View->value,
+        );
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertSame(AttributePermission::View, $policy->resolvePermission($user, $attrId));
+    }
+
+    #[Test]
+    public function takesMostPermissiveAcrossMultipleRoles(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, ['products.view']);
+
+        // First role: per-attribute Restricted. Second role: per-group Edit.
+        // Most permissive wins → Edit.
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchAllAssociative')
+            ->willReturn([
+                ['role_id' => self::ROLE_ID],
+                ['role_id' => self::ROLE_ID_SECOND],
+            ]);
+
+        $connection->method('fetchOne')
+            ->willReturnCallback(static function (string $sql, array $params) {
+                if (str_contains($sql, 'FROM role_attribute_permissions')) {
+                    return self::ROLE_ID === $params['role_id'] ? AttributePermission::Restricted->value : false;
+                }
+                if (str_contains($sql, 'FROM role_attribute_group_permissions')) {
+                    return self::ROLE_ID_SECOND === $params['role_id'] ? AttributePermission::Edit->value : false;
+                }
+                if (str_contains($sql, 'FROM roles WHERE id')) {
+                    return AttributePermission::Restricted->value;
+                }
+
+                return false;
+            });
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertSame(AttributePermission::Edit, $policy->resolvePermission($user, $attrId));
+    }
+
+    #[Test]
+    public function returnsRestrictedWhenUserCarriesNoRoles(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, ['products.view']);
+        $connection = $this->createMock(Connection::class);
+        $connection->method('fetchAllAssociative')->willReturn([]);
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertSame(AttributePermission::Restricted, $policy->resolvePermission($user, $attrId));
+    }
+
+    #[Test]
+    public function canEditAttributeReflectsEditPermission(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, ['products.edit']);
+        $connection = $this->stubConnection(
+            roleIds: [self::ROLE_ID],
+            perAttribute: AttributePermission::Edit->value,
+        );
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertTrue($policy->canEditAttribute($user, $attrId));
+        self::assertTrue($policy->canViewAttribute($user, $attrId));
+    }
+
+    #[Test]
+    public function canEditFalseWhenOnlyViewGranted(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, ['products.view']);
+        $connection = $this->stubConnection(
+            roleIds: [self::ROLE_ID],
+            perAttribute: AttributePermission::View->value,
+        );
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertFalse($policy->canEditAttribute($user, $attrId));
+        self::assertTrue($policy->canViewAttribute($user, $attrId));
+    }
+
+    #[Test]
+    public function canViewFalseWhenRestricted(): void
+    {
+        $user = $this->user();
+        $attrId = Uuid::v7();
+
+        $resolver = $this->resolverWith($user, ['products.view']);
+        $connection = $this->stubConnection(
+            roleIds: [self::ROLE_ID],
+            perAttribute: AttributePermission::Restricted->value,
+        );
+
+        $policy = new AttributePermissionPolicy($connection, $resolver);
+
+        self::assertFalse($policy->canViewAttribute($user, $attrId));
+        self::assertFalse($policy->canEditAttribute($user, $attrId));
+    }
+
+    private function user(): User
+    {
+        return new User(
+            new Tenant('alpha', 'Alpha'),
+            'tester@alpha.localhost',
+            'placeholder',
+            ['ROLE_USER'],
+            Uuid::v7(),
+        );
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    /**
+     * @param list<string> $roleIds
+     */
+    private function stubConnection(
+        array $roleIds,
+        ?string $perAttribute = null,
+        ?string $perGroup = null,
+        ?string $roleDefault = null,
+    ): Connection {
+        $connection = $this->createMock(Connection::class);
+
+        $connection->method('fetchAllAssociative')
+            ->willReturn(array_map(static fn (string $id): array => ['role_id' => $id], $roleIds));
+
+        $connection->method('fetchOne')
+            ->willReturnCallback(static function (string $sql) use ($perAttribute, $perGroup, $roleDefault) {
+                if (str_contains($sql, 'FROM role_attribute_permissions')) {
+                    return $perAttribute ?? false;
+                }
+                if (str_contains($sql, 'FROM role_attribute_group_permissions')) {
+                    return $perGroup ?? false;
+                }
+                if (str_contains($sql, 'FROM roles WHERE id')) {
+                    return $roleDefault ?? false;
+                }
+
+                return false;
+            });
+
+        return $connection;
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-008 — `AttributePermissionPolicy` resolving 3-state attribute permissions (restricted / view / edit) per PRD §3.5.

**Krok 0 (PRD cross-ref):**
- §3.5 read ✓ — resolution chain (broad gate → attribute → group → role default), decyzja designerska A (per-attribute grants NIE bypass broad gate)
- §3.2 cross-tab ✓ — UI integration deferred to Phase 4 #687 (Mercure) + Phase 5 (Settings UI)
- Resolution priority verified: broad gate → attribute → group → role default
- Multi-role merging: max(rank), matches PermissionResolver union semantics
- `integration_visible` flag NOT here — independent semantics in serializer (RBAC-P3-012 #675)

## Deliverables

- `AttributePermission` enum (`Identity/Domain/Rbac/`) with `rank()` / `canView()` / `canEdit()`
- `AttributePermissionPolicy` service (`Identity/Application/Policy/`) — DBAL-based resolver, short-circuits at Edit
- 9 unit tests w/ mocked Connection — per branch of resolution chain

## Scope cut (documented in code + PR body)

- **Cache + 4 invalidation listeners** → Phase 6 #720 (benchmark-driven). 3 indexed SELECTs per resolve are cheap for MVP; cache is profiling-driven optimisation, not premature.
- **Response shape `{value, editable, reason}`** → RBAC-P3-012 #675 (field-level serializer). Policy returns only the enum.
- **PATCH atomic transaction integration** → RBAC-P3-012 #675 (request body validator).
- **Cross-tab UI badge counter** → Phase 4 #687.
- **Migration v1→v2** (PRD §3.5) — N/A, clean greenfield without `attributes.restricted_roles` JSONB.

## Test plan

- [x] 9 unit tests pass
- [x] Deptrac green (0 violations)
- [ ] CI green (PHPStan, Biome, full test suite, security audit, Playwright)

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)