### PR TITLE
fix(admin): drzewo kategorii widoczne przy pierwszym wejściu /modeling/categories

### DIFF
--- a/apps/admin/e2e/categories-first-load.spec.ts
+++ b/apps/admin/e2e/categories-first-load.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1126 — /modeling/categories must show the (Product) tree on a fresh visit
+ * without the operator manually toggling the ObjectType selector.
+ *
+ * Regression: the selector emitted its auto-selected ObjectType via a
+ * render-phase setSearchParams, which React applied unreliably; the list
+ * `useList` is gated on that URL param, so the tree rendered empty on first
+ * load. Moving the auto-select into a post-commit useEffect stamps the URL
+ * reliably.
+ *
+ * Marked `fixme` in CI for the shared-suite auth rate-limiter reason
+ * (see settings-channels-crud.spec.ts).
+ */
+const E2E_BLOCKED_BY_RATE_LIMITER =
+  'Pending storageState rollout: spec lands after the 5/15min auth rate limiter is exhausted';
+
+test.describe('#1126 — categories first-load', () => {
+  test('fresh visit auto-selects a tree and lists its categories', async ({ page }) => {
+    test.fixme(true, E2E_BLOCKED_BY_RATE_LIMITER);
+    await loginAsAdmin(page);
+    await page.goto('/modeling/categories'); // clean URL, no targetObjectTypeId
+    await page.waitForTimeout(2500);
+
+    // The selector auto-stamps its ObjectType id into the URL post-commit.
+    await expect(page).toHaveURL(/targetObjectTypeId=[0-9a-f-]{36}/);
+    // The Product tree's seeded demo categories are visible without any toggle.
+    await expect(page.getByText(/apparel|footwear|outdoor|odzie|obuwie/i).first()).toBeVisible();
+  });
+});

--- a/apps/admin/src/components/modeling/object-type-filter-dropdown.tsx
+++ b/apps/admin/src/components/modeling/object-type-filter-dropdown.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { jsonFetch } from '@/lib/http';
@@ -77,11 +78,21 @@ export function ObjectTypeFilterDropdown({ value, onChange, className }: Props) 
   // Auto-select the first option when the URL param doesn't match anything
   // in the fetched list (initial render OR after the operator demoted the
   // previously-selected OT via toggle).
+  //
+  // #1126 — this MUST run in an effect, not during render. The parent
+  // (CategoriesTreePage) gates its category `useList` on the URL param this
+  // emits; calling `onChange` (→ setSearchParams) during a child's render is
+  // unreliable in React and left the param empty on first load, so the tree
+  // rendered empty until the operator manually toggled the select. A
+  // post-commit effect stamps the URL reliably → the list enables + loads.
   const firstOption = options[0];
   const valueMatches = options.some((ot) => ot.id === value);
-  if (!query.isLoading && firstOption !== undefined && !valueMatches) {
-    onChange(firstOption.id, firstOption.kind);
-  }
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `onChange` is recreated each render by the parent; `valueMatches` gates re-emits so omitting it avoids a render loop.
+  useEffect(() => {
+    if (!query.isLoading && firstOption !== undefined && !valueMatches) {
+      onChange(firstOption.id, firstOption.kind);
+    }
+  }, [query.isLoading, firstOption?.id, firstOption?.kind, valueMatches]);
 
   if (query.isLoading) {
     return (


### PR DESCRIPTION
## Summary
Przy pierwszym wejściu na `/modeling/categories` drzewo było puste mimo zaznaczonego „Produkt" — dopiero przełączenie selecta je pokazywało. Fix: auto-select OT w `ObjectTypeFilterDropdown` przeniesiony z fazy renderu do `useEffect`.

## Root cause
Selektor auto-wybierał pierwszy categorizable OT przez `onChange`→`setSearchParams` **w fazie renderu**. Wywołanie setState rodzica podczas renderu dziecka jest w React niepewne → URL param `targetObjectTypeId` pozostawał pusty przy pierwszym ładowaniu. `CategoriesTreePage` gatuje `useList` na tym paramie (`enabled: targetObjectTypeId !== ''`) → pusta lista. Select pokazywał „Produkt" tylko jako fallback wizualny (`value ?? firstOption?.id`). Regresja z PR-C #1123.

## Frontend changes
- `object-type-filter-dropdown.tsx`: auto-select w `useEffect` (post-commit), gated przez `valueMatches` (brak pętli). `biome-ignore` dla `useExhaustiveDependencies` (onChange recreated each render).

## Quality gates
- TypeScript noEmit: 0, Biome strict: 0, Vite build: green.
- **Browser smoke**: świeże wejście na `/modeling/categories` → URL dostaje `?targetObjectTypeId=…&targetType=product`, drzewo Produkt (apparel/footwear/outdoor) widoczne **bez** przełączania; brak „Brak kategorii…".
- Playwright `categories-first-load.spec.ts` (`test.fixme` w CI — rate limiter).

**End-to-end smoke-tested** lokalnie w przeglądarce.

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)