### PR TITLE
fix(identity): /products 500 — AttributePermissionPolicy column drift

### DIFF
--- a/apps/api/migrations/Version20260518160000.php
+++ b/apps/api/migrations/Version20260518160000.php
@@ -80,16 +80,22 @@ final class Version20260518160000 extends AbstractMigration
         SQL);
 
         // ─── 3. role_attribute_permissions (per-attribute override) ─────
+        // Column `permission_level` follows the entity ORM mapping
+        // ({@see RoleAttributePermission.orm.xml}). An earlier draft of
+        // this migration used `permission`; aligned here so a fresh
+        // migrate-up matches what entity auto-schema produces, and the
+        // {@see AttributePermissionPolicy} resolver does not have to
+        // branch on the column name.
         $this->addSql(<<<'SQL'
             CREATE TABLE role_attribute_permissions (
                 role_id UUID NOT NULL,
                 attribute_id UUID NOT NULL,
-                permission VARCHAR(16) NOT NULL,
+                permission_level VARCHAR(16) NOT NULL,
                 created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (role_id, attribute_id),
                 CONSTRAINT chk_role_attribute_permissions_value
-                    CHECK (permission IN ('restricted', 'view', 'edit')),
+                    CHECK (permission_level IN ('restricted', 'view', 'edit')),
                 CONSTRAINT fk_role_attribute_permissions_role
                     FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
                 CONSTRAINT fk_role_attribute_permissions_attribute
@@ -100,16 +106,17 @@ final class Version20260518160000 extends AbstractMigration
         $this->addSql('CREATE INDEX idx_role_attribute_permissions_attribute ON role_attribute_permissions (attribute_id)');
 
         // ─── 4. role_attribute_group_permissions (per-group override) ───
+        // Same column-name convention as #3 (`permission_level`).
         $this->addSql(<<<'SQL'
             CREATE TABLE role_attribute_group_permissions (
                 role_id UUID NOT NULL,
                 attribute_group_id UUID NOT NULL,
-                permission VARCHAR(16) NOT NULL,
+                permission_level VARCHAR(16) NOT NULL,
                 created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (role_id, attribute_group_id),
                 CONSTRAINT chk_role_attribute_group_permissions_value
-                    CHECK (permission IN ('restricted', 'view', 'edit')),
+                    CHECK (permission_level IN ('restricted', 'view', 'edit')),
                 CONSTRAINT fk_role_attribute_group_permissions_role
                     FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE,
                 CONSTRAINT fk_role_attribute_group_permissions_group

--- a/apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php
+++ b/apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php
@@ -8,6 +8,9 @@ use App\Identity\Application\PermissionResolverInterface;
 use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Rbac\AttributePermission;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -132,8 +135,12 @@ readonly class AttributePermissionPolicy
     private function resolveForRole(string $roleId, Uuid $attributeId): AttributePermission
     {
         // 1. Per-attribute override — direct lookup, primary-key indexed.
+        //    The column name (`permission_level`) follows the entity ORM
+        //    mapping in {@see RoleAttributePermission.orm.xml}; an older
+        //    iteration of {@see Version20260518160000} declared `permission`
+        //    and never landed.
         $perAttr = $this->connection->fetchOne(
-            'SELECT permission FROM role_attribute_permissions WHERE role_id = :role_id AND attribute_id = :attribute_id',
+            'SELECT permission_level FROM role_attribute_permissions WHERE role_id = :role_id AND attribute_id = :attribute_id',
             ['role_id' => $roleId, 'attribute_id' => $attributeId->toRfc4122()],
         );
         if (false !== $perAttr && \is_string($perAttr)) {
@@ -142,36 +149,73 @@ readonly class AttributePermissionPolicy
 
         // 2. Per-group override — attribute may belong to multiple groups;
         //    take the most-permissive group grant for this role.
-        $perGroup = $this->connection->fetchOne(
-            <<<'SQL'
-                SELECT rgp.permission
-                  FROM role_attribute_group_permissions rgp
-                  JOIN attribute_group_attributes aga ON aga.attribute_group_id = rgp.attribute_group_id
-                 WHERE rgp.role_id = :role_id
-                   AND aga.attribute_id = :attribute_id
-                 ORDER BY CASE rgp.permission
-                              WHEN 'edit' THEN 2
-                              WHEN 'view' THEN 1
-                              ELSE 0
-                          END DESC
-                 LIMIT 1
-                SQL,
-            ['role_id' => $roleId, 'attribute_id' => $attributeId->toRfc4122()],
-        );
-        if (false !== $perGroup && \is_string($perGroup)) {
-            return AttributePermission::from($perGroup);
+        //
+        //    `role_attribute_group_permissions` is only present on DBs that
+        //    ran {@see Version20260518160000}. Local stacks bootstrapped
+        //    via `doctrine:schema:create` from entities never get the
+        //    table (no entity exists for it). Treat a missing table as
+        //    "no per-group override" — same outcome as an empty row set.
+        try {
+            $perGroup = $this->connection->fetchOne(
+                <<<'SQL'
+                    SELECT rgp.permission_level
+                      FROM role_attribute_group_permissions rgp
+                      JOIN attribute_group_attributes aga ON aga.attribute_group_id = rgp.attribute_group_id
+                     WHERE rgp.role_id = :role_id
+                       AND aga.attribute_id = :attribute_id
+                     ORDER BY CASE rgp.permission_level
+                                  WHEN 'edit' THEN 2
+                                  WHEN 'view' THEN 1
+                                  ELSE 0
+                              END DESC
+                     LIMIT 1
+                    SQL,
+                ['role_id' => $roleId, 'attribute_id' => $attributeId->toRfc4122()],
+            );
+            if (false !== $perGroup && \is_string($perGroup)) {
+                return AttributePermission::from($perGroup);
+            }
+        } catch (TableNotFoundException|InvalidFieldNameException|DatabaseObjectNotFoundException) {
+            // schema not migrated yet — drop through to role default
         }
 
         // 3. Role default — column defaults to 'edit' for tenant-level
         //    roles, 'view' for viewer, 'restricted' for explicit setups.
-        $default = $this->connection->fetchOne(
-            'SELECT default_attribute_permission FROM roles WHERE id = :role_id',
-            ['role_id' => $roleId],
-        );
-        if (false !== $default && \is_string($default)) {
-            return AttributePermission::from($default);
+        //    Same compatibility note: `roles.default_attribute_permission`
+        //    only exists when the original migration ran; otherwise we
+        //    infer from `roles.code` to preserve the migration's intent
+        //    (viewer → View, everyone else → Edit).
+        try {
+            $default = $this->connection->fetchOne(
+                'SELECT default_attribute_permission FROM roles WHERE id = :role_id',
+                ['role_id' => $roleId],
+            );
+            if (false !== $default && \is_string($default)) {
+                return AttributePermission::from($default);
+            }
+        } catch (InvalidFieldNameException|DatabaseObjectNotFoundException) {
+            return $this->inferDefaultFromRoleCode($roleId);
         }
 
-        return AttributePermission::Restricted;
+        return $this->inferDefaultFromRoleCode($roleId);
+    }
+
+    /**
+     * Compatibility fallback when `roles.default_attribute_permission`
+     * is missing (DB created from entities, not migrations). Mirrors the
+     * UPDATEs from {@see Version20260518160000}: `viewer` → View,
+     * everyone else who already passed the broad gate → Edit.
+     */
+    private function inferDefaultFromRoleCode(string $roleId): AttributePermission
+    {
+        $code = $this->connection->fetchOne(
+            'SELECT code FROM roles WHERE id = :role_id',
+            ['role_id' => $roleId],
+        );
+        if (false === $code || !\is_string($code)) {
+            return AttributePermission::Restricted;
+        }
+
+        return 'viewer' === $code ? AttributePermission::View : AttributePermission::Edit;
     }
 }


### PR DESCRIPTION
## Problem

`/products` (and any other page reading `/api/object_types/{id}/list-schema`) returns 500:
```
column "permission" does not exist
LINE 1: SELECT permission FROM role_attribute_permissions WHERE role...
```

The frontend surfaces it as **"Could not load list schema."**

## Root cause

`AttributePermissionPolicy` (PR #805 / RBAC-P3 #671) was wired in expecting schema elements that drifted from the entity layer on local dev stacks bootstrapped via `doctrine:schema:create`:

| Code expects | ORM mapping / actual DB |
|---|---|
| `SELECT permission FROM role_attribute_permissions` | column is `permission_level` ([RoleAttributePermission.orm.xml:26](apps/api/src/Identity/Infrastructure/Doctrine/Orm/Mapping/RoleAttributePermission.orm.xml#L26)) |
| `role_attribute_group_permissions` table | doesn't exist — no entity ships for it |
| `roles.default_attribute_permission` column | doesn't exist — no entity field |

The first query 500s with `column "permission" does not exist`, masking the wider drift. The migration that declared the original `permission` column ([Version20260518160000](apps/api/migrations/Version20260518160000.php)) never ran (`doctrine_migration_versions` is empty on local DBs), so the entity layer is the actual source of truth.

## Fix

**Backend — [`AttributePermissionPolicy.php`](apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php):**
- Query 1 (per-attribute override) now uses `permission_level` — matches the entity and the actual column name.
- Queries 2 + 3 (per-group override + role default) wrapped in `try/catch` that swallows `TableNotFoundException` / `InvalidFieldNameException` / `DatabaseObjectNotFoundException` and falls through. Local DBs without the schema delta no longer 500.
- New private `inferDefaultFromRoleCode()` mirrors the migration's `UPDATE` intent (viewer → `View`, everyone else who passed the broad gate → `Edit`). super_admin keeps seeing every attribute even when `roles.default_attribute_permission` is missing.

**Migration — [`Version20260518160000.php`](apps/api/migrations/Version20260518160000.php):**
- `permission` → `permission_level` in both `CREATE TABLE` statements + `CHECK` constraints. A fresh `migrate-up` now produces the same shape as entity auto-schema. Migration has never been executed on the local DB (`doctrine_migration_versions` empty); CI/test DBs run from the same source so this stays in sync.

## Verification

- `docker compose exec -T api composer phpstan` — **green** (0 errors).
- `docker compose exec -T -e APP_ENV=test api ./bin/phpunit tests/Unit/Identity/ tests/Integration/Catalog/SystemAttributesAuditGroupTest.php tests/Integration/Catalog/BuiltInProductRelationAttributesSeederTest.php` — **OK (195 tests, 465 assertions)**.
- Live-stack smoke:
  - `GET /api/auth/login` → 200, JWT minted.
  - `GET /api/object_types/{product}/list-schema` → **200** with full column list (was 500 before).
  - `GET /api/products?itemsPerPage=2` → **200**, `totalItems=100`.

## Test plan

- [ ] CI passes (PHPStan, PHPUnit, Playwright).
- [ ] Open `/products` on https://pim.localhost — list renders, no "Could not load list schema" error.

## Note

This is a pre-existing bug from PR #805 (the wider RBAC-P3 marathon), surfaced after the MODRC-01..05 marathon when the operator opened `/products`. Not caused by the Option Y work — confirmed with the operator before patching.