### PR TITLE
feat(admin): extract system Powiązania zwrotne section (MODRC-03)

### DIFF
--- a/apps/admin/src/features/catalog/products/components/relations-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/relations-tab.tsx
@@ -1,14 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  ArrowDownLeft,
-  ChevronDown,
-  ChevronUp,
-  Link2,
-  Plus,
-  Search,
-  Trash2,
-  X,
-} from 'lucide-react';
+import { ChevronDown, ChevronUp, Link2, Plus, Search, Trash2, X } from 'lucide-react';
 import { type FormEvent, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -20,6 +11,7 @@ import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 import { RelationInlineEditPanel } from './relation-inline-edit-panel';
+import { SystemReverseRelationsSection } from './system-reverse-relations-section';
 
 /**
  * ADR-014 / MOD-12 (#904) — „Powiązania" tab on the product detail page.
@@ -174,46 +166,7 @@ export function RelationsTab({ productId }: RelationsTabProps) {
         />
       ))}
 
-      {reverseGroups.length > 0 ? (
-        <div className="rounded-2xl border border-line bg-surface p-5 soft-shadow">
-          <div className="flex items-center gap-2">
-            <ArrowDownLeft className="size-4 text-muted-foreground" />
-            <h3 className="text-sm font-semibold">
-              {t('relations.reverse_title', { defaultValue: 'Powiązania zwrotne (read-only)' })}
-            </h3>
-          </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {t('relations.reverse_desc', {
-              defaultValue: 'Obiekty, które wskazują na ten produkt przez swoje atrybuty relacji.',
-            })}
-          </p>
-          <div className="mt-4 space-y-3">
-            {reverseGroups.map((group) => (
-              <div
-                key={`${group.sourceObjectType.id}:${group.attribute.id}`}
-                className="rounded-xl border border-line bg-background p-3"
-              >
-                <div className="text-xs font-medium">
-                  <span className="text-foreground">{group.attribute.code}</span>
-                  <span className="ml-2 text-muted-foreground">
-                    ({group.sourceObjectType.code} / {group.sourceObjectType.kind})
-                  </span>
-                </div>
-                <ul className="mt-2 flex flex-wrap gap-1.5">
-                  {group.sources.map((src) => (
-                    <li
-                      key={src.relationId}
-                      className="rounded-md bg-zinc-100 px-2 py-1 text-xs font-mono"
-                    >
-                      {src.code}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : null}
+      <SystemReverseRelationsSection groups={reverseGroups} />
     </div>
   );
 }

--- a/apps/admin/src/features/catalog/products/components/system-reverse-relations-section.tsx
+++ b/apps/admin/src/features/catalog/products/components/system-reverse-relations-section.tsx
@@ -1,0 +1,102 @@
+import { ArrowDownLeft, Lock } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * MODRC-03 (#1082) — system section listing objects that point at the
+ * current one through any relation attribute. After Option Y the
+ * legacy "Powiązania" AttributeGroup is gone, so reverse links no
+ * longer have a user-managed home — this is the single auto-generated
+ * landing pad. Visually marked as `system` + zinc-tinted styling so the
+ * operator can tell it apart from user-defined groups. Read-only:
+ * edits live on the source side.
+ *
+ * Data shape mirrors the existing `GET /api/objects/{id}/relations/reverse`
+ * response (MOD-07).
+ */
+export interface ReverseGroupRow {
+  sourceObjectType: { id: string; code: string; kind: string };
+  attribute: { id: string; code: string; label: Record<string, string> | null };
+  sources: Array<{ id: string; code: string; relationId: string; position: number }>;
+}
+
+export interface SystemReverseRelationsSectionProps {
+  groups: ReverseGroupRow[];
+  className?: string;
+}
+
+export function SystemReverseRelationsSection({
+  groups,
+  className,
+}: SystemReverseRelationsSectionProps) {
+  const { t } = useTranslation();
+
+  if (groups.length === 0) return null;
+
+  return (
+    <section
+      aria-label={t('relations.reverse_section_aria', {
+        defaultValue: 'Powiązania zwrotne (sekcja systemowa, read-only)',
+      })}
+      className={cn('rounded-2xl border border-zinc-200 bg-zinc-50/60 p-5 soft-shadow', className)}
+    >
+      <header className="flex items-center gap-2">
+        <ArrowDownLeft className="size-4 text-zinc-500" aria-hidden />
+        <h3 className="text-sm font-semibold text-zinc-800">
+          {t('relations.reverse_title', { defaultValue: 'Powiązania zwrotne' })}
+        </h3>
+        <span
+          className="inline-flex items-center gap-1 rounded bg-zinc-200/70 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-600"
+          title={t('relations.reverse_system_badge_tooltip', {
+            defaultValue: 'Sekcja generowana automatycznie — edycja po stronie obiektu źródłowego.',
+          })}
+        >
+          <Lock className="size-2.5" aria-hidden />
+          {t('relations.reverse_system_badge_label', { defaultValue: 'system' })}
+        </span>
+      </header>
+      <p className="mt-1 text-xs text-zinc-500">
+        {t('relations.reverse_desc', {
+          defaultValue: 'Obiekty, które wskazują na ten produkt przez swoje atrybuty relacji.',
+        })}
+      </p>
+      <div className="mt-4 space-y-3">
+        {groups.map((group) => (
+          <div
+            key={`${group.sourceObjectType.id}:${group.attribute.id}`}
+            className="rounded-xl border border-zinc-200 bg-white p-3"
+          >
+            <div className="text-xs font-medium">
+              <span className="text-foreground">{group.attribute.code}</span>
+              <span className="ml-2 text-muted-foreground">
+                ({group.sourceObjectType.code} / {group.sourceObjectType.kind})
+              </span>
+            </div>
+            <ul className="mt-2 flex flex-wrap gap-1.5">
+              {group.sources.map((src) => (
+                <li key={src.relationId}>
+                  <Link
+                    to={resolveSourceHref(group.sourceObjectType.kind, src.id)}
+                    className="inline-block rounded-md bg-zinc-100 px-2 py-1 font-mono text-xs text-zinc-800 transition hover:bg-zinc-200 hover:text-zinc-900"
+                    title={t('relations.reverse_open_source_tooltip', {
+                      defaultValue: 'Otwórz obiekt źródłowy',
+                    })}
+                  >
+                    {src.code}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function resolveSourceHref(kind: string, id: string): string {
+  if (kind === 'product') return `/products/${id}`;
+  return `/objects/${id}`;
+}


### PR DESCRIPTION
## Summary

MODRC-03 from the Option Y batch. After MODRC-01 removed the seeded `relations` AttributeGroup, reverse links lost their user-managed home. This PR extracts the existing reverse panel inside `RelationsTab` into a dedicated `SystemReverseRelationsSection` component with explicit `system` badge, zinc-tinted background, and clickable source rows so the operator can see this is a platform-generated landing pad (not a user-defined group) and can navigate to the source object in one click.

## Changes

- **New component** [`apps/admin/src/features/catalog/products/components/system-reverse-relations-section.tsx`](apps/admin/src/features/catalog/products/components/system-reverse-relations-section.tsx) — renders the reverse groups list with:
  - Header: `↩ Powiązania zwrotne` + `🔒 system` badge (tooltip explains it's auto-generated, edits live on source side).
  - Zinc-tinted background (`bg-zinc-50/60`) + zinc borders so it stands apart from user-defined group cards.
  - Source codes rendered as `<Link>` chips — clicking navigates to `/products/{id}` for `kind=product`, `/objects/{id}` otherwise.
  - `aria-label` + `Lock` icon for accessibility.
  - No-op render when `groups.length === 0` (visibility AC-1).

- **`relations-tab.tsx`** — drops the inline reverse panel (40 lines), the `ArrowDownLeft` import, and the duplicate `ReverseGroupPayload` type. Delegates to the new component.

## Acceptance criteria — addressed

- AC-1 obiekt bez reverse → sekcja nie renderuje się: `groups.length === 0 → return null`.
- AC-2 obiekt z ≥1 reverse → sekcja renderuje listę: existing query (`/api/objects/{id}/relations/reverse`) drives input.
- AC-3 pogrupowane per source ObjectType + atrybut źródłowy: shape kept from MOD-07 response.
- AC-4 wizualnie odróżnialna od user-defined: zinc bg + `system` badge + `Lock` icon.
- AC-5 klik w reverse → nawigacja do źródła: `<Link>` with kind-aware href.
- AC-6 read-only: no mutation handlers attached to source chips.
- AC-7 perf <100ms on 50k+: unchanged — existing `idx_object_relations_target` (MOD-02) keeps the query fast; no new endpoints.
- AC-8 E2E A→B → "Powiązania zwrotne" widoczne: covered by existing reverse-relations E2E in the suite; new Playwright spec to be added in follow-up alongside MODRC-05 (deferred — heavy fixture cost).

## Quality gates

- `NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @pim/admin typecheck` — green.
- `pnpm --filter @pim/admin lint` — 0 errors (6 warnings + 8 infos pre-existed).
- `NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @pim/admin build` — green.

## Test plan

- [ ] CI passes (Biome strict, TypeScript noEmit, Playwright).
- [ ] Visual: product detail with reverse links — section renders zinc-tinted, badge "system" visible, source codes navigate on click.
- [ ] Visual: product detail without reverse — section not rendered.

## Dependencies

Builds on MODRC-01 (#1085, merged). Independent of MODRC-02 (#1086) and MODRC-05.

Closes #1082
Refs #1080 #1081 #1083 #1084