### PR TITLE
feat(catalog): object_relations CRUD endpoints (MOD-06)

### DIFF
--- a/apps/api/src/Catalog/Application/ObjectRelationService.php
+++ b/apps/api/src/Catalog/Application/ObjectRelationService.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectRelation;
+use App\Catalog\Domain\RelationCardinality;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ADR-014 / MOD-06 (#898) — domain service for object↔object relations.
+ *
+ * Backs the three endpoints on `ObjectRelationController`:
+ *   - listing the relations of an object grouped by attribute,
+ *   - atomic replace of relations for a single (source, attribute),
+ *   - single-row remove.
+ *
+ * Tenant scope: every lookup goes through TenantFilter-bound
+ * repositories so cross-tenant ids resolve to NotFound (404). The
+ * service additionally checks that source + target objects + the
+ * attribute all share the active tenant — this guards against the rare
+ * case where a controller fabricates an entity reference before the
+ * filter has had a chance to vet it.
+ */
+final class ObjectRelationService
+{
+    public function __construct(
+        private readonly ObjectRelationRepositoryInterface $relations,
+        private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly TenantContext $tenantContext,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @return list<ObjectRelation>
+     */
+    public function listForSource(CatalogObject $source, Attribute $attribute): array
+    {
+        return $this->relations->findBySourceAndAttribute($source, $attribute);
+    }
+
+    /**
+     * Atomically replace the relations under `(source, attribute)` with the
+     * supplied target object list. Idempotent: when the new list equals the
+     * existing one, the function still touches each row (position update)
+     * but introduces no schema delta. Cardinality `one` allows at most one
+     * target — extra entries reject with 422.
+     *
+     * @param list<Uuid> $targetObjectIds
+     */
+    public function replaceForSourceAndAttribute(
+        CatalogObject $source,
+        Attribute $attribute,
+        array $targetObjectIds,
+    ): void {
+        $this->guardAttribute($attribute);
+        $this->guardCardinality($attribute, $targetObjectIds);
+
+        $tenant = $this->tenantContext->get();
+        $resolvedTargets = [];
+        foreach ($targetObjectIds as $position => $targetId) {
+            $target = $this->objects->findById($targetId);
+            if (null === $target) {
+                throw new NotFoundHttpException(\sprintf(
+                    'Target object "%s" was not found in this tenant.',
+                    $targetId->toRfc4122(),
+                ));
+            }
+            if (null !== $tenant && $target->getTenant()?->getId()->equals($tenant->getId()) !== true) {
+                throw new NotFoundHttpException(\sprintf(
+                    'Target object "%s" was not found in this tenant.',
+                    $targetId->toRfc4122(),
+                ));
+            }
+            if ($target->getId()->equals($source->getId())) {
+                throw new UnprocessableEntityHttpException(
+                    'A relation cannot point at the source object itself.',
+                );
+            }
+            $this->guardTargetObjectType($attribute, $target);
+            $resolvedTargets[] = $target;
+        }
+
+        // Atomic replace: drop existing → insert new. One transaction.
+        $this->em->wrapInTransaction(function () use ($source, $attribute, $resolvedTargets): void {
+            foreach ($this->relations->findBySourceAndAttribute($source, $attribute) as $existing) {
+                $this->relations->remove($existing);
+            }
+            $this->em->flush();
+
+            foreach ($resolvedTargets as $position => $target) {
+                $row = new ObjectRelation(
+                    source: $source,
+                    target: $target,
+                    attribute: $attribute,
+                    position: $position,
+                );
+                $this->relations->add($row);
+            }
+            $this->em->flush();
+        });
+    }
+
+    public function removeOne(
+        CatalogObject $source,
+        Attribute $attribute,
+        CatalogObject $target,
+    ): bool {
+        foreach ($this->relations->findBySourceAndAttribute($source, $attribute) as $existing) {
+            if ($existing->getTarget()->getId()->equals($target->getId())) {
+                $this->relations->remove($existing);
+                $this->em->flush();
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<Uuid> $targetObjectIds
+     */
+    private function guardCardinality(Attribute $attribute, array $targetObjectIds): void
+    {
+        if (RelationCardinality::One === $attribute->getRelationCardinality() && \count($targetObjectIds) > 1) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Attribute "%s" has cardinality=one; only a single target is allowed.',
+                $attribute->getCode(),
+            ));
+        }
+    }
+
+    private function guardAttribute(Attribute $attribute): void
+    {
+        if (AttributeType::Relation !== $attribute->getType()) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Attribute "%s" is not of type "relation".',
+                $attribute->getCode(),
+            ));
+        }
+    }
+
+    private function guardTargetObjectType(Attribute $attribute, CatalogObject $target): void
+    {
+        $allowedIds = $attribute->getRelationTargetObjectTypeIds();
+        if ([] === $allowedIds) {
+            return;
+        }
+        if (!\in_array($target->getObjectType()->getId()->toRfc4122(), $allowedIds, true)) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Target object "%s" has ObjectType "%s" which is not in the allowed targets of attribute "%s".',
+                $target->getId()->toRfc4122(),
+                $target->getObjectType()->getCode(),
+                $attribute->getCode(),
+            ));
+        }
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\ObjectRelationService;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ADR-014 / MOD-06 (#898) — REST endpoints exposing the object↔object
+ * link junction (`object_relations`) created in MOD-02.
+ *
+ *   GET    /api/objects/{id}/relations
+ *   PUT    /api/objects/{id}/relations/{attributeCode}
+ *   DELETE /api/objects/{id}/relations/{attributeCode}/{targetId}
+ *
+ * Tenant scope: every read goes through TenantFilter-bound repositories,
+ * so a cross-tenant source id returns 404 immediately. The PUT body
+ * carries a list of target `id` strings (with optional `metadata` once
+ * MOD-08 lands; ignored for now).
+ *
+ * Cardinality + target ObjectType validation lives in
+ * {@see ObjectRelationService}; this controller is a thin HTTP veneer.
+ */
+final class ObjectRelationController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    private const string CODE_REGEX = '[a-z][a-z0-9_]{0,63}';
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly AttributeRepositoryInterface $attributes,
+        private readonly ObjectRelationService $service,
+        private readonly TenantContext $tenantContext,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    #[Route(
+        '/api/objects/{id}/relations',
+        name: 'pim_objects_relations_list',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function list(string $id): JsonResponse
+    {
+        $source = $this->fetchObject($id);
+
+        // We don't have a "find all relation attributes for an ObjectType"
+        // shortcut here, so we walk the effective list of attributes via the
+        // object_type_attributes junction (relation type only). For each
+        // attribute, ask the service for its rows. The shape mirrors the FE
+        // grouping in the MOD-12 tab.
+        $relationAttributes = $this->relationAttributesForSource($source);
+
+        $groups = [];
+        foreach ($relationAttributes as $attribute) {
+            $rows = $this->service->listForSource($source, $attribute);
+            $groups[] = [
+                'attribute' => [
+                    'id' => $attribute->getId()->toRfc4122(),
+                    'code' => $attribute->getCode(),
+                    'label' => $attribute->getLabel(),
+                    'cardinality' => $attribute->getRelationCardinality()?->value,
+                    'advanced' => $attribute->isRelationAdvanced(),
+                ],
+                'relations' => array_map(
+                    static fn ($row): array => [
+                        'id' => $row->getId()->toRfc4122(),
+                        'targetObjectId' => $row->getTarget()->getId()->toRfc4122(),
+                        'position' => $row->getPosition(),
+                        'metadata' => $row->getMetadata(),
+                    ],
+                    $rows,
+                ),
+            ];
+        }
+
+        return new JsonResponse([
+            'sourceObjectId' => $source->getId()->toRfc4122(),
+            'relationAttributes' => $groups,
+        ]);
+    }
+
+    #[Route(
+        '/api/objects/{id}/relations/{attributeCode}',
+        name: 'pim_objects_relations_put',
+        requirements: ['id' => self::UUID_REGEX, 'attributeCode' => self::CODE_REGEX],
+        methods: ['PUT'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'edit')]
+    public function put(string $id, string $attributeCode, Request $request): JsonResponse
+    {
+        $source = $this->fetchObject($id);
+        $attribute = $this->fetchAttribute($attributeCode);
+
+        $payload = json_decode($request->getContent(), true);
+        if (!\is_array($payload)) {
+            throw new BadRequestHttpException('Body must be a JSON object.');
+        }
+        $rawTargets = $payload['targets'] ?? null;
+        if (!\is_array($rawTargets)) {
+            throw new BadRequestHttpException('Field "targets" must be an array of `{id}` objects (or UUID strings).');
+        }
+
+        $targetIds = [];
+        foreach ($rawTargets as $entry) {
+            $rawId = \is_array($entry) ? ($entry['id'] ?? null) : $entry;
+            if (!\is_string($rawId) || !Uuid::isValid($rawId)) {
+                throw new BadRequestHttpException('Each target must carry a valid UUID `id`.');
+            }
+            $targetIds[] = Uuid::fromString($rawId);
+        }
+
+        $this->service->replaceForSourceAndAttribute($source, $attribute, $targetIds);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    #[Route(
+        '/api/objects/{id}/relations/{attributeCode}/{targetId}',
+        name: 'pim_objects_relations_delete',
+        requirements: [
+            'id' => self::UUID_REGEX,
+            'attributeCode' => self::CODE_REGEX,
+            'targetId' => self::UUID_REGEX,
+        ],
+        methods: ['DELETE'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'edit')]
+    public function delete(string $id, string $attributeCode, string $targetId): JsonResponse
+    {
+        $source = $this->fetchObject($id);
+        $attribute = $this->fetchAttribute($attributeCode);
+        $target = $this->fetchObject($targetId);
+
+        // Idempotent: missing row is success (204). Matches the rest of
+        // the catalog DELETE conventions.
+        $this->service->removeOne($source, $attribute, $target);
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private function fetchObject(string $rawId): \App\Catalog\Domain\Entity\CatalogObject
+    {
+        $object = $this->objects->findById(Uuid::fromString($rawId));
+        if (null === $object) {
+            throw new NotFoundHttpException(\sprintf('Object "%s" was not found.', $rawId));
+        }
+
+        return $object;
+    }
+
+    private function fetchAttribute(string $code): \App\Catalog\Domain\Entity\Attribute
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new NotFoundHttpException('Tenant context not set.');
+        }
+        $attribute = $this->attributes->findByCode($code, $tenant);
+        if (null === $attribute) {
+            throw new NotFoundHttpException(\sprintf('Attribute "%s" was not found.', $code));
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * @return list<\App\Catalog\Domain\Entity\Attribute>
+     */
+    private function relationAttributesForSource(\App\Catalog\Domain\Entity\CatalogObject $source): array
+    {
+        // Lightweight inline query — the FE grouping needs only the
+        // attributes of type=relation attached to the source's ObjectType
+        // via the object_type_attributes junction. CategoryAttributeGroup
+        // distribution adds more in MOD-12 once the resolver wiring
+        // ships; for now base-only is the documented MVP.
+        /** @var list<\App\Catalog\Domain\Entity\Attribute> $rows */
+        $rows = $this->em
+            ->createQuery(
+                'SELECT a FROM '.\App\Catalog\Domain\Entity\Attribute::class.' a'
+                .' JOIN '.ObjectTypeAttribute::class.' j WITH j.attribute = a'
+                .' WHERE j.objectType = :type AND a.type = :type_value'
+                .' ORDER BY j.sortOrder ASC, a.code ASC'
+            )
+            ->setParameter('type', $source->getObjectType())
+            ->setParameter('type_value', \App\Catalog\Domain\AttributeType::Relation->value)
+            ->getResult();
+
+        return $rows;
+    }
+}

--- a/apps/api/tests/Api/Catalog/ObjectRelationsCrudApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectRelationsCrudApiTest.php
@@ -7,7 +7,6 @@ namespace App\Tests\Api\Catalog;
 use App\Catalog\Application\BuiltInProductRelationAttributesSeeder;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
-use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Shared\Domain\Tenant;
 use PHPUnit\Framework\Attributes\Test;
@@ -52,10 +51,14 @@ final class ObjectRelationsCrudApiTest extends CatalogApiTestCase
         $body = $listResp->toArray();
         self::assertSame($source->getId()->toRfc4122(), $body['sourceObjectId']);
 
-        $crossSell = $this->groupForCode($body['relationAttributes'], 'cross_sell');
-        self::assertCount(2, $crossSell['relations']);
-        self::assertSame($a->getId()->toRfc4122(), $crossSell['relations'][0]['targetObjectId']);
-        self::assertSame($b->getId()->toRfc4122(), $crossSell['relations'][1]['targetObjectId']);
+        /** @var list<array<string, mixed>> $relationAttributes */
+        $relationAttributes = $body['relationAttributes'];
+        $crossSell = $this->groupForCode($relationAttributes, 'cross_sell');
+        /** @var list<array{targetObjectId: string, position: int}> $relations */
+        $relations = $crossSell['relations'];
+        self::assertCount(2, $relations);
+        self::assertSame($a->getId()->toRfc4122(), $relations[0]['targetObjectId']);
+        self::assertSame($b->getId()->toRfc4122(), $relations[1]['targetObjectId']);
     }
 
     #[Test]
@@ -81,7 +84,9 @@ final class ObjectRelationsCrudApiTest extends CatalogApiTestCase
         self::assertSame(204, $deleteResp->getStatusCode(), $deleteResp->getContent(false));
 
         $listResp = $client->request('GET', '/api/objects/'.$source->getId()->toRfc4122().'/relations');
-        $related = $this->groupForCode($listResp->toArray()['relationAttributes'], 'related');
+        /** @var list<array<string, mixed>> $relationAttributes */
+        $relationAttributes = $listResp->toArray()['relationAttributes'];
+        $related = $this->groupForCode($relationAttributes, 'related');
         self::assertSame([], $related['relations']);
     }
 
@@ -109,9 +114,9 @@ final class ObjectRelationsCrudApiTest extends CatalogApiTestCase
     private function groupForCode(array $groups, string $code): array
     {
         foreach ($groups as $group) {
-            \assert(\is_array($group));
-            \assert(\is_array($group['attribute']));
-            if ($code === $group['attribute']['code']) {
+            /** @var array{code: string} $attribute */
+            $attribute = $group['attribute'];
+            if ($code === $attribute['code']) {
                 return $group;
             }
         }
@@ -135,10 +140,5 @@ final class ObjectRelationsCrudApiTest extends CatalogApiTestCase
         $em->flush();
 
         return $object;
-    }
-
-    private function attributeRepository(): AttributeRepositoryInterface
-    {
-        return self::getContainer()->get(AttributeRepositoryInterface::class);
     }
 }

--- a/apps/api/tests/Api/Catalog/ObjectRelationsCrudApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectRelationsCrudApiTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInProductRelationAttributesSeeder;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * ADR-014 / MOD-06 (#898) — CRUD smoke for `/api/objects/{id}/relations`.
+ */
+final class ObjectRelationsCrudApiTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        // Seed 5 built-in relation attrs on Product (cross_sell, up_sell, …)
+        // so the controller has something to look up by code.
+        self::getContainer()->get(BuiltInProductRelationAttributesSeeder::class)->seed($tenant);
+    }
+
+    #[Test]
+    public function putReplacesRelationsForAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $source = $this->makeProduct('SOURCE-A');
+        $a = $this->makeProduct('TARGET-A');
+        $b = $this->makeProduct('TARGET-B');
+
+        $resp = $client->request('PUT', '/api/objects/'.$source->getId()->toRfc4122().'/relations/cross_sell', [
+            'json' => [
+                'targets' => [
+                    ['id' => $a->getId()->toRfc4122()],
+                    ['id' => $b->getId()->toRfc4122()],
+                ],
+            ],
+        ]);
+        self::assertSame(204, $resp->getStatusCode(), $resp->getContent(false));
+
+        $listResp = $client->request('GET', '/api/objects/'.$source->getId()->toRfc4122().'/relations');
+        self::assertSame(200, $listResp->getStatusCode());
+        $body = $listResp->toArray();
+        self::assertSame($source->getId()->toRfc4122(), $body['sourceObjectId']);
+
+        $crossSell = $this->groupForCode($body['relationAttributes'], 'cross_sell');
+        self::assertCount(2, $crossSell['relations']);
+        self::assertSame($a->getId()->toRfc4122(), $crossSell['relations'][0]['targetObjectId']);
+        self::assertSame($b->getId()->toRfc4122(), $crossSell['relations'][1]['targetObjectId']);
+    }
+
+    #[Test]
+    public function deleteRemovesSingleRelation(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $source = $this->makeProduct('SRC-DEL');
+        $target = $this->makeProduct('TGT-DEL');
+
+        // Seed one relation first.
+        $client->request('PUT', '/api/objects/'.$source->getId()->toRfc4122().'/relations/related', [
+            'json' => ['targets' => [['id' => $target->getId()->toRfc4122()]]],
+        ]);
+        $deleteResp = $client->request(
+            'DELETE',
+            \sprintf(
+                '/api/objects/%s/relations/related/%s',
+                $source->getId()->toRfc4122(),
+                $target->getId()->toRfc4122(),
+            ),
+        );
+        self::assertSame(204, $deleteResp->getStatusCode(), $deleteResp->getContent(false));
+
+        $listResp = $client->request('GET', '/api/objects/'.$source->getId()->toRfc4122().'/relations');
+        $related = $this->groupForCode($listResp->toArray()['relationAttributes'], 'related');
+        self::assertSame([], $related['relations']);
+    }
+
+    #[Test]
+    public function putRejectsCrossTenantTarget(): void
+    {
+        $client = $this->authenticatedClient();
+        $source = $this->makeProduct('SRC-XTEN');
+
+        // The Acme tenant is seeded by CatalogApiTestCase as a separate
+        // shell; its built-in Product ObjectType is reachable only
+        // through TenantContext switching. Use a syntactically-valid but
+        // unknown UUID — same effect (404 inside the service).
+        $client->request('PUT', '/api/objects/'.$source->getId()->toRfc4122().'/relations/cross_sell', [
+            'json' => ['targets' => [['id' => '01234567-1234-7000-8000-000000000000']]],
+        ]);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $groups
+     *
+     * @return array<string, mixed>
+     */
+    private function groupForCode(array $groups, string $code): array
+    {
+        foreach ($groups as $group) {
+            \assert(\is_array($group));
+            \assert(\is_array($group['attribute']));
+            if ($code === $group['attribute']['code']) {
+                return $group;
+            }
+        }
+        self::fail(\sprintf('Group for attribute code "%s" not found in response.', $code));
+    }
+
+    private function makeProduct(string $sku): CatalogObject
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        // TenantContext is required by TenantAssignmentListener at persist time.
+        self::getContainer()->get(\App\Shared\Application\TenantContext::class)->set($tenant);
+
+        $productType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $object = new CatalogObject($productType, $sku);
+        $em->persist($object);
+        $em->flush();
+
+        return $object;
+    }
+
+    private function attributeRepository(): AttributeRepositoryInterface
+    {
+        return self::getContainer()->get(AttributeRepositoryInterface::class);
+    }
+}


### PR DESCRIPTION
## Summary

ADR-014 / MOD-06 (#898) — REST endpoints na junction `object_relations` z MOD-02. Trzy routes:
- `GET /api/objects/{id}/relations` — grupowane per atrybut relation
- `PUT /api/objects/{id}/relations/{attributeCode}` — atomic replace
- `DELETE /api/objects/{id}/relations/{attributeCode}/{targetId}` — idempotent

`ObjectRelationController` = HTTP veneer. `ObjectRelationService` (nowy) trzyma business rules.

## Walidacja w `ObjectRelationService`

- Source/target objects rozwiązywane przez TenantFilter-bound repos → cross-tenant id = 404
- Attribute musi być `type=relation`
- Cardinality `one` → max 1 target (>1 → 422)
- Target ObjectType musi być w `relation_target_object_type_ids` allow-list atrybutu (pusta lista = no constraint, zgodnie z MOD-05)
- No self-loop (entity + CHECK constraint z MOD-02)

PUT wraps in `EntityManager::wrapInTransaction`: drop existing → insert new w jednej transakcji, z position zgodnym z kolejnością input'u. DELETE idempotent (204 nawet jak row nieobecny).

## Tests

`ObjectRelationsCrudApiTest` (3/3):
- [x] PUT replaces relations, GET reflects
- [x] DELETE removes single relation, GET shows empty
- [x] PUT z unknown target UUID → 404 (tenant guard)

## Scope decisions

- **GET list** — zwraca attribute z `type=relation` przypisane do source's ObjectType przez `object_type_attributes` junction. Category-distributed relation attributes (MOD-03 overlay) **nie ujęte** w tym PR — UI tab w MOD-12 może rozszerzyć gdy potrzeba.
- **PUT body shape** — `{ "targets": [{ "id": "uuid" }, ...] }`. `metadata` per row (MOD-08 advanced) — ignored teraz, dorobimy w MOD-08.
- **Reverse relations** (MOD-07) — osobny endpoint, nie ten PR.

## Quality gates (local)

- [x] PHPStan max → 0 errors
- [x] PHPUnit ObjectRelationsCrudApiTest → 3/3 OK
- [ ] CI green

Closes #898.