### PR TITLE
feat(catalog): ADR-015 PR-A — schema dla drzew kategorii per ObjectType

### DIFF
--- a/Project Plan/01-architektura-pim.md
+++ b/Project Plan/01-architektura-pim.md
@@ -1231,6 +1231,27 @@ Opcja (Y) zachowuje killer feature ADR-012 (dziedziczenie grup atrybutów po drz
 
 **Uzupełnienie 2026-05-28 (Option Y, batch MODRC-01..05 — supersedes MODR-02/06/07):** Seedowana grupa „Powiązania" wycofana razem z audit (#1074 / Version20260527100000 → #1080 / Version20260528100000). 5 built-in atrybutów typu `relation` (`cross_sell`, `up_sell`, `related`, `alternative`, `accessory`) pozostaje seedowanych na Product ObjectType **jako loose `ObjectTypeAttribute`** (bez grupy). Operator świadomie tworzy grupę dowolnego code'u i `display_mode`, jeśli chce zakładkę lub sekcję inline. Forward Relations tab detection w `product-detail-page.tsx` przechodzi z `code === 'relations'` na detection po typie atrybutu (`g.attributes.some(a => a.type === 'relation')`). Reverse relations renderują się w **systemowej sekcji „Powiązania zwrotne"** (MODRC-03 #1082) — jedyna wirtualna zakładka, auto-generowana gdy obiekt jest celem. Inline relation editor w `attr-row.tsx` (MODRC-05 #1084) zapewnia parytę z innymi atrybutami niezależnie od `display_mode` grupy. Świadomie odrzucone alternatywy (flaga `has_relations`, magiczna widoczność, seed grupy) w `feature-modeling-data-model.md` §12.0.
 
+### ADR-015: Drzewa kategorii per ObjectType (rewizja modelu kategorii z ADR-014)
+
+**Status:** Accepted (2026-05-30).
+
+**Kontekst.** ADR-014 zakładał JEDNO współdzielone drzewo kategorii per tenant (`objects` kind='category', ltree `path`); `objects.object_type_id` wskazywał wbudowany typ „Category", a dystrybucja grup atrybutów szła przez `category_attribute_groups.target_object_type_id`. Select „Object Type" na `/modeling/categories` zmieniał tylko target dystrybucji, nie samo drzewo, i obsługiwał wyłącznie built-in categorizable OT (kontrakt API po `kind`). Operator potrzebuje, by każdy kategoryzowalny ObjectType miał **własne, niezależne drzewo kategorii**, wybierane selektorem.
+
+**Decyzja.**
+- Drzewo kategorii jest **partycjonowane per docelowy ObjectType**. Nowa kolumna `objects.category_target_object_type_id` (UUID, NULL dla nie-kategorii, ustawiana na create dla `kind='category'`, FK→`object_types` ON DELETE RESTRICT) wyznacza, do którego drzewa należy kategoria.
+- Unikalność kodu kategorii jest **per-drzewo**: `objects_tenant_kind_code_uniq` zastąpione dwoma partial unique indexami — `(tenant_id, kind, code) WHERE kind <> 'category'` oraz `(tenant_id, category_target_object_type_id, code) WHERE kind = 'category'`. Ten sam `code` (np. „elektronika") może istnieć w wielu drzewach.
+- **`is_categorizable` bramkuje** posiadanie drzewa: semantyka flagi = „instancje tego ObjectType mogą być przypisane do drzewa (i dziedziczyć atrybuty z kategorii)". Select listuje wszystkie OT z `is_categorizable=true` (built-in **i custom**); kontrakt API kategorii przechodzi z `objectTypeKind` (enum) na `objectTypeId` (UUID).
+- Instancja OT=X może być przypisana tylko do kategorii z drzewa X (walidacja w handlerze przypisania → 422). Dziecko-kategoria musi należeć do tego samego drzewa co rodzic.
+- `category_attribute_groups.target_object_type_id` dla danej kategorii równy jej `category_target_object_type_id` (target wynika z drzewa); junction zostaje dla wielu grup per kategoria.
+
+**Migracja (Version20260530120000, expand-contract).** Krok expand: dodanie kolumny + FK + index, backfill istniejących kategorii do built-in Product OT per tenant (Product był jedynym categorizable; stare drzewo obsługiwało Product), swap unique index. Pozostałe ObjectType startują **bez drzewa** (puste) — drzewo powstaje gdy operator włączy `is_categorizable` i utworzy pierwszą kategorię. Built-in „Category" OT (`objects.object_type_id`) bez zmian.
+
+**Konsekwencje.** (+) Czytelny mental model „osobne drzewa, wybierz które edytujesz"; custom OT w pełni wspierane. (−) Tracimy współdzielenie jednej kategorii przez wiele OT (dziś nieużywane). (−) Wysoki blast radius — zmiana unikalności + scope ltree dotyka każdego odczytu kategorii; mitygacja: expand-contract + partial unique + pełen ApiTestCase/cross-tenant/Playwright per faza (PR-A schema, PR-B API+resolver, PR-C FE).
+
+**Alternatywy odrzucone:** (a) status quo „jedno drzewo + multi-target" — nie spełnia żądania; (b) osobny category-kind ObjectType per drzewo — mnoży byty infrastrukturalne; (c) zachowanie współdzielenia kategorii między OT — niewykorzystane, komplikuje UX i unikalność ścieżek.
+
+**Referencje:** ADR-014 (rewidowany w zakresie scope drzewa; reszta — primary category overlay, cumulative resolution, EffectiveAttributeGroupResolver — w mocy). Plan implementacji: PR-A (#1118) schema+encja+create, PR-B API+resolver+walidacja przypisania, PR-C FE (dropdown all-categorizable + objectTypeId, list/new/show per drzewo, reword etykiety `is_categorizable` → „czy obiekty mogą być przypisane do drzewa").
+
 ## 14. Roadmap rozwoju
 
 Roadmap fazowa, wysokopoziomowa. Szczegółowy backlog i estymacje w dokumencie `02-plan-projektu-pim.md`.

--- a/apps/api/migrations/Version20260530120000.php
+++ b/apps/api/migrations/Version20260530120000.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * ADR-015 — category trees scoped per ObjectType.
+ *
+ * Until now there was ONE shared category tree per tenant: all `kind='category'`
+ * objects lived in a single ltree namespace and the `category_attribute_groups`
+ * junction's `target_object_type_id` decided which ObjectType inherited groups.
+ *
+ * ADR-015 partitions the tree by the ObjectType it organizes. A new
+ * `objects.category_target_object_type_id` column marks which categorizable
+ * ObjectType's tree a category belongs to (NULL for non-category rows). The
+ * per-tenant `(kind, code)` uniqueness is replaced by:
+ *   - `(tenant_id, kind, code)` for non-category rows (unchanged semantics),
+ *   - `(tenant_id, category_target_object_type_id, code)` for categories, so the
+ *     same code (e.g. "elektronika") can exist in two different trees.
+ *
+ * Backfill (operator decision): existing categories move into the built-in
+ * Product tree per tenant — Product is the only `is_categorizable` built-in
+ * today and the legacy single tree served it. Other ObjectTypes start with no
+ * tree (empty) until the operator flips `is_categorizable` and creates one.
+ *
+ * Expand-contract: this is the expand step (additive column + index swap). No
+ * data is dropped; `down()` restores the original single unique index.
+ */
+final class Version20260530120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-015: add objects.category_target_object_type_id + per-tree category code uniqueness';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE objects ADD COLUMN category_target_object_type_id UUID DEFAULT NULL');
+        $this->addSql(
+            'ALTER TABLE objects ADD CONSTRAINT objects_category_target_ot_fk'
+            .' FOREIGN KEY (category_target_object_type_id) REFERENCES object_types (id)'
+            .' ON DELETE RESTRICT NOT DEFERRABLE'
+        );
+        $this->addSql('CREATE INDEX objects_category_target_ot_idx ON objects (category_target_object_type_id)');
+
+        // Backfill: existing categories -> built-in Product OT of the same tenant.
+        $this->addSql(
+            'UPDATE objects o SET category_target_object_type_id = ('
+            .' SELECT ot.id FROM object_types ot'
+            ." WHERE ot.tenant_id = o.tenant_id AND ot.kind = 'product' AND ot.is_built_in = true"
+            .' LIMIT 1'
+            .") WHERE o.kind = 'category'"
+        );
+
+        // Swap the single per-tenant code uniqueness for kind-aware partial indexes.
+        $this->addSql('DROP INDEX objects_tenant_kind_code_uniq');
+        $this->addSql(
+            'CREATE UNIQUE INDEX objects_tenant_kind_code_noncat_uniq'
+            ." ON objects (tenant_id, kind, code) WHERE kind <> 'category'"
+        );
+        $this->addSql(
+            'CREATE UNIQUE INDEX objects_tenant_cat_tree_code_uniq'
+            ." ON objects (tenant_id, category_target_object_type_id, code) WHERE kind = 'category'"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX objects_tenant_cat_tree_code_uniq');
+        $this->addSql('DROP INDEX objects_tenant_kind_code_noncat_uniq');
+        $this->addSql('CREATE UNIQUE INDEX objects_tenant_kind_code_uniq ON objects (tenant_id, kind, code)');
+
+        $this->addSql('ALTER TABLE objects DROP CONSTRAINT objects_category_target_ot_fk');
+        $this->addSql('DROP INDEX objects_category_target_ot_idx');
+        $this->addSql('ALTER TABLE objects DROP COLUMN category_target_object_type_id');
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectCommand.php
+++ b/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectCommand.php
@@ -40,6 +40,7 @@ final readonly class CreateCatalogObjectCommand
         public array $attributes = [],
         public ?array $categoryIds = null,
         public ?Uuid $primaryCategoryId = null,
+        public ?Uuid $categoryTargetObjectTypeId = null,
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectHandler.php
+++ b/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectHandler.php
@@ -71,6 +71,40 @@ final readonly class CreateCatalogObjectHandler
             $object->assignParent($parent);
         }
 
+        // ADR-015 — a category belongs to exactly one categorizable
+        // ObjectType's tree. Require the scope on create; when a parent is
+        // given, the child must join the same tree as its parent (a subtree
+        // cannot jump trees).
+        if (ObjectKind::Category === $command->expectedKind) {
+            if (null === $command->categoryTargetObjectTypeId) {
+                throw new UnprocessableEntityHttpException(
+                    '"categoryTargetObjectTypeId" is required when creating a category.',
+                );
+            }
+            $targetType = $this->objectTypes->findById($command->categoryTargetObjectTypeId);
+            if (null === $targetType) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Target ObjectType "%s" was not found.',
+                    $command->categoryTargetObjectTypeId->toRfc4122(),
+                ));
+            }
+            if (!$targetType->isCategorizable()) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'ObjectType "%s" is not categorizable; enable it before creating its category tree.',
+                    $targetType->getCode(),
+                ));
+            }
+            if (null !== $parent) {
+                $parentTarget = $parent->getCategoryTargetObjectType();
+                if (null === $parentTarget || !$parentTarget->getId()->equals($targetType->getId())) {
+                    throw new UnprocessableEntityHttpException(
+                        'A child category must belong to the same ObjectType tree as its parent.',
+                    );
+                }
+            }
+            $object->scopeCategoryTo($targetType);
+        }
+
         // VIEW-04 (#408) — derive the ltree `path` here rather than in a
         // Doctrine prePersist listener. ORM 3 freezes the insert
         // change-set before listeners run, so a `prePersist` write to

--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -83,7 +83,7 @@ final readonly class DemoCatalogSeeder
             $assetType->assignLabelAttribute($attributes['name']);
             $this->em->flush();
 
-            $categories = $this->seedCategories($categoryType, $attributes);
+            $categories = $this->seedCategories($categoryType, $productType, $attributes);
             $this->em->flush();
 
             $assets = $this->seedAssets($assetType, $tenant, $attributes);
@@ -183,7 +183,7 @@ final readonly class DemoCatalogSeeder
      *
      * @return list<CatalogObject>
      */
-    private function seedCategories(ObjectType $type, array $attributes): array
+    private function seedCategories(ObjectType $type, ObjectType $productType, array $attributes): array
     {
         $defs = [
             ['CAT-FOOTWEAR', 'footwear',  'Obuwie',         'Buty męskie i damskie'],
@@ -196,6 +196,8 @@ final readonly class DemoCatalogSeeder
         $categories = [];
         foreach ($defs as [$code, $path, $name, $description]) {
             $category = new CatalogObject($type, $code);
+            // ADR-015 — demo categories live in the Product tree.
+            $category->scopeCategoryTo($productType);
             $category->transitionTo(CatalogObject::STATUS_PUBLISHED);
             $category->attachToPath($path);
 

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -64,6 +64,16 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     private string $code;
     private ?self $parent = null;
 
+    /**
+     * ADR-015 — the categorizable ObjectType whose tree this category
+     * belongs to. Only meaningful for `kind='category'` (NULL otherwise);
+     * partitions the otherwise-shared ltree namespace so each ObjectType
+     * has its own category tree. The category distributes attribute groups
+     * to instances of this target ObjectType (the `target_object_type_id`
+     * in `category_attribute_groups` equals this scope by construction).
+     */
+    private ?ObjectType $categoryTargetObjectType = null;
+
     private bool $enabled = true;
 
     private string $status = self::STATUS_DRAFT;
@@ -190,6 +200,25 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     public function getKind(): ObjectKind
     {
         return $this->kind;
+    }
+
+    /**
+     * ADR-015 — the ObjectType tree this category belongs to (NULL for
+     * non-category rows).
+     */
+    public function getCategoryTargetObjectType(): ?ObjectType
+    {
+        return $this->categoryTargetObjectType;
+    }
+
+    /**
+     * ADR-015 — assign this category to a categorizable ObjectType's tree.
+     * Set once at create time (the create handler enforces presence +
+     * `is_categorizable` for `kind='category'`).
+     */
+    public function scopeCategoryTo(ObjectType $objectType): void
+    {
+        $this->categoryTargetObjectType = $objectType;
     }
 
     public function getCode(): string

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObjectInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObjectInput.php
@@ -95,4 +95,14 @@ final class CatalogObjectInput
     #[Assert\Uuid(versions: [Assert\Uuid::V7_MONOTONIC])]
     #[Groups(['object:create'])]
     public ?string $primaryCategoryId = null;
+
+    /**
+     * ADR-015 — id of the categorizable {@see \App\Catalog\Domain\Entity\ObjectType}
+     * whose category tree this new category joins. Required when the sugar
+     * path is `/api/categories` (the handler raises 422 if missing or if the
+     * target ObjectType is not `is_categorizable`). Ignored for other kinds.
+     */
+    #[Assert\Uuid(versions: [Assert\Uuid::V7_MONOTONIC])]
+    #[Groups(['object:create'])]
+    public ?string $categoryTargetObjectTypeId = null;
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php
@@ -106,6 +106,12 @@ final readonly class CatalogObjectProcessor implements ProcessorInterface
             ? Uuid::fromString($data->primaryCategoryId)
             : null;
 
+        // ADR-015 — scope of the category tree this category joins.
+        $categoryTargetObjectTypeId = null !== $data->categoryTargetObjectTypeId
+            && '' !== $data->categoryTargetObjectTypeId
+            ? Uuid::fromString($data->categoryTargetObjectTypeId)
+            : null;
+
         $command = new CreateCatalogObjectCommand(
             objectTypeId: Uuid::fromString($data->objectTypeId),
             code: $data->code,
@@ -114,6 +120,7 @@ final readonly class CatalogObjectProcessor implements ProcessorInterface
             attributes: $data->attributes ?? [],
             categoryIds: $categoryIds,
             primaryCategoryId: $primaryCategoryId,
+            categoryTargetObjectTypeId: $categoryTargetObjectTypeId,
         );
 
         $envelope = $this->dispatch($command);

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -8,13 +8,18 @@
             table="objects"
             repository-class="App\Catalog\Infrastructure\Doctrine\Repository\DoctrineCatalogObjectRepository">
 
-        <unique-constraints>
-            <unique-constraint name="objects_tenant_kind_code_uniq" columns="tenant_id,kind,code"/>
-        </unique-constraints>
-
+        <!--
+            ADR-015: per-tenant `code` uniqueness is enforced by two PARTIAL
+            unique indexes (kind <> 'category', and kind = 'category' scoped by
+            category_target_object_type_id) defined in migration
+            Version20260530120000. Partial indexes can't be expressed in ORM
+            XML, so — like the ltree GIST/BTree indexes — they live in the
+            migration only.
+        -->
         <indexes>
             <index name="objects_tenant_type_idx" columns="tenant_id,object_type_id"/>
             <index name="objects_tenant_kind_idx" columns="tenant_id,kind"/>
+            <index name="objects_category_target_ot_idx" columns="category_target_object_type_id"/>
             <!--
                 HARD-01: composite index for tree-mode product list (PR #514)
                 and category-children listing. Lets the planner satisfy
@@ -43,6 +48,11 @@
 
         <many-to-one field="parent" target-entity="App\Catalog\Domain\Entity\CatalogObject">
             <join-column name="parent_id" referenced-column-name="id" nullable="true" on-delete="SET NULL"/>
+        </many-to-one>
+
+        <!-- ADR-015 — the ObjectType tree this category belongs to (NULL for non-category rows). -->
+        <many-to-one field="categoryTargetObjectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
+            <join-column name="category_target_object_type_id" referenced-column-name="id" nullable="true" on-delete="RESTRICT"/>
         </many-to-one>
 
         <field name="enabled" type="boolean">

--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php
@@ -106,12 +106,17 @@ final class CatalogObjectPolyKindGetTest extends CatalogApiTestCase
         string $code,
         ObjectKind $kind,
     ): string {
+        $payload = [
+            'code' => $code,
+            'objectTypeId' => $this->objectTypeIdFor($kind),
+        ];
+        // ADR-015 — categories must declare the categorizable ObjectType tree.
+        if (ObjectKind::Category === $kind) {
+            $payload['categoryTargetObjectTypeId'] = $this->objectTypeIdFor(ObjectKind::Product);
+        }
         $response = $client->request('POST', $sugarPath, [
             'headers' => ['content-type' => 'application/ld+json'],
-            'body' => json_encode([
-                'code' => $code,
-                'objectTypeId' => $this->objectTypeIdFor($kind),
-            ], JSON_THROW_ON_ERROR),
+            'body' => json_encode($payload, JSON_THROW_ON_ERROR),
         ]);
         $body = $response->toArray();
         $id = $body['id'] ?? null;

--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPostTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPostTest.php
@@ -74,12 +74,78 @@ final class CatalogObjectPolyKindPostTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'poly_post_category',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                // ADR-015 — a category must declare the categorizable
+                // ObjectType tree it joins (Product is the only built-in).
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $body = $response->toArray();
         self::assertSame('poly_post_category', $body['code'] ?? null);
         self::assertSame('category', $body['kind'] ?? null);
+    }
+
+    #[Test]
+    public function postCategoryWithoutTargetObjectTypeReturns422(): void
+    {
+        // ADR-015 — categoryTargetObjectTypeId is mandatory for categories.
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'adr015_noscope',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    #[Test]
+    public function postCategoryWithNonCategorizableTargetReturns422(): void
+    {
+        // ADR-015 — the target ObjectType must be is_categorizable. Asset is not.
+        $client = $this->authenticatedClient();
+
+        $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'adr015_asset_scope',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Asset),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    #[Test]
+    public function sameCategoryCodeAllowedInDifferentTrees(): void
+    {
+        // ADR-015 — per-tree code uniqueness. Make a second categorizable OT,
+        // then create the same code in both Product's tree and its tree.
+        $client = $this->authenticatedClient();
+        $secondTreeOtId = $this->seedCategorizableObjectType('cars_adr015', 'Cars ADR015');
+
+        $first = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'adr015_dup',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertSame(Response::HTTP_CREATED, $first->getStatusCode());
+
+        $second = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'adr015_dup',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $secondTreeOtId,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        // Same code, different tree → allowed.
+        self::assertSame(Response::HTTP_CREATED, $second->getStatusCode());
     }
 
     #[Test]
@@ -146,6 +212,7 @@ final class CatalogObjectPolyKindPostTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'POLY-POST-MISMATCH',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
@@ -160,6 +227,25 @@ final class CatalogObjectPolyKindPostTest extends CatalogApiTestCase
         $tenantContext->set($tenant);
 
         $ot = new ObjectType($code, ObjectKind::Custom, ['pl' => $label, 'en' => $label]);
+        $em = $this->em();
+        $em->persist($ot);
+        $em->flush();
+
+        $tenantContext->clear();
+
+        return $ot->getId()->toRfc4122();
+    }
+
+    private function seedCategorizableObjectType(string $code, string $label): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $ot = new ObjectType($code, ObjectKind::Custom, ['pl' => $label, 'en' => $label]);
+        $ot->setCategorizable(true);
         $em = $this->em();
         $em->persist($ot);
         $em->flush();

--- a/apps/api/tests/Api/Catalog/CatalogObjectsPickerEndpointTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectsPickerEndpointTest.php
@@ -54,6 +54,7 @@ final class CatalogObjectsPickerEndpointTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'CAT-POLY',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
 

--- a/apps/api/tests/Api/Catalog/CategoriesApiTest.php
+++ b/apps/api/tests/Api/Catalog/CategoriesApiTest.php
@@ -20,6 +20,7 @@ final class CategoriesApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'electronics',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
 
@@ -53,6 +54,7 @@ final class CategoriesApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'medical',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
 
@@ -70,6 +72,7 @@ final class CategoriesApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'lekarz',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         self::assertResponseStatusCodeSame(201);
@@ -81,6 +84,7 @@ final class CategoriesApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'chirurg',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
                 'parentId' => $rootId,
             ], JSON_THROW_ON_ERROR),
         ]);
@@ -98,6 +102,7 @@ final class CategoriesApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'usage_target',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         self::assertResponseStatusCodeSame(201);

--- a/apps/api/tests/Api/Catalog/CategoryAttributeGroupApiTest.php
+++ b/apps/api/tests/Api/Catalog/CategoryAttributeGroupApiTest.php
@@ -199,6 +199,7 @@ final class CategoryAttributeGroupApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => $code,
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         $id = $response->toArray()['id'] ?? null;

--- a/apps/api/tests/Api/Catalog/CategoryMoveApiTest.php
+++ b/apps/api/tests/Api/Catalog/CategoryMoveApiTest.php
@@ -83,6 +83,7 @@ final class CategoryMoveApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => $code,
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         $id = $response->toArray()['id'] ?? null;
@@ -99,6 +100,7 @@ final class CategoryMoveApiTest extends CatalogApiTestCase
                 'code' => $code,
                 'parentId' => $parentId,
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         $id = $response->toArray()['id'] ?? null;

--- a/apps/api/tests/Api/Catalog/CategoryProductsApiTest.php
+++ b/apps/api/tests/Api/Catalog/CategoryProductsApiTest.php
@@ -127,6 +127,7 @@ final class CategoryProductsApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => $code,
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         $id = $response->toArray()['id'] ?? null;

--- a/apps/api/tests/Api/Catalog/DuplicateProductApiTest.php
+++ b/apps/api/tests/Api/Catalog/DuplicateProductApiTest.php
@@ -139,6 +139,7 @@ final class DuplicateProductApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'CAT-500',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ])->toArray();
 

--- a/apps/api/tests/Api/Catalog/ObjectKindRoutingApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectKindRoutingApiTest.php
@@ -36,6 +36,7 @@ final class ObjectKindRoutingApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'CAT-1',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         self::assertResponseStatusCodeSame(201);

--- a/apps/api/tests/Api/Catalog/ProductCategoryAssignmentApiTest.php
+++ b/apps/api/tests/Api/Catalog/ProductCategoryAssignmentApiTest.php
@@ -292,6 +292,7 @@ final class ProductCategoryAssignmentApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => $code,
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
         $id = $response->toArray()['id'] ?? null;

--- a/apps/api/tests/Api/Catalog/ProductsApiTest.php
+++ b/apps/api/tests/Api/Catalog/ProductsApiTest.php
@@ -47,6 +47,7 @@ final class ProductsApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'SKU-MISMATCH',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
 
@@ -70,6 +71,7 @@ final class ProductsApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'CAT-100',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ]);
 
@@ -148,6 +150,7 @@ final class ProductsApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'CAT-CROSS',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ])->toArray();
         $id = $created['id'] ?? null;
@@ -170,6 +173,7 @@ final class ProductsApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'cat_a_891',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ])->toArray();
         $catB = $client->request('POST', '/api/categories', [
@@ -177,6 +181,7 @@ final class ProductsApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'cat_b_891',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ])->toArray();
         $catAId = $catA['id'] ?? null;
@@ -217,6 +222,7 @@ final class ProductsApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'cat_primary_orphan_891',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ])->toArray();
         $catB = $client->request('POST', '/api/categories', [
@@ -224,6 +230,7 @@ final class ProductsApiTest extends CatalogApiTestCase
             'body' => json_encode([
                 'code' => 'cat_primary_orphan_b_891',
                 'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
             ], JSON_THROW_ON_ERROR),
         ])->toArray();
         $catAId = $catA['id'] ?? null;

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -8422,6 +8422,17 @@
                             "string",
                             "null"
                         ]
+                    },
+                    "categoryTargetObjectTypeId": {
+                        "format": "uuid",
+                        "description": "ADR-015 \u2014 id of the categorizable {@see \\App\\Catalog\\Domain\\Entity\\ObjectType}\nwhose category tree this new category joins. Required when the sugar\npath is `/api/categories` (the handler raises 422 if missing or if the\ntarget ObjectType is not `is_categorizable`). Ignored for other kinds.",
+                        "externalDocs": {
+                            "url": "https://schema.org/identifier"
+                        },
+                        "type": [
+                            "string",
+                            "null"
+                        ]
                     }
                 }
             },


### PR DESCRIPTION
## Summary
PR-A z planu ADR-015 (osobne drzewa kategorii per ObjectType). Warstwa backendowa: schemat + encja + create flow + ADR. Bez zmian API listy/FE (PR-B/PR-C).

## Backend changes
- **Migracja `Version20260530120000`** (expand-contract): `objects.category_target_object_type_id` (UUID NULL, FK→object_types ON DELETE RESTRICT, index). Backfill: istniejące kategorie → built-in Product OT per tenant. Unikalność kodu kategorii per-drzewo: drop `objects_tenant_kind_code_uniq` → dwa partial unique (`kind<>'category'` oraz `(tenant, category_target_object_type_id, code) WHERE kind='category'`).
- **Encja `CatalogObject`** + mapping XML: pole `categoryTargetObjectType` (many-to-one, nullable) + getter `getCategoryTargetObjectType()` + `scopeCategoryTo()`.
- **Create flow**: `CreateCatalogObjectCommand/Handler` + `CatalogObjectInput` + processor przyjmują `categoryTargetObjectTypeId`; dla `kind='category'` wymagane, walidacja że to `is_categorizable` OT, dziecko musi być w tym samym drzewie co rodzic.
- **DemoCatalogSeeder**: demo-kategorie scoped do Product.
- **ADR-015** w `Project Plan/01-architektura-pim.md`.

## Quality gates
- PHPStan max: **0**
- PHPUnit: focused suite kategorii/poly-kind **50/50** + zaktualizowane istniejące testy (10 plików dostało scope w payloadach) + nowe ADR-015: missing scope→422, non-categorizable→422, ten sam kod w dwóch drzewach→OK.
- Migracja up/down zaaplikowana na dev DB; backfill zweryfikowany (kategorie → Product, partial unique indexy obecne).
- OpenAPI snapshot zregenerowany.

## Smoke (live, dev)
- `POST /api/categories` ze scope=Product → 201; bez scope → 422; scope=Asset (non-categorizable) → 422.

**Część większego planu ADR-015** (PR-A schema → PR-B API+resolver+walidacja przypisania → PR-C FE dropdown/list/new/show). Pełny scope per-OT drzew (filtr listy, custom OT w dropdownie, walidacja przypisania obiektów) dochodzi w PR-B/PR-C.

Refs #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)