### PR TITLE
feat(admin): #682 sidebar nav permission filtering

### DIFF
--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -15,6 +15,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router';
 
+import { isMenuRefVisible, useIdentity } from '@/lib/identity';
 import { type EffectiveMenuItem, useEffectiveMenu } from '@/lib/use-effective-menu';
 import { cn } from '@/lib/utils';
 
@@ -147,11 +148,22 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
   const { t } = useTranslation();
 
   const { data, isError } = useEffectiveMenu();
+  const { identity } = useIdentity();
 
   // While loading on a fresh reload, show the fallback list — without it
   // the sidebar flashes empty for ~50-200ms on every hard navigation.
   // On error, the fallback also kicks in (graceful degradation).
-  const items: EffectiveMenuItem[] = data && !isError ? data.visible : FALLBACK_ITEMS;
+  const rawItems: EffectiveMenuItem[] = data && !isError ? data.visible : FALLBACK_ITEMS;
+
+  // RBAC-P4-005 (#682) — second-line filter against the identity store.
+  // Backend `useEffectiveMenu` already filters server-side per Phase 6
+  // retrofit; this pass hides any leftover entry the SPA cached before
+  // a permission revoke / role change landed (the Mercure invalidation
+  // in RBAC-P4-010 #687 keeps the cache fresh between refreshes).
+  // Items without an entry in MENU_PERMISSIONS are treated as public.
+  const items: EffectiveMenuItem[] = rawItems.filter((item) =>
+    isMenuRefVisible(identity, item.ref),
+  );
 
   const activeModulesCount = items.filter((item) => !item.comingSoon).length;
 

--- a/apps/admin/src/lib/identity/index.ts
+++ b/apps/admin/src/lib/identity/index.ts
@@ -12,6 +12,7 @@ export {
   type Identity,
   type MeResponse,
 } from './identity';
+export { isMenuRefVisible, MENU_PERMISSIONS } from './menu-permissions';
 export {
   decideFieldMode,
   type FieldRenderMode,

--- a/apps/admin/src/lib/identity/menu-permissions.ts
+++ b/apps/admin/src/lib/identity/menu-permissions.ts
@@ -1,0 +1,73 @@
+import type { Identity } from './identity';
+import { hasAnyPermission } from './identity';
+
+/**
+ * RBAC-P4-005 (#682) — sidebar / menu permission gating map.
+ *
+ * Each entry maps a menu `ref` (the stable backend identifier used by
+ * `useEffectiveMenu()` and the system-menu registry) to the PRD §3.2
+ * permission codes that should make the entry visible. The semantics
+ * are "any of" — the menu entry shows up when the caller holds at
+ * least one of the listed codes.
+ *
+ * Entries not in the map are considered public — the legacy behaviour
+ * where the sidebar is identical for every authenticated user. Adding
+ * a new gated entry is a single map row; nothing else moves.
+ *
+ * Cross-cutting note — backend `useEffectiveMenu()` is itself permission-
+ * aware in Phase 6 (it filters server-side once the
+ * `#[RequiresPermission]` retrofit lands). The frontend filter here is
+ * the second-line defence + the UX layer that hides "appears coming
+ * soon" links before the backend trims the list.
+ */
+export const MENU_PERMISSIONS: Readonly<Record<string, readonly string[]>> = {
+  // Catalog
+  products: ['products.view'],
+  categories: ['categories.view'],
+  multimedia: ['multimedia.view'],
+
+  // Modeling (per PRD §3.2 macierz — Modeler / Owner / Admin)
+  modeling: ['modeling.view'],
+
+  // Settings — single-permission collapse covers every sub-item; users
+  // who lack everything see the entry hidden entirely.
+  settings: [
+    'settings.users.manage',
+    'settings.roles.manage',
+    'settings.tenant.manage',
+    'settings.integrations.manage',
+    'settings.billing.manage',
+  ],
+
+  // Imports / Exports — own scope is enough to show the entry.
+  imports: ['imports.view_own', 'imports.view_all'],
+  exports: ['exports.view_own', 'exports.view_all'],
+
+  // Workflow inbox (Approver + Owner per macierz).
+  workflow: ['workflow.view'],
+
+  // API configurator visibility tied to integrations management.
+  api_configurator: ['settings.integrations.manage'],
+};
+
+/**
+ * Decides whether the given menu `ref` should be visible to the caller.
+ *
+ *   - Identity still loading → return false. The sidebar renders the
+ *     fallback (cached) list and swaps once /api/auth/me lands; the
+ *     50–200ms flash with no permissions is preferable to flashing
+ *     forbidden entries.
+ *   - Unmapped `ref` → visible (treated as public).
+ *   - Mapped `ref`   → visible iff caller holds at least one of the
+ *     mapped codes.
+ */
+export function isMenuRefVisible(identity: Identity | null, ref: string): boolean {
+  if (!identity) {
+    return false;
+  }
+  const required = MENU_PERMISSIONS[ref];
+  if (!required) {
+    return true;
+  }
+  return hasAnyPermission(identity, required);
+}


### PR DESCRIPTION
## Summary

RBAC-P4-005 — second-line frontend filter on top of backend-driven `useEffectiveMenu()`. Menu entries hidden by a permission revoke stay hidden in the SPA cache; Mercure SSE invalidation (#687) keeps the cache fresh.

`MENU_PERMISSIONS` map + `isMenuRefVisible(identity, ref)` ("any of" semantics). Entries unmapped = public (legacy).

Coverage today: products / categories / multimedia / modeling / workflow → `.view`; settings → any of users / roles / tenant / integrations / billing; imports / exports → own or all; api_configurator → `settings.integrations.manage`.

## Test plan

- [x] Typecheck green, Biome clean
- [ ] CI green

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)