### PR TITLE
fix(objects): uniwersalny przycisk Dodaj zamiast Nowy produkt

### DIFF
--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -661,7 +661,7 @@ export function UniversalListPage({
         <Button asChild className="h-11 rounded-2xl px-4">
           <Link to={createPath}>
             <Plus className="size-4" />
-            {t('products.toolbar.new_product', { defaultValue: 'Dodaj' })}
+            {t('products.toolbar.add', { defaultValue: 'Dodaj' })}
             <kbd className="ml-1.5 rounded bg-white/15 px-1 py-0.5 font-mono text-[10px]">⌘N</kbd>
           </Link>
         </Button>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1349,6 +1349,7 @@
       "more_filters": "More",
       "import": "Import",
       "new_product": "New product",
+      "add": "Add",
       "channel_filter_pending": "Per-channel filter waits for epic 0.6 (channel_publications)"
     },
     "counter": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1380,6 +1380,7 @@
       "more_filters": "Więcej",
       "import": "Import",
       "new_product": "Nowy produkt",
+      "add": "Dodaj",
       "channel_filter_pending": "Filtr per kanał czeka na epik 0.6 (channel_publications)"
     },
     "counter": {


### PR DESCRIPTION
## Summary
Na listach custom object (`/objects/:slug`, np. Salony sprzedaży, Samochody) przycisk tworzenia pokazywał „Nowy produkt". Teraz pokazuje neutralne „Dodaj".

## Root cause
`universal-list-page.tsx` (wspólny komponent dla wszystkich ObjectType) miał na sztywno `t('products.toolbar.new_product')` = „Nowy produkt".

## Frontend changes
- Nowy klucz i18n `products.toolbar.add` = „Dodaj" / „Add" (pl + en).
- `universal-list-page.tsx` używa `products.toolbar.add`. Dedykowana lista produktów zachowuje własny `new_product`.

## Quality gates
- Biome strict: 0 błędów.
- Typecheck / Vite build / Playwright — w CI.

## Smoke test plan (po merge)
Login → `/objects/salony_sprzedazy` → przycisk „Dodaj" (nie „Nowy produkt").

## Świadome odejścia
Brak E2E — zmiana wyłącznie etykiety (i18n); weryfikacja przez i18n parity + typecheck + smoke.

Closes #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
