### PR TITLE
feat(admin): #706 Settings → Billing placeholder + tenant.plan

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -190,6 +190,10 @@ const IntegrationsLayout = lazyPage(
   'IntegrationsLayout',
 );
 const AiSettingsPage = lazyPage(() => import('@/features/settings/ai'), 'AiSettingsPage');
+const BillingSettingsPage = lazyPage(
+  () => import('@/features/settings/billing'),
+  'BillingSettingsPage',
+);
 const LocalesSettingsPage = lazyPage(
   () => import('@/features/settings/locales'),
   'LocalesSettingsPage',
@@ -414,6 +418,7 @@ function App() {
                   <Route path="users" element={<UsersSettingsPage />} />
                   <Route path="roles" element={<RolesSettingsPage />} />
                   <Route path="security" element={<SecuritySettingsPage />} />
+                  <Route path="billing" element={<BillingSettingsPage />} />
                   <Route path="ai" element={<AiSettingsPage />} />
                 </Route>
                 {/* Top-level Integracje hub — łączy Imports MVP (epik 0.13)

--- a/apps/admin/src/features/settings/billing/index.tsx
+++ b/apps/admin/src/features/settings/billing/index.tsx
@@ -1,0 +1,108 @@
+import { CreditCard, Mail, ShieldAlert } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { PermissionGate } from '@/components/identity';
+import { Button } from '@/components/ui/button';
+import { useIdentity } from '@/lib/identity';
+
+/**
+ * RBAC-P5-016 (#706) — placeholder for Settings → Billing.
+ *
+ * Owner-only via {@link PermissionGate} (`user.admin` until #720
+ * retrofit migrates onto the PRD §3.2 `settings.billing.manage`
+ * permission code). The actual billing integration ships in Faza 1
+ * — this page only surfaces the current plan tier read from
+ * `/api/auth/me` (extended in this PR) and a mailto link so the
+ * Owner has a route to contact support today.
+ */
+export function BillingSettingsPage() {
+  return (
+    <PermissionGate code="user.admin" fallback={<ForbiddenFallback />}>
+      <BillingPlaceholder />
+    </PermissionGate>
+  );
+}
+
+function BillingPlaceholder() {
+  const { t } = useTranslation();
+  const { identity } = useIdentity();
+  const plan = identity?.tenant?.plan ?? null;
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="display text-xl font-semibold tracking-tight">
+          {t('settings.billing.title')}
+        </h2>
+        <p className="max-w-2xl text-sm text-muted-foreground">{t('settings.billing.intro')}</p>
+      </header>
+
+      <section
+        aria-labelledby="settings-billing-current-plan"
+        className="rounded-lg border bg-background p-6 shadow-sm"
+      >
+        <div className="flex items-start gap-4">
+          <span
+            className="inline-grid size-10 place-items-center rounded-md bg-accent-violet/10 text-accent-violet"
+            aria-hidden="true"
+          >
+            <CreditCard className="size-5" />
+          </span>
+          <div className="flex-1 space-y-1">
+            <h3
+              id="settings-billing-current-plan"
+              className="text-sm font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              {t('settings.billing.current_plan_label')}
+            </h3>
+            <p className="text-2xl font-semibold tracking-tight">
+              {plan ? t(`settings.billing.plans.${plan}`, { defaultValue: plan }) : '—'}
+            </p>
+            <p className="text-xs text-muted-foreground">{t('settings.billing.upgrade_hint')}</p>
+          </div>
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="settings-billing-coming-soon"
+        className="rounded-lg border border-dashed bg-muted/30 p-6"
+      >
+        <div className="flex items-start gap-4">
+          <span
+            className="inline-grid size-10 place-items-center rounded-md bg-amber-100 text-amber-700"
+            aria-hidden="true"
+          >
+            <ShieldAlert className="size-5" />
+          </span>
+          <div className="space-y-2">
+            <h3 id="settings-billing-coming-soon" className="text-sm font-semibold tracking-tight">
+              {t('settings.billing.coming_soon_title')}
+            </h3>
+            <p className="max-w-xl text-sm text-muted-foreground">
+              {t('settings.billing.coming_soon_description')}
+            </p>
+            <Button asChild size="sm" variant="outline" className="gap-1.5">
+              <a href="mailto:support@cortex.pl?subject=Billing%20enquiry">
+                <Mail className="size-4" aria-hidden="true" />
+                {t('settings.billing.contact_support')}
+              </a>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ForbiddenFallback() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex min-h-[320px] flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-background p-8 text-center">
+      <ShieldAlert className="size-8 text-muted-foreground" aria-hidden="true" />
+      <h2 className="text-sm font-semibold">{t('settings.billing.forbidden_title')}</h2>
+      <p className="max-w-md text-xs text-muted-foreground">
+        {t('settings.billing.forbidden_description')}
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/src/layout/SettingsLayout.tsx
+++ b/apps/admin/src/layout/SettingsLayout.tsx
@@ -1,4 +1,5 @@
 import {
+  CreditCard,
   KeyRound,
   Languages,
   type LucideIcon,
@@ -26,6 +27,7 @@ const SETTINGS_NAV: readonly SettingsNavItem[] = [
   { to: '/settings/users', icon: Users, label: 'settings.nav.users' },
   { to: '/settings/roles', icon: ShieldCheck, label: 'settings.nav.roles' },
   { to: '/settings/security', icon: KeyRound, label: 'settings.nav.security' },
+  { to: '/settings/billing', icon: CreditCard, label: 'settings.nav.billing' },
   { to: '/settings/ai', icon: Sparkles, label: 'settings.nav.ai' },
 ] as const;
 

--- a/apps/admin/src/lib/identity/identity.ts
+++ b/apps/admin/src/lib/identity/identity.ts
@@ -15,7 +15,7 @@ export interface MeResponse {
   email: string;
   /** Symfony Security role strings (legacy + scoped roles). */
   roles: string[];
-  tenant: { id: string; code: string; name: string } | null;
+  tenant: { id: string; code: string; name: string; plan?: string } | null;
   last_login_at: string | null;
   /** PRD §3.2 permission codes — flat strings like `products.view`. */
   permissions: string[];
@@ -37,7 +37,7 @@ export interface Identity {
   id: string;
   email: string;
   roles: string[];
-  tenant: { id: string; code: string; name: string } | null;
+  tenant: { id: string; code: string; name: string; plan?: string } | null;
   lastLoginAt: string | null;
   permissions: ReadonlySet<string>;
   localeScope: string[];

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -63,6 +63,7 @@
       "users": "Users",
       "roles": "Roles",
       "security": "Password policy, 2FA",
+      "billing": "Subscription",
       "ai": "AI configuration"
     },
     "placeholder": {
@@ -82,6 +83,22 @@
       "protected_tooltip": "This item is required and cannot be hidden",
       "toast_error": "Failed to save changes",
       "error_loading": "Could not load menu configuration."
+    },
+    "billing": {
+      "title": "Subscription",
+      "intro": "Current tenant plan. The full payment-gateway integration ships in Phase 1 — plan changes go through support until then.",
+      "current_plan_label": "Current plan",
+      "upgrade_hint": "Need to change your plan? Use the button below to message support.",
+      "coming_soon_title": "Billing integration coming soon",
+      "coming_soon_description": "MVP does not charge inside PIM — Stripe + VAT invoices land in Phase 1. Support will adjust the plan manually and send a proforma invoice in the meantime.",
+      "contact_support": "Contact support",
+      "forbidden_title": "Access denied",
+      "forbidden_description": "Only the tenant Owner can see the Subscription page. Reach out to your administrator if you need access.",
+      "plans": {
+        "starter": "Starter",
+        "pro": "Pro",
+        "enterprise": "Enterprise"
+      }
     },
     "users": {
       "title": "Users",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -65,6 +65,7 @@
       "users": "Użytkownicy",
       "roles": "Role",
       "security": "Polityka Haseł, 2FA",
+      "billing": "Subskrypcja",
       "ai": "Konfiguracja AI"
     },
     "placeholder": {
@@ -84,6 +85,22 @@
       "protected_tooltip": "Ta pozycja jest wymagana i nie może być ukryta",
       "toast_error": "Nie udało się zapisać zmian",
       "error_loading": "Nie udało się załadować konfiguracji menu."
+    },
+    "billing": {
+      "title": "Subskrypcja",
+      "intro": "Aktualny plan tenanta. Pełna integracja z bramką płatności pojawi się w Fazie 1 — na razie zmiana planu wymaga kontaktu z supportem.",
+      "current_plan_label": "Aktualny plan",
+      "upgrade_hint": "Chcesz zmienić plan? Kliknij niżej, żeby napisać do supportu.",
+      "coming_soon_title": "Pełna integracja billingu w przygotowaniu",
+      "coming_soon_description": "W MVP nie pobieramy płatności w PIM — Stripe + faktury VAT dochodzą w Fazie 1. Do tego czasu support dopasuje plan ręcznie i prześle fakturę proformę.",
+      "contact_support": "Skontaktuj się z supportem",
+      "forbidden_title": "Brak dostępu",
+      "forbidden_description": "Tylko Owner tenanta widzi sekcję Subskrypcja. Skontaktuj się z administratorem, jeśli potrzebujesz dostępu.",
+      "plans": {
+        "starter": "Starter",
+        "pro": "Pro",
+        "enterprise": "Enterprise"
+      }
     },
     "users": {
       "title": "Użytkownicy",

--- a/apps/api/src/Identity/Presentation/MeController.php
+++ b/apps/api/src/Identity/Presentation/MeController.php
@@ -80,6 +80,11 @@ final readonly class MeController
                 'id' => $tenant->getId()->toRfc4122(),
                 'code' => $tenant->getCode(),
                 'name' => $tenant->getName(),
+                // RBAC-P5-016 (#706) — Settings → Billing placeholder
+                // surfaces the current plan tier read-only. Phase 1 ships
+                // the actual billing integration; until then this field
+                // is the only signal the placeholder page consumes.
+                'plan' => $tenant->getPlan(),
             ],
             'last_login_at' => $user->getLastLoginAt()?->format(DateTimeInterface::ATOM),
             'permissions' => $permissions->getCodes(),

--- a/apps/api/tests/Api/Identity/MeEndpointTest.php
+++ b/apps/api/tests/Api/Identity/MeEndpointTest.php
@@ -69,6 +69,10 @@ final class MeEndpointTest extends ApiTestCase
         self::assertIsArray($body['tenant'] ?? null);
         self::assertSame(self::TENANT_CODE, $body['tenant']['code'] ?? null);
         self::assertSame('Demo Tenant', $body['tenant']['name'] ?? null);
+        // RBAC-P5-016 (#706) — billing page reads tenant.plan; the default
+        // for a freshly minted Tenant aggregate is "starter" (see PLAN_*
+        // constants on Tenant).
+        self::assertSame('starter', $body['tenant']['plan'] ?? null);
         self::assertArrayHasKey('last_login_at', $body);
     }
 


### PR DESCRIPTION
## Summary

- Owner-only Settings → Billing page surfaces the current tenant plan
  tier (`starter` / `pro` / `enterprise`) with a placeholder explaining
  that the real billing integration arrives in Phase 1.
- `mailto:support@cortex.pl` button covers the today-path for plan
  changes.
- `GET /api/auth/me` now returns `tenant.plan` so the placeholder reads
  the value without a dedicated endpoint.

## Scope decisions

- **Reuses the Phase-5 retrofit gate** (`user.admin`). PRD §3.2
  `settings.billing.manage` is part of the Phase 6 retrofit batch (#720+).
- **Non-owner fallback ships** as a centred ShieldAlert card so the
  permission denial does not look like a missing page.

## Test plan

- [x] PHPStan max + Biome strict + tsc green on changed files
- [x] PHPUnit `MeEndpointTest` — `tenant.plan` now asserted ('starter')
- [x] Live smoke: `GET /api/auth/me` returns `tenant.plan: "starter"`
      on the demo tenant; sidebar surfaces Subskrypcja entry

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)