### PR TITLE
fix(admin): i18n key effective_model zwraca obiekt zamiast stringa w sidebarze obiektu

### DIFF
--- a/apps/admin/src/features/catalog/products/components/effective-model-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/effective-model-card.tsx
@@ -30,7 +30,7 @@ export function EffectiveModelCard({
   return (
     <Card className="rounded-2xl border-line bg-surface p-5 soft-shadow">
       <div className="mb-2.5 text-[12px] font-medium text-zinc-500">
-        {t('products.detail.sidebar.effective_model', { defaultValue: 'Efektywny model' })}
+        {t('products.detail.sidebar.effective_model.title', { defaultValue: 'Efektywny model' })}
       </div>
       <p className="mb-2 text-[12px] text-zinc-500">
         {t('products.detail.sidebar.effective_model.intro', {

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1567,6 +1567,7 @@
           "title": "Variants"
         },
         "effective_model": {
+          "title": "Effective model",
           "intro": "Object attributes come from:",
           "see_in_modeling": "Open in Modeling →"
         }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1615,6 +1615,7 @@
           "title": "Warianty"
         },
         "effective_model": {
+          "title": "Efektywny model",
           "intro": "Atrybuty obiektu pochodzą z:",
           "see_in_modeling": "Zobacz w Modelowanie →"
         }


### PR DESCRIPTION
## Summary
Sidebar „Efektywny model" na stronie szczegółów obiektu pokazywał komunikat błędu zamiast nagłówka. Naprawia klucz i18n.

## Root cause
`effective-model-card.tsx` wołał `t('products.detail.sidebar.effective_model')`, ale ten klucz to obiekt (`{intro, see_in_modeling}`). i18next (config domyślny, `returnObjects: false`) ignoruje `defaultValue` dla klucza-obiektu i zwraca string-komunikat błędu, renderowany jako nagłówek.

## Frontend changes
- `effective_model.title` dodany w `pl.json` (Efektywny model) + `en.json` (Effective model).
- Nagłówek w `effective-model-card.tsx` używa `effective_model.title`.

## Quality gates
- TypeScript noEmit: 0
- Biome strict: 0
- Vite build: green
- Browser smoke (Playwright): nagłówek „Effective model", brak komunikatu i18n, brak czerwonych errorów w console.

## Smoke test plan
1. Login admin@demo.localhost / changeme.
2. `/objects/salony_sprzedazy/{id}` → sidebar pokazuje „Efektywny model"/„Effective model".
3. DevTools Console — brak erroru i18n.

**End-to-end smoke-tested** w przeglądarce (screenshot: nagłówek poprawny, błąd zniknął).

## Świadome odejścia
- **Select/multiselect na stronie obiektu** (zgłoszony równolegle): po wyczerpującej weryfikacji na aktualnym main (detail+create × stacked+tab × select+multiselect × zapis/persist) — **działa end-to-end** (prawdopodobnie naprawiony przez #1107). Bez zmiany kodu; jeśli nadal nie działa po hard-refresh → osobny ticket z krokami.

Closes #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)