### PR TITLE
feat(catalog): advanced relations metadata (MOD-08)

### DIFF
--- a/apps/api/src/Catalog/Application/ObjectRelationService.php
+++ b/apps/api/src/Catalog/Application/ObjectRelationService.php
@@ -11,6 +11,7 @@ use App\Catalog\Domain\Entity\ObjectRelation;
 use App\Catalog\Domain\RelationCardinality;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface;
+use App\Catalog\Domain\Validator\RelationMetadataValidator;
 use App\Shared\Application\TenantContext;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -39,6 +40,7 @@ final class ObjectRelationService
         private readonly CatalogObjectRepositoryInterface $objects,
         private readonly TenantContext $tenantContext,
         private readonly EntityManagerInterface $em,
+        private readonly RelationMetadataValidator $metadataValidator,
     ) {
     }
 
@@ -57,19 +59,24 @@ final class ObjectRelationService
      * but introduces no schema delta. Cardinality `one` allows at most one
      * target — extra entries reject with 422.
      *
-     * @param list<Uuid> $targetObjectIds
+     * MOD-08 (#900): each entry MAY carry a per-link metadata payload that
+     * gets validated against the attribute's advanced-fields schema. For
+     * `advanced=false` attributes metadata MUST be empty.
+     *
+     * @param list<array{id: Uuid, metadata?: array<string, mixed>}> $targets
      */
     public function replaceForSourceAndAttribute(
         CatalogObject $source,
         Attribute $attribute,
-        array $targetObjectIds,
+        array $targets,
     ): void {
         $this->guardAttribute($attribute);
-        $this->guardCardinality($attribute, $targetObjectIds);
+        $this->guardCardinality($attribute, $targets);
 
         $tenant = $this->tenantContext->get();
-        $resolvedTargets = [];
-        foreach ($targetObjectIds as $position => $targetId) {
+        $resolved = [];
+        foreach ($targets as $position => $entry) {
+            $targetId = $entry['id'];
             $target = $this->objects->findById($targetId);
             if (null === $target) {
                 throw new NotFoundHttpException(\sprintf(
@@ -89,22 +96,29 @@ final class ObjectRelationService
                 );
             }
             $this->guardTargetObjectType($attribute, $target);
-            $resolvedTargets[] = $target;
+
+            $metadata = $this->metadataValidator->validateAndNormalise(
+                $attribute,
+                $entry['metadata'] ?? [],
+            );
+
+            $resolved[] = ['target' => $target, 'metadata' => $metadata];
         }
 
         // Atomic replace: drop existing → insert new. One transaction.
-        $this->em->wrapInTransaction(function () use ($source, $attribute, $resolvedTargets): void {
+        $this->em->wrapInTransaction(function () use ($source, $attribute, $resolved): void {
             foreach ($this->relations->findBySourceAndAttribute($source, $attribute) as $existing) {
                 $this->relations->remove($existing);
             }
             $this->em->flush();
 
-            foreach ($resolvedTargets as $position => $target) {
+            foreach ($resolved as $position => $entry) {
                 $row = new ObjectRelation(
                     source: $source,
-                    target: $target,
+                    target: $entry['target'],
                     attribute: $attribute,
                     position: $position,
+                    metadata: $entry['metadata'],
                 );
                 $this->relations->add($row);
             }
@@ -130,11 +144,11 @@ final class ObjectRelationService
     }
 
     /**
-     * @param list<Uuid> $targetObjectIds
+     * @param list<array{id: Uuid, metadata?: array<string, mixed>}> $targets
      */
-    private function guardCardinality(Attribute $attribute, array $targetObjectIds): void
+    private function guardCardinality(Attribute $attribute, array $targets): void
     {
-        if (RelationCardinality::One === $attribute->getRelationCardinality() && \count($targetObjectIds) > 1) {
+        if (RelationCardinality::One === $attribute->getRelationCardinality() && \count($targets) > 1) {
             throw new UnprocessableEntityHttpException(\sprintf(
                 'Attribute "%s" has cardinality=one; only a single target is allowed.',
                 $attribute->getCode(),

--- a/apps/api/src/Catalog/Domain/Validator/RelationMetadataValidator.php
+++ b/apps/api/src/Catalog/Domain/Validator/RelationMetadataValidator.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Domain\Validator;
+
+use App\Catalog\Domain\Entity\Attribute;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * ADR-014 / MOD-08 (#900) — validates per-link metadata payloads on
+ * `object_relations.metadata` against the advanced-field schema declared
+ * in `Attribute.validation_rules.advanced_fields`.
+ *
+ * Schema convention (lives in `validation_rules` JSONB so we don't grow a
+ * second JSONB column on `attributes`):
+ *
+ *   {
+ *     "advanced_fields": [
+ *       {"code": "priority",    "type": "number",  "label": {...}, "required": true},
+ *       {"code": "recommended", "type": "boolean", "label": {...}, "required": false}
+ *     ]
+ *   }
+ *
+ * Supported field types in MOD-08: `text`, `number`, `boolean`. Richer
+ * types (`select`, `asset`) land in follow-up when the FE editor for
+ * advanced metadata is built (MOD-12).
+ *
+ * `advanced=false` attribute → metadata payload MUST be empty. The
+ * validator rejects stray fields up front so the persistence layer never
+ * sees half-defined relation rows.
+ */
+final readonly class RelationMetadataValidator
+{
+    private const array SUPPORTED_FIELD_TYPES = ['text', 'number', 'boolean'];
+
+    /**
+     * @param array<string, mixed> $metadata
+     *
+     * @return array<string, mixed> the sanitised payload (extra keys
+     *                              stripped, types coerced when safe)
+     */
+    public function validateAndNormalise(Attribute $attribute, array $metadata): array
+    {
+        if (!$attribute->isRelationAdvanced()) {
+            if ([] !== $metadata) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Attribute "%s" is not advanced; metadata payload must be empty.',
+                    $attribute->getCode(),
+                ));
+            }
+
+            return [];
+        }
+
+        $fields = $this->extractAdvancedFields($attribute);
+        $byCode = [];
+        foreach ($fields as $field) {
+            $byCode[$field['code']] = $field;
+        }
+
+        // Reject unknown keys up front so the caller knows immediately
+        // when the schema doesn't match.
+        foreach (array_keys($metadata) as $key) {
+            if (!isset($byCode[$key])) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Unknown metadata field "%s" on attribute "%s".',
+                    $key,
+                    $attribute->getCode(),
+                ));
+            }
+        }
+
+        $sanitised = [];
+        foreach ($byCode as $code => $field) {
+            $isPresent = \array_key_exists($code, $metadata);
+            if (!$isPresent) {
+                if ($field['required']) {
+                    throw new UnprocessableEntityHttpException(\sprintf(
+                        'Metadata field "%s" is required on attribute "%s".',
+                        $code,
+                        $attribute->getCode(),
+                    ));
+                }
+                continue;
+            }
+
+            $sanitised[$code] = $this->coerceValue($code, $field['type'], $metadata[$code], $attribute);
+        }
+
+        return $sanitised;
+    }
+
+    /**
+     * @return list<array{code: string, type: string, label: array<string, string>, required: bool}>
+     */
+    private function extractAdvancedFields(Attribute $attribute): array
+    {
+        $rules = $attribute->getValidationRules();
+        $raw = $rules['advanced_fields'] ?? [];
+        if (!\is_array($raw)) {
+            return [];
+        }
+
+        $fields = [];
+        foreach ($raw as $entry) {
+            if (!\is_array($entry)) {
+                continue;
+            }
+            $code = $entry['code'] ?? null;
+            $type = $entry['type'] ?? null;
+            if (!\is_string($code) || '' === $code || !\is_string($type)) {
+                continue;
+            }
+            if (!\in_array($type, self::SUPPORTED_FIELD_TYPES, true)) {
+                continue;
+            }
+            $label = $entry['label'] ?? [];
+            if (!\is_array($label)) {
+                $label = [];
+            }
+            $labelMap = [];
+            foreach ($label as $locale => $text) {
+                if (\is_string($locale) && \is_string($text)) {
+                    $labelMap[$locale] = $text;
+                }
+            }
+            $fields[] = [
+                'code' => $code,
+                'type' => $type,
+                'label' => $labelMap,
+                'required' => (bool) ($entry['required'] ?? false),
+            ];
+        }
+
+        return $fields;
+    }
+
+    private function coerceValue(string $code, string $type, mixed $raw, Attribute $attribute): mixed
+    {
+        return match ($type) {
+            'text' => $this->expectString($code, $raw, $attribute),
+            'number' => $this->expectNumber($code, $raw, $attribute),
+            'boolean' => $this->expectBoolean($code, $raw, $attribute),
+            default => throw new UnprocessableEntityHttpException(\sprintf(
+                'Unsupported metadata field type "%s" on attribute "%s".',
+                $type,
+                $attribute->getCode(),
+            )),
+        };
+    }
+
+    private function expectString(string $code, mixed $raw, Attribute $attribute): string
+    {
+        if (!\is_string($raw)) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Metadata field "%s" on attribute "%s" expects a string.',
+                $code,
+                $attribute->getCode(),
+            ));
+        }
+
+        return $raw;
+    }
+
+    private function expectNumber(string $code, mixed $raw, Attribute $attribute): int|float
+    {
+        if (\is_int($raw) || \is_float($raw)) {
+            return $raw;
+        }
+        throw new UnprocessableEntityHttpException(\sprintf(
+            'Metadata field "%s" on attribute "%s" expects a number.',
+            $code,
+            $attribute->getCode(),
+        ));
+    }
+
+    private function expectBoolean(string $code, mixed $raw, Attribute $attribute): bool
+    {
+        if (\is_bool($raw)) {
+            return $raw;
+        }
+        throw new UnprocessableEntityHttpException(\sprintf(
+            'Metadata field "%s" on attribute "%s" expects a boolean.',
+            $code,
+            $attribute->getCode(),
+        ));
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php
@@ -121,16 +121,26 @@ final class ObjectRelationController
             throw new BadRequestHttpException('Field "targets" must be an array of `{id}` objects (or UUID strings).');
         }
 
-        $targetIds = [];
+        /** @var list<array{id: Uuid, metadata: array<string, mixed>}> $targets */
+        $targets = [];
         foreach ($rawTargets as $entry) {
             $rawId = \is_array($entry) ? ($entry['id'] ?? null) : $entry;
             if (!\is_string($rawId) || !Uuid::isValid($rawId)) {
                 throw new BadRequestHttpException('Each target must carry a valid UUID `id`.');
             }
-            $targetIds[] = Uuid::fromString($rawId);
+            $metadata = [];
+            if (\is_array($entry) && isset($entry['metadata'])) {
+                $rawMetadata = $entry['metadata'];
+                if (!\is_array($rawMetadata)) {
+                    throw new BadRequestHttpException('Field "metadata" must be a JSON object.');
+                }
+                /** @var array<string, mixed> $rawMetadata */
+                $metadata = $rawMetadata;
+            }
+            $targets[] = ['id' => Uuid::fromString($rawId), 'metadata' => $metadata];
         }
 
-        $this->service->replaceForSourceAndAttribute($source, $attribute, $targetIds);
+        $this->service->replaceForSourceAndAttribute($source, $attribute, $targets);
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }

--- a/apps/api/tests/Api/Catalog/ObjectRelationsAdvancedMetadataApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectRelationsAdvancedMetadataApiTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\RelationCardinality;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * ADR-014 / MOD-08 (#900) — advanced relations carry per-link metadata
+ * validated against the attribute's `validation_rules.advanced_fields`
+ * schema.
+ */
+final class ObjectRelationsAdvancedMetadataApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function putAcceptsMetadataMatchingAdvancedFieldsSchema(): void
+    {
+        $client = $this->authenticatedClient();
+        $source = $this->makeProduct('SRC-ADV-1');
+        $target = $this->makeProduct('TGT-ADV-1');
+        $attr = $this->createAdvancedRelationAttribute('priority_accessories');
+
+        $resp = $client->request('PUT', '/api/objects/'.$source->getId()->toRfc4122().'/relations/'.$attr->getCode(), [
+            'json' => [
+                'targets' => [
+                    [
+                        'id' => $target->getId()->toRfc4122(),
+                        'metadata' => [
+                            'priority' => 5,
+                            'recommended' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        self::assertSame(204, $resp->getStatusCode(), $resp->getContent(false));
+
+        $listResp = $client->request('GET', '/api/objects/'.$source->getId()->toRfc4122().'/relations');
+        $body = $listResp->toArray();
+        /** @var list<array{attribute: array{code: string}, relations: list<array{metadata: array<string, mixed>}>}> $groups */
+        $groups = $body['relationAttributes'];
+        $group = null;
+        foreach ($groups as $g) {
+            if ($attr->getCode() === $g['attribute']['code']) {
+                $group = $g;
+                break;
+            }
+        }
+        self::assertNotNull($group);
+        self::assertCount(1, $group['relations']);
+        self::assertSame(['priority' => 5, 'recommended' => true], $group['relations'][0]['metadata']);
+    }
+
+    #[Test]
+    public function putRejectsMetadataMissingRequiredField(): void
+    {
+        $client = $this->authenticatedClient();
+        $source = $this->makeProduct('SRC-ADV-2');
+        $target = $this->makeProduct('TGT-ADV-2');
+        $attr = $this->createAdvancedRelationAttribute('required_meta');
+
+        $client->request('PUT', '/api/objects/'.$source->getId()->toRfc4122().'/relations/'.$attr->getCode(), [
+            'json' => [
+                'targets' => [
+                    [
+                        'id' => $target->getId()->toRfc4122(),
+                        'metadata' => ['recommended' => true],
+                    ],
+                ],
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function putRejectsMetadataWithWrongFieldType(): void
+    {
+        $client = $this->authenticatedClient();
+        $source = $this->makeProduct('SRC-ADV-3');
+        $target = $this->makeProduct('TGT-ADV-3');
+        $attr = $this->createAdvancedRelationAttribute('type_meta');
+
+        $client->request('PUT', '/api/objects/'.$source->getId()->toRfc4122().'/relations/'.$attr->getCode(), [
+            'json' => [
+                'targets' => [
+                    [
+                        'id' => $target->getId()->toRfc4122(),
+                        'metadata' => [
+                            'priority' => 'high',          // expected number, got string
+                            'recommended' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    #[Test]
+    public function putRejectsMetadataOnNonAdvancedAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+        $source = $this->makeProduct('SRC-NONADV');
+        $target = $this->makeProduct('TGT-NONADV');
+        $attr = $this->createRelationAttribute('plain_meta', advanced: false);
+
+        $client->request('PUT', '/api/objects/'.$source->getId()->toRfc4122().'/relations/'.$attr->getCode(), [
+            'json' => [
+                'targets' => [
+                    [
+                        'id' => $target->getId()->toRfc4122(),
+                        'metadata' => ['priority' => 1],
+                    ],
+                ],
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    private function createAdvancedRelationAttribute(string $code): Attribute
+    {
+        return $this->createRelationAttribute($code, advanced: true);
+    }
+
+    private function createRelationAttribute(string $code, bool $advanced): Attribute
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $productType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $attribute = new Attribute($code, ['en' => $code], AttributeType::Relation);
+        $attribute->setRelationCardinality(RelationCardinality::Many);
+        $attribute->setRelationTargetObjectTypeIds([$productType->getId()->toRfc4122()]);
+        $attribute->setRelationAdvanced($advanced);
+        if ($advanced) {
+            $attribute->updateValidationRules([
+                'advanced_fields' => [
+                    ['code' => 'priority', 'type' => 'number', 'label' => ['en' => 'Priority'], 'required' => true],
+                    ['code' => 'recommended', 'type' => 'boolean', 'label' => ['en' => 'Recommended'], 'required' => false],
+                ],
+            ]);
+        }
+        $em->persist($attribute);
+        $em->flush();
+
+        // Wire to Product ObjectType so the relations list endpoint sees it.
+        $em->persist(new ObjectTypeAttribute($productType, $attribute));
+        $em->flush();
+
+        return $attribute;
+    }
+
+    private function makeProduct(string $sku): CatalogObject
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $productType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $object = new CatalogObject($productType, $sku);
+        $em->persist($object);
+        $em->flush();
+
+        return $object;
+    }
+}


### PR DESCRIPTION
## Summary

ADR-014 / MOD-08 (#900). Per-link metadata na `object_relations.metadata` walidowane przeciw schemie zdefiniowanej w `Attribute.validation_rules.advanced_fields`. Nie dorabiamy kolejnej JSONB kolumny na `attributes` — wystarczy istniejące validation_rules.

Schema convention:
```json
{
  "advanced_fields": [
    {"code": "priority",    "type": "number",  "label": {...}, "required": true},
    {"code": "recommended", "type": "boolean", "label": {...}, "required": false}
  ]
}
```

Wspierane typy w MOD-08: text/number/boolean. Richer types (select, asset) → follow-up gdy FE editor (MOD-12) potrzebuje.

## Walidacja

`RelationMetadataValidator::validateAndNormalise`:
- `advanced=false` attr → metadata MUST be empty
- unknown keys → 422
- missing required → 422
- type mismatch → 422
- output stripped do declared fields w declaration order

## PUT body shape extended

```json
{
  "targets": [
    {"id": "<uuid>", "metadata": {"priority": 5, "recommended": true}}
  ]
}
```

`ObjectRelationService::replaceForSourceAndAttribute` zmieniła sygnaturę z `list<Uuid>` na `list<array{id, metadata?}>`. Controller bridguje JSON body. Metadata round-tripuje przez `object_relations.metadata JSONB` (z MOD-02 schema).

## Tests

`ObjectRelationsAdvancedMetadataApiTest` (4/4):
- [x] valid metadata → 204 + GET echoes
- [x] missing required → 422
- [x] wrong type → 422
- [x] metadata on advanced=false → 422

Existing MOD-06 `ObjectRelationsCrudApiTest` (3/3) nadal zielony — controller wraps `metadata: []` gdy body bez `metadata`.

Closes #900 — next: MOD-09 (#901) orphaned values.