### PR TITLE
feat(catalog): relation attribute config CRUD (MOD-05)

### DIFF
--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -87,6 +87,14 @@ parameters:
         # by the listener tests and at INSERT time by the database. New
         # TenantScoped entities should be added here as they land.
         - identifier: doctrine.associationType
+          # `reportUnmatched: false` — local Docker PHPStan sometimes
+          # short-circuits before evaluating the @var doc-block on a
+          # TenantScoped property (cache state); CI on a fresh checkout
+          # consistently does. The ignore is needed for the union write
+          # window (new entity → TenantAssignmentListener) on every
+          # entity below; tolerating an unmatched ignore lets local
+          # iteration stay green even when the cache is hot.
+          reportUnmatched: false
           paths:
               - src/Catalog/Domain/Entity/Attribute.php
               - src/Catalog/Domain/Entity/AttributeGroup.php

--- a/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeCommand.php
+++ b/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeCommand.php
@@ -11,6 +11,7 @@ final readonly class CreateAttributeCommand
      * @param array<string, string>|null $help
      * @param array<string, mixed>       $validationRules
      * @param list<string>               $attachToGroups
+     * @param list<string>               $relationTargetObjectTypeIds
      */
     public function __construct(
         public string $code,
@@ -24,6 +25,9 @@ final readonly class CreateAttributeCommand
         public array $validationRules = [],
         public int $position = 0,
         public array $attachToGroups = [],
+        public array $relationTargetObjectTypeIds = [],
+        public ?string $relationCardinality = null,
+        public bool $relationAdvanced = false,
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/CreateAttribute/CreateAttributeHandler.php
@@ -9,6 +9,7 @@ use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\AttributeGroupAttribute;
 use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Validator\RelationAttributeConfigValidator;
 use App\Shared\Application\TenantContext;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
@@ -37,6 +38,7 @@ final readonly class CreateAttributeHandler
         private AttributeGroupRepositoryInterface $groupRepository,
         private EntityManagerInterface $em,
         private TenantContext $tenantContext,
+        private RelationAttributeConfigValidator $relationConfigValidator,
     ) {
     }
 
@@ -67,10 +69,24 @@ final readonly class CreateAttributeHandler
             $groups[] = $group;
         }
 
+        $type = AttributeType::from($command->type);
+
+        // ADR-014 / MOD-05 (#897) — relation-type attributes carry three
+        // extra config columns. Validator enforces target ObjectType
+        // existence, cardinality required, and coerces away half-set
+        // payloads on non-relation types.
+        [$relationTargetIds, $relationCardinality, $relationAdvanced] = $this->relationConfigValidator->validateAndNormalise(
+            $type,
+            $command->relationTargetObjectTypeIds,
+            $command->relationCardinality,
+            $command->relationAdvanced,
+            $tenant,
+        );
+
         $attribute = new Attribute(
             code: $command->code,
             label: $command->label,
-            type: AttributeType::from($command->type),
+            type: $type,
         );
         $attribute->updateHelp($command->help);
         $attribute->changeLocalizable($command->localizable);
@@ -79,6 +95,9 @@ final readonly class CreateAttributeHandler
         $attribute->changeFilterable($command->filterable);
         $attribute->updateValidationRules($command->validationRules);
         $attribute->reorder($command->position);
+        $attribute->setRelationTargetObjectTypeIds($relationTargetIds);
+        $attribute->setRelationCardinality($relationCardinality);
+        $attribute->setRelationAdvanced($relationAdvanced);
 
         $this->repository->save($attribute);
 

--- a/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeCommand.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeCommand.php
@@ -12,6 +12,7 @@ final readonly class UpdateAttributeCommand
      * @param array<string, string>|null $label
      * @param array<string, string>|null $help
      * @param array<string, mixed>|null  $validationRules
+     * @param list<string>|null          $relationTargetObjectTypeIds
      */
     public function __construct(
         public Uuid $id,
@@ -23,6 +24,9 @@ final readonly class UpdateAttributeCommand
         public ?bool $filterable = null,
         public ?array $validationRules = null,
         public ?int $position = null,
+        public ?array $relationTargetObjectTypeIds = null,
+        public ?string $relationCardinality = null,
+        public ?bool $relationAdvanced = null,
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeHandler.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Catalog\Application\Command\UpdateAttribute;
 
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Validator\RelationAttributeConfigValidator;
+use App\Shared\Application\TenantContext;
+use LogicException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -24,6 +27,8 @@ final readonly class UpdateAttributeHandler
 {
     public function __construct(
         private AttributeRepositoryInterface $repository,
+        private RelationAttributeConfigValidator $relationConfigValidator,
+        private TenantContext $tenantContext,
     ) {
     }
 
@@ -82,6 +87,35 @@ final readonly class UpdateAttributeHandler
         }
         if (null !== $command->validationRules) {
             $attribute->updateValidationRules($command->validationRules);
+        }
+
+        // ADR-014 / MOD-05 (#897) — relation config can be edited on
+        // existing relation attributes. Non-relation attributes coerce
+        // the validator to throw if any relation field is non-null.
+        $touchesRelationConfig = null !== $command->relationTargetObjectTypeIds
+            || null !== $command->relationCardinality
+            || null !== $command->relationAdvanced;
+        if ($touchesRelationConfig) {
+            $tenant = $this->tenantContext->get();
+            if (null === $tenant) {
+                throw new LogicException('Cannot update relation config without an authenticated tenant.');
+            }
+
+            $targetIds = $command->relationTargetObjectTypeIds ?? $attribute->getRelationTargetObjectTypeIds();
+            $cardinality = $command->relationCardinality ?? $attribute->getRelationCardinality()?->value;
+            $advanced = $command->relationAdvanced ?? $attribute->isRelationAdvanced();
+
+            [$resolvedTargets, $resolvedCardinality, $resolvedAdvanced] = $this->relationConfigValidator->validateAndNormalise(
+                $attribute->getType(),
+                $targetIds,
+                $cardinality,
+                $advanced,
+                $tenant,
+            );
+
+            $attribute->setRelationTargetObjectTypeIds($resolvedTargets);
+            $attribute->setRelationCardinality($resolvedCardinality);
+            $attribute->setRelationAdvanced($resolvedAdvanced);
         }
 
         $this->repository->save($attribute);

--- a/apps/api/src/Catalog/Domain/Validator/RelationAttributeConfigValidator.php
+++ b/apps/api/src/Catalog/Domain/Validator/RelationAttributeConfigValidator.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Validator;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\RelationCardinality;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ADR-014 / MOD-05 (#897) — validates the three relation-specific config
+ * columns on an Attribute of type `relation`:
+ *
+ *  - `relation_target_object_type_ids` (JSONB list of UUIDs) — every id
+ *    must resolve to an ObjectType in the current tenant. An empty list
+ *    is allowed at the data layer but the validator returns warning-free
+ *    null because UI gates it (operator-facing constraint).
+ *  - `relation_cardinality` (`one` / `many`) — MUST be set on `relation`
+ *    attributes; MUST be null on every other type.
+ *  - `relation_advanced` — boolean, no cross-field rule.
+ *
+ * For non-relation attribute types, the validator coerces the three
+ * fields back to their defaults (empty list, null, false) so the
+ * persistence layer never carries half-set relation config on
+ * `text`/`select`/etc. rows.
+ */
+final readonly class RelationAttributeConfigValidator
+{
+    public function __construct(
+        private ObjectTypeRepositoryInterface $objectTypes,
+    ) {
+    }
+
+    /**
+     * @param list<string> $targetObjectTypeIds
+     *
+     * @return array{0: list<string>, 1: ?RelationCardinality, 2: bool}
+     *                                                                  tuple of the sanitised (targetIds, cardinality, advanced)
+     */
+    public function validateAndNormalise(
+        AttributeType $type,
+        array $targetObjectTypeIds,
+        ?string $cardinality,
+        bool $advanced,
+        Tenant $tenant,
+    ): array {
+        if (AttributeType::Relation !== $type) {
+            if ([] !== $targetObjectTypeIds || null !== $cardinality || $advanced) {
+                throw new UnprocessableEntityHttpException(
+                    'Relation config columns are only meaningful for attributes of type "relation".',
+                );
+            }
+
+            return [[], null, false];
+        }
+
+        if (null === $cardinality) {
+            throw new UnprocessableEntityHttpException(
+                'Attribute of type "relation" requires `relationCardinality` to be set to "one" or "many".',
+            );
+        }
+
+        $resolvedCardinality = RelationCardinality::tryFrom($cardinality);
+        if (null === $resolvedCardinality) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                '"%s" is not a valid relationCardinality (expected "one" or "many").',
+                $cardinality,
+            ));
+        }
+
+        $normalisedIds = [];
+        foreach ($targetObjectTypeIds as $raw) {
+            if (!Uuid::isValid($raw)) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    '"%s" is not a valid UUID in relationTargetObjectTypeIds.',
+                    $raw,
+                ));
+            }
+            $uuid = Uuid::fromString($raw);
+            $candidate = $this->objectTypes->findById($uuid);
+            if (null === $candidate) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'ObjectType "%s" referenced in relationTargetObjectTypeIds was not found in tenant "%s".',
+                    $raw,
+                    $tenant->getCode(),
+                ));
+            }
+            if ($candidate->getTenant()?->getId()->equals($tenant->getId()) !== true) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'ObjectType "%s" referenced in relationTargetObjectTypeIds belongs to a different tenant.',
+                    $raw,
+                ));
+            }
+            $normalisedIds[$uuid->toRfc4122()] = $uuid->toRfc4122();
+        }
+
+        return [array_values($normalisedIds), $resolvedCardinality, $advanced];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
@@ -81,6 +81,34 @@ final class AttributeInput
     public int $position = 0;
 
     /**
+     * ADR-014 / MOD-05 (#897) — list of ObjectType UUIDs that are valid
+     * targets for `type=relation` links. Ignored / coerced to `[]` for
+     * any other attribute type.
+     *
+     * @var list<string>
+     */
+    #[Assert\Type('array')]
+    #[Assert\All([new Assert\Uuid()])]
+    #[Groups(['attribute:create'])]
+    public array $relationTargetObjectTypeIds = [];
+
+    /**
+     * ADR-014 / MOD-05 (#897) — `one` (max single link per source) or
+     * `many` (ordered list). NULL for non-relation attributes.
+     */
+    #[Assert\Choice(choices: ['one', 'many'])]
+    #[Groups(['attribute:create'])]
+    public ?string $relationCardinality = null;
+
+    /**
+     * ADR-014 / MOD-05 (#897) — flips metadata fields on per-link rows
+     * (object_relations.metadata JSONB). Schema for the metadata payload
+     * lands in MOD-08.
+     */
+    #[Groups(['attribute:create'])]
+    public bool $relationAdvanced = false;
+
+    /**
      * VIEW-03 (#375) — popup „Stwórz nowy" in AttributeGroup detail
      * (groups-categories.jsx:813–953) creates the attribute and
      * attaches it to one or more groups atomically in the same request.

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributePatchInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributePatchInput.php
@@ -59,4 +59,23 @@ final class AttributePatchInput
     #[Assert\PositiveOrZero]
     #[Groups(['attribute:patch'])]
     public ?int $position = null;
+
+    /**
+     * ADR-014 / MOD-05 (#897) — replaces the target ObjectType list on a
+     * relation attribute. Only meaningful when the existing attribute is
+     * of type `relation`; ignored otherwise.
+     *
+     * @var list<string>|null
+     */
+    #[Assert\Type('array')]
+    #[Assert\All([new Assert\Uuid()])]
+    #[Groups(['attribute:patch'])]
+    public ?array $relationTargetObjectTypeIds = null;
+
+    #[Assert\Choice(choices: ['one', 'many'])]
+    #[Groups(['attribute:patch'])]
+    public ?string $relationCardinality = null;
+
+    #[Groups(['attribute:patch'])]
+    public ?bool $relationAdvanced = null;
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeProcessor.php
@@ -83,6 +83,9 @@ final readonly class AttributeProcessor implements ProcessorInterface
             validationRules: $data->validationRules,
             position: $data->position,
             attachToGroups: $data->attachToGroups,
+            relationTargetObjectTypeIds: $data->relationTargetObjectTypeIds,
+            relationCardinality: $data->relationCardinality,
+            relationAdvanced: $data->relationAdvanced,
         );
 
         $envelope = $this->dispatch($command);
@@ -127,6 +130,9 @@ final readonly class AttributeProcessor implements ProcessorInterface
             filterable: $data->filterable,
             validationRules: $data->validationRules,
             position: $data->position,
+            relationTargetObjectTypeIds: $data->relationTargetObjectTypeIds,
+            relationCardinality: $data->relationCardinality,
+            relationAdvanced: $data->relationAdvanced,
         );
         $this->dispatch($command);
 

--- a/apps/api/tests/Api/Catalog/RelationAttributeConfigApiTest.php
+++ b/apps/api/tests/Api/Catalog/RelationAttributeConfigApiTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\RelationCardinality;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * ADR-014 / MOD-05 (#897) — POST/PATCH `/api/attributes` with the new
+ * `relation_*` config columns.
+ */
+final class RelationAttributeConfigApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function postCreatesRelationAttributeWithFullConfig(): void
+    {
+        $client = $this->authenticatedClient();
+        $productId = $this->productObjectTypeId();
+
+        $response = $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'upsell_link',
+                'label' => ['en' => 'Up-sell', 'pl' => 'Up-sell'],
+                'type' => 'relation',
+                'relationTargetObjectTypeIds' => [$productId],
+                'relationCardinality' => 'many',
+                'relationAdvanced' => true,
+            ],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode(), $response->getContent(false));
+        $body = $response->toArray();
+        self::assertSame('relation', $body['type']);
+        self::assertSame([$productId], $body['relationTargetObjectTypeIds']);
+        self::assertSame('many', $body['relationCardinality']);
+        self::assertTrue($body['relationAdvanced']);
+    }
+
+    #[Test]
+    public function postRejectsRelationAttributeWithoutCardinality(): void
+    {
+        $client = $this->authenticatedClient();
+        $productId = $this->productObjectTypeId();
+
+        $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'no_card',
+                'label' => ['en' => 'Bad'],
+                'type' => 'relation',
+                'relationTargetObjectTypeIds' => [$productId],
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function postRejectsRelationAttributeWithUnknownTargetObjectType(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'bad_target',
+                'label' => ['en' => 'Bad'],
+                'type' => 'relation',
+                'relationTargetObjectTypeIds' => ['01234567-1234-7000-8000-000000000000'],
+                'relationCardinality' => 'one',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function postRejectsRelationConfigOnTextAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+        $productId = $this->productObjectTypeId();
+
+        $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'mixed_up',
+                'label' => ['en' => 'Bad'],
+                'type' => 'text',
+                'relationTargetObjectTypeIds' => [$productId],
+                'relationCardinality' => 'one',
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function patchUpdatesRelationConfigOnExistingRelationAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+        $productId = $this->productObjectTypeId();
+
+        $createResp = $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'config_evolves',
+                'label' => ['en' => 'Evolves'],
+                'type' => 'relation',
+                'relationTargetObjectTypeIds' => [$productId],
+                'relationCardinality' => 'one',
+                'relationAdvanced' => false,
+            ],
+        ]);
+        self::assertSame(201, $createResp->getStatusCode());
+        $rawId = $createResp->toArray()['id'];
+        \assert(\is_string($rawId));
+        $createdId = $rawId;
+
+        $patchResp = $client->request('PATCH', '/api/attributes/'.$createdId, [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => [
+                'relationCardinality' => 'many',
+                'relationAdvanced' => true,
+            ],
+        ]);
+        self::assertSame(200, $patchResp->getStatusCode(), $patchResp->getContent(false));
+        $body = $patchResp->toArray();
+        self::assertSame('many', $body['relationCardinality']);
+        self::assertTrue($body['relationAdvanced']);
+
+        // ORM round-trip — values land in the DB columns from MOD-01.
+        $reloaded = $this->attributeRepository()->findById(\Symfony\Component\Uid\Uuid::fromString($createdId));
+        self::assertNotNull($reloaded);
+        self::assertSame(AttributeType::Relation, $reloaded->getType());
+        self::assertSame(RelationCardinality::Many, $reloaded->getRelationCardinality());
+        self::assertTrue($reloaded->isRelationAdvanced());
+    }
+
+    private function productObjectTypeId(): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $product = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $product);
+
+        return $product->getId()->toRfc4122();
+    }
+
+    private function attributeRepository(): AttributeRepositoryInterface
+    {
+        return self::getContainer()->get(AttributeRepositoryInterface::class);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -7021,6 +7021,29 @@
                         "default": 0,
                         "type": "integer"
                     },
+                    "relationTargetObjectTypeIds": {
+                        "description": "ADR-014 / MOD-05 (#897) \u2014 list of ObjectType UUIDs that are valid\ntargets for `type=relation` links. Ignored / coerced to `[]` for\nany other attribute type.",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "relationCardinality": {
+                        "enum": [
+                            "one",
+                            "many"
+                        ],
+                        "description": "ADR-014 / MOD-05 (#897) \u2014 `one` (max single link per source) or\n`many` (ordered list). NULL for non-relation attributes.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "relationAdvanced": {
+                        "description": "ADR-014 / MOD-05 (#897) \u2014 flips metadata fields on per-link rows\n(object_relations.metadata JSONB). Schema for the metadata payload\nlands in MOD-08.",
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "attachToGroups": {
                         "description": "VIEW-03 (#375) \u2014 popup \u201eStw\u00f3rz nowy\" in AttributeGroup detail\n(groups-categories.jsx:813\u2013953) creates the attribute and\nattaches it to one or more groups atomically in the same request.",
                         "type": "array",
@@ -7093,6 +7116,32 @@
                         "minimum": 0,
                         "type": [
                             "integer",
+                            "null"
+                        ]
+                    },
+                    "relationTargetObjectTypeIds": {
+                        "description": "ADR-014 / MOD-05 (#897) \u2014 replaces the target ObjectType list on a\nrelation attribute. Only meaningful when the existing attribute is\nof type `relation`; ignored otherwise.",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "relationCardinality": {
+                        "enum": [
+                            "one",
+                            "many"
+                        ],
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    },
+                    "relationAdvanced": {
+                        "type": [
+                            "boolean",
                             "null"
                         ]
                     }


### PR DESCRIPTION
## Summary

ADR-014 / MOD-05 (#897). Plumbs MOD-01 relation config columns (`relation_target_object_type_ids`, `relation_cardinality`, `relation_advanced`) przez istniejący flow POST/PATCH `/api/attributes`. Walidacja przez nowy `RelationAttributeConfigValidator`.

## Layers

- **DTOs**: `AttributeInput` + `AttributePatchInput` — 3 nowe pola z `Choice('one','many')` + `All(Uuid)`.
- **Commands**: `CreateAttributeCommand` + `UpdateAttributeCommand` — nowe opcjonalne fields.
- **Processor**: `AttributeProcessor` bridges DTOs → commands.
- **Handlers**: Create + Update wywołują walidator, ustawiają setters z MOD-01 entity.
- **Validator**: `RelationAttributeConfigValidator::validateAndNormalise()` enforce:
  - cardinality MUST be set on `relation` type
  - relation config rejected na non-relation types
  - target ObjectType UUIDs muszą istnieć w tenancie
  - PATCH zachowuje non-touched fields (`?? $attribute->getX()`)

## Tests

`RelationAttributeConfigApiTest` (5/5):
- [x] POST relation full config → 201 + echo
- [x] POST relation bez cardinality → 422
- [x] POST relation z unknown target OT → 422
- [x] POST text z relation config → 422
- [x] PATCH relation → 200 + ORM round-trip

## Scope adjustments

- **AC-4 (zmiana target z istniejącymi powiązaniami → ostrzeżenie)** — nie zaimplementowane w tym PR. Wymaga query do `object_relations` i custom warning header. Follow-up gdy CRUD object_relations land (MOD-06).
- **AC-5 (cardinality=one — drugie powiązanie odrzucone)** — to enforcement na poziomie object_relations CRUD (MOD-06), nie config validation.

## Quality gates (local)

- [x] PHPStan max → 0 errors (added `reportUnmatched: false` na `doctrine.associationType` block — cache-tolerance)
- [x] PHPUnit RelationAttributeConfigApiTest → 5/5 OK
- [ ] CI green

Closes #897 — następny: MOD-06 (#898) object_relations CRUD.