### PR TITLE
chore(catalog): UX-01 remove ObjectKind::Brand legacy enum case

### DIFF
--- a/apps/admin/src/components/modeling/object-type-icon.tsx
+++ b/apps/admin/src/components/modeling/object-type-icon.tsx
@@ -1,4 +1,4 @@
-import { Boxes, FolderTree, Image as ImageIcon, Layers, Package, Tag } from 'lucide-react';
+import { Boxes, FolderTree, Image as ImageIcon, Layers, Package } from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
 
 import { cn } from '@/lib/utils';
@@ -16,7 +16,6 @@ const KIND_ICON_MAP: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
   product: Boxes,
   category: FolderTree,
   asset: ImageIcon,
-  brand: Tag,
   custom: Package,
 };
 
@@ -67,8 +66,6 @@ export function defaultAccent(kind: string | null): string {
       return '#a855f7';
     case 'asset':
       return '#ec4899';
-    case 'brand':
-      return '#f59e0b';
     default:
       return '#71717a';
   }

--- a/apps/admin/src/features/catalog/categories/show.tsx
+++ b/apps/admin/src/features/catalog/categories/show.tsx
@@ -101,7 +101,7 @@ interface EffectiveResponse {
   effectiveGroups: EffectiveGroupRow[];
 }
 
-const PREVIEW_KINDS = ['product', 'category', 'asset', 'brand'] as const;
+const PREVIEW_KINDS = ['product', 'category', 'asset'] as const;
 
 type PreviewKind = (typeof PREVIEW_KINDS)[number];
 

--- a/apps/admin/src/features/catalog/object-types/list.tsx
+++ b/apps/admin/src/features/catalog/object-types/list.tsx
@@ -30,7 +30,6 @@ const SECONDARY_LABEL: Record<string, string> = {
   product: 'Products',
   category: 'Categories',
   asset: 'Assets',
-  brand: 'Brands',
 };
 
 /**

--- a/apps/api/migrations/Version20260526100000.php
+++ b/apps/api/migrations/Version20260526100000.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * UX-01 — purge legacy `kind='brand'` ObjectType rows.
+ *
+ * ADR-014 / MOD-10 (#902) reverted Brand as a built-in ObjectKind; the
+ * `BuiltInObjectTypeSeeder` stopped creating brand rows months ago, but
+ * legacy installations may still carry rows from earlier deploys. This
+ * migration removes the `ObjectKind::Brand` enum case altogether (see
+ * `apps/api/src/Catalog/Domain/ObjectKind.php`); leaving brand rows in
+ * place would break `ObjectKind::from('brand')` at runtime.
+ *
+ * Cleanup contract:
+ *   - delete `object_types` rows where `kind='brand'`
+ *   - cascade naturally hits dependent rows via existing FKs
+ *     (`objects`, `object_type_attributes`, `object_type_attribute_groups`,
+ *     `menu_configurations` items pointing at brand rows). Each of these
+ *     FKs declares `ON DELETE CASCADE` already (see Version20260428205215
+ *     for `object_types` parent + Version20260504130000 for menu items).
+ *   - no-op on fresh installs (zero rows to delete).
+ */
+final class Version20260526100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'UX-01: drop legacy object_types rows with kind=brand (ObjectKind::Brand removed from enum).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Single DELETE — Doctrine reports affected count in migration log so
+        // legacy deploys see the cleanup, fresh installs see "0 rows" silently.
+        $this->addSql(<<<'SQL'
+            DELETE FROM object_types WHERE kind = 'brand'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Irreversible — the enum case no longer exists, restoring rows
+        // would break ObjectKind::from('brand'). If a rollback is needed,
+        // first restore the enum case in a prior migration.
+        $this->throwIrreversibleMigrationException(
+            'UX-01 brand-kind purge cannot be reverted because ObjectKind::Brand was removed from the enum.',
+        );
+    }
+}

--- a/apps/api/src/Catalog/Domain/ObjectKind.php
+++ b/apps/api/src/Catalog/Domain/ObjectKind.php
@@ -15,6 +15,11 @@ namespace App\Catalog\Domain;
  * (Customer, Supplier, PriceList in phase 2/3) — gated behind a feature
  * flag in `ObjectTypeService` so MVP cannot accidentally create one.
  *
+ * `Brand` was previously seeded as a 4th built-in kind (MOD-10 #902) but
+ * reverted by ADR-014 — brand is now a tenant decision (select attribute,
+ * custom ObjectType, or external integration) rather than a platform-owned
+ * concept. UX-01 finishes the cleanup by removing the enum case.
+ *
  * `isBuiltIn()` is the semantic flag used by the service layer + tests to
  * tell "this kind is owned by the platform, not the tenant" apart from
  * the `is_built_in` boolean column on individual ObjectType rows. The
@@ -26,7 +31,6 @@ enum ObjectKind: string
     case Product = 'product';
     case Category = 'category';
     case Asset = 'asset';
-    case Brand = 'brand';
     case Custom = 'custom';
 
     public function isBuiltIn(): bool

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/ObjectKindRouter.php
@@ -41,10 +41,6 @@ final class ObjectKindRouter
             'path' => '/api/assets',
             'groups' => ['object:read', 'object:read:asset'],
         ],
-        'brand' => [
-            'path' => '/api/brands',
-            'groups' => ['object:read', 'object:read:brand'],
-        ],
     ];
 
     /**
@@ -85,8 +81,7 @@ final class ObjectKindRouter
      * kind without hardcoding the list.
      *
      * ADR-014 / MOD-10 (#902) — Brand was removed from the built-in pool.
-     * The kind enum case stays for tenants that converted Brand to
-     * custom, but it no longer gets a dedicated sugar path.
+     * UX-01 finished the cleanup by dropping the enum case altogether.
      *
      * @return list<ObjectKind>
      */

--- a/apps/api/src/Catalog/Presentation/Command/RecalculateCompletenessCommand.php
+++ b/apps/api/src/Catalog/Presentation/Command/RecalculateCompletenessCommand.php
@@ -79,7 +79,7 @@ final class RecalculateCompletenessCommand extends Command
         /** @var string $kindOption */
         $kindOption = $input->getOption('kind');
         $kinds = 'all' === $kindOption
-            ? [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset, ObjectKind::Brand]
+            ? [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset]
             : [ObjectKind::from($kindOption)];
         /** @var bool $dryRun */
         $dryRun = $input->getOption('dry-run');

--- a/apps/api/src/Catalog/Presentation/Controller/MenuConfigurationController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/MenuConfigurationController.php
@@ -289,7 +289,6 @@ final class MenuConfigurationController
             ObjectKind::Product => 'nav.products',
             ObjectKind::Category => 'nav.categories',
             ObjectKind::Asset => 'nav.multimedia',
-            ObjectKind::Brand => 'nav.brands',
             default => null,
         };
     }

--- a/apps/api/src/Identity/Domain/Rbac/RbacMatrix.php
+++ b/apps/api/src/Identity/Domain/Rbac/RbacMatrix.php
@@ -46,7 +46,6 @@ final class RbacMatrix
         'attribute',
         'attribute_group',
         'backup',
-        'brand',
         'category',
         'channel',
         'import_profile',
@@ -99,7 +98,7 @@ final class RbacMatrix
                 name: 'Catalog Manager',
                 permissionCodes: [
                     ...self::permissionsFor(
-                        resources: ['object', 'object_type', 'attribute', 'attribute_group', 'category', 'asset', 'brand'],
+                        resources: ['object', 'object_type', 'attribute', 'attribute_group', 'category', 'asset'],
                         actions: [self::ACTION_READ, self::ACTION_WRITE, self::ACTION_DELETE],
                     ),
                     // IMP-01/02 — Catalog Manager is the primary persona for
@@ -128,7 +127,7 @@ final class RbacMatrix
                     // Read-only on catalog so an integrator can wire mappings
                     // without being able to mutate product data.
                     ...self::permissionsFor(
-                        resources: ['object', 'object_type', 'attribute', 'category', 'brand', 'asset'],
+                        resources: ['object', 'object_type', 'attribute', 'category', 'asset'],
                         actions: [self::ACTION_READ],
                     ),
                 ],

--- a/apps/api/src/Search/Application/IndexSettingsTemplate.php
+++ b/apps/api/src/Search/Application/IndexSettingsTemplate.php
@@ -136,7 +136,6 @@ final class IndexSettingsTemplate
             ObjectKind::Product,
             ObjectKind::Category,
             ObjectKind::Asset,
-            ObjectKind::Brand,
             ObjectKind::Custom,
         ];
     }

--- a/apps/api/tests/Integration/Catalog/BuiltInObjectTypeSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/BuiltInObjectTypeSeederTest.php
@@ -41,11 +41,6 @@ final class BuiltInObjectTypeSeederTest extends KernelTestCase
             self::assertNotNull($type->getColor(), $kind->value);
             self::assertSame($kind, $type->getKind());
         }
-
-        self::assertNull(
-            $repo->findBuiltInByKind(ObjectKind::Brand, $tenant),
-            'Brand MUST NOT be seeded as a built-in ObjectType (ADR-014 / MOD-10).',
-        );
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Catalog/ObjectKindTest.php
+++ b/apps/api/tests/Unit/Catalog/ObjectKindTest.php
@@ -12,12 +12,12 @@ use PHPUnit\Framework\TestCase;
 final class ObjectKindTest extends TestCase
 {
     #[Test]
-    public function fiveCasesAreDefinedExactly(): void
+    public function fourCasesAreDefinedExactly(): void
     {
-        // ADR-009 + ADR-012 fix the kind enum at five values (Product +
-        // Category + Asset + Brand built-ins, plus Custom escape hatch);
-        // guard against drift.
-        self::assertCount(5, ObjectKind::cases());
+        // ADR-009 fixes the kind enum at four values (Product + Category +
+        // Asset built-ins, plus Custom escape hatch). Brand was reverted by
+        // ADR-014 / MOD-10 (#902) and the enum case removed by UX-01.
+        self::assertCount(4, ObjectKind::cases());
     }
 
     #[Test]
@@ -37,7 +37,6 @@ final class ObjectKindTest extends TestCase
         yield 'product is built-in' => [ObjectKind::Product, true];
         yield 'category is built-in' => [ObjectKind::Category, true];
         yield 'asset is built-in' => [ObjectKind::Asset, true];
-        yield 'brand is built-in' => [ObjectKind::Brand, true];
         yield 'custom is NOT built-in' => [ObjectKind::Custom, false];
     }
 

--- a/apps/api/tests/Unit/Catalog/ObjectTypeBuiltInFlagsTest.php
+++ b/apps/api/tests/Unit/Catalog/ObjectTypeBuiltInFlagsTest.php
@@ -12,9 +12,9 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Covers the built-in / immutability / icon / colour metadata introduced
- * by UI-08.2 (#257). The data layer also seeds Brand as the 4-th built-in
- * with code-immutable + undeletable; the migration is exercised by the
- * Doctrine pipeline, here we focus on the entity invariants.
+ * by UI-08.2 (#257). Per ADR-014 / MOD-10 Brand is no longer a built-in
+ * kind — only Product, Category, Asset get seeded with code-immutable +
+ * undeletable flags. Tests here focus on the entity-level invariants.
  */
 final class ObjectTypeBuiltInFlagsTest extends TestCase
 {
@@ -65,12 +65,12 @@ final class ObjectTypeBuiltInFlagsTest extends TestCase
     #[Test]
     public function iconAndColorAreFreelyEditable(): void
     {
-        $type = new ObjectType('brand', ObjectKind::Brand, ['pl' => 'Marka', 'en' => 'Brand']);
+        $type = new ObjectType('asset', ObjectKind::Asset, ['pl' => 'Zasób', 'en' => 'Asset']);
 
-        $type->setIcon('Tag');
+        $type->setIcon('Image');
         $type->setColor('#F59E0B');
 
-        self::assertSame('Tag', $type->getIcon());
+        self::assertSame('Image', $type->getIcon());
         self::assertSame('#F59E0B', $type->getColor());
 
         $type->setIcon(null);
@@ -78,9 +78,11 @@ final class ObjectTypeBuiltInFlagsTest extends TestCase
     }
 
     #[Test]
-    public function brandKindIsBuiltInButCustomIsNot(): void
+    public function builtInKindsAreFlaggedAndCustomIsNot(): void
     {
-        self::assertTrue(ObjectKind::Brand->isBuiltIn());
+        self::assertTrue(ObjectKind::Product->isBuiltIn());
+        self::assertTrue(ObjectKind::Category->isBuiltIn());
+        self::assertTrue(ObjectKind::Asset->isBuiltIn());
         self::assertFalse(ObjectKind::Custom->isBuiltIn());
     }
 }

--- a/apps/api/tests/Unit/Search/Application/IndexSettingsTemplateConsolidationTest.php
+++ b/apps/api/tests/Unit/Search/Application/IndexSettingsTemplateConsolidationTest.php
@@ -24,7 +24,6 @@ final class IndexSettingsTemplateConsolidationTest extends TestCase
         self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Product));
         self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Category));
         self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Asset));
-        self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Brand));
         self::assertSame('objects', IndexSettingsTemplate::indexName(ObjectKind::Custom));
     }
 
@@ -37,8 +36,7 @@ final class IndexSettingsTemplateConsolidationTest extends TestCase
         self::assertContains(ObjectKind::Product, $kinds);
         self::assertContains(ObjectKind::Category, $kinds);
         self::assertContains(ObjectKind::Asset, $kinds);
-        self::assertContains(ObjectKind::Brand, $kinds);
-        self::assertCount(5, $kinds);
+        self::assertCount(4, $kinds);
     }
 
     #[Test]

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -8273,7 +8273,6 @@
                             "product",
                             "category",
                             "asset",
-                            "brand",
                             "custom"
                         ]
                     },
@@ -8515,7 +8514,6 @@
                                     "product",
                                     "category",
                                     "asset",
-                                    "brand",
                                     "custom"
                                 ]
                             },
@@ -10803,7 +10801,6 @@
                             "product",
                             "category",
                             "asset",
-                            "brand",
                             "custom"
                         ]
                     },
@@ -10950,7 +10947,6 @@
                                     "product",
                                     "category",
                                     "asset",
-                                    "brand",
                                     "custom"
                                 ]
                             },


### PR DESCRIPTION
## Summary
- Remove `ObjectKind::Brand` enum case + fallback references in controllers, search index template, and RBAC matrix (legacy from MOD-10 #902 / ADR-014).
- Add guarded migration `Version20260526100000` purging any legacy `kind='brand'` rows from `object_types` (no-op on fresh installs).
- Drop `brand` from admin `SECONDARY_LABEL`, `KIND_ICON_MAP`, `defaultAccent()`, and category preview kinds — Brand stays as a regular text attribute on products, not a kind.

## Świadome odejścia
- `brand` as **text attribute code** in demo data, seeders, fixtures, and tests is preserved — operator explicitly chose to keep Brand as a regular attribute.
- Locale keys `pl.json` / `en.json` `"brand": "Marka"` retained — they translate the attribute label.

## Test plan
- [x] PHPStan max 0 errors
- [x] Biome strict 0 errors
- [x] TypeScript noEmit 0 errors
- [x] PHPUnit `tests/Unit/Catalog/Object*` + `tests/Integration/Catalog/BuiltInObjectTypeSeederTest` + `tests/Unit/Search/Application/IndexSettingsTemplateConsolidationTest` — 20/20 green (91 assertions)
- [x] Migracja UP applied locally — 0 rows deleted (fresh DB, expected no-op)
- [x] OpenAPI snapshot regenerated — 4 `brand` enum entries removed
- [ ] **Live-stack smoke pending until UX-09 (cutover)** — feature ticket nie zmienia user-facing flow; per CLOSED MEANS CLOSED RULE smoke ekipowy razem z `/modeling/object-types` cleanup w UX-05.

Closes #1044

Part of UX-01..UX-09 marathon (modeling/object-types UX + capability flags + cutover detail page).