### PR TITLE
fix(admin): ukryj puste grupy atrybutów na karcie obiektu

### DIFF
--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -110,7 +110,13 @@ export function UniversalCreatePage({
         },
       ),
   });
-  const groups = useMemo(() => groupsQuery.data?.groups ?? [], [groupsQuery.data]);
+  // Hide empty groups (0 attributes) — mirror universal-detail-page so the
+  // create form never shows an empty "0/0" tab for a group whose attributes
+  // were all removed in modeling. Modeling views keep empty groups.
+  const groups = useMemo(
+    () => (groupsQuery.data?.groups ?? []).filter((g) => g.attributes.length > 0),
+    [groupsQuery.data],
+  );
 
   // #1098 — mirror MODR-04 split from product-detail-page: tab-mode
   // groups become their own tab, stacked-mode groups live inline

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -161,7 +161,15 @@ export function UniversalDetailPage({
       unwrapAttributesIndexed(product?.attributesIndexed as Record<string, unknown> | undefined),
     [product?.attributesIndexed],
   );
-  const groups = useMemo(() => groupsQuery.data?.groups ?? [], [groupsQuery.data]);
+  // Hide empty groups (0 attributes) from the object card: after an
+  // operator deletes the last attribute of a group, the backend still
+  // returns the now-empty group (it's a valid modeling construct), but
+  // rendering it as an empty "0/0" tab/card is noise. Modeling views keep
+  // empty groups; here we only render groups that contribute attributes.
+  const groups = useMemo(
+    () => (groupsQuery.data?.groups ?? []).filter((g) => g.attributes.length > 0),
+    [groupsQuery.data],
+  );
 
   const tabModeGroups = useMemo(
     () => groups.filter((g) => (g.display_mode ?? 'tab') === 'tab'),


### PR DESCRIPTION
## Summary
Po usunięciu ostatniego atrybutu z grupy, pusta grupa nadal pokazywała się jako zakładka + karta „0/0 wypełnione" na karcie obiektu. Ten PR ukrywa puste grupy na widoku obiektu (detail + create).

## Root cause
`GET /api/objects/{id}/effective-attribute-groups` zwraca też puste grupy (poprawne w modelowaniu). FE (`universal-detail-page` + `universal-create-page`) filtrował grupy tylko po `display_mode`, nie po liczbie atrybutów → pusta zakładka „0/0".

## Frontend changes
- `universal-detail-page.tsx` + `universal-create-page.tsx`: `groups` filtrowane do `attributes.length > 0`. Pochodne (zakładki, karty, badge, sidebar „Effective model") automatycznie pomijają puste grupy.
- Widok modelowania i kontrakt API bez zmian.

## Quality gates
- TypeScript noEmit: 0
- Biome strict: 0
- Browser smoke (Playwright): zakładka „Pracownicy" (pusta grupa) zniknęła z paska zakładek i z sidebara; grupy z atrybutami (salony_sprzedazy, Engine) renderują się normalnie.

## Smoke test plan
1. Login admin@demo.localhost / changeme.
2. `/objects/salony_sprzedazy/{id}` → brak zakładki/karty pustej grupy.
3. Grupy z atrybutami widoczne normalnie.
4. Console — brak errorów.

**End-to-end smoke-tested** w przeglądarce (screenshot: zakładki = Atrybuty/salony_sprzedazy/Engine/multimedia, brak „Pracownicy").

## Świadome odejścia
- Backend nadal zwraca puste grupy (celowo — modelowanie ich potrzebuje). Filtr jest prezentacyjny na karcie obiektu.

Closes #1112

🤖 Generated with [Claude Code](https://claude.com/claude-code)