### PR TITLE
fix(admin): ObjectListView create dialog + always-visible toolbar (#1014)

### DIFF
--- a/apps/admin/src/components/objects/create-object-dialog.tsx
+++ b/apps/admin/src/components/objects/create-object-dialog.tsx
@@ -1,0 +1,211 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { HttpError, jsonFetch } from '@/lib/http';
+
+/**
+ * #1014 — minimal create dialog for custom-kind ObjectTypes (Bug A fix).
+ *
+ * Custom kinds have no dedicated sugar create route (`/products/new`
+ * etc. only exist for built-in product/category/asset/brand). Pre-fix
+ * `handleCreate` for custom kinds navigated to `/objects/{code}/new`
+ * which does not exist — the App-level catch-all redirected to
+ * `/dashboard`, completely blocking the create flow.
+ *
+ * This dialog ships the minimum-viable form: code + name. POST goes to
+ * the poly-kind `/api/objects` (added in #981 for the relation-picker
+ * `Utwórz i podepnij` flow) with body
+ * `{ code, objectTypeId, attributes: { name } }`. Backend derives the
+ * kind from `objectTypeId` (per `CatalogObjectProcessor::expectedKindFor`).
+ *
+ * Out of scope (deferred to ULV-10 wizard UI step):
+ *   - Full attribute form following list-schema (relations, options, etc.).
+ *   - Per-attribute validation feedback beyond the backend 422 message.
+ *   - Multi-step wizard for categorizable / variant-bearing kinds.
+ *
+ * On success the dialog invalidates the `object-list` query for this
+ * ObjectType so the populated list (or empty-state → new row) refreshes
+ * immediately.
+ */
+export interface CreateObjectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  objectTypeId: string;
+  objectTypeCode: string;
+  objectTypeLabel: string;
+}
+
+export function CreateObjectDialog({
+  open,
+  onOpenChange,
+  objectTypeId,
+  objectTypeCode,
+  objectTypeLabel,
+}: CreateObjectDialogProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [code, setCode] = useState('');
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setCode('');
+    setName('');
+    setError(null);
+    setBusy(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (busy) return;
+
+    const trimmedCode = code.trim();
+    const trimmedName = name.trim();
+    if (trimmedCode.length === 0) {
+      setError(
+        t('object_list.create_dialog.error_code_required', {
+          defaultValue: 'Code is required.',
+        }),
+      );
+      return;
+    }
+
+    setError(null);
+    setBusy(true);
+    try {
+      await jsonFetch<{ id?: string }>('/api/objects', {
+        method: 'POST',
+        contentType: 'application/ld+json',
+        accept: 'application/ld+json',
+        body: {
+          code: trimmedCode,
+          objectTypeId,
+          attributes: trimmedName.length > 0 ? { name: trimmedName } : {},
+        },
+      });
+      // Refresh the list view so the newly-created row appears immediately.
+      await queryClient.invalidateQueries({
+        queryKey: ['object-list', objectTypeId],
+      });
+      reset();
+      onOpenChange(false);
+    } catch (err) {
+      if (err instanceof HttpError) {
+        const detail =
+          err.body && typeof err.body === 'object' && 'detail' in err.body
+            ? String((err.body as Record<string, unknown>).detail)
+            : null;
+        if (err.status === 409) {
+          setError(
+            t('object_list.create_dialog.error_duplicate_code', {
+              defaultValue: 'Object with this code already exists.',
+            }),
+          );
+        } else {
+          setError(detail ?? `HTTP ${err.status}`);
+        }
+      } else {
+        setError(
+          t('object_list.create_dialog.error_generic', {
+            defaultValue: 'Could not create object.',
+          }),
+        );
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) reset();
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t('object_list.create_dialog.title', {
+              defaultValue: 'Create {{type}}',
+              type: objectTypeLabel,
+            })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('object_list.create_dialog.description', {
+              defaultValue: 'Provide the unique code and an optional display name.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor={`create-object-code-${objectTypeCode}`}>
+              {t('object_list.create_dialog.code_label', { defaultValue: 'Code' })}
+              <span className="text-destructive"> *</span>
+            </Label>
+            <Input
+              id={`create-object-code-${objectTypeCode}`}
+              autoFocus
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder={t('object_list.create_dialog.code_placeholder', {
+                defaultValue: 'e.g. CAR-001',
+              })}
+              required
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor={`create-object-name-${objectTypeCode}`}>
+              {t('object_list.create_dialog.name_label', { defaultValue: 'Name' })}
+            </Label>
+            <Input
+              id={`create-object-name-${objectTypeCode}`}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t('object_list.create_dialog.name_placeholder', {
+                defaultValue: 'Display name (optional)',
+              })}
+            />
+          </div>
+          {error !== null ? (
+            <div
+              role="alert"
+              className="rounded border border-destructive bg-destructive/5 px-3 py-2 text-sm text-destructive"
+            >
+              {error}
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+              disabled={busy}
+            >
+              {t('object_list.create_dialog.cancel', { defaultValue: 'Cancel' })}
+            </Button>
+            <Button type="submit" disabled={busy || code.trim().length === 0}>
+              {busy
+                ? t('object_list.create_dialog.submitting', { defaultValue: 'Creating…' })
+                : t('object_list.create_dialog.submit', { defaultValue: 'Create' })}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/components/objects/object-list-view.tsx
+++ b/apps/admin/src/components/objects/object-list-view.tsx
@@ -193,28 +193,9 @@ export function ObjectListView({ objectTypeId, onCreate }: ObjectListViewProps) 
     );
   };
 
-  const noResultsForFilters =
-    totalItems === 0 &&
-    !listQuery.isLoading &&
-    (appliedSearch.length > 0 || statusFilter.length > 0);
-  const trulyEmpty = totalItems === 0 && !listQuery.isLoading && !noResultsForFilters;
-
-  if (trulyEmpty) {
-    return (
-      <div className="space-y-4">
-        <header className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">{typeLabel}</h1>
-          {onCreate !== undefined ? (
-            <Button onClick={onCreate}>
-              <Plus className="size-4" />
-              {t('object_list.cta_create', { defaultValue: 'Create' })}
-            </Button>
-          ) : null}
-        </header>
-        <EmptyStateObject objectType={objectType} onCreate={onCreate} />
-      </div>
-    );
-  }
+  const hasFilters = appliedSearch.length > 0 || statusFilter.length > 0;
+  const noResultsForFilters = totalItems === 0 && !listQuery.isLoading && hasFilters;
+  const trulyEmpty = totalItems === 0 && !listQuery.isLoading && !hasFilters;
 
   return (
     <div className="space-y-4">
@@ -318,56 +299,63 @@ export function ObjectListView({ objectTypeId, onCreate }: ObjectListViewProps) 
         </select>
       </div>
 
-      {noResultsForFilters ? (
+      {/* #1014 — body conditional: empty state, no-results, or table.
+          Search/status toolbar above always renders so operators can
+          interact with filters even when the current view is empty. */}
+      {trulyEmpty ? (
+        <EmptyStateObject objectType={objectType} onCreate={onCreate} />
+      ) : noResultsForFilters ? (
         <div className="rounded border bg-muted/30 p-6 text-center text-sm text-muted-foreground">
           {t('object_list.no_results', {
             defaultValue: 'No objects match the current search / filter.',
           })}
         </div>
-      ) : null}
-
-      <Table>
-        <TableHeader>
-          <TableRow>
-            {visibleColumns.map((c) => (
-              <TableHead key={c.key}>{c.label[locale] ?? c.label.en ?? c.key}</TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {listQuery.isLoading ? (
-            <TableRow>
-              <TableCell colSpan={visibleColumns.length}>
-                {t('object_list.loading', { defaultValue: 'Loading…' })}
-              </TableCell>
-            </TableRow>
-          ) : (
-            items.map((item) => (
-              <TableRow key={item.id}>
+      ) : (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
                 {visibleColumns.map((c) => (
-                  <TableCell key={c.key}>{renderCell(c, item)}</TableCell>
+                  <TableHead key={c.key}>{c.label[locale] ?? c.label.en ?? c.key}</TableHead>
                 ))}
               </TableRow>
-            ))
-          )}
-        </TableBody>
-      </Table>
+            </TableHeader>
+            <TableBody>
+              {listQuery.isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={visibleColumns.length}>
+                    {t('object_list.loading', { defaultValue: 'Loading…' })}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                items.map((item) => (
+                  <TableRow key={item.id}>
+                    {visibleColumns.map((c) => (
+                      <TableCell key={c.key}>{renderCell(c, item)}</TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
 
-      {next !== undefined ? (
-        <div className="flex justify-end">
-          <Button
-            variant="outline"
-            onClick={() => {
-              const lastId = items[items.length - 1]?.id;
-              if (lastId !== undefined) {
-                setCursorAfter(lastId);
-              }
-            }}
-          >
-            {t('object_list.next_page', { defaultValue: 'Next page' })}
-          </Button>
-        </div>
-      ) : null}
+          {next !== undefined ? (
+            <div className="flex justify-end">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  const lastId = items[items.length - 1]?.id;
+                  if (lastId !== undefined) {
+                    setCursorAfter(lastId);
+                  }
+                }}
+              >
+                {t('object_list.next_page', { defaultValue: 'Next page' })}
+              </Button>
+            </div>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/admin/src/features/catalog/objects/list-page.tsx
+++ b/apps/admin/src/features/catalog/objects/list-page.tsx
@@ -1,33 +1,35 @@
 import { useQuery } from '@tanstack/react-query';
-import { useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 
+import { CreateObjectDialog } from '@/components/objects/create-object-dialog';
 import { ObjectListView } from '@/components/objects/object-list-view';
 import { jsonFetch } from '@/lib/http';
 
 /**
- * ULV-08 (#990) + #1012 — `/objects/:slug` route renders the universal
- * `ObjectListView` for the ObjectType whose `code` (per ULV-01 reused as
- * URL slug) matches.
+ * ULV-08 (#990) + #1012 + #1014 — `/objects/:slug` route renders the
+ * universal `ObjectListView` for the ObjectType whose `code` (per ULV-01
+ * reused as URL slug) matches.
  *
- * Resolution: we query `/api/object_types?code={slug}&itemsPerPage=1`
- * (the `code` filter shipped in #1012 — without it the GetCollection
- * ignored the param and returned every type, so the FE picked
- * `members[0]` = `product` for every slug). Cached 5 min.
+ * Slug resolution: `/api/object_types?code={slug}&itemsPerPage=1`
+ * (filter shipped in #1012). Client-side guard verifies
+ * `member.code === slug` post-fetch as defence-in-depth.
  *
- * Client-side guard: we still verify `member.code === slug` post-fetch
- * as defence-in-depth — if the filter ever regresses the page renders
- * the slug-not-found error instead of silently showing the wrong list.
- *
- * `/products`, `/categories`, `/assets` keep working through their own
- * routes; the cutover to consolidate them onto `/objects/{slug}` is the
- * deferred ULV-11 follow-up. 404-style error in the current tenant if
- * the slug does not match an ObjectType.
+ * Create flow (per kind, #1014 fix):
+ *   - Built-in `product` / `category` / `asset` keep their dedicated
+ *     create routes (`/products/new`, `/modeling/categories?action=create`,
+ *     `/multimedia?action=upload`).
+ *   - Built-in `brand` falls through to the modal — there is no dedicated
+ *     brand create page; the modal handles it via the poly-kind POST.
+ *   - Every other kind (custom) opens `CreateObjectDialog` in-page —
+ *     pre-fix navigated to `/objects/{code}/new` which the App-level
+ *     catch-all redirected to `/dashboard`, breaking the flow entirely.
  */
 interface ObjectTypeLookupRow {
   id: string;
   code: string;
+  label?: Record<string, string>;
 }
 
 interface ObjectTypeLookupResponse {
@@ -35,10 +37,18 @@ interface ObjectTypeLookupResponse {
   'hydra:member'?: ObjectTypeLookupRow[];
 }
 
+const ROUTABLE_BUILT_IN_KINDS: Record<string, string> = {
+  product: '/products/new',
+  category: '/modeling/categories?action=create',
+  asset: '/multimedia?action=upload',
+};
+
 export function ObjectListPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language.split('-')[0] ?? 'en';
   const navigate = useNavigate();
   const { slug } = useParams<{ slug: string }>();
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   const lookup = useQuery({
     queryKey: ['object-type-by-code', slug],
@@ -51,10 +61,6 @@ export function ObjectListPage() {
       });
       const members = response.member ?? response['hydra:member'] ?? [];
       const first = members[0];
-      // Defence in depth — refuse to render if the row returned by the
-      // backend does not match the slug we asked for. Protects against
-      // a regression in the `code` filter where the GetCollection
-      // returns every row regardless of the query param.
       if (first === undefined || first.code !== slug) {
         return null;
       }
@@ -62,26 +68,25 @@ export function ObjectListPage() {
     },
   });
 
-  // #1012 — built-in kinds keep their dedicated create flows
-  // (`/products/new` etc.); custom kinds get a generic placeholder that
-  // operators can replace once the dedicated wizard lands.
   const handleCreate = useCallback(() => {
     if (!lookup.data) return;
     const code = lookup.data.code;
-    if (code === 'product') {
-      navigate('/products/new');
+    const sugarPath = ROUTABLE_BUILT_IN_KINDS[code];
+    if (sugarPath !== undefined) {
+      navigate(sugarPath);
       return;
     }
-    if (code === 'category') {
-      navigate('/modeling/categories?action=create');
-      return;
-    }
-    if (code === 'asset') {
-      navigate('/multimedia?action=upload');
-      return;
-    }
-    navigate(`/objects/${code}/new`);
+    // Every other kind (custom + built-in brand) opens the in-page
+    // dialog instead of navigating to a non-existent `/objects/{code}/new`
+    // route (the App catch-all would redirect to /dashboard — #1014 bug A).
+    setCreateDialogOpen(true);
   }, [lookup.data, navigate]);
+
+  const typeLabel = useMemo(() => {
+    if (!lookup.data) return '';
+    const labels = lookup.data.label ?? {};
+    return labels[locale] ?? labels.en ?? lookup.data.code;
+  }, [lookup.data, locale]);
 
   if (lookup.isLoading) {
     return (
@@ -105,7 +110,18 @@ export function ObjectListPage() {
     );
   }
 
-  return <ObjectListView objectTypeId={lookup.data.id} onCreate={handleCreate} />;
+  return (
+    <>
+      <ObjectListView objectTypeId={lookup.data.id} onCreate={handleCreate} />
+      <CreateObjectDialog
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        objectTypeId={lookup.data.id}
+        objectTypeCode={lookup.data.code}
+        objectTypeLabel={typeLabel}
+      />
+    </>
+  );
 }
 
 export default ObjectListPage;


### PR DESCRIPTION
## Summary

Naprawa dwóch bugów post-marathon zgłoszonych przez operatora (#1014).

## Root cause

**Bug A:** [App.tsx:560](apps/admin/src/App.tsx#L560) catch-all `<Route path="*" → Navigate to /dashboard>` matchuje `/objects/samochody/new` (route nie istnieje). `handleCreate` w list-page.tsx routujący custom kindy na ten URL kończył się redirectem na dashboard.

**Bug B:** [object-list-view.tsx:202](apps/admin/src/components/objects/object-list-view.tsx#L202) `if (trulyEmpty) return <empty>` early return omijał renderowanie search/status toolbar. Operatorzy na `/objects/samochody` (0 items custom kind) widzieli tylko empty state bez search.

## Frontend changes

- **NEW `apps/admin/src/components/objects/create-object-dialog.tsx`** — minimum-viable modal: pola `code` + `name`. POST `/api/objects` (poly-kind z #981) z body `{code, objectTypeId, attributes:{name}}`. queryClient invalidates `object-list` po success. Error handling dla 409 (duplicate code).
- **`list-page.tsx`** — `handleCreate` refactor:
  - `product` → `/products/new`
  - `category` → `/modeling/categories?action=create`
  - `asset` → `/multimedia?action=upload`
  - każdy inny kind (custom + built-in brand) → otwiera dialog w-page
- **`object-list-view.tsx`** — refactor renderowania:
  - Usunięty `trulyEmpty` early return.
  - Single return z conditional body: empty state | no-results message | Table.
  - Toolbar (search + status + Create CTA) ZAWSZE renderowany.

## Backend changes

N/A — POST `/api/objects` poly-kind z #981 oraz SkuFilter/StatusFilter z PR #1013 już działają (smoke proof poniżej).

## Quality gates

- ✅ TypeScript noEmit zielony (`NODE_OPTIONS=--max-old-space-size=4096`)
- ✅ Biome strict zielony
- ⏳ Playwright/Vite build — CI

## Live-stack smoke proof (`https://pim.localhost`)

```
$ POST /api/objects {code:CAR-001, objectTypeId:samochody_uuid, attributes:{name:BMW X5}}
→ HTTP 201
  {id, code:CAR-001, kind:custom, status:draft,
   attributesIndexed:{name:{value:"BMW X5"}}}

$ GET /api/objects?objectType=samochody_uuid&itemsPerPage=5
→ {total:1, items:[{code:CAR-001, kind:custom, status:draft, name:BMW X5}]}
```

## Smoke test plan (manual po merge)

1. Login `admin@demo.localhost / changeme`
2. `/objects/samochody` → toolbar widoczny (search + status + „+ Create" right-top) + empty state poniżej
3. Klik „+ Create" → modal z polami Code + Name (Code required)
4. Wpisz `CAR-002` / `Audi A4` → Create → modal się zamyka → lista pokazuje 2 wpisy (CAR-001 + CAR-002)
5. `/objects/product` → 98 produktów + toolbar
6. Search „DEMO-05" → po 300ms 10 wyników
7. Status „Draft" → 9 wyników
8. Klik X w search → reset, lista wraca
9. Klik „+ Create" na product → routing do `/products/new` (zachowane, bez modalu)
10. DevTools Console — brak czerwonych errorów

## Świadome odejścia

- Pełen attribute form (poza `code`+`name`) → ULV-10 wizard UI step (deferred)
- Advanced filter builder + Saved Views → ULV-07 deferred items
- 422 inline validation feedback dla `completeness_rules.required` — wyświetlamy plain `detail` z backendu (out of scope rich form)

Closes #1014