### PR TITLE
fix(catalog,admin): render tab-mode attribute groups in /objects/:slug/new

### DIFF
--- a/apps/admin/e2e/1096-universal-create-renders-tab-mode-groups.spec.ts
+++ b/apps/admin/e2e/1096-universal-create-renders-tab-mode-groups.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1096 — `/objects/:slug/new` (UniversalCreatePage) must render
+ * AttributeGroups attached to the ObjectType regardless of the junction
+ * `display_mode`. The wizard defaults to `'tab'`, so every fresh custom
+ * ObjectType used to show "Ten typ obiektu nie ma jeszcze atrybutów"
+ * until the operator manually toggled display_mode to `'stacked'` per
+ * group.
+ *
+ * The spec creates everything via API (mirrors the
+ * 1076-audit-group-no-lock pattern), navigates to the create page, and
+ * asserts the attribute fields render. Cleanup tears down the
+ * ObjectType and the AttributeGroup; the attributes stay in the global
+ * library (they are not exclusively owned by the group).
+ */
+test('UniversalCreatePage renders attribute groups attached with display_mode="tab"', async ({
+  page,
+}) => {
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const stamp = Date.now().toString(36);
+  const otCode = `samochody_e2e_${stamp}`;
+  const groupCode = `silnik_e2e_${stamp}`;
+  const attrMocCode = `moc_e2e_${stamp}`;
+  const attrSpalanieCode = `spalanie_e2e_${stamp}`;
+
+  // 1. Custom ObjectType (kind defaults to 'custom' for POSTs that do
+  //    not collide with built-in product/category/asset codes).
+  const otResp = await page.request.post('/api/object_types', {
+    data: {
+      code: otCode,
+      label: { pl: 'Samochody E2E', en: 'Cars E2E' },
+      icon: '🚗',
+      color: '#0ea5e9',
+      hierarchical: false,
+      hasVariants: false,
+      abstract: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(otResp.status(), await otResp.text()).toBe(201);
+  const objectTypeId = ((await otResp.json()) as { id: string }).id;
+
+  // 2. AttributeGroup (default is_system_group=false, display_mode is
+  //    set on the junction not on the group itself).
+  const groupResp = await page.request.post('/api/attribute_groups', {
+    data: { code: groupCode, label: { pl: 'Silnik', en: 'Engine' } },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(groupResp.status(), await groupResp.text()).toBe(201);
+  const groupId = ((await groupResp.json()) as { id: string }).id;
+
+  try {
+    // 3. Two text attributes — global library (no group ownership yet).
+    for (const [code, labelPl, labelEn] of [
+      [attrMocCode, 'Moc', 'Power'],
+      [attrSpalanieCode, 'Spalanie', 'Consumption'],
+    ] as const) {
+      const attrResp = await page.request.post('/api/attributes', {
+        data: { code, type: 'text', label: { pl: labelPl, en: labelEn }, required: false },
+        headers: {
+          ...bearer,
+          accept: 'application/ld+json',
+          'content-type': 'application/ld+json',
+        },
+      });
+      expect(attrResp.status(), await attrResp.text()).toBe(201);
+    }
+
+    // 4. Attach both attributes to the group.
+    const attachResp = await page.request.post(
+      `/api/attribute_groups/${groupId}/attributes/bulk-attach`,
+      {
+        data: { attributeCodes: [attrMocCode, attrSpalanieCode] },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      },
+    );
+    expect(attachResp.status(), await attachResp.text()).toBe(200);
+
+    // 5. Attach the group to the ObjectType. Default display_mode='tab'
+    //    — exactly the case the bug report describes.
+    const attachGroupResp = await page.request.post(
+      `/api/object_types/${objectTypeId}/groups/${groupId}`,
+      { headers: bearer },
+    );
+    expect(attachGroupResp.status()).toBe(204);
+
+    // 6. Sanity check the preview endpoint actually returns the group
+    //    with display_mode='tab' — pre-fix verification, also helps
+    //    diagnose if the BE contract ever drifts.
+    const previewResp = await page.request.post(
+      `/api/object_types/${objectTypeId}/effective-attribute-groups/preview`,
+      {
+        data: { categoryIds: [] },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      },
+    );
+    expect(previewResp.status()).toBe(200);
+    const previewBody = (await previewResp.json()) as {
+      groups: { code: string; display_mode: string; attributes: { code: string }[] }[];
+    };
+    const silnikGroup = previewBody.groups.find((g) => g.code === groupCode);
+    expect(silnikGroup, JSON.stringify(previewBody.groups)).toBeDefined();
+    expect(silnikGroup?.display_mode).toBe('tab');
+    expect(silnikGroup?.attributes.map((a) => a.code).sort()).toEqual(
+      [attrMocCode, attrSpalanieCode].sort(),
+    );
+
+    // 7. UI assertion — the create page must render the group card and
+    //    the attribute rows, NOT the empty-state hint.
+    await page.goto(`/objects/${otCode}/new`);
+
+    await expect(page.getByText(/ten typ obiektu nie ma jeszcze atrybut[óo]w/i)).toHaveCount(0);
+
+    // Group card label — match Polish or English (Playwright suite runs
+    // in either locale depending on the browser language).
+    await expect(page.getByText(/silnik|engine/i).first()).toBeVisible();
+
+    // Counter renders regardless of locale: `<filled> / <total> filled · 0%`.
+    await expect(page.getByText(/0\s*\/\s*2/).first()).toBeVisible();
+
+    // Both attribute labels render as field rows.
+    await expect(page.getByText(/^moc$|^power$/i).first()).toBeVisible();
+    await expect(page.getByText(/^spalanie$|^consumption$/i).first()).toBeVisible();
+  } finally {
+    await page.request.delete(`/api/object_types/${objectTypeId}`, { headers: bearer });
+    await page.request.delete(`/api/attribute_groups/${groupId}`, { headers: bearer });
+  }
+});

--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -74,6 +74,12 @@ export function UniversalCreatePage({
   // with an empty categoryIds payload so the response shape mirrors
   // the detail page; category-driven overlay during create is a
   // follow-up.
+  //
+  // #1096 — render every group inline as a stacked card regardless of
+  // its `display_mode`. The detail page (MODR-04) splits tab-mode
+  // groups into their own tabs, but during create the operator fills
+  // initial values in a single form; tab navigation here would just
+  // add friction and hide fields behind clicks.
   const groupsQuery = useQuery<{ groups: GroupMeta[] }>({
     queryKey: ['object-type', objectTypeId, 'effective-attribute-groups', 'preview', 'empty'],
     enabled: objectTypeId !== '',
@@ -90,7 +96,6 @@ export function UniversalCreatePage({
       ),
   });
   const groups = groupsQuery.data?.groups ?? [];
-  const stackedGroups = groups.filter((g) => (g.display_mode ?? 'tab') === 'stacked');
 
   const toggleGroup = (groupId: string): void => {
     setExpandedGroups((prev) => {
@@ -218,7 +223,7 @@ export function UniversalCreatePage({
         <div className="min-w-0 space-y-3">
           {groupsQuery.isLoading ? (
             <p className="text-sm text-muted-foreground">{t('app.loading')}</p>
-          ) : stackedGroups.length === 0 ? (
+          ) : groups.length === 0 ? (
             <div className="border-line bg-surface rounded-2xl border border-dashed p-6 text-center">
               <p className="text-ink text-[13px] font-medium">
                 {t('object_create.no_attributes', {
@@ -234,7 +239,7 @@ export function UniversalCreatePage({
               </p>
             </div>
           ) : (
-            stackedGroups.map((group) => (
+            groups.map((group) => (
               <AttrGroupCard
                 key={group.id}
                 id={group.id}


### PR DESCRIPTION
## Summary

Custom ObjectTypes utworzone przez modeling wizard pokazywały „Ten typ obiektu nie ma jeszcze atrybutów" na `/objects/:slug/new`, mimo że operator przypisał grupę atrybutów. `UniversalCreatePage` filtrowała grupy wyłącznie po `display_mode === 'stacked'`, a default w wizardzie to `'tab'` — każda nowo dołączona grupa była niewidoczna w create flow.

## Root cause

`apps/admin/src/components/objects/universal-create-page.tsx:93` (przed fixem):

```ts
const stackedGroups = groups.filter((g) => (g.display_mode ?? 'tab') === 'stacked');
```

Komponent renderuje tylko `stackedGroups` (`apps/admin/src/components/objects/universal-create-page.tsx:237`). Brak fallbacku tab UI → tab-mode grupy znikają z UX. Regresja założona w UP-08 (#1029) jako tymczasowa do follow-up'u, który nigdy nie wszedł.

Backend zwraca grupę poprawnie: `EffectiveAttributeGroupResolver::resolveForCategoryList(type, [])` w `apps/api/src/Catalog/Domain/Service/EffectiveAttributeGroupResolver.php:145-168` returns `loadObjectTypeGroups($type)` ze wszystkimi junctions `ObjectTypeAttributeGroup` z poprawnym `display_mode`.

## Backend changes

N/A — bug tylko FE. Schema, endpointy, resolvery bez zmian.

## Frontend changes

- `apps/admin/src/components/objects/universal-create-page.tsx` — usunięty filtr `stackedGroups`, render wszystkich `groups` jako stacked cards inline (`AttrGroupCard` + `AttrRow`). Empty state trigger pozostaje `groups.length === 0` (legit case). Komentarz nad query dopisany z linkiem do #1096.
- `apps/admin/e2e/1096-universal-create-renders-tab-mode-groups.spec.ts` — nowy spec: tworzy custom OT + AttributeGroup + 2 atrybuty + attach z domyślnym `display_mode='tab'`, weryfikuje preview endpoint + UI render (locale-independent).

## Quality gates

- Biome strict: 0 errors w nowych plikach (baseline 6 warnings + 8 infos w innych plikach pozostają).
- TypeScript strict: 0 errors (NODE_OPTIONS=--max-old-space-size=4096).
- Build: OK (3.06s).
- Playwright: 1/1 zielony lokalnie (`1096-universal-create-renders-tab-mode-groups.spec.ts`).
- pnpm audit: 0 high/critical (baseline: 1 low + 2 moderate).
- PHPStan/PHPUnit/composer audit pominięte — BE bez zmian.

## Smoke test plan (po merge)

1. Login `admin@demo.localhost / changeme`.
2. Modelowanie → utwórz custom OT „Samochody" (slug `samochody`).
3. Attach AttributeGroup `Silnik` (2 atrybuty `moc`, `spalanie`), zostaw default display_mode='tab' (badge „Zakładka").
4. Otwórz `https://pim.localhost/objects/samochody/new`.
5. Oczekiwane: card „Silnik" z polami `moc`, `spalanie`. **Brak** komunikatu „nie ma jeszcze atrybutów".
6. Wypełnij Kod (`CAR-001`) + wartości → **Utwórz** → HTTP 201 → navigate do detail.
7. DevTools Console — 0 errorów.
8. Negative case: drugi OT bez grup → create page → empty state komunikat (legit).

## Świadome odejścia

- **Products create page** ma analogiczny filtr w `apps/admin/src/features/catalog/products/components/product-detail-page.tsx:786` (`activeTab === 'attributes'` → render tylko `stackedGroups`), ale MVP product ma built-in stacked grupę `Identyfikacja` która maskuje bug. Out of scope tego ticketu — osobny ticket jeśli surface.
- **Tabs w create flow** — świadomy wybór: inline jako stacked cards zamiast tabs. Tabs dodawały friction (przełączanie zakładek przed Save). Detail page nadal ma tabs per `display_mode='tab'` (MODR-04 zachowane).

Closes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)
