### PR TITLE
feat(catalog): UX-04 poly-kind /api/objects/{id}/assets

### DIFF
--- a/apps/api/src/Asset/Presentation/Controller/ProductAssetsController.php
+++ b/apps/api/src/Asset/Presentation/Controller/ProductAssetsController.php
@@ -22,8 +22,11 @@ use Symfony\Component\Uid\Uuid;
  *   - `POST   /api/products/{id}/assets`             — link assets (m2m)
  *   - `DELETE /api/products/{id}/assets/{assetId}`   — unlink
  *
- * The product detail view calls these to render the multimedia grid
- * and to attach picks from the library or fresh uploads.
+ * UX-04 — every method is *also* exposed at `/api/objects/{id}/assets`
+ * so any ObjectType with `hasMultimedia=true` (custom or built-in)
+ * lights up the same data flow. Single handler, multiple Route attrs
+ * — pattern recycled from UP-04 (generate-variants) and UP-07a
+ * (effective-attribute-groups).
  *
  * The link table only stores `(asset_id, product_id, position)` — the
  * GET endpoint resolves each id back into the same payload shape the
@@ -39,10 +42,11 @@ final readonly class ProductAssetsController
     }
 
     #[Route(path: '/api/products/{id}/assets', name: 'pim_products_assets_list', methods: ['GET'], format: 'json')]
+    #[Route(path: '/api/objects/{id}/assets', name: 'pim_objects_assets_list', methods: ['GET'], format: 'json')]
     #[RequiresPermission(module: 'asset', action: 'read')]
     public function list(string $id): JsonResponse
     {
-        $productId = $this->parseUuid($id, 'product');
+        $productId = $this->parseUuid($id, 'object');
         $assetIds = $this->linker->findAssetIdsForProduct($productId);
 
         $payload = [];
@@ -57,10 +61,11 @@ final readonly class ProductAssetsController
     }
 
     #[Route(path: '/api/products/{id}/assets', name: 'pim_products_assets_link', methods: ['POST'], format: 'json')]
+    #[Route(path: '/api/objects/{id}/assets', name: 'pim_objects_assets_link', methods: ['POST'], format: 'json')]
     #[RequiresPermission(module: 'asset', action: 'write')]
     public function link(string $id, Request $request): JsonResponse
     {
-        $productId = $this->parseUuid($id, 'product');
+        $productId = $this->parseUuid($id, 'object');
 
         $payload = json_decode($request->getContent(), true);
         if (!\is_array($payload) || !\is_array($payload['assetIds'] ?? null)) {
@@ -99,10 +104,16 @@ final readonly class ProductAssetsController
         methods: ['DELETE'],
         format: 'json',
     )]
+    #[Route(
+        path: '/api/objects/{id}/assets/{assetId}',
+        name: 'pim_objects_assets_unlink',
+        methods: ['DELETE'],
+        format: 'json',
+    )]
     #[RequiresPermission(module: 'asset', action: 'write')]
     public function unlink(string $id, string $assetId): JsonResponse
     {
-        $productId = $this->parseUuid($id, 'product');
+        $productId = $this->parseUuid($id, 'object');
         $rawAssetId = $this->parseUuid($assetId, 'asset');
 
         // Same Asset-id-or-CatalogObject-id tolerance as `link()`.


### PR DESCRIPTION
## Summary
- `ProductAssetsController` gets a second `#[Route]` per method exposing the multimedia endpoints under `/api/objects/{id}/...` (list / link / unlink).
- Internal error-message label changes from `'product'` to `'object'` since the handler is now generic.
- Variants already went poly-kind in UP-04; UX-04 only fills the multimedia gap.

## Świadome odejścia
- No capability gate on BE (`hasMultimedia=true` check) — UI handles tab visibility (UX-06/UX-08). Defensive: data stays linked across flag flips.
- `product_assets.product_id` column name stays legacy — rename to `object_id` is a separate follow-up touching integrations.
- OpenAPI snapshot unchanged — custom Symfony controllers don't surface there; integrators read `debug:router`.

## Test plan
- [x] PHPStan max 0 errors
- [x] Live: `GET /api/objects/{product_id}/assets` → 200 with empty member array
- [x] `debug:router` shows 6 routes (3 product aliases + 3 objects)
- [ ] End-to-end link/unlink deferred to UX-08 (Multimedia tab in UniversalDetailPage)

Closes #1052

Part of UX-01..UX-09 marathon.