### PR TITLE
MODR-08: feat(admin): relation widget — rich preview card + batch target summaries

### DIFF
--- a/apps/admin/src/features/catalog/products/components/relations-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/relations-tab.tsx
@@ -271,6 +271,34 @@ function RelationGroupCard({
 
   const targetIds = attributeQuery.data?.relationTargetObjectTypeIds ?? [];
 
+  // MODR-08 (#930) — batch-fetch a summary (code + name + ObjectType code)
+  // for every currently linked target so the preview cards render in a
+  // single round trip instead of N parallel GET /api/objects/{id} calls.
+  const linkedTargetIds = useMemo(
+    () =>
+      Array.from(new Set(group.relations.map((r) => r.targetObjectId)))
+        .sort()
+        .filter((v) => v.length > 0),
+    [group.relations],
+  );
+  const summariesQuery = useQuery<RelationTargetSummary[]>({
+    queryKey: ['objects', 'summaries', linkedTargetIds],
+    queryFn: () =>
+      jsonFetch<RelationTargetSummary[]>('/api/objects/summaries', {
+        method: 'POST',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: { ids: linkedTargetIds },
+      }),
+    enabled: linkedTargetIds.length > 0,
+    staleTime: 30_000,
+  });
+  const summariesById = useMemo(() => {
+    const map = new Map<string, RelationTargetSummary>();
+    for (const s of summariesQuery.data ?? []) map.set(s.id, s);
+    return map;
+  }, [summariesQuery.data]);
+
   const handleAdd = (newTargetId: string) => {
     const existing = group.relations.map((r) => ({
       id: r.targetObjectId,
@@ -332,6 +360,7 @@ function RelationGroupCard({
               row={row}
               advanced={attribute.advanced}
               advancedFields={extractAdvancedFields(attributeQuery.data?.validationRules)}
+              summary={summariesById.get(row.targetObjectId)}
               onRemove={() => deleteMutation.mutate(row.targetObjectId)}
               onMetadataChange={(next) => handleMetadataChange(row.targetObjectId, next)}
               disabled={writeMutation.isPending || deleteMutation.isPending}
@@ -352,10 +381,18 @@ function RelationGroupCard({
   );
 }
 
+interface RelationTargetSummary {
+  id: string;
+  code: string;
+  name: string | null;
+  objectType: { id: string; code: string; kind: string };
+}
+
 function RelationRowItem({
   row,
   advanced,
   advancedFields,
+  summary,
   onRemove,
   onMetadataChange,
   disabled,
@@ -368,28 +405,39 @@ function RelationRowItem({
     label: Record<string, string>;
     required: boolean;
   }>;
+  /**
+   * MODR-08 (#930) — pre-fetched summary from the batch endpoint
+   * (`POST /api/objects/summaries`). When absent, the card falls back
+   * to the target UUID's first 8 characters.
+   */
+  summary?: RelationTargetSummary;
   onRemove: () => void;
   onMetadataChange: (next: Record<string, unknown>) => void;
   disabled: boolean;
 }) {
   const { t, i18n } = useTranslation();
   const locale = i18n.language === 'pl' ? 'pl' : 'en';
-  const targetQuery = useQuery<{ id: string; code: string }>({
-    queryKey: ['objects', row.targetObjectId, 'minimal'],
-    queryFn: () =>
-      jsonFetch<{ id: string; code: string }>(`/api/objects/${row.targetObjectId}`, {
-        accept: 'application/json',
-      }),
-    staleTime: 60_000,
-  });
 
   const targetMetadata = normaliseMetadata(row.metadata);
+  const displayCode = summary?.code ?? row.targetObjectId.slice(0, 8);
+  const displayName = summary?.name ?? null;
+  const objectTypeCode = summary?.objectType.code ?? null;
 
   return (
     <div className="rounded-xl border border-line bg-background p-3">
       <div className="flex items-center justify-between gap-2">
-        <div className="text-sm font-mono">
-          {targetQuery.data?.code ?? row.targetObjectId.slice(0, 8)}
+        <div className="min-w-0">
+          {displayName !== null ? (
+            <div className="truncate text-sm font-semibold tracking-tight">{displayName}</div>
+          ) : null}
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span className="font-mono">{displayCode}</span>
+            {objectTypeCode ? (
+              <span className="rounded bg-muted px-1.5 py-0.5 font-mono uppercase tracking-wide">
+                {objectTypeCode}
+              </span>
+            ) : null}
+          </div>
         </div>
         <Button
           type="button"

--- a/apps/api/migrations/Version20260524170000.php
+++ b/apps/api/migrations/Version20260524170000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ADR-014 / MODR-08 (#930) — adds `relation_preview_fields` to the
+ * `attributes` table. The column carries a JSONB list of target
+ * attribute codes that should render inside the relation widget's
+ * preview card on the product detail page. Empty list = default
+ * preview (target object code + name).
+ *
+ * The column is only meaningful for attributes whose `type='relation'`;
+ * other types ignore it.
+ */
+final class Version20260524170000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-014 / MODR-08 (#930): add attributes.relation_preview_fields JSONB.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE attributes
+                ADD COLUMN relation_preview_fields JSONB NOT NULL DEFAULT '[]'::jsonb
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE attributes DROP COLUMN relation_preview_fields
+        SQL);
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeCommand.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeCommand.php
@@ -13,6 +13,7 @@ final readonly class UpdateAttributeCommand
      * @param array<string, string>|null $help
      * @param array<string, mixed>|null  $validationRules
      * @param list<string>|null          $relationTargetObjectTypeIds
+     * @param list<string>|null          $relationPreviewFields
      */
     public function __construct(
         public Uuid $id,
@@ -27,6 +28,7 @@ final readonly class UpdateAttributeCommand
         public ?array $relationTargetObjectTypeIds = null,
         public ?string $relationCardinality = null,
         public ?bool $relationAdvanced = null,
+        public ?array $relationPreviewFields = null,
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateAttribute/UpdateAttributeHandler.php
@@ -118,6 +118,13 @@ final readonly class UpdateAttributeHandler
             $attribute->setRelationAdvanced($resolvedAdvanced);
         }
 
+        // MODR-08 (#930) — preview field list can be edited independently
+        // of the rest of the relation config; the entity setter normalises
+        // duplicates and empty strings.
+        if (null !== $command->relationPreviewFields) {
+            $attribute->setRelationPreviewFields($command->relationPreviewFields);
+        }
+
         $this->repository->save($attribute);
     }
 }

--- a/apps/api/src/Catalog/Domain/Entity/Attribute.php
+++ b/apps/api/src/Catalog/Domain/Entity/Attribute.php
@@ -105,6 +105,16 @@ class Attribute implements TenantScoped
 
     private bool $relationAdvanced = false;
 
+    /**
+     * MODR-08 (#930) — list of target attribute codes to surface in the
+     * relation widget's preview card. Empty list (default) → preview
+     * falls back to target object code + name. Meaningful only when
+     * `$type === AttributeType::Relation`.
+     *
+     * @var list<string>
+     */
+    private array $relationPreviewFields = [];
+
     private int $position = 0;
     private DateTimeImmutable $createdAt;
 
@@ -333,5 +343,31 @@ class Attribute implements TenantScoped
     public function setRelationAdvanced(bool $advanced): void
     {
         $this->relationAdvanced = $advanced;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getRelationPreviewFields(): array
+    {
+        return $this->relationPreviewFields;
+    }
+
+    /**
+     * @param list<string> $fields
+     */
+    public function setRelationPreviewFields(array $fields): void
+    {
+        $normalized = [];
+        foreach ($fields as $field) {
+            if ('' === $field) {
+                continue;
+            }
+            if (\in_array($field, $normalized, true)) {
+                continue;
+            }
+            $normalized[] = $field;
+        }
+        $this->relationPreviewFields = $normalized;
     }
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributePatchInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributePatchInput.php
@@ -78,4 +78,17 @@ final class AttributePatchInput
 
     #[Groups(['attribute:patch'])]
     public ?bool $relationAdvanced = null;
+
+    /**
+     * MODR-08 (#930) — list of target attribute codes shown inside the
+     * relation widget's preview card. Empty list keeps the default
+     * (target object code + name). Meaningful only for relation
+     * attributes.
+     *
+     * @var list<string>|null
+     */
+    #[Assert\Type('array')]
+    #[Assert\All([new Assert\Type('string'), new Assert\NotBlank()])]
+    #[Groups(['attribute:patch'])]
+    public ?array $relationPreviewFields = null;
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/AttributeProcessor.php
@@ -133,6 +133,7 @@ final readonly class AttributeProcessor implements ProcessorInterface
             relationTargetObjectTypeIds: $data->relationTargetObjectTypeIds,
             relationCardinality: $data->relationCardinality,
             relationAdvanced: $data->relationAdvanced,
+            relationPreviewFields: $data->relationPreviewFields,
         );
         $this->dispatch($command);
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/Attribute.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/Attribute.orm.xml
@@ -84,6 +84,12 @@
                 <option name="default">false</option>
             </options>
         </field>
+        <field name="relationPreviewFields" type="json" column="relation_preview_fields">
+            <options>
+                <option name="jsonb">true</option>
+                <option name="default">[]</option>
+            </options>
+        </field>
         <field name="position" type="integer">
             <options>
                 <option name="default">0</option>

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectSummaryBatchController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectSummaryBatchController.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use InvalidArgumentException;
+use JsonException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * MODR-08 (#930) — batch object summary endpoint.
+ *
+ *   POST /api/objects/summaries
+ *   Body: { "ids": ["<uuid>", ...] }      max 200 ids
+ *   Resp: [{ id, code, name, objectType: { code, kind } }, ...]
+ *
+ * Lets the product detail page resolve linked target objects in a single
+ * round trip rather than N individual `GET /api/objects/{id}` requests
+ * — the prior pattern for the relation widget. The response intentionally
+ * stays small (no attributes_indexed, no completeness): a richer rich-
+ * preview-card payload should request its own dedicated fields list.
+ *
+ * Cross-tenant ids return as missing — `findByIds()` applies TenantFilter.
+ */
+final class ObjectSummaryBatchController
+{
+    private const int MAX_IDS_PER_REQUEST = 200;
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $objects,
+    ) {
+    }
+
+    #[Route(
+        '/api/objects/summaries',
+        name: 'pim_objects_summaries_batch',
+        methods: ['POST'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $body = $request->getContent();
+        if ('' === $body) {
+            return new JsonResponse([]);
+        }
+
+        try {
+            $decoded = json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new BadRequestHttpException('Request body is not valid JSON.', $e);
+        }
+        if (!\is_array($decoded) || !\array_key_exists('ids', $decoded) || !\is_array($decoded['ids'])) {
+            throw new BadRequestHttpException('Body must contain `ids` (array of UUID strings).');
+        }
+
+        if (\count($decoded['ids']) > self::MAX_IDS_PER_REQUEST) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'At most %d ids per batch (got %d).',
+                self::MAX_IDS_PER_REQUEST,
+                \count($decoded['ids']),
+            ));
+        }
+
+        $uuids = [];
+        $seen = [];
+        foreach ($decoded['ids'] as $raw) {
+            if (!\is_string($raw) || '' === $raw) {
+                continue;
+            }
+            try {
+                $uuid = Uuid::fromString($raw);
+            } catch (InvalidArgumentException) {
+                continue;
+            }
+            $key = $uuid->toRfc4122();
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $uuids[] = $uuid;
+        }
+
+        if ([] === $uuids) {
+            return new JsonResponse([]);
+        }
+
+        $summaries = [];
+        foreach ($uuids as $uuid) {
+            $obj = $this->objects->findById($uuid);
+            if (null === $obj) {
+                continue;
+            }
+            $indexed = $obj->getAttributesIndexed();
+            $name = self::pickName($indexed);
+            $type = $obj->getObjectType();
+            $summaries[] = [
+                'id' => $obj->getId()->toRfc4122(),
+                'code' => $obj->getCode(),
+                'name' => $name,
+                'objectType' => [
+                    'id' => $type->getId()->toRfc4122(),
+                    'code' => $type->getCode(),
+                    'kind' => $type->getKind()->value,
+                ],
+            ];
+        }
+
+        return new JsonResponse($summaries);
+    }
+
+    /**
+     * Best-effort display name resolution from `attributes_indexed`.
+     * Falls back to NULL when no obvious candidate exists; the FE then
+     * uses the object code instead.
+     *
+     * @param array<string, mixed>|null $indexed
+     */
+    private static function pickName(?array $indexed): ?string
+    {
+        if (null === $indexed) {
+            return null;
+        }
+        foreach (['name', 'title', 'label'] as $candidate) {
+            $value = $indexed[$candidate] ?? null;
+            if (\is_string($value) && '' !== $value) {
+                return $value;
+            }
+            if (\is_array($value)) {
+                // Locale-scoped string: prefer pl, then en, then any.
+                foreach (['pl', 'en'] as $locale) {
+                    $localized = $value[$locale] ?? null;
+                    if (\is_string($localized) && '' !== $localized) {
+                        return $localized;
+                    }
+                }
+                foreach ($value as $localized) {
+                    if (\is_string($localized) && '' !== $localized) {
+                        return $localized;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectTypeEffectiveGroupsPreviewController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectTypeEffectiveGroupsPreviewController.php
@@ -297,6 +297,7 @@ final class ObjectTypeEffectiveGroupsPreviewController
         if (AttributeType::Relation === $attribute->getType()) {
             $payload['relation_target_object_type_ids'] = $attribute->getRelationTargetObjectTypeIds();
             $payload['relation_cardinality'] = $attribute->getRelationCardinality()?->value;
+            $payload['relation_preview_fields'] = $attribute->getRelationPreviewFields();
         }
 
         return $payload;

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -361,6 +361,9 @@ final class ProductReadEndpointsController
         if (AttributeType::Relation === $attribute->getType()) {
             $payload['relation_target_object_type_ids'] = $attribute->getRelationTargetObjectTypeIds();
             $payload['relation_cardinality'] = $attribute->getRelationCardinality()?->value;
+            // MODR-08 (#930) — list of target attribute codes the rich
+            // preview card surfaces. Empty list = default card layout.
+            $payload['relation_preview_fields'] = $attribute->getRelationPreviewFields();
         }
 
         return $payload;

--- a/apps/api/tests/Api/Catalog/ObjectSummaryBatchApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectSummaryBatchApiTest.php
@@ -31,15 +31,19 @@ final class ObjectSummaryBatchApiTest extends CatalogApiTestCase
         ])->toArray();
 
         self::assertCount(2, $body);
-        $codes = array_map(static fn (array $r): string => $r['code'], $body);
-        sort($codes);
-        self::assertSame(['SUM-A', 'SUM-B'], $codes);
+        $codes = [];
         foreach ($body as $row) {
+            \assert(\is_array($row));
             self::assertArrayHasKey('id', $row);
             self::assertArrayHasKey('name', $row);
             self::assertArrayHasKey('objectType', $row);
+            \assert(\is_array($row['objectType']));
             self::assertSame('product', $row['objectType']['code']);
+            \assert(\is_string($row['code']));
+            $codes[] = $row['code'];
         }
+        sort($codes);
+        self::assertSame(['SUM-A', 'SUM-B'], $codes);
     }
 
     #[Test]
@@ -53,6 +57,7 @@ final class ObjectSummaryBatchApiTest extends CatalogApiTestCase
         ])->toArray();
 
         self::assertCount(1, $body);
+        \assert(\is_array($body[0]));
         self::assertSame('SUM-OK', $body[0]['code']);
     }
 

--- a/apps/api/tests/Api/Catalog/ObjectSummaryBatchApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectSummaryBatchApiTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * MODR-08 (#930) — `POST /api/objects/summaries` returns lightweight
+ * `{id, code, name, objectType}` rows for a list of object UUIDs. Used
+ * by the relation widget's rich preview card path.
+ */
+final class ObjectSummaryBatchApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function returnsSummariesForKnownIds(): void
+    {
+        $client = $this->authenticatedClient();
+        $a = $this->seedProduct('SUM-A');
+        $b = $this->seedProduct('SUM-B');
+
+        $body = $client->request('POST', '/api/objects/summaries', [
+            'json' => ['ids' => [$a->getId()->toRfc4122(), $b->getId()->toRfc4122()]],
+        ])->toArray();
+
+        self::assertCount(2, $body);
+        $codes = array_map(static fn (array $r): string => $r['code'], $body);
+        sort($codes);
+        self::assertSame(['SUM-A', 'SUM-B'], $codes);
+        foreach ($body as $row) {
+            self::assertArrayHasKey('id', $row);
+            self::assertArrayHasKey('name', $row);
+            self::assertArrayHasKey('objectType', $row);
+            self::assertSame('product', $row['objectType']['code']);
+        }
+    }
+
+    #[Test]
+    public function unknownIdsAreSilentlySkipped(): void
+    {
+        $client = $this->authenticatedClient();
+        $a = $this->seedProduct('SUM-OK');
+
+        $body = $client->request('POST', '/api/objects/summaries', [
+            'json' => ['ids' => [$a->getId()->toRfc4122(), '01234567-1234-7000-8000-000000000000']],
+        ])->toArray();
+
+        self::assertCount(1, $body);
+        self::assertSame('SUM-OK', $body[0]['code']);
+    }
+
+    #[Test]
+    public function rejectsBodyMissingIds(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects/summaries', [
+            'json' => ['something' => 'else'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    #[Test]
+    public function rejectsTooManyIds(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects/summaries', [
+            'json' => ['ids' => array_fill(0, 201, '01234567-1234-7000-8000-000000000000')],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    private function seedProduct(string $code): CatalogObject
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        $object->updateAttributeIndex(['name' => 'Display '.$code]);
+        $em = $this->em();
+        $em->persist($object);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $object;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -7144,6 +7144,16 @@
                             "boolean",
                             "null"
                         ]
+                    },
+                    "relationPreviewFields": {
+                        "description": "MODR-08 (#930) \u2014 list of target attribute codes shown inside the\nrelation widget's preview card. Empty list keeps the default\n(target object code + name). Meaningful only for relation\nattributes.",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             },


### PR DESCRIPTION
## Summary
Replaces the monospace UUID-only rendering of currently-linked relation targets with a richer preview card (name + code + ObjectType chip), and replaces the N-parallel \`/api/objects/{id}\` lookups with a single batch call.

## Backend
- **Migration** \`Version20260524170000\`: \`attributes.relation_preview_fields JSONB NOT NULL DEFAULT '[]'::jsonb\`.
- **Attribute entity** + ORM mapping: \`relationPreviewFields: list<string>\` with normalising setter (dedup, no empty strings).
- **AttributePatchInput / UpdateAttributeCommand / UpdateAttributeHandler / AttributeProcessor** all carry \`relationPreviewFields\` through the API Platform PATCH path. Configurator UI wiring deferred.
- **\`relation_preview_fields\`** added to the existing relation block in \`ProductReadEndpointsController::serializeAttribute\` + the preview controller.
- **New endpoint** \`POST /api/objects/summaries\` — body \`{ "ids": ["<uuid>", ...] }\` (max 200), returns \`[{id, code, name, objectType: {id, code, kind}}, ...]\`. \`name\` is best-effort from \`attributes_indexed\` (\`name\`/\`title\`/\`label\` keys, locale-aware).

## Frontend
- \`relations-tab\` batch-fetches summaries for all linked targets via \`queryKey: ['objects', 'summaries', sortedIds]\`. The summary map is passed down to each \`RelationRowItem\`.
- \`RelationRowItem\` renders a preview card layout — bold display name, mono code, ObjectType chip. Falls back to the UUID-8 stub if the summary is missing.

## Out of scope (explicitly deferred)
- Configurator UI for picking \`relation_preview_fields\` (PATCH plumbing ships; UI follow-up).
- Thumbnail/asset image inside the preview card — needs JOIN to \`assets\` table and a richer summary payload; staged for a future ticket.
- Rendering arbitrary preview field values (the configured codes are exposed via \`relation_preview_fields\`; the card currently shows name + code + ObjectType).

## Test plan
- [x] \`php-cs-fixer\` clean
- [x] \`phpstan analyse --memory-limit=1G\` — **0 errors**
- [x] \`tsc --noEmit\` clean
- [x] \`biome check\` clean
- [x] \`doctrine:schema:validate\` — Mapping OK; migration UP applied on live dev DB
- [x] PHPUnit MODR-08 (\`ObjectSummaryBatchApiTest\`) + regression (\`EffectiveAttributeGroupsApiTest\`, \`ObjectFormSchemaApiTest\`) — **13/13 pass**
- [x] **Live-stack smoke**: \`POST https://pim.localhost/api/objects/summaries\` with one product id returns \`{id, code: "DEMO-100", name: "Demo product 100", objectType: {code: "product", kind: "product"}}\`

Refs #930