### PR TITLE
MODR-06: feat(admin): "Powiązania" tab visibility — group attrs OR reverse relations

### DIFF
--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -245,16 +245,42 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     () => groups.filter((g) => (g.display_mode ?? 'tab') === 'stacked'),
     [groups],
   );
+
+  // MODR-06 (#928) — lightweight probe for incoming links so the
+  // "Powiązania" tab can surface even when the object has no forward
+  // relation attributes (e.g. a Category referenced from products).
+  const reverseRelationsQuery = useQuery<{ hasReverse: boolean; count: number }>({
+    queryKey: ['objects', id, 'relations', 'reverse', 'count'],
+    queryFn: () =>
+      jsonFetch<{ hasReverse: boolean; count: number }>(
+        `/api/objects/${id}/relations/reverse/count`,
+      ),
+    enabled: isEditMode && id !== '',
+    staleTime: 30_000,
+  });
+  const hasReverseRelations = reverseRelationsQuery.data?.hasReverse ?? false;
+  const hasForwardRelationsGroup = useMemo(
+    () => groups.some((g) => g.code === 'relations'),
+    [groups],
+  );
+  const shouldSurfaceRelationsTab = hasForwardRelationsGroup || hasReverseRelations;
+
   const visibleTabs: readonly TabKey[] = useMemo(() => {
     if (mode === 'create') return ['attributes'];
+    const fromGroups = tabModeGroups.map((g) => g.code);
+    // MODR-06 (#928) — inject a synthetic `relations` tab when the
+    // object has reverse links but no forward `relations` AttributeGroup.
+    const ensureRelations =
+      shouldSurfaceRelationsTab && !fromGroups.includes('relations') ? ['relations'] : [];
     return [
       'attributes' as const,
-      ...tabModeGroups.map((g) => g.code),
+      ...fromGroups,
+      ...ensureRelations,
       'categories' as const,
       'history' as const,
       'variants' as const,
     ];
-  }, [mode, tabModeGroups]);
+  }, [mode, tabModeGroups, shouldSurfaceRelationsTab]);
 
   // Keep activeTab valid as group set changes (e.g. groups data arrives
   // after first render or a tab→stacked switch in the wizard).
@@ -752,6 +778,15 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                 return <RelationsTab productId={id} />;
               }
               return renderStackedGroup(tabGroup);
+            }
+
+            // MODR-06 (#928) — synthetic `relations` tab for the
+            // reverse-only case (object has no forward AttributeGroup
+            // but is pointed at from elsewhere). RelationsTab already
+            // gracefully renders just the reverse panel when forward
+            // groups are empty.
+            if (activeTab === 'relations' && mode === 'edit') {
+              return <RelationsTab productId={id} />;
             }
 
             if (mode === 'edit' && isSpecialTab(activeTab)) {

--- a/apps/api/src/Catalog/Application/ObjectRelationService.php
+++ b/apps/api/src/Catalog/Application/ObjectRelationService.php
@@ -65,6 +65,14 @@ final class ObjectRelationService
     }
 
     /**
+     * MODR-06 (#928) — count of incoming links for the tab-visibility check.
+     */
+    public function countByTarget(CatalogObject $target): int
+    {
+        return $this->relations->countByTarget($target);
+    }
+
+    /**
      * Atomically replace the relations under `(source, attribute)` with the
      * supplied target object list. Idempotent: when the new list equals the
      * existing one, the function still touches each row (position update)

--- a/apps/api/src/Catalog/Domain/Repository/ObjectRelationRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/ObjectRelationRepositoryInterface.php
@@ -38,4 +38,12 @@ interface ObjectRelationRepositoryInterface
      * @return list<ObjectRelation>
      */
     public function findByTarget(CatalogObject $target): array;
+
+    /**
+     * MODR-06 (#928) — lightweight `count(*)` of incoming links. The
+     * product detail page uses this to decide whether to surface the
+     * "Powiązania" tab when the object has no forward relation attributes
+     * (e.g. a Category that is only ever referenced from products).
+     */
+    public function countByTarget(CatalogObject $target): int;
 }

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectRelationRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectRelationRepository.php
@@ -72,4 +72,16 @@ final class DoctrineObjectRelationRepository extends ServiceEntityRepository imp
 
         return $rows;
     }
+
+    public function countByTarget(CatalogObject $target): int
+    {
+        $result = $this->createQueryBuilder('r')
+            ->select('COUNT(r.id)')
+            ->andWhere('r.target = :target')
+            ->setParameter('target', $target)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $result;
+    }
 }

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php
@@ -145,6 +145,35 @@ final class ObjectRelationController
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }
 
+    /**
+     * MODR-06 (#928) — lightweight count of reverse relations. Returned
+     * alongside a boolean so the frontend can decide whether to show the
+     * "Powiązania" tab when an object has no forward relation attributes
+     * but is still pointed-at from elsewhere. The route is declared
+     * *before* the heavy `reverse` route below so the more specific path
+     * wins in the Symfony router.
+     */
+    #[Route(
+        '/api/objects/{id}/relations/reverse/count',
+        name: 'pim_objects_relations_reverse_count',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+        priority: 10,
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function reverseCount(string $id): JsonResponse
+    {
+        $target = $this->fetchObject($id);
+        $count = $this->service->countByTarget($target);
+
+        return new JsonResponse([
+            'targetObjectId' => $target->getId()->toRfc4122(),
+            'count' => $count,
+            'hasReverse' => $count > 0,
+        ]);
+    }
+
     #[Route(
         '/api/objects/{id}/relations/reverse',
         name: 'pim_objects_relations_reverse',

--- a/apps/api/tests/Api/Catalog/ObjectRelationsReverseApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectRelationsReverseApiTest.php
@@ -77,6 +77,44 @@ final class ObjectRelationsReverseApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function reverseCountReturnsZeroForOrphan(): void
+    {
+        $client = $this->authenticatedClient();
+        $orphan = $this->makeProduct('REV-COUNT-EMPTY');
+
+        $body = $client->request(
+            'GET',
+            '/api/objects/'.$orphan->getId()->toRfc4122().'/relations/reverse/count',
+        )->toArray();
+        self::assertSame($orphan->getId()->toRfc4122(), $body['targetObjectId']);
+        self::assertSame(0, $body['count']);
+        self::assertFalse($body['hasReverse']);
+    }
+
+    #[Test]
+    public function reverseCountReflectsIncomingLinks(): void
+    {
+        $client = $this->authenticatedClient();
+        $target = $this->makeProduct('REV-COUNT-TGT');
+        $sourceA = $this->makeProduct('REV-COUNT-A');
+        $sourceB = $this->makeProduct('REV-COUNT-B');
+
+        $client->request('PUT', '/api/objects/'.$sourceA->getId()->toRfc4122().'/relations/cross_sell', [
+            'json' => ['targets' => [['id' => $target->getId()->toRfc4122()]]],
+        ]);
+        $client->request('PUT', '/api/objects/'.$sourceB->getId()->toRfc4122().'/relations/up_sell', [
+            'json' => ['targets' => [['id' => $target->getId()->toRfc4122()]]],
+        ]);
+
+        $body = $client->request(
+            'GET',
+            '/api/objects/'.$target->getId()->toRfc4122().'/relations/reverse/count',
+        )->toArray();
+        self::assertSame(2, $body['count']);
+        self::assertTrue($body['hasReverse']);
+    }
+
+    #[Test]
     public function reverseReturns404ForUnknownObjectId(): void
     {
         $client = $this->authenticatedClient();


### PR DESCRIPTION
## Summary
The "Powiązania" tab now surfaces when either the object has a forward \`relations\` AttributeGroup *or* the object is referenced by at least one incoming \`object_relations\` row. The reverse-only case (e.g. a Category that is referenced from products but doesn't itself host relation attributes) gets a synthetic tab that delegates to the existing \`RelationsTab\`.

## Backend
- \`ObjectRelationRepositoryInterface\` + Doctrine impl gain \`countByTarget()\`.
- \`ObjectRelationService::countByTarget()\` proxies it for the controller layer.
- New lightweight route \`GET /api/objects/{id}/relations/reverse/count\` returning \`{ targetObjectId, count, hasReverse }\`. \`priority: 10\` on the attribute makes the count route win over the more general \`/reverse\` path.

## Frontend
- \`product-detail-page.tsx\` adds a \`useQuery\` for \`reverse/count\`; the result feeds \`shouldSurfaceRelationsTab\` (forward group present OR reverse exists).
- \`visibleTabs\` injects a synthetic \`relations\` tab when the forward AttributeGroup is missing but reverse links exist.
- Render dispatch: \`activeTab === 'relations'\` always renders \`RelationsTab\` in edit mode — forward and reverse panels both flow through its existing query pipeline.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [x] \`phpstan analyse --memory-limit=1G\` — **0 errors**
- [x] PHPUnit reverse suite — **5/5 pass** (new \`reverseCountReturnsZeroForOrphan\` + \`reverseCountReflectsIncomingLinks\`)
- [x] **Live-stack smoke** on \`https://pim.localhost\`:
  - \`GET /api/objects/<product>/relations/reverse/count\` → \`{count:0, hasReverse:false}\` for an orphan product
  - Existing reverse list endpoint still returns the full payload at \`/api/objects/{id}/relations/reverse\`

Refs #928