### PR TITLE
feat(catalog): ULV-05 universal POST /api/objects/bulk delete endpoint

### DIFF
--- a/apps/api/src/Catalog/Presentation/Controller/BulkObjectsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkObjectsController.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ULV-05 (#987) — universal bulk-action endpoint for the ObjectListView
+ * pipeline.
+ *
+ * `POST /api/objects/bulk` accepts a tuple of `(action, object_ids[])`
+ * and applies the action across every kind of CatalogObject — including
+ * custom kinds that the per-kind sugar endpoints (`/api/products/bulk-*`
+ * etc.) cannot serve.
+ *
+ * MVP scope (minimum viable per ULV epic prioritisation):
+ *   - Single action supported in this slice: `delete`. Other generic
+ *     actions (change_status, assign_category, export) defer to a
+ *     follow-up that pulls each from the existing rich product-side
+ *     handlers ({@see BulkActionsController}) and generalises them.
+ *   - Hard limit 1000 object_ids per request — exceeded → 400 / Problem
+ *     Details. Async batching via Symfony Messenger lands in the same
+ *     follow-up.
+ *   - Permission re-check is server-side via the generic ULV-04a
+ *     `object.{action}` PRD code — every object_id in the request must
+ *     resolve to the same tenant and the caller must hold the verb. Any
+ *     object missing the grant → entire request fails (no partial
+ *     execution).
+ *   - Audit log entry is deferred to the follow-up — the existing
+ *     `AuditLog` entity is `Identity_Internals` and Catalog cannot
+ *     consume it without a dedicated `Identity_Contracts` interface
+ *     that does not yet exist. The dh-auditor bundle still records
+ *     domain entity mutations on the `objects` table via `objects_audit`,
+ *     so the per-row deletion trail is preserved.
+ */
+final class BulkObjectsController
+{
+    private const int HARD_CAP = 1000;
+    private const array SUPPORTED_ACTIONS = ['delete'];
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly TenantContext $tenantContext,
+        private readonly Security $security,
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+    ) {
+    }
+
+    #[Route('/api/objects/bulk', name: 'pim_objects_bulk', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'object', action: 'delete')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+
+        /** @var array<string, mixed> $body */
+        $body = json_decode($request->getContent(), true) ?? [];
+
+        $action = $body['action'] ?? null;
+        if (!\is_string($action) || !\in_array($action, self::SUPPORTED_ACTIONS, true)) {
+            throw new BadRequestHttpException(
+                \sprintf('Unsupported action; expected one of: %s.', implode(', ', self::SUPPORTED_ACTIONS)),
+            );
+        }
+
+        $objectIds = $body['object_ids'] ?? null;
+        if (!\is_array($objectIds) || [] === $objectIds) {
+            throw new BadRequestHttpException('object_ids must be a non-empty array of UUIDs.');
+        }
+
+        if (\count($objectIds) > self::HARD_CAP) {
+            throw new BadRequestHttpException(\sprintf('object_ids exceeds %d hard cap.', self::HARD_CAP));
+        }
+
+        $normalised = [];
+        foreach ($objectIds as $id) {
+            if (!\is_string($id) || !Uuid::isValid($id)) {
+                throw new BadRequestHttpException('object_ids contains a non-UUID value.');
+            }
+            $normalised[] = $id;
+        }
+        $objectIds = array_values(array_unique($normalised));
+
+        // `IS_AUTHENTICATED_FULLY` above guarantees a logged-in principal;
+        // we do not need the User entity here, only the per-object voter
+        // chain that reads it through the token.
+
+        // Per-object permission re-check — every CatalogObject must pass
+        // the existing tenant-aware DELETE voter chain (CatalogObjectVoter
+        // + per-kind sibling voters). The generic ObjectScopedVoter from
+        // ULV-04a layers on top once both PRs land; this endpoint relies
+        // on the legacy gate today so it ships without ULV-04a coupling.
+        $affected = [];
+        /** @var array<string, ObjectType> $seenTypes */
+        $seenTypes = [];
+
+        // Only `delete` is supported in this MVP slice (guarded above); the
+        // mapping pre-exists for the follow-up that adds change_status etc.
+        $voterAttribute = 'DELETE';
+
+        foreach ($objectIds as $rawId) {
+            $catalogObject = $this->catalogObjects->findById(Uuid::fromString($rawId));
+            if (null === $catalogObject) {
+                continue; // Already gone — nothing to delete.
+            }
+
+            $objectTenant = $catalogObject->getTenant();
+            if (null === $objectTenant || $objectTenant->getId()->toRfc4122() !== $tenant->getId()->toRfc4122()) {
+                throw new AccessDeniedHttpException(\sprintf('Object %s is outside the current tenant.', $rawId));
+            }
+
+            if (!$this->security->isGranted($voterAttribute, $catalogObject)) {
+                throw new AccessDeniedHttpException(
+                    \sprintf('Missing %s permission for object %s.', $action, $rawId),
+                );
+            }
+
+            $objectType = $catalogObject->getObjectType();
+            $seenTypes[$objectType->getId()->toRfc4122()] = $objectType;
+            $affected[] = $catalogObject;
+        }
+
+        if ([] !== $affected) {
+            foreach ($affected as $row) {
+                $this->em->remove($row);
+            }
+            $this->em->flush();
+        }
+
+        return new JsonResponse(
+            [
+                'action' => $action,
+                'requested' => \count($objectIds),
+                'affected' => \count($affected),
+                'object_types' => array_keys($seenTypes),
+            ],
+            Response::HTTP_OK,
+        );
+    }
+}

--- a/apps/api/tests/Api/Catalog/BulkObjectsApiTest.php
+++ b/apps/api/tests/Api/Catalog/BulkObjectsApiTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * ULV-05 (#987) — `POST /api/objects/bulk` smoke.
+ */
+final class BulkObjectsApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function rejectsMissingAction(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/objects/bulk', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode([], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsUnknownAction(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/objects/bulk', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode([
+                'action' => 'archive',
+                'object_ids' => [Uuid::v7()->toRfc4122()],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsMalformedObjectIds(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/objects/bulk', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode([
+                'action' => 'delete',
+                'object_ids' => ['not-a-uuid'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsExceedingHardCap(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $ids = [];
+        for ($i = 0; $i < 1001; ++$i) {
+            $ids[] = Uuid::v7()->toRfc4122();
+        }
+
+        $response = $client->request('POST', '/api/objects/bulk', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode(['action' => 'delete', 'object_ids' => $ids], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function deletesProductsViaBulkEndpoint(): void
+    {
+        $product1 = $this->seedProduct('SKU-BULK-001');
+        $product2 = $this->seedProduct('SKU-BULK-002');
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/objects/bulk', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode([
+                'action' => 'delete',
+                'object_ids' => [
+                    $product1->getId()->toRfc4122(),
+                    $product2->getId()->toRfc4122(),
+                ],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+        self::assertSame('delete', $payload['action']);
+        self::assertSame(2, $payload['requested']);
+        self::assertSame(2, $payload['affected']);
+
+        $this->em()->clear();
+        $repo = self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+        self::assertNull($repo->findById($product1->getId()));
+        self::assertNull($repo->findById($product2->getId()));
+    }
+
+    private function seedProduct(string $code): CatalogObject
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $type);
+
+        $object = new CatalogObject($type, $code);
+        $object->updateAttributeIndex(['name' => 'Display '.$code]);
+        $em = $this->em();
+        $em->persist($object);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $object;
+    }
+
+    #[Test]
+    public function returnsZeroAffectedForUnknownIds(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/objects/bulk', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode([
+                'action' => 'delete',
+                'object_ids' => [Uuid::v7()->toRfc4122(), Uuid::v7()->toRfc4122()],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+        self::assertSame(2, $payload['requested']);
+        self::assertSame(0, $payload['affected']);
+    }
+}


### PR DESCRIPTION
## Summary

ULV-05 (#987) — uniwersalny bulk endpoint dla ObjectListView. Akceptuje `(action, object_ids[])` tuple i wykonuje akcję across kind — custom kinds też (per-kind endpointy nie pokrywają).

**MVP slice** (minimum viable per epik UI-08 priorytyzacja):
- Tylko `delete` action; pozostałe (change_status, assign_category, export) defer do follow-up generalizującego istniejący `BulkActionsController`
- Hard cap 1000 object_ids; >1000 → 400 (async batching deferred)
- Per-object voter re-check przez istniejący `CatalogObjectVoter` chain (tenant scope + legacy `object.delete` code)
- Audit log deferred — `AuditLog` w `Identity_Internals` wymaga contracts interface (out of scope)

## Quality gates

- ✅ PHPStan max — 0 errors
- ✅ Api/Catalog/BulkObjectsApiTest — 6/6, 13 assertions (missing action, unknown action, malformed UUID, hard cap, real delete, unknown IDs returns affected=0)

## Live-stack smoke (`https://pim.localhost`)

\`\`\`
\$ POST /api/objects/bulk {action:\"delete\", object_ids:[\"<uuid1>\",\"<uuid2>\"]}
→ HTTP 200
  {action:\"delete\", requested:2, affected:2, object_types:[\"<product_type_uuid>\"]}

\$ POST /api/objects/bulk {} → HTTP 400 \"Unsupported action; expected one of: delete\"
\$ POST /api/objects/bulk {action:\"delete\", object_ids:[\"not-a-uuid\"]} → HTTP 400
\`\`\`

## Świadome odejścia

- `change_status` / `assign_category` / `export` actions — deferred do follow-up. Existing `BulkActionsController` ma rich per-action handlers; generalization wymaga ekstraktu interfejsów.
- Async batching via Symfony Messenger — defer follow-up; 1000 sync limit przechodzi w pojedynczym requeście dla ULV-06 use cases.
- Audit log — wymaga `Identity_Contracts` interface dla AuditLog. dh-auditor bundle nadal trackuje per-row deletions.
- Permission via nowy `ObjectScopedVoter` (ULV-04a) — używa legacy `CatalogObjectVoter` żeby nie blokować na ULV-04a merge.

## Dependencies

Wymaga: #984 ULV-03 — ✅ merged.

## Test plan

- [x] PHPStan + 6 Api tests zielone
- [x] Live-stack smoke: 200 delete, 400 validation
- [ ] CI green

Closes #987