### PR TITLE
fix(catalog): poly-kind GET /api/objects/{id} — relation inline edit preview

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -306,6 +306,18 @@
                     <paginationField field="id" direction="DESC"/>
                 </paginationViaCursor>
             </operation>
+
+            <!-- Poly-kind detail counterpart to GetCollection above (#977).
+                 RelationInlineEditPanel fetches a target object's detail by
+                 UUID without knowing its kind upfront (the chosen target may
+                 be a product, category, or asset — the relation attribute's
+                 `allowedObjectTypeIds` spans kinds). No `extraProperties.kind`
+                 → KindItemExtension no-ops; TenantFilter + the `READ object`
+                 voter still scope the read to the current tenant + grant. -->
+            <operation class="ApiPlatform\Metadata\Get"
+                       uriTemplate="/objects/{id}{._format}"
+                       name="objects_get"
+                       security="is_granted('READ', object)"/>
         </operations>
     </resource>
 </resources>

--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Application\SeedTenantPrdRolesService;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Poly-kind Get at `/api/objects/{id}` (#977).
+ *
+ * RelationInlineEditPanel calls this endpoint to fetch a target object's
+ * detail by UUID without knowing its kind upfront — the per-kind sugar
+ * paths (`/api/products/{id}` etc.) can't be used because the relation
+ * attribute's `allowedObjectTypeIds` can span multiple kinds.
+ *
+ * The endpoint defines no `extraProperties.kind`, so KindItemExtension
+ * no-ops; the read is still narrowed by the TenantFilter + `READ object`
+ * voter.
+ */
+final class CatalogObjectPolyKindGetTest extends CatalogApiTestCase
+{
+    private const string TENANT_B_CODE = 'other';
+    private const string ADMIN_B_EMAIL = 'admin@other.localhost';
+
+    #[Test]
+    public function unauthenticatedRequestReturns401(): void
+    {
+        static::createClient()->request('GET', '/api/objects/'.Uuid::v7()->toRfc4122());
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function getReturnsProductDetail(): void
+    {
+        $client = $this->authenticatedClient();
+        $id = $this->createObject($client, '/api/products', 'SKU-POLY-GET-PRODUCT', ObjectKind::Product);
+
+        $response = $client->request('GET', '/api/objects/'.$id, [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertSame($id, $body['id'] ?? null);
+        self::assertSame('SKU-POLY-GET-PRODUCT', $body['code'] ?? null);
+        self::assertSame('product', $body['kind'] ?? null);
+    }
+
+    #[Test]
+    public function getReturnsCategoryDetail(): void
+    {
+        $client = $this->authenticatedClient();
+        $id = $this->createObject($client, '/api/categories', 'CAT-POLY-GET', ObjectKind::Category);
+
+        $response = $client->request('GET', '/api/objects/'.$id, [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+        $body = $response->toArray();
+        self::assertSame($id, $body['id'] ?? null);
+        self::assertSame('CAT-POLY-GET', $body['code'] ?? null);
+        self::assertSame('category', $body['kind'] ?? null);
+    }
+
+    #[Test]
+    public function getReturns404ForUnknownUuid(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('GET', '/api/objects/'.Uuid::v7()->toRfc4122(), [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function tenantFilterBlocksCrossTenantRead(): void
+    {
+        // Seed tenant B + admin and create a product owned by tenant B.
+        $tenantB = $this->bootstrapTenantB();
+        $clientB = $this->authenticatedClient(self::ADMIN_B_EMAIL);
+        $idB = $this->createObjectForTenant($clientB, '/api/products', 'SKU-TENANT-B-GET', ObjectKind::Product, $tenantB);
+
+        // Tenant A admin must not see tenant B object via the poly-kind path.
+        $clientA = $this->authenticatedClient();
+        $clientA->request('GET', '/api/objects/'.$idB, [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    private function createObject(
+        \ApiPlatform\Symfony\Bundle\Test\Client $client,
+        string $sugarPath,
+        string $code,
+        ObjectKind $kind,
+    ): string {
+        $response = $client->request('POST', $sugarPath, [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => $code,
+                'objectTypeId' => $this->objectTypeIdFor($kind),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $body = $response->toArray();
+        $id = $body['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    private function createObjectForTenant(
+        \ApiPlatform\Symfony\Bundle\Test\Client $client,
+        string $sugarPath,
+        string $code,
+        ObjectKind $kind,
+        Tenant $tenant,
+    ): string {
+        $response = $client->request('POST', $sugarPath, [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => $code,
+                'objectTypeId' => $this->objectTypeIdForTenant($kind, $tenant),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $body = $response->toArray();
+        $id = $body['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    private function objectTypeIdForTenant(ObjectKind $kind, Tenant $tenant): string
+    {
+        $type = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind($kind, $tenant);
+        \assert(null !== $type);
+
+        return $type->getId()->toRfc4122();
+    }
+
+    private function bootstrapTenantB(): Tenant
+    {
+        $em = $this->em();
+
+        $tenantB = new Tenant(self::TENANT_B_CODE, 'Other Tenant');
+        $em->persist($tenantB);
+        $em->flush();
+
+        self::getContainer()->get(SeedTenantPrdRolesService::class)->seed($tenantB);
+        $tenantOwnerB = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('tenant_owner', $tenantB);
+        \assert(null !== $tenantOwnerB);
+
+        $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        \assert(null !== $superAdmin);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenantB, self::ADMIN_B_EMAIL, '', ['ROLE_USER']);
+        $adminB = new User($tenantB, self::ADMIN_B_EMAIL, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $adminB->addRole($superAdmin);
+        $adminB->addRole($tenantOwnerB);
+        $em->persist($adminB);
+        $em->flush();
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($tenantB);
+
+        return $tenantB;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -2950,6 +2950,90 @@
                 "x-cortex-permission": "products.view"
             }
         },
+        "/api/objects/{id}": {
+            "get": {
+                "operationId": "objects_get",
+                "tags": [
+                    "CatalogObject"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CatalogObject resource",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CatalogObject.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CatalogObject-admin.read"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Retrieves a CatalogObject resource.",
+                "description": "Retrieves a CatalogObject resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "CatalogObject identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "x-cortex-permission": "products.view"
+            }
+        },
         "/api/products": {
             "get": {
                 "operationId": "products_get_collection",


### PR DESCRIPTION
## Summary

Naprawia pusty preview inline-edit panelu w tab „Powiązania" karty produktu — dotychczas po expand karty target obiektu wyświetlał się komunikat „Nie udało się załadować obiektu docelowego." zamiast formularza edycji. Brakował poly-kind endpoint `GET /api/objects/{id}` — był tylko poly-kind `GetCollection` (#976), nie było analogicznego Get.

## Root cause

`RelationInlineEditPanel` woła trzy równoległe queries (`/api/objects/summaries`, `/api/objects/{id}`, `/api/objects/{id}/form-schema`). Drugi z nich zwracał 404 dla każdego kind, bo w `CatalogObject.xml` operacje Get były tylko per-kind sugar-paths (`/products/{id}` itp.), a poly-kind `Get /objects/{id}` nigdy nie został dodany.

## Backend changes

- `apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml` — dodana operacja `Get /objects/{id}` bez `extraProperties.kind`. `KindItemExtension` no-opuje analogicznie do `KindCollectionExtension`, więc TenantFilter + voter `READ object` zostają jedynymi mechanizmami filtrowania.
- `apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php` — nowy ApiTestCase (5 testów): 401 unauth, 200 product detail, 200 category detail, 404 dla nieistniejącego UUID, 404 cross-tenant.
- `docs/api-spec/v0.json` — regen snapshot z nową operacją `objects_get`.

## Frontend changes

Brak — `RelationInlineEditPanel` już wołał poprawny endpoint zgodnie z konwencją `/api/objects/*`. Bug był wyłącznie po stronie BE.

## Quality gates

- PHPStan max: 0 errors.
- PHPUnit `CatalogObjectPolyKindGetTest`: 5/5 zielone (11 assertions, ~9.3s).
- composer audit: 1 medium (twig `CVE-2026-46634`, znane), 0 high/critical.
- OpenAPI snapshot zregenerowany i scommitowany.
- Lokalny smoke test (curl + UI): wymaga restart api kontenera (FrankenPHP worker cache stale) + powtórzenia przez operatora — patrz Smoke test plan.

## Smoke test plan

Per CLAUDE.md SMOKE TEST RULE — przed claim „działa":

1. `docker compose restart api && sleep 4` (FrankenPHP worker musi przeładować metadata po zmianie XML resource).
2. Login admin@demo.localhost / changeme na https://pim.localhost.
3. **Produkty** → otworzyć dowolny produkt z powiązaniami (np. `975TGT-MPKU0RS5-744` ze zgłoszenia operatora).
4. Tab **Powiązania** → klik chevron expand na karcie wybranego target obiektu.
5. DevTools Network: `GET /api/objects/{id}` → status **200**, response JSON z `id` + `code` + `kind` + `attributesIndexed`.
6. UI: karta rozwija się i pokazuje panel edycji (warning „Edytujesz współdzielony obiekt" + grupy atrybutów + przyciski Zapisz/Anuluj). Brak komunikatu „Nie udało się załadować obiektu docelowego.".
7. DevTools Console: brak czerwonych errorów.

## Świadome odejścia

- Nie zmienialiśmy `RelationInlineEditPanel` po stronie FE — alternatywne podejście „użyj sugar-path `/api/{kind}/{id}` z dependent query po summary" jest wolniejsze i mniej spójne z architekturą `/api/objects` (poly-kind) wprowadzoną w #976.
- Endpoint `GET /api/objects/{id}` celowo NIE waliduje kind targetu — to projekt: poly-kind detail pozwala FE pobrać dowolny obiekt po UUID bez wiedzy o kindzie, zgodnie z konwencją wprowadzoną dla picker'a (`/api/objects` GetCollection).

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)
