### PR TITLE
fix(import): plik eksportu importuje się z powrotem bez błędów (round-trip)

### DIFF
--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -8,11 +8,14 @@ use App\Import\Application\Service\ImportObjectCreator;
 use App\Import\Application\Service\ImportProgressPublisher;
 use App\Import\Application\Service\ImportRowReader;
 use App\Import\Application\Service\ImportValidationService;
+use App\Import\Domain\ColumnHeader;
 use App\Import\Domain\Entity\ImportLog;
 use App\Import\Domain\Entity\ImportSession;
 use App\Import\Domain\Message\ImportRunMessage;
 use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
 use App\Import\Domain\ReservedMappingTarget;
+use App\Import\Domain\SystemColumn;
+use App\Import\Domain\ValueObject\ResolvedImportValue;
 use App\Import\Domain\ValueObject\ValidationError;
 use App\Shared\Application\AbstractBatchHandler;
 use App\Shared\Application\BulkOperationInProgressException;
@@ -168,11 +171,11 @@ final class ImportRunHandler extends AbstractBatchHandler
                 $rowOk = [] === $blockingErrors;
 
                 if ($rowOk) {
-                    $valueByAttributeCode = $this->materialiseValues($cells, $columnMapping);
+                    $resolvedValues = $this->materialiseValues($cells, $columnMapping);
                     $this->creator->create(
                         objectType: $session->getTargetObjectType(),
-                        sku: $valueByAttributeCode['sku'] ?? \sprintf('IMPORT-%d', $rowNumber),
-                        valueByAttributeCode: $valueByAttributeCode,
+                        sku: $this->skuFrom($resolvedValues, $rowNumber),
+                        resolvedValues: $resolvedValues,
                         attributesByCode: $attributesByCode,
                         importSessionId: $session->getId(),
                         categoryCode: $this->extractCategoryCode($cells, $columnMapping),
@@ -266,22 +269,55 @@ final class ImportRunHandler extends AbstractBatchHandler
     }
 
     /**
+     * Resolves every mapped, non-system column into a {@see ResolvedImportValue}
+     * carrying the attribute code + the locale parsed from its dotted
+     * header. A list (not a flat map) keeps several localised columns that
+     * target the same attribute (`name.pl`, `name.en`) distinct (#1130).
+     *
      * @param array<string, string|null> $cells
      * @param array<string, string>      $columnMapping
      *
-     * @return array<string, string|null>
+     * @return list<ResolvedImportValue>
      */
     private function materialiseValues(array $cells, array $columnMapping): array
     {
         $out = [];
         foreach ($columnMapping as $columnHeader => $attributeCode) {
+            if (SystemColumn::isSystem($columnHeader)) {
+                continue;
+            }
             if ('' === $attributeCode || ReservedMappingTarget::isReserved($attributeCode)) {
                 continue;
             }
-            $out[$attributeCode] = $cells[$columnHeader] ?? null;
+            $out[] = new ResolvedImportValue(
+                attributeCode: $attributeCode,
+                locale: ColumnHeader::localeOf($columnHeader),
+                rawValue: $cells[$columnHeader] ?? null,
+            );
         }
 
         return $out;
+    }
+
+    /**
+     * SKU is non-localised — the first resolved `sku` value with content
+     * wins. Falls back to a synthetic code so a row that somehow passed
+     * validation without one still persists rather than collides on an
+     * empty unique key.
+     *
+     * @param list<ResolvedImportValue> $resolvedValues
+     */
+    private function skuFrom(array $resolvedValues, int $rowNumber): string
+    {
+        foreach ($resolvedValues as $resolved) {
+            if ('sku' === $resolved->attributeCode
+                && null !== $resolved->rawValue
+                && '' !== $resolved->rawValue) {
+                return $resolved->rawValue;
+            }
+        }
+
+        return \sprintf('IMPORT-%d', $rowNumber);
     }
 
     /**

--- a/apps/api/src/Import/Application/Service/AutoMapper.php
+++ b/apps/api/src/Import/Application/Service/AutoMapper.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Service;
 
+use App\Import\Domain\ColumnHeader;
 use App\Import\Domain\Enum\MappingConfidence;
+use App\Import\Domain\SystemColumn;
 use App\Import\Domain\ValueObject\ColumnMappingSuggestion;
 
 /**
@@ -42,8 +44,28 @@ final readonly class AutoMapper
 
         $suggestions = [];
         foreach ($columnHeaders as $index => $header) {
-            $normalised = $this->normalise($header);
             $sampleValues = $this->sliceSample($sampleRows, $index);
+
+            // Read-only / system export columns (timestamps, status,
+            // completeness, …) have no Attribute behind them — suggest
+            // Skip so re-importing an export is a one-click round-trip
+            // rather than a wall of manual rows (#1130).
+            if (SystemColumn::isSystem($header)) {
+                $suggestions[] = new ColumnMappingSuggestion(
+                    columnIndex: $index,
+                    columnHeader: $header,
+                    suggestedAttributeCode: null,
+                    confidence: MappingConfidence::Skip,
+                    sampleValues: $sampleValues,
+                );
+                continue;
+            }
+
+            // Localised export columns carry a dotted locale suffix
+            // (`name.pl`). Match on the attribute base so they auto-map to
+            // their attribute; the locale is re-derived from the header at
+            // validation / persistence time.
+            $normalised = $this->normalise(ColumnHeader::baseOf($header));
 
             if ('' === $normalised) {
                 $suggestions[] = new ColumnMappingSuggestion(

--- a/apps/api/src/Import/Application/Service/CompositeValueParser.php
+++ b/apps/api/src/Import/Application/Service/CompositeValueParser.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+/**
+ * Parses the composite scalar strings the exporter emits for `price` and
+ * `metric` attributes back into the JSONB envelope the catalog stores.
+ *
+ * Export side ({@see \App\Export\Application\Builder\ValueSerializer}):
+ *   - price  → `"20.99 EUR"`  (`sprintf('%s %s', amount, currency)`)
+ *   - metric → `"0.3 g"`      (`sprintf('%s %s', value, unit)`)
+ *
+ * Import side (this class) reverses that so the round-trip is loss-free
+ * (#1130). The numeric part accepts both `.` and `,` decimal separators
+ * (operator-friendly CSVs); the trailing token becomes the currency /
+ * unit. A bare number (`"20.99"`) parses with no currency / unit — valid
+ * input even if the catalog later prefers a currency.
+ *
+ * Returns null when the leading token is not numeric, so the validator can
+ * surface an InvalidType error instead of persisting garbage.
+ */
+final class CompositeValueParser
+{
+    /**
+     * @return array{amount: float, currency?: string}|null
+     */
+    public function parsePrice(string $raw): ?array
+    {
+        [$amount, $rest] = $this->split($raw);
+        if (null === $amount) {
+            return null;
+        }
+
+        $out = ['amount' => $amount];
+        if (null !== $rest) {
+            $out['currency'] = strtoupper($rest);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array{value: float, unit?: string}|null
+     */
+    public function parseMetric(string $raw): ?array
+    {
+        [$value, $rest] = $this->split($raw);
+        if (null === $value) {
+            return null;
+        }
+
+        $out = ['value' => $value];
+        if (null !== $rest) {
+            $out['unit'] = $rest;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Whether the raw cell is a plain number or a `<number> <token>`
+     * composite — drives the validator's accept / reject decision for
+     * price + metric columns.
+     */
+    public function isNumericOrComposite(string $raw): bool
+    {
+        return null !== $this->split($raw)[0];
+    }
+
+    /**
+     * Splits a cell into its leading numeric token and the trailing
+     * remainder (currency / unit), or [null, null] when the leading token
+     * is not numeric.
+     *
+     * @return array{0: float|null, 1: string|null}
+     */
+    private function split(string $raw): array
+    {
+        $trimmed = trim($raw);
+        if ('' === $trimmed) {
+            return [null, null];
+        }
+
+        $parts = preg_split('/\s+/', $trimmed, 2);
+        if (false === $parts) {
+            return [null, null];
+        }
+
+        $numeric = str_replace(',', '.', $parts[0]);
+        if (!is_numeric($numeric)) {
+            return [null, null];
+        }
+
+        $rest = isset($parts[1]) ? trim($parts[1]) : '';
+
+        return [(float) $numeric, '' === $rest ? null : $rest];
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -13,6 +13,7 @@ use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Provenance;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Import\Domain\ValueObject\ResolvedImportValue;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Uid\Uuid;
@@ -36,22 +37,24 @@ final class ImportObjectCreator
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly CompositeValueParser $compositeValueParser,
     ) {
     }
 
     /**
-     * @param array<string, string|null> $valueByAttributeCode
-     * @param array<string, Attribute>   $attributesByCode
-     * @param ?string                    $categoryCode         `code` of the category to assign the new
-     *                                                         product to. Single category per row
-     *                                                         (becomes primary). Silently skipped when
-     *                                                         the lookup fails — the validator emitted
-     *                                                         the CategoryNotFound warning earlier.
+     * @param list<ResolvedImportValue> $resolvedValues   mapped cells with the locale parsed from
+     *                                                    their dotted header (`name.pl` → `pl`)
+     * @param array<string, Attribute>  $attributesByCode
+     * @param ?string                   $categoryCode     `code` of the category to assign the new
+     *                                                    product to. Single category per row
+     *                                                    (becomes primary). Silently skipped when
+     *                                                    the lookup fails — the validator emitted
+     *                                                    the CategoryNotFound warning earlier.
      */
     public function create(
         ObjectType $objectType,
         string $sku,
-        array $valueByAttributeCode,
+        array $resolvedValues,
         array $attributesByCode,
         Uuid $importSessionId,
         ?string $categoryCode = null,
@@ -61,11 +64,12 @@ final class ImportObjectCreator
         $object->assignImportSession($importSessionId);
         $this->em->persist($object);
 
-        foreach ($valueByAttributeCode as $attributeCode => $rawValue) {
+        foreach ($resolvedValues as $resolved) {
+            $rawValue = $resolved->rawValue;
             if (null === $rawValue || '' === $rawValue) {
                 continue;
             }
-            $attribute = $attributesByCode[$attributeCode] ?? null;
+            $attribute = $attributesByCode[$resolved->attributeCode] ?? null;
             if (!$attribute instanceof Attribute) {
                 continue;
             }
@@ -80,6 +84,7 @@ final class ImportObjectCreator
                 attribute: $attribute,
                 value: $valuePayload,
                 provenance: Provenance::Import,
+                locale: $resolved->locale,
             ));
         }
 
@@ -99,18 +104,27 @@ final class ImportObjectCreator
     }
 
     /**
-     * Maps the raw CSV cell into the JSONB shape expected by
-     * {@see ObjectValue::$value}. Returns null when the value is
-     * uninterpretable for the attribute type — that path stays out of
-     * the import (the validator already flagged it as InvalidType).
+     * Maps the raw CSV / XLSX cell into the JSONB shape stored on
+     * {@see ObjectValue::$value} for the attribute type (shapes documented
+     * on the entity + docs/api/jsonb-schemas.md). Returns null when the
+     * value is uninterpretable — that path stays out of the import (the
+     * validator already flagged it as InvalidType).
      *
      * @return array<string, mixed>|null
      */
     private function buildValuePayload(Attribute $attribute, string $raw): ?array
     {
         return match ($attribute->getType()) {
-            AttributeType::Number, AttributeType::Price, AttributeType::Metric => $this->numericPayload($raw),
+            AttributeType::Number => $this->numericPayload($raw),
+            // Composite envelopes mirror the exporter: price keeps
+            // {amount, currency}, metric keeps {value, unit} (#1130).
+            AttributeType::Price => $this->compositeValueParser->parsePrice($raw),
+            AttributeType::Metric => $this->compositeValueParser->parseMetric($raw),
             AttributeType::Boolean => ['value' => $this->parseBoolean($raw)],
+            AttributeType::Select => ['option_code' => $raw],
+            AttributeType::Multiselect => $this->multiSelectPayload($raw),
+            AttributeType::Asset => ['asset_id' => $raw],
+            AttributeType::Relation, AttributeType::Reference => ['object_id' => $raw],
             default => ['value' => $raw],
         };
     }
@@ -126,6 +140,23 @@ final class ImportObjectCreator
         }
 
         return ['value' => (float) $normalised];
+    }
+
+    /**
+     * Splits the pipe-joined token list the exporter writes for
+     * multiselect values (`ValueSerializer::MULTI_VALUE_GLUE`) back into
+     * an option-code array.
+     *
+     * @return array{option_codes: list<string>}
+     */
+    private function multiSelectPayload(string $raw): array
+    {
+        $codes = array_values(array_filter(
+            array_map('trim', explode('|', $raw)),
+            static fn (string $code): bool => '' !== $code,
+        ));
+
+        return ['option_codes' => $codes];
     }
 
     private function parseBoolean(string $raw): bool

--- a/apps/api/src/Import/Application/Service/ImportRowReader.php
+++ b/apps/api/src/Import/Application/Service/ImportRowReader.php
@@ -55,6 +55,14 @@ final readonly class ImportRowReader
     }
 
     /**
+     * Maps cells by their column letter (`A`, `B`, …) rather than by the
+     * iterator position. Exported XLSX files omit empty cells, so the
+     * data row can jump `A2 → C2` (skipping a blank `parent_sku`). A
+     * positional `headers[$i] => cells[$i]` mapping would then shift every
+     * value left of the gap onto the wrong header. Keying both the header
+     * row and each data row on the column coordinate keeps them aligned
+     * regardless of which cells the file materialises (#1130).
+     *
      * @return Generator<int, array<string, string|null>>
      */
     private function iterateXlsx(string $absolutePath): Generator
@@ -64,22 +72,32 @@ final readonly class ImportRowReader
         $spreadsheet = $reader->load($absolutePath);
         $sheet = $spreadsheet->getSheet(0);
 
-        $headers = [];
+        /** @var array<string, string> $headersByColumn column letter → header label */
+        $headersByColumn = [];
         $rowNumber = 0;
         foreach ($sheet->getRowIterator() as $row) {
             ++$rowNumber;
-            $cells = [];
+
+            $cellsByColumn = [];
             foreach ($row->getCellIterator() as $cell) {
                 $value = $cell->getValue();
-                $cells[] = null === $value ? null : (string) (\is_scalar($value) ? $value : '');
+                $cellsByColumn[$cell->getColumn()] = null === $value
+                    ? null
+                    : (string) (\is_scalar($value) ? $value : '');
             }
+
             if (1 === $rowNumber) {
-                $headers = array_map(static fn (?string $v): string => $v ?? '', $cells);
+                foreach ($cellsByColumn as $column => $label) {
+                    if (null !== $label && '' !== $label) {
+                        $headersByColumn[$column] = $label;
+                    }
+                }
                 continue;
             }
+
             $assoc = [];
-            foreach ($headers as $index => $header) {
-                $assoc[$header] = $cells[$index] ?? null;
+            foreach ($headersByColumn as $column => $header) {
+                $assoc[$header] = $cellsByColumn[$column] ?? null;
             }
             yield $rowNumber - 1 => $assoc;
         }

--- a/apps/api/src/Import/Application/Service/ImportValidationService.php
+++ b/apps/api/src/Import/Application/Service/ImportValidationService.php
@@ -10,10 +10,12 @@ use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Import\Domain\ColumnHeader;
 use App\Import\Domain\Enum\FileEncoding;
 use App\Import\Domain\Enum\ImportErrorType;
 use App\Import\Domain\Enum\ImportLogLevel;
 use App\Import\Domain\ReservedMappingTarget;
+use App\Import\Domain\SystemColumn;
 use App\Import\Domain\ValueObject\ValidationError;
 use App\Import\Domain\ValueObject\ValidationResult;
 use App\Shared\Application\TenantContext;
@@ -45,6 +47,7 @@ final readonly class ImportValidationService
         private CatalogObjectRepositoryInterface $catalogObjects,
         private TenantContext $tenantContext,
         private ImportRowReader $rowReader,
+        private CompositeValueParser $compositeValueParser,
     ) {
     }
 
@@ -130,10 +133,25 @@ final readonly class ImportValidationService
     ): array {
         $errors = [];
 
-        $valueByAttribute = [];
+        // Each entry is one mapped cell with the locale parsed from its
+        // dotted header (`name.pl` → locale `pl`). Several localised
+        // columns can target the same attribute, so we keep a list rather
+        // than a flat code → value map (which the round-trip export would
+        // otherwise collapse — #1130).
+        /** @var list<array{code: string, locale: ?string, value: ?string, header: string}> $cellValues */
+        $cellValues = [];
+        // Tracks whether an attribute has a non-empty value in ANY locale
+        // column — drives the required-attribute check.
+        $presentByAttribute = [];
         $categoryCellValue = null;
         $categoryColumnName = null;
         foreach ($columnMapping as $columnHeader => $attributeCode) {
+            // System / read-only export columns (timestamps, status,
+            // completeness, …) never carry an Attribute value — skip them
+            // so re-importing an export does not flag them.
+            if (SystemColumn::isSystem($columnHeader)) {
+                continue;
+            }
             if (ReservedMappingTarget::SKIP === $attributeCode || '' === $attributeCode) {
                 continue;
             }
@@ -149,14 +167,24 @@ final readonly class ImportValidationService
                 }
                 continue;
             }
-            $valueByAttribute[$attributeCode] = $cells[$columnHeader] ?? null;
+            $cell = $cells[$columnHeader] ?? null;
+            $cellValues[] = [
+                'code' => $attributeCode,
+                'locale' => ColumnHeader::localeOf($columnHeader),
+                'value' => $cell,
+                'header' => $columnHeader,
+            ];
+            if (null !== $cell && '' !== $cell) {
+                $presentByAttribute[$attributeCode] = true;
+            }
         }
 
-        $sku = $valueByAttribute[self::SKU_ATTRIBUTE_CODE] ?? null;
+        $sku = $this->firstNonEmptyValueFor(self::SKU_ATTRIBUTE_CODE, $cellValues);
 
         foreach (self::REQUIRED_ATTRIBUTE_CODES as $requiredCode) {
-            $value = $valueByAttribute[$requiredCode] ?? null;
-            if (null === $value || '' === $value) {
+            // A localised required attribute (`name.pl`/`name.en`) is
+            // satisfied when any one locale carries a value.
+            if (!isset($presentByAttribute[$requiredCode])) {
                 $errors[] = new ValidationError(
                     rowNumber: $rowNumber,
                     sku: $sku,
@@ -164,7 +192,7 @@ final readonly class ImportValidationService
                     level: ImportLogLevel::Error,
                     message: \sprintf('Missing required attribute "%s".', $requiredCode),
                     columnName: $requiredCode,
-                    columnValue: $value,
+                    columnValue: null,
                 );
             }
         }
@@ -196,11 +224,12 @@ final readonly class ImportValidationService
             }
         }
 
-        foreach ($valueByAttribute as $attributeCode => $value) {
+        foreach ($cellValues as $cellValue) {
+            $value = $cellValue['value'];
             if (null === $value || '' === $value) {
                 continue;
             }
-            $attribute = $attributesByCode[$attributeCode] ?? null;
+            $attribute = $attributesByCode[$cellValue['code']] ?? null;
             if (!$attribute instanceof Attribute) {
                 continue;
             }
@@ -212,7 +241,7 @@ final readonly class ImportValidationService
                     errorType: ImportErrorType::InvalidType,
                     level: ImportLogLevel::Error,
                     message: $typeError,
-                    columnName: $attributeCode,
+                    columnName: $cellValue['header'],
                     columnValue: $value,
                 );
             }
@@ -274,9 +303,15 @@ final readonly class ImportValidationService
     private function validateScalarType(Attribute $attribute, string $value): ?string
     {
         return match ($attribute->getType()) {
-            AttributeType::Number, AttributeType::Price, AttributeType::Metric => is_numeric(str_replace(',', '.', $value))
-                    ? null
-                    : \sprintf('"%s" is not a valid number for "%s".', $value, $attribute->getCode()),
+            AttributeType::Number => is_numeric(str_replace(',', '.', $value))
+                ? null
+                : \sprintf('"%s" is not a valid number for "%s".', $value, $attribute->getCode()),
+            // Price + metric round-trip as `<number> <currency|unit>`
+            // (e.g. "20.99 EUR", "0.3 g") — accept the composite form the
+            // exporter emits, not just a bare number.
+            AttributeType::Price, AttributeType::Metric => $this->compositeValueParser->isNumericOrComposite($value)
+                ? null
+                : \sprintf('"%s" is not a valid number for "%s".', $value, $attribute->getCode()),
             AttributeType::Date => false === strtotime($value)
                 ? \sprintf('"%s" is not a valid date for "%s".', $value, $attribute->getCode())
                 : null,
@@ -285,5 +320,26 @@ final readonly class ImportValidationService
                 : \sprintf('"%s" is not a valid boolean for "%s".', $value, $attribute->getCode()),
             default => null,
         };
+    }
+
+    /**
+     * First non-empty cell value targeting the given attribute code,
+     * across every (locale) column that maps to it.
+     *
+     * @param list<array{code: string, locale: ?string, value: ?string, header: string}> $cellValues
+     */
+    private function firstNonEmptyValueFor(string $attributeCode, array $cellValues): ?string
+    {
+        foreach ($cellValues as $cellValue) {
+            if ($cellValue['code'] !== $attributeCode) {
+                continue;
+            }
+            $value = $cellValue['value'];
+            if (null !== $value && '' !== $value) {
+                return $value;
+            }
+        }
+
+        return null;
     }
 }

--- a/apps/api/src/Import/Domain/ColumnHeader.php
+++ b/apps/api/src/Import/Domain/ColumnHeader.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain;
+
+/**
+ * Parses an import column header into its attribute base + optional
+ * locale modifier — the import-side mirror of the exporter's
+ * {@see \App\Export\Application\Builder\ColumnResolver} grammar.
+ *
+ * Export emits localised values with a dotted suffix: `name.pl`,
+ * `description.pl` (PRD-PIM-exports.md §6.1). Attribute codes are
+ * `[a-z0-9_]` and never contain a dot, so the first `.` unambiguously
+ * separates the attribute code from its locale modifier.
+ *
+ * MVP scope (#1130): the suffix is interpreted as a locale. Channel-scoped
+ * columns (`description.shopify`) and the combined `locale.channel`
+ * notation are deferred to the channels epic (#1147) — until then a
+ * channel suffix would be read as a locale, matching the exporter's own
+ * single-segment grammar.
+ */
+final class ColumnHeader
+{
+    /**
+     * The attribute code part of the header (everything before the first
+     * dot). `name.pl` → `name`; `price` → `price`.
+     */
+    public static function baseOf(string $header): string
+    {
+        $pos = strpos($header, '.');
+
+        return false === $pos ? $header : substr($header, 0, $pos);
+    }
+
+    /**
+     * The locale modifier (everything after the first dot), or null when
+     * the column carries no suffix. `name.pl` → `pl`; `price` → null.
+     */
+    public static function localeOf(string $header): ?string
+    {
+        $pos = strpos($header, '.');
+        if (false === $pos) {
+            return null;
+        }
+        $modifier = substr($header, $pos + 1);
+
+        return '' === $modifier ? null : $modifier;
+    }
+}

--- a/apps/api/src/Import/Domain/SystemColumn.php
+++ b/apps/api/src/Import/Domain/SystemColumn.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain;
+
+/**
+ * Read-only / system columns the exporter emits (PRD-PIM-exports.md §5.3
+ * built-ins) that must never be re-imported as Attribute values.
+ *
+ * The round-trip contract (#1130) requires the importer to accept its own
+ * export without error. Those columns describe catalog state owned by the
+ * platform (timestamps, authorship, denormalised completeness, publication
+ * status) — there is no Attribute behind them, so the wizard auto-skips
+ * them and the validator never flags them as "unknown" or "missing".
+ *
+ * `sku` / `category` are deliberately NOT here — they carry meaning on the
+ * import side (object code + category assignment). `parent_sku` IS skipped:
+ * variant parent linking is out of MVP import scope (see
+ * {@see \App\Import\Application\Service\ImportObjectCreator} — "master rows
+ * only").
+ */
+final class SystemColumn
+{
+    /** @var list<string> */
+    private const array HEADERS = [
+        'parent_sku',
+        'status',
+        'enabled',
+        'completeness_pct',
+        'created_at',
+        'updated_at',
+        'created_by',
+        'updated_by',
+    ];
+
+    public static function isSystem(string $header): bool
+    {
+        return \in_array(strtolower(trim($header)), self::HEADERS, true);
+    }
+}

--- a/apps/api/src/Import/Domain/ValueObject/ResolvedImportValue.php
+++ b/apps/api/src/Import/Domain/ValueObject/ResolvedImportValue.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\ValueObject;
+
+/**
+ * One mapped cell ready for persistence: the attribute code it targets,
+ * the optional locale parsed from a dotted column header (`name.pl` →
+ * locale `pl`), and the raw string value.
+ *
+ * Replaces the flat `attribute_code → value` map the importer used before
+ * #1130 — that shape collided when several localised columns (`name.pl`,
+ * `name.en`) targeted the same attribute. A list of resolved values lets
+ * the creator write one {@see \App\Catalog\Domain\Entity\ObjectValue} per
+ * (attribute, locale) pair.
+ */
+final readonly class ResolvedImportValue
+{
+    public function __construct(
+        public string $attributeCode,
+        public ?string $locale,
+        public ?string $rawValue,
+    ) {
+    }
+}

--- a/apps/api/tests/Api/Import/ImportRoundTripApiTest.php
+++ b/apps/api/tests/Api/Import/ImportRoundTripApiTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #1130 — the exporter's own output must re-import without spurious
+ * type / required errors (round-trip contract, PRD-PIM-exports.md §8).
+ *
+ * Covers the three validation-side contract fixes in one dry-run:
+ *   - a system column (`created_at`) is skipped even when mapped to an
+ *     attribute, so its ISO timestamp never trips the numeric check;
+ *   - a localised column (`name.pl`) satisfies the required `name`;
+ *   - composite price / metric cells (`20.99 EUR`, `0.3 g`) validate.
+ */
+final class ImportRoundTripApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function exportFormatRowValidatesWithoutBlockingErrors(): void
+    {
+        $this->seedRoundTripAttributes();
+        $csvPath = $this->writeRoundTripCsv();
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions/validate-dry-run', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode([
+                            'sku' => 'sku',
+                            // Deliberately mis-mapped to a numeric attribute:
+                            // the system-column skip must win regardless.
+                            'created_at' => 'price',
+                            'name.pl' => 'name',
+                            'price' => 'price',
+                            'weight' => 'weight',
+                        ], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => [
+                        'file' => new UploadedFile($csvPath, 'round-trip.csv', 'text/csv', null, true),
+                    ],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $response = $client->getResponse();
+            self::assertNotNull($response);
+            $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+
+            self::assertSame(1, $body['total_rows']);
+            self::assertSame(1, $body['success_count'], 'Round-trip export row validates clean.');
+            self::assertSame(0, $body['error_count'], 'No spurious type / required errors on re-import.');
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    private function seedRoundTripAttributes(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $price = new Attribute('price', ['en' => 'Price'], AttributeType::Price);
+        $weight = new Attribute('weight', ['en' => 'Weight'], AttributeType::Metric);
+        $position = 1;
+        foreach ([$sku, $name, $price, $weight] as $attribute) {
+            $em->persist($attribute);
+            $em->persist(new ObjectTypeAttribute($product, $attribute, false, $position++));
+        }
+        $em->flush();
+    }
+
+    private function writeRoundTripCsv(): string
+    {
+        $contents = "sku;created_at;name.pl;price;weight\n"
+            ."RT-1;2026-05-28T20:14:59+00:00;Buty sportowe;20.99 EUR;0.3 g\n";
+        $path = tempnam(sys_get_temp_dir(), 'imp-round-trip-');
+        \assert(false !== $path);
+        $renamed = $path.'.csv';
+        rename($path, $renamed);
+        file_put_contents($renamed, $contents);
+
+        return $renamed;
+    }
+}

--- a/apps/api/tests/Unit/Import/AutoMapperTest.php
+++ b/apps/api/tests/Unit/Import/AutoMapperTest.php
@@ -106,6 +106,53 @@ final class AutoMapperTest extends TestCase
     }
 
     #[Test]
+    public function localisedHeaderMatchesItsAttributeBase(): void
+    {
+        // Re-importing an export: `name.pl` / `description.en` must auto-map
+        // to their attribute (the locale is re-derived from the header
+        // later), not fall through to manual (#1130).
+        $mapper = $this->mapperWithDictionary([
+            'name' => ['aliases' => ['name', 'nazwa']],
+            'description' => ['aliases' => ['description', 'opis']],
+        ]);
+
+        $suggestions = $mapper->map(
+            ['name', 'description'],
+            ['name.pl', 'description.en'],
+            [],
+        );
+
+        self::assertSame('name', $suggestions[0]->suggestedAttributeCode);
+        self::assertSame(MappingConfidence::Auto, $suggestions[0]->confidence);
+        self::assertSame('description', $suggestions[1]->suggestedAttributeCode);
+        self::assertSame(MappingConfidence::Auto, $suggestions[1]->confidence);
+    }
+
+    #[Test]
+    public function systemColumnsAreSuggestedAsSkip(): void
+    {
+        $mapper = $this->mapperWithDictionary([
+            'sku' => ['aliases' => ['sku']],
+        ]);
+
+        $suggestions = $mapper->map(
+            ['sku'],
+            ['sku', 'created_at', 'updated_at', 'completeness_pct', 'status', 'enabled', 'parent_sku'],
+            [],
+        );
+
+        self::assertSame(MappingConfidence::Auto, $suggestions[0]->confidence, 'sku still auto-maps.');
+        foreach (\array_slice($suggestions, 1) as $suggestion) {
+            self::assertSame(
+                MappingConfidence::Skip,
+                $suggestion->confidence,
+                \sprintf('System column "%s" should be Skip.', $suggestion->columnHeader),
+            );
+            self::assertNull($suggestion->suggestedAttributeCode);
+        }
+    }
+
+    #[Test]
     public function diacriticsAreNormalisedThroughTheStripper(): void
     {
         $mapper = $this->mapperWithRealDictionary();

--- a/apps/api/tests/Unit/Import/CompositeValueParserTest.php
+++ b/apps/api/tests/Unit/Import/CompositeValueParserTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Application\Service\CompositeValueParser;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class CompositeValueParserTest extends TestCase
+{
+    #[Test]
+    public function parsesPriceWithCurrency(): void
+    {
+        $parser = new CompositeValueParser();
+
+        self::assertSame(['amount' => 20.99, 'currency' => 'EUR'], $parser->parsePrice('20.99 EUR'));
+        self::assertSame(['amount' => 21.99, 'currency' => 'USD'], $parser->parsePrice('21.99 USD'));
+    }
+
+    #[Test]
+    public function parsesPriceWithCommaDecimalSeparator(): void
+    {
+        $parser = new CompositeValueParser();
+
+        self::assertSame(['amount' => 20.99, 'currency' => 'PLN'], $parser->parsePrice('20,99 PLN'));
+    }
+
+    #[Test]
+    public function parsesBarePriceWithoutCurrency(): void
+    {
+        $parser = new CompositeValueParser();
+
+        self::assertSame(['amount' => 20.99], $parser->parsePrice('20.99'));
+    }
+
+    #[Test]
+    public function uppercasesCurrencyToken(): void
+    {
+        $parser = new CompositeValueParser();
+
+        self::assertSame(['amount' => 5.0, 'currency' => 'EUR'], $parser->parsePrice('5 eur'));
+    }
+
+    #[Test]
+    public function parsesMetricWithUnit(): void
+    {
+        $parser = new CompositeValueParser();
+
+        self::assertSame(['value' => 0.3, 'unit' => 'g'], $parser->parseMetric('0.3 g'));
+        self::assertSame(['value' => 0.4, 'unit' => 'cm'], $parser->parseMetric('0.4 cm'));
+    }
+
+    #[Test]
+    public function parsesBareMetricWithoutUnit(): void
+    {
+        $parser = new CompositeValueParser();
+
+        self::assertSame(['value' => 11.0], $parser->parseMetric('11'));
+    }
+
+    #[Test]
+    public function rejectsNonNumericLeadingToken(): void
+    {
+        $parser = new CompositeValueParser();
+
+        self::assertNull($parser->parsePrice('not-a-number'));
+        self::assertNull($parser->parseMetric('heavy'));
+        self::assertNull($parser->parsePrice(''));
+        self::assertNull($parser->parsePrice('EUR 20'));
+    }
+
+    #[Test]
+    public function isNumericOrCompositeAcceptsNumbersAndComposites(): void
+    {
+        $parser = new CompositeValueParser();
+
+        self::assertTrue($parser->isNumericOrComposite('20.99 EUR'));
+        self::assertTrue($parser->isNumericOrComposite('0.3 g'));
+        self::assertTrue($parser->isNumericOrComposite('100'));
+        self::assertTrue($parser->isNumericOrComposite('20,99'));
+        self::assertFalse($parser->isNumericOrComposite('not-a-number'));
+        self::assertFalse($parser->isNumericOrComposite(''));
+    }
+}

--- a/apps/api/tests/Unit/Import/ImportRowReaderTest.php
+++ b/apps/api/tests/Unit/Import/ImportRowReaderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Application\Service\DelimiterDetector;
+use App\Import\Application\Service\EncodingDetector;
+use App\Import\Application\Service\ImportRowReader;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ImportRowReaderTest extends TestCase
+{
+    #[Test]
+    public function xlsxRowsMapByColumnCoordinateNotPosition(): void
+    {
+        // Header skips column B (the exporter omits empty cells). A naive
+        // positional reader would shift `name` onto the blank header and
+        // leak the B2 cell; coordinate mapping keeps each value under its
+        // own header (#1130).
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'sku');
+        // B1 intentionally left blank.
+        $sheet->setCellValue('C1', 'name');
+        $sheet->setCellValue('D1', 'price');
+
+        $sheet->setCellValue('A2', 'RT-1');
+        $sheet->setCellValue('B2', 'leaked-if-positional');
+        $sheet->setCellValue('C2', 'Buty');
+        $sheet->setCellValue('D2', '20.99 EUR');
+
+        $path = tempnam(sys_get_temp_dir(), 'imp-reader-unit-').'.xlsx';
+        new XlsxWriter($spreadsheet)->save($path);
+
+        try {
+            $reader = new ImportRowReader(new EncodingDetector(), new DelimiterDetector());
+            $rows = iterator_to_array($reader->read($path));
+
+            self::assertCount(1, $rows);
+            $row = $rows[1];
+            self::assertSame('RT-1', $row['sku']);
+            self::assertSame('Buty', $row['name']);
+            self::assertSame('20.99 EUR', $row['price']);
+            self::assertArrayNotHasKey('', $row, 'Blank header column must not produce a key.');
+            self::assertNotContains('leaked-if-positional', $row, 'B2 has no header — its value must not leak.');
+        } finally {
+            @unlink($path);
+        }
+    }
+}

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -11,6 +11,7 @@ use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Import\Application\Service\CompositeValueParser;
 use App\Import\Application\Service\DelimiterDetector;
 use App\Import\Application\Service\EncodingDetector;
 use App\Import\Application\Service\ImportRowReader;
@@ -52,6 +53,7 @@ final class ImportValidationServiceTest extends TestCase
             catalogObjects: $catalogRepo,
             tenantContext: $tenantContext,
             rowReader: new ImportRowReader(new EncodingDetector(), new DelimiterDetector()),
+            compositeValueParser: new CompositeValueParser(),
         );
 
         $csv = "sku;name;price\nOK-1;Foo;9.99\nEXISTING-1;Bar;14.99\n;Anon;5\nDUP-1;Dup;1\nDUP-1;Dup again;2\nBAD-1;Has bad price;not-a-number\n";
@@ -75,6 +77,59 @@ final class ImportValidationServiceTest extends TestCase
             self::assertContains(ImportErrorType::MissingRequired->value, $errorTypes);
             self::assertContains(ImportErrorType::DuplicateSkuInFile->value, $errorTypes);
             self::assertContains(ImportErrorType::InvalidType->value, $errorTypes);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function roundTripExportColumnsValidateWithoutBlockingErrors(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $attributeRepo = new InMemoryAttributeRepository([
+            'sku' => new Attribute('sku', ['en' => 'SKU'], AttributeType::Text),
+            'name' => new Attribute('name', ['en' => 'Name'], AttributeType::Text),
+            'price' => new Attribute('price', ['en' => 'Price'], AttributeType::Price),
+            'weight' => new Attribute('weight', ['en' => 'Weight'], AttributeType::Metric),
+        ]);
+        $catalogRepo = new InMemoryCatalogObjectRepository([]);
+
+        $tenantContext = new TenantContext();
+        $tenantContext->set($tenant);
+
+        $service = new ImportValidationService(
+            attributes: $attributeRepo,
+            catalogObjects: $catalogRepo,
+            tenantContext: $tenantContext,
+            rowReader: new ImportRowReader(new EncodingDetector(), new DelimiterDetector()),
+            compositeValueParser: new CompositeValueParser(),
+        );
+
+        // The exporter's own format: a system column (created_at), a
+        // localised name (name.pl) standing in for the bare required
+        // `name`, and composite price / metric cells.
+        $csv = "sku;created_at;name.pl;price;weight\n"
+            ."RT-1;2026-05-28T20:14:59+00:00;Buty;20.99 EUR;0.3 g\n";
+        $path = $this->writeTempCsv($csv);
+
+        try {
+            $product = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+            $result = $service->validate(
+                absolutePath: $path,
+                columnMapping: [
+                    'sku' => 'sku',
+                    'created_at' => 'skip',
+                    'name.pl' => 'name',
+                    'price' => 'price',
+                    'weight' => 'weight',
+                ],
+                target: $product,
+            );
+
+            self::assertSame(1, $result->totalRows);
+            self::assertSame(1, $result->successCount, 'Round-trip export row validates clean.');
+            self::assertSame(0, $result->errorCount);
+            self::assertSame([], $result->errors);
         } finally {
             @unlink($path);
         }


### PR DESCRIPTION
## Summary
Plik eksportu produktów (xlsx/csv) wrzucony z powrotem do importu generował „0 OK / 999 błędów". PR przywraca kontrakt round-trip (PRD-PIM-exports.md §8): importer akceptuje teraz dokładnie to, co eksporter wyemitował.

Decyzja kierunkowa (z treści ticketu — „preferowane"): **import kompatybilny z eksportem**, a nie osobny profil round-trip.

## Root cause (4 niezależne niezgodności)
1. **Wartości złożone** — eksport zapisuje `"20.99 EUR"` / `"0.3 g"`; import walidował przez gołe `is_numeric()` → `invalid_type`.
2. **Kolumny lokalizowane** — eksport używa `name.pl`; import wymagał gołego `name` → `Missing required name` w każdym wierszu, a kolumna nie matchowała atrybutu.
3. **Kolumny systemowe** — `created_at`, `status`, `completeness_pct`, `updated_by`, … nie miały ścieżki SKIP.
4. **Sparse cells** — `ImportRowReader::iterateXlsx` mapował komórki pozycyjnie, kruche na rzadkich wierszach eksportu.

## Backend changes
- **`ColumnHeader`** (nowy) — parsuje dotted-suffix lokalizacji (`name.pl` → atrybut `name`, locale `pl`), lustro eksportowego `ColumnResolver`.
- **`CompositeValueParser`** (nowy) — odwraca price/metric do envelope JSONB (`{amount, currency}` / `{value, unit}`); współdzielony przez walidator i creatora; akceptuje separator `.` i `,`.
- **`SystemColumn`** (nowy) — auto-SKIP kolumn read-only w walidatorze, run-handlerze i `AutoMapper` (sugerowane jako Skip).
- **`ImportRowReader`** — mapowanie komórek XLSX po literze kolumny (cell-coordinate), nie po pozycji iteratora.
- **`ImportValidationService`** — required lokalizowane (`name` spełnione przez którekolwiek `name.<locale>`); walidacja typu price/metric przez composite parser; pomijanie kolumn systemowych.
- **`ImportObjectCreator`** — zapis poprawnego envelope per typ (price/metric/select/multiselect/asset/relation) + locale z dotted header. `ResolvedImportValue` zastępuje płaską mapę `code→value` (kolizja przy `name.pl`+`name.en`).
- **`AutoMapper`** — match po bazie atrybutu (strip locale suffix) → `name.pl` auto-mapuje na `name`; kolumny systemowe → Skip.

## Frontend changes
Brak zmian kodu — auto-map jest BE-driven; istniejący kreator (`StepMapping.tsx`) renderuje poprawione sugestie (localized → atrybut, system → Skip) bez modyfikacji.

## Quality gates
- **PHPStan max**: 0 błędów.
- **PHPUnit**: pełny pakiet Import **114/114** zielony. Nowe/rozszerzone: `CompositeValueParserTest`, `ImportRowReaderTest` (sparse xlsx), `ImportRoundTripApiTest` (dry-run export-format → 0 blocking), rozszerzony `ImportValidationServiceTest` + `AutoMapperTest`.
- **composer audit**: pre-existing twig CVE (advisory, nieblokujący — osobny maintenance ticket); brak nowych zależności.
- OpenAPI snapshot: bez zmian (brak nowych/zmienionych endpointów — tylko logika walidacji/parsowania).

## Smoke test (wykonany na żywym stacku — `https://pim.localhost`)
Login `admin@demo.localhost` → na **realnym pliku operatora** (`import pim-export-20260530-144844.xlsx`, 48 kolumn):
- `auto-map`: `name.pl`/`name.en` → `name` (auto), `created_at`/`status`/`completeness_pct`/`updated_by`/`parent_sku` → **skip**, `price`/`weight`/`brand`/`color` → auto.
- `validate-dry-run`: typy błędów **wyłącznie** `missing_required: name` — zniknęły wszystkie `invalid_type` (price `20.99 EUR`, weight `0.3 g`) oraz `missing sku` i szum kolumn systemowych.
- **Pozytywny**: CSV w formacie eksportu z realnymi wartościami (localized name + `20.99 EUR` + `21,99 USD` + `0.3 g`/`0.4 cm` + system column) → **2/2 OK, 0 błędów**.

## Świadome odejścia
- **Pozostałe `missing_required: name` na pliku operatora to realny brak danych, nie bug importu**: profil eksportu wyemitował kolumny `name.pl/en/fr/es`, a produkty mają `name` globalny (locale=null) → eksport zapisał puste komórki name.*. To kwestia eksportu/lokalizacji (**#1146**), nie parsowania importu.
- **Upsert istniejących produktów** poza zakresem — import tworzy nowe obiekty (re-import istniejącego SKU = warning `DuplicateSkuInDb`; unikat `objects_tenant_kind_code` blokuje duplikat). Testowalny kontrakt #1130 = dry-run validation (0 blocking errors). Pełen upsert = osobny ticket.
- **Sufiks kanałowy** (`description.shopify`) interpretowany dziś jako locale (jak grammar eksportu single-segment). Rozdzielenie locale vs channel → epik kanałów (**#1147**).
- **`status`/`enabled`/`parent_sku`** pomijane (import nie ustawia stanu publikacji ani variant-parent w MVP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
