### PR TITLE
feat(identity): #674 WorkflowStatePolicy (PRD §3.8)

### DIFF
--- a/apps/api/src/Identity/Application/Policy/WorkflowStatePolicy.php
+++ b/apps/api/src/Identity/Application/Policy/WorkflowStatePolicy.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+
+/**
+ * RBAC-P3-011 (#674) — per-workflow-state edit policy aligned with the
+ * PRD §3.8 (forward-spec) role × state matrix.
+ *
+ * CatalogObject ships three statuses today (`draft`, `published`,
+ * `archived`) — the `review` state mentioned in the ticket prospectively
+ * lands with a dedicated Symfony Workflow definition later (epic 0.6
+ * or follow-up). The policy maps onto the current three:
+ *
+ *   - **draft**       — editable by every role that holds
+ *                       `products.edit` (Owner / Admin / Catalog Manager
+ *                       / Marketing / Channel Manager per macierz),
+ *   - **published**   — editable only by roles holding
+ *                       `workflow.edit_any_state` (Owner / Admin per
+ *                       PrdRoleTemplates). Anyone else needs the
+ *                       *auto-unpublish* path: caller posts
+ *                       `?auto_unpublish=true`, the policy reports
+ *                       `requiresAutoUnpublish()=true`, and the controller
+ *                       atomically transitions published → draft + edit +
+ *                       audit_log special_flag `AUTO_UNPUBLISH_FOR_EDIT`,
+ *   - **archived**    — locked, no edits in MVP (archived state is the
+ *                       "soft-deleted" terminal status; restoration goes
+ *                       through a separate transition endpoint).
+ *
+ * The policy returns booleans only — the actual auto-transition
+ * (state mutation + atomic edit + audit entry) is the controller /
+ * Symfony Workflow's responsibility once it lands. This keeps the
+ * authorization layer free of side effects.
+ *
+ * Auto-transition permission code (`workflow.transition.unpublish`) is
+ * not yet seeded in `PrdRoleTemplates` — the policy short-circuits to
+ * `false` until the seeder adds it, so the auto-unpublish path is
+ * effectively dormant until the macierz catches up. A focused
+ * follow-up adds the code + UI toggle.
+ */
+final readonly class WorkflowStatePolicy
+{
+    public const string STATE_DRAFT = 'draft';
+    public const string STATE_PUBLISHED = 'published';
+    public const string STATE_ARCHIVED = 'archived';
+
+    public function __construct(private PermissionResolverInterface $resolver)
+    {
+    }
+
+    /**
+     * @param non-empty-string $state
+     */
+    public function canEditInState(User $user, string $state): bool
+    {
+        $permissions = $this->resolver->resolve($user);
+
+        return match ($state) {
+            self::STATE_DRAFT => $permissions->has('products.edit'),
+            self::STATE_PUBLISHED => $permissions->has('workflow.edit_any_state'),
+            self::STATE_ARCHIVED => false,
+            default => false,
+        };
+    }
+
+    /**
+     * Indicates whether the caller could edit a `published` entity via
+     * the auto-unpublish transition path (caller passes
+     * `?auto_unpublish=true`).
+     *
+     * Returns true only when:
+     *   - the entity is in `published` state,
+     *   - the caller has `products.edit` (broad edit gate),
+     *   - the caller does NOT have `workflow.edit_any_state` (otherwise
+     *     they would edit-in-place without transition),
+     *   - the caller has `workflow.transition.unpublish` (currently
+     *     unseeded — see class-level note).
+     */
+    public function requiresAutoUnpublish(User $user, string $state): bool
+    {
+        if (self::STATE_PUBLISHED !== $state) {
+            return false;
+        }
+
+        $permissions = $this->resolver->resolve($user);
+        if (!$permissions->has('products.edit')) {
+            return false;
+        }
+        if ($permissions->has('workflow.edit_any_state')) {
+            return false;
+        }
+
+        return $permissions->has('workflow.transition.unpublish');
+    }
+}

--- a/apps/api/tests/Unit/Identity/Application/Policy/WorkflowStatePolicyTest.php
+++ b/apps/api/tests/Unit/Identity/Application/Policy/WorkflowStatePolicyTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Application\Policy;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Application\Policy\WorkflowStatePolicy;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-011 (#674) — WorkflowStatePolicy unit coverage of the
+ * per-state edit matrix + auto-unpublish detection.
+ */
+final class WorkflowStatePolicyTest extends TestCase
+{
+    #[Test]
+    public function ownerCanEditInAnyState(): void
+    {
+        $policy = new WorkflowStatePolicy($this->resolverWith([
+            'products.edit',
+            'workflow.edit_any_state',
+        ]));
+
+        self::assertTrue($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_DRAFT));
+        self::assertTrue($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_PUBLISHED));
+    }
+
+    #[Test]
+    public function catalogManagerCanEditDraftButNotPublished(): void
+    {
+        // Catalog Manager has products.edit but lacks workflow.edit_any_state.
+        $policy = new WorkflowStatePolicy($this->resolverWith(['products.edit']));
+
+        self::assertTrue($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_DRAFT));
+        self::assertFalse($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_PUBLISHED));
+    }
+
+    #[Test]
+    public function archivedStateLocksOutEveryone(): void
+    {
+        // Even Owner cannot edit archived entities — that goes through a
+        // restoration endpoint, not a direct PATCH.
+        $policy = new WorkflowStatePolicy($this->resolverWith([
+            'products.edit',
+            'workflow.edit_any_state',
+        ]));
+
+        self::assertFalse($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_ARCHIVED));
+    }
+
+    #[Test]
+    public function viewerWithoutEditCannotEditAnyState(): void
+    {
+        $policy = new WorkflowStatePolicy($this->resolverWith(['products.view']));
+
+        self::assertFalse($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_DRAFT));
+        self::assertFalse($policy->canEditInState($this->user(), WorkflowStatePolicy::STATE_PUBLISHED));
+    }
+
+    #[Test]
+    public function autoUnpublishOnlyForCatalogManagerWithTransitionCode(): void
+    {
+        // Catalog Manager + workflow.transition.unpublish → auto path active.
+        $policy = new WorkflowStatePolicy($this->resolverWith([
+            'products.edit',
+            'workflow.transition.unpublish',
+        ]));
+
+        self::assertTrue($policy->requiresAutoUnpublish($this->user(), WorkflowStatePolicy::STATE_PUBLISHED));
+        // Not in published state → false.
+        self::assertFalse($policy->requiresAutoUnpublish($this->user(), WorkflowStatePolicy::STATE_DRAFT));
+    }
+
+    #[Test]
+    public function ownerSkipsAutoUnpublishBecauseTheyEditInPlace(): void
+    {
+        // Owner has workflow.edit_any_state — they edit published directly,
+        // no transition needed.
+        $policy = new WorkflowStatePolicy($this->resolverWith([
+            'products.edit',
+            'workflow.edit_any_state',
+            'workflow.transition.unpublish',
+        ]));
+
+        self::assertFalse($policy->requiresAutoUnpublish($this->user(), WorkflowStatePolicy::STATE_PUBLISHED));
+    }
+
+    #[Test]
+    public function viewerCannotTriggerAutoUnpublish(): void
+    {
+        // No products.edit → no auto-unpublish even if transition code present.
+        $policy = new WorkflowStatePolicy($this->resolverWith([
+            'workflow.transition.unpublish',
+        ]));
+
+        self::assertFalse($policy->requiresAutoUnpublish($this->user(), WorkflowStatePolicy::STATE_PUBLISHED));
+    }
+
+    #[Test]
+    public function unknownStateDenies(): void
+    {
+        $policy = new WorkflowStatePolicy($this->resolverWith([
+            'products.edit',
+            'workflow.edit_any_state',
+        ]));
+
+        // PHPStan @param non-empty-string — call with a literal to satisfy.
+        self::assertFalse($policy->canEditInState($this->user(), 'review'));
+    }
+
+    private function user(): User
+    {
+        return new User(
+            new Tenant('alpha', 'Alpha'),
+            'tester@alpha.localhost',
+            'placeholder',
+            ['ROLE_USER'],
+            Uuid::v7(),
+        );
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-011 — `WorkflowStatePolicy` mapping the per-role-per-state edit matrix onto CatalogObject's current three statuses (`draft`/`published`/`archived`):

- **draft** — `products.edit` required
- **published** — `workflow.edit_any_state` required (Owner / Admin per PrdRoleTemplates)
- **archived** — locked, no edits (restoration via separate transition endpoint)

`requiresAutoUnpublish(User, state)` reports when the caller could edit a published entity via the `?auto_unpublish=true` transition path — Catalog Manager-style role with `products.edit` + `workflow.transition.unpublish` but no `workflow.edit_any_state`. The controller / Symfony Workflow performs the actual state mutation + atomic edit + audit entry; this policy returns only booleans.

## Deferred (documented in code)

- `workflow.transition.unpublish` is not yet in `PrdRoleTemplates` — auto-unpublish path is dormant until the seeder catches up. Follow-up adds the code + Settings UI toggle.
- `review` state lands with a dedicated Symfony Workflow definition later (epic 0.6 / follow-up).

## Test plan

- [x] 8 unit tests pass
- [x] Deptrac green
- [ ] CI green

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)