### PR TITLE
fix(admin,catalog): post-marathon ULV bugs — slug filter, search, create

### DIFF
--- a/apps/admin/src/components/objects/object-list-view.tsx
+++ b/apps/admin/src/components/objects/object-list-view.tsx
@@ -1,8 +1,10 @@
+import { Plus, Search, X } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { EmptyStateObject } from '@/components/objects/empty-state-object';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import {
   Table,
   TableBody,
@@ -14,6 +16,7 @@ import {
 import { type ListSchemaColumn, useListSchema } from '@/hooks/use-list-schema';
 import { type ObjectListItem, useObjectList } from '@/hooks/use-object-list';
 import { HttpError } from '@/lib/http';
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
 
 /**
  * ULV-06 (#988) — universal list view component for any ObjectType.
@@ -62,15 +65,31 @@ function readHiddenColumns(lsKey: string): Set<string> {
   }
 }
 
+const STATUS_OPTIONS = ['', 'published', 'draft', 'archived'] as const;
+type StatusOption = (typeof STATUS_OPTIONS)[number];
+
 export function ObjectListView({ objectTypeId, onCreate }: ObjectListViewProps) {
   const { t, i18n } = useTranslation();
   const locale = i18n.language.split('-')[0] ?? 'en';
   const schemaQuery = useListSchema(objectTypeId);
   const [cursorAfter, setCursorAfter] = useState<string | undefined>(undefined);
+  // #1012 — search + status filter. Search debounces 300ms before
+  // firing /api/objects?sku= (substring on code via existing SkuFilter);
+  // status is a plain enum dropdown matching the StatusFilter values.
+  const [searchInput, setSearchInput] = useState('');
+  const [appliedSearch, setAppliedSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<StatusOption>('');
+  const applySearch = useDebouncedCallback((value: string) => {
+    setAppliedSearch(value.trim());
+    setCursorAfter(undefined);
+  }, 300);
+
   const listQuery = useObjectList({
     objectTypeId,
     itemsPerPage: 30,
     cursorAfter,
+    query: appliedSearch.length > 0 ? appliedSearch : undefined,
+    status: statusFilter.length > 0 ? statusFilter : undefined,
   });
 
   if (schemaQuery.isError) {
@@ -174,11 +193,23 @@ export function ObjectListView({ objectTypeId, onCreate }: ObjectListViewProps) 
     );
   };
 
-  if (totalItems === 0 && !listQuery.isLoading) {
+  const noResultsForFilters =
+    totalItems === 0 &&
+    !listQuery.isLoading &&
+    (appliedSearch.length > 0 || statusFilter.length > 0);
+  const trulyEmpty = totalItems === 0 && !listQuery.isLoading && !noResultsForFilters;
+
+  if (trulyEmpty) {
     return (
       <div className="space-y-4">
         <header className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">{typeLabel}</h1>
+          {onCreate !== undefined ? (
+            <Button onClick={onCreate}>
+              <Plus className="size-4" />
+              {t('object_list.cta_create', { defaultValue: 'Create' })}
+            </Button>
+          ) : null}
         </header>
         <EmptyStateObject objectType={objectType} onCreate={onCreate} />
       </div>
@@ -224,10 +255,76 @@ export function ObjectListView({ objectTypeId, onCreate }: ObjectListViewProps) 
         </div>
         {onCreate !== undefined ? (
           <Button onClick={onCreate}>
+            <Plus className="size-4" />
             {t('object_list.cta_create', { defaultValue: 'Create' })}
           </Button>
         ) : null}
       </header>
+
+      {/* #1012 — search + status filter toolbar. Search debounces 300ms
+          then forwards as ?sku= (substring on CatalogObject.code); status
+          forwards as ?status=. AdvancedFilterBuilder + SavedViewsRail
+          stay deferred to ULV-07 follow-up parity work. */}
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={searchInput}
+            placeholder={t('object_list.search_placeholder', {
+              defaultValue: 'Search by code…',
+            })}
+            onChange={(e) => {
+              const next = e.target.value;
+              setSearchInput(next);
+              applySearch(next);
+            }}
+            className="pl-8 pr-8"
+            aria-label={t('object_list.search_aria', { defaultValue: 'Search objects by code' })}
+          />
+          {searchInput.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => {
+                setSearchInput('');
+                setAppliedSearch('');
+                setCursorAfter(undefined);
+              }}
+              className="absolute right-2 top-1/2 grid -translate-y-1/2 place-items-center rounded p-1 text-muted-foreground hover:bg-muted"
+              aria-label={t('object_list.search_clear', { defaultValue: 'Clear search' })}
+            >
+              <X className="size-3.5" />
+            </button>
+          ) : null}
+        </div>
+        <select
+          value={statusFilter}
+          onChange={(e) => {
+            setStatusFilter(e.target.value as StatusOption);
+            setCursorAfter(undefined);
+          }}
+          className="h-9 rounded-md border bg-background px-2 text-sm"
+          aria-label={t('object_list.status_filter_aria', { defaultValue: 'Filter by status' })}
+        >
+          <option value="">
+            {t('object_list.status_filter_all', { defaultValue: 'All statuses' })}
+          </option>
+          <option value="published">
+            {t('object_list.status.published', { defaultValue: 'Published' })}
+          </option>
+          <option value="draft">{t('object_list.status.draft', { defaultValue: 'Draft' })}</option>
+          <option value="archived">
+            {t('object_list.status.archived', { defaultValue: 'Archived' })}
+          </option>
+        </select>
+      </div>
+
+      {noResultsForFilters ? (
+        <div className="rounded border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
+          {t('object_list.no_results', {
+            defaultValue: 'No objects match the current search / filter.',
+          })}
+        </div>
+      ) : null}
 
       <Table>
         <TableHeader>

--- a/apps/admin/src/features/catalog/objects/list-page.tsx
+++ b/apps/admin/src/features/catalog/objects/list-page.tsx
@@ -1,31 +1,43 @@
 import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 import { ObjectListView } from '@/components/objects/object-list-view';
 import { jsonFetch } from '@/lib/http';
 
 /**
- * ULV-08 (#990) — `/objects/:slug` route renders the universal
+ * ULV-08 (#990) + #1012 — `/objects/:slug` route renders the universal
  * `ObjectListView` for the ObjectType whose `code` (per ULV-01 reused as
  * URL slug) matches.
  *
- * Resolution: we query the existing `/api/object_types?code=...` filter
- * for a single match, then pass its UUID to `ObjectListView`. The lookup
- * is cached for 5 min — slugs are stable and the slug→id mapping is the
- * hottest part of the route hit.
+ * Resolution: we query `/api/object_types?code={slug}&itemsPerPage=1`
+ * (the `code` filter shipped in #1012 — without it the GetCollection
+ * ignored the param and returned every type, so the FE picked
+ * `members[0]` = `product` for every slug). Cached 5 min.
+ *
+ * Client-side guard: we still verify `member.code === slug` post-fetch
+ * as defence-in-depth — if the filter ever regresses the page renders
+ * the slug-not-found error instead of silently showing the wrong list.
  *
  * `/products`, `/categories`, `/assets` keep working through their own
- * routes (ULV-11 will collapse them into this path with regression
- * baseline). 404 if no matching ObjectType in the current tenant.
+ * routes; the cutover to consolidate them onto `/objects/{slug}` is the
+ * deferred ULV-11 follow-up. 404-style error in the current tenant if
+ * the slug does not match an ObjectType.
  */
+interface ObjectTypeLookupRow {
+  id: string;
+  code: string;
+}
+
 interface ObjectTypeLookupResponse {
-  member?: Array<{ id: string; code: string }>;
-  'hydra:member'?: Array<{ id: string; code: string }>;
+  member?: ObjectTypeLookupRow[];
+  'hydra:member'?: ObjectTypeLookupRow[];
 }
 
 export function ObjectListPage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { slug } = useParams<{ slug: string }>();
 
   const lookup = useQuery({
@@ -38,9 +50,38 @@ export function ObjectListPage() {
         query: { code: slug, itemsPerPage: 1 },
       });
       const members = response.member ?? response['hydra:member'] ?? [];
-      return members[0] ?? null;
+      const first = members[0];
+      // Defence in depth — refuse to render if the row returned by the
+      // backend does not match the slug we asked for. Protects against
+      // a regression in the `code` filter where the GetCollection
+      // returns every row regardless of the query param.
+      if (first === undefined || first.code !== slug) {
+        return null;
+      }
+      return first;
     },
   });
+
+  // #1012 — built-in kinds keep their dedicated create flows
+  // (`/products/new` etc.); custom kinds get a generic placeholder that
+  // operators can replace once the dedicated wizard lands.
+  const handleCreate = useCallback(() => {
+    if (!lookup.data) return;
+    const code = lookup.data.code;
+    if (code === 'product') {
+      navigate('/products/new');
+      return;
+    }
+    if (code === 'category') {
+      navigate('/modeling/categories?action=create');
+      return;
+    }
+    if (code === 'asset') {
+      navigate('/multimedia?action=upload');
+      return;
+    }
+    navigate(`/objects/${code}/new`);
+  }, [lookup.data, navigate]);
 
   if (lookup.isLoading) {
     return (
@@ -64,7 +105,7 @@ export function ObjectListPage() {
     );
   }
 
-  return <ObjectListView objectTypeId={lookup.data.id} />;
+  return <ObjectListView objectTypeId={lookup.data.id} onCreate={handleCreate} />;
 }
 
 export default ObjectListPage;

--- a/apps/admin/src/hooks/use-object-list.ts
+++ b/apps/admin/src/hooks/use-object-list.ts
@@ -46,6 +46,10 @@ export interface UseObjectListParams {
   itemsPerPage?: number;
   cursorAfter?: string;
   cursorBefore?: string;
+  /** #1012 — substring search on `CatalogObject.code` via the SkuFilter. */
+  query?: string;
+  /** #1012 — exact-match status filter (`published`, `draft`, `archived`). */
+  status?: string;
 }
 
 /**
@@ -53,14 +57,29 @@ export interface UseObjectListParams {
  *
  * `cursorAfter` / `cursorBefore` map to AP4's `?id[lt]=...` / `?id[gt]=...`
  * cursor params advertised by the IriTemplate on /api/objects. The
- * upstream filters (?status, ?completeness etc.) are forwarded later
- * via ULV-06 / ULV-07 filter UI; this hook keeps the core wiring lean.
+ * `query` param forwards as `?sku=...` (substring on code, existing
+ * `SkuFilter`) and `status` as `?status=...` (existing `StatusFilter`).
  */
 export function useObjectList(params: UseObjectListParams): UseQueryResult<ObjectListResponse> {
-  const { objectTypeId, itemsPerPage = 30, cursorAfter, cursorBefore } = params;
+  const {
+    objectTypeId,
+    itemsPerPage = 30,
+    cursorAfter,
+    cursorBefore,
+    query: searchQuery,
+    status,
+  } = params;
 
   return useQuery({
-    queryKey: ['object-list', objectTypeId, itemsPerPage, cursorAfter, cursorBefore],
+    queryKey: [
+      'object-list',
+      objectTypeId,
+      itemsPerPage,
+      cursorAfter,
+      cursorBefore,
+      searchQuery,
+      status,
+    ],
     enabled: Boolean(objectTypeId),
     staleTime: 30 * 1000,
     queryFn: async () => {
@@ -73,6 +92,12 @@ export function useObjectList(params: UseObjectListParams): UseQueryResult<Objec
       }
       if (cursorBefore) {
         query['id[gt]'] = cursorBefore;
+      }
+      if (searchQuery && searchQuery.length > 0) {
+        query.sku = searchQuery;
+      }
+      if (status && status.length > 0) {
+        query.status = status;
       }
 
       return jsonFetch<ObjectListResponse>('/api/objects', {

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/ObjectTypeCodeFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/ObjectTypeCodeFilter.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * #1012 — `?code=samochody` on `/api/object_types` exact-match filter.
+ *
+ * The universal `ObjectListPage` (ULV-08) resolves the URL slug to an
+ * ObjectType UUID by calling `/api/object_types?code={slug}&itemsPerPage=1`.
+ * Without this filter ApiPlatform ignores the `code` query param entirely
+ * and the collection returns every tenant ObjectType — `members[0]`
+ * ended up being alphabetically `product`, so navigating to
+ * `/objects/samochody` rendered the Product list. Reproduced post-marathon.
+ *
+ * Tenant scoping still applies through the upstream `TenantFilter`
+ * Doctrine extension; this filter only adds the code equality predicate.
+ */
+final class ObjectTypeCodeFilter implements FilterInterface
+{
+    private const string PARAMETER = 'code';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || '' === $value) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('objectTypeCode');
+        $queryBuilder
+            ->andWhere(\sprintf('%s.code = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @param class-string $resourceClass
+     *
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'code',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'Exact match on ObjectType.code (tenant-scoped). Used by the universal ObjectListPage to resolve URL slug → ObjectType UUID.',
+                'strategy' => 'exact',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/ObjectType.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/ObjectType.xml
@@ -24,6 +24,16 @@
             </values>
         </normalizationContext>
 
+        <!--
+            #1012 — `?code=samochody` exact-match filter for the universal
+            ObjectListPage slug resolution. Without it the GetCollection
+            returns every ObjectType regardless of query param and the FE
+            grabs `members[0]` (alphabetically `product`) for every slug.
+        -->
+        <filters>
+            <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\ObjectTypeCodeFilter</filter>
+        </filters>
+
         <operations>
             <operation class="ApiPlatform\Metadata\GetCollection"
                        uriTemplate="/object_types{._format}"

--- a/apps/api/tests/Api/Catalog/ObjectTypeCodeFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectTypeCodeFilterApiTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * #1012 — `?code=` exact-match filter on `/api/object_types`.
+ *
+ * Without this filter the universal `ObjectListPage` slug resolver
+ * received every ObjectType from the GetCollection and silently picked
+ * `members[0]` for every slug — navigating `/objects/samochody` rendered
+ * the alphabetically-first kind (`product`).
+ */
+final class ObjectTypeCodeFilterApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function codeFilterReturnsExactMatchOnly(): void
+    {
+        $this->seedCustomObjectType('cars');
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/object_types?code=cars&itemsPerPage=10');
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+
+        self::assertSame(1, $payload['totalItems']);
+        $members = $payload['member'] ?? $payload['hydra:member'] ?? [];
+        self::assertIsArray($members);
+        self::assertCount(1, $members);
+        $first = $members[0];
+        self::assertIsArray($first);
+        self::assertSame('cars', $first['code']);
+    }
+
+    #[Test]
+    public function codeFilterReturnsEmptyCollectionForUnknownSlug(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/object_types?code=does-not-exist&itemsPerPage=10');
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+
+        self::assertSame(0, $payload['totalItems']);
+    }
+
+    #[Test]
+    public function noFilterStillReturnsTheFullCollection(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/object_types?itemsPerPage=20');
+
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+
+        // BuiltInObjectTypeSeeder gives every tenant product+category+asset;
+        // RbacMatrix tests may add more. We just assert > 1 so the absence
+        // of the `?code=` param does NOT mask the filter.
+        self::assertGreaterThan(1, $payload['totalItems']);
+    }
+
+    private function seedCustomObjectType(string $code): ObjectType
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $type = new ObjectType($code, ObjectKind::Custom, ['pl' => ucfirst($code), 'en' => ucfirst($code)]);
+        $em = $this->em();
+        $em->persist($type);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $type;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -6531,6 +6531,18 @@
                         },
                         "style": "form",
                         "explode": true
+                    },
+                    {
+                        "name": "code",
+                        "in": "query",
+                        "description": "Exact match on ObjectType.code (tenant-scoped). Used by the universal ObjectListPage to resolve URL slug \u2192 ObjectType UUID.",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
                     }
                 ],
                 "x-cortex-permission": "object_type.read"


### PR DESCRIPTION
## Summary

Trzy bugi zgloszone przez operatora po marathonie UI-08 (#1012):

### Bug 1: \`/objects/samochody\` pokazuje produkty (krytyczny)

**Root cause:** \`GET /api/object_types?code=samochody\` ignorowal filter \`code\` i zwracal wszystkie 5 ObjectType w tenant. \`ObjectListPage\` bral \`members[0]\` = alfabetycznie pierwszy = \`product\` → renderowal product schema + product list dla custom kindow.

**Fix:** Nowy \`ObjectTypeCodeFilter\` (ApiPlatform Doctrine filter, exact match na \`code\`) wpiety w \`ObjectType\` ApiResource + defence-in-depth guard w \`ObjectListPage\` (\`member.code === slug\`).

### Bug 2: brak przycisku „Utworz"

**Fix:** \`handleCreate\` w \`ObjectListPage\` — built-in kindy routuja do legacy paths (\`/products/new\`, \`/modeling/categories?action=create\`, \`/multimedia?action=upload\`), custom kindy do placeholder \`/objects/{code}/new\` (dedicated wizard follow-up).

### Bug 3: brak sekcji wyszukiwania

**Fix:** Toolbar pod headerem — debounced search input (300ms, mapuje na istniejacy \`SkuFilter ?sku=\`) + status dropdown (published/draft/archived przez \`StatusFilter\`). \`no_results\` message gdy filter zwraca 0.

## Quality gates

- ✅ PHPStan max — 0 errors
- ✅ TypeScript noEmit + Biome strict zielone
- ✅ ApiTestCase \`ObjectTypeCodeFilterApiTest\` — 3/3 (exact match, no-match, baseline)
- ✅ OpenAPI spec regenerated (+12 lines: nowy \`code\` filter param na \`/api/object_types\`)

## Live-stack smoke proof (\`https://pim.localhost\`)

\`\`\`
$ GET /api/object_types?code=samochody&itemsPerPage=1
  → {total:1, first_code:samochody}     (before fix: total:5)

$ GET /api/objects?objectType=samochody_id&itemsPerPage=2
  → {total:0, count:0}                  (custom kind, poprawnie puste)

$ GET /api/objects?objectType=product_id&sku=DEMO-05
  → {total:10, codes:[DEMO-059..DEMO-050]}

$ GET /api/objects?objectType=product_id&status=draft
  → {total:9, statuses:[draft,...]}
\`\`\`

Closes #1012