### PR TITLE
fix(catalog,admin): relation picker w UniversalCreatePage + 2-step save

### DIFF
--- a/apps/admin/e2e/1102-relation-picker-in-create.spec.ts
+++ b/apps/admin/e2e/1102-relation-picker-in-create.spec.ts
@@ -1,0 +1,266 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1102 — relation attributes on UniversalCreatePage must render the
+ * RelationCreateField picker (Combobox / MultiSelect), and the create
+ * flow has to persist picks through a second-step PUT
+ * `/api/objects/{newId}/relations/{attributeCode}` once the main POST
+ * lands.
+ *
+ * Spec creates:
+ *   - target ObjectType (kind=custom, slug salon-target-<ts>),
+ *   - source ObjectType (kind=custom, slug source-ot-<ts>) attached with
+ *     a relation Attribute pointing at the target type, cardinality=many,
+ *   - one target object to pick.
+ * Then drives the UI: open `/objects/source-ot-<ts>/new`, pick the
+ * target via MultiSelect, save, and assert the new object exists with
+ * the relation persisted (`/api/objects/{newId}/relations` reflects it).
+ */
+test('UniversalCreatePage relation attribute renders picker and persists targets via PUT', async ({
+  page,
+}) => {
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const stamp = Date.now().toString(36);
+  const targetOtCode = `target_ot_${stamp}`;
+  const sourceOtCode = `source_ot_${stamp}`;
+  const groupCode = `wybor_${stamp}`;
+  const attrCode = `picked_${stamp}`;
+  const targetCode = `T_${stamp}`;
+
+  // 1. Target OT.
+  const targetOtResp = await page.request.post('/api/object_types', {
+    data: {
+      code: targetOtCode,
+      label: { pl: 'Target', en: 'Target' },
+      icon: '📦',
+      color: '#10b981',
+      hierarchical: false,
+      hasVariants: false,
+      abstract: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(targetOtResp.status(), await targetOtResp.text()).toBe(201);
+  const targetOtId = ((await targetOtResp.json()) as { id: string }).id;
+
+  // 2. Source OT.
+  const sourceOtResp = await page.request.post('/api/object_types', {
+    data: {
+      code: sourceOtCode,
+      label: { pl: 'Source', en: 'Source' },
+      icon: '🔗',
+      color: '#0ea5e9',
+      hierarchical: false,
+      hasVariants: false,
+      abstract: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(sourceOtResp.status(), await sourceOtResp.text()).toBe(201);
+  const sourceOtId = ((await sourceOtResp.json()) as { id: string }).id;
+
+  // 3. AttributeGroup + relation Attribute.
+  const groupResp = await page.request.post('/api/attribute_groups', {
+    data: { code: groupCode, label: { pl: 'Wybór', en: 'Pick' } },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(groupResp.status(), await groupResp.text()).toBe(201);
+  const groupId = ((await groupResp.json()) as { id: string }).id;
+
+  try {
+    const attrResp = await page.request.post('/api/attributes', {
+      data: {
+        code: attrCode,
+        type: 'relation',
+        label: { pl: 'Picked', en: 'Picked' },
+        required: false,
+        relationTargetObjectTypeIds: [targetOtId],
+        relationCardinality: 'many',
+      },
+      headers: {
+        ...bearer,
+        accept: 'application/ld+json',
+        'content-type': 'application/ld+json',
+      },
+    });
+    expect(attrResp.status(), await attrResp.text()).toBe(201);
+
+    const attachAttrResp = await page.request.post(
+      `/api/attribute_groups/${groupId}/attributes/bulk-attach`,
+      {
+        data: { attributeCodes: [attrCode] },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      },
+    );
+    expect(attachAttrResp.status()).toBe(200);
+
+    const attachGroupResp = await page.request.post(
+      `/api/object_types/${sourceOtId}/groups/${groupId}`,
+      { headers: bearer },
+    );
+    expect(attachGroupResp.status()).toBe(204);
+
+    // ObjectRelationController::list filters relation attributes by the
+    // `object_type_attributes` junction (direct OT-attribute attach, NOT
+    // via attribute groups). Mirror what the modeling wizard does
+    // when it attaches relation attributes — bulk-attach so the GET
+    // /relations endpoint surfaces the picked targets after PUT.
+    // `?code=` is not an actual AP4 filter on /api/attributes (returns
+    // the unfiltered page), so paginate and find the row by exact code
+    // client-side.
+    const attrLookup = await page.request.get('/api/attributes?itemsPerPage=500', {
+      headers: { ...bearer, accept: 'application/ld+json' },
+    });
+    expect(attrLookup.status()).toBe(200);
+    const attrLookupBody = (await attrLookup.json()) as {
+      member?: { id: string; code: string }[];
+      'hydra:member'?: { id: string; code: string }[];
+    };
+    const attrRows = attrLookupBody.member ?? attrLookupBody['hydra:member'] ?? [];
+    const attrRow = attrRows.find((row) => row.code === attrCode);
+    expect(attrRow, `attribute "${attrCode}" not in /api/attributes page`).toBeDefined();
+    const directAttachResp = await page.request.post(
+      `/api/object_types/${sourceOtId}/attributes/bulk-attach`,
+      {
+        data: { attributeIds: [attrRow?.id ?? ''] },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      },
+    );
+    // Endpoint returns 200 on success per AttachObjectTypeAttributeController,
+    // but 204 No Content can land here when the attribute was already
+    // attached to the OT (idempotent path). Accept both.
+    expect([200, 204]).toContain(directAttachResp.status());
+
+    // Sanity: object_type_attributes junction now carries the relation
+    // attribute. If this list is empty the test is misconfigured before
+    // the UI portion even starts.
+    const attachedResp = await page.request.get(
+      `/api/object_types/${sourceOtId}/attached_attributes`,
+      { headers: { ...bearer, accept: 'application/json' } },
+    );
+    expect(attachedResp.status()).toBe(200);
+    const attachedRaw = (await attachedResp.json()) as unknown;
+    const attachedList = Array.isArray(attachedRaw)
+      ? (attachedRaw as Array<{ code: string }>)
+      : ((attachedRaw as { member?: Array<{ code: string }> }).member ?? []);
+    const attachedCodes = attachedList.map((row) => row.code);
+    expect(attachedCodes, JSON.stringify(attachedRaw)).toContain(attrCode);
+
+    // 4. One target object so the picker has something to show.
+    const targetObjResp = await page.request.post('/api/objects', {
+      data: { code: targetCode, objectTypeId: targetOtId },
+      headers: {
+        ...bearer,
+        accept: 'application/ld+json',
+        'content-type': 'application/ld+json',
+      },
+    });
+    expect(targetObjResp.status(), await targetObjResp.text()).toBe(201);
+    const targetObjectId = ((await targetObjResp.json()) as { id: string }).id;
+
+    try {
+      // 5. Open the create page; pick the target via MultiSelect.
+      await page.goto(`/objects/${sourceOtCode}/new`);
+
+      // The relation attribute lives in a tab-mode group. When the OT
+      // has additional stacked attributes (e.g. system created_at) the
+      // header shows a tablist with Atrybuty + Pick; otherwise the
+      // single Pick group renders inline without a tablist (the
+      // `visibleTabs.length > 1` gate in UniversalCreatePage). Handle
+      // both layouts.
+      const pickTab = page.getByRole('tab', { name: /^pick$/i });
+      if (await pickTab.isVisible().catch(() => false)) {
+        await pickTab.click();
+        await expect(pickTab).toHaveAttribute('aria-selected', 'true');
+      }
+
+      // RelationCreateField renders a MultiSelect — its trigger is the
+      // only element on the page that exposes `aria-haspopup="listbox"`.
+      const multiSelectTrigger = page.locator('[aria-haspopup="listbox"]').first();
+      await expect(multiSelectTrigger).toBeVisible();
+      await multiSelectTrigger.click();
+
+      // Wait for the popover to render — its options are the only
+      // <button> elements whose accessible name starts with `T_`.
+      const targetOption = page.getByRole('button', { name: targetCode });
+      await expect(targetOption).toBeVisible();
+      await targetOption.click();
+
+      // Trigger should now show a chip with the target code; assert
+      // before moving on so a silent click failure is caught early.
+      await expect(multiSelectTrigger.getByText(targetCode)).toBeVisible();
+
+      // Click the page background to close the popover; Escape would
+      // race the popover close with the next focus and occasionally
+      // swallow the next keystroke.
+      await page.locator('body').click({ position: { x: 10, y: 10 } });
+
+      const newCarCode = `S_${stamp}`;
+      await page.getByPlaceholder(/kod \(np\. car-001\)/i).fill(newCarCode);
+
+      // Capture the relation PUT so we can fail loud if it never fires
+      // and inspect the body if the PUT lands but the relation does not
+      // persist downstream.
+      const relationsPutPromise = page.waitForRequest(
+        (request) => request.url().includes('/relations/') && request.method() === 'PUT',
+        { timeout: 10_000 },
+      );
+      await page.getByRole('button', { name: /^utw[oó]rz$|^create$/i }).click();
+      const relationsPutRequest = await relationsPutPromise;
+      const putBody = relationsPutRequest.postDataJSON() as unknown;
+      const putUrl = relationsPutRequest.url();
+      const relationsPutResponse = await relationsPutRequest.response();
+      const putStatus = relationsPutResponse?.status() ?? 0;
+      expect(putStatus, `PUT ${putUrl}\nrequest body: ${JSON.stringify(putBody)}`).toBe(204);
+
+      // Wait for the redirect to detail (.../<uuid>) — that's the proof
+      // the POST + PUT both completed.
+      await page.waitForURL(new RegExp(`/objects/${sourceOtCode}/[0-9a-f-]{36}`));
+      const url = page.url();
+      const newObjectId = url.split('/').at(-1) ?? '';
+      expect(newObjectId).toMatch(/^[0-9a-f-]{36}$/);
+
+      // 6. BE proof: the relation is persisted in `object_relations`.
+      // Use the browser session (same cookie auth as the FE write
+      // path) so any tenant-context drift between BE write + read does
+      // not mask a successful PUT.
+      // Use the same Bearer the setup steps used. Browser cookie auth
+      // does not persist the in-memory JWT across a page navigation, so
+      // a cookie-only fetch lands 401.
+      const relationsResp = await page.request.get(`/api/objects/${newObjectId}/relations`, {
+        headers: { ...bearer, accept: 'application/json' },
+      });
+      const relationsText = await relationsResp.text();
+      expect(relationsResp.status(), `body: ${relationsText.slice(0, 400)}`).toBe(200);
+      const typed = JSON.parse(relationsText) as {
+        relationAttributes: {
+          attribute: { code: string };
+          relations: { targetObjectId: string }[];
+        }[];
+      };
+      const link = typed.relationAttributes.find((a) => a.attribute.code === attrCode);
+      expect(link, JSON.stringify(typed)).toBeDefined();
+      expect(link?.relations.map((r) => r.targetObjectId)).toContain(targetObjectId);
+
+      // Cleanup the freshly created source object.
+      await page.request.delete(`/api/objects/${newObjectId}`, { headers: bearer });
+    } finally {
+      await page.request.delete(`/api/objects/${targetObjectId}`, { headers: bearer });
+    }
+  } finally {
+    await page.request.delete(`/api/object_types/${sourceOtId}`, { headers: bearer });
+    await page.request.delete(`/api/object_types/${targetOtId}`, { headers: bearer });
+    await page.request.delete(`/api/attribute_groups/${groupId}`, { headers: bearer });
+  }
+});

--- a/apps/admin/src/components/objects/relation-create-field.tsx
+++ b/apps/admin/src/components/objects/relation-create-field.tsx
@@ -1,0 +1,113 @@
+/*
+ * #1102 — picker for `type='relation'` attributes during object create.
+ *
+ * The detail-page editor (`RelationInlineEditor`) needs an existing object
+ * id to read `/api/objects/{id}/relations`. In create flow there is no id
+ * yet, so we collect target ids into the form's dirtyFields and the
+ * parent (`UniversalCreatePage`) writes them via PUT
+ * `/api/objects/{newId}/relations/{attributeCode}` after the main POST
+ * succeeds.
+ *
+ * Candidates come from the same poly-kind `GET /api/objects?sku=` endpoint
+ * the detail-page ObjectPickerDialog uses; we filter by the attribute's
+ * `relation_target_object_type_ids` client-side. itemsPerPage=200 is
+ * generous for MVP (~50k SKU max per the planning doc) and gets replaced
+ * with a BE `objectTypeIds[]=` filter when scale demands it.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
+import { MultiSelect, type MultiSelectOption } from '@/components/ui/multi-select';
+import type { AttributeMeta } from '@/features/catalog/products/components/types';
+import { jsonFetch } from '@/lib/http';
+
+interface CandidateRow {
+  id: string;
+  code?: string;
+  objectType?: { id?: string } | null;
+}
+
+interface ObjectsListResponse {
+  member?: CandidateRow[];
+  'hydra:member'?: CandidateRow[];
+}
+
+export interface RelationCreateFieldProps {
+  attribute: AttributeMeta;
+  value: unknown;
+  onChange: (next: unknown) => void;
+}
+
+export function RelationCreateField({
+  attribute,
+  value,
+  onChange,
+}: RelationCreateFieldProps): React.ReactElement {
+  const { t } = useTranslation();
+  const allowedTypeIds = attribute.relation_target_object_type_ids ?? [];
+  const cardinality = attribute.relation_cardinality ?? 'many';
+
+  const candidatesQuery = useQuery<ObjectsListResponse>({
+    queryKey: ['relation-candidates', allowedTypeIds.join(',')],
+    queryFn: () =>
+      jsonFetch<ObjectsListResponse>('/api/objects?itemsPerPage=200', {
+        accept: 'application/ld+json',
+      }),
+    staleTime: 30_000,
+  });
+
+  const candidates = candidatesQuery.data?.member ?? candidatesQuery.data?.['hydra:member'] ?? [];
+  const filtered =
+    allowedTypeIds.length === 0
+      ? candidates
+      : candidates.filter((row) => {
+          const otId = row.objectType?.id;
+          return typeof otId === 'string' && allowedTypeIds.includes(otId);
+        });
+
+  if (candidatesQuery.isLoading) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        {t('relation_create_field.loading', { defaultValue: 'Ładowanie kandydatów…' })}
+      </p>
+    );
+  }
+
+  if (cardinality === 'one') {
+    const options: ComboboxOption[] = filtered.map((row) => ({
+      value: row.id,
+      label: row.code ?? row.id,
+    }));
+    const currentValue = typeof value === 'string' && value !== '' ? value : null;
+    return (
+      <Combobox
+        options={options}
+        value={currentValue}
+        onChange={(next) => onChange(next)}
+        placeholder={t('relation_create_field.placeholder', { defaultValue: 'Wybierz…' })}
+        className="rounded-xl text-[13.5px]"
+      />
+    );
+  }
+
+  const options: MultiSelectOption[] = filtered.map((row) => ({
+    value: row.id,
+    label: row.code ?? row.id,
+  }));
+  const currentValues = readMultiValue(value);
+  return (
+    <MultiSelect
+      options={options}
+      value={currentValues}
+      onChange={(next) => onChange(next)}
+      placeholder={t('relation_create_field.placeholder', { defaultValue: 'Wybierz…' })}
+      className="rounded-xl text-[13.5px]"
+    />
+  );
+}
+
+function readMultiValue(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string' && v !== '');
+}

--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -162,23 +162,53 @@ export function UniversalCreatePage({
     }
     setIsSaving(true);
     try {
-      const attributes = stripAttributes(dirtyFields);
+      // #1102 — relation values live in `object_relations`, not
+      // `object_values`. The POST /api/objects payload only handles
+      // the latter, so split the dirty dict in two: ordinary attrs
+      // ride along with the POST, relation attrs get one PUT each
+      // after the main row exists.
+      const relationCodes = collectRelationCodes(groups);
+      const { normal, relations } = splitDirtyAttributes(dirtyFields, relationCodes);
       const body: Record<string, unknown> = {
         objectTypeId,
         code: trimmedCode,
       };
-      if (Object.keys(attributes).length > 0) body.attributes = attributes;
+      if (Object.keys(normal).length > 0) body.attributes = normal;
       const created = await jsonFetch<{ id: string }>('/api/objects', {
         method: 'POST',
         contentType: 'application/ld+json',
         body,
       });
-      toast.success(
-        t('object_create.success', {
-          defaultValue: 'Utworzono {{code}}',
-          code: trimmedCode,
-        }),
-      );
+
+      const relationFailures: string[] = [];
+      for (const [attrCode, targets] of Object.entries(relations)) {
+        if (targets.length === 0) continue;
+        try {
+          await jsonFetch(`/api/objects/${created.id}/relations/${attrCode}`, {
+            method: 'PUT',
+            contentType: 'application/json',
+            body: { targets: targets.map((id) => ({ id })) },
+          });
+        } catch {
+          relationFailures.push(attrCode);
+        }
+      }
+
+      if (relationFailures.length > 0) {
+        toast.error(
+          t('object_create.relations_partial_error', {
+            defaultValue: 'Obiekt utworzony, ale relacje nie zapisane: {{codes}}',
+            codes: relationFailures.join(', '),
+          }),
+        );
+      } else {
+        toast.success(
+          t('object_create.success', {
+            defaultValue: 'Utworzono {{code}}',
+            code: trimmedCode,
+          }),
+        );
+      }
       navigate(detailPathFor(created.id));
     } catch {
       toast.error(t('object_create.failed', { defaultValue: 'Nie udało się utworzyć obiektu' }));
@@ -208,6 +238,7 @@ export function UniversalCreatePage({
           isEditing={true}
           isLocked={attr.is_system}
           onChange={(next) => setFieldValue(attr.code, next)}
+          createMode={true}
         />
       ))}
     </AttrGroupCard>
@@ -379,13 +410,39 @@ export function UniversalCreatePage({
   );
 }
 
-function stripAttributes(dirty: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
+function collectRelationCodes(groups: GroupMeta[]): Set<string> {
+  const codes = new Set<string>();
+  for (const group of groups) {
+    for (const attr of group.attributes) {
+      if (attr.type === 'relation') codes.add(attr.code);
+    }
+  }
+  return codes;
+}
+
+function splitDirtyAttributes(
+  dirty: Record<string, unknown>,
+  relationCodes: Set<string>,
+): { normal: Record<string, unknown>; relations: Record<string, string[]> } {
+  const normal: Record<string, unknown> = {};
+  const relations: Record<string, string[]> = {};
   for (const [k, v] of Object.entries(dirty)) {
     if (k === 'sku' || k === 'code') continue;
-    out[k] = v;
+    if (relationCodes.has(k)) {
+      relations[k] = toIdList(v);
+      continue;
+    }
+    normal[k] = v;
   }
-  return out;
+  return { normal, relations };
+}
+
+function toIdList(value: unknown): string[] {
+  if (typeof value === 'string' && value !== '') return [value];
+  if (Array.isArray(value)) {
+    return value.filter((v): v is string => typeof v === 'string' && v !== '');
+  }
+  return [];
 }
 
 function countFilled(group: GroupMeta, dirty: Record<string, unknown>): number {

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -1,6 +1,7 @@
 import { Copy, Link2, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { WysiwygEditor } from '@/components/catalog/wysiwyg-editor';
+import { RelationCreateField } from '@/components/objects/relation-create-field';
 import { type Provenance, ProvenanceBadge } from '@/components/provenance-badge';
 import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
 import { Input } from '@/components/ui/input';
@@ -35,6 +36,15 @@ export interface AttrRowProps {
    * cache key as the dedicated Relations tab.
    */
   relationContextProductId?: string;
+  /**
+   * #1102 — opt-in: in the object create flow (`UniversalCreatePage`)
+   * there is no productId yet, so a relation attribute renders
+   * `RelationCreateField` (search + multi-select of target objects).
+   * The chosen ids land in the parent's dirty-fields dict and are
+   * sent through PUT `/api/objects/{newId}/relations/{attributeCode}`
+   * after the main POST succeeds.
+   */
+  createMode?: boolean;
 }
 
 /**
@@ -54,6 +64,7 @@ export function AttrRow({
   onChange,
   onCopyToOthers,
   relationContextProductId,
+  createMode = false,
 }: AttrRowProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
@@ -123,6 +134,8 @@ export function AttrRow({
             attributeId={attribute.id}
             attributeCode={attribute.code}
           />
+        ) : attribute.type === 'relation' && createMode && editable ? (
+          <RelationCreateField attribute={attribute} value={value} onChange={onChange} />
         ) : editable ? (
           attribute.type === 'wysiwyg' ? (
             <WysiwygEditor


### PR DESCRIPTION
## Summary

Operator zgłosił: na `/objects/samochody/new` atrybut typu `relation` (`relacja_do_salonu`) renderował się jako text input zamiast pickera. Dodatkowo BE `POST /api/objects` nie obsługuje relacji w `attributes` payload — relations żyją w osobnej tabeli `object_relations` zarządzanej przez `PUT /api/objects/{id}/relations/{attributeCode}`. Implementacja wymaga 2-step save: POST obiekt → PUT relacje per code.

## Root cause

[`apps/admin/src/features/catalog/products/components/attr-row.tsx:118-126`](apps/admin/src/features/catalog/products/components/attr-row.tsx#L118-L126) gate'uje `RelationInlineEditor` za `relationContextProductId` (potrzebny do GET /api/objects/{id}/relations). W create flow brak ID → fallback do text input.

## Backend changes

N/A — endpointy istnieją: `POST /api/objects`, `PUT /api/objects/{id}/relations/{attributeCode}`.

## Frontend changes

- Nowy [`apps/admin/src/components/objects/relation-create-field.tsx`](apps/admin/src/components/objects/relation-create-field.tsx) — mini-picker:
  - Cardinality=one → `<Combobox>` single UUID, cardinality=many → `<MultiSelect>` list UUIDs.
  - Fetch candidates: `/api/objects?itemsPerPage=200` (mirror ObjectPickerDialog pattern), filter client-side po `attribute.relation_target_object_type_ids`.
- [`apps/admin/src/features/catalog/products/components/attr-row.tsx`](apps/admin/src/features/catalog/products/components/attr-row.tsx): nowy prop `createMode?: boolean`. Branch `attribute.type === 'relation' && createMode && editable` → `<RelationCreateField>`.
- [`apps/admin/src/components/objects/universal-create-page.tsx`](apps/admin/src/components/objects/universal-create-page.tsx):
  - `createMode={true}` na każdym `<AttrRow>`.
  - `handleCreate` refactor: `collectRelationCodes(groups)` + `splitDirtyAttributes` → normal/relations. POST `/api/objects` z normal, potem per relation code → PUT `/api/objects/{newId}/relations/{code}` z `{targets: [{id}, …]}`. Partial relation failure → toast error + nadal navigate do detail (recoverable).
- [`apps/admin/e2e/1102-relation-picker-in-create.spec.ts`](apps/admin/e2e/1102-relation-picker-in-create.spec.ts): nowy spec — tworzy source/target OT, atrybut relation (cardinality=many), klika picker, save → asserts PUT 204 + GET /relations zawiera picked target.

## Quality gates

- Biome strict: 0 errors w nowych plikach.
- TypeScript strict: 0 errors.
- Playwright: 1/1 zielony lokalnie (5.8s).
- Live-stack smoke BE: POST + PUT + GET cycle verified (curl, source/target/relation persistowane).

## Smoke test plan (po merge)

1. Login `admin@demo.localhost / changeme`.
2. `https://pim.localhost/objects/samochody/new`.
3. Tab „Atrybuty" → pole `relacja_do_salonu` widoczne jako MultiSelect z listą salonów (zamiast text input).
4. Picknij salon + wpisz Kod (`CAR-001`) + **Utwórz**.
5. HTTP 201 (POST /api/objects) + HTTP 204 (PUT /relations) w DevTools Network.
6. Navigate do detail page — sekcja relations pokazuje picked salon.
7. DevTools Console — 0 errorów.

## Świadome odejścia

- **Inline-create target object** w pickerze (jak ObjectPickerDialog na detail) — out of scope. Operator może wcześniej utworzyć target.
- **BE-side atomic transaction** (POST z embedded relations) — wymaga BE change, follow-up.
- **Wymóg direct OT-attribute attach** dla `GET /relations` (relationAttributesForSource filtruje tylko po `object_type_attributes` junction) — to BE constraint nie naprawiany w tym PR. Spec dodaje direct attach jako workaround. Operator's istniejący atrybut `relacja_do_salonu` ma to z natury (attached przez wizard).

Closes #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)