### PR TITLE
fix(admin): RelationInlineEditor zawsze widoczny (regresja po #1093)

### DIFF
--- a/apps/admin/e2e/975-relation-picker-candidates.spec.ts
+++ b/apps/admin/e2e/975-relation-picker-candidates.spec.ts
@@ -65,20 +65,11 @@ test('relation picker lists candidates and narrows on `?sku=` filter', async ({ 
   await page.goto(`/products/${source.id}/edit`);
   await expect(page).toHaveURL(/\/products\/[0-9a-f-]{36}\/edit$/);
 
-  // Issue #1092 — relation attrs are now normal attributes and render
-  // INLINE in the default `Atrybuty` tab (no synthetic "Powiązania"
-  // tab unless the object has reverse links pointing at it). AttrRow
-  // gates its editor surface on the page-level "isEditing" toggle, so
-  // click the "Edytuj" button first to expose the inline relation
-  // picker buttons.
-  await page
-    .getByRole('button', { name: /^(edytuj|edit)$/i })
-    .first()
-    .click();
-
-  // Every built-in relation attribute renders its own "Dodaj
-  // powiązanie" button via RelationInlineEditor; pick the first one
-  // (cross_sell, position 10 in the seeder).
+  // Issue #1094 — RelationInlineEditor renders regardless of the
+  // page-level Edytuj toggle. It is self-contained (own query, own
+  // modal picker, own mutations) and does not participate in the
+  // dirty-fields flow, so it lives OUTSIDE the `editable` branch in
+  // AttrRow. No Edytuj click required.
   const addLinkButton = page
     .getByRole('button', { name: /^(dodaj powi[ąa]zanie|add link|add relation)$/i })
     .first();

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -107,7 +107,23 @@ export function AttrRow({
       </div>
 
       <div className="min-w-0">
-        {editable ? (
+        {/* Issue #1094 — relation attrs render their full inline editor
+            regardless of the page-level Edytuj toggle. RelationInlineEditor
+            is self-contained: own query (`['objects', productId, 'relations']`),
+            modal-driven picker, mutations against /api/objects/{id}/relations.
+            It does not participate in the dirty-fields flow, so it should
+            never live behind `editable`. Pre-#1093 the synthetic Relations
+            tab rendered RelationsTab standalone, also bypassing the page
+            toggle; this preserves that UX for the inline path. */}
+        {attribute.type === 'relation' &&
+        typeof relationContextProductId === 'string' &&
+        relationContextProductId.length > 0 ? (
+          <RelationInlineEditor
+            productId={relationContextProductId}
+            attributeId={attribute.id}
+            attributeCode={attribute.code}
+          />
+        ) : editable ? (
           attribute.type === 'wysiwyg' ? (
             <WysiwygEditor
               value={stringValue}
@@ -176,18 +192,6 @@ export function AttrRow({
                 defaultValue: 'Wybierz…',
               })}
               className="rounded-xl text-[13.5px]"
-            />
-          ) : attribute.type === 'relation' &&
-            typeof relationContextProductId === 'string' &&
-            relationContextProductId.length > 0 ? (
-            // MODRC-05 (#1084) — render the full relation picker inline
-            // whenever the parent supplies a productId. The same UI as the
-            // dedicated Relations tab, so relations work like any other
-            // attribute regardless of the hosting group's display_mode.
-            <RelationInlineEditor
-              productId={relationContextProductId}
-              attributeId={attribute.id}
-              attributeCode={attribute.code}
             />
           ) : (
             <Input


### PR DESCRIPTION
## Summary

Operator po PR #1093: "mam atrybut Up_sell w grupie wyświetlanej jako zakładka, ALE nie mogę dodać powiązanych produktów. Ta funkcjonalność zniknęła." Picker był niewidoczny dopóki operator nie kliknął Edytuj — regresja UX wprowadzona po przejściu z synthetic Relations tab na inline rendering.

## Root cause

AttrRow gates input surface behind `editable = isEditing && !isLocked`, więc inner `attribute.type === 'relation'` branch nigdy nie renderował RelationInlineEditor zanim operator kliknął Edytuj. Pre-#1093 synthetic RelationsTab był standalone (bez toggle dependency). Post-#1093 inline rendering inherited the gate.

RelationInlineEditor jest **self-contained**: własny query `['objects', productId, 'relations']`, modal-driven picker, mutacje przez `/api/objects/{id}/relations`. NIE partycypuje w dirty-fields flow → niesłusznie był za `editable` gate.

## Frontend changes

- **REFACTOR** `apps/admin/src/features/catalog/products/components/attr-row.tsx` — lift relation case poza `editable` conditional:
  ```tsx
  {attribute.type === 'relation' && relationContextProductId ? (
    <RelationInlineEditor ... />   // zawsze widoczny
  ) : editable ? (
    /* inputs */
  ) : (
    /* readonly placeholder */
  )}
  ```
  Inner relation case (zbędny po lift) usunięty.
- **UPDATE** `apps/admin/e2e/975-relation-picker-candidates.spec.ts` — drop `await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click()`, picker reachable immediately.

## Quality gates

- TypeScript noEmit: **0**
- Biome strict: **0** errors
- Vite build: **ok** (681ms)
- Playwright (local): `975-relation-picker-candidates.spec.ts` **1/1 zielony, 4.8s**

## Smoke test plan

1. Login admin@demo.localhost / changeme.
2. `https://pim.localhost/products/019e6e53-7911-77e9-b247-29850f2ed374` — bez klikania Edytuj.
3. Klik zakładki z relation attrami.
4. Atrybut Up_sell renderuje RelationInlineEditor — widoczna lista powiązań + przycisk "Dodaj powiązanie".
5. Klik "Dodaj powiązanie" → picker modal → wybór target → zapisz.
6. Powiązanie pojawia się w grid.
7. DevTools Console — brak czerwonych errorów.

## Świadome odejścia

- RelationInlineEditor UX refactor (kompaktowy widok) — defer.
- Copy-to-others dla relations — bez zmian.

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)