### PR TITLE
MODR-03: feat(admin): object form renderer — placement by AttributeGroup + display_mode

### DIFF
--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -55,15 +55,16 @@ import type {
 import { VariantsListCard } from './variants-list-card';
 import { VariantsTabHost } from './variants-tab-host';
 
-const TABS = [
-  'attributes',
-  'multimedia',
-  'categories',
-  'relations',
-  'history',
-  'variants',
-] as const;
-type TabKey = (typeof TABS)[number];
+/**
+ * MODR-03 (#925) — special-purpose tabs that are NOT driven by
+ * `effectiveGroups`. `attributes` hosts every `display_mode='stacked'`
+ * group as inline sections; the rest are bespoke views (categories
+ * picker, audit log, variants tree). Tab-mode groups become tabs
+ * dynamically — see `useDynamicTabs`.
+ */
+const SPECIAL_TABS = ['attributes', 'categories', 'history', 'variants'] as const;
+type SpecialTabKey = (typeof SPECIAL_TABS)[number];
+type TabKey = SpecialTabKey | string;
 
 const GROUP_ICONS: Record<string, string> = {
   identification: '🔑',
@@ -230,6 +231,38 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   });
 
   const groups = useMemo(() => groupsQuery.data?.groups ?? [], [groupsQuery.data]);
+
+  // MODR-03 (#925) — tab list derived dynamically from `groups`:
+  // every group with `display_mode='tab'` becomes its own tab; groups
+  // with `display_mode='stacked'` (and the synthetic "default" bucket)
+  // collect into the single `attributes` tab. Hooks must live above
+  // the loading early-return below to obey rules-of-hooks.
+  const tabModeGroups = useMemo(
+    () => groups.filter((g) => (g.display_mode ?? 'tab') === 'tab'),
+    [groups],
+  );
+  const stackedGroups = useMemo(
+    () => groups.filter((g) => (g.display_mode ?? 'tab') === 'stacked'),
+    [groups],
+  );
+  const visibleTabs: readonly TabKey[] = useMemo(() => {
+    if (mode === 'create') return ['attributes'];
+    return [
+      'attributes' as const,
+      ...tabModeGroups.map((g) => g.code),
+      'categories' as const,
+      'history' as const,
+      'variants' as const,
+    ];
+  }, [mode, tabModeGroups]);
+
+  // Keep activeTab valid as group set changes (e.g. groups data arrives
+  // after first render or a tab→stacked switch in the wizard).
+  useEffect(() => {
+    if (!visibleTabs.includes(activeTab)) {
+      setActiveTab('attributes');
+    }
+  }, [activeTab, visibleTabs]);
 
   // Default expand all groups once they first arrive (mockup shows every
   // section open). Refetches after the first success keep the operator's
@@ -401,8 +434,6 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     typeof attrs.category === 'string' && attrs.category !== ''
       ? attrs.category
       : (objectTypeName ?? '—');
-
-  const visibleTabs: readonly TabKey[] = mode === 'create' ? (['attributes'] as const) : TABS;
 
   return (
     <div className="bg-zinc-50 -mx-6 -mt-6 min-h-[calc(100vh-3rem)]">
@@ -605,6 +636,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
           >
             {visibleTabs.map((tab) => {
               const isActive = activeTab === tab;
+              const badge = tabBadge(tab, groups, stackedGroups, product);
               return (
                 <button
                   key={tab}
@@ -617,17 +649,15 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                     isActive ? 'text-zinc-900' : 'text-zinc-500 hover:text-zinc-800',
                   )}
                 >
-                  {t(`products.detail.tabs.${tab}`, {
-                    defaultValue: TAB_DEFAULT_LABELS[tab],
-                  })}
-                  {tabBadge(tab, groups, product) !== null ? (
+                  {tabLabel(tab, groups, lang, t)}
+                  {badge !== null ? (
                     <span
                       className={cn(
                         'num rounded px-1.5 py-0.5 text-[10.5px]',
                         isActive ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-500',
                       )}
                     >
-                      {tabBadge(tab, groups, product)}
+                      {badge}
                     </span>
                   ) : null}
                   {isActive ? (
@@ -654,56 +684,82 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
       {/* Body */}
       <div className="grid grid-cols-1 gap-5 px-7 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="min-w-0 space-y-3">
-          {activeTab === 'attributes' ? (
-            <>
-              {groups.map((group) => (
-                <AttrGroupCard
-                  key={group.id}
-                  id={group.id}
-                  title={group.label[lang] ?? group.code}
-                  icon={GROUP_ICONS[group.code]}
-                  filledCount={countFilled(group, fieldValue)}
-                  totalCount={group.attributes.length}
-                  expanded={expandedGroups.has(group.id)}
-                  onToggle={() => toggleGroup(group.id)}
-                  isSystem={group.code === 'audit'}
-                >
-                  {group.attributes.map((attr) => (
-                    <AttrRow
-                      key={attr.id}
-                      attribute={attr}
-                      value={fieldValue(attr.code)}
-                      provenance={resolveProvenance(attr, product)}
-                      locale={locale}
-                      isEditing={isEditing}
-                      isLocked={attr.is_system}
-                      onChange={(next) => setFieldValue(attr.code, next)}
-                    />
-                  ))}
-                </AttrGroupCard>
-              ))}
-              <button
-                type="button"
-                onClick={() =>
-                  toast.info(
-                    t('products.detail.add_attribute_group.unavailable', {
-                      defaultValue: 'Custom grupy ad-hoc — follow-up',
-                    }),
-                  )
-                }
-                className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-zinc-300 text-[13px] font-medium text-zinc-500 hover:bg-white hover:text-zinc-900"
+          {(() => {
+            // MODR-03 (#925) — content area dispatch based on active tab.
+            // 'attributes' hosts every stacked group as inline AttrGroupCard
+            // sections; a tab-mode group code renders that single group;
+            // 'categories'/'history'/'variants' delegate to bespoke components.
+            const renderStackedGroup = (group: GroupMeta) => (
+              <AttrGroupCard
+                key={group.id}
+                id={group.id}
+                title={group.label[lang] ?? group.code}
+                icon={GROUP_ICONS[group.code]}
+                filledCount={countFilled(group, fieldValue)}
+                totalCount={group.attributes.length}
+                expanded={expandedGroups.has(group.id)}
+                onToggle={() => toggleGroup(group.id)}
+                isSystem={group.code === 'audit'}
               >
-                +{' '}
-                {t('products.detail.add_attribute_group.label', {
-                  defaultValue: 'Dodaj grupę atrybutów ad-hoc',
-                })}
-              </button>
-            </>
-          ) : null}
+                {group.attributes.map((attr) => (
+                  <AttrRow
+                    key={attr.id}
+                    attribute={attr}
+                    value={fieldValue(attr.code)}
+                    provenance={resolveProvenance(attr, product)}
+                    locale={locale}
+                    isEditing={isEditing}
+                    isLocked={attr.is_system}
+                    onChange={(next) => setFieldValue(attr.code, next)}
+                  />
+                ))}
+              </AttrGroupCard>
+            );
 
-          {activeTab !== 'attributes' && mode === 'edit' ? (
-            <OtherTabs activeTab={activeTab} productId={id} />
-          ) : null}
+            if (activeTab === 'attributes') {
+              return (
+                <>
+                  {stackedGroups.map(renderStackedGroup)}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      toast.info(
+                        t('products.detail.add_attribute_group.unavailable', {
+                          defaultValue: 'Custom grupy ad-hoc — follow-up',
+                        }),
+                      )
+                    }
+                    className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-zinc-300 text-[13px] font-medium text-zinc-500 hover:bg-white hover:text-zinc-900"
+                  >
+                    +{' '}
+                    {t('products.detail.add_attribute_group.label', {
+                      defaultValue: 'Dodaj grupę atrybutów ad-hoc',
+                    })}
+                  </button>
+                </>
+              );
+            }
+
+            // Tab-mode AttributeGroup → render only that group, with
+            // bespoke components for media/relations that retain their
+            // legacy data flow (m2m assets, relation links endpoint).
+            const tabGroup = tabModeGroups.find((g) => g.code === activeTab);
+            if (tabGroup && mode === 'edit') {
+              if (tabGroup.code === 'media' || tabGroup.code === 'multimedia') {
+                return <ProductMultimediaTab productId={id} />;
+              }
+              if (tabGroup.code === 'relations') {
+                return <RelationsTab productId={id} />;
+              }
+              return renderStackedGroup(tabGroup);
+            }
+
+            if (mode === 'edit' && isSpecialTab(activeTab)) {
+              return <OtherTabs activeTab={activeTab} productId={id} />;
+            }
+
+            return null;
+          })()}
 
           {mode === 'create' && createCategoryIds.length === 0 ? (
             <p className="px-1 text-[12px] text-muted-foreground">
@@ -790,31 +846,55 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   );
 }
 
-const TAB_DEFAULT_LABELS: Record<TabKey, string> = {
+const SPECIAL_TAB_DEFAULT_LABELS: Record<SpecialTabKey, string> = {
   attributes: 'Atrybuty',
-  multimedia: 'Multimedia',
   categories: 'Kategorie',
-  relations: 'Powiązania',
   history: 'Historia',
   variants: 'Warianty',
 };
 
+function tabLabel(
+  tab: TabKey,
+  groups: GroupMeta[],
+  lang: 'pl' | 'en',
+  t: (key: string, options?: { defaultValue?: string }) => string,
+): string {
+  if (isSpecialTab(tab)) {
+    return t(`products.detail.tabs.${tab}`, {
+      defaultValue: SPECIAL_TAB_DEFAULT_LABELS[tab],
+    });
+  }
+  const group = groups.find((g) => g.code === tab);
+  if (!group) return tab;
+  const i18nKey = `products.detail.tabs.group_${group.code}`;
+  const fallback = group.label[lang] ?? group.code;
+  return t(i18nKey, { defaultValue: fallback });
+}
+
+function isSpecialTab(tab: TabKey): tab is SpecialTabKey {
+  return (SPECIAL_TABS as readonly string[]).includes(tab);
+}
+
 function tabBadge(
   tab: TabKey,
   groups: GroupMeta[],
+  stackedGroups: GroupMeta[],
   product: CatalogObjectDto | null | undefined,
 ): number | null {
-  if (tab === 'attributes') return groups.length === 0 ? null : groups.length;
-  if (tab === 'multimedia') return null;
+  if (tab === 'attributes') {
+    return stackedGroups.length === 0 ? null : stackedGroups.length;
+  }
   if (tab === 'categories') return null;
-  if (tab === 'relations') return null;
   if (tab === 'history') return null;
   if (tab === 'variants') {
     const count = (product?.attributesIndexed as { variantsCount?: number } | undefined)
       ?.variantsCount;
     return typeof count === 'number' ? count : null;
   }
-  return null;
+  // Tab-mode AttributeGroup → badge shows the attribute count when > 0.
+  const group = groups.find((g) => g.code === tab);
+  if (!group) return null;
+  return group.attributes.length === 0 ? null : group.attributes.length;
 }
 
 function stripAttributes(dirty: Record<string, unknown>): Record<string, unknown> {
@@ -852,10 +932,12 @@ function resolveProvenance(
   return 'manual';
 }
 
-function OtherTabs({ activeTab, productId }: { activeTab: TabKey; productId: string }) {
-  if (activeTab === 'multimedia') return <ProductMultimediaTab productId={productId} />;
+function OtherTabs({ activeTab, productId }: { activeTab: SpecialTabKey; productId: string }) {
+  // MODR-03 (#925) — multimedia/relations branches removed; those tabs
+  // are now derived from `effectiveGroups` (display_mode='tab') and
+  // dispatched inline in the renderer (Media+Relations groups keep
+  // their bespoke components for the legacy m2m/links data flow).
   if (activeTab === 'categories') return <CategoriesTab productId={productId} />;
-  if (activeTab === 'relations') return <RelationsTab productId={productId} />;
   if (activeTab === 'history') return <HistoryStub />;
   if (activeTab === 'variants') return <VariantsTabHost productId={productId} />;
   return null;

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -70,6 +70,13 @@ export interface GroupMeta {
   code: string;
   label: { pl?: string; en?: string };
   position: number;
+  /**
+   * MODR-01 (#923) — `tab` renders the group as its own tab on the
+   * product detail page; `stacked` renders it as an inline section under
+   * the default "Attributes" tab. Falls back to `tab` when the backend
+   * predates the column.
+   */
+  display_mode?: 'tab' | 'stacked';
   attributes: AttributeMeta[];
 }
 

--- a/apps/api/migrations/Version20260524160000.php
+++ b/apps/api/migrations/Version20260524160000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ADR-014 / MODR-03 (#925) — preserve the pre-existing visual layout of
+ * the Product detail page by shifting the seeded `audit` AttributeGroup
+ * junctions from `display_mode='tab'` (DB default introduced in MODR-01
+ * #923) to `display_mode='stacked'`. The new dynamic renderer puts every
+ * `tab`-mode group in its own tab; without this shift the audit group
+ * would jump out of the unified "Attributes" tab and become a sibling
+ * of Multimedia / Relations — a regression vs. the prior layout.
+ *
+ * Down path puts audit junctions back to `tab` (matching the
+ * MODR-01 column default).
+ */
+final class Version20260524160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-014 / MODR-03 (#925): pin audit AttributeGroup junctions to display_mode=stacked.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE object_type_attribute_groups otag
+            SET display_mode = 'stacked'
+            FROM attribute_groups ag
+            WHERE otag.attribute_group_id = ag.id
+              AND ag.code = 'audit'
+              AND ag.is_system_group = true
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE object_type_attribute_groups otag
+            SET display_mode = 'tab'
+            FROM attribute_groups ag
+            WHERE otag.attribute_group_id = ag.id
+              AND ag.code = 'audit'
+              AND ag.is_system_group = true
+        SQL);
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInSystemAttributesSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInSystemAttributesSeeder.php
@@ -157,7 +157,12 @@ final readonly class BuiltInSystemAttributesSeeder
                 if (\in_array($objectType->getId()->toRfc4122(), $alreadyAttached, true)) {
                     continue;
                 }
-                $this->em->persist(new ObjectTypeAttributeGroup($objectType, $auditGroup, position: 999));
+                $this->em->persist(new ObjectTypeAttributeGroup(
+                    $objectType,
+                    $auditGroup,
+                    position: 999,
+                    displayMode: ObjectTypeAttributeGroup::DISPLAY_MODE_STACKED,
+                ));
             }
             $this->em->flush();
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/AutoAttachAuditGroupListener.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/EventListener/AutoAttachAuditGroupListener.php
@@ -66,7 +66,12 @@ final class AutoAttachAuditGroupListener
         }
 
         $em = $event->getObjectManager();
-        $junction = new ObjectTypeAttributeGroup($entity, $auditGroup, position: 999);
+        $junction = new ObjectTypeAttributeGroup(
+            $entity,
+            $auditGroup,
+            position: 999,
+            displayMode: ObjectTypeAttributeGroup::DISPLAY_MODE_STACKED,
+        );
 
         $this->attaching = true;
         try {

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectTypeEffectiveGroupsPreviewController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectTypeEffectiveGroupsPreviewController.php
@@ -123,6 +123,7 @@ final class ObjectTypeEffectiveGroupsPreviewController
 
         $groups = $this->resolver->resolveForCategoryList($objectType, $categories);
         $byGroup = $this->resolver->loadGroupAttributes($groups);
+        $displayModes = $this->resolver->loadObjectTypeGroupDisplayModes($objectType);
 
         /** @var array<string, Attribute> $optionsAttrs */
         $optionsAttrs = [];
@@ -166,6 +167,7 @@ final class ObjectTypeEffectiveGroupsPreviewController
                 'color' => $group->getColor(),
                 'is_system_group' => $group->isSystemGroup(),
                 'position' => $position,
+                'display_mode' => $displayModes[$group->getId()->toRfc4122()] ?? 'tab',
                 'attributes' => $attributes,
             ];
         }
@@ -202,6 +204,7 @@ final class ObjectTypeEffectiveGroupsPreviewController
                 'is_system_group' => false,
                 'is_synthetic' => true,
                 'position' => \count($effective),
+                'display_mode' => 'stacked',
                 'attributes' => $defaultAttributes,
             ];
         }

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -184,6 +184,7 @@ final class ProductReadEndpointsController
 
         $groups = $this->resolver->resolve($product);
         $byGroup = $this->resolver->loadGroupAttributes($groups);
+        $displayModes = $this->resolver->loadObjectTypeGroupDisplayModes($product->getObjectType());
 
         // Pre-pass: collect every select / multiselect Attribute reachable
         // from this product so we can ship its `AttributeOption` list in the
@@ -235,6 +236,7 @@ final class ProductReadEndpointsController
                 'color' => $group->getColor(),
                 'is_system_group' => $group->isSystemGroup(),
                 'position' => $position,
+                'display_mode' => $displayModes[$group->getId()->toRfc4122()] ?? 'tab',
                 'attributes' => $attributes,
             ];
         }
@@ -279,6 +281,7 @@ final class ProductReadEndpointsController
                 'is_system_group' => false,
                 'is_synthetic' => true,
                 'position' => \count($effective),
+                'display_mode' => 'stacked',
                 'attributes' => $defaultAttributes,
             ];
         }

--- a/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
@@ -106,6 +106,62 @@ final class EffectiveAttributeGroupsApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function exposesDisplayModePerGroupAndSyntheticGroupIsStacked(): void
+    {
+        // MODR-03 (#925) — every group in the payload carries a
+        // `display_mode`. Audit (real group) is `stacked` after the
+        // MODR-03 data migration; the synthetic "default" bucket is
+        // always `stacked` so it never spawns a tab on the frontend.
+        $client = $this->authenticatedClient();
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $productType = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        // Seed the audit system group + attach one loose attribute so
+        // both an audit (stacked) and a synthetic default (stacked)
+        // group appear in the response.
+        self::getContainer()->get(BuiltInSystemAttributesSeeder::class)->seed($tenant);
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+        $brandAttr = new Attribute('modr03_brand', ['pl' => 'Marka', 'en' => 'Brand'], AttributeType::Text);
+        $em = $this->em();
+        $em->persist($brandAttr);
+        $em->flush();
+        self::getContainer()->get(ObjectTypeService::class)
+            ->assignAttribute($productType, $brandAttr, required: false, sortOrder: 0);
+        $tenantContext->clear();
+
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'MODR03-DM',
+                'objectTypeId' => $productType->getId()->toRfc4122(),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+        $id = $created['id'] ?? null;
+        \assert(\is_string($id));
+
+        $body = $client->request('GET', '/api/products/'.$id.'/effective-attribute-groups')->toArray();
+        $groups = $body['groups'] ?? [];
+        \assert(\is_array($groups));
+
+        $modesByCode = [];
+        foreach ($groups as $g) {
+            \assert(\is_array($g));
+            self::assertArrayHasKey('display_mode', $g, 'Group missing display_mode: '.json_encode($g));
+            self::assertContains($g['display_mode'], ['tab', 'stacked']);
+            $modesByCode[$g['code']] = $g['display_mode'];
+        }
+
+        self::assertSame('stacked', $modesByCode['audit'] ?? null, 'audit group must be stacked post-MODR-03 migration');
+        self::assertSame('stacked', $modesByCode['default'] ?? null, 'synthetic default group must be stacked');
+    }
+
+    #[Test]
     public function omitsDefaultGroupWhenEveryAttributeBelongsToAGroup(): void
     {
         $client = $this->authenticatedClient();

--- a/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
@@ -154,7 +154,9 @@ final class EffectiveAttributeGroupsApiTest extends CatalogApiTestCase
             \assert(\is_array($g));
             self::assertArrayHasKey('display_mode', $g, 'Group missing display_mode: '.json_encode($g));
             self::assertContains($g['display_mode'], ['tab', 'stacked']);
-            $modesByCode[$g['code']] = $g['display_mode'];
+            $code = $g['code'] ?? null;
+            \assert(\is_string($code));
+            $modesByCode[$code] = $g['display_mode'];
         }
 
         self::assertSame('stacked', $modesByCode['audit'] ?? null, 'audit group must be stacked post-MODR-03 migration');


### PR DESCRIPTION
## Summary
- Product detail page tab strip is now derived dynamically from the `effective-attribute-groups` payload: each group with `display_mode='tab'` becomes its own tab, each `stacked` group is inline under the single "Atrybuty" tab. Special tabs (`categories`, `history`, `variants`) remain hardcoded — they are not AttributeGroups.
- Hardcoded `multimedia` / `relations` tab IDs removed from `OtherTabs`. Those groups now appear automatically via `effectiveGroups` and dispatch to their bespoke components (`ProductMultimediaTab`, `RelationsTab`) when their tab is active — legacy m2m / relation-links endpoint flow preserved.

## Backend
- `ProductReadEndpointsController::effectiveAttributeGroups` and `ObjectTypeEffectiveGroupsPreviewController::preview` add `display_mode` to each group payload using MODR-01 (#923) `loadObjectTypeGroupDisplayModes()` resolver helper.
- Synthetic "default" bucket pinned to `stacked` so orphan loose attributes never spawn a top-level tab.
- `BuiltInSystemAttributesSeeder` + `AutoAttachAuditGroupListener` seed the `audit` junction with `displayMode='stacked'` instead of the MODR-01 default `tab`, so audit metadata stays inline as before MODR-03.
- Migration `Version20260524160000` retrofits the same shift onto existing tenants — preserves AC-6 (no visual regression on existing forms).

## Frontend
- `GroupMeta` gains optional `display_mode: 'tab' | 'stacked'`.
- `product-detail-page.tsx`:
  - `TABS` constant → `SPECIAL_TABS` (only `attributes`/`categories`/`history`/`variants`) + dynamic tab list from groups (via `useMemo`).
  - `activeTab` validity enforced via `useEffect` (snaps to `attributes` if the group set changes and the previous tab disappeared).
  - `tabBadge` updated: tab-mode group shows its attribute count.

## Test plan
- [x] `php-cs-fixer` clean
- [x] `phpstan analyse --memory-limit=1G` — **0 errors**
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [x] PHPUnit MODR-03 — new `exposesDisplayModePerGroupAndSyntheticGroupIsStacked` test pass
- [x] PHPUnit regression — **63/63 pass** (form-schema, effective-attribute-groups, ObjectTypeView01, ObjectTypeAttachedAttributes, BuiltInProductMediaSeeder, BuiltInProductRelationSeeder, SystemAttributesAuditGroup, EffectiveAttributeGroupResolver{,Product}, AttributeGroupFirstClass, MODR-01 PATCH)
- [x] Migration `Version20260524160000` UP applied on live dev DB — audit junctions now `display_mode='stacked'` across all tenants
- [x] **Live-stack smoke test** on `https://pim.localhost`:
  - `GET /api/products/<id>/effective-attribute-groups` returns groups with `display_mode`:
    - `media` → `tab`, `relations` → `tab`, `audit` → `stacked`, `default` (synthetic) → `stacked`
  - Product detail page renders (SPA serves; full E2E click-through covered by Playwright in CI)

Refs #925