### PR TITLE
fix(catalog): możliwość usuwania atrybutów ze strony szczegółów + guard 409 dla atrybutów w użyciu

### DIFF
--- a/apps/admin/e2e/attributes-delete.spec.ts
+++ b/apps/admin/e2e/attributes-delete.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * fix(catalog) #1108 — Attribute delete from the detail page.
+ *
+ * Golden path: list → create a throwaway attribute → detail page →
+ * "Usuń atrybut" → confirm dialog → back on the library list with the
+ * attribute gone.
+ *
+ * Marked `fixme` in CI for the same reason as settings-channels-crud.spec.ts:
+ * it lands deep in the shared Playwright run, after earlier specs have
+ * exhausted the 5/15min auth rate-limiter cache, so loginAsAdmin sees
+ * `/login` instead of `/dashboard`. Local runs (cold cache) pass.
+ * Coverage is preserved by AttributesCrudApiTest (happy 204, system 422,
+ * in-use 409) + the manual smoke in the PR test plan. Re-enable once the
+ * suite migrates to Playwright `storageState` (one login per worker).
+ */
+const E2E_BLOCKED_BY_RATE_LIMITER =
+  'Pending storageState rollout: spec lands after the 5/15min auth rate limiter is exhausted';
+
+test.describe('fix(catalog) #1108 — Attributes · delete from detail page', () => {
+  test('happy path: create → detail → delete → gone from list', async ({ page }) => {
+    test.fixme(true, E2E_BLOCKED_BY_RATE_LIMITER);
+    await loginAsAdmin(page);
+
+    const uniqueCode = `e2e_del_${Date.now().toString(36)}`;
+
+    // 1. Library list → "Nowy atrybut".
+    await page.goto('/modeling/attributes');
+    await page.getByRole('link', { name: /nowy atrybut|new attribute/i }).click();
+    await expect(page).toHaveURL(/\/modeling\/attributes\/new$/);
+
+    // 2. Fill code + name, keep default type, submit → detail page.
+    await page.getByPlaceholder('np. warranty_months').fill(uniqueCode);
+    await page
+      .getByPlaceholder(/krótki opis|short description/i)
+      .first()
+      .fill('E2E delete');
+    await page.getByRole('button', { name: /utw[óo]rz atrybut|create attribute/i }).click();
+    await expect(page).toHaveURL(/\/modeling\/attributes\/[0-9a-f-]{36}$/);
+
+    // 3. Click "Usuń atrybut" → confirm dialog appears.
+    await page.getByRole('button', { name: /usu[ńn] atrybut|delete attribute/i }).click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    // 4. Confirm deletion → redirect to the library list.
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: /usu[ńn] atrybut|delete attribute/i })
+      .click();
+    await expect(page).toHaveURL(/\/modeling\/attributes$/);
+
+    // 5. The deleted attribute is no longer listed.
+    await expect(page.getByText(uniqueCode, { exact: false })).toHaveCount(0);
+  });
+});

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -9,6 +9,7 @@ import {
   Pencil,
   Save,
   Shield,
+  Trash2,
   TriangleAlert,
   X,
   Zap,
@@ -29,6 +30,7 @@ import {
 import { WhereUsedList } from '@/components/modeling/where-used-list';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -138,6 +140,8 @@ function Editor({
   const [filterable, setFilterable] = useState(attribute.filterable ?? false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   // ADR-014 / MOD-13 (#905) — relation config state, hydrated from the
   // attribute payload. Initial JSONB shape: validation_rules.advanced_fields.
@@ -329,8 +333,76 @@ function Editor({
     onClose();
   };
 
+  // Destructive: deletes the attribute and returns to the library. The BE
+  // rejects system attributes (422) and in-use attributes (409); on the
+  // latter we surface the human-readable `detail` so the operator knows to
+  // detach / migrate first. Success bubbles up via `onClose` → the list
+  // refetches on mount and the row is gone.
+  const deleteAttribute = async () => {
+    setDeleting(true);
+    try {
+      await jsonFetch(`/api/attributes/${attribute.id}`, {
+        method: 'DELETE',
+        accept: 'application/json',
+      });
+      setDeleteOpen(false);
+      toast.success(t('attributes.delete.success', { defaultValue: 'Atrybut został usunięty.' }));
+      onClose();
+    } catch (err) {
+      setDeleteOpen(false);
+      if (err instanceof HttpError) {
+        const detail =
+          err.body && typeof err.body === 'object' && 'detail' in err.body
+            ? String((err.body as Record<string, unknown>).detail)
+            : null;
+        toast.error(
+          detail ??
+            t('attributes.delete.error_in_use', {
+              defaultValue:
+                'Nie można usunąć atrybutu, który jest w użyciu. Odepnij go lub zmigruj.',
+            }),
+        );
+      } else {
+        toast.error(t('app.delete_error', { defaultValue: 'Nie udało się usunąć' }));
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   return (
     <div className={cn('space-y-6', dirty ? 'pb-24' : '')}>
+      <Dialog open={deleteOpen} onOpenChange={(next) => (!next ? setDeleteOpen(false) : undefined)}>
+        <DialogContent>
+          <div className="space-y-2">
+            <DialogTitle>
+              {t('attributes.delete.confirm_title', { defaultValue: 'Usunąć atrybut?' })}
+            </DialogTitle>
+            <DialogDescription>
+              {t('attributes.delete.confirm_body', {
+                defaultValue:
+                  'Atrybut "{{code}}" zostanie trwale usunięty wraz z jego wartościami słownikowymi. Tej operacji nie można cofnąć.',
+                code: attribute.code,
+              })}
+            </DialogDescription>
+          </div>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button variant="ghost" onClick={() => setDeleteOpen(false)} disabled={deleting}>
+              {t('app.cancel', { defaultValue: 'Anuluj' })}
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={deleting}
+              onClick={() => {
+                void deleteAttribute();
+              }}
+            >
+              {t('attributes.delete.confirm_submit', { defaultValue: 'Usuń atrybut' })}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
       <div className="flex items-center justify-between">
         <Button asChild variant="ghost" size="sm" className="-ml-3">
           <Link to="/modeling/attributes">
@@ -384,6 +456,19 @@ function Editor({
                 <TriangleAlert className="size-4" />
                 {t('modeling.attributes.migration.action_label', { defaultValue: 'Migruj typ' })}
               </Link>
+            </Button>
+          ) : null}
+          {!isSystem ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              aria-label={t('attributes.delete.action', { defaultValue: 'Usuń atrybut' })}
+              onClick={() => setDeleteOpen(true)}
+              className="h-9 rounded-xl bg-rose-50 text-rose-700 hover:bg-rose-100"
+            >
+              <Trash2 className="size-4" />
+              {t('attributes.delete.action', { defaultValue: 'Usuń atrybut' })}
             </Button>
           ) : null}
           {!isSystem ? (

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -7,7 +7,8 @@
     "close": "Close",
     "cancel": "Cancel",
     "save": "Save",
-    "brand_subtitle_fallback": "Workspace"
+    "brand_subtitle_fallback": "Workspace",
+    "delete_error": "Failed to delete"
   },
   "user_menu": {
     "aria_label": "User menu",
@@ -1008,6 +1009,14 @@
     },
     "actions": {
       "view": "View"
+    },
+    "delete": {
+      "action": "Delete attribute",
+      "confirm_title": "Delete attribute?",
+      "confirm_body": "Attribute \"{{code}}\" will be permanently deleted along with its option values. This action cannot be undone.",
+      "confirm_submit": "Delete attribute",
+      "success": "Attribute deleted.",
+      "error_in_use": "Cannot delete an attribute that is in use. Detach or migrate it first."
     }
   },
   "attribute_groups": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -7,7 +7,8 @@
     "close": "Zamknij",
     "cancel": "Anuluj",
     "save": "Zapisz",
-    "brand_subtitle_fallback": "Workspace"
+    "brand_subtitle_fallback": "Workspace",
+    "delete_error": "Nie udało się usunąć"
   },
   "user_menu": {
     "aria_label": "Menu użytkownika",
@@ -1018,6 +1019,14 @@
     },
     "actions": {
       "view": "Podgląd"
+    },
+    "delete": {
+      "action": "Usuń atrybut",
+      "confirm_title": "Usunąć atrybut?",
+      "confirm_body": "Atrybut \"{{code}}\" zostanie trwale usunięty wraz z jego wartościami słownikowymi. Tej operacji nie można cofnąć.",
+      "confirm_submit": "Usuń atrybut",
+      "success": "Atrybut został usunięty.",
+      "error_in_use": "Nie można usunąć atrybutu, który jest w użyciu. Odepnij go lub zmigruj."
     }
   },
   "attribute_groups": {

--- a/apps/api/src/Catalog/Application/Command/DeleteAttribute/DeleteAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/DeleteAttribute/DeleteAttributeHandler.php
@@ -4,28 +4,38 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application\Command\DeleteAttribute;
 
+use App\Catalog\Application\Query\Usage\UsageQueryService;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
- * VIEW-02 (#374) — deletes an Attribute. System attributes (`is_system=true`)
- * are non-deletable per UI-08.3 (#258); the FE removes the trash button for
- * system rows but the BE guard is the source of truth.
+ * VIEW-02 (#374) — deletes an Attribute. The delete trigger lives on the
+ * attribute detail page (`show.tsx`); the trash button is only rendered for
+ * non-system rows but the BE guards below are the source of truth.
  *
- * Cascade behavior: the AttributeOption.attribute_id FK has
- * ON DELETE CASCADE so options vanish with the attribute. ObjectValue
- * rows referencing the attribute are NOT cascaded — Postgres FK is
- * RESTRICT (Sprint 0 design). If the operator wants to remove an
- * attribute that's still in use, the AttributeMigration flow (Sprint 0
- * `/migrate-type` endpoint) is the supported path.
+ * Two guards, both backed by Postgres FK semantics:
+ *   - System attributes (`is_system=true`) are immutable per UI-08.3 (#258) → 422.
+ *   - Attributes still in use are non-deletable → 409: `object_type_attributes`
+ *     and `object_values` both have ON DELETE RESTRICT, so the DB would reject
+ *     the delete anyway. We pre-check via UsageQueryService to return a helpful
+ *     message instead of a raw 500, and catch the FK violation as a safety-net
+ *     for the race window left by the 60s usage cache. The supported path for
+ *     removing an in-use attribute is detach + the `/migrate-type` flow.
+ *
+ * Cascade behavior: `attribute_options.attribute_id` and
+ * `attribute_group_attributes.attribute_id` are ON DELETE CASCADE, so options
+ * and group memberships vanish with the attribute and never block deletion.
  */
 #[AsMessageHandler]
 final readonly class DeleteAttributeHandler
 {
     public function __construct(
         private AttributeRepositoryInterface $repository,
+        private UsageQueryService $usageQueryService,
     ) {
     }
 
@@ -46,6 +56,29 @@ final readonly class DeleteAttributeHandler
             ));
         }
 
-        $this->repository->remove($attribute);
+        $usage = $this->usageQueryService->forAttribute($attribute);
+        $objectTypeCount = \count($usage['objectTypes']);
+        $instanceCount = $usage['instanceCount'];
+        if ($objectTypeCount > 0 || $instanceCount > 0) {
+            throw $this->inUseConflict($attribute->getCode(), $objectTypeCount, $instanceCount);
+        }
+
+        try {
+            $this->repository->remove($attribute);
+        } catch (ForeignKeyConstraintViolationException) {
+            // Safety-net: usage cache (60s TTL) may have been stale and a new
+            // attachment/value slipped in between the pre-check and remove.
+            throw $this->inUseConflict($attribute->getCode(), $objectTypeCount, $instanceCount);
+        }
+    }
+
+    private function inUseConflict(string $code, int $objectTypeCount, int $instanceCount): ConflictHttpException
+    {
+        return new ConflictHttpException(\sprintf(
+            'Attribute "%s" is attached to %d object type(s) and used by %d object(s); detach or migrate it before deleting.',
+            $code,
+            $objectTypeCount,
+            $instanceCount,
+        ));
     }
 }

--- a/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
@@ -145,6 +145,24 @@ final class AttributesCrudApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function deleteRejectsAttributeInUseWith409(): void
+    {
+        // Attribute attached to an ObjectType → object_type_attributes FK is
+        // ON DELETE RESTRICT, so the delete must be blocked with a clean 409.
+        $id = $this->seedAttribute('warranty_months', AttributeType::Number);
+        $this->attachAttributeToProductType($id);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('DELETE', '/api/attributes/'.$id->toRfc4122());
+
+        self::assertSame(409, $response->getStatusCode());
+
+        // Attribute must still exist after a rejected delete.
+        $repo = self::getContainer()->get(AttributeRepositoryInterface::class);
+        self::assertNotNull($repo->findById($id));
+    }
+
+    #[Test]
     public function postWithAttachToGroupsCreatesJunctionRows(): void
     {
         $client = $this->authenticatedClient();
@@ -220,5 +238,26 @@ final class AttributesCrudApiTest extends CatalogApiTestCase
         $repo->save($attribute);
 
         return $attribute->getId();
+    }
+
+    private function attachAttributeToProductType(\Symfony\Component\Uid\Uuid $attributeId): void
+    {
+        $ctx = self::getContainer()->get(TenantContext::class);
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $ctx->set($tenant);
+
+        $attribute = self::getContainer()->get(AttributeRepositoryInterface::class)->findById($attributeId);
+        \assert($attribute instanceof Attribute);
+
+        $objectType = self::getContainer()
+            ->get(\App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(\App\Catalog\Domain\ObjectKind::Product, $tenant);
+        \assert(null !== $objectType);
+
+        $junction = new \App\Catalog\Domain\Entity\ObjectTypeAttribute($objectType, $attribute);
+        self::getContainer()
+            ->get(\App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface::class)
+            ->save($junction);
     }
 }


### PR DESCRIPTION
## Summary

Dodaje brakujący trigger usuwania atrybutu w UI oraz domyka backendowy guard, by usunięcie atrybutu w użyciu zwracało czyste 409 zamiast surowego 500. Backend `DELETE /api/attributes/{id}` istniał od VIEW-02 (#374), ale FE nigdy nie dostał przycisku.

## Root cause

Niedokończony feature: warstwa BE delete gotowa, FE bez triggera. Dodatkowo `DeleteAttributeHandler` blokował tylko atrybuty systemowe — FK `object_type_attributes`/`object_values` to `ON DELETE RESTRICT`, więc usunięcie atrybutu w użyciu leciało jako 500 (DBAL constraint violation).

## Backend changes

- `DeleteAttributeHandler`: pre-check przez `UsageQueryService::forAttribute()` — jeśli atrybut przypięty do ObjectType lub ma wartości na obiektach → `ConflictHttpException` (409) z komunikatem zawierającym liczby. Catch `ForeignKeyConstraintViolationException` jako safety-net dla wyścigu z 60s cache usage. Grupy atrybutów (CASCADE) celowo nie blokują.
- Aktualizacja PHPDoc handlera (realny flow zamiast wzmianki o nieistniejącym przycisku).
- Bez migracji, bez zmiany schematu, bez zmiany kontraktu API (DELETE + security `is_granted('DELETE', object)` już zadeklarowane w `Attribute.xml`).

## Frontend changes

- `attributes/show.tsx`: przycisk „Usuń atrybut" (rose, `Trash2`) w prawym stacku nagłówka, renderowany tylko dla `!isSystem`.
- Dialog potwierdzenia (`Dialog` z Radix → focus trap/ARIA za darmo) z treścią ostrzegającą o trwałości operacji.
- Mutacja przez `jsonFetch` DELETE (spójnie z resztą pliku) → toast sukcesu + redirect do listy; 409/422 → toast z `detail` z backendu, atrybut zostaje.
- Klucze i18n `attributes.delete.*` + `app.delete_error` w `pl.json` + `en.json`.

## Quality gates

- PHPStan max: **0**
- Biome strict: **0** (warnings/infos pre-existing)
- PHPUnit `AttributesCrudApiTest`: **9/9** — nowy `deleteRejectsAttributeInUseWith409` + istniejące happy 204 / system 422 bez regresji
- FE typecheck + build: green
- composer/pnpm audit: brak **nowych** podatności — advisory medium/high/critical są pre-existing stack drift (diff nie dotyka `composer.lock`/lockfiles), tracked przez maintenance ticket cadence

## Smoke test plan

Live-stack API smoke (https://pim.localhost) wykonany **przed** mergem:
- `POST /api/attributes` (nowy) → `DELETE` → **204**
- `DELETE` atrybutu `cross_sell` (przypięty do 1 ObjectType) → **409** + `detail: "...is attached to 1 object type(s)..."`
- `DELETE` atrybutu systemowego → **422**

UI smoke (po merge): `/modeling/attributes/{id}` → „Usuń atrybut" → dialog → potwierdź → redirect + toast; atrybut systemowy bez przycisku; atrybut w użyciu → toast 409.

End-to-end **zsmoke-testowane na żywym backendzie** (API). UI golden path pokryty Playwright specem (`test.fixme` w CI z powodu auth rate-limitera, jak `settings-channels-crud.spec.ts`; pokrycie przez ApiTestCase + manual smoke).

## Świadome odejścia

- **Bulk delete** z listy — poza zakresem (osobny ticket jeśli potrzebny).
- **Trash w wierszu listy** — świadomie pominięte per decyzja operatora (usuwanie tylko na stronie szczegółów).
- **Jednoklikowe odpięcie + usunięcie** atrybutu w użyciu — poza zakresem; ścieżką pozostaje detach / `/migrate-type`.

Closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)