### PR TITLE
feat(identity): #701 revoke API token confirm modal

### DIFF
--- a/apps/admin/src/features/settings/api-tokens/RevokeTokenModal.tsx
+++ b/apps/admin/src/features/settings/api-tokens/RevokeTokenModal.tsx
@@ -1,0 +1,125 @@
+import { ShieldOff } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+
+import type { ApiTokenListItem } from './types';
+
+interface RevokeTokenModalProps {
+  token: ApiTokenListItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+/**
+ * RBAC-P5-011 (#701) — confirm modal for `DELETE /api/api-tokens/{id}`.
+ *
+ * Following the CLAUDE.md "hard confirm pattern" for destructive
+ * actions (and PRD §5.3 spec line *„Type token name to confirm"*),
+ * the operator must type the token's name verbatim before the
+ * Revoke button enables. This matches the bulk-delete flow used
+ * elsewhere in the admin and keeps an accidental click from
+ * invalidating an integration in production.
+ *
+ * The endpoint is idempotent — re-revoking returns 200 without
+ * mutating state, so the FE does not need to special-case the
+ * race-condition where two operators click Revoke at the same
+ * instant.
+ */
+export function RevokeTokenModal({ token, open, onOpenChange, onSuccess }: RevokeTokenModalProps) {
+  const { t } = useTranslation();
+  const [confirmation, setConfirmation] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = () => {
+    setConfirmation('');
+    setSubmitting(false);
+  };
+
+  const close = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const canSubmit = token !== null && confirmation === token.name && !submitting;
+
+  const handleRevoke = async () => {
+    if (!token || !canSubmit) return;
+    setSubmitting(true);
+    try {
+      await jsonFetch(`/api/api-tokens/${token.id}`, {
+        method: 'DELETE',
+        accept: 'application/json',
+      });
+      toast.success(t('settings.api_tokens.revoke.toast_success', { name: token.name }));
+      onSuccess();
+      close(false);
+    } catch (error: unknown) {
+      const status = (error as { status?: number })?.status;
+      if (status === 403) {
+        toast.error(t('settings.api_tokens.revoke.error_forbidden'));
+      } else if (status === 404) {
+        toast.error(t('settings.api_tokens.revoke.error_not_found'));
+      } else {
+        toast.error(t('settings.api_tokens.revoke.error_generic'));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="mb-2 inline-grid size-10 place-items-center rounded-full bg-rose-100 text-rose-700">
+            <ShieldOff className="size-5" aria-hidden="true" />
+          </div>
+          <DialogTitle>{t('settings.api_tokens.revoke.title')}</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {t('settings.api_tokens.revoke.body', { name: token?.name ?? '' })}
+        </p>
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+          {t('settings.api_tokens.revoke.warning')}
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="revoke-confirmation">
+            {t('settings.api_tokens.revoke.confirm_label', { name: token?.name ?? '' })}
+          </Label>
+          <Input
+            id="revoke-confirmation"
+            value={confirmation}
+            onChange={(e) => setConfirmation(e.target.value)}
+            placeholder={token?.name ?? ''}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => close(false)} disabled={submitting}>
+            {t('settings.api_tokens.revoke.cancel')}
+          </Button>
+          <Button onClick={handleRevoke} disabled={!canSubmit} variant="destructive">
+            {submitting
+              ? t('settings.api_tokens.revoke.submitting')
+              : t('settings.api_tokens.revoke.confirm')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/features/settings/api-tokens/index.tsx
+++ b/apps/admin/src/features/settings/api-tokens/index.tsx
@@ -1,9 +1,15 @@
 import { useList } from '@refinedev/core';
-import { KeyRound, Plus, ShieldOff } from 'lucide-react';
+import { KeyRound, MoreHorizontal, Plus } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import {
   Table,
   TableBody,
@@ -14,6 +20,7 @@ import {
 } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 
+import { RevokeTokenModal } from './RevokeTokenModal';
 import type { ApiTokenListItem } from './types';
 
 type Scope = 'own' | 'tenant';
@@ -46,6 +53,14 @@ export function ApiTokensSettingsPage() {
   const tokens: ApiTokenListItem[] = result?.data ?? [];
   const isLoading = query.isLoading;
   const isError = query.isError;
+  const refetch = query.refetch;
+
+  const [revokeTarget, setRevokeTarget] = useState<ApiTokenListItem | null>(null);
+  const [revokeOpen, setRevokeOpen] = useState(false);
+  const openRevoke = (token: ApiTokenListItem) => {
+    setRevokeTarget(token);
+    setRevokeOpen(true);
+  };
 
   return (
     <div className="space-y-4">
@@ -118,11 +133,26 @@ export function ApiTokensSettingsPage() {
               </TableRow>
             )}
             {tokens.map((token) => (
-              <TokenRow key={token.id} token={token} scope={scope} locale={i18n.language} />
+              <TokenRow
+                key={token.id}
+                token={token}
+                scope={scope}
+                locale={i18n.language}
+                onRevoke={openRevoke}
+              />
             ))}
           </TableBody>
         </Table>
       </div>
+
+      <RevokeTokenModal
+        token={revokeTarget}
+        open={revokeOpen}
+        onOpenChange={setRevokeOpen}
+        onSuccess={() => {
+          void refetch();
+        }}
+      />
     </div>
   );
 }
@@ -154,10 +184,12 @@ function TokenRow({
   token,
   scope,
   locale,
+  onRevoke,
 }: {
   token: ApiTokenListItem;
   scope: Scope;
   locale: string;
+  onRevoke: (token: ApiTokenListItem) => void;
 }) {
   const { t } = useTranslation();
   const lastUsed = token.last_used_at
@@ -212,16 +244,26 @@ function TokenRow({
       <TableCell className="text-xs text-muted-foreground">{lastUsed}</TableCell>
       <TableCell className="text-xs text-muted-foreground">{expires}</TableCell>
       <TableCell className="pr-5 text-right">
-        <Button
-          variant="ghost"
-          size="icon"
-          disabled
-          aria-disabled="true"
-          aria-label={t('settings.api_tokens.row_actions')}
-          title={t('settings.api_tokens.actions_pending_hint')}
-        >
-          <ShieldOff className="size-4" />
-        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={t('settings.api_tokens.row_actions')}
+              disabled={token.status !== 'active'}
+            >
+              <MoreHorizontal className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              onSelect={() => onRevoke(token)}
+              className="text-rose-600 focus:text-rose-700"
+            >
+              {t('settings.api_tokens.action_revoke')}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </TableCell>
     </TableRow>
   );

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -129,7 +129,21 @@
       "last_used_never": "never",
       "expires_never": "no expiry",
       "row_actions": "Row actions",
-      "actions_pending_hint": "Revoke + details land in #701.",
+      "action_revoke": "Revoke token",
+      "actions_pending_hint": "Token detail lands in a follow-up.",
+      "revoke": {
+        "title": "Revoke API token",
+        "body": "Once revoked, any integration using „{{name}}” starts getting 401s immediately. This action is irreversible.",
+        "warning": "⚠ Verify this won't break a production integration — the token may be used by CI, a scheduler or a B2B partner.",
+        "confirm_label": "Type „{{name}}” to confirm",
+        "cancel": "Cancel",
+        "confirm": "Revoke token",
+        "submitting": "Revoking...",
+        "toast_success": "Token „{{name}}” has been revoked.",
+        "error_forbidden": "You do not have permission to revoke this token.",
+        "error_not_found": "Token not found or belongs to another tenant.",
+        "error_generic": "Could not revoke the token."
+      },
       "empty": "No tokens yet. Click „Create token” once it lands (#700).",
       "error_loading": "Could not load API tokens.",
       "status": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -131,7 +131,21 @@
       "last_used_never": "nigdy",
       "expires_never": "bez daty wygaśnięcia",
       "row_actions": "Akcje wiersza",
-      "actions_pending_hint": "Revoke + szczegóły dochodzą w #701.",
+      "action_revoke": "Odwołaj token",
+      "actions_pending_hint": "Szczegóły tokenu dochodzą w follow-up.",
+      "revoke": {
+        "title": "Odwołaj token API",
+        "body": "Po odwołaniu, integracje używające „{{name}}” natychmiast zaczną otrzymywać 401. Operacja jest nieodwracalna.",
+        "warning": "⚠ Sprawdź, czy nie zepsujesz produkcyjnej integracji — token może być w użyciu przez CI, scheduler lub partnera B2B.",
+        "confirm_label": "Wpisz „{{name}}” aby potwierdzić",
+        "cancel": "Anuluj",
+        "confirm": "Odwołaj token",
+        "submitting": "Odwołuję...",
+        "toast_success": "Token „{{name}}” został odwołany.",
+        "error_forbidden": "Brak uprawnień do odwołania tego tokenu.",
+        "error_not_found": "Token nie istnieje lub należy do innego tenanta.",
+        "error_generic": "Nie udało się odwołać tokenu."
+      },
       "empty": "Brak tokenów. Utwórz pierwszy klikając „Utwórz token” (wkrótce).",
       "error_loading": "Nie udało się załadować listy tokenów.",
       "status": {

--- a/apps/api/src/Identity/Presentation/Controller/RevokeApiTokenController.php
+++ b/apps/api/src/Identity/Presentation/Controller/RevokeApiTokenController.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\ApiTokenRepositoryInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P5-011 (#701) — `DELETE /api/api-tokens/{id}` revokes a token.
+ *
+ * Revocation is non-destructive (sets `revoked_at` timestamp); the row
+ * stays in the table so audit logs keep their FK references and the
+ * Settings → API tokens list can still display revoked entries with
+ * their last-used metadata. The `RbacApiTokenAuthenticator` rejects
+ * any incoming `Authorization: Token ...` whose hash maps to a row
+ * with `revoked_at IS NOT NULL`.
+ *
+ * Two scopes share one endpoint:
+ *   - the token's owner can always revoke their own token
+ *     (`api_tokens.own.crud` per PRD §3.2),
+ *   - holders of `api_tokens.all.view_revoke` can revoke any token
+ *     in their tenant.
+ *
+ * Cross-tenant safety: TenantFilter scopes the lookup; defence-in-
+ * depth equality check on caller + subject tenant ids forbids
+ * surfacing a token from another tenant even if the filter misfires.
+ *
+ * Already-revoked tokens are idempotent — re-revoking returns 200
+ * with the same response (Frontend caches the list and might POST
+ * twice if the operator double-clicks).
+ */
+final readonly class RevokeApiTokenController
+{
+    public function __construct(
+        private Security $security,
+        private ApiTokenRepositoryInterface $tokens,
+        private PermissionResolverInterface $resolver,
+    ) {
+    }
+
+    #[Route(path: '/api/api-tokens/{id}', methods: ['DELETE'], name: 'api_api_tokens_revoke', requirements: ['id' => '[0-9a-f-]{36}'])]
+    #[RequiresPermission(module: 'user', action: 'read')]
+    public function __invoke(string $id): JsonResponse
+    {
+        $caller = $this->security->getUser();
+        if (!$caller instanceof User) {
+            return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
+        }
+
+        try {
+            $uuid = Uuid::fromString($id);
+        } catch (\InvalidArgumentException) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Token not found.');
+        }
+
+        $token = $this->tokens->findById($uuid);
+        if (null === $token) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Token not found.');
+        }
+
+        if (!$caller->getTenant()->getId()->equals($token->getTenantId())) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Token not found.');
+        }
+
+        $owns = $caller->getId()->equals($token->getUserId());
+        $mayManageAll = $this->resolver->resolve($caller)->has('api_tokens.all.view_revoke');
+        if (!$owns && !$mayManageAll) {
+            return $this->problem(
+                Response::HTTP_FORBIDDEN,
+                'Forbidden',
+                'You can revoke only your own API tokens unless you hold the api_tokens.all.view_revoke permission.',
+            );
+        }
+
+        if (!$token->isRevoked()) {
+            $token->revoke();
+            $this->tokens->save($token);
+        }
+
+        return new JsonResponse([
+            'id' => $token->getId()->toRfc4122(),
+            'status' => 'revoked',
+            'revoked_at' => $token->getRevokedAt()?->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    private function problem(int $status, string $title, string $detail): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'type' => 'about:blank',
+                'title' => $title,
+                'status' => $status,
+                'detail' => $detail,
+            ],
+            $status,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
+    }
+}

--- a/apps/api/src/Identity/Presentation/Controller/RevokeApiTokenController.php
+++ b/apps/api/src/Identity/Presentation/Controller/RevokeApiTokenController.php
@@ -8,6 +8,8 @@ use App\Identity\Application\PermissionResolverInterface;
 use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Repository\ApiTokenRepositoryInterface;
+use DateTimeInterface;
+use InvalidArgumentException;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -58,7 +60,7 @@ final readonly class RevokeApiTokenController
 
         try {
             $uuid = Uuid::fromString($id);
-        } catch (\InvalidArgumentException) {
+        } catch (InvalidArgumentException) {
             return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Token not found.');
         }
 
@@ -89,7 +91,7 @@ final readonly class RevokeApiTokenController
         return new JsonResponse([
             'id' => $token->getId()->toRfc4122(),
             'status' => 'revoked',
-            'revoked_at' => $token->getRevokedAt()?->format(\DateTimeInterface::ATOM),
+            'revoked_at' => $token->getRevokedAt()?->format(DateTimeInterface::ATOM),
         ]);
     }
 


### PR DESCRIPTION
## Summary

**Backend** — `DELETE /api/api-tokens/{id}` (`RevokeApiTokenController`):
- `ApiToken::revoke()` sets `revoked_at`; row stays for audit FK + the Settings list display.
- Owner can always revoke their own token. `api_tokens.all.view_revoke` (PRD §3.2 Owner/Admin) can revoke any token in their tenant.
- Tenant boundary equality check on top of TenantFilter — defence in depth.
- Idempotent — re-revoking returns 200 without mutating state.
- Permission gate: `user.read` (legacy RbacMatrix); Phase 6 retrofit migrates to `api_tokens.own.crud` / `api_tokens.all.view_revoke`.

**Frontend** — `RevokeTokenModal`:
- CLAUDE.md hard-confirm pattern — operator must type the token's exact name before the Revoke button enables. Matches PRD §5.3 *„Type token name to confirm"*.
- Warning copy: irreversible, may break CI / scheduler / B2B partner integrations.
- 403 / 404 / generic toasts.
- 3-dot menu in `<ApiTokensSettingsPage>` (#699) now wires a real DropdownMenu with the destructive Revoke item. Already-revoked rows disable the trigger.

## Test plan

- [x] PHPStan max + tsc-noEmit green
- [x] Live smoke: `DELETE /api/api-tokens/{id}` on the demo token → 200, `status:"revoked"`, `revoked_at` set
- [x] Idempotency: second DELETE on the same token returns 200 without mutating `revoked_at`

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)