### PR TITLE
feat(catalog): AttributeCodeUniquenessValidator (MOD-04)

### DIFF
--- a/apps/api/src/Catalog/Domain/Validator/AttributeCodeConflict.php
+++ b/apps/api/src/Catalog/Domain/Validator/AttributeCodeConflict.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Validator;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ADR-014 / MOD-04 (#896) — value object describing where an Attribute code
+ * already exists in the target ObjectType's effective model.
+ *
+ * Returned by {@see AttributeCodeUniquenessValidator::validate} when a
+ * collision is detected. The controller layer projects the fields into an
+ * RFC 7807 Problem Details response so the FE can render
+ * "Already used in: base layer / category Telewizory".
+ *
+ * `existingLocation` is a stable machine-readable token:
+ *   - `'base'`           — directly attached to the ObjectType via
+ *                          `object_type_attributes`.
+ *   - `'category:<code>'` — distributed to the ObjectType via a
+ *                          `category_attribute_groups` row whose source
+ *                          category has the given `code`.
+ */
+final readonly class AttributeCodeConflict
+{
+    public function __construct(
+        public string $code,
+        public string $existingLocation,
+        public Uuid $conflictingAttributeId,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Domain/Validator/AttributeCodeUniquenessValidator.php
+++ b/apps/api/src/Catalog/Domain/Validator/AttributeCodeUniquenessValidator.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Validator;
+
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Entity\CategoryAttributeGroup;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * ADR-014 / MOD-04 (#896) — checks that an Attribute code is unique within
+ * the **effective attribute model** of a target ObjectType.
+ *
+ * The effective model has two layers per ADR-014:
+ *   1. **Base** — `object_type_attributes` junction. Attributes directly
+ *      attached to the ObjectType.
+ *   2. **Category-distributed** — `category_attribute_groups` whose
+ *      `target_object_type_id` points at this ObjectType, transitively
+ *      including every Attribute attached to each such AttributeGroup via
+ *      `attribute_group_attributes`.
+ *
+ * The validator runs at attach-time (before adding an attribute to an OT's
+ * base or to a group that distributes to that OT). It does NOT replace the
+ * existing tenant-wide unique constraint on `attributes(tenant_id, code)`
+ * — that constraint still guards against two attribute rows with the same
+ * code in one tenant. This validator narrows the check to a single OT's
+ * effective model so the operator sees a precise error message
+ * (`existing_location` distinguishes "already in base" from "comes from
+ * category X").
+ *
+ * Returns the {@see AttributeCodeConflict} on collision, `null` when the
+ * code is free in the model. Callers translate the conflict into a
+ * Problem Details 422 response.
+ */
+final readonly class AttributeCodeUniquenessValidator
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    public function validate(
+        string $code,
+        ObjectType $objectType,
+        ?Attribute $excludeAttribute = null,
+    ): ?AttributeCodeConflict {
+        $excludeId = $excludeAttribute?->getId()->toRfc4122();
+
+        // Layer 1 — directly attached via object_type_attributes.
+        /** @var ObjectTypeAttribute|null $direct */
+        $direct = $this->em
+            ->createQuery(
+                'SELECT j, a FROM '.ObjectTypeAttribute::class.' j'
+                .' JOIN j.attribute a'
+                .' WHERE j.objectType = :type AND a.code = :code'
+                .(null !== $excludeId ? ' AND a.id <> :excludeId' : '')
+            )
+            ->setParameter('type', $objectType)
+            ->setParameter('code', $code)
+            ->setMaxResults(1)
+            ->setParameters(
+                null !== $excludeId
+                    ? ['type' => $objectType, 'code' => $code, 'excludeId' => $excludeId]
+                    : ['type' => $objectType, 'code' => $code],
+            )
+            ->getOneOrNullResult();
+
+        if (null !== $direct) {
+            return new AttributeCodeConflict(
+                code: $code,
+                existingLocation: 'base',
+                conflictingAttributeId: $direct->getAttribute()->getId(),
+            );
+        }
+
+        // Layer 2 — distributed via category_attribute_groups → attribute_group_attributes.
+        /** @var array<int, array{a_id: string, category_id: string}> $rows */
+        $rows = $this->em
+            ->createQuery(
+                'SELECT a.id AS a_id, cag.categoryObjectId AS category_id'
+                .' FROM '.CategoryAttributeGroup::class.' cag'
+                .' JOIN '.AttributeGroupAttribute::class.' aga'
+                .' WITH aga.attributeGroup = cag.attributeGroup'
+                .' JOIN aga.attribute a'
+                .' WHERE cag.targetObjectType = :type AND a.code = :code'
+                .(null !== $excludeId ? ' AND a.id <> :excludeId' : '')
+            )
+            ->setParameters(
+                null !== $excludeId
+                    ? ['type' => $objectType, 'code' => $code, 'excludeId' => $excludeId]
+                    : ['type' => $objectType, 'code' => $code],
+            )
+            ->setMaxResults(1)
+            ->getArrayResult();
+
+        if ([] !== $rows) {
+            $row = $rows[0];
+
+            $categoryId = $row['category_id'];
+            $categoryToken = $categoryId instanceof \Symfony\Component\Uid\Uuid
+                ? $categoryId->toRfc4122()
+                : (string) $categoryId;
+            $attributeId = $row['a_id'];
+            $conflictingId = $attributeId instanceof \Symfony\Component\Uid\Uuid
+                ? $attributeId
+                : \Symfony\Component\Uid\Uuid::fromString((string) $attributeId);
+
+            return new AttributeCodeConflict(
+                code: $code,
+                existingLocation: 'category:'.$categoryToken,
+                conflictingAttributeId: $conflictingId,
+            );
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Validator/AttributeCodeUniquenessValidator.php
+++ b/apps/api/src/Catalog/Domain/Validator/AttributeCodeUniquenessValidator.php
@@ -10,6 +10,7 @@ use App\Catalog\Domain\Entity\CategoryAttributeGroup;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
 
 /**
  * ADR-014 / MOD-04 (#896) — checks that an Attribute code is unique within
@@ -100,22 +101,29 @@ final readonly class AttributeCodeUniquenessValidator
         if ([] !== $rows) {
             $row = $rows[0];
 
-            $categoryId = $row['category_id'];
-            $categoryToken = $categoryId instanceof \Symfony\Component\Uid\Uuid
-                ? $categoryId->toRfc4122()
-                : (string) $categoryId;
-            $attributeId = $row['a_id'];
-            $conflictingId = $attributeId instanceof \Symfony\Component\Uid\Uuid
-                ? $attributeId
-                : \Symfony\Component\Uid\Uuid::fromString((string) $attributeId);
-
             return new AttributeCodeConflict(
                 code: $code,
-                existingLocation: 'category:'.$categoryToken,
-                conflictingAttributeId: $conflictingId,
+                existingLocation: 'category:'.$this->toUuidString($row['category_id']),
+                conflictingAttributeId: \Symfony\Component\Uid\Uuid::fromString($this->toUuidString($row['a_id'])),
             );
         }
 
         return null;
+    }
+
+    /**
+     * `getArrayResult` returns Doctrine's `uuid` type as `Uuid` on local
+     * hydration but as a string under CI's stricter PHPStan analysis.
+     * Normalise both paths to RFC-4122 string.
+     */
+    private function toUuidString(mixed $raw): string
+    {
+        if ($raw instanceof \Symfony\Component\Uid\Uuid) {
+            return $raw->toRfc4122();
+        }
+        if (\is_string($raw)) {
+            return $raw;
+        }
+        throw new LogicException('Expected Uuid or string from Doctrine array result, got '.\get_debug_type($raw).'.');
     }
 }

--- a/apps/api/src/Catalog/Presentation/Controller/AttachObjectTypeAttributeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttachObjectTypeAttributeController.php
@@ -5,14 +5,18 @@ declare(strict_types=1);
 namespace App\Catalog\Presentation\Controller;
 
 use App\Catalog\Application\ObjectTypeService;
+use App\Catalog\Domain\Entity\Attribute as CatalogAttribute;
+use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Catalog\Domain\Validator\AttributeCodeUniquenessValidator;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -42,6 +46,7 @@ final class AttachObjectTypeAttributeController
         private readonly AttributeRepositoryInterface $attributes,
         private readonly ObjectTypeService $service,
         private readonly Connection $connection,
+        private readonly AttributeCodeUniquenessValidator $codeUniqueness,
     ) {
     }
 
@@ -64,6 +69,8 @@ final class AttachObjectTypeAttributeController
         if (null === $attribute) {
             throw new NotFoundHttpException(\sprintf('Attribute "%s" was not found.', $attributeId));
         }
+
+        $this->guardCodeUniqueness($objectType, $attribute);
 
         $sortOrder = $this->nextSortOrder($id);
         $this->service->assignAttribute($objectType, $attribute, false, $sortOrder);
@@ -130,6 +137,7 @@ final class AttachObjectTypeAttributeController
             if (null === $attribute) {
                 throw new NotFoundHttpException(\sprintf('Attribute "%s" was not found.', $rawId));
             }
+            $this->guardCodeUniqueness($objectType, $attribute);
             $this->service->assignAttribute($objectType, $attribute, false, $sortOrder);
             ++$sortOrder;
         }
@@ -150,5 +158,36 @@ final class AttachObjectTypeAttributeController
         );
 
         return \is_scalar($raw) ? (int) $raw : 0;
+    }
+
+    /**
+     * ADR-014 / MOD-04 (#896) — reject attach when the attribute's code is
+     * already present in the target ObjectType's effective model (base or
+     * category-distributed) via a *different* attribute row. Same-attribute
+     * idempotent re-attach is allowed (validator excludes the attribute
+     * being attached, so the ObjectTypeService::assignAttribute upsert path
+     * keeps working).
+     */
+    private function guardCodeUniqueness(ObjectType $objectType, CatalogAttribute $attribute): void
+    {
+        $conflict = $this->codeUniqueness->validate(
+            $attribute->getCode(),
+            $objectType,
+            excludeAttribute: $attribute,
+        );
+
+        if (null === $conflict) {
+            return;
+        }
+
+        throw new HttpException(
+            422,
+            \sprintf(
+                'Attribute code "%s" already exists in ObjectType "%s" model (location: %s).',
+                $conflict->code,
+                $objectType->getCode(),
+                $conflict->existingLocation,
+            ),
+        );
     }
 }

--- a/apps/api/tests/Integration/Catalog/AttributeCodeUniquenessValidatorTest.php
+++ b/apps/api/tests/Integration/Catalog/AttributeCodeUniquenessValidatorTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\CategoryAttributeGroup;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Catalog\Domain\Validator\AttributeCodeUniquenessValidator;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * ADR-014 / MOD-04 (#896) — validator coverage for attribute code uniqueness
+ * within the effective ObjectType model.
+ */
+final class AttributeCodeUniquenessValidatorTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($this->tenant);
+    }
+
+    #[Test]
+    public function unusedCodeIsAccepted(): void
+    {
+        $product = $this->productType();
+
+        $conflict = $this->validator()->validate('brand_new_code', $product);
+
+        self::assertNull($conflict);
+    }
+
+    #[Test]
+    public function codePresentInBaseLayerReturnsBaseConflict(): void
+    {
+        $em = $this->em();
+        $product = $this->productType();
+
+        $existing = new Attribute('description', ['en' => 'Description'], AttributeType::Text);
+        $em->persist($existing);
+        $em->flush();
+        $em->persist(new ObjectTypeAttribute($product, $existing));
+        $em->flush();
+
+        $conflict = $this->validator()->validate('description', $product);
+
+        self::assertNotNull($conflict);
+        self::assertSame('description', $conflict->code);
+        self::assertSame('base', $conflict->existingLocation);
+        self::assertTrue($conflict->conflictingAttributeId->equals($existing->getId()));
+    }
+
+    #[Test]
+    public function codeAttachedToBaseAsTheSameAttributeIsNotAConflictWhenExcluded(): void
+    {
+        // Idempotent re-attach: the validator is asked "would adding this
+        // attribute to base introduce a clash?" — the answer is no, because
+        // the row referenced is the same Attribute being re-checked.
+        $em = $this->em();
+        $product = $this->productType();
+
+        $existing = new Attribute('description', ['en' => 'Description'], AttributeType::Text);
+        $em->persist($existing);
+        $em->flush();
+        $em->persist(new ObjectTypeAttribute($product, $existing));
+        $em->flush();
+
+        $conflict = $this->validator()->validate(
+            'description',
+            $product,
+            excludeAttribute: $existing,
+        );
+
+        self::assertNull($conflict);
+    }
+
+    #[Test]
+    public function codeDistributedViaCategoryAttributeGroupReturnsCategoryConflict(): void
+    {
+        $em = $this->em();
+        $product = $this->productType();
+
+        // Category C declares a group G that distributes to Product. G
+        // already carries an attribute with code "color"; distributing the
+        // group puts "color" into Product's effective model via the
+        // category layer.
+        $category = $this->makeCategory('electronics', 'electronics');
+
+        $group = new AttributeGroup('marketing', ['en' => 'Marketing']);
+        $em->persist($group);
+        $em->flush();
+
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Text);
+        $em->persist($color);
+        $em->flush();
+        $em->persist(new AttributeGroupAttribute($group, $color, 1));
+        $em->persist(new CategoryAttributeGroup($category->getId(), $product, $group, 1));
+        $em->flush();
+
+        $conflict = $this->validator()->validate('color', $product);
+
+        self::assertNotNull($conflict);
+        self::assertSame('color', $conflict->code);
+        self::assertStringStartsWith('category:', $conflict->existingLocation);
+        self::assertTrue($conflict->conflictingAttributeId->equals($color->getId()));
+    }
+
+    #[Test]
+    public function codePresentInDifferentObjectTypeDoesNotConflict(): void
+    {
+        // AC-3: same code on an unrelated ObjectType (category here) does
+        // NOT conflict with the product model — the current tenant-wide DB
+        // unique constraint still blocks duplicate rows in `attributes`,
+        // but the validator's view of "effective ObjectType model" is
+        // narrower and tolerates the same code living on a different OT
+        // model. Useful once tenant-wide uniqueness is relaxed in a follow-
+        // up; the contract is correct today.
+        $em = $this->em();
+        $category = $this->categoryType();
+
+        $existing = new Attribute('description', ['en' => 'Description'], AttributeType::Text);
+        $em->persist($existing);
+        $em->flush();
+        $em->persist(new ObjectTypeAttribute($category, $existing));
+        $em->flush();
+
+        $conflict = $this->validator()->validate('description', $this->productType());
+
+        self::assertNull($conflict);
+    }
+
+    private function validator(): AttributeCodeUniquenessValidator
+    {
+        return self::getContainer()->get(AttributeCodeUniquenessValidator::class);
+    }
+
+    private function productType(): \App\Catalog\Domain\Entity\ObjectType
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $this->tenant);
+        \assert(null !== $type);
+
+        return $type;
+    }
+
+    private function categoryType(): \App\Catalog\Domain\Entity\ObjectType
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Category, $this->tenant);
+        \assert(null !== $type);
+
+        return $type;
+    }
+
+    private function makeCategory(string $code, string $path): CatalogObject
+    {
+        $em = $this->em();
+        $type = $this->categoryType();
+        $category = new CatalogObject($type, $code);
+        $category->attachToPath($path);
+        $em->persist($category);
+        $em->flush();
+
+        return $category;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}


### PR DESCRIPTION
## Summary

ADR-014 / MOD-04 (#896). Walidator zwęża sprawdzenie unikalności kodu atrybutu z "unique per tenant" (constraint DB) do "unique within target ObjectType's effective model". Detekcja kolizji w obu warstwach modelu:
1. **Base** — `object_type_attributes`
2. **Category-distributed** — `category_attribute_groups` → `attribute_group_attributes`

Walidator zwraca `AttributeCodeConflict` value object z `code`, `existingLocation` (`'base'` lub `'category:<uuid>'`), oraz id konfliktującego atrybutu. Controllery rzucają HTTP 422.

Wired in:
- `AttachObjectTypeAttributeController::attach` + `::bulkAttach` — przed `assignAttribute`, walidator sprawdza efektywny model OT z `excludeAttribute` (idempotent re-attach OK).

## Scope decisions

- **AC-3** (same code in different unrelated ObjectType allowed) — walidator zwraca `null` w tym przypadku. Constraint DB `attributes_tenant_code_uniq` nadal blokuje per-tenant w obecnym modelu; relaksacja schema → follow-up gdy model przejdzie na per-OT.
- **AttributeGroupAttribute attach** — nie ruszane w tym PR (validator gotowy do wpięcia tam w follow-up).
- **UI hint dla sufiksu kategorii** (`opis_telewizory`) — frontend, nie backend, follow-up dla MOD-13.

## Tests

- [x] 5/5 integration cases: unused code OK / base conflict / idempotent re-attach (exclude) OK / category-distributed conflict / cross-OT same code OK
- [x] PHPStan max → 0 errors
- [ ] CI green

Closes #896 — następny: MOD-05 (#897) backend config relation attribute.