### PR TITLE
feat(catalog): ADR-015 PR-D — guard przypisania cross-tree (422)

### DIFF
--- a/apps/api/src/Catalog/Application/CategoryTreeAssignmentGuard.php
+++ b/apps/api/src/Catalog/Application/CategoryTreeAssignmentGuard.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+
+/**
+ * ADR-015 — guards object↔category assignment against cross-tree mixing.
+ *
+ * Each category belongs to exactly one categorizable ObjectType's tree
+ * (`category_target_object_type_id`). An object may only be filed under
+ * categories from its own ObjectType's tree, so a product cannot be
+ * assigned a "Salony sprzedaży" category and vice-versa.
+ *
+ * This is defense-in-depth: the modeling UI already lists only same-tree
+ * categories (PR-C filter), but the API must reject a hand-crafted
+ * cross-tree assignment with a clean 422 instead of silently persisting
+ * an attribute-distribution mismatch.
+ */
+final class CategoryTreeAssignmentGuard
+{
+    public function assertSameTree(CatalogObject $object, CatalogObject $category): void
+    {
+        $tree = $category->getCategoryTargetObjectType();
+        if (null === $tree || !$tree->getId()->equals($object->getObjectType()->getId())) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Category "%s" belongs to a different ObjectType tree and cannot be assigned to a "%s" object.',
+                $category->getCode(),
+                $object->getObjectType()->getCode(),
+            ));
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectHandler.php
+++ b/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectHandler.php
@@ -36,6 +36,7 @@ final readonly class CreateCatalogObjectHandler
         private ObjectTypeRepositoryInterface $objectTypes,
         private ObjectAttributesUpserter $attributesUpserter,
         private ObjectCategoryRepositoryInterface $objectCategories,
+        private \App\Catalog\Application\CategoryTreeAssignmentGuard $treeGuard,
     ) {
     }
 
@@ -162,6 +163,8 @@ final readonly class CreateCatalogObjectHandler
                         $categoryId->toRfc4122(),
                     ));
                 }
+                // ADR-015 — the category must belong to this object's tree.
+                $this->treeGuard->assertSameTree($object, $category);
             }
             $this->objectCategories->replaceForProduct($object, $command->categoryIds, $command->primaryCategoryId);
         }

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectCategoryAssignmentController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectCategoryAssignmentController.php
@@ -61,6 +61,7 @@ final class ObjectCategoryAssignmentController
         private readonly CatalogObjectRepositoryInterface $objects,
         private readonly ObjectCategoryRepositoryInterface $assignments,
         private readonly TenantContext $tenantContext,
+        private readonly \App\Catalog\Application\CategoryTreeAssignmentGuard $treeGuard,
     ) {
     }
 
@@ -141,7 +142,8 @@ final class ObjectCategoryAssignmentController
         }
 
         foreach ($categoryUuids as $uuid) {
-            $this->mustFindCategory($uuid->toRfc4122());
+            $category = $this->mustFindCategory($uuid->toRfc4122());
+            $this->treeGuard->assertSameTree($object, $category);
         }
 
         $this->assignments->replaceForProduct($object, $categoryUuids, $primaryUuid);
@@ -172,6 +174,7 @@ final class ObjectCategoryAssignmentController
             throw new UnprocessableEntityHttpException(\sprintf('"categoryId" is not a valid UUID: %s.', $rawCategory), $e);
         }
         $category = $this->mustFindCategory($categoryUuid->toRfc4122());
+        $this->treeGuard->assertSameTree($object, $category);
 
         $isPrimary = (bool) ($payload['isPrimary'] ?? false);
 

--- a/apps/api/src/Catalog/Presentation/Controller/ProductCategoryAssignmentController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductCategoryAssignmentController.php
@@ -59,6 +59,7 @@ final class ProductCategoryAssignmentController
         private readonly CatalogObjectRepositoryInterface $objects,
         private readonly ObjectCategoryRepositoryInterface $assignments,
         private readonly TenantContext $tenantContext,
+        private readonly \App\Catalog\Application\CategoryTreeAssignmentGuard $treeGuard,
     ) {
     }
 
@@ -142,7 +143,8 @@ final class ProductCategoryAssignmentController
         // touching the junction. Protects against half-applied replaces if a
         // single bad id were buried mid-list.
         foreach ($categoryUuids as $uuid) {
-            $this->mustFindCategory($uuid->toRfc4122());
+            $category = $this->mustFindCategory($uuid->toRfc4122());
+            $this->treeGuard->assertSameTree($product, $category);
         }
 
         $this->assignments->replaceForProduct($product, $categoryUuids, $primaryUuid);
@@ -173,6 +175,7 @@ final class ProductCategoryAssignmentController
             throw new UnprocessableEntityHttpException(\sprintf('"categoryId" is not a valid UUID: %s.', $rawCategory), $e);
         }
         $category = $this->mustFindCategory($categoryUuid->toRfc4122());
+        $this->treeGuard->assertSameTree($product, $category);
 
         $isPrimary = (bool) ($payload['isPrimary'] ?? false);
 

--- a/apps/api/tests/Api/Catalog/ProductCategoryAssignmentApiTest.php
+++ b/apps/api/tests/Api/Catalog/ProductCategoryAssignmentApiTest.php
@@ -300,4 +300,51 @@ final class ProductCategoryAssignmentApiTest extends CatalogApiTestCase
 
         return $id;
     }
+
+    #[Test]
+    public function putRejectsCrossTreeCategoryWith422(): void
+    {
+        // ADR-015 PR-D — a product cannot be assigned a category from a
+        // different ObjectType's tree.
+        $client = $this->authenticatedClient();
+        $productId = $this->createProduct($client, 'sku_crosstree');
+        $otherTreeOt = $this->seedCategorizableObjectType('cars_crosstree', 'Cars cross-tree');
+        $foreignCategory = $client->request('POST', '/api/categories', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'foreign_tree_cat',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $otherTreeOt,
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray()['id'] ?? null;
+        \assert(\is_string($foreignCategory));
+
+        $client->request('PUT', "/api/products/{$productId}/categories", [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'categoryIds' => [$foreignCategory],
+                'primaryCategoryId' => $foreignCategory,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    private function seedCategorizableObjectType(string $code, string $label): string
+    {
+        $ctx = self::getContainer()->get(\App\Shared\Application\TenantContext::class);
+        $tenant = self::getContainer()->get(\Doctrine\ORM\EntityManagerInterface::class)
+            ->getRepository(\App\Shared\Domain\Tenant::class)
+            ->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof \App\Shared\Domain\Tenant);
+        $ctx->set($tenant);
+
+        $ot = new \App\Catalog\Domain\Entity\ObjectType($code, ObjectKind::Custom, ['pl' => $label, 'en' => $label]);
+        $ot->setCategorizable(true);
+        $em = self::getContainer()->get(\Doctrine\ORM\EntityManagerInterface::class);
+        $em->persist($ot);
+        $em->flush();
+        $ctx->clear();
+
+        return $ot->getId()->toRfc4122();
+    }
 }


### PR DESCRIPTION
## Summary
Hardening z #1121 (część 1/2). `CategoryTreeAssignmentGuard`: obiekt może być przypisany tylko do kategorii z drzewa swojego ObjectType (`category.category_target_object_type_id == object.objectType`). Cross-tree → **422** zamiast cichego zapisu niespójności dystrybucji atrybutów.

## Backend changes
- Nowy `CategoryTreeAssignmentGuard` (Application).
- Wpięty w `ProductCategoryAssignmentController` (replace+add), `ObjectCategoryAssignmentController` (replace+add), `CreateCatalogObjectHandler` (atomic categoryIds path).

## Quality gates
- PHPStan max: **0**
- PHPUnit: assignment/create/categories **51/51**, w tym nowy `putRejectsCrossTreeCategoryWith422`; same-tree (200) bez regresji.
- Bez zmian API/FE → bez OpenAPI regen.

## Defense-in-depth
UI (PR-C) i tak listuje tylko kategorie z drzewa obiektu; to zabezpiecza API przed ręcznie spreparowanym payloadem.

## Pozostała część #1121 (osobny follow-up)
`EffectiveAttributeGroups` `kind`→`objectId` dla podglądu dystrybucji atrybutów w custom-OT drzewach okazało się **większym refaktorem** (endpointy declare/list/preview + resolver + panel FE, rozmiar zbliżony do PR-A) — celowo nie bundlowane tutaj, zostaje w #1121.

Refs #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)