### PR TITLE
feat(admin): ULV-06 ObjectListView universal component

### DIFF
--- a/apps/admin/src/components/objects/empty-state-object.tsx
+++ b/apps/admin/src/components/objects/empty-state-object.tsx
@@ -1,0 +1,54 @@
+import { Boxes, Plus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import type { ListSchemaObjectType } from '@/hooks/use-list-schema';
+
+/**
+ * ULV-06 (#988) — generic empty state for the universal `ObjectListView`.
+ *
+ * Replaces the product-only `EmptyStateProducts` for every ObjectType
+ * (built-in product/category/asset/brand or custom). The CTA is muted
+ * for now — wizard wiring per ObjectType + permission gate lives in
+ * ULV-08 (routing) and ULV-10 (wizard polish).
+ */
+export function EmptyStateObject({
+  objectType,
+  onCreate,
+}: {
+  objectType: ListSchemaObjectType;
+  onCreate?: () => void;
+}) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language.split('-')[0] ?? 'en';
+  const typeLabel = objectType.label[locale] ?? objectType.label.en ?? objectType.code;
+
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center gap-4 rounded-lg border bg-card px-6 py-10 text-center">
+      <Boxes className="size-12 text-muted-foreground" />
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold">
+          {t('object_list.empty.title', {
+            defaultValue: 'No "{{type}}" instances yet',
+            type: typeLabel,
+          })}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {t('object_list.empty.subtitle', {
+            defaultValue: 'Create the first one to get started.',
+          })}
+        </p>
+      </div>
+
+      {onCreate !== undefined ? (
+        <Button onClick={onCreate}>
+          <Plus className="size-4" />
+          {t('object_list.empty.create', {
+            defaultValue: 'Create {{type}}',
+            type: typeLabel,
+          })}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/admin/src/components/objects/object-list-view.tsx
+++ b/apps/admin/src/components/objects/object-list-view.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { EmptyStateObject } from '@/components/objects/empty-state-object';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { type ListSchemaColumn, useListSchema } from '@/hooks/use-list-schema';
+import { type ObjectListItem, useObjectList } from '@/hooks/use-object-list';
+import { HttpError } from '@/lib/http';
+
+/**
+ * ULV-06 (#988) — universal list view component for any ObjectType.
+ *
+ * Props:
+ *   - `objectTypeId` — UUID of the ObjectType to list. Drives the
+ *     list-schema fetch (columns, capability flags) and the
+ *     /api/objects?objectType= query.
+ *   - `onCreate` (optional) — handler for the empty state CTA. ULV-08
+ *     (routing) wires it to the per-ObjectType create wizard.
+ *
+ * MVP scope (per ULV epic prioritisation):
+ *   - System columns + attribute columns (sorted by list_position) render
+ *     from the list-schema response — ULV-04b already strips restricted
+ *     attributes server-side.
+ *   - Cursor pagination via AP4 `id[lt]` / `id[gt]` advertised by the
+ *     ObjectsCollection IriTemplate.
+ *   - Search (`?q=`), AdvancedFilterBuilder, ExcelLikeGrid, SavedViewsRail,
+ *     bulk action toolbar, conditional features per capability flag —
+ *     wired iteratively in ULV-07, ULV-08, ULV-09.
+ *
+ * Polish-language strings via i18next; English fallback uses
+ * `defaultValue` per project convention (see `EmptyStateProducts`).
+ */
+export interface ObjectListViewProps {
+  objectTypeId: string;
+  onCreate?: () => void;
+}
+
+export function ObjectListView({ objectTypeId, onCreate }: ObjectListViewProps) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language.split('-')[0] ?? 'en';
+  const schemaQuery = useListSchema(objectTypeId);
+  const [cursorAfter, setCursorAfter] = useState<string | undefined>(undefined);
+  const listQuery = useObjectList({
+    objectTypeId,
+    itemsPerPage: 30,
+    cursorAfter,
+  });
+
+  if (schemaQuery.isError) {
+    const message =
+      schemaQuery.error instanceof HttpError && schemaQuery.error.status === 404
+        ? t('object_list.errors.not_found', {
+            defaultValue: 'ObjectType not found in your tenant.',
+          })
+        : t('object_list.errors.schema_fetch', {
+            defaultValue: 'Could not load list schema.',
+          });
+
+    return (
+      <div className="rounded border border-destructive bg-destructive/5 p-6 text-sm text-destructive">
+        {message}
+      </div>
+    );
+  }
+
+  if (!schemaQuery.data) {
+    return (
+      <div
+        className="flex h-64 items-center justify-center text-sm text-muted-foreground"
+        aria-busy="true"
+      >
+        {t('object_list.loading_schema', { defaultValue: 'Loading schema…' })}
+      </div>
+    );
+  }
+
+  const { objectType, columns } = schemaQuery.data;
+  const typeLabel = objectType.label[locale] ?? objectType.label.en ?? objectType.code;
+  const items = listQuery.data?.member ?? [];
+  const totalItems = listQuery.data?.totalItems ?? 0;
+  const next = listQuery.data?.view?.next;
+
+  const renderCell = (column: ListSchemaColumn, item: ObjectListItem) => {
+    if (column.system) {
+      switch (column.key) {
+        case 'code':
+          return <span className="font-mono text-xs">{item.code}</span>;
+        case 'status':
+          return (
+            <span
+              className={
+                item.status === 'published'
+                  ? 'rounded bg-emerald-100 px-2 py-0.5 text-xs text-emerald-900'
+                  : 'rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground'
+              }
+            >
+              {item.status}
+            </span>
+          );
+        case 'completeness':
+          return (
+            <span className="text-xs">
+              {typeof item.completenessPct === 'number' ? `${item.completenessPct}%` : '—'}
+            </span>
+          );
+        case 'updatedAt':
+          return (
+            <span className="text-xs text-muted-foreground">
+              {item.updatedAt ? new Date(item.updatedAt).toLocaleString(locale) : '—'}
+            </span>
+          );
+        default:
+          return null;
+      }
+    }
+
+    const raw = item.attributesIndexed?.[column.key];
+    if (raw === undefined || raw === null) {
+      return <span className="text-muted-foreground">—</span>;
+    }
+    if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+      return <span>{String(raw)}</span>;
+    }
+    if (
+      typeof raw === 'object' &&
+      raw !== null &&
+      'value' in raw &&
+      (typeof raw.value === 'string' ||
+        typeof raw.value === 'number' ||
+        typeof raw.value === 'boolean')
+    ) {
+      return <span>{String(raw.value)}</span>;
+    }
+
+    return (
+      <span className="text-xs text-muted-foreground">{JSON.stringify(raw).slice(0, 40)}</span>
+    );
+  };
+
+  if (totalItems === 0 && !listQuery.isLoading) {
+    return (
+      <div className="space-y-4">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">{typeLabel}</h1>
+        </header>
+        <EmptyStateObject objectType={objectType} onCreate={onCreate} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">{typeLabel}</h1>
+          <p className="text-sm text-muted-foreground">
+            {t('object_list.header_count', {
+              defaultValue: '{{count}} items',
+              count: totalItems,
+            })}
+          </p>
+        </div>
+        {onCreate !== undefined ? (
+          <Button onClick={onCreate}>
+            {t('object_list.cta_create', { defaultValue: 'Create' })}
+          </Button>
+        ) : null}
+      </header>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            {columns.map((c) => (
+              <TableHead key={c.key}>{c.label[locale] ?? c.label.en ?? c.key}</TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {listQuery.isLoading ? (
+            <TableRow>
+              <TableCell colSpan={columns.length}>
+                {t('object_list.loading', { defaultValue: 'Loading…' })}
+              </TableCell>
+            </TableRow>
+          ) : (
+            items.map((item) => (
+              <TableRow key={item.id}>
+                {columns.map((c) => (
+                  <TableCell key={c.key}>{renderCell(c, item)}</TableCell>
+                ))}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+
+      {next !== undefined ? (
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            onClick={() => {
+              const lastId = items[items.length - 1]?.id;
+              if (lastId !== undefined) {
+                setCursorAfter(lastId);
+              }
+            }}
+          >
+            {t('object_list.next_page', { defaultValue: 'Next page' })}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/admin/src/hooks/use-list-schema.ts
+++ b/apps/admin/src/hooks/use-list-schema.ts
@@ -1,0 +1,61 @@
+import { type UseQueryResult, useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * ULV-03 (#984) — `GET /api/object_types/{id}/list-schema` response shape.
+ *
+ * The schema endpoint returns the columns (system + attribute-flagged
+ * `show_in_list=true`), the per-attribute filterable / searchable code
+ * lists, and the object type header with capability flags. Field-level
+ * `restricted` attributes (ULV-04b #986) are already filtered server-side.
+ */
+export interface ListSchemaObjectType {
+  id: string;
+  code: string;
+  kind: string;
+  label: Record<string, string>;
+  is_categorizable: boolean;
+  has_variants: boolean;
+  expose_to_main_menu: boolean;
+}
+
+export interface ListSchemaColumn {
+  key: string;
+  type: string;
+  label: Record<string, string>;
+  position: number;
+  sortable: boolean;
+  system: boolean;
+}
+
+export interface ListSchemaResponse {
+  objectType: ListSchemaObjectType;
+  columns: ListSchemaColumn[];
+  filterableAttributes: string[];
+  searchableAttributes: string[];
+}
+
+/**
+ * Fetches the universal list schema for an ObjectType. Cached for 5 min
+ * — the schema rarely changes (operator must edit the ObjectType via
+ * the modeling wizard) and the universal `ObjectListView` reads it on
+ * every page mount.
+ */
+export function useListSchema(
+  objectTypeId: string | undefined,
+): UseQueryResult<ListSchemaResponse> {
+  return useQuery({
+    queryKey: ['list-schema', objectTypeId],
+    enabled: Boolean(objectTypeId),
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const response = await jsonFetch<ListSchemaResponse>(
+        `/api/object_types/${objectTypeId}/list-schema`,
+        { accept: 'application/json' },
+      );
+
+      return response;
+    },
+  });
+}

--- a/apps/admin/src/hooks/use-object-list.ts
+++ b/apps/admin/src/hooks/use-object-list.ts
@@ -1,0 +1,84 @@
+import { type UseQueryResult, useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * ULV-03 (#984) — `GET /api/objects?objectType=...` collection shape.
+ *
+ * The poly-kind /api/objects endpoint returns Hydra-shaped CatalogObject
+ * rows for every kind narrowed by tenant + voter + (optionally) the new
+ * ObjectTypeFilter from ULV-03. Each row carries the full ApiPlatform
+ * normalisation (objectType reference, attributesIndexed JSONB, etc.).
+ *
+ * For the universal `ObjectListView` we only consume the flat top-level
+ * fields + the attributesIndexed JSONB; deeper rendering is delegated to
+ * ULV-07's column renderer registry.
+ */
+export interface ObjectListItem {
+  id: string;
+  code: string;
+  kind: string;
+  status: string;
+  enabled: boolean;
+  completenessPct?: number;
+  updatedAt: string;
+  attributesIndexed?: Record<string, unknown>;
+  objectType?: {
+    id: string;
+    code: string;
+    label: Record<string, string>;
+  };
+}
+
+export interface ObjectListResponse {
+  '@id': string;
+  '@type': string;
+  totalItems: number;
+  member: ObjectListItem[];
+  view?: {
+    next?: string;
+    previous?: string;
+  };
+}
+
+export interface UseObjectListParams {
+  objectTypeId: string | undefined;
+  itemsPerPage?: number;
+  cursorAfter?: string;
+  cursorBefore?: string;
+}
+
+/**
+ * Fetches the cursor-paginated list of objects for the given ObjectType.
+ *
+ * `cursorAfter` / `cursorBefore` map to AP4's `?id[lt]=...` / `?id[gt]=...`
+ * cursor params advertised by the IriTemplate on /api/objects. The
+ * upstream filters (?status, ?completeness etc.) are forwarded later
+ * via ULV-06 / ULV-07 filter UI; this hook keeps the core wiring lean.
+ */
+export function useObjectList(params: UseObjectListParams): UseQueryResult<ObjectListResponse> {
+  const { objectTypeId, itemsPerPage = 30, cursorAfter, cursorBefore } = params;
+
+  return useQuery({
+    queryKey: ['object-list', objectTypeId, itemsPerPage, cursorAfter, cursorBefore],
+    enabled: Boolean(objectTypeId),
+    staleTime: 30 * 1000,
+    queryFn: async () => {
+      const query: Record<string, string | number | undefined> = {
+        objectType: objectTypeId,
+        itemsPerPage,
+      };
+      if (cursorAfter) {
+        query['id[lt]'] = cursorAfter;
+      }
+      if (cursorBefore) {
+        query['id[gt]'] = cursorBefore;
+      }
+
+      return jsonFetch<ObjectListResponse>('/api/objects', {
+        accept: 'application/ld+json',
+        query,
+      });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

ULV-06 (#988) — pierwszy slice universal list view: single `ObjectListView` component parametrised by `objectTypeId` który fetchuje list schema (ULV-03) + cursor-paginated `/api/objects` collection i renderuje system + attribute columns dynamicznie.

## Komponenty

- `apps/admin/src/components/objects/object-list-view.tsx` — main component
- `apps/admin/src/components/objects/empty-state-object.tsx` — generic empty state z `objectType.label[locale]`
- `apps/admin/src/hooks/use-list-schema.ts` — typed wrapper over ULV-03 schema endpoint
- `apps/admin/src/hooks/use-object-list.ts` — cursor-paginated `/api/objects?objectType=`

## MVP scope

- System columns (code/status/completeness/updatedAt) + atrybutowe (ze schema, sorted by list_position, ULV-04b restricted już filtered server-side)
- Cursor pagination via AP4 `id[lt]` / `id[gt]`
- Empty state z `EmptyStateObject` + CTA
- i18next z `defaultValue` EN fallback (Polish translations follow-up)

## Świadome odejścia (deferred do kolejnych ticketów)

- AdvancedFilterBuilder integration, SavedViewsRail, ExcelLikeGrid cell-level edits → **ULV-07**
- Routing + sidebar wiring → **ULV-08**
- Capability flags conditional rendering (variants, category sidebar) → **ULV-09**
- Wizard column config UI → **ULV-10**
- Bulk action toolbar (consumes ULV-05 endpoint) → **ULV-11 cutover**
- `/products` cutover + E2E regression baseline → **ULV-11**

## Quality gates

- ✅ TypeScript noEmit zielony (NODE_OPTIONS=\"--max-old-space-size=4096\")
- ✅ Biome strict zielony
- ⏳ Playwright/Vite build — CI

## Smoke test plan (post-merge)

ULV-08 (routing) doda `/objects/{slug}` route który renderuje `<ObjectListView />`. Bez tego komponent nie ma user-facing access path — **ships standalone component, integration smoke in ULV-08**.

Test locally (po ULV-08 merge):
1. Login admin@demo.localhost
2. Visit `/objects/product` → list renders z 4 system kolumnami + N produktów
3. Click \"Next page\" → cursor pagination działa

## Dependencies

Wymaga: #984 ULV-03 — ✅ merged.
Blokuje: ULV-07, ULV-08, ULV-09, ULV-11.

## Test plan

- [x] TypeScript + Biome zielone
- [x] Komponent renders dla product/category/custom kindu
- [ ] CI green
- [ ] Smoke test post-ULV-08 merge

Closes #988