### PR TITLE
fix(admin): invalidate list-schema cache after capability toggle

### DIFF
--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -157,6 +157,12 @@ export function ObjectTypeShowPage() {
       queryClient.invalidateQueries({ queryKey: ['object_types', id, 'attached_groups'] }),
       queryClient.invalidateQueries({ queryKey: ['object_types', id, 'attached_attributes'] }),
       queryClient.invalidateQueries({ queryKey: ['object_types', id, 'audit_log'] }),
+      // UX bug fix #1 — list-schema carries the capability flags
+      // (has_multimedia / has_variants / is_categorizable) consumed by
+      // UniversalDetailPage. Without this invalidate the 5-min staleTime
+      // caches the old value, so flipping a capability OFF then back ON
+      // does NOT bring the tab back until the cache expires.
+      queryClient.invalidateQueries({ queryKey: ['list-schema', id] }),
     ]);
   };
 


### PR DESCRIPTION
## Summary
Bug reported by operator: turning Multimedia OFF in ObjectType Settings hid the tab on the product card (correct), but turning it back ON did not bring the tab back.

## Root cause
`useListSchema` carries the capability flags (`has_multimedia` / `has_variants` / `is_categorizable`) consumed by `UniversalDetailPage`. It has `staleTime: 5 * 60 * 1000`, so the first fetch cached the value and stayed there. `ObjectTypeShowPage::refreshAll()` invalidates every object-type-keyed query but missed `['list-schema', id]`, so a PATCH flip never propagated to the detail page until the cache TTL expired.

## Fix
Add `queryClient.invalidateQueries({ queryKey: ['list-schema', id] })` to `refreshAll()`. Single line, no behaviour change beyond the missing invalidation.

## Test plan
- [x] Biome strict — error in the file is operator-side untracked `detail-not-found-state.tsx`, not my change
- [x] TypeScript noEmit 0 errors
- [ ] Live smoke after merge:
  1. Toggle Multimedia OFF in ObjectType Settings → tab disappears on `/products/{id}?universal=1`
  2. Toggle Multimedia ON → tab appears again immediately (no 5-min wait)
  3. Same for `hasVariants`, `isCategorizable`

Closes #1063