### PR TITLE
feat(admin): #678 identity bootstrap (/me extension + Identity hooks)

### DIFF
--- a/apps/admin/src/lib/identity/identity.ts
+++ b/apps/admin/src/lib/identity/identity.ts
@@ -1,0 +1,122 @@
+/**
+ * RBAC-P4-001 (#678) — identity bootstrap shape returned by GET /api/auth/me.
+ *
+ * Mirrors `App\Identity\Presentation\MeController` 1:1 after the
+ * Phase 4 extension that adds the flat PRD §3.2 permission codes
+ * plus locale / channel / attribute_group scopes (each scope
+ * `[]`/`["*"]` = no restriction, matching `UserRole` storage).
+ *
+ * Consumers should always go through {@link useIdentity}; the raw
+ * response is exported for the rare callsite that needs the wire shape
+ * (e.g. tests asserting backward compatibility).
+ */
+export interface MeResponse {
+  id: string;
+  email: string;
+  /** Symfony Security role strings (legacy + scoped roles). */
+  roles: string[];
+  tenant: { id: string; code: string; name: string } | null;
+  last_login_at: string | null;
+  /** PRD §3.2 permission codes — flat strings like `products.view`. */
+  permissions: string[];
+  /** PRD §3.6 locale narrowing. */
+  locale_scope: string[];
+  /** PRD §3.7 channel narrowing. */
+  channel_scope: string[];
+  /** Modeler / channel-scoped role group narrowing. */
+  attribute_group_scope: string[];
+}
+
+/**
+ * Hydrated identity payload consumed by `useIdentity()` and the
+ * permission helpers. Wraps the wire shape with O(1) Set-backed
+ * permission lookup and convenience getters; everything immutable
+ * and serialisable so React's Suspense / dehydration can roundtrip it.
+ */
+export interface Identity {
+  id: string;
+  email: string;
+  roles: string[];
+  tenant: { id: string; code: string; name: string } | null;
+  lastLoginAt: string | null;
+  permissions: ReadonlySet<string>;
+  localeScope: string[];
+  channelScope: string[];
+  attributeGroupScope: string[];
+}
+
+const WILDCARD = '*';
+
+/**
+ * Hydrate the wire shape into the consumer-facing {@link Identity}.
+ * Pure / synchronous so it can be called both in the React Query
+ * select() function and in unit tests without bootstrapping
+ * any provider.
+ */
+export function hydrateIdentity(response: MeResponse): Identity {
+  return {
+    id: response.id,
+    email: response.email,
+    roles: response.roles,
+    tenant: response.tenant,
+    lastLoginAt: response.last_login_at,
+    permissions: new Set(response.permissions),
+    localeScope: response.locale_scope,
+    channelScope: response.channel_scope,
+    attributeGroupScope: response.attribute_group_scope,
+  };
+}
+
+export function hasPermission(identity: Identity | null, code: string): boolean {
+  if (!identity) {
+    return false;
+  }
+  return identity.permissions.has(code);
+}
+
+export function hasAnyPermission(identity: Identity | null, codes: readonly string[]): boolean {
+  if (!identity) {
+    return false;
+  }
+  return codes.some((code) => identity.permissions.has(code));
+}
+
+export function hasAllPermissions(identity: Identity | null, codes: readonly string[]): boolean {
+  if (!identity) {
+    return false;
+  }
+  return codes.every((code) => identity.permissions.has(code));
+}
+
+/**
+ * PRD §3.6 — empty scope OR explicit `["*"]` mean no restriction. A
+ * narrowed list grants only its members. The same convention applies
+ * to {@link canEditChannel}.
+ */
+export function canEditLocale(identity: Identity | null, locale: string): boolean {
+  if (!identity) {
+    return false;
+  }
+  return scopeAllows(identity.localeScope, locale);
+}
+
+export function canEditChannel(identity: Identity | null, channel: string): boolean {
+  if (!identity) {
+    return false;
+  }
+  return scopeAllows(identity.channelScope, channel);
+}
+
+export function canEditAttributeGroup(identity: Identity | null, groupCode: string): boolean {
+  if (!identity) {
+    return false;
+  }
+  return scopeAllows(identity.attributeGroupScope, groupCode);
+}
+
+function scopeAllows(scope: string[], value: string): boolean {
+  if (scope.length === 0 || scope.includes(WILDCARD)) {
+    return true;
+  }
+  return scope.includes(value);
+}

--- a/apps/admin/src/lib/identity/index.ts
+++ b/apps/admin/src/lib/identity/index.ts
@@ -1,0 +1,25 @@
+/**
+ * RBAC-P4-001 (#678) — identity module surface for admin app.
+ */
+export {
+  canEditAttributeGroup,
+  canEditChannel,
+  canEditLocale,
+  hasAllPermissions,
+  hasAnyPermission,
+  hasPermission,
+  hydrateIdentity,
+  type Identity,
+  type MeResponse,
+} from './identity';
+
+export {
+  IDENTITY_QUERY_KEY,
+  useCanEditAttributeGroup,
+  useCanEditChannel,
+  useCanEditLocale,
+  useCanI,
+  useCanIAll,
+  useCanIAny,
+  useIdentity,
+} from './use-identity';

--- a/apps/admin/src/lib/identity/use-identity.ts
+++ b/apps/admin/src/lib/identity/use-identity.ts
@@ -1,0 +1,91 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '../http';
+import {
+  canEditAttributeGroup,
+  canEditChannel,
+  canEditLocale,
+  hasAllPermissions,
+  hasAnyPermission,
+  hasPermission,
+  hydrateIdentity,
+  type Identity,
+  type MeResponse,
+} from './identity';
+
+/**
+ * RBAC-P4-001 (#678) — React Query hook exposing the bootstrap
+ * identity to admin components.
+ *
+ *   - Cached under the stable key `['rbac', 'identity']` so any
+ *     component can share the same fetch without duplicating the
+ *     /api/auth/me round-trip. Mercure SSE invalidation (RBAC-P4-010
+ *     #687) will call `queryClient.invalidateQueries({ queryKey:
+ *     IDENTITY_QUERY_KEY })` when a role / permission grant changes.
+ *   - `select()` hydrates the wire shape into the consumer-facing
+ *     {@link Identity} so the Set-backed `hasPermission` is computed
+ *     once per fetch rather than on every render.
+ *   - `retry: false` because a failed /me means the session is dead;
+ *     the http layer + Refine AuthProvider drive logout.
+ *
+ * Companion helpers (`useCanI`, `useCanEditLocale`, …) wrap the
+ * hook for declarative usage — see RBAC-P4-004 (#681).
+ */
+export const IDENTITY_QUERY_KEY = ['rbac', 'identity'] as const;
+
+interface UseIdentityResult {
+  identity: Identity | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useIdentity(): UseIdentityResult {
+  const query = useQuery({
+    queryKey: IDENTITY_QUERY_KEY,
+    queryFn: () => jsonFetch<MeResponse>('/api/auth/me', { accept: 'application/json' }),
+    select: hydrateIdentity,
+    retry: false,
+    staleTime: 5 * 60_000,
+  });
+
+  return {
+    identity: query.data ?? null,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}
+
+/**
+ * Convenience hook — true when the caller holds the given PRD §3.2 code.
+ * Returns false during the initial fetch so gated UI stays hidden
+ * until the response lands (avoids the click-through flash).
+ */
+export function useCanI(code: string): boolean {
+  const { identity } = useIdentity();
+  return hasPermission(identity, code);
+}
+
+export function useCanIAny(codes: readonly string[]): boolean {
+  const { identity } = useIdentity();
+  return hasAnyPermission(identity, codes);
+}
+
+export function useCanIAll(codes: readonly string[]): boolean {
+  const { identity } = useIdentity();
+  return hasAllPermissions(identity, codes);
+}
+
+export function useCanEditLocale(locale: string): boolean {
+  const { identity } = useIdentity();
+  return canEditLocale(identity, locale);
+}
+
+export function useCanEditChannel(channel: string): boolean {
+  const { identity } = useIdentity();
+  return canEditChannel(identity, channel);
+}
+
+export function useCanEditAttributeGroup(groupCode: string): boolean {
+  const { identity } = useIdentity();
+  return canEditAttributeGroup(identity, groupCode);
+}

--- a/apps/api/src/Identity/Presentation/MeController.php
+++ b/apps/api/src/Identity/Presentation/MeController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Identity\Presentation;
 
+use App\Identity\Application\PermissionResolverInterface;
 use App\Identity\Domain\Entity\User;
 use DateTimeInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -14,16 +15,37 @@ use Symfony\Component\Routing\Attribute\Route;
 /**
  * GET /api/auth/me — return the principal currently authenticated by the JWT.
  *
- * Used by the admin SPA on bootstrap to populate the user menu and decide
- * which sidebar entries are reachable, and by integration clients smoke-
- * testing their token. The shape stays minimal — id, email, the resolved
- * role list, the tenant header (code + name), and `last_login_at` — so the
- * payload doubles as the boot manifest without leaking permission internals.
+ * Used by the admin SPA on bootstrap to populate the identity store
+ * (`useIdentity()` hook) and decide which sidebar entries / form fields
+ * are reachable, and by integration clients smoke-testing their token.
+ *
+ * Response shape (after RBAC-P4-001 #678):
+ *
+ *   - `id`, `email`, `roles`            — Symfony Security role strings
+ *                                          (legacy + scoped roles),
+ *   - `tenant: {id, code, name}`        — caller's tenant header,
+ *   - `last_login_at`                   — ATOM-formatted timestamp,
+ *   - `permissions: string[]`           — flat PRD §3.2 permission codes
+ *                                          aggregated from every assigned
+ *                                          role (`products.view`,
+ *                                          `settings.users.manage`, …),
+ *   - `locale_scope: string[]`          — union of role locale scopes;
+ *                                          `[]` / `["*"]` = no
+ *                                          restriction (PRD §3.6),
+ *   - `channel_scope: string[]`         — same for channels (PRD §3.7),
+ *   - `attribute_group_scope: string[]` — group narrowing for the
+ *                                          Modeler / channel-scoped
+ *                                          roles.
+ *
+ * The frontend Set-backed identity store turns the permissions array
+ * into O(1) `hasPermission(code)` lookups; locale / channel arrays
+ * drive value-edit gating in the dynamic form renderer (RBAC-P4-009).
  */
 final readonly class MeController
 {
     public function __construct(
         private Security $security,
+        private PermissionResolverInterface $resolver,
     ) {
     }
 
@@ -48,6 +70,7 @@ final readonly class MeController
         }
 
         $tenant = $user->getTenant();
+        $permissions = $this->resolver->resolve($user);
 
         return new JsonResponse([
             'id' => $user->getId()->toRfc4122(),
@@ -59,6 +82,10 @@ final readonly class MeController
                 'name' => $tenant->getName(),
             ],
             'last_login_at' => $user->getLastLoginAt()?->format(DateTimeInterface::ATOM),
+            'permissions' => $permissions->getCodes(),
+            'locale_scope' => $permissions->getLocaleScope(),
+            'channel_scope' => $permissions->getChannelScope(),
+            'attribute_group_scope' => $permissions->getAttributeGroupScope(),
         ]);
     }
 }


### PR DESCRIPTION
## Summary

RBAC-P4-001 — extend `/api/auth/me` with the PRD §3.2/§3.6/§3.7 permission set + new frontend `useIdentity()` hook layer.

**Backend** — `MeController` reads `PermissionResolver` and returns:

```json
{
  "id": "...", "email": "...", "roles": [...], "tenant": {...},
  "last_login_at": "...",
  "permissions": ["products.view", "settings.users.manage", ...],
  "locale_scope": [], "channel_scope": [], "attribute_group_scope": []
}
```

**Frontend** (`apps/admin/src/lib/identity/`) — module surface:
- `useIdentity()` React Query hook (`IDENTITY_QUERY_KEY = ['rbac','identity']`) with Set-backed permission lookup
- `useCanI(code)`, `useCanIAny(codes[])`, `useCanIAll(codes[])`
- `useCanEditLocale(locale)`, `useCanEditChannel(channel)`, `useCanEditAttributeGroup(groupCode)` — wildcard convention handled inside (`[]`/`["*"]` = no restriction)

## Live-stack smoke

```
$ curl /api/auth/me  (admin token)
→ permissions: [50+ codes incl. products.view, settings.users.manage,
    workflow.edit_any_state, audit.view_cross_user, ...]
→ locale_scope/channel_scope: [] (Owner — no narrowing)
```

## Deferred to focused Phase 4 follow-ups

- MFA challenge UI → #689 (MFA setup wizard).
- `<PermissionGate>` component → #681.
- Refine route guards + 403 page → #680.
- Mercure SSE identity invalidation → #687.
- Tenant switch dropdown → #683.

## Test plan

- [x] Backend smoke (curl) — permissions[] populated end-to-end
- [x] Full Identity unit suite green (171 tests)
- [x] Frontend typecheck green
- [x] Deptrac green
- [ ] CI green

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)