### PR TITLE
feat(identity): #697 attribute-permission overrides — backend + role-editor tab

### DIFF
--- a/Project Plan/PRD/PRD-PIM-final-audit.md
+++ b/Project Plan/PRD/PRD-PIM-final-audit.md
@@ -1,0 +1,322 @@
+# PRD — Cortex PIM: Final Audit (Security + Wydajność + Jakość kodu)
+
+**Typ dokumentu:** Product Requirements Document — Final audit przed go-live
+**Status:** 🔵 **Placeholder** — nie wykonujemy teraz, aktywujemy w określonym momencie cyklu (patrz §7 Trigger conditions)
+**Data utworzenia:** 2026-05-16
+**Wersja:** 1.0 (placeholder)
+**Adresat:** Marcin (solo dev) — operator decyzji *„kiedy aktywujemy"*
+**Powiązane dokumenty:**
+- [`07-rbac-implementation-plan.md`](../07-rbac-implementation-plan.md) — istniejący plan tooling/testing dla RBAC (overlap §6)
+- [`PRD/PRD-PIM-rbac.md`](PRD-PIM-rbac.md) — RBAC master spec
+- [`PRD/PRD-PIM-list-advanced.md`](PRD-PIM-list-advanced.md), [`PRD/PRD-PIM-exports.md`](PRD-PIM-exports.md) — feature PRDs z own risk registers
+
+> **Nota o scope.** To **placeholder PRD** — dokument który eksponuje świadomie odłożoną pracę żeby nie zniknęła z radaru. Nie generuje ticketów ani działań. Aktywacja = świadoma decyzja Marcina (Trigger conditions §7).
+
+---
+
+## 1. Cel dokumentu
+
+Final audit jest **meta-warstwą** ponad istniejącym tools stack (`07-rbac-implementation-plan.md` §3). Eksponuje 3 elementy które nasz obecny plan **nie ma explicit**:
+
+1. **Release Readiness Checklist** — jeden artefakt z must-pass gates per release
+2. **SLO/SLA dokument** — twarde progi wydajności (p95/p99 latency, throughput, error budgets, memory limits)
+3. **Risk Register master** — rolled-up rejestr ryzyk cross-PRD z status per risk
+
+Plus **performance tooling** którego brakuje w obecnym RBAC plan (~7 narzędzi).
+
+Razem: **świadomy ship-readiness layer** — przejście z *„tools stack done"* na *„release decision can be made"*.
+
+## 2. Trzy warstwy audytu (industry standard)
+
+Audit dzielimy na 3 warstwy zgodnie z best practices dla SaaS B2B przed go-live:
+
+### 2.1 Jakość kodu
+
+**Cel:** kod ma poziom *„maintained by team for 5 lat"*, nie *„LLM-generated tech debt"*.
+
+**Co już mamy** (z `07-rbac-implementation-plan.md` §3.2):
+- PHPStan max + 3 custom rules (RequiresPermissionAnnotationRule, FlushWithoutClearRule, HardcodedRoleCheckRule)
+- Biome strict (TypeScript frontend)
+- Semgrep + custom OWASP rules
+- Infection PHP mutation testing (MSI 80%+ Identity)
+- PHPUnit + ApiTestCase + Playwright
+
+**Czego brakuje:**
+- **Deptrac** — DDD bounded contexts enforcement (Catalog / Channel / Asset / Integration / Identity / Agent / ApiConfigurator). Bez tego po 6 miesiącach kod ma cross-context imports → architectural debt. *„Severity: HIGH"* (bo robimy DDD).
+- **QueryCountAssertions w testach** — Doctrine N+1 detection automatic, bez tego N+1 wykryjemy tylko przez Blackfire lub manual review. *„Severity: MEDIUM"*.
+- **Rector** — automated refactoring + Symfony major bumps (Symfony 7.4 → 8.0 ETA ~2027). *„Severity: MEDIUM"* (long-term maintainability).
+- **Knip** — frontend dead code detection (TypeScript unused exports). *„Severity: MEDIUM"* (drobne, ale kumuluje się).
+
+**Świadomie odrzucone:** Psalm strict (per `Project Plan/06-sprint-0-findings.md`), PHP-CS-Fixer/ECS (PHPStan + Biome pokrywają 95%).
+
+### 2.2 Bezpieczeństwo
+
+**Cel:** zero CRITICAL/HIGH findings przed onboardingiem pierwszego płacącego klienta. Pełen audit trail. Compliance-ready (RODO, future ISO 27001 / SOC 2).
+
+**Co już mamy** (z `07-rbac-implementation-plan.md` §3.1, §3.3, §3.5, RBAC-P7):
+- Dependency scanning: Roave Security Advisories, Symfony Security Checker, Dependabot, OWASP Dependency-Check, npm audit, Snyk free tier
+- Secret scanning: TruffleHog + GitLeaks (pre-commit + CI)
+- Multi-tenancy isolation: Doctrine TenantFilter + Postgres RLS + dedicated cross-tenant test suite (Layer 3 z `07-plan` §2.2)
+- Cross-tenant fuzz testing (property-based 100 users × 10 tenants)
+- DAST: OWASP ZAP nightly w CI
+- Manual red-team Marcina (RBAC-P7-001, 15-point checklist)
+- External pentest preparation + execution (RBAC-P7-002, P7-003)
+- Encryption: Postgres at-rest, MinIO at-rest, TLS 1.3 in-transit, AES-256-GCM dla secretów (MFA, integration tokens)
+- API token scopes + auto-rotation reminders
+
+**Czego brakuje:**
+- **BYOK Anthropic credit encryption review** — wzmiankowane w PRD ale brak dedykowanego ticketu z verification (kto ma dostęp do kluczy klientów, jak rotation działa). *„Severity: HIGH"* (gdy mamy klientów Pro/Enterprise z BYOK).
+- **Compliance gap analysis** — RODO checklist (Right to be Forgotten, Data Portability), future ISO 27001 / SOC 2 gap assessment. *„Severity: MEDIUM"* (post-launch, ale przed enterprise sales).
+
+### 2.3 Wydajność
+
+**Cel:** SLA achievable dla pierwszych design partners. Performance benchmarki na **realistic dataset** (100k-500k SKU per industry standard PIM mid-market).
+
+**Co już mamy** (z `07-rbac-implementation-plan.md` §3.4):
+- Prometheus alert `frankenphp_worker_memory_bytes > 256MB`
+- Grafana RBAC-specific dashboards (RBAC-P6-009)
+- Performance targets w ticketach (np. RBAC-P5-007 export <30s dla 50k SKU)
+- Per-permission cache w Redis (PermissionResolver TTL 5min + event invalidation)
+- Memory safety patterns (FrankenPHP worker mode — `EntityManager::clear()` po batch flush)
+
+**Czego brakuje (NAJWIĘKSZA LUKA):**
+- **Blackfire lub Tideways** — production profiler dla PHP. Bez tego performance debugging w produkcji = guess work. Prometheus mówi *„memory wzrosło"* — Blackfire mówi *„w funkcji X, wiersz Y, na zapytaniu Z"*. *„Severity: HIGH"* — wymóg dla FrankenPHP worker mode + long-running operations.
+- **k6 lub Gatling load testing** — zero ticketów dla load testów. Bez tego nie wiemy czy SaaS wytrzyma 100 concurrent users × 5 tenantów. *„Severity: HIGH"* — przed soft launch MUSI być.
+- **Realistic dataset fixtures (100k-500k SKU)** — wzmiankowane w PRD ale brak setup. Bez tego benchmarki są symboliczne (50k MVP target jest skromny vs industry 100k-500k). *„Severity: HIGH"* — prereq dla pentest + load testing + performance benchmarks.
+- **EXPLAIN ANALYZE strategy + Postgres `auto_explain`** — implicit pokryte przez Blackfire, ale dedicated strategy wartościowa. *„Severity: LOW"* (covered indirectly).
+
+## 3. Trzy artefakty meta-procesowe
+
+Oprócz tooling gaps, audit potrzebuje **3 dokumentów decyzyjnych** które obecny plan nie ma explicit:
+
+### 3.1 Release Readiness Checklist
+
+**Lokalizacja:** `docs/release/release-readiness-checklist.md` (do utworzenia)
+
+**Cel:** jeden master checklist must-pass dla każdego release/phase milestone. Konkretne progi + kto akceptuje + artefakty.
+
+**Treść (template):**
+
+```markdown
+## Release Readiness Checklist — Cortex PIM v{X.Y}
+
+### Quality gates (must-pass — blocker if red)
+- [ ] PHPStan max ✓ (0 violations w wszystkich bundles)
+- [ ] Biome strict ✓ (0 errors frontend)
+- [ ] Test coverage ≥ 95% Identity bundle, ≥ 80% global
+- [ ] Mutation Score Indicator (MSI) ≥ 80% Identity, ≥ 70% global
+- [ ] Cross-tenant isolation suite — 100% pass (0 skips allowed)
+- [ ] Field-level scrubbing suite — 100% pass
+- [ ] Playwright E2E RBAC scenarios — 100% pass
+- [ ] Deptrac DDD enforcement — 0 cross-context violations
+
+### Security gates (must-pass)
+- [ ] Zero CRITICAL/HIGH vuln w `composer audit` + `npm audit`
+- [ ] Zero CRITICAL OWASP ZAP findings w nightly scan
+- [ ] Manual red-team Marcina (15-point) — 100% pass lub fix
+- [ ] External pentest (jeśli budżet) — 0 CRITICAL open
+- [ ] Secret scan (TruffleHog + GitLeaks) — 0 leaked secrets w repo
+- [ ] Custom PHPStan rules — 0 violations w całym repo
+
+### Performance gates (must-pass — wymagają SLO doc §3.2)
+- [ ] p95 API latency < SLO threshold na realistic dataset
+- [ ] FrankenPHP worker memory < 256MB sustained
+- [ ] Bulk operations spełniają SLO thresholds
+- [ ] Zero N+1 queries w hot paths (Blackfire profile pass)
+- [ ] k6 load test — meeting throughput SLO bez 5xx errors
+
+### Process gates
+- [ ] `agent/lessons.md` updated z lessons z tej fazy
+- [ ] `agent/current_status.md` reflects current state
+- [ ] Risk register (§3.3) reviewed — żadne unaddressed CRITICAL
+- [ ] Change log updated
+- [ ] User-facing docs updated (Privacy Policy, Terms, Security Overview)
+
+### Sign-off (solo dev = self-checkpoint)
+- [ ] Marcin self-review — checklist 100% green lub explicit waiver z uzasadnieniem
+- [ ] Soft launch design partner #1 (po Phase 7 RBAC) — zero CRITICAL incidents w 4-week window
+```
+
+**Estymacja stworzenia:** ~3-4h. Bardzo wysokie ROI.
+
+### 3.2 SLO/SLA dokument
+
+**Lokalizacja:** `docs/operations/slo-sla.md` (do utworzenia)
+
+**Cel:** twarde performance thresholds + availability targets per pricing tier. Wymagane przed pierwszą rozmową sales z design partner.
+
+**Treść (template):**
+
+```markdown
+## Cortex PIM — SLO/SLA Document
+
+### Availability SLO per tier
+- Free / Trial: 99% uptime
+- Starter: 99.5%
+- Pro: 99.9%
+- Enterprise: 99.95% + dedicated read replicas
+
+### API Performance SLO (p95/p99 latency)
+| Endpoint | Dataset | p95 | p99 |
+|---|---|---|---|
+| GET /api/products (paginated list) | 50k SKU | <300ms | <500ms |
+| GET /api/products (paginated list) | 200k SKU | <400ms | <700ms |
+| GET /api/products/{id} | N/A | <100ms | <200ms |
+| PATCH /api/products/{id} | bulk session impact | <500ms | <1s |
+| POST bulk-actions/edit-attribute (1000 produktów sync) | N/A | <30s | <60s |
+| Cmd+K agent tool call | 50 calls/h limit | <3s | <5s |
+
+### Throughput SLO
+- Concurrent users per tenant: 50 sustained, 100 burst (1min)
+- Bulk operations queue: max 3 concurrent per tenant (Pro), unlimited (Enterprise)
+- Imports throughput: 5000 SKU/min dla XLSX
+
+### Memory limits
+- FrankenPHP worker: <256MB sustained, <512MB peak
+- Redis cache: <1GB per tenant
+- MinIO bucket: 50GB included (Pro), unlimited (Enterprise)
+
+### Error rate budgets
+- 5xx errors: <0.1% requests/dzień
+- 401/403 (security denial): tracked w Grafana, alert > 10/min from single IP
+
+### Performance test thresholds (release-blocking)
+- p95 latency w SLO + 10% tolerance
+- Throughput SLO must be met under load
+- Zero N+1 w hot paths (Blackfire profile)
+- Zero memory leaks (worker stable po 1h sustained load)
+```
+
+**Estymacja stworzenia + walidacja benchmarkami:** ~6-10h.
+
+### 3.3 Risk Register master (cross-PRD)
+
+**Lokalizacja:** `docs/risk-register.md` (do utworzenia)
+
+**Cel:** rolled-up rejestr ryzyk z wszystkich PRD (RBAC §14, list-advanced §14, exports §14) z status per risk + monthly review.
+
+**Status legend:**
+- 🔴 **Open** — unaddressed, blocking release
+- 🟡 **Mitigated** — fix in plan, tracked w ticket
+- 🟢 **Accepted** — świadomie zaakceptowane (out of scope), reviewed quarterly
+- ⚫ **Closed** — resolved, regression test in place
+
+**Treść (template):**
+
+```markdown
+## Risk Register — Cortex PIM (Master)
+
+| ID | Risk | Source PRD | Severity | Status | Mitigation | Owner | Review date |
+|---|---|---|---|---|---|---|---|
+| R-30 | List feature scope creep | list-advanced §14 | High | 🟡 | RBAC Phase 5-6 + cuts | Marcin | 2026-Q3 |
+| R-40 | Multi-value serialization convention | exports §14 | Medium | 🟡 | Sprint 1 POC | Marcin | Phase 2 RBAC |
+| R-42 | Performance 50k SKU benchmark | exports §14 | Medium | 🟡 | Blackfire profile Phase 6 | Marcin | Phase 6 RBAC |
+| R-45 | Self-audit only w MVP | exports §14 | Medium | 🟡 | Cross-user audit deferred | Marcin | Post-launch |
+| R-50 | RBAC scope creep +24-33h po 3-state | rbac §14 + v2.1 | Medium | 🟢 | Świadoma akceptacja | Marcin | Quarterly |
+| ... | ... | ... | ... | ... | ... | ... | ... |
+```
+
+**Estymacja stworzenia (consolidacja):** ~2-3h + monthly maintenance ~30min.
+
+## 4. Estymacja epiku Final Audit
+
+Łączny scope (gdy aktywujemy):
+
+| Element | Estymacja |
+|---|---|
+| **Tooling backend** | |
+| Deptrac setup (DDD enforcement) | 6-10h |
+| Blackfire profiler integration | 4-6h |
+| QueryCountAssertions helper + tests | 3-5h |
+| Rector setup | 2-4h |
+| **Tooling frontend** | |
+| Knip dead code detection | 2-3h |
+| **Performance testing** | |
+| k6 load testing setup + scenarios | 10-15h |
+| Realistic dataset fixtures (100k+ SKU) | 4-6h |
+| **Process artefakty** | |
+| Release Readiness Checklist (§3.1) | 3-4h |
+| SLO/SLA dokument + walidacja (§3.2) | 6-10h |
+| Risk Register master (§3.3) | 2-3h |
+| **Security deep-dive** | |
+| BYOK Anthropic credit encryption review | 4-6h |
+| Compliance gap analysis (RODO + ISO 27001 prep) | 4-8h |
+| **TOTAL** | **~50-80h** |
+
+~10-12 ticketów, **1.5-2 tygodnie solo dev**.
+
+## 5. Sequencing opcje
+
+**(A) Parallel z RBAC Phase 5-6** — uruchomienie ~tydzień 12-13 (po Phase 4 RBAC complete), żeby być ready na soft launch (RBAC-P7-006, tydzień 18-19). **Optymalne pod release timing.**
+
+**(B) Po RBAC Phase 7 zakończonej** — start tydzień 19-20, rozszerzenie pełnego harmonogramu MVP do 21-23 tygodni. **Czystszy scope separation, ale opóźnia soft launch.**
+
+**(C) Demand-driven** — start gdy pierwszy design partner zapyta o SLA / pentest report. Reaktywne. **Najtaniej teraz, najdroższy fix later.**
+
+**Rekomendacja (gdy aktywujemy):** **(A) Parallel** — performance benchmarki są **prereq dla soft launch credibility** z design partners. Wbicie ich w równoległy tor zachowuje go-live timing.
+
+## 6. Cross-cutting z istniejącymi planami
+
+Audit **NIE duplikuje** istniejących planów — dopełnia je:
+
+| Element audytu | Status w RBAC plan | Status w final audit |
+|---|---|---|
+| Tooling tests/lint/security | ✅ Full coverage | (zostaje w RBAC plan) |
+| Pentest manual red-team | ✅ RBAC-P7-001 | (zostaje w RBAC plan) |
+| External pentest | ✅ RBAC-P7-002, P7-003 | (zostaje w RBAC plan) |
+| Cross-tenant isolation suite | ✅ Layer 3 | (zostaje w RBAC plan) |
+| Deptrac, Blackfire, k6 | ❌ Brak | **➕ Tu dodajemy** |
+| Realistic dataset 100k+ SKU | 🟡 Częściowo (50k MVP target) | **➕ Tu rozszerzamy** |
+| Release Readiness Checklist | ❌ Brak (per-PR DoD only) | **➕ Tu dodajemy** |
+| SLO/SLA | 🟡 SLA tabela w `docs/legal/security-overview.md` (RBAC-P7-005) | **➕ Tu rozszerzamy z performance SLO** |
+| Risk register | 🟡 Per-PRD §14 (RBAC, list, exports) | **➕ Tu konsolidujemy** |
+
+**Konsekwencja:** epik *„Final Audit"* nie wymaga refactor RBAC plan. Add-on tylko.
+
+## 7. Trigger conditions (kiedy aktywujemy)
+
+Plik jest **placeholder** dopóki:
+
+- ❌ NIE — gdy RBAC Phase 1-4 trwa (priorytetowo cross-tenant isolation + auth + permission engine)
+- ✅ TAK — gdy RBAC Phase 5 (Settings UI) startuje **i** harmonogram pokazuje że soft launch jest <8 tygodni od teraz
+- ✅ TAK — gdy pierwszy design partner sign-off pre-trial wymaga SLA dokumentu
+- ✅ TAK — gdy Marcin świadomie decyduje *„kończę MVP, idę na hardening sprint"*
+- ✅ TAK — gdy first paying customer onboard się — wtedy compliance + audit register staje się legal requirement
+- ✅ TAK — gdy pierwsze CRITICAL bug w produkcji (post-launch reactive) — wskazuje brakujący profilera/load test
+
+**Default**: aktywujemy **równolegle z RBAC Phase 5** (tydzień 11-13) per recommendation (A) z §5.
+
+## 8. Open questions (do walidacji gdy aktywujemy)
+
+1. **Blackfire vs Tideways** — wybór profilera. Blackfire free tier 100 profiles/miesiąc wystarczy dla solo dev MVP. Tideways tańszy w paid tier długoterminowo. Decision Sprint 1 audytu.
+2. **k6 vs Gatling** — k6 nowszy, JavaScript-based, lepsza UX. Gatling battle-tested, Scala-based. **Default k6** (lower learning curve).
+3. **External pentest budget** — synced z RBAC-P7-002. Jeśli budżet 5-10k PLN przyznany dla RBAC pentest, można rozszerzyć scope o performance + compliance audit za dodatkowe 3-5k PLN.
+4. **Dataset source 100k+ SKU** — synthetic generation vs real-world (kosztem licencji)? Default: synthetic z realistic distribution (Faker + custom rules dla brand/category mix).
+5. **Compliance scope** — RODO checklist obowiązkowo, ISO 27001 + SOC 2 jako post-MVP candidates. Decision: kiedy zaczynamy ISO 27001 prep (typowo 12-18 miesięcy proces)?
+
+## 9. Co dalej
+
+Plik jest **placeholder** — nic nie wykonujemy teraz.
+
+**Co Marcin robi z tym dokumentem:**
+
+1. **Trzyma w `Project Plan/PRD/`** jako reference dla *„odłożona praca, nie zapomniana"*.
+2. **Reviewuje monthly** czy któryś z trigger conditions §7 się aktywował.
+3. **Aktywuje** świadomą decyzją gdy timing pasuje:
+   - Generuje `15-quality-perf-tickets.md` z ~10-12 ticketów per §4 estymacja
+   - Update `02-plan-projektu-pim.md` z dodaniem epiku *„Final Audit"*
+   - Update `07-rbac-implementation-plan.md` z reference do `15-quality-perf-tickets.md`
+   - Status placeholder → `Draft` → `In Progress` → `Done`
+
+**Co NIE robimy teraz:**
+- Tickets w `15-quality-perf-tickets.md` (nie istnieje)
+- Tooling install (Deptrac, Blackfire, k6)
+- Dataset generation
+- SLO/SLA dokument finalize
+- Risk register consolidacja
+
+**Świadomy out-of-scope** w sensie *„planujemy, ale nie wykonujemy"*. To **rejestrujemy** żeby nie zniknęło z radaru przed pierwszym design partnerem / pierwszym pentest-em / pierwszym performance incident.
+
+---
+
+*Plik wygenerowany 2026-05-16 jako placeholder. Status: 🔵 Placeholder — aktywuje się świadomą decyzją per Trigger conditions §7. Po aktywacji → zmiana statusu na `Draft` + generacja ticketów + update referencji w innych planach.*

--- a/apps/admin/src/features/settings/roles/AttributePermissionsTab.tsx
+++ b/apps/admin/src/features/settings/roles/AttributePermissionsTab.tsx
@@ -1,0 +1,537 @@
+import { ChevronDown, ChevronRight, Save, Search, ShieldCheck } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/components/ui/toast';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+export type AttributePermissionLevel = 'view' | 'edit' | 'restricted' | null;
+
+interface ApiAttribute {
+  id: string;
+  code: string;
+  label: Record<string, string>;
+  type: string;
+  is_localizable: boolean;
+  is_required: boolean;
+  permission_level: AttributePermissionLevel;
+}
+
+interface ApiGroup {
+  group_id: string | null;
+  group_code: string | null;
+  group_label: Record<string, string> | null;
+  attributes: ApiAttribute[];
+}
+
+interface ApiResponse {
+  role_id: string;
+  groups: ApiGroup[];
+}
+
+type FilterMode = 'all' | 'view' | 'edit' | 'restricted' | 'overridden';
+
+interface AttributePermissionsTabProps {
+  roleId: string | null;
+  /** Disable inputs while the parent form is mid-submit. */
+  disabled?: boolean;
+}
+
+/**
+ * RBAC-P5-007 (#697) — "Uprawnienia per atrybut" tab inside the role
+ * editor.
+ *
+ * The tab is independent of the matrix grid (#696) — the resolver
+ * consults it as a per-attribute override that takes precedence over
+ * the module-level grant. `permission_level: null` means "no override,
+ * fall back to the matrix"; explicit `restricted` denies even when the
+ * matrix would grant.
+ *
+ * Save model: own button (separate from the role-editor save) because
+ * loading + writing the overrides goes through a dedicated endpoint
+ * (`PUT /api/roles/{id}/attribute-permissions`) and a bulk replace
+ * inside the role-editor submit would silently widen the audit trail.
+ *
+ * Scope intentionally trimmed for this MVP:
+ *   - Per-attribute 3-state segmented control (the spec's hero UI).
+ *   - Per-group bulk-apply button (sets every visible attribute in the
+ *     group to the chosen level).
+ *   - Search box (case-insensitive substring on code + every locale
+ *     label).
+ *   - Filter chips for current state.
+ *
+ * Deferred (flagged inline):
+ *   - Cross-tab badges back into the matrix tab (#696) — needs Mercure
+ *     SSE or a shared store; tracked as follow-up.
+ *   - "Preview changes" modal for bulk apply > 5 attributes.
+ *   - Virtualized list for 200+ attributes — current implementation
+ *     paints all rows; perf measured fine at 32 attrs in the demo
+ *     tenant, revisit when a real fixture pushes past ~150.
+ */
+export function AttributePermissionsTab({
+  roleId,
+  disabled = false,
+}: AttributePermissionsTabProps) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language;
+
+  const [groups, setGroups] = useState<ApiGroup[]>([]);
+  const [original, setOriginal] = useState<Record<string, AttributePermissionLevel>>({});
+  const [draft, setDraft] = useState<Record<string, AttributePermissionLevel>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [filter, setFilter] = useState<FilterMode>('all');
+  const [search, setSearch] = useState('');
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!roleId) return;
+    let cancelled = false;
+    setLoading(true);
+    jsonFetch<ApiResponse>(`/api/roles/${roleId}/attribute-permissions`, { method: 'GET' })
+      .then((data) => {
+        if (cancelled) return;
+        setGroups(data.groups);
+        const seeded: Record<string, AttributePermissionLevel> = {};
+        for (const group of data.groups) {
+          for (const attr of group.attributes) {
+            seeded[attr.id] = attr.permission_level;
+          }
+        }
+        setOriginal(seeded);
+        setDraft(seeded);
+        // Auto-expand groups that have ANY override so the operator
+        // sees what's already configured without clicking through.
+        const expandKeys = new Set<string>();
+        for (const group of data.groups) {
+          if (group.attributes.some((a) => a.permission_level !== null)) {
+            expandKeys.add(group.group_id ?? '__ungrouped__');
+          }
+        }
+        setExpanded(expandKeys);
+      })
+      .catch(() => {
+        if (!cancelled) toast.error(t('settings.roles.attr_perms.error_load'));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [roleId, t]);
+
+  const dirty = useMemo(() => {
+    for (const id in draft) {
+      if (draft[id] !== (original[id] ?? null)) return true;
+    }
+    for (const id in original) {
+      if (!(id in draft)) return true;
+    }
+    return false;
+  }, [draft, original]);
+
+  const setLevel = (attrId: string, level: AttributePermissionLevel) => {
+    setDraft((prev) => ({ ...prev, [attrId]: level }));
+  };
+
+  const applyToGroup = (group: ApiGroup, level: AttributePermissionLevel) => {
+    setDraft((prev) => {
+      const next = { ...prev };
+      for (const attr of visibleAttributes(group, search, filter, draft)) {
+        next[attr.id] = level;
+      }
+      return next;
+    });
+  };
+
+  const handleReset = () => {
+    setDraft(original);
+  };
+
+  const handleSave = async () => {
+    if (!roleId || saving) return;
+    setSaving(true);
+    try {
+      const payload = {
+        attribute_permissions: Object.entries(draft)
+          .filter(([, level]) => level !== null)
+          .map(([attribute_id, permission_level]) => ({ attribute_id, permission_level })),
+      };
+      const result = await jsonFetch<ApiResponse>(`/api/roles/${roleId}/attribute-permissions`, {
+        method: 'PUT',
+        body: payload,
+        accept: 'application/json',
+        contentType: 'application/json',
+      });
+      setGroups(result.groups);
+      const fresh: Record<string, AttributePermissionLevel> = {};
+      for (const group of result.groups) {
+        for (const attr of group.attributes) {
+          fresh[attr.id] = attr.permission_level;
+        }
+      }
+      setOriginal(fresh);
+      setDraft(fresh);
+      toast.success(t('settings.roles.attr_perms.toast_saved'));
+    } catch (error: unknown) {
+      const status = (error as { status?: number; body?: { detail?: string } })?.status;
+      const body = (error as { body?: { detail?: string } })?.body;
+      if (status === 400) {
+        toast.error(body?.detail ?? t('settings.roles.attr_perms.error_validation'));
+      } else if (status === 403) {
+        toast.error(t('settings.roles.attr_perms.error_forbidden'));
+      } else {
+        toast.error(t('settings.roles.attr_perms.error_generic'));
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const overrideCount = useMemo(
+    () => Object.values(draft).filter((l) => l !== null).length,
+    [draft],
+  );
+
+  if (!roleId) {
+    return (
+      <div className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        {t('settings.roles.attr_perms.create_first')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[240px]">
+          <Search
+            className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            type="search"
+            placeholder={t('settings.roles.attr_perms.search_placeholder')}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <FilterChips value={filter} onChange={setFilter} />
+        <span className="ml-auto text-xs text-muted-foreground">
+          {t('settings.roles.attr_perms.override_count', { count: overrideCount })}
+        </span>
+      </div>
+
+      <div className="rounded-md border border-dashed bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+        {t('settings.roles.attr_perms.cross_tab_deferred')}
+      </div>
+
+      {loading ? (
+        <div className="h-64 animate-pulse rounded-lg border bg-muted/30" />
+      ) : (
+        <div className="space-y-2">
+          {groups.map((group) => {
+            const visible = visibleAttributes(group, search, filter, draft);
+            if (visible.length === 0) return null;
+            const groupKey = group.group_id ?? '__ungrouped__';
+            const isExpanded = expanded.has(groupKey);
+            return (
+              <GroupPanel
+                key={groupKey}
+                group={group}
+                visible={visible}
+                draft={draft}
+                onChangeLevel={setLevel}
+                onBulkApply={(level) => applyToGroup(group, level)}
+                isExpanded={isExpanded}
+                onToggle={() => {
+                  setExpanded((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(groupKey)) next.delete(groupKey);
+                    else next.add(groupKey);
+                    return next;
+                  });
+                }}
+                locale={locale}
+                disabled={disabled || saving}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleReset}
+          disabled={!dirty || disabled || saving}
+        >
+          {t('settings.roles.attr_perms.reset')}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleSave}
+          disabled={!dirty || disabled || saving}
+          className="gap-1.5"
+        >
+          <Save className="size-4" aria-hidden="true" />
+          {saving ? t('settings.roles.attr_perms.saving') : t('settings.roles.attr_perms.save')}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface GroupPanelProps {
+  group: ApiGroup;
+  visible: ApiAttribute[];
+  draft: Record<string, AttributePermissionLevel>;
+  onChangeLevel: (attrId: string, level: AttributePermissionLevel) => void;
+  onBulkApply: (level: AttributePermissionLevel) => void;
+  isExpanded: boolean;
+  onToggle: () => void;
+  locale: string;
+  disabled: boolean;
+}
+
+function GroupPanel({
+  group,
+  visible,
+  draft,
+  onChangeLevel,
+  onBulkApply,
+  isExpanded,
+  onToggle,
+  locale,
+  disabled,
+}: GroupPanelProps) {
+  const { t } = useTranslation();
+  const groupLabel =
+    group.group_label?.[locale] ??
+    group.group_label?.en ??
+    group.group_code ??
+    t('settings.roles.attr_perms.group_ungrouped');
+
+  const visibleLevels = new Set(visible.map((a) => draft[a.id] ?? '__none__'));
+  const isMixed = visibleLevels.size > 1;
+  const allLevel = visibleLevels.size === 1 ? Array.from(visibleLevels)[0] : null;
+
+  return (
+    <div className="overflow-hidden rounded-md border bg-background shadow-sm">
+      <div className="flex items-center justify-between gap-3 border-b bg-muted/40 px-3 py-2">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex items-center gap-2 text-sm font-medium hover:underline"
+          aria-expanded={isExpanded}
+        >
+          {isExpanded ? (
+            <ChevronDown className="size-4" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="size-4" aria-hidden="true" />
+          )}
+          <ShieldCheck className="size-3.5 text-accent-violet" aria-hidden="true" />
+          <span>{groupLabel}</span>
+          <span className="text-xs font-normal text-muted-foreground">
+            ({t('settings.roles.attr_perms.attribute_count', { count: visible.length })})
+          </span>
+          {isMixed ? (
+            <span className="rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700 ring-1 ring-amber-200">
+              {t('settings.roles.attr_perms.mixed')}
+            </span>
+          ) : null}
+        </button>
+        <div className="flex items-center gap-1">
+          {(['restricted', 'view', 'edit'] as const).map((level) => (
+            <button
+              key={level}
+              type="button"
+              onClick={() => onBulkApply(level)}
+              disabled={disabled}
+              className={cn(
+                'rounded-md border px-2 py-1 text-[11px] font-medium transition-colors',
+                allLevel === level
+                  ? levelStyle(level, true)
+                  : 'border-transparent text-muted-foreground hover:bg-background',
+              )}
+              title={t('settings.roles.attr_perms.bulk_hint', {
+                level: t(`settings.roles.attr_perms.level.${level}`),
+              })}
+            >
+              {t(`settings.roles.attr_perms.bulk_${level}`)}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => onBulkApply(null)}
+            disabled={disabled}
+            className={cn(
+              'rounded-md border px-2 py-1 text-[11px] font-medium transition-colors',
+              allLevel === '__none__'
+                ? 'border-input bg-muted text-foreground'
+                : 'border-transparent text-muted-foreground hover:bg-background',
+            )}
+            title={t('settings.roles.attr_perms.bulk_clear_hint')}
+          >
+            {t('settings.roles.attr_perms.bulk_clear')}
+          </button>
+        </div>
+      </div>
+      {isExpanded ? (
+        <ul className="divide-y">
+          {visible.map((attr) => (
+            <AttributeRow
+              key={attr.id}
+              attr={attr}
+              level={draft[attr.id] ?? null}
+              onChange={(level) => onChangeLevel(attr.id, level)}
+              locale={locale}
+              disabled={disabled}
+            />
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+interface AttributeRowProps {
+  attr: ApiAttribute;
+  level: AttributePermissionLevel;
+  onChange: (level: AttributePermissionLevel) => void;
+  locale: string;
+  disabled: boolean;
+}
+
+function AttributeRow({ attr, level, onChange, locale, disabled }: AttributeRowProps) {
+  const { t } = useTranslation();
+  const label = attr.label[locale] ?? attr.label.en ?? attr.code;
+  return (
+    <li className="flex items-center justify-between gap-3 px-3 py-2 hover:bg-muted/20">
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="font-medium">{label}</span>
+          <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+            {attr.code}
+          </span>
+          <span className="rounded bg-violet-50 px-1.5 py-0.5 text-[10px] font-medium text-violet-700 ring-1 ring-violet-200">
+            {attr.type}
+          </span>
+          {attr.is_localizable ? (
+            <span className="rounded bg-blue-50 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 ring-1 ring-blue-200">
+              {t('settings.roles.attr_perms.localizable')}
+            </span>
+          ) : null}
+          {attr.is_required ? (
+            <span className="rounded bg-rose-50 px-1.5 py-0.5 text-[10px] font-medium text-rose-700 ring-1 ring-rose-200">
+              {t('settings.roles.attr_perms.required')}
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex items-center gap-1 rounded-md border bg-muted/40 p-0.5">
+        {(['restricted', 'view', 'edit'] as const).map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onChange(option)}
+            disabled={disabled}
+            className={cn(
+              'rounded px-2 py-1 text-[11px] font-medium transition-colors',
+              level === option
+                ? levelStyle(option, true)
+                : 'text-muted-foreground hover:bg-background',
+            )}
+            aria-pressed={level === option}
+          >
+            {t(`settings.roles.attr_perms.level.${option}`)}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          disabled={disabled}
+          className={cn(
+            'rounded px-2 py-1 text-[11px] font-medium transition-colors',
+            level === null
+              ? 'bg-background text-foreground'
+              : 'text-muted-foreground hover:bg-background',
+          )}
+          aria-pressed={level === null}
+          title={t('settings.roles.attr_perms.level.inherit_hint')}
+        >
+          {t('settings.roles.attr_perms.level.inherit')}
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function FilterChips({
+  value,
+  onChange,
+}: {
+  value: FilterMode;
+  onChange: (next: FilterMode) => void;
+}) {
+  const { t } = useTranslation();
+  const options: FilterMode[] = ['all', 'overridden', 'view', 'edit', 'restricted'];
+  return (
+    <div className="inline-flex rounded-md border bg-background p-0.5">
+      {options.map((option) => (
+        <button
+          key={option}
+          type="button"
+          onClick={() => onChange(option)}
+          className={cn(
+            'rounded px-2 py-1 text-[11px] font-medium transition-colors',
+            value === option
+              ? 'bg-foreground text-background'
+              : 'text-muted-foreground hover:bg-muted',
+          )}
+        >
+          {t(`settings.roles.attr_perms.filter.${option}`)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function visibleAttributes(
+  group: ApiGroup,
+  search: string,
+  filter: FilterMode,
+  draft: Record<string, AttributePermissionLevel>,
+): ApiAttribute[] {
+  const needle = search.trim().toLowerCase();
+  return group.attributes.filter((attr) => {
+    const level = draft[attr.id] ?? null;
+    if (filter === 'overridden' && level === null) return false;
+    if (filter !== 'all' && filter !== 'overridden' && level !== filter) return false;
+    if (needle.length > 0) {
+      const haystack = `${attr.code} ${Object.values(attr.label).join(' ')}`.toLowerCase();
+      if (!haystack.includes(needle)) return false;
+    }
+    return true;
+  });
+}
+
+function levelStyle(level: 'view' | 'edit' | 'restricted', active: boolean): string {
+  if (!active) return '';
+  switch (level) {
+    case 'view':
+      return 'border-blue-300 bg-blue-50 text-blue-800';
+    case 'edit':
+      return 'border-emerald-300 bg-emerald-50 text-emerald-800';
+    case 'restricted':
+      return 'border-rose-300 bg-rose-50 text-rose-800';
+  }
+}

--- a/apps/admin/src/features/settings/roles/RoleEditorPage.tsx
+++ b/apps/admin/src/features/settings/roles/RoleEditorPage.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { toast } from '@/components/ui/toast';
 import { jsonFetch } from '@/lib/http';
 
+import { AttributePermissionsTab } from './AttributePermissionsTab';
 import { type PermissionGroup, PermissionMatrix } from './PermissionMatrix';
 import type { RoleDetail } from './types';
 
@@ -342,6 +343,17 @@ export function RoleEditorPage() {
             disabled={submitting || deleting}
           />
         )}
+      </div>
+
+      {/* RBAC-P5-007 (#697) — per-attribute overrides. Lives as its
+          own section with its own save button: loading + writing goes
+          through a dedicated endpoint and a bulk replace inside the
+          role-editor submit would silently widen the audit trail. */}
+      <div className="space-y-2">
+        <div className="flex items-baseline justify-between">
+          <Label>{t('settings.roles.attr_perms.section_title')}</Label>
+        </div>
+        <AttributePermissionsTab roleId={role?.id ?? null} disabled={submitting || deleting} />
       </div>
     </form>
   );

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -333,6 +333,48 @@
         "system": "System",
         "custom": "Custom"
       },
+      "attr_perms": {
+        "section_title": "Per-attribute permissions (override)",
+        "search_placeholder": "Search attributes...",
+        "override_count": "{{count}} active override(s)",
+        "create_first": "Save the role before editing per-attribute permissions.",
+        "cross_tab_deferred": "Cross-tab badge counters on the matrix + sticky info banner deferred — they land once Mercure SSE sync is wired (separate ticket).",
+        "group_ungrouped": "Ungrouped",
+        "attribute_count_one": "{{count}} attribute",
+        "attribute_count_other": "{{count}} attributes",
+        "attribute_count": "{{count}} attributes",
+        "mixed": "Mixed",
+        "localizable": "i18n",
+        "required": "Required",
+        "level": {
+          "view": "View",
+          "edit": "Edit",
+          "restricted": "Restricted",
+          "inherit": "Inherit",
+          "inherit_hint": "No override — falls back to the role matrix grant"
+        },
+        "filter": {
+          "all": "All",
+          "overridden": "Overridden",
+          "view": "View",
+          "edit": "Edit",
+          "restricted": "Restricted"
+        },
+        "bulk_view": "View for all",
+        "bulk_edit": "Edit for all",
+        "bulk_restricted": "Restrict all",
+        "bulk_clear": "Clear",
+        "bulk_hint": "Set {{level}} on the visible attributes in this group",
+        "bulk_clear_hint": "Remove overrides on the visible attributes — falls back to the matrix",
+        "reset": "Reset changes",
+        "save": "Save overrides",
+        "saving": "Saving...",
+        "toast_saved": "Per-attribute overrides saved.",
+        "error_load": "Could not load per-attribute overrides.",
+        "error_validation": "Backend rejected the submission.",
+        "error_forbidden": "You don't have permission.",
+        "error_generic": "Could not save overrides."
+      },
       "editor": {
         "back": "Back to roles",
         "title_create": "New custom role",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -335,6 +335,48 @@
         "system": "System",
         "custom": "Custom"
       },
+      "attr_perms": {
+        "section_title": "Uprawnienia per atrybut (override)",
+        "search_placeholder": "Szukaj atrybutów...",
+        "override_count": "{{count}} aktywnych override'ów",
+        "create_first": "Zapisz rolę przed edycją uprawnień per-atrybut.",
+        "cross_tab_deferred": "Cross-tab badge counters w macierzy + sticky info banner deferowane — pojawią się po wdrożeniu Mercure SSE sync (osobny ticket).",
+        "group_ungrouped": "Bez grupy",
+        "attribute_count_one": "{{count}} atrybut",
+        "attribute_count_other": "{{count}} atrybutów",
+        "attribute_count": "{{count}} atrybutów",
+        "mixed": "Mieszane",
+        "localizable": "i18n",
+        "required": "Wymagany",
+        "level": {
+          "view": "Podgląd",
+          "edit": "Edycja",
+          "restricted": "Zablokowane",
+          "inherit": "Domyślne",
+          "inherit_hint": "Bez override — używa grantu z macierzy roli"
+        },
+        "filter": {
+          "all": "Wszystkie",
+          "overridden": "Z override'em",
+          "view": "Podgląd",
+          "edit": "Edycja",
+          "restricted": "Zablokowane"
+        },
+        "bulk_view": "Podgląd dla wszystkich",
+        "bulk_edit": "Edycja dla wszystkich",
+        "bulk_restricted": "Zablokuj wszystkie",
+        "bulk_clear": "Wyczyść",
+        "bulk_hint": "Ustaw {{level}} dla widocznych atrybutów w grupie",
+        "bulk_clear_hint": "Usuń override dla widocznych atrybutów — wraca do macierzy",
+        "reset": "Cofnij zmiany",
+        "save": "Zapisz override'y",
+        "saving": "Zapisuję...",
+        "toast_saved": "Override'y per-atrybut zapisane.",
+        "error_load": "Nie udało się załadować override'ów per-atrybut.",
+        "error_validation": "Backend odrzucił dane.",
+        "error_forbidden": "Brak uprawnień.",
+        "error_generic": "Nie udało się zapisać override'ów."
+      },
       "editor": {
         "back": "Wróć do listy ról",
         "title_create": "Nowa rola customowa",

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -148,6 +148,7 @@ parameters:
 
         Identity_Internals:
             - Identity_Contracts
+            - Catalog_Contracts
             - Shared
         Identity_Contracts:
             - Shared

--- a/apps/api/migrations/Version20260520090000.php
+++ b/apps/api/migrations/Version20260520090000.php
@@ -39,7 +39,7 @@ final class Version20260520090000 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql(<<<'SQL'
-            CREATE TABLE role_attribute_permissions (
+            CREATE TABLE IF NOT EXISTS role_attribute_permissions (
                 id UUID NOT NULL,
                 role_id UUID NOT NULL,
                 attribute_id UUID NOT NULL,
@@ -54,15 +54,15 @@ final class Version20260520090000 extends AbstractMigration
             )
         SQL);
         $this->addSql(<<<'SQL'
-            CREATE UNIQUE INDEX role_attribute_permissions_role_attr_uniq
+            CREATE UNIQUE INDEX IF NOT EXISTS role_attribute_permissions_role_attr_uniq
                 ON role_attribute_permissions (role_id, attribute_id)
         SQL);
         $this->addSql(<<<'SQL'
-            CREATE INDEX role_attribute_permissions_role_idx
+            CREATE INDEX IF NOT EXISTS role_attribute_permissions_role_idx
                 ON role_attribute_permissions (role_id)
         SQL);
         $this->addSql(<<<'SQL'
-            CREATE INDEX role_attribute_permissions_attr_idx
+            CREATE INDEX IF NOT EXISTS role_attribute_permissions_attr_idx
                 ON role_attribute_permissions (attribute_id)
         SQL);
     }

--- a/apps/api/migrations/Version20260520090000.php
+++ b/apps/api/migrations/Version20260520090000.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * RBAC-P5-007 (#697) — `role_attribute_permissions` table for 3-state
+ * per-attribute grants overriding the role-level matrix.
+ *
+ * Permission level enum (text, not native enum for migration friendliness):
+ *   - `view`       — read-only override; role can read this attribute
+ *                    even if its module-level grant says `restricted`.
+ *   - `edit`       — read + write override.
+ *   - `restricted` — explicitly hidden from this role, regardless of
+ *                    its module-level grant. Persisting `restricted`
+ *                    rather than omitting the row lets the resolver
+ *                    distinguish "no opinion, fall back to matrix"
+ *                    from "explicit deny".
+ *
+ * No FK to `attributes(id)` because the Catalog bundle owns that table
+ * and a cross-bundle FK would couple bounded contexts beyond what
+ * ADR-009 allows; the resolver validates referenced attribute existence
+ * at write time via the AttributeRepository.
+ *
+ * `role_id` FK is ON DELETE CASCADE — deleting a custom role wipes its
+ * attribute overrides too, mirroring how `role_permissions` cascades.
+ */
+final class Version20260520090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'RBAC-P5-007 — role_attribute_permissions table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE role_attribute_permissions (
+                id UUID NOT NULL,
+                role_id UUID NOT NULL,
+                attribute_id UUID NOT NULL,
+                permission_level VARCHAR(16) NOT NULL,
+                created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL,
+                PRIMARY KEY (id),
+                CONSTRAINT fk_role_attribute_permissions_role
+                    FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
+                CONSTRAINT role_attribute_permissions_level_check
+                    CHECK (permission_level IN ('view', 'edit', 'restricted'))
+            )
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX role_attribute_permissions_role_attr_uniq
+                ON role_attribute_permissions (role_id, attribute_id)
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE INDEX role_attribute_permissions_role_idx
+                ON role_attribute_permissions (role_id)
+        SQL);
+        $this->addSql(<<<'SQL'
+            CREATE INDEX role_attribute_permissions_attr_idx
+                ON role_attribute_permissions (attribute_id)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE role_attribute_permissions');
+    }
+}

--- a/apps/api/src/Catalog/Application/DoctrineAttributeCatalogReader.php
+++ b/apps/api/src/Catalog/Application/DoctrineAttributeCatalogReader.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Contracts\Query\AttributeSummary;
+use App\Catalog\Contracts\Service\AttributeCatalogReader;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use Symfony\Component\Uid\Uuid;
+
+use const PHP_INT_MAX;
+
+/**
+ * RBAC-P5-007 (#697) — adapter that turns Catalog domain attributes
+ * into {@see AttributeSummary} DTOs for cross-BC consumption.
+ *
+ * Lives in Application (not Domain) because it depends on a Shared
+ * `TenantRepositoryInterface` to look up the Tenant entity needed by
+ * the underlying repository. Callers pass a tenant id; the adapter
+ * resolves it once per request.
+ */
+final readonly class DoctrineAttributeCatalogReader implements AttributeCatalogReader
+{
+    public function __construct(
+        private AttributeRepositoryInterface $attributes,
+        private TenantRepositoryInterface $tenants,
+    ) {
+    }
+
+    public function findAllByTenant(Uuid $tenantId): array
+    {
+        $tenant = $this->tenants->findById($tenantId);
+        if (null === $tenant) {
+            return [];
+        }
+
+        $summaries = [];
+        foreach ($this->attributes->findAllByTenant($tenant) as $attribute) {
+            $group = $attribute->getGroup();
+            $summaries[] = new AttributeSummary(
+                id: $attribute->getId(),
+                tenantId: $tenantId,
+                code: $attribute->getCode(),
+                label: $attribute->getLabel(),
+                type: $attribute->getType()->value,
+                isLocalizable: $attribute->isLocalizable(),
+                isRequired: $attribute->isRequired(),
+                isSystem: $attribute->isSystem(),
+                groupId: $group?->getId(),
+                groupCode: $group?->getCode(),
+                groupLabel: null === $group ? [] : $group->getLabel(),
+                groupPosition: $group?->getPosition() ?? PHP_INT_MAX,
+            );
+        }
+
+        return $summaries;
+    }
+
+    public function findOnTenant(Uuid $attributeId, Uuid $tenantId): ?AttributeSummary
+    {
+        $attribute = $this->attributes->findById($attributeId);
+        if (null === $attribute) {
+            return null;
+        }
+        $attrTenant = $attribute->getTenant();
+        if (null === $attrTenant || !$tenantId->equals($attrTenant->getId())) {
+            return null;
+        }
+
+        $group = $attribute->getGroup();
+
+        return new AttributeSummary(
+            id: $attribute->getId(),
+            tenantId: $tenantId,
+            code: $attribute->getCode(),
+            label: $attribute->getLabel(),
+            type: $attribute->getType()->value,
+            isLocalizable: $attribute->isLocalizable(),
+            isRequired: $attribute->isRequired(),
+            isSystem: $attribute->isSystem(),
+            groupId: $group?->getId(),
+            groupCode: $group?->getCode(),
+            groupLabel: null === $group ? [] : $group->getLabel(),
+            groupPosition: $group?->getPosition() ?? PHP_INT_MAX,
+        );
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Query/AttributeSummary.php
+++ b/apps/api/src/Catalog/Contracts/Query/AttributeSummary.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Query;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P5-007 (#697) — cross-BC read projection of
+ * {@see \App\Catalog\Domain\Entity\Attribute} for the Identity bundle.
+ *
+ * Identity's role attribute-permissions tab needs to enumerate the
+ * tenant's attributes (grouped by AttributeGroup) without coupling
+ * to the full Catalog domain model. This DTO carries only what the
+ * Settings UI projects to the operator: id + code + localised label
+ * + type tag + flags + group metadata.
+ */
+final readonly class AttributeSummary
+{
+    /**
+     * @param array<string, string> $label
+     * @param array<string, string> $groupLabel
+     */
+    public function __construct(
+        public Uuid $id,
+        public Uuid $tenantId,
+        public string $code,
+        public array $label,
+        public string $type,
+        public bool $isLocalizable,
+        public bool $isRequired,
+        public bool $isSystem,
+        public ?Uuid $groupId,
+        public ?string $groupCode,
+        public array $groupLabel,
+        public int $groupPosition,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Contracts/Service/AttributeCatalogReader.php
+++ b/apps/api/src/Catalog/Contracts/Service/AttributeCatalogReader.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Service;
+
+use App\Catalog\Contracts\Query\AttributeSummary;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P5-007 (#697) — cross-BC read API the Identity bundle uses to
+ * paint its attribute-permission tab.
+ *
+ * Identity owns the "which role overrides which attribute" mapping
+ * (`role_attribute_permissions` table) but does NOT own attribute
+ * metadata; Catalog does. Rather than coupling Identity to
+ * `App\Catalog\Domain\Repository\AttributeRepositoryInterface`
+ * (which would break the Identity_Internals → Catalog_Internals
+ * deptrac fence), Identity depends on this contracts-layer reader
+ * and gets back lean {@see AttributeSummary} DTOs.
+ */
+interface AttributeCatalogReader
+{
+    /**
+     * @return list<AttributeSummary> ordered by group position, then
+     *                                attribute code, so the role
+     *                                editor renders deterministically
+     */
+    public function findAllByTenant(Uuid $tenantId): array;
+
+    /**
+     * Validates that an attribute exists on the given tenant. Returns
+     * the summary on hit, null on miss (unknown id OR cross-tenant id).
+     */
+    public function findOnTenant(Uuid $attributeId, Uuid $tenantId): ?AttributeSummary;
+}

--- a/apps/api/src/Catalog/Domain/Repository/AttributeRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/AttributeRepositoryInterface.php
@@ -28,4 +28,14 @@ interface AttributeRepositoryInterface
      * @return list<string>
      */
     public function filterableCodes(): array;
+
+    /**
+     * RBAC-P5-007 (#697) — every attribute on the given tenant, ordered
+     * by attribute-group sequence then attribute code so the role
+     * editor's "Uprawnienia per atrybut" tab can render the grouped
+     * list in PRD §3.5 layout without a follow-up query per group.
+     *
+     * @return list<Attribute>
+     */
+    public function findAllByTenant(Tenant $tenant): array;
 }

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineAttributeRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineAttributeRepository.php
@@ -62,4 +62,20 @@ class DoctrineAttributeRepository extends ServiceEntityRepository implements Att
 
         return $codes;
     }
+
+    public function findAllByTenant(Tenant $tenant): array
+    {
+        /** @var list<Attribute> $result */
+        $result = $this->createQueryBuilder('a')
+            ->leftJoin('a.group', 'g')
+            ->where('a.tenant = :tenant')
+            ->setParameter('tenant', $tenant)
+            ->orderBy('g.position', 'ASC')
+            ->addOrderBy('g.id', 'ASC')
+            ->addOrderBy('a.code', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
 }

--- a/apps/api/src/Identity/Application/RoleAttributePermissionResponseBuilder.php
+++ b/apps/api/src/Identity/Application/RoleAttributePermissionResponseBuilder.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application;
+
+use App\Catalog\Contracts\Query\AttributeSummary;
+use App\Identity\Domain\Entity\RoleAttributePermission;
+
+/**
+ * RBAC-P5-007 (#697) — builds the per-role, per-attribute matrix the
+ * "Uprawnienia per atrybut" tab consumes.
+ *
+ * The wire shape groups attributes by AttributeGroup so the FE renders
+ * the accordion panels without an extra grouping pass; each attribute
+ * row carries the current override level (or `null` to indicate
+ * "no override, fall back to the role matrix"), the localised label
+ * (PL + EN), and a `type` tag the FE shows as a small badge.
+ *
+ * Response envelope:
+ *   {
+ *     "role_id":     "uuid",
+ *     "groups": [
+ *       {
+ *         "group_id":     "uuid|null",   // null = ungrouped bucket
+ *         "group_code":   "string|null",
+ *         "group_label":  { "pl": "...", "en": "..." } | null,
+ *         "attributes": [
+ *           {
+ *             "id":               "uuid",
+ *             "code":             "name",
+ *             "label":            { "pl": "...", "en": "..." },
+ *             "type":             "text|number|...",
+ *             "is_localizable":   bool,
+ *             "is_required":      bool,
+ *             "permission_level": "view|edit|restricted|null"
+ *           }, ...
+ *         ]
+ *       }, ...
+ *     ]
+ *   }
+ */
+final class RoleAttributePermissionResponseBuilder
+{
+    /**
+     * @param iterable<AttributeSummary>        $attributes
+     * @param iterable<RoleAttributePermission> $overrides
+     *
+     * @return array{
+     *     role_id: string,
+     *     groups: list<array{
+     *         group_id: ?string,
+     *         group_code: ?string,
+     *         group_label: ?array<string, string>,
+     *         attributes: list<array{
+     *             id: string,
+     *             code: string,
+     *             label: array<string, string>,
+     *             type: string,
+     *             is_localizable: bool,
+     *             is_required: bool,
+     *             permission_level: ?string
+     *         }>
+     *     }>
+     * }
+     */
+    public function build(string $roleId, iterable $attributes, iterable $overrides): array
+    {
+        $overrideByAttr = [];
+        foreach ($overrides as $override) {
+            $overrideByAttr[$override->getAttributeId()->toRfc4122()] = $override->getPermissionLevel();
+        }
+
+        /**
+         * @var array<string, array{
+         *     group_id: ?string,
+         *     group_code: ?string,
+         *     group_label: ?array<string, string>,
+         *     attributes: list<array{
+         *         id: string,
+         *         code: string,
+         *         label: array<string, string>,
+         *         type: string,
+         *         is_localizable: bool,
+         *         is_required: bool,
+         *         permission_level: ?string
+         *     }>
+         * }> $bucketed
+         */
+        $bucketed = [];
+
+        foreach ($attributes as $summary) {
+            $groupKey = null === $summary->groupId ? '__ungrouped__' : $summary->groupId->toRfc4122();
+
+            if (!isset($bucketed[$groupKey])) {
+                $bucketed[$groupKey] = [
+                    'group_id' => $summary->groupId?->toRfc4122(),
+                    'group_code' => $summary->groupCode,
+                    'group_label' => [] === $summary->groupLabel ? null : $summary->groupLabel,
+                    'attributes' => [],
+                ];
+            }
+
+            $attrId = $summary->id->toRfc4122();
+            $bucketed[$groupKey]['attributes'][] = [
+                'id' => $attrId,
+                'code' => $summary->code,
+                'label' => self::ensureLabelMap($summary->label),
+                'type' => $summary->type,
+                'is_localizable' => $summary->isLocalizable,
+                'is_required' => $summary->isRequired,
+                'permission_level' => $overrideByAttr[$attrId] ?? null,
+            ];
+        }
+
+        return [
+            'role_id' => $roleId,
+            'groups' => array_values($bucketed),
+        ];
+    }
+
+    /**
+     * @param array<string, string> $raw
+     *
+     * @return array<string, string>
+     */
+    private static function ensureLabelMap(array $raw): array
+    {
+        // Guard against legacy rows missing the JSONB locale map — keep
+        // the response shape stable so the FE can always read `label.pl`
+        // / `label.en` without conditional fallbacks.
+        return [] === $raw ? ['pl' => '', 'en' => ''] : $raw;
+    }
+}

--- a/apps/api/src/Identity/Domain/Entity/RoleAttributePermission.php
+++ b/apps/api/src/Identity/Domain/Entity/RoleAttributePermission.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Entity;
+
+use DateTimeImmutable;
+use InvalidArgumentException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P5-007 (#697) — per-attribute permission override on a role,
+ * implementing the 3-state grant scheme from PRD-PIM-rbac §3.5.
+ *
+ * Resolution order (consumed by Phase 3 AttributePermissionPolicy, not
+ * yet wired — that's the cross-tab sync deferred to a follow-up):
+ *   1. If a row exists for (role_id, attribute_id) → use its level.
+ *   2. Otherwise fall back to the role's module-level grant (the
+ *      checkbox matrix from #696).
+ *
+ * Storing `restricted` explicitly (rather than omitting the row) is
+ * intentional: it lets an operator override a role that has `edit`
+ * on the matrix for a whole module but should NOT touch a single
+ * sensitive attribute (e.g. `cost_price` on Products). Without the
+ * explicit row, the matrix grant would always win.
+ *
+ * No FK to {@see \App\Catalog\Domain\Entity\Attribute} because Catalog
+ * owns that table and cross-bundle FKs leak bounded-context boundaries;
+ * the write path validates attribute existence via the repository.
+ */
+class RoleAttributePermission
+{
+    public const string LEVEL_VIEW = 'view';
+    public const string LEVEL_EDIT = 'edit';
+    public const string LEVEL_RESTRICTED = 'restricted';
+
+    private const array LEVELS = [self::LEVEL_VIEW, self::LEVEL_EDIT, self::LEVEL_RESTRICTED];
+
+    private Uuid $id;
+
+    private Uuid $roleId;
+
+    private Uuid $attributeId;
+
+    private string $permissionLevel;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Uuid $roleId,
+        Uuid $attributeId,
+        string $permissionLevel,
+        ?Uuid $id = null,
+        ?DateTimeImmutable $createdAt = null,
+    ) {
+        self::assertLevel($permissionLevel);
+        $now = $createdAt ?? new DateTimeImmutable();
+        $this->id = $id ?? Uuid::v7();
+        $this->roleId = $roleId;
+        $this->attributeId = $attributeId;
+        $this->permissionLevel = $permissionLevel;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getRoleId(): Uuid
+    {
+        return $this->roleId;
+    }
+
+    public function getAttributeId(): Uuid
+    {
+        return $this->attributeId;
+    }
+
+    public function getPermissionLevel(): string
+    {
+        return $this->permissionLevel;
+    }
+
+    public function setPermissionLevel(string $level): void
+    {
+        self::assertLevel($level);
+        $this->permissionLevel = $level;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function levels(): array
+    {
+        return self::LEVELS;
+    }
+
+    private static function assertLevel(string $level): void
+    {
+        if (!\in_array($level, self::LEVELS, true)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Invalid permission level `%s`. Expected one of: %s',
+                $level,
+                implode(', ', self::LEVELS),
+            ));
+        }
+    }
+}

--- a/apps/api/src/Identity/Domain/Repository/RoleAttributePermissionRepositoryInterface.php
+++ b/apps/api/src/Identity/Domain/Repository/RoleAttributePermissionRepositoryInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Domain\Repository;
+
+use App\Identity\Domain\Entity\RoleAttributePermission;
+use Symfony\Component\Uid\Uuid;
+
+interface RoleAttributePermissionRepositoryInterface
+{
+    public function findById(Uuid $id): ?RoleAttributePermission;
+
+    public function findByRoleAndAttribute(Uuid $roleId, Uuid $attributeId): ?RoleAttributePermission;
+
+    /**
+     * @return list<RoleAttributePermission>
+     */
+    public function findByRole(Uuid $roleId): array;
+
+    public function save(RoleAttributePermission $entity): void;
+
+    public function remove(RoleAttributePermission $entity): void;
+
+    /**
+     * Bulk-replace the attribute-permission set on a role. Deletes any
+     * row for `roleId` whose `attributeId` is not in the new set, and
+     * upserts the new rows. Single transaction so the resolver never
+     * sees a half-applied state.
+     *
+     * @param list<RoleAttributePermission> $next replacement set; each
+     *                                            entity's `roleId` must
+     *                                            equal the `$roleId`
+     *                                            argument
+     */
+    public function replaceForRole(Uuid $roleId, array $next): void;
+}

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/RoleAttributePermission.orm.xml
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/RoleAttributePermission.orm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Identity\Domain\Entity\RoleAttributePermission"
+            table="role_attribute_permissions"
+            repository-class="App\Identity\Infrastructure\Doctrine\Repository\DoctrineRoleAttributePermissionRepository">
+
+        <unique-constraints>
+            <unique-constraint name="role_attribute_permissions_role_attr_uniq" columns="role_id,attribute_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="role_attribute_permissions_role_idx" columns="role_id"/>
+            <index name="role_attribute_permissions_attr_idx" columns="attribute_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <field name="roleId" type="uuid" column="role_id"/>
+        <field name="attributeId" type="uuid" column="attribute_id"/>
+        <field name="permissionLevel" type="string" length="16" column="permission_level"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineRoleAttributePermissionRepository.php
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineRoleAttributePermissionRepository.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Doctrine\Repository;
+
+use App\Identity\Domain\Entity\RoleAttributePermission;
+use App\Identity\Domain\Repository\RoleAttributePermissionRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<RoleAttributePermission>
+ */
+class DoctrineRoleAttributePermissionRepository extends ServiceEntityRepository implements RoleAttributePermissionRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RoleAttributePermission::class);
+    }
+
+    public function findById(Uuid $id): ?RoleAttributePermission
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    public function findByRoleAndAttribute(Uuid $roleId, Uuid $attributeId): ?RoleAttributePermission
+    {
+        return $this->findOneBy([
+            'roleId' => $roleId,
+            'attributeId' => $attributeId,
+        ]);
+    }
+
+    public function findByRole(Uuid $roleId): array
+    {
+        /** @var list<RoleAttributePermission> $result */
+        $result = $this->createQueryBuilder('rap')
+            ->where('rap.roleId = :roleId')
+            ->setParameter('roleId', $roleId)
+            ->orderBy('rap.attributeId', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    public function save(RoleAttributePermission $entity): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($entity);
+        $em->flush();
+    }
+
+    public function remove(RoleAttributePermission $entity): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($entity);
+        $em->flush();
+    }
+
+    public function replaceForRole(Uuid $roleId, array $next): void
+    {
+        $em = $this->getEntityManager();
+        $em->wrapInTransaction(function () use ($em, $roleId, $next): void {
+            // Index existing rows for this role for O(1) lookup against the new set.
+            $existing = $this->findByRole($roleId);
+            $existingByAttr = [];
+            foreach ($existing as $row) {
+                $existingByAttr[$row->getAttributeId()->toRfc4122()] = $row;
+            }
+
+            $nextByAttr = [];
+            foreach ($next as $row) {
+                if (!$row->getRoleId()->equals($roleId)) {
+                    throw new LogicException('All replacement rows must share the target roleId.');
+                }
+                $nextByAttr[$row->getAttributeId()->toRfc4122()] = $row;
+            }
+
+            // Drop rows no longer in the replacement set.
+            foreach ($existingByAttr as $attrId => $row) {
+                if (!isset($nextByAttr[$attrId])) {
+                    $em->remove($row);
+                }
+            }
+
+            // Update existing rows in place + persist new ones.
+            foreach ($nextByAttr as $attrId => $row) {
+                if (isset($existingByAttr[$attrId])) {
+                    $existingByAttr[$attrId]->setPermissionLevel($row->getPermissionLevel());
+                } else {
+                    $em->persist($row);
+                }
+            }
+
+            $em->flush();
+        });
+    }
+}

--- a/apps/api/src/Identity/Presentation/Controller/RoleAttributePermissionsController.php
+++ b/apps/api/src/Identity/Presentation/Controller/RoleAttributePermissionsController.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Catalog\Contracts\Service\AttributeCatalogReader;
+use App\Identity\Application\RoleAttributePermissionResponseBuilder;
+use App\Identity\Domain\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\RoleAttributePermission;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleAttributePermissionRepositoryInterface;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use InvalidArgumentException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P5-007 (#697) — endpoints for per-attribute permission overrides
+ * on a role.
+ *
+ *   - GET /api/roles/{id}/attribute-permissions
+ *     Returns the full attribute catalogue for the caller's tenant,
+ *     bucketed by AttributeGroup, with each attribute's current
+ *     override level for this role (null = no override → falls back
+ *     to the role's matrix grant from #696).
+ *
+ *   - PUT /api/roles/{id}/attribute-permissions
+ *     Replaces the entire override set for the role in one
+ *     transactional sweep. Body shape:
+ *       { "attribute_permissions": [
+ *           { "attribute_id": "uuid", "permission_level": "view|edit|restricted" },
+ *           ...
+ *       ] }
+ *     Omitted attribute ids drop their override row (resolver falls
+ *     back to the matrix). Cross-tenant attribute ids surface as 400
+ *     ("Unknown attribute id").
+ *
+ * Identity reads Catalog metadata through {@see AttributeCatalogReader}
+ * (Catalog_Contracts layer) to honour the BC fence — Identity does NOT
+ * import `App\Catalog\Domain\Repository\AttributeRepositoryInterface`.
+ *
+ * Permission gate: `user.admin` per Phase 6 retrofit (#720+) plan —
+ * the consumer side (a Phase 3 AttributePermissionPolicy that reads
+ * these rows during read/write voting) is wired separately.
+ */
+final readonly class RoleAttributePermissionsController
+{
+    public function __construct(
+        private Security $security,
+        private RoleRepositoryInterface $roles,
+        private AttributeCatalogReader $attributeReader,
+        private RoleAttributePermissionRepositoryInterface $overrides,
+        private RoleAttributePermissionResponseBuilder $builder,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/roles/{id}/attribute-permissions',
+        methods: ['GET'],
+        name: 'api_roles_attribute_permissions_get',
+        requirements: ['id' => '[0-9a-f-]{36}'],
+    )]
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function get(string $id): JsonResponse
+    {
+        $caller = $this->security->getUser();
+        if (!$caller instanceof User) {
+            return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
+        }
+
+        $role = $this->loadAccessibleRole($caller, $id);
+        if ($role instanceof JsonResponse) {
+            return $role;
+        }
+
+        $attributes = $this->attributeReader->findAllByTenant($caller->getTenant()->getId());
+        $overrides = $this->overrides->findByRole($role->getId());
+
+        return new JsonResponse($this->builder->build($role->getId()->toRfc4122(), $attributes, $overrides));
+    }
+
+    #[Route(
+        path: '/api/roles/{id}/attribute-permissions',
+        methods: ['PUT'],
+        name: 'api_roles_attribute_permissions_replace',
+        requirements: ['id' => '[0-9a-f-]{36}'],
+    )]
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function replace(string $id, Request $request): JsonResponse
+    {
+        $caller = $this->security->getUser();
+        if (!$caller instanceof User) {
+            return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
+        }
+
+        $role = $this->loadAccessibleRole($caller, $id);
+        if ($role instanceof JsonResponse) {
+            return $role;
+        }
+
+        /** @var array<string, mixed>|null $payload */
+        $payload = json_decode($request->getContent(), true);
+        if (!\is_array($payload)) {
+            return $this->problem(Response::HTTP_BAD_REQUEST, 'Bad Request', 'Request body must be JSON.');
+        }
+
+        $items = $payload['attribute_permissions'] ?? null;
+        if (!\is_array($items)) {
+            return $this->problem(
+                Response::HTTP_BAD_REQUEST,
+                'Bad Request',
+                '`attribute_permissions` must be an array.',
+            );
+        }
+
+        $tenantId = $caller->getTenant()->getId();
+        $next = [];
+        $seenAttrIds = [];
+
+        foreach ($items as $rawItem) {
+            if (!\is_array($rawItem)) {
+                return $this->problem(
+                    Response::HTTP_BAD_REQUEST,
+                    'Bad Request',
+                    'Each `attribute_permissions` entry must be an object.',
+                );
+            }
+            $rawId = $rawItem['attribute_id'] ?? null;
+            $rawLevel = $rawItem['permission_level'] ?? null;
+            if (!\is_string($rawId) || !\is_string($rawLevel)) {
+                return $this->problem(
+                    Response::HTTP_BAD_REQUEST,
+                    'Bad Request',
+                    'Each entry needs `attribute_id` (UUID string) and `permission_level` (string).',
+                );
+            }
+
+            try {
+                $attrUuid = Uuid::fromString($rawId);
+            } catch (InvalidArgumentException) {
+                return $this->problem(
+                    Response::HTTP_BAD_REQUEST,
+                    'Bad Request',
+                    \sprintf('Invalid attribute id `%s`.', $rawId),
+                );
+            }
+
+            if (isset($seenAttrIds[$attrUuid->toRfc4122()])) {
+                return $this->problem(
+                    Response::HTTP_BAD_REQUEST,
+                    'Bad Request',
+                    \sprintf('Duplicate `attribute_id` `%s` in payload.', $rawId),
+                );
+            }
+            $seenAttrIds[$attrUuid->toRfc4122()] = true;
+
+            $summary = $this->attributeReader->findOnTenant($attrUuid, $tenantId);
+            if (null === $summary) {
+                return $this->problem(
+                    Response::HTTP_BAD_REQUEST,
+                    'Bad Request',
+                    \sprintf('Unknown attribute id `%s`.', $rawId),
+                );
+            }
+
+            try {
+                $next[] = new RoleAttributePermission(
+                    roleId: $role->getId(),
+                    attributeId: $attrUuid,
+                    permissionLevel: $rawLevel,
+                );
+            } catch (InvalidArgumentException $e) {
+                return $this->problem(Response::HTTP_BAD_REQUEST, 'Bad Request', $e->getMessage());
+            }
+        }
+
+        $this->overrides->replaceForRole($role->getId(), $next);
+
+        // Re-read the fresh set so the response reflects the persisted
+        // state (avoids drift if a listener mutated anything async).
+        $persisted = $this->overrides->findByRole($role->getId());
+        $attributes = $this->attributeReader->findAllByTenant($tenantId);
+
+        return new JsonResponse($this->builder->build($role->getId()->toRfc4122(), $attributes, $persisted));
+    }
+
+    private function loadAccessibleRole(User $caller, string $id): Role|JsonResponse
+    {
+        try {
+            $uuid = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Role not found.');
+        }
+
+        $role = $this->roles->findById($uuid);
+        if (null === $role) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Role not found.');
+        }
+
+        if (!$role->isGlobal()) {
+            $roleTenant = $role->getTenant();
+            if (null === $roleTenant || !$caller->getTenant()->getId()->equals($roleTenant->getId())) {
+                return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Role not found.');
+            }
+        }
+
+        return $role;
+    }
+
+    private function problem(int $status, string $title, string $detail): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'type' => 'about:blank',
+                'title' => $title,
+                'status' => $status,
+                'detail' => $detail,
+            ],
+            $status,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/TenantAuditCommand.php
@@ -117,6 +117,11 @@ final class TenantAuditCommand extends Command
         // inherited via user_id FK to users(tenant_id). Coexists with
         // legacy `user_roles` M2M until #644 delta migrations consolidate.
         'user_role_assignments',
+        // RBAC-P5-007 (#697) — per-attribute 3-state permission override
+        // on a role. Junction; tenant scope inherited via role_id FK to
+        // roles(tenant_id), and the attribute_id half is validated against
+        // the caller's tenant at write time by the controller.
+        'role_attribute_permissions',
     ];
 
     /**

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -139,6 +139,11 @@ final class InMemoryAttributeRepository implements AttributeRepositoryInterface
 
         return $codes;
     }
+
+    public function findAllByTenant(Tenant $tenant): array
+    {
+        return array_values($this->byCode);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Backend** — new `role_attribute_permissions` table (3-state: `view` / `edit` / `restricted`) + 2 REST endpoints under `user.admin`:
  - `GET /api/roles/{id}/attribute-permissions` — bucketed by AttributeGroup, each attribute carries the current override level (`null` = no override → falls back to the role matrix grant from #696).
  - `PUT /api/roles/{id}/attribute-permissions` — transactional replace; omitted ids drop their row, cross-tenant attribute ids → 400.
- Storing `restricted` explicitly (vs omitting the row) lets a role with a broad matrix grant deny a single sensitive attribute (e.g. `cost_price`) without dropping the matrix-level access.
- **Cross-BC fence respected:** Identity does NOT import `App\Catalog\Domain\Repository\AttributeRepositoryInterface`. New `AttributeCatalogReader` interface + `AttributeSummary` DTO live in `App\Catalog\Contracts\*`. Deptrac ruleset extended to allow `Identity_Internals → Catalog_Contracts` (mirrors the existing Channel / Asset / Search edges).
- **Frontend** — `AttributePermissionsTab` lives inside `RoleEditorPage` as its own section with its own save+reset buttons. Search box, 5 filter chips (All / Overridden / View / Edit / Restricted), per-group accordion with bulk-apply buttons (Restricted / View / Edit / Clear), per-attribute 3-state segmented control (Restricted / View / Edit / Inherit).

## Scope decisions

The ticket spans 12-18h with a long list of nice-to-haves. Shipped slice covers all 4 hero ACs (3-state per attribute, bulk per group, search, filter). **Deferred** flagged inline in the tab UI:
- **Cross-tab badge counters in the matrix (#696)** — needs Mercure SSE or shared store; tracked as a follow-up.
- **Preview modal for bulk > 5** — current bulk button mutates state directly with the visible-filter discipline; preview adds a step but doesn't change semantics.
- **Virtualized list for 200+ attrs** — current impl paints all rows; perf is fine at 32 attrs in the demo tenant. Revisit when a fixture pushes past ~150.
- **Sticky info banner for "matrix blocks broad permission"** — needs the matrix grant set for the role; left as a follow-up alongside the cross-tab sync.

## Test plan

- [x] PHPStan max — green
- [x] Deptrac — 0 violations after adding `Identity_Internals → Catalog_Contracts`
- [x] TypeScript noEmit — green
- [x] Biome strict — green
- [x] Live-stack smoke:
  - `GET /api/roles/{viewer}/attribute-permissions` → 200, 1 group, 32 attrs, all `permission_level: null`
  - `PUT` with `[{a1: view}, {a2: restricted}]` → 200, re-read shows the two overrides
  - `PUT` with invalid level `wat` → 400 `Invalid permission level 'wat'. Expected one of: view, edit, restricted`
  - `PUT` with empty array → 200, all override rows cleared
- [ ] Manual UI smoke after merge: open `/settings/roles/{custom-role-id}/edit` → scroll to "Per-attribute permissions" → expand group → toggle attr to `edit` → save → reload → state persists.

Refs #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)