### PR TITLE
docs(agent): UX-01..UX-09 marathon closure narrative + lessons

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,55 @@
 # Current Status
 
+## 2026-05-26: 🏁 Epik UX (Modeling/Object-Types polish) — marathon closed (9/9 shipped)
+
+**Milestone:** Marathon UX-01..UX-09 (PR-y #1045/#1047/#1049/#1053/#1051/#1055/#1057/#1059/#1061) dla operatora po wątpliwościach przy `/modeling/object-types` ("multimedia są hardcoded a powinny być capability flag", "kategorie/asset nie mają sensu w modeling"). Kapitalna decyzja: trzy capability flags (`hasVariants` / `isCategorizable` / `hasMultimedia`) sterują *którymi zakładkami* operator widzi, nie strukturą encji. Multimedia przestaje być AttributeGroup.
+
+### Final PR record
+
+| Ticket | PR | Scope shipped | Status |
+|---|---|---|---|
+| UX-01 | [#1045](../../pull/1045) | Remove `ObjectKind::Brand` enum case + RbacMatrix/IndexSettings/MenuConfig refs + admin SECONDARY_LABEL / icon map + migration deleting legacy `kind='brand'` rows | ✅ merged |
+| UX-02 | [#1047](../../pull/1047) | Delete `BuiltInProductMediaAttributesSeeder` + AppFixtures wiring + migration purging `attribute_groups` rows with `code IN ('media','multimedia')` + dispatch usuwany w `ProductDetailPage` | ✅ merged |
+| UX-03 | [#1049](../../pull/1049) | `ObjectTypeService::update()` accepts `hasMultimedia`; drops fieldLocked guards on `hasVariants`/`isCategorizable`/`hasMultimedia` (built-in editable); Asset rejected for `hasMultimedia=true`; serializer exposes the flag | ✅ merged |
+| UX-04 | [#1053](../../pull/1053) | Poly-kind `/api/objects/{id}/assets` (GET/POST/DELETE) via multiple `#[Route]` on `ProductAssetsController` — handler kind-agnostic for all multimedia paths | ✅ merged |
+| UX-05 | [#1051](../../pull/1051) | `/modeling/object-types` list hides `kind IN ('category','asset')`; deep-link guard `<Navigate>` na show.tsx dla tych kindów | ✅ merged |
+| UX-06 | [#1055](../../pull/1055) | `show.tsx` Settings card: new `hasMultimedia` toggle (Asset locked), relabel `hasVariants` → "Czy mają warianty?", relabel `isCategorizable` → "Czy można je przypisywać do kategorii?", built-in unlock | ✅ merged |
+| UX-07 | [#1057](../../pull/1057) | `ObjectTypeWizard` Step 3 Settings: new `hasMultimedia` + `isCategorizable` toggles + relabel; single follow-up PATCH bundles `exposeToMainMenu` + new flags (POST endpoint doesn't accept them in body) | ✅ merged |
+| UX-08 | [#1059](../../pull/1059) | `UniversalDetailPage` adds conditional Multimedia (delegates to `ProductMultimediaTab` with objectId — backend kind-agnostic via UX-04 alias) and Variants (minimal poly-kind reader `?parent_id=`) tabs; `useListSchema` exposes `has_multimedia` | ✅ merged |
+| UX-09 | [#1061](../../pull/1061) | `/products/:id?universal=1` opt-in preview path → `UniversalDetailPage`; default render stays legacy `ProductDetailPage` (Playwright caught RelationsTab regression) — flip to default after 4 follow-up power-feature migrations | 🟡 opt-in preview shipped, default cutover deferred |
+
+### Świadome odejścia (consolidated)
+
+- **UX-09** nie flippuje defaultu — `/products/:id` zostaje legacy `ProductDetailPage` (gold-standard z RelationsTab + Variants editor + Sync/Agent sidebars + Duplicate/Preview). `?universal=1` to opt-in preview. Cztery follow-up tickety przed final cutover:
+  1. Poly-kind `RelationsTab` + "Dodaj powiązanie" CTA
+  2. Variants full editor (axis matrix + bulk generator)
+  3. `SyncStatusCard` + `AgentSuggestionsCard` (sidebar)
+  4. `DuplicateButton` + `PreviewButton` (header)
+- **UX-08** Variants panel: minimal read-only list (`/api/objects?parent_id=`). Full editor zostaje legacy.
+- **UX-08** Multimedia tab: delegacja do `ProductMultimediaTab(productId={objectId})` zamiast nowy `ObjectMultimediaTab` — refactor komponentu na `apiPath` prop = follow-up.
+- **UX-02** migration `down()` irreversible by design (seeder już deleted).
+- **UX-01** Brand jako `text` attribute code w demo data zostaje — operator wprost: "Brand zostawiamy jako zwykły atrybut".
+
+### Bottom-line stan po marathonie
+
+- `/modeling/object-types` → tylko Product (built-in) + custom widoczne. Category/Asset/Brand redirect na list.
+- ObjectType detail (show.tsx) → 3 capability toggles edytowalne dla każdego kindu (z Asset/Category symmetric guards).
+- ObjectType wizard (new) → te same 3 capability toggles w Step 3 (bundle PATCH po POST).
+- `/objects/{slug}/{id}` (custom kindy) → `UniversalDetailPage` z conditional Multimedia + Categories + Variants tabs sterowanymi flagami.
+- `/products/{id}` → default legacy (gold-standard) + `?universal=1` opt-in preview.
+- Backend: `BuiltInProductMediaAttributesSeeder` deleted, Brand enum case removed, capability flags unlocked dla built-in (Product editable), poly-kind `/api/objects/{id}/assets` action.
+
+### Lessons (do `lessons.md` osobnym PR-em)
+
+- **Playwright catches semantic regressions, not just visual** — UX-09 początkowo flipował default na UniversalDetailPage. Lokalnie typecheck/lint zielone, ale Playwright `975-relation-picker` E2E zawiódł na missing "Dodaj powiązanie" CTA. Cutover ZEPSUŁ flow który nie miał poly-kind RelationsTab. Lesson: każdy "cutover" PR wymaga sprawdzenia LISTY istniejących E2E spec'ów na docelowej route przed merge. Default flip to operacja wyłącznie po pełnym feature parity, NIE w środku marathonu.
+- **PRZED `composer phpstan` lokalnie zawsze sprawdź wszystkie referencje per file: PHPStan max widzi cross-file** — UX-01 PHPStan lokalnie pass, ale CI failed na `ObjectKindRouter::BUILT_IN_ROUTES` z `'brand'` key — file którego nie touchowałem ale który deklarował phpdoc type kompatybilny z usuniętym enum case. Lesson: po usunięciu enum case z `Domain/ObjectKind.php`, `rg "ObjectKind::Brand|case Brand|'brand'"` PRZED commitem na CAŁY apps/api.
+- **API Platform XML serializer groups vs ApiResource definition** — UX-03 wymagało dodania `<attribute name="hasMultimedia">` w `Catalog/Infrastructure/Serializer/ObjectType.xml` (NIE w `ApiPlatform/Resource/ObjectType.xml`). Resource XML pokazuje grupy normalizacyjne (`admin:read`), serializer XML mapuje atrybuty na grupy. Dwa odrębne miejsca.
+- **Stack PR-ów oszczędza czas marathonu** — UX-09 musiał używać prop'ów z UX-08 (`hasMultimedia`, `hasVariants`). Branch UX-09 utworzony od UX-08 + PR base=main. Po merge UX-08 → main, rebase UX-09 + force-push = clean single-commit diff. Każdy ticket = własny CI cycle bez czekania na sąsiednie merge'e.
+- **Symmetric kind guards for capability flags** — `isCategorizable=true` blocked dla Category (circular dependency), `hasMultimedia=true` blocked dla Asset (asset IS multimedia). Wzór: jeśli flaga semantically oznacza "ma X w sobie", a kind sam JEST X, to flag musi być rejected. Symmetric guards ułatwiają debugowanie + dokumentowanie.
+- **PR opening podczas heavy CI** — w marathonie UX-01..UX-09 7 PR-ów było jednocześnie open. Każdy własny CI cycle 5-15 min. Merge "as soon as green" w kolejności zaimplementowania (nie zależności logicznej) pozwala na maksymalne wykorzystanie czasu CI.
+
+---
+
 ## 2026-05-25: 🏁 Epik UP (Universal Page Parity) — marathon closed (12/12 shipped)
 
 **Milestone:** Epik UP zamknięty drugim ciągiem maratońskim po Epiku UI-08. Operator po post-UI-08 manual smoke teście odrzucił MVP `ObjectListView` jako "półśrodek" — Epik UP wydziela `/products` *list/show/create* (1085+1033+5 linii) do parametryzowanych komponentów konsumowanych przez `/products` ORAZ `/objects/:slug`. ADR-009 finalna realizacja.

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,41 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z marathonu UX-01..UX-09 (2026-05-26, capability flags + cutover guard)
+
+### Patterns to Follow
+
+1. **Symmetric kind guards dla capability flag** — `isCategorizable=true` blocked dla Category (circular dependency w resolverze), `hasMultimedia=true` blocked dla Asset (asset IS multimedia). Wzór: jeśli flaga semantically oznacza "ma X w sobie", a kind sam JEST X, to flag musi być rejected na warstwie service. UI lock w show.tsx mirror'uje BE rejection. Symmetric guards ułatwiają debugowanie + dokumentowanie + tests pisanie ("rejects hasMultimedia=true on Asset" + "rejects isCategorizable=true on Category" = mirror tests).
+
+2. **Stack PR-ów oszczędza czas marathonu** — UX-09 wymagał prop'ów z UX-08 (`hasMultimedia`, `hasVariants` w `UniversalDetailPage`). Branch UX-09 utworzony od UX-08 + PR `base=main`. Po merge UX-08 → main, `git rebase origin/main` + `git push --force-with-lease` = clean single-commit diff. Każdy ticket = własny CI cycle bez czekania na sąsiednie merge'e. Stack do 3-4 PR-ów manageable; powyżej rebase chains zaczynają boleć.
+
+3. **`single follow-up PATCH bundle` po POST** — `POST /api/object_types` przyjmuje tylko core + `hasVariants`; capability flags (`hasMultimedia`, `isCategorizable`, `exposeToMainMenu`) wymagają osobnego PATCH. UX-07 wzorzec: jeden PATCH z mergeniem 3 opt-in flagów, nie 3 round-tripy. Jeden network call + jedna error obsługa.
+
+4. **Multiple #[Route] attrs dla poly-kind w custom Symfony controller (NIE ApiPlatform Resource)** — UX-04 dodaje `/api/objects/{id}/assets` jako alias `/api/products/{id}/assets` przez drugi `#[Route]` attribute na istniejących metodach. Tożsame z UP-04 wzorcem dla ApiPlatform Resource methods. Backend kind-agnostic (link table `product_assets.product_id` faktycznie przechowuje CatalogObject UUID — `product_id` to legacy nazwa kolumny). Frontend może pass'ować `productId={objectId}` do legacy komponentu i działa.
+
+### Patterns to Avoid
+
+1. **NIE flipować default'u na cutoverze bez sprawdzenia wszystkich E2E spec'ów na docelowej route** — UX-09 początkowo flipował default `/products/:id` na `UniversalDetailPage`. Lokalnie typecheck/lint zielone, ale Playwright `apps/admin/e2e/975-relation-picker-candidates.spec.ts` zfailowało na missing "Dodaj powiązanie" CTA. Cutover zepsuł flow który wymagał legacy-only komponentu (`RelationsTab`). Lesson: każdy "cutover" PR wymaga manual smoke listy istniejących E2E spec'ów na docelowej route PRZED merge. Default flip to operacja wyłącznie po pełnym feature parity, NIE w środku marathonu. Solution: ship opt-in path (`?universal=1`) jako preview, zostaw default na legacy. Default flip = osobny ticket po follow-up'ach.
+
+2. **PHPStan max może lokalnie passować, ale CI failuje na cross-file zależnościach** — UX-01 PHPStan lokalnie pass, CI failed na `ObjectKindRouter::BUILT_IN_ROUTES` z `'brand'` key — file deklarował phpdoc `array<value-of<ObjectKind>, ...>` ale ObjectKind nie miał już case Brand. Lokalne PHPStan cache nie miał invalidowanej tej referencji. Lesson: po usunięciu enum case z `Domain/ObjectKind.php`, **ZAWSZE** `rg "ObjectKind::<Case>|case <Case>|'<value>'"` na CAŁY `apps/api/src` PRZED commitem. Cache invalidation po enum changes wymaga full rerun.
+
+3. **Subject `feat(scope): ABC..XYZ` z myślnikiem może przekroczyć 72 znaki commitlint limit** — UX-09 początkowy commit fail bo subject `feat(admin): UX-09 cutover /products/:id to UniversalDetailPage + ?legacy=1 fallback` = 80 znaków. Lesson: pre-emptive count subject length, target ≤65 znaków + body opisuje resztę.
+
+### Package Quirks
+
+1. **`pnpm biome format --write <file>` auto-fix formatting** — gdy Biome zgłasza format error w pre-commit, ręczne edytowanie zatkanej linii jest wolne. `pnpm biome format --write <path/to/file.tsx>` rozwiązuje większość przypadków (string break, parameter wrap). Lokalne `pnpm lint --fix` szerszy zakres ale `format --write` na single file = punktowy fix.
+
+2. **`docker compose exec -T -e APP_ENV=test api ./bin/phpunit ...`** — bez `APP_ENV=test` PHPUnit kernel boots w dev mode → "Could not find service test.service_container" failure. Wzór dla każdej PHPUnit run w docker.
+
+### Decyzje świadome (UX marathon)
+
+- **Multimedia jako capability, nie AttributeGroup** (operator decision): `BuiltInProductMediaAttributesSeeder` deleted, migration czyszcząca grupę 'media' z bazy. Multimedia tab pojawia się na podstawie `ObjectType.hasMultimedia` flag, nie obecności group w `effective_attribute_groups`. Sterowanie capability'ami przez toggle UI, nie przez attribute group attach/detach.
+- **Category + Asset hidden z `/modeling/object-types`** — `<Navigate>` redirect dla `kind IN ('category','asset')`. Operator: "tego już nie będziemy potrzebować". API endpoint /api/object_types nadal zwraca wszystkie kindy (potrzebne dla slug resolution w UniversalListPage).
+- **Brand demoted z built-in do zwykłego atrybutu** — ObjectKind::Brand enum case removed, RbacMatrix '`brand'` resource dropped, BuiltInObjectTypeSeeder usunięty. Demo data + tests używające `'brand'` jako attribute code (Text) zostają — operator: "Brand zostawiamy jako zwykły atrybut".
+- **UX-09 opt-in zamiast full cutover** — Playwright złapał regresję RelationsTab. Default `/products/:id` zostaje legacy ProductDetailPage. `?universal=1` to opt-in preview UniversalDetailPage. 4 follow-up tickety przed final flip.
+
+---
+
 ## Lessons z Epiku UP (2026-05-25, Universal Page Parity — extraction zamiast parallel MVP)
 
 ### Patterns to Follow


### PR DESCRIPTION
## Summary
- `agent/current_status.md` gains the full UX-01..UX-09 marathon entry — final PR record (9 tickets, 1 opt-in), świadome odejścia (4 follow-up tickets before /products/:id default flip), bottom-line route table, lessons summary.
- `agent/lessons.md` appends a marathon Lessons section with the patterns surfaced (symmetric kind guards, stacked PR rebases, bundled follow-up PATCH, multiple Route poly-kind in plain Symfony controllers) and the anti-patterns (cutover-by-default without E2E sweep — Playwright caught RelationsTab regression; PHPStan local pass != CI pass on enum-case removal).

No code changes.

## Test plan
- [x] Markdown only — no CI gates beyond markdownlint (none configured).