### PR TITLE
refactor(catalog): make relations AttributeGroup optional (un-seed) (MODRC-01)

### DIFF
--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -269,11 +269,14 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     staleTime: 30_000,
   });
   const hasReverseRelations = reverseRelationsQuery.data?.hasReverse ?? false;
-  const hasForwardRelationsGroup = useMemo(
-    () => groups.some((g) => g.code === 'relations'),
+  // MODRC-01 (#1080) — relations group is no longer seeded, so detect the
+  // Relations tab from any relation-type attribute on the object, regardless
+  // of which group (or the synthetic default bucket) hosts it.
+  const hasForwardRelationAttributes = useMemo(
+    () => groups.some((g) => g.attributes.some((a) => a.type === 'relation')),
     [groups],
   );
-  const shouldSurfaceRelationsTab = hasForwardRelationsGroup || hasReverseRelations;
+  const shouldSurfaceRelationsTab = hasForwardRelationAttributes || hasReverseRelations;
 
   const visibleTabs: readonly TabKey[] = useMemo(() => {
     if (mode === 'create') return ['attributes'];

--- a/apps/api/migrations/Version20260528100000.php
+++ b/apps/api/migrations/Version20260528100000.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * MODRC-01 (#1080) — make relations AttributeGroup optional.
+ *
+ * Analogous to Version20260527100000 for audit (#1074). The five built-in
+ * relation attributes (`cross_sell`, `up_sell`, `related`, `alternative`,
+ * `accessory`) remain in `attributes` with `is_system=true`, but the old
+ * seeded `code='relations'` AttributeGroup is no longer forced — operators
+ * group these attributes themselves via custom AttributeGroups.
+ *
+ * Deleting the group cascades old group↔attribute and ObjectType↔group
+ * junctions through existing FKs.
+ */
+final class Version20260528100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make relations AttributeGroup optional by removing the legacy seeded "relations" rows; keep relation attributes.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            DELETE FROM attribute_groups
+            WHERE code = 'relations'
+              AND is_system_group = true
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException(
+            'Relations AttributeGroup is now user-managed modeling configuration; recreate it manually if needed.',
+        );
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInProductRelationAttributesSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInProductRelationAttributesSeeder.php
@@ -6,13 +6,9 @@ namespace App\Catalog\Application;
 
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
-use App\Catalog\Domain\Entity\AttributeGroup;
-use App\Catalog\Domain\Entity\AttributeGroupAttribute;
 use App\Catalog\Domain\Entity\ObjectTypeAttribute;
-use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\RelationCardinality;
-use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Shared\Application\TenantContext;
@@ -24,12 +20,12 @@ use Doctrine\ORM\EntityManagerInterface;
  * `relation`-typed Attributes attached to the Product ObjectType
  * (`cross_sell`, `up_sell`, `related`, `alternative`, `accessory`).
  *
- * Replaces the legacy {@see BuiltInAssociationTypeSeeder} that seeded
- * four `association_types` rows. The new seeder is wider: each "kind of
- * link" is a first-class Attribute carrying full MOD-01 config
- * (`relation_target_object_type_ids`, `relation_cardinality`,
- * `relation_advanced`) and lives in an AttributeGroup ("Powiązania") so
- * the modeling UI surfaces them as a regular tab on the product form.
+ * MODRC-01 (#1080): the legacy seeded "Powiązania" AttributeGroup is no
+ * longer created. The 5 relation attributes are attached to the Product
+ * ObjectType as loose {@see ObjectTypeAttribute} rows; if an operator
+ * wants them visually grouped, they create a custom AttributeGroup and
+ * attach the attributes themselves (analogous to the audit attributes
+ * after #1074).
  *
  * Run order in the fixtures / onboarding pipeline:
  *   1. {@see BuiltInObjectTypeSeeder::seed}
@@ -37,15 +33,13 @@ use Doctrine\ORM\EntityManagerInterface;
  *   3. {@see self::seed}            ← here
  *
  * Idempotent: each lookup is keyed by `(tenant, code)`; re-runs after the
- * 6 rows exist (1 group + 5 attributes) are no-ops. Attribute → group +
- * Attribute → ObjectType junctions are also re-checked before insert.
+ * 5 rows exist are no-ops. Attribute → ObjectType junction is also
+ * re-checked before insert.
  */
 final readonly class BuiltInProductRelationAttributesSeeder
 {
-    /** Position of the "Powiązania" AttributeGroup in the form layout. */
-    private const int GROUP_POSITION = 500;
-
-    private const string GROUP_CODE = 'relations';
+    /** Layout offset used when computing per-attribute `sortOrder`. */
+    private const int SORT_OFFSET = 500;
 
     /**
      * @var array<string, array{label: array<string, string>, position: int, advanced: bool}>
@@ -80,7 +74,6 @@ final readonly class BuiltInProductRelationAttributesSeeder
 
     public function __construct(
         private AttributeRepositoryInterface $attributeRepository,
-        private AttributeGroupRepositoryInterface $attributeGroupRepository,
         private ObjectTypeRepositoryInterface $objectTypeRepository,
         private EntityManagerInterface $em,
         private TenantContext $tenantContext,
@@ -104,46 +97,9 @@ final readonly class BuiltInProductRelationAttributesSeeder
                 return 0;
             }
 
-            // Step 1 — ensure the "Powiązania" AttributeGroup exists and is
-            // wired to the Product ObjectType.
-            $group = $this->attributeGroupRepository->findByCode(self::GROUP_CODE, $tenant);
-            if (null === $group) {
-                $group = new AttributeGroup(
-                    code: self::GROUP_CODE,
-                    label: ['pl' => 'Powiązania', 'en' => 'Relations'],
-                    position: self::GROUP_POSITION,
-                    description: [
-                        'pl' => 'Wbudowane atrybuty łączące produkt z innymi produktami (ADR-014).',
-                        'en' => 'Built-in attributes linking the product to other products (ADR-014).',
-                    ],
-                    icon: 'Link2',
-                    color: '#0EA5E9',
-                    isSystemGroup: true,
-                    autoAttached: false,
-                    isRequiredSection: false,
-                    isShared: false,
-                    hasConditionalVisibility: false,
-                );
-                $this->em->persist($group);
-                $this->em->flush();
-            }
-
-            $groupAttachedToProduct = $this->em
-                ->createQuery(
-                    'SELECT 1 FROM '.ObjectTypeAttributeGroup::class.' j'
-                    .' WHERE j.objectType = :objectType AND j.attributeGroup = :group'
-                )
-                ->setParameter('objectType', $productType)
-                ->setParameter('group', $group)
-                ->setMaxResults(1)
-                ->getOneOrNullResult();
-            if (null === $groupAttachedToProduct) {
-                $this->em->persist(new ObjectTypeAttributeGroup($productType, $group, position: self::GROUP_POSITION));
-                $this->em->flush();
-            }
-
-            // Step 2 — seed each missing relation attribute, wire to the
-            // group + ObjectType junctions.
+            // Seed each missing relation attribute and wire it directly to the
+            // Product ObjectType. No AttributeGroup is created — placement is
+            // explicit modeling configuration (MODRC-01).
             $created = 0;
             $productTargetIds = [$productType->getId()->toRfc4122()];
             foreach (self::DEFINITIONS as $code => $definition) {
@@ -161,16 +117,11 @@ final readonly class BuiltInProductRelationAttributesSeeder
                 $this->em->persist($attribute);
                 $this->em->flush();
 
-                $this->em->persist(new AttributeGroupAttribute(
-                    attributeGroup: $group,
-                    attribute: $attribute,
-                    position: $definition['position'],
-                ));
                 $this->em->persist(new ObjectTypeAttribute(
                     objectType: $productType,
                     attribute: $attribute,
                     requiredForCompleteness: false,
-                    sortOrder: self::GROUP_POSITION + $definition['position'],
+                    sortOrder: self::SORT_OFFSET + $definition['position'],
                 ));
                 $this->em->flush();
                 ++$created;

--- a/apps/api/src/Catalog/Application/Command/DeleteAttributeGroup/DeleteAttributeGroupHandler.php
+++ b/apps/api/src/Catalog/Application/Command/DeleteAttributeGroup/DeleteAttributeGroupHandler.php
@@ -14,6 +14,13 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class DeleteAttributeGroupHandler
 {
+    /**
+     * Codes that were once seeded as `is_system_group=true` but are now
+     * user-managed (#1074 audit, #1080 relations). Legacy databases may
+     * still carry these rows; DELETE is allowed so operators can clean up.
+     */
+    private const array LEGACY_USER_MANAGED_SYSTEM_GROUP_CODES = ['audit', 'relations'];
+
     public function __construct(
         private AttributeGroupRepositoryInterface $repository,
         private EntityManagerInterface $em,
@@ -30,9 +37,13 @@ final readonly class DeleteAttributeGroupHandler
             ));
         }
 
-        // System-owned groups are never deletable. Legacy `audit` rows are
-        // user-managed modeling configuration after #1074 and remain removable.
-        if ($group->isSystemGroup() && 'audit' !== $group->getCode()) {
+        // System-owned groups are never deletable, with one allow-list for
+        // legacy codes that are now user-managed modeling config (#1074
+        // audit, #1080 relations).
+        if (
+            $group->isSystemGroup()
+            && !\in_array($group->getCode(), self::LEGACY_USER_MANAGED_SYSTEM_GROUP_CODES, true)
+        ) {
             throw new UnprocessableEntityHttpException(\sprintf(
                 'AttributeGroup "%s" is system-managed and cannot be deleted.',
                 $group->getCode(),

--- a/apps/api/tests/Api/Catalog/AttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributeGroupsApiTest.php
@@ -147,6 +147,27 @@ final class AttributeGroupsApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function deleteAllowsLegacyRelationsSystemGroup(): void
+    {
+        // MODRC-01 (#1080) — relations group is now user-managed. Legacy
+        // rows from BuiltInProductRelationAttributesSeeder pre-#1080 are
+        // removable via DELETE just like the audit row.
+        $client = $this->authenticatedClient();
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $tenantContext->set($tenant);
+        $relations = new AttributeGroup('relations', ['en' => 'Relations'], isSystemGroup: true);
+        $this->em()->persist($relations);
+        $this->em()->flush();
+        $tenantContext->clear();
+
+        $delete = $client->request('DELETE', '/api/attribute_groups/'.$relations->getId()->toRfc4122());
+
+        self::assertSame(204, $delete->getStatusCode());
+    }
+
+    #[Test]
     public function deleteBlocksWhenGroupIsAttachedToObjectType(): void
     {
         $client = $this->authenticatedClient();

--- a/apps/api/tests/Integration/Catalog/BuiltInProductRelationAttributesSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/BuiltInProductRelationAttributesSeederTest.php
@@ -7,11 +7,13 @@ namespace App\Tests\Integration\Catalog;
 use App\Catalog\Application\BuiltInObjectTypeSeeder;
 use App\Catalog\Application\BuiltInProductRelationAttributesSeeder;
 use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\RelationCardinality;
 use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -58,18 +60,39 @@ final class BuiltInProductRelationAttributesSeederTest extends KernelTestCase
     }
 
     #[Test]
-    public function seedAttachesPowiazaniaGroupToProductObjectType(): void
+    public function seedDoesNotCreateRelationsAttributeGroup(): void
     {
+        // MODRC-01 (#1080): the legacy "Powiązania" AttributeGroup is no
+        // longer seeded. Operators group relation attributes themselves
+        // via custom AttributeGroups (analogous to audit after #1074).
         $tenant = $this->createTenant('demo');
         $this->builtInObjectTypeSeeder()->seed($tenant);
 
         $this->seeder()->seed($tenant);
 
         $group = $this->attributeGroupRepository()->findByCode('relations', $tenant);
-        self::assertNotNull($group, 'relations AttributeGroup should be seeded');
-        self::assertSame('relations', $group->getCode());
-        self::assertSame(['pl' => 'Powiązania', 'en' => 'Relations'], $group->getLabel());
-        self::assertTrue($group->isSystemGroup());
+        self::assertNull($group, 'relations AttributeGroup must not be seeded');
+    }
+
+    #[Test]
+    public function seedAttachesRelationAttributesDirectlyToProductObjectType(): void
+    {
+        $tenant = $this->createTenant('demo');
+        $this->builtInObjectTypeSeeder()->seed($tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $this->seeder()->seed($tenant);
+
+        $productType = $this->objectTypeRepository()->findBuiltInByKind(ObjectKind::Product, $tenant);
+        self::assertNotNull($productType);
+        $em = $this->em();
+        foreach (self::EXPECTED_CODES as $code) {
+            $attribute = $this->attributeRepository()->findByCode($code, $tenant);
+            self::assertNotNull($attribute);
+            $junction = $em->getRepository(ObjectTypeAttribute::class)
+                ->findOneBy(['objectType' => $productType, 'attribute' => $attribute]);
+            self::assertNotNull($junction, "ObjectTypeAttribute missing for {$code}");
+        }
     }
 
     #[Test]
@@ -121,12 +144,19 @@ final class BuiltInProductRelationAttributesSeederTest extends KernelTestCase
 
     private function createTenant(string $code): Tenant
     {
-        $em = self::getContainer()->get('doctrine')->getManager();
-        \assert($em instanceof EntityManagerInterface);
+        $em = $this->em();
         $tenant = new Tenant($code, ucfirst($code).' Tenant');
         $em->persist($tenant);
         $em->flush();
 
         return $tenant;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
     }
 }


### PR DESCRIPTION
## Summary

MODRC-01 from the Option Y batch (analogous to #1074 for audit). The legacy seeded `relations` AttributeGroup ("Powiązania") is no longer created. The five built-in relation attributes (`cross_sell`, `up_sell`, `related`, `alternative`, `accessory`) remain seeded as system attributes and stay attached to the Product ObjectType as loose `ObjectTypeAttribute` rows. Placement under a custom AttributeGroup is now explicit modeling configuration the operator owns.

## Backend changes

- `BuiltInProductRelationAttributesSeeder` — drop the `AttributeGroup` creation block (lines 109–129), drop the `ObjectTypeAttributeGroup` junction (lines 131–143), drop the `AttributeGroupAttribute` insert (lines 164–168). Seeder mints attributes + `ObjectTypeAttribute` junctions only. `SORT_OFFSET` constant replaces the now-meaningless `GROUP_POSITION`.
- `DeleteAttributeGroupHandler` — generalize the existing audit exception into `LEGACY_USER_MANAGED_SYSTEM_GROUP_CODES = ['audit', 'relations']` constant. Legacy `is_system_group=true` rows with either code are deletable; everything else still 422s.
- New migration `Version20260528100000` — `DELETE FROM attribute_groups WHERE code='relations' AND is_system_group=true`. Cascade clears the group↔attribute and group↔ObjectType junctions via existing FKs. DOWN is irreversible per the same pattern used by `Version20260527100000` (#1074).

## Tests

- `BuiltInProductRelationAttributesSeederTest` — replace the `seedAttachesPowiazaniaGroupToProductObjectType` test with two new tests: one confirms the group is NOT seeded, the other asserts each relation attribute owns an `ObjectTypeAttribute` row to Product. Existing CRUD-style assertions on the five attribute rows preserved.
- `AttributeGroupsApiTest` — add `deleteAllowsLegacyRelationsSystemGroup` mirroring `deleteAllowsLegacyAuditSystemGroup`.

## Quality gates

- `docker compose exec -T api composer phpstan` — green (0 errors).
- `docker compose exec -T -e APP_ENV=test api ./bin/phpunit tests/Integration/Catalog/BuiltInProductRelationAttributesSeederTest.php tests/Api/Catalog/AttributeGroupsApiTest.php tests/Api/Catalog/ObjectRelationsCrudApiTest.php tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php` — `OK (24 tests, 113 assertions)`.

## Test plan

- [ ] CI passes (PHPStan, PHPUnit, OpenAPI spec drift, lint).
- [ ] Post-merge: `pnpm stack:up && docker compose exec api ./bin/console doctrine:migrations:migrate -n` removes the legacy `relations` row.
- [ ] `GET /api/attribute_groups` no longer returns a row with `code='relations'`.
- [ ] `GET /api/objects/{product}/form-schema` still surfaces the five relation attributes (in the synthetic default bucket if no user group hosts them).
- [ ] Legacy DBs (with the old seeded row still present) accept `DELETE /api/attribute_groups/{id}` for the `relations` code with 204.

Closes #1080
Refs #1081 #1082 #1083 #1084