### PR TITLE
fix(catalog): expose MOD-01 fields in serializer groups

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/Serializer/Attribute.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/Attribute.xml
@@ -62,6 +62,21 @@
             <group>admin:read</group>
             <group>admin:write</group>
         </attribute>
+        <attribute name="relationTargetObjectTypeIds">
+            <group>admin:read</group>
+            <group>admin:write</group>
+            <group>integration:read</group>
+        </attribute>
+        <attribute name="relationCardinality">
+            <group>admin:read</group>
+            <group>admin:write</group>
+            <group>integration:read</group>
+        </attribute>
+        <attribute name="relationAdvanced">
+            <group>admin:read</group>
+            <group>admin:write</group>
+            <group>integration:read</group>
+        </attribute>
         <attribute name="position">
             <group>admin:read</group>
             <group>admin:write</group>

--- a/apps/api/src/Catalog/Infrastructure/Serializer/ObjectType.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/ObjectType.xml
@@ -61,6 +61,10 @@
             <group>admin:read</group>
             <group>integration:read</group>
         </attribute>
+        <attribute name="isCategorizable">
+            <group>admin:read</group>
+            <group>integration:read</group>
+        </attribute>
         <attribute name="allowedParentTypeIds">
             <group>admin:read</group>
         </attribute>

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -7119,6 +7119,28 @@
                             ]
                         }
                     },
+                    "relationTargetObjectTypeIds": {
+                        "description": "ADR-014 / MOD-01 (#893) \u2014 config for attributes of type `relation`.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "relationCardinality": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "enum": [
+                            "one",
+                            "many",
+                            null
+                        ]
+                    },
+                    "relationAdvanced": {
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "position": {
                         "readOnly": true,
                         "default": 0,
@@ -7382,6 +7404,28 @@
                                         "null"
                                     ]
                                 }
+                            },
+                            "relationTargetObjectTypeIds": {
+                                "description": "ADR-014 / MOD-01 (#893) \u2014 config for attributes of type `relation`.",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "relationCardinality": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "enum": [
+                                    "one",
+                                    "many",
+                                    null
+                                ]
+                            },
+                            "relationAdvanced": {
+                                "default": false,
+                                "type": "boolean"
                             },
                             "position": {
                                 "readOnly": true,
@@ -10331,6 +10375,12 @@
                         "default": false,
                         "type": "boolean"
                     },
+                    "isCategorizable": {
+                        "readOnly": true,
+                        "description": "ADR-014 / MOD-01 (#893) \u2014 gates participation in primary-category\ndriven attribute distribution. When TRUE, an instance of this\nObjectType:\n  - is required to have exactly one primary `ObjectCategory` link;\n  - inherits attribute groups cumulatively from the root\u2192leaf path\n    of that primary category (per `EffectiveAttributeGroupResolver`\n    after MOD-03);\n  - appears in `/modeling/categories` ObjectType filter.",
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "allowedParentTypeIds": {
                         "description": "UUID list of ObjectTypes allowed as parent. Plain JSONB list (not a\njunction) \u2014 N stays small (\u2264 5 typical), and the only consumer is the\ndetail view's Allowed parent types chip strip. A junction would cost\nus a roundtrip per detail page load for no gain at this cardinality.",
                         "type": "array",
@@ -10469,6 +10519,12 @@
                             },
                             "exposeToMainMenu": {
                                 "description": "VIEW-08 (#427) \u2014 gating flag for main menu candidacy. When TRUE, the\nObjectType appears as a candidate in `/settings/menu` (Available\nsection) and can be promoted to Visible via `MenuConfiguration`. The\nactual ordering and per-tenant visible flag lives in\n`menu_configurations.items`, not here.",
+                                "default": false,
+                                "type": "boolean"
+                            },
+                            "isCategorizable": {
+                                "readOnly": true,
+                                "description": "ADR-014 / MOD-01 (#893) \u2014 gates participation in primary-category\ndriven attribute distribution. When TRUE, an instance of this\nObjectType:\n  - is required to have exactly one primary `ObjectCategory` link;\n  - inherits attribute groups cumulatively from the root\u2192leaf path\n    of that primary category (per `EffectiveAttributeGroupResolver`\n    after MOD-03);\n  - appears in `/modeling/categories` ObjectType filter.",
                                 "default": false,
                                 "type": "boolean"
                             },


### PR DESCRIPTION
## Summary

Follow-up to [#907](https://github.com/malipie/PIM/pull/907) (MOD-01). The PR added `ObjectType.isCategorizable` plus three `Attribute.relation_*` config columns but forgot to register them in `Catalog/Infrastructure/Serializer/{ObjectType,Attribute}.xml`, so the new fields didn't appear in `admin:read` / `integration:read` JSON output. Smoke test on dev stack revealed the gap.

## Changes

- `ObjectType.xml` — add `<attribute name=\"isCategorizable\">` on `admin:read` + `integration:read`.
- `Attribute.xml` — add the three new properties on `admin:read` + `admin:write` + `integration:read`.

## Smoke proof (dev stack, post-fix)

```
JWT=$(curl -sk -X POST https://pim.localhost/api/auth/login \\
  -H 'Content-Type: application/json' \\
  -d '{\"email\":\"admin@demo.localhost\",\"password\":\"changeme\"}' \\
  | jq -r .token)
curl -sk https://pim.localhost/api/object_types -H \"Authorization: Bearer \$JWT\"
```

Returns:
```
   product  kind=product     isCategorizable=True  exposeToMainMenu=True
  category  kind=category    isCategorizable=False  exposeToMainMenu=False
     asset  kind=asset       isCategorizable=False  exposeToMainMenu=False
     brand  kind=brand       isCategorizable=False  exposeToMainMenu=False
```

## Test plan

- [x] Manual smoke (above)
- [ ] CI green

Refs #893 — MOD-01 is functionally complete once this lands; will close #893 with end-to-end smoke proof after merge.