### PR TITLE
feat(identity): #707 magic-link accept invitation page

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -10,6 +10,7 @@ import { ToastProvider } from '@/components/ui/toast';
 // landing screen. Each route gets its own chunk; revisits hit the
 // HTTP cache after the first lazy load.
 import { DashboardPage } from '@/features/dashboard/page';
+import { AcceptInvitationPage } from '@/features/identity/accept-invitation/AcceptInvitationPage';
 import { LoginPage } from '@/features/identity/auth/login';
 import { AppLayout } from '@/layout/AppLayout';
 import { SettingsLayout } from '@/layout/SettingsLayout';
@@ -339,6 +340,7 @@ function App() {
           <Suspense fallback={<RouteFallback />}>
             <Routes>
               <Route path="/login" element={<LoginPage />} />
+              <Route path="/accept-invitation" element={<AcceptInvitationPage />} />
               <Route
                 element={
                   <AuthedRoute>

--- a/apps/admin/src/features/identity/accept-invitation/AcceptInvitationPage.tsx
+++ b/apps/admin/src/features/identity/accept-invitation/AcceptInvitationPage.tsx
@@ -1,0 +1,340 @@
+import { CheckCircle2, KeyRound, Loader2, ShieldAlert } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useSearchParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from '@/components/ui/toast';
+import { authProvider } from '@/lib/auth-provider';
+import { HttpError, jsonFetch } from '@/lib/http';
+
+const TOKEN_RE = /^[a-f0-9]{64}$/;
+
+interface VerifyResponse {
+  status: 'valid' | 'expired' | 'accepted' | 'revoked' | 'not_found';
+  email?: string;
+  tenant_name?: string;
+  expires_at?: string;
+}
+
+type VerifyState =
+  | { kind: 'pending' }
+  | { kind: 'invalid'; reason: 'malformed' | 'not_found' }
+  | { kind: 'expired' | 'revoked' | 'accepted'; email?: string; tenant_name?: string }
+  | { kind: 'valid'; email: string; tenant_name?: string; expires_at?: string };
+
+/**
+ * RBAC-P5-017 (#707) — magic-link accept invitation page.
+ *
+ * Public route at `/accept-invitation?token=<64 hex>`. Three branches:
+ *
+ *   1. Pre-flight verify — GET /api/invitations/{token}/verify
+ *      Renders a spinner; if the API replies with `status !== valid` we
+ *      short-circuit to a dedicated error card without ever showing
+ *      the password form, so the operator never types into a doomed
+ *      submission.
+ *   2. Password setup — single-step form (new + confirm). The PRD §5.3
+ *      mockup mentions an optional MFA enrol step; that ships with the
+ *      MFA wizard (#689 / #703) so the route can drop it in without
+ *      schema changes. Min 12 characters matches the change-password
+ *      flow (#702).
+ *   3. Success — POSTs accept + immediately logs the new user in via
+ *      the standard auth-provider, redirecting to /dashboard. The
+ *      `User` row + `UserRole` assignment already exist server-side
+ *      so the JWT issuance is a regular json_login call.
+ */
+export function AcceptInvitationPage() {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get('token') ?? '';
+
+  const [state, setState] = useState<VerifyState>({ kind: 'pending' });
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!TOKEN_RE.test(token)) {
+      setState({ kind: 'invalid', reason: 'malformed' });
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await jsonFetch<VerifyResponse>(`/api/invitations/${token}/verify`, {
+          accept: 'application/json',
+        });
+        if (cancelled) return;
+        if ('valid' === response.status && response.email) {
+          setState({
+            kind: 'valid',
+            email: response.email,
+            tenant_name: response.tenant_name,
+            expires_at: response.expires_at,
+          });
+          return;
+        }
+        if ('not_found' === response.status) {
+          setState({ kind: 'invalid', reason: 'not_found' });
+          return;
+        }
+        // 'expired' | 'accepted' | 'revoked' — narrow explicitly so the
+        // discriminated union accepts the assignment.
+        if (
+          'expired' === response.status ||
+          'accepted' === response.status ||
+          'revoked' === response.status
+        ) {
+          setState({
+            kind: response.status,
+            email: response.email,
+            tenant_name: response.tenant_name,
+          });
+        }
+      } catch (error) {
+        if (cancelled) return;
+        // 410 (expired/revoked/accepted) lands here as HttpError because
+        // jsonFetch throws on non-2xx. Re-parse the body so the UX still
+        // distinguishes the three states.
+        if (error instanceof HttpError && error.status === 410) {
+          const body = error.body as VerifyResponse;
+          const kind: 'expired' | 'accepted' | 'revoked' =
+            'accepted' === body?.status || 'revoked' === body?.status ? body.status : 'expired';
+          setState({
+            kind,
+            email: body?.email,
+            tenant_name: body?.tenant_name,
+          });
+          return;
+        }
+        setState({ kind: 'invalid', reason: 'not_found' });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (state.kind !== 'valid') return;
+    if (submitting || password.length < 12 || password !== confirm) return;
+    setSubmitting(true);
+    try {
+      await jsonFetch(`/api/invitations/${token}/accept`, {
+        method: 'POST',
+        body: { password },
+        accept: 'application/json',
+        contentType: 'application/json',
+      });
+      // Backend created the User + UserRole; log in via the standard
+      // flow so the auth-provider populates the token store + redirects
+      // to /dashboard.
+      const result = await authProvider.login?.({ email: state.email, password });
+      if (result?.success) {
+        toast.success(t('accept_invitation.toast_success'));
+        navigate('/dashboard', { replace: true });
+      } else {
+        // Acceptance succeeded but login failed — send the user to
+        // /login so they can re-authenticate manually instead of
+        // being stuck on this page.
+        toast.success(t('accept_invitation.toast_accepted_login_required'));
+        navigate('/login', { replace: true });
+      }
+    } catch (error) {
+      const message =
+        error instanceof HttpError && error.status === 400
+          ? t('accept_invitation.error_validation')
+          : t('accept_invitation.error_generic');
+      toast.error(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/30 p-6">
+      <div className="w-full max-w-md">
+        {state.kind === 'pending' && <PendingCard />}
+        {state.kind === 'invalid' && <InvalidCard reason={state.reason} />}
+        {(state.kind === 'expired' || state.kind === 'revoked' || state.kind === 'accepted') && (
+          <ErrorCard kind={state.kind} email={state.email} tenant_name={state.tenant_name} />
+        )}
+        {state.kind === 'valid' && (
+          <ValidCard
+            email={state.email}
+            tenant_name={state.tenant_name}
+            expires_at={state.expires_at}
+            password={password}
+            confirm={confirm}
+            onPasswordChange={setPassword}
+            onConfirmChange={setConfirm}
+            onSubmit={submit}
+            submitting={submitting}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PendingCard() {
+  const { t } = useTranslation();
+  return (
+    <section className="rounded-2xl border bg-background p-8 text-center shadow-sm">
+      <Loader2 className="mx-auto size-10 animate-spin text-muted-foreground" />
+      <p className="mt-4 text-sm text-muted-foreground">{t('accept_invitation.verifying')}</p>
+    </section>
+  );
+}
+
+function InvalidCard({ reason }: { reason: 'malformed' | 'not_found' }) {
+  const { t } = useTranslation();
+  return (
+    <section className="rounded-2xl border bg-background p-8 text-center shadow-sm">
+      <div
+        className="mx-auto mb-3 grid size-12 place-items-center rounded-full bg-rose-100 text-rose-700"
+        aria-hidden="true"
+      >
+        <ShieldAlert className="size-6" />
+      </div>
+      <h1 className="display text-xl font-semibold tracking-tight">
+        {t('accept_invitation.invalid_title')}
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {reason === 'malformed'
+          ? t('accept_invitation.invalid_body_malformed')
+          : t('accept_invitation.invalid_body_not_found')}
+      </p>
+      <Button asChild variant="outline" size="sm" className="mt-5">
+        <a href="/login">{t('accept_invitation.go_login')}</a>
+      </Button>
+    </section>
+  );
+}
+
+function ErrorCard({
+  kind,
+  email,
+  tenant_name,
+}: {
+  kind: 'expired' | 'revoked' | 'accepted';
+  email?: string;
+  tenant_name?: string;
+}) {
+  const { t } = useTranslation();
+  const titleKey = `accept_invitation.${kind}_title` as const;
+  const bodyKey = `accept_invitation.${kind}_body` as const;
+  return (
+    <section className="rounded-2xl border bg-background p-8 text-center shadow-sm">
+      <div
+        className="mx-auto mb-3 grid size-12 place-items-center rounded-full bg-amber-100 text-amber-700"
+        aria-hidden="true"
+      >
+        <ShieldAlert className="size-6" />
+      </div>
+      <h1 className="display text-xl font-semibold tracking-tight">{t(titleKey)}</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {t(bodyKey, { email: email ?? '', tenant_name: tenant_name ?? '' })}
+      </p>
+      <Button asChild variant="outline" size="sm" className="mt-5">
+        <a href="/login">{t('accept_invitation.go_login')}</a>
+      </Button>
+    </section>
+  );
+}
+
+interface ValidCardProps {
+  email: string;
+  tenant_name?: string;
+  expires_at?: string;
+  password: string;
+  confirm: string;
+  onPasswordChange: (value: string) => void;
+  onConfirmChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent) => void;
+  submitting: boolean;
+}
+
+function ValidCard({
+  email,
+  tenant_name,
+  password,
+  confirm,
+  onPasswordChange,
+  onConfirmChange,
+  onSubmit,
+  submitting,
+}: ValidCardProps) {
+  const { t } = useTranslation();
+  const tooShort = password.length > 0 && password.length < 12;
+  const mismatch = confirm.length > 0 && password !== confirm;
+  const canSubmit = password.length >= 12 && password === confirm && !submitting;
+
+  return (
+    <section className="rounded-2xl border bg-background p-8 shadow-sm">
+      <div
+        className="mx-auto mb-3 grid size-12 place-items-center rounded-full bg-emerald-100 text-emerald-700"
+        aria-hidden="true"
+      >
+        <CheckCircle2 className="size-6" />
+      </div>
+      <h1 className="display text-center text-xl font-semibold tracking-tight">
+        {t('accept_invitation.valid_title', { tenant_name: tenant_name ?? '' })}
+      </h1>
+      <p className="mt-2 text-center text-sm text-muted-foreground">
+        {t('accept_invitation.valid_body', { email })}
+      </p>
+
+      <form className="mt-6 space-y-4" onSubmit={onSubmit}>
+        <div className="space-y-1.5">
+          <Label htmlFor="accept-password">{t('accept_invitation.field_new')}</Label>
+          <div className="relative">
+            <KeyRound
+              className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              id="accept-password"
+              type="password"
+              value={password}
+              onChange={(e) => onPasswordChange(e.target.value)}
+              required
+              autoComplete="new-password"
+              className="pl-9"
+            />
+          </div>
+          {tooShort ? (
+            <p className="text-xs text-rose-600">
+              {t('accept_invitation.error_too_short', { min: 12 })}
+            </p>
+          ) : null}
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="accept-confirm">{t('accept_invitation.field_confirm')}</Label>
+          <Input
+            id="accept-confirm"
+            type="password"
+            value={confirm}
+            onChange={(e) => onConfirmChange(e.target.value)}
+            required
+            autoComplete="new-password"
+            aria-invalid={mismatch}
+          />
+          {mismatch ? (
+            <p className="text-xs text-rose-600">{t('accept_invitation.error_mismatch')}</p>
+          ) : null}
+        </div>
+
+        <Button type="submit" disabled={!canSubmit} className="w-full">
+          {submitting ? t('accept_invitation.submitting') : t('accept_invitation.submit')}
+        </Button>
+      </form>
+    </section>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1571,5 +1571,30 @@
       "guidance": "Use the ownership transfer flow (Settings → Tenant) instead of assigning Owner twice.",
       "close": "Close"
     }
+  },
+  "accept_invitation": {
+    "verifying": "Verifying invitation...",
+    "invalid_title": "Invalid invitation",
+    "invalid_body_malformed": "The invitation link is malformed. Make sure you copied the whole URL from the email.",
+    "invalid_body_not_found": "This invitation does not exist. It may have already been accepted or revoked.",
+    "expired_title": "Invitation expired",
+    "expired_body": "The invitation for {{email}} has expired. Ask {{tenant_name}} for a fresh invite.",
+    "revoked_title": "Invitation revoked",
+    "revoked_body": "An administrator revoked the invitation for {{email}}. Contact {{tenant_name}} if this is a mistake.",
+    "accepted_title": "Invitation already accepted",
+    "accepted_body": "The account for {{email}} already exists. Sign in normally with the password you set earlier.",
+    "valid_title": "Join {{tenant_name}}",
+    "valid_body": "Set a password for {{email}} — you'll use it on every sign-in.",
+    "field_new": "New password (min 12 chars)",
+    "field_confirm": "Confirm password",
+    "submit": "Activate account and sign in",
+    "submitting": "Activating account...",
+    "error_too_short": "Password must be at least {{min}} characters long.",
+    "error_mismatch": "Passwords do not match.",
+    "error_validation": "Backend validation rejected the submission.",
+    "error_generic": "Could not activate the account. Please try again.",
+    "go_login": "Go to sign in",
+    "toast_success": "Account activated. Welcome!",
+    "toast_accepted_login_required": "Account activated. Please sign in to continue."
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1613,5 +1613,30 @@
       "guidance": "Skorzystaj z transferu właścicielstwa (Settings → Tenant) zamiast przypisywać Owner po raz drugi.",
       "close": "Zamknij"
     }
+  },
+  "accept_invitation": {
+    "verifying": "Sprawdzam zaproszenie...",
+    "invalid_title": "Niepoprawne zaproszenie",
+    "invalid_body_malformed": "Link zaproszenia jest nieprawidłowy. Sprawdź, czy skopiowałeś cały URL z emaila.",
+    "invalid_body_not_found": "To zaproszenie nie istnieje. Mogło zostać już zaakceptowane lub wycofane.",
+    "expired_title": "Zaproszenie wygasło",
+    "expired_body": "Zaproszenie dla {{email}} wygasło. Poproś {{tenant_name}} o nowe zaproszenie.",
+    "revoked_title": "Zaproszenie zostało wycofane",
+    "revoked_body": "Administrator wycofał zaproszenie dla {{email}}. Skontaktuj się z {{tenant_name}}, jeśli to pomyłka.",
+    "accepted_title": "Zaproszenie już zaakceptowane",
+    "accepted_body": "Konto {{email}} już istnieje. Zaloguj się normalnie używając hasła ustawionego wcześniej.",
+    "valid_title": "Dołącz do {{tenant_name}}",
+    "valid_body": "Ustaw hasło dla {{email}} — używaj go przy każdym logowaniu.",
+    "field_new": "Nowe hasło (min 12 znaków)",
+    "field_confirm": "Powtórz hasło",
+    "submit": "Aktywuj konto i zaloguj",
+    "submitting": "Aktywuję konto...",
+    "error_too_short": "Hasło musi mieć co najmniej {{min}} znaków.",
+    "error_mismatch": "Hasła nie są identyczne.",
+    "error_validation": "Wprowadzone dane nie przeszły walidacji backendu.",
+    "error_generic": "Nie udało się aktywować konta. Spróbuj ponownie.",
+    "go_login": "Przejdź do logowania",
+    "toast_success": "Konto aktywowane. Witaj!",
+    "toast_accepted_login_required": "Konto aktywowane. Zaloguj się, żeby kontynuować."
   }
 }

--- a/apps/api/config/packages/security.yaml
+++ b/apps/api/config/packages/security.yaml
@@ -74,6 +74,10 @@ security:
         # /api/invitations/{token}/accept matches the path below; the
         # token character class is enforced at the controller route level.
         - { path: '^/api/invitations/[a-f0-9]+/accept$', roles: PUBLIC_ACCESS }
+        # RBAC-P5-017 (#707) — accept invitation page calls verify before
+        # showing the password form. Same auth model as /accept: the
+        # token IS the auth factor; account does not exist yet.
+        - { path: '^/api/invitations/[a-f0-9]+/verify$', roles: PUBLIC_ACCESS }
         - { path: '^/api/auth/password-reset/(request|confirm)$', roles: PUBLIC_ACCESS }
         # RBAC-P2-012/013/014 SSO callback endpoints — provider's OAuth/SAML
         # assertion IS the auth factor; no PIM session required.

--- a/apps/api/src/Identity/Application/InvitationService.php
+++ b/apps/api/src/Identity/Application/InvitationService.php
@@ -24,6 +24,8 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Uid\Uuid;
 
+use const DATE_ATOM;
+
 /**
  * RBAC-P2-008 (#657) — magic-link invitation orchestrator.
  *
@@ -179,6 +181,59 @@ final class InvitationService
         $this->invitations->save($invitation);
 
         return $user;
+    }
+
+    /**
+     * RBAC-P5-017 (#707) — read-only inspect for the magic-link accept
+     * page. Returns a snapshot of the invitation state so the FE can
+     * branch between "show password form" / "already accepted" /
+     * "revoked or expired" without leaking enough metadata to enumerate
+     * other invitations: only `status`, the target email and the
+     * inviting tenant's display name make it across.
+     *
+     * Always returns a status — null token / no match collapses into
+     * `not_found` so the controller surface stays uniform.
+     *
+     * @return array{
+     *     status: 'valid'|'expired'|'accepted'|'revoked'|'not_found',
+     *     email?: string,
+     *     tenant_name?: string,
+     *     expires_at?: string
+     * }
+     */
+    public function verify(string $plaintextToken): array
+    {
+        if ('' === $plaintextToken) {
+            return ['status' => 'not_found'];
+        }
+
+        $tokenHash = $this->tokenHasher->hash($plaintextToken);
+        $invitation = $this->invitations->findByHash($tokenHash);
+        if (null === $invitation) {
+            return ['status' => 'not_found'];
+        }
+
+        /** @var Tenant|null $tenant */
+        $tenant = $this->em->find(Tenant::class, $invitation->getTenantId()->toRfc4122());
+        $tenantName = null !== $tenant ? $tenant->getName() : '';
+
+        $base = [
+            'email' => $invitation->getEmail(),
+            'tenant_name' => $tenantName,
+            'expires_at' => $invitation->getExpiresAt()->format(DATE_ATOM),
+        ];
+
+        if ($invitation->isAccepted()) {
+            return ['status' => 'accepted', ...$base];
+        }
+        if ($invitation->isRevoked()) {
+            return ['status' => 'revoked', ...$base];
+        }
+        if ($invitation->getExpiresAt() < new DateTimeImmutable()) {
+            return ['status' => 'expired', ...$base];
+        }
+
+        return ['status' => 'valid', ...$base];
     }
 
     public function revoke(Uuid $invitationId): void

--- a/apps/api/src/Identity/Presentation/Controller/InvitationController.php
+++ b/apps/api/src/Identity/Presentation/Controller/InvitationController.php
@@ -103,4 +103,28 @@ final class InvitationController extends AbstractController
             'status' => 'accepted',
         ], 201);
     }
+
+    /**
+     * RBAC-P5-017 (#707) — read-only inspect for the magic-link accept
+     * page. The FE calls this before showing the password form so the
+     * operator never types a password into a form that will fail on
+     * submit (expired / revoked / already-accepted token).
+     *
+     * Public route — token IS the auth factor.
+     */
+    #[Route(path: '/api/invitations/{token}/verify', methods: ['GET'], name: 'api_invitations_verify', requirements: ['token' => '[a-f0-9]{64}'])]
+    #[\App\Identity\Domain\Attribute\NoPermissionRequired(reason: 'Magic-link verify is open by design — token IS the auth factor; account does not exist yet.')]
+    public function verify(string $token): JsonResponse
+    {
+        $snapshot = $this->invitations->verify($token);
+        $status = $snapshot['status'];
+
+        $httpStatus = match ($status) {
+            'valid' => 200,
+            'accepted', 'expired', 'revoked' => 410,
+            default => 404,
+        };
+
+        return new JsonResponse($snapshot, $httpStatus);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the loop on the magic-link invitation flow that #657 opened on the backend and #692 wired in the admin UI.

**Backend**
- New `GET /api/invitations/{token}/verify` — read-only pre-flight inspect. Returns `{status, email, tenant_name, expires_at}`. 200 valid, 410 accepted/expired/revoked, 404 unknown.
- `InvitationService::verify()` — pure read mirroring `Invitation` lifecycle branches.
- security.yaml PUBLIC_ACCESS rule for `^/api/invitations/[a-f0-9]+/verify$` — same posture as `/accept`.

**Frontend**
- `/accept-invitation?token=<64 hex>` public route (added next to `/login` in App.tsx).
- Four-card state machine: pending (verify spinner), invalid (malformed / not_found), error (expired / revoked / accepted), valid (password + confirm form).
- Min 12 char password to match `/api/me/change-password` (#702).
- Success → POST `/accept` → `authProvider.login()` → `/dashboard`. Login failure post-accept falls through to `/login` with a toast.

PRD §5.3 mentions an optional MFA enrol step; that lands with the MFA wizard (#689 / #703) so this route can drop it in without schema changes.

## Test plan

- [x] PHPStan max + Biome strict + tsc-noEmit green
- [x] Live smoke against `pim.localhost`:
      - `POST /api/invitations` → 201 with `token_dev_only`
      - `GET /api/invitations/{token}/verify` → 200 `{status:"valid", email, tenant_name, expires_at}`
      - `GET /api/invitations/{bogus_64hex}/verify` → 404 `{status:"not_found"}`

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)