### PR TITLE
MODR-02: refactor(catalog): un-hardcode Multimedia tab as seeded AttributeGroup

### DIFF
--- a/apps/api/src/Catalog/Application/BuiltInProductMediaAttributesSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInProductMediaAttributesSeeder.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * ADR-014 / MODR-02 (#924) — per-tenant seeder for the built-in
+ * "Multimedia" AttributeGroup attached to the Product ObjectType.
+ *
+ * Counterpart to {@see BuiltInProductRelationAttributesSeeder} for the
+ * media side. The group is seeded empty in MVP — `asset`-typed attributes
+ * hosted in it are added through Modelowanie when the operator wires
+ * specific media slots (or a follow-up ticket migrates the legacy
+ * `product_assets` m2m into a first-class `asset` attribute).
+ *
+ * The whole point of MODR-02 is to *stop hardcoding* the Multimedia tab:
+ * once the group exists with `is_system_group=true` (so it cannot be
+ * detached) and `display_mode='tab'` (inherited via the MODR-01 column
+ * default), the form-schema renderer (MODR-03) can derive the tab from
+ * `effectiveGroups` like every other group.
+ *
+ * Idempotent: re-runs after the row exists are no-ops.
+ */
+final readonly class BuiltInProductMediaAttributesSeeder
+{
+    /** Position of the "Multimedia" AttributeGroup in the form layout. */
+    private const int GROUP_POSITION = 400;
+
+    private const string GROUP_CODE = 'media';
+
+    public function __construct(
+        private AttributeGroupRepositoryInterface $attributeGroupRepository,
+        private ObjectTypeRepositoryInterface $objectTypeRepository,
+        private EntityManagerInterface $em,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    /**
+     * Seed the missing built-in media group for the given tenant. Returns
+     * 1 if a new group was created, 0 if it already existed.
+     */
+    public function seed(Tenant $tenant): int
+    {
+        $previous = $this->tenantContext->get();
+        $this->tenantContext->set($tenant);
+
+        try {
+            $productType = $this->objectTypeRepository->findBuiltInByKind(ObjectKind::Product, $tenant);
+            if (null === $productType) {
+                return 0;
+            }
+
+            $created = 0;
+            $group = $this->attributeGroupRepository->findByCode(self::GROUP_CODE, $tenant);
+            if (null === $group) {
+                $group = new AttributeGroup(
+                    code: self::GROUP_CODE,
+                    label: ['pl' => 'Multimedia', 'en' => 'Media'],
+                    position: self::GROUP_POSITION,
+                    description: [
+                        'pl' => 'Wbudowana grupa na pliki produktu — zdjęcia, dokumenty, multimedia (ADR-014).',
+                        'en' => 'Built-in group for product media — images, documents, multimedia (ADR-014).',
+                    ],
+                    icon: 'Image',
+                    color: '#8B5CF6',
+                    isSystemGroup: true,
+                    autoAttached: false,
+                    isRequiredSection: false,
+                    isShared: false,
+                    hasConditionalVisibility: false,
+                );
+                $this->em->persist($group);
+                $this->em->flush();
+                $created = 1;
+            }
+
+            $groupAttachedToProduct = $this->em
+                ->createQuery(
+                    'SELECT 1 FROM '.ObjectTypeAttributeGroup::class.' j'
+                    .' WHERE j.objectType = :objectType AND j.attributeGroup = :group'
+                )
+                ->setParameter('objectType', $productType)
+                ->setParameter('group', $group)
+                ->setMaxResults(1)
+                ->getOneOrNullResult();
+            if (null === $groupAttachedToProduct) {
+                $this->em->persist(new ObjectTypeAttributeGroup($productType, $group, position: self::GROUP_POSITION));
+                $this->em->flush();
+            }
+
+            return $created;
+        } finally {
+            if (null === $previous) {
+                $this->tenantContext->clear();
+            } else {
+                $this->tenantContext->set($previous);
+            }
+        }
+    }
+}

--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\DataFixtures;
 
 use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Application\BuiltInProductMediaAttributesSeeder;
 use App\Catalog\Application\BuiltInProductRelationAttributesSeeder;
 use App\Catalog\Application\BuiltInSmartFilterPresetsSeeder;
 use App\Catalog\Application\BuiltInSystemAttributesSeeder;
@@ -67,6 +68,7 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
         private readonly BuiltInObjectTypeSeeder $builtInSeeder,
         private readonly BuiltInSystemAttributesSeeder $systemAttributesSeeder,
         private readonly BuiltInProductRelationAttributesSeeder $productRelationAttributesSeeder,
+        private readonly BuiltInProductMediaAttributesSeeder $productMediaAttributesSeeder,
         private readonly ObjectTypeRepositoryInterface $objectTypeRepository,
         private readonly DemoCatalogSeeder $demoCatalogSeeder,
         private readonly DefaultMenuSeeder $defaultMenuSeeder,
@@ -145,6 +147,11 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
             // attributes on Product ObjectType + the "Powiązania" group
             // that hosts them. Replaces BuiltInAssociationTypeSeeder.
             $this->productRelationAttributesSeeder->seed($tenant);
+            // ADR-014 / MODR-02 (#924): seed the built-in "Multimedia"
+            // AttributeGroup on Product so it stops being a hardcoded
+            // tab. Empty in MVP — `asset`-typed attributes wired through
+            // Modelowanie in follow-up tickets.
+            $this->productMediaAttributesSeeder->seed($tenant);
             // VIEW-08 (#427): seed the default sidebar layout (8 items
             // matching the legacy hard-coded sidebar minus Services).
             $this->defaultMenuSeeder->seed($tenant);

--- a/apps/api/tests/Integration/Catalog/BuiltInProductMediaAttributesSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/BuiltInProductMediaAttributesSeederTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Application\BuiltInProductMediaAttributesSeeder;
+use App\Catalog\Application\BuiltInProductRelationAttributesSeeder;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * MODR-02 (#924) — `BuiltInProductMediaAttributesSeeder` creates an empty
+ * "Multimedia" AttributeGroup, marks it system, and attaches it to Product
+ * with `display_mode='tab'` (default from MODR-01 #923 column).
+ */
+final class BuiltInProductMediaAttributesSeederTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function seedCreatesMediaGroupAttachedToProductWithDefaultTabDisplayMode(): void
+    {
+        $tenant = $this->bootAndSeedTenant('modr02a');
+
+        $created = self::getContainer()
+            ->get(BuiltInProductMediaAttributesSeeder::class)
+            ->seed($tenant);
+
+        self::assertSame(1, $created);
+
+        $group = self::getContainer()->get(AttributeGroupRepositoryInterface::class)
+            ->findByCode('media', $tenant);
+        self::assertInstanceOf(AttributeGroup::class, $group);
+        self::assertTrue($group->isSystemGroup(), 'media group must be system');
+
+        $junction = $this->findJunction($tenant, $group);
+        self::assertInstanceOf(ObjectTypeAttributeGroup::class, $junction);
+        self::assertSame('tab', $junction->getDisplayMode(), 'display_mode defaults to tab (MODR-01)');
+    }
+
+    #[Test]
+    public function seedIsIdempotent(): void
+    {
+        $tenant = $this->bootAndSeedTenant('modr02b');
+        $seeder = self::getContainer()->get(BuiltInProductMediaAttributesSeeder::class);
+
+        $created = $seeder->seed($tenant);
+        self::assertSame(1, $created, 'first run creates the group');
+
+        $secondRun = $seeder->seed($tenant);
+        self::assertSame(0, $secondRun, 'second run is a no-op');
+    }
+
+    #[Test]
+    public function relationsGroupAlreadyHasDefaultTabDisplayMode(): void
+    {
+        $tenant = $this->bootAndSeedTenant('modr02c');
+
+        self::getContainer()
+            ->get(BuiltInProductRelationAttributesSeeder::class)
+            ->seed($tenant);
+
+        $group = self::getContainer()->get(AttributeGroupRepositoryInterface::class)
+            ->findByCode('relations', $tenant);
+        self::assertInstanceOf(AttributeGroup::class, $group);
+
+        $junction = $this->findJunction($tenant, $group);
+        self::assertInstanceOf(ObjectTypeAttributeGroup::class, $junction);
+        self::assertSame('tab', $junction->getDisplayMode());
+    }
+
+    private function bootAndSeedTenant(string $code): Tenant
+    {
+        self::bootKernel();
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        $tenant = new Tenant($code, 'MODR-02 tenant '.$code);
+        $em->persist($tenant);
+        $em->flush();
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($tenant);
+
+        return $tenant;
+    }
+
+    private function findJunction(Tenant $tenant, AttributeGroup $group): ?ObjectTypeAttributeGroup
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        $product = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $product);
+
+        $junction = $em->getRepository(ObjectTypeAttributeGroup::class)
+            ->findOneBy(['objectType' => $product, 'attributeGroup' => $group]);
+
+        return $junction instanceof ObjectTypeAttributeGroup ? $junction : null;
+    }
+}


### PR DESCRIPTION
## Summary
- Seeds built-in "Multimedia" AttributeGroup (`code=media`, position 400, `is_system_group=true`) attached to Product ObjectType, mirroring `BuiltInProductRelationAttributesSeeder`.
- Default `display_mode='tab'` inherited from MODR-01 (#923) column default.
- System flag blocks detach (existing `AttachObjectTypeAttributeGroupController::detach` enforcement applies).
- Group is empty in MVP — concrete `asset`-typed attributes wired via Modelowanie in follow-up tickets.

## Explicit scope boundary
Renderer-side un-hardcode (`product-detail-page.tsx` TABS array hardcoding `'multimedia'`/`'relations'`) is **deferred to MODR-03 (#925)** per its scope. MODR-02 ships the seeded groups + DB plumbing; MODR-03 rewires the renderer to consume them from `effectiveGroups`.

## Test plan
- [x] `php-cs-fixer` clean
- [x] `phpstan analyse --memory-limit=1G` — **0 errors**
- [x] `doctrine:schema:validate` — Mapping OK
- [x] PHPUnit MODR-02 seeder suite (`BuiltInProductMediaAttributesSeederTest`) — **3/3 pass**
- [x] Regression: BuiltInProductRelationAttributesSeederTest + SystemAttributesAuditGroupTest + EffectiveAttributeGroupResolverTest + EffectiveAttributeGroupResolverProductTest — **20/20 pass**
- [x] **Live-stack smoke test** on `https://pim.localhost`:
  - `GET /api/object_types/<product>/attached_groups` → `media` group present (`system=true`, `attrsCount=0`), alongside existing `relations` and `audit`
  - `GET /api/objects/<product>/form-schema` → `effectiveGroups` includes `{code:"media", display_mode:"tab", attributes:[]}`
  - `DELETE .../groups/<media>` → **HTTP 403** (`media is a system group and cannot be detached`)
  - `PATCH .../groups/<media> {"display_mode":"stacked"}` → **HTTP 204** + DB reflects `stacked`
  - Reset back to `tab` → **HTTP 204**

Refs #924