### PR TITLE
MODR-08 follow-up: feat(admin): UI editor for relation_preview_fields

### DIFF
--- a/apps/admin/src/components/modeling/relation-config-panel.tsx
+++ b/apps/admin/src/components/modeling/relation-config-panel.tsx
@@ -17,6 +17,13 @@ export interface RelationConfigValue {
   cardinality: 'one' | 'many';
   advanced: boolean;
   advancedFields: RelationAdvancedField[];
+  /**
+   * MODR-08 (#930) — list of target attribute codes surfaced inside the
+   * relation widget's preview card. Empty list keeps the default
+   * (target object code + name). Persisted as `relation_preview_fields`
+   * on the Attribute entity; PATCH plumbing wired since MODR-08.
+   */
+  previewFields: string[];
 }
 
 interface RelationConfigPanelProps {
@@ -318,7 +325,102 @@ export function RelationConfigPanel({
             </div>
           ) : null}
         </div>
+
+        {/* MODR-08 (#930) — preview fields editor. Drives the rich
+            preview card layout inside the relation widget. Empty list =
+            default (target object code + name). */}
+        <div className="border-t border-zinc-100 pt-5">
+          <PreviewFieldsEditor
+            value={value.previewFields}
+            disabled={disabled}
+            onChange={(next) => onChange({ ...value, previewFields: next })}
+          />
+        </div>
       </CardContent>
     </Card>
+  );
+}
+
+function PreviewFieldsEditor({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: string[];
+  disabled: boolean;
+  onChange: (next: string[]) => void;
+}) {
+  const { t } = useTranslation();
+  const update = (idx: number, code: string) => {
+    if (disabled) return;
+    const next = [...value];
+    next[idx] = code;
+    onChange(next);
+  };
+  const add = () => {
+    if (disabled) return;
+    onChange([...value, '']);
+  };
+  const remove = (idx: number) => {
+    if (disabled) return;
+    onChange(value.filter((_, i) => i !== idx));
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="text-[13px] font-medium text-zinc-700">
+          {t('attributes.relation_preview_fields_label', {
+            defaultValue: 'Pola podglądu w karcie powiązania',
+          })}
+        </div>
+        <div className="mt-0.5 text-[12px] text-muted-foreground">
+          {t('attributes.relation_preview_fields_desc', {
+            defaultValue:
+              'Kody atrybutów obiektu docelowego (np. „sku", „price") wyświetlanych w karcie. Pusta lista — pokazuje sam code + name.',
+          })}
+        </div>
+      </div>
+      {value.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-zinc-300 px-4 py-3 text-[12px] text-muted-foreground">
+          {t('attributes.relation_preview_fields_empty', {
+            defaultValue: 'Brak pól — klik „+ Pole" doda wiersz z kodem atrybutu targetu.',
+          })}
+        </div>
+      ) : null}
+      {value.map((code, idx) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: append-only editor with idx-based mutations
+          key={idx}
+          className="grid grid-cols-[1fr,auto] items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2"
+        >
+          <Input
+            placeholder={t('attributes.relation_preview_fields_placeholder', {
+              defaultValue: 'kod atrybutu (np. price, sku)',
+            })}
+            value={code}
+            disabled={disabled}
+            onChange={(e) => update(idx, e.target.value)}
+            className="font-mono"
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            disabled={disabled}
+            onClick={() => remove(idx)}
+            aria-label={t('attributes.relation_preview_fields_remove', {
+              defaultValue: 'Usuń pole podglądu',
+            })}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+      ))}
+      <Button variant="ghost" size="sm" type="button" disabled={disabled} onClick={add}>
+        <Plus className="size-4" />
+        {t('attributes.relation_preview_fields_add', { defaultValue: '+ Pole' })}
+      </Button>
+    </div>
   );
 }

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -53,6 +53,9 @@ interface AttributeDetail {
   relationTargetObjectTypeIds?: string[];
   relationCardinality?: 'one' | 'many' | null;
   relationAdvanced?: boolean;
+  // MODR-08 (#930) — list of target attribute codes shown in the
+  // relation widget's preview card. Empty list → default name+code.
+  relationPreviewFields?: string[];
   validationRules?: Record<string, unknown> | null;
 }
 
@@ -161,7 +164,38 @@ function Editor({
     cardinality: (attribute.relationCardinality as 'one' | 'many') ?? 'many',
     advanced: attribute.relationAdvanced ?? false,
     advancedFields: initialRelationFields,
+    previewFields: attribute.relationPreviewFields ?? [],
   });
+
+  // MODR-08 follow-up — fetch `relationPreviewFields` from a dedicated
+  // endpoint because ApiPlatform's GET /api/attributes/{id} omits the
+  // property from its JSON-LD response (PropertyInfo discovery quirk —
+  // see AttributeRelationPreviewFieldsController for context).
+  const previewFieldsQuery = useQuery<{
+    attributeId: string;
+    relationPreviewFields: string[];
+  }>({
+    queryKey: ['attributes', attribute.id, 'relation_preview_fields'],
+    queryFn: () =>
+      jsonFetch<{ attributeId: string; relationPreviewFields: string[] }>(
+        `/api/attributes/${attribute.id}/relation_preview_fields`,
+        { accept: 'application/json' },
+      ),
+    enabled: attribute.type === 'relation',
+    staleTime: 30_000,
+  });
+  useEffect(() => {
+    if (previewFieldsQuery.data === undefined) return;
+    setRelationConfig((prev) => {
+      if (
+        prev.previewFields.length === previewFieldsQuery.data?.relationPreviewFields.length &&
+        prev.previewFields.every((v, i) => v === previewFieldsQuery.data?.relationPreviewFields[i])
+      ) {
+        return prev;
+      }
+      return { ...prev, previewFields: previewFieldsQuery.data.relationPreviewFields };
+    });
+  }, [previewFieldsQuery.data]);
 
   // Fetch tenant ObjectTypes for the multi-select. Cheap query, cached.
   const objectTypesQuery = useQuery<
@@ -196,6 +230,7 @@ function Editor({
     cardinality: (attribute.relationCardinality as 'one' | 'many') ?? 'many',
     advanced: attribute.relationAdvanced ?? false,
     advancedFields: initialRelationFields,
+    previewFields: previewFieldsQuery.data?.relationPreviewFields ?? [],
   });
   const relationDirty =
     attribute.type === 'relation' && JSON.stringify(relationConfig) !== initialRelationSnapshot;
@@ -252,6 +287,11 @@ function Editor({
         body.validationRules = relationConfig.advanced
           ? { ...(attribute.validationRules ?? {}), advanced_fields: fields }
           : { ...(attribute.validationRules ?? {}), advanced_fields: [] };
+        // MODR-08 follow-up — preview fields list. Strip empty rows;
+        // backend setter dedups anyway but a clean payload reads better.
+        body.relationPreviewFields = relationConfig.previewFields
+          .map((c) => c.trim())
+          .filter((c) => c !== '');
       }
       await jsonFetch(`/api/attributes/${attribute.id}`, {
         method: 'PATCH',

--- a/apps/api/src/Catalog/Presentation/Controller/AttributeRelationPreviewFieldsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttributeRelationPreviewFieldsController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * MODR-08 (#930) follow-up — dedicated read endpoint for the
+ * `relation_preview_fields` column on `attributes`. ApiPlatform 4's
+ * PropertyInfo extractor refused to surface the new JSONB array
+ * property through the regular `GET /api/attributes/{id}` JSON-LD
+ * response even after a full cache rebuild (other identical-shape
+ * JSONB array fields on the same entity, e.g.
+ * `relation_target_object_type_ids`, do surface — the discrepancy
+ * appears to be an AP4 metadata-discovery quirk on properties added
+ * after the resource's first compile). Rather than fighting AP4
+ * metadata, we expose a small dedicated endpoint the relation
+ * configurator uses to read the persisted list back.
+ *
+ * `PATCH /api/attributes/{id}` already accepts `relationPreviewFields`
+ * via {@see \App\Catalog\Infrastructure\ApiPlatform\Resource\AttributePatchInput}.
+ */
+final class AttributeRelationPreviewFieldsController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly AttributeRepositoryInterface $attributes,
+    ) {
+    }
+
+    #[Route(
+        '/api/attributes/{id}/relation_preview_fields',
+        name: 'pim_attributes_relation_preview_fields',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'attribute', action: 'read')]
+    public function __invoke(string $id): JsonResponse
+    {
+        $attribute = $this->attributes->findById(Uuid::fromString($id));
+        if (null === $attribute) {
+            throw new NotFoundHttpException(\sprintf('Attribute "%s" was not found.', $id));
+        }
+
+        return new JsonResponse([
+            'attributeId' => $attribute->getId()->toRfc4122(),
+            'relationPreviewFields' => $attribute->getRelationPreviewFields(),
+        ]);
+    }
+}

--- a/apps/api/tests/Api/Catalog/AttributeRelationPreviewFieldsApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeRelationPreviewFieldsApiTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * MODR-08 (#930) follow-up — `GET /api/attributes/{id}/relation_preview_fields`
+ * exposes the JSONB list omitted from the standard ApiPlatform JSON-LD
+ * response for the Attribute entity.
+ */
+final class AttributeRelationPreviewFieldsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function getReturnsEmptyListByDefault(): void
+    {
+        $client = $this->authenticatedClient();
+        $attr = $this->seedAttribute('mod_attr_a');
+
+        $body = $client->request(
+            'GET',
+            '/api/attributes/'.$attr->getId()->toRfc4122().'/relation_preview_fields',
+        )->toArray();
+
+        self::assertSame($attr->getId()->toRfc4122(), $body['attributeId']);
+        self::assertSame([], $body['relationPreviewFields']);
+    }
+
+    #[Test]
+    public function patchPlusGetRoundTripsTheConfiguredList(): void
+    {
+        $client = $this->authenticatedClient();
+        $attr = $this->seedAttribute('mod_attr_b');
+
+        $client->request('PATCH', '/api/attributes/'.$attr->getId()->toRfc4122(), [
+            'json' => ['relationPreviewFields' => ['sku', 'price']],
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+
+        $body = $client->request(
+            'GET',
+            '/api/attributes/'.$attr->getId()->toRfc4122().'/relation_preview_fields',
+        )->toArray();
+        self::assertSame(['sku', 'price'], $body['relationPreviewFields']);
+    }
+
+    #[Test]
+    public function getReturns404ForUnknownAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request(
+            'GET',
+            '/api/attributes/01234567-1234-7000-8000-000000000000/relation_preview_fields',
+        );
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    private function seedAttribute(string $code): Attribute
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $attr = new Attribute($code, ['pl' => 'Test', 'en' => 'Test'], AttributeType::Relation);
+        $em = $this->em();
+        $em->persist($attr);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $attr;
+    }
+}


### PR DESCRIPTION
## Summary
Wires the deferred UI for MODR-08 (#930) preview-fields config. Operator can now pick which target attribute codes the relation widget renders in the preview card from the attribute show page (\`/modeling/attributes/{id}\`).

## Backend
- **New endpoint** \`GET /api/attributes/{id}/relation_preview_fields\` → \`{attributeId, relationPreviewFields}\`.

  Workaround for an ApiPlatform 4 PropertyInfo quirk: the new JSONB array property is silently omitted from the standard JSON-LD Attribute response even though the getter and ORM mapping exist (other identical-shape JSONB array properties on the same entity, e.g. \`relationTargetObjectTypeIds\`, surface fine). Verified via OpenAPI inspection: \`Attribute-admin.read\` schema includes \`relationTargetObjectTypeIds\`/\`relationCardinality\`/\`relationAdvanced\` but not \`relationPreviewFields\`. Adding a \`<properties>\` block to the AP4 XML resource broke routing; using a small dedicated controller is the least invasive fix.
- **PHPUnit** \`AttributeRelationPreviewFieldsApiTest\` — 3/3 pass: default empty list, PATCH+GET round-trip, 404.

## Frontend
- \`RelationConfigValue\` gains \`previewFields: string[]\`.
- \`RelationConfigPanel\` renders a new \`PreviewFieldsEditor\` section under the advanced toggle: code-only inputs with add/remove buttons, hint copy ("Pusta lista — pokazuje sam code + name").
- \`AttributeShowPage\`:
  - Seeds \`previewFields\` from the new endpoint via \`useQuery\`, syncing \`relationConfig.previewFields\` on data arrival.
  - Dirty-snapshot uses the same query data so an initial fetch doesn't mark the form as dirty.
  - Save handler ships \`relationPreviewFields\` (trimmed, no empties) in the PATCH body alongside the existing relation config.

## Test plan
- [x] PHPStan max — 0 errors
- [x] \`tsc -b --noEmit\` clean
- [x] \`biome check\` — 1 pre-existing warning (unrelated)
- [x] PHPUnit MODR-08 FU — 3/3 pass
- [x] OpenAPI snapshot regenerated
- [x] **Live-stack smoke** on \`https://pim.localhost\`:
  - \`GET /api/attributes/<id>/relation_preview_fields\` on a seeded \`cross_sell\` attribute returns the persisted list
  - \`PATCH /api/attributes/<id>\` with \`relationPreviewFields: ["sku", "price"]\` → HTTP 200, list persisted (verified by re-GET)

Refs #930