### PR TITLE
feat(identity): #675 FieldRestrictionFilter (PRD §3.5)

### DIFF
--- a/apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php
+++ b/apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php
@@ -58,7 +58,7 @@ use Symfony\Component\Uid\Uuid;
  * 3-state values — the serializer composes them with the integration
  * flag for the final response shape.
  */
-final readonly class AttributePermissionPolicy
+readonly class AttributePermissionPolicy
 {
     public function __construct(
         private Connection $connection,

--- a/apps/api/src/Identity/Application/Serializer/FieldRestrictionFilter.php
+++ b/apps/api/src/Identity/Application/Serializer/FieldRestrictionFilter.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Serializer;
+
+use App\Identity\Application\Policy\AttributePermissionPolicy;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\AttributePermission;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-012 (#675) — composes {@see AttributePermissionPolicy} with the
+ * `integration_visible` flag to produce the per-attribute response shape
+ * defined in PRD §3.5.
+ *
+ * Input  — map of `attributeId (UUID string)` → raw value (already
+ *          serialised by upstream normaliser).
+ * Output — map of `attributeId (UUID string)` → {@see RestrictedField}.
+ *          Keys whose resolved permission is `Restricted` are removed
+ *          entirely; PRD §3.5: *„`'restricted'` → field NIE w response
+ *          (full removal)"*.
+ *
+ * `integration_visible` composition (PRD §3.5):
+ *
+ *   - default flag value on Attribute is `true` — no effect.
+ *   - flag `false` for a given attribute → caller sees the field as
+ *     `view-only` regardless of per-role grant; the
+ *     `RestrictedField::reason` is set to `integration_visible` so the
+ *     frontend can surface the right tooltip.
+ *   - `integration_visible=false` does NOT promote `restricted` to
+ *     visible; if the policy already says `restricted`, the field is
+ *     still removed.
+ *
+ * Wiring per endpoint (CatalogObject serializer hook, ApiToken response
+ * normaliser, audit log filter) is the Phase 6 retrofit's
+ * responsibility — this filter is the building block. Tests cover the
+ * pure filter behaviour; integration tests come with the wiring.
+ */
+final readonly class FieldRestrictionFilter
+{
+    public function __construct(private AttributePermissionPolicy $policy)
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $valuesByAttributeId           map `attributeId (uuid)` → raw value
+     * @param array<string, bool>  $integrationVisibleByAttribute map `attributeId (uuid)` → integration_visible flag; missing keys default to true
+     *
+     * @return array<string, RestrictedField>
+     */
+    public function restrict(
+        User $user,
+        array $valuesByAttributeId,
+        array $integrationVisibleByAttribute = [],
+    ): array {
+        $out = [];
+        foreach ($valuesByAttributeId as $attributeIdString => $value) {
+            $attributeId = Uuid::fromString($attributeIdString);
+            $permission = $this->policy->resolvePermission($user, $attributeId);
+
+            if (AttributePermission::Restricted === $permission) {
+                continue;
+            }
+
+            $visible = $integrationVisibleByAttribute[$attributeIdString] ?? true;
+            if (!$visible) {
+                // integration_visible=false demotes edit/view to view-only
+                // with the dedicated reason — PRD §3.5 makes this flag
+                // *independent* of per-role grant, so we apply it after
+                // the policy resolved the role decision.
+                $out[$attributeIdString] = RestrictedField::viewOnly(
+                    $value,
+                    RestrictedField::REASON_INTEGRATION_HIDDEN,
+                );
+                continue;
+            }
+
+            $out[$attributeIdString] = AttributePermission::Edit === $permission
+                ? RestrictedField::editable($value)
+                : RestrictedField::viewOnly($value);
+        }
+
+        return $out;
+    }
+}

--- a/apps/api/src/Identity/Application/Serializer/RestrictedField.php
+++ b/apps/api/src/Identity/Application/Serializer/RestrictedField.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Serializer;
+
+/**
+ * RBAC-P3-012 (#675) — value object describing the response shape per
+ * attribute, per PRD §3.5.
+ *
+ *   - `value`     — the attribute value (already serialised by the
+ *                   normaliser),
+ *   - `editable`  — false when the caller can read but not write
+ *                   (`view` permission); true for `edit`,
+ *   - `reason`    — explanation surfaced to the frontend so it can
+ *                   render the input as read-only with a tooltip
+ *                   (`view_only`, `integration_visible`).
+ *
+ * The `restricted` permission case produces NO `RestrictedField` — the
+ * filter removes the key entirely. See {@see FieldRestrictionFilter}.
+ */
+final readonly class RestrictedField
+{
+    public const string REASON_VIEW_ONLY = 'view_only';
+    public const string REASON_INTEGRATION_HIDDEN = 'integration_visible';
+
+    private function __construct(
+        public mixed $value,
+        public bool $editable,
+        public ?string $reason,
+    ) {
+    }
+
+    public static function editable(mixed $value): self
+    {
+        return new self($value, true, null);
+    }
+
+    public static function viewOnly(mixed $value, string $reason = self::REASON_VIEW_ONLY): self
+    {
+        return new self($value, false, $reason);
+    }
+
+    /**
+     * @return array{value: mixed, editable: bool, reason?: string}
+     */
+    public function toArray(): array
+    {
+        $shape = ['value' => $this->value, 'editable' => $this->editable];
+        if (null !== $this->reason) {
+            $shape['reason'] = $this->reason;
+        }
+
+        return $shape;
+    }
+}

--- a/apps/api/tests/Unit/Identity/Application/Serializer/FieldRestrictionFilterTest.php
+++ b/apps/api/tests/Unit/Identity/Application/Serializer/FieldRestrictionFilterTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Application\Serializer;
+
+use App\Identity\Application\Policy\AttributePermissionPolicy;
+use App\Identity\Application\Serializer\FieldRestrictionFilter;
+use App\Identity\Application\Serializer\RestrictedField;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\AttributePermission;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P3-012 (#675) — FieldRestrictionFilter unit coverage of the
+ * response-shape composition (per PRD §3.5).
+ */
+final class FieldRestrictionFilterTest extends TestCase
+{
+    #[Test]
+    public function restrictedAttributesAreRemovedFromResponse(): void
+    {
+        $editableId = Uuid::v7();
+        $restrictedId = Uuid::v7();
+
+        $policy = $this->policyMap([
+            $editableId->toRfc4122() => AttributePermission::Edit,
+            $restrictedId->toRfc4122() => AttributePermission::Restricted,
+        ]);
+
+        $filter = new FieldRestrictionFilter($policy);
+        $result = $filter->restrict($this->user(), [
+            $editableId->toRfc4122() => 'Czujnik',
+            $restrictedId->toRfc4122() => 999.99,
+        ]);
+
+        self::assertCount(1, $result);
+        self::assertArrayHasKey($editableId->toRfc4122(), $result);
+        self::assertArrayNotHasKey($restrictedId->toRfc4122(), $result);
+    }
+
+    #[Test]
+    public function viewPermissionProducesViewOnlyShape(): void
+    {
+        $id = Uuid::v7();
+        $policy = $this->policyMap([$id->toRfc4122() => AttributePermission::View]);
+        $filter = new FieldRestrictionFilter($policy);
+
+        $result = $filter->restrict($this->user(), [$id->toRfc4122() => 1234.56]);
+
+        $field = $result[$id->toRfc4122()];
+        self::assertInstanceOf(RestrictedField::class, $field);
+        self::assertSame(1234.56, $field->value);
+        self::assertFalse($field->editable);
+        self::assertSame(RestrictedField::REASON_VIEW_ONLY, $field->reason);
+    }
+
+    #[Test]
+    public function editPermissionProducesEditableShapeWithoutReason(): void
+    {
+        $id = Uuid::v7();
+        $policy = $this->policyMap([$id->toRfc4122() => AttributePermission::Edit]);
+        $filter = new FieldRestrictionFilter($policy);
+
+        $result = $filter->restrict($this->user(), [$id->toRfc4122() => 'value']);
+
+        $field = $result[$id->toRfc4122()];
+        self::assertTrue($field->editable);
+        self::assertNull($field->reason);
+        self::assertSame('value', $field->value);
+    }
+
+    #[Test]
+    public function integrationVisibleFalseDemotesEditToViewOnly(): void
+    {
+        $id = Uuid::v7();
+        $policy = $this->policyMap([$id->toRfc4122() => AttributePermission::Edit]);
+        $filter = new FieldRestrictionFilter($policy);
+
+        $result = $filter->restrict(
+            $this->user(),
+            [$id->toRfc4122() => 'value'],
+            [$id->toRfc4122() => false],
+        );
+
+        $field = $result[$id->toRfc4122()];
+        self::assertFalse($field->editable);
+        self::assertSame(RestrictedField::REASON_INTEGRATION_HIDDEN, $field->reason);
+    }
+
+    #[Test]
+    public function integrationVisibleFalseDoesNotPromoteRestrictedToVisible(): void
+    {
+        $id = Uuid::v7();
+        $policy = $this->policyMap([$id->toRfc4122() => AttributePermission::Restricted]);
+        $filter = new FieldRestrictionFilter($policy);
+
+        $result = $filter->restrict(
+            $this->user(),
+            [$id->toRfc4122() => 'value'],
+            [$id->toRfc4122() => false],
+        );
+
+        // Restricted from the policy stays removed even when the flag is
+        // set — the flag only demotes edit/view, never promotes restricted.
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function missingIntegrationFlagDefaultsToTrue(): void
+    {
+        $id = Uuid::v7();
+        $policy = $this->policyMap([$id->toRfc4122() => AttributePermission::Edit]);
+        $filter = new FieldRestrictionFilter($policy);
+
+        // Flag map is empty → defaults to true → edit stays editable.
+        $result = $filter->restrict($this->user(), [$id->toRfc4122() => 'value']);
+
+        self::assertTrue($result[$id->toRfc4122()]->editable);
+        self::assertNull($result[$id->toRfc4122()]->reason);
+    }
+
+    #[Test]
+    public function emptyMapReturnsEmpty(): void
+    {
+        $policy = $this->createMock(AttributePermissionPolicy::class);
+        $policy->expects(self::never())->method('resolvePermission');
+
+        $filter = new FieldRestrictionFilter($policy);
+
+        self::assertSame([], $filter->restrict($this->user(), []));
+    }
+
+    #[Test]
+    public function restrictedFieldToArrayShapeMatchesPrdSection35(): void
+    {
+        $field = RestrictedField::editable('foo');
+        self::assertSame(['value' => 'foo', 'editable' => true], $field->toArray());
+
+        $view = RestrictedField::viewOnly(42);
+        self::assertSame(['value' => 42, 'editable' => false, 'reason' => 'view_only'], $view->toArray());
+
+        $integration = RestrictedField::viewOnly('secret', RestrictedField::REASON_INTEGRATION_HIDDEN);
+        self::assertSame(
+            ['value' => 'secret', 'editable' => false, 'reason' => 'integration_visible'],
+            $integration->toArray(),
+        );
+    }
+
+    private function user(): User
+    {
+        return new User(
+            new Tenant('alpha', 'Alpha'),
+            'tester@alpha.localhost',
+            'placeholder',
+            ['ROLE_USER'],
+            Uuid::v7(),
+        );
+    }
+
+    /**
+     * @param array<string, AttributePermission> $byAttribute
+     */
+    private function policyMap(array $byAttribute): AttributePermissionPolicy
+    {
+        $policy = $this->createMock(AttributePermissionPolicy::class);
+        $policy->method('resolvePermission')
+            ->willReturnCallback(static function (User $_user, Uuid $attributeId) use ($byAttribute): AttributePermission {
+                $key = $attributeId->toRfc4122();
+
+                return $byAttribute[$key] ?? AttributePermission::Restricted;
+            });
+
+        return $policy;
+    }
+}


### PR DESCRIPTION
## Summary

RBAC-P3-012 — `FieldRestrictionFilter` + `RestrictedField` value object composing `AttributePermissionPolicy` (#671) with the `integration_visible` flag for the response shape PRD §3.5 mandates:

**Krok 0 (PRD cross-ref):**
- §3.5 read ✓ — response shape `{value, editable, reason?}` per attribute; restricted = full removal
- §3.2 cross-tab ✓ — UI integration via Phase 4 #687
- Resolution priority delegated entirely to #671 (zero duplication)
- `integration_visible` flag handled here (PRD §3.5 explicit: serializer composes both)
- Cache invalidation inherits from PermissionResolver

## Decision tree

| Policy result | integration_visible | Output |
|---|---|---|
| Restricted | * | key removed |
| Edit | true | `{value, editable: true}` |
| Edit | false | `{value, editable: false, reason: 'integration_visible'}` |
| View | true | `{value, editable: false, reason: 'view_only'}` |
| View | false | `{value, editable: false, reason: 'integration_visible'}` |

## Deferred (documented in PR + code)

- **Wiring** to CatalogObject normaliser / ApiToken response / audit log filter → Phase 6 retrofit (~60 endpoints).
- **Formal `#[Groups]` annotations** for `integration:secrets` / `audit:cross_user` → Phase 6.
- **DynamicGroupsContextBuilder** Symfony Serializer extension → Phase 6.
- **Property-based fuzzing (30+ fields × 10 ról)** → Phase 7 #722 (pentest).

## Side change

Drops `final` from `AttributePermissionPolicy` so PHPUnit can mock it in this filter's tests. Readonly stays; class still reads final-by-convention.

## Test plan

- [x] 8 unit tests pass
- [x] Full Identity test suite green (32 tests)
- [x] Deptrac green
- [ ] CI green

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)