### PR TITLE
refactor(modeling): usuń obsolete pola ObjectType (hierarchical/abstract/allowed-parent)

### DIFF
--- a/apps/admin/src/components/modeling/object-type-wizard.tsx
+++ b/apps/admin/src/components/modeling/object-type-wizard.tsx
@@ -82,11 +82,9 @@ export function ObjectTypeWizard() {
   const [code, setCode] = useState<string>('');
   const [icon, setIcon] = useState<string>(DEFAULT_WIZARD_ICONS[0]);
   const [color, setColor] = useState<string>(DEFAULT_WIZARD_COLORS[0]);
-  const [hierarchical, setHierarchical] = useState(false);
   const [hasVariants, setHasVariants] = useState(false);
   const [hasMultimedia, setHasMultimedia] = useState(false);
   const [isCategorizable, setIsCategorizable] = useState(false);
-  const [abstractFlag, setAbstractFlag] = useState(false);
   const [exposeToMainMenu, setExposeToMainMenu] = useState(false);
   const [pickedGroupIds, setPickedGroupIds] = useState<Set<string>>(new Set());
   // MODR-04 (#926) — display_mode per picked group. Defaults to 'tab'
@@ -216,9 +214,7 @@ export function ObjectTypeWizard() {
           ),
           icon,
           color,
-          hierarchical,
           hasVariants,
-          abstract: abstractFlag,
         },
       });
 
@@ -691,16 +687,6 @@ export function ObjectTypeWizard() {
                   {t('object_type_wizard.step_3_label', { defaultValue: 'Ustawienia' })}
                 </div>
                 <SettingToggleRow
-                  label={t('object_types.setting_hierarchical_label', {
-                    defaultValue: 'Is hierarchical',
-                  })}
-                  description={t('object_types.setting_hierarchical_desc', {
-                    defaultValue: 'Obiekty mogą tworzyć drzewo (jak Category)',
-                  })}
-                  checked={hierarchical}
-                  onChange={setHierarchical}
-                />
-                <SettingToggleRow
                   label={t('object_types.setting_variants_label', {
                     defaultValue: 'Czy mają warianty?',
                   })}
@@ -732,14 +718,6 @@ export function ObjectTypeWizard() {
                   })}
                   checked={isCategorizable}
                   onChange={setIsCategorizable}
-                />
-                <SettingToggleRow
-                  label={t('object_types.setting_abstract_label', { defaultValue: 'Is abstract' })}
-                  description={t('object_types.setting_abstract_desc', {
-                    defaultValue: 'Nie można tworzyć instancji bezpośrednio (tylko przez sub-typy)',
-                  })}
-                  checked={abstractFlag}
-                  onChange={setAbstractFlag}
                 />
                 {/* VIEW-08 (#427) — main menu candidacy. Mirrors show.tsx
                     so operator can promote the new ObjectType in the
@@ -926,12 +904,6 @@ export function ObjectTypeWizard() {
                   •{' '}
                   {t('object_type_wizard.tip_name_visibility', {
                     defaultValue: 'Nazwa pojawia się w UI i navbarze',
-                  })}
-                </li>
-                <li>
-                  •{' '}
-                  {t('object_type_wizard.tip_hierarchical', {
-                    defaultValue: 'Hierarchical = drzewo (jak Category)',
                   })}
                 </li>
                 <li>

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -646,17 +646,6 @@ export function ObjectTypeShowPage() {
             {t('object_types.settings_section', { defaultValue: 'Settings' })}
           </div>
           <SettingToggleRow
-            label={t('object_types.setting_hierarchical_label', {
-              defaultValue: 'Is hierarchical',
-            })}
-            description={t('object_types.setting_hierarchical_desc', {
-              defaultValue: 'Obiekty mogą tworzyć drzewo (jak Category)',
-            })}
-            checked={Boolean(objectType.hierarchical)}
-            locked={isBuiltIn}
-            onChange={(next) => void handlePatch({ hierarchical: next })}
-          />
-          <SettingToggleRow
             label={t('object_types.setting_variants_label', {
               defaultValue: 'Czy mają warianty?',
             })}
@@ -687,15 +676,6 @@ export function ObjectTypeShowPage() {
               })}
             </div>
           ) : null}
-          <SettingToggleRow
-            label={t('object_types.setting_abstract_label', { defaultValue: 'Is abstract' })}
-            description={t('object_types.setting_abstract_desc', {
-              defaultValue: 'Nie można tworzyć instancji bezpośrednio (tylko przez sub-typy)',
-            })}
-            checked={Boolean(objectType.abstract)}
-            locked={isBuiltIn}
-            onChange={(next) => void handlePatch({ abstract: next })}
-          />
           {/* VIEW-08 (#427) — main menu candidacy. Asset is locked because
               /assets has its own DAM page; the generic listing route would
               404 in MVP (ships in B-2). */}
@@ -764,43 +744,6 @@ export function ObjectTypeShowPage() {
                 })}
               </div>
             ) : null}
-          </div>
-          <div className="border-t border-zinc-100 pt-5">
-            <div className="mb-2 text-[11.5px] font-medium text-zinc-500">
-              {t('object_types.allowed_parent_types_label', {
-                defaultValue: 'Allowed parent types',
-              })}
-            </div>
-            <div className="flex items-center gap-2">
-              {(objectType.allowedParentTypeIds ?? []).length === 0 ? (
-                <span className="text-[12px] text-muted-foreground">
-                  {t('object_types.allowed_parent_types_empty', {
-                    defaultValue: 'Brak — typ nie posiada rodzica.',
-                  })}
-                </span>
-              ) : (
-                (objectType.allowedParentTypeIds ?? []).map((parentId) => (
-                  <span
-                    key={parentId}
-                    className="rounded-lg bg-zinc-100 px-2.5 py-1 text-[12px] font-medium text-zinc-700"
-                  >
-                    {parentId}
-                  </span>
-                ))
-              )}
-              {!isBuiltIn ? (
-                <button
-                  type="button"
-                  className="rounded-lg border border-dashed border-zinc-200 px-2.5 py-1 text-[12px] text-zinc-500 hover:border-zinc-400 hover:text-zinc-900"
-                  disabled
-                  title={t('object_types.add_parent_deferred', {
-                    defaultValue: 'Implementacja w VIEW-04 (Categories).',
-                  })}
-                >
-                  + {t('object_types.add_parent_type', { defaultValue: 'Add parent type' })}
-                </button>
-              ) : null}
-            </div>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
Usunięcie trzech mylących/martwych pól strukturalnych ObjectType z UI (kreator + widok szczegółów). Zamyka trzy zgłoszenia operatora dotyczące tego samego formularza.

> Jeden PR dla #1131 + #1132 + #1133 — wszystkie dotyczą tego samego widoku (kreator/detal ObjectType) i tego samego wzorca (usunięcie pola); rozdzielanie generowałoby konflikty na tym samym pliku. Zgodne z wyjątkiem SKILL-BUG-FIX-TICKET dla powiązanych zmian w jednym flow.

## Zmiany
- **#1131 „Is hierarchical"** — hierarchia wynika z `kind`/przeznaczenia (po per-ObjectType category trees #1125–#1129); ręczny toggle był mylący. Usunięty z kreatora i detalu.
- **#1132 „Is abstract"** — żadna logika nie czyta tej flagi (martwe pole). Toggle usunięty.
- **#1133 „Allowed parent types"** — sekcja nigdy nie była podpięta (read-only chipy z „Implementacja w VIEW-04"). Usunięta z detalu.

## Frontend changes
- `object-type-wizard.tsx` — usunięte toggle „Is hierarchical" + „Is abstract", powiązany state i pola payloadu (`hierarchical`, `abstract`), tip o hierarchii.
- `object-types/show.tsx` — usunięte toggle „Is hierarchical" + „Is abstract" oraz sekcja „Allowed parent types".

## Backend
- Bez zmian. Pola encji zostają (deprecated); `ObjectTypeService::create` domyślnie ustawia `hierarchical=false`, `abstract=false`, więc pominięcie ich w payloadzie kreatora jest bezpieczne. Built-in ObjectType (category) ma `hierarchical` ustawiane przy seedzie — bez regresji.

## Quality gates
- Typecheck 0 · Biome strict 0.
- Pełny build + Playwright w CI.

## Smoke test plan (po merge)
Login → `/modeling` → kreator ObjectType (krok Ustawienia): brak „Is hierarchical" i „Is abstract". Detal istniejącego ObjectType: brak tych toggli i sekcji „Allowed parent types"; pozostałe ustawienia (warianty, multimedia, kategorie, menu) działają.

## Świadome odejścia
Klucze i18n usuniętych pól zostają w `pl/en.json` (nieużywane, nieszkodliwe) — sprzątanie kluczy poza zakresem. Brak nowego Playwright — usunięcie elementów UI, pokryte typecheck + manual smoke.

Closes #1131
Closes #1132
Closes #1133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
