### PR TITLE
fix(catalog): resolver base+primary overlay (MOD-03)

### DIFF
--- a/apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php
+++ b/apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php
@@ -65,39 +65,46 @@ final readonly class EffectiveAttributeGroupResolver
     /**
      * Resolve effective groups for an existing object's form.
      *
+     * ADR-014 / MOD-03 (#895) — two layers:
+     *
+     * 1. **Base** — `loadObjectTypeGroups($type)` always returns the
+     *    ObjectType's directly attached groups. Applies to every kind
+     *    (Product, Category, Asset, custom) and fixes #3-#28: a Category
+     *    instance now renders its own base groups instead of an empty
+     *    form when no parent categories carry declared groups.
+     *
+     * 2. **Primary-category overlay** — only when `ObjectType.is_categorizable
+     *    = true` and the object has a primary `ObjectCategory` assignment.
+     *    The primary's ancestor chain (root → leaf, including the primary
+     *    itself) is walked and `CategoryAttributeGroup` rows targeting this
+     *    ObjectType are merged into the result. Secondary category
+     *    assignments are intentionally ignored — they classify the object,
+     *    not its attribute set.
+     *
+     * For non-categorizable ObjectTypes (Category, Asset, custom kinds with
+     * `is_categorizable=false`) layer 2 is skipped entirely. For
+     * categorizable objects without a primary the result is just the base
+     * layer (no overlay until the operator picks one).
+     *
      * @return list<AttributeGroup>
      */
     public function resolve(CatalogObject $object): array
     {
         $type = $object->getObjectType();
-
         $groups = $this->loadObjectTypeGroups($type);
 
-        if (ObjectKind::Category === $object->getKind()) {
-            // Walk the object's own ancestor chain to gather declared groups
-            // targeting category itself (preview semantics: "groups visible
-            // when editing a category sitting on this branch").
-            $ancestorIds = $this->collectCategoryAncestorIds($object);
+        if (!$type->isCategorizable()) {
+            return array_values($groups);
+        }
+
+        $primary = $this->productCategories->findPrimary($object);
+        if (null === $primary) {
+            return array_values($groups);
+        }
+
+        $ancestorIds = $this->collectCategoryAncestorIds($primary->getCategory(), includeSelf: true);
+        if ([] !== $ancestorIds) {
             $this->mergeCategoryGroups($groups, $ancestorIds, $type);
-        } elseif (ObjectKind::Product === $object->getKind()) {
-            // PCAT-03: for each assigned category, gather its ancestor
-            // chain (including the category itself) and merge declared
-            // groups targeting this product's ObjectType. Deduplication
-            // by UUID happens inside mergeCategoryGroups so multi-category
-            // products don't double-count shared ancestors (e.g. two
-            // assignments under the same root category).
-            $assignments = $this->productCategories->findByProduct($object);
-            if ([] !== $assignments) {
-                $ancestorMap = [];
-                foreach ($assignments as $assignment) {
-                    foreach ($this->collectCategoryAncestorIds($assignment->getCategory(), includeSelf: true) as $id) {
-                        $ancestorMap[$id->toRfc4122()] = $id;
-                    }
-                }
-                if ([] !== $ancestorMap) {
-                    $this->mergeCategoryGroups($groups, array_values($ancestorMap), $type);
-                }
-            }
         }
 
         return array_values($groups);

--- a/apps/api/tests/Integration/Catalog/EffectiveAttributeGroupResolverProductTest.php
+++ b/apps/api/tests/Integration/Catalog/EffectiveAttributeGroupResolverProductTest.php
@@ -118,15 +118,16 @@ final class EffectiveAttributeGroupResolverProductTest extends KernelTestCase
     }
 
     #[Test]
-    public function resolveDeduplicatesGroupsAcrossOverlappingAssignments(): void
+    public function resolveIgnoresSecondaryCategoryAssignments(): void
     {
         $em = $this->em();
         $productType = $this->productType();
 
-        // Two sibling categories under the same root. Each declares its
-        // own group, plus the shared root declares a shared group. A
-        // product assigned to BOTH siblings must see the root group only
-        // once (dedup by AttributeGroup id).
+        // ADR-014 / MOD-03: only the primary category contributes to the
+        // attribute overlay. Sibling categories under the same root each
+        // declare their own group; assigning the product to BOTH but
+        // marking only the left as primary must yield the left chain
+        // (shared-root + left-group) without right-group.
         $root = $this->makeCategory('shared-root', 'shared');
         $left = $this->makeCategory('left', 'shared.left', parent: $root);
         $right = $this->makeCategory('right', 'shared.right', parent: $root);
@@ -146,12 +147,39 @@ final class EffectiveAttributeGroupResolverProductTest extends KernelTestCase
         $groups = $this->resolver()->resolve($product);
         $codes = array_map(static fn (AttributeGroup $g): string => $g->getCode(), $groups);
 
-        self::assertContains('shared-group', $codes);
-        self::assertContains('left-group', $codes);
-        self::assertContains('right-group', $codes);
-        // Each code appears at most once even though the root is in both
-        // ancestor chains.
+        self::assertContains('shared-group', $codes, 'primary ancestor chain contributes');
+        self::assertContains('left-group', $codes, 'primary itself contributes');
+        self::assertNotContains('right-group', $codes, 'secondary categories MUST NOT contribute');
+        // Dedup invariant still holds.
         self::assertSame(\count($codes), \count(array_unique($codes)));
+    }
+
+    #[Test]
+    public function resolveReturnsBaseGroupsForNonCategorizableObjectType(): void
+    {
+        // ADR-014 / MOD-03 — Category itself has is_categorizable=false,
+        // so its instance form must show its own base AttributeGroups
+        // (the audit group seeded by BuiltInSystemAttributesSeeder) and
+        // skip the category overlay entirely. Fixes #3-#28.
+        $category = $this->makeCategory('telewizory', 'elektronika.tv');
+
+        $groups = $this->resolver()->resolve($category);
+        $codes = array_map(static fn (AttributeGroup $g): string => $g->getCode(), $groups);
+
+        self::assertContains('audit', $codes, 'Category instance must render its own base audit group');
+    }
+
+    #[Test]
+    public function resolveSkipsOverlayWhenCategorizableButNoPrimaryAssignment(): void
+    {
+        $product = $this->makeProduct('sku-no-primary');
+
+        $groups = $this->resolver()->resolve($product);
+        $codes = array_map(static fn (AttributeGroup $g): string => $g->getCode(), $groups);
+
+        // Only the base ObjectType layer applies — same as before any
+        // assignment lands.
+        self::assertSame(['audit'], $codes);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Naprawia [ADR-014](Project%20Plan/01-architektura-pim.md) źródło 3 oraz objaw #3-#28. `EffectiveAttributeGroupResolver::resolve()` przepisany na dwuwarstwowy model:

1. **Base** — `loadObjectTypeGroups($type)` zawsze. Dla każdego kindu (Product, Category, Asset, custom). Fix #3-#28: Category instance renderuje swoje base groups bez polegania na ancestor walk.
2. **Primary-category overlay** — gated przez `ObjectType.is_categorizable` (flag z MOD-01). Walk primary's root→leaf path + merge `CategoryAttributeGroup` targetujących ObjectType. **Secondary kategorie ignorowane.**

Branche per-kind (Product vs Category) usunięte z `resolve()` — `is_categorizable` jest jedynym gate'em. `resolveForCategoryPreview()` (preview dla `/categories/{id}/preview`) nietknięty.

## Behavior changes

| Scenario | Pre-ADR-014 | Post-MOD-03 |
|---|---|---|
| Category instance form | Empty / no base groups | **Base groups (audit + any attached)** ← fixes #3-#28 |
| Product assigned to A (primary) + B (secondary), each z własną grupą | A-group + B-group | **A-group only** (B ignored) |
| Product bez assignments | Base groups only | Base groups only (unchanged) |
| Product primary on leaf 3-level tree | Walk leaf → branch → root | Walk leaf → branch → root (unchanged) |
| Asset / Brand / custom is_categorizable=false | (kind-based skip) | **Skip overlay via `!isCategorizable()`** |

## Tests

- [x] PHPStan max → 0 errors
- [x] PHPUnit resolver suite (unit + 2 integration files) → **14/14 OK** (56 assertions)
- `resolveDeduplicatesGroupsAcrossOverlappingAssignments` → renamed `resolveIgnoresSecondaryCategoryAssignments` z asercjami zgodnymi z ADR-014.
- Nowe: `resolveReturnsBaseGroupsForNonCategorizableObjectType`, `resolveSkipsOverlayWhenCategorizableButNoPrimaryAssignment`.
- [ ] CI green
- [ ] Live-stack smoke po merge

## Cache invalidation

Bez zmian. `ObjectFormSchemaCacheInvalidator::collect(ObjectCategory)` już bursta per-type tag przy postPersist/postUpdate/postRemove na junction — primary flag flip dotyka tego entity, więc invalidation działa.

Closes #895 — następny: MOD-04 (#896) walidacja unikalności kodów.