### PR TITLE
fix(catalog,admin): tabs in UniversalCreatePage + refetch preview on mount

### DIFF
--- a/apps/admin/e2e/1096-universal-create-renders-tab-mode-groups.spec.ts
+++ b/apps/admin/e2e/1096-universal-create-renders-tab-mode-groups.spec.ts
@@ -3,22 +3,20 @@ import { expect, test } from '@playwright/test';
 import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
 
 /**
- * #1096 — `/objects/:slug/new` (UniversalCreatePage) must render
- * AttributeGroups attached to the ObjectType regardless of the junction
- * `display_mode`. The wizard defaults to `'tab'`, so every fresh custom
- * ObjectType used to show "Ten typ obiektu nie ma jeszcze atrybutów"
- * until the operator manually toggled display_mode to `'stacked'` per
- * group.
+ * #1096 / #1098 — `/objects/:slug/new` (UniversalCreatePage) must:
+ *   1. Render AttributeGroups attached to the ObjectType regardless of
+ *      the junction `display_mode` (#1096 — the wizard defaults to
+ *      'tab', so every fresh custom ObjectType used to show
+ *      "Ten typ obiektu nie ma jeszcze atrybutów").
+ *   2. Split tab-mode groups into their own tabs (matching MODR-04 on
+ *      the detail page) and refetch the preview on every mount so a
+ *      newly attached group surfaces without a hard refresh (#1098).
  *
- * The spec creates everything via API (mirrors the
- * 1076-audit-group-no-lock pattern), navigates to the create page, and
- * asserts the attribute fields render. Cleanup tears down the
- * ObjectType and the AttributeGroup; the attributes stay in the global
- * library (they are not exclusively owned by the group).
+ * The spec creates two tab-mode AttributeGroups via API, asserts the
+ * tab list renders both, asserts each tab reveals its own attribute
+ * rows on click, and tears everything down in `finally`.
  */
-test('UniversalCreatePage renders attribute groups attached with display_mode="tab"', async ({
-  page,
-}) => {
+test('UniversalCreatePage renders one tab per tab-mode AttributeGroup', async ({ page }) => {
   const loginResponse = await page.request.post('/api/auth/login', {
     data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
     headers: { accept: 'application/json' },
@@ -31,9 +29,12 @@ test('UniversalCreatePage renders attribute groups attached with display_mode="t
 
   const stamp = Date.now().toString(36);
   const otCode = `samochody_e2e_${stamp}`;
-  const groupCode = `silnik_e2e_${stamp}`;
+  const groupSilnikCode = `silnik_e2e_${stamp}`;
+  const groupWnetrzeCode = `wnetrze_e2e_${stamp}`;
   const attrMocCode = `moc_e2e_${stamp}`;
   const attrSpalanieCode = `spalanie_e2e_${stamp}`;
+  const attrKierownicaCode = `kierownica_e2e_${stamp}`;
+  const attrFoteleCode = `fotele_e2e_${stamp}`;
 
   // 1. Custom ObjectType (kind defaults to 'custom' for POSTs that do
   //    not collide with built-in product/category/asset codes).
@@ -52,20 +53,30 @@ test('UniversalCreatePage renders attribute groups attached with display_mode="t
   expect(otResp.status(), await otResp.text()).toBe(201);
   const objectTypeId = ((await otResp.json()) as { id: string }).id;
 
-  // 2. AttributeGroup (default is_system_group=false, display_mode is
-  //    set on the junction not on the group itself).
-  const groupResp = await page.request.post('/api/attribute_groups', {
-    data: { code: groupCode, label: { pl: 'Silnik', en: 'Engine' } },
+  // 2. Two AttributeGroups (default is_system_group=false; the
+  //    junction display_mode defaults to 'tab' on the attach endpoint,
+  //    exactly the case from the bug report).
+  const silnikResp = await page.request.post('/api/attribute_groups', {
+    data: { code: groupSilnikCode, label: { pl: 'Silnik', en: 'Engine' } },
     headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
   });
-  expect(groupResp.status(), await groupResp.text()).toBe(201);
-  const groupId = ((await groupResp.json()) as { id: string }).id;
+  expect(silnikResp.status(), await silnikResp.text()).toBe(201);
+  const silnikGroupId = ((await silnikResp.json()) as { id: string }).id;
+
+  const wnetrzeResp = await page.request.post('/api/attribute_groups', {
+    data: { code: groupWnetrzeCode, label: { pl: 'Wnętrze', en: 'Interior' } },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(wnetrzeResp.status(), await wnetrzeResp.text()).toBe(201);
+  const wnetrzeGroupId = ((await wnetrzeResp.json()) as { id: string }).id;
 
   try {
-    // 3. Two text attributes — global library (no group ownership yet).
+    // 3. Four text attributes — global library (no group ownership yet).
     for (const [code, labelPl, labelEn] of [
       [attrMocCode, 'Moc', 'Power'],
       [attrSpalanieCode, 'Spalanie', 'Consumption'],
+      [attrKierownicaCode, 'Kierownica', 'Steering wheel'],
+      [attrFoteleCode, 'Podgrzewane fotele', 'Heated seats'],
     ] as const) {
       const attrResp = await page.request.post('/api/attributes', {
         data: { code, type: 'text', label: { pl: labelPl, en: labelEn }, required: false },
@@ -78,27 +89,37 @@ test('UniversalCreatePage renders attribute groups attached with display_mode="t
       expect(attrResp.status(), await attrResp.text()).toBe(201);
     }
 
-    // 4. Attach both attributes to the group.
-    const attachResp = await page.request.post(
-      `/api/attribute_groups/${groupId}/attributes/bulk-attach`,
+    // 4. Attach attributes to their groups.
+    const silnikAttachResp = await page.request.post(
+      `/api/attribute_groups/${silnikGroupId}/attributes/bulk-attach`,
       {
         data: { attributeCodes: [attrMocCode, attrSpalanieCode] },
         headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
       },
     );
-    expect(attachResp.status(), await attachResp.text()).toBe(200);
+    expect(silnikAttachResp.status(), await silnikAttachResp.text()).toBe(200);
 
-    // 5. Attach the group to the ObjectType. Default display_mode='tab'
-    //    — exactly the case the bug report describes.
-    const attachGroupResp = await page.request.post(
-      `/api/object_types/${objectTypeId}/groups/${groupId}`,
-      { headers: bearer },
+    const wnetrzeAttachResp = await page.request.post(
+      `/api/attribute_groups/${wnetrzeGroupId}/attributes/bulk-attach`,
+      {
+        data: { attributeCodes: [attrKierownicaCode, attrFoteleCode] },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      },
     );
-    expect(attachGroupResp.status()).toBe(204);
+    expect(wnetrzeAttachResp.status(), await wnetrzeAttachResp.text()).toBe(200);
 
-    // 6. Sanity check the preview endpoint actually returns the group
-    //    with display_mode='tab' — pre-fix verification, also helps
-    //    diagnose if the BE contract ever drifts.
+    // 5. Attach both groups to the ObjectType with the default
+    //    display_mode='tab'.
+    for (const groupId of [silnikGroupId, wnetrzeGroupId]) {
+      const attachResp = await page.request.post(
+        `/api/object_types/${objectTypeId}/groups/${groupId}`,
+        { headers: bearer },
+      );
+      expect(attachResp.status()).toBe(204);
+    }
+
+    // 6. Sanity check the preview endpoint returns both groups with
+    //    display_mode='tab'.
     const previewResp = await page.request.post(
       `/api/object_types/${objectTypeId}/effective-attribute-groups/preview`,
       {
@@ -110,31 +131,41 @@ test('UniversalCreatePage renders attribute groups attached with display_mode="t
     const previewBody = (await previewResp.json()) as {
       groups: { code: string; display_mode: string; attributes: { code: string }[] }[];
     };
-    const silnikGroup = previewBody.groups.find((g) => g.code === groupCode);
-    expect(silnikGroup, JSON.stringify(previewBody.groups)).toBeDefined();
-    expect(silnikGroup?.display_mode).toBe('tab');
-    expect(silnikGroup?.attributes.map((a) => a.code).sort()).toEqual(
-      [attrMocCode, attrSpalanieCode].sort(),
-    );
+    const previewCodes = previewBody.groups.map((g) => g.code).sort();
+    expect(previewCodes).toEqual([groupSilnikCode, groupWnetrzeCode].sort());
+    for (const group of previewBody.groups) expect(group.display_mode).toBe('tab');
 
-    // 7. UI assertion — the create page must render the group card and
-    //    the attribute rows, NOT the empty-state hint.
+    // 7. UI: navigate to the create page and assert the tab list +
+    //    per-tab content.
     await page.goto(`/objects/${otCode}/new`);
 
     await expect(page.getByText(/ten typ obiektu nie ma jeszcze atrybut[óo]w/i)).toHaveCount(0);
 
-    // Group card label — match Polish or English (Playwright suite runs
-    // in either locale depending on the browser language).
-    await expect(page.getByText(/silnik|engine/i).first()).toBeVisible();
+    // Both tab buttons render in the tablist. Locale chooses the label
+    // text but the regex covers PL and EN.
+    const tablist = page.getByRole('tablist');
+    await expect(tablist).toBeVisible();
+    const silnikTab = tablist.getByRole('tab', { name: /silnik|engine/i });
+    const wnetrzeTab = tablist.getByRole('tab', { name: /wn[eę]trze|interior/i });
+    await expect(silnikTab).toBeVisible();
+    await expect(wnetrzeTab).toBeVisible();
 
-    // Counter renders regardless of locale: `<filled> / <total> filled · 0%`.
-    await expect(page.getByText(/0\s*\/\s*2/).first()).toBeVisible();
-
-    // Both attribute labels render as field rows.
+    // Default active tab — the first tab-mode group (BE position 0).
+    await expect(silnikTab).toHaveAttribute('aria-selected', 'true');
     await expect(page.getByText(/^moc$|^power$/i).first()).toBeVisible();
     await expect(page.getByText(/^spalanie$|^consumption$/i).first()).toBeVisible();
+
+    // Switch to the Wnętrze tab — its attribute rows take over.
+    await wnetrzeTab.click();
+    await expect(wnetrzeTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.getByText(/^kierownica$|^steering/i).first()).toBeVisible();
+    await expect(page.getByText(/podgrzewane fotele|heated seats/i).first()).toBeVisible();
+
+    // Silnik fields are no longer in the DOM after the switch.
+    await expect(page.getByText(/^moc$|^power$/i)).toHaveCount(0);
   } finally {
     await page.request.delete(`/api/object_types/${objectTypeId}`, { headers: bearer });
-    await page.request.delete(`/api/attribute_groups/${groupId}`, { headers: bearer });
+    await page.request.delete(`/api/attribute_groups/${silnikGroupId}`, { headers: bearer });
+    await page.request.delete(`/api/attribute_groups/${wnetrzeGroupId}`, { headers: bearer });
   }
 });

--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -19,7 +19,7 @@
  */
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Save } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
 import { Button } from '@/components/ui/button';
@@ -29,6 +29,7 @@ import { AttrGroupCard } from '@/features/catalog/products/components/attr-group
 import { AttrRow } from '@/features/catalog/products/components/attr-row';
 import type { GroupMeta, ProductLocale } from '@/features/catalog/products/components/types';
 import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
 
 export interface UniversalCreatePageProps {
   objectTypeId: string;
@@ -53,6 +54,8 @@ const GROUP_ICONS: Record<string, string> = {
   cennik: '💰',
 };
 
+const ATTRIBUTES_TAB = 'attributes';
+
 export function UniversalCreatePage({
   objectTypeId,
   objectTypeCode,
@@ -68,6 +71,7 @@ export function UniversalCreatePage({
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [isSaving, setIsSaving] = useState(false);
   const [locale] = useState<ProductLocale>('pl');
+  const [activeTab, setActiveTab] = useState<string>(ATTRIBUTES_TAB);
 
   // UP-08 — fetch the ObjectType's effective groups without an object
   // context (no categories selected). Uses the `/preview` POST endpoint
@@ -75,15 +79,16 @@ export function UniversalCreatePage({
   // the detail page; category-driven overlay during create is a
   // follow-up.
   //
-  // #1096 — render every group inline as a stacked card regardless of
-  // its `display_mode`. The detail page (MODR-04) splits tab-mode
-  // groups into their own tabs, but during create the operator fills
-  // initial values in a single form; tab navigation here would just
-  // add friction and hide fields behind clicks.
+  // #1098 — `refetchOnMount: 'always'` keeps the tab list aligned with
+  // modeling changes the operator just made. Without it the 5-minute
+  // staleTime + lack of cross-page invalidation hides newly attached
+  // groups (e.g. operator attaches a second AttributeGroup in
+  // modeling, navigates back here, and only sees the cached payload).
   const groupsQuery = useQuery<{ groups: GroupMeta[] }>({
     queryKey: ['object-type', objectTypeId, 'effective-attribute-groups', 'preview', 'empty'],
     enabled: objectTypeId !== '',
-    staleTime: 5 * 60 * 1000,
+    staleTime: 30_000,
+    refetchOnMount: 'always',
     queryFn: () =>
       jsonFetch<{ groups: GroupMeta[] }>(
         `/api/object_types/${objectTypeId}/effective-attribute-groups/preview`,
@@ -95,7 +100,43 @@ export function UniversalCreatePage({
         },
       ),
   });
-  const groups = groupsQuery.data?.groups ?? [];
+  const groups = useMemo(() => groupsQuery.data?.groups ?? [], [groupsQuery.data]);
+
+  // #1098 — mirror MODR-04 split from product-detail-page: tab-mode
+  // groups become their own tab, stacked-mode groups live inline
+  // inside the default "Atrybuty" tab. Operator gets the same mental
+  // model in create as in detail.
+  const tabModeGroups = useMemo(
+    () => groups.filter((g) => (g.display_mode ?? 'tab') === 'tab'),
+    [groups],
+  );
+  const stackedGroups = useMemo(
+    () => groups.filter((g) => (g.display_mode ?? 'tab') === 'stacked'),
+    [groups],
+  );
+
+  const visibleTabs: readonly string[] = useMemo(() => {
+    if (groups.length === 0) return [];
+    const tabs: string[] = [];
+    // Hide the synthetic Atrybuty tab when no stacked groups exist —
+    // otherwise the operator stares at an empty default tab before
+    // they realise the data lives behind a different chip.
+    if (stackedGroups.length > 0 || tabModeGroups.length === 0) {
+      tabs.push(ATTRIBUTES_TAB);
+    }
+    for (const group of tabModeGroups) tabs.push(group.code);
+    return tabs;
+  }, [groups, stackedGroups, tabModeGroups]);
+
+  // Keep activeTab valid when the visible tab set changes (e.g. groups
+  // arrive after first render, operator attaches a new group via
+  // modeling and the refetch lands).
+  useEffect(() => {
+    if (visibleTabs.length === 0) return;
+    if (!visibleTabs.includes(activeTab)) {
+      setActiveTab(visibleTabs[0] ?? ATTRIBUTES_TAB);
+    }
+  }, [activeTab, visibleTabs]);
 
   const toggleGroup = (groupId: string): void => {
     setExpandedGroups((prev) => {
@@ -144,6 +185,41 @@ export function UniversalCreatePage({
     } finally {
       setIsSaving(false);
     }
+  };
+
+  const renderGroup = (group: GroupMeta) => (
+    <AttrGroupCard
+      key={group.id}
+      id={group.id}
+      title={group.label[lang] ?? group.code}
+      icon={GROUP_ICONS[group.code]}
+      filledCount={countFilled(group, dirtyFields)}
+      totalCount={group.attributes.length}
+      expanded={expandedGroups.has(group.id) || expandedGroups.size === 0}
+      onToggle={() => toggleGroup(group.id)}
+    >
+      {group.attributes.map((attr) => (
+        <AttrRow
+          key={attr.id}
+          attribute={attr}
+          value={dirtyFields[attr.code]}
+          provenance="manual"
+          locale={locale}
+          isEditing={true}
+          isLocked={attr.is_system}
+          onChange={(next) => setFieldValue(attr.code, next)}
+        />
+      ))}
+    </AttrGroupCard>
+  );
+
+  const tabLabel = (tab: string): string => {
+    if (tab === ATTRIBUTES_TAB) {
+      return t('object_create.tabs.attributes', { defaultValue: 'Atrybuty' });
+    }
+    const group = tabModeGroups.find((g) => g.code === tab);
+    if (group === undefined) return tab;
+    return group.label[lang] ?? group.code;
   };
 
   return (
@@ -217,6 +293,41 @@ export function UniversalCreatePage({
             </div>
           </div>
         </div>
+
+        {visibleTabs.length > 1 ? (
+          <div className="flex items-center gap-1 border-t border-zinc-100 px-7">
+            <div
+              className="flex flex-1 items-center gap-1"
+              role="tablist"
+              aria-label={t('object_create.tabs.aria', { defaultValue: 'Zakładki typu obiektu' })}
+            >
+              {visibleTabs.map((tab) => {
+                const isActive = activeTab === tab;
+                return (
+                  <button
+                    key={tab}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    onClick={() => setActiveTab(tab)}
+                    className={cn(
+                      'relative inline-flex h-[44px] items-center gap-2 px-3.5 text-[13px] font-medium tracking-tight',
+                      isActive ? 'text-zinc-900' : 'text-zinc-500 hover:text-zinc-800',
+                    )}
+                  >
+                    {tabLabel(tab)}
+                    {isActive ? (
+                      <span
+                        className="absolute -bottom-px left-0 right-0 h-[2px] rounded-t bg-zinc-900"
+                        aria-hidden
+                      />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
       </header>
 
       <div className="grid grid-cols-1 gap-5 px-7 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
@@ -238,32 +349,14 @@ export function UniversalCreatePage({
                 })}
               </p>
             </div>
+          ) : activeTab === ATTRIBUTES_TAB ? (
+            stackedGroups.map(renderGroup)
           ) : (
-            groups.map((group) => (
-              <AttrGroupCard
-                key={group.id}
-                id={group.id}
-                title={group.label[lang] ?? group.code}
-                icon={GROUP_ICONS[group.code]}
-                filledCount={countFilled(group, dirtyFields)}
-                totalCount={group.attributes.length}
-                expanded={expandedGroups.has(group.id) || expandedGroups.size === 0}
-                onToggle={() => toggleGroup(group.id)}
-              >
-                {group.attributes.map((attr) => (
-                  <AttrRow
-                    key={attr.id}
-                    attribute={attr}
-                    value={dirtyFields[attr.code]}
-                    provenance="manual"
-                    locale={locale}
-                    isEditing={true}
-                    isLocked={attr.is_system}
-                    onChange={(next) => setFieldValue(attr.code, next)}
-                  />
-                ))}
-              </AttrGroupCard>
-            ))
+            (() => {
+              const tabGroup = tabModeGroups.find((g) => g.code === activeTab);
+              if (tabGroup === undefined) return null;
+              return renderGroup(tabGroup);
+            })()
           )}
         </div>
 


### PR DESCRIPTION
## Summary

Follow-up do #1097. Operator dodał drugą grupę atrybutów (`Wnętrze`, display_mode='tab') do OT `samochody` i zgłosił dwa problemy: (a) druga grupa nie widoczna mimo BE preview zwracającego obie, (b) UX render inline jako stacked cards zamiast jako zakładki (operator chce parity z modelowaniem i detail page MODR-04).

## Root cause

**(a) Druga grupa znika** — `apps/admin/src/components/objects/universal-create-page.tsx:86` (przed fixem) miał `staleTime: 5 * 60 * 1000`. React Query trzyma response 5 min bez refetcha przy remount, a modeling pages nie invalidują klucza `['object-type', otId, 'effective-attribute-groups', 'preview', 'empty']` po attach grupy → wraca na create page → stale cache.

**(b) UX inline zamiast zakładek** — #1097 świadomie usunęło filtr i renderowało wszystkie groups inline. Decyzja błędna; operator chce identyczny mental model co detail page (MODR-04: tab-mode → osobna zakładka, stacked → inline).

## Backend changes

N/A — BE preview poprawny, zwraca wszystkie grupy z właściwym `display_mode`.

## Frontend changes

`apps/admin/src/components/objects/universal-create-page.tsx`:
- `tabModeGroups`/`stackedGroups` derive (filter po `display_mode`).
- `visibleTabs = ['attributes', ...tabModeGroups.map(g => g.code)]`; tab `Atrybuty` ukryta gdy brak stacked groups (żeby operator nie patrzył na pustą zakładkę).
- `activeTab: useState<string>('attributes')` + `useEffect` korygujący gdy visible set się zmienia.
- Tab list w headerze: `role="tablist"`, `role="tab"`, `aria-selected`, accent border na aktywnej.
- Render per active tab: `attributes` → stacked inline; tab-mode code → single group.
- `refetchOnMount: 'always'` + `staleTime: 30_000` w `groupsQuery`.

`apps/admin/e2e/1096-universal-create-renders-tab-mode-groups.spec.ts`:
- Spec teraz tworzy DWIE tab-mode grupy (Silnik + Wnętrze), asserts tab list + klika obie zakładki, weryfikuje że pola się rozdzielają per zakładka.

## Quality gates

- Biome strict: 0 errors w nowych plikach (6 baseline warnings + 8 infos w innych plikach pozostają).
- TypeScript strict: 0 errors (NODE_OPTIONS=--max-old-space-size=4096).
- Build: OK.
- Playwright: 1/1 zielony lokalnie (4.6s).
- pnpm audit: 0 high/critical.
- Live-stack smoke (operator setup, OT `019e7045-ceb6-75d3-bd3f-aaa98cac702f`): BE preview zwraca 3 grupy (silnik tab, wnetrze tab, synthetic default stacked z `relacja_do_salonu`). Po fixie operator zobaczy 3 zakładki: „Atrybuty" (default, pokazuje `relacja_do_salonu`) + „Silnik" + „Wnętrze".

## Smoke test plan (po merge)

1. Login `admin@demo.localhost / changeme`.
2. Otwórz `https://pim.localhost/objects/samochody/new`.
3. Oczekiwane: tab list z 3 zakładkami w kolejności per `position` BE: „Atrybuty" (active default) / „Silnik" / „Wnętrze".
4. „Atrybuty" → widoczne pole `relacja_do_salonu`.
5. Klik „Silnik" → pola `moc`, `spalanie`.
6. Klik „Wnętrze" → pola `kierownica`, `podgrzewane_fotele`.
7. **Cache invalidation test**: bez page reload przejdź do modelowania OT, attach kolejną grupę → wróć na create page → nowa zakładka się pojawia (refetchOnMount działa).
8. Wypełnij Kod (`CAR-001`) + wartości w różnych tabach → **Utwórz** → HTTP 201 → navigate do detail.
9. DevTools Console — 0 errorów.

## Świadome odejścia

- **Invalidate klucza preview z modeling pages** po attach/detach/PATCH — preferowane long-term (3-4 punkty w modeling do edycji). Out of scope — `refetchOnMount: 'always'` rozwiązuje operator problem bez touchowania modeling kodu.
- **Tab badge counter** (filled/total per tab) — feature creep, start without.
- **Add attribute group ad-hoc button** — out of scope w create flow.

Closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)
