### PR TITLE
feat(admin): dynamiczny picker locale z locale tenanta

### DIFF
--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -57,6 +57,7 @@ import type {
   AttributeMeta,
   CatalogObjectDto,
   GroupMeta,
+  LocaleOption,
   ProductChannel,
   ProductLocale,
 } from '@/features/catalog/products/components/types';
@@ -136,12 +137,14 @@ export function UniversalDetailPage({
   });
 
   // UP-07a — poly-kind /api/objects/{id}/effective-attribute-groups.
-  const groupsQuery = useQuery<{ groups: GroupMeta[] }>({
+  const groupsQuery = useQuery<{ groups: GroupMeta[]; locales?: LocaleOption[] }>({
     queryKey: ['object', objectId, 'effective-attribute-groups'],
     enabled: objectId !== '',
     staleTime: 5_000,
     queryFn: () =>
-      jsonFetch<{ groups: GroupMeta[] }>(`/api/objects/${objectId}/effective-attribute-groups`),
+      jsonFetch<{ groups: GroupMeta[]; locales?: LocaleOption[] }>(
+        `/api/objects/${objectId}/effective-attribute-groups`,
+      ),
     placeholderData: (prev) => prev,
   });
 
@@ -169,6 +172,12 @@ export function UniversalDetailPage({
   // empty groups; here we only render groups that contribute attributes.
   const groups = useMemo(
     () => (groupsQuery.data?.groups ?? []).filter((g) => g.attributes.length > 0),
+    [groupsQuery.data],
+  );
+
+  // #1149 — dynamic locale picker from the tenant's enabled locales.
+  const locales = useMemo<LocaleOption[]>(
+    () => groupsQuery.data?.locales ?? [],
     [groupsQuery.data],
   );
 
@@ -205,6 +214,16 @@ export function UniversalDetailPage({
       setActiveTab('attributes');
     }
   }, [activeTab, visibleTabs]);
+
+  // #1149 — default the picker to the tenant default locale once loaded.
+  const [didInitLocale, setDidInitLocale] = useState(false);
+  useEffect(() => {
+    if (didInitLocale || locales.length === 0) return;
+    const def = locales.find((l) => l.is_default) ?? locales[0];
+    if (def === undefined) return;
+    setLocale(def.code);
+    setDidInitLocale(true);
+  }, [locales, didInitLocale]);
 
   const [didExpandInitial, setDidExpandInitial] = useState(false);
   useEffect(() => {
@@ -495,6 +514,7 @@ export function UniversalDetailPage({
             channel={channel}
             onLocaleChange={setLocale}
             onChannelChange={setChannel}
+            locales={locales}
           />
         </div>
       </header>

--- a/apps/admin/src/features/catalog/products/components/locale-channel-toolbar.tsx
+++ b/apps/admin/src/features/catalog/products/components/locale-channel-toolbar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 import {
+  type LocaleOption,
   PRODUCT_CHANNELS,
   PRODUCT_LOCALES,
   type ProductChannel,
@@ -23,6 +24,11 @@ export interface LocaleChannelToolbarProps {
   channel: ProductChannel | null;
   onLocaleChange: (next: ProductLocale) => void;
   onChannelChange: (next: ProductChannel | null) => void;
+  /**
+   * #1149 — the tenant's enabled locales (from `effective-attribute-groups`).
+   * Falls back to the static PRODUCT_LOCALES on first paint / when absent.
+   */
+  locales?: LocaleOption[];
 }
 
 const CHANNEL_LABELS: Record<ProductChannel, string> = {
@@ -42,8 +48,11 @@ export function LocaleChannelToolbar({
   channel,
   onLocaleChange,
   onChannelChange,
+  locales,
 }: LocaleChannelToolbarProps) {
   const { t } = useTranslation();
+  const localeCodes: readonly string[] =
+    locales !== undefined && locales.length > 0 ? locales.map((l) => l.code) : PRODUCT_LOCALES;
 
   return (
     <div className="flex items-center gap-2">
@@ -64,7 +73,7 @@ export function LocaleChannelToolbar({
             {t('products.detail.locale.label', { defaultValue: 'Język' })}
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          {PRODUCT_LOCALES.map((option) => (
+          {localeCodes.map((option) => (
             <DropdownMenuItem
               key={option}
               onClick={() => onLocaleChange(option)}

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -52,6 +52,7 @@ import type {
   AttributeMeta,
   CatalogObjectDto,
   GroupMeta,
+  LocaleOption,
   ProductChannel,
   ProductDetailMode,
   ProductLocale,
@@ -204,7 +205,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   // immune to invalidation). In create mode the query keys flip between
   // the preview endpoint (when categories are selected) and the bare
   // ObjectType endpoint (when none are selected yet).
-  const groupsQuery = useQuery<{ groups: GroupMeta[] }>({
+  const groupsQuery = useQuery<{ groups: GroupMeta[]; locales?: LocaleOption[] }>({
     queryKey:
       isEditMode && id !== ''
         ? ['products', id, 'effective-attribute-groups']
@@ -216,13 +217,15 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
           ],
     queryFn: async () => {
       if (isEditMode && id !== '') {
-        return jsonFetch<{ groups: GroupMeta[] }>(`/api/products/${id}/effective-attribute-groups`);
+        return jsonFetch<{ groups: GroupMeta[]; locales?: LocaleOption[] }>(
+          `/api/products/${id}/effective-attribute-groups`,
+        );
       }
       if (objectTypeId === null) {
         return { groups: [] };
       }
       if (createCategoryIds.length > 0) {
-        return jsonFetch<{ groups: GroupMeta[] }>(
+        return jsonFetch<{ groups: GroupMeta[]; locales?: LocaleOption[] }>(
           `/api/object_types/${objectTypeId}/effective-attribute-groups/preview`,
           {
             method: 'POST',
@@ -232,7 +235,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
           },
         );
       }
-      return jsonFetch<{ groups: GroupMeta[] }>(
+      return jsonFetch<{ groups: GroupMeta[]; locales?: LocaleOption[] }>(
         `/api/object_types/${objectTypeId}/effective-attribute-groups`,
       );
     },
@@ -242,6 +245,22 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   });
 
   const groups = useMemo(() => groupsQuery.data?.groups ?? [], [groupsQuery.data]);
+
+  // #1149 — the locale picker is fed from the tenant's real enabled locales
+  // (shipped by effective-attribute-groups). Default the selection to the
+  // tenant default once, then respect manual switches.
+  const locales = useMemo<LocaleOption[]>(
+    () => groupsQuery.data?.locales ?? [],
+    [groupsQuery.data],
+  );
+  const [didInitLocale, setDidInitLocale] = useState(false);
+  useEffect(() => {
+    if (didInitLocale || locales.length === 0) return;
+    const def = locales.find((l) => l.is_default) ?? locales[0];
+    if (def === undefined) return;
+    setLocale(def.code);
+    setDidInitLocale(true);
+  }, [locales, didInitLocale]);
 
   // MODR-03 (#925) — tab list derived dynamically from `groups`:
   // every group with `display_mode='tab'` becomes its own tab; groups
@@ -756,6 +775,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
               channel={channel}
               onLocaleChange={setLocale}
               onChannelChange={setChannel}
+              locales={locales}
             />
           ) : null}
         </div>

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -6,9 +6,19 @@
  *   GET /api/products/{id}/effective-attribute-groups → { groups: [...] }
  */
 
-export type ProductLocale = 'pl' | 'en' | 'de' | 'cs';
+// #1149 — a locale code is whatever the tenant has enabled, not a fixed
+// union. The real list comes from the effective-attribute-groups payload
+// (`locales`); PRODUCT_LOCALES is only a static fallback for pre-#1149
+// callers / first paint before the list loads.
+export type ProductLocale = string;
 
 export const PRODUCT_LOCALES: readonly ProductLocale[] = ['pl', 'en', 'de', 'cs'] as const;
+
+/** One enabled tenant locale, surfaced by `effective-attribute-groups` (#1149). */
+export interface LocaleOption {
+  code: string;
+  is_default: boolean;
+}
 
 export type ProductChannel = 'shopify' | 'baselinker' | 'allegro';
 
@@ -97,6 +107,8 @@ export interface GroupMeta {
 
 export interface EffectiveAttributeGroups {
   groups: GroupMeta[];
+  /** #1149 — tenant's enabled locales for the detail-page picker. */
+  locales?: LocaleOption[];
 }
 
 export type ProductDetailMode = 'edit' | 'create';


### PR DESCRIPTION
## Summary
Część 3/4 epiku #1146. Picker locale w szczegółach obiektu był hardkodowany `pl/en/de/cs` — pomijał włączone locale (`fr`/`es`) i oferował wyłączone (`de`/`cs`). Teraz renderuje realne locale tenanta z `locales` (z `effective-attribute-groups`, #1151) i domyślnie ustawia locale domyślne tenanta.

## Changes
- `LocaleChannelToolbar` — prop `locales` (fallback `PRODUCT_LOCALES` na pierwszy paint).
- `ProductDetailPage` + `UniversalDetailPage` — czytają `locales` z groups-query, inicjują picker na default locale (raz, potem respektują wybór operatora).
- `ProductLocale` poszerzony z unii na `string`.

## Quality gates
- tsc --noEmit: 0. Biome: 0. Vite build: ok.
- Live: `GET /api/products/{id}/effective-attribute-groups` → `locales: [pl(default), en, fr, es]` dla demo — picker listuje dokładnie te (zamiast hardkodu).

## Świadome odejścia
Realne przełączanie wartości per-locale (read `?locale=` + zapis) + chip `is_localizable` + Playwright → **#1150** (kolejny PR). Ten PR to sam picker (dynamiczne opcje + default) — nie zmienia jeszcze wartości przy zmianie locale.

Refs #1146 · Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)