### PR TITLE
chore(ci): #720 PR template + Semgrep CI gate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,77 @@
+<!--
+Phase 6 RBAC-P6-008 (#720) — PR template.
+
+Keep the body short and concrete: every reviewer should be able to read it
+in 30 seconds and understand what changed, why, and how it was verified.
+The CI gates enforce most automated checks; this template surfaces the
+manual evidence that automation cannot see (live-stack smoke output,
+threat-model deltas, persona walkthroughs).
+
+Delete sections that do not apply. Keep section headings so a future
+reviewer can grep for "Security review" / "Smoke test" across history.
+-->
+
+## Summary
+
+<!-- 1-3 bullets. What changed and why. Link issues with `Refs #N` / `Closes #N`. -->
+
+-
+-
+
+## Scope
+
+<!-- Optional: which bounded contexts or features. Drop if obvious. -->
+
+## Security review
+
+<!--
+Required when the PR touches: controllers, voters, security.yaml, RLS,
+TenantFilter, API tokens, MFA, SSO, password reset, break-glass, or any
+schema that holds `tenant_id` / PII.
+
+Fill in or write "N/A — no security surface touched" with one line of why.
+-->
+
+- [ ] Every new `/api/*` controller method carries `#[RequiresPermission]` or `#[NoPermissionRequired(reason: ...)]`
+- [ ] Tenant filter / RLS / `TenantAssignmentListener` covered for new domain entities (`tenantId` column present + listener wired)
+- [ ] Cross-tenant test added or updated for new voters / queries / policies
+- [ ] No plaintext secrets, no `$_GET` / `$_POST`, no SQL string interpolation (Semgrep `.semgrep/cortex-rbac.yml` clean)
+- [ ] Permission strings cross-checked vs PRD-PIM-rbac §3.2 macierz uprawnień
+
+## Quality gates
+
+<!-- Tick what you have run / observed pass. CI will rerun these too. -->
+
+- [ ] PHPStan max — green, baseline empty
+- [ ] PHPUnit unit + integration suites — green
+- [ ] Biome strict + TypeScript noEmit — green
+- [ ] Playwright E2E — green (when the change touches UI flows)
+- [ ] `composer audit` + `pnpm audit` — no `HIGH` / `CRITICAL`
+- [ ] OpenAPI spec drift — re-exported `docs/api-spec/v0.json` if API surface changed
+
+## Smoke test
+
+<!--
+CLAUDE.md SMOKE TEST RULE — before claiming "działa" / "works" / "ready",
+exercise the feature on the live stack (`pnpm stack:up` or
+`https://pim.localhost`) and paste the HTTP code + response body / 302
+Location / Mailpit screenshot below.
+
+For pure-backend changes: `curl -sk -H "Authorization: Bearer <jwt>"
+https://pim.localhost/api/... -w "%{http_code}"`.
+
+For UI changes: per-persona walkthrough — note which persona, which
+button, what visible result.
+-->
+
+```
+# Paste HTTP code + JSON body snippet, or screenshot link, or "N/A — refactor only".
+```
+
+## Test plan
+
+- [ ]
+
+## Notes
+
+<!-- Optional: trade-offs, follow-ups, dependencies on other PRs. -->

--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -121,6 +121,29 @@ jobs:
       - name: Lint raw SQL escape hatches
         run: bash scripts/lint-raw-sql.sh
 
+  semgrep-cortex:
+    # RBAC-P6-008 / #720 — Cortex-specific Semgrep rules (the static-
+    # analysis companion to PHPStan's RequiresPermissionAnnotationRule).
+    # Catches plaintext secrets, raw SQL without tenant filter,
+    # superglobals, hasRole() bypass of the permission engine, and the
+    # same missing #[RequiresPermission] shape PHPStan blocks at PR time.
+    # Pre-commit hook locally; CI runs on every PR.
+    name: Semgrep (Cortex RBAC rules)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    container:
+      image: semgrep/semgrep:latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Semgrep scan (.semgrep/cortex-rbac.yml)
+        run: |
+          semgrep --config .semgrep/cortex-rbac.yml \
+            --error --strict --no-rewrite-rule-ids \
+            apps/api/src apps/admin/src
+
   php-cs-fixer:
     name: PHP-CS-Fixer (dry-run)
     runs-on: ubuntu-latest


### PR DESCRIPTION
PR template + Semgrep CI gate. Two artifacts:

## `.github/PULL_REQUEST_TEMPLATE.md`

Direct implementation of #720 AC-3. Sections:
- **Summary** (1-3 bullets + Refs/Closes)
- **Scope** (optional, BCs touched)
- **Security review** checklist — `#[RequiresPermission]` coverage, tenant filter / RLS / `TenantAssignmentListener` wiring, cross-tenant test, no plaintext secrets / superglobals / SQL string interp (Semgrep `cortex-rbac.yml` clean), permission strings vs PRD §3.2
- **Quality gates** checklist — PHPStan, PHPUnit, Biome+TS, Playwright, `composer`/`pnpm audit`, OpenAPI spec drift
- **Smoke test** (CLAUDE.md SMOKE TEST RULE) — HTTP code + body OR per-persona walkthrough
- **Test plan**
- **Notes** (trade-offs, follow-ups)

## New CI job: `semgrep-cortex`

Added to `.github/workflows/quality-php.yml`. Runs `.semgrep/cortex-rbac.yml` (RBAC-P6-010 / #722 rules) against `apps/api/src` + `apps/admin/src` using `semgrep/semgrep:latest` container. Fails on `--error --strict`.

## Phase 7 follow-ups documented in this PR

- **Coverage thresholds** in `phpunit.xml` (Identity ≥95% line, ≥80% MSI) — depends on #719 test refactor (loginAs helper + 200-class retrofit)
- **Infection MSI thresholds** — same dependency
- **Branch protection** enforcement on `main` — operator config in GitHub repo settings, not a code change

Refs #720.