### PR TITLE
feat(catalog): ObjectType.is_categorizable + Attribute.relation_* config (MOD-01)

### DIFF
--- a/Project Plan/01-architektura-pim.md
+++ b/Project Plan/01-architektura-pim.md
@@ -1162,6 +1162,68 @@ Asymetria zysków vs koszt jest klasyczna i sprawdzona w ADR-003 (multi-tenant r
 - ADR-009 (generic ObjectType z built-in Product/Category/Asset) — sprawdzony pattern *„infrastruktura full-scope, UX zoptymalizowany pod MVP"*.
 - ADR-006 (hybrid attribute model) — RBAC field-level filtering operuje na `object_values JSONB` zgodnie z ADR-006; per-attribute 3-state permissions parametryzują serialization context.
 
+### ADR-014: Model dystrybucji atrybutów (primary category overlay) + relacje obiekt↔obiekt
+
+**Status:** Zaakceptowany (2026-05-23)
+
+**Rewiduje:** ADR-012 w trzech punktach (patrz Konsekwencje). Reszta ADR-012 (AttributeGroup jako first-class entity, M:N junctions, `EffectiveAttributeGroupResolver`) pozostaje w mocy.
+
+**Kontekst:**
+Przy ~60% ukończenia systemu, w sesji burzy mózgów (2026-05-23) wykryto cztery nieścisłości w module Modelowanie, które okazały się **jednym problemem architektonicznym** — niespójnym modelem dystrybucji atrybutów:
+
+1. **Marka jako built-in ObjectType bez uzasadnienia.** ADR-012 (Konsekwencje, *„Brand jako 4-ty built-in ObjectType"*) wprowadził Brand do puli built-in obok Product/Category/Asset. W praktyce: Brand nie renderuje się w widoku edycji Produktu (brak wpięcia jako atrybut ani relacja), a built-in status nie ma uzasadnienia — marka jest decyzją biznesową tenanta (jeden chce `select`, inny osobny ObjectType).
+2. **Brak modelu relacji obiekt↔obiekt.** Tenant tworzy ObjectType (np. Up-Selling, Marka) i chce powiązać go z innym obiektem (Pimcore-style). Brak UX, brak logiki, brak typu atrybutu obsługującego referencję.
+3. **ObjectType-Category ma zdefiniowane atrybuty, ale formularz instancji ich nie renderuje** (objaw zgłoszony jako #3-#28). Root cause: form renderer szuka atrybutów *przez kategorię obiektu*, a Category nie ma „swojej kategorii" → atrybuty bazowe ObjectType są ignorowane.
+4. **Niejasność czy każdy ObjectType jest kategoryzowany.** Select „Object Type" w `/modeling/categories` zakłada że każdy ObjectType wiąże się z kategorią. Nie ma to sensu dla ObjectType nie-kategoryzowanych (Brand, Asset).
+
+Root cause: system zahardkodował **kategorię jako jedyny mechanizm dystrybucji atrybutów**. Działa dla Produktu (kategoryzowany), łamie się dla wszystkiego innego. ADR-012 model (`EffectiveAttributeGroupResolver` z 4 źródłami) był poprawny kierunkowo, ale implementacja go nie realizuje, a sam ADR-012 nie rozróżniał kategorii primary vs secondary i nie adresował relacji.
+
+**Rozważane opcje (model dystrybucji atrybutów):**
+- **(X) Czysty ObjectType-driven (Pimcore Class).** ObjectType definiuje wszystkie atrybuty, kategoria = wyłącznie drzewo klasyfikacji, zero wpływu na atrybuty. Odrzucony — eliminuje *„różne atrybuty dla różnych grup produktów"* (telewizor `przekątna` vs pralka `pojemność_bębna`), co jest realnym wymaganiem PIM mid-market.
+- **(Y) Hybrid: ObjectType base + primary category overlay (cumulative po drzewie).** ObjectType daje bazę atrybutów (zawsze, każda instancja). ObjectType z `is_categorizable=true` ma dodatkowo **jedną kategorię główną (primary)**, która przez swoją ścieżkę w drzewie kategorii dodaje kontekstowe atrybuty kumulatywnie (root→leaf). Pozostałe kategorie (secondary, N) służą wyłącznie klasyfikacji. **Wybrany.**
+- **(Z) Family-based (Akeneo).** Osobny byt `Family` jako attribute-driver, Category czysto klasyfikacyjna. Odrzucony jako zbyt ciężki — dodatkowy byt domenowy, dodatkowy CRUD, dodatkowy concept dla operatora. Primary category osiąga 90% wartości Family bez nowego bytu.
+
+**Decyzja:** Opcja (Y) + sześć doprecyzowań:
+
+1. **Capability flags na `ObjectType`:** `expose_to_main_menu` (czy ObjectType ma pozycję w sidebar — istniejąca kolumna z VIEW-08 / #427, reused; w mini-specu i wcześniejszych draftach pojawiała się jako `show_in_main_menu`) i `is_categorizable` (czy instancje mają kategorię główną przydzielającą atrybuty — dodane w MOD-01 / #893). Brak flagi `is_relation_target` — **każdy ObjectType może być celem relacji domyślnie**.
+2. **Primary + secondary categories.** Instancja kategoryzowalnego ObjectType ma dokładnie 1 kategorię główną (`is_primary=true` w junction obiekt↔kategoria) + N kategorii dodatkowych. Tylko primary uczestniczy w dystrybucji atrybutów; secondary = klasyfikacja/nawigacja.
+3. **Cumulative resolution po ścieżce drzewa.** Produkt z primary category liść `Elektronika > RTV > Telewizory` dostaje sumę grup atrybutów przypisanych do każdego węzła ścieżki (`Elektronika` + `RTV` + `Telewizory`). Wspólne atrybuty definiowane wysoko w drzewie, specyficzne nisko. `EffectiveAttributeGroupResolver` (ADR-012) zachowany, ale parametryzowany **primary category path**, nie zbiorem wszystkich kategorii obiektu.
+4. **Relacja = typ atrybutu `relation`.** Atrybut typu `relation` z konfiguracją: `target_object_type` (jeden lub wiele), `cardinality` (one/many), `advanced` (relacja z metadanymi — własne pola na powiązaniu). Reverse relations auto-generowane (obiekt-target widzi read-only sekcję *„powiązania zwrotne"*). Brak osobnego bytu „Association" — relacja mieści się w istniejącym modelu atrybutów. Typ `asset` pozostaje osobny (specjalizowany UX: DAM picker, miniaturka, kadrowanie) — nie ujednolicany z `relation`.
+5. **Kody atrybutów globalnie unikalne w obrębie ObjectType.** Atrybut jest albo bazowy (ObjectType), albo kontekstowy (kategoria) — nigdy oba. Walidacja w Modelowaniu blokuje duplikat kodu. Konwencja nazewnicza dla atrybutów kontekstowych: sufiks kategorii (`opis_telewizory`, `opis_buty`) — zapobiega kolizjom i czyni model czytelnym.
+6. **Brand NIE jest built-in.** Built-in ObjectType zostają wyłącznie `Product`, `Category`, `Asset` (zgodnie z pierwotnym ADR-009). Brand → custom ObjectType lub atrybut `select`, decyzja tenanta.
+
+**Uzasadnienie:**
+Opcja (Y) zachowuje killer feature ADR-012 (dziedziczenie grup atrybutów po drzewie kategorii — czego Akeneo/Pimcore nie mają natywnie), ale naprawia jego trzy luki: brak rozróżnienia primary/secondary (produkt w wielu kategoriach miał ambiguous attribute set), brak modelu relacji, błędny built-in Brand. Primary category jako attribute-driver świadomie *„miesza dwie role"* kategorii (klasyfikacja + dystrybucja atrybutów) — to zaakceptowany trade-off: prostota (brak bytu Family) kosztem czystości (reorganizacja drzewa ma side-effect na atrybuty produktów; mityguje to ostrzeżenie UI + orphaned values handling). Relacja jako typ atrybutu (nie osobny byt Association) trzyma spójność z ADR-006/009 — wszystko jest atrybutem na `object_values JSONB`.
+
+**Konsekwencje:**
+
+*Rewizja ADR-012:*
+- **REVERT „Brand jako 4-ty built-in ObjectType"** (ADR-012 Konsekwencje, linia o `#UI-08.2`). Built-in = Product/Category/Asset. Rozszerzenie `object_types` o `is_built_in/code_immutable/deletable/icon/color` zostaje, ale Brand nie jest seedowany jako built-in.
+- **`category_attribute_groups` (ADR-012)** — semantyka doprecyzowana: junction działa tylko dla **primary category** obiektu, nie dla zbioru wszystkich kategorii. `EffectiveAttributeGroupResolver` źródło (3) *„dziedziczone po drzewie root→leaf"* parametryzowane primary category path.
+- **`EffectiveAttributeGroupResolver` źródło (2) *„globalne dla ObjectType"*** musi zwracać atrybuty bazowe **dla każdego ObjectType, niezależnie od kategoryzacji** — to naprawia objaw #3-#28 (Category-jako-ObjectType renderuje swoje atrybuty bazowe).
+
+*Nowe elementy schematu:*
+- `object_types` + kolumna `is_categorizable BOOLEAN` (MOD-01 / #893). `expose_to_main_menu BOOLEAN` (ekwiwalent semantyczny `show_in_main_menu`) już istniał od VIEW-08 / #427 — reused, brak rename.
+- Junction obiekt↔kategoria (`object_categories`) + kolumna `is_primary BOOLEAN`; partial unique index gwarantuje dokładnie 1 primary per obiekt kategoryzowalny. *(Już istnieje od PCAT-01 / `Version20260510221123` — MOD-01 nie dotyka schematu junction'a.)*
+- `attributes` + obsługa typu `relation`: kolumny `relation_target_object_type_ids JSONB`, `relation_cardinality VARCHAR(8) CHECK IN ('one','many')`, `relation_advanced BOOLEAN` (MOD-01 / #893). `AttributeType::Relation` enum case już istniał — brak migracji enum.
+- Tabela powiązań `object_relations` (`source_object_id`, `target_object_id`, `attribute_id`, `position`, `metadata JSONB` dla advanced) — **zastępuje** `object_associations` z ADR-009 (MOD-02 / #894). Hardcoded enum typów ADR-009 (`cross_sell`, `up_sell`, `related`, `alternative`, `accessory`) był MVP-placeholderem; ADR-014 go generalizuje: każdy typ asocjacji staje się seedowanym built-in atrybutem typu `relation` na ObjectType Product. Migracja: 5 typów → 5 atrybutów `relation`, przepisanie wierszy `object_associations.type` → `object_relations.attribute_id`, DROP `object_associations`.
+- Orphaned values: wartości atrybutu który zniknął z modelu (zmiana primary category) **pozostają w `object_values`** ukryte i nieedytowalne; powrót do kategorii przywraca widoczność.
+
+*Naprawa objawów:*
+- #1 (Marka) — usunięcie Brand z built-in + migracja istniejącej „Marki" (custom ObjectType lub atrybut, per stan tenanta).
+- #2 (relacje) — typ atrybutu `relation` + zakładka „Powiązania" (AttributeGroup) + reverse relations.
+- #3-#28 (Category nie renderuje atrybutów) — fix wiring `EffectiveAttributeGroupResolver` źródło (2).
+- #4 (każdy ObjectType kategoryzowany) — flaga `is_categorizable`; `/modeling/categories` select „Object Type" filtruje tylko do ObjectType z `is_categorizable=true`.
+
+*Sequencing:* Rewizja Modelowania jest blokująca dla dalszych prac w epiku UI-08. Capability flags + primary category + relacje wchodzą przed dalszym CRUD-em obiektów. Szczegółowy kontrakt: `Project Plan/UI/feature-modeling-data-model.md`.
+
+**Referencje:**
+- `Project Plan/UI/feature-modeling-data-model.md` — mini-spec implementacyjny (model, schema delta, UX, migracja, API, user stories, estymacja).
+- ADR-012 (AttributeGroup first-class) — ADR-014 rewiduje 3 punkty, zachowuje resztę.
+- ADR-009 (generic ObjectType) — ADR-014 respektuje; built-in = Product/Category/Asset zgodnie z pierwotnym ADR-009.
+- ADR-006 (hybrid attribute model) — relacja jako typ atrybutu operuje na `object_values JSONB` zgodnie z ADR-006.
+- `Project Plan/UI/epik-08-modelowanie.md` — epik UI-08, do aktualizacji o capability flags + relacje + primary category.
+
 ## 14. Roadmap rozwoju
 
 Roadmap fazowa, wysokopoziomowa. Szczegółowy backlog i estymacje w dokumencie `02-plan-projektu-pim.md`.

--- a/Project Plan/UI/feature-modeling-data-model-tickets.md
+++ b/Project Plan/UI/feature-modeling-data-model-tickets.md
@@ -1,0 +1,571 @@
+# Tickety — Modelowanie: model dystrybucji atrybutów + relacje (ADR-014)
+
+**Typ dokumentu:** Backlog ticketów — ready-to-paste GitHub Issues
+**Status:** Draft — gotowe do utworzenia GitHub Issues przez agenta kodującego
+**Powiązane:**
+- [ADR-014](../01-architektura-pim.md) — *„Model dystrybucji atrybutów + relacje obiekt↔obiekt"*
+- [`feature-modeling-data-model.md`](feature-modeling-data-model.md) — mini-spec implementacyjny (kontrakt)
+- [`epik-08-modelowanie.md`](epik-08-modelowanie.md) — epik UI-08 (nadrzędny)
+
+> **Cel:** rewizja modelu Modelowania per ADR-014. Naprawia 4 nieścisłości wykryte przy ~60% systemu: Marka built-in, brak modelu relacji, Category nie renderuje atrybutów (#3-#28), niejasność kategoryzacji.
+> **Blokujące** dla dalszego CRUD-u obiektów w epiku UI-08.
+> **14 ticketów, ~75-105h** (~2-3 tygodnie solo dev). Estymacja niższa niż mini-spec §13 bo `EffectiveAttributeGroupResolver` JEST już zaimplementowany i merged — MOD-03 to fix/refactor, nie implementacja od zera.
+
+---
+
+## Konwencje
+
+- Numer: `MOD-NN`. Po utworzeniu w GitHub: dopisany numer issue (`MOD-01 / #NNN`).
+- Pola: Typ (Conventional Commits) / Epik / Estymacja / Dependencies / Risk flags / Cel / Scope / Acceptance criteria / Files affected / Testing / DoD.
+- Tytuł issue po angielsku (Conventional Commits), opis po polsku.
+- Labels: `modeling` + `adr-014` + `epik-ui-08` + risk flag jeśli dotyczy.
+
+## Graf zależności
+
+```
+MOD-01 (schema: capability flags + is_primary + relation config) ── foundation
+MOD-02 (schema: object_relations + migracja object_associations) ── foundation
+        │
+        ├── MOD-03 (EffectiveAttributeGroupResolver fix — naprawa #3-#28)
+        ├── MOD-04 (walidacja unikalności kodów atrybutów)
+        ├── MOD-05 (typ atrybutu `relation` — backend config)
+        │       └── MOD-06 (object_relations CRUD)
+        │               ├── MOD-07 (reverse relations)
+        │               └── MOD-08 (advanced relations — metadata)
+        ├── MOD-09 (orphaned values handling)
+        └── MOD-10 (migracja built-in „Marki")
+        │
+        ▼
+MOD-11 (frontend: modal create + capability flags)   ── po MOD-01, MOD-03
+MOD-12 (frontend: zakładka „Powiązania")             ── po MOD-06, MOD-07, MOD-08
+MOD-13 (frontend: konfigurator atrybutu `relation`)  ── po MOD-05
+MOD-14 (docs: update epik-08-modelowanie.md)         ── równolegle
+```
+
+---
+
+## MOD-01 / #893: feat(catalog): schema delta — capability flags + primary category + relation attribute config
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **4-6h** (zredukowane do ~2-3h po scope reconciliation 2026-05-24 — patrz „Scope adjustment" niżej).
+
+**Dependencies:** Blocks MOD-03..MOD-13. Blocked by — brak (foundation).
+
+**Scope adjustment (2026-05-24, plan-mode reconciliation z istniejącym kodem):**
+- `show_in_main_menu` *(spec)* = istniejące `expose_to_main_menu` *(kod, VIEW-08 / #427)* — **reuse**, ADR-014 + mini-spec zaktualizowane do canonical name.
+- `ObjectCategory.is_primary BOOLEAN` + partial unique index — **już istnieje** od PCAT-01 / `Version20260510221123`, MOD-01 nie dotyka.
+- `AttributeType::Relation` enum case — **już istnieje** od #31 (linia 36 w `AttributeType.php`), MOD-01 nie dotyka enum/walidacji.
+- Aktualny MOD-01 scope: 1 nowa kolumna na `object_types` (`is_categorizable`) + 3 nowe kolumny na `attributes` (`relation_target_object_type_ids`, `relation_cardinality`, `relation_advanced`).
+
+**Risk flags:**
+- `is_primary` partial unique index — dokładnie 1 primary per obiekt. Błąd = produkt z 2 primary = ambiguous attribute set. *(Mitigacja: index istnieje już od PCAT-01 — MOD-01 nie zmienia.)*
+- `object_categories` może już istnieć (ADR-009 schema) — migracja dodaje kolumnę, nie tworzy tabeli od zera. *(Confirmed: istnieje, MOD-01 nie dotyka.)*
+
+**Cel:** Schema delta dla ADR-014 — capability flags na ObjectType, primary flag na junction obiekt↔kategoria, konfiguracja atrybutu typu `relation`.
+
+**Scope:**
+```sql
+ALTER TABLE object_types ADD COLUMN show_in_main_menu BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE object_types ADD COLUMN is_categorizable  BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE object_categories ADD COLUMN is_primary BOOLEAN NOT NULL DEFAULT false;
+CREATE UNIQUE INDEX idx_object_categories_primary
+    ON object_categories(object_id) WHERE is_primary = true;
+
+ALTER TABLE attributes ADD COLUMN relation_target_object_type_ids JSONB DEFAULT '[]'::JSONB;
+ALTER TABLE attributes ADD COLUMN relation_cardinality VARCHAR(8)
+    CHECK (relation_cardinality IN ('one', 'many'));
+ALTER TABLE attributes ADD COLUMN relation_advanced BOOLEAN NOT NULL DEFAULT false;
+```
+- Dodać `relation` do dozwolonych typów atrybutu (enum/walidacja).
+- Seed built-in ObjectType (Product/Category/Asset) z poprawnymi flagami: Product `is_categorizable=true, show_in_main_menu=true`; Category/Asset `is_categorizable=false`.
+- Entity classes (ObjectType, Attribute, ObjectCategory) — nowe properties + getters.
+
+**Acceptance criteria:**
+- [ ] AC-1: Kolumny dodane, migracja UP+DOWN testowana w testcontainers
+- [ ] AC-2: Partial unique index — próba 2 primary dla 1 obiektu → constraint violation
+- [ ] AC-3: Built-in ObjectType mają poprawne flagi po seed
+- [ ] AC-4: `doctrine:schema:validate` pass
+- [ ] AC-5: Typ `relation` akceptowany przez walidację atrybutu
+
+**Files affected:** `src/Catalog/Doctrine/Migrations/Version*.php`, `src/Catalog/Entity/{ObjectType,Attribute,ObjectCategory}.php`
+
+**Testing:** Unit (entity) + integration (migracja UP/DOWN + constraint).
+
+**DoD:** AC + PHPStan max + CI green + migracja rollback test.
+
+---
+
+## MOD-02 / #894: feat(catalog): schema — object_relations table + migracja object_associations
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **4-6h**
+
+**Dependencies:** Blocks MOD-05, MOD-06. Blocked by — brak (foundation, równolegle z MOD-01).
+
+**Risk flags:**
+- **Migracja danych** — istniejące wiersze `object_associations` z hardcoded `type` muszą być przepisane. Brak migracji = utrata powiązań.
+- `object_associations` DROP — destrukcyjne. Migracja musi najpierw przepisać, potem DROP, z rollback path.
+
+**Cel:** Utworzyć `object_relations` (per ADR-014) zastępujące `object_associations`. Hardcoded enum typów → seedowane built-in atrybuty `relation`.
+
+**Scope:**
+```sql
+CREATE TABLE object_relations (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    source_object_id UUID NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+    target_object_id UUID NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+    attribute_id UUID NOT NULL REFERENCES attributes(id),
+    position INTEGER NOT NULL DEFAULT 0,
+    metadata JSONB DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_object_relations_source ON object_relations(source_object_id, attribute_id);
+CREATE INDEX idx_object_relations_target ON object_relations(target_object_id);
+```
+- Seed 5 built-in atrybutów typu `relation` na ObjectType Product: `cross_sell`, `up_sell`, `related`, `alternative`, `accessory` (cardinality=many, target=Product, advanced=false).
+- Migracja danych: per wiersz `object_associations` → znajdź odpowiadający seedowany atrybut po `type`, wstaw wiersz `object_relations` z `attribute_id`.
+- DROP `object_associations` po migracji danych.
+- Entity `ObjectRelation`.
+
+**Acceptance criteria:**
+- [ ] AC-1: Tabela `object_relations` utworzona z indeksami
+- [ ] AC-2: 5 built-in atrybutów `relation` seedowanych na Product
+- [ ] AC-3: Istniejące wiersze `object_associations` przepisane na `object_relations` (test: insert sample association → migracja → wiersz w object_relations z poprawnym attribute_id)
+- [ ] AC-4: `object_associations` DROP-nięte po migracji
+- [ ] AC-5: Migracja DOWN przywraca `object_associations` (rollback path)
+- [ ] AC-6: Cross-tenant — `tenant_id` na object_relations, TenantFilter applied
+
+**Files affected:** `src/Catalog/Doctrine/Migrations/Version*.php`, `src/Catalog/Entity/ObjectRelation.php`
+
+**Testing:** Integration (migracja danych UP — sample associations przepisane; DOWN — przywrócone).
+
+**DoD:** AC + migracja danych smoke test (paste przed/po) + CI green.
+
+---
+
+## MOD-03 / #895: fix(catalog): EffectiveAttributeGroupResolver — base attributes for every ObjectType + primary category path
+
+**Typ:** `fix` | **Epik:** UI-08 | **Estymacja:** **5-8h**
+
+**Dependencies:** Blocks MOD-11. Blocked by MOD-01.
+
+**Risk flags:**
+- `EffectiveAttributeGroupResolver` JEST zaimplementowany i merged (potwierdzone) — to **refactor istniejącego**, nie implementacja od zera. Zmiana logiki resolvera dotyka renderowania KAŻDEGO formularza obiektu — regresja = wszystkie formatki broken.
+- Cache resolvera (Redis 5min TTL z ADR-012) — invalidation musi uwzględnić nowy primary category param.
+
+**Cel:** Naprawić objaw #3-#28. Resolver musi zwracać atrybuty bazowe ObjectType **zawsze** (źródło 2, niezależnie od kategoryzacji) + parametryzować dziedziczenie po **primary category path** zamiast zbioru wszystkich kategorii.
+
+**Scope:**
+- Źródło (2) *„globalne dla ObjectType"* — zwraca grupy bazowe dla każdego ObjectType (Product, Category, Asset, custom) niezależnie od `is_categorizable`. To naprawia Category-jako-ObjectType nie renderujący swoich atrybutów.
+- Źródło (3) *„dziedziczone po drzewie"* — parametryzowane **primary category path** (root→leaf cumulative), nie zbiorem wszystkich kategorii obiektu. Sekundarne kategorie ignorowane w resolverze.
+- Dla ObjectType `is_categorizable=false` — źródło (3) zwraca pusty zbiór (brak kategorii = brak overlay).
+- Cache key uwzględnia primary category id (nie listę wszystkich kategorii).
+- Endpoint `GET /api/objects/{id}/form-schema` — bez zmiany sygnatury, zmiana wewnętrznej logiki resolvera.
+
+**Acceptance criteria:**
+- [ ] AC-1: ObjectType Category — formularz instancji renderuje atrybuty bazowe (name, seo_title, seo_description, main_image) — **naprawa #3-#28**
+- [ ] AC-2: Product z primary category `Elektronika > RTV > Telewizory` dostaje atrybuty kumulatywnie ze ścieżki (3 węzły)
+- [ ] AC-3: Product secondary categories — NIE wpływają na atrybuty
+- [ ] AC-4: ObjectType `is_categorizable=false` — resolver zwraca tylko warstwę bazową
+- [ ] AC-5: Cache invalidation działa przy zmianie primary category obiektu
+- [ ] AC-6: Existing form-schema testy nadal pass (brak regresji)
+
+**Files affected:** `src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php`, `src/Catalog/EventListener/ObjectFormSchemaListener.php`
+
+**Testing:** Unit (resolver — base layer dla każdego ObjectType, cumulative path) + integration (form-schema endpoint per ObjectType) + regresja istniejących testów.
+
+**DoD:** AC + smoke test: utwórz kategorię → formularz pokazuje name/seo_title (objaw #3-#28 naprawiony) + CI green.
+
+---
+
+## MOD-04 / #896: feat(catalog): walidacja unikalności kodów atrybutów w obrębie ObjectType
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **3-4h**
+
+**Dependencies:** Blocked by MOD-01.
+
+**Risk flags:**
+- Walidacja musi sprawdzać kod przeciw **całemu efektywnemu modelowi** ObjectType (bazowe + wszystkie kategorie dystrybuujące do tego ObjectType) — nie tylko bezpośrednim atrybutom.
+
+**Cel:** Kod atrybutu globalnie unikalny w obrębie ObjectType. Atrybut albo bazowy, albo kontekstowy — nigdy oba. Walidacja blokuje duplikat.
+
+**Scope:**
+- Walidator przy create/update atrybutu — sprawdza czy kod już istnieje w modelu docelowego ObjectType (warstwa bazowa + grupy kategorii dystrybuujących do tego ObjectType).
+- Błąd RFC 7807 Problem Details — `field: "code", reason: "duplicate_in_object_type", existing_location: "base|category:X"`.
+- Konwencja nazewnicza dla atrybutów kontekstowych — UI hint przy tworzeniu atrybutu w kategorii: sufiks kategorii sugerowany (`opis_telewizory`). Nie hard-enforced, ale podpowiedziane.
+
+**Acceptance criteria:**
+- [ ] AC-1: Próba dodania atrybutu o kodzie istniejącym w warstwie bazowej → 422 z reason
+- [ ] AC-2: Próba dodania atrybutu o kodzie istniejącym w kategorii dystrybuującej do tego ObjectType → 422
+- [ ] AC-3: Ten sam kod w innym ObjectType (niepowiązanym) → dozwolone
+- [ ] AC-4: UI hint sufiksu kategorii przy tworzeniu atrybutu kontekstowego
+
+**Files affected:** `src/Catalog/Validator/AttributeCodeUniquenessValidator.php`, `src/Catalog/Controller/AttributeController.php`
+
+**Testing:** Unit (walidator — kolizje base/category/cross-objecttype) + integration (endpoint 422).
+
+**DoD:** AC + PHPStan max + CI green.
+
+---
+
+## MOD-05 / #897: feat(catalog): typ atrybutu `relation` — backend konfiguracja w Modelowaniu
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **6-8h**
+
+**Dependencies:** Blocks MOD-06, MOD-13. Blocked by MOD-01, MOD-02.
+
+**Risk flags:**
+- `relation_target_object_type_ids` JSONB — walidacja że wskazane ObjectType istnieją w tenant.
+- Zmiana target ObjectType na istniejącym atrybucie relation z danymi → orphaned object_relations (powiązania do ObjectType już niedozwolonego).
+
+**Cel:** Obsłużyć typ atrybutu `relation` w Modelowaniu — definicja, konfiguracja (target, cardinality, advanced), walidacja.
+
+**Scope:**
+- Atrybut typu `relation` — config: `relation_target_object_type_ids` (1+ ObjectType), `relation_cardinality` (one/many), `relation_advanced` (bool).
+- Walidacja: target ObjectType istnieją; przy `cardinality=one` — max 1 powiązanie per obiekt-źródło.
+- Walidacja zmiany konfiguracji na atrybucie z danymi — ostrzeżenie/blokada gdy zmiana target unieważnia istniejące powiązania.
+- API: `POST/PATCH /api/attributes` obsługuje typ `relation` + jego config.
+
+**Acceptance criteria:**
+- [ ] AC-1: Utworzenie atrybutu `relation` z target=[Brand], cardinality=one → zapisane
+- [ ] AC-2: Utworzenie z target=[Product], cardinality=many, advanced=true → zapisane
+- [ ] AC-3: Target wskazujący nieistniejący ObjectType → 422
+- [ ] AC-4: Zmiana target na atrybucie z istniejącymi powiązaniami → ostrzeżenie z liczbą affected
+- [ ] AC-5: cardinality=one — drugie powiązanie dla tego samego źródła → odrzucone
+
+**Files affected:** `src/Catalog/Entity/Attribute.php`, `src/Catalog/Validator/RelationAttributeValidator.php`, `src/Catalog/Controller/AttributeController.php`
+
+**Testing:** Unit (walidacja config) + integration (CRUD atrybutu relation).
+
+**DoD:** AC + PHPStan max + CI green.
+
+---
+
+## MOD-06 / #898: feat(catalog): object_relations CRUD — backend endpointy
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **6-8h**
+
+**Dependencies:** Blocks MOD-07, MOD-08, MOD-12. Blocked by MOD-05.
+
+**Risk flags:**
+- Cardinality enforcement — `one` pozwala max 1 wiersz `object_relations` per (source, attribute).
+- `position` reorder — atomic update przy drag-drop wielu wierszy.
+- Cross-tenant — powiązanie tylko między obiektami tego samego tenant.
+
+**Cel:** CRUD powiązań obiekt↔obiekt — endpointy do dodawania/usuwania/reorder relacji per atrybut.
+
+**Scope:**
+- `GET /api/objects/{id}/relations` — powiązania obiektu pogrupowane per atrybut relation.
+- `PUT /api/objects/{id}/relations/{attributeCode}` — ustaw powiązania dla danego atrybutu (lista target_object_id + position). Atomic.
+- `DELETE /api/objects/{id}/relations/{attributeCode}/{targetId}` — usuń pojedyncze powiązanie.
+- Cardinality enforcement (one → max 1).
+- Cross-tenant guard — target musi być w tym samym tenant.
+- Walidacja — target ObjectType zgodny z `relation_target_object_type_ids` atrybutu.
+
+**Acceptance criteria:**
+- [ ] AC-1: PUT relations dla atrybutu many → lista powiązań zapisana z position
+- [ ] AC-2: PUT dla atrybutu one z 2 targetami → 422
+- [ ] AC-3: Powiązanie do obiektu spoza dozwolonego ObjectType → 422
+- [ ] AC-4: Powiązanie cross-tenant → 403/404
+- [ ] AC-5: DELETE pojedynczego powiązania → usunięte, reszta nienaruszona
+- [ ] AC-6: Reorder (PUT z nową kolejnością position) → atomic
+
+**Files affected:** `src/Catalog/Controller/ObjectRelationController.php`, `src/Catalog/Domain/Service/ObjectRelationService.php`
+
+**Testing:** Integration (CRUD + cardinality + cross-tenant).
+
+**DoD:** AC + cross-tenant test + CI green.
+
+---
+
+## MOD-07 / #899: feat(catalog): reverse relations — query + endpoint
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **4-6h**
+
+**Dependencies:** Blocks MOD-12. Blocked by MOD-06.
+
+**Risk flags:**
+- Reverse lookup przy 200k+ SKU — `idx_object_relations_target` (z MOD-02) krytyczny dla performance.
+- Reverse to read-only — żadnej edycji po stronie targetu.
+
+**Cel:** Powiązania zwrotne — obiekt-target widzi read-only kto na niego wskazuje.
+
+**Scope:**
+- `GET /api/objects/{id}/relations/reverse` — lista *„obiekt X wskazuje na mnie przez atrybut Y"*.
+- Grupowanie per (source ObjectType, atrybut) — np. *„up-sell dla: [Product A, Product B]"*.
+- Read-only — brak endpointów modyfikujących reverse.
+- Performance — query po `idx_object_relations_target`.
+
+**Acceptance criteria:**
+- [ ] AC-1: Obiekt B (target up_sell z A) — `GET .../reverse` zwraca A z atrybutem `up_sell`
+- [ ] AC-2: Reverse pogrupowane per atrybut źródłowy
+- [ ] AC-3: Brak powiązań zwrotnych → pusta lista (nie błąd)
+- [ ] AC-4: Performance — reverse lookup <100ms na dataset 50k+ powiązań
+
+**Files affected:** `src/Catalog/Controller/ObjectRelationController.php` (rozszerzenie), `src/Catalog/Domain/Service/ObjectRelationService.php`
+
+**Testing:** Integration (reverse lookup) + performance (50k+ powiązań benchmark).
+
+**DoD:** AC + benchmark w PR + CI green.
+
+---
+
+## MOD-08 / #900: feat(catalog): advanced relations — metadata na powiązaniu
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **8-12h**
+
+**Dependencies:** Blocks MOD-12. Blocked by MOD-06.
+
+**Risk flags:**
+- Advanced relation podwaja złożoność — `metadata JSONB` ma własny schemat per atrybut (pola metadanych zdefiniowane w konfiguracji atrybutu relation).
+- Walidacja metadanych — typy pól, required.
+
+**Cel:** Relacje z metadanymi — powiązanie ma własne pola (np. `priorytet`, `rekomendowane`).
+
+**Scope:**
+- Konfiguracja atrybutu `relation` z `advanced=true` — definicja pól metadanych (kod, typ, label, required) w config atrybutu.
+- `object_relations.metadata JSONB` — przechowuje wartości pól metadanych per powiązanie.
+- Walidacja metadanych przy PUT/PATCH relations — zgodność z definicją pól.
+- Endpoint `PUT /api/objects/{id}/relations/{attributeCode}` — body powiązań zawiera `metadata` per target.
+
+**Acceptance criteria:**
+- [ ] AC-1: Atrybut relation advanced z polami metadanych [priorytet:number, rekomendowane:boolean]
+- [ ] AC-2: PUT relations z metadata per powiązanie → zapisane w `object_relations.metadata`
+- [ ] AC-3: Walidacja — metadata niezgodne z definicją (zły typ) → 422
+- [ ] AC-4: Required field metadanych pusty → 422
+- [ ] AC-5: Atrybut relation `advanced=false` — metadata ignorowane/odrzucone
+
+**Files affected:** `src/Catalog/Domain/Service/ObjectRelationService.php`, `src/Catalog/Validator/RelationMetadataValidator.php`
+
+**Testing:** Unit (walidacja metadanych) + integration (CRUD z metadata).
+
+**DoD:** AC + PHPStan max + CI green.
+
+---
+
+## MOD-09 / #901: feat(catalog): orphaned values — handling przy zmianie primary category
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **4-6h**
+
+**Dependencies:** Blocked by MOD-01, MOD-03.
+
+**Risk flags:**
+- Orphaned values **NIE są kasowane** — pozostają w `object_values`, ukryte. Błąd = utrata danych klienta przy zmianie kategorii.
+
+**Cel:** Zmiana primary category → atrybuty spoza nowego modelu znikają z formularza, ale wartości zostają w bazie (ukryte, reaktywowalne).
+
+**Scope:**
+- Przy zmianie primary category obiektu — przelicz efektywny model (resolver MOD-03).
+- Wartości atrybutów spoza nowego efektywnego modelu — **pozostają** w `object_values`, oznaczone jako poza-modelem (filtrowane przy renderze form-schema).
+- Powrót do poprzedniej primary category → wartości wracają widoczne.
+- Brak zmiany schematu — logika filtrowania w resolverze/serializerze form-schema.
+- Completeness — orphaned values NIE liczą się do completeness (poza modelem).
+
+**Acceptance criteria:**
+- [ ] AC-1: Produkt z `przekatna=55"`, zmiana primary category na „Pralki" → `przekatna` znika z form-schema, wartość zostaje w `object_values`
+- [ ] AC-2: Powrót do „Telewizory" → `przekatna=55"` wraca widoczne
+- [ ] AC-3: Orphaned value nie liczy się do completeness
+- [ ] AC-4: form-schema nie renderuje orphaned values
+
+**Files affected:** `src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php` (filtrowanie), `src/Catalog/Domain/Service/CompletenessCalculator.php`
+
+**Testing:** Integration (zmiana kategorii → orphaned → powrót).
+
+**DoD:** AC + smoke test (zmiana kategorii, wartość zachowana) + CI green.
+
+---
+
+## MOD-10 / #902: feat(catalog): migracja built-in „Marki" — usunięcie z puli built-in
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **3-5h**
+
+**Dependencies:** Blocked by MOD-01.
+
+**Risk flags:**
+- Migracja destrukcyjna jeśli źle — Marka może być używana przez tenantów. Audyt stanu PRZED migration script.
+- Per-tenant decyzja — Marka używana jako ObjectType (zostaje custom) vs nieużywana (usuwana).
+
+**Cel:** Usunąć Brand z puli built-in ObjectType (REVERT ADR-012). Migracja istniejącej „Marki".
+
+**Scope:**
+- Audyt: czy/jak „Marka" istnieje w bazie (built-in ObjectType? atrybut? per tenant).
+- Migration script:
+  - Marka jako ObjectType **używany** (ma instancje) → konwersja na custom ObjectType (`is_built_in=false`).
+  - Marka jako ObjectType **nieużywany** (0 instancji) → usunięcie.
+  - Built-in pula → wyłącznie Product/Category/Asset.
+- Seed/fixtures — usunąć Brand z built-in seed.
+
+**Acceptance criteria:**
+- [ ] AC-1: Audyt stanu „Marki" udokumentowany w PR description
+- [ ] AC-2: Marka z instancjami → custom ObjectType, instancje zachowane
+- [ ] AC-3: Marka bez instancji → usunięta
+- [ ] AC-4: Built-in pula = Product/Category/Asset (test: query is_built_in)
+- [ ] AC-5: Migracja DOWN — rollback path (lub udokumentowane czemu nieodwracalna)
+
+**Files affected:** `src/Catalog/Doctrine/Migrations/Version*.php`, seed/fixtures built-in ObjectType
+
+**Testing:** Integration (migracja per scenariusz: używana/nieużywana).
+
+**DoD:** AC + audyt w PR + smoke test + CI green.
+
+---
+
+## MOD-11 / #903: feat(admin): modal create obiektu (krok primary category) + capability flags toggles
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **6-8h**
+
+**Dependencies:** Blocked by MOD-01, MOD-03.
+
+**Risk flags:**
+- Modal create rozgałęzia się per `is_categorizable` — kategoryzowalny ma krok kategorii, nie-kategoryzowalny pomija.
+
+**Cel:** Frontend — modal tworzenia obiektu z krokiem wyboru primary category (dla kategoryzowalnych) + toggles capability flags w edycji ObjectType.
+
+**Scope:**
+- Modal create obiektu kategoryzowalnego — krok 1: wybór primary category (wymuszone, zaczytuje atrybuty), info hint.
+- Modal create obiektu nie-kategoryzowalnego — pomija krok kategorii, od razu formularz.
+- Edycja ObjectType — toggles `show_in_main_menu` + `is_categorizable`.
+- Sidebar — reaguje na `show_in_main_menu` (ObjectType z `false` znika z menu).
+- `/modeling/categories` select „Object Type" — filtruje do `is_categorizable=true`.
+
+**Acceptance criteria:**
+- [ ] AC-1: Tworzenie Produktu → modal wymusza primary category, formatka zaczytuje atrybuty cumulative
+- [ ] AC-2: Tworzenie nie-kategoryzowalnego ObjectType → modal bez kroku kategorii
+- [ ] AC-3: Toggle `show_in_main_menu=false` → ObjectType znika z sidebar
+- [ ] AC-4: `/modeling/categories` select pokazuje tylko `is_categorizable=true`
+- [ ] AC-5: E2E — pełen flow tworzenia produktu z kategorią
+
+**Files affected:** `apps/admin/src/components/modeling/CreateObjectModal.tsx`, `apps/admin/src/components/modeling/ObjectTypeEditor.tsx`, `apps/admin/src/components/Sidebar.tsx`
+
+**Testing:** Unit (Vitest) + E2E Playwright (create flow per ObjectType type).
+
+**DoD:** AC + E2E + CI green.
+
+---
+
+## MOD-12 / #904: feat(admin): zakładka „Powiązania" — picker / grid / advanced / reverse
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **12-16h**
+
+**Dependencies:** Blocked by MOD-06, MOD-07, MOD-08.
+
+**Risk flags:**
+- Najcięższy ticket frontendowy. 4 tryby renderu (one/many/advanced/reverse) w jednej zakładce.
+- Grid reorder drag-drop + edycja metadanych inline (advanced).
+
+**Cel:** Frontend — zakładka „Powiązania" w formularzu edycji obiektu, renderująca atrybuty typu `relation`.
+
+**Scope:**
+- Zakładka „Powiązania" = AttributeGroup z atrybutami typu `relation`.
+- Atrybut `cardinality=one` → picker (jedna referencja, modal wyboru obiektu).
+- Atrybut `cardinality=many` → grid: lista powiązań, dodaj (picker)/usuń/reorder drag-drop.
+- Atrybut `advanced=true` → grid z edytowalnymi kolumnami metadanych.
+- Sekcja read-only *„Powiązania zwrotne"* — auto-generowana z `GET .../relations/reverse`.
+- Picker obiektu — search + filtr po dozwolonych ObjectType.
+
+**Acceptance criteria:**
+- [ ] AC-1: Atrybut relation one → picker, wybór jednego obiektu
+- [ ] AC-2: Atrybut relation many → grid, dodawanie/usuwanie/reorder
+- [ ] AC-3: Atrybut advanced → grid z edycją metadanych per wiersz
+- [ ] AC-4: Sekcja „Powiązania zwrotne" renderuje reverse, read-only
+- [ ] AC-5: Picker filtruje obiekty do dozwolonych target ObjectType
+- [ ] AC-6: E2E — dodanie up-sell, sprawdzenie reverse u targetu
+
+**Files affected:** `apps/admin/src/components/object-editor/RelationsTab.tsx`, `RelationPicker.tsx`, `RelationGrid.tsx`, `ReverseRelationsSection.tsx`
+
+**Testing:** Unit (Vitest) + E2E Playwright (dodanie relacji + reverse — analog US-MOD-004/005).
+
+**DoD:** AC + E2E + accessibility (axe-core) + CI green.
+
+---
+
+## MOD-13 / #905: feat(admin): konfigurator atrybutu `relation` w Modelowaniu
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **6-8h**
+
+**Dependencies:** Blocked by MOD-05.
+
+**Risk flags:**
+- Konfigurator advanced — definicja pól metadanych (dynamiczna lista kod/typ/label/required).
+
+**Cel:** Frontend — UI dodawania/edycji atrybutu typu `relation` w Modelowaniu.
+
+**Scope:**
+- W edytorze atrybutu — wybór typu `relation` odsłania konfigurator:
+  - Target ObjectType — multi-select z listy ObjectType tenanta.
+  - Cardinality — radio one/many.
+  - Advanced — toggle; gdy ON → edytor pól metadanych (lista: kod, typ, label, required).
+- Walidacja po stronie UI + obsługa błędów 422 z backendu (MOD-05).
+
+**Acceptance criteria:**
+- [ ] AC-1: Wybór typu `relation` → konfigurator widoczny
+- [ ] AC-2: Multi-select target ObjectType działa
+- [ ] AC-3: Toggle advanced → edytor pól metadanych
+- [ ] AC-4: Zapis → atrybut relation z config zapisany (integracja z MOD-05)
+- [ ] AC-5: Błąd 422 z backendu → czytelny komunikat
+
+**Files affected:** `apps/admin/src/components/modeling/AttributeEditor.tsx`, `RelationConfigPanel.tsx`
+
+**Testing:** Unit (Vitest) + E2E (utworzenie atrybutu relation — analog US-MOD-002).
+
+**DoD:** AC + E2E + CI green.
+
+---
+
+## MOD-14 / #906: docs(modeling): update epik-08-modelowanie.md — capability flags + relacje + primary category
+
+**Typ:** `docs` | **Epik:** UI-08 | **Estymacja:** **2-3h**
+
+**Dependencies:** Równolegle (brak blokad).
+
+**Cel:** Zaktualizować `epik-08-modelowanie.md` o decyzje ADR-014 — capability flags, relacje jako typ atrybutu, primary/secondary categories, naprawa #3-#28.
+
+**Scope:**
+- Sekcje epiku dotyczące modelu atrybutów — dopisać warstwę base + primary category overlay cumulative.
+- Dodać sekcję relacji (typ atrybutu `relation`, reverse, advanced).
+- Dodać capability flags ObjectType.
+- Cross-reference do ADR-014 + `feature-modeling-data-model.md`.
+- Usunąć/poprawić wzmianki o Brand jako built-in (jeśli są).
+
+**Acceptance criteria:**
+- [ ] AC-1: Epik zawiera model dwuwarstwowy + cumulative
+- [ ] AC-2: Sekcja relacji dodana
+- [ ] AC-3: Capability flags udokumentowane
+- [ ] AC-4: Cross-reference do ADR-014 + mini-spec
+- [ ] AC-5: Brak nieaktualnych wzmianek o Brand built-in
+
+**Files affected:** `Project Plan/UI/epik-08-modelowanie.md`
+
+**Testing:** N/A (dokumentacja) — review spójności z ADR-014.
+
+**DoD:** AC + review + merge.
+
+---
+
+## Podsumowanie
+
+| Ticket | Estymacja | Warstwa |
+|---|---|---|
+| MOD-01 schema flags | 4-6h | Backend foundation |
+| MOD-02 object_relations + migracja | 4-6h | Backend foundation |
+| MOD-03 resolver fix (#3-#28) | 5-8h | Backend |
+| MOD-04 walidacja kodów | 3-4h | Backend |
+| MOD-05 typ relation config | 6-8h | Backend |
+| MOD-06 relations CRUD | 6-8h | Backend |
+| MOD-07 reverse relations | 4-6h | Backend |
+| MOD-08 advanced relations | 8-12h | Backend |
+| MOD-09 orphaned values | 4-6h | Backend |
+| MOD-10 migracja Marki | 3-5h | Backend |
+| MOD-11 frontend modal + flags | 6-8h | Frontend |
+| MOD-12 frontend Powiązania | 12-16h | Frontend |
+| MOD-13 frontend konfigurator relation | 6-8h | Frontend |
+| MOD-14 docs epik-08 | 2-3h | Docs |
+| **TOTAL** | **~73-104h** | 14 ticketów |
+
+~2-3 tygodnie solo dev. Blokujące dla dalszego CRUD-u obiektów w epiku UI-08.
+
+**Sugerowana kolejność:** MOD-01 + MOD-02 (foundation, równolegle) → MOD-03/04/05/09/10 → MOD-06 → MOD-07/08 → MOD-11/13 → MOD-12 → MOD-14 (równolegle w dowolnym momencie).
+
+---
+
+*Backlog wygenerowany 2026-05-23 jako realizacja ADR-014. Agent kodujący: utwórz GitHub Issues z tych ticketów (tytuł = nagłówek `## MOD-NN:` bez prefiksu, body = treść ticketu, labels `modeling`+`adr-014`+`epik-ui-08`). Per ticket dotykający >3 plików — Plan Mode przed implementacją (CLAUDE.md).*

--- a/Project Plan/UI/feature-modeling-data-model.md
+++ b/Project Plan/UI/feature-modeling-data-model.md
@@ -1,0 +1,261 @@
+# Feature (mini-spec) — Model danych Modelowania: dystrybucja atrybutów + relacje
+
+## Status: 🟢 szczegół (mini-spec) — kontrakt implementacyjny dla ADR-014
+
+> **Mini-spec** realizujący [ADR-014](../01-architektura-pim.md) (*„Model dystrybucji atrybutów + relacje obiekt↔obiekt"*). Powstał z sesji burzy mózgów 2026-05-23 po wykryciu 4 nieścisłości w Modelowaniu przy ~60% systemu.
+> **Rewiduje:** ADR-012 w 3 punktach (Brand built-in, `category_attribute_groups` semantyka, `EffectiveAttributeGroupResolver` źródło bazowe).
+> **Wzorzec:** Akeneo (dziedziczenie grup po drzewie) + Pimcore (relacja jako typ pola, capability flags) + świadome uproszczenie (primary category zamiast osobnego bytu Family).
+
+---
+
+## 1. Cel
+
+Naprawić niespójny model dystrybucji atrybutów. Root cause: system zahardkodował kategorię jako jedyny mechanizm przydziału atrybutów — działa dla Produktu, łamie się dla każdego nie-kategoryzowanego ObjectType. Mini-spec ustala **jeden spójny model** obejmujący: ObjectType base + primary category overlay, relacje obiekt↔obiekt, capability flags, naprawę objawu #3-#28, migrację „Marki".
+
+## 2. Model dystrybucji atrybutów
+
+### 2.1 Dwa źródła atrybutów
+
+Każda instancja obiektu dostaje atrybuty z **dwóch warstw**:
+
+```
+WARSTWA 1 — ObjectType base (ZAWSZE, dla każdego ObjectType)
+   Atrybuty / grupy atrybutów przypisane bezpośrednio do ObjectType.
+   Działa identycznie dla Product, Category, Asset, Service, Brand — wszystkich.
+   To naprawia objaw #3-#28: Category-jako-ObjectType renderuje swoje
+   atrybuty bazowe (name, seo_title...) niezależnie od kategoryzacji.
+
+WARSTWA 2 — Primary category overlay (TYLKO ObjectType z is_categorizable=true)
+   Instancja ma 1 kategorię główną (primary). Jej ścieżka w drzewie
+   kategorii dodaje kontekstowe grupy atrybutów — KUMULATYWNIE root→leaf.
+```
+
+### 2.2 Cumulative resolution po ścieżce drzewa
+
+Produkt z primary category liść `Elektronika > RTV > Telewizory`:
+
+```
+ObjectType "Product" base:        name, sku, price, status        (warstwa 1)
++ kategoria "Elektronika":        gwarancja, marka                 (warstwa 2, root)
++ kategoria "RTV":                klasa_energetyczna                (warstwa 2)
++ kategoria "Telewizory":         przekatna, rozdzielczosc          (warstwa 2, liść)
+─────────────────────────────────────────────────────────────────
+= efektywny zestaw atrybutów produktu (suma)
+```
+
+Wspólne atrybuty definiowane wysoko w drzewie (DRY), specyficzne nisko. `EffectiveAttributeGroupResolver` (z ADR-012) parametryzowany **primary category path**, nie zbiorem wszystkich kategorii obiektu.
+
+### 2.3 Primary vs secondary categories
+
+- **Primary category** — dokładnie 1 per obiekt kategoryzowalny. Jest attribute-driverem (warstwa 2). Wybierana w modalu tworzenia obiektu (krok 1, wymuszone — zaczytuje atrybuty do formatki).
+- **Secondary categories** — N dodatkowych. Wyłącznie klasyfikacja / nawigacja w drzewie. Zero wpływu na atrybuty.
+
+### 2.4 Capability flags ObjectType
+
+| Flaga | Znaczenie | Domyślnie |
+|---|---|---|
+| `expose_to_main_menu` *(canonical column name; we dropped `show_in_main_menu` rename — column existed since VIEW-08 / #427)* | Czy ObjectType ma własną pozycję w sidebar admina | `true` dla standalone (Product, Service) |
+| `is_categorizable` | Czy instancje mają kategorię główną (warstwa 2 aktywna) | `true` Product, `false` Category/Asset/Brand |
+
+**Brak flagi `is_relation_target`** — każdy ObjectType może być celem relacji domyślnie (decyzja: relacja jest własnością ObjectType-źródła, nie targetu).
+
+## 3. Relacje obiekt↔obiekt
+
+### 3.1 Relacja = typ atrybutu `relation`
+
+Relacja **nie jest osobnym bytem** — to typ atrybutu obok `text`, `number`, `select`, `asset`. W Modelowaniu ObjectType dodajesz atrybut typu `relation` z konfiguracją:
+
+```
+Atrybut typu `relation`:
+  ├─ target_object_type:  [Brand]  lub multi: [Product, Service]
+  ├─ cardinality:         one (jedna referencja) | many (lista)
+  ├─ advanced:            false (prosta referencja)
+  │                       true  (relacja z metadanymi — własne pola na powiązaniu)
+  └─ attribute_group:     dowolna grupa (np. "Powiązania")
+```
+
+### 3.2 Reverse relations (Pimcore-style)
+
+Relacje są **dwukierunkowe w odczycie**. Product A ma `up_sell → Product B`. Obiekt B w zakładce „Powiązania" widzi auto-generowaną **read-only** sekcję *„Powiązania zwrotne: jestem up-sellem dla → [A]"*. Reverse generowany przez query po `object_relations`, nieedytowalny (edycja tylko po stronie źródła).
+
+### 3.3 Advanced relations (metadane na powiązaniu)
+
+Gdy `advanced=true`, powiązanie ma **własne pola** (np. Product → akcesoria, każde akcesorium z polem `priorytet` / `rekomendowane`). Metadane w `object_relations.metadata JSONB`. UI grid powiązań pozwala edytować metadane per wiersz.
+
+### 3.4 Asset = osobny typ (nie relacja)
+
+Typ atrybutu `asset` pozostaje **odrębny** od `relation`. Asset ma specjalizowany UX (DAM picker, miniaturka, kadrowanie, upload) — ujednolicanie z `relation` byłoby sztuczne. `main_image`, `gallery` to typ `asset`, nie `relation→Asset`.
+
+### 3.5 Zakładka „Powiązania"
+
+Atrybuty typu `relation` wpadają do AttributeGroup (jak każdy atrybut). Domyślnie grupa „Powiązania" → renderuje się jako zakładka w formularzu edycji. *(Decyzja Marcina: wszystkie relacje w jednej fixed zakładce „Powiązania". Uwaga implementacyjna: technicznie relacja jest zwykłym atrybutem w grupie — „fixed" oznacza seed grupy „Powiązania" jako domyślny target dla atrybutów `relation`, nie hardcoded osobny mechanizm.)*
+
+## 4. Schema (delta)
+
+> **Stan w kodzie (po MOD-01 / #893):** część schematu była już zaimplementowana wcześniejszymi ticketami. MOD-01 dodaje **tylko 4 nowe kolumny** (1 na `object_types`, 3 na `attributes`). Junction `object_categories` z `is_primary` istnieje od PCAT-01 (`Version20260510221123`). `AttributeType::Relation` enum case istniał od pierwszej iteracji backlogu (#31).
+
+```sql
+-- ObjectType — capability flags
+-- show_in_main_menu reuses existing `expose_to_main_menu` column (VIEW-08 / #427); brak rename.
+ALTER TABLE object_types ADD COLUMN is_categorizable BOOLEAN NOT NULL DEFAULT false;
+
+-- Obiekt ↔ kategoria — primary flag (JUŻ ISTNIEJE od PCAT-01 / Version20260510221123)
+-- ALTER TABLE object_categories ADD COLUMN is_primary BOOLEAN NOT NULL DEFAULT false;
+-- CREATE UNIQUE INDEX object_categories_one_primary_per_object
+--     ON object_categories(object_id) WHERE is_primary = true;
+
+-- Atrybut typu relation — konfiguracja (MOD-01 / #893)
+ALTER TABLE attributes ADD COLUMN relation_target_object_type_ids JSONB NOT NULL DEFAULT '[]'::JSONB;
+ALTER TABLE attributes ADD COLUMN relation_cardinality VARCHAR(8) DEFAULT NULL;
+ALTER TABLE attributes ADD CONSTRAINT attributes_relation_cardinality_chk
+    CHECK (relation_cardinality IS NULL OR relation_cardinality IN ('one', 'many'));
+ALTER TABLE attributes ADD COLUMN relation_advanced BOOLEAN NOT NULL DEFAULT false;
+-- type='relation' już istnieje w enumie AttributeType (AttributeType.php:36) od #31
+
+-- Powiązania obiekt↔obiekt
+CREATE TABLE object_relations (
+    id                UUID PRIMARY KEY,
+    tenant_id         UUID NOT NULL REFERENCES tenants(id),
+    source_object_id  UUID NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+    target_object_id  UUID NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+    attribute_id      UUID NOT NULL REFERENCES attributes(id),  -- który atrybut relation
+    position          INTEGER NOT NULL DEFAULT 0,               -- kolejność w grid (many)
+    metadata          JSONB DEFAULT '{}'::JSONB,                 -- advanced relations
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_object_relations_source ON object_relations(source_object_id, attribute_id);
+CREATE INDEX idx_object_relations_target ON object_relations(target_object_id);  -- reverse lookup
+```
+
+**Uwagi:**
+- `idx_object_relations_target` — krytyczny dla reverse relations performance przy 200k+ SKU.
+- **`object_associations` (ADR-009) zastępowane przez `object_relations`** (decyzja 2026-05-23). ADR-009 miał hardcoded enum `type` (cross_sell/up_sell/related/alternative/accessory). ADR-014 generalizuje: każdy typ → seedowany built-in atrybut typu `relation` na ObjectType Product. Migracja: utworzyć 5 atrybutów `relation`, przepisać wiersze `object_associations` (`type` → odpowiedni `attribute_id`) na `object_relations`, DROP `object_associations`.
+- Orphaned values — brak zmiany schematu; `object_values` zachowuje wartości atrybutów spoza efektywnego modelu (filtrowane przy renderze formularza).
+
+## 5. Kolizja kodów + konwencja nazewnicza
+
+- Kod atrybutu **globalnie unikalny w obrębie ObjectType**. Atrybut jest albo bazowy (warstwa 1), albo kontekstowy (warstwa 2 — przypisany do kategorii) — nigdy oba.
+- Walidacja w Modelowaniu **blokuje** dodanie atrybutu o kodzie który już istnieje w modelu ObjectType (bazowym lub w którejkolwiek kategorii dystrybuującej do tego ObjectType).
+- **Konwencja:** atrybuty kontekstowe z sufiksem kategorii — `opis_telewizory`, `opis_buty`, `material_buty`. Zapobiega kolizjom, czyni model czytelnym (od razu widać do której kategorii atrybut należy).
+
+## 6. Orphaned values (zmiana primary category)
+
+Telewizor ma `przekatna=55"`. Zmiana primary category na „Pralki" → `przekatna` znika z efektywnego modelu. Wartość:
+- **Pozostaje w `object_values`** — ukryta, nieedytowalna.
+- Powrót do kategorii „Telewizory" → wartość wraca, widoczna.
+- UI formularza nie renderuje orphaned values (są poza efektywnym modelem). Opcjonalnie: sekcja diagnostyczna *„wartości spoza modelu"* — Faza 1+, nie MVP.
+
+## 7. UX
+
+### 7.1 Modal tworzenia obiektu (kategoryzowalny ObjectType)
+
+```
+┌─ Nowy Produkt — krok 1: Kategoria główna ──────────────┐
+│                                                         │
+│  Wybierz kategorię główną (określa atrybuty):           │
+│  [Elektronika > RTV > Telewizory          ▼]            │
+│                                                         │
+│  ℹ Kategoria główna zaczytuje kontekstowe atrybuty.     │
+│    Dodatkowe kategorie przypiszesz po utworzeniu.       │
+│                                                         │
+│                                  [Anuluj]  [Dalej →]   │
+└─────────────────────────────────────────────────────────┘
+```
+
+ObjectType **nie-kategoryzowalny** (Brand, Service bez kategorii) — modal pomija krok kategorii, od razu formularz z atrybutami bazowymi.
+
+### 7.2 Formularz edycji — zakładki
+
+- Zakładki = AttributeGroups efektywnego modelu (warstwa 1 + warstwa 2 cumulative).
+- Atrybuty typu `relation` → zakładka „Powiązania":
+  - `cardinality=one` → picker (jedna referencja, np. Brand)
+  - `cardinality=many` → grid z listą, dodaj/usuń/reorder; advanced → edytowalne kolumny metadanych
+  - Sekcja read-only *„Powiązania zwrotne"* — auto-generowana z reverse lookup
+
+### 7.3 Modelowanie ObjectType
+
+- Capability flags `expose_to_main_menu` + `is_categorizable` jako toggles w edycji ObjectType.
+- Dodanie atrybutu typu `relation` → konfigurator: target ObjectType(s), cardinality, advanced toggle.
+- `/modeling/categories` select „Object Type" — filtruje tylko do ObjectType z `is_categorizable=true`.
+
+## 8. Migracja + naprawa objawów
+
+| Objaw | Naprawa |
+|---|---|
+| #1 Marka built-in | Usunięcie Brand z puli built-in. Migracja istniejącej „Marki": jeśli używana jako ObjectType → zostaje jako custom ObjectType; jeśli nie używana → usuwana. Decyzja per stan tenanta w migration script. |
+| #2 Brak relacji | Typ atrybutu `relation` + `object_relations` + zakładka „Powiązania" + reverse. |
+| #3-#28 Category nie renderuje atrybutów | Fix `EffectiveAttributeGroupResolver` źródło (2) — zwraca atrybuty bazowe ObjectType **zawsze**, niezależnie od kategoryzacji. |
+| #4 Każdy ObjectType kategoryzowany | Flaga `is_categorizable`; UI Modelowania i `/modeling/categories` reagują na flagę. |
+
+## 9. Permissions (RBAC)
+
+- Modelowanie ObjectType / atrybutów / relacji → permission `modeling.*` (z macierzy RBAC §3.2 — Modeler, Owner, Admin).
+- Dodanie/zmiana relacji w instancji obiektu → permission edycji danego ObjectType (`products.edit` itd.).
+- Capability flags edycja → `modeling.object_types.edit`.
+
+## 10. API endpoints (delta)
+
+| Endpoint | Metoda | Cel |
+|---|---|---|
+| `/api/object-types/{id}` | PATCH | Update capability flags (expose_to_main_menu, is_categorizable) |
+| `/api/objects/{id}/form-schema` | GET | Efektywny model atrybutów (warstwa 1 + 2 cumulative) — istniejący, parametryzowany primary category |
+| `/api/objects/{id}/categories` | PUT | Przypisanie kategorii (1 primary + N secondary) |
+| `/api/objects/{id}/relations` | GET/PUT | Powiązania obiektu (per atrybut relation) |
+| `/api/objects/{id}/relations/reverse` | GET | Powiązania zwrotne (read-only) |
+| `/api/attributes` | POST/PATCH | Obsługa typu `relation` + walidacja unikalności kodu |
+
+## 11. User stories
+
+| ID | Persona | Story |
+|---|---|---|
+| US-MOD-001 | Adam | Tworzy custom ObjectType „Service", ustawia `is_categorizable=false` — instancje nie wymagają kategorii |
+| US-MOD-002 | Adam | Dodaje atrybut `up_sell` typu `relation`, target=Product, cardinality=many — pojawia się zakładka „Powiązania" |
+| US-MOD-003 | Kasia | Tworzy Produkt — modal wymusza wybór kategorii głównej, formatka zaczytuje atrybuty kumulatywnie ze ścieżki drzewa |
+| US-MOD-004 | Kasia | Edytuje Telewizor — w zakładce „Powiązania" dodaje 3 produkty up-sell przez grid |
+| US-MOD-005 | Kasia | Otwiera Produkt B — widzi read-only sekcję *„jestem up-sellem dla: A"* |
+| US-MOD-006 | Adam | Tworzy atrybut `opis_telewizory` w kategorii Telewizory — walidacja przechodzi (unikalny kod) |
+| US-MOD-007 | Adam | Próbuje dodać drugi atrybut o kodzie `opis` — walidacja blokuje (kolizja z bazowym) |
+| US-MOD-008 | Kasia | Zmienia primary category Telewizora na „Pralki" — `przekatna` znika z formatki, wartość zachowana ukryta |
+| US-MOD-009 | Adam | Edytuje ObjectType „Brand", ustawia `expose_to_main_menu=false` — Brand znika z sidebar, dostępny tylko jako target relacji |
+| US-MOD-010 | Adam | Dodaje atrybut `akcesoria` typu `relation` advanced — każde powiązanie ma pole `priorytet` |
+
+## 12. Out of scope (MVP)
+
+- ❌ **Family jako osobny byt** — świadomie odrzucone (ADR-014 opcja Z). Primary category wystarcza.
+- ❌ **Sekcja diagnostyczna orphaned values** w UI — Faza 1+. MVP: orphaned po prostu ukryte.
+- ❌ **Relacje wielopoziomowe / przechodnie** (A→B→C auto-discovery) — Faza 2.
+- ❌ **`visible_when` reguły composite** dla relacji — proste tak/nie z ADR-012, composite Faza 1.
+- ❌ **Multi-tab dla relacji** (osobne „Powiązania handlowe" / „techniczne") — MVP: jedna zakładka „Powiązania". *(Uwaga: technicznie relacja jest atrybutem w grupie — rozszerzenie do wielu zakładek to zmiana seedu grup, nie architektury.)*
+
+## 13. Estymacja
+
+| Element | Estymacja |
+|---|---|
+| Schema delta (capability flags, is_primary, relation config, object_relations) | 6-8h |
+| `EffectiveAttributeGroupResolver` — fix źródło (2) + primary category path param | 8-12h |
+| Typ atrybutu `relation` — backend (config, walidacja, CRUD object_relations) | 12-16h |
+| Reverse relations — query + endpoint + cache | 4-6h |
+| Advanced relations — metadata JSONB + grid edit logika | 8-12h |
+| Orphaned values — handling przy zmianie primary category | 4-6h |
+| Walidacja unikalności kodów atrybutów | 3-4h |
+| Migracja built-in „Marki" | 3-5h |
+| Frontend — modal create (krok kategoria), capability flags toggles | 6-8h |
+| Frontend — zakładka „Powiązania" (picker / grid / advanced / reverse) | 12-16h |
+| Frontend — konfigurator atrybutu `relation` w Modelowaniu | 6-8h |
+| Testy — unit + integration + E2E (cumulative resolution, relacje, orphaned) | 10-14h |
+| **TOTAL** | **~82-115h** |
+
+~12-15 ticketów, ~2-3 tygodnie solo dev. Wchodzi w epik UI-08 (Modelowanie) jako rewizja — blokujące dla dalszego CRUD-u obiektów.
+
+## 14. Co dalej
+
+1. Walidacja: czy `EffectiveAttributeGroupResolver` z ADR-012 jest już zaimplementowany (wtedy fix) czy nie (wtedy implementacja od zera).
+2. ~~Decyzja: `object_associations` reused czy nowa tabela~~ — **rozstrzygnięte 2026-05-23: zastępowane przez `object_relations`** (patrz §4 Uwagi).
+3. Update `epik-08-modelowanie.md` — capability flags + relacje + primary/secondary categories.
+4. Migracja „Marki" — audyt stanu w bazie przed napisaniem migration script.
+5. Wireframes — modal create (krok kategoria), zakładka „Powiązania" (picker/grid/reverse), konfigurator relacji.
+6. Rozpisanie ticketów (~12-15) gdy decyzja o starcie implementacji — analogicznie do RBAC backlog.
+
+---
+
+*Mini-spec wygenerowany 2026-05-23 jako kontrakt implementacyjny ADR-014. Status: 🟢 szczegół. Powstał z sesji burzy mózgów (4 fale) po wykryciu nieścisłości Modelowania przy ~60% systemu. Następna iteracja: walidacja stanu `EffectiveAttributeGroupResolver` + wireframes + rozpisanie ticketów.*

--- a/apps/api/migrations/Version20260524100000.php
+++ b/apps/api/migrations/Version20260524100000.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ADR-014 / MOD-01 (#893) — schema delta for capability flags + relation attribute config.
+ *
+ * Adds:
+ *   - `object_types.is_categorizable BOOLEAN` — gates whether instances of
+ *     this ObjectType participate in primary-category-driven attribute
+ *     distribution. Seeded `true` for `kind=product`, `false` otherwise.
+ *     The other capability flag from ADR-014 (`show_in_main_menu`) reuses
+ *     the existing `expose_to_main_menu` column (VIEW-08 / #427); no rename.
+ *
+ *   - `attributes.relation_target_object_type_ids JSONB DEFAULT '[]'` —
+ *     list of allowed target ObjectType IDs for attributes of type
+ *     `relation`. Empty list = unconstrained (any ObjectType acceptable).
+ *
+ *   - `attributes.relation_cardinality VARCHAR(8)` with CHECK constraint
+ *     limited to `('one', 'many')`. NULL for non-relation attribute types.
+ *
+ *   - `attributes.relation_advanced BOOLEAN DEFAULT false` — flips on
+ *     metadata-bearing relations (own fields on the link itself; UX
+ *     materialized in MOD-08).
+ *
+ * Two items from the MOD-01 spec are intentionally NOT included because
+ * they already exist in the schema:
+ *   - `object_categories.is_primary BOOLEAN` + partial unique index —
+ *     shipped in PCAT-01 (`Version20260510221123`).
+ *   - `AttributeType::Relation` enum case — already present in
+ *     `AttributeType` since the initial #31 backlog (line 36).
+ *
+ * Reversible: down() drops the four added columns. `is_categorizable`
+ * default propagates to all rows so the rollback is safe even for tenants
+ * created post-MOD-01.
+ */
+final class Version20260524100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-014 / MOD-01 (#893): add object_types.is_categorizable + attributes.relation_* config columns.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // ObjectType capability flag.
+        $this->addSql('ALTER TABLE object_types ADD COLUMN is_categorizable BOOLEAN NOT NULL DEFAULT false');
+
+        // Seed the historical Product-as-categorizable assumption. New tenants
+        // get the same default through BuiltInObjectTypeSeeder.
+        $this->addSql("UPDATE object_types SET is_categorizable = true WHERE kind = 'product'");
+
+        // Attribute relation-type config columns.
+        $this->addSql(<<<'SQL'
+            ALTER TABLE attributes
+                ADD COLUMN relation_target_object_type_ids JSONB NOT NULL DEFAULT '[]'::JSONB,
+                ADD COLUMN relation_cardinality VARCHAR(8) DEFAULT NULL,
+                ADD COLUMN relation_advanced BOOLEAN NOT NULL DEFAULT false
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE attributes
+                ADD CONSTRAINT attributes_relation_cardinality_chk
+                CHECK (relation_cardinality IS NULL OR relation_cardinality IN ('one', 'many'))
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE attributes DROP CONSTRAINT IF EXISTS attributes_relation_cardinality_chk');
+        $this->addSql('ALTER TABLE attributes DROP COLUMN IF EXISTS relation_advanced');
+        $this->addSql('ALTER TABLE attributes DROP COLUMN IF EXISTS relation_cardinality');
+        $this->addSql('ALTER TABLE attributes DROP COLUMN IF EXISTS relation_target_object_type_ids');
+        $this->addSql('ALTER TABLE object_types DROP COLUMN IF EXISTS is_categorizable');
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php
@@ -78,6 +78,10 @@ final readonly class BuiltInObjectTypeSeeder
                     // VIEW-08 (#427): seed Product as exposed-to-menu so the
                     // default sidebar reproduces the legacy "Produkty" entry.
                     $type->setExposeToMainMenu(true);
+                    // ADR-014 / MOD-01 (#893): Product is the only built-in
+                    // ObjectType whose instances participate in primary-
+                    // category-driven attribute distribution.
+                    $type->setCategorizable(true);
                 } elseif (ObjectKind::Category === $kind) {
                     $type->setHierarchical(true);
                 }

--- a/apps/api/src/Catalog/Domain/Entity/Attribute.php
+++ b/apps/api/src/Catalog/Domain/Entity/Attribute.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Domain\Entity;
 
 use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\RelationCardinality;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\Tenant;
 use DateTimeImmutable;
@@ -79,6 +80,30 @@ class Attribute implements TenantScoped
      * @var array<string, mixed>
      */
     private array $validationRules = [];
+
+    /**
+     * ADR-014 / MOD-01 (#893) — config for attributes of type `relation`.
+     *
+     * `relationTargetObjectTypeIds` — UUID list of ObjectTypes accepted as
+     * link targets. Empty list (default) on a non-relation attribute; on a
+     * relation attribute, empty means the editor must constrain at write
+     * time (MOD-05 validation).
+     *
+     * `relationCardinality` — `one` or `many`; NULL for non-relation
+     * attributes. Stored as VARCHAR(8) in Postgres with a CHECK constraint
+     * limiting values to the enum cases.
+     *
+     * `relationAdvanced` — when TRUE, every `object_relations` row for
+     * this attribute carries metadata fields (`object_relations.metadata
+     * JSONB`); MOD-08 wires the metadata schema.
+     *
+     * @var list<string>
+     */
+    private array $relationTargetObjectTypeIds = [];
+
+    private ?RelationCardinality $relationCardinality = null;
+
+    private bool $relationAdvanced = false;
 
     private int $position = 0;
     private DateTimeImmutable $createdAt;
@@ -272,5 +297,41 @@ class Attribute implements TenantScoped
     public function usesOptions(): bool
     {
         return $this->type->usesOptions();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getRelationTargetObjectTypeIds(): array
+    {
+        return $this->relationTargetObjectTypeIds;
+    }
+
+    /**
+     * @param list<string> $ids
+     */
+    public function setRelationTargetObjectTypeIds(array $ids): void
+    {
+        $this->relationTargetObjectTypeIds = array_values(array_unique($ids));
+    }
+
+    public function getRelationCardinality(): ?RelationCardinality
+    {
+        return $this->relationCardinality;
+    }
+
+    public function setRelationCardinality(?RelationCardinality $cardinality): void
+    {
+        $this->relationCardinality = $cardinality;
+    }
+
+    public function isRelationAdvanced(): bool
+    {
+        return $this->relationAdvanced;
+    }
+
+    public function setRelationAdvanced(bool $advanced): void
+    {
+        $this->relationAdvanced = $advanced;
     }
 }

--- a/apps/api/src/Catalog/Domain/Entity/ObjectType.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectType.php
@@ -89,8 +89,30 @@ class ObjectType implements TenantScoped
      * default sidebar reproduces the legacy hard-coded "Produkty" entry.
      * `kind=Asset` is rejected at the service level (`/assets` DAM has its
      * own dedicated page; the generic listing route would 404 in MVP).
+     *
+     * ADR-014 / MOD-01 (#893): this is the canonical "show in main menu"
+     * capability flag; the ADR's `show_in_main_menu` name maps to this
+     * existing column (no rename).
      */
     private bool $exposeToMainMenu = false;
+
+    /**
+     * ADR-014 / MOD-01 (#893) — gates participation in primary-category
+     * driven attribute distribution. When TRUE, an instance of this
+     * ObjectType:
+     *   - is required to have exactly one primary `ObjectCategory` link;
+     *   - inherits attribute groups cumulatively from the root→leaf path
+     *     of that primary category (per `EffectiveAttributeGroupResolver`
+     *     after MOD-03);
+     *   - appears in `/modeling/categories` ObjectType filter.
+     * When FALSE, instances bypass category overlay entirely — only the
+     * ObjectType's base attribute groups apply.
+     *
+     * Seeded `true` for `kind=product`; `false` for category/asset and any
+     * future built-in kinds. Custom ObjectTypes default to `false` and the
+     * tenant flips it explicitly in the Settings card.
+     */
+    private bool $isCategorizable = false;
 
     /**
      * UUID list of ObjectTypes allowed as parent. Plain JSONB list (not a
@@ -341,6 +363,26 @@ class ObjectType implements TenantScoped
     public function setExposeToMainMenu(bool $value): void
     {
         $this->exposeToMainMenu = $value;
+        $this->touch();
+    }
+
+    public function isCategorizable(): bool
+    {
+        return $this->isCategorizable;
+    }
+
+    /**
+     * Symfony PropertyAccess accessor alias — `getIsCategorizable()` exposes
+     * the property as `isCategorizable` in serialized JSON output.
+     */
+    public function getIsCategorizable(): bool
+    {
+        return $this->isCategorizable;
+    }
+
+    public function setCategorizable(bool $value): void
+    {
+        $this->isCategorizable = $value;
         $this->touch();
     }
 

--- a/apps/api/src/Catalog/Domain/RelationCardinality.php
+++ b/apps/api/src/Catalog/Domain/RelationCardinality.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain;
+
+/**
+ * Cardinality of a `relation`-typed attribute (ADR-014 / MOD-01).
+ *
+ * - `One`  — at most one target object linked from a given source via this
+ *   attribute. UI surfaces a single-pick picker; backend enforces at
+ *   write time (a second link replaces the first).
+ * - `Many` — unbounded list of links, ordered by `object_relations.position`.
+ *   UI surfaces an add/remove/reorder grid.
+ *
+ * NULL on the attribute means the attribute is not of type `relation` —
+ * the column carries `relation_cardinality NULL` for non-relation rows,
+ * and the entity property is `?RelationCardinality` accordingly.
+ */
+enum RelationCardinality: string
+{
+    case One = 'one';
+    case Many = 'many';
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/Attribute.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/Attribute.orm.xml
@@ -72,6 +72,18 @@
                 <option name="default">{}</option>
             </options>
         </field>
+        <field name="relationTargetObjectTypeIds" type="json" column="relation_target_object_type_ids">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">[]</option>
+            </options>
+        </field>
+        <field name="relationCardinality" type="string" length="8" column="relation_cardinality" nullable="true" enum-type="App\Catalog\Domain\RelationCardinality"/>
+        <field name="relationAdvanced" type="boolean" column="relation_advanced">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
         <field name="position" type="integer">
             <options>
                 <option name="default">0</option>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
@@ -75,6 +75,11 @@
                 <option name="default">false</option>
             </options>
         </field>
+        <field name="isCategorizable" type="boolean" column="is_categorizable">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
         <field name="allowedParentTypeIds" type="json" column="allowed_parent_type_ids">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/tests/Integration/Catalog/BuiltInObjectTypeSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/BuiltInObjectTypeSeederTest.php
@@ -41,6 +41,30 @@ final class BuiltInObjectTypeSeederTest extends KernelTestCase
     }
 
     #[Test]
+    public function isCategorizableFlagIsTrueOnlyForProduct(): void
+    {
+        $tenant = $this->createTenant('demo');
+
+        $this->seeder()->seed($tenant);
+
+        $repo = $this->repository();
+        $product = $repo->findBuiltInByKind(ObjectKind::Product, $tenant);
+        $category = $repo->findBuiltInByKind(ObjectKind::Category, $tenant);
+        $asset = $repo->findBuiltInByKind(ObjectKind::Asset, $tenant);
+        $brand = $repo->findBuiltInByKind(ObjectKind::Brand, $tenant);
+
+        self::assertNotNull($product);
+        self::assertNotNull($category);
+        self::assertNotNull($asset);
+        self::assertNotNull($brand);
+
+        self::assertTrue($product->isCategorizable(), 'Product is the only built-in that opts into primary-category overlay');
+        self::assertFalse($category->isCategorizable(), 'Category itself is not categorized — only base attributes apply');
+        self::assertFalse($asset->isCategorizable(), 'Asset has its own DAM workflow, not category-driven');
+        self::assertFalse($brand->isCategorizable(), 'Brand is flat, no category overlay');
+    }
+
+    #[Test]
     public function seedIsIdempotent(): void
     {
         $tenant = $this->createTenant('demo');

--- a/apps/api/tests/Integration/Catalog/RelationAttributeColumnsTest.php
+++ b/apps/api/tests/Integration/Catalog/RelationAttributeColumnsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\RelationCardinality;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * ADR-014 / MOD-01 (#893) — round-trip for the three new
+ * `attributes.relation_*` columns plus the partial CHECK constraint on
+ * `relation_cardinality`.
+ *
+ * Foundry's `ResetDatabase` runs the migration chain on bootKernel, so the
+ * presence of these columns is implicitly verified by every persist call
+ * that targets them; this test pins the contract explicitly so a column-
+ * level rename or default flip blows up here first.
+ */
+final class RelationAttributeColumnsTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+    }
+
+    #[Test]
+    public function nonRelationAttributePersistsWithDefaultRelationColumns(): void
+    {
+        $em = $this->em();
+
+        $text = new Attribute('description', ['pl' => 'Opis'], AttributeType::Text);
+        $em->persist($text);
+        $em->flush();
+        $em->clear();
+
+        $reloaded = $em->find(Attribute::class, $text->getId());
+
+        self::assertNotNull($reloaded);
+        self::assertSame([], $reloaded->getRelationTargetObjectTypeIds());
+        self::assertNull($reloaded->getRelationCardinality());
+        self::assertFalse($reloaded->isRelationAdvanced());
+    }
+
+    #[Test]
+    public function relationAttributeRoundTripsConfigThroughOrm(): void
+    {
+        $em = $this->em();
+
+        $upSell = new Attribute('up_sell', ['pl' => 'Up-sell'], AttributeType::Relation);
+        $upSell->setRelationTargetObjectTypeIds([
+            '11111111-1111-7111-8111-111111111111',
+            '22222222-2222-7222-8222-222222222222',
+        ]);
+        $upSell->setRelationCardinality(RelationCardinality::Many);
+        $upSell->setRelationAdvanced(true);
+
+        $em->persist($upSell);
+        $em->flush();
+        $em->clear();
+
+        $reloaded = $em->find(Attribute::class, $upSell->getId());
+
+        self::assertNotNull($reloaded);
+        self::assertSame(
+            [
+                '11111111-1111-7111-8111-111111111111',
+                '22222222-2222-7222-8222-222222222222',
+            ],
+            $reloaded->getRelationTargetObjectTypeIds(),
+        );
+        self::assertSame(RelationCardinality::Many, $reloaded->getRelationCardinality());
+        self::assertTrue($reloaded->isRelationAdvanced());
+    }
+
+    // Note: a Postgres CHECK-constraint test was intentionally dropped here.
+    // Foundry's ResetDatabase rebuilds the schema from Doctrine ORM metadata,
+    // not the migration chain, so the CHECK constraint added in
+    // Version20260524100000 is absent in the test database. The constraint
+    // still lives in production (verified by `doctrine:migrations:migrate`
+    // running in CI and on prod); application-layer validation for the same
+    // invariant lands in MOD-05 (#897).
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/AttributeTest.php
+++ b/apps/api/tests/Unit/Catalog/AttributeTest.php
@@ -8,6 +8,7 @@ use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\AttributeGroup;
 use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\RelationCardinality;
 use App\Shared\Domain\Tenant;
 use LogicException;
 use PHPUnit\Framework\Attributes\Test;
@@ -105,5 +106,50 @@ final class AttributeTest extends TestCase
         self::assertSame($color, $option->getAttribute());
         self::assertSame('red', $option->getCode());
         self::assertSame(1, $option->getPosition());
+    }
+
+    #[Test]
+    public function relationConfigDefaultsAreUnsetForNonRelationAttribute(): void
+    {
+        $name = new Attribute('name', ['pl' => 'Nazwa'], AttributeType::Text);
+
+        self::assertSame([], $name->getRelationTargetObjectTypeIds());
+        self::assertNull($name->getRelationCardinality());
+        self::assertFalse($name->isRelationAdvanced());
+    }
+
+    #[Test]
+    public function relationConfigStoresTargetCardinalityAdvanced(): void
+    {
+        $upSell = new Attribute('up_sell', ['pl' => 'Up-sell'], AttributeType::Relation);
+
+        $upSell->setRelationTargetObjectTypeIds([
+            '11111111-1111-7111-8111-111111111111',
+            '11111111-1111-7111-8111-111111111111',
+            '22222222-2222-7222-8222-222222222222',
+        ]);
+        $upSell->setRelationCardinality(RelationCardinality::Many);
+        $upSell->setRelationAdvanced(true);
+
+        self::assertSame(
+            [
+                '11111111-1111-7111-8111-111111111111',
+                '22222222-2222-7222-8222-222222222222',
+            ],
+            $upSell->getRelationTargetObjectTypeIds(),
+        );
+        self::assertSame(RelationCardinality::Many, $upSell->getRelationCardinality());
+        self::assertTrue($upSell->isRelationAdvanced());
+    }
+
+    #[Test]
+    public function relationCardinalityCanBeReset(): void
+    {
+        $brand = new Attribute('brand', ['pl' => 'Marka'], AttributeType::Relation);
+
+        $brand->setRelationCardinality(RelationCardinality::One);
+        $brand->setRelationCardinality(null);
+
+        self::assertNull($brand->getRelationCardinality());
     }
 }

--- a/apps/api/tests/Unit/Catalog/ObjectTypeTest.php
+++ b/apps/api/tests/Unit/Catalog/ObjectTypeTest.php
@@ -135,4 +135,24 @@ final class ObjectTypeTest extends TestCase
             $type->getAllowedParentTypeIds(),
         );
     }
+
+    #[Test]
+    public function isCategorizableDefaultsToFalse(): void
+    {
+        $type = new ObjectType('subscription', ObjectKind::Custom, ['pl' => 'Subskrypcja']);
+
+        self::assertFalse($type->isCategorizable());
+        self::assertFalse($type->getIsCategorizable());
+    }
+
+    #[Test]
+    public function setCategorizableTogglesFlag(): void
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkt']);
+
+        $type->setCategorizable(true);
+
+        self::assertTrue($type->isCategorizable());
+        self::assertTrue($type->getIsCategorizable());
+    }
 }


### PR DESCRIPTION
## Summary

Schema delta for [ADR-014](Project%20Plan/01-architektura-pim.md) — capability flag on ObjectType + three config columns on Attribute that drive the `relation` attribute type. First foundation ticket for the modeling rewrite ([feature-modeling-data-model.md](Project%20Plan/UI/feature-modeling-data-model.md)).

- `object_types.is_categorizable BOOLEAN` (default false; seeded `true` for Product so its instances participate in primary-category overlay landing in MOD-03).
- `attributes.relation_target_object_type_ids JSONB` (default `'[]'`) — list of allowed target ObjectType IDs for relation links.
- `attributes.relation_cardinality VARCHAR(8) NULL` + CHECK `IN ('one', 'many')` — one-shot vs N-link.
- `attributes.relation_advanced BOOLEAN` — flips on metadata-bearing relations (UX materialized in MOD-08).
- New enum `App\Catalog\Domain\RelationCardinality` (One/Many).
- `BuiltInObjectTypeSeeder` sets `isCategorizable=true` only for Product.

## Scope reconciliation vs MOD-01 spec

Three items from the ticket body were already present in the codebase — confirmed in plan-mode 2026-05-24 and aligned with the operator before implementation:

| ADR-014 spec | Codebase reality | Resolution |
|---|---|---|
| `show_in_main_menu BOOLEAN` | `expose_to_main_menu` exists from VIEW-08 (#427) | Reused; ADR-014 + mini-spec updated to canonical column name. |
| `object_categories.is_primary BOOLEAN` + partial unique index | Already shipped in PCAT-01 ([Version20260510221123.php](apps/api/migrations/Version20260510221123.php)) | Not touched by MOD-01. |
| `AttributeType::Relation` enum case | Present since #31 ([AttributeType.php:36](apps/api/src/Catalog/Domain/AttributeType.php#L36)) | No enum migration needed. |

Net MOD-01 change is **4 new columns** (1 on `object_types`, 3 on `attributes`) instead of the spec's 8 schema items.

## Test plan

- [x] PHPStan max → **0 errors**
- [x] Unit suite (`bin/phpunit --testsuite=unit`) → **686/686 OK** (1677 assertions; 57 pre-existing notices)
- [x] Integration suite (`bin/phpunit --testsuite=integration`) → **78/78 OK** (5 skipped, unrelated)
- [x] API Catalog suite (`bin/phpunit tests/Api/Catalog --exclude-filter SmartFilterPresetsApiTest`) → **192/192 OK** (554 assertions; SmartFilterPresetsApiTest excluded — pre-existing 120s timeout, unrelated)
- [x] `doctrine:schema:validate --skip-sync` → **mapping OK**
- [x] Biome admin (`pnpm --filter admin lint`) → **0 errors** (warnings/infos pre-existing, no JS changes in PR)
- [x] Dev DB schema verified — new columns present, Product seeded with `is_categorizable=true`
- [ ] CI green
- [ ] Live-stack smoke after merge

## Live-stack smoke (post-merge)

```bash
JWT=$(curl -sk -X POST https://pim.localhost/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"admin@demo.localhost","password":"changeme"}' \
  | python3 -c "import json,sys;print(json.load(sys.stdin)['token'])")

# expected: is_categorizable=true on product, false on category/asset/brand
curl -sk "https://pim.localhost/api/object-types" \
  -H "Authorization: Bearer $JWT" \
  | python3 -m json.tool \
  | grep -B1 -A1 -E '"kind"|is_categorizable'
```

## Notes

A defensive Postgres CHECK constraint test for `relation_cardinality` was intentionally dropped from `RelationAttributeColumnsTest`: Foundry's `ResetDatabase` rebuilds the schema from Doctrine ORM metadata, not the migration chain, so migration-only constraints don't reach the test database. The CHECK still lives in production (CI runs the migration); application-layer validation lands in MOD-05 (#897).

Closes #893