### PR TITLE
feat(identity): #673 OwnershipPolicy (PRD §3.2 own/all routing)

### DIFF
--- a/apps/api/src/Identity/Application/Policy/OwnershipPolicy.php
+++ b/apps/api/src/Identity/Application/Policy/OwnershipPolicy.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use InvalidArgumentException;
+
+/**
+ * RBAC-P3-010 (#673) — own / all scope resolution for the operational
+ * resources that carry an ownership dimension per PRD §3.2:
+ *
+ *   - `imports`     — `imports.view_own` / `imports.view_all`,
+ *   - `exports`     — `exports.view_own` / `exports.view_all`,
+ *   - `multimedia`  — `multimedia.add_edit_own` /
+ *                     `multimedia.add_edit_any`,
+ *   - `api_tokens`  — `api_tokens.own.crud` /
+ *                     `api_tokens.all.view_revoke`,
+ *   - `audit`       — `audit.view_own` / `audit.view_cross_user`.
+ *
+ * The policy is intentionally **not** applied to domain resources
+ * (products, categories) — those are tenant-scoped only; ownership has
+ * no semantics there (per ticket discussion).
+ *
+ * `?scope=own|all` query-parameter interpretation:
+ *
+ *   - `?scope=all` + user has `*.view_all` → repository filters by
+ *                     tenant only;
+ *   - `?scope=all` + user has only `*.view_own` → caller denied
+ *                     (`canRequestScope(All) === false`);
+ *   - `?scope=own` or absent + user has `*.view_own` → repository
+ *                     filters by tenant AND created_by/uploaded_by/
+ *                     user_id (column varies per resource);
+ *   - both owns + all granted → default `own`; calling
+ *                     `effectiveScope(?'all')` returns `All` only when
+ *                     the caller explicitly asked.
+ *
+ * The column-mapping concern (created_by vs uploaded_by vs user_id)
+ * lives at the repository layer per resource — this policy decides
+ * whether the scope is *allowed*; the query layer applies the right
+ * WHERE clause.
+ */
+final readonly class OwnershipPolicy
+{
+    /**
+     * Mapping (resource → [own_code, all_code]) for every resource type
+     * with ownership semantics in MVP. Adding a new resource means one
+     * entry here plus a controller-side `?scope=` interpretation.
+     */
+    private const array RESOURCE_CODES = [
+        'imports' => ['imports.view_own', 'imports.view_all'],
+        'exports' => ['exports.view_own', 'exports.view_all'],
+        'multimedia' => ['multimedia.add_edit_own', 'multimedia.add_edit_any'],
+        'api_tokens' => ['api_tokens.own.crud', 'api_tokens.all.view_revoke'],
+        'audit' => ['audit.view_own', 'audit.view_cross_user'],
+    ];
+
+    public function __construct(private PermissionResolverInterface $resolver)
+    {
+    }
+
+    public function canViewOwn(User $user, string $resourceType): bool
+    {
+        [$ownCode] = $this->codesFor($resourceType);
+
+        return $this->resolver->resolve($user)->has($ownCode);
+    }
+
+    public function canViewAll(User $user, string $resourceType): bool
+    {
+        [, $allCode] = $this->codesFor($resourceType);
+
+        return $this->resolver->resolve($user)->has($allCode);
+    }
+
+    /**
+     * Returns the scope the caller can actually execute. If the caller
+     * lacks even `*.view_own`, returns null (controller responds 403).
+     * Otherwise:
+     *   - requested === Scope::All + caller has all_code → Scope::All,
+     *   - requested === Scope::All + caller has only own_code → null
+     *     (controller responds 403),
+     *   - requested === Scope::Own / null + caller has own_code →
+     *     Scope::Own,
+     *   - requested === Scope::Own / null + caller has only all_code →
+     *     Scope::Own (own ⊆ all, the broader-scope only role still
+     *     sees their own data).
+     */
+    public function effectiveScope(User $user, string $resourceType, ?OwnershipScope $requested): ?OwnershipScope
+    {
+        [$ownCode, $allCode] = $this->codesFor($resourceType);
+        $permissions = $this->resolver->resolve($user);
+        $hasOwn = $permissions->has($ownCode);
+        $hasAll = $permissions->has($allCode);
+
+        if (!$hasOwn && !$hasAll) {
+            return null;
+        }
+
+        if (OwnershipScope::All === $requested) {
+            return $hasAll ? OwnershipScope::All : null;
+        }
+
+        // requested === Own or null → default to own. own ⊆ all so a
+        // caller with only all_code still sees their own rows.
+        return OwnershipScope::Own;
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function codesFor(string $resourceType): array
+    {
+        if (!\array_key_exists($resourceType, self::RESOURCE_CODES)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Unknown ownership resource type "%s". Known: %s.',
+                $resourceType,
+                implode(', ', array_keys(self::RESOURCE_CODES)),
+            ));
+        }
+
+        return self::RESOURCE_CODES[$resourceType];
+    }
+}

--- a/apps/api/src/Identity/Application/Policy/OwnershipScope.php
+++ b/apps/api/src/Identity/Application/Policy/OwnershipScope.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+/**
+ * RBAC-P3-010 (#673) — scope dimension carried by the `?scope=own|all`
+ * query parameter on operational resource collections.
+ */
+enum OwnershipScope: string
+{
+    case Own = 'own';
+    case All = 'all';
+}

--- a/apps/api/tests/Unit/Identity/Application/Policy/OwnershipPolicyTest.php
+++ b/apps/api/tests/Unit/Identity/Application/Policy/OwnershipPolicyTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Application\Policy\OwnershipPolicy;
+use App\Identity\Application\Policy\OwnershipScope;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Shared\Domain\Tenant;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-010 (#673) — OwnershipPolicy unit coverage of the
+ * own / all routing per resource type.
+ */
+final class OwnershipPolicyTest extends TestCase
+{
+    #[Test]
+    public function canViewOwnReadsCorrectCodePerResource(): void
+    {
+        $policy = new OwnershipPolicy($this->resolverWith(['exports.view_own']));
+
+        self::assertTrue($policy->canViewOwn($this->user(), 'exports'));
+        self::assertFalse($policy->canViewOwn($this->user(), 'imports'));
+    }
+
+    #[Test]
+    public function canViewAllReadsCorrectCodePerResource(): void
+    {
+        $policy = new OwnershipPolicy($this->resolverWith(['exports.view_all']));
+
+        self::assertTrue($policy->canViewAll($this->user(), 'exports'));
+        self::assertFalse($policy->canViewAll($this->user(), 'imports'));
+    }
+
+    #[Test]
+    public function effectiveScopeReturnsNullWhenNeitherCodeGranted(): void
+    {
+        $policy = new OwnershipPolicy($this->resolverWith([]));
+
+        self::assertNull($policy->effectiveScope($this->user(), 'exports', OwnershipScope::Own));
+        self::assertNull($policy->effectiveScope($this->user(), 'exports', OwnershipScope::All));
+        self::assertNull($policy->effectiveScope($this->user(), 'exports', null));
+    }
+
+    #[Test]
+    public function effectiveScopeWithOnlyOwnDeniesAllScopeRequest(): void
+    {
+        $policy = new OwnershipPolicy($this->resolverWith(['exports.view_own']));
+
+        self::assertSame(OwnershipScope::Own, $policy->effectiveScope($this->user(), 'exports', null));
+        self::assertSame(OwnershipScope::Own, $policy->effectiveScope($this->user(), 'exports', OwnershipScope::Own));
+        self::assertNull($policy->effectiveScope($this->user(), 'exports', OwnershipScope::All));
+    }
+
+    #[Test]
+    public function effectiveScopeWithBothCodesDefaultsToOwn(): void
+    {
+        $policy = new OwnershipPolicy($this->resolverWith(['exports.view_own', 'exports.view_all']));
+
+        // Default scope is own — caller must opt in to `all` explicitly.
+        self::assertSame(OwnershipScope::Own, $policy->effectiveScope($this->user(), 'exports', null));
+        self::assertSame(OwnershipScope::All, $policy->effectiveScope($this->user(), 'exports', OwnershipScope::All));
+    }
+
+    #[Test]
+    public function effectiveScopeOnAllOnlyRoleStillSeesOwnRows(): void
+    {
+        // Edge case — Integration Manager has only `*.view_all`; the
+        // own subset is implicit (own ⊆ all). They never need to ask
+        // for own scope, but if they do (or if it's the default), they
+        // get it.
+        $policy = new OwnershipPolicy($this->resolverWith(['exports.view_all']));
+
+        self::assertSame(OwnershipScope::Own, $policy->effectiveScope($this->user(), 'exports', null));
+        self::assertSame(OwnershipScope::All, $policy->effectiveScope($this->user(), 'exports', OwnershipScope::All));
+    }
+
+    #[Test]
+    public function multimediaResourceUsesAddEditCodes(): void
+    {
+        $policy = new OwnershipPolicy($this->resolverWith(['multimedia.add_edit_any']));
+
+        self::assertTrue($policy->canViewAll($this->user(), 'multimedia'));
+        self::assertFalse($policy->canViewOwn($this->user(), 'multimedia'));
+    }
+
+    #[Test]
+    public function apiTokensResourceUsesOwnCrudAndAllViewRevokeCodes(): void
+    {
+        $policy = new OwnershipPolicy($this->resolverWith(['api_tokens.own.crud']));
+
+        self::assertTrue($policy->canViewOwn($this->user(), 'api_tokens'));
+        self::assertFalse($policy->canViewAll($this->user(), 'api_tokens'));
+    }
+
+    #[Test]
+    public function unknownResourceTypeThrows(): void
+    {
+        $policy = new OwnershipPolicy($this->resolverWith([]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $policy->canViewOwn($this->user(), 'products');
+    }
+
+    private function user(): User
+    {
+        return new User(
+            new Tenant('alpha', 'Alpha'),
+            'tester@alpha.localhost',
+            'placeholder',
+            ['ROLE_USER'],
+            Uuid::v7(),
+        );
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-010 — `OwnershipPolicy` + `OwnershipScope` enum routing the `?scope=own|all` query param against the macierz pairs:

| Resource | Own code | All code |
|---|---|---|
| imports | `imports.view_own` | `imports.view_all` |
| exports | `exports.view_own` | `exports.view_all` |
| multimedia | `multimedia.add_edit_own` | `multimedia.add_edit_any` |
| api_tokens | `api_tokens.own.crud` | `api_tokens.all.view_revoke` |
| audit | `audit.view_own` | `audit.view_cross_user` |

`effectiveScope()` returns null when neither code is granted (controller 403). Default `Own`; caller must opt in to `All` explicitly. Domain resources (products, categories) intentionally excluded — tenant-scoped only, ownership has no macierz semantics.

Repository-layer column mapping (created_by vs uploaded_by vs user_id) belongs to the query layer per resource — this policy decides what is *allowed*.

## Test plan

- [x] 9 unit tests pass
- [x] Deptrac green
- [ ] CI green

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)