### PR TITLE
refactor(catalog): ULV-02 consolidate Meilisearch into single objects index

### DIFF
--- a/apps/api/src/Search/Application/BulkCatalogObjectIndexer.php
+++ b/apps/api/src/Search/Application/BulkCatalogObjectIndexer.php
@@ -58,30 +58,25 @@ final readonly class BulkCatalogObjectIndexer
             ->select('o')
             ->from(CatalogObject::class, 'o');
 
+        // ULV-02 (#983) — every kind (custom included) writes to the
+        // consolidated `objects` index. The previous custom-kind skip is
+        // gone; the per-kind buffer collapses to a single flat buffer.
         if ($kind instanceof ObjectKind) {
             $qb->where('o.kind = :kind')->setParameter('kind', $kind);
-        } else {
-            $qb->where('o.kind != :customKind')->setParameter('customKind', ObjectKind::Custom);
         }
         $qb->orderBy('o.id', 'ASC');
 
         $count = 0;
         $batches = 0;
-        $perKindBuffer = [];
+        $buffer = [];
 
         foreach ($qb->getQuery()->toIterable() as $row) {
-            $rowKind = $row->getKind();
-            if (ObjectKind::Custom === $rowKind) {
-                continue;
-            }
-
-            $perKindBuffer[$rowKind->value][] = $this->toDocument($row);
+            $buffer[] = $this->toDocument($row);
             ++$count;
 
-            // Flush a per-kind buffer when it reaches the Meili batch size.
-            if (\count($perKindBuffer[$rowKind->value]) >= self::MEILI_BATCH_SIZE) {
-                $this->flushBatch($client, $rowKind, $perKindBuffer[$rowKind->value], $dryRun);
-                $perKindBuffer[$rowKind->value] = [];
+            if (\count($buffer) >= self::MEILI_BATCH_SIZE) {
+                $this->flushBatch($client, $buffer, $dryRun);
+                $buffer = [];
                 ++$batches;
                 if (null !== $onProgress) {
                     $onProgress($count, self::MEILI_BATCH_SIZE);
@@ -96,16 +91,11 @@ final readonly class BulkCatalogObjectIndexer
             }
         }
 
-        // Flush any leftover buffers.
-        foreach ($perKindBuffer as $value => $documents) {
-            if ([] === $documents) {
-                continue;
-            }
-            $rowKind = ObjectKind::from($value);
-            $this->flushBatch($client, $rowKind, $documents, $dryRun);
+        if ([] !== $buffer) {
+            $this->flushBatch($client, $buffer, $dryRun);
             ++$batches;
             if (null !== $onProgress) {
-                $onProgress($count, \count($documents));
+                $onProgress($count, \count($buffer));
             }
         }
 
@@ -115,11 +105,10 @@ final readonly class BulkCatalogObjectIndexer
     /**
      * @param list<array<string, mixed>> $documents
      */
-    private function flushBatch(\Meilisearch\Client $client, ObjectKind $kind, array $documents, bool $dryRun): void
+    private function flushBatch(\Meilisearch\Client $client, array $documents, bool $dryRun): void
     {
         if ($dryRun) {
             $this->logger->info('Reindex dry-run batch.', [
-                'kind' => $kind->value,
                 'count' => \count($documents),
             ]);
 
@@ -127,11 +116,10 @@ final readonly class BulkCatalogObjectIndexer
         }
 
         try {
-            $client->index(IndexSettingsTemplate::indexName($kind))->addDocuments($documents);
+            $client->index(IndexSettingsTemplate::indexName())->addDocuments($documents);
         } catch (Throwable $e) {
             $this->logger->warning('Reindex batch push failed: {message}', [
                 'message' => $e->getMessage(),
-                'kind' => $kind->value,
                 'count' => \count($documents),
             ]);
         }
@@ -162,7 +150,10 @@ final readonly class BulkCatalogObjectIndexer
             'createdAt' => $object->getCreatedAt()->getTimestamp(),
             'updatedAt' => $object->getUpdatedAt()->getTimestamp(),
         ];
-        if (ObjectKind::Product === $object->getKind()) {
+        // ULV-02 (#983) — any categorizable ObjectType gets its category
+        // codes denormalised so the category-tree filter sidebar resolves
+        // through Meili across kinds.
+        if ($object->getObjectType()->isCategorizable()) {
             $base['category'] = array_map(
                 static fn (ObjectCategory $a): string => $a->getCategory()->getCode(),
                 $this->objectCategories->findByProduct($object),

--- a/apps/api/src/Search/Application/CatalogIndexCollector.php
+++ b/apps/api/src/Search/Application/CatalogIndexCollector.php
@@ -32,7 +32,7 @@ final class CatalogIndexCollector implements ResetInterface
     /** @var array<string, true> objectId (RFC4122 string) => true */
     private array $upserts = [];
 
-    /** @var array<string, ObjectKind> objectId (RFC4122 string) => kind */
+    /** @var array<string, ObjectKind> objectId (RFC4122 string) => kind (telemetry only post-ULV) */
     private array $deletes = [];
 
     public function queueUpsert(Uuid $id): void
@@ -45,6 +45,11 @@ final class CatalogIndexCollector implements ResetInterface
         $this->upserts[$rfc] = true;
     }
 
+    /**
+     * `$kind` is retained as a legacy hint (telemetry, logging). ULV-02
+     * (#983) consolidated the per-kind indexes into a single `objects`
+     * index, so the collector no longer partitions deletes by kind.
+     */
     public function queueDelete(Uuid $id, ObjectKind $kind): void
     {
         $rfc = $id->toRfc4122();

--- a/apps/api/src/Search/Application/CatalogObjectIndexer.php
+++ b/apps/api/src/Search/Application/CatalogObjectIndexer.php
@@ -64,11 +64,9 @@ final readonly class CatalogObjectIndexer
             return;
         }
 
-        if (ObjectKind::Custom === $object->getKind()) {
-            // Custom kinds have no MVP index per ADR-009; phase 2/3 unlock.
-            return;
-        }
-
+        // ULV-02 (#983) — custom kinds land in the consolidated `objects`
+        // index alongside built-ins; the universal list view treats every
+        // ObjectType uniformly. The previous Phase 2/3 skip is gone.
         $this->push($object);
     }
 
@@ -92,19 +90,10 @@ final readonly class CatalogObjectIndexer
             return;
         }
 
-        /** @var array<string, list<array<string, mixed>>> $byKind */
-        $byKind = [];
-        foreach ($objects as $object) {
-            $kind = $object->getKind();
-            if (ObjectKind::Custom === $kind) {
-                continue;
-            }
-            $byKind[$kind->value][] = $this->toDocument($object);
-        }
-
-        if ([] === $byKind) {
-            return;
-        }
+        // ULV-02 (#983) — single `objects` index for every ObjectKind
+        // (custom included), so the by-kind partition is gone. The early
+        // empty-$objects guard above keeps this list non-empty.
+        $documents = array_map(fn ($o) => $this->toDocument($o), $objects);
 
         try {
             $client = $this->clientFactory->create();
@@ -121,32 +110,26 @@ final readonly class CatalogObjectIndexer
             return;
         }
 
-        foreach ($byKind as $kindValue => $documents) {
-            $kind = ObjectKind::from($kindValue);
-            foreach (array_chunk($documents, self::BATCH_SIZE) as $chunk) {
-                try {
-                    $client->index(IndexSettingsTemplate::indexName($kind))->addDocuments($chunk);
-                } catch (Throwable $e) {
-                    // Fail-soft per chunk — same rationale as above.
-                    $this->logger->warning('Index batch push failed: {message}', [
-                        'message' => $e->getMessage(),
-                        'kind' => $kind->value,
-                        'count' => \count($chunk),
-                    ]);
-                }
+        foreach (array_chunk($documents, self::BATCH_SIZE) as $chunk) {
+            try {
+                $client->index(IndexSettingsTemplate::indexName())->addDocuments($chunk);
+            } catch (Throwable $e) {
+                // Fail-soft per chunk — same rationale as above.
+                $this->logger->warning('Index batch push failed: {message}', [
+                    'message' => $e->getMessage(),
+                    'count' => \count($chunk),
+                ]);
             }
         }
     }
 
     public function remove(Uuid $objectId, ObjectKind $kind): void
     {
-        if (ObjectKind::Custom === $kind) {
-            return;
-        }
-
+        // ULV-02 (#983) — single `objects` index; the `$kind` argument is
+        // legacy hint kept for telemetry and call-site BC.
         try {
             $client = $this->clientFactory->create();
-            $client->index(IndexSettingsTemplate::indexName($kind))->deleteDocument($objectId->toRfc4122());
+            $client->index(IndexSettingsTemplate::indexName())->deleteDocument($objectId->toRfc4122());
         } catch (Throwable $e) {
             $this->logger->warning('Index delete failed: {message}', [
                 'message' => $e->getMessage(),
@@ -167,18 +150,11 @@ final readonly class CatalogObjectIndexer
             return;
         }
 
-        /** @var array<string, list<string>> $idsByKind */
-        $idsByKind = [];
-        foreach ($kindByIdRfc4122 as $id => $kind) {
-            if (ObjectKind::Custom === $kind) {
-                continue;
-            }
-            $idsByKind[$kind->value][] = $id;
-        }
-
-        if ([] === $idsByKind) {
-            return;
-        }
+        // ULV-02 (#983) — single `objects` index; kind partition replaced
+        // by a flat list of ids. Custom kinds are included now.
+        // The early `[] === $kindByIdRfc4122` guard above keeps this
+        // non-empty.
+        $ids = array_keys($kindByIdRfc4122);
 
         try {
             $client = $this->clientFactory->create();
@@ -190,17 +166,13 @@ final readonly class CatalogObjectIndexer
             return;
         }
 
-        foreach ($idsByKind as $kindValue => $ids) {
-            $kind = ObjectKind::from($kindValue);
-            try {
-                $client->index(IndexSettingsTemplate::indexName($kind))->deleteDocuments($ids);
-            } catch (Throwable $e) {
-                $this->logger->warning('Index batch delete failed: {message}', [
-                    'message' => $e->getMessage(),
-                    'kind' => $kind->value,
-                    'count' => \count($ids),
-                ]);
-            }
+        try {
+            $client->index(IndexSettingsTemplate::indexName())->deleteDocuments($ids);
+        } catch (Throwable $e) {
+            $this->logger->warning('Index batch delete failed: {message}', [
+                'message' => $e->getMessage(),
+                'count' => \count($ids),
+            ]);
         }
     }
 
@@ -208,7 +180,7 @@ final readonly class CatalogObjectIndexer
     {
         try {
             $client = $this->clientFactory->create();
-            $client->index(IndexSettingsTemplate::indexName($object->getKind()))
+            $client->index(IndexSettingsTemplate::indexName())
                 ->addDocuments([$this->toDocument($object)]);
         } catch (Throwable $e) {
             $this->logger->warning('Index push failed: {message}', [
@@ -244,7 +216,10 @@ final readonly class CatalogObjectIndexer
             'createdAt' => $object->getCreatedAt()->getTimestamp(),
             'updatedAt' => $object->getUpdatedAt()->getTimestamp(),
         ];
-        if (ObjectKind::Product === $object->getKind()) {
+        // Category denormalisation: any ObjectType with `isCategorizable=true`
+        // gets its category code array surfaced so the universal list view's
+        // category-tree filter (ULV-09) resolves through Meili.
+        if ($object->getObjectType()->isCategorizable()) {
             $base['category'] = array_map(
                 static fn (ObjectCategory $a): string => $a->getCategory()->getCode(),
                 $this->objectCategories->findByProduct($object),

--- a/apps/api/src/Search/Application/CatalogSearchService.php
+++ b/apps/api/src/Search/Application/CatalogSearchService.php
@@ -61,9 +61,8 @@ final readonly class CatalogSearchService
         array $rangeFilters = [],
         ?string $customFilterExpression = null,
     ): array {
-        if (ObjectKind::Custom === $kind) {
-            return $this->emptyResult();
-        }
+        // ULV-02 (#983) — custom kinds land in the consolidated `objects`
+        // index alongside built-ins; no early-return skip anymore.
 
         $tenant = $this->tenantProvider->getCurrent();
         if (!$tenant instanceof Tenant) {
@@ -75,6 +74,10 @@ final readonly class CatalogSearchService
 
         $tenantFilter = \sprintf('tenantId = "%s"', $tenant->getId()->toRfc4122());
         $extraFilters = [];
+        // ULV-02 — every kind shares one index, so we constrain by the
+        // `kind` filterable to preserve the legacy "show me only products"
+        // behaviour callers still expect.
+        $extraFilters[] = \sprintf('kind = "%s"', $kind->value);
         foreach ($filters as $key => $value) {
             if (\is_array($value)) {
                 $orParts = [];
@@ -99,7 +102,9 @@ final readonly class CatalogSearchService
         if (null !== $customFilterExpression && '' !== trim($customFilterExpression)) {
             $extraFilters[] = '('.$customFilterExpression.')';
         }
-        $filterExpression = trim($tenantFilter.([] !== $extraFilters ? ' AND '.implode(' AND ', $extraFilters) : ''));
+        // ULV-02 — `$extraFilters` always carries at least the `kind`
+        // filter we added above, so the conditional join is unconditional.
+        $filterExpression = trim($tenantFilter.' AND '.implode(' AND ', $extraFilters));
 
         $options = [
             'filter' => $filterExpression,
@@ -128,7 +133,7 @@ final readonly class CatalogSearchService
 
         try {
             $client = $this->clientFactory->create();
-            $result = $client->index(IndexSettingsTemplate::indexName($kind))->search($query, $options);
+            $result = $client->index(IndexSettingsTemplate::indexName())->search($query, $options);
             $raw = $result->toArray();
         } catch (Throwable $e) {
             $this->logger->warning('Meilisearch query failed: {message}', [
@@ -190,7 +195,8 @@ final readonly class CatalogSearchService
      */
     private function filterableAttributesFor(ObjectKind $kind): array
     {
-        $settings = new IndexSettingsTemplate()->settingsFor($kind);
+        // ULV-02 — single index settings; `$kind` retained as legacy hint.
+        $settings = new IndexSettingsTemplate()->settingsFor();
         $raw = $settings['filterableAttributes'] ?? [];
         if (!\is_array($raw)) {
             return [];

--- a/apps/api/src/Search/Application/IndexSettingsTemplate.php
+++ b/apps/api/src/Search/Application/IndexSettingsTemplate.php
@@ -6,46 +6,72 @@ namespace App\Search\Application;
 
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
-use LogicException;
 
 /**
- * Per-`ObjectKind` Meilisearch index settings template (#49 / 0.5.1).
+ * Universal Meilisearch index settings (ULV-02 / #983).
  *
- * VIEW-38 (#579) — the product index's `filterableAttributes` is now
- * built dynamically: a small reserved set (system-owned columns Meili
- * always needs) unioned with the distinct codes of every
- * `attributes.is_filterable=true` row. Operators flip the toggle in
- * Settings → Attributes and the next request that refreshes settings
- * (postPersist/postUpdate listener) exposes the new filter target
- * without a deploy.
+ * One consolidated `objects` index replaces the pre-ULV per-kind layout
+ * (`products`, `categories`, `assets`, `brands`). Each document carries
+ * `tenantId` + `objectTypeId` as filterable facets so the read side can
+ * scope by ObjectType the same way it scopes by tenant. Custom kinds get
+ * indexed too — previously skipped in MVP per ADR-009, ULV-02 unlocks
+ * them because the universal list view treats every ObjectType uniformly.
  *
- * Other kinds (Category / Asset / Brand) keep the static list — they
- * carry no operator-extensible attribute slot in MVP.
+ * `filterableAttributes` is the union of every pre-ULV kind's filterables
+ * plus the dynamic attribute codes (`attributes.is_filterable=true`) the
+ * `AttributeFilterableProvisionListener` syncs whenever the operator flips
+ * the toggle in Settings → Attributes.
+ *
+ * `indexName()` keeps its signature so the 12 existing call sites compile
+ * unchanged; the `ObjectKind` argument is now an unused legacy hint kept
+ * to preserve the public API across the cutover.
  */
 final class IndexSettingsTemplate
 {
+    public const string INDEX_NAME = 'objects';
+
     /**
-     * Reserved filterable fields the product index always carries
-     * regardless of operator-defined attributes. `tenantId` enforces
-     * the multi-tenant isolation filter in `CatalogSearchService`;
-     * `kind` / `status` / `enabled` / `objectTypeId` drive UI surfaces
-     * (variant toggle, status pills, type-scoped saved views);
-     * `sync_status_aggregate` is the badge column;
-     * `completeness_pct` powers the Red (<50%) smart preset;
-     * `category` is denormalized by the indexer from `object_categories`
-     * (not a user attribute, but a join surface needed for the
-     * `IS EMPTY category` preset).
+     * Reserved filterable fields the universal index always carries
+     * regardless of operator-defined attributes. `tenantId` enforces the
+     * multi-tenant isolation filter; `objectTypeId` scopes the universal
+     * list to a specific ObjectType (ULV-03). `kind` stays so the legacy
+     * variant-toggle / kind-aware UI surfaces keep working. `category`
+     * is denormalized by the indexer from `object_categories` for the
+     * `is_categorizable` filter sidebar; `parentId` powers the variant
+     * tree view; `mime_type` filters assets; `status`/`enabled` drive
+     * status pills; `completeness_pct` powers the Red preset.
      *
      * @var list<string>
      */
-    private const array PRODUCT_RESERVED_FILTERABLE = [
-        'tenantId', 'kind', 'status', 'enabled', 'objectTypeId',
-        'completeness_pct', 'sync_status_aggregate', 'category',
-        // `parentId` exposed so the variant-tree view (only masters) can
-        // mirror its `parent_id IS NULL` filter on cross-page selection
-        // through Meili (`BulkSelectionController` reads `variants_mode`
-        // from the body and emits the matching filter).
-        'parentId',
+    private const array RESERVED_FILTERABLE = [
+        'tenantId', 'objectTypeId', 'kind',
+        'status', 'enabled',
+        'completeness_pct', 'sync_status_aggregate',
+        'category', 'parentId', 'mime_type',
+    ];
+
+    /**
+     * Union of pre-ULV searchable attributes across the four built-in
+     * kinds. Custom kinds inherit this baseline; per-attribute searchable
+     * extensions (if introduced later) ride on `is_searchable` like the
+     * filterable toggle.
+     *
+     * @var list<string>
+     */
+    private const array UNIVERSAL_SEARCHABLE = [
+        'code', 'name', 'sku', 'brand', 'description',
+        'path', 'seo_title',
+        'alt_text', 'caption',
+    ];
+
+    /**
+     * Union of pre-ULV sortable attributes. `price` lands here so the
+     * legacy product-list sort options still resolve.
+     *
+     * @var list<string>
+     */
+    private const array UNIVERSAL_SORTABLE = [
+        'createdAt', 'updatedAt', 'name', 'price',
     ];
 
     public function __construct(
@@ -54,84 +80,64 @@ final class IndexSettingsTemplate
     }
 
     /**
-     * Index name per kind. `kind=custom` is reserved for Faza 2/3
-     * (per ADR-009) — the indexer skips custom kinds in MVP.
+     * Always returns the universal `objects` index name. The `?ObjectKind`
+     * argument is a legacy hint kept to preserve every pre-ULV call site
+     * without a churn-only rename.
      */
-    public static function indexName(ObjectKind $kind): string
+    public static function indexName(?ObjectKind $kind = null): string
     {
-        return match ($kind) {
-            ObjectKind::Product => 'products',
-            ObjectKind::Category => 'categories',
-            ObjectKind::Asset => 'assets',
-            ObjectKind::Brand => 'brands',
-            ObjectKind::Custom => throw new LogicException('Custom kind has no MVP index — phase 2/3 unlock.'),
-        };
+        return self::INDEX_NAME;
     }
 
     /**
      * @return array<string, mixed> settings payload accepted by
      *                              `Meilisearch\Endpoints\Indexes::updateSettings`
      */
-    public function settingsFor(ObjectKind $kind): array
+    public function settingsFor(?ObjectKind $kind = null): array
     {
-        return match ($kind) {
-            ObjectKind::Product => [
-                'searchableAttributes' => ['code', 'name', 'sku', 'brand', 'description'],
-                'filterableAttributes' => $this->productFilterableAttributes(),
-                'sortableAttributes' => ['createdAt', 'updatedAt', 'name', 'price'],
-                'displayedAttributes' => ['*'],
-                'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
-                // Meili's default `maxTotalHits` (1000) caps cross-page
-                // selection at the first page and silently truncates the
-                // result. Operator's "Zaznacz wszystkie pasujące" loop
-                // page-by-page tops out at 1000 even though tenants
-                // routinely run 5–10× that. Raised to match the bulk
-                // selection HARD_CAP (10 000) — `BulkSelectionController`
-                // already enforces that as the absolute ceiling.
-                'pagination' => ['maxTotalHits' => 10_000],
-            ],
-            ObjectKind::Category => [
-                'searchableAttributes' => ['code', 'name', 'path', 'seo_title'],
-                'filterableAttributes' => ['tenantId', 'kind', 'parentId', 'objectTypeId'],
-                'sortableAttributes' => ['createdAt', 'updatedAt', 'name'],
-                'displayedAttributes' => ['*'],
-                'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
-            ],
-            ObjectKind::Asset => [
-                'searchableAttributes' => ['code', 'name', 'alt_text', 'caption'],
-                'filterableAttributes' => ['tenantId', 'kind', 'mime_type', 'objectTypeId'],
-                'sortableAttributes' => ['createdAt', 'updatedAt'],
-                'displayedAttributes' => ['*'],
-                'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
-            ],
-            ObjectKind::Brand => [
-                'searchableAttributes' => ['code', 'name', 'description'],
-                'filterableAttributes' => ['tenantId', 'kind', 'enabled', 'objectTypeId'],
-                'sortableAttributes' => ['createdAt', 'updatedAt', 'name'],
-                'displayedAttributes' => ['*'],
-                'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
-            ],
-            ObjectKind::Custom => throw new LogicException('Custom kind has no MVP settings template.'),
-        };
+        return [
+            'searchableAttributes' => self::UNIVERSAL_SEARCHABLE,
+            'filterableAttributes' => $this->filterableAttributes(),
+            'sortableAttributes' => self::UNIVERSAL_SORTABLE,
+            'displayedAttributes' => ['*'],
+            'rankingRules' => ['words', 'typo', 'proximity', 'attribute', 'sort', 'exactness'],
+            // Meili's default `maxTotalHits` (1000) caps cross-page
+            // selection at the first page and silently truncates the
+            // result. Raised to match the bulk selection HARD_CAP
+            // (10 000) — `BulkSelectionController` already enforces that
+            // as the absolute ceiling.
+            'pagination' => ['maxTotalHits' => 10_000],
+        ];
     }
 
     /**
      * @return list<string>
      */
-    private function productFilterableAttributes(): array
+    private function filterableAttributes(): array
     {
         $dynamic = null === $this->attributes ? [] : $this->attributes->filterableCodes();
-        $merged = array_values(array_unique([...self::PRODUCT_RESERVED_FILTERABLE, ...$dynamic]));
+        $merged = array_values(array_unique([...self::RESERVED_FILTERABLE, ...$dynamic]));
         sort($merged);
 
         return $merged;
     }
 
     /**
+     * Every ObjectKind is indexed under the universal `objects` index.
+     * Custom kinds were previously skipped per ADR-009 (MVP scope) — ULV
+     * unlocks them because the universal list treats every ObjectType
+     * uniformly. Used by `MeilisearchIndexProvisioner` + reindex CLI.
+     *
      * @return list<ObjectKind>
      */
     public static function indexedKinds(): array
     {
-        return [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand];
+        return [
+            ObjectKind::Product,
+            ObjectKind::Category,
+            ObjectKind::Asset,
+            ObjectKind::Brand,
+            ObjectKind::Custom,
+        ];
     }
 }

--- a/apps/api/src/Search/Application/MeilisearchIndexProvisioner.php
+++ b/apps/api/src/Search/Application/MeilisearchIndexProvisioner.php
@@ -9,16 +9,17 @@ use App\Search\Infrastructure\MeilisearchClientFactory;
 use Throwable;
 
 /**
- * Idempotent index bootstrap for Meilisearch (#49 / 0.5.1).
+ * Idempotent index bootstrap for Meilisearch (ULV-02 / #983).
  *
- * Creates each kind's index if missing and writes the settings
- * template (`searchable`, `filterable`, `sortable`, `displayed`,
- * `ranking`). Re-runs are no-ops because Meili's `updateSettings`
- * is itself idempotent — same payload, same task acknowledgment.
+ * Creates the consolidated `objects` index if missing and writes its
+ * settings template (`searchable`, `filterable`, `sortable`, `displayed`,
+ * `ranking`, `pagination`). Re-runs are no-ops because Meili's
+ * `updateSettings` is itself idempotent.
  *
- * Used by the `pim:search:health` CLI (this ticket) and the future
- * `pim:search:reindex` command (#51) so a fresh stack always has
- * the right index shape before any document push.
+ * Pre-ULV provisioned four per-kind indexes (`products`, `categories`,
+ * `assets`, `brands`); the cleanup of those legacy indexes happens via
+ * `pim:search:cleanup-legacy-indexes` (a one-shot CLI) so a tenant can
+ * stage the migration: provision new → reindex → drop old.
  */
 final readonly class MeilisearchIndexProvisioner
 {
@@ -29,33 +30,36 @@ final readonly class MeilisearchIndexProvisioner
     }
 
     /**
-     * @return array<string, string> Map of `ObjectKind->value` to the
-     *                               task UID returned by Meili. Useful
-     *                               for the health command to surface a
-     *                               concrete handle per kind.
+     * Provisions the single `objects` index. Returns the task UID Meili
+     * returned for the settings update so the health command can surface
+     * a concrete handle. Keyed by `'objects'` for backward-compatible
+     * call sites (was keyed by kind value pre-ULV).
+     *
+     * @return array<string, string>
      */
     public function provision(): array
     {
         $client = $this->clientFactory->create();
-        $tasks = [];
+        $name = IndexSettingsTemplate::indexName();
 
-        foreach (IndexSettingsTemplate::indexedKinds() as $kind) {
-            $name = IndexSettingsTemplate::indexName($kind);
-            $client->createIndex($name, ['primaryKey' => 'id']);
+        $client->createIndex($name, ['primaryKey' => 'id']);
+        $task = $client->index($name)->updateSettings($this->template->settingsFor());
+        $taskUid = $task['taskUid'] ?? $task['uid'] ?? '';
 
-            $task = $client->index($name)->updateSettings($this->template->settingsFor($kind));
-            $taskUid = $task['taskUid'] ?? $task['uid'] ?? '';
-            $tasks[$kind->value] = \is_scalar($taskUid) ? (string) $taskUid : '';
-        }
-
-        return $tasks;
+        return [
+            $name => \is_scalar($taskUid) ? (string) $taskUid : '',
+        ];
     }
 
-    public function indexExists(ObjectKind $kind): bool
+    /**
+     * `$kind` is retained as a legacy hint — every kind resolves to the
+     * universal `objects` index post-ULV.
+     */
+    public function indexExists(?ObjectKind $kind = null): bool
     {
         $client = $this->clientFactory->create();
         try {
-            $client->index(IndexSettingsTemplate::indexName($kind))->fetchInfo();
+            $client->index(IndexSettingsTemplate::indexName())->fetchInfo();
 
             return true;
         } catch (Throwable) {

--- a/apps/api/src/Search/Presentation/Command/SearchCleanupLegacyIndexesCommand.php
+++ b/apps/api/src/Search/Presentation/Command/SearchCleanupLegacyIndexesCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Search\Presentation\Command;
+
+use App\Search\Infrastructure\MeilisearchClientFactory;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+/**
+ * ULV-02 (#983) one-shot cleanup: drop the pre-ULV per-kind Meilisearch
+ * indexes (`products`, `categories`, `assets`, `brands`) after the
+ * consolidated `objects` index has been provisioned and reindexed.
+ *
+ * Run sequence for the cutover:
+ *   1. `pim:search:health`        — provisions the new `objects` index
+ *   2. `pim:search:reindex --purge` — populates `objects` from Postgres
+ *   3. `pim:search:cleanup-legacy-indexes` — drops the four old indexes
+ *
+ * Skips deletion when the cluster does not contain a given legacy
+ * index — repeatable safe.
+ */
+#[AsCommand(
+    name: 'pim:search:cleanup-legacy-indexes',
+    description: 'Drop pre-ULV per-kind Meilisearch indexes (products/categories/assets/brands).',
+)]
+final class SearchCleanupLegacyIndexesCommand extends Command
+{
+    private const array LEGACY_INDEXES = ['products', 'categories', 'assets', 'brands'];
+
+    public function __construct(
+        private readonly MeilisearchClientFactory $clientFactory,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_NONE,
+            'Report which legacy indexes would be dropped without deleting them.',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = true === $input->getOption('dry-run');
+
+        try {
+            $client = $this->clientFactory->create();
+        } catch (Throwable $e) {
+            $io->error('Cannot reach Meilisearch: '.$e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $present = [];
+        foreach ($client->getIndexes()->getResults() as $index) {
+            $present[] = $index->getUid();
+        }
+
+        $rows = [];
+        foreach (self::LEGACY_INDEXES as $name) {
+            $exists = \in_array($name, $present, true);
+            if (!$exists) {
+                $rows[] = [$name, 'absent', 'skip'];
+
+                continue;
+            }
+            if ($dryRun) {
+                $rows[] = [$name, 'present', 'would delete'];
+
+                continue;
+            }
+            try {
+                $client->deleteIndex($name);
+                $rows[] = [$name, 'present', 'deleted'];
+            } catch (Throwable $e) {
+                $rows[] = [$name, 'present', 'FAILED — '.$e->getMessage()];
+            }
+        }
+
+        $io->table(['Index', 'State', 'Action'], $rows);
+
+        return Command::SUCCESS;
+    }
+}

--- a/apps/api/src/Search/Presentation/Command/SearchHealthCommand.php
+++ b/apps/api/src/Search/Presentation/Command/SearchHealthCommand.php
@@ -62,16 +62,18 @@ final class SearchHealthCommand extends Command
 
         $io->success(\sprintf('Meilisearch healthy (status=%s).', $status));
 
+        // ULV-02 (#983) — one consolidated `objects` index covers every
+        // kind. The health command now reports a single row.
         $tasks = $this->provisioner->provision();
-        $rows = [];
-        foreach (IndexSettingsTemplate::indexedKinds() as $kind) {
-            $rows[] = [
-                IndexSettingsTemplate::indexName($kind),
-                $kind->value,
-                $tasks[$kind->value] ?? '-',
-            ];
-        }
-        $io->table(['Index', 'Kind', 'Settings task UID'], $rows);
+        $name = IndexSettingsTemplate::indexName();
+        $io->table(
+            ['Index', 'Indexed kinds', 'Settings task UID'],
+            [[
+                $name,
+                implode(', ', array_map(static fn ($k) => $k->value, IndexSettingsTemplate::indexedKinds())),
+                $tasks[$name] ?? '-',
+            ]],
+        );
 
         return Command::SUCCESS;
     }

--- a/apps/api/src/Search/Presentation/Command/SearchReindexCommand.php
+++ b/apps/api/src/Search/Presentation/Command/SearchReindexCommand.php
@@ -84,24 +84,22 @@ final class SearchReindexCommand extends Command
         if ('all' !== $kindOption) {
             $kind = ObjectKind::tryFrom($kindOption);
             if (null === $kind) {
-                $io->error(\sprintf('Unknown kind "%s". Use product, category, asset, or all.', $kindOption));
+                $io->error(\sprintf('Unknown kind "%s". Use product, category, asset, brand, custom, or all.', $kindOption));
 
                 return Command::INVALID;
             }
-            if (ObjectKind::Custom === $kind) {
-                $io->error('Custom kind has no MVP index — phase 2/3 unlock.');
-
-                return Command::INVALID;
-            }
+            // ULV-02 (#983) — custom kinds now land in the consolidated
+            // `objects` index alongside built-ins.
         }
 
         $dryRun = true === $input->getOption('dry-run');
         $purge = true === $input->getOption('purge');
 
         $io->title(\sprintf(
-            '%s reindex of %s%s',
+            '%s reindex of %s into %s%s',
             $dryRun ? 'DRY-RUN' : 'Live',
-            null === $kind ? 'every built-in kind' : IndexSettingsTemplate::indexName($kind),
+            null === $kind ? 'every kind' : $kind->value,
+            IndexSettingsTemplate::indexName(),
             $purge ? ' (purging existing docs first)' : '',
         ));
 
@@ -152,15 +150,20 @@ final class SearchReindexCommand extends Command
             return;
         }
 
-        $kinds = null === $kind ? IndexSettingsTemplate::indexedKinds() : [$kind];
-        foreach ($kinds as $k) {
-            $name = IndexSettingsTemplate::indexName($k);
-            try {
+        // ULV-02 (#983) — single `objects` index. When `--kind=foo` is set
+        // we purge only documents of that kind via filter; full purge drops
+        // everything in the index.
+        $name = IndexSettingsTemplate::indexName();
+        try {
+            if (null === $kind) {
                 $client->index($name)->deleteAllDocuments();
-                $io->writeln(\sprintf('  purged: %s', $name));
-            } catch (Throwable $e) {
-                $io->warning(\sprintf('Purge of "%s" failed: %s', $name, $e->getMessage()));
+                $io->writeln(\sprintf('  purged all documents in: %s', $name));
+            } else {
+                $client->index($name)->deleteDocuments(['filter' => \sprintf('kind = "%s"', $kind->value)]);
+                $io->writeln(\sprintf('  purged kind=%s documents in: %s', $kind->value, $name));
             }
+        } catch (Throwable $e) {
+            $io->warning(\sprintf('Purge of "%s" failed: %s', $name, $e->getMessage()));
         }
     }
 }

--- a/apps/api/tests/Unit/Search/Application/IndexSettingsTemplateConsolidationTest.php
+++ b/apps/api/tests/Unit/Search/Application/IndexSettingsTemplateConsolidationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Search\Application;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Search\Application\IndexSettingsTemplate;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ULV-02 (#983) — covers the per-kind → consolidated `objects` index
+ * cutover: every `indexName()` call resolves to the universal index,
+ * `settingsFor()` returns one merged settings payload, and custom kinds
+ * are now included in `indexedKinds()`.
+ */
+final class IndexSettingsTemplateConsolidationTest extends TestCase
+{
+    #[Test]
+    public function indexNameAlwaysReturnsUniversalIndexRegardlessOfKind(): void
+    {
+        self::assertSame('objects', IndexSettingsTemplate::indexName());
+        self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Product));
+        self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Category));
+        self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Asset));
+        self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Brand));
+        self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Custom));
+    }
+
+    #[Test]
+    public function indexedKindsIncludesCustomPostConsolidation(): void
+    {
+        $kinds = IndexSettingsTemplate::indexedKinds();
+
+        self::assertContains(ObjectKind::Custom, $kinds);
+        self::assertContains(ObjectKind::Product, $kinds);
+        self::assertContains(ObjectKind::Category, $kinds);
+        self::assertContains(ObjectKind::Asset, $kinds);
+        self::assertContains(ObjectKind::Brand, $kinds);
+        self::assertCount(5, $kinds);
+    }
+
+    #[Test]
+    public function settingsForReturnsUnionPayloadIndependentOfKindArgument(): void
+    {
+        $template = new IndexSettingsTemplate();
+
+        $a = $template->settingsFor();
+        $b = $template->settingsFor(ObjectKind::Product);
+        $c = $template->settingsFor(ObjectKind::Custom);
+
+        self::assertSame($a, $b, 'settings must be identical regardless of kind hint');
+        self::assertSame($a, $c);
+
+        self::assertArrayHasKey('filterableAttributes', $a);
+        $filterable = $a['filterableAttributes'];
+        self::assertIsArray($filterable);
+        self::assertContains('tenantId', $filterable, 'tenant isolation filter is mandatory');
+        self::assertContains('objectTypeId', $filterable, 'ULV scope filter is mandatory');
+        self::assertContains('kind', $filterable, 'BC kind filter retained');
+    }
+
+    #[Test]
+    public function searchableAndSortableAreUnionOfPreUlvKinds(): void
+    {
+        $settings = new IndexSettingsTemplate()->settingsFor();
+
+        $searchable = $settings['searchableAttributes'];
+        self::assertIsArray($searchable);
+        // pre-ULV product searchable
+        self::assertContains('code', $searchable);
+        self::assertContains('name', $searchable);
+        self::assertContains('sku', $searchable);
+        // pre-ULV category searchable
+        self::assertContains('path', $searchable);
+        self::assertContains('seo_title', $searchable);
+        // pre-ULV asset searchable
+        self::assertContains('alt_text', $searchable);
+        self::assertContains('caption', $searchable);
+
+        $sortable = $settings['sortableAttributes'];
+        self::assertIsArray($sortable);
+        self::assertContains('createdAt', $sortable);
+        self::assertContains('price', $sortable);
+    }
+}


### PR DESCRIPTION
## Summary

ULV-02 (#983) — refactor Meilisearch z 4 per-kind indeksów (`products`, `categories`, `assets`, `brands`) do jednego uniwersalnego `objects` z facetem `object_type_id` + `kind`. Custom kinds dołączają (pre-ULV były skipowane jako MVP scope per ADR-009).

To prerequisite dla ULV-03 (generic list endpoint) — uniwersalna lista musi czytać z jednego indeksu, niezależnie od ObjectType.

## Zmiany

- **`IndexSettingsTemplate`** — `indexName()` zawsze `'objects'`; `settingsFor()` zwraca union (searchable/sortable/filterable z każdego pre-ULV kind'a + dynamiczne attributes.is_filterable=true codes). `Custom` dołączony do `indexedKinds()`.
- **`CatalogObjectIndexer` / `BulkCatalogObjectIndexer`** — per-kind partition + custom skip usunięte. Category denormalizacja keyuje teraz off `ObjectType::isCategorizable()` zamiast hardcoded `kind=product`.
- **`CatalogSearchService`** — query do `'objects'`, dodaje automatyczny filter `kind = "X"` zachowując BC dla "show me only products" callerów.
- **`MeilisearchIndexProvisioner`** — provisions only `'objects'`.
- **`SearchHealthCommand`** — single-row report.
- **`SearchReindexCommand`** — `--kind=custom` akceptowany; purge używa kind-scoped Meili filter.
- **Nowy CLI `pim:search:cleanup-legacy-indexes`** — one-shot cleanup dla 4 starych indexów (idempotent, dry-run).
- **Legacy hint preservation** — `?ObjectKind $kind` argument zachowany w 12 call sites jako no-op żeby uniknąć churn-only renames.

## Quality gates

- ✅ PHPStan max — 0 errors
- ✅ PHPUnit unit/Search — 38/38 zielone (+ 4 nowe dla `IndexSettingsTemplate` consolidation: indexName universal, indexedKinds includes Custom, settingsFor returns same union regardless of kind, searchable/sortable union)
- ✅ Api/Search — 3/3 zielone
- ✅ Api/Catalog/QuickSearchApiTest — 3/3 zielone

## Live-stack smoke proof

Cutover sequence wykonany na `https://pim.localhost`:

```
$ docker compose exec api php bin/console pim:search:health
[OK] Meilisearch healthy (status=available).
 Index    Indexed kinds                            Settings task UID
 objects  product, category, asset, brand, custom  16982

$ docker compose exec api php bin/console pim:search:reindex --purge
Live reindex of every kind into objects (purging existing docs first)
  purged all documents in: objects
[OK] Reindex complete — indexed 0 row(s) in 0 batch(es).
(Empty DB; reindex path validated, no rows to push.)

$ docker compose exec api php bin/console pim:search:cleanup-legacy-indexes
 Index       State    Action
 products    present  deleted
 categories  present  deleted
 assets      present  deleted
 brands      present  deleted

$ docker compose exec api curl http://meilisearch:7700/indexes ...
"objects"   ← jedyny pozostały indeks
```

## Świadome odejścia

- Pre-ULV `Custom` MVP skip usunięty — custom kindy są teraz indeksowane od dnia 1 (spec §3 pkt 1 wymaga uniwersalnego traktowania).
- `?ObjectKind` argument zostawiony w `indexName()`/`settingsFor()`/`provision()` jako no-op zamiast pełnego API breakage — łatwiejsza migracja consumers, dropuje się w przyszłej cleanup PR.

## Test plan

- [x] PHPStan + Biome zielone
- [x] PHPUnit unit + search + catalog api zielone
- [x] Live-stack: provision → reindex → cleanup → tylko `objects` zostaje
- [ ] CI green przed merge

Closes #983