### PR TITLE
fix(identity): egzekwowanie MFA przy logowaniu (bypass)

### DIFF
--- a/apps/admin/src/features/identity/auth/login.tsx
+++ b/apps/admin/src/features/identity/auth/login.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useLogin } from '@refinedev/core';
+import { type AuthActionResponse, useLogin } from '@refinedev/core';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
@@ -15,81 +16,167 @@ const loginSchema = z.object({
   password: z.string().min(1),
 });
 
+const mfaSchema = z.object({
+  code: z.string().min(1),
+});
+
 type LoginValues = z.infer<typeof loginSchema>;
+type MfaValues = z.infer<typeof mfaSchema>;
+
+/** Variables accepted by the auth provider's `login` — password step OR 2FA step. */
+type LoginVariables = Partial<LoginValues> & { mfaToken?: string; code?: string };
+
+interface MfaChallengeResult {
+  mfaRequired?: boolean;
+  mfaToken?: string;
+}
 
 export function LoginPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { mutate: login, isPending } = useLogin<LoginValues>();
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    setError,
-  } = useForm<LoginValues>({ resolver: zodResolver(loginSchema) });
+  const { mutate: login, isPending } = useLogin<LoginVariables>();
 
-  const submit = handleSubmit((values) => {
+  // #1141 — once the password step reports `mfa_required`, we hold the
+  // short-lived challenge token and switch the form to the code step.
+  const [mfaToken, setMfaToken] = useState<string | null>(null);
+
+  const passwordForm = useForm<LoginValues>({ resolver: zodResolver(loginSchema) });
+  const mfaForm = useForm<MfaValues>({ resolver: zodResolver(mfaSchema) });
+
+  const goTo = (response: AuthActionResponse | undefined): void => {
+    const target = response?.redirectTo ?? '/dashboard';
+    navigate(typeof target === 'string' ? target : '/dashboard', { replace: true });
+  };
+
+  const submitPassword = passwordForm.handleSubmit((values) => {
     login(values, {
       onSuccess: (response) => {
-        // Refine collapses both validation and HTTP failures into a successful
-        // mutation with `success: false`; the routerProvider would normally
-        // honor the redirect — we do it manually since the admin uses plain
-        // react-router-7 instead of @refinedev/react-router.
-        if (response?.success === false) {
-          const message =
-            (response.error as { message?: string } | undefined)?.message ?? 'auth.login_failed';
-          setError('root', { message });
+        const result = response as (AuthActionResponse & MfaChallengeResult) | undefined;
+        if (result?.mfaRequired === true && typeof result.mfaToken === 'string') {
+          setMfaToken(result.mfaToken);
+          mfaForm.reset();
           return;
         }
-        const target = response?.redirectTo ?? '/dashboard';
-        navigate(typeof target === 'string' ? target : '/dashboard', { replace: true });
+        if (result?.success === false) {
+          passwordForm.setError('root', {
+            message: result.error?.message ?? 'auth.login_failed',
+          });
+          return;
+        }
+        goTo(result);
       },
       onError: () => {
-        setError('root', { message: 'auth.login_failed' });
+        passwordForm.setError('root', { message: 'auth.login_failed' });
       },
     });
   });
 
-  const rootErrorKey = errors.root?.message ?? null;
+  const submitMfa = mfaForm.handleSubmit((values) => {
+    if (mfaToken === null) {
+      return;
+    }
+    login(
+      { mfaToken, code: values.code },
+      {
+        onSuccess: (response) => {
+          if (response?.success === false) {
+            mfaForm.setError('root', {
+              message: response.error?.message ?? 'auth.mfa_invalid_code',
+            });
+            return;
+          }
+          goTo(response);
+        },
+        onError: () => {
+          mfaForm.setError('root', { message: 'auth.mfa_invalid_code' });
+        },
+      },
+    );
+  });
+
+  const backToPassword = (): void => {
+    setMfaToken(null);
+    mfaForm.reset();
+  };
+
+  const passwordRootError = passwordForm.formState.errors.root?.message ?? null;
+  const mfaRootError = mfaForm.formState.errors.root?.message ?? null;
+  const inMfaStep = mfaToken !== null;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4">
       <Card className="w-full max-w-sm">
         <CardHeader>
-          <CardTitle>{t('auth.login_title')}</CardTitle>
-          <CardDescription>{t('auth.login_subtitle')}</CardDescription>
+          <CardTitle>{inMfaStep ? t('auth.mfa_title') : t('auth.login_title')}</CardTitle>
+          <CardDescription>
+            {inMfaStep ? t('auth.mfa_subtitle') : t('auth.login_subtitle')}
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={submit} className="space-y-4" noValidate>
-            <div className="space-y-2">
-              <Label htmlFor="email">{t('auth.email')}</Label>
-              <Input
-                id="email"
-                type="email"
-                autoComplete="username"
-                aria-invalid={errors.email ? 'true' : 'false'}
-                {...register('email')}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">{t('auth.password')}</Label>
-              <Input
-                id="password"
-                type="password"
-                autoComplete="current-password"
-                aria-invalid={errors.password ? 'true' : 'false'}
-                {...register('password')}
-              />
-            </div>
-            {rootErrorKey ? (
-              <p className="text-sm text-destructive" role="alert">
-                {t(rootErrorKey)}
-              </p>
-            ) : null}
-            <Button type="submit" className="w-full" disabled={isPending}>
-              {isPending ? t('auth.submitting') : t('auth.submit')}
-            </Button>
-          </form>
+          {inMfaStep ? (
+            <form onSubmit={submitMfa} className="space-y-4" noValidate>
+              <div className="space-y-2">
+                <Label htmlFor="mfa-code">{t('auth.mfa_code')}</Label>
+                <Input
+                  id="mfa-code"
+                  type="text"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  autoFocus
+                  aria-invalid={mfaForm.formState.errors.code ? 'true' : 'false'}
+                  {...mfaForm.register('code')}
+                />
+              </div>
+              {mfaRootError ? (
+                <p className="text-sm text-destructive" role="alert">
+                  {t(mfaRootError)}
+                </p>
+              ) : null}
+              <Button type="submit" className="w-full" disabled={isPending}>
+                {isPending ? t('auth.submitting') : t('auth.mfa_submit')}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                className="w-full"
+                onClick={backToPassword}
+                disabled={isPending}
+              >
+                {t('auth.mfa_back')}
+              </Button>
+            </form>
+          ) : (
+            <form onSubmit={submitPassword} className="space-y-4" noValidate>
+              <div className="space-y-2">
+                <Label htmlFor="email">{t('auth.email')}</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  autoComplete="username"
+                  aria-invalid={passwordForm.formState.errors.email ? 'true' : 'false'}
+                  {...passwordForm.register('email')}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="password">{t('auth.password')}</Label>
+                <Input
+                  id="password"
+                  type="password"
+                  autoComplete="current-password"
+                  aria-invalid={passwordForm.formState.errors.password ? 'true' : 'false'}
+                  {...passwordForm.register('password')}
+                />
+              </div>
+              {passwordRootError ? (
+                <p className="text-sm text-destructive" role="alert">
+                  {t(passwordRootError)}
+                </p>
+              ) : null}
+              <Button type="submit" className="w-full" disabled={isPending}>
+                {isPending ? t('auth.submitting') : t('auth.submit')}
+              </Button>
+            </form>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/apps/admin/src/lib/auth-provider.ts
+++ b/apps/admin/src/lib/auth-provider.ts
@@ -18,6 +18,12 @@ interface LoginResponse {
   token: string;
 }
 
+/** #1141 — shape returned by /api/auth/login when the account has active MFA. */
+interface MfaChallenge {
+  mfa_required?: boolean;
+  mfa_token?: string;
+}
+
 interface MeResponse {
   id: string;
   email: string;
@@ -54,16 +60,52 @@ export interface MeIdentity {
  */
 export const authProvider: AuthProvider = {
   async login(payload) {
-    const { email, password } = payload as LoginPayload;
+    const { email, password, mfaToken, code } = payload as LoginPayload & {
+      mfaToken?: string;
+      code?: string;
+    };
+
+    // Second factor (#1141): redeem the challenge token minted after the
+    // password step for the real JWT. A wrong/expired code surfaces as a
+    // recoverable error so the UI can let the user retry.
+    if (typeof mfaToken === 'string' && mfaToken !== '') {
+      try {
+        const response = await jsonFetch<LoginResponse>('/api/auth/2fa/login', {
+          method: 'POST',
+          body: { mfa_token: mfaToken, code },
+          contentType: 'application/json',
+          accept: 'application/json',
+        });
+        setAccessToken(response.token);
+        return { success: true, redirectTo: '/dashboard' };
+      } catch {
+        return { success: false, error: { name: 'MfaError', message: 'auth.mfa_invalid_code' } };
+      }
+    }
+
+    // Password step.
     try {
-      const response = await jsonFetch<LoginResponse>('/api/auth/login', {
+      const response = await jsonFetch<Partial<LoginResponse> & MfaChallenge>('/api/auth/login', {
         method: 'POST',
         body: { email, password },
         contentType: 'application/json',
         accept: 'application/json',
       });
-      setAccessToken(response.token);
-      return { success: true, redirectTo: '/dashboard' };
+      if (response.mfa_required === true && typeof response.mfa_token === 'string') {
+        // Password accepted, but the account requires a second factor. Surface
+        // the challenge token so the UI can collect the TOTP / backup code.
+        return {
+          success: false,
+          error: { name: 'MfaRequired', message: 'auth.mfa_required' },
+          mfaRequired: true,
+          mfaToken: response.mfa_token,
+        };
+      }
+      if (typeof response.token === 'string') {
+        setAccessToken(response.token);
+        return { success: true, redirectTo: '/dashboard' };
+      }
+      return { success: false, error: { name: 'LoginError', message: 'auth.login_failed' } };
     } catch (error) {
       const message =
         error instanceof HttpError && error.status === 401

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -36,6 +36,13 @@
     "submitting": "Signing in...",
     "invalid_credentials": "Invalid email or password.",
     "login_failed": "Sign-in failed. Please try again.",
+    "mfa_title": "Two-factor verification",
+    "mfa_subtitle": "Enter the code from your authenticator app or a backup code.",
+    "mfa_code": "Verification code",
+    "mfa_submit": "Verify",
+    "mfa_back": "Back to sign in",
+    "mfa_required": "Two-factor verification required.",
+    "mfa_invalid_code": "Invalid or expired code. Please try again.",
     "session_expired": "Your session has expired. Please sign in again.",
     "first_login_password": {
       "title": "First sign-in — change your password",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -36,6 +36,13 @@
     "submitting": "Logowanie...",
     "invalid_credentials": "Nieprawidłowy e-mail lub hasło.",
     "login_failed": "Nie udało się zalogować. Spróbuj ponownie.",
+    "mfa_title": "Weryfikacja dwuetapowa",
+    "mfa_subtitle": "Wpisz kod z aplikacji uwierzytelniającej lub kod zapasowy.",
+    "mfa_code": "Kod weryfikacyjny",
+    "mfa_submit": "Zweryfikuj",
+    "mfa_back": "Wróć do logowania",
+    "mfa_required": "Wymagana weryfikacja dwuetapowa.",
+    "mfa_invalid_code": "Nieprawidłowy lub przeterminowany kod. Spróbuj ponownie.",
     "session_expired": "Sesja wygasła. Zaloguj się ponownie.",
     "first_login_password": {
       "title": "Pierwsze logowanie — zmień hasło",

--- a/apps/api/config/packages/security.yaml
+++ b/apps/api/config/packages/security.yaml
@@ -74,6 +74,10 @@ security:
         # must be reachable without an access token because the typical
         # caller has just had its access token expire.
         - { path: ^/api/auth/refresh, roles: PUBLIC_ACCESS }
+        # #1141 — second factor of login. The caller has passed the password
+        # step but holds no JWT yet; authority is the opaque, short-lived
+        # challenge token minted after the password step (see MfaLoginController).
+        - { path: ^/api/auth/2fa/login, roles: PUBLIC_ACCESS }
         # RBAC-P2-008 (#657) / P2-009 (#658) — magic-link accept + password
         # reset confirm are open by design: the token IS the auth factor.
         # /api/invitations/{token}/accept matches the path below; the

--- a/apps/api/src/Identity/Application/MfaLoginChallengeStore.php
+++ b/apps/api/src/Identity/Application/MfaLoginChallengeStore.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application;
+
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Short-lived, server-side challenge for the second factor of login (#1141).
+ *
+ * When a user with active TOTP passes password authentication, the login
+ * success handler does NOT mint a JWT — it parks the authenticated identity
+ * behind an opaque challenge token stored here (cache, 5-minute TTL). The
+ * dedicated `POST /api/auth/2fa/login` endpoint then exchanges
+ * `{mfa_token, code}` for the real JWT once the code verifies.
+ *
+ * The token is opaque random bytes — NOT a JWT — so on its own it can never
+ * satisfy the API firewall; it only unlocks the second-factor exchange. A
+ * bounded attempt counter caps online brute-force of the 6-digit code per
+ * password login without needing a separate rate limiter.
+ */
+final readonly class MfaLoginChallengeStore
+{
+    private const string KEY_PREFIX = 'mfa.login.';
+    private const int TTL_SECONDS = 300;
+    private const int MAX_ATTEMPTS = 5;
+
+    public function __construct(
+        private CacheItemPoolInterface $cache,
+        private UserRepositoryInterface $users,
+        private TotpEnrolmentService $enrolment,
+    ) {
+    }
+
+    /**
+     * Park a password-authenticated user behind a fresh challenge token.
+     */
+    public function issue(User $user): string
+    {
+        $token = bin2hex(random_bytes(32));
+        $item = $this->cache->getItem(self::KEY_PREFIX.$token);
+        $item->set(['uid' => $user->getId()->toRfc4122(), 'attempts' => 0]);
+        $item->expiresAfter(self::TTL_SECONDS);
+        $this->cache->save($item);
+
+        return $token;
+    }
+
+    /**
+     * Exchange a challenge token + second-factor code for the user.
+     *
+     * Returns null on an unknown/expired token, an invalid code, or once the
+     * attempt budget is exhausted (the challenge is discarded in that case).
+     * A successful exchange consumes the challenge so it cannot be replayed.
+     */
+    public function consume(string $token, string $code): ?User
+    {
+        if ('' === $token || '' === $code) {
+            return null;
+        }
+
+        $key = self::KEY_PREFIX.$token;
+        $item = $this->cache->getItem($key);
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        $data = $item->get();
+        $uid = null;
+        $attempts = 0;
+        if (\is_array($data)) {
+            $rawUid = $data['uid'] ?? null;
+            $uid = \is_string($rawUid) ? $rawUid : null;
+            $rawAttempts = $data['attempts'] ?? null;
+            $attempts = \is_int($rawAttempts) ? $rawAttempts : 0;
+        }
+
+        if (null === $uid || !Uuid::isValid($uid)) {
+            $this->cache->deleteItem($key);
+
+            return null;
+        }
+
+        $user = $this->users->findById(Uuid::fromString($uid));
+        if (!$user instanceof User || !$user->isTotpEnabled()) {
+            $this->cache->deleteItem($key);
+
+            return null;
+        }
+
+        if ($this->enrolment->verify($user, $code)) {
+            $this->cache->deleteItem($key);
+
+            return $user;
+        }
+
+        if (++$attempts >= self::MAX_ATTEMPTS) {
+            $this->cache->deleteItem($key);
+
+            return null;
+        }
+
+        $item->set(['uid' => $uid, 'attempts' => $attempts]);
+        $item->expiresAfter(self::TTL_SECONDS);
+        $this->cache->save($item);
+
+        return null;
+    }
+}

--- a/apps/api/src/Identity/Presentation/LoginSuccessHandler.php
+++ b/apps/api/src/Identity/Presentation/LoginSuccessHandler.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Identity\Presentation;
 
+use App\Identity\Application\MfaLoginChallengeStore;
 use App\Identity\Application\RefreshTokenService;
 use App\Identity\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -34,11 +36,26 @@ final readonly class LoginSuccessHandler implements AuthenticationSuccessHandler
         private AuthCookieFactory $cookies,
         private EntityManagerInterface $em,
         private ClockInterface $clock,
+        private MfaLoginChallengeStore $mfaChallenge,
     ) {
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token): ?Response
     {
+        $user = $token->getUser();
+
+        // Second factor required (#1141): the password step succeeded but the
+        // user has active TOTP. Do NOT mint a JWT or refresh cookie yet —
+        // park the identity behind a short-lived challenge the client redeems
+        // at POST /api/auth/2fa/login with a TOTP / backup code. Without this
+        // gate, enabling MFA had no effect on login.
+        if ($user instanceof User && $user->isTotpEnabled()) {
+            return new JsonResponse([
+                'mfa_required' => true,
+                'mfa_token' => $this->mfaChallenge->issue($user),
+            ]);
+        }
+
         $response = $this->inner->onAuthenticationSuccess($request, $token);
         if (!$response instanceof Response) {
             // Lexik never returns null in practice, but the interface allows
@@ -47,7 +64,6 @@ final readonly class LoginSuccessHandler implements AuthenticationSuccessHandler
             return $response;
         }
 
-        $user = $token->getUser();
         if (!$user instanceof User) {
             // Should never happen — the json_login firewall is wired to the
             // entity provider for App\Identity\Domain\Entity\User. If it

--- a/apps/api/src/Identity/Presentation/MfaLoginController.php
+++ b/apps/api/src/Identity/Presentation/MfaLoginController.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation;
+
+use App\Identity\Application\MfaLoginChallengeStore;
+use App\Identity\Application\RefreshTokenService;
+use App\Identity\Contracts\Attribute\NoPermissionRequired;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * POST /api/auth/2fa/login — second factor of login (#1141).
+ *
+ * Completes a login that {@see LoginSuccessHandler} parked because the user
+ * has active TOTP. Body: `{ "mfa_token": "...", "code": "123456" }` — the
+ * code may be a TOTP code or a one-shot backup code. On success it mints the
+ * JWT + refresh cookie exactly like the password step would have, and stamps
+ * the login.
+ *
+ * Anonymous (PUBLIC_ACCESS in security.yaml): the caller has no access token
+ * yet — authority comes from the opaque, short-lived challenge token minted
+ * after the password step, redeemed once here.
+ */
+final readonly class MfaLoginController
+{
+    public function __construct(
+        private MfaLoginChallengeStore $challenges,
+        private RefreshTokenService $refreshTokens,
+        private AuthCookieFactory $cookies,
+        private JWTTokenManagerInterface $jwtManager,
+        private EntityManagerInterface $em,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    #[Route(path: '/api/auth/2fa/login', methods: ['POST'], name: 'api_auth_2fa_login')]
+    #[NoPermissionRequired(reason: 'Second factor of login — caller holds no JWT yet; authority is the short-lived challenge token minted after the password step.')]
+    public function __invoke(Request $request): Response
+    {
+        $raw = $request->getContent();
+        try {
+            $body = json_decode('' === $raw ? '{}' : $raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->problem('Malformed JSON body.');
+        }
+        if (!\is_array($body)) {
+            return $this->problem('Malformed JSON body.');
+        }
+
+        $tokenRaw = $body['mfa_token'] ?? null;
+        $codeRaw = $body['code'] ?? null;
+        $mfaToken = \is_string($tokenRaw) ? $tokenRaw : '';
+        $code = match (true) {
+            \is_string($codeRaw) => trim($codeRaw),
+            \is_int($codeRaw) => (string) $codeRaw,
+            default => '',
+        };
+
+        $user = $this->challenges->consume($mfaToken, $code);
+        if (null === $user) {
+            return $this->problem('Invalid or expired challenge, or wrong verification code.');
+        }
+
+        $jwt = $this->jwtManager->create($user);
+        $user->recordLogin($this->clock->now());
+        $issued = $this->refreshTokens->issueForUser($user);
+        $this->em->flush();
+
+        $response = new JsonResponse(['token' => $jwt]);
+        $response->headers->setCookie($this->cookies->issue($issued['raw'], $this->clock->now()));
+
+        return $response;
+    }
+
+    private function problem(string $detail): JsonResponse
+    {
+        $status = Response::HTTP_UNAUTHORIZED;
+
+        return new JsonResponse(
+            [
+                'type' => 'about:blank',
+                'title' => Response::$statusTexts[$status],
+                'status' => $status,
+                'detail' => $detail,
+            ],
+            $status,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
+    }
+}

--- a/apps/api/tests/Api/Identity/MfaLoginApiTest.php
+++ b/apps/api/tests/Api/Identity/MfaLoginApiTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Application\TotpEnrolmentService;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use OTPHP\TOTP;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #1141 — second-factor enforcement on `POST /api/auth/login`.
+ *
+ * Before this ticket, enabling TOTP had no effect on login: the password
+ * step issued a JWT directly. Now a user with active TOTP is parked behind
+ * a challenge and must redeem `POST /api/auth/2fa/login` with a TOTP or
+ * backup code to get the JWT.
+ */
+final class MfaLoginApiTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_CODE = 'demo';
+    private const string MFA_EMAIL = 'mfa@demo.localhost';
+    private const string PLAIN_EMAIL = 'plain@demo.localhost';
+    private const string PASSWORD = 'changeme';
+
+    private string $totpSecret = '';
+    private string $backupCode = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+        $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        \assert(null !== $superAdmin);
+
+        $tenant = new Tenant(self::TENANT_CODE, 'Demo Tenant');
+        $em->persist($tenant);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $mfaUser = new User($tenant, self::MFA_EMAIL, '');
+        $mfaUser = new User($tenant, self::MFA_EMAIL, $hasher->hashPassword($mfaUser, self::PASSWORD));
+        $mfaUser->addRole($superAdmin);
+        $em->persist($mfaUser);
+
+        $plain = new User($tenant, self::PLAIN_EMAIL, '');
+        $plain = new User($tenant, self::PLAIN_EMAIL, $hasher->hashPassword($plain, self::PASSWORD));
+        $plain->addRole($superAdmin);
+        $em->persist($plain);
+        $em->flush();
+
+        // Activate TOTP for the MFA user via the service (mirrors enrol → confirm).
+        $enrolment = self::getContainer()->get(TotpEnrolmentService::class);
+        $enrol = $enrolment->enrol($mfaUser);
+        $secret = $enrol['secret'];
+        \assert('' !== $secret);
+        $enrolment->confirm($mfaUser, TOTP::createFromSecret($secret)->now());
+
+        $this->totpSecret = $secret;
+        $this->backupCode = $enrol['backup_codes'][0];
+    }
+
+    #[Test]
+    public function loginWithActiveMfaReturnsChallengeNotToken(): void
+    {
+        $client = static::createClient();
+        $body = $this->passwordStep($client);
+
+        self::assertTrue($body['mfa_required'] ?? false);
+        self::assertArrayHasKey('mfa_token', $body);
+        self::assertArrayNotHasKey('token', $body);
+    }
+
+    #[Test]
+    public function secondFactorWithValidTotpIssuesJwt(): void
+    {
+        $client = static::createClient();
+        $mfaToken = $this->mfaTokenFrom($this->passwordStep($client));
+
+        $response = $client->request('POST', '/api/auth/2fa/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(
+                ['mfa_token' => $mfaToken, 'code' => $this->totpNow()],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $out = $response->toArray();
+        self::assertArrayHasKey('token', $out);
+        $jwt = $out['token'];
+        self::assertIsString($jwt);
+        // A real, well-formed JWT (header.payload.signature) was minted —
+        // same path as a password-only login.
+        self::assertSame(2, substr_count($jwt, '.'));
+    }
+
+    private function totpNow(): string
+    {
+        $secret = $this->totpSecret;
+        \assert('' !== $secret);
+
+        return TOTP::createFromSecret($secret)->now();
+    }
+
+    #[Test]
+    public function secondFactorRejectsWrongCode(): void
+    {
+        $client = static::createClient();
+        $mfaToken = $this->mfaTokenFrom($this->passwordStep($client));
+
+        $client->request('POST', '/api/auth/2fa/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['mfa_token' => $mfaToken, 'code' => '000000'], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function secondFactorAcceptsBackupCode(): void
+    {
+        $client = static::createClient();
+        $mfaToken = $this->mfaTokenFrom($this->passwordStep($client));
+
+        $response = $client->request('POST', '/api/auth/2fa/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['mfa_token' => $mfaToken, 'code' => $this->backupCode], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertArrayHasKey('token', $response->toArray());
+    }
+
+    #[Test]
+    public function userWithoutMfaLogsInDirectly(): void
+    {
+        $client = static::createClient();
+        $response = $client->request('POST', '/api/auth/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(
+                ['email' => self::PLAIN_EMAIL, 'password' => self::PASSWORD],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+
+        self::assertResponseIsSuccessful();
+        $out = $response->toArray();
+        self::assertArrayHasKey('token', $out);
+        self::assertArrayNotHasKey('mfa_required', $out);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function passwordStep(Client $client): array
+    {
+        $response = $client->request('POST', '/api/auth/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(
+                ['email' => self::MFA_EMAIL, 'password' => self::PASSWORD],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+        self::assertResponseIsSuccessful();
+
+        return $response->toArray();
+    }
+
+    /**
+     * @param array<int|string, mixed> $body
+     */
+    private function mfaTokenFrom(array $body): string
+    {
+        $token = $body['mfa_token'] ?? null;
+        \assert(\is_string($token) && '' !== $token);
+
+        return $token;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
## Summary
Egzekwowanie drugiego składnika (MFA/TOTP) przy logowaniu. Wcześniej użytkownik z włączonym MFA mógł zalogować się samym e-mailem + hasłem — `LoginSuccessHandler` wystawiał JWT bez challenge'u (integracja login-flow była nieukończonym follow-upem). **Luka bezpieczeństwa.**

## Root cause
`LoginSuccessHandler::onAuthenticationSuccess` nigdy nie sprawdzał `isTotpEnabled()` — od razu wydawał JWT + refresh cookie. Endpointy enrol/verify/disable istniały, ale challenge przy `POST /api/auth/login` nie został podpięty.

## Backend changes
- **`MfaLoginChallengeStore`** — wydaje krótkożyciowy, nieprzewidywalny token wyzwania (cache `cache.app`, TTL 300s, licznik prób MAX 5). Token jest opaque (NIE JWT), więc sam nie przejdzie firewalla API.
- **`LoginSuccessHandler`** — gdy `isTotpEnabled()`: zamiast JWT zwraca `{ mfa_required: true, mfa_token }` (bez tokena, bez cookie, bez `recordLogin`).
- **`MfaLoginController`** — `POST /api/auth/2fa/login` (PUBLIC_ACCESS): wymienia `{mfa_token, code}` (TOTP lub kod zapasowy, przez `TotpEnrolmentService::verify`) na JWT + refresh cookie + `recordLogin`. Brute-force ograniczony licznikiem prób wyzwania.
- **`security.yaml`** — `^/api/auth/2fa/login` → PUBLIC_ACCESS.

## Frontend changes
- `auth-provider.ts` — `login()` obsługuje dwa kroki: hasło → (jeśli `mfa_required`) krok kodu → `2fa/login`.
- `login.tsx` — dwustopniowy formularz: e-mail/hasło → kod weryfikacyjny (TOTP lub zapasowy) + „Wróć do logowania".
- i18n pl/en (`auth.mfa_*`).

## Tests
- `MfaLoginApiTest` (5/5): login z MFA → challenge (bez tokena); poprawny TOTP → JWT; zły kod → 401; kod zapasowy → JWT; user bez MFA → token bezpośrednio. PHPStan max: 0.

## Live-stack smoke (pim.localhost, z cleanupem)
1. admin login → token. 2. enrol → secret. 3. verify → MFA on. 4. **fresh login → `mfa_required=true, has_token=false`**. 5. **2fa/login (TOTP) → `has_token=true`**. 6. bogus challenge → 401. 7. disable → MFA off. 8. admin login → token (stan przywrócony). **Działa end-to-end.**

## Quality gates
- PHPStan max 0 · Biome strict 0 · Typecheck 0 · PHPUnit MfaLoginApiTest 5/5 · OpenAPI: brak driftu (trasy custom auth poza eksportem AP).

## Świadome odejścia
- Brak osobnego Symfony rate-limitera na `2fa/login` — brute-force ograniczany licznikiem prób wyzwania (MAX 5/challenge, TTL 5 min). Audit log MFA jako ewentualny follow-up (istniejący login flow też nie audytuje).
- Brak Playwright MFA (wymaga znanego sekretu TOTP w przeglądarce) — pokryte ApiTestCase + live smoke.

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)
