### PR TITLE
fix(modeling): widok Atrybut — sekcja 'Typy obiektów' z toggle chipami

### DIFF
--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -32,6 +32,7 @@ import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/ui/toast';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -521,6 +522,8 @@ function Editor({
         </Card>
 
         <AttachedGroupsCard attribute={attribute} locale={locale} />
+
+        <AttachedObjectTypesCard attribute={attribute} locale={locale} />
 
         {attribute.type === 'relation' ? (
           <RelationConfigPanel
@@ -1023,6 +1026,169 @@ function AttachedGroupsCard({ attribute, locale }: { attribute: AttributeDetail;
           void attachByCodes([group.code]);
         }}
       />
+    </Card>
+  );
+}
+
+interface ObjectTypeRow {
+  id: string;
+  code: string;
+  kind: string;
+  label?: Record<string, string> | string | null;
+}
+
+/**
+ * #979 — toggle-chip card for `object_type_attributes` ownership. Operator
+ * picks which ObjectTypes carry this attribute directly from the Attribute
+ * detail view; previously the only path was navigating into each
+ * ObjectType edit screen. Without a row in the junction the attribute is
+ * invisible on product/category/asset detail tabs even when assigned to a
+ * group that's already attached to the ObjectType — group membership and
+ * ObjectType ownership are two separate junctions by design (ADR-009).
+ */
+function AttachedObjectTypesCard({
+  attribute,
+  locale,
+}: {
+  attribute: AttributeDetail;
+  locale: string;
+}) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  const allObjectTypesQuery = useQuery<ObjectTypeRow[]>({
+    queryKey: ['object_types', 'all'],
+    queryFn: async () => {
+      const data = await jsonFetch<ObjectTypeRow[] | { member?: ObjectTypeRow[] }>(
+        '/api/object_types?itemsPerPage=200',
+        { accept: 'application/json' },
+      );
+      if (Array.isArray(data)) return data;
+      return data.member ?? [];
+    },
+    staleTime: 60_000,
+  });
+
+  const ownerIdsQuery = useQuery<{ objectTypeIds: string[] }>({
+    queryKey: ['attribute', attribute.id, 'owner_object_types'],
+    queryFn: () =>
+      jsonFetch<{ attributeId: string; objectTypeIds: string[] }>(
+        `/api/attributes/${attribute.id}/owner_object_types`,
+        { accept: 'application/json' },
+      ),
+    staleTime: 30_000,
+  });
+
+  const isSystem = attribute.system === true;
+  const ownerIds = new Set(ownerIdsQuery.data?.objectTypeIds ?? []);
+  const allObjectTypes = allObjectTypesQuery.data ?? [];
+
+  const reload = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: ['attribute', attribute.id, 'owner_object_types'],
+      }),
+      queryClient.invalidateQueries({ queryKey: ['attribute', attribute.id] }),
+      queryClient.invalidateQueries({ queryKey: ['attributes'] }),
+    ]);
+  };
+
+  const toggle = async (otId: string, attached: boolean) => {
+    setError(null);
+    setPendingId(otId);
+    try {
+      await jsonFetch(`/api/object_types/${otId}/attributes/${attribute.id}`, {
+        method: attached ? 'DELETE' : 'POST',
+        accept: 'application/json',
+      });
+      await reload();
+      toast.success(
+        attached
+          ? t('modeling.attributes.object_type_detach_success', {
+              defaultValue: 'Odpięto atrybut od typu obiektu.',
+            })
+          : t('modeling.attributes.object_type_attach_success', {
+              defaultValue: 'Dodano atrybut do typu obiektu.',
+            }),
+      );
+    } catch (err) {
+      if (err instanceof HttpError) {
+        const detail =
+          err.body && typeof err.body === 'object' && 'detail' in err.body
+            ? String((err.body as Record<string, unknown>).detail)
+            : null;
+        setError(detail ?? `HTTP ${err.status}`);
+      } else {
+        setError(
+          t('modeling.attributes.object_type_toggle_error', {
+            defaultValue: 'Nie udało się zmienić przypisania.',
+          }),
+        );
+      }
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  const labelFor = (ot: ObjectTypeRow): string => {
+    if (ot.label === null || ot.label === undefined) return ot.code;
+    if (typeof ot.label === 'string') return ot.label;
+    return ot.label[locale] ?? ot.label.pl ?? ot.label.en ?? ot.code;
+  };
+
+  return (
+    <Card className="p-6">
+      <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {t('modeling.attributes.attached_object_types_title', {
+          defaultValue: 'Typy obiektów',
+        })}
+      </div>
+      <p className="mb-3 text-[11.5px] text-muted-foreground">
+        {t('modeling.attributes.attached_object_types_help', {
+          defaultValue:
+            'Wybierz typy obiektów, na których atrybut ma być dostępny. Aby pojawił się np. na karcie produktu, musi być dołączony do odpowiedniego typu.',
+        })}
+      </p>
+
+      {allObjectTypes.length === 0 ? (
+        <p className="text-[11.5px] text-muted-foreground">
+          {t('modeling.attributes.attached_object_types_empty', {
+            defaultValue: 'Brak dostępnych typów obiektów w tenancie.',
+          })}
+        </p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {allObjectTypes.map((ot) => {
+            const attached = ownerIds.has(ot.id);
+            const isPending = pendingId === ot.id;
+            return (
+              <button
+                key={ot.id}
+                type="button"
+                aria-pressed={attached}
+                disabled={isSystem || isPending}
+                onClick={() => {
+                  void toggle(ot.id, attached);
+                }}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[12.5px] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-400 focus-visible:ring-offset-1',
+                  attached
+                    ? 'border-violet-300 bg-violet-50 text-violet-800 hover:bg-violet-100'
+                    : 'border-zinc-200 bg-zinc-50 text-zinc-700 hover:bg-zinc-100',
+                  (isSystem || isPending) && 'cursor-not-allowed opacity-60',
+                )}
+              >
+                <span className="font-medium">{labelFor(ot)}</span>
+                <span className="font-mono text-[10.5px] text-muted-foreground">({ot.code})</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {error !== null ? <p className="mt-3 text-[12px] text-destructive">{error}</p> : null}
     </Card>
   );
 }

--- a/apps/api/src/Catalog/Domain/Repository/ObjectTypeAttributeRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/ObjectTypeAttributeRepositoryInterface.php
@@ -15,6 +15,11 @@ interface ObjectTypeAttributeRepositoryInterface
      */
     public function findByObjectType(ObjectType $objectType): array;
 
+    /**
+     * @return list<ObjectTypeAttribute>
+     */
+    public function findByAttribute(Attribute $attribute): array;
+
     public function findOne(ObjectType $objectType, Attribute $attribute): ?ObjectTypeAttribute;
 
     public function save(ObjectTypeAttribute $junction): void;

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectTypeAttributeRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectTypeAttributeRepository.php
@@ -37,6 +37,21 @@ class DoctrineObjectTypeAttributeRepository extends ServiceEntityRepository impl
         return $rows;
     }
 
+    /**
+     * @return list<ObjectTypeAttribute>
+     */
+    public function findByAttribute(Attribute $attribute): array
+    {
+        /** @var list<ObjectTypeAttribute> $rows */
+        $rows = $this->createQueryBuilder('ota')
+            ->andWhere('ota.attribute = :attribute')
+            ->setParameter('attribute', $attribute)
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
     public function findOne(ObjectType $objectType, Attribute $attribute): ?ObjectTypeAttribute
     {
         return $this->findOneBy(['objectType' => $objectType, 'attribute' => $attribute]);

--- a/apps/api/src/Catalog/Presentation/Controller/AttributeOwnerObjectTypesController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttributeOwnerObjectTypesController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * #979 — list ObjectTypes that own a given attribute via the
+ * `object_type_attributes` junction. Powers the "Typy obiektów" toggle-chip
+ * card in the Modeling → Attribute detail view: the operator can see and
+ * change ObjectType ownership directly from the attribute page instead of
+ * navigating into each ObjectType edit screen.
+ *
+ * Mutations stay on the existing endpoints
+ * ({@see AttachObjectTypeAttributeController} `POST`/`DELETE`
+ * `/api/object_types/{id}/attributes/{attributeId}`) — this controller is
+ * read-only and intentionally narrow.
+ */
+final class AttributeOwnerObjectTypesController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly AttributeRepositoryInterface $attributes,
+        private readonly ObjectTypeAttributeRepositoryInterface $junctions,
+    ) {
+    }
+
+    #[Route(
+        '/api/attributes/{id}/owner_object_types',
+        name: 'pim_attributes_owner_object_types',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'attribute', action: 'read')]
+    public function __invoke(string $id): JsonResponse
+    {
+        $attribute = $this->attributes->findById(Uuid::fromString($id));
+        if (null === $attribute) {
+            throw new NotFoundHttpException(\sprintf('Attribute "%s" was not found.', $id));
+        }
+
+        $ids = [];
+        foreach ($this->junctions->findByAttribute($attribute) as $junction) {
+            $ids[] = $junction->getObjectType()->getId()->toRfc4122();
+        }
+
+        return new JsonResponse([
+            'attributeId' => $attribute->getId()->toRfc4122(),
+            'objectTypeIds' => $ids,
+        ]);
+    }
+}

--- a/apps/api/tests/Api/Catalog/AttributeOwnerObjectTypesApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeOwnerObjectTypesApiTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #979 — `GET /api/attributes/{id}/owner_object_types` exposes the list of
+ * ObjectType UUIDs that own a given attribute through the
+ * `object_type_attributes` junction.
+ *
+ * Mutations stay on the existing
+ * `/api/object_types/{id}/attributes/{attributeId}` POST/DELETE endpoints
+ * (covered separately); this suite asserts the read-side wiring and the
+ * tenant isolation guard, plus the happy round-trip through attach/detach.
+ */
+final class AttributeOwnerObjectTypesApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function unauthenticatedRequestReturns401(): void
+    {
+        static::createClient()->request(
+            'GET',
+            '/api/attributes/01234567-1234-7000-8000-000000000000/owner_object_types',
+        );
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function getReturnsEmptyListWhenAttributeHasNoOwners(): void
+    {
+        $client = $this->authenticatedClient();
+        $attr = $this->seedAttribute('mod_attr_no_owners');
+
+        $body = $client->request(
+            'GET',
+            '/api/attributes/'.$attr->getId()->toRfc4122().'/owner_object_types',
+        )->toArray();
+
+        self::assertSame($attr->getId()->toRfc4122(), $body['attributeId']);
+        self::assertSame([], $body['objectTypeIds']);
+    }
+
+    #[Test]
+    public function getReflectsAttachAndDetachRoundTrip(): void
+    {
+        $client = $this->authenticatedClient();
+        $attr = $this->seedAttribute('mod_attr_round_trip');
+        $productOtId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        // Initially empty.
+        $body = $client->request(
+            'GET',
+            '/api/attributes/'.$attr->getId()->toRfc4122().'/owner_object_types',
+        )->toArray();
+        self::assertSame([], $body['objectTypeIds']);
+
+        // Attach via existing endpoint.
+        $client->request(
+            'POST',
+            '/api/object_types/'.$productOtId.'/attributes/'.$attr->getId()->toRfc4122(),
+        );
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // Now the GET should list the Product ObjectType.
+        $body = $client->request(
+            'GET',
+            '/api/attributes/'.$attr->getId()->toRfc4122().'/owner_object_types',
+        )->toArray();
+        self::assertSame([$productOtId], $body['objectTypeIds']);
+
+        // Detach.
+        $client->request(
+            'DELETE',
+            '/api/object_types/'.$productOtId.'/attributes/'.$attr->getId()->toRfc4122(),
+        );
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        // Back to empty.
+        $body = $client->request(
+            'GET',
+            '/api/attributes/'.$attr->getId()->toRfc4122().'/owner_object_types',
+        )->toArray();
+        self::assertSame([], $body['objectTypeIds']);
+    }
+
+    #[Test]
+    public function getReturnsAllOwnersWhenAttributeIsAttachedToMultipleObjectTypes(): void
+    {
+        $client = $this->authenticatedClient();
+        // Pick a non-system attribute code (`code` is unique per tenant) and
+        // attach it to two kinds via the existing bulk-attach plumbing.
+        $attr = $this->seedAttribute('mod_attr_multi_owner');
+
+        $productOtId = $this->objectTypeIdFor(ObjectKind::Product);
+        $categoryOtId = $this->objectTypeIdFor(ObjectKind::Category);
+
+        $client->request('POST', '/api/object_types/'.$productOtId.'/attributes/bulk-attach', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['attributeIds' => [$attr->getId()->toRfc4122()]], JSON_THROW_ON_ERROR),
+        ]);
+        $client->request('POST', '/api/object_types/'.$categoryOtId.'/attributes/bulk-attach', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['attributeIds' => [$attr->getId()->toRfc4122()]], JSON_THROW_ON_ERROR),
+        ]);
+
+        $body = $client->request(
+            'GET',
+            '/api/attributes/'.$attr->getId()->toRfc4122().'/owner_object_types',
+        )->toArray();
+
+        self::assertEqualsCanonicalizing([$productOtId, $categoryOtId], $body['objectTypeIds']);
+    }
+
+    #[Test]
+    public function getReturns404ForUnknownAttribute(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request(
+            'GET',
+            '/api/attributes/01234567-1234-7000-8000-000000000000/owner_object_types',
+        );
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    private function seedAttribute(string $code): Attribute
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $attr = new Attribute($code, ['pl' => 'Test', 'en' => 'Test'], AttributeType::Text);
+        $em = $this->em();
+        $em->persist($attr);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $attr;
+    }
+}


### PR DESCRIPTION
## Summary

Naprawia brak ścieżki w UI do przypisania atrybutu do ObjectType z poziomu widoku „Modelowanie → Atrybut". Dotychczas operator dodawał atrybut do AttributeGroup, ale junction `object_type_attributes` pozostawała pusta i atrybut nie pojawiał się w karcie produktu / kategorii / zasobu. Operatorzy mylili chipy „Konfiguracja relacji → Dozwolone ObjectType (cele relacji)" z attribute → ObjectType ownership.

## Root cause

W widoku Atrybut detail (`/modeling/attributes/{id}`) były dwa kontrolki z chipami ObjectType — żaden z nich nie pisał do `object_type_attributes`:
- `AttachedGroupsCard` ([show.tsx:523](apps/admin/src/features/catalog/attributes/show.tsx#L523)) → tylko `attribute_group_attributes`.
- `RelationConfigPanel` → tylko `relationTargetObjectTypeIds` (target whitelist dla relation linkowania).

Tab „Powiązania" w karcie produktu pyta [ObjectRelationController.php:278-298](apps/api/src/Catalog/Presentation/Controller/ObjectRelationController.php#L278-L298) `WHERE j.objectType = :type` na `object_type_attributes` — bez wpisu w tej junkcji atrybut był niewidoczny.

## Backend changes

- `apps/api/src/Catalog/Presentation/Controller/AttributeOwnerObjectTypesController.php` — **nowy** read-only endpoint `GET /api/attributes/{id}/owner_object_types` zwracający `{attributeId, objectTypeIds[]}`. Mutacje zostają na istniejącym `AttachObjectTypeAttributeController` (`POST`/`DELETE` `/api/object_types/{id}/attributes/{attributeId}`).
- `apps/api/src/Catalog/Domain/Repository/ObjectTypeAttributeRepositoryInterface.php` — dodana metoda `findByAttribute()`.
- `apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectTypeAttributeRepository.php` — implementacja.
- `apps/api/tests/Api/Catalog/AttributeOwnerObjectTypesApiTest.php` — **nowy** ApiTestCase (5 testów: 401, empty list, attach/detach round-trip, multi-owner, 404 unknown).

## Frontend changes

- `apps/admin/src/features/catalog/attributes/show.tsx`:
  - **Nowa karta** `AttachedObjectTypesCard` między `AttachedGroupsCard` a `RelationConfigPanel`.
  - Chipy każdego ObjectType tenanta (kindy product/category/asset/custom). Selected = wypełniony chip, click toggle = `POST` attach lub `DELETE` detach.
  - Toast feedback + cache invalidation (`['attribute', id, 'owner_object_types']`, `['attribute', id]`, `['attributes']`) → form-schema produktu odświeża się natychmiast.
  - Disabled dla `attribute.system === true`.
  - Aria-pressed + visible focus ring (a11y).

## Quality gates

- PHPStan max: 0 errors.
- PHPUnit `AttributeOwnerObjectTypesApiTest`: 5/5 zielone.
- composer audit: 0 high/critical (1 medium twig CVE, znane).
- pnpm audit: 0 high/critical (1 low + 2 moderate, pre-existing).
- Biome strict: 0 errors (warningi w innych plikach pre-existing).
- TypeScript noEmit: 0 errors.
- OpenAPI snapshot: bez zmian (custom Symfony controller, nie API Platform `<operation>` — nie trafia do snapshotu, podobnie jak `relation_preview_fields`).
- **Live-stack smoke**: end-to-end na realnym atrybucie operatora.

## Smoke test plan (po merge)

Per CLAUDE.md SMOKE TEST RULE:

1. `docker compose restart api && sleep 5` (FrankenPHP worker reload).
2. Login admin@demo.localhost / changeme na https://pim.localhost.
3. **Modelowanie → Atrybuty** → otworzyć `relacje_do_salonow_sprzedazy`.
4. Zlokalizować nową sekcję **„Typy obiektów"** poniżej „Dołącz do grup".
5. Kliknąć chip „Produkt" → DevTools Network `POST /api/object_types/{product-id}/attributes/{attribute-id}` → 204. Chip staje się wypełniony (violet). Toast „Dodano atrybut do typu obiektu.".
6. Przejść do dowolnego produktu (np. `975TGT-MPKU0RS5-744`) → tab **Powiązania**.
7. Karta dla `relacje_do_salonow_sprzedazy` jest widoczna w liście (powinno być 7 cardów: 6 dotychczasowych + nowy).
8. Wrócić do widoku atrybutu, kliknąć chip „Produkt" ponownie → 204 `DELETE` → chip wraca do outline. Toast „Odpięto atrybut od typu obiektu.".
9. DevTools Console: brak czerwonych errorów.

**Smoke test już zweryfikowany przez curl na żywym stacku** (patrz issue close comment z proof'em po merge'u).

## Świadome odejścia

- **Poza scope**: auto-derive `object_type_attributes` z `attribute_group_attributes` (dodanie atrybutu do grupy która jest na ObjectType → auto-insert do junction ownerów). To zmiana modelowa wymagająca ADR — Akeneo-style „group = folder, attribute = wybrany per ObjectType" jest świadomy design.
- **Poza scope**: lepsze komunikowanie semantyki RelationConfigPanel (tooltip / podtytuł, że „Dozwolone ObjectType" to TARGETS, nie owners). Follow-up UX ticket.
- **Poza scope**: badge counts w „Gdzie używane → Typy obiektów" — używa osobnej query `UsageQueryService` i invalidate query z chipa odświeża cache.

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)
