### PR TITLE
feat(admin): per-locale odczyt + zapis wartości w szczegółach obiektu

### DIFF
--- a/apps/admin/e2e/products-locale-switch.spec.ts
+++ b/apps/admin/e2e/products-locale-switch.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * Operator report (#1146/#1150, 2026-05-30): selecting a language version
+ * in the object detail did nothing. Spec exercises the end-to-end flow:
+ *
+ *  1. Create a localizable attribute, attach it to the Product ObjectType.
+ *  2. Seed a product, open detail → edit.
+ *  3. Edit the localizable field under the default locale (pl), save.
+ *  4. Switch the picker to EN — the field shows the pl value as fallback;
+ *     overwrite it with an EN value, save.
+ *  5. Switch back to PL — the pl value is intact (distinct from EN).
+ *
+ * Also asserts the picker is populated from the tenant's real locales
+ * (not the old hardcoded pl/en/de/cs).
+ *
+ * `test.fixme` in CI for the shared auth-rate-limiter storageState gap.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+const FIELD_LABEL = /^(Tytuł lokalny|Local title)$/;
+
+test('locale switch reads + writes per-locale values', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const token = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${token}` };
+
+  const ts = uniqueSku('LOC')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+  const attrCode = `loctitle_${ts}`;
+
+  const otResp = await page.request.get('/api/object_types', { headers: bearer });
+  const otBody = (await otResp.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const types = otBody.member ?? otBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  // Localizable attribute, attached directly to the Product ObjectType.
+  const attrResp = await page.request.post('/api/attributes', {
+    data: {
+      code: attrCode,
+      type: 'text',
+      label: { pl: 'Tytuł lokalny', en: 'Local title' },
+      localizable: true,
+      required: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+  });
+  expect(attrResp.status(), await attrResp.text()).toBe(201);
+  const attrId = ((await attrResp.json()) as { id: string }).id;
+
+  const attachResp = await page.request.post(
+    `/api/object_types/${productType.id}/attributes/${attrId}`,
+    { headers: bearer },
+  );
+  expect([200, 201, 204]).toContain(attachResp.status());
+
+  const sku = uniqueSku('LOC');
+  const createResponse = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: sku, objectTypeId: productType.id, attributes: { name: `Locale spec ${sku}` } },
+  });
+  expect(createResponse.status(), await createResponse.text()).toBe(201);
+  const product = (await createResponse.json()) as { id: string };
+
+  await page.goto(`/products/${product.id}`);
+  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  const saveButton = page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i });
+  await expect(saveButton).toBeVisible();
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  const fieldRow = () =>
+    page
+      .getByText(FIELD_LABEL)
+      .first()
+      .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+
+  // 1. Edit under the default locale (pl) + save.
+  await fieldRow().scrollIntoViewIfNeeded();
+  const plInput = fieldRow().locator('input[type="text"]');
+  await plInput.fill('Wartość PL');
+  await saveButton.click();
+  await expect(page.getByRole('button', { name: /^(edytuj|edit)$/i })).toBeVisible();
+
+  // Picker is populated from the tenant's real locales (EN present).
+  await page.getByRole('button', { name: /^(język|language)$/i }).click();
+  // Items render as "<code> <label>" (e.g. "en English") — match the code
+  // prefix so the assertion is independent of the label language.
+  const enItem = page.getByRole('menuitem', { name: /^en\b/i });
+  await expect(enItem).toBeVisible();
+  await enItem.click();
+
+  // 2. EN shows the pl fallback; overwrite with an EN value + save.
+  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  await fieldRow().scrollIntoViewIfNeeded();
+  const enInput = fieldRow().locator('input[type="text"]');
+  await expect(enInput).toHaveValue('Wartość PL'); // fallback to global/pl
+  await enInput.fill('Value EN');
+  await saveButton.click();
+  await expect(page.getByRole('button', { name: /^(edytuj|edit)$/i })).toBeVisible();
+  await expect(fieldRow().getByText('Value EN')).toBeVisible();
+
+  // 3. Switch back to PL — the pl value is intact + distinct from EN.
+  await page.getByRole('button', { name: /^(język|language)$/i }).click();
+  await page.getByRole('menuitem', { name: /^pl\b/i }).click();
+  await expect(fieldRow().getByText('Wartość PL')).toBeVisible();
+  await expect(fieldRow().getByText('Value EN')).toHaveCount(0);
+});

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -124,13 +124,18 @@ export function UniversalDetailPage({
   const navigate = useNavigate();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
 
+  // #1150 — active locale drives the object read + write. Declared before
+  // the object query so it can be part of the query key (switching the
+  // picker refetches the locale-resolved reading).
+  const [locale, setLocale] = useState<ProductLocale>('pl');
+
   // UP-07 — poly-kind GET /api/objects/{id} (existing AP4 ApiResource).
   const objectQuery = useQuery({
-    queryKey: ['object', objectId],
+    queryKey: ['object', objectId, locale],
     enabled: objectId !== '',
     staleTime: 30_000,
     queryFn: async (): Promise<CatalogObjectDto> => {
-      return jsonFetch<CatalogObjectDto>(`/api/objects/${objectId}`, {
+      return jsonFetch<CatalogObjectDto>(`/api/objects/${objectId}?locale=${locale}`, {
         accept: 'application/ld+json',
       });
     },
@@ -200,7 +205,6 @@ export function UniversalDetailPage({
   }, [tabModeGroups, isCategorizable, hasMultimedia, hasVariants]);
 
   const [activeTab, setActiveTab] = useState<TabKey>('attributes');
-  const [locale, setLocale] = useState<ProductLocale>('pl');
   const [channel, setChannel] = useState<ProductChannel | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
@@ -224,6 +228,11 @@ export function UniversalDetailPage({
     setLocale(def.code);
     setDidInitLocale(true);
   }, [locales, didInitLocale]);
+
+  // #1150 — switching locale discards unsaved edits (saves before switch).
+  useEffect(() => {
+    setDirtyFields({});
+  }, [locale]);
 
   const [didExpandInitial, setDidExpandInitial] = useState(false);
   useEffect(() => {
@@ -260,7 +269,9 @@ export function UniversalDetailPage({
     setIsSaving(true);
     try {
       const attributes = stripAttributes(dirtyFields);
-      await jsonFetch(`/api/objects/${objectId}`, {
+      // #1150 — write in the active locale (BE routes localizable attrs to
+      // that locale, others stay global).
+      await jsonFetch(`/api/objects/${objectId}?locale=${locale}`, {
         method: 'PATCH',
         contentType: 'application/merge-patch+json',
         body: { attributes },

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -293,12 +293,10 @@ function relationTooltip(
 }
 
 function isLocaleScoped(attribute: AttributeMeta): boolean {
-  // Heuristic until backend exposes `is_localized` on AttributeMeta:
-  // PL/EN suffixed codes (`name_pl`, `description_en`) and richtext/text
-  // attributes flagged as system are treated as content surfaces that
-  // benefit from a locale chip in the row label.
-  if (/_pl$|_en$|_de$|_cs$/i.test(attribute.code)) return true;
-  return attribute.type === 'richtext' || attribute.type === 'textarea';
+  // #1150 — the backend now ships the real `is_localizable` flag (#1151),
+  // so the locale chip reflects whether the value is actually per-locale
+  // instead of guessing from the code suffix / type.
+  return attribute.is_localizable === true;
 }
 
 function optionLabel(option: AttributeOptionMeta, lang: 'pl' | 'en'): string {

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -1,4 +1,3 @@
-import { useOne } from '@refinedev/core';
 import { useQuery } from '@tanstack/react-query';
 import {
   ArrowLeft,
@@ -130,10 +129,19 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     return searchParams.get('primary');
   }, [mode, searchParams]);
 
-  const { result, query } = useOne<CatalogObjectDto>({
-    resource: 'products',
-    id,
-    queryOptions: { enabled: isEditMode && id !== '' },
+  const [locale, setLocale] = useState<ProductLocale>('pl');
+
+  // #1150 — load the product in the active locale so localizable values
+  // reflect the picker. Replaces Refine's useOne (its getOne drops the
+  // query string); the locale is part of the query key, so switching the
+  // picker refetches the locale-resolved reading.
+  const productQuery = useQuery<CatalogObjectDto>({
+    queryKey: ['products', id, locale],
+    queryFn: () =>
+      jsonFetch<CatalogObjectDto>(`/api/products/${id}?locale=${locale}`, {
+        accept: 'application/ld+json',
+      }),
+    enabled: isEditMode && id !== '',
   });
 
   const { objectTypeId } = useDefaultObjectType('product');
@@ -146,7 +154,6 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   const hasMultimediaCapability = schemaQuery.data?.objectType.has_multimedia ?? false;
 
   const [activeTab, setActiveTab] = useState<TabKey>('attributes');
-  const [locale, setLocale] = useState<ProductLocale>('pl');
   const [channel, setChannel] = useState<ProductChannel | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(!isEditMode);
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
@@ -193,7 +200,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     }));
   }, [mode, createCategoryIds, createPrimaryId, categoriesListQuery.data]);
 
-  const product = isEditMode ? result : null;
+  const product = isEditMode ? (productQuery.data ?? null) : null;
   const attrs = useMemo(
     () =>
       unwrapAttributesIndexed(product?.attributesIndexed as Record<string, unknown> | undefined),
@@ -261,6 +268,12 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     setLocale(def.code);
     setDidInitLocale(true);
   }, [locales, didInitLocale]);
+
+  // #1150 — switching locale discards unsaved edits so a pl edit is never
+  // written to the en row; the operator saves before switching.
+  useEffect(() => {
+    setDirtyFields({});
+  }, [locale]);
 
   // MODR-03 (#925) — tab list derived dynamically from `groups`:
   // every group with `display_mode='tab'` becomes its own tab; groups
@@ -421,12 +434,14 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
           return;
         }
         const attributes = stripAttributes(dirtyFields);
-        await jsonFetch(`/api/products/${id}`, {
+        // #1150 — write in the active locale: localizable attributes land
+        // on that locale's row, others stay global (BE decides per flag).
+        await jsonFetch(`/api/products/${id}?locale=${locale}`, {
           method: 'PATCH',
           contentType: 'application/merge-patch+json',
           body: { attributes },
         });
-        await query.refetch();
+        await productQuery.refetch();
         setDirtyFields({});
         setIsEditing(false);
         toast.success(t('products.detail.save.success', { defaultValue: 'Zapisano zmiany' }));
@@ -469,10 +484,10 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   // still-loading and pinned the page on an infinite "Ładowanie…". Refine's
   // `useOne` returns `isLoading=false`, `isError=true`, `data=undefined`
   // after a 404, so we now check `isError` explicitly.
-  if (isEditMode && query.isLoading) {
+  if (isEditMode && productQuery.isLoading) {
     return <DetailLoadingState />;
   }
-  if (isEditMode && (query.isError || product === null || product === undefined)) {
+  if (isEditMode && (productQuery.isError || product === null || product === undefined)) {
     return (
       <DetailNotFoundState
         id={id}


### PR DESCRIPTION
## Summary
Część 4/4 (finalna) epiku #1146. Zmiana locale w szczegółach obiektu **realnie** przełącza wyświetlane/edytowane wartości — operator: „teraz to nie działa".

## Changes
- `ProductDetailPage` — `useOne` (Refine `getOne` gubi query-string) zastąpione `useQuery` keyed `['products', id, locale]` z `?locale=`; PATCH zapisuje z `?locale=`.
- `UniversalDetailPage` — `?locale=` na GET `/api/objects/{id}` (+ query key) i PATCH.
- Zmiana locale czyści niezapisane edycje (edit pl nie trafi do wiersza en — operator zapisuje przed przełączeniem).
- `AttrRow` chip locale czyta realną flagę `is_localizable` (#1151) zamiast heurystyki po sufiksie kodu.

## Quality gates
- tsc --noEmit: 0. Biome: 0 errors. Vite build: ok.
- Playwright `products-locale-switch.spec.ts` (zielony lokalnie): edit PL → save → przełącz EN (pokazuje fallback PL) → edit EN → save → powrót PL: wartość PL nienaruszona i różna od EN; picker zasilony locale tenanta. `test.fixme` w CI (znany storageState gap).

## Smoke test (end-to-end, Playwright na żywym stacku)
Atrybut localizable na produkcie → edycja per-locale działa: PL i EN trzymają różne wartości, fallback do globalnej gdy locale niewypełnione. Artefakty testowe posprzątane z demo DB.

## Świadome odejścia (całość epiku #1146)
- Per-locale wartości nie są w `attributes_indexed`/Meilisearch (cache global-only) — search/listy na wersji primary. Per-locale search/completeness → #1152 (deferred).
- `?locale=` nie jest jeszcze zadeklarowany jako parametr OpenAPI (czytany przez provider/processor).

Closes #1150 · Closes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)