### PR TITLE
feat(catalog): UP-01 poly-kind PATCH + DELETE /api/objects/{id}

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -351,6 +351,40 @@
                     </values>
                 </denormalizationContext>
             </operation>
+
+            <!-- Poly-kind PATCH (UP-01 #1016) — mirror of the per-kind sugar
+                 PATCH (`/api/products/{id}` etc.) without an `extraProperties.kind`
+                 lock. Kind is derived per-instance: the loaded CatalogObject
+                 already carries its kind on the entity, and `CatalogObjectProcessor`
+                 reuses the per-kind validation/listener chain the sugar paths use.
+                 Enables `UniversalDetailPage` (UP-07) to PATCH any kind via a
+                 single endpoint without dispatching on the sugar path. -->
+            <operation class="ApiPlatform\Metadata\Patch"
+                       uriTemplate="/objects/{id}{._format}"
+                       name="objects_patch"
+                       input="App\Catalog\Infrastructure\ApiPlatform\Resource\CatalogObjectPatchInput"
+                       processor="App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectProcessor"
+                       security="is_granted('UPDATE', object)">
+                <denormalizationContext>
+                    <values>
+                        <value name="groups">
+                            <values>
+                                <value>object:patch</value>
+                            </values>
+                        </value>
+                    </values>
+                </denormalizationContext>
+            </operation>
+
+            <!-- Poly-kind DELETE (UP-01 #1016) — same rationale as PATCH.
+                 `CatalogObjectProcessor` handles the per-kind cleanup
+                 (variant cascade, category un-link, audit emit) — kind is
+                 read off the loaded entity. -->
+            <operation class="ApiPlatform\Metadata\Delete"
+                       uriTemplate="/objects/{id}{._format}"
+                       name="objects_delete"
+                       processor="App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectProcessor"
+                       security="is_granted('DELETE', object)"/>
         </operations>
     </resource>
 </resources>

--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPatchDeleteTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPatchDeleteTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * UP-01 (#1016) — Poly-kind PATCH + DELETE at `/api/objects/{id}`.
+ *
+ * The `UniversalDetailPage` (UP-07) needs a single endpoint per CatalogObject
+ * regardless of kind so the React mutate path does not branch on
+ * `/api/products/{id}` vs `/api/objects/{id}`. Both PATCH and DELETE
+ * operations have no `extraProperties.kind` lock — `CatalogObjectProcessor`
+ * derives the kind off the loaded entity and routes to the same handlers
+ * the sugar paths use.
+ */
+final class CatalogObjectPolyKindPatchDeleteTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function patchUpdatesProductLikeSugarPath(): void
+    {
+        $client = $this->authenticatedClient();
+        $createResponse = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'POLY-PATCH-PROD',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $id = $createResponse->toArray()['id'] ?? null;
+        self::assertIsString($id);
+
+        // PATCH a generic system field (status) so the assertion does not
+        // depend on the test database having a specific Attribute row seeded.
+        $patchResponse = $client->request('PATCH', '/api/objects/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode([
+                'status' => 'published',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+        $body = $patchResponse->toArray();
+        self::assertSame('published', $body['status'] ?? null);
+        self::assertSame('product', $body['kind'] ?? null);
+    }
+
+    #[Test]
+    public function patchUpdatesCustomKindObject(): void
+    {
+        $client = $this->authenticatedClient();
+        $customOtId = $this->seedCustomObjectType('test_custom_patch', 'Test Custom');
+
+        $createResponse = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'CUSTOM-PATCH-001',
+                'objectTypeId' => $customOtId,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $id = $createResponse->toArray()['id'] ?? null;
+        self::assertIsString($id);
+
+        $patchResponse = $client->request('PATCH', '/api/objects/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode([
+                'status' => 'archived',
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_OK);
+        $body = $patchResponse->toArray();
+        self::assertSame('custom', $body['kind'] ?? null);
+        self::assertSame('archived', $body['status'] ?? null);
+    }
+
+    #[Test]
+    public function deleteRemovesObjectLikeSugarPath(): void
+    {
+        $client = $this->authenticatedClient();
+        $createResponse = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'POLY-DEL-PROD',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $id = $createResponse->toArray()['id'] ?? null;
+        self::assertIsString($id);
+
+        $client->request('DELETE', '/api/objects/'.$id);
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $client->request('GET', '/api/objects/'.$id);
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
+    public function deleteRemovesCustomKindObject(): void
+    {
+        $client = $this->authenticatedClient();
+        $customOtId = $this->seedCustomObjectType('test_custom_delete', 'Test Custom Del');
+
+        $createResponse = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'CUSTOM-DEL-001',
+                'objectTypeId' => $customOtId,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+        $id = $createResponse->toArray()['id'] ?? null;
+        self::assertIsString($id);
+
+        $client->request('DELETE', '/api/objects/'.$id);
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $client->request('GET', '/api/objects/'.$id);
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    #[Test]
+    public function patchUnknownIdReturns404(): void
+    {
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/objects/01234567-1234-7000-8000-000000000000', [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode([
+                'attributes' => ['name' => 'Anything'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+
+    private function seedCustomObjectType(string $code, string $label): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $ot = new ObjectType($code, ObjectKind::Custom, ['pl' => $label, 'en' => $label]);
+        $em = $this->em();
+        $em->persist($ot);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $ot->getId()->toRfc4122();
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -3175,6 +3175,212 @@
                     }
                 ],
                 "x-cortex-permission": "products.view"
+            },
+            "delete": {
+                "operationId": "objects_delete",
+                "tags": [
+                    "CatalogObject"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "CatalogObject resource deleted"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Removes the CatalogObject resource.",
+                "description": "Removes the CatalogObject resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "CatalogObject identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "x-cortex-permission": "products.delete"
+            },
+            "patch": {
+                "operationId": "objects_patch",
+                "tags": [
+                    "CatalogObject"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CatalogObject resource updated",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CatalogObject.jsonld-admin.read"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CatalogObject-admin.read"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "400": {
+                        "description": "Invalid input",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "422": {
+                        "description": "An error occurred",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ConstraintViolation"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "content": {
+                            "application/ld+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error.jsonld"
+                                }
+                            },
+                            "application/problem+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "links": {}
+                    }
+                },
+                "summary": "Updates the CatalogObject resource.",
+                "description": "Updates the CatalogObject resource.",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "CatalogObject identifier",
+                        "required": true,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "simple",
+                        "explode": false
+                    }
+                ],
+                "requestBody": {
+                    "description": "The updated CatalogObject resource",
+                    "content": {
+                        "application/merge-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CatalogObject.CatalogObjectPatchInput-object.patch.jsonMergePatch"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "x-cortex-permission": "products.edit"
             }
         },
         "/api/products": {


### PR DESCRIPTION
## Summary

UP-01 (#1016) — poly-kind PATCH + DELETE `/api/objects/{id}` analogicznie do POST z #981. UniversalDetailPage (UP-07) wymaga single endpoint per CatalogObject niezależnie od kindu.

## Zmiany

- **CatalogObject.xml**: 2 nowe operations bez extraProperties.kind lock (kind derived z loaded entity przez CatalogObjectProcessor).
- **ApiTestCase `CatalogObjectPolyKindPatchDeleteTest`**: 5 testów — product PATCH+DELETE, custom kind PATCH+DELETE, unknown ID 404.
- **OpenAPI spec**: +206 lines (2 new operations).

## Quality gates

- ✅ PHPStan max
- ✅ 5/5 ApiTestCase zielone
- ✅ OpenAPI regenerated

## Live-stack smoke

```
POST /api/objects -> 201
PATCH /api/objects/{id} {attributes:{name:Patched}} -> 200
DELETE /api/objects/{id} -> 204
GET /api/objects/{id} -> 404
```

## Dependencies

Brak. Foundation dla UP-07 (UniversalDetailPage mutate path).

Closes #1016