### PR TITLE
fix(catalog): usuwanie własnych presetów Smart Filter na liście (#1205)

### DIFF
--- a/apps/admin/e2e/1205-smart-filter-preset-delete.spec.ts
+++ b/apps/admin/e2e/1205-smart-filter-preset-delete.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1205 — deleting a user-created Smart Filter preset from the list view.
+ *
+ * The backend DELETE endpoint and the `useSmartPresets().remove` hook
+ * already existed; this proves the (previously missing) UI: the chip's
+ * hover/focus-revealed × → confirmation dialog → DELETE → chip gone.
+ *
+ * Deterministic: the preset is seeded via API (POST), then the spec drives
+ * the delete UI on `/products`, which renders the same shared
+ * `SmartFilterPresetsRow` + `DeletePresetDialog` as the universal list.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other
+ * UI-seeded specs.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('a user Smart Filter preset can be deleted from the list view', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+
+  const presetName = `E2E ${uniqueSku('PRESET')}`;
+
+  // Seed a user-created (non-built-in) preset scoped to the products list.
+  // `/products` is the universal list for the built-in product ObjectType,
+  // which loads presets by its OT code `product` (singular) — not the legacy
+  // `products` resource string.
+  const createResp = await page.request.post('/api/smart-filter-presets', {
+    headers: { ...bearer, 'content-type': 'application/json' },
+    data: {
+      name: { pl: presetName, en: presetName },
+      icon: '⭐',
+      query: { attr: 'main_image', op: 'IS EMPTY' },
+      resource: 'product',
+    },
+  });
+  expect(createResp.status(), await createResp.text()).toBe(201);
+
+  const presetsRow = page.getByRole('tablist', { name: /smart filtry/i });
+  await page.goto('/products');
+  await expect(presetsRow).toBeVisible();
+
+  const chip = presetsRow.getByRole('tab', { name: new RegExp(presetName, 'i') });
+  await expect(chip).toBeVisible();
+
+  // The delete affordance is revealed on hover/focus-within of the chip.
+  await chip.hover();
+  const deleteButton = page.getByRole('button', {
+    name: new RegExp(`usuń preset ${presetName}`, 'i'),
+  });
+  await deleteButton.click();
+
+  // Confirmation dialog → confirm → DELETE 204 → chip disappears.
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  const deleteResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/smart-filter-presets/') &&
+      response.request().method() === 'DELETE',
+  );
+  await dialog.getByRole('button', { name: /^(usuń preset|delete preset)$/i }).click();
+  expect((await deleteResponse).status()).toBe(204);
+
+  await expect(chip).toBeHidden();
+});

--- a/apps/admin/src/components/catalog/delete-preset-dialog.tsx
+++ b/apps/admin/src/components/catalog/delete-preset-dialog.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { toast } from '@/components/ui/toast';
+import type { SmartFilterPreset } from '@/lib/filters/use-smart-presets';
+
+interface DeletePresetDialogProps {
+  /** The preset to delete, or `null` when the dialog is closed. */
+  preset: SmartFilterPreset | null;
+  /** Closes the dialog (sets `preset` back to null in the parent). */
+  onClose: () => void;
+  /** Called after a successful delete so the parent can clear active state. */
+  onDeleted: (presetId: string) => void;
+  /** `useSmartPresets().remove` — issues the DELETE and reloads the list. */
+  remove: (id: string) => Promise<void>;
+}
+
+/**
+ * #1205 — confirmation before deleting a user-created Smart Filter preset.
+ * Destructive (irreversible) action, so it goes through a modal per the
+ * CLAUDE.md rule. Built-in/system presets never reach here (the row hides
+ * the affordance for them).
+ */
+export function DeletePresetDialog({
+  preset,
+  onClose,
+  onDeleted,
+  remove,
+}: DeletePresetDialogProps) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language.startsWith('en') ? 'en' : 'pl';
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const name = preset ? (preset.name[lang] ?? preset.name.pl) : '';
+
+  const confirm = async (): Promise<void> => {
+    if (preset === null) return;
+    setIsDeleting(true);
+    try {
+      await remove(preset.id);
+      onDeleted(preset.id);
+      toast.success(
+        t('products.smart_filters.delete_success', { defaultValue: 'Preset usunięty' }),
+      );
+      onClose();
+    } catch {
+      toast.error(
+        t('products.smart_filters.delete_failed', { defaultValue: 'Nie udało się usunąć presetu' }),
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={preset !== null}
+      onOpenChange={(open) => {
+        if (!open && !isDeleting) onClose();
+      }}
+    >
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>
+            {t('products.smart_filters.delete_confirm_title', { defaultValue: 'Usunąć preset?' })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('products.smart_filters.delete_confirm_body', {
+              defaultValue: 'Preset „{{name}}" zostanie trwale usunięty.',
+              name,
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="mt-4 gap-2">
+          <Button variant="outline" onClick={onClose} disabled={isDeleting}>
+            {t('common.cancel', { defaultValue: 'Anuluj' })}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              void confirm();
+            }}
+            disabled={isDeleting}
+          >
+            {t('products.smart_filters.delete_confirm_cta', { defaultValue: 'Usuń preset' })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/components/catalog/smart-filter-presets-row.tsx
+++ b/apps/admin/src/components/catalog/smart-filter-presets-row.tsx
@@ -1,4 +1,4 @@
-import { Plus, Sparkles } from 'lucide-react';
+import { Plus, Sparkles, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import type { SmartFilterPreset } from '@/lib/filters/use-smart-presets';
@@ -28,6 +28,13 @@ interface SmartFilterPresetsRowProps {
   onSelect: (preset: SmartFilterPreset | null) => void;
   onCreate: () => void;
   isLoading?: boolean;
+  /**
+   * #1205 — when provided, user-created presets (not built-in/system) get a
+   * hover/focus-revealed delete affordance. Built-in and system presets are
+   * never deletable (the backend rejects them anyway), so the control is
+   * suppressed for them.
+   */
+  onDelete?: (preset: SmartFilterPreset) => void;
 }
 
 export function SmartFilterPresetsRow({
@@ -36,6 +43,7 @@ export function SmartFilterPresetsRow({
   onSelect,
   onCreate,
   isLoading = false,
+  onDelete,
 }: SmartFilterPresetsRowProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language.startsWith('en') ? 'en' : 'pl';
@@ -85,37 +93,62 @@ export function SmartFilterPresetsRow({
             const labelKey = BUILT_IN_LABEL_KEY[preset.slug];
             const fallbackLabel = preset.name[lang] ?? preset.name.pl;
             const label = labelKey ? t(labelKey, { defaultValue: fallbackLabel }) : fallbackLabel;
+            const isDeletable = onDelete !== undefined && !preset.is_built_in && !preset.is_system;
             return (
-              <button
-                key={preset.id}
-                type="button"
-                role="tab"
-                aria-selected={isActive}
-                onClick={() => {
-                  onSelect(isActive ? null : preset);
-                }}
-                className={cn(
-                  'group shrink-0 inline-flex items-center gap-2 h-9 px-3 rounded-2xl text-[12.5px] font-medium transition border focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900',
-                  isActive
-                    ? 'bg-zinc-900 text-white border-zinc-900'
-                    : 'bg-zinc-50 text-zinc-700 border-zinc-100 hover:bg-white hover:border-zinc-200',
-                )}
-              >
-                <span className="text-[14px] leading-none" aria-hidden="true">
-                  {preset.icon}
-                </span>
-                <span>{label}</span>
-                {preset.count !== undefined && (
-                  <span
+              // Wrapper keeps the select chip and the delete control as
+              // siblings (a button cannot be nested inside another button).
+              <div key={preset.id} className="group/preset relative shrink-0 inline-flex">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => {
+                    onSelect(isActive ? null : preset);
+                  }}
+                  className={cn(
+                    'inline-flex items-center gap-2 h-9 px-3 rounded-2xl text-[12.5px] font-medium transition border focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900',
+                    isDeletable && 'pr-7',
+                    isActive
+                      ? 'bg-zinc-900 text-white border-zinc-900'
+                      : 'bg-zinc-50 text-zinc-700 border-zinc-100 hover:bg-white hover:border-zinc-200',
+                  )}
+                >
+                  <span className="text-[14px] leading-none" aria-hidden="true">
+                    {preset.icon}
+                  </span>
+                  <span>{label}</span>
+                  {preset.count !== undefined && (
+                    <span
+                      className={cn(
+                        'text-[10.5px] tabular-nums font-mono',
+                        isActive ? 'text-white/60' : 'text-zinc-400',
+                      )}
+                    >
+                      {preset.count}
+                    </span>
+                  )}
+                </button>
+                {isDeletable && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onDelete(preset);
+                    }}
+                    aria-label={t('products.smart_filters.delete_aria', {
+                      defaultValue: 'Usuń preset {{name}}',
+                      name: label,
+                    })}
                     className={cn(
-                      'text-[10.5px] tabular-nums font-mono',
-                      isActive ? 'text-white/60' : 'text-zinc-400',
+                      'absolute right-1 top-1/2 -translate-y-1/2 grid h-5 w-5 place-items-center rounded-full opacity-0 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900 group-hover/preset:opacity-100 group-focus-within/preset:opacity-100',
+                      isActive
+                        ? 'text-white/70 hover:bg-white/20 hover:text-white'
+                        : 'text-zinc-400 hover:bg-zinc-200 hover:text-zinc-700',
                     )}
                   >
-                    {preset.count}
-                  </span>
+                    <X className="size-3" />
+                  </button>
                 )}
-              </button>
+              </div>
             );
           })}
       </div>

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -38,6 +38,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
 import { BulkBar } from '@/components/catalog/bulk-bar';
+import { DeletePresetDialog } from '@/components/catalog/delete-preset-dialog';
 import { type ExcelColumn, ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
 import { FilterChipsBar } from '@/components/catalog/filter-chips-bar';
 import {
@@ -278,8 +279,10 @@ export function UniversalListPage({
     presets: smartPresets,
     isLoading: smartPresetsLoading,
     create: createSmartPreset,
+    remove: removeSmartPreset,
   } = useSmartPresets({ withCounts: true, resource: objectTypeCode });
   const [activeSmartPresetId, setActiveSmartPresetId] = useState<string | null>(null);
+  const [presetToDelete, setPresetToDelete] = useState<SmartFilterPreset | null>(null);
   const [advancedPanelOpen, setAdvancedPanelOpen] = useState(false);
   const [panelConditions, setPanelConditions] = useState<FilterCondition[]>([]);
   const [matchOperator, setMatchOperator] = useState<'AND' | 'OR'>('AND');
@@ -613,7 +616,22 @@ export function UniversalListPage({
           }
           setShowSaveAsPresetModal(true);
         }}
+        onDelete={(preset) => {
+          setPresetToDelete(preset);
+        }}
         isLoading={smartPresetsLoading}
+      />
+
+      <DeletePresetDialog
+        preset={presetToDelete}
+        onClose={() => {
+          setPresetToDelete(null);
+        }}
+        onDeleted={(presetId) => {
+          // Drop the active filter if the deleted preset was applied.
+          if (activeSmartPresetId === presetId) handleApplySmartPreset(null);
+        }}
+        remove={removeSmartPreset}
       />
 
       <div className="flex flex-wrap items-center gap-3">

--- a/apps/admin/src/features/catalog/products/list.tsx
+++ b/apps/admin/src/features/catalog/products/list.tsx
@@ -69,6 +69,7 @@ const ExportModal = lazy(() =>
   import('@/features/exports/wizard/ExportModal').then((m) => ({ default: m.ExportModal })),
 );
 
+import { DeletePresetDialog } from '@/components/catalog/delete-preset-dialog';
 import { EmptyStateProducts } from '@/components/catalog/empty-state-products';
 import { type ExcelColumn, ExcelLikeGrid } from '@/components/catalog/excel-like-grid';
 import { FilterChipsBar } from '@/components/catalog/filter-chips-bar';
@@ -247,8 +248,10 @@ export function ProductListPage() {
     presets: smartPresets,
     isLoading: smartPresetsLoading,
     create: createSmartPreset,
+    remove: removeSmartPreset,
   } = useSmartPresets({ withCounts: true });
   const [activeSmartPresetId, setActiveSmartPresetId] = useState<string | null>(null);
+  const [presetToDelete, setPresetToDelete] = useState<SmartFilterPreset | null>(null);
   const [advancedPanelOpen, setAdvancedPanelOpen] = useState(false);
   const [panelConditions, setPanelConditions] = useState<FilterCondition[]>([]);
   const [matchOperator, setMatchOperator] = useState<'AND' | 'OR'>('AND');
@@ -586,7 +589,21 @@ export function ProductListPage() {
           }
           setShowSaveAsPresetModal(true);
         }}
+        onDelete={(preset) => {
+          setPresetToDelete(preset);
+        }}
         isLoading={smartPresetsLoading}
+      />
+
+      <DeletePresetDialog
+        preset={presetToDelete}
+        onClose={() => {
+          setPresetToDelete(null);
+        }}
+        onDeleted={(presetId) => {
+          if (activeSmartPresetId === presetId) handleApplySmartPreset(null);
+        }}
+        remove={removeSmartPreset}
       />
 
       <div className="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
Dodaje brakujące UI do usuwania **własnych** presetów Smart Filter z listy (uniwersalnej `/objects/:slug` oraz produktów `/products`). Backend (`DELETE /api/smart-filter-presets/{id}`) i hook `useSmartPresets().remove` już istniały — brakowało wyłącznie kontrolki i wpięcia.

## Root cause
`SmartFilterPresetsRow` nie miał propa `onDelete` ani kontrolki usuwania; listy nie destrukturyzowały `remove`. Chipy były read-only → operator nie miał jak usunąć własnego presetu.

## Frontend changes
- `smart-filter-presets-row.tsx`: opcjonalny `onDelete`; dla `!is_built_in && !is_system` przycisk × ujawniany na hover/`focus-within` (sibling przycisku select — bez zagnieżdżania buttonów), `aria-label` z nazwą.
- `delete-preset-dialog.tsx` (nowy): wspólny confirm Dialog (Radix) — tytuł + nazwa presetu + Anuluj/Usuń; wykonuje `remove()`, toast sukcesu/błędu.
- `universal-list-page.tsx` + `products/list.tsx`: destrukturyzacja `remove`, stan `presetToDelete`, render dialogu; po usunięciu czyści aktywny filtr jeśli usuwany był aktywny.
- i18n przez `t(..., {defaultValue})` (PL domyślnie), spójnie z istniejącym `products.smart_filters.*`.

## Backend changes
Brak — endpoint i ownership-guard (built-in/system odrzucane) już są.

## Quality gates
- typecheck: zielony. Biome strict: 0 errors. build admin: zielony.
- Playwright `1205-smart-filter-preset-delete.spec.ts`: **zielony lokalnie** (seed presetu przez API → hover chip → × → confirm → DELETE 204 → chip znika).
- `composer audit` w CI czerwony = **pre-existing** (twig CVE + krok CI bez `composer install`), niezwiązany z tym FE-only PR-em.

## Smoke test plan (po merge)
1. Login admin@demo.localhost/changeme.
2. `/objects/samochody` (lub `/products`) → utwórz własny preset (panel zaawansowany → warunek → „Własny preset").
3. Hover/focus na chip → widoczny × → klik → confirm Dialog → „Usuń preset".
4. Preset znika, toast „Preset usunięty". Built-in presety bez ×.
5. DevTools Console — czysto.

## Świadome odejścia
- Brak — pełen scope ticketu (obie listy: uniwersalna + legacy products).

🤖 Generated with [Claude Code](https://claude.com/claude-code)