### PR TITLE
feat(catalog): 4 nowe typy atrybutów — textarea, datetime, color, email

### DIFF
--- a/apps/admin/e2e/1177-attribute-types-simple.spec.ts
+++ b/apps/admin/e2e/1177-attribute-types-simple.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1177 — four new attribute types (textarea, datetime user-facing, color,
+ * email). Mirrors the #1138 asset-picker spec flow:
+ *
+ *  1. Create one custom attribute per new type, attach each directly to the
+ *     built-in Product ObjectType (synthetic "default" group).
+ *  2. Seed a product, open detail → edit.
+ *  3. Assert each row renders the correct control:
+ *       - textarea → <textarea>
+ *       - datetime → <input type="datetime-local">
+ *       - color    → <input type="color"> (+ hex text field)
+ *       - email    → <input type="email">
+ *  4. Fill values, save → PATCH 200 → reload → assert each value persists.
+ *
+ * `fixme` in CI for the same `storageState` reason the other UI-seeded specs
+ * use; locally (cold rate-limiter) it is the smoke gate.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('new simple attribute types render their controls and round-trip', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+
+  const ts = uniqueSku('T1177')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+
+  // Resolve the built-in Product ObjectType.
+  const otResp = await page.request.get('/api/object_types', { headers: bearer });
+  const otBody = (await otResp.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const types = otBody.member ?? otBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  // Bilingual labels + a matching regex: the admin UI may render in pl or
+  // en, and AttrRow falls back to the attribute code when the active
+  // locale's label is missing (see #1138 ASSET_LABEL convention).
+  const specs = [
+    { type: 'textarea', code: `desc_${ts}`, pl: 'Krótki opis', en: 'Short description' },
+    { type: 'datetime', code: `release_${ts}`, pl: 'Premiera', en: 'Release date' },
+    { type: 'color', code: `color_${ts}`, pl: 'Kolor produktu', en: 'Product color' },
+    { type: 'email', code: `email_${ts}`, pl: 'Email dostawcy', en: 'Supplier email' },
+  ] as const;
+
+  for (const spec of specs) {
+    const attrResp = await page.request.post('/api/attributes', {
+      data: {
+        code: spec.code,
+        type: spec.type,
+        label: { pl: spec.pl, en: spec.en },
+        required: false,
+      },
+      headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+    });
+    expect(attrResp.status(), await attrResp.text()).toBe(201);
+    const attrId = ((await attrResp.json()) as { id: string }).id;
+
+    const attachResp = await page.request.post(
+      `/api/object_types/${productType.id}/attributes/${attrId}`,
+      { headers: bearer },
+    );
+    expect([200, 201, 204]).toContain(attachResp.status());
+  }
+
+  // Seed a product on the Product ObjectType.
+  const sku = uniqueSku('T1177');
+  const createResponse = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: sku, objectTypeId: productType.id, attributes: { name: `1177 spec ${sku}` } },
+  });
+  expect(createResponse.status(), await createResponse.text()).toBe(201);
+  const product = (await createResponse.json()) as { id: string };
+
+  const groupsResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/effective-attribute-groups') &&
+      response.request().method() === 'GET',
+    { timeout: 15_000 },
+  );
+  await page.goto(`/products/${product.id}`);
+  await groupsResponse;
+  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible();
+
+  // AttrRow renders each editable control with id `attr-<code>` — target it
+  // directly (the form may list a row more than once, and labels fall back
+  // to the code when the active locale's label is absent, so an id selector
+  // is the deterministic anchor). The CSS tag/type guards are the regression
+  // catch: each type must render its dedicated control, not a plain input.
+  const [textareaCode, datetimeCode, colorCode, emailCode] = specs.map((s) => s.code);
+
+  const textarea = page.locator(`textarea#attr-${textareaCode}`).first();
+  await textarea.scrollIntoViewIfNeeded();
+  await expect(textarea).toBeVisible();
+  await textarea.fill('Lekki, oddychający materiał.');
+
+  const datetime = page.locator(`input#attr-${datetimeCode}[type="datetime-local"]`).first();
+  await expect(datetime).toBeVisible();
+  await datetime.fill('2027-03-15T14:30');
+
+  const color = page.locator(`input#attr-${colorCode}[type="color"]`).first();
+  await expect(color).toBeVisible();
+  await color.fill('#1a2b3c');
+
+  const email = page.locator(`input#attr-${emailCode}[type="email"]`).first();
+  await expect(email).toBeVisible();
+  await email.fill('supplier@example.com');
+
+  // Save → PATCH 200.
+  const patchResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/products/') && response.request().method() === 'PATCH',
+  );
+  await page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i }).click();
+  expect((await patchResponse).status()).toBe(200);
+
+  // Reload → values persist (read-only render).
+  await page.reload();
+  await expect(page.getByText('Lekki, oddychający materiał.')).toBeVisible();
+  await expect(page.getByText('2027-03-15 14:30')).toBeVisible();
+  await expect(page.getByText('#1a2b3c')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'supplier@example.com' })).toBeVisible();
+});

--- a/apps/admin/src/components/modeling/add-attributes-from-library-dialog.tsx
+++ b/apps/admin/src/components/modeling/add-attributes-from-library-dialog.tsx
@@ -25,6 +25,7 @@ interface UsageResp {
 const TYPE_OPTIONS = [
   'all',
   'text',
+  'textarea',
   'number',
   'boolean',
   'select',
@@ -37,6 +38,8 @@ const TYPE_OPTIONS = [
   'price',
   'metric',
   'wysiwyg',
+  'color',
+  'email',
 ] as const;
 
 interface Props {
@@ -200,9 +203,13 @@ export function AddAttributesFromLibraryDialog({
             onChange={(e) => setTypeFilter(e.target.value as (typeof TYPE_OPTIONS)[number])}
             className="h-10 rounded-xl border border-zinc-200 bg-white px-3 text-[13px] font-medium"
           >
-            {TYPE_OPTIONS.map((t) => (
-              <option key={t} value={t}>
-                {t === 'all' ? 'Wszystkie typy' : t}
+            {TYPE_OPTIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt === 'all'
+                  ? t('modeling.attributeGroups.add_from_library.all_types', {
+                      defaultValue: 'Wszystkie typy',
+                    })
+                  : t(`attribute_type.${opt}`, { defaultValue: opt })}
               </option>
             ))}
           </select>

--- a/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
@@ -36,6 +36,7 @@ interface ObjectTypePickerRow {
 
 const TYPES = [
   'text',
+  'textarea',
   'number',
   'select',
   'multiselect',
@@ -48,6 +49,8 @@ const TYPES = [
   'price',
   'metric',
   'wysiwyg',
+  'color',
+  'email',
 ] as const;
 
 interface Props {
@@ -298,7 +301,7 @@ export function CreateAttributeForObjectTypeDialog({
                 >
                   {TYPES.map((opt) => (
                     <option key={opt} value={opt}>
-                      {opt}
+                      {t(`attribute_type.${opt}`, { defaultValue: opt })}
                     </option>
                   ))}
                 </select>

--- a/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
@@ -36,6 +36,7 @@ interface ObjectTypePickerRow {
 
 const TYPES = [
   'text',
+  'textarea',
   'number',
   'select',
   'multiselect',
@@ -48,6 +49,8 @@ const TYPES = [
   'price',
   'metric',
   'wysiwyg',
+  'color',
+  'email',
 ] as const;
 
 interface Props {
@@ -264,9 +267,9 @@ export function CreateAttributeInGroupDialog({
                   onChange={(e) => setType(e.target.value as (typeof TYPES)[number])}
                   className="mt-1.5 h-10 w-full rounded-xl border border-zinc-200 bg-white px-3 text-[13px] font-medium"
                 >
-                  {TYPES.map((t) => (
-                    <option key={t} value={t}>
-                      {t}
+                  {TYPES.map((opt) => (
+                    <option key={opt} value={opt}>
+                      {t(`attribute_type.${opt}`, { defaultValue: opt })}
                     </option>
                   ))}
                 </select>

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -33,6 +33,7 @@ const TYPE_FILTERS = [
   'all',
   'system',
   'text',
+  'textarea',
   'number',
   'boolean',
   'select',
@@ -45,6 +46,8 @@ const TYPE_FILTERS = [
   'price',
   'metric',
   'wysiwyg',
+  'color',
+  'email',
 ] as const;
 
 type TypeFilter = (typeof TYPE_FILTERS)[number];
@@ -150,19 +153,23 @@ export function AttributesListPage() {
             className="flex-1 min-w-[180px] bg-transparent text-[13.5px] outline-none placeholder:text-muted-foreground"
           />
           <div className="flex flex-wrap items-center gap-1">
-            {TYPE_FILTERS.map((t) => (
+            {TYPE_FILTERS.map((opt) => (
               <button
-                key={t}
+                key={opt}
                 type="button"
-                onClick={() => setFilter(t)}
+                onClick={() => setFilter(opt)}
                 className={cn(
                   'flex h-7 items-center rounded-lg px-2.5 text-[11.5px] font-medium transition',
-                  filter === t
+                  filter === opt
                     ? 'bg-zinc-900 text-white'
                     : 'text-muted-foreground hover:bg-zinc-100',
                 )}
               >
-                {t === 'all' ? 'wszystkie' : t}
+                {opt === 'all'
+                  ? t('attributes.filter.all', { defaultValue: 'wszystkie' })
+                  : opt === 'system'
+                    ? t('attributes.filter.system', { defaultValue: 'system' })
+                    : t(`attribute_type.${opt}`, { defaultValue: opt })}
               </button>
             ))}
           </div>
@@ -287,7 +294,7 @@ function TypeBadge({ type }: { type: string }) {
   const tone =
     type === 'number' || type === 'metric' || type === 'price'
       ? 'bg-accent-blue/10 text-accent-blue'
-      : type === 'select' || type === 'multiselect'
+      : type === 'select' || type === 'multiselect' || type === 'color'
         ? 'bg-accent-amber/10 text-accent-amber'
         : type === 'boolean'
           ? 'bg-accent-emerald/10 text-accent-emerald'

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -198,6 +198,38 @@ export function AttrRow({
               onChange={(event) => onChange(event.target.value === '' ? null : event.target.value)}
               className="w-full rounded-xl border-zinc-200 bg-white px-3 py-2 text-[13.5px]"
             />
+          ) : attribute.type === 'color' ? (
+            // #1177 — native colour picker paired with a hex text field so
+            // operators can paste an exact `#RRGGBB` or pick visually. The
+            // picker falls back to black when the stored value is not a
+            // valid hex (e.g. empty / legacy rgb), but the text field keeps
+            // showing the raw value for editing.
+            <div className="flex items-center gap-2">
+              <input
+                id={`attr-${attribute.code}`}
+                type="color"
+                value={isHexColor(stringValue) ? stringValue : '#000000'}
+                onChange={(event) => onChange(event.target.value)}
+                className="h-9 w-12 cursor-pointer rounded-lg border border-zinc-200 bg-white p-1"
+                aria-label={label}
+              />
+              <Input
+                type="text"
+                value={stringValue}
+                onChange={(event) => onChange(event.target.value)}
+                placeholder="#RRGGBB"
+                className="w-32 rounded-xl border-zinc-200 bg-white px-3 py-2 font-mono text-[13px]"
+              />
+            </div>
+          ) : attribute.type === 'email' ? (
+            <Input
+              id={`attr-${attribute.code}`}
+              type="email"
+              value={stringValue}
+              onChange={(event) => onChange(event.target.value)}
+              placeholder="name@example.com"
+              className="w-full rounded-xl border-zinc-200 bg-white px-3 py-2 text-[13.5px]"
+            />
           ) : attribute.type === 'select' ? (
             <Combobox
               options={toComboboxOptions(selectOptions, lang)}
@@ -229,6 +261,21 @@ export function AttrRow({
           )
         ) : attribute.type === 'wysiwyg' ? (
           <WysiwygEditor value={stringValue} onChange={() => undefined} readOnly />
+        ) : attribute.type === 'color' && isHexColor(stringValue) ? (
+          <div className="flex items-center gap-2 px-3 py-2 text-[13.5px]">
+            <span
+              className="size-4 rounded border border-zinc-200"
+              style={{ background: stringValue }}
+              aria-hidden
+            />
+            <span className="font-mono text-[13px] text-ink">{stringValue}</span>
+          </div>
+        ) : attribute.type === 'email' && stringValue !== '' ? (
+          <div className="px-3 py-2 text-[13.5px]">
+            <a href={`mailto:${stringValue}`} className="text-accent-blue hover:underline">
+              {stringValue}
+            </a>
+          </div>
         ) : (
           <div
             className={cn(
@@ -347,6 +394,14 @@ function readDatetimeValue(value: unknown): string {
   if (typeof value !== 'string') return '';
   const head = value.slice(0, 16);
   return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(head) ? head : '';
+}
+
+/**
+ * `<input type="color">` only accepts a `#rrggbb` value. #1177 — used to
+ * decide whether the stored colour can drive the native picker / swatch.
+ */
+function isHexColor(value: string): boolean {
+  return /^#[0-9a-fA-F]{6}$/.test(value);
 }
 
 /**

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -10,6 +10,24 @@
     "brand_subtitle_fallback": "Workspace",
     "delete_error": "Failed to delete"
   },
+  "attribute_type": {
+    "text": "Text",
+    "textarea": "Text area",
+    "number": "Number",
+    "select": "Select",
+    "multiselect": "Multi-select",
+    "date": "Date",
+    "datetime": "Date & time",
+    "boolean": "Yes/No",
+    "asset": "Asset",
+    "reference": "Reference",
+    "relation": "Relation",
+    "price": "Price",
+    "metric": "Metric",
+    "wysiwyg": "Rich text",
+    "color": "Color",
+    "email": "Email"
+  },
   "user_menu": {
     "aria_label": "User menu",
     "account": "Account",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -10,6 +10,24 @@
     "brand_subtitle_fallback": "Workspace",
     "delete_error": "Nie udało się usunąć"
   },
+  "attribute_type": {
+    "text": "Tekst",
+    "textarea": "Pole tekstowe",
+    "number": "Liczba",
+    "select": "Lista wyboru",
+    "multiselect": "Wielokrotny wybór",
+    "date": "Data",
+    "datetime": "Data i czas",
+    "boolean": "Tak/Nie",
+    "asset": "Zasób",
+    "reference": "Referencja",
+    "relation": "Relacja",
+    "price": "Cena",
+    "metric": "Miara",
+    "wysiwyg": "Tekst sformatowany",
+    "color": "Kolor",
+    "email": "E-mail"
+  },
   "user_menu": {
     "aria_label": "Menu użytkownika",
     "account": "Konto",

--- a/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
@@ -82,6 +82,20 @@ final class FilterDslResolver
             self::OP_EQ, self::OP_NEQ, self::OP_IS_EMPTY, self::OP_IS_NOT_EMPTY,
             self::OP_STARTS_WITH, self::OP_ENDS_WITH, self::OP_CONTAINS, self::OP_NOT_CONTAINS,
         ],
+        // #1177 — textarea/email share the text operator set (free-form
+        // strings); color is exact-match / set membership (visual filter).
+        'textarea' => [
+            self::OP_EQ, self::OP_NEQ, self::OP_IS_EMPTY, self::OP_IS_NOT_EMPTY,
+            self::OP_STARTS_WITH, self::OP_ENDS_WITH, self::OP_CONTAINS, self::OP_NOT_CONTAINS,
+        ],
+        'email' => [
+            self::OP_EQ, self::OP_NEQ, self::OP_IS_EMPTY, self::OP_IS_NOT_EMPTY,
+            self::OP_STARTS_WITH, self::OP_ENDS_WITH, self::OP_CONTAINS, self::OP_NOT_CONTAINS,
+        ],
+        'color' => [
+            self::OP_EQ, self::OP_NEQ, self::OP_IN, self::OP_NOT_IN,
+            self::OP_IS_EMPTY, self::OP_IS_NOT_EMPTY,
+        ],
         'number' => [
             self::OP_EQ, self::OP_NEQ, self::OP_LT, self::OP_GT, self::OP_LTE, self::OP_GTE,
             self::OP_BETWEEN, self::OP_IS_EMPTY, self::OP_IS_NOT_EMPTY,

--- a/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
+++ b/apps/api/src/Catalog/Application/Query/GetObjectTypeListSchema/GetObjectTypeListSchemaHandler.php
@@ -215,7 +215,9 @@ final readonly class GetObjectTypeListSchemaHandler
         }
 
         return match ($attribute->getType()) {
-            AttributeType::Text, AttributeType::Wysiwyg => true,
+            // #1177 — textarea is free-form text content scored well by
+            // Meilisearch full-text; color/email are exact-match, not searchable.
+            AttributeType::Text, AttributeType::Wysiwyg, AttributeType::Textarea => true,
             default => false,
         };
     }

--- a/apps/api/src/Catalog/Application/Validation/AttributeValueValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/AttributeValueValidator.php
@@ -75,6 +75,10 @@ final readonly class AttributeValueValidator
             AttributeType::Price->value => new TypeValidator\PriceValidator(),
             AttributeType::Metric->value => new TypeValidator\MetricValidator(),
             AttributeType::Wysiwyg->value => new TypeValidator\WysiwygValidator(),
+            AttributeType::Datetime->value => new TypeValidator\DatetimeValidator(),
+            AttributeType::Textarea->value => new TypeValidator\TextareaValidator(),
+            AttributeType::Color->value => new TypeValidator\ColorValidator(),
+            AttributeType::Email->value => new TypeValidator\EmailValidator(),
         ]);
     }
 }

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/ColorValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/ColorValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `color` AttributeType validator (#1177).
+ *
+ * Stores the colour as a string in `object_values.value->>'value'`.
+ * Rule from `Attribute.validation_rules`:
+ *   - `color_format` (string): `hex` (default) → `#RRGGBB`;
+ *     `rgb` → `rgb(r, g, b)` with each channel 0-255.
+ */
+final class ColorValidator implements AttributeValueValidatorInterface
+{
+    private const HEX_PATTERN = '/^#[0-9a-fA-F]{6}$/';
+    private const RGB_PATTERN = '/^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/';
+
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $raw = $value['value'] ?? null;
+        if (!\is_string($raw) || '' === $raw) {
+            return [new ValidationError('value.value', 'color.expected_string', 'Color value must be a non-empty string.')];
+        }
+
+        $rules = $attribute->getValidationRules();
+        $format = \is_string($rules['color_format'] ?? null) ? $rules['color_format'] : 'hex';
+
+        if ('rgb' === $format) {
+            if (1 !== preg_match(self::RGB_PATTERN, $raw, $m)) {
+                return [new ValidationError('value.value', 'color.invalid_rgb', \sprintf('Color "%s" is not a valid rgb(r, g, b) string.', $raw))];
+            }
+            foreach (\array_slice($m, 1) as $channel) {
+                if ((int) $channel > 255) {
+                    return [new ValidationError('value.value', 'color.channel_out_of_range', \sprintf('Color "%s" has an rgb channel above 255.', $raw))];
+                }
+            }
+
+            return [];
+        }
+
+        if (1 !== preg_match(self::HEX_PATTERN, $raw)) {
+            return [new ValidationError('value.value', 'color.invalid_hex', \sprintf('Color "%s" is not a valid #RRGGBB hex string.', $raw))];
+        }
+
+        return [];
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/DatetimeValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/DatetimeValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `datetime` AttributeType validator (#1177).
+ *
+ * Accepts ISO 8601 strings carrying a time component (the admin form
+ * sends `YYYY-MM-DDTHH:mm` from `<input type="datetime-local">`); a
+ * date-only string also parses. Mirrors {@see DateValidator} including
+ * the `min` / `max` rule names (ISO 8601 strings) so the two sibling
+ * temporal validators stay consistent.
+ */
+final class DatetimeValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $raw = $value['value'] ?? null;
+        if (!\is_string($raw) || '' === $raw) {
+            return [new ValidationError('value.value', 'datetime.expected_iso_string', 'Datetime value must be a non-empty ISO 8601 string.')];
+        }
+
+        $parsed = date_create_immutable($raw);
+        if (false === $parsed) {
+            return [new ValidationError('value.value', 'datetime.unparseable', \sprintf('Datetime "%s" is not a valid ISO 8601 string.', $raw))];
+        }
+
+        $errors = [];
+        $rules = $attribute->getValidationRules();
+        if (\is_string($rules['min'] ?? null)) {
+            $min = date_create_immutable($rules['min']);
+            if (false !== $min && $parsed < $min) {
+                $errors[] = new ValidationError('value.value', 'datetime.below_min', \sprintf('Datetime %s is before min %s.', $raw, $rules['min']));
+            }
+        }
+        if (\is_string($rules['max'] ?? null)) {
+            $max = date_create_immutable($rules['max']);
+            if (false !== $max && $parsed > $max) {
+                $errors[] = new ValidationError('value.value', 'datetime.above_max', \sprintf('Datetime %s is after max %s.', $raw, $rules['max']));
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/EmailValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/EmailValidator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+use const FILTER_VALIDATE_EMAIL;
+
+/**
+ * `email` AttributeType validator (#1177).
+ *
+ * Stores the address as a string in `object_values.value->>'value'`.
+ * Format is checked with PHP's `FILTER_VALIDATE_EMAIL` (RFC 5322-lite).
+ * Optional rule from `Attribute.validation_rules`:
+ *   - `pattern` (string): extra PCRE the address must match (e.g. a
+ *     corporate domain allow-list).
+ */
+final class EmailValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $raw = $value['value'] ?? null;
+        if (!\is_string($raw) || '' === $raw) {
+            return [new ValidationError('value.value', 'email.expected_string', 'Email value must be a non-empty string.')];
+        }
+
+        if (false === filter_var($raw, FILTER_VALIDATE_EMAIL)) {
+            return [new ValidationError('value.value', 'email.invalid', \sprintf('Value "%s" is not a valid email address.', $raw))];
+        }
+
+        $errors = [];
+        $pattern = $attribute->getValidationRules()['pattern'] ?? null;
+        if (\is_string($pattern) && '' !== $pattern && 1 !== preg_match($pattern, $raw)) {
+            $errors[] = new ValidationError('value.value', 'email.pattern_mismatch', \sprintf('Email does not match pattern %s.', $pattern));
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/TextareaValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/TextareaValidator.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
+use App\Catalog\Application\Validation\ValidationError;
+use App\Catalog\Domain\Entity\Attribute;
+
+/**
+ * `textarea` AttributeType validator (#1177).
+ *
+ * Multi-line plain text without HTML — distinct from `wysiwyg`. Rules
+ * from `Attribute.validation_rules`:
+ *   - `max_length` (int): UTF-8 character cap
+ *   - `min_length` (int): UTF-8 character floor
+ *
+ * Unlike `text` there is no `pattern` rule: a free-form description is
+ * not a candidate for regex shaping.
+ */
+final class TextareaValidator implements AttributeValueValidatorInterface
+{
+    public function validate(Attribute $attribute, array $value): array
+    {
+        $raw = $value['value'] ?? null;
+
+        if (!\is_string($raw)) {
+            return [new ValidationError('value.value', 'textarea.expected_string', 'Textarea value must be a string.')];
+        }
+
+        $errors = [];
+        $rules = $attribute->getValidationRules();
+        $length = mb_strlen($raw, 'UTF-8');
+
+        $max = $rules['max_length'] ?? null;
+        if (\is_int($max) && $length > $max) {
+            $errors[] = new ValidationError('value.value', 'textarea.too_long', \sprintf('Text exceeds max_length=%d (got %d).', $max, $length));
+        }
+        $min = $rules['min_length'] ?? null;
+        if (\is_int($min) && $length < $min) {
+            $errors[] = new ValidationError('value.value', 'textarea.too_short', \sprintf('Text shorter than min_length=%d (got %d).', $min, $length));
+        }
+
+        return $errors;
+    }
+}

--- a/apps/api/src/Catalog/Domain/AttributeType.php
+++ b/apps/api/src/Catalog/Domain/AttributeType.php
@@ -8,7 +8,7 @@ namespace App\Catalog\Domain;
  * Catalog of attribute types supported in MVP.
  *
  * Per ADR-006 (hybrid attribute model): every catalog attribute carries a
- * type that drives storage, validation, and rendering. The 10 cases below
+ * type that drives storage, validation, and rendering. The cases below
  * cover MVP needs — adding a new type is a coordinated change across:
  *   - this enum (new case);
  *   - per-type validator (#39 / 0.3.9);
@@ -51,19 +51,50 @@ enum AttributeType: string
     case Wysiwyg = 'wysiwyg';
 
     /**
-     * UI-08.3 (#258) — system attribute types. Used by `created_at`/
-     * `updated_at` (Datetime) and `created_by`/`updated_by` (Reference, with
-     * `validation_rules.target_entity = 'user'` per epik plan §12.2).
+     * UI-08.3 (#258) — date + time value.
      *
-     * Read-only in MVP: no AttributeValueValidator binding because system
-     * attributes are never written via the catalog write path — they are
-     * stamped on the `objects` row by Doctrine listeners and surfaced in the
-     * form schema for display only. A future ticket adds renderers; until
-     * then the dispatcher's "no validator registered" branch is the safe
-     * fallback if anyone ever tries to POST a value against these.
+     * Originally introduced as a read-only *system* type backing
+     * `created_at`/`updated_at`. Since #1177 it is also a user-facing,
+     * writable type (release date + time, promotion deadline, delivery
+     * schedule) with a {@see TypeValidator\DatetimeValidator} binding.
+     * The system fields stay read-only via the instance-level
+     * {@see Attribute::isSystem()} flag, not via the type, so the two
+     * use-cases coexist on one enum case.
      */
     case Datetime = 'datetime';
+
+    /**
+     * UI-08.3 (#258) — system attribute type. Used by `created_by`/
+     * `updated_by` (Reference, with `validation_rules.target_entity = 'user'`
+     * per epik plan §12.2).
+     *
+     * Read-only in MVP: no AttributeValueValidator binding because the
+     * reference values are stamped on the `objects` row by Doctrine
+     * listeners and surfaced in the form schema for display only. The
+     * dispatcher's "no validator registered" branch is the safe fallback
+     * if anyone ever tries to POST a value against it.
+     */
     case Reference = 'reference';
+
+    /**
+     * #1177 — short plain-text without HTML. Distinct from `wysiwyg`
+     * (rich HTML) and `text` (single line): renders a multi-line
+     * `<textarea>` and keeps CSV export readable. Stored as a single
+     * `string` in `object_values.value->>'value'`.
+     */
+    case Textarea = 'textarea';
+
+    /**
+     * #1177 — colour value as a hex (`#RRGGBB`) or `rgb(...)` string.
+     * UI renders a colour picker + swatch chip; usable as a visual filter.
+     */
+    case Color = 'color';
+
+    /**
+     * #1177 — email address (manufacturer/supplier contact). Validated
+     * against an RFC 5322-lite pattern; UI renders an `<input type="email">`.
+     */
+    case Email = 'email';
 
     public function usesOptions(): bool
     {
@@ -72,6 +103,6 @@ enum AttributeType: string
 
     public function isSystemType(): bool
     {
-        return self::Datetime === $this || self::Reference === $this;
+        return self::Reference === $this;
     }
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/AttributeInput.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *   - code (snake_case, immutable post-create)
  *   - label (JSONB { pl, en, ... })
  *   - help (JSONB, optional)
- *   - type (one of 10 AttributeType enum values)
+ *   - type (one of the user-facing AttributeType enum values)
  *   - flags: localizable, scopable, required
  *   - validationRules (JSONB, e.g. { max_length: 280 })
  */
@@ -46,7 +46,7 @@ final class AttributeInput
     public ?array $help = null;
 
     #[Assert\NotBlank]
-    #[Assert\Choice(choices: ['text', 'number', 'select', 'multiselect', 'date', 'boolean', 'asset', 'relation', 'price', 'metric', 'wysiwyg'])]
+    #[Assert\Choice(choices: ['text', 'number', 'select', 'multiselect', 'date', 'boolean', 'asset', 'relation', 'price', 'metric', 'wysiwyg', 'datetime', 'textarea', 'color', 'email'])]
     #[Groups(['attribute:create'])]
     public string $type = 'text';
 

--- a/apps/api/src/Export/Application/Builder/ValueSerializer.php
+++ b/apps/api/src/Export/Application/Builder/ValueSerializer.php
@@ -52,6 +52,10 @@ final class ValueSerializer
 
         return match ($type) {
             AttributeType::Text, AttributeType::Wysiwyg => $this->pickValue($payload),
+            // #1177 — textarea/color/email all store a scalar string in
+            // `value->>'value'`, so they serialise like Text (keeps CSV
+            // export readable, which is a primary driver for `textarea`).
+            AttributeType::Textarea, AttributeType::Color, AttributeType::Email => $this->pickValue($payload),
             AttributeType::Number => $this->pickValue($payload),
             AttributeType::Date, AttributeType::Datetime => $this->pickValue($payload),
             AttributeType::Boolean => $this->boolOf($payload),

--- a/apps/api/tests/Unit/Catalog/AttributeTypeTest.php
+++ b/apps/api/tests/Unit/Catalog/AttributeTypeTest.php
@@ -12,13 +12,16 @@ use PHPUnit\Framework\TestCase;
 final class AttributeTypeTest extends TestCase
 {
     #[Test]
-    public function thirteenCasesAreDefinedExactly(): void
+    public function casesAreDefinedExactly(): void
     {
-        // 10 user-facing types from ADR-006 + 2 system types added by UI-08.3
-        // (#258): `datetime` and `reference` + 1 user-facing `wysiwyg` from
-        // VIEW-07.2 (#423). Guard against accidental case removal/addition.
-        self::assertCount(13, AttributeType::cases());
-        self::assertCount(2, array_filter(AttributeType::cases(), static fn (AttributeType $t) => $t->isSystemType()));
+        // 10 user-facing types from ADR-006 + `wysiwyg` (VIEW-07.2 #423)
+        // + `datetime`/`reference` (UI-08.3 #258) + `textarea`/`color`/`email`
+        // (#1177). `datetime` is now user-facing (#1177); only `reference`
+        // stays a system type. Guard against accidental case removal/addition.
+        self::assertCount(16, AttributeType::cases());
+        self::assertCount(1, array_filter(AttributeType::cases(), static fn (AttributeType $t) => $t->isSystemType()));
+        self::assertTrue(AttributeType::Reference->isSystemType());
+        self::assertFalse(AttributeType::Datetime->isSystemType());
     }
 
     #[Test]
@@ -49,6 +52,9 @@ final class AttributeTypeTest extends TestCase
         yield 'metric does not use options' => [AttributeType::Metric, false];
         yield 'datetime does not use options' => [AttributeType::Datetime, false];
         yield 'reference does not use options' => [AttributeType::Reference, false];
+        yield 'textarea does not use options' => [AttributeType::Textarea, false];
+        yield 'color does not use options' => [AttributeType::Color, false];
+        yield 'email does not use options' => [AttributeType::Email, false];
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Catalog/SystemAttributesAuditGroupTest.php
+++ b/apps/api/tests/Unit/Catalog/SystemAttributesAuditGroupTest.php
@@ -56,10 +56,14 @@ final class SystemAttributesAuditGroupTest extends TestCase
     }
 
     #[Test]
-    public function datetimeAndReferenceTypesAreSystemTypes(): void
+    public function onlyReferenceIsASystemType(): void
     {
-        self::assertTrue(AttributeType::Datetime->isSystemType());
+        // #1177 — `datetime` became a user-facing, validated type; `created_at`/
+        // `updated_at` stay read-only via the instance `isSystem` flag (see
+        // markSystemFlipsTheFlag), not via the type. Only `reference` remains
+        // a system type.
         self::assertTrue(AttributeType::Reference->isSystemType());
+        self::assertFalse(AttributeType::Datetime->isSystemType());
         self::assertFalse(AttributeType::Text->isSystemType());
         self::assertFalse(AttributeType::Date->isSystemType());
         self::assertFalse(AttributeType::Relation->isSystemType());

--- a/apps/api/tests/Unit/Catalog/Validation/AttributeValueValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/AttributeValueValidatorTest.php
@@ -52,10 +52,10 @@ final class AttributeValueValidatorTest extends TestCase
         $validator = AttributeValueValidator::default();
 
         // Smoke: every non-system AttributeType case must dispatch to a real
-        // validator, not the unsupported_type fallback. System types
-        // (`datetime`, `reference` per UI-08.3) are intentionally read-only
-        // — they have no validator binding and the dispatcher's fallback is
-        // expected behaviour for them.
+        // validator, not the unsupported_type fallback. The only system type
+        // (`reference` per UI-08.3) is intentionally read-only — it has no
+        // validator binding and the dispatcher's fallback is expected
+        // behaviour for it. `datetime` became user-facing in #1177.
         foreach (AttributeType::cases() as $type) {
             if ($type->isSystemType()) {
                 continue;
@@ -76,12 +76,13 @@ final class AttributeValueValidatorTest extends TestCase
     {
         $validator = AttributeValueValidator::default();
 
-        foreach ([AttributeType::Datetime, AttributeType::Reference] as $type) {
-            $attribute = new Attribute('sys_'.$type->value, ['en' => 'sys'], $type);
-            $errors = $validator->validate($attribute, []);
+        // `reference` is the only remaining read-only system type (#1177
+        // promoted `datetime` to a user-facing, validated type).
+        $type = AttributeType::Reference;
+        $attribute = new Attribute('sys_'.$type->value, ['en' => 'sys'], $type);
+        $errors = $validator->validate($attribute, []);
 
-            self::assertNotEmpty($errors);
-            self::assertSame('attribute.unsupported_type', $errors[0]->code);
-        }
+        self::assertNotEmpty($errors);
+        self::assertSame('attribute.unsupported_type', $errors[0]->code);
     }
 }

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/ColorValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/ColorValidatorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\ColorValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class ColorValidatorTest extends TestCase
+{
+    private ColorValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new ColorValidator();
+        $this->attribute = new Attribute('product_color', ['pl' => 'Kolor'], AttributeType::Color);
+    }
+
+    #[Test]
+    public function validHexPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => '#1a2b3c']));
+    }
+
+    #[Test]
+    public function emptyPayloadFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, []);
+
+        self::assertCount(1, $errors);
+        self::assertSame('color.expected_string', $errors[0]->code);
+    }
+
+    #[Test]
+    public function malformedHexFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => '123456']);
+
+        self::assertSame('color.invalid_hex', $errors[0]->code);
+    }
+
+    #[Test]
+    public function shortHexFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => '#fff']);
+
+        self::assertSame('color.invalid_hex', $errors[0]->code);
+    }
+
+    #[Test]
+    public function validRgbPassesWhenFormatIsRgb(): void
+    {
+        $this->attribute->updateValidationRules(['color_format' => 'rgb']);
+
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => 'rgb(26, 43, 60)']));
+    }
+
+    #[Test]
+    public function rgbChannelAbove255Fails(): void
+    {
+        $this->attribute->updateValidationRules(['color_format' => 'rgb']);
+
+        $errors = $this->validator->validate($this->attribute, ['value' => 'rgb(300, 0, 0)']);
+
+        self::assertSame('color.channel_out_of_range', $errors[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/DatetimeValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/DatetimeValidatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\DatetimeValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DatetimeValidatorTest extends TestCase
+{
+    private DatetimeValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new DatetimeValidator();
+        $this->attribute = new Attribute('release_at', ['pl' => 'Premiera'], AttributeType::Datetime);
+    }
+
+    #[Test]
+    public function datetimeLocalStringPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => '2027-03-15T14:30']));
+    }
+
+    #[Test]
+    public function emptyPayloadFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, []);
+
+        self::assertCount(1, $errors);
+        self::assertSame('datetime.expected_iso_string', $errors[0]->code);
+    }
+
+    #[Test]
+    public function unparseableStringFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => 'not-a-date']);
+
+        self::assertCount(1, $errors);
+        self::assertSame('datetime.unparseable', $errors[0]->code);
+    }
+
+    #[Test]
+    public function belowMinFails(): void
+    {
+        $this->attribute->updateValidationRules(['min' => '2027-01-01T00:00']);
+
+        $errors = $this->validator->validate($this->attribute, ['value' => '2026-12-31T23:59']);
+
+        self::assertSame('datetime.below_min', $errors[0]->code);
+    }
+
+    #[Test]
+    public function aboveMaxFails(): void
+    {
+        $this->attribute->updateValidationRules(['max' => '2027-01-01T00:00']);
+
+        $errors = $this->validator->validate($this->attribute, ['value' => '2027-06-01T12:00']);
+
+        self::assertSame('datetime.above_max', $errors[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/EmailValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/EmailValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\EmailValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class EmailValidatorTest extends TestCase
+{
+    private EmailValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new EmailValidator();
+        $this->attribute = new Attribute('supplier_email', ['pl' => 'Email dostawcy'], AttributeType::Email);
+    }
+
+    #[Test]
+    public function validAddressPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => 'contact@example.com']));
+    }
+
+    #[Test]
+    public function emptyPayloadFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, []);
+
+        self::assertCount(1, $errors);
+        self::assertSame('email.expected_string', $errors[0]->code);
+    }
+
+    #[Test]
+    public function malformedAddressFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => 'not-an-email']);
+
+        self::assertSame('email.invalid', $errors[0]->code);
+    }
+
+    #[Test]
+    public function patternRuleNarrowsAllowedDomain(): void
+    {
+        $this->attribute->updateValidationRules(['pattern' => '/@example\.com$/']);
+
+        $ok = $this->validator->validate($this->attribute, ['value' => 'a@example.com']);
+        $bad = $this->validator->validate($this->attribute, ['value' => 'a@other.com']);
+
+        self::assertSame([], $ok);
+        self::assertSame('email.pattern_mismatch', $bad[0]->code);
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/TextareaValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/TextareaValidatorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
+
+use App\Catalog\Application\Validation\TypeValidator\TextareaValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class TextareaValidatorTest extends TestCase
+{
+    private TextareaValidator $validator;
+    private Attribute $attribute;
+
+    protected function setUp(): void
+    {
+        $this->validator = new TextareaValidator();
+        $this->attribute = new Attribute('short_desc', ['pl' => 'Krótki opis'], AttributeType::Textarea);
+    }
+
+    #[Test]
+    public function multiLineStringPasses(): void
+    {
+        self::assertSame([], $this->validator->validate($this->attribute, ['value' => "line 1\nline 2"]));
+    }
+
+    #[Test]
+    public function nonStringValueFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, ['value' => 42]);
+
+        self::assertCount(1, $errors);
+        self::assertSame('textarea.expected_string', $errors[0]->code);
+    }
+
+    #[Test]
+    public function emptyPayloadFails(): void
+    {
+        $errors = $this->validator->validate($this->attribute, []);
+
+        self::assertCount(1, $errors);
+        self::assertSame('textarea.expected_string', $errors[0]->code);
+    }
+
+    #[Test]
+    public function maxLengthIsEnforcedInUtf8Characters(): void
+    {
+        $this->attribute->updateValidationRules(['max_length' => 3]);
+
+        $errors = $this->validator->validate($this->attribute, ['value' => 'łóść']);
+
+        self::assertCount(1, $errors);
+        self::assertSame('textarea.too_long', $errors[0]->code);
+    }
+
+    #[Test]
+    public function minLengthIsEnforced(): void
+    {
+        $this->attribute->updateValidationRules(['min_length' => 5]);
+
+        $errors = $this->validator->validate($this->attribute, ['value' => 'hi']);
+
+        self::assertSame('textarea.too_short', $errors[0]->code);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -7599,7 +7599,10 @@
                             "metric",
                             "wysiwyg",
                             "datetime",
-                            "reference"
+                            "reference",
+                            "textarea",
+                            "color",
+                            "email"
                         ]
                     },
                     "validationRules": {
@@ -7711,7 +7714,11 @@
                             "relation",
                             "price",
                             "metric",
-                            "wysiwyg"
+                            "wysiwyg",
+                            "datetime",
+                            "textarea",
+                            "color",
+                            "email"
                         ],
                         "default": "text",
                         "type": "string"
@@ -7944,7 +7951,10 @@
                                     "metric",
                                     "wysiwyg",
                                     "datetime",
-                                    "reference"
+                                    "reference",
+                                    "textarea",
+                                    "color",
+                                    "email"
                                 ]
                             },
                             "validationRules": {

--- a/docs/api/jsonb-schemas.md
+++ b/docs/api/jsonb-schemas.md
@@ -95,9 +95,10 @@ Schema unionowa — pole `validation_rules` jest interpretowane przez validator 
   "properties": {
     "max_length":   { "type": "integer", "minimum": 1, "description": "text, wysiwyg" },
     "min_length":   { "type": "integer", "minimum": 0, "description": "text, wysiwyg" },
-    "pattern":      { "type": "string", "description": "text — regex JS-compatible" },
-    "min":          { "type": "number", "description": "number, metric, price" },
-    "max":          { "type": "number", "description": "number, metric, price" },
+    "pattern":      { "type": "string", "description": "text, email — regex JS-compatible (email: extra domain allow-list on top of RFC 5322 check)" },
+    "color_format": { "enum": ["hex", "rgb"], "description": "color (#1177) — `hex` (#RRGGBB, default) or `rgb` (rgb(r, g, b))" },
+    "min":          { "type": ["number", "string"], "description": "number, metric, price (number); date, datetime (ISO 8601 string — floor)" },
+    "max":          { "type": ["number", "string"], "description": "number, metric, price (number); date, datetime (ISO 8601 string — ceil)" },
     "min_amount":   { "type": "number", "description": "price — wymóg na amount" },
     "max_amount":   { "type": "number", "description": "price" },
     "currencies":   { "type": "array", "items": { "type": "string", "minLength": 3, "maxLength": 3 }, "description": "price — allowed ISO 4217 codes" },


### PR DESCRIPTION
## Cel
Dodaje cztery proste typy atrybutów w Modelowanie → Atrybuty (część 1/3 batcha #1177). Zamyka #1177.

| Typ | Uzasadnienie |
|-----|--------------|
| `textarea` | Krótki opis plain-text bez HTML; completeness odrębny od `wysiwyg`; czytelny eksport CSV |
| `datetime` (user-facing) | Data premiery + godzina, termin promocji, harmonogram dostaw |
| `color` | Kolor produktu jako hex/RGB — picker + chip + filtr wizualny |
| `email` | Adres email (kontakt do producenta/dostawcy) |

## Backend
- `AttributeType`: nowe case'y `Textarea`/`Color`/`Email`; **`datetime` staje się user-facing** — `isSystemType()` zwężony do `Reference`. System fields `created_at`/`updated_at` pozostają read-only przez flagę encji `Attribute::isSystem` (nie przez typ).
- 4 walidatory (`TextareaValidator` — length; `DatetimeValidator` — ISO 8601 + `min`/`max` jak `DateValidator`; `ColorValidator` — `color_format` hex/rgb; `EmailValidator` — RFC 5322 + opcjonalny `pattern`) zarejestrowane w `AttributeValueValidator::default()`.
- `AttributeInput` `#[Assert\Choice]` rozszerzony o 4 typy.
- **Koordynacja cross-system** (ADR-006): dodane gałęzie do *wyczerpującego* `match` w `ValueSerializer` (eksport CSV — inaczej `UnhandledMatchError`), `textarea` do heurystyki `isSearchable`, oraz wpisy w macierzy operatorów filtra `FilterDslResolver` (color = exact/IN, textarea/email = text ops).

## Frontend
- Typy dodane do obu dialogów tworzenia atrybutu, filtra listy atrybutów i pickera z biblioteki.
- `attr-row`: natywny `<input type="color">` + pole hex; `<input type="email">`; read-only ze swatch+hex / linkiem `mailto:`. (`textarea`/`datetime` miały już renderery.)
- Labelki typów tłumaczalne — nowy namespace i18n `attribute_type` (pl+en) z `defaultValue` fallback.

## Doc
- `docs/api/jsonb-schemas.md` §2: dodany klucz `color_format`; `min`/`max` opisane też dla date/datetime; `pattern` także dla email.

## Testy / bramki
- Unit: 4 nowe testy walidatorów; zaktualizowane `AttributeTypeTest` (16 case'ów, 1 system), `AttributeValueValidatorTest`, `SystemAttributesAuditGroupTest`. **735 unit pass.**
- **PHPStan max: czysto** (potwierdza też wyczerpalność `match` w `ValueSerializer` dla 16 typów).
- **Biome + tsc: czysto.**
- **Playwright E2E** (`1177-attribute-types-simple.spec.ts`) — **przeszedł na żywym stacku**: tworzy atrybut każdego typu → przypina do Product OT → tworzy produkt → renderuje właściwą kontrolkę (textarea / datetime-local / color / email) → ustawia wartości → PATCH 200 → reload → wszystkie 4 wartości persystują. `fixme` w CI (auth rate-limiter, wzorzec #1138).

## Smoke test (SMOKE TEST RULE)
Zweryfikowane end-to-end przez powyższy E2E na `https://pim.localhost` z realnymi danymi: round-trip wszystkich 4 typów działa, brak błędów w Console, statusy 2xx/PATCH 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)