### PR TITLE
feat(identity): #672 LocaleChannelScopePolicy (PRD §3.6/§3.7)

### DIFF
--- a/apps/api/src/Identity/Application/Policy/LocaleChannelScopePolicy.php
+++ b/apps/api/src/Identity/Application/Policy/LocaleChannelScopePolicy.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+
+/**
+ * RBAC-P3-009 (#672) — per-locale and per-channel scope enforcement per
+ * PRD §3.6 / §3.7.
+ *
+ * Each user role row carries `locale_scope` and `channel_scope` arrays
+ * (aggregated via `PermissionResolver` into a single
+ * {@see \App\Identity\Domain\Rbac\PermissionSet}). The policy answers
+ * the question *"may the caller edit/view this attribute's locale /
+ * channel variant?"*.
+ *
+ * Wildcard convention (matches `UserRole` storage convention):
+ *   - `[]`        — no restriction (the role has not narrowed scope),
+ *   - `["*"]`     — explicit wildcard, same meaning as empty,
+ *   - `["en"]`    — only that locale is allowed,
+ *   - mixed       — union of allowed locales across the user's roles
+ *                   (PermissionSet already aggregates roles).
+ *
+ * Channel scope behaves identically. The policy is stateless — every
+ * call resolves through the cached PermissionSet — so no service-level
+ * cache is needed on top.
+ *
+ * Atomic transaction note (per ticket discussion): when a PATCH body
+ * carries multiple locale or channel variants for the same attribute,
+ * the validator iterates them and rejects the whole request if any
+ * variant fails — this policy returns boolean per variant; the request
+ * body validator (RBAC-P3-012 #675) drives the iteration + rollback.
+ */
+final readonly class LocaleChannelScopePolicy
+{
+    public const string WILDCARD = '*';
+
+    public function __construct(private PermissionResolverInterface $resolver)
+    {
+    }
+
+    public function canEditLocale(User $user, string $locale): bool
+    {
+        return $this->localeAllowed(
+            $this->resolver->resolve($user)->getLocaleScope(),
+            $locale,
+        );
+    }
+
+    public function canEditChannel(User $user, string $channel): bool
+    {
+        return $this->channelAllowed(
+            $this->resolver->resolve($user)->getChannelScope(),
+            $channel,
+        );
+    }
+
+    /**
+     * Combined check for the common case of *attribute value* edits that
+     * carry both dimensions. Returns false on the first dimension that
+     * fails, so callers don't need to compose the two booleans.
+     */
+    public function canEditValue(User $user, string $locale, string $channel): bool
+    {
+        $permissions = $this->resolver->resolve($user);
+
+        return $this->localeAllowed($permissions->getLocaleScope(), $locale)
+            && $this->channelAllowed($permissions->getChannelScope(), $channel);
+    }
+
+    /**
+     * @param list<string> $scope
+     */
+    private function localeAllowed(array $scope, string $locale): bool
+    {
+        return $this->scopeAllows($scope, $locale);
+    }
+
+    /**
+     * @param list<string> $scope
+     */
+    private function channelAllowed(array $scope, string $channel): bool
+    {
+        return $this->scopeAllows($scope, $channel);
+    }
+
+    /**
+     * @param list<string> $scope
+     */
+    private function scopeAllows(array $scope, string $value): bool
+    {
+        if ([] === $scope || \in_array(self::WILDCARD, $scope, true)) {
+            return true;
+        }
+
+        return \in_array($value, $scope, true);
+    }
+}

--- a/apps/api/tests/Unit/Identity/Application/Policy/LocaleChannelScopePolicyTest.php
+++ b/apps/api/tests/Unit/Identity/Application/Policy/LocaleChannelScopePolicyTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Application\Policy\LocaleChannelScopePolicy;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-009 (#672) — LocaleChannelScopePolicy unit coverage of the
+ * wildcard / narrowed / union conventions.
+ */
+final class LocaleChannelScopePolicyTest extends TestCase
+{
+    #[Test]
+    public function emptyScopeAllowsEveryLocale(): void
+    {
+        $policy = new LocaleChannelScopePolicy($this->resolverWith(
+            localeScope: [],
+            channelScope: [],
+        ));
+
+        self::assertTrue($policy->canEditLocale($this->user(), 'pl'));
+        self::assertTrue($policy->canEditLocale($this->user(), 'en'));
+        self::assertTrue($policy->canEditChannel($this->user(), 'shopify'));
+    }
+
+    #[Test]
+    public function wildcardAllowsEveryLocale(): void
+    {
+        $policy = new LocaleChannelScopePolicy($this->resolverWith(
+            localeScope: [LocaleChannelScopePolicy::WILDCARD],
+            channelScope: [LocaleChannelScopePolicy::WILDCARD],
+        ));
+
+        self::assertTrue($policy->canEditLocale($this->user(), 'pl'));
+        self::assertTrue($policy->canEditChannel($this->user(), 'shopify'));
+    }
+
+    #[Test]
+    public function narrowedLocaleAllowsOnlyListed(): void
+    {
+        $policy = new LocaleChannelScopePolicy($this->resolverWith(
+            localeScope: ['en'],
+            channelScope: [],
+        ));
+
+        self::assertTrue($policy->canEditLocale($this->user(), 'en'));
+        self::assertFalse($policy->canEditLocale($this->user(), 'pl'));
+    }
+
+    #[Test]
+    public function narrowedChannelAllowsOnlyListed(): void
+    {
+        $policy = new LocaleChannelScopePolicy($this->resolverWith(
+            localeScope: [],
+            channelScope: ['allegro'],
+        ));
+
+        self::assertTrue($policy->canEditChannel($this->user(), 'allegro'));
+        self::assertFalse($policy->canEditChannel($this->user(), 'shopify'));
+    }
+
+    #[Test]
+    public function canEditValueRequiresBothDimensionsToPass(): void
+    {
+        $policy = new LocaleChannelScopePolicy($this->resolverWith(
+            localeScope: ['en'],
+            channelScope: ['shopify'],
+        ));
+
+        self::assertTrue($policy->canEditValue($this->user(), 'en', 'shopify'));
+        self::assertFalse($policy->canEditValue($this->user(), 'pl', 'shopify'));
+        self::assertFalse($policy->canEditValue($this->user(), 'en', 'allegro'));
+        self::assertFalse($policy->canEditValue($this->user(), 'pl', 'allegro'));
+    }
+
+    #[Test]
+    public function unionAcrossMultipleLocalesAllowsAny(): void
+    {
+        // The resolver already aggregates roles into one PermissionSet —
+        // a user with two roles narrowed to ["en"] and ["pl"] respectively
+        // sees the union ["en", "pl"].
+        $policy = new LocaleChannelScopePolicy($this->resolverWith(
+            localeScope: ['en', 'pl'],
+            channelScope: [],
+        ));
+
+        self::assertTrue($policy->canEditLocale($this->user(), 'en'));
+        self::assertTrue($policy->canEditLocale($this->user(), 'pl'));
+        self::assertFalse($policy->canEditLocale($this->user(), 'de'));
+    }
+
+    private function user(): User
+    {
+        return new User(
+            new Tenant('alpha', 'Alpha'),
+            'tester@alpha.localhost',
+            'placeholder',
+            ['ROLE_USER'],
+            Uuid::v7(),
+        );
+    }
+
+    /**
+     * @param list<string> $localeScope
+     * @param list<string> $channelScope
+     */
+    private function resolverWith(array $localeScope, array $channelScope): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->willReturn(new PermissionSet(
+            permissionCodes: ['products.edit'],
+            localeScope: $localeScope,
+            channelScope: $channelScope,
+        ));
+
+        return $resolver;
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-009 — `LocaleChannelScopePolicy` enforces per-locale + per-channel scope from the aggregated `PermissionSet`. Wildcard `[]` / `["*"]` / narrowed list / role-union — convention matches `UserRole` storage.

Three entry points: `canEditLocale` / `canEditChannel` / `canEditValue` (combined).

PATCH atomic transaction integration → RBAC-P3-012 #675 (request body validator drives the loop + rollback; this policy returns boolean per variant).

## Test plan

- [x] 6 unit tests pass
- [x] Deptrac green
- [ ] CI green

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)