### PR TITLE
feat(identity): #695 Settings → Roles list + GET /api/roles

### DIFF
--- a/apps/admin/e2e/settings-roles-list.spec.ts
+++ b/apps/admin/e2e/settings-roles-list.spec.ts
@@ -25,13 +25,15 @@ test('Settings → Roles list — smoke', async ({ page }) => {
   ).toBeVisible();
   await expect(page.getByRole('table')).toBeVisible();
 
-  // The 4 seeded global roles must each render with a System badge. We
-  // scope through the table to avoid cross-matching the sidebar nav item.
+  // The 4 seeded global roles must each render. Use `.first()` because
+  // each role surfaces both the human-readable name ("Viewer") and the
+  // monospaced code identifier ("viewer") — Playwright's strict mode
+  // refuses the assertion otherwise.
   const table = page.getByRole('table');
-  await expect(table.getByText(/super admin/i)).toBeVisible();
-  await expect(table.getByText(/catalog manager/i)).toBeVisible();
-  await expect(table.getByText(/integration manager/i)).toBeVisible();
-  await expect(table.getByText(/^viewer$/i)).toBeVisible();
+  await expect(table.getByText(/super admin/i).first()).toBeVisible();
+  await expect(table.getByText(/catalog manager/i).first()).toBeVisible();
+  await expect(table.getByText(/integration manager/i).first()).toBeVisible();
+  await expect(table.getByText('Viewer', { exact: true })).toBeVisible();
   // At least one System badge (capitalised) must be visible. The custom
   // path isn't seeded in dev, so we don't assert the Custom badge here.
   await expect(table.getByText(/^system$/i).first()).toBeVisible();

--- a/apps/admin/e2e/settings-roles-list.spec.ts
+++ b/apps/admin/e2e/settings-roles-list.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * RBAC-P5-005 (#695) — Settings → Roles list smoke.
+ *
+ * One login covers everything visible — the auth-rate-limiter is
+ * shared across the suite and other RBAC specs (#691, #692, #696)
+ * already chew through 4 of the 5 attempts per 15min window.
+ */
+test('Settings → Roles list — smoke', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/settings/roles');
+
+  await page.waitForResponse(
+    (response) => response.url().includes('/api/roles') && response.request().method() === 'GET',
+  );
+
+  // Heading + create CTA + table render. Create CTA is disabled until the
+  // role builder ships (#696) so we assert it exists rather than clickable.
+  await expect(page.getByRole('heading', { level: 2, name: /^role$|^roles$/i })).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /utwórz rolę customową|create custom role/i }),
+  ).toBeVisible();
+  await expect(page.getByRole('table')).toBeVisible();
+
+  // The 4 seeded global roles must each render with a System badge. We
+  // scope through the table to avoid cross-matching the sidebar nav item.
+  const table = page.getByRole('table');
+  await expect(table.getByText(/super admin/i)).toBeVisible();
+  await expect(table.getByText(/catalog manager/i)).toBeVisible();
+  await expect(table.getByText(/integration manager/i)).toBeVisible();
+  await expect(table.getByText(/^viewer$/i)).toBeVisible();
+  // At least one System badge (capitalised) must be visible. The custom
+  // path isn't seeded in dev, so we don't assert the Custom badge here.
+  await expect(table.getByText(/^system$/i).first()).toBeVisible();
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -288,6 +288,13 @@ function App() {
               list: '/settings/users',
             },
             {
+              // RBAC-P5-005 (#695) — Settings → Roles list. Lists system
+              // templates + tenant custom roles with user counts. Create/edit
+              // routes land with #696 (custom role builder).
+              name: 'roles',
+              list: '/settings/roles',
+            },
+            {
               name: 'import-sessions',
               list: '/integrations/imports/sessions',
               show: '/integrations/imports/:id',

--- a/apps/admin/src/features/settings/roles/RoleTypeBadge.tsx
+++ b/apps/admin/src/features/settings/roles/RoleTypeBadge.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+import type { RoleListType } from './types';
+
+interface RoleTypeBadgeProps {
+  type: RoleListType;
+}
+
+/**
+ * RBAC-P5-005 (#695) — System / Custom badge for the Settings → Roles
+ * table. Visual style mirrors the status pill from the Users list so
+ * the Settings surface stays coherent across pages.
+ */
+export function RoleTypeBadge({ type }: RoleTypeBadgeProps) {
+  const { t } = useTranslation();
+
+  const variant: Record<RoleListType, { cls: string; labelKey: string }> = {
+    system: {
+      cls: 'bg-violet-50 text-violet-700 ring-violet-200',
+      labelKey: 'settings.roles.type.system',
+    },
+    custom: {
+      cls: 'bg-cyan-50 text-cyan-700 ring-cyan-200',
+      labelKey: 'settings.roles.type.custom',
+    },
+  };
+
+  const { cls, labelKey } = variant[type];
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide ring-1',
+        cls,
+      )}
+    >
+      {t(labelKey)}
+    </span>
+  );
+}

--- a/apps/admin/src/features/settings/roles/RolesListView.tsx
+++ b/apps/admin/src/features/settings/roles/RolesListView.tsx
@@ -1,0 +1,185 @@
+import { useList } from '@refinedev/core';
+import { MoreHorizontal, Plus, ShieldCheck } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+import { RoleTypeBadge } from './RoleTypeBadge';
+import type { RoleListItem } from './types';
+
+/**
+ * RBAC-P5-005 (#695) — Settings → Roles list. Surfaces every seeded
+ * system role plus the caller tenant's custom roles, each annotated
+ * with the in-tenant user count. Action affordances (View permissions,
+ * Edit, Duplicate, Delete) ship as visually disabled stubs until the
+ * dedicated tickets land:
+ *   - #696 — custom role builder UI (Create / Edit),
+ *   - #697 — per-attribute permissions tab,
+ *   - #698 — auto-grant + scope panel.
+ *
+ * Delete is permanently disabled for system roles per PRD §3.2 macierz
+ * (seeded templates are immutable code). For custom roles delete will
+ * unlock once the backend gains the soft-delete + last-role-protection
+ * guarantees expected by #696.
+ */
+export function RolesListView() {
+  const { t, i18n } = useTranslation();
+
+  const { result, query: listQuery } = useList<RoleListItem>({
+    resource: 'roles',
+    pagination: { mode: 'off' },
+  });
+  const isLoading = listQuery.isLoading;
+  const isError = listQuery.isError;
+  const roles: RoleListItem[] = result?.data ?? [];
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="display text-xl font-semibold tracking-tight">
+            {t('settings.roles.title')}
+          </h2>
+          <p className="max-w-2xl text-sm text-muted-foreground">{t('settings.roles.intro')}</p>
+        </div>
+        <Button
+          size="sm"
+          className="gap-1.5"
+          disabled
+          aria-disabled="true"
+          title={t('settings.roles.create_pending_hint')}
+        >
+          <Plus className="size-4" aria-hidden="true" />
+          {t('settings.roles.create_cta')}
+        </Button>
+      </header>
+
+      <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="pl-5">{t('settings.roles.col_name')}</TableHead>
+              <TableHead>{t('settings.roles.col_type')}</TableHead>
+              <TableHead>{t('settings.roles.col_permissions')}</TableHead>
+              <TableHead>{t('settings.roles.col_user_count')}</TableHead>
+              <TableHead className="pr-5 text-right" aria-label={t('settings.roles.col_actions')} />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isError && (
+              <TableRow>
+                <TableCell colSpan={5} className="py-8 text-center text-sm text-rose-600">
+                  {t('settings.roles.error_loading')}
+                </TableCell>
+              </TableRow>
+            )}
+            {!isError && isLoading && roles.length === 0 && <SkeletonRows />}
+            {!isError && !isLoading && roles.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="py-12 text-center text-sm text-muted-foreground">
+                  {t('settings.roles.empty')}
+                </TableCell>
+              </TableRow>
+            )}
+            {roles.map((role) => (
+              <RoleRow key={role.id} role={role} locale={i18n.language} />
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+function RoleRow({ role, locale }: { role: RoleListItem; locale: string }) {
+  const { t } = useTranslation();
+  const createdAt = new Date(role.created_at).toLocaleDateString(locale);
+
+  return (
+    <TableRow>
+      <TableCell className="pl-5">
+        <div className="flex items-center gap-3">
+          <span
+            className="inline-grid size-8 place-items-center rounded-md bg-accent-violet/10 text-accent-violet"
+            aria-hidden="true"
+          >
+            <ShieldCheck className="size-4" />
+          </span>
+          <div className="min-w-0">
+            <div className="text-sm font-medium">{role.name}</div>
+            <div className="font-mono text-[11px] text-muted-foreground">{role.code}</div>
+          </div>
+        </div>
+      </TableCell>
+      <TableCell>
+        <RoleTypeBadge type={role.type} />
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">
+        {t('settings.roles.permissions_count', { count: role.permissions_count })}
+      </TableCell>
+      <TableCell className="text-xs text-muted-foreground">
+        <div className="flex flex-col">
+          <span className="text-sm text-foreground">{role.user_count}</span>
+          <span className={cn(0 === role.user_count && 'text-muted-foreground/70')}>
+            {t('settings.roles.created_at', { date: createdAt })}
+          </span>
+        </div>
+      </TableCell>
+      <TableCell className="pr-5 text-right">
+        <Button
+          variant="ghost"
+          size="icon"
+          disabled
+          aria-label={t('settings.roles.row_actions')}
+          aria-disabled="true"
+          title={
+            'system' === role.type
+              ? t('settings.roles.system_immutable_hint')
+              : t('settings.roles.actions_pending_hint')
+          }
+        >
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function SkeletonRows() {
+  return (
+    <>
+      {[0, 1, 2, 3].map((row) => (
+        <TableRow key={row}>
+          <TableCell className="pl-5">
+            <div className="flex items-center gap-3">
+              <div className="size-8 animate-pulse rounded-md bg-muted" />
+              <div className="space-y-1.5">
+                <div className="h-3 w-32 animate-pulse rounded bg-muted" />
+                <div className="h-3 w-20 animate-pulse rounded bg-muted/60" />
+              </div>
+            </div>
+          </TableCell>
+          <TableCell>
+            <div className="h-4 w-16 animate-pulse rounded bg-muted" />
+          </TableCell>
+          <TableCell>
+            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+          </TableCell>
+          <TableCell>
+            <div className="h-3 w-12 animate-pulse rounded bg-muted" />
+          </TableCell>
+          <TableCell className="pr-5" />
+        </TableRow>
+      ))}
+    </>
+  );
+}

--- a/apps/admin/src/features/settings/roles/index.tsx
+++ b/apps/admin/src/features/settings/roles/index.tsx
@@ -1,5 +1,10 @@
-import { ComingSoonPlaceholder } from '@/features/settings/ComingSoonPlaceholder';
+import { RolesListView } from './RolesListView';
 
+/**
+ * RBAC-P5-005 (#695) — entry point for `/settings/roles`. The view
+ * itself lives next to its helpers (RoleTypeBadge) so #696/#697 can
+ * extend without restructuring this module.
+ */
 export function RolesSettingsPage() {
-  return <ComingSoonPlaceholder titleKey="settings.nav.roles" />;
+  return <RolesListView />;
 }

--- a/apps/admin/src/features/settings/roles/types.ts
+++ b/apps/admin/src/features/settings/roles/types.ts
@@ -1,0 +1,19 @@
+/**
+ * RBAC-P5-005 (#695) — wire shape for the Settings → Roles list.
+ * Mirrors {@link RoleListResponseBuilder} on the API side. Lives here
+ * so the contract stays alongside the consumer when the role builder
+ * (#696) extends the projection.
+ */
+
+export type RoleListType = 'system' | 'custom';
+
+export interface RoleListItem {
+  id: string;
+  code: string;
+  name: string;
+  type: RoleListType;
+  user_count: number;
+  is_built_in: boolean;
+  created_at: string;
+  permissions_count: number;
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -115,6 +115,30 @@
         "active": "Active",
         "disabled": "Deactivated"
       }
+    },
+    "roles": {
+      "title": "Roles",
+      "intro": "Seeded system templates + per-tenant custom roles. Permission editing, duplicating and creating new custom roles arrive in follow-up tickets.",
+      "create_cta": "Create custom role",
+      "create_pending_hint": "Custom role builder coming in #696.",
+      "col_name": "Name",
+      "col_type": "Type",
+      "col_permissions": "Permissions",
+      "col_user_count": "Users / created",
+      "col_actions": "Actions",
+      "permissions_count_one": "{{count}} permission",
+      "permissions_count_other": "{{count}} permissions",
+      "permissions_count": "{{count}} permissions",
+      "created_at": "since {{date}}",
+      "empty": "No roles available for this tenant.",
+      "error_loading": "Could not load roles list.",
+      "row_actions": "Row actions (coming soon)",
+      "system_immutable_hint": "System roles are immutable — create a custom role if you need different permissions.",
+      "actions_pending_hint": "Edit / duplicate / delete land in #696.",
+      "type": {
+        "system": "System",
+        "custom": "Custom"
+      }
     }
   },
   "catalogs_pdf": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -117,6 +117,30 @@
         "active": "Aktywny",
         "disabled": "Dezaktywowany"
       }
+    },
+    "roles": {
+      "title": "Role",
+      "intro": "Predefiniowane role systemowe + role customowe per tenant. Edycja uprawnień, klonowanie i tworzenie nowych ról dochodzą w kolejnych ticketach.",
+      "create_cta": "Utwórz rolę customową",
+      "create_pending_hint": "Kreator ról customowych wkrótce (#696).",
+      "col_name": "Nazwa",
+      "col_type": "Typ",
+      "col_permissions": "Uprawnienia",
+      "col_user_count": "Użytkownicy / utworzono",
+      "col_actions": "Akcje",
+      "permissions_count_one": "{{count}} uprawnienie",
+      "permissions_count_other": "{{count}} uprawnień",
+      "permissions_count": "{{count}} uprawnień",
+      "created_at": "od {{date}}",
+      "empty": "Brak ról dla tego tenanta.",
+      "error_loading": "Nie udało się załadować listy ról.",
+      "row_actions": "Akcje wiersza (wkrótce)",
+      "system_immutable_hint": "Role systemowe są niezmienne — utwórz rolę customową, jeśli potrzebujesz innych uprawnień.",
+      "actions_pending_hint": "Edycja / duplikacja / usuwanie dochodzą w #696.",
+      "type": {
+        "system": "System",
+        "custom": "Custom"
+      }
     }
   },
   "catalogs_pdf": {

--- a/apps/api/src/Identity/Application/RoleListResponseBuilder.php
+++ b/apps/api/src/Identity/Application/RoleListResponseBuilder.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application;
+
+use App\Identity\Domain\Entity\Role;
+use DateTimeInterface;
+
+/**
+ * RBAC-P5-005 (#695) — projection helper for the Settings → Roles
+ * list. Discriminates system (`tenant IS NULL`) and custom roles via
+ * the `type` field and surfaces the M2M user count alongside each
+ * entry so the badge + count column in the UI render in one round
+ * trip.
+ */
+final class RoleListResponseBuilder
+{
+    public const string TYPE_SYSTEM = 'system';
+    public const string TYPE_CUSTOM = 'custom';
+
+    /**
+     * @param iterable<array{role: Role, user_count: int}> $rows
+     *
+     * @return list<array{
+     *     id: string,
+     *     code: string,
+     *     name: string,
+     *     type: string,
+     *     user_count: int,
+     *     is_built_in: bool,
+     *     created_at: string,
+     *     permissions_count: int
+     * }>
+     */
+    public function buildList(iterable $rows): array
+    {
+        $out = [];
+        foreach ($rows as $row) {
+            $role = $row['role'];
+            $type = $role->isGlobal() ? self::TYPE_SYSTEM : self::TYPE_CUSTOM;
+            $out[] = [
+                'id' => $role->getId()->toRfc4122(),
+                'code' => $role->getCode(),
+                'name' => $role->getName(),
+                'type' => $type,
+                'user_count' => $row['user_count'],
+                'is_built_in' => $role->isGlobal(),
+                'created_at' => $role->getCreatedAt()->format(DateTimeInterface::ATOM),
+                'permissions_count' => $role->getPermissions()->count(),
+            ];
+        }
+
+        return $out;
+    }
+}

--- a/apps/api/src/Identity/Domain/Repository/RoleRepositoryInterface.php
+++ b/apps/api/src/Identity/Domain/Repository/RoleRepositoryInterface.php
@@ -4,15 +4,36 @@ declare(strict_types=1);
 
 namespace App\Identity\Domain\Repository;
 
+use App\Identity\Domain\Entity\Role;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
 interface RoleRepositoryInterface
 {
-    public function findById(\Symfony\Component\Uid\Uuid $id): ?\App\Identity\Domain\Entity\Role;
+    public function findById(Uuid $id): ?Role;
 
-    public function findGlobalByCode(string $code): ?\App\Identity\Domain\Entity\Role;
+    public function findGlobalByCode(string $code): ?Role;
 
-    public function findByCode(string $code, ?\App\Shared\Domain\Tenant $tenant = null): ?\App\Identity\Domain\Entity\Role;
+    public function findByCode(string $code, ?Tenant $tenant = null): ?Role;
 
-    public function save(\App\Identity\Domain\Entity\Role $entity): void;
+    public function save(Role $entity): void;
 
-    public function remove(\App\Identity\Domain\Entity\Role $entity): void;
+    public function remove(Role $entity): void;
+
+    /**
+     * RBAC-P5-005 (#695) — listing for the Settings → Roles page.
+     *
+     * Returns every global (system) role plus the custom roles defined
+     * by the supplied tenant, each paired with the number of users
+     * within that tenant who currently hold the role.
+     *
+     * The shape stays a list of plain arrays rather than a dedicated
+     * projection class so the Doctrine repository can use a single
+     * QueryBuilder + groupBy without introducing a new domain DTO. The
+     * application layer wraps these tuples into JSON via
+     * {@see \App\Identity\Application\RoleListResponseBuilder}.
+     *
+     * @return list<array{role: Role, user_count: int}>
+     */
+    public function findAllForTenantWithUserCount(Tenant $tenant): array;
 }

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineRoleRepository.php
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineRoleRepository.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Identity\Infrastructure\Doctrine\Repository;
 
 use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Repository\RoleRepositoryInterface;
 use App\Shared\Domain\Tenant;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @extends ServiceEntityRepository<Role>
@@ -30,7 +32,7 @@ class DoctrineRoleRepository extends ServiceEntityRepository implements RoleRepo
         return $this->findOneBy(['code' => $code, 'tenant' => $tenant]);
     }
 
-    public function findById(\Symfony\Component\Uid\Uuid $id): ?Role
+    public function findById(Uuid $id): ?Role
     {
         return parent::find($id->toRfc4122());
     }
@@ -47,5 +49,84 @@ class DoctrineRoleRepository extends ServiceEntityRepository implements RoleRepo
         $em = $this->getEntityManager();
         $em->remove($entity);
         $em->flush();
+    }
+
+    public function findAllForTenantWithUserCount(Tenant $tenant): array
+    {
+        // Roles visible to the tenant = every global role + the tenant's own
+        // custom roles. The Settings → Roles list orders them with system
+        // (global) roles first (PRD §3.2 macierz prescribes that on-screen
+        // grouping), then name ASC.
+        /** @var list<Role> $roles */
+        $roles = $this->createQueryBuilder('r')
+            ->where('r.tenant IS NULL OR r.tenant = :tenant')
+            ->setParameter('tenant', $tenant->getId())
+            ->orderBy('CASE WHEN r.tenant IS NULL THEN 0 ELSE 1 END', 'ASC')
+            ->addOrderBy('r.name', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        if ([] === $roles) {
+            return [];
+        }
+
+        $userCounts = $this->countUsersByRole($tenant, $roles);
+
+        $out = [];
+        foreach ($roles as $role) {
+            $roleId = $role->getId()->toRfc4122();
+            $out[] = [
+                'role' => $role,
+                'user_count' => $userCounts[$roleId] ?? 0,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Single batched COUNT(*) against `user_roles` (legacy Sprint-0 M2M).
+     * The newer `user_role_assignments` junction (RBAC-P1-008) is consulted
+     * by the PermissionResolver hot path but is not yet the source of truth
+     * for membership counts — once #644 delta-migrations consolidate, this
+     * method picks up the union of both tables. Today the M2M is what the
+     * fixture admin and seeded users actually live on, so it returns
+     * realistic counts for the demo tenant.
+     *
+     * @param list<Role> $roles
+     *
+     * @return array<string, int> roleId (RFC4122) → user count
+     */
+    private function countUsersByRole(Tenant $tenant, array $roles): array
+    {
+        $roleIds = array_map(static fn (Role $role): string => $role->getId()->toRfc4122(), $roles);
+
+        /** @var list<array{role_id: mixed, cnt: int|string}> $rows */
+        $rows = $this->getEntityManager()->createQueryBuilder()
+            ->select('r.id AS role_id', 'COUNT(u.id) AS cnt')
+            ->from(User::class, 'u')
+            ->innerJoin('u.assignedRoles', 'r')
+            ->where('u.tenant = :tenant')
+            ->andWhere('r.id IN (:roleIds)')
+            ->groupBy('r.id')
+            ->setParameter('tenant', $tenant->getId())
+            ->setParameter('roleIds', $roleIds)
+            ->getQuery()
+            ->getArrayResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $rawRoleId = $row['role_id'];
+            if ($rawRoleId instanceof Uuid) {
+                $roleId = $rawRoleId->toRfc4122();
+            } elseif (\is_string($rawRoleId)) {
+                $roleId = $rawRoleId;
+            } else {
+                continue;
+            }
+            $counts[$roleId] = (int) $row['cnt'];
+        }
+
+        return $counts;
     }
 }

--- a/apps/api/src/Identity/Presentation/Controller/RolesListController.php
+++ b/apps/api/src/Identity/Presentation/Controller/RolesListController.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Identity\Application\RoleListResponseBuilder;
+use App\Identity\Domain\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * RBAC-P5-005 (#695) — `GET /api/roles` listing for Settings → Roles.
+ *
+ * Returns every global (system) role plus the caller tenant's custom
+ * roles, paired with the number of users in that tenant who currently
+ * hold each role. System roles surface as `type: "system"` with
+ * `is_built_in: true`; custom roles surface as `type: "custom"`.
+ *
+ * The response is wrapped in the same Hydra-compatible envelope used
+ * by {@see UsersListController} so the admin data-provider unwraps
+ * `member` / `totalItems` consistently across Settings pages.
+ */
+final readonly class RolesListController
+{
+    public function __construct(
+        private Security $security,
+        private RoleRepositoryInterface $roles,
+        private RoleListResponseBuilder $builder,
+    ) {
+    }
+
+    #[Route(path: '/api/roles', methods: ['GET'], name: 'api_roles_list')]
+    /*
+     * Same `user.admin` gate as the Users list — Settings → Roles is part
+     * of the same Settings → Users management surface. Phase 6 retrofit
+     * (#720+) migrates onto PRD §3.2 `settings.roles.manage`.
+     */
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function __invoke(): JsonResponse
+    {
+        $principal = $this->security->getUser();
+        if (!$principal instanceof User) {
+            return new JsonResponse(
+                [
+                    'type' => 'about:blank',
+                    'title' => 'Unauthorized',
+                    'status' => Response::HTTP_UNAUTHORIZED,
+                    'detail' => 'No authenticated user.',
+                ],
+                Response::HTTP_UNAUTHORIZED,
+                ['Content-Type' => 'application/problem+json; charset=utf-8'],
+            );
+        }
+
+        $rows = $this->roles->findAllForTenantWithUserCount($principal->getTenant());
+        $member = $this->builder->buildList($rows);
+
+        return new JsonResponse([
+            'member' => $member,
+            'totalItems' => \count($member),
+            'meta' => [
+                'page' => 1,
+                'per_page' => \count($member),
+                'total_pages' => 1,
+            ],
+        ]);
+    }
+}

--- a/apps/api/tests/Api/Identity/RolesListControllerTest.php
+++ b/apps/api/tests/Api/Identity/RolesListControllerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * RBAC-P5-005 (#695) — Settings → Roles list endpoint coverage.
+ *
+ * Invariants:
+ *  - lists every seeded global role plus the caller tenant's custom
+ *    roles (custom from a different tenant must NOT appear);
+ *  - `user_count` reflects only users from the caller tenant;
+ *  - `type` discriminates system (global) vs custom;
+ *  - non-admin (Catalog Manager) → 403, same `user.admin` gate as
+ *    {@see UsersListController}.
+ */
+final class RolesListControllerTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_A_CODE = 'demo';
+    private const string TENANT_B_CODE = 'other';
+
+    private const string ADMIN_A_EMAIL = 'admin@demo.localhost';
+    private const string CATALOG_A_EMAIL = 'catalog@demo.localhost';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+
+        $roles = self::getContainer()->get(RoleRepositoryInterface::class);
+        $superAdmin = $roles->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        $catalogManager = $roles->findGlobalByCode(RbacMatrix::ROLE_CATALOG_MANAGER);
+        \assert(null !== $superAdmin && null !== $catalogManager);
+
+        $tenantA = new Tenant(self::TENANT_A_CODE, 'Demo Tenant');
+        $tenantB = new Tenant(self::TENANT_B_CODE, 'Other Tenant');
+        $em->persist($tenantA);
+        $em->persist($tenantB);
+
+        // Custom role on tenant A — must appear in the listing alongside
+        // the 4 system templates.
+        $customA = new Role('custom_a', 'Custom Role A', $tenantA);
+        $em->persist($customA);
+
+        // Custom role on tenant B — must NOT appear when authenticating
+        // as tenant A admin (cross-tenant isolation).
+        $customB = new Role('custom_b', 'Custom Role B', $tenantB);
+        $em->persist($customB);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $adminStub = new User($tenantA, self::ADMIN_A_EMAIL, '');
+        $admin = new User($tenantA, self::ADMIN_A_EMAIL, $hasher->hashPassword($adminStub, 'changeme'));
+        $admin->addRole($superAdmin);
+        $em->persist($admin);
+
+        $catalogStub = new User($tenantA, self::CATALOG_A_EMAIL, '');
+        $catalog = new User($tenantA, self::CATALOG_A_EMAIL, $hasher->hashPassword($catalogStub, 'changeme'));
+        $catalog->addRole($catalogManager);
+        $em->persist($catalog);
+
+        $em->flush();
+    }
+
+    #[Test]
+    public function returnsSystemRolesPlusTenantCustom(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/roles');
+
+        self::assertResponseStatusCodeSame(200);
+        $body = $this->decodeResponse($client);
+
+        // 4 seeded system roles + custom_a (tenant A's own custom role) = 5.
+        // custom_b lives on tenant B and must NOT appear.
+        self::assertSame(5, $body['totalItems'] ?? null);
+
+        $codes = $this->extractField($body, 'code');
+        self::assertContains(RbacMatrix::ROLE_SUPER_ADMIN, $codes);
+        self::assertContains(RbacMatrix::ROLE_CATALOG_MANAGER, $codes);
+        self::assertContains(RbacMatrix::ROLE_INTEGRATION_MANAGER, $codes);
+        self::assertContains(RbacMatrix::ROLE_VIEWER, $codes);
+        self::assertContains('custom_a', $codes);
+        self::assertNotContains('custom_b', $codes);
+    }
+
+    #[Test]
+    public function classifiesRoleTypeAsSystemOrCustom(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/roles');
+
+        $body = $this->decodeResponse($client);
+        $members = $body['member'] ?? [];
+        \assert(\is_array($members));
+
+        foreach ($members as $row) {
+            \assert(\is_array($row));
+            $code = $row['code'] ?? null;
+            $type = $row['type'] ?? null;
+            $isBuiltIn = $row['is_built_in'] ?? null;
+            if ('custom_a' === $code) {
+                self::assertSame('custom', $type);
+                self::assertFalse($isBuiltIn);
+            } else {
+                self::assertSame('system', $type);
+                self::assertTrue($isBuiltIn);
+            }
+        }
+    }
+
+    #[Test]
+    public function reportsUserCountPerRole(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('GET', '/api/roles');
+
+        $body = $this->decodeResponse($client);
+        $counts = $this->extractCounts($body);
+
+        // The fixture wires one admin + one catalog_manager on tenant A.
+        self::assertSame(1, $counts[RbacMatrix::ROLE_SUPER_ADMIN] ?? null);
+        self::assertSame(1, $counts[RbacMatrix::ROLE_CATALOG_MANAGER] ?? null);
+        self::assertSame(0, $counts[RbacMatrix::ROLE_VIEWER] ?? null);
+        self::assertSame(0, $counts['custom_a'] ?? null);
+    }
+
+    #[Test]
+    public function nonAdminUserReceives403(): void
+    {
+        $client = $this->clientFor(self::CATALOG_A_EMAIL);
+        $client->request('GET', '/api/roles');
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertResponseHeaderSame('content-type', 'application/problem+json');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeResponse(Client $client): array
+    {
+        $response = $client->getResponse();
+        \assert(null !== $response);
+
+        /** @var array<string, mixed> $payload */
+        $payload = $response->toArray();
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return list<string>
+     */
+    private function extractField(array $body, string $field): array
+    {
+        $members = $body['member'] ?? [];
+        \assert(\is_array($members));
+        $out = [];
+        foreach ($members as $row) {
+            \assert(\is_array($row));
+            $value = $row[$field] ?? null;
+            \assert(\is_string($value));
+            $out[] = $value;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return array<string, int>
+     */
+    private function extractCounts(array $body): array
+    {
+        $members = $body['member'] ?? [];
+        \assert(\is_array($members));
+        $out = [];
+        foreach ($members as $row) {
+            \assert(\is_array($row));
+            $code = $row['code'] ?? null;
+            $count = $row['user_count'] ?? null;
+            \assert(\is_string($code) && \is_int($count));
+            $out[$code] = $count;
+        }
+
+        return $out;
+    }
+
+    private function clientFor(string $email): Client
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail($email);
+        \assert(null !== $user);
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
## Summary

- New `/settings/roles` page wired through Refine's `useList` against a
  new `GET /api/roles` endpoint.
- Lists every seeded system role (`tenant IS NULL`) plus the caller
  tenant's custom roles, paired with an in-tenant user count from the
  legacy `user_roles` M2M.
- Gated by `user.admin` from the seeded RbacMatrix — same Phase-6-pending
  super-admin-only gate used in #691 until the macierz onto
  `settings.roles.manage` retrofit lands.

## Scope decisions

- **Create / row-action buttons ship disabled** with explicit pending
  hints — the custom role builder lives in #696 and shapes the create
  payload + cross-tab badge integration.
- **System roles get an immutable tooltip** per PRD §3.2 macierz.
  Delete will *never* unlock for system roles in the UI; backend already
  enforces it because system roles are code (`tenant_id NULL`).
- **User count uses the legacy `user_roles` M2M** — the new
  `user_role_assignments` junction (RBAC-P1-008) is still the
  PermissionResolver's hot path, but membership counting consolidates
  in #644 delta-migrations.

## Test plan

- [x] PHPStan max + Biome strict + tsc-noEmit green on changed files
- [x] PHPUnit `RolesListControllerTest` — 4 tests / 24 assertions:
      cross-tenant isolation, role-type discrimination, user-count
      accuracy, 403 for catalog manager (`user.admin` gate)
- [x] Live-stack smoke against `https://pim.localhost`:
      - `GET /api/roles` → 200, 4 system roles, `super_admin.user_count=1`,
        `permissions_count` 15-76 per role, no custom roles in dev seed
      - `GET /api/roles` without auth → 401
- [ ] Playwright `settings-roles-list.spec.ts` — added; CI executes

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)