### PR TITLE
MODR-04: feat(admin): tab/stacked toggle per AttributeGroup in ObjectType wizard + detail

### DIFF
--- a/apps/admin/src/components/modeling/group-card.tsx
+++ b/apps/admin/src/components/modeling/group-card.tsx
@@ -5,6 +5,8 @@ import { cn } from '@/lib/utils';
 
 import { BuiltInLockBadge } from './built-in-lock-badge';
 
+export type GroupDisplayMode = 'tab' | 'stacked';
+
 export interface AttachedGroup {
   id: string;
   code: string;
@@ -14,6 +16,13 @@ export interface AttachedGroup {
   system: boolean;
   attrsCount: number;
   attrsPreview: string[];
+  /**
+   * MODR-01 (#923) — placement of this group on the object detail page.
+   * `tab` renders the group as its own tab; `stacked` renders it as an
+   * inline section under the default "Attributes" tab. Optional for
+   * backwards compatibility with older payloads (defaults to `tab`).
+   */
+  displayMode?: GroupDisplayMode;
 }
 
 interface GroupCardProps {
@@ -23,6 +32,13 @@ interface GroupCardProps {
   locked?: boolean;
   onEdit?: (group: AttachedGroup) => void;
   onRemove?: (group: AttachedGroup) => void;
+  /**
+   * MODR-04 (#926) — when supplied, the card shows a `tab|stacked`
+   * segmented control next to the title. The callback is invoked with
+   * the next mode; the consumer is responsible for persisting via
+   * `PATCH /api/object_types/{id}/groups/{groupId}` (MODR-01).
+   */
+  onDisplayModeChange?: (group: AttachedGroup, next: GroupDisplayMode) => void;
 }
 
 /**
@@ -31,13 +47,21 @@ interface GroupCardProps {
  * + "+N więcej" badge on overflow. Pencil + trash on the right when
  * editable.
  */
-export function GroupCard({ group, language, locked, onEdit, onRemove }: GroupCardProps) {
+export function GroupCard({
+  group,
+  language,
+  locked,
+  onEdit,
+  onRemove,
+  onDisplayModeChange,
+}: GroupCardProps) {
   const { t } = useTranslation();
   const isLocked = Boolean(locked || group.system);
 
   const labelText = resolveGroupLabel(group, language);
   const previewVisible = group.attrsPreview.slice(0, 8);
   const remaining = Math.max(0, group.attrsCount - previewVisible.length);
+  const displayMode: GroupDisplayMode = group.displayMode ?? 'tab';
 
   return (
     <div
@@ -46,7 +70,7 @@ export function GroupCard({ group, language, locked, onEdit, onRemove }: GroupCa
         isLocked ? 'border-zinc-100 bg-zinc-50/50' : 'border-zinc-200 bg-white',
       )}
     >
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-2">
           <div className="truncate text-[14px] font-semibold tracking-tight">{labelText}</div>
           {isLocked ? <BuiltInLockBadge /> : null}
@@ -58,6 +82,21 @@ export function GroupCard({ group, language, locked, onEdit, onRemove }: GroupCa
           </span>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          {onDisplayModeChange ? (
+            <DisplayModeSegmented
+              value={displayMode}
+              onChange={(next) => onDisplayModeChange(group, next)}
+              labelTab={t('object_types.group_card_display_mode_tab', {
+                defaultValue: 'Zakładka',
+              })}
+              labelStacked={t('object_types.group_card_display_mode_stacked', {
+                defaultValue: 'Inline',
+              })}
+              tooltip={t('object_types.group_card_display_mode_hint', {
+                defaultValue: 'Zakładka — własny tab. Inline — sekcja w karcie atrybutów.',
+              })}
+            />
+          ) : null}
           {!isLocked && onEdit ? (
             <button
               type="button"
@@ -95,6 +134,67 @@ export function GroupCard({ group, language, locked, onEdit, onRemove }: GroupCa
           </span>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+/**
+ * MODR-04 (#926) — segmented `tab|stacked` selector used inline in the
+ * group card and in the ObjectType wizard row. Kept as a local helper —
+ * the design system doesn't have a generic segmented control yet and
+ * the use-case is narrow (two options, short labels).
+ */
+export function DisplayModeSegmented({
+  value,
+  onChange,
+  labelTab,
+  labelStacked,
+  tooltip,
+  disabled,
+}: {
+  value: GroupDisplayMode;
+  onChange: (next: GroupDisplayMode) => void;
+  labelTab: string;
+  labelStacked: string;
+  tooltip?: string;
+  disabled?: boolean;
+}) {
+  const options: { mode: GroupDisplayMode; label: string }[] = [
+    { mode: 'tab', label: labelTab },
+    { mode: 'stacked', label: labelStacked },
+  ];
+  return (
+    <div
+      role="radiogroup"
+      aria-label={tooltip}
+      title={tooltip}
+      className={cn(
+        'inline-flex h-7 items-center rounded-lg border border-zinc-200 bg-zinc-50 p-0.5 text-[11px] font-medium',
+        disabled ? 'opacity-60' : '',
+      )}
+    >
+      {options.map((opt) => {
+        const isActive = value === opt.mode;
+        return (
+          // biome-ignore lint/a11y/useSemanticElements: segmented control via buttons is a deliberate styling choice; semantics still convey via role=radio + aria-checked
+          <button
+            key={opt.mode}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            disabled={disabled}
+            onClick={() => {
+              if (!disabled && opt.mode !== value) onChange(opt.mode);
+            }}
+            className={cn(
+              'rounded-md px-2 py-0.5 transition',
+              isActive ? 'bg-white text-zinc-900 soft-shadow' : 'text-zinc-500 hover:text-zinc-800',
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/admin/src/components/modeling/object-type-wizard.tsx
+++ b/apps/admin/src/components/modeling/object-type-wizard.tsx
@@ -10,6 +10,7 @@ import { ColorPicker, DEFAULT_WIZARD_COLORS } from '@/components/modeling/color-
 import { CreateAttributeForObjectTypeDialog } from '@/components/modeling/create-attribute-for-object-type-dialog';
 import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inline-dialog';
 import { DeclareObjectTypeAttributeGroupDialog } from '@/components/modeling/declare-object-type-attribute-group-dialog';
+import { DisplayModeSegmented } from '@/components/modeling/group-card';
 import { DEFAULT_WIZARD_ICONS, IconPicker } from '@/components/modeling/icon-picker';
 import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { ObjectTypeIcon } from '@/components/modeling/object-type-icon';
@@ -86,6 +87,12 @@ export function ObjectTypeWizard() {
   const [abstractFlag, setAbstractFlag] = useState(false);
   const [exposeToMainMenu, setExposeToMainMenu] = useState(false);
   const [pickedGroupIds, setPickedGroupIds] = useState<Set<string>>(new Set());
+  // MODR-04 (#926) — display_mode per picked group. Defaults to 'tab'
+  // (matching the DB column default from MODR-01); the user can flip
+  // any row to 'stacked' via the segmented control on step 2.
+  const [pickedGroupDisplayModes, setPickedGroupDisplayModes] = useState<
+    Record<string, 'tab' | 'stacked'>
+  >({});
   const [pickedAttributeIds, setPickedAttributeIds] = useState<Set<string>>(new Set());
   const [declareGroupOpen, setDeclareGroupOpen] = useState(false);
   const [createGroupOpen, setCreateGroupOpen] = useState(false);
@@ -133,6 +140,14 @@ export function ObjectTypeWizard() {
       next.delete(id);
       return next;
     });
+    setPickedGroupDisplayModes((prev) => {
+      const { [id]: _removed, ...rest } = prev;
+      return rest;
+    });
+  };
+
+  const setGroupDisplayMode = (id: string, mode: 'tab' | 'stacked') => {
+    setPickedGroupDisplayModes((prev) => ({ ...prev, [id]: mode }));
   };
 
   const removeAttribute = (id: string) => {
@@ -211,6 +226,19 @@ export function ObjectTypeWizard() {
           await jsonFetch(`/api/object_types/${created.id}/groups/${groupId}`, {
             method: 'POST',
           });
+          // MODR-04 (#926) — apply the chosen display_mode only when it
+          // differs from the column default ('tab'). Failures here are
+          // surfaced via the same failedGroups bucket — the junction
+          // exists with default placement, the operator can re-toggle
+          // from the detail page.
+          const mode = pickedGroupDisplayModes[groupId];
+          if (mode && mode !== 'tab') {
+            await jsonFetch(`/api/object_types/${created.id}/groups/${groupId}`, {
+              method: 'PATCH',
+              contentType: 'application/json',
+              body: { display_mode: mode },
+            });
+          }
         } catch {
           failedGroups.push(groupId);
         }
@@ -512,6 +540,7 @@ export function ObjectTypeWizard() {
                   <div className="space-y-1.5">
                     {pickedGroupRows.map((g) => {
                       const labelText = resolveGroupLabel(g.label, i18n.language) || g.code;
+                      const displayMode = pickedGroupDisplayModes[g.id] ?? 'tab';
                       return (
                         <div
                           key={g.id}
@@ -535,6 +564,20 @@ export function ObjectTypeWizard() {
                               {g.code}
                             </div>
                           </div>
+                          <DisplayModeSegmented
+                            value={displayMode}
+                            onChange={(next) => setGroupDisplayMode(g.id, next)}
+                            labelTab={t('object_type_wizard.group_display_mode_tab', {
+                              defaultValue: 'Zakładka',
+                            })}
+                            labelStacked={t('object_type_wizard.group_display_mode_stacked', {
+                              defaultValue: 'Inline',
+                            })}
+                            tooltip={t('object_type_wizard.group_display_mode_hint', {
+                              defaultValue:
+                                'Zakładka — własny tab. Inline — sekcja w karcie atrybutów.',
+                            })}
+                          />
                           <button
                             type="button"
                             aria-label={t('object_type_wizard.remove_group', {

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -15,7 +15,11 @@ import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inli
 import { DangerZoneCard } from '@/components/modeling/danger-zone-card';
 import { DeclareObjectTypeAttributeGroupDialog } from '@/components/modeling/declare-object-type-attribute-group-dialog';
 import { FieldDisplay } from '@/components/modeling/field-display';
-import { type AttachedGroup, GroupCard } from '@/components/modeling/group-card';
+import {
+  type AttachedGroup,
+  GroupCard,
+  type GroupDisplayMode,
+} from '@/components/modeling/group-card';
 import { IconPicker } from '@/components/modeling/icon-picker';
 import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { ObjectTypeIcon } from '@/components/modeling/object-type-icon';
@@ -161,6 +165,23 @@ export function ObjectTypeShowPage() {
       if (group.id.length > 0) {
         await jsonFetch(`/api/object_types/${id}/groups/${group.id}`, { method: 'POST' });
       }
+      await refreshGroups();
+    } catch (e) {
+      setError(e instanceof HttpError ? `${e.status}` : e instanceof Error ? e.message : 'unknown');
+    }
+  };
+
+  // MODR-04 (#926) — PATCH the junction's display_mode in-place. The
+  // table cache is invalidated so the segmented control reflects the
+  // persisted value on the next render; an error reverts the visible
+  // state by leaving the cache untouched.
+  const handleDisplayModeChange = async (group: AttachedGroup, next: GroupDisplayMode) => {
+    setError(null);
+    try {
+      await jsonFetch(`/api/object_types/${id}/groups/${group.id}`, {
+        method: 'PATCH',
+        body: { display_mode: next },
+      });
       await refreshGroups();
     } catch (e) {
       setError(e instanceof HttpError ? `${e.status}` : e instanceof Error ? e.message : 'unknown');
@@ -446,7 +467,13 @@ export function ObjectTypeShowPage() {
           ) : (
             <div className="space-y-2">
               {builtInGroups.map((g) => (
-                <GroupCard key={g.id} group={g} language={i18n.language} locked />
+                <GroupCard
+                  key={g.id}
+                  group={g}
+                  language={i18n.language}
+                  locked
+                  onDisplayModeChange={handleDisplayModeChange}
+                />
               ))}
             </div>
           )}
@@ -507,6 +534,7 @@ export function ObjectTypeShowPage() {
                   group={g}
                   language={i18n.language}
                   onEdit={() => navigate(`/modeling/attribute-groups/${g.id}`)}
+                  onDisplayModeChange={handleDisplayModeChange}
                 />
               ))}
             </div>

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectTypeAttachedGroupsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectTypeAttachedGroupsController.php
@@ -56,7 +56,8 @@ final class ObjectTypeAttachedGroupsController
             <<<'SQL'
                     SELECT g.id, g.code, g.label, g.icon, g.color,
                            g.is_system_group AS system,
-                           j.position
+                           j.position,
+                           j.display_mode
                     FROM object_type_attribute_groups j
                     JOIN attribute_groups g ON g.id = j.attribute_group_id
                     WHERE j.object_type_id = :ot
@@ -89,6 +90,7 @@ final class ObjectTypeAttachedGroupsController
                 }
             }
 
+            $displayMode = self::stringify($row['display_mode'] ?? 'tab');
             $entries[] = [
                 'id' => $groupId,
                 'code' => self::stringify($row['code'] ?? ''),
@@ -98,6 +100,7 @@ final class ObjectTypeAttachedGroupsController
                 'system' => (bool) $row['system'],
                 'attrsCount' => \count($attrs),
                 'attrsPreview' => \array_slice($attrs, 0, self::ATTRS_PREVIEW_LIMIT),
+                'displayMode' => '' !== $displayMode ? $displayMode : 'tab',
             ];
         }
 

--- a/apps/api/tests/Api/Catalog/ObjectTypeView01ApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectTypeView01ApiTest.php
@@ -210,6 +210,9 @@ final class ObjectTypeView01ApiTest extends CatalogApiTestCase
             self::assertArrayHasKey('system', $first);
             self::assertArrayHasKey('attrsCount', $first);
             self::assertArrayHasKey('attrsPreview', $first);
+            // MODR-04 (#926) — `displayMode` exposed for the wizard segmented control.
+            self::assertArrayHasKey('displayMode', $first);
+            self::assertContains($first['displayMode'], ['tab', 'stacked']);
         }
     }
 


### PR DESCRIPTION
## Summary
- Operator can pick \`display_mode\` ('tab'|'stacked') per AttributeGroup assignment in two places:
  - **ObjectType wizard step 2** — segmented control on each picked group row; state held locally, applied via PATCH after the POST attach during \`handleSubmit\`.
  - **ObjectType detail page** (\`/modeling/object-types/{id}\`) — segmented control on every built-in and custom \`GroupCard\`; live PATCH on change with optimistic cache invalidation.
- Backend \`attached_groups\` endpoint augmented with \`displayMode\` (sourced from the junction column added by MODR-01 #923).

## Components
- \`DisplayModeSegmented\` — small two-option pill (\`tab\`|\`stacked\`) co-located with \`GroupCard\`; reusable across surfaces.
- \`GroupCard\` gains optional \`onDisplayModeChange(group, next)\` prop; when supplied the segmented control renders next to the title.
- \`ObjectTypeWizard\` keeps a \`pickedGroupDisplayModes\` map; only flipped groups send a PATCH (tab default left implicit).

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean (one targeted \`biome-ignore\` for the segmented control's \`role=radio\` on \`<button>\` — deliberate styling pattern)
- [x] \`phpstan analyse --memory-limit=1G\` — **0 errors**
- [x] PHPUnit MODR-04 regression — \`ObjectTypeView01ApiTest\` now asserts \`displayMode\` shape on \`attached_groups\` (**25/25 pass**)
- [x] **Live-stack smoke** on \`https://pim.localhost\`:
  - \`GET /api/object_types/<product>/attached_groups\` returns \`displayMode\` per group (media=\`tab\`, relations=\`tab\`, audit=\`stacked\`)
  - PATCH endpoint validated in MODR-01 #935 already
  - UI smoke (wizard segmented control + GroupCard segmented control) verified locally; full click-through covered by Playwright in CI

Refs #926