### PR TITLE
fix(asset): miniatury multimediów nie renderują się — 403 na /preview

### DIFF
--- a/apps/api/src/Asset/Presentation/Controller/PreviewAssetController.php
+++ b/apps/api/src/Asset/Presentation/Controller/PreviewAssetController.php
@@ -7,7 +7,7 @@ namespace App\Asset\Presentation\Controller;
 use App\Asset\Domain\Entity\AssetVariant;
 use App\Asset\Domain\Repository\AssetRepositoryInterface;
 use App\Asset\Domain\ThumbnailsStatus;
-use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Attribute\NoPermissionRequired;
 use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
@@ -50,7 +50,7 @@ final readonly class PreviewAssetController
     }
 
     #[Route(path: '/api/assets/{id}/preview', name: 'pim_assets_preview', methods: ['GET'])]
-    #[RequiresPermission(module: 'asset', action: 'read')]
+    #[NoPermissionRequired(reason: 'Registered under PUBLIC_ACCESS in security.yaml — <img> tags cannot send the Bearer token. Path-knowledge (UUID v7, 128-bit, non-enumerable) gates access; tenant isolation is by-id inside the handler. A RequiresPermission gate here would 403 every <img> request (anonymous principal) and break all thumbnails.')]
     public function __invoke(string $id, ?string $variant = null): StreamedResponse
     {
         $assetId = Uuid::fromString($id);

--- a/apps/api/tests/Api/Asset/AssetPreviewPublicAccessApiTest.php
+++ b/apps/api/tests/Api/Asset/AssetPreviewPublicAccessApiTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Asset;
+
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression for #1143 — asset thumbnails (`<img src="/api/assets/{id}/preview">`)
+ * returned 403 for every request because the controller carried
+ * `#[RequiresPermission]` while the route is `PUBLIC_ACCESS`: an `<img>`
+ * tag cannot send the Bearer token, so the request is anonymous and the
+ * EndpointGuardListener rejected it before the controller ran.
+ *
+ * The endpoint must be reachable anonymously — an unknown asset yields a
+ * 404 (handler reached), never a 401/403 (guard short-circuit).
+ */
+final class AssetPreviewPublicAccessApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function previewIsReachableAnonymouslyAndReturns404ForUnknownAsset(): void
+    {
+        // No Authorization header — mirrors a browser `<img>` request.
+        $client = static::createClient();
+        $client->request('GET', '/api/assets/00000000-0000-0000-0000-000000000000/preview');
+
+        // 404 = controller ran and found no asset. 401/403 would mean the
+        // RBAC guard blocked the anonymous request (the #1143 regression).
+        self::assertResponseStatusCodeSame(404);
+    }
+}


### PR DESCRIPTION
## Summary
Miniatury assetów (`<img src="/api/assets/{id}/preview">`) zwracały 403 dla każdego żądania — na liście `/assets` i w zakładce Multimedia obiektu.

## Root cause
Trasa `/api/assets/{id}/preview` jest `PUBLIC_ACCESS` w `security.yaml` (bo `<img>` nie wyśle nagłówka `Authorization: Bearer`), ale kontroler miał `#[RequiresPermission(module:'asset', action:'read')]`. `EndpointGuardListener` przy anonimowym principalu rzuca `PermissionDeniedException` → 403, zanim kontroler się wykona.

## Fix
Zamiana `#[RequiresPermission]` → `#[NoPermissionRequired(reason: ...)]`. Dostęp gated nieodgadywalnością UUID v7 + izolacja tenanta liczona w handlerze (zgodnie z kontraktem opisanym w `security.yaml`).

## Backend changes
- `PreviewAssetController` — `#[NoPermissionRequired]` zamiast `#[RequiresPermission]`.

## Quality gates
- PHPStan max: 0 (zmienione pliki).
- PHPUnit: nowy `AssetPreviewPublicAccessApiTest` — anonimowy GET `/preview` dla nieznanego assetu → 404 (regresja: wcześniej 403). 1/1 zielony.
- Pełny PHPUnit + audyty w CI.

## Smoke test plan (po merge)
Login (admin@demo.localhost / changeme) → `/assets` → miniatury widoczne; produkt → zakładka Multimedia → miniatury; brak 403 w DevTools Network. Curl: `GET /api/assets/{realny-id}/preview` bez tokena → 200.

## Świadome odejścia
Brak Playwright E2E — zmiana czysto backendowa (atrybut auth), bez modyfikacji FE; weryfikacja przez ApiTestCase + live curl smoke. Hardening signed-URL pozostaje follow-upem Fazy 1 (jak w komentarzu `security.yaml`).

Closes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)