### PR TITLE
fix(catalog,admin): Relations attrs = normal attrs (drop synthetic tab + drop system lock)

### DIFF
--- a/apps/admin/e2e/975-relation-picker-candidates.spec.ts
+++ b/apps/admin/e2e/975-relation-picker-candidates.spec.ts
@@ -60,26 +60,29 @@ test('relation picker lists candidates and narrows on `?sku=` filter', async ({ 
   });
   expect(targetResponse.status()).toBe(201);
 
-  // Navigate straight to the source product in edit mode — relations
-  // tab only renders when `mode === 'edit'`.
+  // Navigate to the source product in edit mode — relation attributes
+  // render inline as AttrRows in the `Atrybuty` tab.
   await page.goto(`/products/${source.id}/edit`);
   await expect(page).toHaveURL(/\/products\/[0-9a-f-]{36}\/edit$/);
 
-  // Switch to the "Powiązania"/"Relations" tab. Seeded via
-  // BuiltInProductRelationAttributesSeeder so every product detail
-  // page has this tab. Match both Polish + English labels + optional
-  // badge count.
-  await page.getByRole('tab', { name: /(powi[ąa]zania|relations)\s*\d*/i }).click();
+  // Issue #1092 — relation attrs are now normal attributes and render
+  // INLINE in the default `Atrybuty` tab (no synthetic "Powiązania"
+  // tab unless the object has reverse links pointing at it). AttrRow
+  // gates its editor surface on the page-level "isEditing" toggle, so
+  // click the "Edytuj" button first to expose the inline relation
+  // picker buttons.
+  await page
+    .getByRole('button', { name: /^(edytuj|edit)$/i })
+    .first()
+    .click();
 
   // Every built-in relation attribute renders its own "Dodaj
-  // powiązanie" button — pick the first one (cross_sell, position 10
-  // in the seeder). We don't bind to a specific card heading because
-  // multiple cards share the same surrounding `div` structure; the
-  // first button is the cross-sell entry point.
+  // powiązanie" button via RelationInlineEditor; pick the first one
+  // (cross_sell, position 10 in the seeder).
   const addLinkButton = page
     .getByRole('button', { name: /^(dodaj powi[ąa]zanie|add link|add relation)$/i })
     .first();
-  await expect(addLinkButton).toBeVisible();
+  await expect(addLinkButton).toBeVisible({ timeout: 15_000 });
 
   // Open the picker modal. Capture the candidate fetch so we can
   // prove the FE talks to `/api/objects?…sku=…` (the bug was

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -270,14 +270,15 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     staleTime: 30_000,
   });
   const hasReverseRelations = reverseRelationsQuery.data?.hasReverse ?? false;
-  // MODRC-01 (#1080) — relations group is no longer seeded, so detect the
-  // Relations tab from any relation-type attribute on the object, regardless
-  // of which group (or the synthetic default bucket) hosts it.
-  const hasForwardRelationAttributes = useMemo(
-    () => groups.some((g) => g.attributes.some((a) => a.type === 'relation')),
-    [groups],
-  );
-  const shouldSurfaceRelationsTab = hasForwardRelationAttributes || hasReverseRelations;
+  // Issue #1092 — forward relation attributes are normal attributes
+  // now: they render inline through their natural group placement
+  // (stacked-mode group → inline in the `attributes` tab; tab-mode
+  // group → its own dedicated tab via `tabModeGroups`). The synthetic
+  // `relations` tab only survives for the reverse-only case (object is
+  // pointed at from elsewhere but has no forward relation attribute of
+  // its own) — that path still needs the bespoke `RelationsTab` because
+  // `effective-attribute-groups` has no concept of "incoming links".
+  const shouldSurfaceRelationsTab = hasReverseRelations;
 
   const visibleTabs: readonly TabKey[] = useMemo(() => {
     if (mode === 'create') return ['attributes'];

--- a/apps/api/migrations/Version20260528110000.php
+++ b/apps/api/migrations/Version20260528110000.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Issue #1092 — normalize built-in relation attributes.
+ *
+ * The 5 seeded relation attributes (`cross_sell`, `up_sell`, `related`,
+ * `alternative`, `accessory`) were previously marked `is_system=true` by
+ * `BuiltInProductRelationAttributesSeeder::markSystem()`. That made them
+ * render a "lock" badge in `/modeling/attributes` and refused detachment
+ * via `DetachAttributeFromGroupHandler` — operators could not move them
+ * to a custom AttributeGroup or remove them from a product.
+ *
+ * Operator request: treat these as regular attributes that can be
+ * grouped / detached / removed freely. The seeder no longer sets the
+ * flag (see same-PR change in BuiltInProductRelationAttributesSeeder);
+ * this migration clears the flag on rows already persisted by historic
+ * seed runs so existing tenants pick up the new behaviour.
+ *
+ * Scoped to `type='relation'` + the explicit code list to keep the
+ * UPDATE off operator-created attrs that happen to share a name.
+ */
+final class Version20260528110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Issue #1092 — drop is_system=true from built-in relation attributes (cross_sell, up_sell, related, alternative, accessory).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE attributes
+            SET is_system = false
+            WHERE type = 'relation'
+              AND code IN ('cross_sell', 'up_sell', 'related', 'alternative', 'accessory')
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            UPDATE attributes
+            SET is_system = true
+            WHERE type = 'relation'
+              AND code IN ('cross_sell', 'up_sell', 'related', 'alternative', 'accessory')
+        SQL);
+    }
+}

--- a/apps/api/src/Catalog/Application/BuiltInProductRelationAttributesSeeder.php
+++ b/apps/api/src/Catalog/Application/BuiltInProductRelationAttributesSeeder.php
@@ -108,8 +108,18 @@ final readonly class BuiltInProductRelationAttributesSeeder
                     continue;
                 }
 
+                // Issue #1092 — relation attributes are NOT marked
+                // `is_system` anymore. Operator wants the 5 built-in
+                // relation attrs (cross_sell, up_sell, related,
+                // alternative, accessory) to behave like normal
+                // attributes: addable, removable, groupable into any
+                // AttributeGroup. The `markSystem()` call that used to
+                // sit here drove the BuiltInLockBadge in
+                // /modeling/attributes and refused detachment via
+                // `DetachAttributeFromGroupHandler`. Migration
+                // Version20260528110000 clears the flag for existing
+                // rows.
                 $attribute = new Attribute($code, $definition['label'], AttributeType::Relation);
-                $attribute->markSystem();
                 $attribute->reorder($definition['position']);
                 $attribute->setRelationTargetObjectTypeIds($productTargetIds);
                 $attribute->setRelationCardinality(RelationCardinality::Many);

--- a/apps/api/tests/Integration/Catalog/BuiltInProductRelationAttributesSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/BuiltInProductRelationAttributesSeederTest.php
@@ -55,7 +55,12 @@ final class BuiltInProductRelationAttributesSeederTest extends KernelTestCase
             self::assertSame(RelationCardinality::Many, $attribute->getRelationCardinality(), "{$code} cardinality");
             self::assertFalse($attribute->isRelationAdvanced(), "{$code} advanced");
             self::assertSame([$productTypeId], $attribute->getRelationTargetObjectTypeIds(), "{$code} target");
-            self::assertTrue($attribute->isSystem(), "{$code} system flag");
+            // Issue #1092 — built-in relation attrs are NO LONGER marked
+            // system. They behave like normal attributes (operator can
+            // detach / group / remove them freely). The seeder lost its
+            // `markSystem()` call and migration Version20260528110000
+            // backfills `is_system=false` for any historic rows.
+            self::assertFalse($attribute->isSystem(), "{$code} system flag");
         }
     }
 


### PR DESCRIPTION
## Summary

Operator zgłosił że atrybuty typu Relations są over-specialized w 3 miejscach:
1. Synthetic "Relations" zakładka pojawia się dla każdego forward relation attra (zamiast renderować je inline w naturalnej grupie).
2. 5 seedowanych built-in relation attrów ma BuiltInLockBadge — operator nie może ich detachować ani przenieść do innej AttributeGroup.
3. DB rows mają `is_system=true` z historycznych seedów.

Naprawa robi z relation attrs **zwykłe atrybuty**.

## Root cause

- `BuiltInProductRelationAttributesSeeder.php:112` wywoływał `$attribute->markSystem()` → BuiltInLockBadge + blokada detachment.
- `product-detail-page.tsx:276-280` ustawiał `shouldSurfaceRelationsTab` na podstawie ANY forward relation attr → synthetic tab forsowany nawet dla attrów które powinny renderować się inline.
- Historyczne DB rows (5 codes) z `is_system=true` wymagają backfill migracji.

## Backend changes

- **NEW** `apps/api/migrations/Version20260528110000.php` — `UPDATE attributes SET is_system=false WHERE type='relation' AND code IN ('cross_sell','up_sell','related','alternative','accessory')`. `down()` ustawia `is_system=true` z powrotem (revert-safe).
- **MODIFY** `BuiltInProductRelationAttributesSeeder.php:111-113` — drop `markSystem()` line (kept `reorder()` + relation-specific setters intact).
- **MODIFY** `BuiltInProductRelationAttributesSeederTest.php:58` — assertion `assertTrue($attribute->isSystem())` → `assertFalse(...)`.

## Frontend changes

- **REFACTOR** `product-detail-page.tsx:272-285`:
  ```tsx
  const shouldSurfaceRelationsTab = hasReverseRelations;  // drop forward check
  ```
  Removed `hasForwardRelationAttributes` useMemo. Forward relation attrs now flow through normal group placement: `display_mode='stacked'` → inline AttrRow (z RelationInlineEditor); `display_mode='tab'` → osobna zakładka tej grupy via `tabModeGroups`. Synthetic Relations tab survives ONLY dla reverse-only case (MODR-06).

## Quality gates

- TypeScript noEmit: **0 errors**
- Biome strict: **0 errors** (warnings unchanged, pre-existing)
- Vite build: **ok**
- PHPStan max / PHPUnit / composer audit: validated via CI

## Smoke test plan (operator po merge'u)

1. Login (admin@demo.localhost / changeme).
2. **`/modeling/attributes`** → `cross_sell`, `up_sell`, `related`, `alternative`, `accessory` — **NIE** ma BuiltInLockBadge.
3. **`/modeling/object-types/<custom-OT>`** → atrybut typu relation można odpiąć (trash icon → 200 OK).
4. **`/modeling/object-types/{product-id}`** → przyjmij dowolny z 5 relation attrów → przenieś do dowolnej custom AttributeGroup → przechodzi bez "system attribute cannot be assigned".
5. **`/products/{id-z-relation-attrami}`** → relation attrs renderują się **inline** w zakładce `Atrybuty` (jeśli grupa stacked / bez grupy) lub w osobnej zakładce (jeśli grupa `display_mode=tab`). **NIE** ma synthetic Relations zakładki (chyba że obiekt ma reverse linki).
6. DevTools Console — brak czerwonych errorów.

## Świadome odejścia

- Per-tenant migration ze zróżnicowanymi defaults `is_system` — defer (YAGNI, wszystkie tenanty chcą tego samego).
- RelationsTab UI rewrite (reverse-only) — zostaje jak jest, gracefully renderuje sam reverse panel.
- Pełne usunięcie RelationsTab — defer, bespoke UI dla reverse links nadal potrzebne.

Closes #1092

🤖 Generated with [Claude Code](https://claude.com/claude-code)