### PR TITLE
fix(catalog): poly-kind POST /api/objects — custom-kind relation targets

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -318,6 +318,32 @@
                        uriTemplate="/objects/{id}{._format}"
                        name="objects_get"
                        security="is_granted('READ', object)"/>
+
+            <!-- Poly-kind create (#981) — relation picker modal's
+                 "Utwórz i podepnij" submits here when the target ObjectType
+                 is a custom kind (no sugar path). No `extraProperties.kind`
+                 is set; CatalogObjectProcessor::expectedKindFor() reads the
+                 ObjectType row keyed by `objectTypeId` in the payload and
+                 uses its kind as the discriminator. Built-in kinds should
+                 still prefer the sugar-path POSTs (/api/products etc.) where
+                 the discriminator is locked at the operation level, but the
+                 poly-kind POST accepts them too for consistency. -->
+            <operation class="ApiPlatform\Metadata\Post"
+                       uriTemplate="/objects{._format}"
+                       name="objects_post"
+                       input="App\Catalog\Infrastructure\ApiPlatform\Resource\CatalogObjectInput"
+                       processor="App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectProcessor"
+                       security="is_granted('CREATE', 'App\\Catalog\\Domain\\Entity\\CatalogObject')">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>object:create</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
         </operations>
     </resource>
 </resources>

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php
@@ -15,6 +15,7 @@ use App\Catalog\Application\Command\UpdateCatalogObject\UpdateCatalogObjectComma
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Catalog\Infrastructure\ApiPlatform\Resource\CatalogObjectInput;
 use App\Catalog\Infrastructure\ApiPlatform\Resource\CatalogObjectPatchInput;
 use InvalidArgumentException;
@@ -53,6 +54,7 @@ final readonly class CatalogObjectProcessor implements ProcessorInterface
     public function __construct(
         private MessageBusInterface $bus,
         private CatalogObjectRepositoryInterface $catalogObjects,
+        private ObjectTypeRepositoryInterface $objectTypes,
     ) {
     }
 
@@ -107,7 +109,7 @@ final readonly class CatalogObjectProcessor implements ProcessorInterface
         $command = new CreateCatalogObjectCommand(
             objectTypeId: Uuid::fromString($data->objectTypeId),
             code: $data->code,
-            expectedKind: $this->kindOrFail($operation),
+            expectedKind: $this->expectedKindFor($operation, $data),
             parentId: null !== $data->parentId ? Uuid::fromString($data->parentId) : null,
             attributes: $data->attributes ?? [],
             categoryIds: $categoryIds,
@@ -200,18 +202,44 @@ final readonly class CatalogObjectProcessor implements ProcessorInterface
         }
     }
 
-    private function kindOrFail(Operation $operation): ObjectKind
+    /**
+     * Per-kind sugar paths (`POST /api/products`, `/api/categories`) declare
+     * their kind via `extraProperties.kind`; CreateCatalogObjectHandler then
+     * 422s when the supplied `objectTypeId` resolves to a different kind, so
+     * a request to `/api/products` with a category ObjectType is rejected.
+     *
+     * The poly-kind `POST /api/objects` (#981) intentionally omits the
+     * discriminator — relation pickers create targets of arbitrary kinds
+     * (built-in product/category/asset AND custom kinds) without knowing
+     * the sugar path. For that path we derive the kind from the ObjectType
+     * row itself; the equality guard in the handler then becomes a no-op
+     * but the rest of its validation (tenant scope, existence) keeps
+     * running unchanged.
+     */
+    private function expectedKindFor(Operation $operation, CatalogObjectInput $data): ObjectKind
     {
         $value = $operation->getExtraProperties()['kind'] ?? null;
-        if (!\is_string($value)) {
-            throw new UnprocessableEntityHttpException('Operation is missing the kind discriminator.');
-        }
-        $kind = ObjectKind::tryFrom($value);
-        if (null === $kind) {
-            throw new UnprocessableEntityHttpException(\sprintf('Unknown ObjectKind "%s".', $value));
+        if (\is_string($value)) {
+            $kind = ObjectKind::tryFrom($value);
+            if (null === $kind) {
+                throw new UnprocessableEntityHttpException(\sprintf('Unknown ObjectKind "%s".', $value));
+            }
+
+            return $kind;
         }
 
-        return $kind;
+        try {
+            $objectTypeId = Uuid::fromString($data->objectTypeId);
+        } catch (InvalidArgumentException $e) {
+            throw new UnprocessableEntityHttpException(\sprintf('"%s" is not a valid UUID.', $data->objectTypeId), $e);
+        }
+
+        $objectType = $this->objectTypes->findById($objectTypeId);
+        if (null === $objectType) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $data->objectTypeId));
+        }
+
+        return $objectType->getKind();
     }
 
     /**

--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPostTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPostTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Application\SeedTenantPrdRolesService;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Poly-kind Post at `/api/objects` (#981).
+ *
+ * The relation picker modal's "Utwórz i podepnij" flow targets this
+ * endpoint when the chosen ObjectType is a custom kind (no sugar path).
+ * CatalogObjectProcessor::expectedKindFor() reads ObjectType.kind from
+ * the row keyed by `objectTypeId` in the payload, then delegates to the
+ * same CreateCatalogObjectHandler that the per-kind sugar paths use.
+ */
+final class CatalogObjectPolyKindPostTest extends CatalogApiTestCase
+{
+    private const string TENANT_B_CODE = 'other';
+    private const string ADMIN_B_EMAIL = 'admin@other.localhost';
+
+    #[Test]
+    public function unauthenticatedRequestReturns401(): void
+    {
+        static::createClient()->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'POLY-POST-UNAUTH',
+                'objectTypeId' => '019e5dd4-476a-7ea5-84df-94f36107f3b4',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[Test]
+    public function postCreatesProductWhenObjectTypeIdResolvesToProductKind(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'POLY-POST-PRODUCT',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $body = $response->toArray();
+        self::assertSame('POLY-POST-PRODUCT', $body['code'] ?? null);
+        self::assertSame('product', $body['kind'] ?? null);
+    }
+
+    #[Test]
+    public function postCreatesCategoryWhenObjectTypeIdResolvesToCategoryKind(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'poly_post_category',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $body = $response->toArray();
+        self::assertSame('poly_post_category', $body['code'] ?? null);
+        self::assertSame('category', $body['kind'] ?? null);
+    }
+
+    #[Test]
+    public function postCreatesObjectForCustomKindObjectType(): void
+    {
+        $client = $this->authenticatedClient();
+        $customOtId = $this->seedCustomObjectType('salon_test', 'Salony Testowe');
+
+        $response = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'SALON-001',
+                'objectTypeId' => $customOtId,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $body = $response->toArray();
+        self::assertSame('SALON-001', $body['code'] ?? null);
+        self::assertSame('custom', $body['kind'] ?? null);
+    }
+
+    #[Test]
+    public function postWithUnknownObjectTypeIdReturns404(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'POLY-POST-MISSING',
+                'objectTypeId' => '01234567-1234-7000-8000-000000000000',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
+    public function postWithCrossTenantObjectTypeIdReturns404(): void
+    {
+        $tenantB = $this->bootstrapTenantB();
+        $otherTenantOtId = $this->objectTypeIdForTenant(ObjectKind::Product, $tenantB);
+
+        // Tenant A admin tries to POST with tenant B's ObjectType id.
+        $clientA = $this->authenticatedClient();
+        $clientA->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'POLY-POST-XTENANT',
+                'objectTypeId' => $otherTenantOtId,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
+    public function sugarPathPostStillRejectsKindMismatch(): void
+    {
+        // Regression guard — the refactor of expectedKindFor() preserves the
+        // sugar-path contract: POST /api/products with a category ObjectType
+        // must 422 (handler equality guard runs because extraProperties.kind
+        // is set on the operation).
+        $client = $this->authenticatedClient();
+        $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'POLY-POST-MISMATCH',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    private function seedCustomObjectType(string $code, string $label): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $ot = new ObjectType($code, ObjectKind::Custom, ['pl' => $label, 'en' => $label]);
+        $em = $this->em();
+        $em->persist($ot);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $ot->getId()->toRfc4122();
+    }
+
+    private function objectTypeIdForTenant(ObjectKind $kind, Tenant $tenant): string
+    {
+        $type = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind($kind, $tenant);
+        \assert(null !== $type);
+
+        return $type->getId()->toRfc4122();
+    }
+
+    private function bootstrapTenantB(): Tenant
+    {
+        $em = $this->em();
+
+        $tenantB = new Tenant(self::TENANT_B_CODE, 'Other Tenant');
+        $em->persist($tenantB);
+        $em->flush();
+
+        self::getContainer()->get(SeedTenantPrdRolesService::class)->seed($tenantB);
+        $tenantOwnerB = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('tenant_owner', $tenantB);
+        \assert(null !== $tenantOwnerB);
+
+        $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        \assert(null !== $superAdmin);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenantB, self::ADMIN_B_EMAIL, '', ['ROLE_USER']);
+        $adminB = new User($tenantB, self::ADMIN_B_EMAIL, $hasher->hashPassword($stub, 'changeme'), ['ROLE_USER']);
+        $adminB->addRole($superAdmin);
+        $adminB->addRole($tenantOwnerB);
+        $em->persist($adminB);
+        $em->flush();
+
+        self::getContainer()->get(\App\Catalog\Application\BuiltInObjectTypeSeeder::class)->seed($tenantB);
+
+        return $tenantB;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -2948,6 +2948,113 @@
                     }
                 ],
                 "x-cortex-permission": "products.view"
+            },
+            "post": {
+                "operationId": "objects_post",
+                "tags": [
+                    "CatalogObject"
+                ],
+                "responses": {
+                    "201": {
+                        "description": "CatalogObject resource created",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CatalogObject.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CatalogObject-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Creates a CatalogObject resource.",
+                "description": "Creates a CatalogObject resource.",
+                "parameters": [],
+                "requestBody": {
+                    "description": "The new CatalogObject resource",
+                    "content": {
+                        "application/ld+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CatalogObject.CatalogObjectInput-object.create"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CatalogObject.CatalogObjectInput-object.create"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "x-cortex-permission": "products.add"
             }
         },
         "/api/objects/{id}": {


### PR DESCRIPTION
## Summary

Naprawia błąd „No route found for 'POST http://pim.localhost/api/objects': Method Not Allowed (Allow: GET)" w modalu „Wybierz obiekt" → „Utwórz i podepnij" w tab Powiązania karty produktu. Dotąd modal nie umiał utworzyć obiektu o custom kind ObjectType (np. „Salony Sprzedaży"), bo sugar paths są tylko dla built-in kindów (product/category/asset).

## Root cause

[`relations-tab.tsx`](apps/admin/src/features/catalog/products/components/relations-tab.tsx) ma fallback `sugarPathForKind('custom') = 'objects'` → `POST /api/objects` → 405, bo [CatalogObject.xml](apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml) eksponuje `/objects` tylko read-only.

[`CatalogObjectProcessor::kindOrFail()`](apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php) wymagał `extraProperties.kind` (`UnprocessableEntityHttpException("Operation is missing the kind discriminator.")`), więc proste dodanie POST'a nie wystarczyłoby.

## Backend changes

- `apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml` — dodana operacja `Post /objects` bez `extraProperties.kind`. Reuse `CatalogObjectInput` + `CatalogObjectProcessor` + grupy denormalizacji `object:create`. Voter `CREATE` na CatalogObject zostaje.
- `apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php`:
  - Nowa metoda `expectedKindFor(Operation, CatalogObjectInput)` zastępuje `kindOrFail()` w kontekście POST.
  - Sugar-path POST (extraProperties.kind set) — używa tej wartości i `CreateCatalogObjectHandler` waliduje kind mismatch jak dotychczas.
  - Poly-kind POST (brak extraProperties.kind) — derived z `ObjectType.kind` po lookup `objectTypeId`. Handler equality guard staje się no-op (kind = ObjectType.kind), reszta walidacji (tenant scope, existence, unique code) bez zmian.
  - Added `ObjectTypeRepositoryInterface` jako constructor dependency.
- `apps/api/tests/Api/Catalog/CatalogObjectPolyKindPostTest.php` — **nowy** ApiTestCase (7 testów):
  - 401 unauth,
  - 201 dla product/category/custom kind przez `/api/objects`,
  - 404 dla missing objectTypeId,
  - 404 cross-tenant ObjectType,
  - **regresja**: sugar-path `POST /api/products` z categoryObjectTypeId → 422 kind mismatch (niezmienione).
- `docs/api-spec/v0.json` — regen z nową operacją `objects_post`.

## Frontend changes

Brak — FE już woła `POST /api/objects` dla custom kindów, BE doganiał kontrakt.

## Quality gates

- PHPStan max: 0 errors.
- PHPUnit `CatalogObjectPolyKindPostTest`: 7/7 zielone (13 assertions).
- composer audit: 0 high/critical.
- OpenAPI snapshot regenerated i scommitowany.
- **Live-stack smoke**: `POST /api/objects` z `objectTypeId` dla custom kind „Salony Sprzedaży" → **HTTP 201**, response: `id, code=salon_smoke_test, kind=custom`.

## Smoke test plan (po merge)

Per CLAUDE.md SMOKE TEST RULE:

1. `docker compose restart api && sleep 5` (FrankenPHP worker reload).
2. Login admin@demo.localhost / changeme.
3. Produkty → otworzyć dowolny produkt → tab **Powiązania** → kafelek „Relacja do salonów sprzedaży".
4. Klik **„+ Dodaj powiązanie"** → modal „Wybierz obiekt".
5. Wprowadzić kod (np. `salon_test_2`) + nazwę (np. „Salon Test 2") → klik **„Utwórz i podepnij"**.
6. DevTools Network: `POST /api/objects` → **201**, brak czerwonego komunikatu w modalu.
7. Modal zamyka się, nowy target („Salon Test 2") pojawia się w karcie powiązania.
8. DevTools Console — brak czerwonych errorów.

## Świadome odejścia

- **Poza scope**: dynamic sugar paths per custom kind (`POST /api/salony_sprzedazy`). Wymaga route generator per ObjectType, znacznie większy refactor.
- **Poza scope**: feature flag re-evaluation dla custom kindów. Operator obszedł flagę MVP — Bug 3 naprawia consequence (404 z modalu), nie sam fakt tworzenia custom ObjectType.
- **Poza scope**: validation czy ObjectType.kind jest dozwolony dla relation attribute (już sprawdza `relationTargetObjectTypeIds` w innym miejscu).

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)
