### PR TITLE
feat(catalog): demote Brand from built-in ObjectType (MOD-10)

### DIFF
--- a/apps/api/migrations/Version20260524120000.php
+++ b/apps/api/migrations/Version20260524120000.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ADR-014 / MOD-10 (#902) — revert the "Brand as 4-th built-in ObjectType"
+ * decision from ADR-012. ADR-014 §6 (Decyzje) puts Brand back into
+ * tenant-territory: it can be a `select` attribute, a custom ObjectType,
+ * or sourced from an external system. The built-in pool is reduced to
+ * Product / Category / Asset (matching the pre-ADR-012 ADR-009 contract).
+ *
+ * Per existing tenant the migration:
+ *   - looks up `object_types` row with `kind='brand'`;
+ *   - counts referencing `objects` (matched by `object_type_id`);
+ *   - **if 0 instances** — DELETE the ObjectType + cascade dependent
+ *     junction rows (`object_type_attributes`,
+ *     `object_type_attribute_groups`, `category_attribute_groups` with
+ *     `target_object_type_id`);
+ *   - **if any instances exist** — convert to a custom ObjectType:
+ *     `is_built_in=false`, `code_immutable=false`, `deletable=true`.
+ *     Operator can now rename, repurpose, or delete the kind through the
+ *     standard `/api/object_types/{id}` flow.
+ *
+ * `ObjectKind::Brand` enum case stays for backward compatibility with
+ * stored rows. Down path recreates the seeded built-in row but does NOT
+ * re-attach any junction that the down-pass deletion may have wiped —
+ * the deletion path is the documented one-way migration.
+ */
+final class Version20260524120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-014 / MOD-10 (#902): demote built-in Brand ObjectType to tenant-custom (or delete when unused).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Step 1 — convert Brand ObjectTypes with at least one instance.
+        $this->addSql(<<<'SQL'
+            UPDATE object_types ot
+            SET is_built_in = false, code_immutable = false, deletable = true
+            WHERE ot.kind = 'brand'
+              AND EXISTS (
+                  SELECT 1 FROM objects o WHERE o.object_type_id = ot.id
+              )
+        SQL);
+
+        // Step 2 — delete unused Brand ObjectTypes. Dependent junction
+        // rows cascade through ON DELETE CASCADE on `object_type_id` /
+        // `target_object_type_id` (set up in earlier migrations).
+        // Defensive: explicitly remove junctions in case CASCADE differs.
+        $this->addSql(<<<'SQL'
+            DELETE FROM object_type_attributes
+            WHERE object_type_id IN (
+                SELECT id FROM object_types WHERE kind = 'brand' AND is_built_in = true
+            )
+        SQL);
+        $this->addSql(<<<'SQL'
+            DELETE FROM object_type_attribute_groups
+            WHERE object_type_id IN (
+                SELECT id FROM object_types WHERE kind = 'brand' AND is_built_in = true
+            )
+        SQL);
+        $this->addSql(<<<'SQL'
+            DELETE FROM category_attribute_groups
+            WHERE target_object_type_id IN (
+                SELECT id FROM object_types WHERE kind = 'brand' AND is_built_in = true
+            )
+        SQL);
+        $this->addSql(<<<'SQL'
+            DELETE FROM object_types
+            WHERE kind = 'brand' AND is_built_in = true
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Restore Brand as a built-in ObjectType per tenant — same shape as
+        // Version20260501110000. Tenants whose Brand was demoted to custom
+        // keep their custom row alongside the re-seeded built-in (the
+        // tenant_code_uniq index allows it because the custom row may have
+        // been re-coded). For tenants where Brand was outright deleted,
+        // this rebuilds the row with the original seed values.
+        $this->addSql(<<<'SQL'
+            INSERT INTO object_types (
+                id, tenant_id, code, kind, is_built_in, code_immutable, deletable,
+                icon, color, label, completeness_rules, hierarchical, has_variants,
+                abstract, expose_to_main_menu, is_categorizable, allowed_parent_type_ids,
+                schema_version, created_at, updated_at
+            )
+            SELECT
+                gen_random_uuid(), t.id, 'brand', 'brand', true, true, false,
+                'Tag', '#F59E0B', '{"pl":"Marka","en":"Brand"}'::jsonb, '{}'::jsonb,
+                false, false, false, false, false, '[]'::jsonb,
+                1, NOW(), NOW()
+            FROM tenants t
+            WHERE NOT EXISTS (
+                SELECT 1 FROM object_types ot
+                WHERE ot.tenant_id = t.id AND ot.code = 'brand'
+            )
+        SQL);
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php
@@ -12,19 +12,26 @@ use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
- * Idempotent per-tenant seeder for the four built-in ObjectTypes:
- * `product`, `category`, `asset`, `brand`. Each seeded row carries
+ * Idempotent per-tenant seeder for the three built-in ObjectTypes:
+ * `product`, `category`, `asset`. Each seeded row carries
  * `is_built_in=true` so {@see ObjectTypeService::delete} blocks deletion,
  * plus `code_immutable=true` + `deletable=false` from UI-08.2.
  *
  * The seeder is the runtime counterpart of the inline INSERTs in
- * migrations `Version20260428222056` (product/category/asset) and
- * `Version20260501110000` (brand). The migrations handle existing
+ * migration `Version20260428222056`. The migration handles existing
  * tenants once; this service handles future tenants and fixtures —
  * `pim:db:reset --with-fixtures` purges the database, so without a
  * runtime seeder the built-in rows would vanish on every reset.
  *
- * Idempotent: re-runs are no-ops once the four rows exist.
+ * MOD-10 (#902): `brand` was previously seeded as a 4-th built-in
+ * (`Version20260501110000`). ADR-014 reverts that — Brand becomes a
+ * tenant-side decision (`select` attribute, custom ObjectType, or
+ * external integration), no longer platform-owned. Existing Brand rows
+ * in production tenants are converted to custom (`is_built_in=false`)
+ * or deleted when unused by the matching MOD-10 migration; the seeder
+ * just stops emitting them.
+ *
+ * Idempotent: re-runs are no-ops once the three rows exist.
  */
 final readonly class BuiltInObjectTypeSeeder
 {
@@ -35,7 +42,6 @@ final readonly class BuiltInObjectTypeSeeder
         'product' => [ObjectKind::Product, ['pl' => 'Produkt', 'en' => 'Product'], 'Package', '#3B82F6'],
         'category' => [ObjectKind::Category, ['pl' => 'Kategoria', 'en' => 'Category'], 'FolderTree', '#10B981'],
         'asset' => [ObjectKind::Asset, ['pl' => 'Zasób', 'en' => 'Asset'], 'Image', '#8B5CF6'],
-        'brand' => [ObjectKind::Brand, ['pl' => 'Marka', 'en' => 'Brand'], 'Tag', '#F59E0B'],
     ];
 
     public function __construct(

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php
@@ -84,10 +84,14 @@ final class ObjectKindRouter
      * built-in kinds so it can stamp one `#[ApiResource]` declaration per
      * kind without hardcoding the list.
      *
+     * ADR-014 / MOD-10 (#902) — Brand was removed from the built-in pool.
+     * The kind enum case stays for tenants that converted Brand to
+     * custom, but it no longer gets a dedicated sugar path.
+     *
      * @return list<ObjectKind>
      */
     public static function builtInKinds(): array
     {
-        return [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand];
+        return [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset];
     }
 }

--- a/apps/api/tests/Api/Catalog/MenuConfigurationApiTest.php
+++ b/apps/api/tests/Api/Catalog/MenuConfigurationApiTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\Api\Identity;
 
 use App\Catalog\Domain\ObjectKind;
-use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use App\Tests\Api\Catalog\CatalogApiTestCase;
@@ -50,7 +49,10 @@ final class MenuConfigurationApiTest extends CatalogApiTestCase
     #[Test]
     public function effectiveExposesProductInVisibleAndOthersInAvailable(): void
     {
-        $this->markBrandAsExposed();
+        // ADR-014 / MOD-10 (#902): Brand is no longer a built-in ObjectType.
+        // Provision a custom OT (`vendor`) instead and flip its
+        // `exposeToMainMenu` to exercise the same code path.
+        $vendorId = $this->provisionCustomExposedObjectType('vendor');
 
         $client = $this->authenticatedClient();
         $response = $client->request('GET', '/api/menu_configuration/effective');
@@ -66,7 +68,7 @@ final class MenuConfigurationApiTest extends CatalogApiTestCase
         /** @var list<array{id: string}> $available */
         $available = $payload['available'];
         $availableRefs = array_column($available, 'id');
-        self::assertContains('object_type:'.$this->brandId(), $availableRefs);
+        self::assertContains('object_type:'.$vendorId, $availableRefs);
     }
 
     #[Test]
@@ -171,8 +173,11 @@ final class MenuConfigurationApiTest extends CatalogApiTestCase
     {
         $client = $this->authenticatedClient();
 
-        $brand = $this->brandId();
-        $response = $client->request('PATCH', '/api/object_types/'.$brand, [
+        // ADR-014 / MOD-10 (#902): Brand demoted from built-in. Provision a
+        // custom OT (`supplier`) with the toggle initially off and exercise
+        // the PATCH → /effective flow that used to ride on Brand.
+        $supplierId = $this->provisionCustomObjectType('supplier');
+        $response = $client->request('PATCH', '/api/object_types/'.$supplierId, [
             'json' => ['exposeToMainMenu' => true],
             'headers' => ['Content-Type' => 'application/merge-patch+json'],
         ]);
@@ -180,12 +185,12 @@ final class MenuConfigurationApiTest extends CatalogApiTestCase
         $body = $response->toArray();
         self::assertTrue($body['exposeToMainMenu']);
 
-        // After the toggle, /effective lists Brand as available.
+        // After the toggle, /effective lists the custom OT as available.
         $effective = $client->request('GET', '/api/menu_configuration/effective')->toArray();
         /** @var list<array{id: string}> $availableItems */
         $availableItems = $effective['available'];
         $availableRefs = array_column($availableItems, 'id');
-        self::assertContains('object_type:'.$brand, $availableRefs);
+        self::assertContains('object_type:'.$supplierId, $availableRefs);
     }
 
     #[Test]
@@ -216,24 +221,56 @@ final class MenuConfigurationApiTest extends CatalogApiTestCase
         return $this->objectTypeIdFor(ObjectKind::Asset);
     }
 
-    private function brandId(): string
-    {
-        return $this->objectTypeIdFor(ObjectKind::Brand);
-    }
-
-    private function markBrandAsExposed(): void
+    /**
+     * ADR-014 / MOD-10 (#902): replacement for the legacy `brandId()` —
+     * provisions a custom ObjectType with the operator-driven
+     * `expose_to_main_menu=false` default. Returns the UUID for use in
+     * /api/object_types/{id} flows. Tenant context is set so the
+     * `TenantAssignmentListener` can stamp it.
+     */
+    private function provisionCustomObjectType(string $code): string
     {
         $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
         \assert($tenant instanceof Tenant);
         $tenantContext = self::getContainer()->get(TenantContext::class);
         $tenantContext->set($tenant);
 
-        $brand = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
-            ->findBuiltInByKind(ObjectKind::Brand, $tenant);
-        \assert(null !== $brand);
-        $brand->setExposeToMainMenu(true);
+        $type = new \App\Catalog\Domain\Entity\ObjectType(
+            $code,
+            ObjectKind::Custom,
+            ['pl' => ucfirst($code), 'en' => ucfirst($code)],
+        );
+        $this->em()->persist($type);
         $this->em()->flush();
 
         $tenantContext->clear();
+
+        return $type->getId()->toRfc4122();
+    }
+
+    /**
+     * Like {@see provisionCustomObjectType} but flips `exposeToMainMenu`
+     * to TRUE in the same transaction — used by the "browse /effective"
+     * test that needs the OT to already be available.
+     */
+    private function provisionCustomExposedObjectType(string $code): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $type = new \App\Catalog\Domain\Entity\ObjectType(
+            $code,
+            ObjectKind::Custom,
+            ['pl' => ucfirst($code), 'en' => ucfirst($code)],
+        );
+        $type->setExposeToMainMenu(true);
+        $this->em()->persist($type);
+        $this->em()->flush();
+
+        $tenantContext->clear();
+
+        return $type->getId()->toRfc4122();
     }
 }

--- a/apps/api/tests/Integration/Catalog/BuiltInObjectTypeSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/BuiltInObjectTypeSeederTest.php
@@ -20,15 +20,18 @@ final class BuiltInObjectTypeSeederTest extends KernelTestCase
     use ResetDatabase;
 
     #[Test]
-    public function seedCreatesFourBuiltInObjectTypesForTenant(): void
+    public function seedCreatesThreeBuiltInObjectTypesForTenant(): void
     {
+        // ADR-014 / MOD-10 (#902) — Brand was demoted from built-in to
+        // tenant-territory. The seeder emits exactly Product / Category /
+        // Asset; Brand is no longer in the DEFINITIONS map.
         $tenant = $this->createTenant('demo');
 
         $created = $this->seeder()->seed($tenant);
 
-        self::assertSame(4, $created);
+        self::assertSame(3, $created);
         $repo = $this->repository();
-        foreach ([ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand] as $kind) {
+        foreach ([ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset] as $kind) {
             $type = $repo->findBuiltInByKind($kind, $tenant);
             self::assertNotNull($type, $kind->value);
             self::assertTrue($type->isBuiltIn());
@@ -38,6 +41,11 @@ final class BuiltInObjectTypeSeederTest extends KernelTestCase
             self::assertNotNull($type->getColor(), $kind->value);
             self::assertSame($kind, $type->getKind());
         }
+
+        self::assertNull(
+            $repo->findBuiltInByKind(ObjectKind::Brand, $tenant),
+            'Brand MUST NOT be seeded as a built-in ObjectType (ADR-014 / MOD-10).',
+        );
     }
 
     #[Test]
@@ -51,17 +59,14 @@ final class BuiltInObjectTypeSeederTest extends KernelTestCase
         $product = $repo->findBuiltInByKind(ObjectKind::Product, $tenant);
         $category = $repo->findBuiltInByKind(ObjectKind::Category, $tenant);
         $asset = $repo->findBuiltInByKind(ObjectKind::Asset, $tenant);
-        $brand = $repo->findBuiltInByKind(ObjectKind::Brand, $tenant);
 
         self::assertNotNull($product);
         self::assertNotNull($category);
         self::assertNotNull($asset);
-        self::assertNotNull($brand);
 
         self::assertTrue($product->isCategorizable(), 'Product is the only built-in that opts into primary-category overlay');
         self::assertFalse($category->isCategorizable(), 'Category itself is not categorized — only base attributes apply');
         self::assertFalse($asset->isCategorizable(), 'Asset has its own DAM workflow, not category-driven');
-        self::assertFalse($brand->isCategorizable(), 'Brand is flat, no category overlay');
     }
 
     #[Test]
@@ -70,7 +75,7 @@ final class BuiltInObjectTypeSeederTest extends KernelTestCase
         $tenant = $this->createTenant('demo');
         $seeder = $this->seeder();
 
-        self::assertSame(4, $seeder->seed($tenant));
+        self::assertSame(3, $seeder->seed($tenant));
         self::assertSame(0, $seeder->seed($tenant), 'second run should be a no-op');
     }
 

--- a/apps/api/tests/Integration/Catalog/SystemAttributesAuditGroupTest.php
+++ b/apps/api/tests/Integration/Catalog/SystemAttributesAuditGroupTest.php
@@ -96,7 +96,10 @@ final class SystemAttributesAuditGroupTest extends KernelTestCase
             ->setParameter('g', $auditGroup)
             ->getResult();
 
-        self::assertCount(4, $junctions, 'Audit group must be attached to all 4 built-in ObjectTypes (product/category/asset/brand).');
+        // ADR-014 / MOD-10 (#902): Brand removed from built-in pool — three
+        // built-ins remain (product/category/asset), each gets the audit
+        // group auto-attached.
+        self::assertCount(3, $junctions, 'Audit group must be attached to all 3 built-in ObjectTypes (product/category/asset).');
         foreach ($junctions as $junction) {
             self::assertInstanceOf(ObjectTypeAttributeGroup::class, $junction);
             self::assertSame(999, $junction->getPosition());

--- a/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/ObjectKindRouterTest.php
+++ b/apps/api/tests/Unit/Catalog/Infrastructure/ApiPlatform/ObjectKindRouterTest.php
@@ -49,12 +49,14 @@ final class ObjectKindRouterTest extends TestCase
     }
 
     #[Test]
-    public function builtInKindsListMatchesAdr009AndAdr012(): void
+    public function builtInKindsListMatchesAdr009AndAdr014(): void
     {
-        // ADR-009 ships product / category / asset; ADR-012 (#257 / UI-08.2)
-        // adds brand as 4-th built-in.
+        // ADR-009 ships product / category / asset. ADR-012 (#257 /
+        // UI-08.2) briefly added `brand` as a 4-th built-in, reverted
+        // by ADR-014 / MOD-10 (#902). The built-in pool is back to the
+        // pre-ADR-012 three kinds.
         self::assertSame(
-            [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand],
+            [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset],
             ObjectKindRouter::builtInKinds(),
         );
     }


### PR DESCRIPTION
## Summary

ADR-014 / MOD-10 (#902). Revertujemy decyzję ADR-012 "Brand jako 4-ty built-in" — Brand wraca do tenant-territory.

## Co lądzie

- `BuiltInObjectTypeSeeder::DEFINITIONS` bez `brand` — świeże tenanty dostają tylko Product/Category/Asset
- `ObjectKindRouter::builtInKinds()` → 3 kindy (Brand jako enum case zostaje dla migracji)
- Migracja `Version20260524120000`:
  - Brand z instancjami → konwersja na custom (`is_built_in=false`, `code_immutable=false`, `deletable=true`)
  - Brand bez instancji → DELETE (z junction cleanup defensywnie)
- Down recreate seedowanego Brand per tenant (matching `Version20260501110000`)

## Audyt stanu Brand

`ObjectKind::Brand` enum case zostaje. W produkcji może istnieć:
- Brand jako built-in z instancjami → demoted to custom (operator widzi w UI Settings → Object Types)
- Brand jako built-in bez instancji → usunięty
- Brand jako custom (już istniał) → bez zmian

## Tests

- [x] `BuiltInObjectTypeSeederTest` (integration, 4/4) — retargetowane na 3 built-ins, asercja `findBuiltInByKind(Brand) === null`
- [x] PHPStan max 0

Closes #902 — kolejne MOD-11..MOD-14 (frontend + docs).