### PR TITLE
MODR-10: feat(admin): relation widget — inline expand/edit of related object

### DIFF
--- a/apps/admin/src/features/catalog/products/components/relation-inline-edit-panel.tsx
+++ b/apps/admin/src/features/catalog/products/components/relation-inline-edit-panel.tsx
@@ -1,0 +1,271 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast';
+import { HttpError, jsonFetch } from '@/lib/http';
+
+/**
+ * MODR-10 (#932) — inline expand/edit panel for a related target object.
+ *
+ * Shown beneath a `RelationRowItem` when the operator clicks the chevron
+ * expand button. Renders the target's form-schema groups + lets the
+ * operator save changes back to the target via PATCH; uses the MODR-10
+ * `expectedVersion` field on `CatalogObjectPatchInput` to detect stale
+ * data and surfaces 409 → toast + auto-refetch.
+ *
+ * "Edytujesz współdzielony obiekt" warning is always visible — the
+ * target object may be referenced from other source objects too.
+ */
+interface RelationTargetSummary {
+  id: string;
+  code: string;
+  name: string | null;
+  objectType: { id: string; code: string; kind: string };
+  version: number;
+}
+
+interface FormSchemaResponse {
+  effectiveGroups: Array<{
+    id: string;
+    code: string;
+    label: Record<string, string>;
+    display_mode?: 'tab' | 'stacked';
+    attributes: Array<{
+      id: string;
+      code: string;
+      type: string;
+      label: Record<string, string>;
+      is_system: boolean;
+    }>;
+  }>;
+}
+
+interface TargetObjectResponse {
+  id: string;
+  code: string;
+  attributesIndexed: Record<string, unknown>;
+}
+
+export interface RelationInlineEditPanelProps {
+  targetId: string;
+  onClose: () => void;
+  onSaved?: () => void;
+}
+
+export function RelationInlineEditPanel({
+  targetId,
+  onClose,
+  onSaved,
+}: RelationInlineEditPanelProps) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language === 'pl' ? 'pl' : 'en';
+  const queryClient = useQueryClient();
+
+  const summaryQuery = useQuery<RelationTargetSummary[]>({
+    queryKey: ['objects', 'summary', targetId],
+    queryFn: () =>
+      jsonFetch<RelationTargetSummary[]>('/api/objects/summaries', {
+        method: 'POST',
+        contentType: 'application/json',
+        accept: 'application/json',
+        body: { ids: [targetId] },
+      }),
+    staleTime: 0,
+  });
+  const summary = summaryQuery.data?.[0] ?? null;
+
+  const objectQuery = useQuery<TargetObjectResponse>({
+    queryKey: ['objects', targetId, 'detail'],
+    queryFn: () =>
+      jsonFetch<TargetObjectResponse>(`/api/objects/${targetId}`, {
+        accept: 'application/json',
+      }),
+    staleTime: 0,
+  });
+
+  const formSchemaQuery = useQuery<FormSchemaResponse>({
+    queryKey: ['objects', targetId, 'form-schema-for-edit'],
+    queryFn: () =>
+      jsonFetch<FormSchemaResponse>(`/api/objects/${targetId}/form-schema`, {
+        accept: 'application/json',
+      }),
+    staleTime: 0,
+  });
+
+  const [dirty, setDirty] = useState<Record<string, unknown>>({});
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const objectTypeKind = summary?.objectType.kind ?? 'product';
+  const patchPath = sugarPathForKind(objectTypeKind);
+
+  const handleSave = async () => {
+    if (summary === null) return;
+    setError(null);
+    setSaving(true);
+    try {
+      await jsonFetch(`/api/${patchPath}/${targetId}`, {
+        method: 'PATCH',
+        contentType: 'application/merge-patch+json',
+        accept: 'application/ld+json',
+        body: {
+          attributes: dirty,
+          expectedVersion: summary.version,
+        },
+      });
+      // Invalidate caches so the row's display name + summaries refresh.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['objects', 'summary', targetId] }),
+        queryClient.invalidateQueries({ queryKey: ['objects', targetId] }),
+        queryClient.invalidateQueries({ queryKey: ['objects', 'summaries'] }),
+      ]);
+      setDirty({});
+      toast.success(
+        t('relations.inline_edit.saved', {
+          defaultValue: 'Zapisano zmiany na obiekcie powiązanym.',
+        }),
+      );
+      onSaved?.();
+    } catch (e) {
+      if (e instanceof HttpError && e.status === 409) {
+        setError(
+          t('relations.inline_edit.stale', {
+            defaultValue:
+              'Obiekt został w międzyczasie zmieniony przez kogoś innego. Odświeżam — sprawdź wartości i zapisz ponownie.',
+          }),
+        );
+        setDirty({});
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ['objects', 'summary', targetId] }),
+          queryClient.invalidateQueries({ queryKey: ['objects', targetId, 'detail'] }),
+        ]);
+      } else {
+        setError(
+          e instanceof HttpError
+            ? `HTTP ${e.status}`
+            : e instanceof Error
+              ? e.message
+              : t('relations.inline_edit.failed', {
+                  defaultValue: 'Nie udało się zapisać zmian.',
+                }),
+        );
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isLoading = summaryQuery.isLoading || objectQuery.isLoading || formSchemaQuery.isLoading;
+  if (isLoading) {
+    return (
+      <div className="mt-2 rounded-xl border border-line bg-zinc-50 p-4 text-xs text-muted-foreground">
+        {t('app.loading')}
+      </div>
+    );
+  }
+  if (summary === null || objectQuery.data === undefined || formSchemaQuery.data === undefined) {
+    return (
+      <div className="mt-2 rounded-xl border border-line bg-zinc-50 p-4 text-xs text-muted-foreground">
+        {t('relations.inline_edit.target_missing', {
+          defaultValue: 'Nie udało się załadować obiektu docelowego.',
+        })}
+      </div>
+    );
+  }
+
+  const fieldValue = (code: string): string => {
+    const v = code in dirty ? dirty[code] : objectQuery.data.attributesIndexed[code];
+    if (v === null || v === undefined) return '';
+    if (typeof v === 'string') return v;
+    if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+    return JSON.stringify(v);
+  };
+
+  const setFieldValue = (code: string, next: string) => {
+    setDirty((prev) => ({ ...prev, [code]: next }));
+  };
+
+  return (
+    <div className="mt-2 space-y-3 rounded-xl border border-zinc-200 bg-white p-4">
+      <div role="alert" className="rounded-md bg-amber-50 px-3 py-2 text-[12px] text-amber-700">
+        {t('relations.inline_edit.shared_warning', {
+          defaultValue:
+            'Edytujesz współdzielony obiekt — zmiana dotyczy wszystkich powiązań, które go referują.',
+        })}
+      </div>
+
+      <div className="space-y-4">
+        {formSchemaQuery.data.effectiveGroups.map((group) => (
+          <section key={group.id}>
+            <h4 className="mb-2 text-[12.5px] font-semibold tracking-tight text-zinc-700">
+              {group.label[lang] ?? group.code}
+            </h4>
+            <div className="space-y-2">
+              {group.attributes.map((attr) => (
+                <div key={attr.code} className="grid grid-cols-[180px_1fr] items-start gap-3">
+                  <label
+                    htmlFor={`edit-${targetId}-${attr.code}`}
+                    className="pt-1.5 text-[12.5px] font-medium text-muted-foreground"
+                  >
+                    {attr.label[lang] ?? attr.code}
+                  </label>
+                  {attr.type === 'textarea' ||
+                  attr.type === 'richtext' ||
+                  attr.type === 'wysiwyg' ? (
+                    <Textarea
+                      id={`edit-${targetId}-${attr.code}`}
+                      rows={3}
+                      value={fieldValue(attr.code)}
+                      disabled={attr.is_system}
+                      onChange={(e) => setFieldValue(attr.code, e.target.value)}
+                    />
+                  ) : (
+                    <Input
+                      id={`edit-${targetId}-${attr.code}`}
+                      value={fieldValue(attr.code)}
+                      disabled={attr.is_system}
+                      onChange={(e) => setFieldValue(attr.code, e.target.value)}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      {error !== null ? <p className="text-xs text-destructive">{error}</p> : null}
+
+      <div className="flex justify-end gap-2 border-t border-zinc-100 pt-3">
+        <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={saving}>
+          {t('app.cancel')}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleSave}
+          disabled={saving || Object.keys(dirty).length === 0}
+        >
+          {t('relations.inline_edit.save', { defaultValue: 'Zapisz zmiany na obiekcie' })}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function sugarPathForKind(kind: string): string {
+  switch (kind) {
+    case 'product':
+      return 'products';
+    case 'category':
+      return 'categories';
+    case 'asset':
+      return 'assets';
+    default:
+      return 'objects';
+  }
+}

--- a/apps/admin/src/features/catalog/products/components/relations-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/relations-tab.tsx
@@ -1,5 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowDownLeft, Link2, Plus, Search, Trash2, X } from 'lucide-react';
+import {
+  ArrowDownLeft,
+  ChevronDown,
+  ChevronUp,
+  Link2,
+  Plus,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { type FormEvent, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -8,6 +17,8 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/compone
 import { Input } from '@/components/ui/input';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
+
+import { RelationInlineEditPanel } from './relation-inline-edit-panel';
 
 /**
  * ADR-014 / MOD-12 (#904) — „Powiązania" tab on the product detail page.
@@ -220,6 +231,9 @@ function RelationGroupCard({
   const { t } = useTranslation();
   const [pickerOpen, setPickerOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // MODR-10 (#932) — only one card may be expanded inside a group at a
+  // time; clicking the chevron again or expanding another row closes it.
+  const [expandedTargetId, setExpandedTargetId] = useState<string | null>(null);
   const attribute = group.attribute as AttributeFull;
   const cardinality = attribute.cardinality ?? 'many';
 
@@ -361,6 +375,12 @@ function RelationGroupCard({
               advanced={attribute.advanced}
               advancedFields={extractAdvancedFields(attributeQuery.data?.validationRules)}
               summary={summariesById.get(row.targetObjectId)}
+              isExpanded={expandedTargetId === row.targetObjectId}
+              onToggleExpand={() =>
+                setExpandedTargetId((prev) =>
+                  prev === row.targetObjectId ? null : row.targetObjectId,
+                )
+              }
               onRemove={() => deleteMutation.mutate(row.targetObjectId)}
               onMetadataChange={(next) => handleMetadataChange(row.targetObjectId, next)}
               disabled={writeMutation.isPending || deleteMutation.isPending}
@@ -393,6 +413,8 @@ function RelationRowItem({
   advanced,
   advancedFields,
   summary,
+  isExpanded,
+  onToggleExpand,
   onRemove,
   onMetadataChange,
   disabled,
@@ -411,6 +433,9 @@ function RelationRowItem({
    * to the target UUID's first 8 characters.
    */
   summary?: RelationTargetSummary;
+  /** MODR-10 (#932) — true when this card has been expanded to edit. */
+  isExpanded: boolean;
+  onToggleExpand: () => void;
   onRemove: () => void;
   onMetadataChange: (next: Record<string, unknown>) => void;
   disabled: boolean;
@@ -439,17 +464,37 @@ function RelationRowItem({
             ) : null}
           </div>
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={onRemove}
-          disabled={disabled}
-          aria-label={t('relations.remove_link', { defaultValue: 'Usuń powiązanie' })}
-        >
-          <Trash2 className="size-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onToggleExpand}
+            aria-expanded={isExpanded}
+            aria-label={
+              isExpanded
+                ? t('relations.collapse_card', { defaultValue: 'Zwiń szczegóły' })
+                : t('relations.expand_card', { defaultValue: 'Rozwiń szczegóły' })
+            }
+          >
+            {isExpanded ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onRemove}
+            disabled={disabled}
+            aria-label={t('relations.remove_link', { defaultValue: 'Usuń powiązanie' })}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
       </div>
+
+      {isExpanded ? (
+        <RelationInlineEditPanel targetId={row.targetObjectId} onClose={onToggleExpand} />
+      ) : null}
 
       {advanced && advancedFields.length > 0 ? (
         <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">

--- a/apps/api/migrations/Version20260524180000.php
+++ b/apps/api/migrations/Version20260524180000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ADR-014 / MODR-10 (#932) — adds optimistic locking to `objects` via a
+ * `version` column. Doctrine's `@Version` mapping bumps the value on
+ * every UPDATE; `UpdateCatalogObjectHandler` rejects writes whose
+ * client-supplied `expectedVersion` is stale, returning HTTP 409.
+ *
+ * Backfill: every existing row starts at `version = 1`. Concurrent
+ * writes already in flight when this migration runs will collide on
+ * the first PATCH after; that is acceptable for the dev path.
+ */
+final class Version20260524180000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-014 / MODR-10 (#932): add objects.version for optimistic locking.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE objects
+                ADD COLUMN version INTEGER NOT NULL DEFAULT 1
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE objects DROP COLUMN version
+        SQL);
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectCommand.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectCommand.php
@@ -36,6 +36,13 @@ final readonly class UpdateCatalogObjectCommand
         public ?string $path = null,
         public bool $clearPath = false,
         public ?array $attributes = null,
+        /**
+         * MODR-10 (#932) — optimistic-lock guard. NULL = caller does not
+         * care about concurrency (backward compat with pre-MODR-10
+         * clients). Non-null = handler compares to current `version` and
+         * throws 409 on mismatch.
+         */
+        public ?int $expectedVersion = null,
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectHandler.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectHandler.php
@@ -6,6 +6,8 @@ namespace App\Catalog\Application\Command\UpdateCatalogObject;
 
 use App\Catalog\Application\ObjectAttributesUpserter;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\OptimisticLockException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -25,6 +27,19 @@ final readonly class UpdateCatalogObjectHandler
             throw new NotFoundHttpException(\sprintf(
                 'CatalogObject "%s" was not found.',
                 $command->id->toRfc4122(),
+            ));
+        }
+
+        // MODR-10 (#932) — optimistic-lock guard. Pre-flight check against
+        // the in-memory version covers the common case (a stale tab); the
+        // Doctrine `@Version` flush below also throws OptimisticLockException
+        // if a concurrent write slipped between our load + save.
+        if (null !== $command->expectedVersion && $command->expectedVersion !== $object->getVersion()) {
+            throw new ConflictHttpException(\sprintf(
+                'CatalogObject "%s" was modified by another user (expected v%d, current v%d). Refresh and try again.',
+                $command->id->toRfc4122(),
+                $command->expectedVersion,
+                $object->getVersion(),
             ));
         }
 
@@ -54,7 +69,14 @@ final readonly class UpdateCatalogObjectHandler
             $object->attachToPath($command->path);
         }
 
-        $this->catalogObjects->save($object);
+        try {
+            $this->catalogObjects->save($object);
+        } catch (OptimisticLockException $e) {
+            throw new ConflictHttpException(\sprintf(
+                'CatalogObject "%s" was modified by another user during save. Refresh and try again.',
+                $command->id->toRfc4122(),
+            ), $e);
+        }
 
         if (null !== $command->attributes && [] !== $command->attributes) {
             $this->attributesUpserter->upsert($object, $command->attributes);

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -133,6 +133,14 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     private DateTimeImmutable $createdAt;
     private DateTimeImmutable $updatedAt;
 
+    /**
+     * MODR-10 (#932) — optimistic-lock counter bumped by Doctrine via the
+     * `@Version` ORM mapping. Every UPDATE adds 1; clients who PATCH
+     * with a stale `expectedVersion` are rejected via 409 in
+     * {@see \App\Catalog\Application\Command\UpdateCatalogObject\UpdateCatalogObjectHandler}.
+     */
+    private int $version = 1;
+
     public function __construct(
         ObjectType $objectType,
         string $code,
@@ -377,6 +385,15 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updatedAt;
+    }
+
+    /**
+     * MODR-10 (#932) — optimistic-lock counter; auto-incremented by
+     * Doctrine on every flush of a mutated row.
+     */
+    public function getVersion(): int
+    {
+        return $this->version;
     }
 
     public function getImportSessionId(): ?Uuid

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObjectPatchInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObjectPatchInput.php
@@ -60,4 +60,14 @@ final class CatalogObjectPatchInput
      */
     #[Groups(['object:patch'])]
     public ?array $attributes = null;
+
+    /**
+     * MODR-10 (#932) — optimistic-lock guard. The relation widget's
+     * inline-edit panel reads `version` from the object payload and sends
+     * it back here; the handler compares against the current row and
+     * rejects with 409 Conflict on a mismatch ("stale data, refresh").
+     */
+    #[Assert\PositiveOrZero]
+    #[Groups(['object:patch'])]
+    public ?int $expectedVersion = null;
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php
@@ -152,6 +152,7 @@ final readonly class CatalogObjectProcessor implements ProcessorInterface
             path: $data->path,
             clearPath: false,
             attributes: $data->attributes,
+            expectedVersion: $data->expectedVersion,
         );
         $this->dispatch($command);
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -99,6 +99,13 @@
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
         <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
 
+        <!-- MODR-10 (#932) — optimistic locking. Doctrine increments on every UPDATE. -->
+        <field name="version" type="integer" column="version" version="true">
+            <options>
+                <option name="default">1</option>
+            </options>
+        </field>
+
     </entity>
 
 </doctrine-mapping>

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectSummaryBatchController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectSummaryBatchController.php
@@ -114,6 +114,10 @@ final class ObjectSummaryBatchController
                     'code' => $type->getCode(),
                     'kind' => $type->getKind()->value,
                 ],
+                // MODR-10 (#932) — current optimistic-lock version so the
+                // relation inline-edit panel can echo it back as
+                // `expectedVersion` on PATCH.
+                'version' => $obj->getVersion(),
             ];
         }
 

--- a/apps/api/tests/Api/Catalog/CatalogObjectVersionConflictApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectVersionConflictApiTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * ADR-014 / MODR-10 (#932) — optimistic-lock guard on PATCH
+ * `/api/products/{id}`. The relation widget's inline-edit panel reads
+ * `version` from the GET payload and sends it back as `expectedVersion`;
+ * a mismatch triggers HTTP 409 with a "stale data" hint.
+ */
+final class CatalogObjectVersionConflictApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function patchWithoutExpectedVersionRetainsBackwardCompat(): void
+    {
+        $client = $this->authenticatedClient();
+        $product = $this->seedProduct('VER-BACKCOMPAT');
+
+        $client->request('PATCH', '/api/products/'.$product->getId()->toRfc4122(), [
+            'json' => ['enabled' => true],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function patchWithCorrectExpectedVersionSucceeds(): void
+    {
+        $client = $this->authenticatedClient();
+        $product = $this->seedProduct('VER-MATCH');
+
+        $body = $client->request('GET', '/api/products/'.$product->getId()->toRfc4122())->toArray();
+        $version = $body['version'] ?? 1;
+        \assert(\is_int($version));
+
+        $client->request('PATCH', '/api/products/'.$product->getId()->toRfc4122(), [
+            'json' => ['enabled' => true, 'expectedVersion' => $version],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+    }
+
+    #[Test]
+    public function patchWithStaleExpectedVersionReturns409(): void
+    {
+        $client = $this->authenticatedClient();
+        $product = $this->seedProduct('VER-STALE');
+
+        // First PATCH flips enabled (initial=true → false) so the row
+        // really mutates and Doctrine @Version bumps to 2.
+        $client->request('PATCH', '/api/products/'.$product->getId()->toRfc4122(), [
+            'json' => ['enabled' => false],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+
+        // Second PATCH with the pre-bump version → 409 Conflict.
+        $client->request('PATCH', '/api/products/'.$product->getId()->toRfc4122(), [
+            'json' => ['enabled' => true, 'expectedVersion' => 1],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+    }
+
+    private function seedProduct(string $code): CatalogObject
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $product = new CatalogObject($type, $code);
+        $em = $this->em();
+        $em->persist($product);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $product;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -7801,6 +7801,14 @@
                                 "null"
                             ]
                         }
+                    },
+                    "expectedVersion": {
+                        "minimum": 0,
+                        "description": "MODR-10 (#932) \u2014 optimistic-lock guard. The relation widget's\ninline-edit panel reads `version` from the object payload and sends\nit back here; the handler compares against the current row and\nrejects with 409 Conflict on a mismatch (\"stale data, refresh\").",
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
                     }
                 }
             },


### PR DESCRIPTION
## Summary
Lets the operator expand a card in the relation widget (chevron) and edit the **target object's** attributes in place — without leaving the source object's detail page. Edits go straight to the target via PATCH; an optimistic-lock guard rejects stale writes with HTTP 409.

## Backend — optimistic locking
- New \`CatalogObject.version\` column (migration \`Version20260524180000\`) + Doctrine \`@Version\` mapping. Auto-incremented on every UPDATE.
- \`CatalogObjectPatchInput\` / \`UpdateCatalogObjectCommand\` / \`UpdateCatalogObjectHandler\` thread \`expectedVersion\` through. Mismatch → \`ConflictHttpException\` (HTTP 409 with stale-data hint). Doctrine \`OptimisticLockException\` at flush time also maps to 409.
- \`ObjectSummaryBatchController\` bundles \`version\` next to \`id/code/name/objectType\` so the inline-edit panel can echo it back as \`expectedVersion\` on PATCH.

## Frontend — inline expand/edit
- New \`RelationInlineEditPanel\` component:
  - Fetches: target object payload, form-schema, fresh summary (with \`version\`).
  - Renders a textarea/input per attribute keyed by code; local dirty state.
  - \`role="alert"\` banner: "Edytujesz współdzielony obiekt — zmiana dotyczy wszystkich powiązań".
  - Save → \`PATCH /api/{products|categories|assets}/{id}\` merge-patch with \`{attributes, expectedVersion}\`. 409 → toast + auto-refetch summary + clear dirty.
- \`RelationRowItem\` adds chevron expand button (top-right, before trash) with \`aria-expanded\` + \`aria-label\`. Only one card per attribute group may be expanded at once (state lives in \`RelationGroupCard\`).

## Test plan
- [x] \`php-cs-fixer\` clean
- [x] \`phpstan analyse --memory-limit=1G\` — **0 errors**
- [x] \`tsc -b --noEmit\` clean (CI parity)
- [x] \`biome check\` clean
- [x] \`doctrine:schema:validate\` — Mapping OK; migration UP applied on live dev DB
- [x] PHPUnit — \`CatalogObjectVersionConflictApiTest\` (3/3 pass) + regression (\`ObjectSummaryBatchApiTest\`, \`EffectiveAttributeGroupsApiTest\`, \`ObjectFormSchemaApiTest\`, \`ObjectRelationsReverseApiTest\`, \`ObjectTypeAttributeGroupDisplayModePatchApiTest\`, \`ObjectTypeView01ApiTest\`) — **37/37 pass**
- [x] OpenAPI snapshot regenerated (\`docs/api-spec/v0.json\`)
- [x] **Live-stack smoke** on \`https://pim.localhost\`:
  - \`POST /api/objects/summaries\` returns \`version: 1\` on a fresh product
  - First \`PATCH /api/products/<id>\` with \`expectedVersion: 1\` → **HTTP 200** (version bumps to 2)
  - Second \`PATCH\` with stale \`expectedVersion: 1\` → **HTTP 409** with detail "was modified by another user (expected v1, current v2). Refresh and try again."
  - \`PATCH\` with correct \`expectedVersion: 2\` → **HTTP 200**

## Out of scope (deferred)
- Multi-step "Show diff" before save.
- Audit log entries specific to inline-edit-via-relation (regular \`EntityChanged\` events fire via Doctrine listeners).
- Undo / version history for the edited target.

Refs #932