### PR TITLE
MODR-10 follow-up: feat(catalog): surface CatalogObject.version in GET responses

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/CatalogObjectVersionNormalizer.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/CatalogObjectVersionNormalizer.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use ArrayObject;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * MODR-10 (#932) follow-up — surfaces the Doctrine `@Version` field on
+ * GET `/api/{products|categories|assets}/{id}` responses.
+ *
+ * ApiPlatform 4's PropertyInfo metadata factory silently skips
+ * properties mapped with Doctrine `version="true"` from its
+ * normalization metadata, so the integer counter that drives the
+ * optimistic-lock guard never reaches the client unless we splice it
+ * in ourselves. This normalizer wraps the default chain and appends
+ * `version` to every `CatalogObject` response.
+ *
+ * Frontend (RelationInlineEditPanel) already prefers the lighter
+ * `/api/objects/summaries` batch endpoint for fetching `version`; this
+ * normalizer is the canonical path — anyone reading
+ * `/api/products/{id}` directly gets the same field.
+ */
+#[AutoconfigureTag('serializer.normalizer', ['priority' => -50])]
+final class CatalogObjectVersionNormalizer implements NormalizerInterface, NormalizerAwareInterface
+{
+    use NormalizerAwareTrait;
+
+    private const string SENTINEL = '__catalog_object_version_normalizer_already_called';
+
+    public function normalize(
+        mixed $data,
+        ?string $format = null,
+        array $context = [],
+    ): ArrayObject|array|string|int|float|bool|null {
+        $context[self::SENTINEL] = true;
+        $payload = $this->normalizer->normalize($data, $format, $context);
+
+        if (!\is_array($payload) || !$data instanceof CatalogObject) {
+            return $payload;
+        }
+
+        $payload['version'] = $data->getVersion();
+
+        return $payload;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        if (true === ($context[self::SENTINEL] ?? false)) {
+            return false;
+        }
+
+        return $data instanceof CatalogObject;
+    }
+
+    /**
+     * @return array<string, bool|null>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [CatalogObject::class => false];
+    }
+}


### PR DESCRIPTION
## Summary
Canonicalises the optimistic-lock \`version\` exposure introduced by MODR-10 (#932). The relation inline-edit panel previously grabbed it from the \`ObjectSummaryBatch\` endpoint as a workaround; this PR makes \`GET /api/{products|categories|assets}/{id}\` include \`version\` directly.

## Why a normalizer?
ApiPlatform 4's PropertyInfo metadata factory silently skips Doctrine \`@Version\`-mapped properties from its normalization metadata — verified empirically:
- \`getVersion(): int\` exists on the entity ✓
- \`<field name="version" version="true" .../>\` mapping ✓
- Reflection sees the method ✓
- ApiPlatform JSON-LD response omits the field anyway

Adding the property via \`<properties>\` in the AP4 XML resource block broke routing for the resource (verified in FU-2 attempt). A small decorator-style Serializer normalizer is the least invasive fix.

## Behaviour
- New \`CatalogObjectVersionNormalizer\` (priority \`-50\`, sentinel-guarded against infinite recursion) wraps the default chain and appends \`version\` to every \`CatalogObject\` response after the regular normalizer finishes.
- The batch summaries endpoint keeps exposing \`version\` too — frontend continues using it for bulk lookups; canonical GET is now equivalent.

## Test plan
- [x] \`phpstan analyse --memory-limit=1G\` — **0 errors**
- [x] PHPUnit \`CatalogObjectVersionConflictApiTest\` — **3/3 pass** (unchanged from MODR-10; verifies the lock guard still works end-to-end)
- [x] **Live-stack smoke** on \`https://pim.localhost\`:
  - \`GET /api/products/<id>\` now includes \`"version": 3\` next to \`code\`, \`enabled\`, etc.
  - \`ObjectSummaryBatch\` still returns the same value (parity check)

Refs #932