### PR TITLE
feat(admin): edytowalna nazwa obiektu (tytuł H1) w trybie edycji

### DIFF
--- a/apps/admin/e2e/object-name-edit.spec.ts
+++ b/apps/admin/e2e/object-name-edit.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * feat(admin) #1116 — editable object name (title) in edit mode.
+ *
+ * Golden path on the universal object detail page: enter edit mode →
+ * the title becomes an editable input → change it → save → reload shows
+ * the new name. The spec restores the original name at the end so it
+ * leaves no residue on the seeded object.
+ *
+ * Marked `fixme` in CI for the shared-suite auth rate-limiter reason
+ * (see settings-channels-crud.spec.ts). Coverage is preserved by the
+ * manual + local browser smoke documented in the PR.
+ */
+const E2E_BLOCKED_BY_RATE_LIMITER =
+  'Pending storageState rollout: spec lands after the 5/15min auth rate limiter is exhausted';
+
+test.describe('feat(admin) #1116 — editable object name', () => {
+  test('edit title → save → persists, then restore', async ({ page }) => {
+    test.fixme(true, E2E_BLOCKED_BY_RATE_LIMITER);
+    await loginAsAdmin(page);
+    await page.goto('/objects/salony_sprzedazy/019e75c8-9a40-7b3a-b9bf-7ec5fe1a0bb7');
+    await page.waitForTimeout(2000);
+
+    await page
+      .getByRole('button', { name: /edytuj|^edit$/i })
+      .first()
+      .click();
+    await page.waitForTimeout(600);
+
+    // The title is now an input carrying the current name.
+    const titleInput = page.getByLabel(/^nazwa$|^name$/i).first();
+    const original = await titleInput.inputValue();
+    const edited = `${original} ✎`;
+
+    await titleInput.fill(edited);
+    await page
+      .getByRole('button', { name: /zapisz zmiany|save changes/i })
+      .first()
+      .click();
+    await page.waitForTimeout(1500);
+    await page.reload();
+    await page.waitForTimeout(2000);
+    await expect(page.getByRole('heading', { level: 1 })).toContainText(edited);
+
+    // Restore original name.
+    await page
+      .getByRole('button', { name: /edytuj|^edit$/i })
+      .first()
+      .click();
+    await page.waitForTimeout(600);
+    await page
+      .getByLabel(/^nazwa$|^name$/i)
+      .first()
+      .fill(original);
+    await page
+      .getByRole('button', { name: /zapisz zmiany|save changes/i })
+      .first()
+      .click();
+    await page.waitForTimeout(1500);
+  });
+});

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -45,6 +45,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import { toast } from '@/components/ui/toast';
 import { AttrGroupCard } from '@/features/catalog/products/components/attr-group-card';
 import { AttrRow } from '@/features/catalog/products/components/attr-row';
@@ -418,9 +419,23 @@ export function UniversalDetailPage({
                     : t('products.detail.status.inactive', { defaultValue: 'Nieaktywny' })}
                 </span>
               </div>
-              <h1 className="font-display mt-1 text-[26px] font-semibold leading-tight tracking-tight">
-                {nameValue}
-              </h1>
+              {isEditing ? (
+                <Input
+                  aria-label={t('object_detail.name_placeholder', { defaultValue: 'Nazwa' })}
+                  placeholder={t('object_detail.name_placeholder', { defaultValue: 'Nazwa' })}
+                  value={
+                    typeof fieldValue('name') === 'string'
+                      ? (fieldValue('name') as string)
+                      : nameValue
+                  }
+                  onChange={(event) => setFieldValue('name', event.target.value)}
+                  className="font-display mt-1 h-11 rounded-lg border-zinc-200 bg-white text-[26px] font-semibold tracking-tight"
+                />
+              ) : (
+                <h1 className="font-display mt-1 text-[26px] font-semibold leading-tight tracking-tight">
+                  {nameValue}
+                </h1>
+              )}
               <div className="mt-2.5 flex flex-wrap items-center gap-2">
                 <span className="soft-shadow rounded-full bg-white px-2 py-1 text-[11px] font-medium text-zinc-700">
                   {objectTypeLabel}

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -672,9 +672,23 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                         : t('products.detail.status.inactive', { defaultValue: 'Nieaktywny' })}
                     </span>
                   </div>
-                  <h1 className="font-display mt-1 text-[26px] font-semibold leading-tight tracking-tight">
-                    {nameValue}
-                  </h1>
+                  {isEditing ? (
+                    <Input
+                      aria-label={t('products.detail.create.placeholder.name', {
+                        defaultValue: 'Nazwa produktu',
+                      })}
+                      placeholder={t('products.detail.create.placeholder.name', {
+                        defaultValue: 'Nazwa produktu',
+                      })}
+                      value={nameValue}
+                      onChange={(event) => setFieldValue('name', event.target.value)}
+                      className="font-display mt-1 h-11 rounded-lg border-zinc-200 bg-white text-[26px] font-semibold tracking-tight"
+                    />
+                  ) : (
+                    <h1 className="font-display mt-1 text-[26px] font-semibold leading-tight tracking-tight">
+                      {nameValue}
+                    </h1>
+                  )}
                   {objectTypeName !== null ? (
                     <div className="mt-2.5 flex flex-wrap items-center gap-2">
                       <span className="rounded-full bg-white px-2 py-1 text-[11px] font-medium text-zinc-700 soft-shadow">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2324,5 +2324,8 @@
     "go_login": "Go to sign in",
     "toast_success": "Account activated. Welcome!",
     "toast_accepted_login_required": "Account activated. Please sign in to continue."
+  },
+  "object_detail": {
+    "name_placeholder": "Name"
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2374,5 +2374,8 @@
     "go_login": "Przejdź do logowania",
     "toast_success": "Konto aktywowane. Witaj!",
     "toast_accepted_login_required": "Konto aktywowane. Zaloguj się, żeby kontynuować."
+  },
+  "object_detail": {
+    "name_placeholder": "Nazwa"
   }
 }


### PR DESCRIPTION
## Summary
Tytuł (H1) na karcie obiektu/produktu był read-only dla istniejących wpisów — nazwę dało się zmienić tylko przez zaszyte pole „Name" w formularzu, więc zmiana nazwy była nieoczywista. Teraz w trybie edycji tytuł renderuje się jako input spięty z atrybutem `name` (ten sam flow `dirtyFields` + zapis co w trybie create), na obu widokach.

## Root cause
Brak edytowalnego tytułu w trybie edit (był tylko w trybie create). Read-only `<h1>` w `universal-detail-page.tsx` i `product-detail-page.tsx`.

## Frontend changes
- `universal-detail-page.tsx`: tytuł → `<Input>` w trybie edycji (import `Input`), spięty z `fieldValue('name')`/`setFieldValue('name', …)`.
- `product-detail-page.tsx`: tytuł w gałęzi edit → `<Input>` (mirror trybu create), spięty z `name`.
- i18n: `object_detail.name_placeholder` (pl „Nazwa" / en „Name") + aria-label; produkt reuse `products.detail.create.placeholder.name`.
- Pole „Name" w formularzu zostaje — oba inputy zsynchronizowane przez `fieldValue('name')`.

## Backend changes
Brak — zapis nazwy już działa (`PATCH` z `attributes.name`).

## Quality gates
- TypeScript noEmit: 0
- Biome strict: 0
- Vite build: green
- Browser smoke (Playwright, oba widoki): edycja tytułu → zapis → nazwa utrzymana po reload → przywrócono oryginał.

## Smoke test plan
1. Login admin@demo.localhost / changeme.
2. `/products/{id}` → „Edytuj" → zmień tytuł → „Zapisz zmiany" → nazwa zmieniona po reload.
3. `/objects/{slug}/{id}` → analogicznie.
4. Console — brak errorów.

**End-to-end smoke-tested** lokalnie w przeglądarce na obu stronach (z przywróceniem nazw). Spec `object-name-edit.spec.ts` dołączony (`test.fixme` w CI — auth rate-limiter, jak inne CRUD-specy).

## Świadome odejścia
- Inline-edit przez klik na tytule w trybie podglądu — poza zakresem (edycja po „Edytuj").
- #2 operatora (osobne drzewa kategorii per ObjectType) — osobny ADR, nie ten PR.

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)