### PR TITLE
feat(identity): #691 Settings → Users list + GET /api/users

### DIFF
--- a/apps/admin/e2e/settings-users-list.spec.ts
+++ b/apps/admin/e2e/settings-users-list.spec.ts
@@ -30,8 +30,10 @@ test('Settings → Users list — smoke', async ({ page }) => {
   await expect(page.getByRole('button', { name: /zaproś użytkownika|invite user/i })).toBeVisible();
   await expect(page.getByRole('table')).toBeVisible();
 
-  // The seeded admin user must appear in the list.
-  await expect(page.getByText('admin@demo.localhost')).toBeVisible();
+  // The seeded admin user must appear in the list. Scope the search to the
+  // table — the top-bar user menu also renders the email, so a global
+  // getByText would fail Playwright's strict-mode resolution.
+  await expect(page.getByRole('table').getByText('admin@demo.localhost')).toBeVisible();
 
   // Search → debounce → filter narrows.
   await page.getByLabel(/wyszukaj użytkowników|search users/i).fill('zzz_no_such_user');

--- a/apps/admin/e2e/settings-users-list.spec.ts
+++ b/apps/admin/e2e/settings-users-list.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * RBAC-P5-001 (#691) — Settings → Users list smoke.
+ *
+ * Single test exercises the surface (table render, search filter, status
+ * filter) with one login. The auth-rate-limiter (5/IP/15min) is shared
+ * across the whole Playwright run; splitting this into multiple per-flow
+ * specs would push the cumulative login count past the limit when the
+ * suite runs after other RBAC specs.
+ */
+test('Settings → Users list — smoke', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  // Sidebar → Settings → Users — direct navigation to the URL rather than
+  // clicking through, because the sidebar contents are tested separately
+  // in #682 (sidebar permission filtering).
+  await page.goto('/settings/users');
+
+  // The fetch for the first page lands while the route hydrates; wait for
+  // it explicitly so the test does not race with the loading skeleton.
+  await page.waitForResponse(
+    (response) => response.url().includes('/api/users') && response.request().method() === 'GET',
+  );
+
+  // Page chrome: heading + invite CTA + table.
+  await expect(page.getByRole('heading', { level: 2, name: /użytkownicy|users/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /zaproś użytkownika|invite user/i })).toBeVisible();
+  await expect(page.getByRole('table')).toBeVisible();
+
+  // The seeded admin user must appear in the list.
+  await expect(page.getByText('admin@demo.localhost')).toBeVisible();
+
+  // Search → debounce → filter narrows.
+  await page.getByLabel(/wyszukaj użytkowników|search users/i).fill('zzz_no_such_user');
+  await page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/users') && response.url().includes('search=zzz_no_such_user'),
+  );
+  await expect(page.getByText(/brak użytkowników|no users/i)).toBeVisible();
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -281,6 +281,13 @@ function App() {
               show: '/integrations/api-configurator/:id',
             },
             {
+              // RBAC-P5-001 (#691) — Settings → Users list. The page lives at
+              // /settings/users; Refine resource registration drives the
+              // useList wiring + future create/edit routes (#692/#693).
+              name: 'users',
+              list: '/settings/users',
+            },
+            {
               name: 'import-sessions',
               list: '/integrations/imports/sessions',
               show: '/integrations/imports/:id',

--- a/apps/admin/src/features/settings/users/StatusBadge.tsx
+++ b/apps/admin/src/features/settings/users/StatusBadge.tsx
@@ -1,0 +1,48 @@
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+import type { UserStatus } from './types';
+
+interface StatusBadgeProps {
+  status: UserStatus;
+}
+
+/**
+ * RBAC-P5-001 (#691) — colour-coded status pill for the Users list.
+ *
+ * Today the backend exposes only `active` / `disabled` (User entity STATUS_*
+ * constants); follow-ups will derive `invited` and `pending` from the
+ * Invitation table (#692) and surface them through this same component
+ * so the visual taxonomy stays in one file.
+ */
+export function StatusBadge({ status }: StatusBadgeProps) {
+  const { t } = useTranslation();
+
+  const variant: Record<UserStatus, { cls: string; dot: string; labelKey: string }> = {
+    active: {
+      cls: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+      dot: 'bg-emerald-500',
+      labelKey: 'settings.users.status.active',
+    },
+    disabled: {
+      cls: 'bg-zinc-100 text-zinc-600 ring-zinc-200',
+      dot: 'bg-zinc-400',
+      labelKey: 'settings.users.status.disabled',
+    },
+  };
+
+  const { cls, dot, labelKey } = variant[status];
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium ring-1',
+        cls,
+      )}
+    >
+      <span className={cn('h-1.5 w-1.5 rounded-full', dot)} aria-hidden="true" />
+      {t(labelKey)}
+    </span>
+  );
+}

--- a/apps/admin/src/features/settings/users/UserAvatar.tsx
+++ b/apps/admin/src/features/settings/users/UserAvatar.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils';
+
+interface UserAvatarProps {
+  initial: string;
+  size?: 'sm' | 'md';
+  seed?: string;
+}
+
+/**
+ * Deterministic circular avatar built from the user's first letter and
+ * a hashed colour. Avoids an image-upload dependency until the profile
+ * editor (RBAC-P5-003 #693) lands — looks consistent across the
+ * Settings UI and matches the mockup (`Zrodla/.../settings/users.jsx`)
+ * even before per-user uploaded avatars exist.
+ */
+export function UserAvatar({ initial, size = 'md', seed }: UserAvatarProps) {
+  const palette = [
+    'bg-violet-100 text-violet-700',
+    'bg-cyan-100 text-cyan-700',
+    'bg-amber-100 text-amber-700',
+    'bg-rose-100 text-rose-700',
+    'bg-emerald-100 text-emerald-700',
+    'bg-blue-100 text-blue-700',
+    'bg-fuchsia-100 text-fuchsia-700',
+  ] as const;
+
+  const source = seed ?? initial;
+  let hash = 0;
+  for (const char of source) {
+    hash = (hash + char.charCodeAt(0)) % palette.length;
+  }
+  const tone = palette[hash];
+
+  const dimensions = size === 'sm' ? 'size-8 text-[12px]' : 'size-9 text-[13px]';
+
+  return (
+    <span
+      className={cn('inline-grid place-items-center rounded-full font-semibold', dimensions, tone)}
+      aria-hidden="true"
+    >
+      {initial}
+    </span>
+  );
+}

--- a/apps/admin/src/features/settings/users/UsersListView.tsx
+++ b/apps/admin/src/features/settings/users/UsersListView.tsx
@@ -1,0 +1,364 @@
+import { useList } from '@refinedev/core';
+import {
+  ChevronLeft,
+  ChevronRight,
+  MoreHorizontal,
+  Search,
+  ShieldCheck,
+  UserPlus,
+} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
+import { cn } from '@/lib/utils';
+
+import { StatusBadge } from './StatusBadge';
+import type { UserListItem, UserStatus } from './types';
+import { UserAvatar } from './UserAvatar';
+
+const PAGE_SIZE = 50;
+type StatusFilter = 'all' | UserStatus;
+
+/**
+ * RBAC-P5-001 (#691) — Settings → Users list with debounced search,
+ * status filter, role filter, and pager.
+ *
+ * Sources data through Refine's `useList`, which hits `/api/users`
+ * exposed by the new `users` resource registered in `App.tsx`. The
+ * data-provider (lib/data-provider.ts) maps `eq` filters straight to
+ * query params and unwraps the `member`/`totalItems` envelope returned
+ * by {@link UsersListController}.
+ *
+ * Action affordances (3-dot menu, *Invite user* button, role chips) are
+ * scaffolded here but their wiring lands in:
+ *   - #692 invite user modal,
+ *   - #693 edit user,
+ *   - #694 deactivate/reactivate,
+ *   - #696/#697 role permissions.
+ *
+ * Each of these tickets layers behaviour onto this same view without
+ * rewriting it.
+ */
+export function UsersListView() {
+  const { t } = useTranslation();
+  const [page, setPage] = useState(1);
+  const [searchInput, setSearchInput] = useState('');
+  const [searchValue, setSearchValue] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [roleFilter, setRoleFilter] = useState<string>('all');
+
+  const filters = useMemo(() => {
+    const out: Array<{ field: string; operator: 'eq'; value: string }> = [];
+    if (statusFilter !== 'all') {
+      out.push({ field: 'status', operator: 'eq', value: statusFilter });
+    }
+    if (searchValue.trim().length > 0) {
+      out.push({ field: 'search', operator: 'eq', value: searchValue.trim() });
+    }
+    if (roleFilter !== 'all') {
+      // Role filter is sent as `role[]=<uuid>` so the backend can later
+      // accept multiple values without a wire-format change — the
+      // data-provider unwraps single-array values into the bracket form.
+      out.push({ field: 'role[]', operator: 'eq', value: roleFilter });
+    }
+    return out;
+  }, [statusFilter, searchValue, roleFilter]);
+
+  const { result, query: listQuery } = useList<UserListItem>({
+    resource: 'users',
+    pagination: { currentPage: page, pageSize: PAGE_SIZE },
+    filters,
+  });
+  const isLoading = listQuery.isLoading;
+  const isError = listQuery.isError;
+
+  // Reset to page 1 whenever any filter changes — pager must not point at
+  // a stale offset that no longer exists in the narrowed result set.
+  useEffect(() => {
+    setPage(1);
+  }, [statusFilter, searchValue, roleFilter]);
+
+  const debouncedSetSearch = useDebouncedCallback((value: string) => {
+    setSearchValue(value);
+  }, 300);
+
+  const onSearchChange = (value: string) => {
+    setSearchInput(value);
+    debouncedSetSearch(value);
+  };
+
+  const total = result?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const users: UserListItem[] = result?.data ?? [];
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="display text-xl font-semibold tracking-tight">
+            {t('settings.users.title')}
+          </h2>
+          <p className="max-w-2xl text-sm text-muted-foreground">{t('settings.users.intro')}</p>
+        </div>
+        <Button size="sm" className="gap-1.5" disabled aria-disabled="true">
+          <UserPlus className="size-4" aria-hidden="true" />
+          {t('settings.users.invite_cta')}
+        </Button>
+      </header>
+
+      <div className="rounded-lg border bg-background p-3 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="relative flex-1">
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              type="search"
+              placeholder={t('settings.users.search_placeholder')}
+              value={searchInput}
+              onChange={(e) => onSearchChange(e.target.value)}
+              className="pl-9"
+              aria-label={t('settings.users.search_aria')}
+            />
+          </div>
+          <FilterSelect
+            label={t('settings.users.filter_status')}
+            value={statusFilter}
+            onChange={(v) => setStatusFilter(v as StatusFilter)}
+            options={[
+              { value: 'all', label: t('settings.users.filter_status_all') },
+              { value: 'active', label: t('settings.users.status.active') },
+              { value: 'disabled', label: t('settings.users.status.disabled') },
+            ]}
+          />
+          <FilterSelect
+            label={t('settings.users.filter_role')}
+            value={roleFilter}
+            onChange={setRoleFilter}
+            options={[{ value: 'all', label: t('settings.users.filter_role_all') }]}
+            disabled
+            disabledHint={t('settings.users.filter_role_pending_hint')}
+          />
+          <div className="text-xs text-muted-foreground sm:ml-auto">
+            {t('settings.users.count', { count: total })}
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-5">{t('settings.users.col_user')}</TableHead>
+              <TableHead>{t('settings.users.col_roles')}</TableHead>
+              <TableHead>{t('settings.users.col_status')}</TableHead>
+              <TableHead>{t('settings.users.col_last_login')}</TableHead>
+              <TableHead className="pr-5 text-right" aria-label={t('settings.users.col_actions')} />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isError && (
+              <TableRow>
+                <TableCell colSpan={5} className="py-8 text-center text-sm text-rose-600">
+                  {t('settings.users.error_loading')}
+                </TableCell>
+              </TableRow>
+            )}
+            {!isError && isLoading && users.length === 0 && <SkeletonRows />}
+            {!isError && !isLoading && users.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="py-12 text-center">
+                  <EmptyState />
+                </TableCell>
+              </TableRow>
+            )}
+            {users.map((user) => (
+              <UserRow key={user.id} user={user} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between rounded-lg border bg-background px-3 py-2 text-sm shadow-sm">
+          <span className="text-muted-foreground">
+            {t('settings.users.pagination_status', { page, total_pages: totalPages })}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1}
+              aria-label={t('settings.users.pagination_prev')}
+            >
+              <ChevronLeft className="size-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page >= totalPages}
+              aria-label={t('settings.users.pagination_next')}
+            >
+              <ChevronRight className="size-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UserRow({ user }: { user: UserListItem }) {
+  const { t, i18n } = useTranslation();
+  const lastLogin = user.last_login_at
+    ? new Date(user.last_login_at).toLocaleString(i18n.language)
+    : t('settings.users.last_login_never');
+
+  return (
+    <TableRow className={cn(user.status === 'disabled' && 'opacity-60')}>
+      <TableCell className="pl-5">
+        <div className="flex items-center gap-3">
+          <UserAvatar initial={user.avatar_initial} seed={user.email} />
+          <div className="min-w-0">
+            <div className="text-sm font-medium">{user.display_name}</div>
+            <div className="truncate text-xs text-muted-foreground">{user.email}</div>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        {user.roles.length === 0 ? (
+          <span className="text-xs text-muted-foreground">{t('settings.users.no_roles')}</span>
+        ) : (
+          <div className="flex flex-wrap gap-1">
+            {user.roles.map((role) => (
+              <RoleChip key={role.id} name={role.name} />
+            ))}
+          </div>
+        )}
+      </TableCell>
+      <TableCell>
+        <StatusBadge status={user.status} />
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">{lastLogin}</TableCell>
+      <TableCell className="pr-5 text-right">
+        <Button
+          variant="ghost"
+          size="icon"
+          disabled
+          aria-label={t('settings.users.row_actions')}
+          aria-disabled="true"
+        >
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function RoleChip({ name }: { name: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-700 ring-1 ring-violet-200">
+      <ShieldCheck className="size-3" aria-hidden="true" />
+      {name}
+    </span>
+  );
+}
+
+function SkeletonRows() {
+  return (
+    <>
+      {[0, 1, 2].map((row) => (
+        <TableRow key={row}>
+          <TableCell className="pl-5">
+            <div className="flex items-center gap-3">
+              <div className="size-9 animate-pulse rounded-full bg-muted" />
+              <div className="space-y-1.5">
+                <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+                <div className="h-3 w-24 animate-pulse rounded bg-muted/60" />
+              </div>
+            </div>
+          </TableCell>
+          <TableCell>
+            <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+          </TableCell>
+          <TableCell>
+            <div className="h-5 w-16 animate-pulse rounded bg-muted" />
+          </TableCell>
+          <TableCell>
+            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+          </TableCell>
+          <TableCell className="pr-5" />
+        </TableRow>
+      ))}
+    </>
+  );
+}
+
+function EmptyState() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 text-center">
+      <UserPlus className="size-8 text-muted-foreground" aria-hidden="true" />
+      <div className="text-sm font-medium">{t('settings.users.empty_title')}</div>
+      <div className="max-w-md text-xs text-muted-foreground">
+        {t('settings.users.empty_description')}
+      </div>
+    </div>
+  );
+}
+
+interface FilterSelectProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: ReadonlyArray<{ value: string; label: string }>;
+  disabled?: boolean;
+  disabledHint?: string;
+}
+
+function FilterSelect({
+  label,
+  value,
+  onChange,
+  options,
+  disabled,
+  disabledHint,
+}: FilterSelectProps) {
+  return (
+    <label
+      className={cn(
+        'inline-flex items-center gap-2 text-xs text-muted-foreground',
+        disabled && 'opacity-60',
+      )}
+      title={disabled ? disabledHint : undefined}
+    >
+      <span>{label}:</span>
+      <select
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-9 rounded-md border border-input bg-background px-2 text-xs text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/apps/admin/src/features/settings/users/index.tsx
+++ b/apps/admin/src/features/settings/users/index.tsx
@@ -1,5 +1,10 @@
-import { ComingSoonPlaceholder } from '@/features/settings/ComingSoonPlaceholder';
+import { UsersListView } from './UsersListView';
 
+/**
+ * RBAC-P5-001 (#691) — entry point for `/settings/users`. The view itself
+ * lives next to its helpers (StatusBadge, UserAvatar) so follow-ups
+ * (#692–#694) can drop in without restructuring this index module.
+ */
 export function UsersSettingsPage() {
-  return <ComingSoonPlaceholder titleKey="settings.nav.users" />;
+  return <UsersListView />;
 }

--- a/apps/admin/src/features/settings/users/types.ts
+++ b/apps/admin/src/features/settings/users/types.ts
@@ -1,0 +1,26 @@
+/**
+ * RBAC-P5-001 (#691) — wire shape for the Settings → Users list. Mirrors
+ * the projection produced by {@link UserListResponseBuilder} on the API
+ * side. Lives next to the page that consumes it so the contract is easy
+ * to audit when the backend evolves.
+ */
+
+export interface UserRoleRef {
+  id: string;
+  code: string;
+  name: string;
+}
+
+export type UserStatus = 'active' | 'disabled';
+
+export interface UserListItem {
+  id: string;
+  email: string;
+  display_name: string;
+  avatar_initial: string;
+  status: UserStatus;
+  roles: UserRoleRef[];
+  last_login_at: string | null;
+  mfa_enabled: boolean;
+  created_at: string;
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -82,6 +82,39 @@
       "protected_tooltip": "This item is required and cannot be hidden",
       "toast_error": "Failed to save changes",
       "error_loading": "Could not load menu configuration."
+    },
+    "users": {
+      "title": "Users",
+      "intro": "Manage user accounts inside this tenant. Magic-link invitations, MFA and role assignment land in follow-up tickets.",
+      "invite_cta": "Invite user",
+      "search_placeholder": "Search by email or name...",
+      "search_aria": "Search users",
+      "filter_status": "Status",
+      "filter_status_all": "All",
+      "filter_role": "Role",
+      "filter_role_all": "All roles",
+      "filter_role_pending_hint": "Role filter unlocks once role management ships (#695).",
+      "count_one": "{{count}} user",
+      "count_other": "{{count}} users",
+      "count": "{{count}} users",
+      "col_user": "User",
+      "col_roles": "Roles",
+      "col_status": "Status",
+      "col_last_login": "Last login",
+      "col_actions": "Actions",
+      "no_roles": "no roles",
+      "row_actions": "Row actions (coming soon)",
+      "last_login_never": "never",
+      "empty_title": "No users",
+      "empty_description": "No user matches the current filters. Clear them or invite the first user.",
+      "error_loading": "Could not load users list.",
+      "pagination_status": "Page {{page}} of {{total_pages}}",
+      "pagination_prev": "Previous page",
+      "pagination_next": "Next page",
+      "status": {
+        "active": "Active",
+        "disabled": "Deactivated"
+      }
     }
   },
   "catalogs_pdf": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -84,6 +84,39 @@
       "protected_tooltip": "Ta pozycja jest wymagana i nie może być ukryta",
       "toast_error": "Nie udało się zapisać zmian",
       "error_loading": "Nie udało się załadować konfiguracji menu."
+    },
+    "users": {
+      "title": "Użytkownicy",
+      "intro": "Zarządzaj kontami w obrębie tenanta. Zaproszenia magic link, MFA i przypisanie ról dochodzą w kolejnych ticketach.",
+      "invite_cta": "Zaproś użytkownika",
+      "search_placeholder": "Szukaj po email lub nazwie...",
+      "search_aria": "Wyszukaj użytkowników",
+      "filter_status": "Status",
+      "filter_status_all": "Wszystkie",
+      "filter_role": "Rola",
+      "filter_role_all": "Wszystkie role",
+      "filter_role_pending_hint": "Filtr po roli dostępny po wdrożeniu zarządzania rolami (#695).",
+      "count_one": "{{count}} użytkownik",
+      "count_other": "{{count}} użytkowników",
+      "count": "{{count}} użytkowników",
+      "col_user": "Użytkownik",
+      "col_roles": "Role",
+      "col_status": "Status",
+      "col_last_login": "Ostatnie logowanie",
+      "col_actions": "Akcje",
+      "no_roles": "brak ról",
+      "row_actions": "Akcje wiersza (wkrótce)",
+      "last_login_never": "nigdy",
+      "empty_title": "Brak użytkowników",
+      "empty_description": "Żaden użytkownik nie pasuje do bieżących filtrów. Wyczyść je albo zaproś pierwszego użytkownika.",
+      "error_loading": "Nie udało się załadować listy użytkowników.",
+      "pagination_status": "Strona {{page}} z {{total_pages}}",
+      "pagination_prev": "Poprzednia strona",
+      "pagination_next": "Następna strona",
+      "status": {
+        "active": "Aktywny",
+        "disabled": "Dezaktywowany"
+      }
     }
   },
   "catalogs_pdf": {

--- a/apps/api/src/Identity/Application/UserListResponseBuilder.php
+++ b/apps/api/src/Identity/Application/UserListResponseBuilder.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application;
+
+use App\Identity\Domain\Entity\User;
+use DateTimeInterface;
+
+use const MB_CASE_TITLE;
+
+/**
+ * Maps {@see User} aggregates onto the JSON shape consumed by the
+ * admin Settings → Users list (RBAC-P5-001 #691).
+ *
+ * Sensitive fields (password hash, TOTP secret, recovery code hashes)
+ * are *never* projected — the only TOTP signal exposed is the boolean
+ * `mfa_enabled`. Tenant boundary is enforced upstream by the repository
+ * query + Doctrine TenantFilter; this builder is intentionally
+ * tenant-agnostic so it can be reused by the SuperAdmin tenant-scoped
+ * view (RBAC-P5-020 #710) without duplicating the projection logic.
+ */
+final class UserListResponseBuilder
+{
+    /**
+     * @param iterable<User> $users
+     *
+     * @return list<array{
+     *     id: string,
+     *     email: string,
+     *     display_name: string,
+     *     avatar_initial: string,
+     *     status: string,
+     *     roles: list<array{id: string, code: string, name: string}>,
+     *     last_login_at: ?string,
+     *     mfa_enabled: bool,
+     *     created_at: string
+     * }>
+     */
+    public function buildList(iterable $users): array
+    {
+        $out = [];
+        foreach ($users as $user) {
+            $out[] = $this->buildOne($user);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     email: string,
+     *     display_name: string,
+     *     avatar_initial: string,
+     *     status: string,
+     *     roles: list<array{id: string, code: string, name: string}>,
+     *     last_login_at: ?string,
+     *     mfa_enabled: bool,
+     *     created_at: string
+     * }
+     */
+    public function buildOne(User $user): array
+    {
+        $email = $user->getEmail();
+        $displayName = $this->deriveDisplayName($email);
+
+        $roles = [];
+        foreach ($user->getAssignedRoles() as $role) {
+            $roles[] = [
+                'id' => $role->getId()->toRfc4122(),
+                'code' => $role->getCode(),
+                'name' => $role->getName(),
+            ];
+        }
+
+        return [
+            'id' => $user->getId()->toRfc4122(),
+            'email' => $email,
+            'display_name' => $displayName,
+            'avatar_initial' => $this->avatarInitial($displayName, $email),
+            'status' => $user->getStatus(),
+            'roles' => $roles,
+            'last_login_at' => $user->getLastLoginAt()?->format(DateTimeInterface::ATOM),
+            'mfa_enabled' => $user->isTotpEnabled(),
+            'created_at' => $user->getCreatedAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * Derive a human-friendly display string from the email until the
+     * schema grows dedicated first_name/last_name columns (deferred to
+     * a profile-fields ticket — tracked in #693 follow-up).
+     */
+    private function deriveDisplayName(string $email): string
+    {
+        // explode() always returns at least one element for a non-empty string,
+        // so the local part is guaranteed; an email without `@` falls through
+        // to using the whole string, which is still a sensible display name.
+        $localPart = explode('@', $email, 2)[0];
+        // Replace common separators with spaces and title-case so
+        // `jan.kowalski` reads as `Jan Kowalski` in the list.
+        $normalised = preg_replace('/[._-]+/', ' ', $localPart);
+        if (null === $normalised || '' === trim($normalised)) {
+            return $email;
+        }
+
+        return mb_convert_case(trim($normalised), MB_CASE_TITLE, 'UTF-8');
+    }
+
+    private function avatarInitial(string $displayName, string $email): string
+    {
+        $source = '' !== trim($displayName) ? $displayName : $email;
+        $first = mb_substr($source, 0, 1, 'UTF-8');
+
+        return mb_strtoupper($first, 'UTF-8');
+    }
+}

--- a/apps/api/src/Identity/Domain/Repository/UserRepositoryInterface.php
+++ b/apps/api/src/Identity/Domain/Repository/UserRepositoryInterface.php
@@ -4,13 +4,62 @@ declare(strict_types=1);
 
 namespace App\Identity\Domain\Repository;
 
+use App\Identity\Domain\Entity\User;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
 interface UserRepositoryInterface
 {
-    public function findById(\Symfony\Component\Uid\Uuid $id): ?\App\Identity\Domain\Entity\User;
+    public function findById(Uuid $id): ?User;
 
-    public function findByEmail(string $email): ?\App\Identity\Domain\Entity\User;
+    public function findByEmail(string $email): ?User;
 
-    public function save(\App\Identity\Domain\Entity\User $entity): void;
+    public function save(User $entity): void;
 
-    public function remove(\App\Identity\Domain\Entity\User $entity): void;
+    public function remove(User $entity): void;
+
+    /**
+     * Paginated listing within a tenant scope, used by the Settings → Users
+     * page (RBAC-P5-001 #691). The Doctrine TenantFilter already narrows
+     * the result set to the active tenant on every read; the explicit
+     * `$tenant` argument here is what the controller logs / audits so the
+     * filter cannot be silently disabled by a misconfigured listener.
+     *
+     * Filters:
+     *  - `$status` — null (any), 'active' or 'disabled' (PRD STATUS_* values);
+     *  - `$roleIds` — null (any), or a list of Role UUIDs (M2M intersection);
+     *  - `$search` — null or a substring matched against `email` (case-insensitive
+     *    via lowercased comparison). Email is the only display identifier today
+     *    (no separate first_name / last_name in `users` table yet).
+     *
+     * Pagination is 1-indexed; `$perPage` is clamped by the controller to the
+     * Settings UI maximum of 50 (PRD §5.3 mockup spec).
+     *
+     * @param list<string>|null $roleIds Role UUIDs as RFC 4122 strings
+     *
+     * @return list<User>
+     */
+    public function findAllByTenantPaginated(
+        Tenant $tenant,
+        ?string $status,
+        ?array $roleIds,
+        ?string $search,
+        int $page,
+        int $perPage,
+    ): array;
+
+    /**
+     * Same filter contract as {@see findAllByTenantPaginated()}, returns the
+     * total row count for pager metadata. Two queries instead of a single
+     * `OVER()` window so we keep the JOIN-on-roles simple — at the
+     * Settings-UI scale (<1k users / tenant) the second query is cheap.
+     *
+     * @param list<string>|null $roleIds
+     */
+    public function countByTenant(
+        Tenant $tenant,
+        ?string $status,
+        ?array $roleIds,
+        ?string $search,
+    ): int;
 }

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineUserRepository.php
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineUserRepository.php
@@ -6,8 +6,11 @@ namespace App\Identity\Infrastructure\Doctrine\Repository;
 
 use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @extends ServiceEntityRepository<User>
@@ -24,7 +27,7 @@ class DoctrineUserRepository extends ServiceEntityRepository implements UserRepo
         return $this->findOneBy(['email' => $email]);
     }
 
-    public function findById(\Symfony\Component\Uid\Uuid $id): ?User
+    public function findById(Uuid $id): ?User
     {
         return parent::find($id->toRfc4122());
     }
@@ -41,5 +44,75 @@ class DoctrineUserRepository extends ServiceEntityRepository implements UserRepo
         $em = $this->getEntityManager();
         $em->remove($entity);
         $em->flush();
+    }
+
+    public function findAllByTenantPaginated(
+        Tenant $tenant,
+        ?string $status,
+        ?array $roleIds,
+        ?string $search,
+        int $page,
+        int $perPage,
+    ): array {
+        $qb = $this->buildBaseQuery($tenant, $status, $roleIds, $search)
+            ->orderBy('u.email', 'ASC')
+            ->setFirstResult(max(0, ($page - 1) * $perPage))
+            ->setMaxResults(max(1, $perPage));
+
+        /** @var list<User> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    public function countByTenant(
+        Tenant $tenant,
+        ?string $status,
+        ?array $roleIds,
+        ?string $search,
+    ): int {
+        $qb = $this->buildBaseQuery($tenant, $status, $roleIds, $search)
+            ->select('COUNT(DISTINCT u.id)');
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @param list<string>|null $roleIds
+     */
+    private function buildBaseQuery(
+        Tenant $tenant,
+        ?string $status,
+        ?array $roleIds,
+        ?string $search,
+    ): QueryBuilder {
+        $qb = $this->createQueryBuilder('u')
+            ->where('u.tenant = :tenant')
+            ->setParameter('tenant', $tenant->getId());
+
+        if (null !== $status) {
+            $qb->andWhere('u.status = :status')->setParameter('status', $status);
+        }
+
+        if (null !== $search && '' !== $search) {
+            $qb->andWhere('LOWER(u.email) LIKE :search')
+                ->setParameter('search', '%'.strtolower($search).'%');
+        }
+
+        if (null !== $roleIds && [] !== $roleIds) {
+            // Intersection with the assigned-roles M2M graph via EXISTS —
+            // a plain INNER JOIN + DISTINCT trips Postgres' "no equality
+            // operator for type json" error because Doctrine projects the
+            // legacy User.roles json column on the select clause.
+            $sub = $this->createQueryBuilder('u_sub')
+                ->select('u_sub.id')
+                ->innerJoin('u_sub.assignedRoles', 'r')
+                ->where('u_sub.id = u.id')
+                ->andWhere('r.id IN (:roleIds)');
+            $qb->andWhere($qb->expr()->exists($sub->getDQL()))
+                ->setParameter('roleIds', $roleIds);
+        }
+
+        return $qb;
     }
 }

--- a/apps/api/src/Identity/Presentation/Controller/UsersListController.php
+++ b/apps/api/src/Identity/Presentation/Controller/UsersListController.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Identity\Application\UserListResponseBuilder;
+use App\Identity\Domain\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * RBAC-P5-001 (#691) — `GET /api/users` listing for the Settings → Users
+ * page. Returns the authenticated principal's tenant only; cross-tenant
+ * isolation is enforced at the repository (`WHERE tenant = :tenant`) on
+ * top of the Doctrine TenantFilter, so even a misconfigured filter cannot
+ * leak rows.
+ *
+ * Response shape is Hydra-compatible so the existing admin data provider
+ * (`apps/admin/src/lib/data-provider.ts`) reads the page without a custom
+ * branch:
+ *
+ *   {
+ *     "member":     [ user-projection, ... ],   // see UserListResponseBuilder
+ *     "totalItems": <int>,                       // total in tenant after filters
+ *     "meta": { "page": <int>, "per_page": <int>, "total_pages": <int> }
+ *   }
+ *
+ * Query params:
+ *   - `page` / `itemsPerPage` (Refine sends both names — accept either)
+ *   - `status` — filter `User::STATUS_ACTIVE` / `User::STATUS_DISABLED`
+ *   - `role[]` — list of Role UUIDs (M2M intersection)
+ *   - `search` — case-insensitive substring on email
+ */
+final readonly class UsersListController
+{
+    private const int MAX_PER_PAGE = 50;
+    private const int DEFAULT_PER_PAGE = 50;
+    private const array ALLOWED_STATUSES = [User::STATUS_ACTIVE, User::STATUS_DISABLED];
+
+    public function __construct(
+        private Security $security,
+        private UserRepositoryInterface $users,
+        private UserListResponseBuilder $builder,
+    ) {
+    }
+
+    #[Route(path: '/api/users', methods: ['GET'], name: 'api_users_list')]
+    /*
+     * Permission gate: `user.admin` from the seeded RbacMatrix until Phase 6
+     * (#720+) retrofits all endpoints onto the PRD §3.2 codes (`settings.users.manage`).
+     * `user.admin` is held only by super_admin in the current matrix — viewer
+     * has `user.read` (read-only-on-everything pattern) so a narrower gate is
+     * needed than the read flag.
+     */
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $principal = $this->security->getUser();
+        if (!$principal instanceof User) {
+            // The JWT firewall + EndpointGuardListener catch this earlier;
+            // defence-in-depth in case a custom route bypasses both.
+            return $this->unauthorized();
+        }
+
+        $tenant = $principal->getTenant();
+
+        $page = max(1, (int) $request->query->get('page', '1'));
+        $perPageRaw = (int) ($request->query->get('itemsPerPage') ?? $request->query->get('per_page') ?? self::DEFAULT_PER_PAGE);
+        $perPage = max(1, min(self::MAX_PER_PAGE, $perPageRaw));
+
+        $status = $request->query->get('status');
+        if (null !== $status && !\in_array($status, self::ALLOWED_STATUSES, true)) {
+            $status = null;
+        }
+
+        $search = $request->query->get('search');
+        if (null !== $search) {
+            $search = trim($search);
+            if ('' === $search) {
+                $search = null;
+            }
+        }
+
+        $roleIdsRaw = $request->query->all('role');
+        $roleIds = [];
+        foreach ($roleIdsRaw as $candidate) {
+            if (\is_string($candidate) && '' !== $candidate) {
+                $roleIds[] = $candidate;
+            }
+        }
+        $roleIds = [] === $roleIds ? null : $roleIds;
+
+        $users = $this->users->findAllByTenantPaginated($tenant, $status, $roleIds, $search, $page, $perPage);
+        $total = $this->users->countByTenant($tenant, $status, $roleIds, $search);
+        $totalPages = (int) ceil($total / $perPage);
+        $totalPages = max(1, $totalPages);
+
+        return new JsonResponse([
+            'member' => $this->builder->buildList($users),
+            'totalItems' => $total,
+            'meta' => [
+                'page' => $page,
+                'per_page' => $perPage,
+                'total_pages' => $totalPages,
+            ],
+        ]);
+    }
+
+    private function unauthorized(): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'type' => 'about:blank',
+                'title' => 'Unauthorized',
+                'status' => Response::HTTP_UNAUTHORIZED,
+                'detail' => 'No authenticated user.',
+            ],
+            Response::HTTP_UNAUTHORIZED,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
+    }
+}

--- a/apps/api/tests/Api/Identity/UsersListControllerTest.php
+++ b/apps/api/tests/Api/Identity/UsersListControllerTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * RBAC-P5-001 (#691) — coverage for the Settings → Users list endpoint.
+ *
+ * Critical invariants (PRD §3.2 macierz + §3.4 tenant isolation):
+ *  - cross-tenant boundary holds (tenant B users invisible to tenant A)
+ *  - `user.admin` permission required (Catalog Manager → 403)
+ *  - filters (status / role / search) narrow the result set correctly
+ *  - response shape is Hydra-compatible (`member`, `totalItems`, `meta`)
+ *  - sensitive fields (password / totp_secret) never appear in the payload
+ */
+final class UsersListControllerTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_A_CODE = 'demo';
+    private const string TENANT_B_CODE = 'other';
+
+    private const string ADMIN_A_EMAIL = 'admin@demo.localhost';
+    private const string CATALOG_A_EMAIL = 'catalog@demo.localhost';
+    private const string VIEWER_A_EMAIL = 'viewer@demo.localhost';
+    private const string ADMIN_B_EMAIL = 'admin@other.localhost';
+
+    private string $catalogManagerRoleId = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+
+        $roles = self::getContainer()->get(RoleRepositoryInterface::class);
+        $superAdmin = $roles->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        $viewer = $roles->findGlobalByCode(RbacMatrix::ROLE_VIEWER);
+        $catalogManager = $roles->findGlobalByCode(RbacMatrix::ROLE_CATALOG_MANAGER);
+        \assert(null !== $superAdmin && null !== $viewer && null !== $catalogManager);
+        $this->catalogManagerRoleId = $catalogManager->getId()->toRfc4122();
+
+        $tenantA = new Tenant(self::TENANT_A_CODE, 'Demo Tenant');
+        $tenantB = new Tenant(self::TENANT_B_CODE, 'Other Tenant');
+        $em->persist($tenantA);
+        $em->persist($tenantB);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $adminA = $this->makeUser($tenantA, self::ADMIN_A_EMAIL, $hasher);
+        $adminA->addRole($superAdmin);
+        $em->persist($adminA);
+
+        $catalogManagerA = $this->makeUser($tenantA, self::CATALOG_A_EMAIL, $hasher);
+        $catalogManagerA->addRole($catalogManager);
+        $em->persist($catalogManagerA);
+
+        $viewerA = $this->makeUser($tenantA, self::VIEWER_A_EMAIL, $hasher);
+        $viewerA->addRole($viewer);
+        $viewerA->disable();
+        $em->persist($viewerA);
+
+        $adminB = $this->makeUser($tenantB, self::ADMIN_B_EMAIL, $hasher);
+        $adminB->addRole($superAdmin);
+        $em->persist($adminB);
+
+        $em->flush();
+    }
+
+    #[Test]
+    public function returnsOnlyUsersFromAuthenticatedTenant(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/users');
+
+        self::assertResponseStatusCodeSame(200);
+        $body = $this->decodeResponse($client);
+
+        self::assertArrayHasKey('member', $body);
+        self::assertArrayHasKey('totalItems', $body);
+        self::assertArrayHasKey('meta', $body);
+        self::assertSame(3, $body['totalItems'] ?? null);
+
+        $emails = $this->emailsOf($body);
+        self::assertContains(self::ADMIN_A_EMAIL, $emails);
+        self::assertContains(self::CATALOG_A_EMAIL, $emails);
+        self::assertContains(self::VIEWER_A_EMAIL, $emails);
+        self::assertNotContains(self::ADMIN_B_EMAIL, $emails);
+    }
+
+    #[Test]
+    public function catalogManagerWithoutAdminPermissionReceives403(): void
+    {
+        // Catalog Manager has the read flag on user via "read on all resources"
+        // but lacks `user.admin` which is super-admin-only in the seeded
+        // matrix. Until #720 retrofit migrates onto `settings.users.manage`,
+        // user.admin is the closest existing super-admin-only gate.
+        $client = $this->clientFor(self::CATALOG_A_EMAIL);
+        $client->request('GET', '/api/users');
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertResponseHeaderSame('content-type', 'application/problem+json');
+    }
+
+    #[Test]
+    public function filtersByStatus(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/users?status=disabled');
+
+        self::assertResponseStatusCodeSame(200);
+        $body = $this->decodeResponse($client);
+
+        self::assertSame(1, $body['totalItems'] ?? null);
+        $emails = $this->emailsOf($body);
+        self::assertSame([self::VIEWER_A_EMAIL], $emails);
+    }
+
+    #[Test]
+    public function filtersByRole(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/users?role[]='.$this->catalogManagerRoleId);
+
+        self::assertResponseStatusCodeSame(200);
+        $body = $this->decodeResponse($client);
+
+        self::assertSame(1, $body['totalItems'] ?? null);
+        $emails = $this->emailsOf($body);
+        self::assertSame([self::CATALOG_A_EMAIL], $emails);
+    }
+
+    #[Test]
+    public function searchesByEmailSubstringCaseInsensitive(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/users?search=CATALOG');
+
+        self::assertResponseStatusCodeSame(200);
+        $body = $this->decodeResponse($client);
+
+        self::assertSame(1, $body['totalItems'] ?? null);
+        $emails = $this->emailsOf($body);
+        self::assertSame([self::CATALOG_A_EMAIL], $emails);
+    }
+
+    #[Test]
+    public function projectionDoesNotLeakSensitiveFields(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/users');
+
+        $body = $this->decodeResponse($client);
+        $members = $body['member'] ?? [];
+        \assert(\is_array($members) && [] !== $members);
+        $first = $members[0];
+        \assert(\is_array($first));
+
+        self::assertArrayNotHasKey('password', $first);
+        self::assertArrayNotHasKey('totp_secret', $first);
+        self::assertArrayNotHasKey('totpSecret', $first);
+        self::assertArrayNotHasKey('totp_backup_codes', $first);
+        self::assertArrayHasKey('mfa_enabled', $first);
+        self::assertIsBool($first['mfa_enabled']);
+    }
+
+    #[Test]
+    public function returnsMetaWithPaginationDetails(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/users?itemsPerPage=2&page=1');
+
+        $body = $this->decodeResponse($client);
+        $members = $body['member'] ?? [];
+        \assert(\is_array($members));
+        $meta = $body['meta'] ?? [];
+        \assert(\is_array($meta));
+
+        self::assertSame(3, $body['totalItems'] ?? null);
+        self::assertCount(2, $members);
+        self::assertSame(1, $meta['page'] ?? null);
+        self::assertSame(2, $meta['per_page'] ?? null);
+        self::assertSame(2, $meta['total_pages'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeResponse(Client $client): array
+    {
+        $response = $client->getResponse();
+        \assert(null !== $response);
+
+        /** @var array<string, mixed> $payload */
+        $payload = $response->toArray();
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return list<string>
+     */
+    private function emailsOf(array $body): array
+    {
+        $members = $body['member'] ?? [];
+        \assert(\is_array($members));
+        $emails = [];
+        foreach ($members as $row) {
+            \assert(\is_array($row));
+            $email = $row['email'] ?? null;
+            \assert(\is_string($email));
+            $emails[] = $email;
+        }
+
+        return $emails;
+    }
+
+    private function makeUser(Tenant $tenant, string $email, UserPasswordHasherInterface $hasher): User
+    {
+        $stub = new User($tenant, $email, '');
+
+        return new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'));
+    }
+
+    private function clientFor(string $email): Client
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail($email);
+        \assert(null !== $user);
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
## Summary

- Wires up the Settings → Users page that replaces the placeholder
  with a paginated, searchable list. Pulls from the new
  `GET /api/users` endpoint, scoped to the caller's tenant via the
  Doctrine TenantFilter on top of an explicit `WHERE tenant = :tenant`
  clause — defence-in-depth against accidental filter removal.
- Endpoint gated by `user.admin` from the seeded RbacMatrix (super_admin
  only). Viewer + Catalog Manager get **403** even though Viewer holds
  `user.read` via the read-on-all-resources pattern. Phase 6 (#720+)
  will retrofit onto PRD §3.2 `settings.users.manage`.
- Projection never leaks `password`, `totp_secret`, `totp_backup_codes`
  — only `mfa_enabled: bool`. Asserted at the response level by the
  PHPUnit suite.

## Scope decisions (vs. ticket spec)

- **Single-role filter (not multi-select)** — multi-select hinted at
  in the UI but disabled until `/settings/roles` lands (#695). The
  data-provider already supports the `role[]=<uuid>` wire format, so
  enabling multi-select is a 1-line FE change once roles are listable.
- **3-dot row actions disabled** — the menu surface ships but every
  action is wired in a follow-up (#692 invite, #693 edit, #694
  deactivate / reactivate / reset MFA).
- **`invited` status not yet surfaced** — backend exposes only
  `active` / `disabled` (the User entity STATUS_* enum). The
  `pending_invitation` derivation against the Invitation table needs
  the invite flow (#692) to populate it; this PR ships the status
  badge component ready to accept it.

## Test plan

- [x] PHPStan max + php-cs-fixer green (`composer lint`)
- [x] Biome strict + tsc -b green on changed files
- [x] PHPUnit `UsersListControllerTest` — 7 tests / 31 assertions: cross-tenant boundary, 403 for sub-admin, status / role / search filters, no sensitive-field leak, meta pagination shape
- [x] Live-stack smoke against `https://pim.localhost`:
  - `POST /api/auth/login` → 200 + JWT (527 chars)
  - `GET /api/users?itemsPerPage=5` → 200, `totalItems: 1`, member projection clean (no password / totp_secret)
  - `GET /api/users?status=active` → `totalItems: 1`, meta `{page:1, per_page:50, total_pages:1}`
  - `GET /api/users?status=disabled` → `totalItems: 0`
  - `GET /api/users?search=zzz_no` → `totalItems: 0`
  - `GET /api/users` (no auth) → **401**
- [x] Admin Vite build — `pnpm --filter @pim/admin build` succeeds, HMR picks up `UsersListView` / `UserAvatar`
- [ ] Playwright `settings-users-list.spec.ts` — added; CI will execute

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)