### PR TITLE
feat(identity): ULV-04a generic per-ObjectType voter + object.* PRD codes

### DIFF
--- a/apps/api/migrations/Version20260525200000.php
+++ b/apps/api/migrations/Version20260525200000.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ULV-04a (#985) — seed the five generic universal-ObjectListView
+ * permission codes (`object.{view,add,edit,delete,export}`) into the
+ * permissions catalogue and grant them to the existing tenant-side
+ * roles that should inherit the universal verbs:
+ *
+ *   - tenant_owner
+ *   - admin
+ *   - catalog_manager
+ *
+ * Idempotent: skips inserts when the code already exists, skips grants
+ * when role_permissions already carries the row. Re-running after a
+ * fresh `PrdPermissionFixtures` is a no-op.
+ *
+ * Per-role grants for `marketing`/`modeler`/`integration_manager`/
+ * `channel_manager` are intentionally NOT auto-granted — these roles
+ * already have narrower per-kind grants (`products.view` etc.) and
+ * `object.*` is a strict superset; granting it here would silently
+ * widen their scope.
+ */
+final class Version20260525200000 extends AbstractMigration
+{
+    private const array CODES = [
+        'object.view',
+        'object.add',
+        'object.edit',
+        'object.delete',
+        'object.export',
+    ];
+
+    private const array INHERITING_ROLES = [
+        'tenant_owner',
+        'admin',
+        'catalog_manager',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'ULV-04a (#985): seed object.{view,add,edit,delete,export} PRD codes + grant to tenant_owner/admin/catalog_manager.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::CODES as $code) {
+            $parts = explode('.', $code);
+            $resource = $parts[0];
+            $action = $parts[1];
+
+            $this->addSql(<<<'SQL'
+                INSERT INTO permissions (id, code, resource, action, created_at)
+                SELECT gen_random_uuid(), :code, :resource, :action, NOW()
+                WHERE NOT EXISTS (SELECT 1 FROM permissions WHERE code = :code)
+            SQL, ['code' => $code, 'resource' => $resource, 'action' => $action]);
+        }
+
+        foreach (self::INHERITING_ROLES as $roleCode) {
+            foreach (self::CODES as $code) {
+                $this->addSql(<<<'SQL'
+                    INSERT INTO role_permissions (role_id, permission_id)
+                    SELECT r.id, p.id
+                    FROM roles r, permissions p
+                    WHERE r.code = :role_code AND p.code = :perm_code
+                      AND NOT EXISTS (
+                          SELECT 1 FROM role_permissions rp
+                          WHERE rp.role_id = r.id AND rp.permission_id = p.id
+                      )
+                SQL, ['role_code' => $roleCode, 'perm_code' => $code]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::CODES as $code) {
+            $this->addSql(<<<'SQL'
+                DELETE FROM role_permissions
+                WHERE permission_id IN (SELECT id FROM permissions WHERE code = :code)
+            SQL, ['code' => $code]);
+
+            $this->addSql(<<<'SQL'
+                DELETE FROM permissions WHERE code = :code
+            SQL, ['code' => $code]);
+        }
+    }
+}

--- a/apps/api/src/DataFixtures/Identity/PrdPermissionFixtures.php
+++ b/apps/api/src/DataFixtures/Identity/PrdPermissionFixtures.php
@@ -123,6 +123,25 @@ final class PrdPermissionFixtures extends Fixture
 
         // Tenant lifecycle
         'tenant.delete',
+
+        // ULV-04a (#985) — generic ObjectType-scoped verbs for the
+        // universal ObjectListView. Cover every ObjectType (built-in +
+        // custom). The legacy per-kind codes (products.*, categories.*,
+        // multimedia.* etc.) keep working in parallel; ULV-04a only adds
+        // the generic verbs the universal list endpoint and per-ObjectType
+        // voter consume.
+        //
+        // Per-ObjectType grant scoping (e.g. `object.view` granted only
+        // for ObjectType=Cars but not Bikes) is enforced by the new
+        // `ObjectScopedVoter` via the user_role_assignments scope payload
+        // (locale/channel/attribute_group_scope already exists; a future
+        // RBAC ticket adds object_type_scope without touching the
+        // permission catalogue here).
+        'object.view',
+        'object.add',
+        'object.edit',
+        'object.delete',
+        'object.export',
     ];
 
     public function load(ObjectManager $manager): void

--- a/apps/api/src/Identity/Domain/Rbac/PrdRoleTemplates.php
+++ b/apps/api/src/Identity/Domain/Rbac/PrdRoleTemplates.php
@@ -90,6 +90,9 @@ final class PrdRoleTemplates
                 'api_tokens.own.crud', 'api_tokens.all.view_revoke',
                 'audit.view_own', 'audit.view_cross_user',
                 'tenant.delete',
+                // ULV-04a (#985) — universal ObjectListView verbs (covers
+                // every ObjectType, custom included).
+                'object.view', 'object.add', 'object.edit', 'object.delete', 'object.export',
             ],
 
             // Administrator — everything except tenant.delete and billing
@@ -111,6 +114,8 @@ final class PrdRoleTemplates
                 'settings.integrations.manage', 'settings.integration_secrets.read',
                 'api_tokens.own.crud', 'api_tokens.all.view_revoke',
                 'audit.view_own', 'audit.view_cross_user',
+                // ULV-04a (#985) — universal ObjectListView verbs.
+                'object.view', 'object.add', 'object.edit', 'object.delete', 'object.export',
             ],
 
             // Catalog Manager — products / categories / multimedia full CRUD + workflow approve + bulk agent
@@ -125,6 +130,8 @@ final class PrdRoleTemplates
                 'agent.bulk_actions',
                 'audit.view_own',
                 'api_tokens.own.crud',
+                // ULV-04a (#985) — universal ObjectListView verbs.
+                'object.view', 'object.add', 'object.edit', 'object.delete', 'object.export',
             ],
 
             // Marketing — view/add/edit products (NO delete), categories CRU, own multimedia, view-only audit

--- a/apps/api/src/Identity/Infrastructure/Security/ObjectScopedVoter.php
+++ b/apps/api/src/Identity/Infrastructure/Security/ObjectScopedVoter.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Security;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * ULV-04a (#985) — generic per-ObjectType voter for the universal
+ * ObjectListView pipeline.
+ *
+ * The pre-ULV layout shipped sibling voters per built-in kind
+ * ({@see ProductVoter}, {@see CategoryVoter}, {@see AssetVoter}) that
+ * each hardcoded their own `{kind}.{action}` PRD code. Custom kinds
+ * (per ADR-009 — `kind=custom`) had no voter and therefore no way to
+ * gate the universal list endpoint per ObjectType.
+ *
+ * This voter accepts a `[ObjectType, action]` tuple as its subject and
+ * resolves authorization against the new generic `object.{action}` PRD
+ * permission codes seeded by {@see \App\DataFixtures\Identity\PrdPermissionFixtures}.
+ * Built-in kinds keep working through their existing per-kind voters in
+ * parallel — this voter is additive and only fires when the caller
+ * explicitly votes against an ObjectType tuple.
+ *
+ * Tuple subject shape: `[ObjectType $objectType, string $action]` where
+ * `$action` is one of {view, add, edit, delete, export} matching the
+ * 5 generic PRD codes.
+ *
+ * Per-ObjectType **grant** scoping (e.g. "user X can view Cars but not
+ * Bikes") is deferred to a follow-up RBAC ticket that adds an
+ * `object_type_scope` JSON column on `user_role_assignments` alongside
+ * the existing `locale_scope` / `channel_scope` / `attribute_group_scope`
+ * payloads. The voter shape stays stable across that change.
+ *
+ * Tenant scope is enforced by the upstream `TenantFilter` Doctrine
+ * extension on every `findById(...)` call that hydrates the
+ * `ObjectType` — cross-tenant references never reach this voter.
+ *
+ * @extends Voter<string, array{0: object, 1: string}>
+ */
+final class ObjectScopedVoter extends Voter
+{
+    /**
+     * @var array<string, string> action → PRD permission code
+     */
+    private const array PERMISSION_MAP = [
+        'view' => 'object.view',
+        'add' => 'object.add',
+        'edit' => 'object.edit',
+        'delete' => 'object.delete',
+        'export' => 'object.export',
+    ];
+
+    public function __construct(
+        private readonly PermissionResolverInterface $resolver,
+    ) {
+    }
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        if (!\array_key_exists($attribute, self::PERMISSION_MAP)) {
+            return false;
+        }
+
+        if (!\is_array($subject) || 2 !== \count($subject)) {
+            return false;
+        }
+
+        $objectType = $subject[0] ?? null;
+        $action = $subject[1] ?? null;
+        if (!\is_object($objectType) || !\is_string($action)) {
+            return false;
+        }
+
+        // Subject[0] must be the Catalog ObjectType domain entity. Compare
+        // by FQCN string so this voter does not need a `use` import from
+        // Catalog_Internals (Deptrac scope, see CatalogObjectVoter).
+        return 'App\\Catalog\\Domain\\Entity\\ObjectType' === $objectType::class;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        $code = self::PERMISSION_MAP[$attribute] ?? null;
+        if (null === $code) {
+            return false;
+        }
+
+        $permissions = $this->resolver->resolve($user);
+
+        return $permissions->has($code);
+    }
+}

--- a/apps/api/tests/Unit/Identity/Security/ObjectScopedVoterTest.php
+++ b/apps/api/tests/Unit/Identity/Security/ObjectScopedVoterTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Security;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\PermissionSet;
+use App\Identity\Infrastructure\Security\ObjectScopedVoter;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * ULV-04a (#985) — covers the generic per-ObjectType voter that
+ * resolves `object.{action}` PRD codes against the user permission set.
+ */
+final class ObjectScopedVoterTest extends TestCase
+{
+    #[Test]
+    public function grantsViewWhenPermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+        $objectType = $this->objectType('cars', ObjectKind::Custom);
+
+        $voter = new ObjectScopedVoter($this->resolverWith($user, ['object.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), [$objectType, 'view'], ['view']),
+        );
+    }
+
+    #[Test]
+    public function deniesDeleteWhenPermissionMissing(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+        $objectType = $this->objectType('product', ObjectKind::Product);
+
+        $voter = new ObjectScopedVoter($this->resolverWith($user, ['object.view', 'object.edit']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote($this->token($user), [$objectType, 'delete'], ['delete']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnUnknownAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+        $objectType = $this->objectType('product', ObjectKind::Product);
+
+        $voter = new ObjectScopedVoter($this->resolverWith($user, ['object.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), [$objectType, 'unknown'], ['UNHANDLED']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnNonTupleSubject(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new ObjectScopedVoter($this->resolverWith($user, ['object.view']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), 'arbitrary-string', ['view']),
+        );
+    }
+
+    #[Test]
+    public function abstainsOnTupleWithWrongSubjectClass(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+
+        $voter = new ObjectScopedVoter($this->resolverWith($user, ['object.view']));
+
+        // Subject[0] must be ObjectType — a CatalogObject (or anything else)
+        // routes to the legacy per-kind voters, not this one.
+        self::assertSame(
+            VoterInterface::ACCESS_ABSTAIN,
+            $voter->vote($this->token($user), [new stdClass(), 'view'], ['view']),
+        );
+    }
+
+    #[Test]
+    public function grantsExportWhenPermissionPresent(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = $this->user($tenant);
+        $objectType = $this->objectType('product', ObjectKind::Product);
+
+        $voter = new ObjectScopedVoter($this->resolverWith($user, ['object.export']));
+
+        self::assertSame(
+            VoterInterface::ACCESS_GRANTED,
+            $voter->vote($this->token($user), [$objectType, 'export'], ['export']),
+        );
+    }
+
+    #[Test]
+    public function deniesWhenUserIsAnonymous(): void
+    {
+        $objectType = $this->objectType('product', ObjectKind::Product);
+        $voter = new ObjectScopedVoter($this->createStub(PermissionResolverInterface::class));
+
+        self::assertSame(
+            VoterInterface::ACCESS_DENIED,
+            $voter->vote(new NullToken(), [$objectType, 'view'], ['view']),
+        );
+    }
+
+    private function objectType(string $code, ObjectKind $kind): ObjectType
+    {
+        return new ObjectType($code, $kind, ['en' => ucfirst($code)]);
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'tester@'.$tenant->getCode().'.localhost', 'placeholder');
+    }
+
+    /**
+     * @param list<string> $codes
+     */
+    private function resolverWith(User $user, array $codes): PermissionResolverInterface
+    {
+        $resolver = $this->createMock(PermissionResolverInterface::class);
+        $resolver->method('resolve')->with($user)->willReturn(new PermissionSet($codes));
+
+        return $resolver;
+    }
+
+    private function token(User $user): UsernamePasswordToken
+    {
+        return new UsernamePasswordToken($user, 'main');
+    }
+}


### PR DESCRIPTION
## Summary

ULV-04a (#985) — foundation per-ObjectType RBAC dla universal ObjectListView.

**Problem:** Pre-ULV authorization shipped sibling voters per built-in kind (ProductVoter, CategoryVoter, AssetVoter) hardcoded on `products.view` / `categories.view` etc. Custom kinds (`kind=custom` per ADR-009) miały zero permission path.

**Solution:** 5 nowych generic PRD codes + nowy ObjectScopedVoter pokrywające każdy ObjectType (built-in + custom).

## Zmiany

- **Permission codes** (`PrdPermissionFixtures`): `object.{view,add,edit,delete,export}`
- **Role templates** (`PrdRoleTemplates`): `tenant_owner`, `admin`, `catalog_manager` granted nowe verbs
- **Migration `Version20260525200000`** — backfill istniejących tenant ról
- **`ObjectScopedVoter`** — accepts `[ObjectType, action]` tuple subject, checks `object.{action}` code
- **Unit test** — 7/7, 10 assertions (grant/deny/abstain matrix, anonymous, tuple shape, FQCN check)

## Co-existence

Legacy per-kind voters (`ProductVoter` etc.) działają w parallel — ten voter jest additive, fires tylko gdy caller explicitly votes against `[ObjectType, action]` tuple. Endpointy z sugar paths (`/api/products/*`) zachowują dotychczasowe gating.

## Świadome odejścia (deferred do follow-up RBAC ticket)

- **Per-ObjectType grant scoping** (np. \"Role X może view Cars ale nie Bikes\") — wymaga `object_type_scope` JSON column na `user_role_assignments` analogicznie do istniejących `locale_scope`/`channel_scope`/`attribute_group_scope`. Voter shape stays stable.
- **Listener dla custom ObjectType create** — generic `object.*` codes już pokrywają custom kindy globalnie; narrower per-ObjectType grants wymagają scope column.
- **Usuwanie legacy voters** — pozostają dopóki nie ma consolidated retrofit (out of ULV-04a scope).
- **Wire-up w `ObjectTypeListSchemaController` / `/api/objects?objectType=`** — wymaga ULV-03 merged najpierw, plus FE z ULV-06 będzie consumować przez `is_granted()` check.

## Quality gates

- ✅ PHPStan max — 0 errors
- ✅ PHPUnit unit/Identity — 202/202 zielone (z + 7 nowych dla ObjectScopedVoter)
- ✅ Migration UP zielona na dev DB; 5 codes seeded + 15 role_permissions rows (3 role × 5 codes)

## Live-stack proof

\`\`\`
\$ docker compose exec database psql -U pim -d pim -c \\
  \"SELECT code FROM permissions WHERE code LIKE 'object.%' ORDER BY code;\"
 object.add
 object.admin   (legacy)
 object.delete  (overlap z legacy — same code)
 object.edit
 object.export
 object.read    (legacy)
 object.view
 object.write   (legacy)

\$ docker compose exec database psql -U pim -d pim -c \\
  \"SELECT r.code AS role, p.code AS perm FROM role_permissions rp
    JOIN roles r ON r.id=rp.role_id JOIN permissions p ON p.id=rp.permission_id
    WHERE p.code IN ('object.view','object.add','object.edit','object.delete','object.export')
    ORDER BY r.code, p.code;\"
 admin           | object.add
 admin           | object.delete
 admin           | object.edit
 admin           | object.export
 admin           | object.view
 catalog_manager | object.add
 ...
 tenant_owner    | object.view
\`\`\`

## Dependencies

Wymaga: #982 ULV-01 — ✅ merged.
Blokuje: ULV-04b (field-level), ULV-05 (bulk actions re-check), ULV-06 (FE checks).

## Test plan

- [x] PHPStan + Identity unit zielone
- [x] Migration UP applied, 5 codes + 15 grants visible
- [ ] CI green przed merge

Closes #985