### PR TITLE
feat(catalog): UP-00 add object_types.has_multimedia capability flag

### DIFF
--- a/apps/api/migrations/Version20260525210000.php
+++ b/apps/api/migrations/Version20260525210000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * UP-00 (#1017) — add `object_types.has_multimedia` capability flag.
+ *
+ * Gates the Multimedia tab on the UniversalDetailPage (UP-07) for any
+ * ObjectType. Built-in product seeded TRUE to match the legacy hard-coded
+ * behaviour (`apps/admin/src/features/catalog/products/show.tsx` always
+ * rendered a multimedia tab for products). Other built-ins + custom kinds
+ * default FALSE — operator opts in via the ObjectType Capability flags
+ * card (UP-07b wizard toggle).
+ *
+ * Backfill: existing product rows updated to TRUE in the same migration
+ * so already-seeded tenants see no regression.
+ */
+final class Version20260525210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'UP-00 (#1017): add object_types.has_multimedia capability flag, backfill product=true.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE object_types
+                ADD COLUMN has_multimedia BOOLEAN NOT NULL DEFAULT FALSE
+        SQL);
+
+        // Backfill existing built-in product rows so already-seeded tenants
+        // keep their multimedia tab without re-running the seeder.
+        $this->addSql(<<<'SQL'
+            UPDATE object_types SET has_multimedia = TRUE
+            WHERE kind = 'product' AND is_built_in = TRUE
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE object_types DROP COLUMN has_multimedia
+        SQL);
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInObjectTypeSeeder.php
@@ -88,6 +88,10 @@ final readonly class BuiltInObjectTypeSeeder
                     // ObjectType whose instances participate in primary-
                     // category-driven attribute distribution.
                     $type->setCategorizable(true);
+                    // UP-00 (#1017): seed Product with multimedia capability
+                    // so the legacy /products multimedia tab renders by
+                    // default. Other kinds opt in via UP-07b wizard toggle.
+                    $type->setHasMultimedia(true);
                 } elseif (ObjectKind::Category === $kind) {
                     $type->setHierarchical(true);
                 }

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
@@ -87,7 +87,7 @@ final readonly class GetObjectTypeListSchemaHandler
     }
 
     /**
-     * @return array{id: string, code: string, kind: string, label: array<string, string>, is_categorizable: bool, has_variants: bool, expose_to_main_menu: bool}
+     * @return array{id: string, code: string, kind: string, label: array<string, string>, is_categorizable: bool, has_variants: bool, has_multimedia: bool, expose_to_main_menu: bool}
      */
     private function projectObjectType(ObjectType $objectType): array
     {
@@ -98,6 +98,9 @@ final readonly class GetObjectTypeListSchemaHandler
             'label' => $objectType->getLabel(),
             'is_categorizable' => $objectType->isCategorizable(),
             'has_variants' => $objectType->hasVariants(),
+            // UP-00 (#1017) — surface multimedia capability so the
+            // UniversalDetailPage (UP-07) can gate the Multimedia tab.
+            'has_multimedia' => $objectType->hasMultimedia(),
             'expose_to_main_menu' => $objectType->isExposedToMainMenu(),
         ];
     }

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/ObjectTypeListSchema.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/ObjectTypeListSchema.php
@@ -32,10 +32,10 @@ namespace App\Catalog\Application\Query\GetObjectTypeListSchema;
 final readonly class ObjectTypeListSchema
 {
     /**
-     * @param array{id: string, code: string, kind: string, label: array<string, string>, is_categorizable: bool, has_variants: bool, expose_to_main_menu: bool} $objectType
-     * @param list<ColumnRow>                                                                                                                                    $columns
-     * @param list<string>                                                                                                                                       $filterableAttributes
-     * @param list<string>                                                                                                                                       $searchableAttributes
+     * @param array{id: string, code: string, kind: string, label: array<string, string>, is_categorizable: bool, has_variants: bool, has_multimedia: bool, expose_to_main_menu: bool} $objectType
+     * @param list<ColumnRow>                                                                                                                                                          $columns
+     * @param list<string>                                                                                                                                                             $filterableAttributes
+     * @param list<string>                                                                                                                                                             $searchableAttributes
      */
     public function __construct(
         public array $objectType,

--- a/apps/api/src/Catalog/Domain/Entity/ObjectType.php
+++ b/apps/api/src/Catalog/Domain/Entity/ObjectType.php
@@ -115,6 +115,18 @@ class ObjectType implements TenantScoped
     private bool $isCategorizable = false;
 
     /**
+     * UP-00 (#1017) — gates the Multimedia tab on the UniversalDetailPage
+     * (UP-07). Built-in product seeded `true` to match legacy hard-coded
+     * behaviour; other built-ins + custom kinds default `false`. The
+     * operator opts in per ObjectType via the UP-07b wizard toggle.
+     *
+     * `kind=product` is implicitly locked at the wizard level — built-in
+     * lock pattern. Other kinds (including future built-in additions) are
+     * free to flip the flag.
+     */
+    private bool $hasMultimedia = false;
+
+    /**
      * UUID list of ObjectTypes allowed as parent. Plain JSONB list (not a
      * junction) — N stays small (≤ 5 typical), and the only consumer is the
      * detail view's Allowed parent types chip strip. A junction would cost
@@ -383,6 +395,26 @@ class ObjectType implements TenantScoped
     public function setCategorizable(bool $value): void
     {
         $this->isCategorizable = $value;
+        $this->touch();
+    }
+
+    public function hasMultimedia(): bool
+    {
+        return $this->hasMultimedia;
+    }
+
+    /**
+     * Symfony PropertyAccess accessor alias — exposes the property as
+     * `hasMultimedia` in serialized JSON output.
+     */
+    public function getHasMultimedia(): bool
+    {
+        return $this->hasMultimedia;
+    }
+
+    public function setHasMultimedia(bool $value): void
+    {
+        $this->hasMultimedia = $value;
         $this->touch();
     }
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/ObjectType.orm.xml
@@ -80,6 +80,11 @@
                 <option name="default">false</option>
             </options>
         </field>
+        <field name="hasMultimedia" type="boolean" column="has_multimedia">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
         <field name="allowedParentTypeIds" type="json" column="allowed_parent_type_ids">
             <options>
                 <option name="jsonb">true</option>


### PR DESCRIPTION
## Summary

UP-00 (#1017) — schema delta dla UniversalDetailPage Multimedia tab gate (UP epic foundation).

## Zmiany

- **Migracja **: `ALTER TABLE object_types ADD COLUMN has_multimedia BOOLEAN NOT NULL DEFAULT FALSE` + backfill `UPDATE product rows TO TRUE` (kompatybilność z legacy multimedia tab).
- **ObjectType entity**: `hasMultimedia`/`setHasMultimedia` + PropertyAccess alias `getHasMultimedia`.
- **ORM mapping**: kolumna z DEFAULT false.
- **BuiltInObjectTypeSeeder**: product seeded `true` żeby nowe tenanty miały multimedia od dnia 1.
- **list-schema endpoint**: handler i DTO eksponują `has_multimedia` w `objectType` header — UP-07 FE gating Multimedia tab.

## Quality gates

- ✅ PHPStan max zielony
- ✅ Migracja UP zielona; backfill: product=t, custom/category/asset=f
- ✅ PHPUnit (Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest + ObjectTypeListSchemaApiTest) — 9/9 zielone

## Live-stack smoke (`https://pim.localhost`)

```
$ GET /api/object_types/product_id/list-schema
  → objectType.has_multimedia: true ✓

$ GET /api/object_types/samochody_id/list-schema
  → objectType.has_multimedia: false ✓
```

## Dependencies

Brak. Foundation dla UP-07 (UniversalDetailPage gating) + UP-07b (wizard toggle).

Closes #1017