### PR TITLE
fix(admin): /settings/ — redirect do pierwszej zakładki (Bezpieczeństwo)

### DIFF
--- a/apps/admin/e2e/settings-index-redirect.spec.ts
+++ b/apps/admin/e2e/settings-index-redirect.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1142 — the Settings landing (`/settings`) must redirect to the first
+ * tab (Security / Bezpieczeństwo), which every authenticated user can
+ * reach (own MFA + password). Previously it pointed at `/settings/menu`.
+ */
+test('Settings index redirects to the Security tab', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  await page.goto('/settings');
+
+  await expect(page).toHaveURL(/\/settings\/security$/);
+});

--- a/apps/admin/src/features/settings/SettingsIndex.tsx
+++ b/apps/admin/src/features/settings/SettingsIndex.tsx
@@ -1,5 +1,8 @@
 import { Navigate } from 'react-router';
 
 export function SettingsIndex() {
-  return <Navigate to="/settings/menu" replace />;
+  // Settings landing redirects to the first tab (Security / Bezpieczeństwo),
+  // which is the first nav item and is available to every authenticated user
+  // (own MFA + password). Previously pointed at /settings/menu. Refs #1142.
+  return <Navigate to="/settings/security" replace />;
 }


### PR DESCRIPTION
## Summary
Po kliknięciu „Ustawienia" wejście na `/settings/` przekierowuje teraz na pierwszą zakładkę **Bezpieczeństwo** (`/settings/security`), zamiast na `/settings/menu`.

## Root cause
`SettingsIndex.tsx` robił `<Navigate to="/settings/menu" replace />`, a pierwsza zakładka w `SettingsLayout` (grupa „account") to `/settings/security`.

## Frontend changes
- `SettingsIndex.tsx` — redirect na `/settings/security`. Zakładka jest dostępna dla każdego zalogowanego użytkownika (własne MFA + hasło), więc redirect jest bezpieczny dla wszystkich ról.

## Tests
- `e2e/settings-index-redirect.spec.ts` — `/settings` → URL kończy się na `/settings/security`.

## Quality gates
- Biome strict: 0 błędów (warningi tylko pre-existing w innym pliku).
- Typecheck / Vite build / Playwright — w CI.

## Smoke test plan (po merge)
Login (admin@demo.localhost / changeme) → klik „Ustawienia" → ląduje na `/settings/security`.

## Świadome odejścia
Brak — zmiana 1-liniowa + spec.

Closes #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)