### PR TITLE
feat(catalog): ekspozycja is_localizable + locales tenanta w effective-groups

### DIFF
--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -53,6 +53,14 @@ export interface AttributeMeta {
   type: string;
   label: { pl?: string; en?: string };
   is_system: boolean;
+  /**
+   * #1151 — whether the attribute carries a distinct value per locale.
+   * Replaces the old code-suffix heuristic for the AttrRow locale chip and
+   * gates the per-locale read/write flow (#1150). `is_scopable` is its
+   * channel-axis counterpart (#1147).
+   */
+  is_localizable?: boolean;
+  is_scopable?: boolean;
   position: number;
   is_required_in_group: boolean;
   visible_when?: unknown;

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -14,6 +14,7 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Domain\Tenant;
 use App\Shared\Infrastructure\Audit\CursorCodec;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
@@ -302,7 +303,33 @@ final class ProductReadEndpointsController
         return new JsonResponse([
             'product_id' => $product->getId()->toRfc4122(),
             'groups' => $effective,
+            // #1149 — the locale picker is fed from here (a `products.view`
+            // endpoint the detail page already calls) rather than the
+            // permission-gated /api/tenant-locales, so an operator without
+            // settings access still gets the tenant's real locales.
+            'locales' => $this->serializeTenantLocales($product),
         ]);
+    }
+
+    /**
+     * @return list<array{code: string, is_default: bool}>
+     */
+    private function serializeTenantLocales(CatalogObject $product): array
+    {
+        $tenant = $product->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return [];
+        }
+        $primary = $tenant->getPrimaryLocale();
+
+        $locales = [];
+        foreach ($tenant->getEnabledLocales() as $code) {
+            $locales[] = ['code' => $code, 'is_default' => $code === $primary];
+        }
+        // Primary first so the picker defaults to it deterministically.
+        usort($locales, static fn (array $a, array $b): int => ($b['is_default'] ? 1 : 0) <=> ($a['is_default'] ? 1 : 0));
+
+        return $locales;
     }
 
     private function mustFindProduct(string $id): CatalogObject
@@ -370,6 +397,12 @@ final class ProductReadEndpointsController
             'type' => $attribute->getType()->value,
             'label' => $attribute->getLabel(),
             'is_system' => $attribute->isSystem(),
+            // #1151 — drives the per-locale value flow on the detail page:
+            // the AttrRow chip + per-locale read/write switch on this flag
+            // instead of the old code-suffix heuristic. is_scopable pairs
+            // it for the channels epic (#1147).
+            'is_localizable' => $attribute->isLocalizable(),
+            'is_scopable' => $attribute->isScopable(),
             'position' => $position,
             'is_required_in_group' => $isRequiredInGroup,
             'visible_when' => $visibleWhen,

--- a/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
+++ b/apps/api/tests/Api/Catalog/EffectiveAttributeGroupsApiTest.php
@@ -109,6 +109,80 @@ final class EffectiveAttributeGroupsApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function exposesIsLocalizablePerAttributeAndTenantLocales(): void
+    {
+        $client = $this->authenticatedClient();
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $productType = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        $tenantContext->set($tenant);
+
+        $localized = new Attribute('loc_title_eag', ['pl' => 'Tytuł', 'en' => 'Title'], AttributeType::Text);
+        $localized->changeLocalizable(true);
+        $shared = new Attribute('shared_brand_eag', ['pl' => 'Marka', 'en' => 'Brand'], AttributeType::Text);
+        $em = $this->em();
+        $em->persist($localized);
+        $em->persist($shared);
+        $em->flush();
+
+        $service = self::getContainer()->get(ObjectTypeService::class);
+        $service->assignAttribute($productType, $localized, required: false, sortOrder: 0);
+        $service->assignAttribute($productType, $shared, required: false, sortOrder: 1);
+        $tenantContext->clear();
+
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'EAG-LOC',
+                'objectTypeId' => $productType->getId()->toRfc4122(),
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+        $id = $created['id'] ?? null;
+        \assert(\is_string($id));
+
+        $body = $client->request('GET', '/api/products/'.$id.'/effective-attribute-groups')->toArray();
+
+        // is_localizable exposed per attribute.
+        $groups = $body['groups'] ?? [];
+        \assert(\is_array($groups));
+        $byCode = [];
+        foreach ($groups as $group) {
+            \assert(\is_array($group));
+            $attributes = $group['attributes'] ?? [];
+            \assert(\is_array($attributes));
+            foreach ($attributes as $attr) {
+                \assert(\is_array($attr) && \is_string($attr['code'] ?? null));
+                $byCode[$attr['code']] = $attr;
+            }
+        }
+        self::assertArrayHasKey('loc_title_eag', $byCode);
+        self::assertTrue($byCode['loc_title_eag']['is_localizable']);
+        self::assertArrayHasKey('shared_brand_eag', $byCode);
+        self::assertFalse($byCode['shared_brand_eag']['is_localizable']);
+
+        // Tenant locales surfaced for the picker (default first).
+        $locales = $body['locales'] ?? [];
+        \assert(\is_array($locales) && [] !== $locales);
+        $codes = [];
+        foreach ($locales as $entry) {
+            \assert(\is_array($entry) && \is_string($entry['code'] ?? null));
+            $codes[] = $entry['code'];
+        }
+        self::assertContains('pl', $codes);
+        self::assertContains('en', $codes);
+        $first = $locales[0];
+        \assert(\is_array($first));
+        self::assertTrue($first['is_default'], 'Default locale is listed first.');
+        self::assertSame('pl', $first['code']);
+    }
+
+    #[Test]
     public function exposesDisplayModePerGroupAndSyntheticGroupIsStacked(): void
     {
         // MODR-03 (#925) — every group in the payload carries a


### PR DESCRIPTION
## Summary
Część 2/4 epiku #1146. Endpoint `effective-attribute-groups` udostępnia teraz `is_localizable` (+ `is_scopable`) per atrybut oraz `locales: [{code, is_default}]` (default pierwszy).

## Po co
- `is_localizable` → karta obiektu steruje flow per-locale realną flagą atrybutu zamiast heurystyki po sufiksie kodu (#1150).
- `locales[]` → dynamiczny picker (#1149) zasilany z endpointu `products.view`, który strona i tak woła — bez sięgania po `/api/tenant-locales` (gated `settings.locales.manage` → 403 dla operatora bez settings).
- Zapis `localizable` już działa (create + PATCH `AttributeProcessor`) — bez zmian.

## Changes
- `ProductReadEndpointsController::serializeAttribute` → `is_localizable` / `is_scopable`; response → `locales` (z `Tenant::getEnabledLocales()` + primary).
- FE `types.ts AttributeMeta` → opcjonalne `is_localizable?` / `is_scopable?`.

## Quality gates
- PHPStan max: 0. PHPUnit `EffectiveAttributeGroupsApiTest` **6/6** (nowy case: is_localizable per atrybut + locales default-first). Custom JsonResponse → brak OpenAPI drift.

Refs #1146 · Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)