### PR TITLE
feat(admin): #848 users list + invitations polish — pixel-perfect to PRD §5.4

### DIFF
--- a/apps/admin/src/features/settings/users/StatusBadge.tsx
+++ b/apps/admin/src/features/settings/users/StatusBadge.tsx
@@ -25,9 +25,14 @@ export function StatusBadge({ status }: StatusBadgeProps) {
       dot: 'bg-emerald-500',
       labelKey: 'settings.users.status.active',
     },
+    invited: {
+      cls: 'bg-amber-50 text-amber-700 ring-amber-200',
+      dot: 'bg-amber-500',
+      labelKey: 'settings.users.status.invited',
+    },
     disabled: {
-      cls: 'bg-zinc-100 text-zinc-600 ring-zinc-200',
-      dot: 'bg-zinc-400',
+      cls: 'bg-rose-50 text-rose-700 ring-rose-200',
+      dot: 'bg-rose-500',
       labelKey: 'settings.users.status.disabled',
     },
   };

--- a/apps/admin/src/features/settings/users/UsersListView.tsx
+++ b/apps/admin/src/features/settings/users/UsersListView.tsx
@@ -2,6 +2,7 @@ import { useList } from '@refinedev/core';
 import {
   ChevronLeft,
   ChevronRight,
+  Mail,
   MoreHorizontal,
   Pencil,
   Search,
@@ -9,6 +10,7 @@ import {
   UserCheck,
   UserMinus,
   UserPlus,
+  X,
 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -37,6 +39,7 @@ import { cn } from '@/lib/utils';
 import { DeactivateUserModal } from './DeactivateUserModal';
 import { EditUserModal } from './EditUserModal';
 import { InviteUserModal } from './InviteUserModal';
+import { invitationValidity, relativeTime } from './relativeTime';
 import { StatusBadge } from './StatusBadge';
 import type { UserListItem, UserStatus } from './types';
 import { UserAvatar } from './UserAvatar';
@@ -131,6 +134,39 @@ export function UsersListView() {
     }
   };
 
+  const handleResendInvitation = async (user: UserListItem) => {
+    if (!user.invitation_id) return;
+    try {
+      await jsonFetch(`/api/invitations/${user.invitation_id}/resend`, {
+        method: 'POST',
+        accept: 'application/json',
+      });
+      toast.success(t('settings.users.invitation_actions.toast_resent', { email: user.email }));
+      void refetch();
+    } catch {
+      toast.error(t('settings.users.invitation_actions.error_resend'));
+    }
+  };
+
+  const handleRevokeInvitation = async (user: UserListItem) => {
+    if (!user.invitation_id) return;
+    if (
+      !window.confirm(t('settings.users.invitation_actions.confirm_revoke', { email: user.email }))
+    ) {
+      return;
+    }
+    try {
+      await jsonFetch(`/api/invitations/${user.invitation_id}/revoke`, {
+        method: 'POST',
+        accept: 'application/json',
+      });
+      toast.success(t('settings.users.invitation_actions.toast_revoked', { email: user.email }));
+      void refetch();
+    } catch {
+      toast.error(t('settings.users.invitation_actions.error_revoke'));
+    }
+  };
+
   // Reset to page 1 whenever any filter changes — pager must not point at
   // a stale offset that no longer exists in the narrowed result set.
   useEffect(() => {
@@ -189,6 +225,7 @@ export function UsersListView() {
             options={[
               { value: 'all', label: t('settings.users.filter_status_all') },
               { value: 'active', label: t('settings.users.status.active') },
+              { value: 'invited', label: t('settings.users.status.invited') },
               { value: 'disabled', label: t('settings.users.status.disabled') },
             ]}
           />
@@ -201,7 +238,7 @@ export function UsersListView() {
             disabledHint={t('settings.users.filter_role_pending_hint')}
           />
           <div className="text-xs text-muted-foreground sm:ml-auto">
-            {t('settings.users.count', { count: total })}
+            {t('settings.users.showing_count', { shown: users.length, total })}
           </div>
         </div>
       </div>
@@ -240,6 +277,8 @@ export function UsersListView() {
                 onEdit={openEdit}
                 onDeactivate={openDeactivate}
                 onReactivate={handleReactivate}
+                onResendInvitation={handleResendInvitation}
+                onRevokeInvitation={handleRevokeInvitation}
               />
             ))}
           </TableBody>
@@ -308,21 +347,37 @@ interface UserRowProps {
   onEdit: (user: UserListItem) => void;
   onDeactivate: (user: UserListItem) => void;
   onReactivate: (user: UserListItem) => void;
+  onResendInvitation: (user: UserListItem) => void;
+  onRevokeInvitation: (user: UserListItem) => void;
 }
 
-function UserRow({ user, onEdit, onDeactivate, onReactivate }: UserRowProps) {
+function UserRow({
+  user,
+  onEdit,
+  onDeactivate,
+  onReactivate,
+  onResendInvitation,
+  onRevokeInvitation,
+}: UserRowProps) {
   const { t, i18n } = useTranslation();
-  const lastLogin = user.last_login_at
-    ? new Date(user.last_login_at).toLocaleString(i18n.language)
-    : t('settings.users.last_login_never');
+  const isInvitation = user.kind === 'invitation';
+  const isDisabled = user.status === 'disabled';
+  const lastLogin = isInvitation
+    ? t('settings.users.last_login_n_a')
+    : relativeTime(t, i18n.language, user.last_login_at);
+  const invitationValidLabel = isInvitation
+    ? invitationValidity(t, user.invitation_expires_at)
+    : null;
 
   return (
-    <TableRow className={cn(user.status === 'disabled' && 'opacity-60')}>
+    <TableRow
+      className={cn((isDisabled || isInvitation) && 'opacity-90', isDisabled && 'opacity-60')}
+    >
       <TableCell className="pl-5">
         <div className="flex items-center gap-3">
           <UserAvatar initial={user.avatar_initial} seed={user.email} />
           <div className="min-w-0">
-            <div className="text-sm font-medium">{user.display_name}</div>
+            <div className="truncate text-sm font-medium">{user.display_name}</div>
             <div className="truncate text-xs text-muted-foreground">{user.email}</div>
           </div>
         </div>
@@ -339,7 +394,12 @@ function UserRow({ user, onEdit, onDeactivate, onReactivate }: UserRowProps) {
         )}
       </TableCell>
       <TableCell>
-        <StatusBadge status={user.status} />
+        <div className="space-y-0.5">
+          <StatusBadge status={user.status} />
+          {invitationValidLabel ? (
+            <div className="text-[10px] text-muted-foreground">{invitationValidLabel}</div>
+          ) : null}
+        </div>
       </TableCell>
       <TableCell className="text-xs text-muted-foreground">{lastLogin}</TableCell>
       <TableCell className="pr-5 text-right">
@@ -350,23 +410,41 @@ function UserRow({ user, onEdit, onDeactivate, onReactivate }: UserRowProps) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onSelect={() => onEdit(user)}>
-              <Pencil className="mr-2 size-4" aria-hidden="true" />
-              {t('settings.users.action_edit')}
-            </DropdownMenuItem>
-            {user.status === 'active' ? (
-              <DropdownMenuItem
-                onSelect={() => onDeactivate(user)}
-                className="text-rose-600 focus:text-rose-700"
-              >
-                <UserMinus className="mr-2 size-4" aria-hidden="true" />
-                {t('settings.users.action_deactivate')}
-              </DropdownMenuItem>
+            {isInvitation ? (
+              <>
+                <DropdownMenuItem onSelect={() => onResendInvitation(user)}>
+                  <Mail className="mr-2 size-4" aria-hidden="true" />
+                  {t('settings.users.invitation_actions.resend')}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => onRevokeInvitation(user)}
+                  className="text-rose-600 focus:text-rose-700"
+                >
+                  <X className="mr-2 size-4" aria-hidden="true" />
+                  {t('settings.users.invitation_actions.revoke')}
+                </DropdownMenuItem>
+              </>
             ) : (
-              <DropdownMenuItem onSelect={() => onReactivate(user)}>
-                <UserCheck className="mr-2 size-4" aria-hidden="true" />
-                {t('settings.users.action_reactivate')}
-              </DropdownMenuItem>
+              <>
+                <DropdownMenuItem onSelect={() => onEdit(user)}>
+                  <Pencil className="mr-2 size-4" aria-hidden="true" />
+                  {t('settings.users.action_edit')}
+                </DropdownMenuItem>
+                {user.status === 'active' ? (
+                  <DropdownMenuItem
+                    onSelect={() => onDeactivate(user)}
+                    className="text-rose-600 focus:text-rose-700"
+                  >
+                    <UserMinus className="mr-2 size-4" aria-hidden="true" />
+                    {t('settings.users.action_deactivate')}
+                  </DropdownMenuItem>
+                ) : (
+                  <DropdownMenuItem onSelect={() => onReactivate(user)}>
+                    <UserCheck className="mr-2 size-4" aria-hidden="true" />
+                    {t('settings.users.action_reactivate')}
+                  </DropdownMenuItem>
+                )}
+              </>
             )}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/admin/src/features/settings/users/relativeTime.ts
+++ b/apps/admin/src/features/settings/users/relativeTime.ts
@@ -1,0 +1,45 @@
+import type { TFunction } from 'i18next';
+
+/**
+ * UI polish #848 — relative-time helper for the Users list "Last login"
+ * column per PRD §5.4 mockup ("2 min ago", "1 hour ago", "yesterday").
+ *
+ * Stays compact + locale-aware via i18n keys; no external dep (date-fns
+ * etc.) because the use site is one column and the math is trivial.
+ * Falls back to absolute date for events older than 14 days where
+ * relative phrasing stops being useful.
+ */
+export function relativeTime(t: TFunction, locale: string, iso: string | null): string {
+  if (null === iso) return t('settings.users.last_login_never');
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return t('settings.users.last_login_never');
+  const now = new Date();
+  const seconds = Math.floor((now.getTime() - then.getTime()) / 1000);
+  if (seconds < 0) return then.toLocaleString(locale);
+  if (seconds < 60) return t('settings.users.relative.just_now');
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return t('settings.users.relative.minutes_ago', { count: minutes });
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return t('settings.users.relative.hours_ago', { count: hours });
+  const days = Math.floor(hours / 24);
+  if (days === 1) return t('settings.users.relative.yesterday');
+  if (days < 14) return t('settings.users.relative.days_ago', { count: days });
+  return then.toLocaleDateString(locale);
+}
+
+/**
+ * UI polish #848 — "link Nd valid" string per PRD §5.4 mockup, where N
+ * is days remaining until invitation expiry. Returns null when the
+ * invitation has expired (the backend filters those out, but defensive).
+ */
+export function invitationValidity(t: TFunction, expiresAtIso: string | null): string | null {
+  if (null === expiresAtIso) return null;
+  const expires = new Date(expiresAtIso);
+  if (Number.isNaN(expires.getTime())) return null;
+  const seconds = Math.floor((expires.getTime() - Date.now()) / 1000);
+  if (seconds <= 0) return null;
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor(seconds / 3600);
+  if (days >= 1) return t('settings.users.invitation_valid_days', { count: days });
+  return t('settings.users.invitation_valid_hours', { count: Math.max(1, hours) });
+}

--- a/apps/admin/src/features/settings/users/types.ts
+++ b/apps/admin/src/features/settings/users/types.ts
@@ -1,8 +1,11 @@
 /**
- * RBAC-P5-001 (#691) — wire shape for the Settings → Users list. Mirrors
- * the projection produced by {@link UserListResponseBuilder} on the API
- * side. Lives next to the page that consumes it so the contract is easy
- * to audit when the backend evolves.
+ * RBAC-P5-001 (#691) + UI polish #848 — wire shape for the Settings →
+ * Users list. Mirrors {@link UserListResponseBuilder} on the API side.
+ *
+ * Pending invitations surface as `kind: 'invitation'` rows so the
+ * §5.4 mockup's three statuses (Active / Invited / Deactivated) all
+ * render from one list. The `invitation_*` fields are populated for
+ * invitation rows and null on user rows.
  */
 
 export interface UserRoleRef {
@@ -11,10 +14,12 @@ export interface UserRoleRef {
   name: string;
 }
 
-export type UserStatus = 'active' | 'disabled';
+export type UserKind = 'user' | 'invitation';
+export type UserStatus = 'active' | 'disabled' | 'invited';
 
 export interface UserListItem {
   id: string;
+  kind: UserKind;
   email: string;
   display_name: string;
   avatar_initial: string;
@@ -23,4 +28,8 @@ export interface UserListItem {
   last_login_at: string | null;
   mfa_enabled: boolean;
   created_at: string;
+  /** Invitation uuid when `kind === 'invitation'`, else null. */
+  invitation_id: string | null;
+  /** ATOM timestamp of invitation expiry when applicable. */
+  invitation_expires_at: string | null;
 }

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -485,6 +485,7 @@
       "count_one": "{{count}} user",
       "count_other": "{{count}} users",
       "count": "{{count}} users",
+      "showing_count": "Showing {{shown}} of {{total}} users",
       "col_user": "User",
       "col_roles": "Roles",
       "col_status": "Status",
@@ -495,6 +496,35 @@
       "action_edit": "Edit",
       "action_deactivate": "Deactivate",
       "action_reactivate": "Reactivate",
+      "last_login_n_a": "—",
+      "invitation_valid_days_one": "(link valid {{count}}d)",
+      "invitation_valid_days_other": "(link valid {{count}}d)",
+      "invitation_valid_days": "(link valid {{count}}d)",
+      "invitation_valid_hours_one": "(link valid {{count}}h)",
+      "invitation_valid_hours_other": "(link valid {{count}}h)",
+      "invitation_valid_hours": "(link valid {{count}}h)",
+      "relative": {
+        "just_now": "just now",
+        "minutes_ago_one": "{{count}} min ago",
+        "minutes_ago_other": "{{count}} min ago",
+        "minutes_ago": "{{count}} min ago",
+        "hours_ago_one": "{{count}} hour ago",
+        "hours_ago_other": "{{count}} hours ago",
+        "hours_ago": "{{count}} hours ago",
+        "yesterday": "yesterday",
+        "days_ago_one": "{{count}} day ago",
+        "days_ago_other": "{{count}} days ago",
+        "days_ago": "{{count}} days ago"
+      },
+      "invitation_actions": {
+        "resend": "Resend invitation",
+        "revoke": "Revoke invitation",
+        "confirm_revoke": "Revoke invitation for {{email}}? The accept link stops working immediately.",
+        "toast_resent": "Invitation resent to {{email}}.",
+        "toast_revoked": "Invitation for {{email}} revoked.",
+        "error_resend": "Could not resend invitation.",
+        "error_revoke": "Could not revoke invitation."
+      },
       "edit": {
         "title": "Edit user",
         "section_roles": "Roles",
@@ -535,6 +565,7 @@
       "pagination_next": "Next page",
       "status": {
         "active": "Active",
+        "invited": "Invited",
         "disabled": "Deactivated"
       }
     },

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -487,6 +487,7 @@
       "count_one": "{{count}} użytkownik",
       "count_other": "{{count}} użytkowników",
       "count": "{{count}} użytkowników",
+      "showing_count": "Pokazuję {{shown}} z {{total}} użytkowników",
       "col_user": "Użytkownik",
       "col_roles": "Role",
       "col_status": "Status",
@@ -497,6 +498,35 @@
       "action_edit": "Edytuj",
       "action_deactivate": "Dezaktywuj",
       "action_reactivate": "Reaktywuj",
+      "last_login_n_a": "—",
+      "invitation_valid_days_one": "(link {{count}} d ważny)",
+      "invitation_valid_days_other": "(link {{count}} d ważny)",
+      "invitation_valid_days": "(link {{count}} d ważny)",
+      "invitation_valid_hours_one": "(link {{count}} h ważny)",
+      "invitation_valid_hours_other": "(link {{count}} h ważny)",
+      "invitation_valid_hours": "(link {{count}} h ważny)",
+      "relative": {
+        "just_now": "przed chwilą",
+        "minutes_ago_one": "{{count}} min temu",
+        "minutes_ago_other": "{{count}} min temu",
+        "minutes_ago": "{{count}} min temu",
+        "hours_ago_one": "{{count}} h temu",
+        "hours_ago_other": "{{count}} h temu",
+        "hours_ago": "{{count}} h temu",
+        "yesterday": "wczoraj",
+        "days_ago_one": "{{count}} dni temu",
+        "days_ago_other": "{{count}} dni temu",
+        "days_ago": "{{count}} dni temu"
+      },
+      "invitation_actions": {
+        "resend": "Wyślij ponownie",
+        "revoke": "Unieważnij zaproszenie",
+        "confirm_revoke": "Na pewno unieważnić zaproszenie dla {{email}}? Link akceptacyjny przestanie działać natychmiast.",
+        "toast_resent": "Wysłano zaproszenie ponownie do {{email}}.",
+        "toast_revoked": "Zaproszenie dla {{email}} unieważnione.",
+        "error_resend": "Nie udało się wysłać zaproszenia ponownie.",
+        "error_revoke": "Nie udało się unieważnić zaproszenia."
+      },
       "edit": {
         "title": "Edytuj użytkownika",
         "section_roles": "Role",
@@ -537,6 +567,7 @@
       "pagination_next": "Następna strona",
       "status": {
         "active": "Aktywny",
+        "invited": "Zaproszony",
         "disabled": "Dezaktywowany"
       }
     },

--- a/apps/api/src/Identity/Application/UserListResponseBuilder.php
+++ b/apps/api/src/Identity/Application/UserListResponseBuilder.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Identity\Application;
 
+use App\Identity\Domain\Entity\Invitation;
+use App\Identity\Domain\Entity\Role;
 use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
 use DateTimeInterface;
 
 use const MB_CASE_TITLE;
@@ -22,11 +25,18 @@ use const MB_CASE_TITLE;
  */
 final class UserListResponseBuilder
 {
+    public function __construct(
+        private readonly RoleRepositoryInterface $roles,
+    ) {
+    }
+
     /**
-     * @param iterable<User> $users
+     * @param iterable<User>       $users
+     * @param iterable<Invitation> $pendingInvitations
      *
      * @return list<array{
      *     id: string,
+     *     kind: string,
      *     email: string,
      *     display_name: string,
      *     avatar_initial: string,
@@ -34,15 +44,24 @@ final class UserListResponseBuilder
      *     roles: list<array{id: string, code: string, name: string}>,
      *     last_login_at: ?string,
      *     mfa_enabled: bool,
-     *     created_at: string
+     *     created_at: string,
+     *     invitation_id: ?string,
+     *     invitation_expires_at: ?string
      * }>
      */
-    public function buildList(iterable $users): array
+    public function buildList(iterable $users, iterable $pendingInvitations = []): array
     {
         $out = [];
         foreach ($users as $user) {
             $out[] = $this->buildOne($user);
         }
+        foreach ($pendingInvitations as $invitation) {
+            $out[] = $this->buildInvitation($invitation);
+        }
+
+        // Deterministic order: by email so the row position is stable
+        // across renders + matches the operator's mental model.
+        usort($out, static fn (array $a, array $b): int => strcmp($a['email'], $b['email']));
 
         return $out;
     }
@@ -50,6 +69,7 @@ final class UserListResponseBuilder
     /**
      * @return array{
      *     id: string,
+     *     kind: string,
      *     email: string,
      *     display_name: string,
      *     avatar_initial: string,
@@ -57,7 +77,9 @@ final class UserListResponseBuilder
      *     roles: list<array{id: string, code: string, name: string}>,
      *     last_login_at: ?string,
      *     mfa_enabled: bool,
-     *     created_at: string
+     *     created_at: string,
+     *     invitation_id: ?string,
+     *     invitation_expires_at: ?string
      * }
      */
     public function buildOne(User $user): array
@@ -76,6 +98,7 @@ final class UserListResponseBuilder
 
         return [
             'id' => $user->getId()->toRfc4122(),
+            'kind' => 'user',
             'email' => $email,
             'display_name' => $displayName,
             'avatar_initial' => $this->avatarInitial($displayName, $email),
@@ -84,6 +107,65 @@ final class UserListResponseBuilder
             'last_login_at' => $user->getLastLoginAt()?->format(DateTimeInterface::ATOM),
             'mfa_enabled' => $user->isTotpEnabled(),
             'created_at' => $user->getCreatedAt()->format(DateTimeInterface::ATOM),
+            'invitation_id' => null,
+            'invitation_expires_at' => null,
+        ];
+    }
+
+    /**
+     * Project a pending invitation as a virtual list row (status =
+     * `invited`). The id field carries the invitation uuid so the FE
+     * 3-dot menu can target the invitation (resend / revoke) instead
+     * of a user that does not exist yet.
+     *
+     * @return array{
+     *     id: string,
+     *     kind: string,
+     *     email: string,
+     *     display_name: string,
+     *     avatar_initial: string,
+     *     status: string,
+     *     roles: list<array{id: string, code: string, name: string}>,
+     *     last_login_at: ?string,
+     *     mfa_enabled: bool,
+     *     created_at: string,
+     *     invitation_id: ?string,
+     *     invitation_expires_at: ?string
+     * }
+     */
+    public function buildInvitation(Invitation $invitation): array
+    {
+        $email = $invitation->getEmail();
+        $displayName = $this->deriveDisplayName($email);
+
+        $role = $this->roles->findById($invitation->getRoleId());
+        $rolesProjection = null === $role ? [] : [self::projectRole($role)];
+
+        return [
+            'id' => $invitation->getId()->toRfc4122(),
+            'kind' => 'invitation',
+            'email' => $email,
+            'display_name' => $displayName,
+            'avatar_initial' => $this->avatarInitial($displayName, $email),
+            'status' => 'invited',
+            'roles' => $rolesProjection,
+            'last_login_at' => null,
+            'mfa_enabled' => false,
+            'created_at' => $invitation->getCreatedAt()->format(DateTimeInterface::ATOM),
+            'invitation_id' => $invitation->getId()->toRfc4122(),
+            'invitation_expires_at' => $invitation->getExpiresAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+
+    /**
+     * @return array{id: string, code: string, name: string}
+     */
+    private static function projectRole(Role $role): array
+    {
+        return [
+            'id' => $role->getId()->toRfc4122(),
+            'code' => $role->getCode(),
+            'name' => $role->getName(),
         ];
     }
 

--- a/apps/api/src/Identity/Presentation/Controller/InvitationActionsController.php
+++ b/apps/api/src/Identity/Presentation/Controller/InvitationActionsController.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Identity\Application\InvitationService;
+use App\Identity\Domain\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\InvitationRepositoryInterface;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use DateTimeInterface;
+use InvalidArgumentException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * UI polish #848 — revoke + resend actions on pending invitations
+ * surfaced in the Settings → Users list (the "Invited" rows from
+ * UserListResponseBuilder).
+ *
+ *   - POST   /api/invitations/{id}/revoke — flips the invitation to
+ *           revoked status; the accept-link stops working immediately
+ *   - POST   /api/invitations/{id}/resend — revokes the current
+ *           invitation and creates a fresh one with a new TTL window,
+ *           triggering the mailer again
+ *
+ * Both gated by `user.admin` (same surface as user invite — the
+ * operator who can invite can also manage pending invitations).
+ */
+final readonly class InvitationActionsController
+{
+    public function __construct(
+        private Security $security,
+        private InvitationRepositoryInterface $invitations,
+        private RoleRepositoryInterface $roles,
+        private InvitationService $service,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/invitations/{id}/revoke',
+        methods: ['POST'],
+        name: 'api_invitations_revoke',
+        requirements: ['id' => '[0-9a-f-]{36}'],
+    )]
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function revoke(string $id): JsonResponse
+    {
+        $caller = $this->callerOrUnauthorized();
+        if ($caller instanceof JsonResponse) {
+            return $caller;
+        }
+
+        try {
+            $uuid = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Invitation not found.');
+        }
+
+        $invitation = $this->invitations->findById($uuid);
+        if (null === $invitation || !$invitation->getTenantId()->equals($caller->getTenant()->getId())) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Invitation not found.');
+        }
+        if (null !== $invitation->getRevokedAt()) {
+            return new JsonResponse(['revoked' => true]);
+        }
+        if (null !== $invitation->getAcceptedAt()) {
+            return $this->problem(
+                Response::HTTP_CONFLICT,
+                'Invitation already accepted',
+                'Accepted invitations cannot be revoked — deactivate the user instead.',
+                ['code' => 'invitation_already_accepted'],
+            );
+        }
+
+        $this->service->revoke($uuid);
+
+        return new JsonResponse(['revoked' => true]);
+    }
+
+    #[Route(
+        path: '/api/invitations/{id}/resend',
+        methods: ['POST'],
+        name: 'api_invitations_resend',
+        requirements: ['id' => '[0-9a-f-]{36}'],
+    )]
+    #[RequiresPermission(module: 'user', action: 'admin')]
+    public function resend(string $id): JsonResponse
+    {
+        $caller = $this->callerOrUnauthorized();
+        if ($caller instanceof JsonResponse) {
+            return $caller;
+        }
+
+        try {
+            $uuid = Uuid::fromString($id);
+        } catch (InvalidArgumentException) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Invitation not found.');
+        }
+
+        $invitation = $this->invitations->findById($uuid);
+        if (null === $invitation || !$invitation->getTenantId()->equals($caller->getTenant()->getId())) {
+            return $this->problem(Response::HTTP_NOT_FOUND, 'Not Found', 'Invitation not found.');
+        }
+        if (null !== $invitation->getAcceptedAt()) {
+            return $this->problem(
+                Response::HTTP_CONFLICT,
+                'Invitation already accepted',
+                'Accepted invitations cannot be resent.',
+                ['code' => 'invitation_already_accepted'],
+            );
+        }
+
+        $role = $this->roles->findById($invitation->getRoleId());
+        if (null === $role) {
+            return $this->problem(
+                Response::HTTP_CONFLICT,
+                'Role missing',
+                'The role attached to this invitation no longer exists.',
+                ['code' => 'role_missing'],
+            );
+        }
+
+        // Revoke + re-create so the resent invitation has a fresh
+        // 7-day TTL and a fresh token (the original plaintext is
+        // hashed in DB; we cannot resurrect it from the existing row).
+        if (null === $invitation->getRevokedAt()) {
+            $this->service->revoke($uuid);
+        }
+
+        $result = $this->service->create(
+            tenant: $caller->getTenant(),
+            email: $invitation->getEmail(),
+            roleCode: $role->getCode(),
+            invitedBy: $caller,
+        );
+
+        $newInvitation = $result['invitation'];
+
+        return new JsonResponse([
+            'invitation_id' => $newInvitation->getId()->toRfc4122(),
+            'email' => $newInvitation->getEmail(),
+            'expires_at' => $newInvitation->getExpiresAt()->format(DateTimeInterface::ATOM),
+            'token_dev_only' => $result['token'],
+        ], Response::HTTP_CREATED);
+    }
+
+    private function callerOrUnauthorized(): User|JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
+        }
+
+        return $user;
+    }
+
+    /**
+     * @param array<string, mixed> $extras
+     */
+    private function problem(int $status, string $title, string $detail, array $extras = []): JsonResponse
+    {
+        return new JsonResponse(
+            array_merge(
+                [
+                    'type' => 'about:blank',
+                    'title' => $title,
+                    'status' => $status,
+                    'detail' => $detail,
+                ],
+                $extras,
+            ),
+            $status,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
+    }
+}

--- a/apps/api/src/Identity/Presentation/Controller/UsersListController.php
+++ b/apps/api/src/Identity/Presentation/Controller/UsersListController.php
@@ -6,8 +6,11 @@ namespace App\Identity\Presentation\Controller;
 
 use App\Identity\Application\UserListResponseBuilder;
 use App\Identity\Domain\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\Invitation;
 use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\InvitationRepositoryInterface;
 use App\Identity\Domain\Repository\UserRepositoryInterface;
+use DateTimeImmutable;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,10 +45,12 @@ final readonly class UsersListController
     private const int MAX_PER_PAGE = 50;
     private const int DEFAULT_PER_PAGE = 50;
     private const array ALLOWED_STATUSES = [User::STATUS_ACTIVE, User::STATUS_DISABLED];
+    private const string STATUS_INVITED = 'invited';
 
     public function __construct(
         private Security $security,
         private UserRepositoryInterface $users,
+        private InvitationRepositoryInterface $invitations,
         private UserListResponseBuilder $builder,
     ) {
     }
@@ -75,7 +80,15 @@ final readonly class UsersListController
         $perPage = max(1, min(self::MAX_PER_PAGE, $perPageRaw));
 
         $status = $request->query->get('status');
-        if (null !== $status && !\in_array($status, self::ALLOWED_STATUSES, true)) {
+        // The polish (#848) introduces a virtual status `invited` for
+        // pending invitation rows. Honour it as a separate axis — when
+        // selected we skip the users fetch entirely and surface only
+        // invitations.
+        $invitedOnly = self::STATUS_INVITED === $status;
+        if (null !== $status && !$invitedOnly && !\in_array($status, self::ALLOWED_STATUSES, true)) {
+            $status = null;
+        }
+        if ($invitedOnly) {
             $status = null;
         }
 
@@ -96,20 +109,65 @@ final readonly class UsersListController
         }
         $roleIds = [] === $roleIds ? null : $roleIds;
 
-        $users = $this->users->findAllByTenantPaginated($tenant, $status, $roleIds, $search, $page, $perPage);
-        $total = $this->users->countByTenant($tenant, $status, $roleIds, $search);
-        $totalPages = (int) ceil($total / $perPage);
+        $users = $invitedOnly
+            ? []
+            : $this->users->findAllByTenantPaginated($tenant, $status, $roleIds, $search, $page, $perPage);
+        $userTotal = $invitedOnly
+            ? 0
+            : $this->users->countByTenant($tenant, $status, $roleIds, $search);
+
+        // Polish (#848): pending invitations surface inline as virtual
+        // rows with status="invited". Included on page 1 either when:
+        //   - no other status filter selected (mixed view)
+        //   - `invited` status explicitly chosen (invitations-only view)
+        // Role filter never applies (invitation has one role assigned
+        // by the inviter — orthogonal to the user-side roles M2M).
+        $pendingInvitations = [];
+        $shouldIncludeInvitations =
+            1 === $page
+            && null === $roleIds
+            && (null === $status || $invitedOnly);
+        if ($shouldIncludeInvitations) {
+            $now = new DateTimeImmutable();
+            foreach ($this->invitations->findByTenant($tenant->getId()) as $invitation) {
+                if ($this->isPending($invitation, $now)) {
+                    if (null !== $search && !str_contains(strtolower($invitation->getEmail()), strtolower($search))) {
+                        continue;
+                    }
+                    $pendingInvitations[] = $invitation;
+                }
+            }
+        }
+
+        $totalPages = (int) ceil($userTotal / $perPage);
         $totalPages = max(1, $totalPages);
 
         return new JsonResponse([
-            'member' => $this->builder->buildList($users),
-            'totalItems' => $total,
+            'member' => $this->builder->buildList($users, $pendingInvitations),
+            'totalItems' => $userTotal + \count($pendingInvitations),
             'meta' => [
                 'page' => $page,
                 'per_page' => $perPage,
                 'total_pages' => $totalPages,
+                'users_total' => $userTotal,
+                'pending_invitations' => \count($pendingInvitations),
             ],
         ]);
+    }
+
+    private function isPending(Invitation $invitation, DateTimeImmutable $now): bool
+    {
+        if (null !== $invitation->getAcceptedAt()) {
+            return false;
+        }
+        if (null !== $invitation->getRevokedAt()) {
+            return false;
+        }
+        if ($invitation->getExpiresAt() <= $now) {
+            return false;
+        }
+
+        return true;
     }
 
     private function unauthorized(): JsonResponse


### PR DESCRIPTION
Closes #848.

## Summary

Refactors Settings → Users to match PRD-PIM-rbac §5.4 mockup.

### Pending invitations surface inline

`UserListResponseBuilder` now emits unified rows with `kind: 'user' | 'invitation'`. Invitation rows render with `status: 'invited'`, the invitation uuid in `id`, and `invitation_expires_at` populated for the "link Nd valid" sub-info.

`UsersListController` fetches pending invitations (not accepted / not revoked / not expired) on page 1. Search filter applies to invitation emails too. `status=invited` short-circuits the user query — only invitations show.

### Invitation actions API

- `POST /api/invitations/{id}/revoke` — accept link stops working immediately (409 if already accepted)
- `POST /api/invitations/{id}/resend` — revoke + recreate with fresh TTL + fire mailer (409 if accepted, 409 if role missing)

### FE polish

- **StatusBadge**: 3 states with colored dots — emerald (active) / amber (invited) / rose (disabled)
- **Relative-time helper** for "Last login": *2 min / 1 hour / yesterday / N days / absolute past 14 days*
- **Per-row 3-dot menu** branches on `kind`:
  - users → Edit / Deactivate / Reactivate
  - invitations → Resend / Revoke
- **"link Nd valid"** sub-info under invited status (matches §5.4 mockup `(link 7d valid)`)
- **"Showing X of Y users"** footer per §5.4 mockup line 1074
- **Status filter dropdown** adds `invited` option

## Test plan

- [x] PHPStan max — green
- [x] TypeScript noEmit — green
- [x] Biome strict — green
- [x] Live-stack smoke:
  - `GET /api/users` → 5 rows (2 users + 3 invitations), `kind` field present, `invitation_expires_at` populated
  - `GET /api/users?status=invited` → only invitations
  - `POST /api/invitations/{id}/revoke` → invitation disappears from list
- [ ] Manual UI smoke after merge: see 3 colored status badges, "2 min ago" relative times, "link 7d valid" sub-info on invited rows

Refs #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)