### PR TITLE
feat(admin): dynamiczny channel picker + per-channel values

### DIFF
--- a/apps/admin/e2e/products-channel-switch.spec.ts
+++ b/apps/admin/e2e/products-channel-switch.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1147/#1155 (channels) — selecting a channel in the object detail must
+ * really switch the channel-scoped values, mirroring the locale axis.
+ *
+ *  1. Create a scopable attribute + a channel, attach the attr to Product.
+ *  2. Seed a product, open detail → edit under "All channels" (global), save.
+ *  3. Switch the picker to the channel — the field shows the global value
+ *     as fallback; overwrite it with a channel value, save.
+ *  4. Switch back to "All channels" — the global value is intact + distinct.
+ *
+ * `test.fixme` in CI for the shared auth-rate-limiter storageState gap.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+const FIELD_LABEL = /^(Cena kanału|Channel price)$/;
+const CHANNEL_LABEL = /Spec Channel|Kanał Spec/;
+
+test('channel switch reads + writes per-channel values', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+  const refresh = await page.request.post('/api/auth/refresh');
+  expect(refresh.status()).toBe(200);
+  const token = ((await refresh.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${token}` };
+
+  const ts = uniqueSku('CH')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+  const attrCode = `chprice_${ts}`;
+  const channelCode = `spec_${ts}`;
+
+  const otResp = await page.request.get('/api/object_types', { headers: bearer });
+  const otBody = (await otResp.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const types = otBody.member ?? otBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  // Scopable attribute attached to the Product ObjectType.
+  const attrResp = await page.request.post('/api/attributes', {
+    data: {
+      code: attrCode,
+      type: 'text',
+      label: { pl: 'Cena kanału', en: 'Channel price' },
+      scopable: true,
+      required: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+  });
+  expect(attrResp.status(), await attrResp.text()).toBe(201);
+  const attrId = ((await attrResp.json()) as { id: string }).id;
+  const attach = await page.request.post(
+    `/api/object_types/${productType.id}/attributes/${attrId}`,
+    { headers: bearer },
+  );
+  expect([200, 201, 204]).toContain(attach.status());
+
+  // A tenant channel (full locale code + currency, per channel validation).
+  const channelResp = await page.request.post('/api/channels', {
+    data: {
+      code: channelCode,
+      label: { pl: 'Kanał Spec', en: 'Spec Channel' },
+      locales: ['pl_PL'],
+      currencies: ['PLN'],
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+  });
+  expect(channelResp.status(), await channelResp.text()).toBe(201);
+
+  const sku = uniqueSku('CH');
+  const createResponse = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: sku, objectTypeId: productType.id, attributes: { name: `Channel spec ${sku}` } },
+  });
+  expect(createResponse.status(), await createResponse.text()).toBe(201);
+  const product = (await createResponse.json()) as { id: string };
+
+  await page.goto(`/products/${product.id}`);
+  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  const saveButton = page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i });
+  await expect(saveButton).toBeVisible();
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  const fieldRow = () =>
+    page
+      .getByText(FIELD_LABEL)
+      .first()
+      .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+
+  // 1. Edit under "All channels" (global) + save.
+  await fieldRow().scrollIntoViewIfNeeded();
+  await fieldRow().locator('input[type="text"]').fill('global-99');
+  await saveButton.click();
+  await expect(page.getByRole('button', { name: /^(edytuj|edit)$/i })).toBeVisible();
+
+  // 2. Switch the channel picker to the new channel.
+  await page.getByRole('button', { name: /^(kanał|channel)$/i }).click();
+  await page.getByRole('menuitem', { name: CHANNEL_LABEL }).click();
+
+  // EN shows the global fallback; overwrite with a channel value + save.
+  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  await fieldRow().scrollIntoViewIfNeeded();
+  const channelInput = fieldRow().locator('input[type="text"]');
+  await expect(channelInput).toHaveValue('global-99');
+  await channelInput.fill('channel-77');
+  await saveButton.click();
+  await expect(page.getByRole('button', { name: /^(edytuj|edit)$/i })).toBeVisible();
+  await expect(fieldRow().getByText('channel-77')).toBeVisible();
+
+  // 3. Back to "All channels" — global value intact + distinct.
+  await page.getByRole('button', { name: /^(kanał|channel)$/i }).click();
+  await page.getByRole('menuitem', { name: /(Wszystkie kanały|All channels)/i }).click();
+  await expect(fieldRow().getByText('global-99')).toBeVisible();
+  await expect(fieldRow().getByText('channel-77')).toHaveCount(0);
+});

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -53,9 +53,11 @@ import { CompletenessRing } from '@/features/catalog/products/components/complet
 import { EffectiveModelCard } from '@/features/catalog/products/components/effective-model-card';
 import { LocaleChannelToolbar } from '@/features/catalog/products/components/locale-channel-toolbar';
 import { ProductMultimediaTab } from '@/features/catalog/products/components/product-multimedia-tab';
+import { scopeQuery } from '@/features/catalog/products/components/scope';
 import type {
   AttributeMeta,
   CatalogObjectDto,
+  ChannelOption,
   GroupMeta,
   LocaleOption,
   ProductChannel,
@@ -128,14 +130,16 @@ export function UniversalDetailPage({
   // the object query so it can be part of the query key (switching the
   // picker refetches the locale-resolved reading).
   const [locale, setLocale] = useState<ProductLocale>('pl');
+  const [channel, setChannel] = useState<ProductChannel | null>(null);
 
   // UP-07 — poly-kind GET /api/objects/{id} (existing AP4 ApiResource).
+  // #1150 / #1155 — locale + channel scope the read (part of the query key).
   const objectQuery = useQuery({
-    queryKey: ['object', objectId, locale],
+    queryKey: ['object', objectId, locale, channel],
     enabled: objectId !== '',
     staleTime: 30_000,
     queryFn: async (): Promise<CatalogObjectDto> => {
-      return jsonFetch<CatalogObjectDto>(`/api/objects/${objectId}?locale=${locale}`, {
+      return jsonFetch<CatalogObjectDto>(`/api/objects/${objectId}${scopeQuery(locale, channel)}`, {
         accept: 'application/ld+json',
       });
     },
@@ -205,7 +209,6 @@ export function UniversalDetailPage({
   }, [tabModeGroups, isCategorizable, hasMultimedia, hasVariants]);
 
   const [activeTab, setActiveTab] = useState<TabKey>('attributes');
-  const [channel, setChannel] = useState<ProductChannel | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
@@ -229,10 +232,24 @@ export function UniversalDetailPage({
     setDidInitLocale(true);
   }, [locales, didInitLocale]);
 
-  // #1150 — switching locale discards unsaved edits (saves before switch).
+  // #1155 — channel picker fed from /api/channels (tenant's real channels).
+  const channelsQuery = useQuery<ChannelOption[]>({
+    queryKey: ['channels', 'picker'],
+    queryFn: async () => {
+      const response = await jsonFetch<{ member?: ChannelOption[] } | ChannelOption[]>(
+        '/api/channels',
+        { accept: 'application/ld+json' },
+      );
+      return Array.isArray(response) ? response : (response.member ?? []);
+    },
+    staleTime: 60_000,
+  });
+  const channels = channelsQuery.data ?? [];
+
+  // #1150 / #1155 — switching locale or channel discards unsaved edits.
   useEffect(() => {
     setDirtyFields({});
-  }, [locale]);
+  }, [locale, channel]);
 
   const [didExpandInitial, setDidExpandInitial] = useState(false);
   useEffect(() => {
@@ -269,9 +286,9 @@ export function UniversalDetailPage({
     setIsSaving(true);
     try {
       const attributes = stripAttributes(dirtyFields);
-      // #1150 — write in the active locale (BE routes localizable attrs to
-      // that locale, others stay global).
-      await jsonFetch(`/api/objects/${objectId}?locale=${locale}`, {
+      // #1150 / #1155 — write in the active locale + channel (BE routes
+      // localizable/scopable attrs to that scope, others stay global).
+      await jsonFetch(`/api/objects/${objectId}${scopeQuery(locale, channel)}`, {
         method: 'PATCH',
         contentType: 'application/merge-patch+json',
         body: { attributes },
@@ -526,6 +543,7 @@ export function UniversalDetailPage({
             onLocaleChange={setLocale}
             onChannelChange={setChannel}
             locales={locales}
+            channels={channels}
           />
         </div>
       </header>

--- a/apps/admin/src/features/catalog/products/components/locale-channel-toolbar.tsx
+++ b/apps/admin/src/features/catalog/products/components/locale-channel-toolbar.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 import {
+  type ChannelOption,
   type LocaleOption,
   PRODUCT_CHANNELS,
   PRODUCT_LOCALES,
@@ -29,9 +30,14 @@ export interface LocaleChannelToolbarProps {
    * Falls back to the static PRODUCT_LOCALES on first paint / when absent.
    */
   locales?: LocaleOption[];
+  /**
+   * #1155 — the tenant's channels (from `/api/channels`). Falls back to the
+   * static PRODUCT_CHANNELS on first paint / when absent.
+   */
+  channels?: ChannelOption[];
 }
 
-const CHANNEL_LABELS: Record<ProductChannel, string> = {
+const CHANNEL_LABELS: Record<string, string> = {
   shopify: 'Shopify',
   baselinker: 'BaseLinker',
   allegro: 'Allegro',
@@ -49,10 +55,21 @@ export function LocaleChannelToolbar({
   onLocaleChange,
   onChannelChange,
   locales,
+  channels,
 }: LocaleChannelToolbarProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language === 'pl' ? 'pl' : 'en';
   const localeCodes: readonly string[] =
     locales !== undefined && locales.length > 0 ? locales.map((l) => l.code) : PRODUCT_LOCALES;
+
+  // #1155 — channel options from the tenant's real channels, falling back
+  // to the static list before /api/channels resolves.
+  const channelList: { code: string; label: string }[] =
+    channels !== undefined && channels.length > 0
+      ? channels.map((c) => ({ code: c.code, label: c.label?.[lang] ?? c.label?.en ?? c.code }))
+      : PRODUCT_CHANNELS.map((c) => ({ code: c, label: CHANNEL_LABELS[c] ?? c }));
+  const channelLabel = (code: string): string =>
+    channelList.find((c) => c.code === code)?.label ?? CHANNEL_LABELS[code] ?? code;
 
   return (
     <div className="flex items-center gap-2">
@@ -100,7 +117,7 @@ export function LocaleChannelToolbar({
           >
             {channel === null
               ? t('products.detail.channel.none', { defaultValue: 'Wszystkie kanały' })
-              : CHANNEL_LABELS[channel]}
+              : channelLabel(channel)}
             <ChevronDown className="size-3" aria-hidden />
           </Button>
         </DropdownMenuTrigger>
@@ -117,13 +134,13 @@ export function LocaleChannelToolbar({
               {t('products.detail.channel.none', { defaultValue: 'Wszystkie kanały' })}
             </span>
           </DropdownMenuItem>
-          {PRODUCT_CHANNELS.map((option) => (
+          {channelList.map((option) => (
             <DropdownMenuItem
-              key={option}
-              onClick={() => onChannelChange(option)}
-              className={option === channel ? 'bg-secondary' : ''}
+              key={option.code}
+              onClick={() => onChannelChange(option.code)}
+              className={option.code === channel ? 'bg-secondary' : ''}
             >
-              <span className="text-xs font-medium">{CHANNEL_LABELS[option]}</span>
+              <span className="text-xs font-medium">{option.label}</span>
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -46,10 +46,12 @@ import { LocaleChannelToolbar } from './locale-channel-toolbar';
 import { PreviewButton } from './preview-button';
 import { ProductMultimediaTab } from './product-multimedia-tab';
 import { RelationsTab } from './relations-tab';
+import { scopeQuery } from './scope';
 import { SyncStatusCard } from './sync-status-card';
 import type {
   AttributeMeta,
   CatalogObjectDto,
+  ChannelOption,
   GroupMeta,
   LocaleOption,
   ProductChannel,
@@ -130,15 +132,17 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   }, [mode, searchParams]);
 
   const [locale, setLocale] = useState<ProductLocale>('pl');
+  const [channel, setChannel] = useState<ProductChannel | null>(null);
 
-  // #1150 — load the product in the active locale so localizable values
-  // reflect the picker. Replaces Refine's useOne (its getOne drops the
-  // query string); the locale is part of the query key, so switching the
-  // picker refetches the locale-resolved reading.
+  // #1150 / #1155 — load the product in the active locale + channel so
+  // localizable / channel-scoped values reflect the picker. Replaces
+  // Refine's useOne (its getOne drops the query string); locale + channel
+  // are part of the query key, so switching either refetches the
+  // scope-resolved reading.
   const productQuery = useQuery<CatalogObjectDto>({
-    queryKey: ['products', id, locale],
+    queryKey: ['products', id, locale, channel],
     queryFn: () =>
-      jsonFetch<CatalogObjectDto>(`/api/products/${id}?locale=${locale}`, {
+      jsonFetch<CatalogObjectDto>(`/api/products/${id}${scopeQuery(locale, channel)}`, {
         accept: 'application/ld+json',
       }),
     enabled: isEditMode && id !== '',
@@ -154,7 +158,6 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   const hasMultimediaCapability = schemaQuery.data?.objectType.has_multimedia ?? false;
 
   const [activeTab, setActiveTab] = useState<TabKey>('attributes');
-  const [channel, setChannel] = useState<ProductChannel | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(!isEditMode);
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
@@ -269,11 +272,26 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     setDidInitLocale(true);
   }, [locales, didInitLocale]);
 
-  // #1150 — switching locale discards unsaved edits so a pl edit is never
-  // written to the en row; the operator saves before switching.
+  // #1155 — channel picker fed from /api/channels (tenant's real channels).
+  const channelsQuery = useQuery<ChannelOption[]>({
+    queryKey: ['channels', 'picker'],
+    queryFn: async () => {
+      const response = await jsonFetch<{ member?: ChannelOption[] } | ChannelOption[]>(
+        '/api/channels',
+        { accept: 'application/ld+json' },
+      );
+      return Array.isArray(response) ? response : (response.member ?? []);
+    },
+    enabled: isEditMode,
+    staleTime: 60_000,
+  });
+  const channels = channelsQuery.data ?? [];
+
+  // #1150 / #1155 — switching locale or channel discards unsaved edits so an
+  // edit is never written to the wrong scope; the operator saves first.
   useEffect(() => {
     setDirtyFields({});
-  }, [locale]);
+  }, [locale, channel]);
 
   // MODR-03 (#925) — tab list derived dynamically from `groups`:
   // every group with `display_mode='tab'` becomes its own tab; groups
@@ -434,9 +452,10 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
           return;
         }
         const attributes = stripAttributes(dirtyFields);
-        // #1150 — write in the active locale: localizable attributes land
-        // on that locale's row, others stay global (BE decides per flag).
-        await jsonFetch(`/api/products/${id}?locale=${locale}`, {
+        // #1150 / #1155 — write in the active locale + channel: localizable
+        // / scopable attributes land on that scope's row, others stay
+        // global (BE decides per flag).
+        await jsonFetch(`/api/products/${id}${scopeQuery(locale, channel)}`, {
           method: 'PATCH',
           contentType: 'application/merge-patch+json',
           body: { attributes },
@@ -791,6 +810,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
               onLocaleChange={setLocale}
               onChannelChange={setChannel}
               locales={locales}
+              channels={channels}
             />
           ) : null}
         </div>

--- a/apps/admin/src/features/catalog/products/components/scope.ts
+++ b/apps/admin/src/features/catalog/products/components/scope.ts
@@ -1,0 +1,12 @@
+/**
+ * #1150 / #1155 — build the `?locale=&channel=` scope query string for
+ * locale/channel-aware object reads + writes. A null channel = "all
+ * channels" (global), so it is omitted.
+ */
+export function scopeQuery(locale: string, channel: string | null): string {
+  const params = new URLSearchParams({ locale });
+  if (channel !== null) {
+    params.set('channel', channel);
+  }
+  return `?${params.toString()}`;
+}

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -20,13 +20,22 @@ export interface LocaleOption {
   is_default: boolean;
 }
 
-export type ProductChannel = 'shopify' | 'baselinker' | 'allegro';
+// #1155 — a channel code is whatever the tenant configured (Settings →
+// Channels), not a fixed union. The real list comes from `/api/channels`;
+// PRODUCT_CHANNELS is only a static fallback before that loads.
+export type ProductChannel = string;
 
 export const PRODUCT_CHANNELS: readonly ProductChannel[] = [
   'shopify',
   'baselinker',
   'allegro',
 ] as const;
+
+/** One tenant channel for the detail-page picker (#1155). */
+export interface ChannelOption {
+  code: string;
+  label?: Record<string, string>;
+}
 
 export interface CatalogObjectDto {
   id: string;


### PR DESCRIPTION
## Summary
Część 3/3 (finalna) epiku #1147. Picker kanału listuje realne kanały tenanta, a jego zmiana **realnie** przełącza wartości channel-scoped (analogicznie do osi locale #1149/#1150).

## Changes
- `LocaleChannelToolbar` — channel dropdown z propa `channels` (z `/api/channels`) zamiast hardkodu `shopify/baselinker/allegro`; „Wszystkie kanały" (null) = global.
- `ProductDetailPage` + `UniversalDetailPage` — fetch `/api/channels`, przekazanie do toolbara, `channel` w query key + `?channel=` na GET i PATCH (obok `?locale=`, przez współdzielony `scopeQuery()`). Zmiana locale/channel czyści niezapisane edycje (brak zapisu do złego scope).
- `ProductChannel` poszerzony z unii na `string`; `ChannelOption`.

## Quality gates
- tsc --noEmit: 0. Biome: 0 errors. Vite build: ok.
- Playwright `products-channel-switch.spec.ts` (zielony lokalnie): edycja All-channels → save → przełącz kanał (fallback global) → edycja → save → powrót All-channels: wartość globalna nienaruszona i różna od kanałowej; picker listuje kanały tenanta. `test.fixme` w CI (storageState gap).

## Świadome odejścia (epik #1147)
- Per-channel wartości poza `attributes_indexed`/Meilisearch (global-only cache).
- `?channel=`/`?locale=` nie zadeklarowane jako parametry OpenAPI.
- Mapowanie aliasów atrybutów per-channel (#1156) — Faza 1 (integracje 0.8/0.9).

Closes #1155 · Closes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)