### PR TITLE
MODR-01: feat(catalog): display_mode on ObjectType×AttributeGroup junction

### DIFF
--- a/apps/api/migrations/Version20260524150000.php
+++ b/apps/api/migrations/Version20260524150000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ADR-014 / MODR-01 (#923) — adds per-assignment `display_mode` to the
+ * `object_type_attribute_groups` junction so the same AttributeGroup can be
+ * a tab in one ObjectType and a stacked inline section in another.
+ *
+ * The column governs the form-schema renderer (MODR-03 #925): `tab` renders
+ * the group as its own tab, `stacked` renders it inline as a section on
+ * the current tab. Default `tab` keeps the existing UX intact.
+ *
+ * Down path drops the column and the CHECK constraint.
+ */
+final class Version20260524150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-014 / MODR-01 (#923): add display_mode (tab|stacked) to object_type_attribute_groups.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE object_type_attribute_groups
+                ADD COLUMN display_mode VARCHAR(8) NOT NULL DEFAULT 'tab'
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE object_type_attribute_groups
+                ADD CONSTRAINT object_type_attribute_groups_display_mode_check
+                CHECK (display_mode IN ('tab', 'stacked'))
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE object_type_attribute_groups
+                DROP CONSTRAINT IF EXISTS object_type_attribute_groups_display_mode_check
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE object_type_attribute_groups
+                DROP COLUMN display_mode
+        SQL);
+    }
+}

--- a/apps/api/src/Catalog/Application/Query/GetObjectFormSchema/GetObjectFormSchemaHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectFormSchema/GetObjectFormSchemaHandler.php
@@ -79,10 +79,17 @@ final readonly class GetObjectFormSchemaHandler
         $type = $object->getObjectType();
         $groups = $this->resolver->resolve($object);
         $byGroup = $this->resolver->loadGroupAttributes($groups);
+        $displayModes = $this->resolver->loadObjectTypeGroupDisplayModes($type);
 
         $effective = [];
         foreach ($groups as $position => $group) {
-            $effective[] = $this->projectGroup($group, $byGroup[$group->getId()->toRfc4122()] ?? [], $position);
+            $key = $group->getId()->toRfc4122();
+            $effective[] = $this->projectGroup(
+                $group,
+                $byGroup[$key] ?? [],
+                $position,
+                $displayModes[$key] ?? 'tab',
+            );
         }
 
         return new ObjectFormSchema(
@@ -102,7 +109,7 @@ final readonly class GetObjectFormSchemaHandler
      *
      * @return array<string, mixed>
      */
-    private function projectGroup(AttributeGroup $group, array $junctions, int $position): array
+    private function projectGroup(AttributeGroup $group, array $junctions, int $position, string $displayMode): array
     {
         $attributes = [];
         foreach ($junctions as $junction) {
@@ -134,6 +141,7 @@ final readonly class GetObjectFormSchemaHandler
             'is_system_group' => $group->isSystemGroup(),
             'auto_attached' => $group->isAutoAttached(),
             'position' => $position,
+            'display_mode' => $displayMode,
             'attributes' => $attributes,
         ];
     }

--- a/apps/api/src/Catalog/Domain/Entity/ObjectTypeAttributeGroup.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectTypeAttributeGroup.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Catalog\Domain\Entity;
 
+use InvalidArgumentException;
+
 /**
  * Junction connecting an AttributeGroup to an ObjectType (M:N) per ADR-012.
  *
@@ -22,18 +24,28 @@ namespace App\Catalog\Domain\Entity;
  */
 class ObjectTypeAttributeGroup
 {
+    public const string DISPLAY_MODE_TAB = 'tab';
+    public const string DISPLAY_MODE_STACKED = 'stacked';
+
+    /** @var list<string> */
+    public const array DISPLAY_MODES = [self::DISPLAY_MODE_TAB, self::DISPLAY_MODE_STACKED];
+
     private ObjectType $objectType;
     private AttributeGroup $attributeGroup;
     private int $position = 0;
+    private string $displayMode = self::DISPLAY_MODE_TAB;
 
     public function __construct(
         ObjectType $objectType,
         AttributeGroup $attributeGroup,
         int $position = 0,
+        string $displayMode = self::DISPLAY_MODE_TAB,
     ) {
         $this->objectType = $objectType;
         $this->attributeGroup = $attributeGroup;
         $this->position = $position;
+        $this->assertDisplayMode($displayMode);
+        $this->displayMode = $displayMode;
     }
 
     public function getObjectType(): ObjectType
@@ -54,5 +66,27 @@ class ObjectTypeAttributeGroup
     public function reorder(int $position): void
     {
         $this->position = $position;
+    }
+
+    public function getDisplayMode(): string
+    {
+        return $this->displayMode;
+    }
+
+    public function changeDisplayMode(string $displayMode): void
+    {
+        $this->assertDisplayMode($displayMode);
+        $this->displayMode = $displayMode;
+    }
+
+    private function assertDisplayMode(string $value): void
+    {
+        if (!\in_array($value, self::DISPLAY_MODES, true)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Invalid display_mode "%s" — expected one of: %s.',
+                $value,
+                implode(', ', self::DISPLAY_MODES),
+            ));
+        }
     }
 }

--- a/apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php
+++ b/apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php
@@ -338,6 +338,34 @@ readonly class EffectiveAttributeGroupResolver
     }
 
     /**
+     * MODR-01 (#923) — returns the `display_mode` for each AttributeGroup
+     * as declared on the `object_type_attribute_groups` junction for the
+     * given ObjectType. Groups not present on the junction (e.g. inherited
+     * from a category) fall back to the default `tab` mode at the caller.
+     *
+     * @return array<string, string> keyed by group UUID, value is 'tab' or 'stacked'
+     */
+    public function loadObjectTypeGroupDisplayModes(ObjectType $type): array
+    {
+        /** @var list<ObjectTypeAttributeGroup> $junctions */
+        $junctions = $this->em
+            ->createQuery(
+                'SELECT j, g FROM '.ObjectTypeAttributeGroup::class.' j'
+                .' JOIN j.attributeGroup g'
+                .' WHERE j.objectType = :type'
+            )
+            ->setParameter('type', $type)
+            ->getResult();
+
+        $modes = [];
+        foreach ($junctions as $junction) {
+            $modes[$junction->getAttributeGroup()->getId()->toRfc4122()] = $junction->getDisplayMode();
+        }
+
+        return $modes;
+    }
+
+    /**
      * Eager-load the AttributeGroupAttribute junctions for a list of
      * groups in one query. Keeps the form-schema endpoint to two round
      * trips (groups + attributes) regardless of the number of groups.

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectTypeAttributeGroup.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectTypeAttributeGroup.orm.xml
@@ -28,6 +28,12 @@
             </options>
         </field>
 
+        <field name="displayMode" column="display_mode" type="string" length="8">
+            <options>
+                <option name="default">tab</option>
+            </options>
+        </field>
+
     </entity>
 
 </doctrine-mapping>

--- a/apps/api/src/Catalog/Presentation/Controller/AttachObjectTypeAttributeGroupController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttachObjectTypeAttributeGroupController.php
@@ -11,7 +11,9 @@ use App\Identity\Contracts\Attribute\RequiresPermission;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -105,6 +107,61 @@ final class AttachObjectTypeAttributeGroupController
             'DELETE FROM object_type_attribute_groups WHERE object_type_id = ? AND attribute_group_id = ?',
             [$id, $groupId],
         );
+
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * MODR-01 (#923) — `PATCH /api/object_types/{id}/groups/{groupId}` updates
+     * the `display_mode` of an existing junction without recreating it.
+     * Body shape: `{ "display_mode": "tab"|"stacked" }`.
+     */
+    #[Route(
+        '/api/object_types/{id}/groups/{groupId}',
+        name: 'pim_object_types_patch_group_assignment',
+        requirements: ['id' => self::UUID_REGEX, 'groupId' => self::UUID_REGEX],
+        methods: ['PATCH'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'modeling.object_types', action: 'add')]
+    public function patch(string $id, string $groupId, Request $request): JsonResponse
+    {
+        $objectType = $this->objectTypes->findById(Uuid::fromString($id));
+        if (null === $objectType) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $id));
+        }
+
+        $group = $this->attributeGroups->findById(Uuid::fromString($groupId));
+        if (null === $group) {
+            throw new NotFoundHttpException(\sprintf('AttributeGroup "%s" was not found.', $groupId));
+        }
+
+        $payload = json_decode($request->getContent(), true);
+        if (!\is_array($payload) || !\array_key_exists('display_mode', $payload)) {
+            throw new BadRequestHttpException('Body must contain `display_mode`.');
+        }
+        $displayMode = $payload['display_mode'];
+        if (!\is_string($displayMode) || !\in_array($displayMode, ObjectTypeAttributeGroup::DISPLAY_MODES, true)) {
+            throw new BadRequestHttpException(\sprintf(
+                'display_mode must be one of: %s.',
+                implode(', ', ObjectTypeAttributeGroup::DISPLAY_MODES),
+            ));
+        }
+
+        $junction = $this->em->find(ObjectTypeAttributeGroup::class, [
+            'objectType' => $objectType,
+            'attributeGroup' => $group,
+        ]);
+        if (!$junction instanceof ObjectTypeAttributeGroup) {
+            throw new NotFoundHttpException(\sprintf(
+                'AttributeGroup "%s" is not attached to ObjectType "%s".',
+                $groupId,
+                $id,
+            ));
+        }
+
+        $junction->changeDisplayMode($displayMode);
+        $this->em->flush();
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }

--- a/apps/api/tests/Api/Catalog/ObjectFormSchemaApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectFormSchemaApiTest.php
@@ -53,6 +53,28 @@ final class ObjectFormSchemaApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function getFormSchemaExposesDisplayModePerGroup(): void
+    {
+        // MODR-01 (#923) — every group in `effectiveGroups` carries the
+        // `display_mode` field; seeded audit junction defaults to 'tab'.
+        $product = $this->seedProduct('SKU-FS-DM-001');
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('GET', '/api/objects/'.$product->getId()->toRfc4122().'/form-schema');
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+        $groups = $payload['effectiveGroups'];
+        self::assertIsArray($groups);
+        self::assertNotEmpty($groups);
+        foreach ($groups as $group) {
+            self::assertIsArray($group);
+            self::assertArrayHasKey('display_mode', $group);
+            self::assertContains($group['display_mode'], ['tab', 'stacked']);
+        }
+    }
+
+    #[Test]
     public function getFormSchemaReturnsNotFoundForUnknownId(): void
     {
         $client = $this->authenticatedClient();

--- a/apps/api/tests/Api/Catalog/ObjectTypeAttributeGroupDisplayModePatchApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectTypeAttributeGroupDisplayModePatchApiTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInSystemAttributesSeeder;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * MODR-01 (#923) — `PATCH /api/object_types/{id}/groups/{groupId}` updates
+ * the per-assignment `display_mode` on the junction.
+ */
+final class ObjectTypeAttributeGroupDisplayModePatchApiTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert(null !== $tenant);
+        self::getContainer()->get(BuiltInSystemAttributesSeeder::class)->seed($tenant);
+    }
+
+    #[Test]
+    public function patchChangesDisplayModeToStacked(): void
+    {
+        $productId = $this->objectTypeIdFor(ObjectKind::Product);
+        $auditGroupId = $this->seededAuditGroupId();
+
+        $client = $this->authenticatedClient();
+
+        $client->request('PATCH', '/api/object_types/'.$productId.'/groups/'.$auditGroupId, [
+            'json' => ['display_mode' => 'stacked'],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // Form-schema for a product of this type must reflect the new mode.
+        $product = $this->seedProduct('SKU-MODR01-001');
+        $response = $client->request(
+            'GET',
+            '/api/objects/'.$product->getId()->toRfc4122().'/form-schema'
+        );
+        self::assertResponseIsSuccessful();
+
+        $payload = $response->toArray();
+        $groups = $payload['effectiveGroups'];
+        self::assertIsArray($groups);
+        $audit = null;
+        foreach ($groups as $group) {
+            \assert(\is_array($group));
+            if (($group['code'] ?? null) === 'audit') {
+                $audit = $group;
+                break;
+            }
+        }
+        self::assertIsArray($audit);
+        self::assertSame('stacked', $audit['display_mode']);
+    }
+
+    #[Test]
+    public function patchRejectsInvalidDisplayMode(): void
+    {
+        $productId = $this->objectTypeIdFor(ObjectKind::Product);
+        $auditGroupId = $this->seededAuditGroupId();
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/object_types/'.$productId.'/groups/'.$auditGroupId, [
+            'json' => ['display_mode' => 'accordion'],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    #[Test]
+    public function patchReturnsNotFoundForMissingAssignment(): void
+    {
+        $productId = $this->objectTypeIdFor(ObjectKind::Product);
+        $unknownGroupId = Uuid::v7()->toRfc4122();
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/object_types/'.$productId.'/groups/'.$unknownGroupId, [
+            'json' => ['display_mode' => 'stacked'],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
+    public function patchReturnsBadRequestWhenBodyMissingField(): void
+    {
+        $productId = $this->objectTypeIdFor(ObjectKind::Product);
+        $auditGroupId = $this->seededAuditGroupId();
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/object_types/'.$productId.'/groups/'.$auditGroupId, [
+            'json' => [],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    #[Test]
+    public function entityRejectsInvalidDisplayMode(): void
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+        $group = self::getContainer()->get(AttributeGroupRepositoryInterface::class)
+            ->findByCode('audit', $tenant);
+        \assert(null !== $group);
+
+        $this->expectException(InvalidArgumentException::class);
+
+        new ObjectTypeAttributeGroup($type, $group, 0, 'invalid_mode');
+    }
+
+    private function seededAuditGroupId(): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $group = self::getContainer()->get(AttributeGroupRepositoryInterface::class)
+            ->findByCode('audit', $tenant);
+        \assert(null !== $group);
+
+        return $group->getId()->toRfc4122();
+    }
+
+    private function seedProduct(string $code): CatalogObject
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert(null !== $tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $product = new CatalogObject($type, $code);
+        $em = $this->em();
+        $em->persist($product);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $product;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `display_mode` (`tab`|`stacked`) column to the `object_type_attribute_groups` junction so the same AttributeGroup can be a tab in one ObjectType and a stacked inline section in another (ADR-014 / Option 2 placement model).
- Wires the column through entity, ORM mapping, `form-schema` serializer (`effectiveGroups[].display_mode`), resolver helper `loadObjectTypeGroupDisplayModes()`, and a new `PATCH /api/object_types/{id}/groups/{groupId}` route updating the assignment without recreating it.
- CHECK constraint rejects values outside the enum. Tenant scope inherited via FK chain (no explicit `tenant_id` column on the junction — already in `TenantAuditCommand::INFRA_TABLES`).

## Foundation note
Blocks MODR-02 (#924), MODR-03 (#925), MODR-04 (#926). Default `tab` keeps existing UX intact for every currently seeded junction.

## Test plan
- [x] `php-cs-fixer` clean
- [x] `phpstan analyse` (level max, 1G memory) — **0 errors**
- [x] `doctrine:schema:validate` — Mapping OK
- [x] Migration UP+DOWN smoke (`doctrine:migrations:execute --up`/`--down`) on live dev DB — column + CHECK constraint added/dropped cleanly
- [x] PHPUnit MODR-01 PATCH suite — **5/5 pass** (`ObjectTypeAttributeGroupDisplayModePatchApiTest`)
- [x] PHPUnit form-schema suite — **4/4 pass** (`ObjectFormSchemaApiTest`, includes new `display_mode` assertion)
- [x] Regression: ObjectTypeView01ApiTest + ObjectTypeAttachedAttributesApiTest + EffectiveAttributeGroupResolverTest + SystemAttributesAuditGroupTest + AttributeGroupFirstClassTest — **35/35 pass**
- [x] **Live-stack smoke test** on `https://pim.localhost` (admin@demo.localhost):
  - `PATCH .../object_types/<product>/groups/<relations>` body `{"display_mode":"stacked"}` → **HTTP 204**
  - DB verify: row updated to `stacked`
  - `PATCH ... {"display_mode":"accordion"}` → **HTTP 400** (`display_mode must be one of: tab, stacked.`)
  - Reset back to `tab` → **HTTP 204**

Refs #923