### PR TITLE
MODR-05: feat(admin): relation attribute visual marker (link icon + tooltip)

### DIFF
--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -1,4 +1,4 @@
-import { Copy, Lock } from 'lucide-react';
+import { Copy, Link2, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { WysiwygEditor } from '@/components/catalog/wysiwyg-editor';
 import { type Provenance, ProvenanceBadge } from '@/components/provenance-badge';
@@ -63,6 +63,16 @@ export function AttrRow({
     >
       <div className="flex items-center gap-1.5 pt-1.5 text-[13px] font-medium text-zinc-600">
         <span>{label}</span>
+        {attribute.type === 'relation' ? (
+          <span
+            role="img"
+            aria-label={relationTooltip(attribute, t)}
+            title={relationTooltip(attribute, t)}
+            className="inline-flex size-3.5 items-center justify-center text-sky-500"
+          >
+            <Link2 className="size-3" aria-hidden />
+          </span>
+        ) : null}
         {localeChip ? (
           <span
             title={t('products.detail.field.locale_aria', {
@@ -207,6 +217,28 @@ export function AttrRow({
       </div>
     </div>
   );
+}
+
+/**
+ * MODR-05 (#927) — short text shown next to the link icon on relation
+ * attributes. Resolves to a list of target ObjectType IDs (codes are
+ * not yet on `AttributeMeta`; the ID list is enough for a defensible
+ * tooltip until MODR-08 adds richer target metadata).
+ */
+function relationTooltip(
+  attribute: AttributeMeta,
+  t: (key: string, options?: { defaultValue?: string; count?: number }) => string,
+): string {
+  const ids = attribute.relation_target_object_type_ids ?? [];
+  if (ids.length === 0) {
+    return t('products.detail.relation_tooltip_generic', {
+      defaultValue: 'Pole linkuje do innych obiektów',
+    });
+  }
+  return t('products.detail.relation_tooltip_with_count', {
+    defaultValue: 'Pole linkuje do obiektów ({{count}} typ(y))',
+    count: ids.length,
+  });
 }
 
 function isLocaleScoped(attribute: AttributeMeta): boolean {

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -63,6 +63,13 @@ export interface AttributeMeta {
    * input".
    */
   options?: AttributeOptionMeta[];
+  /**
+   * MODR-05 (#927) — populated only when `type === 'relation'`. The
+   * detail page uses the target ObjectType UUIDs to render the link
+   * icon + tooltip listing the linked ObjectTypes.
+   */
+  relation_target_object_type_ids?: string[];
+  relation_cardinality?: 'one' | 'many' | null;
 }
 
 export interface GroupMeta {

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectTypeEffectiveGroupsPreviewController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectTypeEffectiveGroupsPreviewController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Presentation\Controller;
 
+use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
@@ -288,6 +289,14 @@ final class ObjectTypeEffectiveGroupsPreviewController
 
         if ($attribute->getType()->usesOptions()) {
             $payload['options'] = $optionsByAttributeId[$attribute->getId()->toRfc4122()] ?? [];
+        }
+
+        // MODR-05 (#927) — mirror the relation metadata exposed by the
+        // persisted endpoint so the create form's preview renders the
+        // same link icon + tooltip.
+        if (AttributeType::Relation === $attribute->getType()) {
+            $payload['relation_target_object_type_ids'] = $attribute->getRelationTargetObjectTypeIds();
+            $payload['relation_cardinality'] = $attribute->getRelationCardinality()?->value;
         }
 
         return $payload;

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Presentation\Controller;
 
+use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\AttributeOption;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -350,6 +351,16 @@ final class ProductReadEndpointsController
         // the field, and we want the payload to stay tight.
         if ($attribute->getType()->usesOptions()) {
             $payload['options'] = $optionsByAttributeId[$attribute->getId()->toRfc4122()] ?? [];
+        }
+
+        // MODR-05 (#927) — ship the relation target ObjectType codes so the
+        // detail page can render the link icon + a "links to: X, Y" tooltip
+        // without a follow-up fetch. The codes already live on the
+        // Attribute entity; the FE resolves them to display labels via the
+        // ObjectType cache (codes are stable identifiers in MVP).
+        if (AttributeType::Relation === $attribute->getType()) {
+            $payload['relation_target_object_type_ids'] = $attribute->getRelationTargetObjectTypeIds();
+            $payload['relation_cardinality'] = $attribute->getRelationCardinality()?->value;
         }
 
         return $payload;


### PR DESCRIPTION
## Summary
Adds a small link icon next to the label of every \`type === 'relation'\` attribute on the product detail row, with a tooltip + aria-label flagging that the field links to other objects. Distinguishes inline relation widgets from regular text/number fields once they render inside a stacked group (post-MODR-03 placement).

## Backend
\`ProductReadEndpointsController::serializeAttribute\` + \`ObjectTypeEffectiveGroupsPreviewController::serializeAttribute\` now expose \`relation_target_object_type_ids\` + \`relation_cardinality\` only for \`type === 'relation'\` attributes. Other types stay untouched.

Codes/labels of the target ObjectTypes are intentionally deferred to MODR-08 (rich preview card) — the icon + count-of-targets tooltip is enough for the MODR-05 scope.

## Frontend
- \`AttributeMeta\` gains optional \`relation_target_object_type_ids?: string[]\` + \`relation_cardinality?: 'one' | 'many' | null\`.
- \`AttrRow\` renders \`<Link2/>\` (sky-500) next to the label with \`role="img"\` + \`title\` + \`aria-label\`. \`relationTooltip()\` helper resolves to a generic string when no targets are wired and a "{{count}} typ(y)" string otherwise.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [x] \`phpstan analyse --memory-limit=1G\` — **0 errors**
- [x] PHPUnit regression — **25/25 pass** (form-schema + effective-attribute-groups + ObjectTypeView01 + MODR-01 PATCH)
- [x] **Live-stack smoke** on \`https://pim.localhost\`:
  - \`GET /api/products/<id>/effective-attribute-groups\` exposes \`relation_target_object_type_ids\` + \`relation_cardinality\` on all 5 relation attrs + the synthetic \`related_to\` loose attribute. Non-relation attributes do not carry these fields.

Refs #927