### PR TITLE
feat(catalog): UP-05 scope SmartFilterPreset per resource

### DIFF
--- a/apps/api/migrations/Version20260525220000.php
+++ b/apps/api/migrations/Version20260525220000.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * UP-05 (#1020) — scope SmartFilterPreset rows per ObjectType via the
+ * `resource` column.
+ *
+ * `resource` is a free-form string mirroring `saved_views.resource` —
+ * stores either the `ObjectType.code` (e.g. `samochody`) or NULL.
+ * NULL = preset is visible across every kind (legacy semantics for the
+ * built-in shipped presets that operate on cross-cutting concerns like
+ * completeness). Tenant-side presets created from `UniversalListPage`
+ * (UP-06) carry the kind's code so they do not pollute other kinds.
+ *
+ * Backfill: existing built-in seeded presets target the product list
+ * (the only existing consumer pre-UP) so they get `resource = 'products'`
+ * — keeps the legacy `/api/products` list looking the same while
+ * preventing them from leaking into `/objects/samochody`.
+ */
+final class Version20260525220000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'UP-05 (#1020): scope smart_filter_presets per resource (ObjectType.code) for UniversalListPage.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE smart_filter_presets
+                ADD COLUMN resource VARCHAR(64) NULL
+        SQL);
+
+        // Backfill: existing rows are product-list presets — scope them
+        // to the legacy `products` resource so `/objects/samochody` does
+        // not surface them.
+        $this->addSql(<<<'SQL'
+            UPDATE smart_filter_presets SET resource = 'products' WHERE resource IS NULL
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX smart_filter_presets_resource_idx
+                ON smart_filter_presets (resource)
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DROP INDEX IF EXISTS smart_filter_presets_resource_idx
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE smart_filter_presets DROP COLUMN resource
+        SQL);
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInSmartFilterPresetsSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInSmartFilterPresetsSeeder.php
@@ -111,6 +111,10 @@ final class BuiltInSmartFilterPresetsSeeder
                 isBuiltIn: true,
                 sortOrder: $def['sort_order'],
                 id: Uuid::fromString($def['id']),
+                // UP-05 (#1020): built-in presets target the legacy product
+                // list. Scoping them to `products` keeps them out of
+                // `/objects/{custom_kind}` views.
+                resource: 'products',
             );
 
             $this->em->persist($preset);

--- a/apps/api/src/Catalog/Domain/Entity/SmartFilterPreset.php
+++ b/apps/api/src/Catalog/Domain/Entity/SmartFilterPreset.php
@@ -46,6 +46,13 @@ class SmartFilterPreset implements TenantScoped, SystemShipped
 
     private bool $isBuiltIn;
     private int $sortOrder;
+    /**
+     * UP-05 (#1020) — scopes the preset to a specific ObjectType.code
+     * (mirrors `saved_views.resource`). NULL = visible across every kind
+     * (legacy semantics). Tenant-side presets created from UniversalListPage
+     * carry the kind code so they stay segregated.
+     */
+    private ?string $resource = null;
     private DateTimeImmutable $createdAt;
     private DateTimeImmutable $updatedAt;
 
@@ -62,6 +69,7 @@ class SmartFilterPreset implements TenantScoped, SystemShipped
         bool $isBuiltIn = false,
         int $sortOrder = 0,
         ?Uuid $id = null,
+        ?string $resource = null,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->slug = $slug;
@@ -71,6 +79,7 @@ class SmartFilterPreset implements TenantScoped, SystemShipped
         $this->userId = $userId;
         $this->isBuiltIn = $isBuiltIn;
         $this->sortOrder = $sortOrder;
+        $this->resource = $resource;
         $this->createdAt = new DateTimeImmutable();
         $this->updatedAt = $this->createdAt;
     }
@@ -197,6 +206,18 @@ class SmartFilterPreset implements TenantScoped, SystemShipped
     public function isTenantShared(): bool
     {
         return null === $this->userId && null !== $this->tenant;
+    }
+
+    public function getResource(): ?string
+    {
+        return $this->resource;
+    }
+
+    public function changeResource(?string $resource): void
+    {
+        $this->guardMutable();
+        $this->resource = $resource;
+        $this->touch();
     }
 
     public function getCreatedAt(): DateTimeImmutable

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/SmartFilterPreset.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/SmartFilterPreset.orm.xml
@@ -11,6 +11,7 @@
             <index name="smart_filter_presets_tenant_idx" columns="tenant_id"/>
             <index name="smart_filter_presets_user_idx" columns="user_id"/>
             <index name="smart_filter_presets_builtin_idx" columns="is_built_in"/>
+            <index name="smart_filter_presets_resource_idx" columns="resource"/>
         </indexes>
 
         <id name="id" type="uuid" column="id">
@@ -49,6 +50,8 @@
                 <option name="default">0</option>
             </options>
         </field>
+
+        <field name="resource" type="string" length="64" nullable="true"/>
 
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
         <field name="updatedAt" type="datetime_immutable" column="updated_at"/>

--- a/apps/api/src/Catalog/Presentation/Controller/SmartFilterPresetController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/SmartFilterPresetController.php
@@ -66,6 +66,11 @@ final class SmartFilterPresetController
         $userId = $user instanceof UserIdentityAware ? $user->getId() : null;
 
         $withCounts = $request->query->getBoolean('counts', false);
+        // UP-05 (#1020) — scope presets per ObjectType.code (mirrors
+        // /api/saved-views?resource=). When absent, fall back to 'products'
+        // for backward compatibility with the legacy product list.
+        $requestedResource = $request->query->getString('resource', 'products');
+        $resource = '' === $requestedResource ? 'products' : $requestedResource;
 
         $qb = $this->em->getRepository(SmartFilterPreset::class)
             ->createQueryBuilder('p')
@@ -82,6 +87,11 @@ final class SmartFilterPresetController
         } else {
             $qb->andWhere('p.tenant IS NULL');
         }
+
+        // Resource scope: matching the requested resource OR cross-kind
+        // (resource IS NULL) presets — same semantic as `saved_views.resource`.
+        $qb->andWhere('p.resource = :resource OR p.resource IS NULL')
+            ->setParameter('resource', $resource);
 
         /** @var list<SmartFilterPreset> $presets */
         $presets = $qb->getQuery()->getResult();
@@ -119,6 +129,11 @@ final class SmartFilterPresetController
         $query = $this->parseQuery($body['query'] ?? null);
         $sortOrderRaw = $body['sort_order'] ?? 100;
         $sortOrder = is_numeric($sortOrderRaw) ? (int) $sortOrderRaw : 100;
+        // UP-05 (#1020) — scope user-created presets to the resource they
+        // were created from (e.g. `samochody`). Defaults to `products` for
+        // backward compatibility with the legacy product list.
+        $resourceRaw = $body['resource'] ?? 'products';
+        $resource = \is_string($resourceRaw) && '' !== $resourceRaw ? $resourceRaw : 'products';
 
         $slug = $this->generateUniqueSlug($name['pl'], $tenant->getId(), $userId);
 
@@ -130,6 +145,7 @@ final class SmartFilterPresetController
             userId: $userId,
             isBuiltIn: false,
             sortOrder: $sortOrder,
+            resource: $resource,
         );
 
         $this->em->persist($preset);
@@ -355,6 +371,7 @@ final class SmartFilterPresetController
             'is_built_in' => $preset->isBuiltIn(),
             'is_system' => $preset->isSystem(),
             'sort_order' => $preset->getSortOrder(),
+            'resource' => $preset->getResource(),
             'created_at' => $preset->getCreatedAt()->format(DateTimeInterface::ATOM),
             'updated_at' => $preset->getUpdatedAt()->format(DateTimeInterface::ATOM),
         ];


### PR DESCRIPTION
## Summary
UP-05 (#1020) — per-resource scoping dla SmartFilterPreset, foundation dla UniversalListPage smart-filter-presets-row.

## Changes
- Migracja: ADD COLUMN resource VARCHAR(64) NULL + backfill 'products' + index
- Entity: getResource/changeResource (guardMutable dla built-in)
- Controller list: ?resource=samochody filter (WHERE resource=:resource OR resource IS NULL)
- Controller create: accept resource (default 'products' dla BC)
- BuiltInSmartFilterPresetsSeeder: scope built-in na 'products'

## Smoke
```
GET /api/smart-filter-presets?resource=products  -> total:5 (slug: inconsistent-translations, etc.)
GET /api/smart-filter-presets?resource=samochody -> total:0
```

Closes #1020