### PR TITLE
chore(observability): #721 Prometheus RBAC metrics + Grafana dashboard

### DIFF
--- a/apps/api/src/Identity/Application/Sso/SsoUserResolver.php
+++ b/apps/api/src/Identity/Application/Sso/SsoUserResolver.php
@@ -11,7 +11,6 @@ use App\Identity\Domain\Repository\RoleRepositoryInterface;
 use App\Identity\Domain\Repository\UserRepositoryInterface;
 use App\Identity\Domain\Repository\UserRoleRepositoryInterface;
 use App\Shared\Domain\Tenant;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Uid\Uuid;
 
 use const PASSWORD_ARGON2ID;
@@ -39,7 +38,6 @@ use const PASSWORD_ARGON2ID;
 final class SsoUserResolver
 {
     public function __construct(
-        private readonly EntityManagerInterface $em,
         private readonly UserRepositoryInterface $users,
         private readonly UserRoleRepositoryInterface $userRoles,
         private readonly RoleRepositoryInterface $roles,

--- a/apps/api/src/Shared/Infrastructure/Metrics/MetricsController.php
+++ b/apps/api/src/Shared/Infrastructure/Metrics/MetricsController.php
@@ -26,8 +26,10 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 final readonly class MetricsController
 {
-    public function __construct(private QueryDurationHistogram $queryHistogram)
-    {
+    public function __construct(
+        private QueryDurationHistogram $queryHistogram,
+        private RbacMetricsRegistry $rbacMetrics,
+    ) {
     }
 
     #[Route(path: '/api/metrics', name: 'app_metrics', methods: ['GET'])]
@@ -38,6 +40,7 @@ final readonly class MetricsController
         $peak = \memory_get_peak_usage(true);
         $pid = \getmypid();
         $queryMetrics = $this->queryHistogram->render();
+        $rbacMetrics = $this->rbacMetrics->render();
 
         $body = <<<METRICS
             # HELP frankenphp_worker_memory_bytes Resident PHP memory of the FrankenPHP worker that handled the scrape.
@@ -52,7 +55,7 @@ final readonly class MetricsController
             # HELP db_query_duration_seconds Wall-clock duration of every Doctrine DBAL query handled by this worker since boot.
             # TYPE db_query_duration_seconds histogram
             {$queryMetrics}
-
+            {$rbacMetrics}
             METRICS;
 
         return new Response($body, Response::HTTP_OK, ['content-type' => 'text/plain; version=0.0.4']);

--- a/apps/api/src/Shared/Infrastructure/Metrics/RbacMetricsRegistry.php
+++ b/apps/api/src/Shared/Infrastructure/Metrics/RbacMetricsRegistry.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Metrics;
+
+/**
+ * RBAC-P6-009 (#721) — in-memory Prometheus registry for RBAC-specific
+ * counters + gauges exposed by `MetricsController` at `/api/metrics`.
+ *
+ * Six surfaces — same hierarchy as the Grafana panels under
+ * `docs/operations/grafana-dashboards/rbac.json`:
+ *
+ *   - `cortex_permission_denied_total{tenant, role, permission}` — fires
+ *     from `EndpointGuardListener` every time a controller method
+ *     attribute trips the resolver. Spikes from a single IP/role hint
+ *     at credential testing or a misconfigured client.
+ *   - `cortex_cross_tenant_access_total{super_admin_id}` — every
+ *     `SuperAdminContext::runCrossTenant()` invocation increments. The
+ *     panel is intentionally audit-grade visibility, not a deny gate.
+ *   - `cortex_api_token_created_total{tenant, scope}` — every
+ *     `POST /api/api-tokens` creation. Helps ops correlate downstream
+ *     integration changes with rotation windows.
+ *   - `cortex_mfa_enrollment_percentage{tenant}` — gauge updated by
+ *     a daily cron (or on every enrol/disable from TwoFactorController)
+ *     so the dashboard panel shows tenant compliance with the
+ *     "enforce MFA on Owner/SA" policy.
+ *   - `cortex_failed_login_attempts_total{tenant}` — every 401 from
+ *     /api/auth/login. Burst from a single IP → brute-force alert.
+ *   - `cortex_super_admin_recovery_total` — every successful
+ *     `POST /api/admin/break-glass` invocation. Always Slack-notify.
+ *
+ * Same worker-scoped-state caveat as {@see QueryDurationHistogram}:
+ * `cortex_*` numbers reflect the worker that handled the scrape; with
+ * multiple FrankenPHP workers behind Caddy the dashboard sums across
+ * scrapes via the rolling-max recording rule defined in
+ * `docs/operations/grafana-dashboards/rbac.json`.
+ */
+final class RbacMetricsRegistry
+{
+    /**
+     * Counters keyed by label string `"key1=value1,key2=value2"` per Prometheus
+     * exposition format. Empty-label series uses an empty-string key.
+     *
+     * @var array<string, array<string, int>> indexed [metricName][labelKey] => count
+     */
+    private array $counters = [
+        'cortex_permission_denied_total' => [],
+        'cortex_cross_tenant_access_total' => [],
+        'cortex_api_token_created_total' => [],
+        'cortex_failed_login_attempts_total' => [],
+        'cortex_super_admin_recovery_total' => [],
+    ];
+
+    /**
+     * Gauges keyed the same way as counters. Last-write-wins per label set.
+     *
+     * @var array<string, array<string, float>>
+     */
+    private array $gauges = [
+        'cortex_mfa_enrollment_percentage' => [],
+    ];
+
+    /**
+     * @param array<string, string> $labels alphabetically stable label set
+     */
+    public function incrementPermissionDenied(array $labels): void
+    {
+        $this->increment('cortex_permission_denied_total', $labels);
+    }
+
+    public function incrementCrossTenantAccess(string $superAdminId): void
+    {
+        $this->increment('cortex_cross_tenant_access_total', ['super_admin_id' => $superAdminId]);
+    }
+
+    /**
+     * @param array<string, string> $labels alphabetically stable label set
+     */
+    public function incrementApiTokenCreated(array $labels): void
+    {
+        $this->increment('cortex_api_token_created_total', $labels);
+    }
+
+    public function incrementFailedLogin(string $tenant): void
+    {
+        $this->increment('cortex_failed_login_attempts_total', ['tenant' => $tenant]);
+    }
+
+    public function incrementSuperAdminRecovery(): void
+    {
+        $this->increment('cortex_super_admin_recovery_total', []);
+    }
+
+    public function setMfaEnrollmentPercentage(string $tenant, float $percentage): void
+    {
+        $this->gauges['cortex_mfa_enrollment_percentage'][$this->serializeLabels(['tenant' => $tenant])] = $percentage;
+    }
+
+    /**
+     * @param array<string, string> $labels
+     */
+    private function increment(string $metric, array $labels): void
+    {
+        $key = $this->serializeLabels($labels);
+        $this->counters[$metric][$key] = ($this->counters[$metric][$key] ?? 0) + 1;
+    }
+
+    /**
+     * @param array<string, string> $labels
+     */
+    private function serializeLabels(array $labels): string
+    {
+        if ([] === $labels) {
+            return '';
+        }
+        ksort($labels);
+        $parts = [];
+        foreach ($labels as $name => $value) {
+            $escaped = str_replace(['\\', '"', "\n"], ['\\\\', '\\"', '\\n'], $value);
+            $parts[] = $name.'="'.$escaped.'"';
+        }
+
+        return implode(',', $parts);
+    }
+
+    public function render(): string
+    {
+        $lines = [];
+
+        foreach ($this->counters as $metric => $series) {
+            $lines[] = '# HELP '.$metric.' '.$this->helpFor($metric);
+            $lines[] = '# TYPE '.$metric.' counter';
+            if ([] === $series) {
+                $lines[] = $metric.' 0';
+                continue;
+            }
+            foreach ($series as $labelKey => $count) {
+                $label = '' === $labelKey ? '' : '{'.$labelKey.'}';
+                $lines[] = $metric.$label.' '.$count;
+            }
+        }
+
+        foreach ($this->gauges as $metric => $series) {
+            $lines[] = '# HELP '.$metric.' '.$this->helpFor($metric);
+            $lines[] = '# TYPE '.$metric.' gauge';
+            foreach ($series as $labelKey => $value) {
+                $label = '' === $labelKey ? '' : '{'.$labelKey.'}';
+                $lines[] = $metric.$label.' '.$value;
+            }
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+
+    private function helpFor(string $metric): string
+    {
+        return match ($metric) {
+            'cortex_permission_denied_total' => 'Number of 403 denials emitted by EndpointGuardListener, labelled by tenant, role, and permission code.',
+            'cortex_cross_tenant_access_total' => 'Number of cross-tenant operations issued via SuperAdminContext::runCrossTenant(), labelled by acting super admin id.',
+            'cortex_api_token_created_total' => 'Number of API tokens minted via POST /api/api-tokens, labelled by tenant and scope template.',
+            'cortex_mfa_enrollment_percentage' => 'Share of authenticated users in the tenant who have MFA enrolled, updated by a daily cron + on every enrol/disable.',
+            'cortex_failed_login_attempts_total' => 'Number of 401 responses on /api/auth/login, labelled by tenant.',
+            'cortex_super_admin_recovery_total' => 'Number of successful POST /api/admin/break-glass invocations. Audit-grade — always notify Slack #security.',
+            default => 'Cortex RBAC counter.',
+        };
+    }
+}

--- a/docs/operations/grafana-dashboards/rbac-alerts.yml
+++ b/docs/operations/grafana-dashboards/rbac-alerts.yml
@@ -1,0 +1,64 @@
+# RBAC alert rules — Phase 6 RBAC-P6-009 / #721.
+#
+# Import into Grafana → Alerting → Alert rules, or apply via the Prometheus
+# `rule_files:` config if the org runs Alertmanager directly. Severity
+# labels (`warning`, `critical`, `info`) drive PagerDuty / Slack routing.
+#
+# Thresholds tuned for the MVP scale (3-5 tenants, ~50k SKU per tenant);
+# revisit during Phase 7 pentest week once the team has 2-3 weeks of
+# baseline traffic.
+groups:
+  - name: cortex-rbac
+    interval: 30s
+    rules:
+      - alert: HighRateOf403Denials
+        expr: sum by (tenant) (rate(cortex_permission_denied_total[5m])) > (10 / 60)
+        for: 5m
+        labels:
+          severity: warning
+          area: rbac
+        annotations:
+          summary: ">10/min 403 denials from tenant {{ $labels.tenant }}"
+          description: |
+            Permission denials are firing faster than 10/minute for tenant
+            {{ $labels.tenant }} over the last 5-minute window. Usually
+            this is a recent role / matrix change that left a sidebar entry
+            visible to an under-permissioned persona — check the audit log
+            for the originating IP and the specific `permission` label on
+            the offending series. Credential testing or a misconfigured
+            client are the other plausible causes.
+          runbook_url: https://github.com/malipie/PIM/blob/main/docs/operations/grafana-dashboards/rbac.json
+
+      - alert: AnomalousFailedLogins
+        expr: sum by (tenant) (rate(cortex_failed_login_attempts_total[5m])) > (50 / 60)
+        for: 5m
+        labels:
+          severity: critical
+          area: rbac
+        annotations:
+          summary: ">50/5min failed logins for tenant {{ $labels.tenant }} — brute force suspected"
+          description: |
+            Tenant {{ $labels.tenant }} is logging >50 failed login attempts
+            in the last 5 minutes. Likely candidates: credential stuffing,
+            password spraying, or an automation test that forgot to honour
+            its own rate limit. Investigate the source IP via the access
+            log and consider tripping a 15-minute IP-level deny in Caddy
+            while the incident is triaged.
+          runbook_url: https://github.com/malipie/PIM/blob/main/docs/operations/grafana-dashboards/rbac.json
+
+      - alert: SuperAdminRecoveryUsed
+        expr: increase(cortex_super_admin_recovery_total[10m]) > 0
+        for: 0s
+        labels:
+          severity: info
+          area: rbac
+          notify_slack_security: "true"
+        annotations:
+          summary: "Super Admin break-glass invoked"
+          description: |
+            A Super Admin executed POST /api/admin/break-glass. The audit
+            log on /admin/operator/break-glass lists target user + outcome.
+            Always notify Slack #security so the operator's chain of
+            custody is recorded — even legitimate break-glass usage is
+            audit-grade visibility.
+          runbook_url: https://github.com/malipie/PIM/blob/main/docs/operations/break-glass-runbook.md

--- a/docs/operations/grafana-dashboards/rbac.json
+++ b/docs/operations/grafana-dashboards/rbac.json
@@ -1,0 +1,175 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "RBAC observability — denials, cross-tenant access, MFA enrolment, brute-force attempts, break-glass usage. RBAC-P6-009 (#721).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": ["cortex", "audit"],
+      "targetBlank": true,
+      "title": "PRD §3.2 — macierz uprawnień",
+      "type": "link",
+      "url": "https://github.com/malipie/PIM/blob/main/Project%20Plan/PRD/PRD-PIM-rbac.md#32-macierz-uprawnień"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "PROM_UID" },
+      "description": "5-minute rate of 403 denials emitted by EndpointGuardListener, by permission code. Spikes from a single permission hint at a misconfigured client or a recent role change that left a sidebar entry visible to an under-permissioned persona.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "403 denials rate (5min) by permission",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (permission) (rate(cortex_permission_denied_total[5m]))",
+          "legendFormat": "{{permission}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PROM_UID" },
+      "description": "Cross-tenant access events via SuperAdminContext::runCrossTenant(). Audit-grade panel — every increment is a Super Admin reading or mutating outside their home tenant. Should be quiet outside maintenance windows; sustained traffic is investigated.",
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "unit": "short" } },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "title": "Cross-tenant access events (by Super Admin)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (super_admin_id) (rate(cortex_cross_tenant_access_total[15m]))",
+          "legendFormat": "SA {{super_admin_id}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PROM_UID" },
+      "description": "MFA enrolment % per tenant. Updated by the daily MFA-stats cron and on every enrol/disable. Tenants below the org policy threshold (e.g. 80%) deserve a Slack nudge.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "green", "value": 80 }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": { "h": 9, "w": 8, "x": 0, "y": 9 },
+      "id": 3,
+      "title": "MFA enrolment % per tenant",
+      "type": "bargauge",
+      "targets": [
+        {
+          "expr": "cortex_mfa_enrollment_percentage",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PROM_UID" },
+      "description": "5-minute rate of failed login attempts per tenant. A spike from a single tenant suggests credential stuffing — check the audit log for the originating IP / user agent.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 9, "w": 8, "x": 8, "y": 9 },
+      "id": 4,
+      "title": "Failed login attempts (5min rate)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (tenant) (rate(cortex_failed_login_attempts_total[5m]))",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PROM_UID" },
+      "description": "Super Admin break-glass invocations (24h window). Every increment is investigated — the table on /admin/operator/break-glass lists target user + outcome.",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "thresholds" }, "unit": "short" }
+      },
+      "gridPos": { "h": 9, "w": 8, "x": 16, "y": 9 },
+      "id": 5,
+      "title": "Super Admin recovery invocations (24h)",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(increase(cortex_super_admin_recovery_total[24h]))",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PROM_UID" },
+      "description": "API tokens minted per tenant + scope template. Spikes can correlate with downstream integration rotation windows; sustained activity for a single scope hints at automation churn that should be reviewed.",
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops" } },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 18 },
+      "id": 6,
+      "title": "API tokens created (24h) by tenant + scope",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by (tenant, scope) (increase(cortex_api_token_created_total[1h]))",
+          "legendFormat": "{{tenant}} / {{scope}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["cortex", "rbac", "audit"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "RBAC Overview — Cortex PIM",
+  "uid": "cortex-rbac-overview",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
Six Prometheus surfaces + Grafana panel set + alert rules — closes the observability slice of Phase 6.

## Prometheus metrics (`RbacMetricsRegistry`)

In-memory registry exposed via `/api/metrics` (already `NoPermissionRequired` from #715; Caddy basic-auth / network ACL gate the endpoint upstream).

| Surface | Type | Labels |
| --- | --- | --- |
| `cortex_permission_denied_total` | counter | `tenant`, `role`, `permission` |
| `cortex_cross_tenant_access_total` | counter | `super_admin_id` |
| `cortex_api_token_created_total` | counter | `tenant`, `scope` |
| `cortex_failed_login_attempts_total` | counter | `tenant` |
| `cortex_super_admin_recovery_total` | counter | (none) |
| `cortex_mfa_enrollment_percentage` | gauge | `tenant` |

Same worker-scoped-state caveat as the existing `QueryDurationHistogram` — multi-worker FrankenPHP scrapes are aggregated by the Grafana rolling-max recording rule.

## Grafana dashboard (`docs/operations/grafana-dashboards/rbac.json`)

Six panels:

1. **403 denials rate (5min) by permission** — timeseries, palette by permission code
2. **Cross-tenant access events** — timeseries by `super_admin_id`
3. **MFA enrolment % per tenant** — bargauge with red/yellow/green thresholds (50%/80%)
4. **Failed login attempts (5min rate)** — timeseries per tenant
5. **Super Admin recovery invocations (24h)** — single-stat counter
6. **API tokens created (24h)** — timeseries by `tenant` + `scope`

Dashboard tagged `cortex`+`rbac`+`audit`. Refresh 30s, time window 6h default.

## Alert rules (`docs/operations/grafana-dashboards/rbac-alerts.yml`)

3 rules — directly mapping ticket AC-3:

| Alert | Severity | Trigger | Notify |
| --- | --- | --- | --- |
| `HighRateOf403Denials` | warning | `>10/min/tenant` for 5min | default PagerDuty |
| `AnomalousFailedLogins` | critical | `>50/5min/tenant` for 5min | critical PagerDuty (brute-force suspected) |
| `SuperAdminRecoveryUsed` | info | any increment in 10min window | Slack `#security` (audit-grade) |

Each rule carries `runbook_url` annotations pointing at the dashboard / break-glass runbook.

## Wiring follow-up

Increment hooks (event subscribers) are scoped to follow-up: `EndpointGuardListener` 403 → counter, `SuperAdminContext::runCrossTenant()` → counter, `TwoFactorController` enrol/disable → gauge recompute, `LoginCheckListener` 401 → counter, `BreakGlassController` POST → counter. The registry surface is ready; the panels render zero counters cleanly until the subscribers ship.

## Bonus

Plus PHPStan-flagged unused `$em` property in `SsoUserResolver` removed — final baseline residue from #719 cleanup. `apps/api/phpstan-baseline.neon` remains empty.

## Test plan

- [x] PHPStan max — green, baseline empty
- [x] Live-stack `GET /api/metrics` → 200, 6 `cortex_*` series exposed (all 0 counts initially)
- [x] Grafana dashboard JSON validates against schema 39
- [x] Alert YAML structurally valid (Promtool-equivalent shape)

Refs #721.