### PR TITLE
feat(catalog): UX-03 unlock capability flags on built-in ObjectType

### DIFF
--- a/apps/api/src/Catalog/Application/ObjectTypeService.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeService.php
@@ -127,6 +127,7 @@ final readonly class ObjectTypeService
         ?array $completenessRules = null,
         ?bool $exposeToMainMenu = null,
         ?bool $isCategorizable = null,
+        ?bool $hasMultimedia = null,
     ): ObjectType {
         $isBuiltIn = $objectType->isBuiltIn();
 
@@ -140,6 +141,12 @@ final readonly class ObjectTypeService
             $objectType->setColor($color);
         }
 
+        // Structural flags (`hierarchical`, `abstract`, `allowedParentTypeIds`,
+        // `completenessRules`) remain locked for built-in rows because they
+        // shape the entity model itself. The three capability flags below
+        // (`hasVariants`, `isCategorizable`, `hasMultimedia`) drive *which
+        // tabs* the operator sees in a detail page and are deliberately
+        // user-editable on Product too — UX-03 unlock per operator decision.
         if (null !== $hierarchical) {
             if ($isBuiltIn && $objectType->isHierarchical() !== $hierarchical) {
                 throw BuiltInObjectTypeException::fieldLocked($objectType, 'hierarchical');
@@ -147,9 +154,6 @@ final readonly class ObjectTypeService
             $objectType->setHierarchical($hierarchical);
         }
         if (null !== $hasVariants) {
-            if ($isBuiltIn && $objectType->hasVariants() !== $hasVariants) {
-                throw BuiltInObjectTypeException::fieldLocked($objectType, 'hasVariants');
-            }
             $objectType->setHasVariants($hasVariants);
         }
         if (null !== $abstract) {
@@ -183,20 +187,29 @@ final readonly class ObjectTypeService
             $objectType->setExposeToMainMenu($exposeToMainMenu);
         }
         if (null !== $isCategorizable) {
-            // ADR-014 / MOD-11 (#903): operator-driven toggle. Reused
-            // ObjectKind::Category exclusion — a category that participates
-            // in its own attribute overlay creates a circular dependency
-            // with the resolver. Other kinds (Product, Asset, custom) are
-            // free to flip; built-in `is_built_in=true` ObjectTypes do NOT
-            // lock this flag because the operator may want Asset to become
-            // categorizable in the future (today: AC blocks via UI hint,
-            // not by service-layer 422).
+            // ADR-014 / MOD-11 (#903): a category that participates in its
+            // own attribute overlay creates a circular dependency with the
+            // resolver. Other kinds (Product, Asset, custom) are free to
+            // flip; built-in `is_built_in=true` rows DO NOT lock this flag
+            // — operator may want Asset to become categorizable later.
             if ($isCategorizable && ObjectKind::Category === $objectType->getKind()) {
                 throw new LogicException(
                     'Category ObjectType cannot be flagged as categorizable — categories drive the overlay, they don\'t consume it.',
                 );
             }
             $objectType->setCategorizable($isCategorizable);
+        }
+        if (null !== $hasMultimedia) {
+            // UX-03: Asset is itself a multimedia object; promoting an Asset
+            // ObjectType to host a Multimedia tab creates a recursive UI
+            // (the multimedia tab would list assets pointing at assets).
+            // Symmetric to the Category exclusion above.
+            if ($hasMultimedia && ObjectKind::Asset === $objectType->getKind()) {
+                throw new LogicException(
+                    'Asset ObjectType cannot have a Multimedia capability — the DAM workflow is the multimedia surface itself.',
+                );
+            }
+            $objectType->setHasMultimedia($hasMultimedia);
         }
 
         $this->em->flush();

--- a/apps/api/src/Catalog/Infrastructure/Serializer/ObjectType.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/ObjectType.xml
@@ -65,6 +65,10 @@
             <group>admin:read</group>
             <group>integration:read</group>
         </attribute>
+        <attribute name="hasMultimedia">
+            <group>admin:read</group>
+            <group>integration:read</group>
+        </attribute>
         <attribute name="allowedParentTypeIds">
             <group>admin:read</group>
         </attribute>

--- a/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/UpdateObjectTypeController.php
@@ -74,6 +74,7 @@ final class UpdateObjectTypeController
                 completenessRules: $this->mapOrNull($body['completenessRules'] ?? null),
                 exposeToMainMenu: $this->boolOrNull($body['exposeToMainMenu'] ?? null),
                 isCategorizable: $this->boolOrNull($body['isCategorizable'] ?? null),
+                hasMultimedia: $this->boolOrNull($body['hasMultimedia'] ?? null),
             );
         } catch (BuiltInObjectTypeException $e) {
             throw new HttpException(Response::HTTP_FORBIDDEN, $e->getMessage(), $e);
@@ -96,6 +97,7 @@ final class UpdateObjectTypeController
             'completenessRules' => $objectType->getCompletenessRules(),
             'exposeToMainMenu' => $objectType->isExposedToMainMenu(),
             'isCategorizable' => $objectType->isCategorizable(),
+            'hasMultimedia' => $objectType->hasMultimedia(),
             'schemaVersion' => $objectType->getSchemaVersion(),
         ]);
     }

--- a/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
+++ b/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
@@ -15,6 +15,7 @@ use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
+use LogicException;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Foundry\Test\Factories;
@@ -142,6 +143,55 @@ final class ObjectTypeServiceTest extends KernelTestCase
         self::assertCount(1, $junctions);
         self::assertTrue($junctions[0]->isRequiredForCompleteness());
         self::assertSame(10, $junctions[0]->getSortOrder());
+    }
+
+    #[Test]
+    public function updateUnlocksCapabilityFlagsOnBuiltInProduct(): void
+    {
+        // UX-03: hasVariants / isCategorizable / hasMultimedia drive *which
+        // tabs* the operator sees, not the entity model itself. They must
+        // be flippable on built-in rows too, otherwise Product is forever
+        // stuck with its seed values.
+        $service = $this->serviceWithCustomEnabled(false);
+        $product = $service->create('product', ObjectKind::Product, ['pl' => 'Produkt'], builtIn: true);
+        $product->setHasVariants(true);
+        $product->setCategorizable(true);
+        $product->setHasMultimedia(true);
+        $this->em()->flush();
+
+        $service->update($product, hasVariants: false);
+        $service->update($product, isCategorizable: false);
+        $service->update($product, hasMultimedia: false);
+
+        self::assertFalse($product->hasVariants());
+        self::assertFalse($product->isCategorizable());
+        self::assertFalse($product->hasMultimedia());
+    }
+
+    #[Test]
+    public function updateStillLocksStructuralFlagsOnBuiltInProduct(): void
+    {
+        // The structural flags (`hierarchical`, `abstract`,
+        // `allowedParentTypeIds`, `completenessRules`) stay locked on
+        // built-ins — they shape the entity model and the seeder owns
+        // their values.
+        $service = $this->serviceWithCustomEnabled(false);
+        $product = $service->create('product', ObjectKind::Product, ['pl' => 'Produkt'], builtIn: true);
+
+        $this->expectException(BuiltInObjectTypeException::class);
+        $service->update($product, hierarchical: true);
+    }
+
+    #[Test]
+    public function updateRejectsHasMultimediaTrueOnAsset(): void
+    {
+        // UX-03: Asset is itself the multimedia surface; promoting an
+        // Asset ObjectType to host a Multimedia tab would be recursive.
+        $service = $this->serviceWithCustomEnabled(false);
+        $asset = $service->create('asset', ObjectKind::Asset, ['pl' => 'Zasób'], builtIn: true);
+
+        $this->expectException(LogicException::class);
+        $service->update($asset, hasMultimedia: true);
     }
 
     #[Test]

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -10894,6 +10894,11 @@
                         "default": false,
                         "type": "boolean"
                     },
+                    "hasMultimedia": {
+                        "description": "UP-00 (#1017) \u2014 gates the Multimedia tab on the UniversalDetailPage\n(UP-07). Built-in product seeded `true` to match legacy hard-coded\nbehaviour; other built-ins + custom kinds default `false`. The\noperator opts in per ObjectType via the UP-07b wizard toggle.",
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "allowedParentTypeIds": {
                         "description": "UUID list of ObjectTypes allowed as parent. Plain JSONB list (not a\njunction) \u2014 N stays small (\u2264 5 typical), and the only consumer is the\ndetail view's Allowed parent types chip strip. A junction would cost\nus a roundtrip per detail page load for no gain at this cardinality.",
                         "type": "array",
@@ -11038,6 +11043,11 @@
                             "isCategorizable": {
                                 "readOnly": true,
                                 "description": "ADR-014 / MOD-01 (#893) \u2014 gates participation in primary-category\ndriven attribute distribution. When TRUE, an instance of this\nObjectType:\n  - is required to have exactly one primary `ObjectCategory` link;\n  - inherits attribute groups cumulatively from the root\u2192leaf path\n    of that primary category (per `EffectiveAttributeGroupResolver`\n    after MOD-03);\n  - appears in `/modeling/categories` ObjectType filter.",
+                                "default": false,
+                                "type": "boolean"
+                            },
+                            "hasMultimedia": {
+                                "description": "UP-00 (#1017) \u2014 gates the Multimedia tab on the UniversalDetailPage\n(UP-07). Built-in product seeded `true` to match legacy hard-coded\nbehaviour; other built-ins + custom kinds default `false`. The\noperator opts in per ObjectType via the UP-07b wizard toggle.",
                                 "default": false,
                                 "type": "boolean"
                             },


### PR DESCRIPTION
## Summary
- `ObjectTypeService::update()` accepts `hasMultimedia` and stops field-locking `hasVariants`/`isCategorizable`/`hasMultimedia` on built-in rows — these three flags drive WHICH TABS show up in detail, not the entity model.
- Structural flags (`hierarchical`, `abstract`, `allowedParentTypeIds`, `completenessRules`) remain locked for built-in rows.
- Asset rejected when `hasMultimedia=true` (symmetric to existing Category rejection for `isCategorizable=true` — both prevent recursive UI configurations).
- `UpdateObjectTypeController` wires `hasMultimedia` into PATCH body + response payload.
- Serializer XML exposes `hasMultimedia` for `admin:read` and `integration:read`.

## Świadome odejścia
- Frontend toggle UI (Modeling show.tsx + relabel + Wizard) ships in UX-06 + UX-07 (this PR is BE-only).
- Smoke test deferred to UX-06 — toggle visible in UI is the user-facing flow.

## Test plan
- [x] PHPStan max — 0 errors
- [x] PHPUnit `tests/Integration/Catalog/ObjectTypeServiceTest` — 11/11 green (3 new + 8 existing)
- [x] OpenAPI snapshot regenerated — `hasMultimedia` field in 2 schemas
- [ ] Live-stack smoke deferred to UX-06 (toggle UI lands)

Closes #1048

Part of UX-01..UX-09 marathon.