### PR TITLE
feat(admin): #708 polish 403 page + protection modals

### DIFF
--- a/apps/admin/src/components/identity/LastAdminProtectionModal.tsx
+++ b/apps/admin/src/components/identity/LastAdminProtectionModal.tsx
@@ -1,0 +1,65 @@
+import { ShieldAlert } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface LastAdminProtectionModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Label shown in the message, e.g. "Anna Kowalska". Passed by the
+   * caller because the protection trigger ships from different flows
+   * (delete user, deactivate user, change role) — each of which has the
+   * subject ready as a domain object.
+   */
+  userLabel: string;
+}
+
+/**
+ * RBAC-P5-018 (#708) — modal warning surfaced when the operator tries to
+ * delete / deactivate / change-role the last user holding the
+ * Administrator role on the tenant.
+ *
+ * The 409 response from the backend voter (RBAC-P3-005) is what guards
+ * the actual mutation. This modal is the UX-side speed bump: it explains
+ * what to do (assign Administrator to another user first) so the
+ * operator does not have to read the API error to recover. The component
+ * is wired by #694 (deactivate user) and #693 (edit user role) — for
+ * #708 we only ship the reusable visual.
+ */
+export function LastAdminProtectionModal({
+  open,
+  onOpenChange,
+  userLabel,
+}: LastAdminProtectionModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="mb-2 inline-grid size-10 place-items-center rounded-full bg-rose-100 text-rose-700">
+            <ShieldAlert className="size-5" aria-hidden="true" />
+          </div>
+          <DialogTitle>{t('rbac.last_admin.title')}</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {t('rbac.last_admin.body', { user: userLabel })}
+        </p>
+        <p className="text-sm text-muted-foreground">{t('rbac.last_admin.guidance')}</p>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('rbac.last_admin.close')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/components/identity/OwnerUniquenessModal.tsx
+++ b/apps/admin/src/components/identity/OwnerUniquenessModal.tsx
@@ -1,0 +1,65 @@
+import { Crown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface OwnerUniquenessModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Display name / email of the existing tenant Owner. Lets the modal
+   * tell the operator who currently holds the role so they can target
+   * the ownership transfer flow at the right user.
+   */
+  currentOwnerLabel?: string;
+}
+
+/**
+ * RBAC-P5-018 (#708) — modal surfaced when the operator tries to assign
+ * the Owner role to a second user while it's already held by someone
+ * else.
+ *
+ * Backend voter (RBAC-P3-005) returns a 409 from such an attempt; this
+ * modal explains the constraint (single Owner per tenant) and suggests
+ * the transfer-ownership flow as the recovery path. The transfer flow
+ * itself ships later — for #708 we only commit the visual + i18n so
+ * #693 (edit user role) can drop it in.
+ */
+export function OwnerUniquenessModal({
+  open,
+  onOpenChange,
+  currentOwnerLabel,
+}: OwnerUniquenessModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="mb-2 inline-grid size-10 place-items-center rounded-full bg-amber-100 text-amber-700">
+            <Crown className="size-5" aria-hidden="true" />
+          </div>
+          <DialogTitle>{t('rbac.owner_uniqueness.title')}</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {currentOwnerLabel
+            ? t('rbac.owner_uniqueness.body_with_owner', { owner: currentOwnerLabel })
+            : t('rbac.owner_uniqueness.body')}
+        </p>
+        <p className="text-sm text-muted-foreground">{t('rbac.owner_uniqueness.guidance')}</p>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('rbac.owner_uniqueness.close')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/components/identity/PermissionRoute.tsx
+++ b/apps/admin/src/components/identity/PermissionRoute.tsx
@@ -1,7 +1,10 @@
-import { ShieldOff } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { ArrowLeft, LogOut, ShieldOff } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 
+import { Button } from '@/components/ui/button';
+import { authProvider } from '@/lib/auth-provider';
 import { useCanI, useCanIAll, useCanIAny, useIdentity } from '@/lib/identity';
 
 /**
@@ -80,23 +83,96 @@ function RouteLoadingShim() {
 }
 
 /**
- * 403 page rendered when a route's permission check fails. Kept inside
- * the same module so it can be the default fallback without forcing
- * callers to import a separate page.
+ * RBAC-P5-018 (#708) — polished 403 page rendered when a route's
+ * permission check fails. Kept inside the same module so it can be the
+ * default fallback without forcing callers to import a separate page.
+ *
+ * Polish over the #680 substrate:
+ *   - centred card with lock/shield icon,
+ *   - back + logout action buttons (back uses router history, logout
+ *     hits the auth-provider so cookies / refresh tokens get wiped),
+ *   - optional `permissionCode` prop surfaces the required code in an
+ *     `<details>` toggle so the operator can copy-paste it into a
+ *     support ticket without inspecting React DevTools,
+ *   - optional `detailMessage` forwards a backend Problem Details
+ *     `detail` string when the 403 came from an API call rather than a
+ *     local route guard.
  */
-export function Forbidden403Page() {
+export interface Forbidden403PageProps {
+  permissionCode?: string;
+  detailMessage?: string;
+}
+
+export function Forbidden403Page({ permissionCode, detailMessage }: Forbidden403PageProps = {}) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [signingOut, setSigningOut] = useState(false);
+
+  const goBack = () => {
+    if (window.history.length > 1) {
+      navigate(-1);
+      return;
+    }
+    navigate('/dashboard', { replace: true });
+  };
+
+  const signOut = async () => {
+    setSigningOut(true);
+    try {
+      await authProvider.logout?.({});
+    } finally {
+      navigate('/login', { replace: true });
+    }
+  };
 
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-8 text-center">
-      <ShieldOff className="size-16 text-muted-foreground" aria-hidden="true" />
-      <h1 className="text-2xl font-semibold">{t('rbac.forbidden.title', 'Access denied')}</h1>
-      <p className="max-w-md text-sm text-muted-foreground">
-        {t(
-          'rbac.forbidden.body',
-          'You do not have permission to view this page. If you believe this is a mistake, contact your tenant administrator.',
-        )}
-      </p>
+    <div className="flex min-h-[60vh] items-center justify-center p-8">
+      <section
+        aria-labelledby="forbidden-403-title"
+        className="w-full max-w-md rounded-2xl border bg-background p-8 text-center shadow-sm"
+      >
+        <div
+          className="mx-auto mb-4 grid size-16 place-items-center rounded-full bg-rose-100 text-rose-700"
+          aria-hidden="true"
+        >
+          <ShieldOff className="size-8" />
+        </div>
+        <h1 id="forbidden-403-title" className="display text-2xl font-semibold tracking-tight">
+          {t('rbac.forbidden.title')}
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {detailMessage ?? t('rbac.forbidden.body')}
+        </p>
+        {permissionCode ? (
+          <details className="mt-4 rounded-md border border-dashed bg-muted/40 p-3 text-left text-xs text-muted-foreground">
+            <summary className="cursor-pointer select-none font-medium">
+              {t('rbac.forbidden.debug_details')}
+            </summary>
+            <p className="mt-2">
+              {t('rbac.forbidden.permission_required_label')}:{' '}
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">
+                {permissionCode}
+              </code>
+            </p>
+          </details>
+        ) : null}
+        <div className="mt-6 flex justify-center gap-2">
+          <Button variant="outline" size="sm" onClick={goBack} className="gap-1.5">
+            <ArrowLeft className="size-4" aria-hidden="true" />
+            {t('rbac.forbidden.back')}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={signOut}
+            disabled={signingOut}
+            className="gap-1.5"
+          >
+            <LogOut className="size-4" aria-hidden="true" />
+            {t('rbac.forbidden.logout')}
+          </Button>
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/admin/src/components/identity/index.ts
+++ b/apps/admin/src/components/identity/index.ts
@@ -1,5 +1,12 @@
 /**
  * RBAC Phase 4 — public surface for identity-aware components.
  */
+export { LastAdminProtectionModal } from './LastAdminProtectionModal';
+export { OwnerUniquenessModal } from './OwnerUniquenessModal';
 export { PermissionGate, type PermissionGateProps } from './PermissionGate';
-export { Forbidden403Page, PermissionRoute, type PermissionRouteProps } from './PermissionRoute';
+export {
+  Forbidden403Page,
+  type Forbidden403PageProps,
+  PermissionRoute,
+  type PermissionRouteProps,
+} from './PermissionRoute';

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1481,5 +1481,28 @@
       "rollback_failed": "Rollback failed.",
       "upload_failed": "File upload failed."
     }
+  },
+  "rbac": {
+    "forbidden": {
+      "title": "Access denied",
+      "body": "You do not have permission to view this page. If you believe this is a mistake, contact your tenant administrator.",
+      "back": "Back",
+      "logout": "Sign out",
+      "debug_details": "Technical details",
+      "permission_required_label": "Required permission"
+    },
+    "last_admin": {
+      "title": "Cannot leave the tenant without an Administrator",
+      "body": "User {{user}} is the last Administrator on this tenant.",
+      "guidance": "Assign the Administrator role to another user first, then come back to this action.",
+      "close": "Close"
+    },
+    "owner_uniqueness": {
+      "title": "A tenant can only have one Owner",
+      "body": "The Owner role is already assigned to another user.",
+      "body_with_owner": "The Owner role is already assigned to {{owner}}.",
+      "guidance": "Use the ownership transfer flow (Settings → Tenant) instead of assigning Owner twice.",
+      "close": "Close"
+    }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1523,5 +1523,28 @@
       "rollback_failed": "Wycofanie importu nie powiodło się.",
       "upload_failed": "Wgranie pliku nie powiodło się."
     }
+  },
+  "rbac": {
+    "forbidden": {
+      "title": "Brak dostępu",
+      "body": "Nie masz uprawnień do tego widoku. Jeśli uważasz, że to pomyłka, skontaktuj się z administratorem tenanta.",
+      "back": "Wróć",
+      "logout": "Wyloguj",
+      "debug_details": "Szczegóły techniczne",
+      "permission_required_label": "Wymagane uprawnienie"
+    },
+    "last_admin": {
+      "title": "Nie można pozostawić tenanta bez Administratora",
+      "body": "Użytkownik {{user}} jest ostatnim Administratorem w tym tenancie.",
+      "guidance": "Przypisz rolę Administrator innemu użytkownikowi najpierw, potem wróć do tej akcji.",
+      "close": "Zamknij"
+    },
+    "owner_uniqueness": {
+      "title": "Tenant może mieć tylko jednego Ownera",
+      "body": "Rola Owner jest już przypisana innemu użytkownikowi.",
+      "body_with_owner": "Rola Owner jest już przypisana użytkownikowi {{owner}}.",
+      "guidance": "Skorzystaj z transferu właścicielstwa (Settings → Tenant) zamiast przypisywać Owner po raz drugi.",
+      "close": "Zamknij"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Polished route-level `Forbidden403Page` from #680: centred card layout,
  rose lock icon, back + sign-out actions, optional `permissionCode`
  details disclosure, optional `detailMessage` for API-driven 403s.
- New `LastAdminProtectionModal` and `OwnerUniquenessModal` shipping as
  standalone components — consumed by #693 (edit user role) and #694
  (deactivate user) once those flows wire delete / change-role.
- Translation keys for the three flows (PL + EN).

## Scope decisions

- **Modals are visual-only today** — `open` / `onOpenChange` API; the
  flows wire the open condition when they ship. Keeps the bundle
  tree-shakeable until needed and means #708 ships without depending on
  #693/#694 work.
- **Sign-out flow** drains the auth provider before navigating to
  `/login` so refresh tokens / cookies get wiped.

## Test plan

- [x] PHPStan / Biome / tsc green on changed files
- [x] Live smoke: render polished Forbidden403Page directly via React
      DevTools — back button history fallback works, sign-out drops the
      JWT cookie and reaches /login. Permission code disclosure visible
      when `permissionCode` is set.

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)