### PR TITLE
feat(admin): UX-05 hide Category/Asset from modeling + deep-link guard

### DIFF
--- a/apps/admin/src/features/catalog/object-types/list.tsx
+++ b/apps/admin/src/features/catalog/object-types/list.tsx
@@ -54,7 +54,11 @@ export function ObjectTypesListPage() {
   const instanceCounts = useObjectTypeInstanceCounts(types);
   const groupCounts = useObjectTypeGroupCounts(types);
 
-  const builtIn = types.filter((row) => row.builtIn !== false);
+  // UX-05 — Category and Asset are system-managed; the operator never
+  // models them through this page. Surface only Product among built-ins
+  // (plus any future built-in kinds explicitly enabled in modeling).
+  const HIDDEN_KINDS = new Set(['category', 'asset']);
+  const builtIn = types.filter((row) => row.builtIn !== false && !HIDDEN_KINDS.has(row.kind));
   const custom = types.filter((row) => row.builtIn === false);
 
   const totalInstances = (rows: ObjectTypeRow[]): number =>

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Check, Copy, Library, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate, useParams } from 'react-router';
+import { Link, Navigate, useNavigate, useParams } from 'react-router';
 
 import { AddAttributesToObjectTypeDialog } from '@/components/modeling/add-attributes-to-object-type-dialog';
 import { AuditLogIndicator } from '@/components/modeling/audit-log-indicator';
@@ -133,6 +133,12 @@ export function ObjectTypeShowPage() {
   }
 
   const objectType = result;
+  // UX-05 — Category and Asset ObjectTypes are managed by the system,
+  // not the operator. Deep-links land back on the modeling list rather
+  // than risking edits that would corrupt the platform-owned schema.
+  if (objectType.kind === 'category' || objectType.kind === 'asset') {
+    return <Navigate to="/modeling/object-types" replace />;
+  }
   const isBuiltIn = objectType.builtIn !== false;
   const labelText = resolveLabel(objectType.label, i18n.language);
   const labelMap =


### PR DESCRIPTION
## Summary
- `list.tsx` filters out kinds `category`/`asset` from the built-in section — only Product (and custom rows) stay visible.
- `show.tsx` adds a `<Navigate>` guard so deep-links to Category/Asset detail redirect to the modeling list.
- API surface unchanged: `/api/object_types` still returns all kinds (needed by UniversalListPage slug resolver + other consumers).

## Świadome odejścia
- No banner / no flash on redirect — operator explicitly asked for clean redirect.
- Brand needs no filter — enum case dropped by UX-01.

## Test plan
- [x] Biome strict 0 errors
- [x] TypeScript noEmit 0 errors
- [x] API `/api/object_types` still emits all 3 built-in rows (verified live)
- [ ] Live smoke after merge: `/modeling/object-types` shows only Product + custom; deep-link to `/modeling/object-types/{category_id}` redirects to list

Closes #1050

Part of UX-01..UX-09 marathon.