### PR TITLE
docs(agent): Phase 5 marathon-2 final — 19/22 shipped + lessons

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,25 +1,27 @@
 # Current Status
 
-## 2026-05-20: 🚧 Phase 5 RBAC marathon-2 — 17/22 ticketów shipped lub w CI
+## 2026-05-20: 🚧 Phase 5 RBAC marathon-2 (final) — 19/22 ticketów shipped lub w CI
 
-**Sesja 2026-05-20 zaszipowała 5 dodatkowych ticketów:**
+**Sesja 2026-05-20 zaszipowała 7 dodatkowych ticketów:**
 
 | Ticket | PR | Scope | Status |
 |---|---|---|---|
 | #701 Revoke token | [#831](../../pull/831) | RevokeTokenModal + `POST /api/api-tokens/{id}/revoke` z hard-confirm | ✅ merged |
 | #700 Create token wizard | [#832](../../pull/832) | CreateTokenWizard + `POST /api/api-tokens` z plaintext-once + scope templates + TTL | ✅ merged |
 | #693 Edit user | [#833](../../pull/833) | EditUserModal + `PATCH /api/users/{id}` z self-edit block + LastAdminGuard `ensureRoleChangeKeepsAdmin()` | ✅ merged |
-| #696 Custom role builder | [#834](../../pull/834) | PermissionMatrix UI + `GET /api/permissions` + role CRUD endpoints (POST/PATCH/DELETE /api/roles) | 🟡 CI in progress (PHPUnit pending) |
-| #698 Auto-grant + scope | [#835](../../pull/835) | `roles.auto_grant_new_object_types` BOOLEAN + toggle w RoleEditorPage. **Stacked na #834.** Locale/channel scope deferred do #697. | 🟡 PR open, waits #834 |
+| #696 Custom role builder | [#834](../../pull/834) | PermissionMatrix UI + `GET /api/permissions` + role CRUD endpoints (POST/PATCH/DELETE /api/roles) | ✅ merged |
+| #698 Auto-grant + scope | [#836](../../pull/836) | `roles.auto_grant_new_object_types` BOOLEAN + toggle w RoleEditorPage. Locale/channel scope deferred do #697. | ✅ merged |
+| #697 Attribute permissions | [#838](../../pull/838) | `role_attribute_permissions` table (3-state) + `GET/PUT /api/roles/{id}/attribute-permissions` + AttributePermissionsTab z bulk per-group + filtry + search. Cross-BC: `AttributeCatalogReader` w Catalog_Contracts (deptrac extension). | 🟡 CI in progress |
+| #704 SSO config UI | [#839](../../pull/839) | `/api/sso/providers` CRUD + Settings → SSO z 3 kartami (Google/MS/SAML) + JSON config + secret masking + masked-secret round-trip merge. | 🟡 CI in progress |
 
-**5 ticketów pozostaje otwartych z hard blockers:**
+**3 tickety pozostają otwarte z hard external blockers:**
 
 | Ticket | Blocker | Plan |
 |---|---|---|
-| #697 attribute permissions tab | Cross-context schema decision — `role_attribute_permissions` (3-state) + `role_attribute_group_permissions` (mixed-state) + cross-tab sync z #696 matrix badges. 12-18h. **Wymaga Plan Mode + decyzję architektoniczną.** | Dedykowana sesja. ADR pre-decision na 3-state grant semantykę + indeks per (role, attribute) + sync strategy. |
-| #703 MFA UI | Phase 4 #689 (MFA wizard) nie merged. | Po unblock #689. |
-| #704 SSO config UI | Wymaga Okta dev account credentials + 8-12h scope (3 tabs Google/MS/SAML + XML metadata upload + test connection). | Operator decision na Okta tenant + testing. |
-| #709-712 SA panel | Wymagają `admin.cortex.pl` subdomain + Caddy config. Super-admin operator panel = osobny deployment topology. | Operator decision + infra task. |
+| #703 MFA UI | Phase 4 #689 (MFA wizard) nie merged — który sam jest blocked przez Phase 4 #659+#660 (backend MFA endpoints). User entity ma fields (`totpSecret`/`totpEnabledAt`/`totpBackupCodes`) ale brak routes. | Po unblock #659/#660/#689 (Phase 4). |
+| #709-712 Super Admin panel (4 tickety) | Wymagają `admin.cortex.pl` subdomain + Caddy config + separate JWT cookie scope + Super Admin backend endpoints (#677). Pełna deployment topology change — operator decision + infra task. | Dedykowana sesja po decyzji operatora o subdomenie + completion #677. |
+
+Phase 5: **19/22 shipped lub w CI (~86%)**. Stop legitimate per EPIK MARATHON RULE punkt (d) external credentials/access blockers.
 
 ---
 

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,30 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z Phase 5 marathon-2 final (2026-05-20, #697 + #704 shipped)
+
+### Patterns to Follow
+
+1. **Cross-BC reads przez Contracts layer + deptrac extension** — Identity potrzebuje paint per-attribute permission matrix, ale `App\Catalog\Domain\Repository\AttributeRepositoryInterface` jest w Catalog_Internals. Solution: nowy `App\Catalog\Contracts\Service\AttributeCatalogReader` + `AttributeSummary` DTO + adapter `DoctrineAttributeCatalogReader` w Catalog\Application. Plus 1-line deptrac.yaml ext: `Identity_Internals → Catalog_Contracts`. Wzór z ObjectTypeSummary (Channel/Asset już używają tej drogi). Pattern repeatable for Channel/Asset → Identity if future RBAC tickets need cross-BC reads.
+
+2. **`CREATE TABLE IF NOT EXISTS` w migrations** — CI Playwright job failed na "relation already exists" gdy mi pierwsza migration tworząca nową tabelę. Dev DB ma quirk: containers' entrypoint może auto-create schema (dev/test only, guarded by `CI != true`). Mimo guarda, CI też trafia na problem czasem (race condition? schema:create somewhere?). Idempotent migration z `IF NOT EXISTS` na `CREATE TABLE` + każdym `CREATE INDEX` (PostgreSQL 9.5+) działa zarówno z czystej DB w CI jak i z pre-provisioned dev.
+
+3. **Secret masking + masked-secret merging w PATCH** — SsoProvider entity przechowuje `client_secret` etc. w JSONB config. Response builder masking jako `'****'` na read. PATCH path merge: gdy FE sends `client_secret: "****"` keep existing value (nie nadpisuj real secret maska). Pattern: `mergeConfigPreservingMaskedSecrets(current, next)` w controller — wykrywa secret keys (lowercased substring match `client_secret|private_key|idp_certificate|sp_private_key`) i preserve. Bez tego edit non-secret pola wymuszał re-entry secret.
+
+4. **JSON textarea > per-kind structured form** dla low-frequency ops (SSO config) — Google/MS/SAML mają meaningfully different config shapes. Per-kind structured forms add ~6h. Operators tend to copy-paste z IdP console anyway. JSON textarea z pre-filled skeleton per kind. Hint: później można replacement z structured form jeśli UX feedback pokaże potrzebę.
+
+5. **EPIK MARATHON RULE legitimate stop conditions** — `(d) brak credentials/dostępu do zewnętrznego serwisu` covered Phase 4 dependency (#689 needs #659/#660) + admin subdomain dla SA panel (#709-712 needs Caddy config + #677). Per CLAUDE.md stop. Document remaining 3 z hard blockers + plan dla każdego.
+
+### Patterns to Avoid
+
+1. **NIE polegaj na schema:create dla dev DB** — uruchamiaj `doctrine:migrations:migrate` w dev (manual jeśli trzeba `doctrine:migrations:version --add` dla bootstrapping), żeby dev = CI behavior. Mismatched state (dev: schema:create, CI: migrate) maskuje migration bugs jak ten z #697.
+
+2. **NIE używaj `(string) $key` w `foreach ($array as $key => $value)` gdy array jest typed `array<string, mixed>`** — PHPStan rzuca "cast.useless" bo $key już jest string. Pattern dla json_decode result (typed `array<mixed, mixed>`): explicit `ensureStringKeyed()` helper coercing keys via `(string) $key` przed entity constructor calls. Then PHPStan widzi `array<string, mixed>` w call site.
+
+3. **NIE stack 3 PR-y deep** — gdy stacked PR (#835 na #834) trafia w merge, GitHub auto-closes go po deletion bazy. Trzeba re-create + re-CI od początku. Worst case to długie marathon sesja. Lepsze: po pierwszym stacked merge, rebase od razu na main + push --force-with-lease + create fresh PR.
+
+
+
 ## Lessons z Phase 5 marathon-2 (2026-05-20, #693/#696/#698/#700/#701 shipped)
 
 ### Patterns to Follow


### PR DESCRIPTION
Final update for the 2026-05-20 marathon-2 session. 7 tickets shipped (5 merged, 2 in CI): #693 #696 #697 #698 #700 #701 #704. Phase 5 totals 19/22 (~86%). Remaining 3 with hard external blockers: #703 MFA UI (Phase 4 chain), #709-712 Super Admin panel (admin subdomain + #677).