### PR TITLE
fix(catalog): własne presety Smart Filter scope per resource

### DIFF
--- a/apps/admin/src/lib/filters/use-smart-presets.ts
+++ b/apps/admin/src/lib/filters/use-smart-presets.ts
@@ -90,7 +90,11 @@ export function useSmartPresets({
   const create: UseSmartPresetsResult['create'] = async (input) => {
     const created = await jsonFetch<SmartFilterPreset>('/api/smart-filter-presets', {
       method: 'POST',
-      body: input,
+      // Scope the new preset to the current resource (ObjectType code) so it
+      // appears in this list's load(), which filters `resource = :resource OR
+      // resource IS NULL`. Without it the backend defaults to 'products' and
+      // the preset is invisible on custom-object lists. Refs #1145.
+      body: { ...input, resource },
     });
     await load();
     return created;

--- a/apps/api/tests/Api/Catalog/SmartFilterPresetsApiTest.php
+++ b/apps/api/tests/Api/Catalog/SmartFilterPresetsApiTest.php
@@ -106,6 +106,56 @@ final class SmartFilterPresetsApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function resourceScopedPresetAppearsOnlyForItsResource(): void
+    {
+        $client = $this->authenticatedClient();
+
+        // #1145 regression: the FE must send `resource` on create. Without
+        // it the backend defaults to 'products', so a preset created from a
+        // custom-object list (e.g. `samochody`) was filtered out of that
+        // list's `?resource=samochody` fetch and never appeared.
+        $client->request('POST', '/api/smart-filter-presets', [
+            'json' => [
+                'name' => ['pl' => 'Samochody nowe', 'en' => 'New cars'],
+                'icon' => '🚗',
+                'query' => ['attr' => 'status', 'op' => '=', 'value' => 'new'],
+                'resource' => 'samochody',
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
+
+        // Visible when listing that resource (next to cross-kind NULL presets).
+        $forSamochody = $client->request('GET', '/api/smart-filter-presets?resource=samochody')->toArray();
+        self::assertContains('samochody-nowe', $this->slugsOf($forSamochody));
+
+        // Hidden when listing a different resource.
+        $forProducts = $client->request('GET', '/api/smart-filter-presets?resource=products')->toArray();
+        self::assertNotContains('samochody-nowe', $this->slugsOf($forProducts));
+    }
+
+    /**
+     * @param array<array-key, mixed> $body
+     *
+     * @return list<string>
+     */
+    private function slugsOf(array $body): array
+    {
+        $data = $body['data'] ?? [];
+        \assert(\is_array($data));
+
+        $slugs = [];
+        foreach ($data as $row) {
+            \assert(\is_array($row));
+            $slug = $row['slug'] ?? null;
+            if (\is_string($slug)) {
+                $slugs[] = $slug;
+            }
+        }
+
+        return $slugs;
+    }
+
+    #[Test]
     public function createRejectsMalformedName(): void
     {
         $client = $this->authenticatedClient();


### PR DESCRIPTION
## Summary
Własne presety Smart Filter dodawane na liście custom object (`/objects/:slug`, np. Samochody) pojawiają się teraz natychmiast i persystują. Wcześniej dodany preset nie wpadał do Smart Filtrów.

## Root cause
`useSmartPresets.create()` wysyłał POST `/api/smart-filter-presets` z `{name, icon, query}` **bez `resource`**. Backend domyślał wtedy `resource = 'products'` ([`SmartFilterPresetController.php:135`](apps/api/src/Catalog/Presentation/Controller/SmartFilterPresetController.php#L135)). Lista filtruje `resource = :resource OR resource IS NULL`, więc preset zapisany jako `products` był niewidoczny na liście `?resource=samochody`.

## Frontend changes
- `use-smart-presets.ts` — `create()` wysyła `resource` (kod ObjectType) w payloadzie: `body: { ...input, resource }`.

## Backend
- Bez zmian — endpoint już poprawnie obsługuje `resource`. Dodany test kontraktowy.

## Tests
- `SmartFilterPresetsApiTest::resourceScopedPresetAppearsOnlyForItsResource` — preset z `resource=samochody` widoczny przy `?resource=samochody`, ukryty przy `?resource=products`. PHPUnit 1/1, PHPStan max 0.

## Quality gates
- PHPStan max: 0. Biome strict: 0. PHPUnit nowy test zielony.
- Pełny PHPUnit + Playwright + typecheck w CI.

## Smoke test plan (po merge)
Login → `/objects/salony_sprzedazy` → dodaj preset Smart Filter → pojawia się natychmiast → reload → nadal jest.

## Świadome odejścia
Brak E2E custom-object (brak seedowanego custom OT w e2e + auth rate-limiter) — pokryte ApiTestCase kontraktu + manual smoke.

Closes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
