### PR TITLE
feat(catalog): odczyt + zapis obiektu w kontekście channel (?channel=)

### DIFF
--- a/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectCommand.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectCommand.php
@@ -49,6 +49,12 @@ final readonly class UpdateCatalogObjectCommand
          * attributes to that locale; non-localizable ones stay global.
          */
         public ?string $locale = null,
+        /**
+         * #1154 — channel scope (code) for the attribute write. NULL =
+         * global. Routes scopable attributes to that channel; others stay
+         * global. Combines with `$locale`.
+         */
+        public ?string $channel = null,
     ) {
     }
 }

--- a/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectHandler.php
+++ b/apps/api/src/Catalog/Application/Command/UpdateCatalogObject/UpdateCatalogObjectHandler.php
@@ -6,6 +6,7 @@ namespace App\Catalog\Application\Command\UpdateCatalogObject;
 
 use App\Catalog\Application\ObjectAttributesUpserter;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Channel\Contracts\ChannelResolverInterface;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\OptimisticLockException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
@@ -19,6 +20,7 @@ final readonly class UpdateCatalogObjectHandler
     public function __construct(
         private CatalogObjectRepositoryInterface $catalogObjects,
         private ObjectAttributesUpserter $attributesUpserter,
+        private ChannelResolverInterface $channels,
     ) {
     }
 
@@ -90,7 +92,24 @@ final readonly class UpdateCatalogObjectHandler
                     $command->locale,
                 ));
             }
-            $this->attributesUpserter->upsert($object, $command->attributes, locale: $command->locale);
+
+            $channelId = null;
+            if (null !== $command->channel && $tenant instanceof Tenant) {
+                $channelId = $this->channels->resolveId($command->channel, $tenant);
+                if (null === $channelId) {
+                    throw new UnprocessableEntityHttpException(\sprintf(
+                        'Channel "%s" was not found for this tenant.',
+                        $command->channel,
+                    ));
+                }
+            }
+
+            $this->attributesUpserter->upsert(
+                $object,
+                $command->attributes,
+                locale: $command->locale,
+                channelId: $channelId,
+            );
         }
     }
 }

--- a/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
+++ b/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
@@ -11,6 +11,7 @@ use App\Catalog\Domain\Provenance;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Map a flat `{attribute_code => value}` payload into `ObjectValue`
@@ -42,19 +43,24 @@ final readonly class ObjectAttributesUpserter
 
     /**
      * @param array<string, mixed> $payload
-     * @param ?string              $locale  active locale scope (#1148). When set
-     *                                      AND the attribute is localizable AND the
-     *                                      locale is not the tenant's primary, the
-     *                                      value is written to that locale; otherwise
-     *                                      it lands on the global (locale=null) row.
-     *                                      Default locale === global keeps legacy data
-     *                                      and non-localizable attributes shared.
+     * @param ?string              $locale    active locale scope (#1148). When set
+     *                                        AND the attribute is localizable AND the
+     *                                        locale is not the tenant's primary, the
+     *                                        value is written to that locale; otherwise
+     *                                        it lands on the global (locale=null) row.
+     *                                        Default locale === global keeps legacy data
+     *                                        and non-localizable attributes shared.
+     * @param ?Uuid                $channelId resolved active channel scope (#1154). When set
+     *                                        AND the attribute is scopable, the value is written
+     *                                        to that channel; otherwise it lands on the global
+     *                                        (channel=null) row.
      */
     public function upsert(
         CatalogObject $object,
         array $payload,
         Provenance $provenance = Provenance::Manual,
         ?string $locale = null,
+        ?Uuid $channelId = null,
     ): void {
         $tenant = $object->getTenant();
         if (!$tenant instanceof Tenant) {
@@ -77,10 +83,11 @@ final readonly class ObjectAttributesUpserter
             }
 
             $targetLocale = $isNonPrimaryLocale && $attribute->isLocalizable() ? $locale : null;
+            $targetChannel = null !== $channelId && $attribute->isScopable() ? $channelId : null;
 
             $jsonbValue = $this->wrapValue($rawValue);
 
-            $existing = $this->values->findOneByScope($object, $attribute, null, $targetLocale);
+            $existing = $this->values->findOneByScope($object, $attribute, $targetChannel, $targetLocale);
             if ($existing instanceof ObjectValue) {
                 $existing->updateValue($jsonbValue);
                 $existing->changeProvenance($provenance);
@@ -94,6 +101,7 @@ final readonly class ObjectAttributesUpserter
                 attribute: $attribute,
                 value: $jsonbValue,
                 provenance: $provenance,
+                channelId: $targetChannel,
                 locale: $targetLocale,
             );
             $this->values->save($value);

--- a/apps/api/src/Catalog/Application/ObjectValueLocaleOverlay.php
+++ b/apps/api/src/Catalog/Application/ObjectValueLocaleOverlay.php
@@ -6,60 +6,102 @@ namespace App\Catalog\Application;
 
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelResolverInterface;
 use App\Shared\Domain\Tenant;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
- * Overlays per-locale {@see \App\Catalog\Domain\Entity\ObjectValue} rows on
- * top of an object's global `attributes_indexed` cache so a locale-scoped
- * read (`GET /api/products/{id}?locale=en`) returns the localized reading
- * (#1146 / #1148).
+ * Overlays per-locale / per-channel {@see \App\Catalog\Domain\Entity\ObjectValue}
+ * rows on top of an object's global `attributes_indexed` cache so a scoped
+ * read (`?locale=en`, `?channel=shopify`, or both) returns the most
+ * specific reading (#1146 / #1148 locale; #1147 / #1154 channel).
  *
  * Contract:
- *   - The default locale is stored as the GLOBAL row (`locale=null`), so a
- *     read in the tenant's primary locale needs no overlay — the cache
- *     already holds those values.
- *   - For any other locale, each localizable attribute that has a
- *     `locale=<code>` row is swapped in; attributes without a per-locale
- *     row keep their global value (fallback — surfaces legacy data and
- *     shared/non-localizable values unchanged).
+ *   - GLOBAL row = `locale=null, channel=null`; it lives in the cache and
+ *     is the fallback. The tenant's primary locale is stored as global, so
+ *     a read in the primary locale needs no locale overlay.
+ *   - Per (effective locale, channel) the most specific applicable row
+ *     wins, falling back down the chain
+ *     `(locale+channel) > channel-only > locale-only > global`.
  *
  * Returns a detached CLONE with the overlaid index — never the managed
- * entity. Mutating the managed instance would leak the locale reading onto
- * the identity map and corrupt any later read of the same object in the
- * same EntityManager (e.g. a subsequent bare GET). The clone shares the
- * entity's relation references (objectType, tenant) so serialization + the
- * READ voter keep working; only the scalar `attributes_indexed` array
- * (copied by value on clone) is overlaid.
+ * entity. Mutating the managed instance would leak the scoped reading onto
+ * the identity map and corrupt a later read of the same object in the same
+ * EntityManager. The clone shares the entity's relation references so
+ * serialization + the READ voter keep working; only the scalar
+ * `attributes_indexed` array (copied by value on clone) is overlaid.
  */
 final readonly class ObjectValueLocaleOverlay
 {
     public function __construct(
         private ObjectValueRepositoryInterface $values,
+        private ChannelResolverInterface $channels,
     ) {
     }
 
-    public function apply(CatalogObject $object, string $locale): CatalogObject
+    public function apply(CatalogObject $object, ?string $locale, ?string $channelCode = null): CatalogObject
     {
         $tenant = $object->getTenant();
-        if (!$tenant instanceof Tenant || !$tenant->isLocaleEnabled($locale)) {
+        if (!$tenant instanceof Tenant) {
+            return $object;
+        }
+
+        if (null !== $locale && !$tenant->isLocaleEnabled($locale)) {
             throw new UnprocessableEntityHttpException(\sprintf(
                 'Locale "%s" is not enabled for this tenant.',
                 $locale,
             ));
         }
+        // Primary locale is stored as the global row, so it needs no
+        // locale-specific overlay — treat it as "no locale scope".
+        $effectiveLocale = null !== $locale && $locale !== $tenant->getPrimaryLocale() ? $locale : null;
 
-        // Primary locale === global row: the cache already holds it.
-        if ($locale === $tenant->getPrimaryLocale()) {
+        $channelId = null;
+        if (null !== $channelCode) {
+            $channelId = $this->channels->resolveId($channelCode, $tenant);
+            if (null === $channelId) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Channel "%s" was not found for this tenant.',
+                    $channelCode,
+                ));
+            }
+        }
+
+        // No active scope → the global cache is already the right reading.
+        if (null === $effectiveLocale && null === $channelId) {
+            return $object;
+        }
+
+        // Per attribute, keep the most specific applicable row above global.
+        $best = [];
+        foreach ($this->values->findByObject($object) as $value) {
+            $valueLocale = $value->getLocale();
+            $valueChannel = $value->getChannelId();
+
+            $localeMatches = null === $valueLocale || (null !== $effectiveLocale && $valueLocale === $effectiveLocale);
+            $channelMatches = null === $valueChannel || (null !== $channelId && $valueChannel->equals($channelId));
+            if (!$localeMatches || !$channelMatches) {
+                continue;
+            }
+
+            $rank = (null !== $valueLocale ? 2 : 0) + (null !== $valueChannel ? 1 : 0);
+            if (0 === $rank) {
+                // Global row — already the cache base.
+                continue;
+            }
+            $code = $value->getAttribute()->getCode();
+            if (!isset($best[$code]) || $rank > $best[$code]['rank']) {
+                $best[$code] = ['rank' => $rank, 'value' => $value->getValue()];
+            }
+        }
+
+        if ([] === $best) {
             return $object;
         }
 
         $indexed = $object->getAttributesIndexed();
-        foreach ($this->values->findByObject($object) as $value) {
-            if ($locale !== $value->getLocale() || null !== $value->getChannelId()) {
-                continue;
-            }
-            $indexed[$value->getAttribute()->getCode()] = $value->getValue();
+        foreach ($best as $code => $entry) {
+            $indexed[$code] = $entry['value'];
         }
 
         $copy = clone $object;

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
@@ -44,9 +44,13 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
             return null;
         }
 
-        $locale = $this->requestStack->getCurrentRequest()?->query->get('locale');
-        if (\is_string($locale) && '' !== $locale) {
-            return $this->overlay->apply($object, $locale);
+        $request = $this->requestStack->getCurrentRequest();
+        $localeParam = $request?->query->get('locale');
+        $channelParam = $request?->query->get('channel');
+        $locale = \is_string($localeParam) && '' !== $localeParam ? $localeParam : null;
+        $channel = \is_string($channelParam) && '' !== $channelParam ? $channelParam : null;
+        if (null !== $locale || null !== $channel) {
+            return $this->overlay->apply($object, $locale, $channel);
         }
 
         return $object;

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectProcessor.php
@@ -158,8 +158,11 @@ final readonly class CatalogObjectProcessor implements ProcessorInterface
         // param (`?locale=en`), not a body field: JSON Merge Patch cannot
         // tell an absent locale from an explicit null, and a body key would
         // collide with the attribute payload.
-        $localeParam = $this->requestStack->getCurrentRequest()?->query->get('locale');
+        $request = $this->requestStack->getCurrentRequest();
+        $localeParam = $request?->query->get('locale');
+        $channelParam = $request?->query->get('channel');
         $locale = \is_string($localeParam) && '' !== $localeParam ? $localeParam : null;
+        $channel = \is_string($channelParam) && '' !== $channelParam ? $channelParam : null;
 
         $command = new UpdateCatalogObjectCommand(
             id: $id,
@@ -172,6 +175,7 @@ final readonly class CatalogObjectProcessor implements ProcessorInterface
             attributes: $data->attributes,
             expectedVersion: $data->expectedVersion,
             locale: $locale,
+            channel: $channel,
         );
         $this->dispatch($command);
 

--- a/apps/api/src/Channel/Contracts/ChannelResolverInterface.php
+++ b/apps/api/src/Channel/Contracts/ChannelResolverInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC port for resolving a channel `code` to its id (#1154).
+ *
+ * Lets the Catalog context route per-channel attribute reads/writes
+ * (`?channel=shopify`) to the right {@see \App\Catalog\Domain\Entity\ObjectValue}
+ * scope without depending on Channel internals — Deptrac allows
+ * Catalog_Internals → Channel_Contracts only.
+ */
+interface ChannelResolverInterface
+{
+    /**
+     * The channel id for the given code within the tenant, or null when no
+     * such channel exists (caller surfaces a 422).
+     */
+    public function resolveId(string $code, Tenant $tenant): ?Uuid;
+}

--- a/apps/api/src/Channel/Infrastructure/ChannelResolver.php
+++ b/apps/api/src/Channel/Infrastructure/ChannelResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure;
+
+use App\Channel\Contracts\ChannelResolverInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * {@see ChannelResolverInterface} backed by the channel repository.
+ */
+final readonly class ChannelResolver implements ChannelResolverInterface
+{
+    public function __construct(
+        private ChannelRepositoryInterface $channels,
+    ) {
+    }
+
+    public function resolveId(string $code, Tenant $tenant): ?Uuid
+    {
+        return $this->channels->findByCode($code, $tenant)?->getId();
+    }
+}

--- a/apps/api/tests/Api/Catalog/CatalogObjectChannelValuesApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectChannelValuesApiTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Domain\Entity\Channel;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #1154 — channel-scoped read (`?channel=`) + write (`PATCH ?channel=`).
+ *
+ * Mirrors the locale axis (#1148): a scopable attribute carries a distinct
+ * value per channel with fallback to the global row; a non-scopable
+ * attribute stays shared regardless of `?channel=`.
+ */
+final class CatalogObjectChannelValuesApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function channelScopedReadAndWriteRoundTrips(): void
+    {
+        $this->seedChannelAttributes();
+        $client = $this->authenticatedClient();
+        $otId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $create = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => [
+                'code' => 'CHAN-RT-1',
+                'objectTypeId' => $otId,
+                'attributes' => ['chan_color' => 'red', 'plain_brand' => 'Acme'],
+            ],
+        ]);
+        self::assertSame(201, $create->getStatusCode());
+        $id = $this->decode($create->getContent())['id'];
+        self::assertIsString($id);
+
+        // PATCH under the "shopify" channel: scopable chan_color → channel
+        // row; non-scopable plain_brand → global (overwrites Acme).
+        $patch = $client->request('PATCH', '/api/products/'.$id.'?channel=shopify', [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['attributes' => ['chan_color' => 'blue', 'plain_brand' => 'AcmeX']],
+        ]);
+        self::assertSame(200, $patch->getStatusCode());
+
+        // Global (no channel) → chan_color keeps red; brand is global AcmeX.
+        $global = $this->attrs($client, $id, null);
+        self::assertSame('red', $global['chan_color']['value']);
+        self::assertSame('AcmeX', $global['plain_brand']['value'], 'Non-scopable write is global.');
+
+        // shopify → overlay swaps chan_color; brand shared.
+        $shopify = $this->attrs($client, $id, 'shopify');
+        self::assertSame('blue', $shopify['chan_color']['value']);
+        self::assertSame('AcmeX', $shopify['plain_brand']['value'], 'Non-scopable is shared across channels.');
+
+        // Another channel with no override → falls back to global.
+        $baselinker = $this->attrs($client, $id, 'baselinker');
+        self::assertSame('red', $baselinker['chan_color']['value']);
+
+        // Poly-kind path serves the same overlay.
+        $poly = $this->attrs($client, $id, 'shopify', '/api/objects/');
+        self::assertSame('blue', $poly['chan_color']['value']);
+    }
+
+    #[Test]
+    public function unknownChannelIsRejected(): void
+    {
+        $this->seedChannelAttributes();
+        $client = $this->authenticatedClient();
+        $otId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $create = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'CHAN-RT-2', 'objectTypeId' => $otId, 'attributes' => ['chan_color' => 'x']],
+        ]);
+        self::assertSame(201, $create->getStatusCode());
+        $id = $this->decode($create->getContent())['id'];
+        self::assertIsString($id);
+
+        $read = $client->request('GET', '/api/products/'.$id.'?channel=nope');
+        self::assertSame(422, $read->getStatusCode());
+
+        $write = $client->request('PATCH', '/api/products/'.$id.'?channel=nope', [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['attributes' => ['chan_color' => 'y']],
+        ]);
+        self::assertSame(422, $write->getStatusCode());
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function attrs(Client $client, string $id, ?string $channel, string $base = '/api/products/'): array
+    {
+        $url = $base.$id.(null !== $channel ? '?channel='.$channel : '');
+        $response = $client->request('GET', $url);
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decode($response->getContent());
+        self::assertIsArray($body['attributesIndexed'] ?? null);
+
+        /** @var array<string, array<string, mixed>> $indexed */
+        $indexed = $body['attributesIndexed'];
+
+        return $indexed;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(string $json): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+
+    private function seedChannelAttributes(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $color = new Attribute('chan_color', ['en' => 'Color', 'pl' => 'Kolor'], AttributeType::Text);
+        $color->changeScopable(true);
+        $brand = new Attribute('plain_brand', ['en' => 'Brand', 'pl' => 'Marka'], AttributeType::Text);
+        // plain_brand stays non-scopable (default false).
+
+        $position = 1;
+        foreach ([$color, $brand] as $attribute) {
+            $em->persist($attribute);
+            $em->persist(new ObjectTypeAttribute($product, $attribute, false, $position++));
+        }
+
+        $em->persist(new Channel('shopify', ['en' => 'Shopify']));
+        $em->persist(new Channel('baselinker', ['en' => 'BaseLinker']));
+        $em->flush();
+    }
+}


### PR DESCRIPTION
## Summary
Część 1/3 epiku #1147 (kanały). Spina istniejący substrate per-channel (`ObjectValue.channelId`, `findOneByScope`, `Attribute.isScopable`) w działający odczyt/zapis w kontekście kanału — analogicznie do osi locale (#1148).

## Backend changes
- **`Channel\Contracts\ChannelResolverInterface`** (code→id) + impl `ChannelResolver`. Deptrac dopuszcza Catalog_Internals → Channel_Contracts, więc Catalog routuje scope per-channel bez sięgania w Channel internals.
- **Overlay (read)** — `CatalogObjectLocaleOverlayProvider`/`ObjectValueLocaleOverlay` zgeneralizowany do macierzy (locale, channel): per atrybut wygrywa najbardziej specyficzny wiersz, fallback `(locale+channel) > channel > locale > global`. Nadal na klonie (bez wycieku na identity map). Nieznany channel → **422**.
- **Write** — PATCH `?channel=` → command → handler resolwuje+waliduje kanał → upserter: atrybut **scopable** → kanał; reszta global; łączy się z `?locale=`.
- `attributes_indexed`/Meilisearch bez zmian (global-only).

## Quality gates
- PHPStan max: 0. **Deptrac: 0 violations** (cross-bundle Catalog→Channel\Contracts OK). 
- PHPUnit: nowy `CatalogObjectChannelValuesApiTest` (read/write/fallback/422 + poly) + regresja locale + rebuilder = **8**; poly/PATCH **18/18**.

## Smoke test (żywy stack `pim.localhost`)
Kanał `smoke_chan` + atrybut scopable na produkcie: `PATCH ?channel=smoke_chan` → 200, zapisał wiersz kanału; `GET` global → wartość globalna nienaruszona; `GET ?channel=smoke_chan` → override; `?channel=nope` → **422**. Artefakty posprzątane.

## Świadome odejścia
- Per-channel wartości poza `attributes_indexed`/Meilisearch (global-only cache).
- `?channel=`/`?locale=` nie zadeklarowane jako parametry OpenAPI.
- FE: strona ustawień kanałów (#1153) + picker/values (#1155) w kolejnych PR-ach.

Refs #1147 · Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)