### PR TITLE
feat(catalog): UP-02 universal /api/objects/bulk-actions/* (mirror 14 actions)

### DIFF
--- a/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/BulkActionsController.php
@@ -68,6 +68,7 @@ final class BulkActionsController
     }
 
     #[Route('/api/products/bulk-actions/preview', name: 'pim_bulk_actions_preview', methods: ['POST'])]
+    #[Route('/api/objects/bulk-actions/preview', name: 'pim_objects_bulk_actions_preview', methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function preview(Request $request): JsonResponse
@@ -258,6 +259,7 @@ final class BulkActionsController
     }
 
     #[Route('/api/products/bulk-actions/{actionType}', name: 'pim_bulk_actions_apply', methods: ['POST'])]
+    #[Route('/api/objects/bulk-actions/{actionType}', name: 'pim_objects_bulk_actions_apply', methods: ['POST'])]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     #[RequiresPermission(module: 'products', action: 'bulk_operations')]
     public function apply(string $actionType, Request $request): JsonResponse


### PR DESCRIPTION
## Summary
UP-02 (#1018) — minimum-viable: dodanie drugiego Route attribute do BulkActionsController preview + apply. Wszystkie 14 akcji + selection cap zachowane bez duplikacji logiki.

Per UP-04 pattern (Symfony 7.x multiple Routes per method).

## Smoke
```
POST /api/objects/bulk-actions/preview {action:set_attribute, target_ids:[p1,p2]} -> 200
```

Legacy /api/products/bulk-actions/* zachowane bez regresji.

Closes #1018