### PR TITLE
feat(modeling): is_categorizable toggle on ObjectType detail (MOD-11)

### DIFF
--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -44,6 +44,7 @@ interface ObjectTypeDetail {
   allowedParentTypeIds?: string[];
   completenessRules?: Record<string, unknown> | null;
   exposeToMainMenu?: boolean;
+  isCategorizable?: boolean;
 }
 
 interface ObjectTypeUsage {
@@ -677,6 +678,34 @@ export function ObjectTypeShowPage() {
                 {t('object_types.setting_expose_menu_asset_locked', {
                   defaultValue:
                     'Asset używa dedykowanego widoku /assets — zarządzaj kolejnością przez system item Multimedia.',
+                })}
+              </div>
+            ) : null}
+          </div>
+          {/* ADR-014 / MOD-11 (#903) — `is_categorizable` toggle. When ON
+              the operator MUST pick a primary category when creating
+              instances; the form layout is then driven by the primary's
+              root→leaf attribute-group overlay (MOD-03). Category kind is
+              locked because categories drive the overlay, they don't
+              consume it. */}
+          <div className="border-t border-zinc-100 pt-5">
+            <SettingToggleRow
+              label={t('object_types.setting_categorizable_label', {
+                defaultValue: 'Wymaga primary category',
+              })}
+              description={t('object_types.setting_categorizable_desc', {
+                defaultValue:
+                  'Po włączeniu instancje tego ObjectType muszą wybrać kategorię główną przy tworzeniu — jej ścieżka root→leaf w drzewie kategorii dodaje atrybuty kumulatywnie (ADR-014). Wyłącz, by formularz pokazywał tylko bazowe atrybuty ObjectType.',
+              })}
+              checked={Boolean(objectType.isCategorizable)}
+              locked={objectType.kind === 'category'}
+              onChange={(next) => void handlePatch({ isCategorizable: next })}
+            />
+            {objectType.kind === 'category' ? (
+              <div className="mt-2 text-[11.5px] text-zinc-500">
+                {t('object_types.setting_categorizable_category_locked', {
+                  defaultValue:
+                    'Kategoria sama definiuje warstwę overlay — nie może być jej konsumentem.',
                 })}
               </div>
             ) : null}

--- a/apps/api/src/Catalog/Application/ObjectTypeService.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeService.php
@@ -126,6 +126,7 @@ final readonly class ObjectTypeService
         ?array $allowedParentTypeIds = null,
         ?array $completenessRules = null,
         ?bool $exposeToMainMenu = null,
+        ?bool $isCategorizable = null,
     ): ObjectType {
         $isBuiltIn = $objectType->isBuiltIn();
 
@@ -180,6 +181,22 @@ final readonly class ObjectTypeService
                 );
             }
             $objectType->setExposeToMainMenu($exposeToMainMenu);
+        }
+        if (null !== $isCategorizable) {
+            // ADR-014 / MOD-11 (#903): operator-driven toggle. Reused
+            // ObjectKind::Category exclusion — a category that participates
+            // in its own attribute overlay creates a circular dependency
+            // with the resolver. Other kinds (Product, Asset, custom) are
+            // free to flip; built-in `is_built_in=true` ObjectTypes do NOT
+            // lock this flag because the operator may want Asset to become
+            // categorizable in the future (today: AC blocks via UI hint,
+            // not by service-layer 422).
+            if ($isCategorizable && ObjectKind::Category === $objectType->getKind()) {
+                throw new LogicException(
+                    'Category ObjectType cannot be flagged as categorizable — categories drive the overlay, they don\'t consume it.',
+                );
+            }
+            $objectType->setCategorizable($isCategorizable);
         }
 
         $this->em->flush();

--- a/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
@@ -73,6 +73,7 @@ final class UpdateObjectTypeController
                 allowedParentTypeIds: $this->idListOrNull($body['allowedParentTypeIds'] ?? null),
                 completenessRules: $this->mapOrNull($body['completenessRules'] ?? null),
                 exposeToMainMenu: $this->boolOrNull($body['exposeToMainMenu'] ?? null),
+                isCategorizable: $this->boolOrNull($body['isCategorizable'] ?? null),
             );
         } catch (BuiltInObjectTypeException $e) {
             throw new HttpException(Response::HTTP_FORBIDDEN, $e->getMessage(), $e);
@@ -94,6 +95,7 @@ final class UpdateObjectTypeController
             'allowedParentTypeIds' => $objectType->getAllowedParentTypeIds(),
             'completenessRules' => $objectType->getCompletenessRules(),
             'exposeToMainMenu' => $objectType->isExposedToMainMenu(),
+            'isCategorizable' => $objectType->isCategorizable(),
             'schemaVersion' => $objectType->getSchemaVersion(),
         ]);
     }


### PR DESCRIPTION
## Summary

ADR-014 / MOD-11 (#903). Toggle `is_categorizable` z MOD-01 (#893) wyeksponowany przez istniejący ObjectType detail + PATCH endpoint.

## Backend

- `ObjectTypeService::update` accepts `?bool $isCategorizable`
- Category kind locked w service layer (kategoria definiuje overlay, nie konsumuje)
- `UpdateObjectTypeController::__invoke` plumbs przez PATCH body + response shape

## Frontend

- `ObjectTypeShowPage.ObjectTypeDetail` → nowe pole `isCategorizable?: boolean`
- Nowy `SettingToggleRow` pod „expose to main menu" — Polish description per ADR-014
- Category kind → lock toggle + hint

## Scope decisions (świadome odejścia)

- **Modal create flow** (primary category step) — już ship przez #891 dla Produktu. Wzór gotowy do reusowania dla custom kategoryzowalnych OT w follow-up gdy będzie potrzeba (MVP: Product jest jedynym kategoryzowalnym built-in).
- **Sidebar reaguje na expose_to_main_menu** — bez zmian, działa od VIEW-08 #427.
- **`/modeling/categories` ObjectType filter** narrowed to `is_categorizable=true` — kolejna iteracja CategoriesTab. Backend już to wspiera (filter w GET by `is_categorizable`).

## Quality gates

- [x] PHPStan max → 0 errors
- [x] admin TS noEmit → 0 errors
- [ ] CI green

Closes #903.