### PR TITLE
fix(admin): remove BUILT-IN ATTRIBUTE GROUPS section from OT detail

### DIFF
--- a/apps/admin/e2e/modeling-object-types.spec.ts
+++ b/apps/admin/e2e/modeling-object-types.spec.ts
@@ -39,15 +39,19 @@ test('VIEW-01 Modeling · Object Types — list + detail + wizard smoke', async 
   await detailLinks.first().click();
   await expect(page).toHaveURL(/\/modeling\/object-types\/[0-9a-f-]{36}/);
 
+  // #1100 — the "BUILT-IN ATTRIBUTE GROUPS" card was removed from this
+  // view; built-in scope is implied by the heading badge and the
+  // CUSTOM ATTRIBUTE GROUPS card still surfaces editable legacy system
+  // groups (audit, relations) alongside true custom ones.
   for (const heading of [
     /identyfikacja|identification/i,
-    /built-in attribute groups/i,
     /custom attribute groups/i,
     /settings|ustawienia/i,
     /where used/i,
   ]) {
     await expect(page.getByText(heading).first()).toBeVisible();
   }
+  await expect(page.getByText(/built-in attribute groups/i)).toHaveCount(0);
 
   // 3. Built-in lock: settings toggles report aria-disabled.
   const togglesAriaDisabled = await page

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -269,7 +269,10 @@ export function ObjectTypeShowPage() {
 
   const builtInGroups = (groups.data ?? []).filter((g) => g.system);
   const customGroups = (groups.data ?? []).filter((g) => !g.system);
-  const lockedBuiltInGroups = builtInGroups.filter((g) => !isLegacyOptionalSystemGroupCode(g.code));
+  // #1100 — the BUILT-IN ATTRIBUTE GROUPS section was removed from
+  // this view; only the legacy optional system groups (audit, relations)
+  // are still surfaced because they are operator-editable and live
+  // inside the CUSTOM ATTRIBUTE GROUPS card alongside true custom ones.
   const legacyOptionalGroups = builtInGroups.filter((g) => isLegacyOptionalSystemGroupCode(g.code));
   const editableGroups = [...legacyOptionalGroups, ...customGroups];
   const enabledLocales = workspace.data?.enabledLocales ?? ['pl', 'en'];
@@ -468,42 +471,6 @@ export function ObjectTypeShowPage() {
               locked
             />
           </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardContent className="space-y-3 p-6">
-          <div className="flex items-center gap-2">
-            <span className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
-              {t('object_types.builtin_groups_section', {
-                defaultValue: 'Built-in attribute groups',
-              })}
-            </span>
-            <BuiltInLockBadge />
-            <span className="ml-1 text-[11px] text-zinc-400">
-              —{' '}
-              {t('object_types.builtin_groups_tagline', {
-                defaultValue: 'system-managed',
-              })}
-            </span>
-          </div>
-          {lockedBuiltInGroups.length === 0 ? (
-            <p className="text-[12.5px] text-muted-foreground">
-              {t('object_types.no_builtin_groups', { defaultValue: 'Brak built-in grup.' })}
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {lockedBuiltInGroups.map((g) => (
-                <GroupCard
-                  key={g.id}
-                  group={g}
-                  language={i18n.language}
-                  locked
-                  onDisplayModeChange={handleDisplayModeChange}
-                />
-              ))}
-            </div>
-          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary

Operator request: usunąć sekcję „BUILT-IN ATTRIBUTE GROUPS — Zablokowane — system-managed" z `/modeling/object-types/<id>` — duplikuje info już zawarte w `BuiltInLockBadge` na headingu i w karcie CUSTOM ATTRIBUTE GROUPS (która exposuje legacy editable system groups: audit, relations).

## Changes

- `apps/admin/src/features/catalog/object-types/show.tsx`: usunięty cały `<Card>` z heading „Built-in attribute groups" + lista `lockedBuiltInGroups`. `BuiltInLockBadge` import zostaje (używany na heading + attribute table). `legacyOptionalGroups` zostaje (używany przez `editableGroups` w CUSTOM groups card).
- `apps/admin/e2e/modeling-object-types.spec.ts`: usunięta asercja `/built-in attribute groups/i` z headings list + dodana asercja `toHaveCount(0)` żeby wykryć regresję jeśli ktoś przywróci.

## Quality gates

- Biome strict: 0 errors w nowych plikach (6 baseline warnings + 8 infos w innych plikach pozostają).
- TS strict: 0 errors.
- pnpm audit: 0 high/critical.
- Live-stack smoke: `/api/object_types/019e7045.../attached_groups` zwraca 2 groups (silnik + wnetrze), system=false → CUSTOM card renderuje je niezależnie.

## Smoke test plan

1. Login `admin@demo.localhost / changeme`.
2. Otwórz `https://pim.localhost/modeling/object-types/019e7045-ceb6-75d3-bd3f-aaa98cac702f` (samochody).
3. **Oczekiwane**: brak sekcji „BUILT-IN ATTRIBUTE GROUPS / Zablokowane — system-managed".
4. CUSTOM ATTRIBUTE GROUPS sekcja nadal pokazuje Silnik + Wnętrze.
5. DangerZone, Settings, Where used karty bez zmian.

Closes #1100

🤖 Generated with [Claude Code](https://claude.com/claude-code)