### PR TITLE
fix(catalog,admin): surface Multimedia tab in UniversalCreatePage

### DIFF
--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -39,6 +39,14 @@ export interface UniversalCreatePageProps {
   backHref: string;
   /** Builder for the detail route after successful create. */
   detailPathFor: (id: string) => string;
+  /**
+   * #1104 — when `true`, surfaces a Multimedia tab next to the
+   * attribute tabs. Uploads need the post-create object id, so the
+   * panel renders a disclaimer pointing the operator at the detail
+   * page; the tab itself stays visible so the capability advertised
+   * in modeling matches what the operator sees here.
+   */
+  hasMultimedia?: boolean;
 }
 
 const GROUP_ICONS: Record<string, string> = {
@@ -55,6 +63,7 @@ const GROUP_ICONS: Record<string, string> = {
 };
 
 const ATTRIBUTES_TAB = 'attributes';
+const MULTIMEDIA_TAB = 'multimedia';
 
 export function UniversalCreatePage({
   objectTypeId,
@@ -62,6 +71,7 @@ export function UniversalCreatePage({
   objectTypeLabel,
   backHref,
   detailPathFor,
+  hasMultimedia = false,
 }: UniversalCreatePageProps) {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
@@ -116,17 +126,21 @@ export function UniversalCreatePage({
   );
 
   const visibleTabs: readonly string[] = useMemo(() => {
-    if (groups.length === 0) return [];
+    if (groups.length === 0 && !hasMultimedia) return [];
     const tabs: string[] = [];
     // Hide the synthetic Atrybuty tab when no stacked groups exist —
     // otherwise the operator stares at an empty default tab before
     // they realise the data lives behind a different chip.
-    if (stackedGroups.length > 0 || tabModeGroups.length === 0) {
+    if (stackedGroups.length > 0 || (tabModeGroups.length === 0 && groups.length > 0)) {
       tabs.push(ATTRIBUTES_TAB);
     }
     for (const group of tabModeGroups) tabs.push(group.code);
+    // #1104 — surface Multimedia capability flagged in modeling.
+    // The panel renders a disclaimer that uploads live on the detail
+    // page (they need the post-create object id).
+    if (hasMultimedia) tabs.push(MULTIMEDIA_TAB);
     return tabs;
-  }, [groups, stackedGroups, tabModeGroups]);
+  }, [groups, stackedGroups, tabModeGroups, hasMultimedia]);
 
   // Keep activeTab valid when the visible tab set changes (e.g. groups
   // arrive after first render, operator attaches a new group via
@@ -248,6 +262,9 @@ export function UniversalCreatePage({
     if (tab === ATTRIBUTES_TAB) {
       return t('object_create.tabs.attributes', { defaultValue: 'Atrybuty' });
     }
+    if (tab === MULTIMEDIA_TAB) {
+      return t('object_create.tabs.multimedia', { defaultValue: 'Multimedia' });
+    }
     const group = tabModeGroups.find((g) => g.code === tab);
     if (group === undefined) return tab;
     return group.label[lang] ?? group.code;
@@ -365,6 +382,20 @@ export function UniversalCreatePage({
         <div className="min-w-0 space-y-3">
           {groupsQuery.isLoading ? (
             <p className="text-sm text-muted-foreground">{t('app.loading')}</p>
+          ) : activeTab === MULTIMEDIA_TAB ? (
+            <div className="border-line bg-surface rounded-2xl border border-dashed p-6 text-center">
+              <p className="text-ink text-[13px] font-medium">
+                {t('object_create.multimedia.unavailable', {
+                  defaultValue: 'Multimedia dostępne po pierwszym zapisie',
+                })}
+              </p>
+              <p className="mt-1 text-[11.5px] text-muted-foreground">
+                {t('object_create.multimedia.hint', {
+                  defaultValue:
+                    'Najpierw utwórz obiekt (Kod + Utwórz). Zdjęcia i pliki dodasz w karcie obiektu po zapisie.',
+                })}
+              </p>
+            </div>
           ) : groups.length === 0 ? (
             <div className="border-line bg-surface rounded-2xl border border-dashed p-6 text-center">
               <p className="text-ink text-[13px] font-medium">

--- a/apps/admin/src/features/catalog/objects/create-page.tsx
+++ b/apps/admin/src/features/catalog/objects/create-page.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate, useParams } from 'react-router';
 
 import { UniversalCreatePage } from '@/components/objects/universal-create-page';
+import { useListSchema } from '@/hooks/use-list-schema';
 import { jsonFetch } from '@/lib/http';
 
 /**
@@ -54,13 +55,15 @@ export function ObjectCreatePage() {
     },
   });
 
+  const schemaQuery = useListSchema(lookup.data?.id);
+
   const typeLabel = useMemo(() => {
     if (!lookup.data) return '';
     const labels = lookup.data.label ?? {};
     return labels[locale] ?? labels.en ?? lookup.data.code;
   }, [lookup.data, locale]);
 
-  if (lookup.isLoading) {
+  if (lookup.isLoading || (lookup.data && schemaQuery.isLoading)) {
     return (
       <div
         aria-busy="true"
@@ -88,6 +91,11 @@ export function ObjectCreatePage() {
     return <Navigate to={legacyRedirect} replace />;
   }
 
+  // #1104 — schema is needed to gate the Multimedia tab; fall back to
+  // `false` if the schema query failed so a transient BE error never
+  // hides the rest of the create form.
+  const hasMultimedia = schemaQuery.data?.objectType.has_multimedia ?? false;
+
   return (
     <UniversalCreatePage
       objectTypeId={lookup.data.id}
@@ -95,6 +103,7 @@ export function ObjectCreatePage() {
       objectTypeLabel={typeLabel}
       backHref={`/objects/${code}`}
       detailPathFor={(id) => `/objects/${code}/${id}`}
+      hasMultimedia={hasMultimedia}
     />
   );
 }


### PR DESCRIPTION
## Summary

ObjectTypes flagged `has_multimedia=true` in modeling advertise Multimedia tab on detail page (UniversalDetailPage:178). Create page silently dropped capability — operator on /objects/samochody/new not seeing the tab despite modeling tooltip promising it.

## Root cause

UniversalCreatePage's `UniversalCreatePageProps` had no `hasMultimedia` and `visibleTabs` only listed attribute groups. Wrapper `ObjectCreatePage` didn't fetch list-schema either.

## Changes

- `apps/admin/src/features/catalog/objects/create-page.tsx`: useListSchema for OT, pass `hasMultimedia` to UniversalCreatePage. Loading state extended to wait for schemaQuery.
- `apps/admin/src/components/objects/universal-create-page.tsx`: new prop `hasMultimedia` (default false). `visibleTabs` appends `multimedia` when flag set. Render branch: when `activeTab === MULTIMEDIA_TAB` → disclaimer card 'Multimedia dostępne po pierwszym zapisie — najpierw utwórz obiekt, potem dodaj zdjęcia/pliki w karcie obiektu'.
- New i18n keys: `object_create.tabs.multimedia`, `object_create.multimedia.unavailable`, `object_create.multimedia.hint`.

## Quality gates

- Biome: 0 errors new files.
- TS strict: 0 errors.
- Live-stack smoke: GET /api/object_types/samochody/list-schema returns `has_multimedia: true` ✓.

## Smoke test

1. Login.
2. /objects/samochody/new → widoczna zakładka Multimedia obok Silnik/Wnętrze.
3. Klik Multimedia → disclaimer card.
4. Wpisz Kod + Utwórz → navigate do detail → multimedia tab z pełnym uploaderem.
5. DevTools Console — 0 errorów.

## Świadome odejścia

- **Inline multimedia uploader w create** — wymaga BE acceptance multipart payload w POST /api/objects (out of scope, follow-up).
- **MultimediaTab w detail page** już działa via UniversalDetailPage — nie dotykamy.

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)