### PR TITLE
feat(catalog): orphaned values excluded from completeness (MOD-09)

### DIFF
--- a/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
+++ b/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
@@ -6,6 +6,7 @@ namespace App\Catalog\Application;
 
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -33,6 +34,7 @@ final readonly class AttributesIndexedRebuilder
 {
     public function __construct(
         private EntityManagerInterface $em,
+        private EffectiveAttributeGroupResolver $resolver,
     ) {
     }
 
@@ -61,6 +63,26 @@ final readonly class AttributesIndexedRebuilder
         // Completeness: required-list / present-count. Empty rules → 100.
         $rules = $object->getObjectType()->getCompletenessRules();
         $required = \is_array($rules['required'] ?? null) ? $rules['required'] : [];
+
+        // ADR-014 / MOD-09 (#901) — orphaned values (codes present in
+        // attributes_indexed but absent from the effective model) MUST
+        // NOT participate in completeness. Likewise, `required` entries
+        // that point at attributes outside the current effective model
+        // are ignored (a Telewizory-only `przekatna` requirement does
+        // not penalise a Pralki primary).
+        //
+        // Fallback: when the effective model is empty (e.g. an ObjectType
+        // with no group attachments yet, the early-bootstrap path on
+        // fixtures, or unit tests with a stub resolver) we keep the
+        // legacy contract — `required` counts as-is.
+        $effectiveCodes = $this->effectiveAttributeCodes($object);
+        if ([] !== $effectiveCodes) {
+            $required = array_values(array_filter(
+                $required,
+                static fn (mixed $code): bool => \is_string($code) && \in_array($code, $effectiveCodes, true),
+            ));
+        }
+
         if ([] === $required) {
             $object->recordCompleteness(['global' => 100]);
 
@@ -75,5 +97,26 @@ final readonly class AttributesIndexedRebuilder
         }
         $pct = (int) round(100 * $present / \count($required));
         $object->recordCompleteness(['global' => $pct]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function effectiveAttributeCodes(CatalogObject $object): array
+    {
+        $groups = $this->resolver->resolve($object);
+        if ([] === $groups) {
+            return [];
+        }
+        $byGroup = $this->resolver->loadGroupAttributes($groups);
+
+        $codes = [];
+        foreach ($byGroup as $junctions) {
+            foreach ($junctions as $junction) {
+                $codes[$junction->getAttribute()->getCode()] = true;
+            }
+        }
+
+        return array_keys($codes);
     }
 }

--- a/apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php
+++ b/apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php
@@ -54,7 +54,7 @@ use Symfony\Component\Uid\Uuid;
  * via the modeling cache pool. The resolver itself never caches — it
  * remains the source of truth for tests + invalidation paths.
  */
-final readonly class EffectiveAttributeGroupResolver
+readonly class EffectiveAttributeGroupResolver
 {
     public function __construct(
         private EntityManagerInterface $em,

--- a/apps/api/tests/Integration/Catalog/OrphanedValuesTest.php
+++ b/apps/api/tests/Integration/Catalog/OrphanedValuesTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\AttributesIndexedRebuilder;
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Application\BuiltInSystemAttributesSeeder;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * ADR-014 / MOD-09 (#901) — orphaned values (attribute codes with stored
+ * values outside the current effective model) MUST NOT contribute to
+ * completeness, and the form-schema MUST NOT render them.
+ */
+final class OrphanedValuesTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($this->tenant);
+        self::getContainer()->get(BuiltInSystemAttributesSeeder::class)->seed($this->tenant);
+    }
+
+    #[Test]
+    public function orphanedValueDoesNotCountTowardsCompleteness(): void
+    {
+        $em = $this->em();
+        $productType = $this->productType();
+
+        // Effective model contains only audit group (system attrs).
+        // We declare a `required` list with two codes:
+        //   - `sku`         — NOT in effective model (orphaned requirement)
+        //   - `updated_at`  — IS in effective model (audit group)
+        // MOD-09 filter projects required onto the effective set; only
+        // `updated_at` remains. Since it has a value, completeness = 100%.
+        $productType->updateCompletenessRules(['required' => ['sku', 'updated_at']]);
+
+        $product = new CatalogObject($productType, 'SKU-ORPH-1');
+        $em->persist($product);
+        $em->flush();
+
+        // Persist an updated_at value to satisfy the lone effective requirement.
+        $updatedAtAttribute = $em->getRepository(Attribute::class)
+            ->findOneBy(['code' => 'updated_at']);
+        \assert(null !== $updatedAtAttribute);
+        $value = new ObjectValue($product, $updatedAtAttribute, ['value' => '2026-05-24T00:00:00+00:00']);
+        $em->persist($value);
+        $em->flush();
+
+        $rebuilder = self::getContainer()->get(AttributesIndexedRebuilder::class);
+        $rebuilder->rebuild($product);
+
+        // `sku` was filtered out (orphaned), only `updated_at` counts and is present → 100.
+        $completeness = $product->getCompleteness();
+        self::assertSame(100, $completeness['global']);
+    }
+
+    #[Test]
+    public function attributeNotInEffectiveModelDoesNotPenaliseCompleteness(): void
+    {
+        $em = $this->em();
+        $productType = $this->productType();
+
+        // Two required codes, both ABSENT from the effective model (audit
+        // group only). MOD-09 filter projects required to empty set →
+        // completeness = 100% (rather than 0%).
+        $productType->updateCompletenessRules(['required' => ['ghost_a', 'ghost_b']]);
+
+        $product = new CatalogObject($productType, 'SKU-ORPH-2');
+        $em->persist($product);
+        $em->flush();
+
+        self::getContainer()->get(AttributesIndexedRebuilder::class)->rebuild($product);
+
+        self::assertSame(100, $product->getCompleteness()['global']);
+    }
+
+    #[Test]
+    public function completenessRespectsAttributesAttachedDirectlyToObjectType(): void
+    {
+        $em = $this->em();
+        $productType = $this->productType();
+
+        // Attach a custom AttributeGroup carrying `sku`. After attachment
+        // `sku` lives in the effective model so a missing value pulls
+        // completeness down.
+        $group = new AttributeGroup('identification', ['en' => 'Identification']);
+        $em->persist($group);
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $em->persist($sku);
+        $em->flush();
+        $em->persist(new AttributeGroupAttribute($group, $sku, 1));
+        $em->persist(new ObjectTypeAttributeGroup($productType, $group, position: 1));
+        $em->flush();
+
+        $productType->updateCompletenessRules(['required' => ['sku']]);
+
+        $product = new CatalogObject($productType, 'SKU-EFFECTIVE');
+        $em->persist($product);
+        $em->flush();
+
+        self::getContainer()->get(AttributesIndexedRebuilder::class)->rebuild($product);
+
+        // sku is in effective model AND required AND missing → 0%
+        self::assertSame(0, $product->getCompleteness()['global']);
+    }
+
+    private function productType(): \App\Catalog\Domain\Entity\ObjectType
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $this->tenant);
+        \assert(null !== $type);
+
+        return $type;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/CompletenessCalculationTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/CompletenessCalculationTest.php
@@ -11,6 +11,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -117,8 +118,16 @@ final class CompletenessCalculationTest extends TestCase
         array $present,
         int $expectedPct,
     ): void {
+        // Resolver stub returns empty effective groups — the rebuilder's
+        // MOD-09 effective-model filter is bypassed (empty effective set
+        // falls back to the legacy `required` count), so this unit test
+        // still exercises the raw math invariants.
+        $resolver = $this->createStub(EffectiveAttributeGroupResolver::class);
+        $resolver->method('resolve')->willReturn([]);
+        $resolver->method('loadGroupAttributes')->willReturn([]);
         $rebuilder = new AttributesIndexedRebuilder(
             $this->createStub(EntityManagerInterface::class),
+            $resolver,
         );
 
         $tenant = self::tenantStub();
@@ -141,8 +150,16 @@ final class CompletenessCalculationTest extends TestCase
     #[Test]
     public function emptyValuesListWithNoRulesYieldsHundredAndEmptyAttributesIndexed(): void
     {
+        // Resolver stub returns empty effective groups — the rebuilder's
+        // MOD-09 effective-model filter is bypassed (empty effective set
+        // falls back to the legacy `required` count), so this unit test
+        // still exercises the raw math invariants.
+        $resolver = $this->createStub(EffectiveAttributeGroupResolver::class);
+        $resolver->method('resolve')->willReturn([]);
+        $resolver->method('loadGroupAttributes')->willReturn([]);
         $rebuilder = new AttributesIndexedRebuilder(
             $this->createStub(EntityManagerInterface::class),
+            $resolver,
         );
 
         $tenant = self::tenantStub();


### PR DESCRIPTION
## Summary

ADR-014 / MOD-09 (#901). `AttributesIndexedRebuilder` filtruje `required` list przeciw efektywnemu modelowi przed liczeniem. Atrybuty z wartościami ale poza efektywnym modelem (orphaned) NIE liczą się; required'y bez attachmentu w efektywnym modelu NIE penalizują.

## Co się NIE zmienia

- Wartości w `object_values` + `attributes_indexed` JSONB pozostają (zgodnie z AC-1). Swap kategorii → wartości wracają.
- Form-schema już filtrował po efektywnym modelu (MOD-03) — tu wpinamy completeness logic.

## Backward compat

Gdy `effectiveCodes` jest puste (fresh OT bez junctions, rebuilder poza kernel, unit testy z stub resolverem) → legacy contract (raw required count).

## Refactor side note

`EffectiveAttributeGroupResolver` zmienione z `final readonly` na `readonly` żeby PHPUnit mógł stubować w testach unit. `final` było lint-level, nie domain invariant.

## Tests

- [x] `CompletenessCalculationTest` (unit) — zachowane via resolver stub (legacy fallback path)
- [x] `OrphanedValuesTest` (integration, 3/3) — orphaned required code, ghost-only required → 100%, effective attr missing → 0%

CI green required.

Closes #901 — next: MOD-10 (#902) migracja built-in Marki.