### PR TITLE
feat(modeling): relation attribute config editor (MOD-13)

### DIFF
--- a/apps/admin/src/components/modeling/relation-config-panel.tsx
+++ b/apps/admin/src/components/modeling/relation-config-panel.tsx
@@ -1,0 +1,324 @@
+import { Plus, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+
+export interface RelationAdvancedField {
+  code: string;
+  type: 'text' | 'number' | 'boolean';
+  label: Record<string, string>;
+  required: boolean;
+}
+
+export interface RelationConfigValue {
+  targetObjectTypeIds: string[];
+  cardinality: 'one' | 'many';
+  advanced: boolean;
+  advancedFields: RelationAdvancedField[];
+}
+
+interface RelationConfigPanelProps {
+  value: RelationConfigValue;
+  objectTypes: Array<{
+    id: string;
+    code: string;
+    kind: string;
+    label?: Record<string, string> | string | null;
+  }>;
+  disabled?: boolean;
+  onChange: (next: RelationConfigValue) => void;
+}
+
+/**
+ * ADR-014 / MOD-13 (#905) — relation-attribute config card rendered inside
+ * the AttributeShowPage editor when `attribute.type === 'relation'`. Three
+ * controls:
+ *   - target ObjectType multi-select (1+ allowed targets);
+ *   - cardinality radio (`one` / `many`);
+ *   - advanced toggle → when ON the per-link metadata fields editor
+ *     surfaces (add/remove rows of kod / typ / label / required).
+ *
+ * Backed by the MOD-05 (#897) handler: every field below is serialised
+ * straight into the PATCH /api/attributes/{id} body
+ * (`relationTargetObjectTypeIds`, `relationCardinality`, `relationAdvanced`)
+ * plus `validationRules.advanced_fields` for the metadata schema.
+ *
+ * The component is fully controlled; the parent owns the value + persists
+ * via the existing save flow. No local effects, no auto-save.
+ */
+export function RelationConfigPanel({
+  value,
+  objectTypes,
+  disabled = false,
+  onChange,
+}: RelationConfigPanelProps) {
+  const { t } = useTranslation();
+
+  const toggleTarget = (id: string) => {
+    if (disabled) return;
+    const has = value.targetObjectTypeIds.includes(id);
+    onChange({
+      ...value,
+      targetObjectTypeIds: has
+        ? value.targetObjectTypeIds.filter((x) => x !== id)
+        : [...value.targetObjectTypeIds, id],
+    });
+  };
+
+  const setCardinality = (next: 'one' | 'many') => {
+    if (disabled) return;
+    onChange({ ...value, cardinality: next });
+  };
+
+  const setAdvanced = (next: boolean) => {
+    if (disabled) return;
+    onChange({
+      ...value,
+      advanced: next,
+      // Clear advanced_fields when turning OFF so a stale schema doesn't
+      // confuse MOD-08 validation downstream.
+      advancedFields: next ? value.advancedFields : [],
+    });
+  };
+
+  const setField = (index: number, patch: Partial<RelationAdvancedField>) => {
+    if (disabled) return;
+    onChange({
+      ...value,
+      advancedFields: value.advancedFields.map((field, i) =>
+        i === index ? { ...field, ...patch } : field,
+      ),
+    });
+  };
+
+  const addField = () => {
+    if (disabled) return;
+    onChange({
+      ...value,
+      advancedFields: [
+        ...value.advancedFields,
+        { code: '', type: 'text', label: {}, required: false },
+      ],
+    });
+  };
+
+  const removeField = (index: number) => {
+    if (disabled) return;
+    onChange({
+      ...value,
+      advancedFields: value.advancedFields.filter((_, i) => i !== index),
+    });
+  };
+
+  return (
+    <Card className="border-zinc-200">
+      <CardContent className="space-y-5 p-6">
+        <div>
+          <div className="text-[15px] font-semibold text-foreground">
+            {t('attributes.relation_config_title', {
+              defaultValue: 'Konfiguracja relacji (ADR-014)',
+            })}
+          </div>
+          <p className="mt-1 text-[12.5px] text-muted-foreground">
+            {t('attributes.relation_config_intro', {
+              defaultValue:
+                'Atrybut typu „relation" łączy obiekt z innym obiektem. Wybierz dozwolone ObjectType, kardynalność i ewentualnie pola metadanych dla każdego powiązania.',
+            })}
+          </p>
+        </div>
+
+        {/* Target ObjectType — multi-select chip strip */}
+        <div>
+          <div className="mb-2 text-[12px] font-medium text-zinc-600">
+            {t('attributes.relation_targets_label', {
+              defaultValue: 'Dozwolone ObjectType (cele relacji)',
+            })}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {objectTypes.length === 0 ? (
+              <span className="text-[12px] text-muted-foreground">
+                {t('attributes.relation_targets_empty', {
+                  defaultValue: 'Brak ObjectType w tenancie — najpierw je utwórz.',
+                })}
+              </span>
+            ) : null}
+            {objectTypes.map((ot) => {
+              const selected = value.targetObjectTypeIds.includes(ot.id);
+              const labelText =
+                typeof ot.label === 'object' && ot.label
+                  ? (ot.label.pl ?? ot.label.en ?? ot.code)
+                  : (ot.label ?? ot.code);
+              return (
+                <button
+                  key={ot.id}
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => toggleTarget(ot.id)}
+                  className={
+                    selected
+                      ? 'inline-flex items-center gap-1.5 rounded-full border border-accent-violet bg-accent-violet/10 px-3 py-1 text-[12px] font-medium text-accent-violet'
+                      : 'inline-flex items-center gap-1.5 rounded-full border border-zinc-300 bg-white px-3 py-1 text-[12px] text-zinc-600 hover:border-zinc-400'
+                  }
+                >
+                  {labelText}
+                  <span className="text-[10px] text-muted-foreground">({ot.kind})</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Cardinality radio */}
+        <div>
+          <div className="mb-2 text-[12px] font-medium text-zinc-600">
+            {t('attributes.relation_cardinality_label', { defaultValue: 'Kardynalność' })}
+          </div>
+          <div className="flex items-center gap-3">
+            {(['one', 'many'] as const).map((opt) => (
+              <label
+                key={opt}
+                className={
+                  value.cardinality === opt
+                    ? 'flex items-center gap-2 rounded-lg border border-accent-violet bg-accent-violet/5 px-3 py-2 text-[13px] text-accent-violet'
+                    : 'flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[13px] text-zinc-700'
+                }
+              >
+                <input
+                  type="radio"
+                  name="relation-cardinality"
+                  checked={value.cardinality === opt}
+                  disabled={disabled}
+                  onChange={() => setCardinality(opt)}
+                />
+                {opt === 'one'
+                  ? t('attributes.relation_card_one', {
+                      defaultValue: 'one — pojedyncza referencja',
+                    })
+                  : t('attributes.relation_card_many', { defaultValue: 'many — lista referencji' })}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Advanced toggle + per-link fields editor */}
+        <div className="border-t border-zinc-100 pt-5">
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              checked={value.advanced}
+              disabled={disabled}
+              onChange={(e) => setAdvanced(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="block text-[13px] font-medium text-zinc-700">
+                {t('attributes.relation_advanced_label', {
+                  defaultValue: 'Advanced — relacja z metadanymi na powiązaniu',
+                })}
+              </span>
+              <span className="mt-0.5 block text-[12px] text-muted-foreground">
+                {t('attributes.relation_advanced_desc', {
+                  defaultValue:
+                    'Każde powiązanie nosi własne pola (np. priorytet, rekomendowane). Wartości walidowane przeciw schemie zdefiniowanej poniżej (MOD-08).',
+                })}
+              </span>
+            </span>
+          </label>
+
+          {value.advanced ? (
+            <div className="mt-4 space-y-3">
+              <div className="text-[12px] font-medium text-zinc-600">
+                {t('attributes.relation_advanced_fields_label', {
+                  defaultValue: 'Pola metadanych per powiązanie',
+                })}
+              </div>
+              {value.advancedFields.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-zinc-300 px-4 py-3 text-[12px] text-muted-foreground">
+                  {t('attributes.relation_advanced_empty', {
+                    defaultValue: 'Brak pól — kliknij „+ Pole" by dodać definicję.',
+                  })}
+                </div>
+              ) : null}
+              {value.advancedFields.map((field, idx) => (
+                <div
+                  // Index-key is acceptable: rows are append/explicit-remove
+                  // only and operate on `idx` directly. Code may be empty
+                  // mid-edit so it cannot be the key.
+                  // biome-ignore lint/suspicious/noArrayIndexKey: append-only editor with idx-based mutations
+                  key={idx}
+                  className="grid grid-cols-[1fr,140px,1fr,auto,auto] items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2"
+                >
+                  <Input
+                    placeholder={t('attributes.relation_advanced_field_code_placeholder', {
+                      defaultValue: 'kod (np. priority)',
+                    })}
+                    value={field.code}
+                    disabled={disabled}
+                    onChange={(e) => setField(idx, { code: e.target.value })}
+                  />
+                  <select
+                    value={field.type}
+                    disabled={disabled}
+                    onChange={(e) =>
+                      setField(idx, { type: e.target.value as RelationAdvancedField['type'] })
+                    }
+                    className="rounded-md border border-zinc-300 bg-white px-2 py-1.5 text-[13px]"
+                  >
+                    <option value="text">text</option>
+                    <option value="number">number</option>
+                    <option value="boolean">boolean</option>
+                  </select>
+                  <Input
+                    placeholder={t('attributes.relation_advanced_field_label_placeholder', {
+                      defaultValue: 'label PL',
+                    })}
+                    value={field.label.pl ?? ''}
+                    disabled={disabled}
+                    onChange={(e) =>
+                      setField(idx, {
+                        label: { ...field.label, pl: e.target.value },
+                      })
+                    }
+                  />
+                  <label className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={field.required}
+                      disabled={disabled}
+                      onChange={(e) => setField(idx, { required: e.target.checked })}
+                    />
+                    required
+                  </label>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => removeField(idx)}
+                    aria-label={t('attributes.relation_advanced_remove', {
+                      defaultValue: 'Usuń pole',
+                    })}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                disabled={disabled}
+                onClick={addField}
+              >
+                <Plus className="size-4" />
+                {t('attributes.relation_advanced_add', { defaultValue: '+ Pole' })}
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -21,6 +21,11 @@ import { AuditLogIndicator } from '@/components/modeling/audit-log-indicator';
 import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inline-dialog';
 import { PickGroupsForAttributeDialog } from '@/components/modeling/pick-groups-for-attribute-dialog';
+import {
+  type RelationAdvancedField,
+  RelationConfigPanel,
+  type RelationConfigValue,
+} from '@/components/modeling/relation-config-panel';
 import { WhereUsedList } from '@/components/modeling/where-used-list';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -44,6 +49,11 @@ interface AttributeDetail {
   unique?: boolean;
   filterable?: boolean;
   system?: boolean;
+  // ADR-014 / MOD-05 (#897) relation config fields surfaced by the API.
+  relationTargetObjectTypeIds?: string[];
+  relationCardinality?: 'one' | 'many' | null;
+  relationAdvanced?: boolean;
+  validationRules?: Record<string, unknown> | null;
 }
 
 /**
@@ -125,10 +135,70 @@ function Editor({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // ADR-014 / MOD-13 (#905) — relation config state, hydrated from the
+  // attribute payload. Initial JSONB shape: validation_rules.advanced_fields.
+  const initialRelationFields: RelationAdvancedField[] = ((): RelationAdvancedField[] => {
+    const rules = attribute.validationRules;
+    if (!rules || typeof rules !== 'object') return [];
+    const raw = (rules as Record<string, unknown>).advanced_fields;
+    if (!Array.isArray(raw)) return [];
+    const out: RelationAdvancedField[] = [];
+    for (const entry of raw) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      const e = entry as Record<string, unknown>;
+      const code = typeof e.code === 'string' ? e.code : '';
+      const type =
+        e.type === 'text' || e.type === 'number' || e.type === 'boolean' ? e.type : 'text';
+      const label =
+        typeof e.label === 'object' && e.label !== null ? (e.label as Record<string, string>) : {};
+      const required = Boolean(e.required);
+      if (code !== '') out.push({ code, type, label, required });
+    }
+    return out;
+  })();
+  const [relationConfig, setRelationConfig] = useState<RelationConfigValue>({
+    targetObjectTypeIds: attribute.relationTargetObjectTypeIds ?? [],
+    cardinality: (attribute.relationCardinality as 'one' | 'many') ?? 'many',
+    advanced: attribute.relationAdvanced ?? false,
+    advancedFields: initialRelationFields,
+  });
+
+  // Fetch tenant ObjectTypes for the multi-select. Cheap query, cached.
+  const objectTypesQuery = useQuery<
+    Array<{
+      id: string;
+      code: string;
+      kind: string;
+      label?: Record<string, string> | string | null;
+    }>
+  >({
+    queryKey: ['relation-config', 'object_types'],
+    queryFn: () =>
+      jsonFetch<
+        Array<{
+          id: string;
+          code: string;
+          kind: string;
+          label?: Record<string, string> | string | null;
+        }>
+      >('/api/object_types', { accept: 'application/json' }),
+    staleTime: 60_000,
+    enabled: attribute.type === 'relation',
+  });
+
   // Reset form when attribute changes (id-keyed Editor remounts on different id).
   useEffect(() => {
     setError(null);
   }, [attribute.id]);
+
+  const initialRelationSnapshot = JSON.stringify({
+    targetObjectTypeIds: attribute.relationTargetObjectTypeIds ?? [],
+    cardinality: (attribute.relationCardinality as 'one' | 'many') ?? 'many',
+    advanced: attribute.relationAdvanced ?? false,
+    advancedFields: initialRelationFields,
+  });
+  const relationDirty =
+    attribute.type === 'relation' && JSON.stringify(relationConfig) !== initialRelationSnapshot;
 
   const dirtyFields = [
     labelPl !== (initialLabel.pl ?? '') || labelEn !== (initialLabel.en ?? ''),
@@ -137,6 +207,7 @@ function Editor({
     scopable !== (attribute.scopable ?? false),
     unique !== (attribute.unique ?? false),
     filterable !== (attribute.filterable ?? false),
+    relationDirty,
   ].filter(Boolean).length;
   const dirty = dirtyFields > 0;
 
@@ -169,6 +240,18 @@ function Editor({
         if (scopable !== (attribute.scopable ?? false)) body.scopable = scopable;
         if (unique !== (attribute.unique ?? false)) body.required = unique; // BE has no `unique` flag yet
         if (filterable !== (attribute.filterable ?? false)) body.filterable = filterable;
+      }
+      if (attribute.type === 'relation' && relationDirty) {
+        body.relationTargetObjectTypeIds = relationConfig.targetObjectTypeIds;
+        body.relationCardinality = relationConfig.cardinality;
+        body.relationAdvanced = relationConfig.advanced;
+        // MOD-08 schema lives in validation_rules.advanced_fields. Strip
+        // empty-code rows defensively (the validator would 422 them but the
+        // UX is friendlier when we drop them upfront).
+        const fields = relationConfig.advancedFields.filter((f) => f.code.trim() !== '');
+        body.validationRules = relationConfig.advanced
+          ? { ...(attribute.validationRules ?? {}), advanced_fields: fields }
+          : { ...(attribute.validationRules ?? {}), advanced_fields: [] };
       }
       await jsonFetch(`/api/attributes/${attribute.id}`, {
         method: 'PATCH',
@@ -398,6 +481,15 @@ function Editor({
         </Card>
 
         <AttachedGroupsCard attribute={attribute} locale={locale} />
+
+        {attribute.type === 'relation' ? (
+          <RelationConfigPanel
+            value={relationConfig}
+            objectTypes={objectTypesQuery.data ?? []}
+            disabled={isSystem || saving}
+            onChange={setRelationConfig}
+          />
+        ) : null}
 
         <WhereUsedList resource="attributes" id={attribute.id} />
       </div>


### PR DESCRIPTION
## Summary

ADR-014 / MOD-13 (#905). Nowy `RelationConfigPanel` na AttributeShowPage editor gdy `type === 'relation'`. Wpięcie do istniejącego save flow.

## Component

`apps/admin/src/components/modeling/relation-config-panel.tsx`:
- Target ObjectType chip strip (multi-select)
- Cardinality radio (one / many)
- Advanced toggle → unlocks advanced-fields editor
- Advanced-fields editor: add/remove rows kod / typ (text|number|boolean) / label PL / required

## Wiring

`AttributeShowPage.Editor`:
- Interface extended (relation_* + validationRules)
- State hydrated z attribute payload (parsing `validation_rules.advanced_fields`)
- Dirty flag bumped on relation snapshot change
- Save dispatches PATCH body z relation fields when dirty

## Quality gates

- [x] admin TS noEmit → 0 errors
- [x] biome → 0 errors (ignore na append-only index-key w advanced-fields editor)
- [ ] CI green

Closes #905.