### PR TITLE
fix(catalog): relation picker — wire /api/objects poly-kind GetCollection

### DIFF
--- a/apps/admin/e2e/975-relation-picker-candidates.spec.ts
+++ b/apps/admin/e2e/975-relation-picker-candidates.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin, uniqueSku } from './helpers/auth';
+
+/**
+ * #975 — Relation picker modal ("Wybierz obiekt") used to render
+ * "Brak dopasowań" for every relation attribute because the FE called
+ * `GET /api/objects` which had no AP4 GetCollection operation. After
+ * the fix (CatalogObject.xml + relations-tab.tsx `?code=` → `?sku=`)
+ * the picker fetches a real list of poly-kind candidates and the
+ * operator can pick a target without leaving the modal.
+ */
+test('relation picker lists candidates and narrows on `?sku=` filter', async ({ page }) => {
+  // First POST after DB reset is slow (attributesIndexed listener warm-up).
+  test.setTimeout(180_000);
+
+  // Direct API login first — we need the JWT for `page.request` calls
+  // below; `apiLogin` only lands the refresh cookie, which is not
+  // attached to ad-hoc requests. We still call `apiLogin` afterwards
+  // so the browser context owns an in-memory token for the UI flow.
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  // Mint two products via API — one becomes the "source" we edit, the
+  // other has to appear in the candidate modal. Both share the demo
+  // tenant so the tenant filter does not hide them.
+  const sourceSku = uniqueSku('975SRC');
+  const targetSku = uniqueSku('975TGT');
+
+  const objectTypesResponse = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
+  expect(objectTypesResponse.status()).toBe(200);
+  const objectTypesBody = (await objectTypesResponse.json()) as {
+    member?: Array<{ id: string; kind: string }>;
+  };
+  const productType = (objectTypesBody.member ?? []).find((row) => row.kind === 'product');
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not seeded for demo tenant.');
+  }
+  const productTypeId = productType.id;
+
+  const sourceResponse = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: sourceSku, objectTypeId: productTypeId },
+  });
+  expect(sourceResponse.status()).toBe(201);
+  const source = (await sourceResponse.json()) as { id: string };
+
+  const targetResponse = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: targetSku, objectTypeId: productTypeId },
+  });
+  expect(targetResponse.status()).toBe(201);
+
+  // Navigate straight to the source product in edit mode — relations
+  // tab only renders when `mode === 'edit'`.
+  await page.goto(`/products/${source.id}/edit`);
+  await expect(page).toHaveURL(/\/products\/[0-9a-f-]{36}\/edit$/);
+
+  // Switch to the "Powiązania"/"Relations" tab. Seeded via
+  // BuiltInProductRelationAttributesSeeder so every product detail
+  // page has this tab. Match both Polish + English labels + optional
+  // badge count.
+  await page.getByRole('tab', { name: /(powi[ąa]zania|relations)\s*\d*/i }).click();
+
+  // Every built-in relation attribute renders its own "Dodaj
+  // powiązanie" button — pick the first one (cross_sell, position 10
+  // in the seeder). We don't bind to a specific card heading because
+  // multiple cards share the same surrounding `div` structure; the
+  // first button is the cross-sell entry point.
+  const addLinkButton = page
+    .getByRole('button', { name: /^(dodaj powi[ąa]zanie|add link|add relation)$/i })
+    .first();
+  await expect(addLinkButton).toBeVisible();
+
+  // Open the picker modal. Capture the candidate fetch so we can
+  // prove the FE talks to `/api/objects?…sku=…` (the bug was
+  // `?code=`, silently ignored by AP4).
+  const candidatesResponsePromise = page.waitForResponse(
+    (response) => response.url().includes('/api/objects?') && response.request().method() === 'GET',
+    { timeout: 15_000 },
+  );
+  await addLinkButton.click();
+
+  // Modal title + the unfiltered candidate list arrives.
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByText(/wybierz obiekt|pick object|select object/i)).toBeVisible();
+
+  const initialResponse = await candidatesResponsePromise;
+  expect(initialResponse.status()).toBe(200);
+
+  // Candidate list contains at least the second product we seeded.
+  // The picker excludes the source product (`excludedObjectIds`)
+  // automatically.
+  await expect(page.getByRole('button', { name: targetSku })).toBeVisible({ timeout: 15_000 });
+
+  // Type a substring → the FE rebuilds the query with `?sku=<query>`;
+  // assert the request URL really uses `sku` (not `code`) and that
+  // the list still contains a row matching the substring.
+  const filteredResponsePromise = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/objects?') &&
+      response.url().includes('sku=') &&
+      response.request().method() === 'GET',
+    { timeout: 15_000 },
+  );
+  await page.getByPlaceholder(/szukaj po kodzie|search by code/i).fill(targetSku);
+  const filteredResponse = await filteredResponsePromise;
+  expect(filteredResponse.status()).toBe(200);
+  expect(filteredResponse.url()).toContain(`sku=${encodeURIComponent(targetSku)}`);
+
+  await expect(page.getByRole('button', { name: targetSku })).toBeVisible();
+});

--- a/apps/admin/src/features/catalog/products/components/relations-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/relations-tab.tsx
@@ -586,11 +586,14 @@ function ObjectPickerDialog({
     queryKey: ['objects', 'picker', debounced, allowedObjectTypeIds.join(',')],
     queryFn: () => {
       const params = new URLSearchParams();
-      if (debounced.length > 0) params.set('code', debounced);
+      // #975 — `SkuFilter` reacts to `?sku=`, matching `code` via case-insensitive
+      // substring LIKE. Earlier `?code=` was silently ignored by AP4. Accept
+      // defaults to `application/ld+json` so the response carries the
+      // `member` envelope we read below; explicit `application/json` would
+      // hand back a raw array AP4 normalises differently.
+      if (debounced.length > 0) params.set('sku', debounced);
       params.set('itemsPerPage', '50');
-      return jsonFetch<ObjectsListResponse>(`/api/objects?${params.toString()}`, {
-        accept: 'application/json',
-      });
+      return jsonFetch<ObjectsListResponse>(`/api/objects?${params.toString()}`);
     },
   });
 

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -281,6 +281,31 @@
                     </values>
                 </extraProperties>
             </operation>
+
+            <!-- ──────────── /api/objects (poly-kind, READ-ONLY) ────────────
+                 Generic read-only endpoint exposing the union of all kinds
+                 (product + category + asset) for cross-kind pickers — the
+                 relation-attribute candidate modal in `relations-tab.tsx`
+                 (#975) needs a single list endpoint because the target
+                 `allowedObjectTypeIds` can span multiple kinds.
+
+                 No `extraProperties.kind` is set, so KindCollectionExtension
+                 no-ops (see KindCollectionExtension::applyToCollection) and
+                 the query returns rows across all kinds, narrowed by the
+                 tenant filter and the CatalogObject voter.
+
+                 Read-only by design — writes still go through the per-kind
+                 sugar paths (`POST /api/{products,categories}`) where
+                 CatalogObjectProcessor enforces the discriminator. -->
+            <operation class="ApiPlatform\Metadata\GetCollection"
+                       uriTemplate="/objects{._format}"
+                       name="objects_get_collection"
+                       paginationType="cursor"
+                       security="is_granted('READ', 'App\\Catalog\\Domain\\Entity\\CatalogObject')">
+                <paginationViaCursor>
+                    <paginationField field="id" direction="DESC"/>
+                </paginationViaCursor>
+            </operation>
         </operations>
     </resource>
 </resources>

--- a/apps/api/tests/Api/Catalog/CatalogObjectsPickerEndpointTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectsPickerEndpointTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Application\SeedTenantPrdRolesService;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Poly-kind GetCollection at `/api/objects` (#975).
+ *
+ * Confirms the relation-attribute candidate picker can fetch a unified
+ * list across kinds, that `?sku=` substring filtering works, that
+ * cursor pagination is honored, and that the tenant filter blocks
+ * cross-tenant reads.
+ */
+final class CatalogObjectsPickerEndpointTest extends CatalogApiTestCase
+{
+    private const string TENANT_B_CODE = 'other';
+    private const string ADMIN_B_EMAIL = 'admin@other.localhost';
+
+    #[Test]
+    public function unauthenticatedRequestReturns401(): void
+    {
+        static::createClient()->request('GET', '/api/objects');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function getCollectionReturnsUnionOfKinds(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'SKU-POLY-PRODUCT',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $client->request('POST', '/api/categories', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'CAT-POLY',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        $response = $client->request('GET', '/api/objects', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        $members = $body['member'] ?? $body['hydra:member'] ?? [];
+        \assert(\is_array($members));
+
+        $kinds = [];
+        foreach ($members as $row) {
+            \assert(\is_array($row));
+            $kind = $row['kind'] ?? null;
+            if (\is_string($kind)) {
+                $kinds[$kind] = true;
+            }
+        }
+        self::assertArrayHasKey('product', $kinds);
+        self::assertArrayHasKey('category', $kinds);
+    }
+
+    #[Test]
+    public function skuQueryParamFiltersByCodeSubstring(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'SKU-NEEDLE-200',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'SKU-HAYSTACK-201',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        $response = $client->request('GET', '/api/objects?sku=needle', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        $members = $body['member'] ?? $body['hydra:member'] ?? [];
+        \assert(\is_array($members));
+
+        $codes = $this->extractCodes($members);
+
+        self::assertContains('SKU-NEEDLE-200', $codes);
+        self::assertNotContains('SKU-HAYSTACK-201', $codes);
+    }
+
+    #[Test]
+    public function itemsPerPageQueryParamCapsResults(): void
+    {
+        $client = $this->authenticatedClient();
+
+        for ($i = 0; $i < 5; ++$i) {
+            $client->request('POST', '/api/products', [
+                'headers' => ['content-type' => 'application/ld+json'],
+                'body' => json_encode([
+                    'code' => 'SKU-PAGE-'.$i,
+                    'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+                ], JSON_THROW_ON_ERROR),
+            ]);
+        }
+
+        $response = $client->request('GET', '/api/objects?itemsPerPage=2', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        $members = $body['member'] ?? $body['hydra:member'] ?? [];
+        \assert(\is_array($members));
+
+        self::assertCount(2, $members);
+    }
+
+    #[Test]
+    public function cursorPaginationViaIdLtAdvancesPage(): void
+    {
+        $client = $this->authenticatedClient();
+
+        for ($i = 0; $i < 3; ++$i) {
+            $client->request('POST', '/api/products', [
+                'headers' => ['content-type' => 'application/ld+json'],
+                'body' => json_encode([
+                    'code' => 'SKU-CURSOR-'.$i,
+                    'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+                ], JSON_THROW_ON_ERROR),
+            ]);
+        }
+
+        $firstPage = $client->request('GET', '/api/objects?itemsPerPage=1', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ])->toArray();
+        $members = $firstPage['member'] ?? $firstPage['hydra:member'] ?? [];
+        \assert(\is_array($members));
+        self::assertCount(1, $members);
+        $firstRow = $members[0];
+        \assert(\is_array($firstRow));
+        $firstId = $firstRow['id'] ?? null;
+        \assert(\is_string($firstId));
+
+        $secondPage = $client->request('GET', '/api/objects?itemsPerPage=1&id[lt]='.$firstId, [
+            'headers' => ['accept' => 'application/ld+json'],
+        ])->toArray();
+        $secondMembers = $secondPage['member'] ?? $secondPage['hydra:member'] ?? [];
+        \assert(\is_array($secondMembers));
+        self::assertCount(1, $secondMembers);
+        $secondRow = $secondMembers[0];
+        \assert(\is_array($secondRow));
+        $secondId = $secondRow['id'] ?? null;
+        \assert(\is_string($secondId));
+        self::assertNotSame($firstId, $secondId);
+    }
+
+    #[Test]
+    public function tenantFilterBlocksCrossTenantReads(): void
+    {
+        // Seed tenant A object via the standard admin client.
+        $clientA = $this->authenticatedClient();
+        $clientA->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'SKU-TENANT-A',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        // Bootstrap tenant B + admin and seed a product visible only to B.
+        $tenantB = $this->bootstrapTenantB();
+        $clientB = $this->authenticatedClient(self::ADMIN_B_EMAIL);
+        $clientB->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'SKU-TENANT-B',
+                'objectTypeId' => $this->objectTypeIdForTenant(ObjectKind::Product, $tenantB),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        $bodyA = $clientA->request('GET', '/api/objects?itemsPerPage=200', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ])->toArray();
+        $membersA = $bodyA['member'] ?? $bodyA['hydra:member'] ?? [];
+        \assert(\is_array($membersA));
+        $codesA = $this->extractCodes($membersA);
+
+        self::assertContains('SKU-TENANT-A', $codesA);
+        self::assertNotContains('SKU-TENANT-B', $codesA);
+
+        $bodyB = $clientB->request('GET', '/api/objects?itemsPerPage=200', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ])->toArray();
+        $membersB = $bodyB['member'] ?? $bodyB['hydra:member'] ?? [];
+        \assert(\is_array($membersB));
+        $codesB = $this->extractCodes($membersB);
+
+        self::assertContains('SKU-TENANT-B', $codesB);
+        self::assertNotContains('SKU-TENANT-A', $codesB);
+    }
+
+    private function bootstrapTenantB(): Tenant
+    {
+        $em = $this->em();
+
+        $tenantB = new Tenant(self::TENANT_B_CODE, 'Other Tenant');
+        $em->persist($tenantB);
+        $em->flush();
+
+        self::getContainer()->get(SeedTenantPrdRolesService::class)->seed($tenantB);
+        $tenantOwnerB = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('tenant_owner', $tenantB);
+        \assert(null !== $tenantOwnerB);
+
+        $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        \assert(null !== $superAdmin);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenantB, self::ADMIN_B_EMAIL, '', ['ROLE_USER']);
+        $adminB = new User($tenantB, self::ADMIN_B_EMAIL, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $adminB->addRole($superAdmin);
+        $adminB->addRole($tenantOwnerB);
+        $em->persist($adminB);
+        $em->flush();
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($tenantB);
+
+        return $tenantB;
+    }
+
+    /**
+     * Pull the `code` field out of an AP4 collection payload while keeping
+     * PHPStan max happy — array_map cannot narrow `mixed` element types so
+     * we iterate manually.
+     *
+     * @param array<array-key, mixed> $members
+     *
+     * @return list<string|null>
+     */
+    private function extractCodes(array $members): array
+    {
+        $codes = [];
+        foreach ($members as $row) {
+            if (!\is_array($row)) {
+                $codes[] = null;
+                continue;
+            }
+            $code = $row['code'] ?? null;
+            $codes[] = \is_string($code) ? $code : null;
+        }
+
+        return $codes;
+    }
+
+    private function objectTypeIdForTenant(ObjectKind $kind, Tenant $tenant): string
+    {
+        $type = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind($kind, $tenant);
+        \assert(null !== $type);
+
+        return $type->getId()->toRfc4122();
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -2729,6 +2729,227 @@
                 "x-cortex-permission": "products.edit"
             }
         },
+        "/api/objects": {
+            "get": {
+                "operationId": "objects_get_collection",
+                "tags": [
+                    "CatalogObject"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CatalogObject collection",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "CatalogObject.jsonld-admin.read collection.",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/HydraCollectionBaseSchema"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "member"
+                                            ],
+                                            "properties": {
+                                                "member": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/CatalogObject.jsonld-admin.read"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CatalogObject-admin.read"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves the collection of CatalogObject resources.",
+                "description": "Retrieves the collection of CatalogObject resources.",
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "The collection page number",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "itemsPerPage",
+                        "in": "query",
+                        "description": "The number of items per page",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 30,
+                            "minimum": 0,
+                            "maximum": 200
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "sku",
+                        "in": "query",
+                        "description": "Case-insensitive substring search on the catalog object code (SKU).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "attribute[:code]",
+                        "in": "query",
+                        "description": "JSONB containment match on the denormalised attributes_indexed cache. Multiple pairs AND together.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    },
+                    {
+                        "name": "category",
+                        "in": "query",
+                        "description": "Category code; matches the row plus every descendant via Postgres ltree containment.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "completeness[eq|gt|gte|lt|lte]",
+                        "in": "query",
+                        "description": "Filter by per-row completeness percentage (`completeness.pct` JSONB key).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Editorial state: draft, published, archived.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "enabled",
+                        "in": "query",
+                        "description": "Publishing kill-switch flag.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "parent_id",
+                        "in": "query",
+                        "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category). Pass the literal string `null` to return masters only (rows whose parent IS NULL).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "order[id]",
+                        "in": "query",
+                        "description": "",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "desc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ]
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "id[lt|gt|lte|gte]",
+                        "in": "query",
+                        "description": "Uuid range filter on the cursor pagination key.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": true
+                    }
+                ],
+                "x-cortex-permission": "products.view"
+            }
+        },
         "/api/products": {
             "get": {
                 "operationId": "products_get_collection",


### PR DESCRIPTION
## Summary

Relation picker modal w produktach (zakładka „Powiązania") wreszcie wyświetla kandydatów: poly-kind endpoint `/api/objects` jest podpięty w AP4, a frontend dotyka istniejącego `SkuFilter` (`?sku=`) zamiast nieobsługiwanego `?code=`. Modal działa end-to-end.

## Root cause

Frontend `ObjectPickerDialog` w [apps/admin/src/features/catalog/products/components/relations-tab.tsx:591](apps/admin/src/features/catalog/products/components/relations-tab.tsx#L591) wołał `GET /api/objects?code=…&itemsPerPage=50`. Endpoint **nie istniał** — [CatalogObject.xml](apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml) deklarował tylko sugar paths `/api/products`, `/api/categories`, `/api/assets`. AP4 zwracał 404 → query data undefined → empty list → „Brak dopasowań" niezależnie od search input. Wtórnie: FE używał `?code=` ale [`SkuFilter`](apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/SkuFilter.php) reaguje wyłącznie na `?sku=`.

## Backend changes

- `apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml` — dodana read-only operacja `GetCollection /api/objects` (bez `extraProperties.kind`, więc [KindCollectionExtension](apps/api/src/Catalog/Infrastructure/ApiPlatform/State/KindCollectionExtension.php) no-op'uje i zwraca union of kinds; tenant filter + voter dziedziczone z resource-level). Write path pozostaje na sugar paths gdzie `CatalogObjectProcessor` egzekwuje kind discriminator.
- `apps/api/tests/Api/Catalog/CatalogObjectsPickerEndpointTest.php` (nowy) — 6 scenariuszy: 401 bez tokena, 200 poly-kind happy path, 200 z `?sku=` substring filter, 200 z `itemsPerPage` cap, 200 z cursor paginacją, izolacja cross-tenant (dwa tenanty, niezależny seed Built-In ObjectTypes).
- `docs/api-spec/v0.json` — regen OpenAPI snapshot zawiera teraz `/api/objects` GetCollection.

## Frontend changes

- `apps/admin/src/features/catalog/products/components/relations-tab.tsx` — `?code=` → `?sku=`; dropped explicit `accept: application/json` na rzecz domyślnego `application/ld+json` (FE czyta `member` envelope, którego raw-array shape nie miał).
- `apps/admin/e2e/975-relation-picker-candidates.spec.ts` (nowy) — pełen flow: login → utworzenie 2 produktów przez API → wejście w detail edit → tab Powiązania → klik „Dodaj powiązanie" → assert modal otwarty + kandydat widoczny + filtrowanie po `?sku=` zwraca pasujący wynik.

## Quality gates

- **PHPStan max**: 0 errors.
- **Biome strict**: 0 errors.
- **PHPUnit (Api/Catalog Products + Categories + new picker)**: 21/21 ✅.
- **TypeScript (admin)**: typecheck ✅.
- **Vite build (admin)**: ✅.
- **Playwright E2E**: `975-relation-picker-candidates.spec.ts` ✅ (4.4s).
- **composer audit**: pre-existing advisories (twig/symfony) — bez nowych wprowadzonych tym PR-em.
- **pnpm audit --audit-level=high**: 0 high/critical.
- **OpenAPI snapshot**: regen i commit (`docs/api-spec/v0.json` zawiera `/api/objects`).

## Smoke test plan

End-to-end action smoke jest objęty Playwrightem i nową ApiTestCase. Po merge planuję dodatkowy manual smoke na żywym stacku (`https://pim.localhost`) — proof do `gh issue close` per **CLOSED MEANS CLOSED RULE**:

- [ ] Login `admin@demo.localhost / changeme`.
- [ ] Otwórz seedowany produkt → tab Powiązania.
- [ ] Klik „+ Dodaj powiązanie" przy `cross_sell` → modal pokazuje listę kandydatów od razu.
- [ ] Wpisz fragment kodu (np. „DEMO-01") → lista zawęża się.
- [ ] DevTools Network: zapytanie do `/api/objects?sku=…&itemsPerPage=50` → 200.
- [ ] DevTools Console: brak czerwonych errorów.
- [ ] Powtórz dla `up_sell` i `related`.

## Świadome odejścia

- **Server-side filter `?objectType=<id1>,<id2>`** — performance follow-up; obecnie 50-item client-side filter wystarczający dla MVP scale (50k SKU).
- **Cursor pagination UI „Load more" w modalu** — first-50 pokrywa typowy use case; UX-follow-up jeśli operator zgłosi.
- **Per-kind permission scoping w pickerze** — `CatalogObjectVoter` jest kind-agnostic, voter-level filtering jest wystarczające.
- **Inline-create flow w pickerze** — działa per MODR-09 (#931), bug nie dotyczył create path.

Closes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)
