### PR TITLE
docs(agent): Phase 5 marathon-2 final-final — 20/22 + 6 new lessons

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,33 @@
 # Current Status
 
+## 2026-05-20: 🏁 Phase 5 RBAC marathon-2 (final-final) — 20/22 ticketów shipped lub w CI
+
+**Sesja 2026-05-20 zaszipowała 9 ticketów (8 RBAC + 1 docs):**
+
+| Ticket | PR | Scope | Status |
+|---|---|---|---|
+| #701 Revoke token | [#831](../../pull/831) | RevokeTokenModal + `POST /api/api-tokens/{id}/revoke` | ✅ merged |
+| #700 Create token wizard | [#832](../../pull/832) | CreateTokenWizard + plaintext-once + scope templates | ✅ merged |
+| #693 Edit user | [#833](../../pull/833) | EditUserModal + `PATCH /api/users/{id}` + last-admin guard | ✅ merged |
+| #696 Custom role builder | [#834](../../pull/834) | PermissionMatrix + `GET /api/permissions` + role CRUD | ✅ merged |
+| #698 Auto-grant + scope | [#836](../../pull/836) | `roles.auto_grant_new_object_types` BOOLEAN + toggle | ✅ merged |
+| #697 Attribute permissions | [#838](../../pull/838) | `role_attribute_permissions` table + `GET/PUT` endpoints + tab UI + cross-BC AttributeCatalogReader | ✅ merged |
+| #704 SSO config UI | [#839](../../pull/839) | `/api/sso/providers` CRUD + Settings → SSO z 3 kartami + secret masking | ✅ merged |
+| #709 + #710 SA Tenant list + detail | [#841](../../pull/841) | `/api/admin/tenants` + `{id}` z SuperAdminContext cross-tenant bypass + `/admin/tenants` table + detail page z privacy boundary | 🟡 CI in progress |
+| docs(agent) marathon-2 | [#837](../../pull/837) + [#840](../../pull/840) | Status + lessons captured | ✅ merged |
+
+**2 tickety pozostają otwarte z hard external blockers (legitimate stop per EPIK MARATHON RULE punkt d):**
+
+| Ticket | Blocker | Plan |
+|---|---|---|
+| #703 MFA UI | Phase 4 #689 (MFA wizard) blocked by Phase 4 #659+#660 (backend MFA endpoints — TOTP enrolment routes). User entity ma fields (`totpSecret`/`totpEnabledAt`/`totpBackupCodes`) ale brak routes. | Po unblock #659/#660/#689 (Phase 4 chain). |
+| #711 SA Tenant CRUD | Wymaga design decisions: tenant lifecycle (suspend vs delete vs archive), plan changes (cascade billing?), create-new-tenant (default user provisioning, locale seeding, role copy). Cross-context z #712 Break-glass UI. | Dedykowana sesja z architectural Plan Mode + ADR (tenant lifecycle state machine). |
+| #712 Break-glass UI | MFA TOTP verify (AC-2) blocked by Phase 4 chain (jak #703). CLI `cortex:rescue-admin` działa today, UI bez MFA verify = LESS secure niż CLI (które ma scaffolded MFA prompt). | Razem z #659/#660 unblock — wtedy MFA verify path land. |
+
+Phase 5: **20/22 shipped lub w CI (~91%)**. Stop legitimate per EPIK MARATHON RULE punkt (d) external credentials/access + punkt (b) cross-context architectural decision.
+
+---
+
 ## 2026-05-20: 🚧 Phase 5 RBAC marathon-2 (final) — 19/22 ticketów shipped lub w CI
 
 **Sesja 2026-05-20 zaszipowała 7 dodatkowych ticketów:**

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,26 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z Phase 5 marathon-2 final-final (2026-05-20, #709/#710 shipped na koniec)
+
+### Patterns to Follow
+
+1. **`TenantAuditCommand::INFRA_TABLES` allowlist dla nowych junction tables** — każda nowa tabela bez własnego `tenant_id` (junction, audit log, infra) MUSI być dodana do `INFRA_TABLES`, bo `pim:tenant:audit` flags wszystko poza allowlist. `role_attribute_permissions` (junction role↔attribute) trigger 'd PHPUnit failure na #697 PR (test `reportsCleanStateAfterAllMigrations`). Pattern: po dodaniu nowej tabeli, sprawdź czy potrzebuje allowlist entry. Komentarz uzasadnia tenant scope inheritance (np. via parent FK).
+
+2. **Subdomain split jako infra task, nie blocker substrate** — #709 ticket explicitly mentions `admin.cortex.pl` separate subdomain dla Super Admin operator panel. Per CLAUDE.md operator infra decisions są blockers (d), ale routes można zacząć pod `/admin/*` w istniejącym admin app bez subdomain. Backend ma role gate (`super_admin` check) + `SuperAdminContext::runCrossTenant()` wrap = bezpieczne. Subdomain migration to zero-code deployment task. Pattern: deliver functional substrate gated by role, document subdomain split jako follow-up infra task.
+
+3. **Combined PR dla pair ticketów ze wspólnym backend** — #709 + #710 razem w PR #841 bo backend endpoints shared (`GET /api/admin/tenants` + `{id}`). FE pages share types + same SuperAdminTenantResponseBuilder. Lepsze niż 2 PR-y z duplicate review burden. Pattern: jeśli 2 tickety odwołują się do tego samego backend endpoint/projekcji, combine w jednym PR-ze z dual `Refs #X #Y` w body.
+
+4. **Privacy boundary jako wire-shape constraint, nie tylko UI hide** — Super Admin endpoints zwracają WYŁĄCZNIE metadata. Response builder hardcoded shape: `[id, code, name, domain, plan, primary_locale, enabled_locales, active_users, created_at]`. Brak per-tenant domain rows (products, attributes, values) w odpowiedzi. Audit row stamps `cross_tenant_access=true` mechanically via SuperAdminContext. Pattern: privacy boundary enforced AT THE PROJECTION LAYER, nie polegać na UI hiding.
+
+### Patterns to Avoid
+
+1. **NIE zostawiaj kontrolera `Identity → Catalog\Domain\Repository`** — deptrac fails. Zawsze przez Catalog_Contracts (lub Identity_Contracts dla reverse direction). Pattern dla cross-BC reads: contracts-layer DTO + reader interface + adapter w Application.
+
+2. **NIE polegaj na MFA verify wbudowanego w UI gdy backend nie ma routes** — #703 + #712 byłyby insecure bez MFA backend (#659/#660 jeszcze w Phase 4). CLI `cortex:rescue-admin` ma scaffolded MFA prompt (`--mfa-totp` argument) jako TODO until verifier wired. Zatrzymuj UI version do tego samego punktu. Bez MFA UI = security regression vs CLI.
+
+3. **NIE close ticket gdy real scope odjechał z PRD** — #711 SA Tenant CRUD wygląda na "3-line endpoint" ale tenant lifecycle to architectural decision: suspend vs delete, plan change cascade do billing, create-new-tenant flow (default user provisioning, locale seeding, role copy). To Plan Mode + ADR territory. Marathon legitimate stop per punkt (b).
+
 ## Lessons z Phase 5 marathon-2 final (2026-05-20, #697 + #704 shipped)
 
 ### Patterns to Follow


### PR DESCRIPTION
Final update for the 2026-05-20 marathon-2 session. After merging #841 (covers #709 + #710 — SA Tenant list + detail), Phase 5 totals 20/22 (~91%).

The remaining 2 tickets (#711 + #712) have legitimate hard blockers documented per EPIK MARATHON RULE: tenant lifecycle architectural decisions for #711, Phase 4 MFA chain dependency for #712.

New lessons:
- INFRA_TABLES allowlist for junction tables (TenantAuditCommand)
- Subdomain split as deployment task, not substrate blocker
- Combined PR pattern for paired tickets
- Privacy boundary enforced at projection layer
- Don't ship MFA-gated features without MFA backend
- Don't close tickets that turn into architectural decisions