### PR TITLE
feat(identity,catalog): ULV-04b wire 3-state AttributePermissionReader into list-schema

### DIFF
--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
@@ -10,6 +10,7 @@ use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Contracts\Policy\AttributePermissionReader;
 
 /**
  * ULV-03 (#984) — resolves the universal list schema for an ObjectType.
@@ -42,6 +43,7 @@ final readonly class GetObjectTypeListSchemaHandler
     public function __construct(
         private ObjectTypeRepositoryInterface $objectTypes,
         private ObjectTypeAttributeRepositoryInterface $junctions,
+        private AttributePermissionReader $attributePermissions,
     ) {
     }
 
@@ -53,6 +55,16 @@ final readonly class GetObjectTypeListSchemaHandler
         }
 
         $junctions = $this->junctions->findByObjectType($objectType);
+        // ULV-04b (#986) — drop junctions whose attribute is `restricted`
+        // for the caller. The 3-state policy resolves to `Restricted`
+        // when no per-role grant exists for the broad gate (PRD §3.5
+        // Step 0) or when an explicit grant restricts it.
+        $junctions = array_values(array_filter(
+            $junctions,
+            fn (ObjectTypeAttribute $j): bool => $this->attributePermissions->canViewAttribute(
+                $j->getAttribute()->getId(),
+            ),
+        ));
         $listJunctions = array_values(array_filter(
             $junctions,
             static fn (ObjectTypeAttribute $j): bool => $j->isShownInList(),

--- a/apps/api/src/Identity/Application/Policy/SecurityAttributePermissionReader.php
+++ b/apps/api/src/Identity/Application/Policy/SecurityAttributePermissionReader.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Policy;
+
+use App\Identity\Contracts\Policy\AttributePermissionReader;
+use App\Identity\Domain\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ULV-04b (#986) — adapter wiring the {@see AttributePermissionReader}
+ * contract to the existing {@see AttributePermissionPolicy} resolver +
+ * Symfony security token.
+ *
+ * The resolver expects a {@see User} entity; this adapter pulls it from
+ * the security token. Anonymous principals → false (restricted) because
+ * no per-attribute grant can apply without a user identity.
+ */
+final readonly class SecurityAttributePermissionReader implements AttributePermissionReader
+{
+    public function __construct(
+        private Security $security,
+        private AttributePermissionPolicy $policy,
+    ) {
+    }
+
+    public function canViewAttribute(Uuid $attributeId): bool
+    {
+        $user = $this->currentUser();
+        if (null === $user) {
+            return false;
+        }
+
+        return $this->policy->canViewAttribute($user, $attributeId);
+    }
+
+    public function canEditAttribute(Uuid $attributeId): bool
+    {
+        $user = $this->currentUser();
+        if (null === $user) {
+            return false;
+        }
+
+        return $this->policy->canEditAttribute($user, $attributeId);
+    }
+
+    private function currentUser(): ?User
+    {
+        $user = $this->security->getUser();
+
+        return $user instanceof User ? $user : null;
+    }
+}

--- a/apps/api/src/Identity/Contracts/Policy/AttributePermissionReader.php
+++ b/apps/api/src/Identity/Contracts/Policy/AttributePermissionReader.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Policy;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ULV-04b (#986) — cross-context contract for the 3-state per-attribute
+ * permission resolution (PRD §3.5).
+ *
+ * The full {@see \App\Identity\Application\Policy\AttributePermissionPolicy}
+ * resolver lives in `Identity_Internals` and cannot be imported by
+ * Catalog (Deptrac). This contract exposes the minimum surface other
+ * bundles need — answering "can the **current** user view / edit this
+ * attribute id" — so the universal list schema (ULV-03) and any future
+ * field-level filtering can gate columns and serialized values without
+ * leaking the policy chain.
+ *
+ * The current user / tenant comes from the Symfony security token via
+ * the adapter; callers do not pass the user explicitly. That keeps the
+ * surface narrow and the contract testable with a simple fake.
+ *
+ * Implementations must return `false` for anonymous principals (no
+ * authenticated user → no view → restricted column).
+ */
+interface AttributePermissionReader
+{
+    public function canViewAttribute(Uuid $attributeId): bool;
+
+    public function canEditAttribute(Uuid $attributeId): bool;
+}

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
@@ -13,6 +13,7 @@ use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Identity\Contracts\Policy\AttributePermissionReader;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
@@ -31,6 +32,7 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         $handler = new GetObjectTypeListSchemaHandler(
             $this->repositoryReturning(null),
             $this->junctionRepositoryReturning([]),
+            $this->permissionsAllow(),
         );
 
         $result = $handler(new GetObjectTypeListSchemaQuery(Uuid::v7()));
@@ -45,6 +47,7 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         $handler = new GetObjectTypeListSchemaHandler(
             $this->repositoryReturning($objectType),
             $this->junctionRepositoryReturning([]),
+            $this->permissionsAllow(),
         );
 
         $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
@@ -74,6 +77,7 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         $handler = new GetObjectTypeListSchemaHandler(
             $this->repositoryReturning($objectType),
             $this->junctionRepositoryReturning([$name, $sku, $hidden, $color, $brand]),
+            $this->permissionsAllow(),
         );
 
         $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
@@ -96,6 +100,7 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         $handler = new GetObjectTypeListSchemaHandler(
             $this->repositoryReturning($objectType),
             $this->junctionRepositoryReturning([$filterable, $notFilterable]),
+            $this->permissionsAllow(),
         );
 
         $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
@@ -115,6 +120,7 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         $handler = new GetObjectTypeListSchemaHandler(
             $this->repositoryReturning($objectType),
             $this->junctionRepositoryReturning([$text, $wysiwyg, $number]),
+            $this->permissionsAllow(),
         );
 
         $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
@@ -123,6 +129,32 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         self::assertContains('name', $schema->searchableAttributes);
         self::assertContains('long_desc', $schema->searchableAttributes);
         self::assertNotContains('weight', $schema->searchableAttributes);
+    }
+
+    #[Test]
+    public function hidesRestrictedAttributeFromColumnsAndFilters(): void
+    {
+        $objectType = $this->makeObjectType();
+        $visible = $this->makeJunction($objectType, 'name', AttributeType::Text, showInList: true, filterable: true);
+        $restricted = $this->makeJunction($objectType, 'margin', AttributeType::Number, showInList: true, filterable: true);
+        $restrictedId = $restricted->getAttribute()->getId()->toRfc4122();
+
+        $handler = new GetObjectTypeListSchemaHandler(
+            $this->repositoryReturning($objectType),
+            $this->junctionRepositoryReturning([$visible, $restricted]),
+            $this->permissionsRestrictByCode($restrictedId),
+        );
+
+        $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
+
+        self::assertNotNull($schema);
+        $attributeKeys = array_column(
+            array_filter($schema->columns, static fn ($c) => !$c['system']),
+            'key',
+        );
+        self::assertSame(['name'], $attributeKeys, 'restricted attribute removed from columns');
+        self::assertNotContains('margin', $schema->filterableAttributes);
+        self::assertContains('name', $schema->filterableAttributes);
     }
 
     #[Test]
@@ -136,6 +168,7 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         $handler = new GetObjectTypeListSchemaHandler(
             $this->repositoryReturning($objectType),
             $this->junctionRepositoryReturning([]),
+            $this->permissionsAllow(),
         );
 
         $schema = $handler(new GetObjectTypeListSchemaQuery($objectType->getId()));
@@ -144,6 +177,42 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
         self::assertTrue($schema->objectType['is_categorizable']);
         self::assertTrue($schema->objectType['has_variants']);
         self::assertTrue($schema->objectType['expose_to_main_menu']);
+    }
+
+    private function permissionsAllow(): AttributePermissionReader
+    {
+        return new class implements AttributePermissionReader {
+            public function canViewAttribute(Uuid $attributeId): bool
+            {
+                return true;
+            }
+
+            public function canEditAttribute(Uuid $attributeId): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    private function permissionsRestrictByCode(string $restrictedCode): AttributePermissionReader
+    {
+        $blockedCode = $restrictedCode;
+
+        return new class($blockedCode) implements AttributePermissionReader {
+            public function __construct(private readonly string $code)
+            {
+            }
+
+            public function canViewAttribute(Uuid $attributeId): bool
+            {
+                return $this->code !== $attributeId->toRfc4122();
+            }
+
+            public function canEditAttribute(Uuid $attributeId): bool
+            {
+                return $this->code !== $attributeId->toRfc4122();
+            }
+        };
     }
 
     private function makeObjectType(): ObjectType


### PR DESCRIPTION
## Summary

ULV-04b (#986) — wire existing Phase 5 #697 infrastructure (`role_attribute_permissions` + `AttributePermissionPolicy`) cross-context tak żeby ULV-03 list-schema endpoint strip'ował restricted kolumny per caller.

**Key insight z research**: 3-state schema + resolver już istnieją z Phase 5 #697. ULV-04b realny scope = nowy contracts interface + integracja w handler.

## Zmiany

- **`Identity\Contracts\Policy\AttributePermissionReader`** — cross-context interface operating on current security token (no User param, avoids Catalog → Identity_Internals coupling)
- **`SecurityAttributePermissionReader`** — adapter z Symfony Security + existing `AttributePermissionPolicy`
- **`GetObjectTypeListSchemaHandler`** — junctions z `Restricted` permission filtered out przed columns/filterable/searchable computation

## Quality gates

- ✅ PHPStan max — 0 errors
- ✅ PHPUnit unit/Catalog Query — 7/7, 27 assertions (+ nowy test: `hidesRestrictedAttributeFromColumnsAndFilters`)

## Świadome odejścia

- **Response-side filtering on /api/objects** — schema endpoint hides restricted kolumny, ale raw payload (`attributesIndexed` JSONB) wciąż zawiera every value. Serializer hook ląduje gdy FE faktycznie surface'uje values w list grid (ULV-06+ scope).
- **Bulk export pruning** — ULV-05 export action jeszcze nie shipped.
- **Audit log na permission denials** — wymaga `Identity_Contracts` interface (jak ULV-05 PR udokumentował).

## Dependencies

Wymaga: #984 ULV-03 (handler) — ✅ merged.

## Test plan

- [x] PHPStan + 7 unit tests zielone
- [x] Restricted attribute hidden from columns + filterable
- [ ] CI green

Closes #986