### PR TITLE
feat(admin): generalize legacy optional system group UX to relations (MODRC-02)

### DIFF
--- a/apps/admin/e2e/1081-relations-group-no-lock.spec.ts
+++ b/apps/admin/e2e/1081-relations-group-no-lock.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+const RELATIONS_GROUP_CODE = 'relations';
+
+/**
+ * #1081 (MODRC-02) — relations group is no longer presented as permanently
+ * locked on /modeling/attribute-groups. The spec is defensive: legacy DBs
+ * may still carry an `is_system_group=true` relations row, fresh installs
+ * have it deleted by migration Version20260528100000. The legacy row is
+ * created via SQL-equivalent API path so the assertion is deterministic.
+ *
+ * Mirrors `1076-audit-group-no-lock.spec.ts` — same JWT helper pattern.
+ */
+test('relations attribute group is not presented as locked in /modeling/attribute-groups', async ({
+  page,
+}) => {
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const create = await page.request.post('/api/attribute_groups', {
+    data: { code: RELATIONS_GROUP_CODE, label: { pl: 'Powiązania', en: 'Relations' } },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  const createdId =
+    create.status() === 201
+      ? ((await create.json()) as { id: string }).id
+      : await locateExistingRelationsId(page, bearer);
+
+  try {
+    await page.goto('/modeling/attribute-groups');
+    const row = page.locator(`a[href="/modeling/attribute-groups/${createdId}"]`);
+    await expect(row).toBeVisible();
+
+    // Lock badge text comes from BuiltInLockBadge ("Wbudowane" / "Built-in").
+    // The relations group must NOT carry it — it's removable.
+    await expect(row.getByText(/wbudowane|built-?in/i)).toHaveCount(0);
+
+    // Detail page exposes Save (=editable) and a DangerZone delete affordance.
+    await row.click();
+    await expect(page).toHaveURL(new RegExp(`/modeling/attribute-groups/${createdId}$`));
+    await expect(page.getByRole('button', { name: /zapisz zmiany|save changes/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /usuń grupę|delete/i }).first()).toBeVisible();
+  } finally {
+    await page.request.delete(`/api/attribute_groups/${createdId}`, { headers: bearer });
+  }
+});
+
+async function locateExistingRelationsId(
+  page: import('@playwright/test').Page,
+  bearer: { authorization: string },
+): Promise<string> {
+  const resp = await page.request.get('/api/attribute_groups?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
+  const payload = (await resp.json()) as {
+    'hydra:member'?: { id: string; code: string }[];
+    member?: { id: string; code: string }[];
+  };
+  const rows = payload.member ?? payload['hydra:member'] ?? [];
+  const match = rows.find((row) => row.code === RELATIONS_GROUP_CODE);
+  if (!match) throw new Error('relations attribute group not present and POST returned non-201');
+  return match.id;
+}

--- a/apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx
@@ -7,6 +7,7 @@ import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { HttpError, jsonFetch } from '@/lib/http';
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import { cn } from '@/lib/utils';
 
 interface AttributeGroupRow {
@@ -194,10 +195,12 @@ export function DeclareAttributeGroupDialog({
                 const isInherited = !isDeclared && Boolean(inheritedFrom);
                 const isDisabled = isDeclared || isInherited;
                 const isPicked = picked.has(g.id);
-                // Legacy `audit` group is user-managed modeling config (#1074):
-                // skip the lock badge so it isn't presented as permanent.
+                // Legacy `audit` (#1074) and `relations` (#1080) are user-managed
+                // modeling config: skip the lock badge so they aren't presented
+                // as permanent.
                 const isLockedSystem =
-                  Boolean(g.is_system_group ?? g.isSystemGroup) && g.code !== 'audit';
+                  Boolean(g.is_system_group ?? g.isSystemGroup) &&
+                  !isLegacyOptionalSystemGroupCode(g.code);
 
                 return (
                   <button

--- a/apps/admin/src/components/modeling/group-card.tsx
+++ b/apps/admin/src/components/modeling/group-card.tsx
@@ -1,6 +1,7 @@
 import { Pencil, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import { cn } from '@/lib/utils';
 
 import { BuiltInLockBadge } from './built-in-lock-badge';
@@ -56,8 +57,8 @@ export function GroupCard({
   onDisplayModeChange,
 }: GroupCardProps) {
   const { t } = useTranslation();
-  const isLegacyAuditGroup = group.code === 'audit';
-  const isLocked = Boolean(locked || (group.system && !isLegacyAuditGroup));
+  const isLegacyOptionalGroup = isLegacyOptionalSystemGroupCode(group.code);
+  const isLocked = Boolean(locked || (group.system && !isLegacyOptionalGroup));
 
   const labelText = resolveGroupLabel(group, language);
   const previewVisible = group.attrsPreview.slice(0, 8);

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -61,6 +61,7 @@ import type {
 } from '@/features/catalog/products/components/types';
 import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
 import { jsonFetch } from '@/lib/http';
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import { cn } from '@/lib/utils';
 
 const SPECIAL_TABS = ['attributes', 'categories', 'multimedia', 'variants'] as const;
@@ -488,7 +489,7 @@ export function UniversalDetailPage({
                 totalCount={group.attributes.length}
                 expanded={expandedGroups.has(group.id)}
                 onToggle={() => toggleGroup(group.id)}
-                isSystem={group.code === 'audit'}
+                isSystem={isLegacyOptionalSystemGroupCode(group.code)}
               >
                 {group.attributes.map((attr) => (
                   <AttrRow

--- a/apps/admin/src/features/catalog/attribute-groups/list.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/list.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { resolveLabel } from '@/features/catalog/attributes/list';
 import { jsonFetch } from '@/lib/http';
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import { cn } from '@/lib/utils';
 
 interface AttributeGroupRow {
@@ -72,10 +73,13 @@ export function AttributeGroupsListPage() {
     (a.position ?? 0) - (b.position ?? 0);
   const systemGroups = filtered.filter((r) => r.systemGroup === true).sort(sortByPosition);
   const businessGroups = filtered.filter((r) => r.systemGroup !== true).sort(sortByPosition);
-  // Legacy `audit` (#1074) is the only system-flagged group that is removable.
-  // Keep the lock affordance on the "System" header only when a truly-locked
-  // group is still present, so audit-only databases don't show misleading UX.
-  const systemSectionHasLockedGroup = systemGroups.some((row) => row.code !== 'audit');
+  // Legacy `audit` (#1074) and `relations` (#1080) are removable even when
+  // `is_system_group=true`. Keep the lock affordance on the "System" header
+  // only when a truly-locked group is still present, so audit/relations-only
+  // databases don't show misleading UX.
+  const systemSectionHasLockedGroup = systemGroups.some(
+    (row) => !isLegacyOptionalSystemGroupCode(row.code),
+  );
 
   return (
     <div className="space-y-6">
@@ -222,7 +226,8 @@ function GroupRowItem({
   const attrCount = usage?.attributeCount ?? 0;
   const typesUsed = usage?.directlyAttachedTo.objectTypes.length ?? 0;
   const categoriesUsed = usage?.directlyAttachedTo.categories.length ?? 0;
-  const isLockedSystemGroup = row.systemGroup === true && row.code !== 'audit';
+  const isLockedSystemGroup =
+    row.systemGroup === true && !isLegacyOptionalSystemGroupCode(row.code);
 
   return (
     <Link

--- a/apps/admin/src/features/catalog/attribute-groups/show.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/show.tsx
@@ -34,6 +34,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { resolveLabel } from '@/features/catalog/attributes/list';
 import { HttpError, jsonFetch } from '@/lib/http';
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import { cn } from '@/lib/utils';
 
 interface AttributeGroupDetail {
@@ -147,8 +148,8 @@ function Editor({
   const [createOpen, setCreateOpen] = useState(false);
 
   const isSystem = group.systemGroup === true;
-  const isLegacyAuditGroup = group.code === 'audit';
-  const isLockedSystemGroup = isSystem && !isLegacyAuditGroup;
+  const isLegacyOptionalGroup = isLegacyOptionalSystemGroupCode(group.code);
+  const isLockedSystemGroup = isSystem && !isLegacyOptionalGroup;
 
   const { data: members = [], refetch: refetchMembers } = useQuery<MemberRow[]>({
     queryKey: ['attribute_groups', group.id, 'attributes'],

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -29,6 +29,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { resolveLabel } from '@/features/catalog/attributes/list';
 import { HttpError, jsonFetch } from '@/lib/http';
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import { useCurrentWorkspace } from '@/lib/use-current-workspace';
 
 interface ObjectTypeDetail {
@@ -268,9 +269,9 @@ export function ObjectTypeShowPage() {
 
   const builtInGroups = (groups.data ?? []).filter((g) => g.system);
   const customGroups = (groups.data ?? []).filter((g) => !g.system);
-  const lockedBuiltInGroups = builtInGroups.filter((g) => g.code !== 'audit');
-  const legacyAuditGroups = builtInGroups.filter((g) => g.code === 'audit');
-  const editableGroups = [...legacyAuditGroups, ...customGroups];
+  const lockedBuiltInGroups = builtInGroups.filter((g) => !isLegacyOptionalSystemGroupCode(g.code));
+  const legacyOptionalGroups = builtInGroups.filter((g) => isLegacyOptionalSystemGroupCode(g.code));
+  const editableGroups = [...legacyOptionalGroups, ...customGroups];
   const enabledLocales = workspace.data?.enabledLocales ?? ['pl', 'en'];
   const primaryLocale = workspace.data?.primaryLocale ?? 'pl';
 
@@ -545,11 +546,11 @@ export function ObjectTypeShowPage() {
               </Button>
             </div>
           </div>
-          {legacyAuditGroups.length > 0 ? (
+          {legacyOptionalGroups.length > 0 ? (
             <div className="rounded-xl border border-amber-100 bg-amber-50/70 px-3 py-2 text-[12px] text-amber-800">
-              {t('object_types.legacy_audit_groups_note', {
+              {t('object_types.legacy_optional_groups_note', {
                 defaultValue:
-                  'Legacy audit group is listed below as removable modeling configuration. Audit fields remain system attributes, but their form visibility is no longer automatic.',
+                  'Legacy system groups (audit, relations) are listed below as removable modeling configuration. The underlying attributes remain system-owned, but their form visibility is no longer automatic.',
               })}
             </div>
           ) : null}

--- a/apps/admin/src/features/catalog/products/components/effective-model-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/effective-model-card.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import { Card } from '@/components/ui/card';
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import type { GroupMeta } from './types';
 import { SYNTHETIC_DEFAULT_GROUP_ID } from './types';
 
@@ -42,7 +43,8 @@ export function EffectiveModelCard({
           .map((group) => {
             const label = group.label[lang] ?? group.code;
             const source = resolveSource(group, objectTypeName, categoryName);
-            const isSystem = group.code === 'audit' || group.code === 'identification';
+            const isSystem =
+              isLegacyOptionalSystemGroupCode(group.code) || group.code === 'identification';
             return (
               <li key={group.id} className="flex items-center gap-2 rounded-lg px-2 py-1">
                 {isSystem ? <Lock className="size-3 text-zinc-300" aria-hidden /> : null}
@@ -69,7 +71,7 @@ function resolveSource(
   objectTypeName?: string | null,
   categoryName?: string | null,
 ): string {
-  if (group.code === 'audit') return 'system';
+  if (isLegacyOptionalSystemGroupCode(group.code)) return 'system';
   if (categoryName !== null && categoryName !== undefined && group.code.startsWith('category_')) {
     return `Kat: ${categoryName}`;
   }

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -31,6 +31,7 @@ import { toast } from '@/components/ui/toast';
 import { useListSchema } from '@/hooks/use-list-schema';
 import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
 import { jsonFetch } from '@/lib/http';
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import { cn } from '@/lib/utils';
 import { useDefaultObjectType } from '../use-default-object-type';
 import { AgentSuggestionsCard } from './agent-suggestions-card';
@@ -763,7 +764,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                 totalCount={group.attributes.length}
                 expanded={expandedGroups.has(group.id)}
                 onToggle={() => toggleGroup(group.id)}
-                isSystem={group.code === 'audit'}
+                isSystem={isLegacyOptionalSystemGroupCode(group.code)}
               >
                 {group.attributes.map((attr) => (
                   <AttrRow

--- a/apps/admin/src/lib/legacy-attribute-groups.ts
+++ b/apps/admin/src/lib/legacy-attribute-groups.ts
@@ -1,0 +1,25 @@
+/**
+ * Legacy AttributeGroup codes that were once seeded as
+ * `is_system_group=true` but are now user-managed modeling configuration:
+ *
+ * - `audit`     — un-seeded by #1074 / Version20260527100000
+ * - `relations` — un-seeded by #1080 (MODRC-01) / Version20260528100000
+ *
+ * Old databases may still carry the legacy rows; the BE
+ * {@link App\Catalog\Application\Command\DeleteAttributeGroup\DeleteAttributeGroupHandler}
+ * allow-lists the same set so DELETE returns 204. The admin lock UX uses
+ * this helper everywhere it previously special-cased `code === 'audit'`,
+ * keeping a single source of truth.
+ */
+export const LEGACY_OPTIONAL_SYSTEM_GROUP_CODES = ['audit', 'relations'] as const;
+
+export type LegacyOptionalSystemGroupCode = (typeof LEGACY_OPTIONAL_SYSTEM_GROUP_CODES)[number];
+
+export function isLegacyOptionalSystemGroupCode(
+  code: string | undefined | null,
+): code is LegacyOptionalSystemGroupCode {
+  return (
+    typeof code === 'string' &&
+    (LEGACY_OPTIONAL_SYSTEM_GROUP_CODES as readonly string[]).includes(code)
+  );
+}


### PR DESCRIPTION
## Summary

MODRC-02 from the Option Y batch. After MODRC-01 (#1085) the legacy `relations` AttributeGroup is no longer seeded, but old DBs may still carry a row with `is_system_group=true`. The admin lock UX previously hard-coded `code === 'audit'` as the only exception; this PR generalizes the allow-list to `['audit', 'relations']` and extracts a shared helper so adding a third code (if ever) stays in one place.

## New utility

- [`apps/admin/src/lib/legacy-attribute-groups.ts`](apps/admin/src/lib/legacy-attribute-groups.ts) — exports `LEGACY_OPTIONAL_SYSTEM_GROUP_CODES` constant and `isLegacyOptionalSystemGroupCode()` type guard. Single source of truth for the FE allow-list; mirrors the BE constant introduced in #1085 (`DeleteAttributeGroupHandler::LEGACY_USER_MANAGED_SYSTEM_GROUP_CODES`).

## Refactored files (every `code === 'audit'` flows through the helper now)

- `components/modeling/group-card.tsx` — `isLocked` check
- `components/modeling/declare-attribute-group-dialog.tsx` — lock badge in picker
- `components/objects/universal-detail-page.tsx` — `AttrGroupCard isSystem`
- `features/catalog/attribute-groups/list.tsx` — section divider lock affordance + row lock badge
- `features/catalog/attribute-groups/show.tsx` — `isLockedSystemGroup` (drives both the Save button visibility and the new DangerZone delete card)
- `features/catalog/object-types/show.tsx` — editable vs. locked built-in groups split + renamed `legacy_audit_groups_note` → `legacy_optional_groups_note` copy
- `features/catalog/products/components/effective-model-card.tsx` — lock icon + `system` source label
- `features/catalog/products/components/product-detail-page.tsx` — `AttrGroupCard isSystem`

## E2E coverage

- [`apps/admin/e2e/1081-relations-group-no-lock.spec.ts`](apps/admin/e2e/1081-relations-group-no-lock.spec.ts) mirrors `1076-audit-group-no-lock.spec.ts`: defensive seed via the API, assert no lock badge in `/modeling/attribute-groups`, confirm Save + delete affordance on the detail page.

## Quality gates

- `NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @pim/admin typecheck` — green.
- `pnpm --filter @pim/admin lint` — 0 errors (6 warnings + 8 infos pre-existed).
- `NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @pim/admin build` — green.

## Test plan

- [ ] CI passes (Biome strict, TypeScript noEmit, Vite build, Playwright).
- [ ] Visual: `/modeling/attribute-groups` — if a legacy `relations` row exists, no lock badge; section divider lock icon only appears when other locked groups remain.
- [ ] Visual: `/modeling/attribute-groups/{relations-id}` — Save + Danger zone delete card visible.
- [ ] Visual: `/modeling/object-types/{product-id}` Built-in vs. Custom split still works for true system groups; legacy audit/relations show in the editable section.

## Dependencies

Blocked by MODRC-01 (#1085) which un-seeds the group + extends the BE allow-list. Merge after #1085 is green.

Closes #1081
Refs #1080 #1082 #1083 #1084