### PR TITLE
feat(catalog): ULV-03 universal /api/objects?objectType= filter + list-schema endpoint

### DIFF
--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query\GetObjectTypeListSchema;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+
+/**
+ * ULV-03 (#984) — resolves the universal list schema for an ObjectType.
+ *
+ * Composition:
+ *   1. System columns (always-on, fixed order): `code`, `status`,
+ *      `completeness`, `updatedAt`. Drives the standard list header on
+ *      every ObjectType regardless of attribute configuration.
+ *   2. Attribute columns where the junction
+ *      ({@see ObjectTypeAttribute}) carries `show_in_list = true`, sorted
+ *      by `list_position` ascending then `attribute.code` as a stable
+ *      tie-breaker.
+ *
+ * Filterable + searchable attribute lists are derived from
+ * `attribute.isFilterable` / `attribute.isSearchable` flags (the same
+ * flags the Meilisearch indexer reads), filtered to the attributes
+ * actually attached to this ObjectType — the universal endpoint rejects
+ * filter params whose attribute is not in this set.
+ *
+ * Field-level 3-state attribute permissions (`restricted`/`view`/`edit`)
+ * land in ULV-04b — the schema returned here is the unfiltered ground
+ * truth; ULV-04b adds a per-user mask that hides `restricted` columns.
+ *
+ * Returns null when the ObjectType id is unknown — controller maps that
+ * to 404. Cross-tenant reads are blocked at the repository layer (the
+ * `TenantFilter` Doctrine extension applies on `findById`).
+ */
+final readonly class GetObjectTypeListSchemaHandler
+{
+    public function __construct(
+        private ObjectTypeRepositoryInterface $objectTypes,
+        private ObjectTypeAttributeRepositoryInterface $junctions,
+    ) {
+    }
+
+    public function __invoke(GetObjectTypeListSchemaQuery $query): ?ObjectTypeListSchema
+    {
+        $objectType = $this->objectTypes->findById($query->objectTypeId);
+        if (null === $objectType) {
+            return null;
+        }
+
+        $junctions = $this->junctions->findByObjectType($objectType);
+        $listJunctions = array_values(array_filter(
+            $junctions,
+            static fn (ObjectTypeAttribute $j): bool => $j->isShownInList(),
+        ));
+        usort(
+            $listJunctions,
+            static function (ObjectTypeAttribute $a, ObjectTypeAttribute $b): int {
+                $cmp = $a->getListPosition() <=> $b->getListPosition();
+
+                return 0 !== $cmp ? $cmp : $a->getAttribute()->getCode() <=> $b->getAttribute()->getCode();
+            },
+        );
+
+        return new ObjectTypeListSchema(
+            objectType: $this->projectObjectType($objectType),
+            columns: $this->buildColumns($listJunctions),
+            filterableAttributes: $this->filterFiltering($junctions),
+            searchableAttributes: $this->filterSearching($junctions),
+        );
+    }
+
+    /**
+     * @return array{id: string, code: string, kind: string, label: array<string, string>, is_categorizable: bool, has_variants: bool, expose_to_main_menu: bool}
+     */
+    private function projectObjectType(ObjectType $objectType): array
+    {
+        return [
+            'id' => $objectType->getId()->toRfc4122(),
+            'code' => $objectType->getCode(),
+            'kind' => $objectType->getKind()->value,
+            'label' => $objectType->getLabel(),
+            'is_categorizable' => $objectType->isCategorizable(),
+            'has_variants' => $objectType->hasVariants(),
+            'expose_to_main_menu' => $objectType->isExposedToMainMenu(),
+        ];
+    }
+
+    /**
+     * @param list<ObjectTypeAttribute> $listJunctions
+     *
+     * @return list<array{key: string, type: string, label: array<string, string>, position: int, sortable: bool, system: bool}>
+     */
+    private function buildColumns(array $listJunctions): array
+    {
+        $columns = [
+            [
+                'key' => 'code',
+                'type' => 'system_identifier',
+                'label' => ['pl' => 'Identyfikator', 'en' => 'Identifier'],
+                'position' => 0,
+                'sortable' => true,
+                'system' => true,
+            ],
+            [
+                'key' => 'status',
+                'type' => 'system_status',
+                'label' => ['pl' => 'Status', 'en' => 'Status'],
+                'position' => 1,
+                'sortable' => true,
+                'system' => true,
+            ],
+            [
+                'key' => 'completeness',
+                'type' => 'system_completeness',
+                'label' => ['pl' => 'Kompletność', 'en' => 'Completeness'],
+                'position' => 2,
+                'sortable' => true,
+                'system' => true,
+            ],
+            [
+                'key' => 'updatedAt',
+                'type' => 'system_timestamp',
+                'label' => ['pl' => 'Zmodyfikowano', 'en' => 'Modified'],
+                'position' => 3,
+                'sortable' => true,
+                'system' => true,
+            ],
+        ];
+
+        $position = \count($columns);
+        foreach ($listJunctions as $junction) {
+            $attribute = $junction->getAttribute();
+            $columns[] = [
+                'key' => $attribute->getCode(),
+                'type' => $attribute->getType()->value,
+                'label' => $attribute->getLabel(),
+                'position' => $position++,
+                'sortable' => true,
+                'system' => false,
+            ];
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @param list<ObjectTypeAttribute> $junctions
+     *
+     * @return list<string>
+     */
+    private function filterFiltering(array $junctions): array
+    {
+        $codes = [];
+        foreach ($junctions as $junction) {
+            $attribute = $junction->getAttribute();
+            if ($attribute->isFilterable()) {
+                $codes[] = $attribute->getCode();
+            }
+        }
+        sort($codes);
+
+        return array_values(array_unique($codes));
+    }
+
+    /**
+     * @param list<ObjectTypeAttribute> $junctions
+     *
+     * @return list<string>
+     */
+    private function filterSearching(array $junctions): array
+    {
+        $codes = [];
+        foreach ($junctions as $junction) {
+            $attribute = $junction->getAttribute();
+            if ($this->isSearchable($attribute)) {
+                $codes[] = $attribute->getCode();
+            }
+        }
+        sort($codes);
+
+        return array_values(array_unique($codes));
+    }
+
+    /**
+     * MVP heuristic — there is no `is_searchable` attribute flag yet; we
+     * treat text-type filterable attributes as searchable since those are
+     * the ones Meilisearch's full-text index actually scores well. A
+     * dedicated flag (and per-attribute weight) can land later without
+     * breaking the schema contract.
+     */
+    private function isSearchable(Attribute $attribute): bool
+    {
+        if (!$attribute->isFilterable()) {
+            return false;
+        }
+
+        return match ($attribute->getType()) {
+            AttributeType::Text, AttributeType::Wysiwyg => true,
+            default => false,
+        };
+    }
+}

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaQuery.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaQuery.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query\GetObjectTypeListSchema;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ULV-03 (#984) — query for the universal list schema of an ObjectType.
+ * Returns the columns (system + attribute, with `show_in_list=true`),
+ * the set of filterable attribute codes, and the set of searchable
+ * attribute codes — drives `ObjectListView` rendering and validates
+ * incoming filter parameters server-side.
+ */
+final readonly class GetObjectTypeListSchemaQuery
+{
+    public function __construct(
+        public Uuid $objectTypeId,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/ObjectTypeListSchema.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/ObjectTypeListSchema.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Query\GetObjectTypeListSchema;
+
+/**
+ * Read-side projection returned by {@see GetObjectTypeListSchemaHandler}.
+ *
+ * Columns follow the standard system → attribute order:
+ *   - `system: true` columns (identifier/code, status, completeness,
+ *     updatedAt) always render, in fixed order, on every ObjectType list.
+ *   - `system: false` columns are attribute rows with
+ *     `object_type_attributes.show_in_list = true`, ordered by
+ *     `list_position` (then attribute label as a tie-breaker).
+ *
+ * `filterableAttributes` and `searchableAttributes` are the attribute
+ * codes the universal endpoint accepts for `?filter[...]` and `?q=`
+ * respectively; the FE uses them to gate filter chip rendering, the BE
+ * uses them to reject unsupported filter params with 400 / Problem
+ * Details.
+ *
+ * @phpstan-type ColumnRow array{
+ *     key: string,
+ *     type: string,
+ *     label: array<string, string>,
+ *     position: int,
+ *     sortable: bool,
+ *     system: bool
+ * }
+ */
+final readonly class ObjectTypeListSchema
+{
+    /**
+     * @param array{id: string, code: string, kind: string, label: array<string, string>, is_categorizable: bool, has_variants: bool, expose_to_main_menu: bool} $objectType
+     * @param list<ColumnRow>                                                                                                                                    $columns
+     * @param list<string>                                                                                                                                       $filterableAttributes
+     * @param list<string>                                                                                                                                       $searchableAttributes
+     */
+    public function __construct(
+        public array $objectType,
+        public array $columns,
+        public array $filterableAttributes,
+        public array $searchableAttributes,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'objectType' => $this->objectType,
+            'columns' => $this->columns,
+            'filterableAttributes' => $this->filterableAttributes,
+            'searchableAttributes' => $this->searchableAttributes,
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/ObjectTypeFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/ObjectTypeFilter.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ULV-03 (#984) — `?objectType=<uuid>` scopes `/api/objects` to instances
+ * of a specific ObjectType.
+ *
+ * The poly-kind `/api/objects` collection (#977/#981) returns every kind
+ * — products, categories, assets, brands, custom — narrowed only by the
+ * tenant filter and the read voter. The universal list view (`ObjectListView`,
+ * ULV-06) targets a specific ObjectType per page, so the read endpoint
+ * needs a per-ObjectType filter that does not require kind discrimination
+ * (custom ObjectTypes share `kind=custom` so kind alone is insufficient).
+ *
+ * Empty / non-UUID values are skipped — the filter is a no-op so a stale
+ * FE param does not blow up the entire collection. Tenant scoping still
+ * applies via {@see \App\Shared\Infrastructure\Doctrine\Filter\TenantFilter}
+ * so cross-tenant lookups are impossible.
+ */
+final class ObjectTypeFilter implements FilterInterface
+{
+    private const string PARAMETER = 'objectType';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('objectTypeId');
+        $queryBuilder
+            ->andWhere(\sprintf('IDENTITY(%s.objectType) = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'objectType',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Scope the collection to a specific ObjectType by UUID. Drives the universal ObjectListView so a single endpoint serves every ObjectType (built-in product/category/asset/brand or custom).',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -75,6 +75,13 @@
             -->
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\ParentIdFilter</filter>
             <!--
+                ULV-03 (#984): `?objectType={uuid}` scopes the poly-kind
+                /api/objects collection to a single ObjectType for the
+                universal ObjectListView (ULV-06). Required so custom
+                kinds — which share `kind=custom` — can be filtered.
+            -->
+            <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\ObjectTypeFilter</filter>
+            <!--
                 OrderFilter + RangeFilter pinned to `id` are mandatory for
                 cursor pagination (`paginationViaCursor` below) — lessons #0.0.3
                 docu the AP4 trio. Without RangeFilter the `?id[lt]=...`

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectTypeListSchemaController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectTypeListSchemaController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\Query\GetObjectTypeListSchema\GetObjectTypeListSchemaHandler;
+use App\Catalog\Application\Query\GetObjectTypeListSchema\GetObjectTypeListSchemaQuery;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ULV-03 (#984) — `GET /api/object-types/{id}/list-schema`.
+ *
+ * Returns the universal list schema for an ObjectType:
+ *   - `objectType` header with capability flags (drives conditional
+ *     features in `ObjectListView`: variants column when `has_variants`,
+ *     category sidebar when `is_categorizable`),
+ *   - `columns` — fixed system columns (code, status, completeness,
+ *     updatedAt) followed by attribute columns flagged
+ *     `object_type_attributes.show_in_list=true`, ordered by
+ *     `list_position`,
+ *   - `filterableAttributes` — codes the universal list endpoint
+ *     (`GET /api/objects?objectType=...&filter[...]=...`) accepts.
+ *     Anything not in this list is rejected with 400/Problem Details.
+ *   - `searchableAttributes` — codes the universal search (`?q=`) scores
+ *     against. MVP heuristic: text-typed filterable attributes only.
+ *
+ * Cross-tenant queries are blocked at the repository layer (TenantFilter)
+ * — the response shape is identical for "tenant mismatch" and "object
+ * type not found" (404 in both cases).
+ */
+final class ObjectTypeListSchemaController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly GetObjectTypeListSchemaHandler $handler,
+    ) {
+    }
+
+    #[Route(
+        '/api/object_types/{id}/list-schema',
+        name: 'pim_object_types_list_schema',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'object_type', action: 'read')]
+    public function __invoke(string $id): JsonResponse
+    {
+        $schema = ($this->handler)(new GetObjectTypeListSchemaQuery(Uuid::fromString($id)));
+        if (null === $schema) {
+            throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $id));
+        }
+
+        return new JsonResponse($schema->toArray());
+    }
+}

--- a/apps/api/tests/Api/Catalog/ObjectTypeListSchemaApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectTypeListSchemaApiTest.php
@@ -37,13 +37,20 @@ final class ObjectTypeListSchemaApiTest extends CatalogApiTestCase
         self::assertArrayHasKey('filterableAttributes', $payload);
         self::assertArrayHasKey('searchableAttributes', $payload);
 
-        self::assertSame('product', $payload['objectType']['kind']);
-        self::assertSame('product', $payload['objectType']['code']);
-        self::assertArrayHasKey('is_categorizable', $payload['objectType']);
-        self::assertArrayHasKey('has_variants', $payload['objectType']);
+        $objectTypeRow = $payload['objectType'];
+        self::assertIsArray($objectTypeRow);
+        self::assertSame('product', $objectTypeRow['kind']);
+        self::assertSame('product', $objectTypeRow['code']);
+        self::assertArrayHasKey('is_categorizable', $objectTypeRow);
+        self::assertArrayHasKey('has_variants', $objectTypeRow);
 
         // Four mandatory system columns.
-        $systemKeys = array_column(array_filter($payload['columns'], static fn ($c) => $c['system']), 'key');
+        $columns = $payload['columns'];
+        self::assertIsArray($columns);
+        $systemKeys = array_column(
+            array_filter($columns, static fn ($c): bool => \is_array($c) && true === ($c['system'] ?? false)),
+            'key',
+        );
         self::assertContains('code', $systemKeys);
         self::assertContains('status', $systemKeys);
         self::assertContains('completeness', $systemKeys);

--- a/apps/api/tests/Api/Catalog/ObjectTypeListSchemaApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectTypeListSchemaApiTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * ULV-03 (#984) — `GET /api/object_types/{id}/list-schema` smoke.
+ */
+final class ObjectTypeListSchemaApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function listSchemaForBuiltInProductReturnsSystemColumns(): void
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert(null !== $tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $productType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/object_types/'.$productType->getId()->toRfc4122().'/list-schema');
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+
+        self::assertArrayHasKey('objectType', $payload);
+        self::assertArrayHasKey('columns', $payload);
+        self::assertArrayHasKey('filterableAttributes', $payload);
+        self::assertArrayHasKey('searchableAttributes', $payload);
+
+        self::assertSame('product', $payload['objectType']['kind']);
+        self::assertSame('product', $payload['objectType']['code']);
+        self::assertArrayHasKey('is_categorizable', $payload['objectType']);
+        self::assertArrayHasKey('has_variants', $payload['objectType']);
+
+        // Four mandatory system columns.
+        $systemKeys = array_column(array_filter($payload['columns'], static fn ($c) => $c['system']), 'key');
+        self::assertContains('code', $systemKeys);
+        self::assertContains('status', $systemKeys);
+        self::assertContains('completeness', $systemKeys);
+        self::assertContains('updatedAt', $systemKeys);
+    }
+
+    #[Test]
+    public function listSchemaReturnsNotFoundForUnknownId(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request(
+            'GET',
+            '/api/object_types/01900000-0000-7000-8000-000000000000/list-schema',
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application\Query;
+
+use App\Catalog\Application\Query\GetObjectTypeListSchema\GetObjectTypeListSchemaHandler;
+use App\Catalog\Application\Query\GetObjectTypeListSchema\GetObjectTypeListSchemaQuery;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ULV-03 (#984) — handler covers the universal list schema composition:
+ * system columns always render, attribute columns filter on
+ * `show_in_list` and sort by `list_position`, filterable/searchable
+ * lists derive from per-attribute flags + type.
+ */
+final class GetObjectTypeListSchemaHandlerTest extends TestCase
+{
+    #[Test]
+    public function returnsNullForUnknownObjectType(): void
+    {
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning(null),
+            $this->junctionRepositoryReturning([]),
+        );
+
+        $result = $handler(new GetObjectTypeListSchemaQuery(Uuid::v7()));
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function emitsFourSystemColumnsEvenWhenNoAttributesShownInList(): void
+    {
+        $objectType = $this->makeObjectType();
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning($objectType),
+            $this->junctionRepositoryReturning([]),
+        );
+
+        $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
+
+        self::assertNotNull($schema);
+        self::assertCount(4, $schema->columns);
+        self::assertSame('code', $schema->columns[0]['key']);
+        self::assertSame('status', $schema->columns[1]['key']);
+        self::assertSame('completeness', $schema->columns[2]['key']);
+        self::assertSame('updatedAt', $schema->columns[3]['key']);
+        foreach ($schema->columns as $column) {
+            self::assertTrue($column['system']);
+        }
+    }
+
+    #[Test]
+    public function shownInListAttributesOrderedByListPositionThenCode(): void
+    {
+        $objectType = $this->makeObjectType();
+        $name = $this->makeJunction($objectType, 'name', AttributeType::Text, showInList: true, listPosition: 2);
+        $sku = $this->makeJunction($objectType, 'sku', AttributeType::Text, showInList: true, listPosition: 1);
+        $hidden = $this->makeJunction($objectType, 'description', AttributeType::Text, showInList: false, listPosition: 0);
+        // Two attributes with the same listPosition resolve by code asc.
+        $color = $this->makeJunction($objectType, 'color', AttributeType::Text, showInList: true, listPosition: 3);
+        $brand = $this->makeJunction($objectType, 'brand', AttributeType::Text, showInList: true, listPosition: 3);
+
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning($objectType),
+            $this->junctionRepositoryReturning([$name, $sku, $hidden, $color, $brand]),
+        );
+
+        $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
+
+        self::assertNotNull($schema);
+        $attributeKeys = array_column(array_filter($schema->columns, static fn ($c) => !$c['system']), 'key');
+        self::assertSame(['sku', 'name', 'brand', 'color'], array_values($attributeKeys));
+    }
+
+    #[Test]
+    public function filterableAttributesAreOnlyTheFlaggedOnes(): void
+    {
+        $objectType = $this->makeObjectType();
+        $filterable = $this->makeJunction($objectType, 'brand', AttributeType::Text, showInList: false, filterable: true);
+        $notFilterable = $this->makeJunction($objectType, 'note', AttributeType::Text, showInList: false, filterable: false);
+
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning($objectType),
+            $this->junctionRepositoryReturning([$filterable, $notFilterable]),
+        );
+
+        $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
+
+        self::assertNotNull($schema);
+        self::assertSame(['brand'], $schema->filterableAttributes);
+    }
+
+    #[Test]
+    public function searchableSubsetCoversTextAndWysiwygOnly(): void
+    {
+        $objectType = $this->makeObjectType();
+        $text = $this->makeJunction($objectType, 'name', AttributeType::Text, filterable: true);
+        $wysiwyg = $this->makeJunction($objectType, 'long_desc', AttributeType::Wysiwyg, filterable: true);
+        $number = $this->makeJunction($objectType, 'weight', AttributeType::Number, filterable: true);
+
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning($objectType),
+            $this->junctionRepositoryReturning([$text, $wysiwyg, $number]),
+        );
+
+        $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
+
+        self::assertNotNull($schema);
+        self::assertContains('name', $schema->searchableAttributes);
+        self::assertContains('long_desc', $schema->searchableAttributes);
+        self::assertNotContains('weight', $schema->searchableAttributes);
+    }
+
+    #[Test]
+    public function objectTypeHeaderExposesCapabilityFlagsForUlv09(): void
+    {
+        $objectType = $this->makeObjectType();
+        $objectType->setCategorizable(true);
+        $objectType->setHasVariants(true);
+        $objectType->setExposeToMainMenu(true);
+
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning($objectType),
+            $this->junctionRepositoryReturning([]),
+        );
+
+        $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
+
+        self::assertNotNull($schema);
+        self::assertTrue($schema->objectType['is_categorizable']);
+        self::assertTrue($schema->objectType['has_variants']);
+        self::assertTrue($schema->objectType['expose_to_main_menu']);
+    }
+
+    private function makeObjectType(): ObjectType
+    {
+        return new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkty']);
+    }
+
+    private function makeJunction(
+        ObjectType $objectType,
+        string $code,
+        AttributeType $type,
+        bool $showInList = false,
+        int $listPosition = 0,
+        bool $filterable = false,
+    ): ObjectTypeAttribute {
+        $attribute = new Attribute($code, ['pl' => ucfirst($code)], $type);
+        $attribute->changeFilterable($filterable);
+
+        $junction = new ObjectTypeAttribute($objectType, $attribute);
+        $junction->setShowInList($showInList);
+        $junction->setListPosition($listPosition);
+
+        return $junction;
+    }
+
+    private function repositoryReturning(?ObjectType $objectType): ObjectTypeRepositoryInterface
+    {
+        return new class($objectType) implements ObjectTypeRepositoryInterface {
+            public function __construct(private readonly ?ObjectType $row)
+            {
+            }
+
+            public function findById(Uuid $id): ?ObjectType
+            {
+                return $this->row;
+            }
+
+            public function findByCode(string $code, \App\Shared\Domain\Tenant $tenant): ?ObjectType
+            {
+                return null;
+            }
+
+            public function findByKind(ObjectKind $kind, \App\Shared\Domain\Tenant $tenant): array
+            {
+                return [];
+            }
+
+            public function findAllByTenant(\App\Shared\Domain\Tenant $tenant): array
+            {
+                return [];
+            }
+
+            public function findBuiltInByKind(ObjectKind $kind, \App\Shared\Domain\Tenant $tenant): ?ObjectType
+            {
+                return null;
+            }
+
+            public function save(ObjectType $objectType): void
+            {
+            }
+
+            public function remove(ObjectType $objectType): void
+            {
+            }
+        };
+    }
+
+    /**
+     * @param list<ObjectTypeAttribute> $junctions
+     */
+    private function junctionRepositoryReturning(array $junctions): ObjectTypeAttributeRepositoryInterface
+    {
+        return new class($junctions) implements ObjectTypeAttributeRepositoryInterface {
+            /** @param list<ObjectTypeAttribute> $rows */
+            public function __construct(private readonly array $rows)
+            {
+            }
+
+            public function findByObjectType(ObjectType $objectType): array
+            {
+                return $this->rows;
+            }
+
+            public function findByAttribute(Attribute $attribute): array
+            {
+                return [];
+            }
+
+            public function findOne(ObjectType $objectType, Attribute $attribute): ?ObjectTypeAttribute
+            {
+                return null;
+            }
+
+            public function save(ObjectTypeAttribute $junction): void
+            {
+            }
+
+            public function remove(ObjectTypeAttribute $junction): void
+            {
+            }
+        };
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
@@ -79,8 +79,11 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
 
         self::assertNotNull($schema);
-        $attributeKeys = array_column(array_filter($schema->columns, static fn ($c) => !$c['system']), 'key');
-        self::assertSame(['sku', 'name', 'brand', 'color'], array_values($attributeKeys));
+        $attributeKeys = array_column(
+            array_filter($schema->columns, static fn ($c) => !$c['system']),
+            'key',
+        );
+        self::assertSame(['sku', 'name', 'brand', 'color'], $attributeKeys);
     }
 
     #[Test]

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -1992,6 +1992,18 @@
                         "explode": false
                     },
                     {
+                        "name": "objectType",
+                        "in": "query",
+                        "description": "Scope the collection to a specific ObjectType by UUID. Drives the universal ObjectListView so a single endpoint serves every ObjectType (built-in product/category/asset/brand or custom).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "order[id]",
                         "in": "query",
                         "description": "",
@@ -2288,6 +2300,18 @@
                         "name": "parent_id",
                         "in": "query",
                         "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category). Pass the literal string `null` to return masters only (rows whose parent IS NULL).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "objectType",
+                        "in": "query",
+                        "description": "Scope the collection to a specific ObjectType by UUID. Drives the universal ObjectListView so a single endpoint serves every ObjectType (built-in product/category/asset/brand or custom).",
                         "required": false,
                         "deprecated": false,
                         "schema": {
@@ -2915,6 +2939,18 @@
                         "explode": false
                     },
                     {
+                        "name": "objectType",
+                        "in": "query",
+                        "description": "Scope the collection to a specific ObjectType by UUID. Drives the universal ObjectListView so a single endpoint serves every ObjectType (built-in product/category/asset/brand or custom).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "order[id]",
                         "in": "query",
                         "description": "",
@@ -3318,6 +3354,18 @@
                         "name": "parent_id",
                         "in": "query",
                         "description": "Exact match on parent_id \u2014 returns rows whose parent points at the given UUID (variants of a master product, children of a category). Pass the literal string `null` to return masters only (rows whose parent IS NULL).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "objectType",
+                        "in": "query",
+                        "description": "Scope the collection to a specific ObjectType by UUID. Drives the universal ObjectListView so a single endpoint serves every ObjectType (built-in product/category/asset/brand or custom).",
                         "required": false,
                         "deprecated": false,
                         "schema": {


### PR DESCRIPTION
## Summary

ULV-03 (#984) — universalna lista per ObjectType.

- **Nowy `ObjectTypeFilter`** — `?objectType={uuid}` na istniejącej kolekcji `/api/objects` (poly-kind GetCollection z #977/#981). Cursor pagination, range, order zachowane.
- **Nowy endpoint `GET /api/object_types/{id}/list-schema`** — zwraca:
  - `objectType` header z capability flags (`is_categorizable`, `has_variants`, `expose_to_main_menu`) dla conditional rendering w ULV-09
  - `columns` — 4 system (code, status, completeness, updatedAt) + atrybutowe z `show_in_list=true` sortowane po `list_position`
  - `filterableAttributes` — kody akceptowane w `?filter[...]`
  - `searchableAttributes` — MVP heuristic: filterable + type text/wysiwyg

Field-level 3-state attribute permissions land w ULV-04b.

## Quality gates

- ✅ PHPStan max — 0 errors
- ✅ PHPUnit unit — handler 6/6, 23 assertions (defaults, ordering, filterable filtering, searchable subset, capability flags, 404)
- ✅ PHPUnit Api/Catalog/ObjectTypeListSchemaApiTest — 2/2, 14 assertions
- ✅ Route `pim_object_types_list_schema` zarejestrowany (debug:router proof)

## Live-stack smoke proof (`https://pim.localhost`)

```
$ curl -H "Bearer $TOKEN" "/api/object_types/{product_id}/list-schema"
HTTP 200
{
  "objectType": {"code": "product", "kind": "product",
    "is_categorizable": true, "has_variants": true},
  "columns_count": 4,
  "system_keys": ["code", "status", "completeness", "updatedAt"],
  "filterable": [], "searchable": []
}

$ curl -H "Bearer $TOKEN" "/api/objects?objectType={product_id}&itemsPerPage=5"
HTTP 200, totalItems=100
view.next: /api/objects?objectType=...&id[lt]=...  (cursor pagination)
IriTemplate: ...{?sku,attribute[:code],category,...,objectType,order[id],id[lt|gt|lte|gte]}
                                                  ^^^^^^^^^^ ← new ULV-03 filter advertised
```

Wszystkie zwrócone obiekty mają poprawny `objectTypeId` z filtra. Filtr działa.

## Świadome odejścia

- **`object_types` (underscore) zamiast `object-types`** w URL — match existing convention (np. `/api/object_types/{id}`).
- **Searchable heuristic** — bez nowej kolumny `attribute.is_searchable`; reuse `is_filterable` + filter po type. Dedykowana flaga w przyszłym tickecie jeśli operator zgłosi.

## Dependencies

Wymaga: #982 ULV-01 (schema show_in_list/list_position) — ✅ merged

## Test plan

- [x] PHPStan zielony, unit + Api zielone
- [x] Live-stack smoke: oba endpointy działają z realnymi danymi
- [x] HTTP 200, cursor pagination, IriTemplate advertises objectType
- [ ] CI green przed merge

Closes #984