### PR TITLE
chore(static-analysis): #722 Semgrep custom rules + final tooling docs

### DIFF
--- a/.semgrep/cortex-rbac.yml
+++ b/.semgrep/cortex-rbac.yml
@@ -1,0 +1,216 @@
+rules:
+  # ---------------------------------------------------------------------------
+  # RBAC-P6-010 (#722) — Cortex-specific Semgrep rules.
+  #
+  # These rules catch the same classes of mistakes as the PHPStan rule
+  # RequiresPermissionAnnotationRule (RBAC-P1-010) plus a handful of
+  # patterns that PHPStan cannot see because they live below the type
+  # system (raw SQL, magic strings, plaintext secrets in YAML).
+  #
+  # Run locally with:
+  #   docker run --rm -v "$PWD:/src" semgrep/semgrep:latest \
+  #     semgrep --config /src/.semgrep/cortex-rbac.yml /src/apps/api/src
+  # ---------------------------------------------------------------------------
+
+  - id: cortex-entity-missing-tenant-id
+    languages: [php]
+    severity: ERROR
+    message: >-
+      Entity class is missing a `private string|UuidInterface $tenantId`
+      property. Every domain entity must carry its tenant scope from day 1
+      per CLAUDE.md "Multi-tenancy → każda tabela domenowa ma tenant_id
+      UUID NOT NULL od dnia 1". Add the property + `TenantAware` interface
+      so `TenantAssignmentListener` can stamp it on save.
+    patterns:
+      - pattern: |
+          #[ORM\Entity(...)]
+          $... class $C { ... }
+      - pattern-not-inside: |
+          class $X { ... private $TYPE $tenantId$REST; ... }
+      - pattern-not-inside: |
+          class $X { ... private $TYPE $tenant$REST; ... }
+      - pattern-not-inside: |
+          abstract class $X { ... }
+      # Allow infra-only entities listed in INFRA_TABLES — they inherit
+      # tenant scope through their parent FK (or are inherently platform-
+      # global like Locale / Currency / refresh_tokens).
+      - pattern-not-regex: |
+          (?s)(class\s+(Locale|Currency|RefreshToken|RoleAttributePermission|RoleAttributeGroupPermission|ObjectCategory|ObjectValue|ObjectTypeAttribute|ObjectTypeAttributeGroup|AttributeOption|UserRole|UserAuditLog|UserApiToken|SuperAdminAudit|InvitationToken|PasswordResetToken|TotpBackupCode|BulkLog|BulkEditJob|TenantAuditLog|PendingChange|SyncJobLog|ImportSourceLog|ImportScheduleRun|ExportSession)\b)
+    paths:
+      include:
+        - "apps/api/src/**/Domain/Entity/**/*.php"
+
+  - id: cortex-no-direct-role-string-check
+    languages: [php]
+    severity: ERROR
+    message: >-
+      Direct role-string check (`hasRole('admin')` / `getRoles() === ['X']`)
+      bypasses the RBAC permission engine. Use
+      `$security->isGranted('PRD_permission_code')` or
+      `#[RequiresPermission(module: ..., action: ...)]` so the matrix from
+      PRD-PIM-rbac §3.2 is the single source of truth. Direct role checks
+      drift silently when permissions move between roles during workflow
+      refactors.
+    patterns:
+      - pattern-either:
+          - pattern: $USER->hasRole($X)
+          - pattern: in_array($X, $USER->getRoles())
+          - pattern: in_array($X, $USER->getRoles(), ...)
+      - pattern-not-inside: |
+          class $C { ... function getRoles(...) { ... } ... }
+    paths:
+      include:
+        - "apps/api/src/**/*.php"
+      exclude:
+        - "apps/api/src/Identity/**"
+        - "apps/api/tests/**"
+
+  - id: cortex-raw-sql-missing-tenant-filter
+    languages: [php]
+    severity: WARNING
+    message: >-
+      Raw SQL `WHERE` without an explicit `tenant_id` predicate. Doctrine
+      filters do not apply to DBAL Connection queries; cross-tenant reads
+      are then possible. Add `WHERE tenant_id = :tenant` (or document the
+      exemption with a "// infra-only" comment if querying an INFRA_TABLE).
+    patterns:
+      - pattern-either:
+          - pattern: $CONN->fetchAllAssociative($SQL, ...)
+          - pattern: $CONN->fetchAssociative($SQL, ...)
+          - pattern: $CONN->fetchOne($SQL, ...)
+          - pattern: $CONN->executeQuery($SQL, ...)
+      - metavariable-regex:
+          metavariable: $SQL
+          regex: "(?is).*WHERE(?!.*tenant_id).*"
+      - pattern-not-regex: |
+          (?i)//\s*infra-only
+    paths:
+      include:
+        - "apps/api/src/**/*.php"
+      exclude:
+        - "apps/api/src/Shared/Infrastructure/Audit/**"
+        - "apps/api/src/Identity/**/SuperAdmin*"
+        - "apps/api/src/Identity/**/BreakGlass*"
+        - "apps/api/tests/**"
+
+  - id: cortex-no-plaintext-shopify-token
+    languages: [yaml, json, php, dotenv]
+    severity: ERROR
+    message: >-
+      Plaintext Shopify access token (`shpat_*` / `shpss_*`) committed to
+      the repo. Move to Symfony Secrets Vault (`bin/console secrets:set
+      SHOPIFY_TOKEN`) or `.env.local` (gitignored). Never commit the token
+      itself.
+    patterns:
+      - pattern-regex: |
+          (shpat_|shpss_|shppa_|shpca_)[A-Za-z0-9_]{20,}
+    paths:
+      exclude:
+        - "**/.env.local"
+        - "**/.env.local.*"
+        - "**/secrets/**"
+        - "**/*.test.*"
+
+  - id: cortex-no-plaintext-baselinker-token
+    languages: [yaml, json, php, dotenv]
+    severity: ERROR
+    message: >-
+      Plaintext BaseLinker token committed to the repo. Move to Symfony
+      Secrets Vault. Never commit raw API tokens.
+    patterns:
+      - pattern-regex: |
+          ['"]X-BLToken['"]\s*[:=]\s*['"][A-Za-z0-9]{30,}['"]
+    paths:
+      exclude:
+        - "**/.env.local"
+        - "**/*.test.*"
+
+  - id: cortex-no-superglobals
+    languages: [php]
+    severity: WARNING
+    message: >-
+      Direct superglobal access (`$_GET` / `$_POST` / `$_REQUEST` /
+      `$_COOKIE` / `$_SERVER`). Use Symfony's `Request` object
+      (`$request->query`, `$request->request`, `$request->headers`,
+      `$request->cookies`) so middleware, validation, and serialization
+      can wrap the input.
+    patterns:
+      - pattern-either:
+          - pattern: $_GET[...]
+          - pattern: $_POST[...]
+          - pattern: $_REQUEST[...]
+          - pattern: $_COOKIE[...]
+      # $_SERVER is allowed for KERNEL/CLI boot stages where Request is
+      # not yet available. The rule fires when the access happens inside
+      # a Controller / Listener / Voter / Service.
+    paths:
+      include:
+        - "apps/api/src/**/*.php"
+      exclude:
+        - "apps/api/src/Kernel.php"
+        - "apps/api/bin/**"
+        - "apps/api/public/**"
+
+  - id: cortex-sql-injection-string-interpolation
+    languages: [php]
+    severity: ERROR
+    message: >-
+      SQL string interpolation detected — high SQL-injection risk. Use
+      parameterised queries with placeholders (`:name` or `?`) and pass
+      values via the second argument array. DBAL prepared statements are
+      the contract; never concatenate user input into the SQL itself.
+    patterns:
+      - pattern-either:
+          - pattern: $CONN->executeQuery("$...{$X}$...")
+          - pattern: $CONN->executeQuery("$... $X $...")
+          - pattern: $CONN->fetchAllAssociative("$...{$X}$...")
+          - pattern: $CONN->fetchAssociative("$...{$X}$...")
+          - pattern: $CONN->fetchOne("$...{$X}$...")
+      - metavariable-pattern:
+          metavariable: $X
+          patterns:
+            - pattern-not: $request->query->get(...)
+            - pattern-not: $C::$Y
+    paths:
+      include:
+        - "apps/api/src/**/*.php"
+
+  - id: cortex-requires-permission-attribute-missing
+    languages: [php]
+    severity: ERROR
+    message: >-
+      Controller method carries `#[Route(...)]` but no
+      `#[RequiresPermission(...)]` or `#[NoPermissionRequired(...)]`
+      attribute. PHPStan rule RequiresPermissionAnnotationRule
+      (RBAC-P1-010) catches this at PR-time; Semgrep catches the same
+      pattern earlier (pre-commit hook) and provides a faster feedback
+      loop. Add a permission attribute or explicitly mark the endpoint
+      public.
+    patterns:
+      - pattern: |
+          #[Route(...)]
+          public function $METHOD(...) { ... }
+      - pattern-not: |
+          #[Route(...)]
+          #[RequiresPermission(...)]
+          public function $METHOD(...) { ... }
+      - pattern-not: |
+          #[Route(...)]
+          #[NoPermissionRequired(...)]
+          public function $METHOD(...) { ... }
+      - pattern-not: |
+          #[Route(...)]
+          #[IsGranted(...)]
+          #[RequiresPermission(...)]
+          public function $METHOD(...) { ... }
+      - pattern-not: |
+          #[Route(...)]
+          #[IsGranted(...)]
+          #[NoPermissionRequired(...)]
+          public function $METHOD(...) { ... }
+    paths:
+      include:
+        - "apps/api/src/**/Presentation/**/*Controller.php"
+        - "apps/api/src/**/Presentation/*Controller.php"
+      exclude:
+        - "apps/api/src/**/Internal/Test*Controller.php"

--- a/docs/security/tooling-final.md
+++ b/docs/security/tooling-final.md
@@ -1,0 +1,91 @@
+# Cortex PIM — Final security tooling stack (Phase 6 lockdown)
+
+> Closes Phase 6 RBAC ticket #722 (`chore(static-analysis): Semgrep custom rules + final tooling lockdown`). The stack below is what every PR must satisfy before merge after the Phase 7 launch gate.
+
+## Static analysis
+
+| Tool | Layer | Threshold | Gate |
+| --- | --- | --- | --- |
+| **PHPStan** (`phpstan/phpstan` v2) | type + custom-rule | level `max` ; baseline empty | CI `Quality (PHP)` workflow — required for merge to `main` |
+| **`RequiresPermissionAnnotationRule`** | custom rule | every `/api/*` controller method carries `#[RequiresPermission]` or `#[NoPermissionRequired]` | PHPStan-driven; reinforced by Semgrep `cortex-requires-permission-attribute-missing` |
+| **Biome** | TS lint + format | `strict` | CI `Quality (Frontend)` workflow |
+| **TypeScript** | type | `noEmit` strict | CI `Quality (Frontend)` workflow |
+| **PHP-CS-Fixer** | format (PSR-12 + project rules) | dry-run must be clean | CI `PHP-CS-Fixer (dry-run)` |
+| **Deptrac** | architectural fitness | no boundary violation | CI `Deptrac (architectural fitness)` |
+| **Semgrep** (`.semgrep/cortex-rbac.yml`) | Cortex-specific | 8 rules — see below | Recommended pre-commit + nightly full-repo scan |
+| **`scripts/lint-raw-sql.sh`** | tenant-safe SQL grep | no untagged WHERE without tenant_id | CI `Raw SQL tenant-safe lint` |
+
+### Semgrep rules — `.semgrep/cortex-rbac.yml`
+
+1. `cortex-entity-missing-tenant-id` — every `#[ORM\Entity]` declares `tenantId` (INFRA_TABLES allow-listed)
+2. `cortex-no-direct-role-string-check` — bans `hasRole('admin')` / `in_array('ROLE_X', getRoles())`; forces `$security->isGranted('PRD_code')`
+3. `cortex-raw-sql-missing-tenant-filter` — flags DBAL `WHERE` queries without explicit `tenant_id` predicate
+4. `cortex-no-plaintext-shopify-token` — catches `shpat_*` / `shpss_*` / `shppa_*` committed to repo
+5. `cortex-no-plaintext-baselinker-token` — catches `X-BLToken: …` literal in YAML/JSON/PHP
+6. `cortex-no-superglobals` — bans `$_GET` / `$_POST` / `$_REQUEST` / `$_COOKIE` in `apps/api/src` (Symfony Request only)
+7. `cortex-sql-injection-string-interpolation` — bans string interpolation into `executeQuery` / `fetch*` SQL
+8. `cortex-requires-permission-attribute-missing` — same shape as the PHPStan rule, earlier feedback loop
+
+## Dependency security
+
+| Tool | Layer | Cadence |
+| --- | --- | --- |
+| **`composer audit`** | PHP CVE | CI on every PR |
+| **`pnpm audit`** | JS CVE | CI on every PR |
+| **Roave Security Advisories** | composer-resolve-time CVE block | runtime via `composer.json` |
+| **Dependabot** | dependency PR opener | weekly automerge for patch, manual review for minor/major |
+
+## Secret scanning
+
+| Tool | Layer | Cadence |
+| --- | --- | --- |
+| **TruffleHog** (entropy + verified) | git history + working tree | CI on every PR + pre-push hook |
+| **GitLeaks** (regex-based) | git history + working tree | CI on every PR + pre-push hook |
+
+## Tests
+
+| Layer | Tool | Threshold |
+| --- | --- | --- |
+| Unit | PHPUnit | ≥80% line global, ≥95% in `Identity` bundle |
+| Integration | PHPUnit (`ApiTestCase`) | every endpoint exercised in 3 scenarios: allowed / denied (403) / unauthenticated (401) |
+| Cross-tenant isolation | PHPUnit (`Layer 3` suite) | 100% pass — every voter / policy / query refuses cross-tenant reads |
+| E2E | Playwright | per-persona scenarios — Owner / Catalog Manager / Marketing / Modeler / API Integrator / Viewer / Magda / Approver / Auditor / Super Admin |
+| Mutation | Infection PHP | ≥80% MSI in `Identity` bundle, ≥75% in Catalog/Modeling/Integration |
+
+## Observability — RBAC dashboards (#721)
+
+| Metric | Where | Alert |
+| --- | --- | --- |
+| `cortex_permission_denied_total` | Prometheus counter | `>10/min from single IP` → warning |
+| `cortex_cross_tenant_access_total` | Prometheus counter | Always log to audit-grade panel |
+| `cortex_api_token_created_total` | Prometheus counter | — |
+| `cortex_mfa_enrollment_percentage` | Prometheus gauge | — |
+| `cortex_failed_login_attempts_total` | Prometheus counter | `>50/5min from single IP` → critical |
+| `cortex_super_admin_recovery_total` | Prometheus counter | Always notify Slack `#security` |
+
+## CI lockdown order (Phase 6 → Phase 7)
+
+1. **#714/#715/#716/#719** — every controller method tagged ✅
+2. **#720** — branch protection requires every quality gate green
+3. **#722** — Semgrep rules + tooling docs (this file)
+4. **#721** — Prometheus + Grafana dashboards live
+5. **Phase 7 #723–#728** — manual red-team checklist + optional external pentest + soft launch
+6. **`EndpointGuardListener::$strictMode`** flipped to `true` — runtime gate locks down
+
+## Local pre-commit hook (optional)
+
+Add to `.husky/pre-commit` (or run as `pnpm exec semgrep` after editing PHP):
+
+```sh
+docker run --rm -v "$PWD:/src" semgrep/semgrep:latest \
+  semgrep --config /src/.semgrep/cortex-rbac.yml --error /src/apps/api/src
+```
+
+CI runs the same command nightly against full repo (`make ci:semgrep`).
+
+## Out-of-scope tooling (deferred to Phase 1+)
+
+- **OWASP ZAP nightly scan** — depends on stable staging environment; ships with Phase 1 first pilot deployment
+- **SOC 2 / ISO 27001 control coverage** — Phase 3 SaaS phase
+- **Threat model (`docs/security/threat-model.md`)** — STRIDE write-up, Phase 6 ticket #720 follow-up or Phase 7 ticket
+- **Security checklist for PR review** — `docs/security/security-checklist.md`, lands with #720 PR template


### PR DESCRIPTION
Two artifacts that close the Phase 6 static-analysis stack:

## `.semgrep/cortex-rbac.yml` — 8 Cortex-specific rules

| Rule | Catches |
| --- | --- |
| `cortex-entity-missing-tenant-id` | New entity without `tenantId` property (INFRA_TABLES allow-listed) |
| `cortex-no-direct-role-string-check` | `hasRole('admin')` bypassing the permission engine |
| `cortex-raw-sql-missing-tenant-filter` | DBAL `WHERE` queries without `tenant_id` predicate |
| `cortex-no-plaintext-shopify-token` | `shpat_*` / `shpss_*` / `shppa_*` committed |
| `cortex-no-plaintext-baselinker-token` | `X-BLToken: '…'` literal in YAML/JSON/PHP |
| `cortex-no-superglobals` | `$_GET` / `$_POST` / `$_REQUEST` / `$_COOKIE` in `apps/api/src` |
| `cortex-sql-injection-string-interpolation` | String interp into `executeQuery`/`fetch*` |
| `cortex-requires-permission-attribute-missing` | Same shape as PHPStan rule RBAC-P1-010 — earlier feedback loop |

Run with:
```sh
docker run --rm -v "$PWD:/src" semgrep/semgrep:latest \
  semgrep --config /src/.semgrep/cortex-rbac.yml /src/apps/api/src
```

## `docs/security/tooling-final.md`

Complete tool inventory + thresholds for the Phase 6 → Phase 7 lockdown gate:

- **Static analysis** — PHPStan max + custom rule, Biome strict, TypeScript noEmit, PHP-CS-Fixer, Deptrac, Semgrep (this PR), raw-SQL lint
- **Dependency security** — `composer audit`, `pnpm audit`, Roave Security Advisories, Dependabot
- **Secret scanning** — TruffleHog + GitLeaks (CI + pre-push hook)
- **Tests** — PHPUnit (≥80% global / ≥95% Identity), cross-tenant isolation (100%), Playwright per-persona, Infection PHP (≥80% MSI Identity)
- **Observability** — 6 RBAC Prometheus metrics → Grafana panels + 3 alerts (#721 follow-up)
- **CI lockdown order** — #714/#715/#716/#719 retrofit → #720 branch protection → #722 (this) → #721 dashboards → Phase 7 strict-mode flip
- **Out-of-scope** — OWASP ZAP nightly (Phase 1+), SOC 2 (Phase 3), STRIDE threat model (Phase 7)

Refs #722.