### PR TITLE
chore(channel): #870 migrate tenants.enabled_locales to tenant_locales

### DIFF
--- a/Project Plan/UI/feature-locales.md
+++ b/Project Plan/UI/feature-locales.md
@@ -1,0 +1,245 @@
+# Feature (mini-spec) — Locales & Internacjonalizacja (`/settings/locales`)
+
+## Status: 🟢 szczegół (mini-spec)
+
+> **Mini-spec** — zwięzła specyfikacja zakładki `/settings/locales`. Krótszy format niż `feature-imports.md` / `feature-list-advanced.md` / `feature-exports.md` — obszar jest mniejszy, decyzje proste.
+> Wzorzec: **Pimcore per-locale UX** (default / fallback / mandatory flags) + **Akeneo channel↔locale binding** + **per-tenant adaptacja pod SaaS**.
+> Powiązane: ADR-011 (per-tenant locale fallback), RBAC-P5-015 (Settings → Tenant config — locales multi-select wzmiankowane), `user_roles.locale_scope` (RBAC per-rola restriction).
+
+---
+
+## 1. Cel feature'a
+
+`/settings/locales` to miejsce gdzie tenant definiuje **z jakimi językami treści pracuje**. Locale = wymiar lokalizacji po którym wartości atrybutów się rozdzielają (`description.pl_PL` vs `description.en_US`).
+
+Zakładka robi 4 rzeczy:
+1. **Aktywacja locales** — tenant wybiera z globalnego katalogu ISO swoje aktywne locales.
+2. **Default locale** — fallback target + język domyślny dla nowych atrybutów.
+3. **Fallback chain** (ADR-011) — gdy brak tłumaczenia, system pokazuje fallback locale.
+4. **Channel↔locale binding** — który locale aktywny na którym kanale dystrybucji.
+
+**Persona główna:** Magda (Marketing/Content) — pracuje multi-locale. **Konfiguruje:** Owner/Admin (Magda używa, nie konfiguruje).
+
+## 2. Model — per-tenant, dwupoziomowy
+
+```
+┌─ POZIOM SYSTEM (globalny, read-only, seeded) ──────────────┐
+│  Katalog locales ISO 639-1 + ISO 3166 (~150 kombinacji):   │
+│  pl_PL, en_US, en_GB, de_DE, de_AT, de_CH, cs_CZ, sk_SK... │
+│  Super Admin NIE zarządza aktywnie — stała referencja.      │
+└─────────────────────────────────────────────────────────────┘
+                    │ tenant aktywuje SWOJE
+                    ▼
+┌─ POZIOM TENANT (/settings/locales) ────────────────────────┐
+│  Aktywne locales + default + fallback chain + channel bind  │
+│  Owner/Admin konfiguruje. To jest /settings/locales.        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Kluczowe:** to **NIE** są *„Ustawienia systemowe"* superadmina (jak w Pimcore single-instance). Cortex jest multi-tenant SaaS — locale config jest **per-tenant**, decyzja biznesowa klienta.
+
+**Locale format:** `język_REGION` (Akeneo style) — `pl_PL`, `de_DE`, `de_AT`. NIE sam język (`pl`, `de`). Format `język_REGION` obsługuje *„ten sam język, różny rynek"* — `de_DE` vs `de_AT` to różne opisy regulacyjne / ceny dla DACH eksportu.
+
+## 3. Schema
+
+```sql
+-- POZIOM SYSTEM: katalog ISO (seeded raz, read-only, brak tenant_id)
+CREATE TABLE locales (
+    code         VARCHAR(10) PRIMARY KEY,   -- 'pl_PL', 'en_US', 'de_DE'
+    language     VARCHAR(3) NOT NULL,        -- 'pl', 'en', 'de' (ISO 639-1)
+    region       VARCHAR(3) NOT NULL,        -- 'PL', 'US', 'DE' (ISO 3166)
+    display_name JSONB NOT NULL,             -- {"pl": "Polski (Polska)", "en": "Polish (Poland)"}
+    is_popular   BOOLEAN NOT NULL DEFAULT false  -- sekcja "Popularne" w dropdown
+);
+
+-- POZIOM TENANT: aktywacja + config
+CREATE TABLE tenant_locales (
+    id               UUID PRIMARY KEY,
+    tenant_id        UUID NOT NULL REFERENCES tenants(id),
+    locale_code      VARCHAR(10) NOT NULL REFERENCES locales(code),
+    is_default       BOOLEAN NOT NULL DEFAULT false,   -- dokładnie 1 per tenant
+    is_mandatory     BOOLEAN NOT NULL DEFAULT false,   -- wlicza się do completeness
+    fallback_locale  VARCHAR(10) REFERENCES locales(code),  -- nullable, tworzy chain
+    sort_order       INTEGER NOT NULL DEFAULT 0,
+    is_active        BOOLEAN NOT NULL DEFAULT true,     -- soft delete (dane zachowane)
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, locale_code)
+);
+CREATE UNIQUE INDEX idx_tenant_locales_default ON tenant_locales(tenant_id) WHERE is_default = true;
+
+-- Channel ↔ locale binding (które locales aktywne per kanał)
+CREATE TABLE channel_locales (
+    tenant_id    UUID NOT NULL REFERENCES tenants(id),
+    channel_id   UUID NOT NULL REFERENCES channels(id),
+    locale_code  VARCHAR(10) NOT NULL REFERENCES locales(code),
+    PRIMARY KEY (tenant_id, channel_id, locale_code)
+);
+```
+
+**Uwagi schema:**
+- `is_default` — partial unique index gwarantuje dokładnie 1 default per tenant.
+- `fallback_locale` — single fallback per locale, tworzy chain (`de_AT → de_DE → en_US → default`). Prostsze mentalnie niż Pimcore CSV-lista wielu fallbacków.
+- `is_active` — soft delete. Deaktywacja locale **nie kasuje** wartości w `object_values` (dane zachowane, reaktywowalne).
+- `is_mandatory` — locale wymagany dla completeness produktu (Pimcore *„Mandatory language"* pattern).
+
+## 4. UX layout
+
+```
+┌─ Ustawienia → Języki i lokalizacje ─────────────────────────────────┐
+│                                                                       │
+│ Aktywne lokalizacje:                          [+ Dodaj lokalizację]  │
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ ⠿ pl_PL  Polski (Polska)    ⭐ Domyślna  ☑ Wymagana            │ │
+│ │           Fallback: —                                      [⋮]  │ │
+│ │ ⠿ en_US  English (US)                    ☑ Wymagana            │ │
+│ │           Fallback: [pl_PL ▼]                              [⋮]  │ │
+│ │ ⠿ de_DE  Deutsch (DE)                    ☐ Wymagana            │ │
+│ │           Fallback: [en_US ▼]                              [⋮]  │ │
+│ │ ⠿ de_AT  Deutsch (AT)                    ☐ Wymagana            │ │
+│ │           Fallback: [de_DE ▼]                              [⋮]  │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+│  ⠿ = drag-reorder (sort_order)                                       │
+│                                                                       │
+│ Przypisanie do kanałów:                                              │
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ Kanał        │ pl_PL │ en_US │ de_DE │ de_AT │                   │ │
+│ │ Shopify      │  ☑    │  ☑    │  ☑    │  ☐    │                   │ │
+│ │ BaseLinker   │  ☑    │  ☐    │  ☐    │  ☐    │                   │ │
+│ │ Allegro      │  ☑    │  ☐    │  ☐    │  ☐    │                   │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+**Modal *„Dodaj lokalizację"*:**
+
+```
+┌─ Dodaj lokalizację ─────────────────────────────────┐
+│ 🔍 Szukaj języka...                                 │
+├──────────────────────────────────────────────────────┤
+│ POPULARNE                                            │
+│  ├─ pl_PL  Polski (Polska)                           │
+│  ├─ en_US  English (US)                              │
+│  ├─ en_GB  English (UK)                              │
+│  ├─ de_DE  Deutsch (Deutschland)                     │
+│  ├─ cs_CZ  Čeština (Česko)                           │
+│  └─ sk_SK  Slovenčina (Slovensko)                    │
+├──────────────────────────────────────────────────────┤
+│ WSZYSTKIE (~150)                                     │
+│  ├─ af     Afrikaans                                 │
+│  ├─ af_NA  Afrikaans (Namibia)                       │
+│  └─ ... (search filtruje)                            │
+└──────────────────────────────────────────────────────┘
+```
+
+**Różnica vs Pimcore screenshot:** Pimcore dropdown wyrzuca od razu `afrikaans, aghem, akan...` — overwhelm. Cortex ma sekcję *„Popularne"* na górze (typowe dla polskiego e-commerce eksportującego do CEE/DACH) + search + pełna lista ISO pod spodem.
+
+## 5. Mechanika
+
+### 5.1 Default locale
+- Dokładnie 1 per tenant. Zmiana default → confirm modal (*„Zmiana wpłynie na nowe atrybuty i fallback"*).
+- Default jest ultimate fallback target — koniec każdego fallback chain.
+- Nie można usunąć/deaktywować default locale (UI blokuje, analog last-admin protection).
+
+### 5.2 Fallback chain (ADR-011)
+- Każdy locale ma opcjonalny single `fallback_locale`. Tworzy chain: `de_AT → de_DE → en_US → pl_PL (default)`.
+- Runtime: gdy `description.de_AT` puste → system zwraca `description.de_DE`, jeśli puste → `description.en_US`, ... aż default.
+- **Cykl detection** — UI blokuje fallback który tworzy pętlę (`A → B → A`).
+- Fallback działa na **read** (wyświetlanie, eksport feed), NIE na completeness scoring (mandatory locale musi być faktycznie wypełniony).
+
+### 5.3 Mandatory flag
+- `is_mandatory = true` → locale wlicza się do completeness produktu.
+- Produkt nie jest *„kompletny"* dopóki wszystkie mandatory locales mają wypełnione localizable atrybuty.
+- Default locale jest **zawsze** mandatory (auto, niewyłączalny).
+- Niemandatory locale = *„nice to have"*, brak tłumaczenia nie obniża completeness.
+
+### 5.4 Soft delete / deaktywacja
+- Usunięcie locale = `is_active = false` (soft). Dane w `object_values` **zachowane**.
+- UI warning przed deaktywacją: *„de_DE: 2000 produktów ma wartości w tym locale. Dane zostaną zachowane, ale niewidoczne. Możesz reaktywować w każdej chwili."*
+- **Brak console command** (vs Pimcore `pimcore:locale:delete-unused-tables`). Cleanup automatyczny (background job) lub przez UI *„Trwale usuń dane locale"* (hard, z hard-confirm typing).
+- Reaktywacja locale → dane wracają, widoczne.
+
+### 5.5 Dodanie nowego locale — wpływ na completeness
+- Dodanie locale `de_AT` → wszystkie localizable atrybuty zyskują pusty slot dla `de_AT`.
+- Jeśli `de_AT` ustawiony jako mandatory → completeness produktów spada (brak tłumaczeń).
+- UX ostrzega przy dodaniu z `is_mandatory=true`: *„Dodanie de_AT jako wymagany obniży completeness — 2000 produktów bez tłumaczeń de_AT."*
+
+## 6. Permissions (RBAC integration)
+
+- **Nowa permission `settings.locales.manage`** — osobna od `manage_tenant`. Rationale: dodanie locale to operacyjna decyzja (Magda's manager może chcieć), nie krytyczna jak billing/tenant deletion. Owner + Admin mają domyślnie.
+- Alternatywa: zostać przy `manage_tenant` (tylko Owner). **Rekomendacja: osobna permission** — Admin powinien móc.
+- Update macierzy RBAC §3.2: dodać wiersz *„Settings — Locales (manage_locales)"* — Owner ✓, Admin ✓, reszta ✗.
+- `tenant_locales` to **pula** z której `user_roles.locale_scope` (RBAC) wybiera per-rola restriction (Magda *„EN-only translator"*).
+
+## 7. API endpoints
+
+| Endpoint | Metoda | Cel |
+|---|---|---|
+| `/api/locales` | GET | Globalny katalog ISO (read-only, dla dropdown) |
+| `/api/tenant-locales` | GET | Aktywne locales tenanta + config |
+| `/api/tenant-locales` | POST | Aktywacja nowego locale |
+| `/api/tenant-locales/{code}` | PATCH | Update (default, mandatory, fallback, sort_order) |
+| `/api/tenant-locales/{code}` | DELETE | Soft delete (is_active=false) |
+| `/api/tenant-locales/{code}/reactivate` | POST | Reaktywacja |
+| `/api/tenant-locales/{code}/purge` | DELETE | Hard delete danych (z hard-confirm) |
+| `/api/channel-locales` | GET/PUT | Channel↔locale binding macierz |
+
+## 8. Dependency na inne obszary
+
+- **Attribute model** — atrybut `localizable: true` generuje wartość per aktywny locale tenanta. Dodanie/usunięcie locale wpływa na localizable atrybuty.
+- **Completeness engine** (epik 02) — mandatory locales wliczają się do completeness scoring.
+- **RBAC** — `user_roles.locale_scope` wybiera z `tenant_locales` puli. Update macierzy §3.2 z `settings.locales.manage`.
+- **Channels** (epik 04 Publikacje) — `channel_locales` binding decyduje który locale idzie do którego feed/sync.
+- **Exports** (`feature-exports.md`) — multi-locale export toggle wybiera z aktywnych locales.
+- **Imports** (`feature-imports.md`) — import multi-locale columns (`description.pl`, `description.en`) mapuje na aktywne locales.
+
+## 9. User stories
+
+| ID | Persona | Story |
+|---|---|---|
+| US-LOC-001 | Owner | Dodaje `de_DE` do tenanta przez modal z sekcji *„Popularne"* |
+| US-LOC-002 | Owner | Ustawia `pl_PL` jako default — system blokuje deaktywację default |
+| US-LOC-003 | Admin | Konfiguruje fallback chain `de_AT → de_DE → en_US` — system wykrywa próbę cyklu i blokuje |
+| US-LOC-004 | Admin | Oznacza `en_US` jako mandatory — completeness produktów bez EN tłumaczeń spada |
+| US-LOC-005 | Admin | Deaktywuje `de_AT` — widzi warning *„2000 produktów ma wartości"*, dane zachowane |
+| US-LOC-006 | Owner | Przypisuje locales do kanałów — Shopify dostaje PL+EN+DE, Allegro tylko PL |
+| US-LOC-007 | Magda | Edytuje produkt — widzi taby tylko dla aktywnych locales tenanta + tych w jej `locale_scope` |
+| US-LOC-008 | Admin | Reaktywuje wcześniej usunięty `de_AT` — dane wracają widoczne |
+
+## 10. Out of scope (mini-spec MVP)
+
+- ❌ **Translation workflow** — eksport do TMS (Smartling/Lokalise), translation memory. Faza 2.
+- ❌ **AI auto-translate** — generowanie tłumaczeń przez LLM. Faza 2 (data-ops agent).
+- ❌ **Per-locale currency binding** — currency jest osobnym konceptem (per channel/market), NIE w `/settings/locales`.
+- ❌ **Locale-specific validation rules** — np. *„niemiecki opis musi mieć disclaimer X"*. Faza 1+.
+- ❌ **Hreflang / SEO locale tags** — generowanie hreflang dla feedów. Faza 1 razem z channel feed engine.
+- ❌ **RTL languages** (arabski, hebrajski) — UI RTL support. Poza MVP scope (ICP to PL/CEE/DACH).
+
+## 11. Estymacja
+
+| Element | Estymacja |
+|---|---|
+| Backend — schema (3 tabele) + ISO katalog seed (~150 locales) | 6-8h |
+| Backend — API endpoints (8) + fallback chain resolution + cycle detection | 10-14h |
+| Backend — completeness integration (mandatory locales) | 4-6h |
+| Backend — soft delete + reactivate + purge logic | 4-6h |
+| Frontend — `/settings/locales` page (lista + drag-reorder + flags) | 8-12h |
+| Frontend — modal *„Dodaj lokalizację"* (popularne + search + ISO) | 4-6h |
+| Frontend — channel↔locale binding macierz | 4-6h |
+| RBAC integration — `settings.locales.manage` permission + macierz update | 2-3h |
+| Testy — unit + integration + E2E + fallback chain edge cases | 8-12h |
+| **TOTAL** | **~50-73h** |
+
+~8-10 ticketów, ~1.5-2 tygodnie solo dev.
+
+## 12. Co dalej
+
+1. Walidacja konceptu — czy `język_REGION` format (vs sam język) jest akceptowalny dla ICP.
+2. Decyzja: `settings.locales.manage` osobna permission vs `manage_tenant` (rekomendacja: osobna).
+3. POC fallback chain resolution — performance przy 200k SKU × 4 locales (czy chain resolution w runtime jest fast, czy cache potrzebny).
+4. Wireframes Figma — przekazać do makiet (analog do RBAC mockups).
+5. Update macierzy RBAC §3.2 — dodać wiersz `settings.locales.manage` gdy feature wchodzi do implementacji.
+6. Sequencing — locale jest **dependency dla wielu obszarów** (attribute model, completeness, channels, exports). Powinno być wcześnie w MVP-Alpha, przed epikiem 04 Publikacje.
+
+---
+
+*Mini-spec wygenerowany 2026-05-16. Status: 🟢 szczegół. Wzorzec: Pimcore per-locale UX + Akeneo channel binding + per-tenant SaaS adaptacja. Następna iteracja: walidacja formatu locale + Figma wireframes + sequencing decision względem epiku 04.*

--- a/apps/api/migrations/Version20260521090000.php
+++ b/apps/api/migrations/Version20260521090000.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Locales feature (#869, LOC-01) — schema foundation.
+ *
+ * Extends the global `locales` catalog with ISO 639-1 + ISO 3166 metadata
+ * (language, region, display_name JSONB, is_popular) and seeds the popular
+ * CEE+DACH subset (14 locales flagged is_popular=true) plus ~30 additional
+ * globally relevant locales.
+ *
+ * Creates per-tenant `tenant_locales` with default / mandatory / fallback /
+ * sort_order / soft-delete state. Partial unique index enforces exactly one
+ * `is_default=true` row per tenant.
+ *
+ * Refactors `channel_locales` to carry an explicit `tenant_id` in the PK so
+ * Postgres RLS and the Doctrine tenant filter can scope it without joining
+ * back to `channels`.
+ */
+final class Version20260521090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Locales feature (#869): ISO catalog + tenant_locales + channel_locales tenant_id PK';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE locales ADD COLUMN IF NOT EXISTS language VARCHAR(8) NOT NULL DEFAULT ''");
+        $this->addSql("ALTER TABLE locales ADD COLUMN IF NOT EXISTS region VARCHAR(8) DEFAULT NULL");
+        $this->addSql("ALTER TABLE locales ADD COLUMN IF NOT EXISTS display_name JSONB NOT NULL DEFAULT '{}'::jsonb");
+        $this->addSql("ALTER TABLE locales ADD COLUMN IF NOT EXISTS is_popular BOOLEAN NOT NULL DEFAULT false");
+
+        $this->seedLocaleCatalog();
+
+        $this->addSql("ALTER TABLE locales ALTER COLUMN language DROP DEFAULT");
+
+        $this->addSql('
+            CREATE TABLE IF NOT EXISTS tenant_locales (
+                id UUID NOT NULL,
+                tenant_id UUID NOT NULL,
+                locale_id UUID NOT NULL,
+                is_default BOOLEAN NOT NULL DEFAULT false,
+                is_mandatory BOOLEAN NOT NULL DEFAULT false,
+                fallback_locale_id UUID DEFAULT NULL,
+                sort_order INTEGER NOT NULL DEFAULT 0,
+                is_active BOOLEAN NOT NULL DEFAULT true,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (id),
+                CONSTRAINT tenant_locales_tenant_locale_uniq UNIQUE (tenant_id, locale_id),
+                CONSTRAINT tenant_locales_tenant_fk FOREIGN KEY (tenant_id)
+                    REFERENCES tenants (id) ON DELETE CASCADE,
+                CONSTRAINT tenant_locales_locale_fk FOREIGN KEY (locale_id)
+                    REFERENCES locales (id) ON DELETE RESTRICT,
+                CONSTRAINT tenant_locales_fallback_fk FOREIGN KEY (fallback_locale_id)
+                    REFERENCES locales (id) ON DELETE SET NULL,
+                CONSTRAINT tenant_locales_no_self_fallback CHECK (fallback_locale_id IS NULL OR fallback_locale_id <> locale_id)
+            )
+        ');
+        $this->addSql('CREATE INDEX IF NOT EXISTS tenant_locales_tenant_idx ON tenant_locales (tenant_id)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS tenant_locales_one_default_per_tenant
+            ON tenant_locales (tenant_id) WHERE is_default = true');
+        $this->addSql('CREATE INDEX IF NOT EXISTS tenant_locales_active_idx
+            ON tenant_locales (tenant_id, is_active)');
+
+        $this->addSql('ALTER TABLE channel_locales ADD COLUMN IF NOT EXISTS tenant_id UUID');
+        $this->addSql('
+            UPDATE channel_locales cl
+            SET tenant_id = c.tenant_id
+            FROM channels c
+            WHERE c.id = cl.channel_id AND cl.tenant_id IS NULL
+        ');
+        $this->addSql('ALTER TABLE channel_locales ALTER COLUMN tenant_id SET NOT NULL');
+        $this->addSql('ALTER TABLE channel_locales DROP CONSTRAINT IF EXISTS channel_locales_pkey');
+        $this->addSql('ALTER TABLE channel_locales
+            ADD CONSTRAINT channel_locales_pkey PRIMARY KEY (tenant_id, channel_id, locale_id)');
+        $this->addSql('
+            ALTER TABLE channel_locales
+            ADD CONSTRAINT channel_locales_tenant_fk FOREIGN KEY (tenant_id)
+                REFERENCES tenants (id) ON DELETE CASCADE
+        ');
+        $this->addSql('CREATE INDEX IF NOT EXISTS channel_locales_tenant_idx ON channel_locales (tenant_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE channel_locales DROP CONSTRAINT IF EXISTS channel_locales_tenant_fk');
+        $this->addSql('DROP INDEX IF EXISTS channel_locales_tenant_idx');
+        $this->addSql('ALTER TABLE channel_locales DROP CONSTRAINT IF EXISTS channel_locales_pkey');
+        $this->addSql('ALTER TABLE channel_locales
+            ADD CONSTRAINT channel_locales_pkey PRIMARY KEY (channel_id, locale_id)');
+        $this->addSql('ALTER TABLE channel_locales DROP COLUMN IF EXISTS tenant_id');
+
+        $this->addSql('DROP TABLE IF EXISTS tenant_locales');
+
+        $this->addSql('ALTER TABLE locales DROP COLUMN IF EXISTS is_popular');
+        $this->addSql('ALTER TABLE locales DROP COLUMN IF EXISTS display_name');
+        $this->addSql('ALTER TABLE locales DROP COLUMN IF EXISTS region');
+        $this->addSql('ALTER TABLE locales DROP COLUMN IF EXISTS language');
+    }
+
+    /**
+     * Seed the ISO catalog. The two pre-existing rows (`pl_PL`, `en_US`)
+     * get backfilled in-place; the rest are inserted with ON CONFLICT DO
+     * NOTHING so re-running the migration on a partially-seeded DB is a
+     * no-op.
+     */
+    private function seedLocaleCatalog(): void
+    {
+        foreach (self::CATALOG as [$code, $language, $region, $pl, $en, $popular]) {
+            $popularLiteral = $popular ? 'true' : 'false';
+            $displayJson = json_encode(['pl' => $pl, 'en' => $en], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+            $this->addSql(sprintf(
+                "UPDATE locales SET language = %s, region = %s, display_name = %s::jsonb, is_popular = %s WHERE code = %s",
+                $this->quote($language),
+                null === $region ? 'NULL' : $this->quote($region),
+                $this->quote($displayJson),
+                $popularLiteral,
+                $this->quote($code),
+            ));
+
+            $labelForLegacy = $pl;
+            $this->addSql(sprintf(
+                "INSERT INTO locales (id, code, label, language, region, display_name, is_popular)
+                 SELECT gen_random_uuid(), %s, %s, %s, %s, %s::jsonb, %s
+                 WHERE NOT EXISTS (SELECT 1 FROM locales WHERE code = %s)",
+                $this->quote($code),
+                $this->quote($labelForLegacy),
+                $this->quote($language),
+                null === $region ? 'NULL' : $this->quote($region),
+                $this->quote($displayJson),
+                $popularLiteral,
+                $this->quote($code),
+            ));
+        }
+    }
+
+    private function quote(string $value): string
+    {
+        return "'" . str_replace("'", "''", $value) . "'";
+    }
+
+    /**
+     * @var list<array{0:string,1:string,2:?string,3:string,4:string,5:bool}>
+     */
+    private const CATALOG = [
+        ['pl_PL', 'pl', 'PL', 'Polski (Polska)', 'Polish (Poland)', true],
+        ['en_US', 'en', 'US', 'Angielski (USA)', 'English (United States)', true],
+        ['en_GB', 'en', 'GB', 'Angielski (Wielka Brytania)', 'English (United Kingdom)', true],
+        ['de_DE', 'de', 'DE', 'Niemiecki (Niemcy)', 'German (Germany)', true],
+        ['de_AT', 'de', 'AT', 'Niemiecki (Austria)', 'German (Austria)', true],
+        ['de_CH', 'de', 'CH', 'Niemiecki (Szwajcaria)', 'German (Switzerland)', true],
+        ['fr_FR', 'fr', 'FR', 'Francuski (Francja)', 'French (France)', true],
+        ['it_IT', 'it', 'IT', 'Włoski (Włochy)', 'Italian (Italy)', true],
+        ['es_ES', 'es', 'ES', 'Hiszpański (Hiszpania)', 'Spanish (Spain)', true],
+        ['cs_CZ', 'cs', 'CZ', 'Czeski (Czechy)', 'Czech (Czechia)', true],
+        ['sk_SK', 'sk', 'SK', 'Słowacki (Słowacja)', 'Slovak (Slovakia)', true],
+        ['hu_HU', 'hu', 'HU', 'Węgierski (Węgry)', 'Hungarian (Hungary)', true],
+        ['ro_RO', 'ro', 'RO', 'Rumuński (Rumunia)', 'Romanian (Romania)', true],
+        ['nl_NL', 'nl', 'NL', 'Holenderski (Holandia)', 'Dutch (Netherlands)', true],
+
+        ['en_CA', 'en', 'CA', 'Angielski (Kanada)', 'English (Canada)', false],
+        ['en_AU', 'en', 'AU', 'Angielski (Australia)', 'English (Australia)', false],
+        ['en_IE', 'en', 'IE', 'Angielski (Irlandia)', 'English (Ireland)', false],
+        ['fr_BE', 'fr', 'BE', 'Francuski (Belgia)', 'French (Belgium)', false],
+        ['fr_CA', 'fr', 'CA', 'Francuski (Kanada)', 'French (Canada)', false],
+        ['fr_CH', 'fr', 'CH', 'Francuski (Szwajcaria)', 'French (Switzerland)', false],
+        ['nl_BE', 'nl', 'BE', 'Holenderski (Belgia)', 'Dutch (Belgium)', false],
+        ['pt_PT', 'pt', 'PT', 'Portugalski (Portugalia)', 'Portuguese (Portugal)', false],
+        ['pt_BR', 'pt', 'BR', 'Portugalski (Brazylia)', 'Portuguese (Brazil)', false],
+        ['es_MX', 'es', 'MX', 'Hiszpański (Meksyk)', 'Spanish (Mexico)', false],
+        ['es_AR', 'es', 'AR', 'Hiszpański (Argentyna)', 'Spanish (Argentina)', false],
+        ['it_CH', 'it', 'CH', 'Włoski (Szwajcaria)', 'Italian (Switzerland)', false],
+        ['da_DK', 'da', 'DK', 'Duński (Dania)', 'Danish (Denmark)', false],
+        ['sv_SE', 'sv', 'SE', 'Szwedzki (Szwecja)', 'Swedish (Sweden)', false],
+        ['no_NO', 'no', 'NO', 'Norweski (Norwegia)', 'Norwegian (Norway)', false],
+        ['fi_FI', 'fi', 'FI', 'Fiński (Finlandia)', 'Finnish (Finland)', false],
+        ['is_IS', 'is', 'IS', 'Islandzki (Islandia)', 'Icelandic (Iceland)', false],
+        ['et_EE', 'et', 'EE', 'Estoński (Estonia)', 'Estonian (Estonia)', false],
+        ['lt_LT', 'lt', 'LT', 'Litewski (Litwa)', 'Lithuanian (Lithuania)', false],
+        ['lv_LV', 'lv', 'LV', 'Łotewski (Łotwa)', 'Latvian (Latvia)', false],
+        ['ru_RU', 'ru', 'RU', 'Rosyjski (Rosja)', 'Russian (Russia)', false],
+        ['uk_UA', 'uk', 'UA', 'Ukraiński (Ukraina)', 'Ukrainian (Ukraine)', false],
+        ['bg_BG', 'bg', 'BG', 'Bułgarski (Bułgaria)', 'Bulgarian (Bulgaria)', false],
+        ['hr_HR', 'hr', 'HR', 'Chorwacki (Chorwacja)', 'Croatian (Croatia)', false],
+        ['sr_RS', 'sr', 'RS', 'Serbski (Serbia)', 'Serbian (Serbia)', false],
+        ['sl_SI', 'sl', 'SI', 'Słoweński (Słowenia)', 'Slovenian (Slovenia)', false],
+        ['el_GR', 'el', 'GR', 'Grecki (Grecja)', 'Greek (Greece)', false],
+        ['tr_TR', 'tr', 'TR', 'Turecki (Turcja)', 'Turkish (Turkey)', false],
+        ['ar_SA', 'ar', 'SA', 'Arabski (Arabia Saudyjska)', 'Arabic (Saudi Arabia)', false],
+        ['he_IL', 'he', 'IL', 'Hebrajski (Izrael)', 'Hebrew (Israel)', false],
+        ['ja_JP', 'ja', 'JP', 'Japoński (Japonia)', 'Japanese (Japan)', false],
+        ['ko_KR', 'ko', 'KR', 'Koreański (Korea Pd.)', 'Korean (South Korea)', false],
+        ['zh_CN', 'zh', 'CN', 'Chiński (uproszczony)', 'Chinese (Simplified)', false],
+        ['zh_TW', 'zh', 'TW', 'Chiński (tradycyjny)', 'Chinese (Traditional)', false],
+    ];
+}

--- a/apps/api/migrations/Version20260522080000.php
+++ b/apps/api/migrations/Version20260522080000.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Locales feature (#870, LOC-02) — backfill `tenant_locales` from the
+ * legacy `tenants.enabled_locales` + `tenants.primary_locale` columns
+ * introduced by #705.
+ *
+ * Maps the ISO 639-1 short codes (`pl`, `en`, `de`, …) the legacy
+ * `/settings/tenant` form stored to the BCP-47 codes (`pl_PL`, `en_US`,
+ * `de_DE`, …) the new `tenant_locales` references. The default `pl` is
+ * mapped to `pl_PL` (Polski-Polska), `en` to `en_US`, `de` to `de_DE` —
+ * matching the most common regional variant for each language.
+ *
+ * Decision: legacy columns are *not* dropped. `WorkspaceController`,
+ * `TenantConfigController`, and `SuperAdminTenantResponseBuilder` continue
+ * to read/write them, so existing UI surfaces (`/settings/tenant`, the
+ * Super Admin operator panel) keep working until LOC-07 (#875) refactors
+ * the frontend to consume `tenant_locales`. A follow-up ticket will drop
+ * the columns once the readers are migrated.
+ *
+ * Idempotent — `ON CONFLICT (tenant_id, locale_id) DO NOTHING` swallows
+ * duplicate rows so re-running the migration after a partial replay leaves
+ * `tenant_locales` in the same shape.
+ */
+final class Version20260522080000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Locales (#870): backfill tenant_locales from tenants.enabled_locales + primary_locale';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            WITH locale_map(short_code, bcp47) AS (
+                VALUES
+                    ('pl', 'pl_PL'),
+                    ('en', 'en_US'),
+                    ('de', 'de_DE'),
+                    ('fr', 'fr_FR'),
+                    ('it', 'it_IT'),
+                    ('es', 'es_ES'),
+                    ('cs', 'cs_CZ'),
+                    ('sk', 'sk_SK'),
+                    ('hu', 'hu_HU'),
+                    ('ro', 'ro_RO'),
+                    ('nl', 'nl_NL'),
+                    ('pt', 'pt_PT'),
+                    ('ru', 'ru_RU'),
+                    ('uk', 'uk_UA')
+            ),
+            expanded AS (
+                SELECT
+                    t.id AS tenant_id,
+                    t.primary_locale AS primary_short,
+                    elem.value AS short_code,
+                    elem.ordinality AS position
+                FROM tenants t,
+                LATERAL jsonb_array_elements_text(COALESCE(t.enabled_locales, '[]'::jsonb))
+                    WITH ORDINALITY AS elem(value, ordinality)
+                WHERE t.deleted_at IS NULL
+            )
+            INSERT INTO tenant_locales (
+                id, tenant_id, locale_id,
+                is_default, is_mandatory, fallback_locale_id,
+                sort_order, is_active, created_at
+            )
+            SELECT
+                gen_random_uuid(),
+                e.tenant_id,
+                l.id,
+                (e.short_code = e.primary_short) AS is_default,
+                (e.short_code = e.primary_short) AS is_mandatory,
+                NULL,
+                (e.position - 1)::int,
+                true,
+                NOW()
+            FROM expanded e
+            JOIN locale_map m ON m.short_code = e.short_code
+            JOIN locales l ON l.code = m.bcp47
+            ON CONFLICT (tenant_id, locale_id) DO NOTHING
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN tenants.enabled_locales IS
+                'DEPRECATED (#869–#878): use tenant_locales table. Kept for read-back compatibility until LOC-07 (#875) migrates /settings/tenant.'
+        SQL);
+        $this->addSql(<<<'SQL'
+            COMMENT ON COLUMN tenants.primary_locale IS
+                'DEPRECATED (#869–#878): use tenant_locales.is_default = true row. Kept for read-back compatibility until LOC-07 (#875).'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("COMMENT ON COLUMN tenants.enabled_locales IS NULL");
+        $this->addSql("COMMENT ON COLUMN tenants.primary_locale IS NULL");
+
+        $this->addSql(<<<'SQL'
+            DELETE FROM tenant_locales
+            WHERE tenant_id IN (
+                SELECT id FROM tenants
+                WHERE enabled_locales IS NOT NULL
+                  AND jsonb_array_length(enabled_locales) > 0
+            )
+        SQL);
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -115,3 +115,13 @@ parameters:
               - src/Export/Domain/Entity/ExportProfile.php
               - src/Backup/Domain/Entity/Backup.php
               - src/Channel/Domain/Entity/TenantLocale.php
+        # Tenant aggregate exposes legacy `$enabledLocales` + `$primaryLocale`
+        # marked `@deprecated` by #870 (LOC-02) until LOC-07 (#875) migrates
+        # `/settings/tenant` to consume `tenant_locales`. The Tenant class
+        # itself still mutates them through `enableLocale()` /
+        # `disableLocale()` / `changePrimaryLocale()` to keep
+        # `WorkspaceController` and `TenantConfigController` functional —
+        # treat in-class access as the supported migration path.
+        - identifier: property.deprecated
+          paths:
+              - src/Shared/Domain/Tenant.php

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -114,3 +114,4 @@ parameters:
               - src/Export/Domain/Entity/ExportSession.php
               - src/Export/Domain/Entity/ExportProfile.php
               - src/Backup/Domain/Entity/Backup.php
+              - src/Channel/Domain/Entity/TenantLocale.php

--- a/apps/api/src/Channel/Domain/Entity/Locale.php
+++ b/apps/api/src/Channel/Domain/Entity/Locale.php
@@ -12,8 +12,9 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * Locales are global infrastructure rows — every tenant references the
  * same `pl_PL` row rather than carrying its own copy. The seeded set in
- * the migration covers the MVP-supported locales; tenants opt-in to a
- * subset via the Channel ↔ Locale M2M.
+ * the migration covers the ISO 639-1 + ISO 3166 catalog used by Cortex
+ * (~45 entries today, 14 of them `is_popular=true` for the CEE+DACH
+ * dropdown shortlist).
  *
  * No TenantScoped: the table sits on the audit allowlist as global
  * infrastructure, like `permissions` and the global RBAC roles.
@@ -28,11 +29,37 @@ class Locale
 
     private string $label;
 
-    public function __construct(string $code, string $label, ?Uuid $id = null)
-    {
+    private string $language = '';
+
+    private ?string $region = null;
+
+    /**
+     * @var array<string,string> two-letter UI-locale ⇒ native display name,
+     *     e.g. {"pl":"Polski (Polska)","en":"Polish (Poland)"}.
+     */
+    private array $displayName = [];
+
+    private bool $isPopular = false;
+
+    /**
+     * @param array<string,string> $displayName
+     */
+    public function __construct(
+        string $code,
+        string $label,
+        ?Uuid $id = null,
+        string $language = '',
+        ?string $region = null,
+        array $displayName = [],
+        bool $isPopular = false,
+    ) {
         $this->id = $id ?? Uuid::v7();
         $this->code = $code;
         $this->label = $label;
+        $this->language = $language;
+        $this->region = $region;
+        $this->displayName = $displayName;
+        $this->isPopular = $isPopular;
     }
 
     public function getId(): Uuid
@@ -53,5 +80,39 @@ class Locale
     public function rename(string $label): void
     {
         $this->label = $label;
+    }
+
+    public function getLanguage(): string
+    {
+        return $this->language;
+    }
+
+    public function getRegion(): ?string
+    {
+        return $this->region;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getDisplayName(): array
+    {
+        return $this->displayName;
+    }
+
+    public function isPopular(): bool
+    {
+        return $this->isPopular;
+    }
+
+    /**
+     * @param array<string,string> $displayName
+     */
+    public function updateMetadata(string $language, ?string $region, array $displayName, bool $isPopular): void
+    {
+        $this->language = $language;
+        $this->region = $region;
+        $this->displayName = $displayName;
+        $this->isPopular = $isPopular;
     }
 }

--- a/apps/api/src/Channel/Domain/Entity/Locale.php
+++ b/apps/api/src/Channel/Domain/Entity/Locale.php
@@ -35,7 +35,7 @@ class Locale
 
     /**
      * @var array<string,string> two-letter UI-locale ⇒ native display name,
-     *     e.g. {"pl":"Polski (Polska)","en":"Polish (Poland)"}.
+     *                           e.g. {"pl":"Polski (Polska)","en":"Polish (Poland)"}.
      */
     private array $displayName = [];
 

--- a/apps/api/src/Channel/Domain/Entity/TenantLocale.php
+++ b/apps/api/src/Channel/Domain/Entity/TenantLocale.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Per-tenant activation of a global `Locale` from the ISO catalog.
+ *
+ * One row per (tenant, locale). Carries the tenant's locale configuration:
+ *
+ *  - `isDefault`  — exactly one per tenant (enforced by partial unique
+ *    index `tenant_locales_one_default_per_tenant`). Ultimate fallback
+ *    target; new attributes default to this locale; cannot be deactivated.
+ *  - `isMandatory` — locale counts towards completeness scoring. The
+ *    default locale is *always* mandatory regardless of this flag's value
+ *    (asserted at the application layer; see #873 / LOC-05).
+ *  - `fallback`   — optional single-locale fallback chain link. Cycle
+ *    detection is enforced by `LocaleFallbackCycleDetector` (#872 /
+ *    LOC-04) and a DB CHECK that blocks self-fallback.
+ *  - `sortOrder`  — operator-defined display order in `/settings/locales`.
+ *  - `isActive`   — soft delete. Deactivation preserves `object_values`
+ *    rows; `purge` is a separate explicit operation (#871 / LOC-03).
+ */
+class TenantLocale implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Locale $locale;
+
+    private bool $isDefault = false;
+
+    private bool $isMandatory = false;
+
+    private ?Locale $fallback = null;
+
+    private int $sortOrder = 0;
+
+    private bool $isActive = true;
+
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        Locale $locale,
+        bool $isDefault = false,
+        bool $isMandatory = false,
+        ?Locale $fallback = null,
+        int $sortOrder = 0,
+        ?Tenant $tenant = null,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->tenant = $tenant;
+        $this->locale = $locale;
+        $this->isDefault = $isDefault;
+        $this->isMandatory = $isMandatory || $isDefault;
+        $this->fallback = $fallback;
+        $this->sortOrder = $sortOrder;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getLocale(): Locale
+    {
+        return $this->locale;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function isMandatory(): bool
+    {
+        return $this->isMandatory;
+    }
+
+    public function getFallback(): ?Locale
+    {
+        return $this->fallback;
+    }
+
+    public function getSortOrder(): int
+    {
+        return $this->sortOrder;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function markAsDefault(): void
+    {
+        $this->isDefault = true;
+        $this->isMandatory = true;
+        $this->isActive = true;
+    }
+
+    public function unmarkAsDefault(): void
+    {
+        $this->isDefault = false;
+    }
+
+    public function setMandatory(bool $mandatory): void
+    {
+        if ($this->isDefault && !$mandatory) {
+            throw new \DomainException('Default locale must remain mandatory.');
+        }
+        $this->isMandatory = $mandatory;
+    }
+
+    public function setFallback(?Locale $fallback): void
+    {
+        if (null !== $fallback && $fallback->getId()->equals($this->locale->getId())) {
+            throw new \DomainException('Locale cannot fall back to itself.');
+        }
+        $this->fallback = $fallback;
+    }
+
+    public function setSortOrder(int $sortOrder): void
+    {
+        $this->sortOrder = $sortOrder;
+    }
+
+    public function deactivate(): void
+    {
+        if ($this->isDefault) {
+            throw new \DomainException('Default locale cannot be deactivated.');
+        }
+        $this->isActive = false;
+    }
+
+    public function reactivate(): void
+    {
+        $this->isActive = true;
+    }
+}

--- a/apps/api/src/Channel/Domain/Entity/TenantLocale.php
+++ b/apps/api/src/Channel/Domain/Entity/TenantLocale.php
@@ -6,6 +6,8 @@ namespace App\Channel\Domain\Entity;
 
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use DomainException;
 use LogicException;
 use Symfony\Component\Uid\Uuid;
 
@@ -45,7 +47,7 @@ class TenantLocale implements TenantScoped
 
     private bool $isActive = true;
 
-    private \DateTimeImmutable $createdAt;
+    private DateTimeImmutable $createdAt;
 
     public function __construct(
         Locale $locale,
@@ -63,7 +65,7 @@ class TenantLocale implements TenantScoped
         $this->isMandatory = $isMandatory || $isDefault;
         $this->fallback = $fallback;
         $this->sortOrder = $sortOrder;
-        $this->createdAt = new \DateTimeImmutable();
+        $this->createdAt = new DateTimeImmutable();
     }
 
     public function getId(): Uuid
@@ -117,7 +119,7 @@ class TenantLocale implements TenantScoped
         return $this->isActive;
     }
 
-    public function getCreatedAt(): \DateTimeImmutable
+    public function getCreatedAt(): DateTimeImmutable
     {
         return $this->createdAt;
     }
@@ -137,7 +139,7 @@ class TenantLocale implements TenantScoped
     public function setMandatory(bool $mandatory): void
     {
         if ($this->isDefault && !$mandatory) {
-            throw new \DomainException('Default locale must remain mandatory.');
+            throw new DomainException('Default locale must remain mandatory.');
         }
         $this->isMandatory = $mandatory;
     }
@@ -145,7 +147,7 @@ class TenantLocale implements TenantScoped
     public function setFallback(?Locale $fallback): void
     {
         if (null !== $fallback && $fallback->getId()->equals($this->locale->getId())) {
-            throw new \DomainException('Locale cannot fall back to itself.');
+            throw new DomainException('Locale cannot fall back to itself.');
         }
         $this->fallback = $fallback;
     }
@@ -158,7 +160,7 @@ class TenantLocale implements TenantScoped
     public function deactivate(): void
     {
         if ($this->isDefault) {
-            throw new \DomainException('Default locale cannot be deactivated.');
+            throw new DomainException('Default locale cannot be deactivated.');
         }
         $this->isActive = false;
     }

--- a/apps/api/src/Channel/Domain/Repository/TenantLocaleRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/TenantLocaleRepositoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Repository;
+
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+interface TenantLocaleRepositoryInterface
+{
+    public function findById(Uuid $id): ?TenantLocale;
+
+    public function findByTenantAndLocale(Tenant $tenant, Locale $locale): ?TenantLocale;
+
+    public function findByTenantAndCode(Tenant $tenant, string $code): ?TenantLocale;
+
+    /**
+     * @return list<TenantLocale> ordered by sortOrder ASC.
+     */
+    public function findActiveForTenant(Tenant $tenant): array;
+
+    /**
+     * @return list<TenantLocale> active + inactive, ordered by sortOrder ASC.
+     */
+    public function findAllForTenant(Tenant $tenant): array;
+
+    public function findDefaultForTenant(Tenant $tenant): ?TenantLocale;
+
+    public function save(TenantLocale $entity): void;
+
+    public function remove(TenantLocale $entity): void;
+}

--- a/apps/api/src/Channel/Domain/Repository/TenantLocaleRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/TenantLocaleRepositoryInterface.php
@@ -18,12 +18,12 @@ interface TenantLocaleRepositoryInterface
     public function findByTenantAndCode(Tenant $tenant, string $code): ?TenantLocale;
 
     /**
-     * @return list<TenantLocale> ordered by sortOrder ASC.
+     * @return list<TenantLocale> ordered by sortOrder ASC
      */
     public function findActiveForTenant(Tenant $tenant): array;
 
     /**
-     * @return list<TenantLocale> active + inactive, ordered by sortOrder ASC.
+     * @return list<TenantLocale> active + inactive, ordered by sortOrder ASC
      */
     public function findAllForTenant(Tenant $tenant): array;
 

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Locale.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Locale.orm.xml
@@ -12,12 +12,25 @@
             <unique-constraint name="locales_code_uniq" columns="code"/>
         </unique-constraints>
 
+        <indexes>
+            <index name="locales_is_popular_idx" columns="is_popular"/>
+            <index name="locales_language_idx" columns="language"/>
+        </indexes>
+
         <id name="id" type="uuid" column="id">
             <generator strategy="NONE"/>
         </id>
 
         <field name="code" type="string" length="16"/>
         <field name="label" type="string" length="64"/>
+        <field name="language" type="string" length="8"/>
+        <field name="region" type="string" length="8" nullable="true"/>
+        <field name="displayName" column="display_name" type="json">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="isPopular" column="is_popular" type="boolean"/>
 
     </entity>
 

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/TenantLocale.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/TenantLocale.orm.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Channel\Domain\Entity\TenantLocale"
+            table="tenant_locales"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\DoctrineTenantLocaleRepository">
+
+        <unique-constraints>
+            <unique-constraint name="tenant_locales_tenant_locale_uniq" columns="tenant_id,locale_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="tenant_locales_tenant_idx" columns="tenant_id"/>
+            <index name="tenant_locales_active_idx" columns="tenant_id,is_active"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="locale" target-entity="App\Channel\Domain\Entity\Locale">
+            <join-column name="locale_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+        </many-to-one>
+
+        <many-to-one field="fallback" target-entity="App\Channel\Domain\Entity\Locale">
+            <join-column name="fallback_locale_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <field name="isDefault" column="is_default" type="boolean"/>
+        <field name="isMandatory" column="is_mandatory" type="boolean"/>
+        <field name="sortOrder" column="sort_order" type="integer"/>
+        <field name="isActive" column="is_active" type="boolean"/>
+        <field name="createdAt" column="created_at" type="datetime_immutable"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineTenantLocaleRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineTenantLocaleRepository.php
@@ -37,7 +37,8 @@ class DoctrineTenantLocaleRepository extends ServiceEntityRepository implements 
 
     public function findByTenantAndCode(Tenant $tenant, string $code): ?TenantLocale
     {
-        return $this->createQueryBuilder('tl')
+        /** @var TenantLocale|null $row */
+        $row = $this->createQueryBuilder('tl')
             ->innerJoin('tl.locale', 'l')
             ->where('tl.tenant = :tenant')
             ->andWhere('l.code = :code')
@@ -45,6 +46,8 @@ class DoctrineTenantLocaleRepository extends ServiceEntityRepository implements 
             ->setParameter('code', $code)
             ->getQuery()
             ->getOneOrNullResult();
+
+        return $row;
     }
 
     public function findActiveForTenant(Tenant $tenant): array

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineTenantLocaleRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineTenantLocaleRepository.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure\Doctrine\Repository;
+
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<TenantLocale>
+ */
+class DoctrineTenantLocaleRepository extends ServiceEntityRepository implements TenantLocaleRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TenantLocale::class);
+    }
+
+    public function findById(Uuid $id): ?TenantLocale
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    public function findByTenantAndLocale(Tenant $tenant, Locale $locale): ?TenantLocale
+    {
+        return $this->findOneBy([
+            'tenant' => $tenant,
+            'locale' => $locale,
+        ]);
+    }
+
+    public function findByTenantAndCode(Tenant $tenant, string $code): ?TenantLocale
+    {
+        return $this->createQueryBuilder('tl')
+            ->innerJoin('tl.locale', 'l')
+            ->where('tl.tenant = :tenant')
+            ->andWhere('l.code = :code')
+            ->setParameter('tenant', $tenant)
+            ->setParameter('code', $code)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findActiveForTenant(Tenant $tenant): array
+    {
+        /** @var list<TenantLocale> $rows */
+        $rows = $this->createQueryBuilder('tl')
+            ->where('tl.tenant = :tenant')
+            ->andWhere('tl.isActive = true')
+            ->orderBy('tl.sortOrder', 'ASC')
+            ->setParameter('tenant', $tenant)
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
+    public function findAllForTenant(Tenant $tenant): array
+    {
+        /** @var list<TenantLocale> $rows */
+        $rows = $this->createQueryBuilder('tl')
+            ->where('tl.tenant = :tenant')
+            ->orderBy('tl.sortOrder', 'ASC')
+            ->setParameter('tenant', $tenant)
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
+    public function findDefaultForTenant(Tenant $tenant): ?TenantLocale
+    {
+        return $this->findOneBy([
+            'tenant' => $tenant,
+            'isDefault' => true,
+        ]);
+    }
+
+    public function save(TenantLocale $entity): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($entity);
+        $em->flush();
+    }
+
+    public function remove(TenantLocale $entity): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($entity);
+        $em->flush();
+    }
+}

--- a/apps/api/src/Channel/Infrastructure/Serializer/Locale.xml
+++ b/apps/api/src/Channel/Infrastructure/Serializer/Locale.xml
@@ -18,5 +18,21 @@
             <group>locale:read</group>
             <group>admin:read</group>
         </attribute>
+        <attribute name="language">
+            <group>locale:read</group>
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="region">
+            <group>locale:read</group>
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="displayName">
+            <group>locale:read</group>
+            <group>admin:read</group>
+        </attribute>
+        <attribute name="popular">
+            <group>locale:read</group>
+            <group>admin:read</group>
+        </attribute>
     </class>
 </serializer>

--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -15,6 +15,7 @@ use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Channel\Domain\Entity\Currency;
 use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
 use App\DataFixtures\Identity\PrdPermissionFixtures;
 use App\Identity\Application\RbacSeeder;
 use App\Identity\Application\SeedTenantPrdRolesService;
@@ -76,14 +77,24 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
     public function load(ObjectManager $manager): void
     {
         // Global infrastructure: locales + currencies. The seed migration
-        // (Version20260429064833) inserts these on fresh schema, but
+        // (Version20260429064833 + #869) inserts these on fresh schema, but
         // `doctrine:fixtures:load` purges the database first — re-seed
-        // here so post-fixtures DB has the same baseline.
-        foreach ([
-            ['pl_PL', 'Polski (Polska)'],
-            ['en_US', 'English (United States)'],
-        ] as [$code, $label]) {
-            $manager->persist(new Locale($code, $label));
+        // the 14 popular CEE+DACH locales here so post-fixtures DB has the
+        // same baseline as a migrated-from-scratch schema (with the popular
+        // subset matching the `is_popular=true` flag in the catalog seed).
+        $localesByCode = [];
+        foreach (self::POPULAR_LOCALES as $entry) {
+            $locale = new Locale(
+                $entry['code'],
+                $entry['displayName']['pl'],
+                null,
+                $entry['language'],
+                $entry['region'],
+                $entry['displayName'],
+                true,
+            );
+            $manager->persist($locale);
+            $localesByCode[$entry['code']] = $locale;
         }
         foreach ([
             ['PLN', 'zł', 'Polish złoty'],
@@ -146,6 +157,19 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
         // inlines these on fresh schema, but fixtures-load purges the
         // database first — re-seed here so the post-fixtures DB matches.
         $this->smartFilterPresetsSeeder->seed();
+
+        // Locales feature (#869, LOC-01): seed each tenant's activated locales.
+        // pl_PL = default + mandatory, en_US = mandatory with fallback=pl_PL.
+        // Mirrors the channel/tenant configuration #705 used to keep on
+        // `tenants.locales` array; LOC-02 (#870) will migrate that legacy
+        // column into these rows for any production tenant that has data.
+        $plPL = $localesByCode['pl_PL'];
+        $enUS = $localesByCode['en_US'];
+        foreach ($tenants as $tenant) {
+            $manager->persist(new TenantLocale($plPL, true, true, null, 0, $tenant));
+            $manager->persist(new TenantLocale($enUS, false, true, $plPL, 1, $tenant));
+        }
+        $manager->flush();
 
         $admins = [
             'demo' => 'admin@demo.localhost',
@@ -232,4 +256,24 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
             $superAdmin->getPermissions()->add($permission);
         }
     }
+
+    /**
+     * @var list<array{code:string,language:string,region:string,displayName:array<string,string>}>
+     */
+    private const POPULAR_LOCALES = [
+        ['code' => 'pl_PL', 'language' => 'pl', 'region' => 'PL', 'displayName' => ['pl' => 'Polski (Polska)', 'en' => 'Polish (Poland)']],
+        ['code' => 'en_US', 'language' => 'en', 'region' => 'US', 'displayName' => ['pl' => 'Angielski (USA)', 'en' => 'English (United States)']],
+        ['code' => 'en_GB', 'language' => 'en', 'region' => 'GB', 'displayName' => ['pl' => 'Angielski (Wielka Brytania)', 'en' => 'English (United Kingdom)']],
+        ['code' => 'de_DE', 'language' => 'de', 'region' => 'DE', 'displayName' => ['pl' => 'Niemiecki (Niemcy)', 'en' => 'German (Germany)']],
+        ['code' => 'de_AT', 'language' => 'de', 'region' => 'AT', 'displayName' => ['pl' => 'Niemiecki (Austria)', 'en' => 'German (Austria)']],
+        ['code' => 'de_CH', 'language' => 'de', 'region' => 'CH', 'displayName' => ['pl' => 'Niemiecki (Szwajcaria)', 'en' => 'German (Switzerland)']],
+        ['code' => 'fr_FR', 'language' => 'fr', 'region' => 'FR', 'displayName' => ['pl' => 'Francuski (Francja)', 'en' => 'French (France)']],
+        ['code' => 'it_IT', 'language' => 'it', 'region' => 'IT', 'displayName' => ['pl' => 'Włoski (Włochy)', 'en' => 'Italian (Italy)']],
+        ['code' => 'es_ES', 'language' => 'es', 'region' => 'ES', 'displayName' => ['pl' => 'Hiszpański (Hiszpania)', 'en' => 'Spanish (Spain)']],
+        ['code' => 'cs_CZ', 'language' => 'cs', 'region' => 'CZ', 'displayName' => ['pl' => 'Czeski (Czechy)', 'en' => 'Czech (Czechia)']],
+        ['code' => 'sk_SK', 'language' => 'sk', 'region' => 'SK', 'displayName' => ['pl' => 'Słowacki (Słowacja)', 'en' => 'Slovak (Slovakia)']],
+        ['code' => 'hu_HU', 'language' => 'hu', 'region' => 'HU', 'displayName' => ['pl' => 'Węgierski (Węgry)', 'en' => 'Hungarian (Hungary)']],
+        ['code' => 'ro_RO', 'language' => 'ro', 'region' => 'RO', 'displayName' => ['pl' => 'Rumuński (Rumunia)', 'en' => 'Romanian (Romania)']],
+        ['code' => 'nl_NL', 'language' => 'nl', 'region' => 'NL', 'displayName' => ['pl' => 'Holenderski (Holandia)', 'en' => 'Dutch (Netherlands)']],
+    ];
 }

--- a/apps/api/src/Shared/Domain/Tenant.php
+++ b/apps/api/src/Shared/Domain/Tenant.php
@@ -57,10 +57,21 @@ class Tenant
      * default. The CHECK constraint on `tenants` guarantees `primaryLocale`
      * is always in this list.
      *
+     * @deprecated since the Locales feature (#869–#878); use the
+     *     `tenant_locales` table instead. This array stays as a read-only
+     *     legacy projection until LOC-07 (#875) migrates `/settings/tenant`
+     *     to read from `tenant_locales`. LOC-02 (#870) backfilled
+     *     `tenant_locales` from this column; production data in the legacy
+     *     column stays consistent until removal in a follow-up ticket.
+     *
      * @var list<string>
      */
     private array $enabledLocales = ['pl', 'en'];
 
+    /**
+     * @deprecated since the Locales feature (#869–#878); use the
+     *     `tenant_locales.is_default = true` row instead.
+     */
     private string $primaryLocale = 'pl';
 
     public function __construct(

--- a/apps/api/tests/Unit/Channel/LocaleTest.php
+++ b/apps/api/tests/Unit/Channel/LocaleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel;
+
+use App\Channel\Domain\Entity\Locale;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class LocaleTest extends TestCase
+{
+    #[Test]
+    public function legacyConstructorRemainsSupported(): void
+    {
+        $locale = new Locale('pl_PL', 'Polski');
+
+        self::assertSame('pl_PL', $locale->getCode());
+        self::assertSame('Polski', $locale->getLabel());
+        self::assertSame('', $locale->getLanguage());
+        self::assertNull($locale->getRegion());
+        self::assertSame([], $locale->getDisplayName());
+        self::assertFalse($locale->isPopular());
+    }
+
+    #[Test]
+    public function extendedConstructorAcceptsCatalogMetadata(): void
+    {
+        $locale = new Locale(
+            'de_AT',
+            'Niemiecki (Austria)',
+            null,
+            'de',
+            'AT',
+            ['pl' => 'Niemiecki (Austria)', 'en' => 'German (Austria)'],
+            true,
+        );
+
+        self::assertSame('de', $locale->getLanguage());
+        self::assertSame('AT', $locale->getRegion());
+        self::assertSame('German (Austria)', $locale->getDisplayName()['en']);
+        self::assertTrue($locale->isPopular());
+    }
+
+    #[Test]
+    public function updateMetadataReplacesAllFields(): void
+    {
+        $locale = new Locale('pl_PL', 'Polski');
+
+        $locale->updateMetadata('pl', 'PL', ['pl' => 'Polski (Polska)'], true);
+
+        self::assertSame('pl', $locale->getLanguage());
+        self::assertSame('PL', $locale->getRegion());
+        self::assertSame(['pl' => 'Polski (Polska)'], $locale->getDisplayName());
+        self::assertTrue($locale->isPopular());
+    }
+}

--- a/apps/api/tests/Unit/Channel/TenantLocaleTest.php
+++ b/apps/api/tests/Unit/Channel/TenantLocaleTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel;
+
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Shared\Domain\Tenant;
+use DomainException;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TenantLocaleTest extends TestCase
+{
+    #[Test]
+    public function defaultsAreInactiveTenantNonDefaultNonMandatory(): void
+    {
+        $locale = new Locale('pl_PL', 'Polski');
+
+        $tenantLocale = new TenantLocale($locale);
+
+        self::assertNull($tenantLocale->getTenant());
+        self::assertSame($locale, $tenantLocale->getLocale());
+        self::assertFalse($tenantLocale->isDefault());
+        self::assertFalse($tenantLocale->isMandatory());
+        self::assertNull($tenantLocale->getFallback());
+        self::assertSame(0, $tenantLocale->getSortOrder());
+        self::assertTrue($tenantLocale->isActive());
+    }
+
+    #[Test]
+    public function defaultLocaleIsForcedMandatory(): void
+    {
+        $locale = new Locale('pl_PL', 'Polski');
+
+        $tenantLocale = new TenantLocale($locale, isDefault: true);
+
+        self::assertTrue($tenantLocale->isDefault());
+        self::assertTrue($tenantLocale->isMandatory());
+    }
+
+    #[Test]
+    public function assignTenantStampsAndRefusesReassignment(): void
+    {
+        $tenantLocale = new TenantLocale(new Locale('pl_PL', 'Polski'));
+        $first = new Tenant('demo', 'Demo');
+        $second = new Tenant('acme', 'Acme');
+
+        $tenantLocale->assignTenant($first);
+        self::assertSame($first, $tenantLocale->getTenant());
+
+        $this->expectException(LogicException::class);
+        $tenantLocale->assignTenant($second);
+    }
+
+    #[Test]
+    public function defaultLocaleRefusesNonMandatoryDowngrade(): void
+    {
+        $tenantLocale = new TenantLocale(new Locale('pl_PL', 'Polski'), isDefault: true);
+
+        $this->expectException(DomainException::class);
+        $tenantLocale->setMandatory(false);
+    }
+
+    #[Test]
+    public function selfFallbackIsRefused(): void
+    {
+        $pl = new Locale('pl_PL', 'Polski');
+        $tenantLocale = new TenantLocale($pl);
+
+        $this->expectException(DomainException::class);
+        $tenantLocale->setFallback($pl);
+    }
+
+    #[Test]
+    public function fallbackToDifferentLocaleSucceeds(): void
+    {
+        $en = new Locale('en_US', 'English');
+        $de = new Locale('de_DE', 'Deutsch');
+        $tenantLocale = new TenantLocale($de);
+
+        $tenantLocale->setFallback($en);
+
+        self::assertSame($en, $tenantLocale->getFallback());
+    }
+
+    #[Test]
+    public function defaultLocaleRefusesDeactivation(): void
+    {
+        $tenantLocale = new TenantLocale(new Locale('pl_PL', 'Polski'), isDefault: true);
+
+        $this->expectException(DomainException::class);
+        $tenantLocale->deactivate();
+    }
+
+    #[Test]
+    public function nonDefaultLocaleDeactivatesAndReactivates(): void
+    {
+        $tenantLocale = new TenantLocale(new Locale('de_DE', 'Deutsch'));
+
+        $tenantLocale->deactivate();
+        self::assertFalse($tenantLocale->isActive());
+
+        $tenantLocale->reactivate();
+        self::assertTrue($tenantLocale->isActive());
+    }
+
+    #[Test]
+    public function markAsDefaultForcesMandatoryAndActive(): void
+    {
+        $tenantLocale = new TenantLocale(new Locale('de_DE', 'Deutsch'));
+        $tenantLocale->deactivate();
+
+        $tenantLocale->markAsDefault();
+
+        self::assertTrue($tenantLocale->isDefault());
+        self::assertTrue($tenantLocale->isMandatory());
+        self::assertTrue($tenantLocale->isActive());
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -10032,6 +10032,27 @@
                     },
                     "label": {
                         "type": "string"
+                    },
+                    "language": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "region": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "displayName": {
+                        "description": "two-letter UI-locale \u21d2 native display name,\ne.g. {\"pl\":\"Polski (Polska)\",\"en\":\"Polish (Poland)\"}.",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "popular": {
+                        "readOnly": true,
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -10040,7 +10061,7 @@
             },
             "Locale-locale.read": {
                 "type": "object",
-                "description": "BCP-47-shaped locale code (`pl_PL`, `en_US`, \u2026) shared across tenants.\n\nLocales are global infrastructure rows \u2014 every tenant references the\nsame `pl_PL` row rather than carrying its own copy. The seeded set in\nthe migration covers the MVP-supported locales; tenants opt-in to a\nsubset via the Channel \u2194 Locale M2M.\n\nNo TenantScoped: the table sits on the audit allowlist as global\ninfrastructure, like `permissions` and the global RBAC roles.",
+                "description": "BCP-47-shaped locale code (`pl_PL`, `en_US`, \u2026) shared across tenants.\n\nLocales are global infrastructure rows \u2014 every tenant references the\nsame `pl_PL` row rather than carrying its own copy. The seeded set in\nthe migration covers the ISO 639-1 + ISO 3166 catalog used by Cortex\n(~45 entries today, 14 of them `is_popular=true` for the CEE+DACH\ndropdown shortlist).\n\nNo TenantScoped: the table sits on the audit allowlist as global\ninfrastructure, like `permissions` and the global RBAC roles.",
                 "properties": {
                     "id": {
                         "type": [
@@ -10055,6 +10076,27 @@
                     },
                     "label": {
                         "type": "string"
+                    },
+                    "language": {
+                        "default": "",
+                        "type": "string"
+                    },
+                    "region": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "displayName": {
+                        "description": "two-letter UI-locale \u21d2 native display name,\ne.g. {\"pl\":\"Polski (Polska)\",\"en\":\"Polish (Poland)\"}.",
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        }
+                    },
+                    "popular": {
+                        "readOnly": true,
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -10082,6 +10124,27 @@
                             },
                             "label": {
                                 "type": "string"
+                            },
+                            "language": {
+                                "default": "",
+                                "type": "string"
+                            },
+                            "region": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "displayName": {
+                                "description": "two-letter UI-locale \u21d2 native display name,\ne.g. {\"pl\":\"Polski (Polska)\",\"en\":\"Polish (Poland)\"}.",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "popular": {
+                                "readOnly": true,
+                                "type": "boolean"
                             }
                         },
                         "required": [
@@ -10089,7 +10152,7 @@
                         ]
                     }
                 ],
-                "description": "BCP-47-shaped locale code (`pl_PL`, `en_US`, \u2026) shared across tenants.\n\nLocales are global infrastructure rows \u2014 every tenant references the\nsame `pl_PL` row rather than carrying its own copy. The seeded set in\nthe migration covers the MVP-supported locales; tenants opt-in to a\nsubset via the Channel \u2194 Locale M2M.\n\nNo TenantScoped: the table sits on the audit allowlist as global\ninfrastructure, like `permissions` and the global RBAC roles."
+                "description": "BCP-47-shaped locale code (`pl_PL`, `en_US`, \u2026) shared across tenants.\n\nLocales are global infrastructure rows \u2014 every tenant references the\nsame `pl_PL` row rather than carrying its own copy. The seeded set in\nthe migration covers the ISO 639-1 + ISO 3166 catalog used by Cortex\n(~45 entries today, 14 of them `is_popular=true` for the CEE+DACH\ndropdown shortlist).\n\nNo TenantScoped: the table sits on the audit allowlist as global\ninfrastructure, like `permissions` and the global RBAC roles."
             },
             "Locale.jsonld-locale.read": {
                 "allOf": [
@@ -10112,6 +10175,27 @@
                             },
                             "label": {
                                 "type": "string"
+                            },
+                            "language": {
+                                "default": "",
+                                "type": "string"
+                            },
+                            "region": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "displayName": {
+                                "description": "two-letter UI-locale \u21d2 native display name,\ne.g. {\"pl\":\"Polski (Polska)\",\"en\":\"Polish (Poland)\"}.",
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            },
+                            "popular": {
+                                "readOnly": true,
+                                "type": "boolean"
                             }
                         },
                         "required": [
@@ -10119,7 +10203,7 @@
                         ]
                     }
                 ],
-                "description": "BCP-47-shaped locale code (`pl_PL`, `en_US`, \u2026) shared across tenants.\n\nLocales are global infrastructure rows \u2014 every tenant references the\nsame `pl_PL` row rather than carrying its own copy. The seeded set in\nthe migration covers the MVP-supported locales; tenants opt-in to a\nsubset via the Channel \u2194 Locale M2M.\n\nNo TenantScoped: the table sits on the audit allowlist as global\ninfrastructure, like `permissions` and the global RBAC roles."
+                "description": "BCP-47-shaped locale code (`pl_PL`, `en_US`, \u2026) shared across tenants.\n\nLocales are global infrastructure rows \u2014 every tenant references the\nsame `pl_PL` row rather than carrying its own copy. The seeded set in\nthe migration covers the ISO 639-1 + ISO 3166 catalog used by Cortex\n(~45 entries today, 14 of them `is_popular=true` for the CEE+DACH\ndropdown shortlist).\n\nNo TenantScoped: the table sits on the audit allowlist as global\ninfrastructure, like `permissions` and the global RBAC roles."
             },
             "ObjectType-admin.read": {
                 "type": "object",
@@ -10464,7 +10548,7 @@
         },
         {
             "name": "Locale",
-            "description": "BCP-47-shaped locale code (`pl_PL`, `en_US`, \u2026) shared across tenants.\n\nLocales are global infrastructure rows \u2014 every tenant references the\nsame `pl_PL` row rather than carrying its own copy. The seeded set in\nthe migration covers the MVP-supported locales; tenants opt-in to a\nsubset via the Channel \u2194 Locale M2M.\n\nNo TenantScoped: the table sits on the audit allowlist as global\ninfrastructure, like `permissions` and the global RBAC roles."
+            "description": "BCP-47-shaped locale code (`pl_PL`, `en_US`, \u2026) shared across tenants.\n\nLocales are global infrastructure rows \u2014 every tenant references the\nsame `pl_PL` row rather than carrying its own copy. The seeded set in\nthe migration covers the ISO 639-1 + ISO 3166 catalog used by Cortex\n(~45 entries today, 14 of them `is_popular=true` for the CEE+DACH\ndropdown shortlist).\n\nNo TenantScoped: the table sits on the audit allowlist as global\ninfrastructure, like `permissions` and the global RBAC roles."
         },
         {
             "name": "AssetStorage",


### PR DESCRIPTION
Closes #870 — LOC-02 of the Locales & i18n feature ([`Project Plan/UI/feature-locales.md`](Project%20Plan/UI/feature-locales.md)).

## Summary

- Backfills `tenant_locales` from the legacy `tenants.enabled_locales` array + `tenants.primary_locale` column #705 introduced.
- Maps ISO 639-1 short codes (`pl`, `en`, `de`, …) to BCP-47 codes (`pl_PL`, `en_US`, `de_DE`, …) — choosing the most common regional variant per language.
- Idempotent: `INSERT … ON CONFLICT (tenant_id, locale_id) DO NOTHING` swallows duplicate inserts so replaying the migration is safe.
- Marks `Tenant::\$enabledLocales` and `Tenant::\$primaryLocale` `@deprecated` and mirrors the deprecation in the DB via `COMMENT ON COLUMN`.

## Decision: legacy columns NOT dropped

`WorkspaceController`, `TenantConfigController`, `SuperAdminTenantResponseBuilder` keep reading/writing `enabledLocales` + `primaryLocale`, so existing UI surfaces (`/settings/tenant`, Super Admin operator panel) stay functional until LOC-07 (#875) refactors the frontend to consume `/api/tenant-locales`. A follow-up ticket will drop the columns once readers are migrated.

## Test plan

- [x] `pim:db:reset --with-fixtures` runs both migrations end-to-end; demo + acme tenants land with 2 `tenant_locales` rows (1 default each), mirroring the fixture seed from #869.
- [x] Smoke: inserted a fresh tenant with `enabled_locales=['de','fr']` + `primary_locale='de'`, re-ran the migration SQL inline; got `de_DE` (is_default=true, sort_order=0) and `fr_FR` (sort_order=1) — ON CONFLICT didn't double-insert.
- [x] `composer phpstan` — clean after adding `property.deprecated` ignore for in-class Tenant access.
- [x] `composer cs-check` — clean.
- [x] `composer deptrac` — 0 violations.
- [x] PHPUnit: full Tenant + Channel suite (127 tests) green.

No new endpoints in this PR; `/api/tenant-locales` lands in LOC-03 (#871).