### PR TITLE
feat(identity): #705 Settings → Tenant config (rename + primary locale)

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -211,6 +211,10 @@ const ApiTokensSettingsPage = lazyPage(
   () => import('@/features/settings/api-tokens'),
   'ApiTokensSettingsPage',
 );
+const TenantSettingsPage = lazyPage(
+  () => import('@/features/settings/tenant'),
+  'TenantSettingsPage',
+);
 
 /**
  * Suspense fallback shown while a route chunk loads. Discreet — the
@@ -440,6 +444,7 @@ function App() {
                   <Route path="api-tokens" element={<ApiTokensSettingsPage />} />
                   <Route path="security" element={<SecuritySettingsPage />} />
                   <Route path="billing" element={<BillingSettingsPage />} />
+                  <Route path="tenant" element={<TenantSettingsPage />} />
                   <Route path="ai" element={<AiSettingsPage />} />
                 </Route>
                 {/* Top-level Integracje hub — łączy Imports MVP (epik 0.13)

--- a/apps/admin/src/features/settings/tenant/index.tsx
+++ b/apps/admin/src/features/settings/tenant/index.tsx
@@ -141,9 +141,7 @@ function TenantConfigForm() {
             <h3 id="tenant-config-heading" className="text-sm font-semibold">
               {t('settings.tenant.identity_title')}
             </h3>
-            <p className="text-xs text-muted-foreground">
-              {t('settings.tenant.identity_intro')}
-            </p>
+            <p className="text-xs text-muted-foreground">{t('settings.tenant.identity_intro')}</p>
           </div>
         </div>
 
@@ -151,9 +149,7 @@ function TenantConfigForm() {
           <div className="space-y-1.5">
             <Label htmlFor="tenant-code">{t('settings.tenant.field_code')}</Label>
             <Input id="tenant-code" value={tenant.code} disabled readOnly />
-            <p className="text-[11px] text-muted-foreground">
-              {t('settings.tenant.code_hint')}
-            </p>
+            <p className="text-[11px] text-muted-foreground">{t('settings.tenant.code_hint')}</p>
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="tenant-plan">{t('settings.tenant.field_plan')}</Label>
@@ -180,9 +176,7 @@ function TenantConfigForm() {
             </span>
             <div>
               <h3 className="text-sm font-semibold">{t('settings.tenant.locales_title')}</h3>
-              <p className="text-xs text-muted-foreground">
-                {t('settings.tenant.locales_intro')}
-              </p>
+              <p className="text-xs text-muted-foreground">{t('settings.tenant.locales_intro')}</p>
             </div>
           </div>
           <div className="space-y-1.5">

--- a/apps/admin/src/features/settings/tenant/index.tsx
+++ b/apps/admin/src/features/settings/tenant/index.tsx
@@ -1,0 +1,237 @@
+import { Building2, Globe, Loader2, ShieldAlert } from 'lucide-react';
+import { type FormEvent, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { PermissionGate } from '@/components/identity';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from '@/components/ui/toast';
+import { HttpError, jsonFetch } from '@/lib/http';
+
+interface TenantConfig {
+  id: string;
+  code: string;
+  name: string;
+  plan: string;
+  domain: string | null;
+  enabled_locales: string[];
+  primary_locale: string;
+  created_at: string;
+}
+
+/**
+ * RBAC-P5-015 (#705) — Settings → Tenant config.
+ *
+ * Owner-only via `PermissionGate(user.admin)` — non-owners get the
+ * shared 403 fallback that the gate provides.
+ *
+ * MVP scope: rename + primary-locale switch. Channels CRUD lives on
+ * its own page (`/settings/channels`, already shipped); deleting the
+ * tenant is destructive enough to deserve its own flow (deferred —
+ * `cortex:tenant:delete` CLI exists for the operator who really
+ * needs it before the danger-zone UI lands).
+ */
+export function TenantSettingsPage() {
+  return (
+    <PermissionGate code="user.admin" fallback={<ForbiddenFallback />}>
+      <TenantConfigForm />
+    </PermissionGate>
+  );
+}
+
+function TenantConfigForm() {
+  const { t, i18n } = useTranslation();
+  const [tenant, setTenant] = useState<TenantConfig | null>(null);
+  const [name, setName] = useState('');
+  const [primaryLocale, setPrimaryLocale] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await jsonFetch<TenantConfig>('/api/tenant', { accept: 'application/json' });
+        if (cancelled) return;
+        setTenant(data);
+        setName(data.name);
+        setPrimaryLocale(data.primary_locale);
+      } catch {
+        if (cancelled) return;
+        toast.error(t('settings.tenant.error_loading'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const dirty =
+    tenant !== null && (name !== tenant.name || primaryLocale !== tenant.primary_locale);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!tenant || !dirty || saving) return;
+    setSaving(true);
+    const payload: Record<string, string> = {};
+    if (name !== tenant.name) payload.name = name.trim();
+    if (primaryLocale !== tenant.primary_locale) payload.primary_locale = primaryLocale;
+    try {
+      const updated = await jsonFetch<TenantConfig>('/api/tenant', {
+        method: 'PATCH',
+        body: payload,
+        accept: 'application/json',
+        contentType: 'application/json',
+      });
+      setTenant(updated);
+      setName(updated.name);
+      setPrimaryLocale(updated.primary_locale);
+      toast.success(t('settings.tenant.toast_saved'));
+    } catch (error) {
+      const status = (error as { status?: number })?.status;
+      if (status === 409) {
+        toast.error(t('settings.tenant.error_primary_not_enabled'));
+      } else if (error instanceof HttpError && error.status === 400) {
+        toast.error(t('settings.tenant.error_validation'));
+      } else {
+        toast.error(t('settings.tenant.error_generic'));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[320px] items-center justify-center rounded-lg border bg-background p-8">
+        <Loader2 className="size-8 animate-spin text-muted-foreground" aria-hidden="true" />
+      </div>
+    );
+  }
+
+  if (!tenant) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h2 className="display text-xl font-semibold tracking-tight">
+          {t('settings.tenant.title')}
+        </h2>
+        <p className="max-w-2xl text-sm text-muted-foreground">{t('settings.tenant.intro')}</p>
+      </header>
+
+      <form
+        className="rounded-lg border bg-background p-6 shadow-sm"
+        onSubmit={submit}
+        aria-labelledby="tenant-config-heading"
+      >
+        <div className="mb-4 flex items-center gap-3">
+          <span
+            className="inline-grid size-10 place-items-center rounded-md bg-accent-violet/10 text-accent-violet"
+            aria-hidden="true"
+          >
+            <Building2 className="size-5" />
+          </span>
+          <div>
+            <h3 id="tenant-config-heading" className="text-sm font-semibold">
+              {t('settings.tenant.identity_title')}
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              {t('settings.tenant.identity_intro')}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="tenant-code">{t('settings.tenant.field_code')}</Label>
+            <Input id="tenant-code" value={tenant.code} disabled readOnly />
+            <p className="text-[11px] text-muted-foreground">
+              {t('settings.tenant.code_hint')}
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="tenant-plan">{t('settings.tenant.field_plan')}</Label>
+            <Input id="tenant-plan" value={tenant.plan} disabled readOnly />
+          </div>
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label htmlFor="tenant-name">{t('settings.tenant.field_name')}</Label>
+            <Input
+              id="tenant-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 space-y-3 border-t pt-6">
+          <div className="flex items-center gap-3">
+            <span
+              className="inline-grid size-10 place-items-center rounded-md bg-cyan-100 text-cyan-700"
+              aria-hidden="true"
+            >
+              <Globe className="size-5" />
+            </span>
+            <div>
+              <h3 className="text-sm font-semibold">{t('settings.tenant.locales_title')}</h3>
+              <p className="text-xs text-muted-foreground">
+                {t('settings.tenant.locales_intro')}
+              </p>
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="tenant-primary-locale">
+              {t('settings.tenant.field_primary_locale')}
+            </Label>
+            <select
+              id="tenant-primary-locale"
+              value={primaryLocale}
+              onChange={(e) => setPrimaryLocale(e.target.value)}
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {tenant.enabled_locales.map((locale) => (
+                <option key={locale} value={locale}>
+                  {locale.toUpperCase()}
+                </option>
+              ))}
+            </select>
+            <p className="text-[11px] text-muted-foreground">
+              {t('settings.tenant.locales_pending_hint')}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end">
+          <Button type="submit" disabled={!dirty || saving}>
+            {saving ? t('settings.tenant.saving') : t('settings.tenant.save')}
+          </Button>
+        </div>
+      </form>
+
+      <p className="text-[11px] text-muted-foreground">
+        {t('settings.tenant.danger_zone_pending', {
+          date: new Date(tenant.created_at).toLocaleDateString(i18n.language),
+        })}
+      </p>
+    </div>
+  );
+}
+
+function ForbiddenFallback() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex min-h-[320px] flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-background p-8 text-center">
+      <ShieldAlert className="size-8 text-muted-foreground" aria-hidden="true" />
+      <h2 className="text-sm font-semibold">{t('settings.tenant.forbidden_title')}</h2>
+      <p className="max-w-md text-xs text-muted-foreground">
+        {t('settings.tenant.forbidden_description')}
+      </p>
+    </div>
+  );
+}

--- a/apps/admin/src/layout/SettingsLayout.tsx
+++ b/apps/admin/src/layout/SettingsLayout.tsx
@@ -1,4 +1,5 @@
 import {
+  Building2,
   CreditCard,
   Key,
   KeyRound,
@@ -29,6 +30,7 @@ const SETTINGS_NAV: readonly SettingsNavItem[] = [
   { to: '/settings/roles', icon: ShieldCheck, label: 'settings.nav.roles' },
   { to: '/settings/api-tokens', icon: Key, label: 'settings.nav.api_tokens' },
   { to: '/settings/security', icon: KeyRound, label: 'settings.nav.security' },
+  { to: '/settings/tenant', icon: Building2, label: 'settings.nav.tenant' },
   { to: '/settings/billing', icon: CreditCard, label: 'settings.nav.billing' },
   { to: '/settings/ai', icon: Sparkles, label: 'settings.nav.ai' },
 ] as const;

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -64,6 +64,7 @@
       "roles": "Roles",
       "api_tokens": "API tokens",
       "security": "Password policy, 2FA",
+      "tenant": "Tenant",
       "billing": "Subscription",
       "ai": "AI configuration"
     },
@@ -137,6 +138,30 @@
         "expired": "Expired",
         "revoked": "Revoked"
       }
+    },
+    "tenant": {
+      "title": "Tenant configuration",
+      "intro": "Name, primary locale and operational metadata. Channels live in Settings → Channels. Full scope (channels CRUD, locale enable/disable, danger zone) lands in follow-up tickets.",
+      "identity_title": "Identity",
+      "identity_intro": "Code is immutable (set at onboarding). Plan changes go through support.",
+      "field_code": "Code",
+      "code_hint": "Code does not change — it's part of URLs and API keys.",
+      "field_plan": "Plan",
+      "field_name": "Tenant name",
+      "locales_title": "Locales",
+      "locales_intro": "Pick the primary locale from the enabled ones. Activating new locales ships in a follow-up.",
+      "field_primary_locale": "Primary locale",
+      "locales_pending_hint": "Editing enabled_locales requires reviewing role scope arrays — UI ships with #698.",
+      "save": "Save changes",
+      "saving": "Saving...",
+      "toast_saved": "Tenant configuration saved.",
+      "error_loading": "Could not load tenant configuration.",
+      "error_validation": "Backend validation rejected the submission.",
+      "error_primary_not_enabled": "The selected primary locale is not enabled.",
+      "error_generic": "Could not save tenant configuration.",
+      "forbidden_title": "Access denied",
+      "forbidden_description": "Only the tenant Owner sees the configuration. Reach out to your administrator if you need access.",
+      "danger_zone_pending": "Tenant deletion (created {{date}}) is parked behind a separate hard-confirm flow — lands in a follow-up ticket."
     },
     "billing": {
       "title": "Subscription",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -66,6 +66,7 @@
       "roles": "Role",
       "api_tokens": "Tokeny API",
       "security": "Polityka Haseł, 2FA",
+      "tenant": "Tenant",
       "billing": "Subskrypcja",
       "ai": "Konfiguracja AI"
     },
@@ -139,6 +140,30 @@
         "expired": "Wygasł",
         "revoked": "Odwołany"
       }
+    },
+    "tenant": {
+      "title": "Konfiguracja tenanta",
+      "intro": "Nazwa, locale primary i metadane operacyjne. Kanały edytujesz w sekcji Settings → Kanały. Pełen scope (channels CRUD, enable/disable locales, danger zone) doejdzie w kolejnych ticketach.",
+      "identity_title": "Identyfikacja",
+      "identity_intro": "Code jest immutable (utworzony przy onboardingu). Plan zmienia support kontaktem.",
+      "field_code": "Kod",
+      "code_hint": "Kod nie zmienia się — jest częścią URL-i i kluczy API.",
+      "field_plan": "Plan",
+      "field_name": "Nazwa tenanta",
+      "locales_title": "Locale",
+      "locales_intro": "Wybierz primary locale spośród aktywowanych. Aktywacja nowych locale dojdzie w follow-up tickecie.",
+      "field_primary_locale": "Primary locale",
+      "locales_pending_hint": "Edycja enabled_locales wymaga rewizji scope ról — UI dojdzie razem z #698.",
+      "save": "Zapisz zmiany",
+      "saving": "Zapisuję...",
+      "toast_saved": "Konfiguracja tenanta zapisana.",
+      "error_loading": "Nie udało się załadować konfiguracji tenanta.",
+      "error_validation": "Wprowadzone dane nie przeszły walidacji backendu.",
+      "error_primary_not_enabled": "Wybrany primary locale nie jest aktywowany.",
+      "error_generic": "Nie udało się zapisać konfiguracji tenanta.",
+      "forbidden_title": "Brak dostępu",
+      "forbidden_description": "Tylko Owner tenanta widzi konfigurację. Skontaktuj się z administratorem, jeśli potrzebujesz dostępu.",
+      "danger_zone_pending": "Usuwanie tenanta (utworzonego {{date}}) zostało przeniesione do osobnego flow z hard-confirm — dochodzi w follow-up."
     },
     "billing": {
       "title": "Subskrypcja",

--- a/apps/api/src/Identity/Presentation/Controller/TenantConfigController.php
+++ b/apps/api/src/Identity/Presentation/Controller/TenantConfigController.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Identity\Domain\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * RBAC-P5-015 (#705) — Settings → Tenant config endpoints.
+ *
+ *   - GET /api/tenant — returns the caller's tenant metadata.
+ *   - PATCH /api/tenant — Owner-only rename / primary-locale change.
+ *
+ * Scope deviations from the ticket spec, documented in code:
+ *   - Channels CRUD lives on `/api/channels` (already shipped); the
+ *     Tenant config page does NOT duplicate it. The PRD §3.2 macierz
+ *     line stays accurate — channels remain settings.channels.* gated.
+ *   - Locales enable/disable left to a follow-up — the underlying
+ *     `Tenant::enableLocale()` exists but the controller surface
+ *     needs ISO 639-1 validation + reseed of role scope arrays
+ *     (RBAC-P3-007 territory).
+ *   - Tenant deletion (danger zone) deferred — it cascades to every
+ *     domain table and needs a separate destructive-confirm flow.
+ *
+ * Permission gate: `user.admin` until Phase 6 retrofit migrates
+ * onto PRD §3.2 `settings.tenant.manage`. The legacy code is held
+ * only by super_admin / tenant_owner so the gate matches the
+ * "Owner only" PRD §3.2 line in practice.
+ */
+final readonly class TenantConfigController
+{
+    public function __construct(
+        private Security $security,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    #[Route(path: '/api/tenant', methods: ['GET'], name: 'api_tenant_get')]
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function get(): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return $this->unauthorized();
+        }
+
+        return new JsonResponse($this->project($user->getTenant()));
+    }
+
+    #[Route(path: '/api/tenant', methods: ['PATCH'], name: 'api_tenant_patch')]
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function patch(Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return $this->unauthorized();
+        }
+
+        /** @var array<string, mixed>|null $payload */
+        $payload = json_decode($request->getContent(), true);
+        if (!\is_array($payload)) {
+            return $this->problem(Response::HTTP_BAD_REQUEST, 'Bad Request', 'Request body must be JSON.');
+        }
+
+        $tenant = $user->getTenant();
+
+        if (\array_key_exists('name', $payload)) {
+            $name = $payload['name'];
+            if (!\is_string($name) || '' === trim($name)) {
+                return $this->problem(Response::HTTP_BAD_REQUEST, 'Bad Request', '`name` must be a non-empty string.');
+            }
+            $tenant->rename(trim($name));
+        }
+
+        if (\array_key_exists('primary_locale', $payload)) {
+            $primary = $payload['primary_locale'];
+            if (!\is_string($primary)) {
+                return $this->problem(Response::HTTP_BAD_REQUEST, 'Bad Request', '`primary_locale` must be a string.');
+            }
+            try {
+                $tenant->changePrimaryLocale($primary);
+            } catch (\Throwable $e) {
+                return $this->problem(
+                    Response::HTTP_CONFLICT,
+                    'Locale not enabled',
+                    $e->getMessage(),
+                );
+            }
+        }
+
+        $this->em->flush();
+
+        return new JsonResponse($this->project($tenant));
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     code: string,
+     *     name: string,
+     *     plan: string,
+     *     domain: ?string,
+     *     enabled_locales: list<string>,
+     *     primary_locale: string,
+     *     created_at: string
+     * }
+     */
+    private function project(Tenant $tenant): array
+    {
+        return [
+            'id' => $tenant->getId()->toRfc4122(),
+            'code' => $tenant->getCode(),
+            'name' => $tenant->getName(),
+            'plan' => $tenant->getPlan(),
+            'domain' => $tenant->getDomain(),
+            'enabled_locales' => $tenant->getEnabledLocales(),
+            'primary_locale' => $tenant->getPrimaryLocale(),
+            'created_at' => $tenant->getCreatedAt()->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    private function unauthorized(): JsonResponse
+    {
+        return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
+    }
+
+    private function problem(int $status, string $title, string $detail): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'type' => 'about:blank',
+                'title' => $title,
+                'status' => $status,
+                'detail' => $detail,
+            ],
+            $status,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
+    }
+}

--- a/apps/api/src/Identity/Presentation/Controller/TenantConfigController.php
+++ b/apps/api/src/Identity/Presentation/Controller/TenantConfigController.php
@@ -7,12 +7,14 @@ namespace App\Identity\Presentation\Controller;
 use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Identity\Domain\Entity\User;
 use App\Shared\Domain\Tenant;
+use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Throwable;
 
 /**
  * RBAC-P5-015 (#705) — Settings → Tenant config endpoints.
@@ -88,7 +90,7 @@ final readonly class TenantConfigController
             }
             try {
                 $tenant->changePrimaryLocale($primary);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 return $this->problem(
                     Response::HTTP_CONFLICT,
                     'Locale not enabled',
@@ -124,7 +126,7 @@ final readonly class TenantConfigController
             'domain' => $tenant->getDomain(),
             'enabled_locales' => $tenant->getEnabledLocales(),
             'primary_locale' => $tenant->getPrimaryLocale(),
-            'created_at' => $tenant->getCreatedAt()->format(\DateTimeInterface::ATOM),
+            'created_at' => $tenant->getCreatedAt()->format(DateTimeInterface::ATOM),
         ];
     }
 


### PR DESCRIPTION
## Summary

Owner-only `/settings/tenant` page that surfaces tenant identity and lets the operator rename the workspace + flip the primary locale.

**Backend**
- `GET /api/tenant` — projection: id, code, name, plan, domain, enabled_locales, primary_locale, created_at. Code + plan are read-only.
- `PATCH /api/tenant` — accepts `name` and/or `primary_locale`. 409 if primary not in enabled_locales, 400 on bad payload. Permission gate: `user.admin` (Phase 6 retrofit → `settings.tenant.manage`).

**Frontend**
- `<TenantSettingsPage>` wrapped in `PermissionGate(user.admin)` — non-owners see the shared ForbiddenFallback from #706.
- Form sections: Identity (code + plan read-only, name editable), Locales (primary-locale select bound to enabled_locales).
- Sidebar nav entry between Security and Billing.

## Scope deviations from PRD spec (documented in code + here)

- **Channels CRUD** stays on `/settings/channels` (already shipped).
- **Locale enable/disable** deferred — needs role-scope reseed when a tenant drops a locale, lands with role editor extension (#698).
- **Tenant deletion** deferred — cascade needs its own hard-confirm UX; `cortex:tenant:delete` CLI is the operator fallback until then.

## Test plan

- [x] PHPStan max + tsc-noEmit green
- [x] Live smoke against `pim.localhost`:
      - `GET /api/tenant` → 200, projection complete
      - `PATCH /api/tenant {"name":"Demo Tenant (Smoke)"}` → 200, name updated
      - `PATCH {"primary_locale":"de"}` → 409 (de not in enabled_locales)

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)