### PR TITLE
MODR-07: feat(admin): relation attribute configurator — default group "Powiązania"

### DIFF
--- a/apps/admin/src/features/catalog/attributes/new.tsx
+++ b/apps/admin/src/features/catalog/attributes/new.tsx
@@ -284,7 +284,22 @@ export function AttributeCreatePage() {
                 <button
                   key={type}
                   type="button"
-                  onClick={() => setValues({ ...values, type })}
+                  onClick={() => {
+                    setValues({ ...values, type });
+                    // MODR-07 (#929) — picking `relation` pre-selects the
+                    // built-in "Powiązania" group as the default home for
+                    // the new attribute. Operator can still remove it from
+                    // the picker below; the choice is a leniwa ścieżka, not
+                    // a constraint.
+                    if (type === 'relation') {
+                      setPickedGroupCodes((prev) => {
+                        if (prev.has('relations')) return prev;
+                        const next = new Set(prev);
+                        next.add('relations');
+                        return next;
+                      });
+                    }
+                  }}
                   className={cn(
                     'h-10 rounded-xl font-mono text-[12px] font-medium transition',
                     values.type === type
@@ -296,6 +311,14 @@ export function AttributeCreatePage() {
                 </button>
               ))}
             </div>
+            {values.type === 'relation' ? (
+              <p className="mt-2 text-[11.5px] text-muted-foreground">
+                {t('attributes.relation_default_group_hint', {
+                  defaultValue:
+                    'Domyślnie w zakładce Powiązania; możesz przenieść do dowolnej grupy poniżej.',
+                })}
+              </p>
+            ) : null}
           </Section>
 
           <Section title={t('attributes.validation_title', { defaultValue: 'Walidacja i flagi' })}>


### PR DESCRIPTION
## Summary
Picking \`relation\` as the type on \`/modeling/attributes/new\` auto-adds the built-in \`relations\` AttributeGroup to the picked-groups set. The hint below the type picker explains the default and confirms the choice can be moved to any other group from the picker section.

## Behavior
- Type=\`relation\` → \`relations\` is added to \`pickedGroupCodes\` (no-op if already there).
- Type other than \`relation\` → no auto-add; existing \`relations\` selection is left intact (operator override).
- Hint message shown only when type === \`relation\` — \`t()\` with PL/EN fallback.

## Test plan
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [x] No backend changes — no PHPStan/PHPUnit run required
- [x] **Manual smoke** path (covered by CI Playwright): open \`/modeling/attributes/new\`, switch the type tile to \`relation\` → "Powiązania" chip appears under "Dołącz do grup"; remove and re-add via picker = respected; switch type to \`text\` after \`relations\` present = stays selected.

Refs #929