### PR TITLE
fix(catalog,admin): drzewa kategorii custom-OT — declare po objectId + redirect po create

### DIFF
--- a/apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx
@@ -25,6 +25,8 @@ interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   categoryId: string;
+  /** ADR-015 — ObjectType id the declaration targets (supports custom-OT trees). */
+  targetObjectTypeId: string;
   /** ObjectKind discriminator the declaration targets (`product` / `service` / `category` / ...). */
   targetObjectTypeKind: string;
   /** AttributeGroup IDs already declared on this category for this target — disabled with a tooltip. */
@@ -49,6 +51,7 @@ export function DeclareAttributeGroupDialog({
   open,
   onOpenChange,
   categoryId,
+  targetObjectTypeId,
   targetObjectTypeKind,
   declaredGroupIds,
   inheritedFromMap,
@@ -120,14 +123,15 @@ export function DeclareAttributeGroupDialog({
         await jsonFetch(`/api/categories/${categoryId}/attribute_groups`, {
           method: 'POST',
           contentType: 'application/json',
-          body: { groupId, targetObjectTypeKind },
+          // ADR-015 — declare by ObjectType id (BE prefers it; supports custom-OT trees).
+          body: { groupId, targetObjectTypeId },
         });
       }
       await queryClient.invalidateQueries({
-        queryKey: ['categories', categoryId, 'attribute_groups', targetObjectTypeKind],
+        queryKey: ['categories', categoryId, 'attribute_groups', targetObjectTypeId],
       });
       await queryClient.invalidateQueries({
-        queryKey: ['categories', categoryId, 'effective-groups', targetObjectTypeKind],
+        queryKey: ['categories', categoryId, 'effective-groups', targetObjectTypeId],
       });
       onDeclared();
       onOpenChange(false);

--- a/apps/admin/src/features/catalog/categories/list.tsx
+++ b/apps/admin/src/features/catalog/categories/list.tsx
@@ -206,6 +206,7 @@ export function CategoriesTreePage() {
           {selectedId ? (
             <CategoryDetailPanel
               categoryId={selectedId}
+              targetObjectTypeId={targetObjectTypeId}
               targetType={targetType}
               locale={i18n.language}
               tree={tree}
@@ -227,11 +228,13 @@ export function CategoriesTreePage() {
 
 function CategoryDetailPanel({
   categoryId,
+  targetObjectTypeId,
   targetType,
   locale,
   tree,
 }: {
   categoryId: string;
+  targetObjectTypeId: string;
   targetType: string;
   locale: string;
   tree: CategoryTreeNode[];
@@ -241,23 +244,27 @@ function CategoryDetailPanel({
 
   const node = useMemo(() => findNode(tree, categoryId), [tree, categoryId]);
 
+  // ADR-015 — resolve declared/effective groups by ObjectType id so custom-OT
+  // category trees work (kind='custom' has no single built-in OT).
   const { data: declared, refetch: refetchDeclared } = useQuery<DeclaredGroupsResponse>({
-    queryKey: ['categories', categoryId, 'attribute_groups', targetType],
+    queryKey: ['categories', categoryId, 'attribute_groups', targetObjectTypeId],
     queryFn: () =>
       jsonFetch<DeclaredGroupsResponse>(
-        `/api/categories/${categoryId}/attribute_groups?targetObjectTypeKind=${targetType}`,
+        `/api/categories/${categoryId}/attribute_groups?targetObjectTypeId=${targetObjectTypeId}`,
         { accept: 'application/json' },
       ),
+    enabled: targetObjectTypeId !== '',
     staleTime: 10_000,
   });
 
   const { data: effective, refetch: refetchEffective } = useQuery<EffectiveResponse>({
-    queryKey: ['categories', categoryId, 'effective-groups', targetType],
+    queryKey: ['categories', categoryId, 'effective-groups', targetObjectTypeId],
     queryFn: () =>
       jsonFetch<EffectiveResponse>(
-        `/api/categories/${categoryId}/effective-groups?objectTypeKind=${targetType}`,
+        `/api/categories/${categoryId}/effective-groups?objectTypeId=${targetObjectTypeId}`,
         { accept: 'application/json' },
       ),
+    enabled: targetObjectTypeId !== '',
     staleTime: 10_000,
   });
 
@@ -510,6 +517,7 @@ function CategoryDetailPanel({
         open={declareOpen}
         onOpenChange={setDeclareOpen}
         categoryId={categoryId}
+        targetObjectTypeId={targetObjectTypeId}
         targetObjectTypeKind={targetType}
         declaredGroupIds={declaredGroupIds}
         inheritedFromMap={inheritedFromMap}

--- a/apps/admin/src/features/catalog/categories/new.tsx
+++ b/apps/admin/src/features/catalog/categories/new.tsx
@@ -137,11 +137,18 @@ export function CategoryCreatePage() {
       });
       const newId = created.id;
       await queryClient.invalidateQueries({ queryKey: ['categories'] });
-      if (newId) {
-        navigate(`/modeling/categories?selected=${newId}`);
-      } else {
-        navigate('/modeling/categories');
+      // ADR-015 — return to the SAME tree the category was created in, else
+      // the list defaults to the first tree (Product) and the freshly created
+      // category is invisible until the operator re-picks its ObjectType.
+      const params = new URLSearchParams();
+      if (targetObjectTypeId) {
+        params.set('targetObjectTypeId', targetObjectTypeId);
+        const targetKind = (objectTypes.data ?? []).find((t) => t.id === targetObjectTypeId)?.kind;
+        if (targetKind) params.set('targetType', targetKind);
       }
+      if (newId) params.set('selected', newId);
+      const qs = params.toString();
+      navigate(qs ? `/modeling/categories?${qs}` : '/modeling/categories');
     } catch (err) {
       setError(
         err instanceof HttpError

--- a/apps/api/src/Catalog/Presentation/Controller/CategoryAttributeGroupController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CategoryAttributeGroupController.php
@@ -71,7 +71,10 @@ final class CategoryAttributeGroupController
     public function list(string $id, Request $request): JsonResponse
     {
         $category = $this->fetchCategory($id);
-        $targetType = $this->resolveTargetType($request->query->get('targetObjectTypeKind'));
+        $targetType = $this->resolveTargetTypeByIdOrKind(
+            $request->query->get('targetObjectTypeId'),
+            $request->query->get('targetObjectTypeKind'),
+        );
 
         $rows = $this->junctions->findByCategoryAndTarget($category, $targetType);
 
@@ -121,11 +124,15 @@ final class CategoryAttributeGroupController
         $payload = $this->decodePayload($request);
         $groupId = $payload['groupId'] ?? null;
         $kindParam = $payload['targetObjectTypeKind'] ?? null;
+        $idParam = $payload['targetObjectTypeId'] ?? null;
 
         if (!\is_string($groupId) || '' === $groupId) {
             throw new UnprocessableEntityHttpException('Field "groupId" is required.');
         }
-        $targetType = $this->resolveTargetType(\is_string($kindParam) ? $kindParam : null);
+        $targetType = $this->resolveTargetTypeByIdOrKind(
+            \is_string($idParam) ? $idParam : null,
+            \is_string($kindParam) ? $kindParam : null,
+        );
 
         try {
             $groupUuid = Uuid::fromString($groupId);
@@ -238,6 +245,33 @@ final class CategoryAttributeGroupController
         }
 
         return $category;
+    }
+
+    /**
+     * ADR-015 — resolve the target ObjectType for a category's group
+     * declaration. `targetObjectTypeId` (UUID) takes precedence and supports
+     * custom-OT category trees; `targetObjectTypeKind` stays as the built-in
+     * fallback for backward compatibility.
+     */
+    private function resolveTargetTypeByIdOrKind(
+        ?string $idParam,
+        ?string $kindParam,
+    ): \App\Catalog\Domain\Entity\ObjectType {
+        if (\is_string($idParam) && '' !== $idParam) {
+            try {
+                $uuid = Uuid::fromString($idParam);
+            } catch (InvalidArgumentException $e) {
+                throw new BadRequestHttpException(\sprintf('Invalid targetObjectTypeId "%s".', $idParam), $e);
+            }
+            $type = $this->objectTypes->findById($uuid);
+            if (null === $type) {
+                throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $idParam));
+            }
+
+            return $type;
+        }
+
+        return $this->resolveTargetType($kindParam);
     }
 
     private function resolveTargetType(?string $kindParam): \App\Catalog\Domain\Entity\ObjectType

--- a/apps/api/src/Catalog/Presentation/Controller/CategoryEffectiveGroupsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CategoryEffectiveGroupsController.php
@@ -10,6 +10,7 @@ use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -60,24 +61,38 @@ final class CategoryEffectiveGroupsController
     #[RequiresPermission(module: 'categories', action: 'view')]
     public function __invoke(string $id, Request $request): JsonResponse
     {
-        $kindParam = $request->query->get('objectTypeKind');
-        if (!\is_string($kindParam) || '' === $kindParam) {
-            throw new BadRequestHttpException('objectTypeKind query parameter is required.');
-        }
-        try {
-            $kind = ObjectKind::from($kindParam);
-        } catch (ValueError $e) {
-            throw new BadRequestHttpException(\sprintf('Unknown objectTypeKind "%s".', $kindParam), $e);
-        }
-
         $tenant = $this->tenantContext->get();
         if (null === $tenant) {
             throw new BadRequestHttpException('No tenant context.');
         }
 
-        $type = $this->objectTypes->findBuiltInByKind($kind, $tenant);
-        if (null === $type) {
-            throw new NotFoundHttpException(\sprintf('Built-in ObjectType for kind "%s" not found.', $kindParam));
+        // ADR-015 — `objectTypeId` (UUID) takes precedence and supports custom
+        // ObjectType category trees; `objectTypeKind` stays as the built-in
+        // fallback for backward compatibility.
+        $objectTypeIdParam = $request->query->get('objectTypeId');
+        if (\is_string($objectTypeIdParam) && '' !== $objectTypeIdParam) {
+            try {
+                $type = $this->objectTypes->findById(Uuid::fromString($objectTypeIdParam));
+            } catch (InvalidArgumentException $e) {
+                throw new BadRequestHttpException(\sprintf('Invalid objectTypeId "%s".', $objectTypeIdParam), $e);
+            }
+            if (null === $type) {
+                throw new NotFoundHttpException(\sprintf('ObjectType "%s" was not found.', $objectTypeIdParam));
+            }
+        } else {
+            $kindParam = $request->query->get('objectTypeKind');
+            if (!\is_string($kindParam) || '' === $kindParam) {
+                throw new BadRequestHttpException('objectTypeId or objectTypeKind query parameter is required.');
+            }
+            try {
+                $kind = ObjectKind::from($kindParam);
+            } catch (ValueError $e) {
+                throw new BadRequestHttpException(\sprintf('Unknown objectTypeKind "%s".', $kindParam), $e);
+            }
+            $type = $this->objectTypes->findBuiltInByKind($kind, $tenant);
+            if (null === $type) {
+                throw new NotFoundHttpException(\sprintf('Built-in ObjectType for kind "%s" not found.', $kindParam));
+            }
         }
 
         $category = $this->objects->findById(Uuid::fromString($id));

--- a/apps/api/tests/Api/Catalog/CategoryAttributeGroupApiTest.php
+++ b/apps/api/tests/Api/Catalog/CategoryAttributeGroupApiTest.php
@@ -222,4 +222,53 @@ final class CategoryAttributeGroupApiTest extends CatalogApiTestCase
 
         return $group->getId()->toRfc4122();
     }
+
+    #[Test]
+    public function declareByObjectTypeIdWorksForCustomTree(): void
+    {
+        // ADR-015 PR-E — declaring a group on a custom-OT category tree via
+        // targetObjectTypeId works (previously kind='custom' → 404
+        // "Built-in ObjectType for kind 'custom' not found").
+        $client = $this->authenticatedClient();
+        $customOt = $this->seedCategorizableObjectType('cars_declare', 'Cars declare');
+        $categoryId = $client->request('POST', '/api/categories', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'cars_root',
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $customOt,
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray()['id'] ?? null;
+        \assert(\is_string($categoryId));
+        $groupId = $this->createBusinessGroup('cars_group');
+
+        $response = $client->request('POST', "/api/categories/{$categoryId}/attribute_groups", [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([
+                'groupId' => $groupId,
+                'targetObjectTypeId' => $customOt,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $targetObjectType = $response->toArray()['targetObjectType'] ?? null;
+        \assert(\is_array($targetObjectType));
+        self::assertSame($customOt, $targetObjectType['id'] ?? null);
+    }
+
+    private function seedCategorizableObjectType(string $code, string $label): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $ctx = self::getContainer()->get(\App\Shared\Application\TenantContext::class);
+        $ctx->set($tenant);
+
+        $ot = new \App\Catalog\Domain\Entity\ObjectType($code, ObjectKind::Custom, ['pl' => $label, 'en' => $label]);
+        $ot->setCategorizable(true);
+        $em = $this->em();
+        $em->persist($ot);
+        $em->flush();
+        $ctx->clear();
+
+        return $ot->getId()->toRfc4122();
+    }
 }


### PR DESCRIPTION
## Summary
Dwa bugi zgłoszone przez operatora przy drzewach kategorii custom-ObjectType (Samochody):

1. **Declare grupy na węźle drzewa custom-OT** → błąd „Built-in ObjectType for kind 'custom' not found". Endpointy `category_attribute_groups` (list/declare) i `effective-groups` rozwiązywały target przez `findBuiltInByKind(kind)` — dla `kind='custom'` brak odpowiedzi. Teraz akceptują `targetObjectTypeId`/`objectTypeId` (UUID) z precedencją nad fallbackiem kind; FE (panel + dialog declare) przekazują id drzewa.
2. **Redirect po utworzeniu kategorii** gubił scope → lista otwierała się na pierwszym drzewie (Produkt), nowa kategoria niewidoczna. Teraz wraca na to samo drzewo (`targetObjectTypeId` + `targetType`).

## Backend changes
- `CategoryAttributeGroupController` (list+declare): nowy `resolveTargetTypeByIdOrKind` — preferuje `targetObjectTypeId` (findById), fallback kind. detach/reorder już były objectId-based.
- `CategoryEffectiveGroupsController`: akceptuje `objectTypeId` (precedencja), fallback `objectTypeKind`.

## Frontend changes
- `categories/list.tsx` (CategoryDetailPanel): fetche declared/effective po `targetObjectTypeId`.
- `declare-attribute-group-dialog.tsx`: POST body `targetObjectTypeId`, invalidate po id.
- `categories/new.tsx`: redirect po create zachowuje `targetObjectTypeId` + `targetType`.

## Quality gates
- PHPStan max: **0**
- PHPUnit: `CategoryAttributeGroupApiTest` **9/9** + nowy `declareByObjectTypeIdWorksForCustomTree`; fallback kind bez regresji.
- TypeScript noEmit + Biome + Vite build: green.
- **Live smoke**: enable categorizable na „Salony" → utwórz kategorię → **declare grupy przez objectId → 201**; list po objectId zwraca grupę; redirect ląduje na właściwym drzewie. Stan przywrócony.

Domyka połowę kind→objectId z #1121 (declare/list/effective). Refs #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)