### PR TITLE
feat(admin): ADR-015 PR-C — drzewa kategorii per ObjectType (FE)

### DIFF
--- a/apps/admin/e2e/category-trees-per-objecttype.spec.ts
+++ b/apps/admin/e2e/category-trees-per-objecttype.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * ADR-015 PR-C (#1122) — per-ObjectType category trees.
+ *
+ * The /modeling/categories ObjectType selector now lists every
+ * is_categorizable ObjectType (built-in + custom) and emits its id; the
+ * tree is filtered to that ObjectType's tree via
+ * ?categoryTargetObjectType=<id>. Switching the selector swaps trees;
+ * "+ Nowa kategoria" creates inside the selected tree.
+ *
+ * Marked `fixme` in CI for the shared-suite auth rate-limiter reason
+ * (see settings-channels-crud.spec.ts). Coverage is preserved by
+ * CategoriesApiTest (listFilterByCategoryTreeReturnsOnlyThatTree),
+ * CatalogObjectPolyKindPostTest (scope create + per-tree uniqueness) and
+ * the local browser smoke documented in the PR.
+ */
+const E2E_BLOCKED_BY_RATE_LIMITER =
+  'Pending storageState rollout: spec lands after the 5/15min auth rate limiter is exhausted';
+
+test.describe('ADR-015 — per-ObjectType category trees', () => {
+  test('selector switches trees; create lands in the selected tree', async ({ page }) => {
+    test.fixme(true, E2E_BLOCKED_BY_RATE_LIMITER);
+    await loginAsAdmin(page);
+    await page.goto('/modeling/categories');
+    await page.waitForTimeout(2000);
+
+    // The ObjectType selector lists categorizable ObjectTypes.
+    const select = page.locator('select').first();
+    await expect(select).toBeVisible();
+    const options = await select.locator('option').allInnerTexts();
+    expect(options.some((o) => /product|produkt/i.test(o))).toBeTruthy();
+
+    // Product tree shows the seeded demo categories.
+    await select.selectOption({ label: /product|produkt/i });
+    await page.waitForTimeout(1200);
+    await expect(page.getByText(/apparel|footwear|outdoor/i).first()).toBeVisible();
+  });
+});

--- a/apps/admin/src/components/modeling/object-type-filter-dropdown.tsx
+++ b/apps/admin/src/components/modeling/object-type-filter-dropdown.tsx
@@ -37,8 +37,10 @@ interface ObjectTypeOption {
 }
 
 interface Props {
+  /** Selected ObjectType id (UUID). ADR-015 — trees are keyed by objectTypeId. */
   value: string | null;
-  onChange: (next: string) => void;
+  /** Emits the chosen ObjectType id + its kind (kind kept for legacy kind-based calls). */
+  onChange: (objectTypeId: string, kind: string) => void;
   className?: string;
 }
 
@@ -63,7 +65,9 @@ export function ObjectTypeFilterDropdown({ value, onChange, className }: Props) 
       const data = await jsonFetch<ObjectTypeOption[]>('/api/object_types', {
         accept: 'application/json',
       });
-      return data.filter((ot) => ot.builtIn === true && ot.isCategorizable === true);
+      // ADR-015 — every categorizable ObjectType (built-in OR custom) owns
+      // its own category tree, so the selector lists all of them.
+      return data.filter((ot) => ot.isCategorizable === true);
     },
     staleTime: 60_000,
   });
@@ -74,9 +78,9 @@ export function ObjectTypeFilterDropdown({ value, onChange, className }: Props) 
   // in the fetched list (initial render OR after the operator demoted the
   // previously-selected OT via toggle).
   const firstOption = options[0];
-  const valueMatches = options.some((ot) => ot.kind === value);
+  const valueMatches = options.some((ot) => ot.id === value);
   if (!query.isLoading && firstOption !== undefined && !valueMatches) {
-    onChange(firstOption.kind);
+    onChange(firstOption.id, firstOption.kind);
   }
 
   if (query.isLoading) {
@@ -136,14 +140,17 @@ export function ObjectTypeFilterDropdown({ value, onChange, className }: Props) 
       </span>
       <select
         className="bg-transparent font-medium outline-none"
-        value={value ?? firstOption?.kind ?? ''}
-        onChange={(e) => onChange(e.target.value)}
+        value={value ?? firstOption?.id ?? ''}
+        onChange={(e) => {
+          const picked = options.find((ot) => ot.id === e.target.value);
+          if (picked !== undefined) onChange(picked.id, picked.kind);
+        }}
         aria-label={t('categories.target_type_aria', {
           defaultValue: 'Filter declared groups by target ObjectType',
         })}
       >
         {options.map((opt) => (
-          <option key={opt.id} value={opt.kind}>
+          <option key={opt.id} value={opt.id}>
             {optionLabel(opt, locale)}
           </option>
         ))}

--- a/apps/admin/src/features/catalog/categories/list.tsx
+++ b/apps/admin/src/features/catalog/categories/list.tsx
@@ -104,12 +104,21 @@ export function CategoriesTreePage() {
   // `is_categorizable=true`). The dropdown emits its choice via
   // `onChange` on mount when the URL param doesn't match anything, so an
   // empty default is correct here — the URL gets stamped on first render.
+  // ADR-015 — the tree is keyed by ObjectType id (`targetObjectTypeId`); the
+  // kind (`targetType`) is kept alongside for the legacy kind-based attribute-
+  // group declaration calls in the detail panel. Both are stamped by the
+  // dropdown on mount, so a reload restores the exact tree + kind.
+  const targetObjectTypeId = searchParams.get('targetObjectTypeId') ?? '';
   const targetType: string = searchParams.get('targetType') ?? 'product';
   const selectedId = searchParams.get('selected') ?? null;
 
   const { result } = useList<CategoryEntry>({
     resource: 'categories',
     pagination: { mode: 'off' },
+    filters: targetObjectTypeId
+      ? [{ field: 'categoryTargetObjectType', operator: 'eq', value: targetObjectTypeId }]
+      : [],
+    queryOptions: { enabled: targetObjectTypeId !== '' },
   });
 
   const tree = useMemo(
@@ -136,9 +145,12 @@ export function CategoriesTreePage() {
     setSearchParams(next, { replace: true });
   };
 
-  const handleTargetChange = (kind: string) => {
+  const handleTargetChange = (objectTypeId: string, kind: string) => {
     const next = new URLSearchParams(searchParams);
+    next.set('targetObjectTypeId', objectTypeId);
     next.set('targetType', kind);
+    // Switching trees invalidates the selected node (it lived in the old tree).
+    next.delete('selected');
     setSearchParams(next, { replace: true });
   };
 
@@ -155,8 +167,17 @@ export function CategoriesTreePage() {
             'Drzewo kategorii deklaruje jakie grupy atrybutów mają obiekty w tej gałęzi. Dziedziczenie idzie w dół — Ortopeda dziedziczy wszystko od Lekarz + Chirurg, plus własne. Inheritance preview pokazuje co użytkownik zobaczy w formularzu.',
         })}
         ctaLabel={t('categories.create_action', { defaultValue: '+ Nowa kategoria' })}
-        ctaTo="/modeling/categories/new"
-        trailing={<ObjectTypeFilterDropdown value={targetType} onChange={handleTargetChange} />}
+        ctaTo={
+          targetObjectTypeId
+            ? `/modeling/categories/new?targetObjectTypeId=${targetObjectTypeId}`
+            : '/modeling/categories/new'
+        }
+        trailing={
+          <ObjectTypeFilterDropdown
+            value={targetObjectTypeId || null}
+            onChange={handleTargetChange}
+          />
+        }
       />
 
       <div className="grid gap-6 lg:grid-cols-[320px_1fr]">

--- a/apps/admin/src/features/catalog/categories/new.tsx
+++ b/apps/admin/src/features/catalog/categories/new.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 
 import { IconPicker } from '@/components/modeling/icon-picker';
 import { Button } from '@/components/ui/button';
@@ -51,6 +51,10 @@ export function CategoryCreatePage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [searchParams] = useSearchParams();
+  // ADR-015 — which ObjectType tree this new category joins (carried from
+  // the categories list selector via ?targetObjectTypeId=).
+  const targetObjectTypeId = searchParams.get('targetObjectTypeId') ?? '';
 
   const [code, setCode] = useState('');
   const [parentId, setParentId] = useState<string>('');
@@ -64,6 +68,10 @@ export function CategoryCreatePage() {
   const { result: parents } = useList<CategoryEntry>({
     resource: 'categories',
     pagination: { mode: 'off' },
+    // ADR-015 — parents must come from the same tree as the new category.
+    filters: targetObjectTypeId
+      ? [{ field: 'categoryTargetObjectType', operator: 'eq', value: targetObjectTypeId }]
+      : [],
   });
 
   const { result: objectTypes } = useList<ObjectTypeRow>({
@@ -114,6 +122,10 @@ export function CategoryCreatePage() {
         code,
         objectTypeId: categoryObjectTypeId,
       };
+      // ADR-015 — the categorizable ObjectType tree this category joins.
+      if (targetObjectTypeId) {
+        body.categoryTargetObjectTypeId = targetObjectTypeId;
+      }
       if (parentId) {
         body.parentId = parentId;
       }

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -746,7 +746,7 @@ export function ObjectTypeShowPage() {
           <div className="border-t border-zinc-100 pt-5">
             <SettingToggleRow
               label={t('object_types.setting_categorizable_label', {
-                defaultValue: 'Czy można je przypisywać do kategorii?',
+                defaultValue: 'Czy obiekty mogą być przypisane do drzewa kategorii?',
               })}
               description={t('object_types.setting_categorizable_desc', {
                 defaultValue:


### PR DESCRIPTION
## Summary
Finalny, widoczny kawałek ADR-015. Select „Object Type" na `/modeling/categories` listuje **wszystkie** kategoryzowalne ObjectType (built-in **i custom**) i przełącza **osobne drzewa**; tworzenie kategorii ląduje w wybranym drzewie.

## Frontend changes
- **`ObjectTypeFilterDropdown`**: usunięty filtr `builtIn===true` (zostaje `isCategorizable`), emituje `objectTypeId` (UUID) + `kind`.
- **`categories/list.tsx`**: URL `targetObjectTypeId` (do filtra `?categoryTargetObjectType=`) + `targetType` (kind, do panelu deklaracji); `useList` filtruje listę; przełączenie drzewa czyści wybrany węzeł; CTA „Nowa kategoria" niesie scope.
- **`categories/new.tsx`**: odczyt `targetObjectTypeId` z URL → `categoryTargetObjectTypeId` w body; picker rodzica filtrowany do tego drzewa.
- **`object-types/show.tsx`**: reword etykiety `is_categorizable` → „Czy obiekty mogą być przypisane do drzewa kategorii?" (feedback operatora — myliła się z osobną flagą `is_hierarchical`).

## Quality gates
- TypeScript noEmit: **0**, Biome strict: **0**, Vite build: green.
- **Browser smoke** (lokalnie): po włączeniu `is_categorizable` na custom OT „Salony sprzedaży" dropdown go listuje; jego drzewo jest **izolowane** (brak kategorii Product); przełączenie selecta zmienia zawartość. (screenshot w opisie sesji)
- Playwright `category-trees-per-objecttype.spec.ts` (`test.fixme` w CI — auth rate-limiter, jak inne); pokrycie BE: `CategoriesApiTest` filtr + `CatalogObjectPolyKindPostTest` scope/uniqueness.

## End-to-end
**Zsmoke-testowane lokalnie w przeglądarce** — select + izolacja drzew działają. Tworzenie: BE przyjmuje `categoryTargetObjectTypeId` (201, zweryfikowane), FE wysyła go z URL.

## Świadome odejścia → #1121 (PR-D)
- Walidacja cross-tree przypisania obiektów + `EffectiveAttributeGroups` `kind`→`objectId` dla preview dystrybucji w custom-OT drzewach. Nieosiągalne z UI (lista filtruje per drzewo).

Completes ADR-015 (PR-A #1119 schema + PR-B #1120 filtr + PR-C FE). Refs #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)