### PR TITLE
feat(catalog): reverse object_relations endpoint (MOD-07)

### DIFF
--- a/apps/api/src/Catalog/Application/ObjectRelationService.php
+++ b/apps/api/src/Catalog/Application/ObjectRelationService.php
@@ -51,6 +51,18 @@ final class ObjectRelationService
     }
 
     /**
+     * MOD-07 (#899) — reverse view: every row pointing AT `$target`.
+     * Returned in `created_at` order so the read-only "Powiązania
+     * zwrotne" panel renders stable groupings.
+     *
+     * @return list<ObjectRelation>
+     */
+    public function findByTarget(CatalogObject $target): array
+    {
+        return $this->relations->findByTarget($target);
+    }
+
+    /**
      * Atomically replace the relations under `(source, attribute)` with the
      * supplied target object list. Idempotent: when the new list equals the
      * existing one, the function still touches each row (position update)

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php
@@ -136,6 +136,55 @@ final class ObjectRelationController
     }
 
     #[Route(
+        '/api/objects/{id}/relations/reverse',
+        name: 'pim_objects_relations_reverse',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function reverse(string $id): JsonResponse
+    {
+        $target = $this->fetchObject($id);
+        $rows = $this->service->findByTarget($target);
+
+        // Group by (source ObjectType, attribute) — UI renders read-only
+        // "powiązania zwrotne" panel split by section.
+        $groups = [];
+        foreach ($rows as $row) {
+            $attribute = $row->getAttribute();
+            $source = $row->getSource();
+            $key = $source->getObjectType()->getId()->toRfc4122().':'.$attribute->getId()->toRfc4122();
+            if (!isset($groups[$key])) {
+                $groups[$key] = [
+                    'sourceObjectType' => [
+                        'id' => $source->getObjectType()->getId()->toRfc4122(),
+                        'code' => $source->getObjectType()->getCode(),
+                        'kind' => $source->getObjectType()->getKind()->value,
+                    ],
+                    'attribute' => [
+                        'id' => $attribute->getId()->toRfc4122(),
+                        'code' => $attribute->getCode(),
+                        'label' => $attribute->getLabel(),
+                    ],
+                    'sources' => [],
+                ];
+            }
+            $groups[$key]['sources'][] = [
+                'id' => $source->getId()->toRfc4122(),
+                'code' => $source->getCode(),
+                'relationId' => $row->getId()->toRfc4122(),
+                'position' => $row->getPosition(),
+            ];
+        }
+
+        return new JsonResponse([
+            'targetObjectId' => $target->getId()->toRfc4122(),
+            'reverseRelations' => array_values($groups),
+        ]);
+    }
+
+    #[Route(
         '/api/objects/{id}/relations/{attributeCode}/{targetId}',
         name: 'pim_objects_relations_delete',
         requirements: [

--- a/apps/api/tests/Api/Catalog/ObjectRelationsReverseApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectRelationsReverseApiTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInProductRelationAttributesSeeder;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * ADR-014 / MOD-07 (#899) — reverse view of `object_relations`.
+ */
+final class ObjectRelationsReverseApiTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(BuiltInProductRelationAttributesSeeder::class)->seed($tenant);
+    }
+
+    #[Test]
+    public function reverseListsSourcesGroupedByObjectTypeAndAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+        $target = $this->makeProduct('TGT-REV');
+        $sourceA = $this->makeProduct('SRC-REV-A');
+        $sourceB = $this->makeProduct('SRC-REV-B');
+
+        // Two products cross-sell the same target.
+        $client->request('PUT', '/api/objects/'.$sourceA->getId()->toRfc4122().'/relations/cross_sell', [
+            'json' => ['targets' => [['id' => $target->getId()->toRfc4122()]]],
+        ]);
+        $client->request('PUT', '/api/objects/'.$sourceB->getId()->toRfc4122().'/relations/cross_sell', [
+            'json' => ['targets' => [['id' => $target->getId()->toRfc4122()]]],
+        ]);
+
+        $response = $client->request('GET', '/api/objects/'.$target->getId()->toRfc4122().'/relations/reverse');
+        self::assertSame(200, $response->getStatusCode(), $response->getContent(false));
+        $body = $response->toArray();
+        self::assertSame($target->getId()->toRfc4122(), $body['targetObjectId']);
+
+        /** @var list<array{attribute: array<string,mixed>, sources: list<array<string,mixed>>}> $reverse */
+        $reverse = $body['reverseRelations'];
+        self::assertCount(1, $reverse, 'one group (Product/cross_sell)');
+        self::assertSame('cross_sell', $reverse[0]['attribute']['code']);
+        self::assertCount(2, $reverse[0]['sources']);
+
+        $sourceCodes = [];
+        foreach ($reverse[0]['sources'] as $s) {
+            $code = $s['code'];
+            \assert(\is_string($code));
+            $sourceCodes[] = $code;
+        }
+        sort($sourceCodes);
+        self::assertSame(['SRC-REV-A', 'SRC-REV-B'], $sourceCodes);
+    }
+
+    #[Test]
+    public function reverseReturnsEmptyEnvelopeWhenNoIncomingRelations(): void
+    {
+        $client = $this->authenticatedClient();
+        $orphan = $this->makeProduct('NO-INBOUND');
+
+        $response = $client->request('GET', '/api/objects/'.$orphan->getId()->toRfc4122().'/relations/reverse');
+        self::assertSame(200, $response->getStatusCode());
+        $body = $response->toArray();
+        self::assertSame($orphan->getId()->toRfc4122(), $body['targetObjectId']);
+        self::assertSame([], $body['reverseRelations']);
+    }
+
+    #[Test]
+    public function reverseReturns404ForUnknownObjectId(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('GET', '/api/objects/01234567-1234-7000-8000-000000000000/relations/reverse');
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    private function makeProduct(string $sku): CatalogObject
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $productType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $object = new CatalogObject($productType, $sku);
+        $em->persist($object);
+        $em->flush();
+
+        return $object;
+    }
+}


### PR DESCRIPTION
## Summary

ADR-014 / MOD-07 (#899). Nowy read-only endpoint `GET /api/objects/{id}/relations/reverse` — zwraca wszystkie `object_relations` wskazujące na ten obiekt, pogrupowane per (source ObjectType, attribute). FE renderuje to jako fixed panel w zakładce Powiązania (gdy operator edytuje obiekt B, widzi z którego A1/A2/... idą cross_sell/up_sell/etc).

## Tests

`ObjectRelationsReverseApiTest` (3/3):
- 2 produkty cross-sell ten sam target → reverse zwraca grupę (Product/cross_sell) z 2 sources
- orphan target → 200 z pustym `reverseRelations`
- unknown target UUID → 404

## Performance

`findByTarget` używa `object_relations_target_idx` (MOD-02). Performance budget <100ms na 50k+ relacjach — index seek + ~N small rows.

## Quality gates (local)

- [x] PHPStan max → 0 errors
- [x] PHPUnit ObjectRelationsReverseApiTest → 3/3 OK
- [ ] CI green

Closes #899 — następne: MOD-08 (#900) advanced metadata.