### PR TITLE
fix(catalog): relation attribute create — RelationConfigPanel w 3 ścieżkach create (Closes #949)

### DIFF
--- a/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
@@ -1,15 +1,38 @@
 import { useInvalidate } from '@refinedev/core';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, GripVertical, Info, X, Zap } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import {
+  RelationConfigPanel,
+  type RelationConfigValue,
+} from '@/components/modeling/relation-config-panel';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
+
+/**
+ * Default relation config (#949) — operator picks targets + cardinality
+ * inline via `RelationConfigPanel` before POST.
+ */
+const DEFAULT_RELATION_CONFIG: RelationConfigValue = {
+  targetObjectTypeIds: [],
+  cardinality: 'many',
+  advanced: false,
+  advancedFields: [],
+  previewFields: [],
+};
+
+interface ObjectTypePickerRow {
+  id: string;
+  code: string;
+  kind: string;
+  label?: Record<string, string> | string | null;
+}
 
 const TYPES = [
   'text',
@@ -78,6 +101,9 @@ export function CreateAttributeForObjectTypeDialog({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeLocale, setActiveLocale] = useState<'pl' | 'en'>('pl');
+  // #949 — relation config inline.
+  const [relationConfig, setRelationConfig] =
+    useState<RelationConfigValue>(DEFAULT_RELATION_CONFIG);
 
   useEffect(() => {
     if (open) {
@@ -91,12 +117,29 @@ export function CreateAttributeForObjectTypeDialog({
       setLocalizable(false);
       setError(null);
       setActiveLocale('pl');
+      setRelationConfig(DEFAULT_RELATION_CONFIG);
     }
   }, [open]);
 
+  // #949 — ObjectTypes list for the relation panel's target multi-select.
+  const objectTypesQuery = useQuery<ObjectTypePickerRow[]>({
+    queryKey: ['relation-config', 'object_types'],
+    queryFn: async () => {
+      const data = await jsonFetch<{ member?: ObjectTypePickerRow[] }>(
+        '/api/object_types?itemsPerPage=200',
+      );
+      return data.member ?? [];
+    },
+    staleTime: 60_000,
+    enabled: open && type === 'relation',
+  });
+
   const showUnit = type === 'number' || type === 'price' || type === 'metric';
   const showOptionsBanner = type === 'select' || type === 'multiselect';
-  const valid = code.trim().length > 0 && namePl.trim().length > 0;
+  const valid =
+    code.trim().length > 0 &&
+    namePl.trim().length > 0 &&
+    (type !== 'relation' || relationConfig.targetObjectTypeIds.length > 0);
 
   const submit = async () => {
     if (!valid) return;
@@ -113,6 +156,22 @@ export function CreateAttributeForObjectTypeDialog({
         required,
       };
       if (unit.trim().length > 0) body.unit = unit.trim();
+
+      // #949 — relation config fields go through the same POST body.
+      // Backend validator requires `relationCardinality` + targets on POST
+      // for `type=relation`. Non-relation types skip these entirely.
+      if (type === 'relation') {
+        body.relationTargetObjectTypeIds = relationConfig.targetObjectTypeIds;
+        body.relationCardinality = relationConfig.cardinality;
+        body.relationAdvanced = relationConfig.advanced;
+        if (relationConfig.advanced) {
+          body.validationRules = {
+            advanced_fields: relationConfig.advancedFields.filter((f) => f.code.trim() !== ''),
+          };
+        }
+        const preview = relationConfig.previewFields.map((c) => c.trim()).filter((c) => c !== '');
+        if (preview.length > 0) body.relationPreviewFields = preview;
+      }
 
       const created = await jsonFetch<CreatedAttributeResponse>('/api/attributes', {
         method: 'POST',
@@ -313,6 +372,31 @@ export function CreateAttributeForObjectTypeDialog({
                     mógł zdefiniować wartości (z tłumaczeniami) w widoku „Zarządzaj wartościami".
                   </div>
                 </div>
+              ) : null}
+            </Section>
+          ) : null}
+
+          {/* #949 — relation config inline. Required so the backend
+              validator doesn't 422 on POST for `type=relation`. */}
+          {type === 'relation' ? (
+            <Section
+              title={t('attributes.relation_config_section', {
+                defaultValue: 'Konfiguracja relacji',
+              })}
+              divider
+            >
+              <RelationConfigPanel
+                value={relationConfig}
+                objectTypes={objectTypesQuery.data ?? []}
+                disabled={submitting}
+                onChange={setRelationConfig}
+              />
+              {relationConfig.targetObjectTypeIds.length === 0 ? (
+                <p className="mt-2 text-[12px] text-amber-600">
+                  {t('attributes.relation_targets_required_hint', {
+                    defaultValue: 'Wybierz co najmniej jeden ObjectType celu relacji.',
+                  })}
+                </p>
               ) : null}
             </Section>
           ) : null}

--- a/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
@@ -1,15 +1,38 @@
 import { useInvalidate } from '@refinedev/core';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Check, GripVertical, Info, X, Zap } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import {
+  RelationConfigPanel,
+  type RelationConfigValue,
+} from '@/components/modeling/relation-config-panel';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
+
+/**
+ * Default relation config (#949) — operator picks targets + cardinality
+ * inline via `RelationConfigPanel` before POST.
+ */
+const DEFAULT_RELATION_CONFIG: RelationConfigValue = {
+  targetObjectTypeIds: [],
+  cardinality: 'many',
+  advanced: false,
+  advancedFields: [],
+  previewFields: [],
+};
+
+interface ObjectTypePickerRow {
+  id: string;
+  code: string;
+  kind: string;
+  label?: Record<string, string> | string | null;
+}
 
 const TYPES = [
   'text',
@@ -57,6 +80,10 @@ export function CreateAttributeInGroupDialog({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [activeLocale, setActiveLocale] = useState<'pl' | 'en'>('pl');
+  // #949 — relation config inline. Reset on dialog open to keep state
+  // bounded to the current creation flow.
+  const [relationConfig, setRelationConfig] =
+    useState<RelationConfigValue>(DEFAULT_RELATION_CONFIG);
 
   useEffect(() => {
     if (open) {
@@ -70,12 +97,30 @@ export function CreateAttributeInGroupDialog({
       setLocalizable(false);
       setError(null);
       setActiveLocale('pl');
+      setRelationConfig(DEFAULT_RELATION_CONFIG);
     }
   }, [open]);
 
+  // #949 — ObjectTypes list for the relation panel's target multi-select.
+  // Only fired when the operator selects `type=relation`.
+  const objectTypesQuery = useQuery<ObjectTypePickerRow[]>({
+    queryKey: ['relation-config', 'object_types'],
+    queryFn: async () => {
+      const data = await jsonFetch<{ member?: ObjectTypePickerRow[] }>(
+        '/api/object_types?itemsPerPage=200',
+      );
+      return data.member ?? [];
+    },
+    staleTime: 60_000,
+    enabled: open && type === 'relation',
+  });
+
   const showUnit = type === 'number' || type === 'price' || type === 'metric';
   const showOptionsBanner = type === 'select' || type === 'multiselect';
-  const valid = code.trim().length > 0 && namePl.trim().length > 0;
+  const valid =
+    code.trim().length > 0 &&
+    namePl.trim().length > 0 &&
+    (type !== 'relation' || relationConfig.targetObjectTypeIds.length > 0);
 
   const submit = async () => {
     if (!valid) return;
@@ -92,6 +137,22 @@ export function CreateAttributeInGroupDialog({
         required,
       };
       if (unit.trim().length > 0) body.unit = unit.trim();
+
+      // #949 — relation config fields go through the same POST body.
+      // Backend validator requires `relationCardinality` + targets on POST
+      // for `type=relation`. Non-relation types skip these entirely.
+      if (type === 'relation') {
+        body.relationTargetObjectTypeIds = relationConfig.targetObjectTypeIds;
+        body.relationCardinality = relationConfig.cardinality;
+        body.relationAdvanced = relationConfig.advanced;
+        if (relationConfig.advanced) {
+          body.validationRules = {
+            advanced_fields: relationConfig.advancedFields.filter((f) => f.code.trim() !== ''),
+          };
+        }
+        const preview = relationConfig.previewFields.map((c) => c.trim()).filter((c) => c !== '');
+        if (preview.length > 0) body.relationPreviewFields = preview;
+      }
 
       // Step 1: create the attribute in the global library.
       await jsonFetch('/api/attributes', {
@@ -279,6 +340,31 @@ export function CreateAttributeInGroupDialog({
                     mógł zdefiniować wartości (z tłumaczeniami) w widoku „Zarządzaj wartościami".
                   </div>
                 </div>
+              ) : null}
+            </Section>
+          ) : null}
+
+          {/* #949 — relation config inline. Required so the backend
+              validator doesn't 422 on POST for `type=relation`. */}
+          {type === 'relation' ? (
+            <Section
+              title={t('attributes.relation_config_section', {
+                defaultValue: 'Konfiguracja relacji',
+              })}
+              divider
+            >
+              <RelationConfigPanel
+                value={relationConfig}
+                objectTypes={objectTypesQuery.data ?? []}
+                disabled={submitting}
+                onChange={setRelationConfig}
+              />
+              {relationConfig.targetObjectTypeIds.length === 0 ? (
+                <p className="mt-2 text-[12px] text-amber-600">
+                  {t('attributes.relation_targets_required_hint', {
+                    defaultValue: 'Wybierz co najmniej jeden ObjectType celu relacji.',
+                  })}
+                </p>
               ) : null}
             </Section>
           ) : null}

--- a/apps/admin/src/features/catalog/attributes/new.tsx
+++ b/apps/admin/src/features/catalog/attributes/new.tsx
@@ -1,5 +1,5 @@
 import { useInvalidate } from '@refinedev/core';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Check, FolderPlus, FolderTree, X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -7,6 +7,10 @@ import { Link, useNavigate } from 'react-router';
 
 import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inline-dialog';
 import { PickGroupsForAttributeDialog } from '@/components/modeling/pick-groups-for-attribute-dialog';
+import {
+  RelationConfigPanel,
+  type RelationConfigValue,
+} from '@/components/modeling/relation-config-panel';
 import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -64,6 +68,27 @@ const EMPTY: CreatePayload = {
   filterable: false,
 };
 
+/**
+ * Default relation config (#949) — operator picks targets + cardinality
+ * inline via `RelationConfigPanel`. `many` is the most common shape
+ * (cross_sell, related, accessory all default to many on the seeded
+ * built-in relation attributes).
+ */
+const DEFAULT_RELATION_CONFIG: RelationConfigValue = {
+  targetObjectTypeIds: [],
+  cardinality: 'many',
+  advanced: false,
+  advancedFields: [],
+  previewFields: [],
+};
+
+interface ObjectTypePickerRow {
+  id: string;
+  code: string;
+  kind: string;
+  label?: Record<string, string> | string | null;
+}
+
 const TYPES = [
   'text',
   'number',
@@ -94,6 +119,25 @@ export function AttributeCreatePage() {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [createGroupOpen, setCreateGroupOpen] = useState(false);
 
+  // #949 — relation attribute config (only meaningful when type=relation).
+  // Backend validator (RelationAttributeConfigValidator) rejects POST with
+  // 422 if `relationCardinality` is null on a relation attribute; we now
+  // render `RelationConfigPanel` inline so the operator can pick targets +
+  // cardinality before submit.
+  const [relationConfig, setRelationConfig] =
+    useState<RelationConfigValue>(DEFAULT_RELATION_CONFIG);
+  const objectTypesQuery = useQuery<ObjectTypePickerRow[]>({
+    queryKey: ['relation-config', 'object_types'],
+    queryFn: async () => {
+      const data = await jsonFetch<{ member?: ObjectTypePickerRow[] }>(
+        '/api/object_types?itemsPerPage=200',
+      );
+      return data.member ?? [];
+    },
+    staleTime: 60_000,
+    enabled: values.type === 'relation',
+  });
+
   const handleSubmit = async () => {
     setError(null);
     setSubmitting(true);
@@ -111,6 +155,22 @@ export function AttributeCreatePage() {
       // when the BE adds it. For now keep it form-only so the FE matches
       // the mockup; submit-side stays no-op.
       // `indexed` is similarly form-only (no `is_indexed` BE column yet).
+
+      // #949 — relation config fields go through the same POST. Filter
+      // empty advanced-field rows (the validator 422s them; the UX is
+      // friendlier when we drop them upfront).
+      if (values.type === 'relation') {
+        body.relationTargetObjectTypeIds = relationConfig.targetObjectTypeIds;
+        body.relationCardinality = relationConfig.cardinality;
+        body.relationAdvanced = relationConfig.advanced;
+        if (relationConfig.advanced) {
+          body.validationRules = {
+            advanced_fields: relationConfig.advancedFields.filter((f) => f.code.trim() !== ''),
+          };
+        }
+        const preview = relationConfig.previewFields.map((c) => c.trim()).filter((c) => c !== '');
+        if (preview.length > 0) body.relationPreviewFields = preview;
+      }
 
       const response = await jsonFetch<{ id?: string }>('/api/attributes', {
         method: 'POST',
@@ -176,7 +236,10 @@ export function AttributeCreatePage() {
     }
   };
 
-  const valid = values.code.trim().length > 0 && values.labelPl.trim().length > 0;
+  const valid =
+    values.code.trim().length > 0 &&
+    values.labelPl.trim().length > 0 &&
+    (values.type !== 'relation' || relationConfig.targetObjectTypeIds.length > 0);
 
   return (
     <div className="space-y-6">
@@ -320,6 +383,32 @@ export function AttributeCreatePage() {
               </p>
             ) : null}
           </Section>
+
+          {/* #949 — relation config inline. The backend validator requires
+              `relationCardinality` + at least one target ObjectType on POST
+              for `type=relation`, so we surface the same controls the edit
+              page uses (MOD-13 #905) right after type pick. */}
+          {values.type === 'relation' ? (
+            <Section
+              title={t('attributes.relation_config_section', {
+                defaultValue: 'Konfiguracja relacji',
+              })}
+            >
+              <RelationConfigPanel
+                value={relationConfig}
+                objectTypes={objectTypesQuery.data ?? []}
+                disabled={submitting}
+                onChange={setRelationConfig}
+              />
+              {relationConfig.targetObjectTypeIds.length === 0 ? (
+                <p className="mt-2 text-[12px] text-amber-600">
+                  {t('attributes.relation_targets_required_hint', {
+                    defaultValue: 'Wybierz co najmniej jeden ObjectType celu relacji.',
+                  })}
+                </p>
+              ) : null}
+            </Section>
+          ) : null}
 
           <Section title={t('attributes.validation_title', { defaultValue: 'Walidacja i flagi' })}>
             <div className="space-y-3">

--- a/apps/api/tests/Api/Catalog/AttributeRelationCreateApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeRelationCreateApiTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * fix(catalog) #949 — POST /api/attributes with type=relation honours
+ * `relationCardinality` + `relationTargetObjectTypeIds` from the create
+ * flows (`/modeling/attributes/new`, `CreateAttributeInGroupDialog`,
+ * `CreateAttributeForObjectTypeDialog`). Regression cover for the bug
+ * where the FE wasn't sending these fields and the backend validator
+ * always 422'd.
+ */
+final class AttributeRelationCreateApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function createWithRelationConfigSucceeds(): void
+    {
+        $productId = $this->productObjectTypeId();
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'relation_ok',
+                'type' => 'relation',
+                'label' => ['pl' => 'Powiązany', 'en' => 'Related'],
+                'relationCardinality' => 'many',
+                'relationTargetObjectTypeIds' => [$productId],
+                'relationAdvanced' => false,
+            ],
+            'headers' => ['content-type' => 'application/ld+json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+    }
+
+    #[Test]
+    public function createRelationWithoutCardinalityReturns422(): void
+    {
+        $productId = $this->productObjectTypeId();
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'relation_missing_card',
+                'type' => 'relation',
+                'label' => ['pl' => 'Brak'],
+                'relationTargetObjectTypeIds' => [$productId],
+            ],
+            'headers' => ['content-type' => 'application/ld+json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    #[Test]
+    public function createRelationWithEmptyTargetsIsAllowedAtDataLayer(): void
+    {
+        // RelationAttributeConfigValidator allows an empty target list at
+        // the persistence layer — the UI gates it (submit guard). Test
+        // documents the contract so a future tightening doesn't surprise
+        // the FE.
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'relation_empty_targets',
+                'type' => 'relation',
+                'label' => ['pl' => 'Brak'],
+                'relationCardinality' => 'many',
+                'relationTargetObjectTypeIds' => [],
+            ],
+            'headers' => ['content-type' => 'application/ld+json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+    }
+
+    #[Test]
+    public function createNonRelationWithStaleRelationFieldsRejects422(): void
+    {
+        // AC-6 — guards the backend contract documented in
+        // `RelationAttributeConfigValidator::validateAndNormalise`: a
+        // non-relation type with non-default relation fields → 422.
+        // Frontend MUST strip these fields client-side when the operator
+        // toggles type away from `relation` (the create flows added in
+        // this PR do exactly that).
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/attributes', [
+            'json' => [
+                'code' => 'text_after_relation',
+                'type' => 'text',
+                'label' => ['pl' => 'Tekstowy'],
+                'relationCardinality' => 'many',
+                'relationTargetObjectTypeIds' => [$this->productObjectTypeId()],
+            ],
+            'headers' => ['content-type' => 'application/ld+json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    private function productObjectTypeId(): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        return $type->getId()->toRfc4122();
+    }
+}


### PR DESCRIPTION
## Summary
Naprawia bug zgłoszony w #949: tworzenie atrybutu typu \`relation\` z 3 ścieżek UI zwracało 422 bo POST body nie zawierało \`relationCardinality\` + \`relationTargetObjectTypeIds\`. MOD-13 (#905) wired \`RelationConfigPanel\` tylko do widoku edit; create flows zostały pominięte.

## Root cause
\`RelationConfigPanel\` był renderowany wyłącznie na \`/modeling/attributes/{id}/show\` (edit). Trzy ścieżki create nie miały żadnych kontrolek na konfigurację relacji ani nie wysyłały odpowiednich pól w POST body. Backend validator (\`RelationAttributeConfigValidator\`) zawsze 422'ował.

## Fix
Inline \`RelationConfigPanel\` (in-place, controlled component reused as-is) w:
- \`apps/admin/src/features/catalog/attributes/new.tsx\`
- \`apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx\`
- \`apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx\`

Każdy flow teraz:
- fetcha \`/api/object_types\` (cached, \`enabled: type === 'relation'\`),
- trzyma local \`relationConfig\` state z defaultami (\`cardinality=many\`, \`targets=[]\`, \`advanced=false\`, \`previewFields=[]\`),
- bramkuje submit gdy \`type=relation && targets.length === 0\` z hintem inline,
- wysyła \`relationTargetObjectTypeIds\` + \`relationCardinality\` + \`relationAdvanced\` + (opcjonalnie advanced fields i preview fields) w POST body **tylko** gdy \`type=relation\` — non-relation types pozostają czyste, dzięki czemu cross-type guard validatora nie 422'i.

## Backend regression coverage
Nowy \`AttributeRelationCreateApiTest\` (4 testy):
- **Happy 201**: \`type=relation\` + \`cardinality=many\` + \`targets=[product]\` → 201.
- **Original bug**: bez \`cardinality\` → 422.
- **Empty targets data layer**: backend pozwala na \`targets=[]\` (UI gates).
- **Stale fields on type=text** → 422 (frontend strips client-side).

Validator dokumentowany jako rygorystyczny — żadne zmiany w \`RelationAttributeConfigValidator\` / \`AttributeInput\` / \`CreateAttributeHandler\`.

## Test plan / quality gates

- [x] PHPStan max: **0 errors**.
- [x] Biome strict: **0 errors**.
- [x] \`tsc -b --noEmit\`: **0 errors** (CI parity).
- [x] PHPUnit: \`AttributeRelationCreateApiTest\` (**4/4**) + regression \`AttributesCrudApiTest\` + \`AttributeRelationPreviewFieldsApiTest\` (**11/11**).
- [x] composer + pnpm audit: 0 high/critical.
- [x] **Live-stack smoke** na \`https://pim.localhost\`:
  - \`POST /api/attributes\` z \`{code, type:relation, label, relationCardinality:many, relationTargetObjectTypeIds:[<product-uuid>]}\` → **HTTP 201**, atrybut zapisany z poprawnym configiem.

## Smoke test plan (operator)

1. Login admin@demo.localhost / changeme.
2. **Path 1** — `/modeling/attributes/new`: wybierz type=\`relation\`, target=Product, cardinality=many → submit → 201 + redirect.
3. **Path 2** — modal "Stwórz nowy" w grupie atrybutów: jak wyżej → 201 + atrybut w grupie.
4. **Path 3** — modal "Stwórz nowy" w ObjectType: jak wyżej → 201 + atrybut w ObjectType.
5. **Edge**: type=\`relation\` bez targetu → submit disabled + hint amber.
6. **Edge**: type=relation + wypełnione → zmiana na text → submit → 201 jako text (bez relation fields).
7. DevTools Console: 0 czerwonych errorów.

## Świadome odejścia

- Refactor wspólny do hooka \`useAttributeCreateForm()\` — pozostaje inline duplikacja (operator nie zgłaszał DRY).
- Playwright E2E spec — odłożone do osobnego ticketu (regression coverage backendowa pokrywa kontrakt; ręczne smoke wystarczy do close).

Closes #949

🤖 Generated with [Claude Code](https://claude.com/claude-code)