### PR TITLE
feat(catalog): #714 add #[RequiresPermission] to Product endpoints

### DIFF
--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -19,6 +19,7 @@ use App\Catalog\Application\Bulk\BulkSetAttributeHandler;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
 use DateTimeInterface;
@@ -68,6 +69,7 @@ final class BulkActionsController
 
     #[Route('/api/products/bulk-actions/preview', name: 'pim_bulk_actions_preview', methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function preview(Request $request): JsonResponse
     {
         /** @var array<string, mixed> $body */
@@ -257,6 +259,7 @@ final class BulkActionsController
 
     #[Route('/api/products/bulk-actions/{actionType}', name: 'pim_bulk_actions_apply', methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function apply(string $actionType, Request $request): JsonResponse
     {
         $tenant = $this->tenantContext->get();

--- a/apps/api/src/Catalog/Presentation/Controller/BulkEditController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkEditController.php
@@ -8,6 +8,7 @@ use App\Catalog\Domain\Entity\BulkEditJob;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -62,6 +63,7 @@ final class BulkEditController
         priority: 200,
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function bulkEdit(Request $request): JsonResponse
     {
         $tenant = $this->tenantContext->get();
@@ -141,6 +143,7 @@ final class BulkEditController
         priority: 200,
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function show(string $id): JsonResponse
     {
         $job = $this->em->getRepository(BulkEditJob::class)->find(Uuid::fromString($id));

--- a/apps/api/src/Catalog/Presentation/Controller/BulkSessionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkSessionsController.php
@@ -7,6 +7,7 @@ namespace App\Catalog\Presentation\Controller;
 use App\Catalog\Application\Bulk\BulkRollbackHandler;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use DateTimeImmutable;
 use DateTimeInterface;
@@ -49,6 +50,7 @@ final class BulkSessionsController
      */
     #[Route('/api/bulk-sessions', name: 'pim_bulk_session_list', methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function list(Request $request): JsonResponse
     {
         $tenant = $this->tenantContext->get();
@@ -101,6 +103,7 @@ final class BulkSessionsController
 
     #[Route('/api/bulk-sessions/{id}', name: 'pim_bulk_session_show', requirements: ['id' => self::UUID_REGEX], methods: ['GET'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function show(string $id): JsonResponse
     {
         $session = $this->loadSession($id);
@@ -142,6 +145,7 @@ final class BulkSessionsController
 
     #[Route('/api/bulk-sessions/{id}/rollback', name: 'pim_bulk_session_rollback', requirements: ['id' => self::UUID_REGEX], methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function rollback(string $id): JsonResponse
     {
         $session = $this->loadSession($id);

--- a/apps/api/src/Catalog/Presentation/Controller/CategoryProductsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CategoryProductsController.php
@@ -6,6 +6,7 @@ namespace App\Catalog\Presentation\Controller;
 
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -47,6 +48,7 @@ final class CategoryProductsController
         methods: ['GET'],
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
     public function __invoke(string $id, Request $request): JsonResponse
     {
         $category = $this->catalogObjects->findById(Uuid::fromString($id));

--- a/apps/api/src/Catalog/Presentation/Controller/DuplicateProductController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/DuplicateProductController.php
@@ -10,6 +10,7 @@ use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Provenance;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -59,6 +60,7 @@ final class DuplicateProductController
         priority: 200,
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'add')]
     public function __invoke(string $id, Request $request): JsonResponse
     {
         $tenant = $this->tenantContext->get();

--- a/apps/api/src/Catalog/Presentation/Controller/GenerateVariantsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/GenerateVariantsController.php
@@ -14,6 +14,7 @@ use App\Catalog\Domain\Provenance;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -96,6 +97,7 @@ final class GenerateVariantsController
         priority: 200,
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'add')]
     public function __invoke(string $master_id, Request $request): JsonResponse
     {
         // Generation can stamp dozens of ObjectValue rows per combination;

--- a/apps/api/src/Catalog/Presentation/Controller/ProductCategoryAssignmentController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductCategoryAssignmentController.php
@@ -9,6 +9,7 @@ use App\Catalog\Domain\Entity\ObjectCategory;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use InvalidArgumentException;
 use JsonException;
@@ -68,6 +69,7 @@ final class ProductCategoryAssignmentController
         methods: ['GET'],
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
     public function list(string $id): JsonResponse
     {
         $product = $this->mustFindProduct($id);
@@ -82,6 +84,7 @@ final class ProductCategoryAssignmentController
         methods: ['PUT'],
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'edit')]
     public function replace(string $id, Request $request): JsonResponse
     {
         $product = $this->mustFindProduct($id);
@@ -154,6 +157,7 @@ final class ProductCategoryAssignmentController
         methods: ['POST'],
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'edit')]
     public function add(string $id, Request $request): JsonResponse
     {
         $product = $this->mustFindProduct($id);
@@ -221,6 +225,7 @@ final class ProductCategoryAssignmentController
         methods: ['DELETE'],
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'edit')]
     public function detach(string $id, string $categoryId): JsonResponse
     {
         $product = $this->mustFindProduct($id);

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -12,6 +12,7 @@ use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Shared\Infrastructure\Audit\CursorCodec;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
@@ -78,6 +79,7 @@ final class ProductReadEndpointsController
         priority: 200,
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
     public function auditLog(string $id, Request $request): JsonResponse
     {
         $product = $this->mustFindProduct($id);
@@ -150,6 +152,7 @@ final class ProductReadEndpointsController
         priority: 200,
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
     public function channelsStatus(string $id): JsonResponse
     {
         $product = $this->mustFindProduct($id);
@@ -174,6 +177,7 @@ final class ProductReadEndpointsController
         priority: 200,
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
     public function effectiveAttributeGroups(string $id): JsonResponse
     {
         $product = $this->mustFindProduct($id);

--- a/apps/api/src/Search/Presentation/Controller/BulkSelectionController.php
+++ b/apps/api/src/Search/Presentation/Controller/BulkSelectionController.php
@@ -8,6 +8,7 @@ use App\Catalog\Application\Filter\FilterDslResolver;
 use App\Catalog\Application\Filter\FilterUrlSerializer;
 use App\Catalog\Domain\Entity\SmartFilterPreset;
 use App\Catalog\Domain\ObjectKind;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Search\Application\CatalogSearchService;
 use App\Shared\Application\TenantContext;
 use Doctrine\ORM\EntityManagerInterface;
@@ -50,6 +51,7 @@ final class BulkSelectionController
 
     #[Route('/api/products/select-all-matching', name: 'pim_bulk_select_all_matching', methods: ['POST'])]
     #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'products', action: 'view')]
     public function selectAllMatching(Request $request): JsonResponse
     {
         /** @var array<string, mixed> $body */

--- a/apps/api/src/Search/Presentation/Controller/ProductQuickSearchController.php
+++ b/apps/api/src/Search/Presentation/Controller/ProductQuickSearchController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Search\Presentation\Controller;
 
 use App\Catalog\Domain\ObjectKind;
+use App\Identity\Domain\Attribute\RequiresPermission;
 use App\Search\Application\CatalogSearchService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -47,6 +48,7 @@ final class ProductQuickSearchController
      */
     #[Route('/api/products/quick-search', name: 'pim_products_quick_search', methods: ['GET'], priority: 200)]
     #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'products', action: 'view')]
     public function __invoke(Request $request): JsonResponse
     {
         $query = trim($request->query->getString('q', ''));


### PR DESCRIPTION
First implementation ticket of Phase 6 RBAC retrofit. Adds `#[RequiresPermission]` to all 19 custom Product/Bulk controller routes flagged by the #713 audit.

## Module/action mapping

| Action | Routes |
| --- | --- |
| `products.view` | 7 read endpoints (audit-log, channels-status, effective-groups, categories list, categories-by-id, quick-search, select-all-matching) |
| `products.edit` | 3 category-assignment mutators |
| `products.add` | duplicate + generate-variants |
| `products.bulk_operations` | 7 bulk-* / bulk-sessions endpoints |

Total: 19 routes across 10 controller classes.

## Files changed

- `Catalog/Presentation/Controller/DuplicateProductController.php`
- `Catalog/Presentation/Controller/GenerateVariantsController.php`
- `Catalog/Presentation/Controller/ProductReadEndpointsController.php` (3 methods)
- `Catalog/Presentation/Controller/ProductCategoryAssignmentController.php` (4 methods)
- `Catalog/Presentation/Controller/BulkActionsController.php` (2 methods)
- `Catalog/Presentation/Controller/BulkEditController.php` (2 methods)
- `Catalog/Presentation/Controller/BulkSessionsController.php` (3 methods)
- `Catalog/Presentation/Controller/CategoryProductsController.php`
- `Search/Presentation/Controller/ProductQuickSearchController.php`
- `Search/Presentation/Controller/BulkSelectionController.php`

## Enforcement

Runtime: `EndpointGuardListener` (Phase 3 #664) reads the attribute on `kernel.controller_arguments` and calls `PermissionResolver::hasPermission()`. Subjects can be added later for resource-level voter dispatch.

Static: `RequiresPermissionAnnotationRule` (Phase 1 #634) — PHPStan rule that fails the build if any `/api/*` controller method lacks either `#[RequiresPermission]` or `#[NoPermissionRequired]`.

## Test plan

- [x] PHPStan max — green on all 10 files
- [x] PHPUnit unit suite — 322/322 green
- [x] Live-stack smoke (admin@demo.localhost on `https://pim.localhost`):
  - `GET /api/products/{id}/audit-log` → 200
  - `GET /api/products/{id}/channels-status` → 200
  - `GET /api/products/{id}/categories` → 200
  - `GET /api/products/quick-search?q=test` → 200
  - `GET /api/bulk-sessions` → 200
  - `POST /api/products/{id}/duplicate` → 201
  - `DELETE /api/products/{new_id}` cleanup → 204

Refs #714.