### PR TITLE
fix(catalog): ukryj systemowe atrybuty audytowe z listy modelowania

### DIFF
--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -83,8 +83,17 @@ export function AttributesListPage() {
   const optionCounts = useOptionCounts(attributes);
 
   const visible = attributes.filter((row) => {
-    if (filter === 'system' && row.system !== true) return false;
-    if (filter !== 'all' && filter !== 'system' && row.type !== filter) return false;
+    // System audit attributes (created_at/updated_at/created_by/updated_by)
+    // are read-only infrastructure — hide them from the default ("all") and
+    // type-filtered views, surfacing them only under the dedicated "system"
+    // chip. Refs #1136.
+    if (filter === 'system') {
+      if (row.system !== true) return false;
+    } else if (row.system === true) {
+      return false;
+    } else if (filter !== 'all' && row.type !== filter) {
+      return false;
+    }
     if (query.length > 0) {
       const q = query.toLowerCase();
       const code = row.code.toLowerCase();


### PR DESCRIPTION
## Summary
Atrybuty systemowe (`created_at`, `updated_at`, `created_by`, `updated_by`) nie zaśmiecają już domyślnej listy modelowania `/modeling/attributes`. Są ukryte z widoku „Wszystkie" i widoków filtrowanych po typie; widoczne tylko pod istniejącym chipem „Systemowe".

## Root cause
Lista filtrowała: chip „Systemowe" → tylko systemowe, chip-typ → dany typ, ale `all` pokazywał wszystko **łącznie z systemowymi**. Pola audytowe (read-only, `markSystem()`) mieszały się z atrybutami biznesowymi.

## Frontend changes
- `attributes/list.tsx` — predykat filtra: systemowe (`row.system === true`) widoczne wyłącznie pod chipem „Systemowe"; ukryte w `all` i filtrach typu.

## Quality gates
- Biome strict: 0.
- Typecheck / Vite build — w CI.

## Smoke test plan (po merge)
Login → `/modeling/attributes` → brak `created_at/updated_at/created_by/updated_by` w domyślnym widoku → klik chip „Systemowe" → systemowe widoczne.

## Świadome odejścia
Brak nowego Playwright — istniejący `attributes-delete.spec.ts` jest `test.fixme` w CI (wyczerpany auth rate-limiter 5/15min, udokumentowane w repo); zmiana to czysty predykat client-side. Coverage: typecheck + manual smoke (zgodnie z wzorcem repo).

Closes #1136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
