### PR TITLE
feat(catalog): ADR-015 PR-B — filtr listy kategorii per drzewo

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/CategoryTreeFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/CategoryTreeFilter.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ADR-015 — `?categoryTargetObjectType=<uuid>` scopes `/api/categories` to a
+ * single ObjectType's tree.
+ *
+ * After ADR-015 each categorizable ObjectType owns an independent category
+ * tree (`objects.category_target_object_type_id`). The modeling UI picks a
+ * tree via the ObjectType selector and lists only that tree's categories;
+ * without this filter the collection returns every tenant category across
+ * all trees and the FE cannot isolate one tree.
+ *
+ * Empty / non-UUID values are a no-op so a stale FE param never breaks the
+ * collection. Tenant scoping still applies via the TenantFilter.
+ */
+final class CategoryTreeFilter implements FilterInterface
+{
+    private const string PARAMETER = 'categoryTargetObjectType';
+
+    public function apply(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?Operation $operation = null,
+        array $context = [],
+    ): void {
+        $filters = $context['filters'] ?? [];
+        if (!\is_array($filters)) {
+            return;
+        }
+
+        $value = $filters[self::PARAMETER] ?? null;
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            return;
+        }
+
+        $alias = $queryBuilder->getRootAliases()[0] ?? null;
+        if (null === $alias) {
+            return;
+        }
+
+        $parameter = $queryNameGenerator->generateParameterName('categoryTreeOt');
+        $queryBuilder
+            ->andWhere(\sprintf('IDENTITY(%s.categoryTargetObjectType) = :%s', $alias, $parameter))
+            ->setParameter($parameter, $value);
+    }
+
+    /**
+     * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool}>
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            self::PARAMETER => [
+                'property' => 'categoryTargetObjectType',
+                'type' => 'string',
+                'required' => false,
+                'description' => 'ADR-015 — scope categories to one ObjectType tree (UUID).',
+            ],
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -82,6 +82,13 @@
             -->
             <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\ObjectTypeFilter</filter>
             <!--
+                ADR-015: `?categoryTargetObjectType={uuid}` scopes
+                /api/categories to a single ObjectType's tree (per-OT
+                category trees). Required so the modeling UI can isolate
+                one tree via the ObjectType selector.
+            -->
+            <filter>App\Catalog\Infrastructure\ApiPlatform\Filter\CategoryTreeFilter</filter>
+            <!--
                 OrderFilter + RangeFilter pinned to `id` are mandatory for
                 cursor pagination (`paginationViaCursor` below) — lessons #0.0.3
                 docu the AP4 trio. Without RangeFilter the `?id[lt]=...`

--- a/apps/api/tests/Api/Catalog/CategoriesApiTest.php
+++ b/apps/api/tests/Api/Catalog/CategoriesApiTest.php
@@ -117,4 +117,64 @@ final class CategoriesApiTest extends CatalogApiTestCase
         self::assertSame(0, $body['descendantCount'] ?? null);
         self::assertSame([], $body['declaredFor'] ?? null);
     }
+
+    #[Test]
+    public function listFilterByCategoryTreeReturnsOnlyThatTree(): void
+    {
+        // ADR-015 — `?categoryTargetObjectType=<uuid>` isolates one tree.
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+        $secondTreeOt = $this->seedCategorizableObjectType('cars_filter', 'Cars filter');
+
+        $client->request('POST', '/api/categories', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'tree_a_only',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $productOt,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $client->request('POST', '/api/categories', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'tree_b_only',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $secondTreeOt,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        $response = $client->request('GET', '/api/categories?categoryTargetObjectType='.$secondTreeOt);
+        self::assertResponseStatusCodeSame(200);
+        $members = $response->toArray()['member'] ?? [];
+        \assert(\is_array($members));
+        $codes = [];
+        foreach ($members as $row) {
+            \assert(\is_array($row));
+            $code = $row['code'] ?? null;
+            if (\is_string($code)) {
+                $codes[] = $code;
+            }
+        }
+        self::assertContains('tree_b_only', $codes);
+        self::assertNotContains('tree_a_only', $codes);
+    }
+
+    private function seedCategorizableObjectType(string $code, string $label): string
+    {
+        $ctx = self::getContainer()->get(\App\Shared\Application\TenantContext::class);
+        $tenant = self::getContainer()->get(\Doctrine\ORM\EntityManagerInterface::class)
+            ->getRepository(\App\Shared\Domain\Tenant::class)
+            ->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof \App\Shared\Domain\Tenant);
+        $ctx->set($tenant);
+
+        $ot = new \App\Catalog\Domain\Entity\ObjectType($code, ObjectKind::Custom, ['pl' => $label, 'en' => $label]);
+        $ot->setCategorizable(true);
+        $em = self::getContainer()->get(\Doctrine\ORM\EntityManagerInterface::class);
+        $em->persist($ot);
+        $em->flush();
+        $ctx->clear();
+
+        return $ot->getId()->toRfc4122();
+    }
 }

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -2004,6 +2004,18 @@
                         "explode": false
                     },
                     {
+                        "name": "categoryTargetObjectType",
+                        "in": "query",
+                        "description": "ADR-015 \u2014 scope categories to one ObjectType tree (UUID).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "order[id]",
                         "in": "query",
                         "description": "",
@@ -2312,6 +2324,18 @@
                         "name": "objectType",
                         "in": "query",
                         "description": "Scope the collection to a specific ObjectType by UUID. Drives the universal ObjectListView so a single endpoint serves every ObjectType (built-in product/category/asset/brand or custom).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "categoryTargetObjectType",
+                        "in": "query",
+                        "description": "ADR-015 \u2014 scope categories to one ObjectType tree (UUID).",
                         "required": false,
                         "deprecated": false,
                         "schema": {
@@ -2951,6 +2975,18 @@
                         "explode": false
                     },
                     {
+                        "name": "categoryTargetObjectType",
+                        "in": "query",
+                        "description": "ADR-015 \u2014 scope categories to one ObjectType tree (UUID).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "order[id]",
                         "in": "query",
                         "description": "",
@@ -3572,6 +3608,18 @@
                         "name": "objectType",
                         "in": "query",
                         "description": "Scope the collection to a specific ObjectType by UUID. Drives the universal ObjectListView so a single endpoint serves every ObjectType (built-in product/category/asset/brand or custom).",
+                        "required": false,
+                        "deprecated": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
+                        "name": "categoryTargetObjectType",
+                        "in": "query",
+                        "description": "ADR-015 \u2014 scope categories to one ObjectType tree (UUID).",
                         "required": false,
                         "deprecated": false,
                         "schema": {


### PR DESCRIPTION
## Summary
PR-B z ADR-015. Dodaje filtr `GET /api/categories?categoryTargetObjectType=<uuid>` scope'ujący kolekcję do drzewa jednego ObjectType — enabler dla selektora drzew w modelowaniu (PR-C).

## Backend changes
- **`CategoryTreeFilter`** (wzór `ObjectTypeFilter`): filtruje po `category_target_object_type_id`; no-op dla pustych/niepoprawnych wartości; tenant-safe (TenantFilter nadal działa).
- Rejestracja filtra na zasobie `/api/categories` (`CatalogObject.xml`).

## Quality gates
- PHPStan max: **0**
- PHPUnit: `CategoriesApiTest` + nowy `listFilterByCategoryTreeReturnsOnlyThatTree` (dwa drzewa → filtr zwraca tylko jedno).
- OpenAPI snapshot zregenerowany (nowy query param).

## Świadome odejścia → PR-D (follow-up)
- Walidacja cross-tree przypisania (obiekt OT=X tylko do kategorii drzewa X → 422) — **nieosiągalne z UI** po PR-C (lista oferuje tylko kategorie z drzewa obiektu), więc bezpiecznie deferowane jako defense-in-depth.
- `EffectiveAttributeGroups` przełączenie `kind`→`objectId` dla custom-OT preview dystrybucji atrybutów.

Część planu ADR-015 (PR-A schema → PR-B filtr → PR-C FE). Refs #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)