### PR TITLE
fix(modeling): filter category target-OT dropdown to is_categorizable=true

### DIFF
--- a/apps/admin/src/components/modeling/object-type-filter-dropdown.tsx
+++ b/apps/admin/src/components/modeling/object-type-filter-dropdown.tsx
@@ -1,29 +1,128 @@
+import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
+import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
-const BUILT_IN_KINDS = ['service', 'product', 'category', 'asset', 'brand'] as const;
-
-export type BuiltInObjectKind = (typeof BUILT_IN_KINDS)[number];
+/**
+ * ADR-014 / MOD-11 (#903) — target ObjectType selector for the category
+ * Detail panel.
+ *
+ * Renders the list of ObjectTypes that are eligible to declare attribute
+ * groups via `CategoryAttributeGroup` rows. Eligibility = `is_built_in
+ * = true` AND `is_categorizable = true`. Built-in is required because
+ * the backend `CategoryEffectiveGroupsController` resolves the target
+ * via `findBuiltInByKind($kind, $tenant)` (one OT per kind); custom OT
+ * support waits on a backend ticket that switches the API contract to
+ * `objectTypeId` (UUID) instead of `objectTypeKind` (enum).
+ *
+ * UX collapse rules:
+ *   - 0 eligible OTs → renders a disabled hint ("no categorizable OT").
+ *   - 1 eligible OT  → auto-selects it and renders a read-only label
+ *     (single-choice dropdown adds visual noise without UX value).
+ *   - 2+ eligible OTs → renders a native `<select>` like before.
+ *
+ * Persistence stays on the parent via the URL search-param contract
+ * (`?targetType=<kind>`). When the URL points at an OT that's been
+ * deleted or flipped to `is_categorizable=false`, the parent should
+ * accept the auto-selected fallback emitted via `onChange` on mount.
+ */
+interface ObjectTypeOption {
+  id: string;
+  code: string;
+  kind: string;
+  label?: Record<string, string> | string | null;
+  builtIn?: boolean;
+  isCategorizable?: boolean;
+}
 
 interface Props {
-  value: BuiltInObjectKind;
-  onChange: (next: BuiltInObjectKind) => void;
+  value: string | null;
+  onChange: (next: string) => void;
   className?: string;
 }
 
-/**
- * VIEW-04 (#408) — target ObjectType selector for the category Detail
- * panel. Persists the chosen kind via the parent (URL search param in
- * the list page) so deep-links into a particular `kind=service` view
- * survive a refresh.
- *
- * MVP scope: built-in kinds only. Custom kinds (per ADR-009 phase 2)
- * stay hidden behind {@link CustomObjectTypeApiGuard} — the dropdown
- * surfaces them automatically once the feature flag flips.
- */
+function optionLabel(opt: ObjectTypeOption, locale: string): string {
+  if (opt.label && typeof opt.label === 'object') {
+    return opt.label[locale] ?? opt.label.pl ?? opt.label.en ?? opt.code;
+  }
+  if (typeof opt.label === 'string' && opt.label !== '') {
+    return opt.label;
+  }
+  // Fallback: capitalised code.
+  return opt.code.charAt(0).toUpperCase() + opt.code.slice(1);
+}
+
 export function ObjectTypeFilterDropdown({ value, onChange, className }: Props) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language === 'pl' ? 'pl' : 'en';
+
+  const query = useQuery<ObjectTypeOption[]>({
+    queryKey: ['modeling', 'categorizable-object-types'],
+    queryFn: async () => {
+      const data = await jsonFetch<ObjectTypeOption[]>('/api/object_types', {
+        accept: 'application/json',
+      });
+      return data.filter((ot) => ot.builtIn === true && ot.isCategorizable === true);
+    },
+    staleTime: 60_000,
+  });
+
+  const options = query.data ?? [];
+
+  // Auto-select the first option when the URL param doesn't match anything
+  // in the fetched list (initial render OR after the operator demoted the
+  // previously-selected OT via toggle).
+  const firstOption = options[0];
+  const valueMatches = options.some((ot) => ot.kind === value);
+  if (!query.isLoading && firstOption !== undefined && !valueMatches) {
+    onChange(firstOption.kind);
+  }
+
+  if (query.isLoading) {
+    return (
+      <span
+        className={cn(
+          'inline-flex h-9 items-center gap-2 rounded-xl border border-line bg-white px-3 text-[12.5px] soft-shadow',
+          className,
+        )}
+      >
+        <span className="text-zinc-500">{t('app.loading')}</span>
+      </span>
+    );
+  }
+
+  if (options.length === 0) {
+    return (
+      <span
+        className={cn(
+          'inline-flex h-9 items-center gap-2 rounded-xl border border-dashed border-line bg-white px-3 text-[12.5px] text-muted-foreground soft-shadow',
+          className,
+        )}
+      >
+        {t('categories.target_type_empty', {
+          defaultValue: 'Brak ObjectType kategoryzowalnych',
+        })}
+      </span>
+    );
+  }
+
+  if (options.length === 1 && firstOption !== undefined) {
+    const only = firstOption;
+    return (
+      <span
+        className={cn(
+          'inline-flex h-9 items-center gap-2 rounded-xl border border-line bg-white px-3 text-[12.5px] soft-shadow',
+          className,
+        )}
+      >
+        <span className="text-zinc-500">
+          {t('categories.target_type_label', { defaultValue: 'Object Type:' })}
+        </span>
+        <span className="font-medium">{optionLabel(only, locale)}</span>
+      </span>
+    );
+  }
 
   return (
     <label
@@ -37,15 +136,15 @@ export function ObjectTypeFilterDropdown({ value, onChange, className }: Props) 
       </span>
       <select
         className="bg-transparent font-medium outline-none"
-        value={value}
-        onChange={(e) => onChange(e.target.value as BuiltInObjectKind)}
+        value={value ?? firstOption?.kind ?? ''}
+        onChange={(e) => onChange(e.target.value)}
         aria-label={t('categories.target_type_aria', {
           defaultValue: 'Filter declared groups by target ObjectType',
         })}
       >
-        {BUILT_IN_KINDS.map((kind) => (
-          <option key={kind} value={kind}>
-            {kind.charAt(0).toUpperCase() + kind.slice(1)}
+        {options.map((opt) => (
+          <option key={opt.id} value={opt.kind}>
+            {optionLabel(opt, locale)}
           </option>
         ))}
       </select>

--- a/apps/admin/src/features/catalog/categories/list.tsx
+++ b/apps/admin/src/features/catalog/categories/list.tsx
@@ -12,10 +12,7 @@ import {
 } from '@/components/modeling/category-tree';
 import { DeclareAttributeGroupDialog } from '@/components/modeling/declare-attribute-group-dialog';
 import { ModelingPageHeader } from '@/components/modeling/modeling-page-header';
-import {
-  type BuiltInObjectKind,
-  ObjectTypeFilterDropdown,
-} from '@/components/modeling/object-type-filter-dropdown';
+import { ObjectTypeFilterDropdown } from '@/components/modeling/object-type-filter-dropdown';
 import { Card } from '@/components/ui/card';
 import { MockBadge } from '@/components/ui/mock-badge';
 import { jsonFetch } from '@/lib/http';
@@ -102,7 +99,12 @@ export function CategoriesTreePage() {
   const { t, i18n } = useTranslation();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const targetType = (searchParams.get('targetType') ?? 'service') as BuiltInObjectKind;
+  // ADR-014 / MOD-11 (#903): default falls back to whatever the dropdown
+  // resolves as the first eligible OT (`is_built_in=true` AND
+  // `is_categorizable=true`). The dropdown emits its choice via
+  // `onChange` on mount when the URL param doesn't match anything, so an
+  // empty default is correct here — the URL gets stamped on first render.
+  const targetType: string = searchParams.get('targetType') ?? 'product';
   const selectedId = searchParams.get('selected') ?? null;
 
   const { result } = useList<CategoryEntry>({
@@ -134,7 +136,7 @@ export function CategoriesTreePage() {
     setSearchParams(next, { replace: true });
   };
 
-  const handleTargetChange = (kind: BuiltInObjectKind) => {
+  const handleTargetChange = (kind: string) => {
     const next = new URLSearchParams(searchParams);
     next.set('targetType', kind);
     setSearchParams(next, { replace: true });
@@ -209,7 +211,7 @@ function CategoryDetailPanel({
   tree,
 }: {
   categoryId: string;
-  targetType: BuiltInObjectKind;
+  targetType: string;
   locale: string;
   tree: CategoryTreeNode[];
 }) {


### PR DESCRIPTION
## Summary

Po ADR-014 / MOD-10 (#902) select „Object Type:" w `/modeling/categories` miał stałą listę `['service', 'product', 'category', 'asset', 'brand']` z czego 4 z 5 są nieaktualne:

| Opcja | Status post-ADR-014 | Problem |
|---|---|---|
| `service` | Nigdy nie built-in w MVP | API zwraca 404 dla `?objectTypeKind=service` o ile operator nie utworzył custom Service |
| `product` | ✅ built-in + `is_categorizable=true` | OK |
| `category` | `is_categorizable=false` | Deklarowanie no-op — resolver po MOD-03 zignoruje |
| `asset` | `is_categorizable=false` | j.w. |
| `brand` | Demoted w MOD-10 — nie built-in | Brak w pool |

## Decyzja

Select **JEST nadal potrzebny** — `CategoryAttributeGroup` junction trzyma `target_object_type_id`, ta sama kategoria może deklarować różne grupy dla różnych OT. ADR-014 nie usuwa tego mechanizmu.

ALE listę trzeba podpiąć pod backend zamiast hardcode'a.

## Refactor

`ObjectTypeFilterDropdown` teraz:
- Fetch z `/api/object_types`
- Filter: `builtIn === true AND isCategorizable === true`
- 0 OT → disabled hint („Brak ObjectType kategoryzowalnych")
- 1 OT → read-only label (single-choice select to noise)
- 2+ OT → native `<select>` jak wcześniej
- Auto-emit `onChange` z first eligible kind gdy URL param nie pasuje (legacy `service`, deleted Brand, demoted OT) — URL gets restamped

`BuiltInObjectKind` literal type retired w favour of plain `string`.

## Świadome odejścia

- **Custom kategoryzowalne OT nie pokazane** — backend `CategoryEffectiveGroupsController` resolves target via `findBuiltInByKind($kind, $tenant)` (one OT per kind). Custom OTs share `kind='custom'`, więc niejednoznaczne. Switching API contract na `?objectTypeId=<uuid>` queued jako follow-up gdy operator faktycznie utworzy pierwszy custom kategoryzowalny OT.

## Quality gates

- [x] admin TS noEmit → 0 errors
- [x] biome → 0 errors
- [ ] CI green
- [ ] Manual smoke — dropdown pokazuje tylko Product na demo tenancie

Refs ADR-014 / MOD-11 (#903). Domyka follow-up item z PR #919.