### PR TITLE
feat(identity): #709 + #710 Super Admin operator panel — Tenant list + detail

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -217,6 +217,10 @@ const TenantSettingsPage = lazyPage(
   () => import('@/features/settings/tenant'),
   'TenantSettingsPage',
 );
+const AdminTenantsListPage = lazyPage(
+  () => import('@/features/admin/tenants'),
+  'AdminTenantsListPage',
+);
 
 /**
  * Suspense fallback shown while a route chunk loads. Discreet — the
@@ -452,6 +456,12 @@ function App() {
                   <Route path="ai" element={<AiSettingsPage />} />
                   <Route path="sso" element={<SsoSettingsPage />} />
                 </Route>
+                {/* RBAC-P5-019 (#709) — Super Admin operator panel.
+                    Lives under /admin/* inside the existing app until
+                    the admin.cortex.pl subdomain split (operator infra
+                    task). Backend already enforces super_admin role +
+                    cross-tenant bypass via SuperAdminContext. */}
+                <Route path="/admin/tenants" element={<AdminTenantsListPage />} />
                 {/* Top-level Integracje hub — łączy Imports MVP (epik 0.13)
                     + Profile API z VIEW-08 (sub-tab API Configurator). Stare
                     ścieżki /publications/* i /api-profiles/* redirectują niżej. */}

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -221,6 +221,10 @@ const AdminTenantsListPage = lazyPage(
   () => import('@/features/admin/tenants'),
   'AdminTenantsListPage',
 );
+const AdminTenantShowPage = lazyPage(
+  () => import('@/features/admin/tenants'),
+  'AdminTenantShowPage',
+);
 
 /**
  * Suspense fallback shown while a route chunk loads. Discreet — the
@@ -462,6 +466,7 @@ function App() {
                     task). Backend already enforces super_admin role +
                     cross-tenant bypass via SuperAdminContext. */}
                 <Route path="/admin/tenants" element={<AdminTenantsListPage />} />
+                <Route path="/admin/tenants/:id" element={<AdminTenantShowPage />} />
                 {/* Top-level Integracje hub — łączy Imports MVP (epik 0.13)
                     + Profile API z VIEW-08 (sub-tab API Configurator). Stare
                     ścieżki /publications/* i /api-profiles/* redirectują niżej. */}

--- a/apps/admin/src/features/admin/tenants/AdminTenantShowPage.tsx
+++ b/apps/admin/src/features/admin/tenants/AdminTenantShowPage.tsx
@@ -1,0 +1,213 @@
+import { ArrowLeft, Building2, Calendar, Globe, Loader2, ShieldAlert, Users } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import type { AdminTenantSummary } from './types';
+
+/**
+ * RBAC-P5-020 (#710) — Super Admin tenant detail.
+ *
+ * Read-only view of the metadata + counters for a single tenant. Uses
+ * the same wire shape as the list endpoint (the backend re-uses
+ * {@link SuperAdminTenantResponseBuilder::buildOne()}), so adding a
+ * field to the API automatically shows up here.
+ *
+ * Privacy boundary same as the list — never displays products,
+ * attributes, or values. Tenant CRUD writes (suspend / change plan)
+ * land in #711 with their own break-glass + audit hooks.
+ */
+export function AdminTenantShowPage() {
+  const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
+  const params = useParams<{ id: string }>();
+  const [tenant, setTenant] = useState<AdminTenantSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [forbidden, setForbidden] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!params.id) return;
+    let cancelled = false;
+    setLoading(true);
+    setForbidden(false);
+    setNotFound(false);
+    setError(false);
+    jsonFetch<AdminTenantSummary>(`/api/admin/tenants/${params.id}`, { method: 'GET' })
+      .then((data) => {
+        if (!cancelled) setTenant(data);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const status = (err as { status?: number })?.status;
+        if (status === 403) setForbidden(true);
+        else if (status === 404) setNotFound(true);
+        else setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [params.id]);
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-md rounded-lg border border-amber-200 bg-amber-50 p-6 text-center text-sm text-amber-800">
+        <ShieldAlert className="mx-auto mb-2 size-8" aria-hidden="true" />
+        <h2 className="display mb-1 text-lg font-semibold">{t('admin.tenants.forbidden_title')}</h2>
+        <p>{t('admin.tenants.forbidden_description')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <header className="space-y-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => navigate('/admin/tenants')}
+          className="-ml-2 gap-1.5 text-muted-foreground"
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          {t('admin.tenants.detail.back')}
+        </Button>
+        <div className="flex items-baseline gap-2">
+          <Building2 className="size-5 text-accent-violet" aria-hidden="true" />
+          <h2 className="display text-xl font-semibold tracking-tight">
+            {tenant?.name ?? t('admin.tenants.detail.loading')}
+          </h2>
+        </div>
+        {tenant ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <span className="font-mono">{tenant.code}</span>
+            {tenant.domain ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>{tenant.domain}</span>
+              </>
+            ) : null}
+          </div>
+        ) : null}
+      </header>
+
+      <div className="rounded-md border border-dashed bg-amber-50 px-3 py-2 text-xs text-amber-900">
+        {t('admin.tenants.privacy_boundary_notice')}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-muted-foreground">
+          <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+        </div>
+      ) : notFound ? (
+        <div className="rounded-md border bg-background px-3 py-8 text-center text-sm text-muted-foreground">
+          {t('admin.tenants.detail.not_found')}
+        </div>
+      ) : error ? (
+        <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+          {t('admin.tenants.error_loading')}
+        </div>
+      ) : tenant ? (
+        <div className="grid gap-3 md:grid-cols-3">
+          <Card
+            icon={Building2}
+            label={t('admin.tenants.detail.field_plan')}
+            value={<PlanBadge plan={tenant.plan} />}
+          />
+          <Card
+            icon={Users}
+            label={t('admin.tenants.detail.field_users')}
+            value={
+              <span className="text-2xl font-semibold tabular-nums">{tenant.active_users}</span>
+            }
+            hint={t('admin.tenants.detail.field_users_hint')}
+          />
+          <Card
+            icon={Calendar}
+            label={t('admin.tenants.detail.field_created')}
+            value={
+              <span className="text-sm">
+                {new Date(tenant.created_at).toLocaleString(i18n.language)}
+              </span>
+            }
+          />
+          <Card
+            icon={Globe}
+            label={t('admin.tenants.detail.field_locales')}
+            value={
+              <div className="flex flex-wrap gap-1">
+                {tenant.enabled_locales.map((locale) => (
+                  <span
+                    key={locale}
+                    className={cn(
+                      'rounded px-1.5 py-0.5 text-[11px] font-mono ring-1',
+                      locale === tenant.primary_locale
+                        ? 'bg-accent-violet/10 text-accent-violet ring-accent-violet/30'
+                        : 'bg-muted text-muted-foreground ring-input',
+                    )}
+                  >
+                    {locale}
+                  </span>
+                ))}
+              </div>
+            }
+            hint={t('admin.tenants.detail.field_locales_hint', { primary: tenant.primary_locale })}
+          />
+          <div className="md:col-span-2 rounded-lg border border-dashed bg-muted/30 p-3 text-xs text-muted-foreground">
+            {t('admin.tenants.detail.crud_deferred')}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Card({
+  icon: Icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: React.ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+  label: string;
+  value: React.ReactNode;
+  hint?: string;
+}) {
+  return (
+    <div className="space-y-2 rounded-lg border bg-background p-3 shadow-sm">
+      <div className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-muted-foreground">
+        <Icon className="size-3.5" aria-hidden={true} />
+        <span>{label}</span>
+      </div>
+      <div>{value}</div>
+      {hint ? <p className="text-[11px] text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+function PlanBadge({ plan }: { plan: string }) {
+  const classes: Record<string, string> = {
+    starter: 'bg-blue-50 text-blue-700 ring-blue-200',
+    growth: 'bg-violet-50 text-violet-700 ring-violet-200',
+    scale: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    enterprise: 'bg-amber-50 text-amber-700 ring-amber-200',
+  };
+  return (
+    <span
+      className={cn(
+        'inline-flex rounded px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide ring-1',
+        classes[plan] ?? 'bg-muted text-muted-foreground ring-input',
+      )}
+    >
+      {plan}
+    </span>
+  );
+}

--- a/apps/admin/src/features/admin/tenants/index.tsx
+++ b/apps/admin/src/features/admin/tenants/index.tsx
@@ -1,0 +1,245 @@
+import { Building2, Loader2, ShieldAlert, Users } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Input } from '@/components/ui/input';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import type { AdminTenantSummary } from './types';
+
+interface ListResponse {
+  member: AdminTenantSummary[];
+  totalItems: number;
+}
+
+type PlanFilter = 'all' | string;
+
+/**
+ * RBAC-P5-019 (#709) — Super Admin operator panel: tenant list.
+ *
+ * Lives at `/admin/tenants` inside the existing admin app. The
+ * long-term home per the ticket spec is the dedicated
+ * `admin.cortex.pl` subdomain; that's an operator infra task
+ * (Caddyfile + cookie domain config) and not a blocker for the
+ * functional substrate — the page works today on the main domain
+ * gated by the `super_admin` role check on the backend.
+ *
+ * **Privacy boundary:** the wire shape carries metadata only (tenant
+ * identity, plan, locale config, active-user counter). Tenant domain
+ * data (products, attributes, values) is NEVER exposed here — the
+ * audit row stamps `cross_tenant_access=true` on every read so the
+ * forensic trail is mechanical.
+ */
+export function AdminTenantsListPage() {
+  const { t } = useTranslation();
+  const [tenants, setTenants] = useState<AdminTenantSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [forbidden, setForbidden] = useState(false);
+  const [error, setError] = useState(false);
+
+  const [search, setSearch] = useState('');
+  const [planFilter, setPlanFilter] = useState<PlanFilter>('all');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    jsonFetch<ListResponse>('/api/admin/tenants', { method: 'GET' })
+      .then((data) => {
+        if (!cancelled) setTenants(data.member);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if ((err as { status?: number })?.status === 403) {
+          setForbidden(true);
+        } else {
+          setError(true);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const plans = useMemo(() => {
+    const seen = new Set<string>();
+    for (const tenant of tenants) seen.add(tenant.plan);
+    return Array.from(seen).sort();
+  }, [tenants]);
+
+  const filtered = useMemo(() => {
+    const needle = search.trim().toLowerCase();
+    return tenants.filter((tenant) => {
+      if (planFilter !== 'all' && tenant.plan !== planFilter) return false;
+      if (needle.length > 0) {
+        const haystack = `${tenant.code} ${tenant.name} ${tenant.domain ?? ''}`.toLowerCase();
+        if (!haystack.includes(needle)) return false;
+      }
+      return true;
+    });
+  }, [tenants, search, planFilter]);
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-md rounded-lg border border-amber-200 bg-amber-50 p-6 text-center text-sm text-amber-800">
+        <ShieldAlert className="mx-auto mb-2 size-8" aria-hidden="true" />
+        <h2 className="display mb-1 text-lg font-semibold">{t('admin.tenants.forbidden_title')}</h2>
+        <p>{t('admin.tenants.forbidden_description')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <header>
+        <div className="flex items-baseline gap-2">
+          <Building2 className="size-5 text-accent-violet" aria-hidden="true" />
+          <h2 className="display text-xl font-semibold tracking-tight">
+            {t('admin.tenants.title')}
+          </h2>
+        </div>
+        <p className="max-w-2xl text-sm text-muted-foreground">{t('admin.tenants.intro')}</p>
+      </header>
+
+      <div className="rounded-md border border-dashed bg-amber-50 px-3 py-2 text-xs text-amber-900">
+        {t('admin.tenants.privacy_boundary_notice')}
+      </div>
+
+      <div className="rounded-lg border bg-background p-3 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          <Input
+            type="search"
+            placeholder={t('admin.tenants.search_placeholder')}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="flex-1"
+          />
+          <label className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+            <span>{t('admin.tenants.filter_plan')}:</span>
+            <select
+              value={planFilter}
+              onChange={(e) => setPlanFilter(e.target.value)}
+              className="h-9 rounded-md border border-input bg-background px-2 text-xs"
+            >
+              <option value="all">{t('admin.tenants.filter_plan_all')}</option>
+              {plans.map((plan) => (
+                <option key={plan} value={plan}>
+                  {plan}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="text-xs text-muted-foreground sm:ml-auto">
+            {t('admin.tenants.count', { count: filtered.length })}
+          </div>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-8 text-muted-foreground">
+          <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+        </div>
+      ) : error ? (
+        <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+          {t('admin.tenants.error_loading')}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-md border bg-background px-3 py-8 text-center text-sm text-muted-foreground">
+          {t('admin.tenants.empty')}
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border bg-background shadow-sm">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 text-left">{t('admin.tenants.col_tenant')}</th>
+                <th className="px-4 py-2 text-left">{t('admin.tenants.col_plan')}</th>
+                <th className="px-4 py-2 text-left">{t('admin.tenants.col_users')}</th>
+                <th className="px-4 py-2 text-left">{t('admin.tenants.col_locales')}</th>
+                <th className="px-4 py-2 text-left">{t('admin.tenants.col_created')}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((tenant) => (
+                <TenantRow key={tenant.id} tenant={tenant} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TenantRow({ tenant }: { tenant: AdminTenantSummary }) {
+  const { i18n } = useTranslation();
+  const createdAt = new Date(tenant.created_at).toLocaleDateString(i18n.language);
+
+  return (
+    <tr className="border-t hover:bg-muted/20">
+      <td className="px-4 py-2.5">
+        <div className="space-y-0.5">
+          <div className="text-sm font-medium">{tenant.name}</div>
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span className="font-mono">{tenant.code}</span>
+            {tenant.domain ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>{tenant.domain}</span>
+              </>
+            ) : null}
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-2.5">
+        <PlanBadge plan={tenant.plan} />
+      </td>
+      <td className="px-4 py-2.5 text-xs">
+        <span className="inline-flex items-center gap-1 text-muted-foreground">
+          <Users className="size-3" aria-hidden="true" />
+          {tenant.active_users}
+        </span>
+      </td>
+      <td className="px-4 py-2.5">
+        <div className="flex flex-wrap gap-1">
+          {tenant.enabled_locales.map((locale) => (
+            <span
+              key={locale}
+              className={cn(
+                'rounded px-1.5 py-0.5 text-[10px] font-mono ring-1',
+                locale === tenant.primary_locale
+                  ? 'bg-accent-violet/10 text-accent-violet ring-accent-violet/30'
+                  : 'bg-muted text-muted-foreground ring-input',
+              )}
+            >
+              {locale}
+            </span>
+          ))}
+        </div>
+      </td>
+      <td className="px-4 py-2.5 text-xs text-muted-foreground">{createdAt}</td>
+    </tr>
+  );
+}
+
+function PlanBadge({ plan }: { plan: string }) {
+  const classes: Record<string, string> = {
+    starter: 'bg-blue-50 text-blue-700 ring-blue-200',
+    growth: 'bg-violet-50 text-violet-700 ring-violet-200',
+    scale: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    enterprise: 'bg-amber-50 text-amber-700 ring-amber-200',
+  };
+  return (
+    <span
+      className={cn(
+        'inline-flex rounded px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide ring-1',
+        classes[plan] ?? 'bg-muted text-muted-foreground ring-input',
+      )}
+    >
+      {plan}
+    </span>
+  );
+}

--- a/apps/admin/src/features/admin/tenants/index.tsx
+++ b/apps/admin/src/features/admin/tenants/index.tsx
@@ -1,12 +1,16 @@
 import { Building2, Loader2, ShieldAlert, Users } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
 
 import { Input } from '@/components/ui/input';
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
+import { AdminTenantShowPage } from './AdminTenantShowPage';
 import type { AdminTenantSummary } from './types';
+
+export { AdminTenantShowPage };
 
 interface ListResponse {
   member: AdminTenantSummary[];
@@ -181,8 +185,8 @@ function TenantRow({ tenant }: { tenant: AdminTenantSummary }) {
   return (
     <tr className="border-t hover:bg-muted/20">
       <td className="px-4 py-2.5">
-        <div className="space-y-0.5">
-          <div className="text-sm font-medium">{tenant.name}</div>
+        <Link to={`/admin/tenants/${tenant.id}`} className="block">
+          <div className="text-sm font-medium hover:underline">{tenant.name}</div>
           <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
             <span className="font-mono">{tenant.code}</span>
             {tenant.domain ? (
@@ -192,7 +196,7 @@ function TenantRow({ tenant }: { tenant: AdminTenantSummary }) {
               </>
             ) : null}
           </div>
-        </div>
+        </Link>
       </td>
       <td className="px-4 py-2.5">
         <PlanBadge plan={tenant.plan} />

--- a/apps/admin/src/features/admin/tenants/types.ts
+++ b/apps/admin/src/features/admin/tenants/types.ts
@@ -1,0 +1,20 @@
+/**
+ * RBAC-P5-019 (#709) — wire shape for `/api/admin/tenants`.
+ * Mirrors {@link SuperAdminTenantResponseBuilder} on the API side.
+ *
+ * **Privacy boundary:** this contract carries metadata only — never
+ * per-tenant domain rows. Adding a field that exposes products /
+ * attributes / values would breach PRD §11.
+ */
+
+export interface AdminTenantSummary {
+  id: string;
+  code: string;
+  name: string;
+  domain: string | null;
+  plan: string;
+  primary_locale: string;
+  enabled_locales: string[];
+  active_users: number;
+  created_at: string;
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -72,7 +72,19 @@
       "empty": "No tenants match the current filters.",
       "error_loading": "Could not load tenants list.",
       "forbidden_title": "Super Admin only",
-      "forbidden_description": "The operator panel is restricted to users with the Super Admin role. Contact your platform administrator."
+      "forbidden_description": "The operator panel is restricted to users with the Super Admin role. Contact your platform administrator.",
+      "detail": {
+        "back": "Back to tenant list",
+        "loading": "Loading...",
+        "not_found": "No tenant found with this ID.",
+        "field_plan": "Plan",
+        "field_users": "Active users",
+        "field_users_hint": "Counts only accounts with status `active`. Deactivated accounts are excluded.",
+        "field_created": "Created",
+        "field_locales": "Locales",
+        "field_locales_hint": "Primary locale: {{primary}}. The rest are secondary.",
+        "crud_deferred": "Plan change / suspend / delete land in #711. Storage usage + bandwidth metrics once the backend exposes a telemetry endpoint."
+      }
     }
   },
   "settings": {

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -53,6 +53,28 @@
     "active_modules_count_one": "{{count}} active module",
     "active_modules_count_other": "{{count}} active modules"
   },
+  "admin": {
+    "tenants": {
+      "title": "Tenants (Super Admin)",
+      "intro": "Cross-tenant list of every tenant on the platform. Metadata only (name, plan, users, locales, creation date). Every read stamps `cross_tenant_access=true` on the audit log.",
+      "privacy_boundary_notice": "Privacy boundary (PRD §11): Super Admin sees tenant metadata only. Domain data (Products, Attributes, Values) stays invisible — enforced at the API endpoint layer, not just the UI.",
+      "search_placeholder": "Search tenant by name, code, or domain...",
+      "filter_plan": "Plan",
+      "filter_plan_all": "All plans",
+      "count_one": "{{count}} tenant",
+      "count_other": "{{count}} tenants",
+      "count": "{{count}} tenants",
+      "col_tenant": "Tenant",
+      "col_plan": "Plan",
+      "col_users": "Active",
+      "col_locales": "Locales",
+      "col_created": "Created",
+      "empty": "No tenants match the current filters.",
+      "error_loading": "Could not load tenants list.",
+      "forbidden_title": "Super Admin only",
+      "forbidden_description": "The operator panel is restricted to users with the Super Admin role. Contact your platform administrator."
+    }
+  },
   "settings": {
     "page_title": "Settings",
     "subnav_aria": "Settings sections",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -74,7 +74,19 @@
       "empty": "Brak tenantów pasujących do filtrów.",
       "error_loading": "Nie udało się załadować listy tenantów.",
       "forbidden_title": "Tylko Super Admin",
-      "forbidden_description": "Operator panel jest dostępny wyłącznie dla użytkowników z rolą Super Admin. Skontaktuj się z administratorem platformy."
+      "forbidden_description": "Operator panel jest dostępny wyłącznie dla użytkowników z rolą Super Admin. Skontaktuj się z administratorem platformy.",
+      "detail": {
+        "back": "Wróć do listy tenantów",
+        "loading": "Wczytywanie...",
+        "not_found": "Nie znaleziono tenanta o tym ID.",
+        "field_plan": "Plan",
+        "field_users": "Aktywni użytkownicy",
+        "field_users_hint": "Liczy tylko konta ze statusem `active`. Deaktywowane są pominięte.",
+        "field_created": "Data utworzenia",
+        "field_locales": "Locales",
+        "field_locales_hint": "Primary locale: {{primary}}. Pozostałe są secondary.",
+        "crud_deferred": "Zmiana planu / suspend / delete tenanta dochodzą w #711. Storage usage + bandwidth metrics gdy backend wystawi telemetry endpoint."
+      }
     }
   },
   "settings": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -55,6 +55,28 @@
     "active_modules_count_many": "{{count}} modułów aktywnych",
     "active_modules_count_other": "{{count}} modułów aktywnych"
   },
+  "admin": {
+    "tenants": {
+      "title": "Tenants (Super Admin)",
+      "intro": "Cross-tenant lista wszystkich tenantów na platformie. Tylko metadata (nazwa, plan, użytkownicy, lokalizacje, data utworzenia). Każde wejście stamps `cross_tenant_access=true` w audit log.",
+      "privacy_boundary_notice": "Privacy boundary (PRD §11): Super Admin widzi wyłącznie metadata tenantów. Dane domenowe (Products, Attributes, Values) są niedostępne — kontrola na poziomie API endpointów, nie tylko UI.",
+      "search_placeholder": "Szukaj tenanta po nazwie, kodzie lub domenie...",
+      "filter_plan": "Plan",
+      "filter_plan_all": "Wszystkie plany",
+      "count_one": "{{count}} tenant",
+      "count_other": "{{count}} tenantów",
+      "count": "{{count}} tenantów",
+      "col_tenant": "Tenant",
+      "col_plan": "Plan",
+      "col_users": "Aktywni",
+      "col_locales": "Locales",
+      "col_created": "Utworzony",
+      "empty": "Brak tenantów pasujących do filtrów.",
+      "error_loading": "Nie udało się załadować listy tenantów.",
+      "forbidden_title": "Tylko Super Admin",
+      "forbidden_description": "Operator panel jest dostępny wyłącznie dla użytkowników z rolą Super Admin. Skontaktuj się z administratorem platformy."
+    }
+  },
   "settings": {
     "page_title": "Ustawienia",
     "subnav_aria": "Sekcje ustawień",

--- a/apps/api/src/Identity/Application/SuperAdmin/SuperAdminTenantResponseBuilder.php
+++ b/apps/api/src/Identity/Application/SuperAdmin/SuperAdminTenantResponseBuilder.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\SuperAdmin;
+
+use App\Shared\Domain\Tenant;
+use DateTimeInterface;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P5-019 (#709) — projection helper for the Super Admin operator
+ * panel's tenant listing.
+ *
+ * Privacy boundary: this builder NEVER touches per-tenant domain rows
+ * (products, attributes, values) — only metadata: tenant identity,
+ * plan, audit timestamps, and aggregate counters (active user count).
+ * PRD §11 forbids Super Admin from reading domain data; the audit log
+ * tag `cross_tenant_access=true` plus this projection's narrow shape
+ * make the boundary mechanical.
+ */
+final readonly class SuperAdminTenantResponseBuilder
+{
+    public function __construct(
+        private Connection $connection,
+    ) {
+    }
+
+    /**
+     * @param iterable<Tenant> $rows
+     *
+     * @return list<array{
+     *     id: string,
+     *     code: string,
+     *     name: string,
+     *     domain: ?string,
+     *     plan: string,
+     *     primary_locale: string,
+     *     enabled_locales: list<string>,
+     *     active_users: int,
+     *     created_at: string
+     * }>
+     */
+    public function buildList(iterable $rows): array
+    {
+        $out = [];
+        foreach ($rows as $tenant) {
+            $out[] = $this->buildOne($tenant);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     code: string,
+     *     name: string,
+     *     domain: ?string,
+     *     plan: string,
+     *     primary_locale: string,
+     *     enabled_locales: list<string>,
+     *     active_users: int,
+     *     created_at: string
+     * }
+     */
+    public function buildOne(Tenant $tenant): array
+    {
+        return [
+            'id' => $tenant->getId()->toRfc4122(),
+            'code' => $tenant->getCode(),
+            'name' => $tenant->getName(),
+            'domain' => $tenant->getDomain(),
+            'plan' => $tenant->getPlan(),
+            'primary_locale' => $tenant->getPrimaryLocale(),
+            'enabled_locales' => $tenant->getEnabledLocales(),
+            'active_users' => $this->countActiveUsers($tenant->getId()),
+            'created_at' => $tenant->getCreatedAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * Counter via raw DBAL — cheaper than booting the full User aggregate
+     * just to count rows. Filters by `status = 'active'` so suspended
+     * accounts don't inflate the headline number.
+     */
+    private function countActiveUsers(Uuid $tenantId): int
+    {
+        $count = $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM users WHERE tenant_id = :tenant_id AND status = 'active'",
+            ['tenant_id' => $tenantId->toRfc4122()],
+        );
+
+        return \is_numeric($count) ? (int) $count : 0;
+    }
+}

--- a/apps/api/src/Identity/Presentation/Controller/SuperAdminTenantsController.php
+++ b/apps/api/src/Identity/Presentation/Controller/SuperAdminTenantsController.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Identity\Application\SuperAdmin\SuperAdminContext;
+use App\Identity\Application\SuperAdmin\SuperAdminTenantResponseBuilder;
+use App\Identity\Domain\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use InvalidArgumentException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * RBAC-P5-019 (#709) + RBAC-P5-020 (#710) — Super Admin operator panel
+ * endpoints for the tenant list + detail views.
+ *
+ *   - GET /api/admin/tenants
+ *     Cross-tenant list of every tenant on the platform, metadata only.
+ *
+ *   - GET /api/admin/tenants/{id}
+ *     Single-tenant detail with metadata + aggregate counters.
+ *
+ * Privacy boundary (PRD §11): the response shape exposes tenant
+ * identity, plan, locale config, and an active-user counter. It NEVER
+ * touches per-tenant domain rows (products, attributes, values) — those
+ * stay invisible to Super Admin per the PIM privacy contract. The
+ * audit subsystem stamps `cross_tenant_access=true` on every entry
+ * produced by this controller via {@see SuperAdminContext}.
+ *
+ * Auth gate: the route requires the global `super_admin` role.
+ * `RequiresPermission(module: 'user', action: 'admin')` keeps the same
+ * legacy attribute the rest of Phase 5 uses + we add an explicit
+ * super-admin role check on top (Phase 6 retrofit migrates onto PRD
+ * `platform.tenants.list` / `platform.tenants.manage`).
+ *
+ * **Deployment topology note:** per #709 the long-term home for these
+ * endpoints is the dedicated `admin.cortex.pl` subdomain with a
+ * separate JWT cookie scope. That split is operator infra work
+ * (Caddyfile + cookie domain config) and is not a blocker for the
+ * functional substrate — the routes work today on the main domain
+ * gated by the role check. The subdomain migration lands in a
+ * follow-up deployment ticket without code changes here.
+ */
+final readonly class SuperAdminTenantsController
+{
+    public function __construct(
+        private Security $security,
+        private SuperAdminContext $superAdminContext,
+        private TenantRepositoryInterface $tenants,
+        private SuperAdminTenantResponseBuilder $builder,
+    ) {
+    }
+
+    #[Route(path: '/api/admin/tenants', methods: ['GET'], name: 'api_admin_tenants_list')]
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function list(): JsonResponse
+    {
+        $superAdminId = $this->requireSuperAdmin();
+        if ($superAdminId instanceof JsonResponse) {
+            return $superAdminId;
+        }
+
+        $rows = $this->superAdminContext->runCrossTenant(
+            $superAdminId,
+            fn (): array => $this->tenants->findAllOrderedByCode(),
+        );
+        $member = $this->builder->buildList($rows);
+
+        return new JsonResponse([
+            'member' => $member,
+            'totalItems' => \count($member),
+            'meta' => [
+                'page' => 1,
+                'per_page' => \count($member),
+                'total_pages' => 1,
+            ],
+        ]);
+    }
+
+    #[Route(
+        path: '/api/admin/tenants/{id}',
+        methods: ['GET'],
+        name: 'api_admin_tenants_detail',
+        requirements: ['id' => '[0-9a-f-]{36}'],
+    )]
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function detail(string $id): JsonResponse
+    {
+        $superAdminId = $this->requireSuperAdmin();
+        if ($superAdminId instanceof JsonResponse) {
+            return $superAdminId;
+        }
+
+        try {
+            $uuid = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Tenant not found.');
+        }
+
+        $tenant = $this->superAdminContext->runCrossTenant(
+            $superAdminId,
+            fn () => $this->tenants->findById($uuid),
+        );
+        if (null === $tenant) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Tenant not found.');
+        }
+
+        return new JsonResponse($this->builder->buildOne($tenant));
+    }
+
+    /**
+     * Returns the active Super Admin's Uuid on success, or a 403 problem
+     * response if the caller does not hold the `super_admin` role.
+     */
+    private function requireSuperAdmin(): Uuid|JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
+        }
+
+        $hasSuperAdmin = false;
+        foreach ($user->getAssignedRoles() as $role) {
+            if (RbacMatrix::ROLE_SUPER_ADMIN === $role->getCode()) {
+                $hasSuperAdmin = true;
+                break;
+            }
+        }
+
+        if (!$hasSuperAdmin) {
+            return $this->problem(
+                Response::HTTP_FORBIDDEN,
+                'Forbidden',
+                'Super Admin role required to access the operator panel.',
+                ['code' => 'super_admin_required'],
+            );
+        }
+
+        return $user->getId();
+    }
+
+    /**
+     * @param array<string, mixed> $extras
+     */
+    private function problem(int $status, string $title, string $detail, array $extras = []): JsonResponse
+    {
+        return new JsonResponse(
+            array_merge(
+                [
+                    'type' => 'about:blank',
+                    'title' => $title,
+                    'status' => $status,
+                    'detail' => $detail,
+                ],
+                $extras,
+            ),
+            $status,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
+    }
+}

--- a/apps/api/src/Shared/Domain/Repository/TenantRepositoryInterface.php
+++ b/apps/api/src/Shared/Domain/Repository/TenantRepositoryInterface.php
@@ -21,4 +21,15 @@ interface TenantRepositoryInterface
     public function save(Tenant $tenant): void;
 
     public function remove(Tenant $tenant): void;
+
+    /**
+     * RBAC-P5-019 (#709) — every tenant on the platform, ordered by code
+     * for deterministic listing in the Super Admin operator panel.
+     * Cross-tenant by design — callers MUST be Super Admin and operate
+     * inside {@see \App\Identity\Application\SuperAdmin\SuperAdminContext}
+     * so the TenantFilter is disabled.
+     *
+     * @return list<Tenant>
+     */
+    public function findAllOrderedByCode(): array;
 }

--- a/apps/api/src/Shared/Infrastructure/Doctrine/Repository/DoctrineTenantRepository.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Repository/DoctrineTenantRepository.php
@@ -43,4 +43,15 @@ class DoctrineTenantRepository extends ServiceEntityRepository implements Tenant
         $em->remove($tenant);
         $em->flush();
     }
+
+    public function findAllOrderedByCode(): array
+    {
+        /** @var list<Tenant> $result */
+        $result = $this->createQueryBuilder('t')
+            ->orderBy('t.code', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
 }

--- a/apps/api/tests/Unit/Shared/Infrastructure/Messenger/TenantContextRebindingMiddlewareTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Messenger/TenantContextRebindingMiddlewareTest.php
@@ -227,4 +227,9 @@ final class InMemoryTenantRepoStub implements TenantRepositoryInterface
     public function remove(Tenant $tenant): void
     {
     }
+
+    public function findAllOrderedByCode(): array
+    {
+        return null === $this->tenant ? [] : [$this->tenant];
+    }
 }


### PR DESCRIPTION
## Summary

Combines **#709 (Tenant list)** + **#710 (Tenant detail)** because the backend endpoint shape is identical and the FE pages share types/components.

### Backend

- `GET /api/admin/tenants` — cross-tenant list under `super_admin` role check + `SuperAdminContext::runCrossTenant()` for TenantFilter bypass.
- `GET /api/admin/tenants/{id}` — single-tenant metadata for detail view.
- Both endpoints stamp `cross_tenant_access=true` + `super_admin_id` on every audit log row produced (via SuperAdminContext).
- TenantRepositoryInterface gains `findAllOrderedByCode()`.

### Privacy boundary (PRD §11)

Wire shape carries metadata only: id, code, name, domain, plan, primary_locale, enabled_locales, active_users (via raw DBAL), created_at. **NEVER** exposes products/attributes/values. Active-user counter filters by `status = 'active'` so suspended accounts don't inflate the headline number.

### Frontend

- `/admin/tenants` — table with search (case-insensitive on code/name/domain), plan filter, plan badges, locale chips (primary highlighted), active-user counter. Forbidden state surfaces inline as \"Super Admin only\" notice.
- `/admin/tenants/{id}` — 4-card grid for plan / active users / created-at / locales, with a deferred-features banner pointing at #711 (tenant CRUD) and at the not-yet-wired storage/bandwidth telemetry.
- Row name links to detail page via `<Link>`.

## Deployment topology decision

Per #709 the long-term home is the dedicated `admin.cortex.pl` subdomain with a separate JWT cookie scope. That split is **operator infra work** (Caddyfile + cookie domain config) and **not a blocker** for the functional substrate — the routes work today on the main domain gated by the role check. The subdomain migration is a deployment-only task and lands without code changes here.

## Acceptance criteria mapping

### #709 — Tenant list
- [ ] AC-1 (`admin.cortex.pl` accessible) — **deferred** to operator infra task. Routes work on main domain today.
- [ ] AC-2 (`/admin/login` separate from user login) — **deferred** along with subdomain. Today: same JWT, role check enforces super_admin scope.
- [x] AC-3 — Tenant list renders metadata.
- [x] AC-4 — Privacy boundary: response shape carries no products/attributes/values.

### #710 — Tenant detail
- [x] AC-1 — Tenant detail page renders all metadata fields.
- [x] AC-2 — Read-only by design (write operations land in #711).
- [x] AC-3 — Privacy boundary maintained (same response shape as list).

## Test plan

- [x] PHPStan max — green
- [x] TypeScript noEmit — green
- [x] Biome strict — green
- [x] Live-stack smoke:
  - `GET /api/admin/tenants` → 200, 2 tenants (acme + demo) with metadata only
  - `GET /api/admin/tenants/{id}` → 200, full detail
  - Bad UUID → 404
  - Privacy: response keys = `[id, code, name, domain, plan, primary_locale, enabled_locales, active_users, created_at]` only — no products/attributes/values fields anywhere.
- [ ] Manual UI smoke after merge: `https://pim.localhost/admin/tenants` → table → click row → detail page.

Refs #709 #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)