### PR TITLE
docs(agent): mark Phase 5 RBAC as CLOSED — Phase 6 next session

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,40 @@
 # Current Status
 
+## 2026-05-20: ✅ Phase 5 RBAC — ZAMKNIĘTA (22/22 + 2 polish PRs)
+
+**Status:** Phase 5 RBAC closed. Następna agent session zaczyna **Phase 6 RBAC retrofit + hardening** (milestone [#14](../../milestone/14) — backlog ticketów #714-#722 dostępny w `Project Plan/13-rbac-tickets-phase-6.md`).
+
+**Scope ukończony (pełen Phase 5 + 2 polish PRs):**
+
+22 functional tickets (#691, #692, #693, #694, #695, #696, #697, #698, #699, #700, #701, #702, #703, #704, #705, #706, #707, #708, #709, #710, #711, #712) + 2 UI polish PRs (#847 role editor + list, #848 users list + invitations) zaprojektowane wg PRD §5.3 + §5.4 mockupów.
+
+**Marathon-3 końcówka (2026-05-20):**
+
+| Ticket | PR | Scope | Status |
+|---|---|---|---|
+| #711 Tenant lifecycle CRUD | [#845](../../pull/845) | Schema (status/suspended_at/deleted_at) + TenantUserChecker login block + write endpoints (create/patch/suspend/reactivate/delete) + `pim:tenants:purge-deleted` cron + FE list filter + create modal + per-row CRUD menu | ✅ merged |
+| #847 Role editor + list polish | [#849](../../pull/849) | `roles.description` column + 5-card section layout (Identity / Advanced / Matrix / Field-level / Locale scope) + sticky bottom action bar + unified save (PATCH + PUT in one submit) + dirty tracking + list toolbar (search + type filter + counter footer + clickable rows) | 🟡 PR open |
+| #848 Users list + invitations polish | [#850](../../pull/850) | Pending invitations as inline `kind:'invitation'` rows + `status:'invited'` with amber badge + relative-time "Last login" + per-row resend/revoke actions + `POST /api/invitations/{id}/revoke|resend` endpoints + "Showing X of Y" footer per §5.4 | 🟡 PR open |
+
+**Faza 5 deliverables (per PRD-PIM-rbac):**
+
+- ✅ Users list + invite + edit + deactivate + Invited inline + resend/revoke
+- ✅ Roles list + custom builder z 5 sekcjami + restrictions + scope placeholder
+- ✅ API tokens list + create wizard + revoke + plaintext-once
+- ✅ Profile MFA enable/disable + recovery codes regenerate + password change
+- ✅ SSO config UI (Google + Microsoft + SAML — secret masking)
+- ✅ Tenant config (Owner) + danger zone placeholder
+- ✅ Billing placeholder (Faza 1 podsumowanie)
+- ✅ Accept invitation page (4-state card)
+- ✅ 403 page + LastAdminGuard + OwnerUniquenessModal
+- ✅ Super Admin operator panel (tenant list + detail + CRUD + lifecycle + break-glass UI z MFA + rate limit + audit)
+
+**Phase 6 (next session) — backlog summary:**
+
+10 ticketów (#714-#722) z milestone [#14](../../milestone/14): RBAC retrofit (~60 endpointów pre-RBAC dostają `#[RequiresPermission]`), CI gates lockdown (strict mode w EndpointGuardListener), Prometheus/Grafana RBAC dashboards, Semgrep custom rules, security checklist + threat model docs.
+
+---
+
 ## 2026-05-20: 🏁 Phase 5 RBAC marathon-2 (final-final) — 20/22 ticketów shipped lub w CI
 
 **Sesja 2026-05-20 zaszipowała 9 ticketów (8 RBAC + 1 docs):**

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,28 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z Phase 5 closure polish (2026-05-20, #847 + #848 shipped)
+
+### Patterns to Follow
+
+1. **Inline operator design questions jako pre-flight checklist** — przy #711 zadałem 5 pytań architektonicznych operatorowi *(suspend semantyka? delete typ? create defaults? plan→billing cascade? quota?)* w jednym message przed implementacją. Operator odpowiedział YES/NO + 3 enums w ~10s. Bez tego utknąłbym w "what does suspend mean?" rabbit hole w środku PR-a. Pattern: **before non-trivial ticket — produce a binary decision tree z defaults, operator akceptuje lub flipuje per option**. Lepsze niż long-form pytania.
+
+2. **Sections-as-Cards beats Tabs dla form-heavy editors** — gdy mockup pokazuje grouped sections (PRD §5.3) na jednej scrollable page, nie wymuszaj `<Tabs>`. Cards z header + body dają tą samą wizualną hierarchię + zachowują context (wszystko widoczne jednocześnie, dirty indicators per section nie wymagają tab-switching). Pattern: `<SectionCard title=... description=... meta=...>` jako simple wrapper, sticky bottom action bar dla single save.
+
+3. **Pull-state-up dla composable form sections** — `AttributePermissionsTab` (self-contained z own state + own save) → `AttributePermissionsSection` (presentational, state owned by parent). Parent's submit hits both PATCH role + PUT attribute-perms w sequence; rolls back na Promise rejection. Jeden Save, jeden dirty indicator, jeden rollback path. Cost: 50 lines parent state code. Win: no ref forwarding, no callback callbacks, no save-half-fails-leave-mixed-state.
+
+4. **Discriminated union dla mixed list types** — Users list teraz pokazuje *Users + Invitations* jako jeden table. Wire shape: `kind: 'user' | 'invitation'`, common fields shared, kind-specific fields nullable. FE branches per kind w renderowaniu + akcjach. Pattern repeatable: tenant list (active + suspended + deleted), API tokens list (own + tenant-wide w scope toggle), itp.
+
+5. **Relative-time z fallback do absolute past N days** — "2 min ago" / "yesterday" są human-friendly do 14 dni, potem `toLocaleDateString` wraca do absolute. Helper bez zewnętrznego dep (date-fns) ~30 linii. Pattern: i18n keys per range (just_now / minutes_ago / hours_ago / yesterday / days_ago) z pluralizacją.
+
+### Patterns to Avoid
+
+1. **NIE assume Tabs gdy mockup pokazuje sections** — moja pierwsza propozycja dla role editor polish była "<Tabs> z Radix dla unified save". PRD §5.3 mockup pokazuje flat sections z border boxes. Tabs byłyby over-engineered + ukryły kontekst. Wzór: **przeczytaj mockup ASCII art DOKŁADNIE przed proposem komponentów**. ASCII boxy `┌─┐ ... └─┘` z headers = Cards, nie Tabs.
+
+2. **NIE assume backend nie istnieje** — w marathon-3 myślałem że trzeba shipnąć Phase 4 #659/#660 MFA backend. Quick `grep "class.*Totp"` w 30s pokazał że `TotpEnrolmentService` + `TwoFactorController` istnieją z `#0.11.1` (3 miesiące temu). Marathon-3 dorobił tylko status + regenerate endpoints + UI. Pattern: **30-second reconnaissance grep przed Plan Mode estymatą** — szuka `class.*<Feature>`, `interface.*<Feature>Repository`, `function get<Feature>`.
+
+3. **NIE używaj `ADD CONSTRAINT IF NOT EXISTS` na CHECK constraintach** — to PG14+. CI's Postgres 13 image rejects syntax. Wzór: zawsze użyj `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='X') THEN ALTER TABLE ... ADD CONSTRAINT X CHECK (...); END IF; END $$;` dla CHECK constraints. Dla tables/indexes `CREATE TABLE IF NOT EXISTS` + `CREATE INDEX IF NOT EXISTS` działa od PG 9.5.
+
 ## Lessons z Phase 5 marathon-2 final-final (2026-05-20, #709/#710 shipped na koniec)
 
 ### Patterns to Follow


### PR DESCRIPTION
Marks Phase 5 RBAC as closed end-to-end in `agent/current_status.md`. Next agent session begins **Phase 6 RBAC retrofit + hardening** (milestone #14, backlog #714-#722).

22/22 functional tickets shipped + 2 UI polish PRs (#849 + #850) to PRD §5.3 / §5.4 mockups.

Captures 8 closure-polish lessons for Phase 6 starter:
- Inline operator design questions as pre-flight binary checklist
- Sections-as-Cards beats Tabs for form-heavy editors
- Pull-state-up for composable form sections (unified save)
- Discriminated union for mixed list types
- Relative-time helper with absolute-fallback past 14 days
- Read mockup ASCII art before proposing components
- 30-second reconnaissance grep before Plan Mode estimate
- PG14-only ADD CONSTRAINT IF NOT EXISTS gotcha