### PR TITLE
feat(admin): inline relation editor in attr-row (MODRC-05)

### DIFF
--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -501,6 +501,7 @@ export function UniversalDetailPage({
                     isEditing={isEditing}
                     isLocked={attr.is_system}
                     onChange={(next) => setFieldValue(attr.code, next)}
+                    relationContextProductId={objectId}
                   />
                 ))}
               </AttrGroupCard>

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -8,6 +8,7 @@ import { MultiSelect, type MultiSelectOption } from '@/components/ui/multi-selec
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
+import { RelationInlineEditor } from './relation-inline-editor';
 import type { AttributeMeta, AttributeOptionMeta, ProductLocale } from './types';
 
 export interface AttrRowProps {
@@ -26,6 +27,14 @@ export interface AttrRowProps {
    * tooltip so we don't lose it for Faza 2 inheritance work.
    */
   onCopyToOthers?: () => void;
+  /**
+   * MODRC-05 (#1084) — when supplied and the attribute is `type='relation'`,
+   * AttrRow renders the inline relation editor (picker + grid) instead of
+   * a plain text input. The parent passes the current object id so the
+   * editor can fetch `/api/objects/{id}/relations` and reuse the same
+   * cache key as the dedicated Relations tab.
+   */
+  relationContextProductId?: string;
 }
 
 /**
@@ -44,6 +53,7 @@ export function AttrRow({
   isLocked,
   onChange,
   onCopyToOthers,
+  relationContextProductId,
 }: AttrRowProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
@@ -166,6 +176,18 @@ export function AttrRow({
                 defaultValue: 'Wybierz…',
               })}
               className="rounded-xl text-[13.5px]"
+            />
+          ) : attribute.type === 'relation' &&
+            typeof relationContextProductId === 'string' &&
+            relationContextProductId.length > 0 ? (
+            // MODRC-05 (#1084) — render the full relation picker inline
+            // whenever the parent supplies a productId. The same UI as the
+            // dedicated Relations tab, so relations work like any other
+            // attribute regardless of the hosting group's display_mode.
+            <RelationInlineEditor
+              productId={relationContextProductId}
+              attributeId={attribute.id}
+              attributeCode={attribute.code}
             />
           ) : (
             <Input

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -776,6 +776,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                     isEditing={isEditing}
                     isLocked={attr.is_system}
                     onChange={(next) => setFieldValue(attr.code, next)}
+                    relationContextProductId={isEditMode ? id : undefined}
                   />
                 ))}
               </AttrGroupCard>

--- a/apps/admin/src/features/catalog/products/components/relation-inline-editor.tsx
+++ b/apps/admin/src/features/catalog/products/components/relation-inline-editor.tsx
@@ -1,0 +1,88 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { jsonFetch } from '@/lib/http';
+import {
+  RelationGroupCard,
+  type RelationGroupPayload,
+  type RelationsResponse,
+} from './relations-tab';
+
+/**
+ * MODRC-05 (#1084) — inline editor used by {@link AttrRow} whenever a
+ * relation-type attribute is placed in a `display_mode='stacked'` group
+ * (or any non-tab context). Re-uses the existing {@link RelationGroupCard}
+ * editor that powers the dedicated Relations tab, so the operator gets
+ * the same picker + grid + advanced metadata UI regardless of the
+ * group's display mode. The reverse panel stays in the Relations tab —
+ * inline is forward-only.
+ *
+ * Data: shares the same `['objects', productId, 'relations']` cache key
+ * as the tab, so the inline editor and the tab stay in sync.
+ */
+export interface RelationInlineEditorProps {
+  productId: string;
+  attributeId: string;
+  attributeCode: string;
+}
+
+export function RelationInlineEditor({
+  productId,
+  attributeId,
+  attributeCode,
+}: RelationInlineEditorProps) {
+  const { t, i18n } = useTranslation();
+  const queryClient = useQueryClient();
+  const locale = i18n.language === 'pl' ? 'pl' : 'en';
+
+  const query = useQuery<RelationsResponse>({
+    queryKey: ['objects', productId, 'relations'],
+    queryFn: () =>
+      jsonFetch<RelationsResponse>(`/api/objects/${productId}/relations`, {
+        accept: 'application/json',
+      }),
+    staleTime: 5_000,
+  });
+
+  if (query.isLoading) {
+    return <p className="text-xs text-muted-foreground">{t('app.loading')}</p>;
+  }
+  if (query.isError || !query.data) {
+    return (
+      <p className="text-xs text-destructive">
+        {t('relations.fetch_error', { defaultValue: 'Nie udało się pobrać powiązań.' })}
+      </p>
+    );
+  }
+
+  const group: RelationGroupPayload | undefined = query.data.relationAttributes.find(
+    (g) => g.attribute.id === attributeId || g.attribute.code === attributeCode,
+  );
+
+  if (!group) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {t('relations.inline_no_attribute', {
+          defaultValue:
+            'Atrybut nie jest jeszcze przypięty do ObjectType — przypisanie idzie przez Modelowanie.',
+        })}
+      </p>
+    );
+  }
+
+  return (
+    <RelationGroupCard
+      productId={productId}
+      group={group}
+      locale={locale}
+      onChange={() => {
+        void queryClient.invalidateQueries({
+          queryKey: ['objects', productId, 'relations'],
+        });
+        void queryClient.invalidateQueries({
+          queryKey: ['objects', productId, 'relations', 'reverse'],
+        });
+      }}
+    />
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/relations-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/relations-tab.tsx
@@ -57,12 +57,12 @@ interface RelationRow {
   metadata: Record<string, unknown> | unknown[];
 }
 
-interface RelationGroupPayload {
+export interface RelationGroupPayload {
   attribute: RelationAttribute;
   relations: RelationRow[];
 }
 
-interface RelationsResponse {
+export interface RelationsResponse {
   sourceObjectId: string;
   relationAttributes: RelationGroupPayload[];
 }
@@ -171,7 +171,7 @@ export function RelationsTab({ productId }: RelationsTabProps) {
   );
 }
 
-function RelationGroupCard({
+export function RelationGroupCard({
   productId,
   group,
   locale,


### PR DESCRIPTION
## Summary

MODRC-05 — final piece of the Option Y batch. Closes the gap where relation attributes placed in a `display_mode='stacked'` group (or any non-tab context) rendered as a plain text input that wrote to the wrong column.

Now `AttrRow` swaps the text input for the **same picker + grid + advanced-metadata editor** that the dedicated Relations tab uses, so relations work like any other attribute regardless of placement.

## Approach

Re-use, don't duplicate. The existing `RelationGroupCard` inside `relations-tab.tsx` already implements the whole editor (picker, grid, advanced metadata, optimistic updates, error states). I exported it + the two payload types and wrapped them in a thin `RelationInlineEditor` that owns the per-attribute fetch + cache key.

The wrapper shares the `['objects', productId, 'relations']` cache key with the tab, so flipping a group between `display_mode='tab'` and `display_mode='stacked'` does not lose state — the same data is rendered in both places.

## Changes

- **New** [`apps/admin/src/features/catalog/products/components/relation-inline-editor.tsx`](apps/admin/src/features/catalog/products/components/relation-inline-editor.tsx) — fetches relations, picks the row for the attribute by id (falls back to code), defers to `RelationGroupCard`. Invalidates both the forward and reverse caches on `onChange`.
- **`relations-tab.tsx`** — exports `RelationGroupCard`, `RelationGroupPayload`, `RelationsResponse` so they're consumable from outside.
- **`attr-row.tsx`** — new optional `relationContextProductId` prop. When set and `attribute.type === 'relation'`, render the inline editor instead of the catch-all text input.
- **`product-detail-page.tsx`** + **`universal-detail-page.tsx`** — thread the current object id into every AttrRow render.

## Quality gates

- `NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @pim/admin typecheck` — green.
- `pnpm --filter @pim/admin lint` — 0 errors (6 warnings + 8 infos pre-existed).
- `NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @pim/admin build` — green.

## Test plan / SMOKE TEST RULE

- [ ] CI passes (Biome strict, TypeScript noEmit, Vite build, Playwright).
- [ ] Live-stack smoke (before claiming "działa"):
  1. Login admin@demo.localhost / changeme on https://pim.localhost.
  2. `/modeling/object-types/{product-id}` — create a custom group `polecane` with `display_mode='stacked'`.
  3. Attach `cross_sell` (or any relation attribute) to `polecane`.
  4. Open any product → the `polecane` section now renders the inline picker.
  5. Add a link → confirm 204 in DevTools → refresh → link persists.
  6. Switch `polecane` to `display_mode='tab'` → same data in the dedicated Relations tab.

Smoke pending on live stack — will paste proof in PR before claiming "działa end-to-end".

## Dependencies

Builds on MODRC-01 (#1085, merged) + MODRC-02 (#1086, in CI). Independent of MODRC-03 (#1088) and MODRC-04 (#1087).

Closes #1084
Refs #1080 #1081 #1082 #1083