### PR TITLE
docs(agent): batch #1130–#1147 status + locale/channel lessons

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,16 @@
 # Current Status
 
+## 2026-05-31: 🏁 batch bug-fix smoke 2026-05-30 (#1130–#1147) — kompletny
+
+Wszystkie 18 zgłoszeń z manualnego smoke testu operatora wdrożone na main. Ta sesja domknęła ostatnie 4 (#1130/#1138 + epiki #1146/#1147):
+
+- **#1130 import round-trip** (PR #1167): importer kompatybilny z formatem eksportu — composite price/metric (`20.99 EUR`/`0.3 g`), kolumny lokalizowane (`name.pl`→atrybut+locale), auto-SKIP kolumn systemowych, reader XLSX po cell-coordinate. Nowe: `ColumnHeader`, `CompositeValueParser`, `SystemColumn`, `ResolvedImportValue`.
+- **#1138 atrybut asset jako picker** (PR #1168): `AssetField` + `AssetAttributePicker` w `attr-row.tsx` (case `asset`) — picker biblioteki + miniatura zamiast tekstu. BE `AssetValidator` bez zmian.
+- **#1146 wersje językowe epik** — 4 PR-y (#1169 BE read/write `?locale=`, #1170 ekspozycja `is_localizable`+`locales[]`, #1171 dynamiczny picker, #1172 per-locale values). #1152 (completeness per-locale) świadomie deferred.
+- **#1147 kanały epik** — 3 PR-y (#1173 BE read/write `?channel=`, #1174 E2E ustawień kanałów — strona już istniała, #1175 picker+values). #1156 (mapowanie aliasów) deferred do Fazy 1.
+
+**Architektura locale/channel (ADR-relevant)**: `CatalogObjectLocaleOverlayProvider` (GET-item, decorating) nakłada wiersze `ObjectValue` per (locale,channel) na globalny `attributes_indexed`, **na klonie** (bez wycieku na identity map); `attributes_indexed`/Meilisearch pozostają **global-only** (search na primary). Zapis przez `?locale=`/`?channel=` query-param → upserter routuje localizable→locale, scopable→channel, reszta global. Cross-BC: `Channel\Contracts\ChannelResolverInterface` (code→id, Deptrac-safe).
+
 ## 2026-05-30: polish drzew kategorii custom-OT (#1126 + #1127)
 - **#1126** (PR #1128, `0951f55`): drzewo kategorii widoczne przy pierwszym wejściu /modeling/categories — auto-select OT w `ObjectTypeFilterDropdown` przeniesiony z render-phase do `useEffect` (URL `targetObjectTypeId` stempluje się niezawodnie → `useList` enabled).
 - **#1127** (PR #1129, `1f5541f`): `categories/show.tsx` `EffectiveAttributesPreview` — preview po `objectTypeId` + lista categorizable OT (built-in+custom) zamiast hardcoded PREVIEW_KINDS; fix błędu „Built-in ObjectType for kind 'custom'". Default = pierwszy categorizable (GET category nie serializuje categoryTargetObjectType — default-to-own-tree = ewent. drobny follow-up).

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,25 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z batcha smoke 2026-05-30 (#1130–#1147, import + asset + locale/channel epiki)
+
+### Patterns to Follow
+- **Read-shaping w ApiPlatform provider → na KLONIE, nie na managed encji.** Nakładanie overlay (per-locale/channel) przez `$object->updateAttributeIndex(...)` na managed encji WYCIEKA na Doctrine identity map → kolejny odczyt tego samego obiektu w tym samym EM (np. bare GET po `?locale=en` GET) serwuje zmutowaną wartość. W produkcji maskowane (EM resetowany per-request w worker mode), ale w shared-EM ApiTestCase pęka. Fix: `$copy = clone $object; $copy->updateAttributeIndex(...); return $copy;` — klon dzieli referencje relacji (objectType/tenant), więc serializer + voter działają; mutowana jest tylko skalarna tablica (kopiowana by-value przy clone). Wzór: `ObjectValueLocaleOverlay`.
+- **Cross-BC zależność tylko przez `<BC>\Contracts`.** Catalog potrzebował resolucji channel code→id; Deptrac dopuszcza `Catalog_Internals → Channel_Contracts` (NIE `Channel_Internals`/Domain). Rozwiązanie: port `Channel\Contracts\ChannelResolverInterface` + impl w `Channel\Infrastructure`. Autowire auto-aliasuje interfejs→jedyną impl (potwierdzone `lint:container`).
+- **Scope jako query-param na PATCH, nie pole w body.** `?locale=`/`?channel=` czytane w processorze z `RequestStack` → command. JSON Merge-Patch nie odróżnia absent-vs-null i kolidowałby z payloadem atrybutów.
+- **Per-locale/channel cache = global-only.** `AttributesIndexedRebuilder` indeksuje TYLKO wiersz globalny (pomija `locale!=null || channel!=null`), inaczej lista/Meilisearch migają wg ostatnio zapisanego scope (niedeterministyczne). Lokalizowane/kanałowe odczyty idą z overlay na read-path.
+
+### Patterns to Avoid
+- **Nie zakładaj że feature „prawdopodobnie brak" bez sprawdzenia.** #1147 parent twierdził brak strony ustawień kanałów — a `/features/channel/channels/` (CRUD + pickery) istniał od maja. Zweryfikuj `debug:router` + `features/` ZANIM zaczniesz budować. #1153 zredukowało się do dodania brakującego E2E.
+- **Playwright spec tworzący dane przez API zaśmieca demo DB.** Atrybuty przypięte do OT pojawiają się na KAŻDYM formularzu produktu; kanały — w każdym pickerze. Po runie sprzątaj artefakty SQL-em (scoped po code-pattern + tenant). Dotyczy #1138/#1146/#1147 spec-ów.
+
+### Package Quirks
+- **Krótkie vs pełne kody locale.** Tenant/ObjectValue locale = krótkie (`pl`, `en`); globalny katalog `locales` + `Channel.locales`/`Channel.currencies` = pełne (`pl_PL`, `en_US`) + walidowane przeciw istniejącym wierszom. Channel create przez `/api/channels` wymaga `locales:["pl_PL"]` + `currencies:["PLN"]` (≥1 każde), nie `["pl"]`.
+- **`?locale=`/`?channel=` czytane przez RequestStack w processorze/provider — NIE są zadeklarowane jako parametry OpenAPI** (świadome odejście; API-first follow-up jeśli potrzebny w spec).
+
+### Decyzje świadome
+- #1152 (completeness per-locale + mandatory/fallback) i #1156 (UI mapowania aliasów per-channel) — deferred (Faza 1 / razem z konektorami). Per-locale/channel wartości NIE są searchable (cache global-only). Activate/deactivate kanału — poza zakresem (encja `Channel` bez `isActive`).
+
 ## Lessons z MODRC-01..05 (2026-05-28, optional relations AttributeGroup — Option Y)
 
 ### Patterns to Follow


### PR DESCRIPTION
## Summary
Aktualizacja plików atomowych (`agent/current_status.md` + `agent/lessons.md`) po domknięciu batcha smoke 2026-05-30 (#1130 import round-trip, #1138 asset picker, #1146 locale epik, #1147 channel epik — wszystkie merged, parenty closed; #1152/#1156 deferred).

Lessons (recyklowalne): clone-based ApiPlatform read overlay (bez wycieku na identity map), cross-BC przez `Channel\Contracts`, scope jako query-param, `attributes_indexed` global-only, krótkie vs pełne kody locale, sprzątanie demo DB po Playwright.

Docs-only — bez zmian kodu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)