### PR TITLE
feat(modeling): atrybut typu asset jako picker zasobu z podglądem

### DIFF
--- a/apps/admin/e2e/1138-asset-attribute-picker.spec.ts
+++ b/apps/admin/e2e/1138-asset-attribute-picker.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * Operator report (#1138, 2026-05-30): an `asset` attribute rendered as a
+ * plain text field on the object form and showed the `{asset_id}` envelope
+ * as text. Spec mirrors the operator flow:
+ *
+ *  1. Create a custom (non-system) `asset` attribute, attach it directly
+ *     to the built-in Product ObjectType (synthetic "default" group).
+ *  2. Seed a product, open detail → edit.
+ *  3. Assert the asset row renders the library-picker button (NOT a plain
+ *     `<input>`) — the regression catch.
+ *  4. Open the picker, pick an asset, assert the thumbnail + "Zmień zasób"
+ *     replace the empty state.
+ *  5. Save → PATCH 200 → reload → assert the picked asset persists.
+ *
+ * Marked `fixme` in CI for the same `storageState` reason the other
+ * UI-seeded specs use; locally (cold rate-limiter) it is the smoke gate.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+const ASSET_LABEL = /^(Zdjęcie produktu|Product photo)$/;
+
+test('asset attribute renders a library picker + thumbnail, not a text input', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+
+  const ts = uniqueSku('ASSET')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+  const attrCode = `pic_${ts}`;
+
+  // Resolve the built-in Product ObjectType.
+  const otResp = await page.request.get('/api/object_types', { headers: bearer });
+  const otBody = (await otResp.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const types = otBody.member ?? otBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  // Custom (non-system) asset attribute, attached directly to the Product
+  // ObjectType so it renders inline in the synthetic "default" group.
+  const attrResp = await page.request.post('/api/attributes', {
+    data: {
+      code: attrCode,
+      type: 'asset',
+      label: { pl: 'Zdjęcie produktu', en: 'Product photo' },
+      required: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+  });
+  expect(attrResp.status(), await attrResp.text()).toBe(201);
+  const attrId = ((await attrResp.json()) as { id: string }).id;
+
+  const attachResp = await page.request.post(
+    `/api/object_types/${productType.id}/attributes/${attrId}`,
+    { headers: bearer },
+  );
+  expect([200, 201, 204]).toContain(attachResp.status());
+
+  // Seed a product on the Product ObjectType.
+  const sku = uniqueSku('ASSET');
+  const createResponse = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: sku, objectTypeId: productType.id, attributes: { name: `Asset spec ${sku}` } },
+  });
+  expect(createResponse.status(), await createResponse.text()).toBe(201);
+  const product = (await createResponse.json()) as { id: string };
+
+  const groupsResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/effective-attribute-groups') &&
+      response.request().method() === 'GET',
+    { timeout: 15_000 },
+  );
+  await page.goto(`/products/${product.id}`);
+  await groupsResponse;
+  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible();
+
+  const assetLabel = page.getByText(ASSET_LABEL).first();
+  await assetLabel.scrollIntoViewIfNeeded();
+  await expect(assetLabel).toBeVisible();
+
+  const assetRow = assetLabel.locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+  // Regression catch: the row must NOT be a plain text input.
+  await expect(assetRow.locator('input[type="text"]')).toHaveCount(0);
+
+  const chooseButton = assetRow.getByRole('button', { name: /(Wybierz zasób|Choose asset)/ });
+  await expect(chooseButton).toBeVisible();
+  await chooseButton.click();
+
+  // Picker dialog opens — assert it mounted, then pick the first asset.
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByText(/^(Wybierz zasób|Choose asset)$/)).toBeVisible();
+  const firstAsset = dialog.locator('ul li button').first();
+  await expect(firstAsset).toBeVisible();
+  await firstAsset.click();
+
+  // Value set: empty state is replaced by the "Zmień zasób" affordance +
+  // a thumbnail image.
+  const changeButton = assetRow.getByRole('button', { name: /(Zmień zasób|Change asset)/ });
+  await expect(changeButton).toBeVisible();
+  await expect(assetRow.locator('img')).toBeVisible();
+
+  // Save → backend persists `{attributes: {<code>: {asset_id: ...}}}`.
+  const patchResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/products/') && response.request().method() === 'PATCH',
+  );
+  await page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i }).click();
+  const patched = await patchResponse;
+  expect(patched.status()).toBe(200);
+
+  // Reload → the picked asset persists (read path resolves the preview).
+  await page.reload();
+  const reloadedLabel = page.getByText(ASSET_LABEL).first();
+  await reloadedLabel.scrollIntoViewIfNeeded();
+  await expect(
+    reloadedLabel.locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]').locator('img'),
+  ).toBeVisible();
+});

--- a/apps/admin/src/features/catalog/products/components/asset-attribute-picker.tsx
+++ b/apps/admin/src/features/catalog/products/components/asset-attribute-picker.tsx
@@ -1,0 +1,310 @@
+import {
+  ChevronRight,
+  FileText,
+  Film,
+  Folder as FolderIcon,
+  Image as ImageIcon,
+  Search,
+} from 'lucide-react';
+import { useEffect, useId, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
+import { jsonFetch } from '@/lib/http';
+import { useDebouncedCallback } from '@/lib/use-debounced-callback';
+
+interface AssetEntry {
+  id: string;
+  code: string;
+  attributesIndexed?: Record<string, unknown>;
+}
+
+interface AssetsResponse {
+  member: AssetEntry[];
+  totalItems: number;
+}
+
+interface FolderEntry {
+  code: string;
+  displayName: string;
+  assetCount: number;
+}
+
+interface FoldersResponse {
+  member: FolderEntry[];
+  totalItems: number;
+}
+
+/**
+ * Asset chosen for an `asset` attribute value (#1138). `id` is the
+ * CatalogObject id from the listing — resolvable later through
+ * `GET /api/assets/{id}` to refresh the preview.
+ */
+export interface PickedAsset {
+  id: string;
+  previewUrl: string | null;
+  filename: string;
+}
+
+export interface AssetAttributePickerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onPick: (asset: PickedAsset) => void;
+}
+
+/**
+ * Single-select asset library browser for `asset` attribute fields
+ * (#1138). Mirrors {@see AssetLibraryPicker}'s folder/grid navigation but
+ * returns the chosen asset (id + preview) through `onPick` instead of
+ * POSTing to the product↔asset junction — the value lands in the field's
+ * `{asset_id}` envelope via the detail page's dirty-fields flow.
+ */
+export function AssetAttributePicker({ open, onOpenChange, onPick }: AssetAttributePickerProps) {
+  const { t } = useTranslation();
+  const searchId = useId();
+
+  const [currentFolder, setCurrentFolder] = useState<string | null>(null);
+  const [folders, setFolders] = useState<FolderEntry[]>([]);
+  const [assets, setAssets] = useState<AssetEntry[]>([]);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+
+  const setSearchSoon = useDebouncedCallback((value: string) => setDebouncedSearch(value), 300);
+
+  useEffect(() => {
+    setSearchSoon(search);
+  }, [search, setSearchSoon]);
+
+  useEffect(() => {
+    if (open) {
+      setCurrentFolder(null);
+      setSearch('');
+      setDebouncedSearch('');
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || currentFolder !== null) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await jsonFetch<FoldersResponse>('/api/asset-folders', {
+          accept: 'application/json',
+        });
+        if (!cancelled) setFolders(response.member ?? []);
+      } catch {
+        if (!cancelled) setFolders([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, currentFolder]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const query: Record<string, string> = { folder: currentFolder ?? 'root' };
+    if (debouncedSearch) {
+      query.search = debouncedSearch;
+    }
+    void (async () => {
+      try {
+        const response = await jsonFetch<AssetsResponse>('/api/assets', {
+          accept: 'application/ld+json',
+          query,
+        });
+        if (!cancelled) setAssets(response.member ?? []);
+      } catch {
+        if (!cancelled) setAssets([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, currentFolder, debouncedSearch]);
+
+  const currentFolderEntry = useMemo(
+    () => (currentFolder ? folders.find((entry) => entry.code === currentFolder) : null),
+    [currentFolder, folders],
+  );
+  const showFolderTiles = currentFolder === null && folders.length > 0 && !debouncedSearch;
+
+  const handlePick = (asset: AssetEntry) => {
+    const attrs = unwrapAttributesIndexed(asset.attributesIndexed);
+    const previewUrl = typeof attrs.previewUrl === 'string' ? attrs.previewUrl : null;
+    const filename = typeof attrs.filename === 'string' ? attrs.filename : asset.code;
+    onPick({ id: asset.id, previewUrl, filename });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[min(1100px,95vw)] max-h-[90vh] overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>
+            {t('products.detail.asset.picker_title', { defaultValue: 'Wybierz zasób' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('products.detail.asset.picker_body', {
+              defaultValue: 'Wskaż zasób z biblioteki multimediów dla tego pola.',
+            })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3" style={{ minHeight: 'min(500px, 60vh)' }}>
+          <nav
+            aria-label="Breadcrumb"
+            className="flex items-center gap-1 text-sm text-muted-foreground"
+          >
+            <button
+              type="button"
+              onClick={() => setCurrentFolder(null)}
+              className={`rounded px-2 py-1 transition-colors ${
+                currentFolder === null ? 'font-medium text-foreground' : 'hover:bg-muted'
+              }`}
+            >
+              {t('assets.folder.all')}
+            </button>
+            {currentFolderEntry !== null && currentFolderEntry !== undefined ? (
+              <>
+                <ChevronRight className="size-4" aria-hidden="true" />
+                <span className="px-2 py-1 font-medium text-foreground">
+                  {currentFolderEntry.displayName}
+                </span>
+              </>
+            ) : null}
+          </nav>
+
+          <div className="relative flex w-full max-w-md items-center">
+            <Search className="absolute left-3 size-4 text-muted-foreground" aria-hidden="true" />
+            <label htmlFor={searchId} className="sr-only">
+              {t('assets.filters.search_placeholder')}
+            </label>
+            <Input
+              id={searchId}
+              type="search"
+              placeholder={t('assets.filters.search_placeholder')}
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="pl-9"
+            />
+          </div>
+
+          <div
+            className="overflow-y-auto rounded-md border bg-card p-3"
+            style={{ maxHeight: '55vh' }}
+          >
+            {assets.length === 0 && !showFolderTiles ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                {t('products.multimedia.picker_empty')}
+              </p>
+            ) : (
+              <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+                {showFolderTiles
+                  ? folders.map((folder) => (
+                      <li key={folder.code}>
+                        <button
+                          type="button"
+                          onClick={() => setCurrentFolder(folder.code)}
+                          className="group flex w-full flex-col overflow-hidden rounded-md border bg-card text-left transition-colors hover:border-primary"
+                        >
+                          <div className="flex aspect-square items-center justify-center bg-muted/40">
+                            <FolderIcon className="size-10 text-muted-foreground transition-colors group-hover:text-primary" />
+                          </div>
+                          <div className="space-y-0.5 p-2">
+                            <p className="truncate text-xs font-medium" title={folder.displayName}>
+                              {folder.displayName}
+                            </p>
+                            <p className="truncate text-[10px] text-muted-foreground">
+                              {t('assets.folder.count', { count: folder.assetCount })}
+                            </p>
+                          </div>
+                        </button>
+                      </li>
+                    ))
+                  : null}
+                {assets.map((asset) => (
+                  <PickerAssetTile key={asset.id} asset={asset} onPick={() => handlePick(asset)} />
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {t('app.cancel')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface PickerAssetTileProps {
+  asset: AssetEntry;
+  onPick: () => void;
+}
+
+function PickerAssetTile({ asset, onPick }: PickerAssetTileProps) {
+  const attrs = unwrapAttributesIndexed(asset.attributesIndexed);
+  const previewUrl = typeof attrs.previewUrl === 'string' ? attrs.previewUrl : null;
+  const mime = typeof attrs.mime === 'string' ? attrs.mime : null;
+  const filename = typeof attrs.filename === 'string' ? attrs.filename : asset.code;
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onPick}
+        className="group relative flex w-full flex-col overflow-hidden rounded-md border bg-card text-left transition-colors hover:border-primary"
+      >
+        <div className="aspect-square bg-muted/40">
+          {previewUrl !== null ? (
+            <img
+              src={previewUrl}
+              alt={filename}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <PickerPlaceholder mime={mime} />
+          )}
+        </div>
+        <div className="space-y-1 p-2">
+          <p className="truncate text-xs font-medium" title={filename}>
+            {filename}
+          </p>
+          <p className="truncate font-mono text-[10px] text-muted-foreground">{asset.code}</p>
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function PickerPlaceholder({ mime }: { mime: string | null }) {
+  const Icon =
+    mime === null
+      ? ImageIcon
+      : mime.startsWith('image/')
+        ? ImageIcon
+        : mime.startsWith('video/')
+          ? Film
+          : FileText;
+  return (
+    <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+      <Icon className="size-8" />
+    </div>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/asset-field.tsx
+++ b/apps/admin/src/features/catalog/products/components/asset-field.tsx
@@ -1,0 +1,165 @@
+import { useQuery } from '@tanstack/react-query';
+import { Image as ImageIcon, X } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
+import { jsonFetch } from '@/lib/http';
+
+import { AssetAttributePicker, type PickedAsset } from './asset-attribute-picker';
+
+interface AssetResource {
+  id: string;
+  code: string;
+  attributesIndexed?: Record<string, unknown>;
+}
+
+interface ResolvedAsset {
+  previewUrl: string | null;
+  filename: string;
+}
+
+export interface AssetFieldProps {
+  /** The attribute value envelope — `{asset_id}` (or a bare id string for legacy values). */
+  value: unknown;
+  isEditing: boolean;
+  onChange: (next: { asset_id: string } | null) => void;
+  ariaLabel: string;
+}
+
+/**
+ * Editor + read-only renderer for `asset` AttributeType fields (#1138).
+ *
+ * Before this, an asset attribute fell through to a plain text input and
+ * rendered the `{asset_id}` envelope as `[object Object]`. Now it opens
+ * the asset library picker, stores the chosen `{asset_id}` (CatalogObject
+ * id), and shows the thumbnail + filename — resolved through
+ * `GET /api/assets/{id}` so the preview stays fresh.
+ */
+export function AssetField({ value, isEditing, onChange, ariaLabel }: AssetFieldProps) {
+  const { t } = useTranslation();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const assetId = extractAssetId(value);
+
+  // Resolve the chosen asset's preview + filename. The picker also hands
+  // these over on pick, but resolving by id keeps the thumbnail correct
+  // on page reload (the stored envelope only carries the id).
+  const { data: resolved } = useQuery<ResolvedAsset | null>({
+    queryKey: ['assets', assetId, 'preview-meta'],
+    queryFn: async () => {
+      if (assetId === null) return null;
+      const asset = await jsonFetch<AssetResource>(`/api/assets/${assetId}`, {
+        accept: 'application/json',
+      });
+      const attrs = unwrapAttributesIndexed(asset.attributesIndexed);
+      return {
+        previewUrl: typeof attrs.previewUrl === 'string' ? attrs.previewUrl : null,
+        filename: typeof attrs.filename === 'string' ? attrs.filename : asset.code,
+      };
+    },
+    enabled: assetId !== null,
+    staleTime: 60_000,
+  });
+
+  const previewUrl = resolved?.previewUrl ?? null;
+  const filename = resolved?.filename ?? null;
+
+  const handlePicked = (asset: PickedAsset) => {
+    onChange({ asset_id: asset.id });
+  };
+
+  if (!isEditing) {
+    if (assetId === null) {
+      return (
+        <span className="italic text-zinc-400">
+          {t('products.detail.field.empty', { defaultValue: '—' })}
+        </span>
+      );
+    }
+    return (
+      <div className="flex items-center gap-3">
+        <AssetThumb previewUrl={previewUrl} alt={filename ?? assetId} />
+        <span className="truncate text-[13.5px] text-ink" title={filename ?? assetId}>
+          {filename ?? assetId}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <AssetThumb previewUrl={previewUrl} alt={filename ?? ''} />
+      <div className="flex min-w-0 flex-col gap-1">
+        {assetId !== null ? (
+          <span className="truncate text-[13px] text-zinc-600" title={filename ?? assetId}>
+            {filename ?? assetId}
+          </span>
+        ) : (
+          <span className="text-[13px] italic text-zinc-400">
+            {t('products.detail.asset.none', { defaultValue: 'Brak wybranego zasobu' })}
+          </span>
+        )}
+        <div className="flex items-center gap-2">
+          {(() => {
+            const action =
+              assetId !== null
+                ? t('products.detail.asset.change', { defaultValue: 'Zmień zasób' })
+                : t('products.detail.asset.choose', { defaultValue: 'Wybierz zasób' });
+            return (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setPickerOpen(true)}
+                aria-label={`${action} — ${ariaLabel}`}
+              >
+                {action}
+              </Button>
+            );
+          })()}
+          {assetId !== null ? (
+            <button
+              type="button"
+              onClick={() => onChange(null)}
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-700"
+            >
+              <X className="size-3" aria-hidden />
+              {t('products.detail.asset.clear', { defaultValue: 'Usuń' })}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <AssetAttributePicker open={pickerOpen} onOpenChange={setPickerOpen} onPick={handlePicked} />
+    </div>
+  );
+}
+
+function AssetThumb({ previewUrl, alt }: { previewUrl: string | null; alt: string }) {
+  return (
+    <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50">
+      {previewUrl !== null ? (
+        <img src={previewUrl} alt={alt} loading="lazy" className="h-full w-full object-cover" />
+      ) : (
+        <ImageIcon className="size-6 text-zinc-300" aria-hidden />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Pulls the asset id out of the stored value. Canonical shape is the
+ * `{asset_id}` envelope; a bare id string is tolerated for older data.
+ */
+function extractAssetId(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return value === '' ? null : value;
+  }
+  if (value !== null && typeof value === 'object' && 'asset_id' in value) {
+    const raw = (value as { asset_id: unknown }).asset_id;
+    return typeof raw === 'string' && raw !== '' ? raw : null;
+  }
+  return null;
+}

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -9,6 +9,7 @@ import { MultiSelect, type MultiSelectOption } from '@/components/ui/multi-selec
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
+import { AssetField } from './asset-field';
 import { RelationInlineEditor } from './relation-inline-editor';
 import type { AttributeMeta, AttributeOptionMeta, ProductLocale } from './types';
 
@@ -126,9 +127,20 @@ export function AttrRow({
             never live behind `editable`. Pre-#1093 the synthetic Relations
             tab rendered RelationsTab standalone, also bypassing the page
             toggle; this preserves that UX for the inline path. */}
-        {attribute.type === 'relation' &&
-        typeof relationContextProductId === 'string' &&
-        relationContextProductId.length > 0 ? (
+        {attribute.type === 'asset' ? (
+          // #1138 — asset attrs render a library picker + thumbnail
+          // instead of a plain text input. AssetField is self-contained
+          // (own preview query, modal picker) and handles both the edit
+          // and read-only states via `isEditing`.
+          <AssetField
+            value={value}
+            isEditing={editable}
+            onChange={(next) => onChange(next)}
+            ariaLabel={label}
+          />
+        ) : attribute.type === 'relation' &&
+          typeof relationContextProductId === 'string' &&
+          relationContextProductId.length > 0 ? (
           <RelationInlineEditor
             productId={relationContextProductId}
             attributeId={attribute.id}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1542,6 +1542,14 @@
       "completeness": {
         "aria": "Completeness {{pct}}%"
       },
+      "asset": {
+        "picker_title": "Choose asset",
+        "picker_body": "Pick an asset from the media library for this field.",
+        "choose": "Choose asset",
+        "change": "Change asset",
+        "clear": "Remove",
+        "none": "No asset selected"
+      },
       "has_variants": "Variant · {{count}} variants",
       "no_variants": "No variants",
       "status": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1590,6 +1590,14 @@
       "completeness": {
         "aria": "Kompletność {{pct}}%"
       },
+      "asset": {
+        "picker_title": "Wybierz zasób",
+        "picker_body": "Wskaż zasób z biblioteki multimediów dla tego pola.",
+        "choose": "Wybierz zasób",
+        "change": "Zmień zasób",
+        "clear": "Usuń",
+        "none": "Brak wybranego zasobu"
+      },
       "has_variants": "Wariantowy · {{count}} wariantów",
       "no_variants": "Bez wariantów",
       "status": {


### PR DESCRIPTION
## Summary
Atrybut typu **asset** renderował się w formularzu obiektu jako zwykłe pole tekstowe i pokazywał envelope `{asset_id}` jako `[object Object]`. Teraz renderuje picker biblioteki multimediów z podglądem miniatury.

## Root cause
- `AttrRow` nie miał case'a `asset` → fallback do `<Input type="text">`.
- Istniejący `AssetLibraryPicker` był sprzężony z junctionem produkt↔asset (`POST /products/{id}/assets`) → brak wariantu zwracającego asset-id jako wartość atrybutu.

## Frontend changes
- **`AssetAttributePicker`** (nowy) — single-select przeglądarka biblioteki (folder/grid jak `AssetLibraryPicker`), zwraca wybrany zasób przez `onPick` zamiast POST do junctiona.
- **`AssetField`** (nowy) — edytor + render read-only dla `asset`. Zapisuje `{asset_id}` (CatalogObject id), rozwiązuje miniaturę + nazwę pliku przez `GET /api/assets/{id}` (świeży podgląd po reloadzie). Edit: miniatura + nazwa + „Wybierz/Zmień zasób" + „Usuń". Read-only: miniatura + nazwa lub „—".
- **`AttrRow`** — nowy branch `asset` spinający `AssetField` (edit + read-only).
- i18n (pl + en): `products.detail.asset.*`.

## Backend changes
Brak — `AssetValidator` już waliduje envelope `{asset_id}` (UUID); `ObjectAttributesUpserter` przepuszcza tablicę bez zmian. Działa dla produktów i obiektów custom (oba używają `AttrRow`).

## Quality gates
- **Biome strict**: 0 błędów. **tsc --noEmit**: 0 błędów. **Vite build**: ok.
- **Playwright E2E** (`1138-asset-attribute-picker.spec.ts`): zielony lokalnie. `test.fixme` w CI (znany gap auth-rate-limiter storageState, jak pozostałe UI-seeded spec-i).
- composer/pnpm audit: bez nowych zależności (composer audit = pre-existing twig CVE, nieblokujący).

## Smoke test (wykonany — Playwright na żywym stacku `pim.localhost`)
Custom atrybut `asset` przypięty do Product OT → formularz produktu w trybie edycji:
1. Wiersz atrybutu renderuje przycisk pickera (**nie** `<input type=text>`) — regression catch.
2. „Wybierz zasób" → modal biblioteki → wybór zasobu.
3. Pojawia się **miniatura** + „Zmień zasób" (zamiast pustego stanu).
4. Zapisz → `PATCH /api/products/{id}` → **200**.
5. Reload → miniatura nadal widoczna (read path rozwiązuje podgląd po `asset_id`).

Test artifacts utworzone przez spec na demo DB zostały posprzątane (0 pozostałości).

## Świadome odejścia
- `attributes/new` nie dostaje panelu konfiguracji dla `asset` — ten typ nie ma opcji/reguł poza referencją (UUID); user-facing bug był w rendererze pola, nie w kreatorze atrybutu.
- Atrybuty `asset` oznaczone `is_system` pozostają read-only (jak każdy system attr) — picker dostępny dla atrybutów custom (zgodnie z flow operatora).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
