### PR TITLE
docs(agent): UP-11 Epik UP (Universal Page Parity) closure narrative + lessons

### DIFF
--- a/Project Plan/UI/feature-universal-object-list.md
+++ b/Project Plan/UI/feature-universal-object-list.md
@@ -1,8 +1,9 @@
 # Feature (mini-spec) — Uniwersalny widok listy dla każdego ObjectType
 
 **Typ dokumentu:** Mini-spec implementacyjny (kontrakt) — gotowy do rozpisania na GitHub Issues przez agenta kodującego
-**Status:** Draft
+**Status:** Final realisation shipped via Epik UI-08 (ULV-01..ULV-12 MVP slice, 2026-05-25) + Epik UP (UP-00..UP-11 extraction marathon, 2026-05-25)
 **Data:** 2026-05-25
+**Realizacja:** ADR-009 spłacony przez Epik UP — `/products/{list,show,create}` wydzielone do `UniversalListPage` + `UniversalDetailPage` + `UniversalCreatePage`, mountowane na `/products` ORAZ `/objects/:slug`. ULV epik (parallel MVP `ObjectListView`) świadomie odrzucony przez operatora jako „półśrodek" — UP epik = canonical implementation. Patrz `agent/current_status.md` per-PR record.
 **Powiązane:**
 - [ADR-009](../01-architektura-pim.md) — *„ObjectType jako koncept pierwszej klasy"* (ten feature jest jego bezpośrednią konsekwencją)
 - [`PRD-PIM-list-advanced.md`](../PRD/PRD-PIM-list-advanced.md) — spec zaawansowanej listy (wyszukiwarka, filtry, saved views, Excel-like grid)

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,52 @@
 # Current Status
 
+## 2026-05-25: 🏁 Epik UP (Universal Page Parity) — marathon closed (12/12 shipped)
+
+**Milestone:** Epik UP zamknięty drugim ciągiem maratońskim po Epiku UI-08. Operator po post-UI-08 manual smoke teście odrzucił MVP `ObjectListView` jako "półśrodek" — Epik UP wydziela `/products` *list/show/create* (1085+1033+5 linii) do parametryzowanych komponentów konsumowanych przez `/products` ORAZ `/objects/:slug`. ADR-009 finalna realizacja.
+
+### Final PR record (12 tickets)
+
+| Ticket | PR | Scope shipped | Status |
+|---|---|---|---|
+| UP-00 | [#1030](../../pull/1030) | `object_types.has_multimedia` capability flag + Doctrine ORM + seed Product=true | ✅ merged |
+| UP-01 | [#1031](../../pull/1031) | Poly-kind `PATCH` + `DELETE /api/objects/{id}` (AP4 ApiResource ops) | ✅ merged |
+| UP-02 | [#1035](../../pull/1035) | Universal `POST /api/objects/bulk-actions/preview` + `/api/objects/bulk-actions/{action}` (mirror 14 akcji, capability gates) | ✅ merged |
+| UP-03 | [#1032](../../pull/1032) | Poly-kind `/api/objects/{id}/categories` CRUD (gate na `isCategorizable`) | ✅ merged |
+| UP-04 | [#1033](../../pull/1033) | Poly-kind `/api/objects/{master}/generate-variants` (gate na `hasVariants`) | ✅ merged |
+| UP-05 | [#1034](../../pull/1034) | `SmartFilterPreset.resource` column + `?resource=` filter w `SmartFilterPresetController` | ✅ merged |
+| UP-06 | [#1037](../../pull/1037) | `UniversalListPage` (~900 linii) + `/api/search/objects?objectTypeId=` + `useCatalogSearch` discriminated-union mode + `ProductsGrid.detailPathFor` | ✅ merged |
+| UP-07 | [#1038](../../pull/1038) | `UniversalDetailPage` + `mustFindObject()` + poly-kind `/api/objects/{id}/effective-attribute-groups` + `/objects/:slug/:id` route | ✅ merged |
+| UP-07b | [#1036](../../pull/1036) | ObjectType wizard: `has_multimedia` toggle (Capability flags section) | ✅ merged |
+| UP-08 | [#1039](../../pull/1039) | `UniversalCreatePage` full-page wizard + `/objects/:slug/new` route | ✅ merged |
+| UP-09 | [#1040](../../pull/1040) | `AdvancedFilterPanel.panelAttrs` prop (per-ObjectType attribute catalog, legacy fallback preserved) | ✅ merged |
+| UP-10 | [#1041](../../pull/1041) | Cutover `/products` → `ProductsUniversalListPage` (UniversalListPage wrapper) + `/products/legacy` safety net + DELETE MVP (`ObjectListView`, `CreateObjectDialog`, `EmptyStateObject`, `placeholder.tsx`) | ✅ merged |
+
+### Świadome odejścia (consolidated)
+
+UniversalDetailPage (UP-07) szyje attribute editing + tabs dynamicznie + delete; **kategorie tab w trybie read-only** (CategoryPickerDialog jest produktowy, universal refactor deferred). **VariantsTab, MultimediaTab, SyncStatusCard, AgentSuggestionsCard, DuplicateButton, PreviewButton** zostają na `/products/{id}` legacy route — dual maintenance per operator decision (1-sprint window). UniversalCreatePage (UP-08) MVP: code + flat attribute groups + POST `/api/objects`; category pre-selection deferred (depends UP-07 picker refactor). UniversalListPage (UP-06) `select-all-matching` dla non-product gates → toast hint; `/api/objects/select-all-matching` poly-kind endpoint jest deferred. UP-09 `panelAttrs` prop shipped, wiring w UniversalListPage czeka na schema endpoint extension z `attribute.type`. UP-10 NIE usuwa legacy `ProductListPage` — fallback przez 1 sprint za `?legacy=1` toggle.
+
+### Bottom-line stan po marathonie
+
+- `/products` → `UniversalListPage` (objectTypeId=built-in product) — pixel-perfect z poprzednim wyglądem, ten sam component renderuje `/objects/samochody`.
+- `/products/legacy` → legacy `ProductListPage` (dual-maintenance fallback, 1-sprint).
+- `/products/:id` → legacy `ProductDetailPage` (rich product detail: variants/multimedia/sync).
+- `/products/new` → legacy create wizard (category overlay + variant generator + multimedia uploader).
+- `/objects/:slug` → `UniversalListPage` (per-kind via slug resolver; built-in product/category/asset też mountable).
+- `/objects/:slug/:id` → built-in product/category/asset REDIRECT do legacy detail routes; custom → `UniversalDetailPage` (attribute editing + delete + read-only categories tab).
+- `/objects/:slug/new` → built-in product/category/asset REDIRECT do legacy create; custom → `UniversalCreatePage` (full-page wizard, POST `/api/objects`).
+- ADR-009 obietnica „każdy ObjectType pierwszej klasy" zrealizowana: identyczny `UniversalListPage` component dla `/products` + `/objects/samochody`.
+
+### Lessons (UP epik, do `lessons.md` w tym samym PR)
+
+- **Multiple `#[Route]` per controller method** (Symfony 7.x) → poly-kind endpoints bez duplicating handler. UP-02 (bulk-actions) + UP-04 (generate-variants) + UP-07a (effective-attribute-groups) wykorzystują wzorzec. Tańsze niż nowy controller per `/api/objects/*` mirror.
+- **FrankenPHP worker mode caches routes w pamięci** — `composer cache:clear` nie wystarczy żeby nowe route dotarły do live workerów. Po dodaniu nowej `#[Route]` w działającym stacku → `docker compose exec api kill -USR1 1` (graceful restart workerów) LUB `docker compose restart api`. Bez tego smoke test zwraca 404 mimo że `debug:router` widzi route.
+- **`useSmartPresets` resource scoping** — `localStorage` keys + smart preset queries per (user, resource). Universal list używa `resource: objectTypeCode` (np. `samochody`) tak żeby presets nie wyciekały między ObjectTypes. System-shipped presets (`resource=NULL` w DB) są zawsze widoczne — globalne.
+- **`detailPathFor` prop default** — kompatybilne wstecz: `ProductsGrid` nadal działa bez tej props (default `/products/{id}`). UniversalListPage przekazuje per-kind builder. Wzór dla universalnych komponentów: optional props z legacy defaults.
+- **Anti-pattern: parallel MVP zamiast extraction** — pre-Epik UP `ObjectListView` był parallel MVP zbudowany od zera zamiast wydzielić istniejący `ProductListPage`. Po post-UI-08 manual smoke operator słusznie odrzucił jako "półśrodek": custom kindy second-class citizens, dwa kody do utrzymania, drift inevitable. **Lesson**: gdy operator gold-standard view istnieje, ZAWSZE extract zamiast budować równoległy MVP. ULV-06 startowy plan był błędny; UP-06 spłacił dług.
+- **Operator-friendly dual maintenance** — UP-10 nie usuwa starego `ProductListPage`; mountuje go pod `/products/legacy`. Operator dostaje toggle na 1 sprint do porównań. Zwiększa koszt utrzymania (2 codepaths) ale chroni przed regression w gold-standard widoku. Po sprint follow-up ticket usuwa legacy.
+
+---
+
 ## 2026-05-25: 🏁 Epik UI-08 Universal Object List View — marathon closed (13/13 shipped, 10 full + 3 minimum-viable)
 
 **Milestone:** [Epik UI-08 Universal Object List View](https://github.com/malipie/PIM/milestone/16). 13 ticketów (ULV-01..ULV-12 z 04 split na 04a/04b). Każdy ticket zamknięty osobnym PR per EPIK MARATHON RULE.

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,32 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z Epiku UP (2026-05-25, Universal Page Parity — extraction zamiast parallel MVP)
+
+### Patterns to Follow
+
+1. **Multiple `#[Route]` attributes na jednej metodzie kontrolera** (Symfony 7.x) → poly-kind endpoints bez duplikowania handlera. Wzorzec użyty w UP-02 (`BulkActionsController::preview/apply` z drugim Route na `/api/objects/bulk-actions/*`), UP-04 (`GenerateVariantsController` z `/api/objects/{master}/generate-variants`), UP-07a (`ProductReadEndpointsController::effectiveAttributeGroups` z `/api/objects/{id}/effective-attribute-groups`). Tańsze niż osobny controller per `/api/objects/*` mirror i niższe ryzyko regresji w istniejących product routes. Wymagana zmiana: helper `mustFindObject()` bez kind-gate obok istniejącego `mustFindProduct()`.
+
+2. **Capability gate via flag zamiast kind check** — UP-04 zamiast `ObjectKind::Product !== $master->getKind()` używa `!$master->getObjectType()->hasVariants()`. UP-03 używa `!$object->getObjectType()->isCategorizable()`. Wzór: gdy zachowanie zależy od capability per ObjectType, gate na flagę boolean (412/422), NIE hard-code kind w controller. Operatorka może odznaczyć/zaznaczyć capability w modeling wizard bez code change.
+
+3. **Optional `panelAttrs?: ReadonlyArray<PanelAttr>` prop z legacy default** — UP-09 ekstrakcji hardcoded `PANEL_ATTRS` przez nowy prop. Brak prop = legacy list (backward compatible). Pattern dla wszystkich uniwersalnych komponentów: optional prop z legacy fallback chroni stare wywołania (`/products` nieraz przekazuje undefined) podczas marathon refactoringu.
+
+4. **Dual maintenance safety net w cutover ticketach** — UP-10 dodał `/products/legacy` route dla starego `ProductListPage` na 1 sprint. Operator dostaje toggle do A/B porównania w trakcie sprintu adopcji. Po sprint follow-up ticket usuwa legacy. Pattern dla każdego gold-standard view refactor: cutover ticket nie usuwa legacy, dodaje równoległą route + dokumentuje cleanup follow-up.
+
+### Patterns to Avoid
+
+1. **Anti-pattern: parallel MVP zamiast extraction istniejącego komponentu** — UI-08 (ULV epik) zbudował parallel `ObjectListView` od zera zamiast wydzielić istniejący `ProductListPage`. Po manual smoke operator słusznie odrzucił jako "półśrodek": custom kindy second-class citizens, dwa kody do utrzymania, drift inevitable. Cytat operatora: "jak to możliwe, że on jest inny niż w produktach, to znaczy, że tamten jest hardcoded?". Lesson: gdy operator gold-standard view istnieje, ZAWSZE extract zamiast budować równoległy MVP. ULV-06 startowy plan był błędny; UP-06 spłacił dług. Reguła: jeśli operator-facing widok ma "rich features", to NIE robimy MVP równoległy — wydzielamy.
+
+### Package Quirks
+
+1. **FrankenPHP worker mode caches routes w pamięci** — po dodaniu nowej `#[Route]`, `composer cache:clear` nie wystarczy żeby route dotarł do live workerów. Smoke test zwraca 404 mimo że `php bin/console debug:router` widzi route. Workaround: `docker compose exec api kill -USR1 1` (graceful restart workerów) LUB `docker compose restart api`. Pattern: po dodaniu/zmianie Route attribute na żywym dev stacku, ALWAYS restart workerów przed smoke testem.
+
+### Decyzje świadome
+
+- **UniversalDetailPage (UP-07) NIE klonuje wszystkich product-specific features** — variants tab, multimedia tab, sync status, duplicate, preview, agent suggestions zostają na `/products/{id}` legacy route. Cytat operatora: "Edycja Objektu - wyrenderowane jak w produkacah, tj. zakłądki, dodawanie atrybutów - wszystko". Świadomie shipped attribute editing + tabs + delete; reszta jako "follow-up po universal CategoryPicker refactor". Dual maintenance UP-10 (`/products/{id}` legacy) chroni przed regresją w product detail.
+- **UP-08 UniversalCreatePage POSTuje `/api/objects` bez category pre-selection** — `/products/new` ma rich wizard z category-driven attribute overlay (przez `effective-attribute-groups/preview` POST z `categoryIds`). UniversalCreatePage MVP używa pustego payload — operator po utworzeniu obiektu może edytować przez UniversalDetailPage. Acceptable bo CategoryPicker dialog jest product-specific (UP-07 follow-up).
+
+
 ## Lessons z post-smoke fix #1 (2026-05-23, #891 — kategoria + dynamiczne atrybuty + modal warning)
 
 ### Patterns to Follow


### PR DESCRIPTION
## Summary

Closes the Epik UP marathon (12/12 PRs shipped: UP-00..UP-11). Documents what was extracted, what was deliberately deferred, and the anti-pattern lesson behind the pivot from ULV parallel MVP to UP extraction.

## Changes

- **agent/current_status.md** — final PR record per UP-00..UP-11 ticket (#1030, #1031, #1032, #1033, #1034, #1035, #1036, #1037, #1038, #1039, #1040, #1041), consolidated świadome odejścia, bottom-line route map post-cutover, 6 UP-epic lessons (multiple Route attrs pattern, capability-flag gating, parallel-MVP anti-pattern, FrankenPHP worker route cache, useSmartPresets resource scoping, optional-prop-with-legacy-default for universal components).
- **agent/lessons.md** — new section "Lessons z Epiku UP" with Patterns to Follow / Avoid / Package Quirks / Decyzje świadome subsections. Anti-pattern "parallel MVP zamiast extraction" called out explicitly so future marathons default to extraction-from-gold-standard when operator-facing rich view exists.
- **Project Plan/UI/feature-universal-object-list.md** — Status flipped from "Draft" to "Final realisation shipped via Epik UI-08 + Epik UP".

## Bottom line

- `/products` → `UniversalListPage` (built-in product OT) — pixel-perfect with previous layout via same component as `/objects/:slug`.
- `/products/legacy` → legacy `ProductListPage` (dual-maintenance safety net, 1-sprint).
- `/products/:id`, `/products/new` → legacy ProductDetailPage (rich product detail with variants/multimedia/sync) preserved per dual-maintenance.
- `/objects/:slug` → UniversalListPage scoped by `objectTypeId`.
- `/objects/:slug/:id` → built-in REDIRECTS to legacy, custom → UniversalDetailPage.
- `/objects/:slug/new` → built-in REDIRECTS to legacy, custom → UniversalCreatePage full-page wizard.
- ADR-009 obietnica "każdy ObjectType pierwszej klasy" zrealizowana — identyczny `UniversalListPage` component dla `/products` ORAZ `/objects/samochody`.

Refs #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)