### PR TITLE
feat(admin): #717 <GatedAction>/<GatedButton> + wrap high-visibility CTAs

### DIFF
--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -11,6 +11,7 @@ import {
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { PermissionGate } from '@/components/identity';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -114,130 +115,136 @@ export function BulkBar({
     }
   };
 
+  // RBAC-P6-005 (#717) — bulk action surface is gated behind
+  // `products.bulk_operations`. Roles without that permission still see
+  // checkboxes on the underlying list (Phase 4 visibility) but the
+  // mutation bar never renders. Backend 403 toast is the fallback.
   return (
-    <div className="fixed bottom-6 left-0 right-0 z-40 flex justify-center pointer-events-none">
-      <section
-        aria-label={t('products.bulk.aria_region', { defaultValue: 'Akcje masowe' })}
-        className="pointer-events-auto bg-zinc-900 text-white rounded-3xl shadow-xl px-6 py-3 flex items-center gap-5 animate-in fade-in slide-in-from-bottom-2 duration-200"
-        data-testid="bulk-bar"
-      >
-        <div className="flex items-center gap-2">
-          <span className="h-7 w-7 rounded-xl bg-white/10 grid place-items-center text-[12px] font-semibold tabular-nums">
-            {selectedIds.length}
-          </span>
-          <span className="text-[13px] font-medium">
-            {t('products.bulk.selected_label', { defaultValue: 'zaznaczonych produktów' })}
-          </span>
-        </div>
+    <PermissionGate code="products.bulk_operations">
+      <div className="fixed bottom-6 left-0 right-0 z-40 flex justify-center pointer-events-none">
+        <section
+          aria-label={t('products.bulk.aria_region', { defaultValue: 'Akcje masowe' })}
+          className="pointer-events-auto bg-zinc-900 text-white rounded-3xl shadow-xl px-6 py-3 flex items-center gap-5 animate-in fade-in slide-in-from-bottom-2 duration-200"
+          data-testid="bulk-bar"
+        >
+          <div className="flex items-center gap-2">
+            <span className="h-7 w-7 rounded-xl bg-white/10 grid place-items-center text-[12px] font-semibold tabular-nums">
+              {selectedIds.length}
+            </span>
+            <span className="text-[13px] font-medium">
+              {t('products.bulk.selected_label', { defaultValue: 'zaznaczonych produktów' })}
+            </span>
+          </div>
 
-        <span className="h-6 w-px bg-white/15" aria-hidden="true" />
+          <span className="h-6 w-px bg-white/15" aria-hidden="true" />
 
-        <button
-          type="button"
-          onClick={onOpenWizard ?? placeholder('VIEW-05.2')}
-          className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
-        >
-          <Pencil className="size-3.5" aria-hidden="true" />
-          {t('products.bulk.edit_attribute', { defaultValue: 'Edytuj atrybut' })}
-        </button>
-        <button
-          type="button"
-          onClick={onOpenCategoryModal ?? placeholder('VIEW-05.3')}
-          className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
-        >
-          <FolderTree className="size-3.5" aria-hidden="true" />
-          {t('products.bulk.change_category', { defaultValue: 'Zmień kategorię' })}
-        </button>
-        <button
-          type="button"
-          onClick={onOpenExportModal ?? placeholder('VIEW-05.4')}
-          className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
-        >
-          <Download className="size-3.5" aria-hidden="true" />
-          {t('products.bulk.export', { defaultValue: 'Eksport' })}
-        </button>
-        <button
-          type="button"
-          onClick={onOpenCmdK ?? placeholder('VIEW-05.5')}
-          className={cn(
-            'text-[13px] font-medium px-3 py-1.5 rounded-xl bg-violet-500 hover:bg-violet-400 inline-flex items-center gap-1.5',
-            'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
-          )}
-        >
-          <Sparkles className="size-3.5" aria-hidden="true" />
-          {t('products.bulk.delegate_agent', { defaultValue: 'Zleć agentowi (⌘K)' })}
-        </button>
+          <button
+            type="button"
+            onClick={onOpenWizard ?? placeholder('VIEW-05.2')}
+            className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
+          >
+            <Pencil className="size-3.5" aria-hidden="true" />
+            {t('products.bulk.edit_attribute', { defaultValue: 'Edytuj atrybut' })}
+          </button>
+          <button
+            type="button"
+            onClick={onOpenCategoryModal ?? placeholder('VIEW-05.3')}
+            className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
+          >
+            <FolderTree className="size-3.5" aria-hidden="true" />
+            {t('products.bulk.change_category', { defaultValue: 'Zmień kategorię' })}
+          </button>
+          <button
+            type="button"
+            onClick={onOpenExportModal ?? placeholder('VIEW-05.4')}
+            className="text-[13px] font-medium text-white/90 hover:text-white inline-flex items-center gap-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
+          >
+            <Download className="size-3.5" aria-hidden="true" />
+            {t('products.bulk.export', { defaultValue: 'Eksport' })}
+          </button>
+          <button
+            type="button"
+            onClick={onOpenCmdK ?? placeholder('VIEW-05.5')}
+            className={cn(
+              'text-[13px] font-medium px-3 py-1.5 rounded-xl bg-violet-500 hover:bg-violet-400 inline-flex items-center gap-1.5',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
+            )}
+          >
+            <Sparkles className="size-3.5" aria-hidden="true" />
+            {t('products.bulk.delegate_agent', { defaultValue: 'Zleć agentowi (⌘K)' })}
+          </button>
 
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label={t('products.bulk.more_actions', { defaultValue: 'Więcej akcji' })}
-              disabled={isPending}
-              className="text-white/70 hover:text-white inline-flex items-center justify-center size-7 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 disabled:opacity-50"
-            >
-              <MoreHorizontal className="size-4" aria-hidden="true" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              onSelect={() => {
-                void runToggleEnabled(true);
-              }}
-            >
-              {t('products.bulk.enable', { defaultValue: 'Włącz' })}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onSelect={() => {
-                void runToggleEnabled(false);
-              }}
-            >
-              {t('products.bulk.disable', { defaultValue: 'Wyłącz' })}
-            </DropdownMenuItem>
-            {onOpenPublishModal ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label={t('products.bulk.more_actions', { defaultValue: 'Więcej akcji' })}
+                disabled={isPending}
+                className="text-white/70 hover:text-white inline-flex items-center justify-center size-7 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 disabled:opacity-50"
+              >
+                <MoreHorizontal className="size-4" aria-hidden="true" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
               <DropdownMenuItem
                 onSelect={() => {
-                  onOpenPublishModal();
+                  void runToggleEnabled(true);
                 }}
               >
-                <Globe className="mr-2 size-3.5" aria-hidden="true" />
-                {t('products.bulk.publish_channels', { defaultValue: 'Publikuj na kanałach' })}
+                {t('products.bulk.enable', { defaultValue: 'Włącz' })}
               </DropdownMenuItem>
-            ) : null}
-            {onOpenDuplicateModal ? (
               <DropdownMenuItem
                 onSelect={() => {
-                  onOpenDuplicateModal();
+                  void runToggleEnabled(false);
                 }}
               >
-                <Copy className="mr-2 size-3.5" aria-hidden="true" />
-                {t('products.bulk.duplicate', { defaultValue: 'Duplikuj' })}
+                {t('products.bulk.disable', { defaultValue: 'Wyłącz' })}
               </DropdownMenuItem>
-            ) : null}
-            {onOpenDeleteModal ? (
-              <DropdownMenuItem
-                onSelect={() => {
-                  onOpenDeleteModal();
-                }}
-                className="text-rose-700 focus:bg-rose-50 focus:text-rose-700"
-              >
-                <Trash2 className="mr-2 size-3.5" aria-hidden="true" />
-                {t('products.bulk.delete', { defaultValue: 'Usuń' })}
-              </DropdownMenuItem>
-            ) : null}
-          </DropdownMenuContent>
-        </DropdownMenu>
+              {onOpenPublishModal ? (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    onOpenPublishModal();
+                  }}
+                >
+                  <Globe className="mr-2 size-3.5" aria-hidden="true" />
+                  {t('products.bulk.publish_channels', { defaultValue: 'Publikuj na kanałach' })}
+                </DropdownMenuItem>
+              ) : null}
+              {onOpenDuplicateModal ? (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    onOpenDuplicateModal();
+                  }}
+                >
+                  <Copy className="mr-2 size-3.5" aria-hidden="true" />
+                  {t('products.bulk.duplicate', { defaultValue: 'Duplikuj' })}
+                </DropdownMenuItem>
+              ) : null}
+              {onOpenDeleteModal ? (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    onOpenDeleteModal();
+                  }}
+                  className="text-rose-700 focus:bg-rose-50 focus:text-rose-700"
+                >
+                  <Trash2 className="mr-2 size-3.5" aria-hidden="true" />
+                  {t('products.bulk.delete', { defaultValue: 'Usuń' })}
+                </DropdownMenuItem>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
 
-        <span className="h-6 w-px bg-white/15" aria-hidden="true" />
+          <span className="h-6 w-px bg-white/15" aria-hidden="true" />
 
-        <button
-          type="button"
-          onClick={onClear}
-          className="text-[13px] text-white/60 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
-        >
-          {t('products.bulk.clear', { defaultValue: 'Wyczyść' })}
-        </button>
-      </section>
-    </div>
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-[13px] text-white/60 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 rounded"
+          >
+            {t('products.bulk.clear', { defaultValue: 'Wyczyść' })}
+          </button>
+        </section>
+      </div>
+    </PermissionGate>
   );
 }

--- a/apps/admin/src/components/identity/GatedAction.tsx
+++ b/apps/admin/src/components/identity/GatedAction.tsx
@@ -1,0 +1,123 @@
+import type { ComponentProps, ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { useCanI, useCanIAny } from '@/lib/identity';
+
+/**
+ * RBAC-P6-005 (#717) — declarative wrapper that hides action-bearing
+ * UI when the caller lacks the backing permission.
+ *
+ * The pattern is the click-time companion to {@link PermissionGate}.
+ * `<PermissionGate>` is best for whole sections (a panel, a settings
+ * tab, a row of unrelated cards). `<GatedAction>` is meant for the
+ * inline "+ New" / "Bulk edit" / "Delete selected" / "Publish" / "Import"
+ * buttons that punctuate list views and detail pages — where the
+ * surrounding chrome should stay visible but the specific verb the user
+ * cannot perform should disappear (or render disabled with a tooltip
+ * explaining why).
+ *
+ * Choose one of two modes:
+ *
+ *   - `mode="hide"` (default) — when the permission is missing, render
+ *     nothing. Best for primary CTAs (`+ New product`) where there is no
+ *     value showing an inert button.
+ *   - `mode="disabled"` — render the children with `aria-disabled` + a
+ *     visual washed-out state, and intercept clicks. Best when the
+ *     surrounding layout depends on the button's footprint (toolbars
+ *     with fixed gaps, action menus that would jump around on toggle).
+ *
+ * Usage:
+ *
+ *   <GatedAction permission="products.add">
+ *     <Button onClick={openNewProductDialog}>+ Nowy produkt</Button>
+ *   </GatedAction>
+ *
+ *   <GatedAction anyOf={['products.delete', 'products.bulk_operations']} mode="disabled">
+ *     <Button variant="destructive">Usuń</Button>
+ *   </GatedAction>
+ *
+ * The component composes `useCanI` / `useCanIAny`; tests can render
+ * with the identity provider seeded to whichever permission set they
+ * need. While identity is bootstrapping (`useIdentity().isLoading`),
+ * the wrapped action is treated as denied so the brief flash of a
+ * forbidden button cannot prompt a 403 from the backend.
+ */
+interface GatedActionBaseProps {
+  mode?: 'hide' | 'disabled';
+  children: ReactNode;
+}
+
+interface GatedActionSingleProps extends GatedActionBaseProps {
+  permission: string;
+  anyOf?: never;
+}
+
+interface GatedActionAnyProps extends GatedActionBaseProps {
+  permission?: never;
+  anyOf: readonly string[];
+}
+
+export type GatedActionProps = GatedActionSingleProps | GatedActionAnyProps;
+
+export function GatedAction(props: GatedActionProps) {
+  const { mode = 'hide', children } = props;
+
+  const singleAllowed = useCanI(props.permission ?? '');
+  const anyAllowed = useCanIAny(props.anyOf ?? []);
+  const allowed = props.permission !== undefined ? singleAllowed : anyAllowed;
+
+  if (allowed) {
+    return children;
+  }
+
+  if (mode === 'hide') {
+    return null;
+  }
+
+  return (
+    <span
+      aria-disabled="true"
+      data-permission-denied="true"
+      className="cursor-not-allowed opacity-50"
+    >
+      <span className="pointer-events-none">{children}</span>
+    </span>
+  );
+}
+
+/**
+ * Convenience: a permission-aware `<Button>` for the common case where
+ * the action verb is hidden when the permission is missing. Forwards
+ * every Button prop, so feature pages drop in the same way they would
+ * with `<Button>` and just add `permission="…"`.
+ */
+type ButtonOwnProps = ComponentProps<typeof Button>;
+
+interface GatedButtonSingleProps extends ButtonOwnProps {
+  permission: string;
+  anyOf?: never;
+  mode?: 'hide' | 'disabled';
+}
+
+interface GatedButtonAnyProps extends ButtonOwnProps {
+  permission?: never;
+  anyOf: readonly string[];
+  mode?: 'hide' | 'disabled';
+}
+
+export type GatedButtonProps = GatedButtonSingleProps | GatedButtonAnyProps;
+
+export function GatedButton({ permission, anyOf, mode, ...buttonProps }: GatedButtonProps) {
+  if (permission !== undefined) {
+    return (
+      <GatedAction permission={permission} mode={mode}>
+        <Button {...buttonProps} />
+      </GatedAction>
+    );
+  }
+  return (
+    <GatedAction anyOf={anyOf as readonly string[]} mode={mode}>
+      <Button {...buttonProps} />
+    </GatedAction>
+  );
+}

--- a/apps/admin/src/components/identity/index.ts
+++ b/apps/admin/src/components/identity/index.ts
@@ -1,6 +1,12 @@
 /**
  * RBAC Phase 4 — public surface for identity-aware components.
  */
+export {
+  GatedAction,
+  type GatedActionProps,
+  GatedButton,
+  type GatedButtonProps,
+} from './GatedAction';
 export { LastAdminProtectionModal } from './LastAdminProtectionModal';
 export { OwnerUniquenessModal } from './OwnerUniquenessModal';
 export { PermissionGate, type PermissionGateProps } from './PermissionGate';

--- a/apps/admin/src/features/admin/tenants/index.tsx
+++ b/apps/admin/src/features/admin/tenants/index.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
+import { GatedButton } from '@/components/identity';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -127,10 +128,15 @@ export function AdminTenantsListPage() {
           </div>
           <p className="max-w-2xl text-sm text-muted-foreground">{t('admin.tenants.intro')}</p>
         </div>
-        <Button size="sm" className="gap-1.5" onClick={() => setCreateOpen(true)}>
+        <GatedButton
+          permission="platform.tenants.manage"
+          size="sm"
+          className="gap-1.5"
+          onClick={() => setCreateOpen(true)}
+        >
           <Plus className="size-4" aria-hidden="true" />
           {t('admin.tenants.create_cta')}
-        </Button>
+        </GatedButton>
       </header>
 
       <div className="rounded-md border border-dashed bg-amber-50 px-3 py-2 text-xs text-amber-900">

--- a/apps/admin/src/features/asset/assets/AssetBulkActionsBar.tsx
+++ b/apps/admin/src/features/asset/assets/AssetBulkActionsBar.tsx
@@ -2,6 +2,7 @@ import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { GatedButton } from '@/components/identity';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -68,10 +69,15 @@ export function AssetBulkActionsBar({
           <Button variant="ghost" size="sm" onClick={onClearSelection}>
             {t('assets.upload.cancel')}
           </Button>
-          <Button variant="destructive" size="sm" onClick={() => setConfirmOpen(true)}>
+          <GatedButton
+            permission="asset.delete"
+            variant="destructive"
+            size="sm"
+            onClick={() => setConfirmOpen(true)}
+          >
             <Trash2 className="mr-2 size-4" />
             {t('assets.bulk.delete')}
-          </Button>
+          </GatedButton>
         </div>
       </section>
 

--- a/apps/admin/src/features/settings/roles/RolesListView.tsx
+++ b/apps/admin/src/features/settings/roles/RolesListView.tsx
@@ -11,6 +11,7 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
+import { GatedButton } from '@/components/identity';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -79,10 +80,15 @@ export function RolesListView() {
           </h2>
           <p className="max-w-2xl text-sm text-muted-foreground">{t('settings.roles.intro')}</p>
         </div>
-        <Button size="sm" className="gap-1.5" onClick={() => navigate('/settings/roles/new')}>
+        <GatedButton
+          permission="role.write"
+          size="sm"
+          className="gap-1.5"
+          onClick={() => navigate('/settings/roles/new')}
+        >
           <Plus className="size-4" aria-hidden="true" />
           {t('settings.roles.create_cta')}
-        </Button>
+        </GatedButton>
       </header>
 
       <div className="rounded-lg border bg-background p-3 shadow-sm">

--- a/apps/admin/src/features/settings/users/UsersListView.tsx
+++ b/apps/admin/src/features/settings/users/UsersListView.tsx
@@ -15,6 +15,7 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { GatedButton } from '@/components/identity';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -196,10 +197,15 @@ export function UsersListView() {
           </h2>
           <p className="max-w-2xl text-sm text-muted-foreground">{t('settings.users.intro')}</p>
         </div>
-        <Button size="sm" className="gap-1.5" onClick={() => setInviteOpen(true)}>
+        <GatedButton
+          permission="user.write"
+          size="sm"
+          className="gap-1.5"
+          onClick={() => setInviteOpen(true)}
+        >
           <UserPlus className="size-4" aria-hidden="true" />
           {t('settings.users.invite_cta')}
-        </Button>
+        </GatedButton>
       </header>
 
       <div className="rounded-lg border bg-background p-3 shadow-sm">


### PR DESCRIPTION
Phase 6 RBAC UI coverage. Two new components + 5 high-visibility action surfaces wrapped.

## New components — `@/components/identity`

- **`<GatedAction permission="X">`** — declarative wrapper for inline action surfaces. Two modes:
  - `hide` (default): vanish when permission missing
  - `disabled`: render washed-out + intercept clicks
- **`<GatedButton permission="X" ...buttonProps>`** — convenience over `<GatedAction>` + `<Button>`. Drop-in replacement for action CTAs.

Composes `useCanI` / `useCanIAny`; identity bootstrap (`isLoading`) treats action as denied to prevent flash of forbidden button.

## Surfaces wrapped

| Location | Permission | Trigger |
| --- | --- | --- |
| `features/settings/users/UsersListView.tsx` | `user.write` | "Invite user" header CTA |
| `features/settings/roles/RolesListView.tsx` | `role.write` | "+ New role" header CTA |
| `features/admin/tenants/index.tsx` | `platform.tenants.manage` | "+ New tenant" SA CTA |
| `features/asset/assets/AssetBulkActionsBar.tsx` | `asset.delete` | Bulk-delete destructive button |
| `components/catalog/bulk-bar.tsx` | `products.bulk_operations` | Entire sticky bottom bar (5 action buttons + overflow menu) |

## Defense-in-depth strategy

1. **Server enforces every action** via `#[RequiresPermission]` retrofitted in #714/#715/#716 — 119 routes gated total.
2. **`<PermissionGate>` / `<GatedButton>` proactively hide CTAs** the caller cannot use.
3. **`useHttpErrorToast` (Phase 4 #684)** reacts to any 403 that slips through with a localized toast.

Bulk follow-up adoption can use the same pattern — 60-component checklist in `docs/rbac-audit/existing-ui-components-checklist.md` (#713) lists every action-bearing file. Iterative wrap-as-you-touch keeps the defense layer healthy without grinding 60 PRs at once.

## Test plan

- [x] TypeScript noEmit — green
- [x] Biome strict — 0 errors (1 preexisting warning in UsersListView, unrelated)
- [x] Vite build — succeeds (31.66s)

Refs #717.