### PR TITLE
feat(admin): ULV-09 capability badges on ObjectListView header

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -112,6 +112,10 @@ const ObjectListingPlaceholder = lazyPage(
   () => import('@/features/catalog/objects/placeholder'),
   'ObjectListingPlaceholder',
 );
+const UniversalObjectListPage = lazyPage(
+  () => import('@/features/catalog/objects/list-page'),
+  'ObjectListPage',
+);
 const ProductCreatePage = lazyPage(
   () => import('@/features/catalog/products/create'),
   'ProductCreatePage',
@@ -397,6 +401,11 @@ function App() {
                 <Route path="/dashboard" element={<DashboardPage />} />
                 <Route path="/products" element={<ProductListPage />} />
                 <Route path="/products/new" element={<ProductCreatePage />} />
+                {/* ULV-08 (#990) — universal /objects/{slug} route renders
+                    the ObjectListView for any ObjectType by code. The
+                    legacy /products / /categories / /assets routes keep
+                    pointing at their own pages until ULV-11 cuts over. */}
+                <Route path="/objects/:slug" element={<UniversalObjectListPage />} />
                 {/* VIEW-07 (#420): edit page is now inline-edit on /products/:id.
                     Keep the legacy path as a back-compat redirect for bookmarks
                     and Refine resource lookups that still ask for `edit`. */}

--- a/apps/admin/src/components/objects/object-list-view.tsx
+++ b/apps/admin/src/components/objects/object-list-view.tsx
@@ -159,8 +159,27 @@ export function ObjectListView({ objectTypeId, onCreate }: ObjectListViewProps) 
   return (
     <div className="space-y-4">
       <header className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">{typeLabel}</h1>
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold">{typeLabel}</h1>
+            {/* ULV-09 (#991) — capability badges: variants + categorizable
+                surface on the header so operators see at a glance whether
+                this ObjectType opts into the conditional features (variant
+                tree, category sidebar). Each badge is muted; the actual
+                feature wiring rides in dedicated tickets (variant column
+                expander + category filter sidebar) which the ULV-09
+                minimum-viable slice keeps deferred so the badge ships now. */}
+            {objectType.has_variants ? (
+              <span className="rounded bg-violet-100 px-2 py-0.5 text-xs text-violet-900">
+                {t('object_list.capability.variants', { defaultValue: 'Variants' })}
+              </span>
+            ) : null}
+            {objectType.is_categorizable ? (
+              <span className="rounded bg-sky-100 px-2 py-0.5 text-xs text-sky-900">
+                {t('object_list.capability.categorizable', { defaultValue: 'Categorized' })}
+              </span>
+            ) : null}
+          </div>
           <p className="text-sm text-muted-foreground">
             {t('object_list.header_count', {
               defaultValue: '{{count}} items',

--- a/apps/admin/src/features/catalog/objects/list-page.tsx
+++ b/apps/admin/src/features/catalog/objects/list-page.tsx
@@ -1,0 +1,70 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router';
+
+import { ObjectListView } from '@/components/objects/object-list-view';
+import { jsonFetch } from '@/lib/http';
+
+/**
+ * ULV-08 (#990) — `/objects/:slug` route renders the universal
+ * `ObjectListView` for the ObjectType whose `code` (per ULV-01 reused as
+ * URL slug) matches.
+ *
+ * Resolution: we query the existing `/api/object_types?code=...` filter
+ * for a single match, then pass its UUID to `ObjectListView`. The lookup
+ * is cached for 5 min — slugs are stable and the slug→id mapping is the
+ * hottest part of the route hit.
+ *
+ * `/products`, `/categories`, `/assets` keep working through their own
+ * routes (ULV-11 will collapse them into this path with regression
+ * baseline). 404 if no matching ObjectType in the current tenant.
+ */
+interface ObjectTypeLookupResponse {
+  member?: Array<{ id: string; code: string }>;
+  'hydra:member'?: Array<{ id: string; code: string }>;
+}
+
+export function ObjectListPage() {
+  const { t } = useTranslation();
+  const { slug } = useParams<{ slug: string }>();
+
+  const lookup = useQuery({
+    queryKey: ['object-type-by-code', slug],
+    enabled: typeof slug === 'string' && slug.length > 0,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async () => {
+      const response = await jsonFetch<ObjectTypeLookupResponse>('/api/object_types', {
+        accept: 'application/ld+json',
+        query: { code: slug, itemsPerPage: 1 },
+      });
+      const members = response.member ?? response['hydra:member'] ?? [];
+      return members[0] ?? null;
+    },
+  });
+
+  if (lookup.isLoading) {
+    return (
+      <div
+        aria-busy="true"
+        className="flex h-64 items-center justify-center text-sm text-muted-foreground"
+      >
+        {t('object_list.resolving_slug', { defaultValue: 'Resolving ObjectType…' })}
+      </div>
+    );
+  }
+
+  if (lookup.isError || lookup.data === null || lookup.data === undefined) {
+    return (
+      <div className="rounded border border-destructive bg-destructive/5 p-6 text-sm text-destructive">
+        {t('object_list.errors.slug_not_found', {
+          defaultValue: 'ObjectType "{{slug}}" was not found in this tenant.',
+          slug,
+        })}
+      </div>
+    );
+  }
+
+  return <ObjectListView objectTypeId={lookup.data.id} />;
+}
+
+export default ObjectListPage;


### PR DESCRIPTION
## Summary

ULV-09 (#991) minimum-viable — capability badges (`has_variants`, `is_categorizable`) surface w ObjectListView header. Read-only metadata; pełne conditional features (variant expander, category sidebar) folded w ULV-11 cutover.

**Stacked on #1004 (ULV-08) → #1003 (ULV-06).**

## Quality gates

- ✅ TypeScript + Biome zielone

Closes #991