### PR TITLE
fix(modeling): Behavior w modalu grupy + ukrycie Conditional visibility

### DIFF
--- a/apps/admin/src/components/modeling/create-group-inline-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-group-inline-dialog.tsx
@@ -2,6 +2,7 @@ import { Check, FolderPlus, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
@@ -48,6 +49,9 @@ export function CreateGroupInlineDialog({ open, onOpenChange, onCreated }: Props
   const [descPl, setDescPl] = useState('');
   const [color, setColor] = useState(SWATCHES[0] ?? '#71717a');
   const [icon, setIcon] = useState(ICONS[0] ?? '📦');
+  // #1139 — Behavior parity with the full-page form (shared / required section).
+  const [shared, setShared] = useState(true);
+  const [requiredSection, setRequiredSection] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -58,6 +62,8 @@ export function CreateGroupInlineDialog({ open, onOpenChange, onCreated }: Props
       setDescPl('');
       setColor(SWATCHES[0] ?? '#71717a');
       setIcon(ICONS[0] ?? '📦');
+      setShared(true);
+      setRequiredSection(false);
       setError(null);
     }
   }, [open]);
@@ -74,6 +80,8 @@ export function CreateGroupInlineDialog({ open, onOpenChange, onCreated }: Props
         label: { pl: namePl.trim() },
         color,
         icon,
+        shared,
+        requiredSection,
       };
       if (descPl.trim().length > 0) body.description = { pl: descPl.trim() };
       const created = await jsonFetch<CreatedAttributeGroupResponse>('/api/attribute_groups', {
@@ -216,6 +224,32 @@ export function CreateGroupInlineDialog({ open, onOpenChange, onCreated }: Props
                 ))}
               </div>
             </div>
+          </div>
+
+          <div className="space-y-2 border-t border-zinc-100 pt-4">
+            <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+              {t('modeling.attributeGroups.behavior_title', { defaultValue: 'Zachowanie' })}
+            </div>
+            <SettingToggleRow
+              label={t('modeling.attributeGroups.behavior_shared_label', {
+                defaultValue: 'Współdzielona',
+              })}
+              description={t('modeling.attributeGroups.behavior_shared_desc', {
+                defaultValue: 'Może być dołączona do wielu ObjectType',
+              })}
+              checked={shared}
+              onChange={setShared}
+            />
+            <SettingToggleRow
+              label={t('modeling.attributeGroups.behavior_required_section_label', {
+                defaultValue: 'Wymagana sekcja',
+              })}
+              description={t('modeling.attributeGroups.behavior_required_section_desc', {
+                defaultValue: 'Grupa zawsze widoczna w formularzu',
+              })}
+              checked={requiredSection}
+              onChange={setRequiredSection}
+            />
           </div>
         </div>
 

--- a/apps/admin/src/features/catalog/attribute-groups/create.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/create.tsx
@@ -325,16 +325,10 @@ export function AttributeGroupCreatePage() {
                 checked={values.shared}
                 onChange={(next) => setValues({ ...values, shared: next })}
               />
-              <SettingToggleRow
-                label={t('modeling.attributeGroups.behavior_conditional_label', {
-                  defaultValue: 'Conditional visibility',
-                })}
-                description={t('modeling.attributeGroups.behavior_conditional_desc', {
-                  defaultValue: 'Pokaż grupę warunkowo (visible_when)',
-                })}
-                checked={values.conditionalVisibility}
-                onChange={(next) => setValues({ ...values, conditionalVisibility: next })}
-              />
+              {/* #1140 — "Conditional visibility" toggle hidden until the
+                  per-attribute visible_when rule editor ships (#UI-08.13).
+                  A toggle with no way to define the rule is dead UI. The
+                  field stays false in the payload (backend default). */}
             </div>
           </Section>
 


### PR DESCRIPTION
## Summary
Parytet sekcji „Zachowanie" w modalu tworzenia grupy atrybutów (#1139) + ukrycie nieaktywnego toggla „Conditional visibility" (#1140). Jeden PR — oba dotyczą formularzy tworzenia grupy atrybutów.

## #1139 — Behavior w modalu
Modal „Stwórz grupę atrybutów" (z `/modeling/attributes/new`) nie miał sekcji „Zachowanie", więc grupy tworzone z modala brały defaulty backendu. Dodane toggle „Współdzielona" (shared) i „Wymagana sekcja" (required section) — te same klucze i18n co pełny formularz — i wysyłane w payloadzie.

## #1140 — ukrycie „Conditional visibility"
Toggle „Conditional visibility" nie ma jeszcze edytora reguł `visible_when` per atrybut (#UI-08.13) — był to martwy przełącznik bez ścieżki użycia. Ukryty w pełnym formularzu i nieobecny w modalu; pole pozostaje `false` (default backendu) do czasu dostarczenia edytora.

## Frontend changes
- `create-group-inline-dialog.tsx` — sekcja „Zachowanie" (shared + requiredSection) + state + payload.
- `attribute-groups/create.tsx` — usunięty toggle „Conditional visibility".

## Quality gates
- Typecheck 0 · Biome strict 0. Pełny build + Playwright w CI.

## Live-stack smoke
`POST /api/attribute_groups` z payloadem modala (`shared=false, requiredSection=true`) → zapisane poprawnie (`shared=False, requiredSection=True`).

## Smoke test plan (po merge)
Login → `/modeling/attributes/new` → „Stwórz grupę" → modal ma sekcję „Zachowanie"; ustaw „Współdzielona" off → utwórz → grupa ma flagę. Pełny formularz `/modeling/attribute-groups/new` → brak toggla „Conditional visibility".

## Świadome odejścia
Brak Playwright (modal/form, auth rate-limiter fixme w repo) — pokryte typecheck + live smoke payloadu.

Closes #1139
Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
