### PR TITLE
fix(admin): AttrGroupCard overflow-visible so popovers escape the card

### DIFF
--- a/apps/admin/src/features/catalog/products/components/attr-group-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-group-card.tsx
@@ -41,7 +41,14 @@ export function AttrGroupCard({
   return (
     <Card
       id={`group-${id}`}
-      className="overflow-hidden rounded-2xl border-line bg-surface soft-shadow"
+      // #1106 — `overflow-hidden` used to clip the rounded-corner body
+      // bleed, but it also clipped MultiSelect/Combobox popovers
+      // rendered by AttrRow children (relation picker, multiselect
+      // options, etc.) since they live inside the card via `absolute`.
+      // `overflow-visible` lets the popover overlay neighbouring rows
+      // and tabs; the rounded-corner bleed is negligible because the
+      // body bg (`bg-zinc-50/40`) only kisses the corner by a few px.
+      className="overflow-visible rounded-2xl border-line bg-surface soft-shadow"
     >
       <button
         type="button"


### PR DESCRIPTION
Closes #1106. `overflow-hidden` on AttrGroupCard outer clipped MultiSelect/Combobox popovers (relation picker, multiselect options, select). Switched to `overflow-visible`. Rounded-corner body bleed is negligible.

Smoke:
1. /objects/samochody/new → 'Wybierz salon' picker → lista salonów widoczna.
2. /objects/salony_sprzedazy/{id} → Pracownicy tab → 3 opcje widoczne (Jan/Marcin/Magdalena).

🤖 Generated with [Claude Code](https://claude.com/claude-code)