### PR TITLE
fix(catalog): atrybuty systemowe — bez lock badge + auto-treść (#1207)

### DIFF
--- a/apps/admin/e2e/1207-system-attributes.spec.ts
+++ b/apps/admin/e2e/1207-system-attributes.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1207 — system attributes (created_at/updated_at/created_by/updated_by) are
+ * treated as normal fields: the "Zablokowane" lock badge is removed from the
+ * attributes library list (and the modeling dialogs / detail page lock icon).
+ *
+ * This spec covers the most visible, deterministic change — the list under the
+ * "system" filter no longer renders the lock badge. The auto-populated values
+ * (created_at/by, updated_at/by) are proven server-side by
+ * CatalogObjectPolyKindGetTest::getInjectsSystemAttributeValues and verified by
+ * the live-stack smoke in the PR.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other UI specs.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('system attributes have no lock badge in the attributes library', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(60_000);
+
+  await loginAsAdmin(page);
+  await page.goto('/modeling/attributes');
+
+  // Filter down to the system audit attributes.
+  await page.getByRole('button', { name: /^system$/i }).click();
+
+  // The system attributes are listed...
+  await expect(page.getByText('created_at', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('updated_by', { exact: true }).first()).toBeVisible();
+
+  // ...but the "Zablokowane" lock badge is gone (treated as normal fields).
+  await expect(page.getByText('Zablokowane')).toHaveCount(0);
+});

--- a/apps/admin/src/components/modeling/add-attributes-from-library-dialog.tsx
+++ b/apps/admin/src/components/modeling/add-attributes-from-library-dialog.tsx
@@ -3,7 +3,6 @@ import { Check, Layers, Search, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { resolveLabel } from '@/features/catalog/attributes/list';
@@ -251,7 +250,6 @@ export function AddAttributesFromLibraryDialog({
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <span className="truncate font-mono text-[13px] font-medium">{a.code}</span>
-                        {a.system ? <BuiltInLockBadge /> : null}
                         {isExisting ? (
                           <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wider text-zinc-700">
                             {t('modeling.attributeGroups.add_from_library.in_group_badge', {

--- a/apps/admin/src/components/modeling/add-attributes-to-object-type-dialog.tsx
+++ b/apps/admin/src/components/modeling/add-attributes-to-object-type-dialog.tsx
@@ -3,7 +3,6 @@ import { Check, Layers, Search, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { resolveLabel } from '@/features/catalog/attributes/list';
@@ -262,7 +261,6 @@ export function AddAttributesToObjectTypeDialog({
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <span className="truncate font-mono text-[13px] font-medium">{a.code}</span>
-                        {a.system ? <BuiltInLockBadge /> : null}
                         {isExisting ? (
                           <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wider text-zinc-700">
                             {t('modeling.objectTypes.add_attributes.attached_badge', {

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
-import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { jsonFetch } from '@/lib/http';
@@ -235,7 +234,6 @@ function AttributeRowItem({
       <span className="min-w-0">
         <span className="flex items-center gap-2">
           <span className="truncate font-mono text-[13.5px] font-medium">{row.code}</span>
-          {row.system ? <BuiltInLockBadge /> : null}
           {row.unique ? (
             <span className="rounded bg-amber-50 px-1 py-0.5 font-mono text-[10px] text-amber-700">
               unique

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -106,7 +106,11 @@ export function AttrRow({
             {localeChip}
           </span>
         ) : null}
-        {isLocked ? <Lock className="size-3 text-zinc-300" aria-hidden /> : null}
+        {/* #1207 — system attributes (created_at/by, updated_at/by) stay
+            read-only but are treated as normal fields: no lock chrome. */}
+        {isLocked && !attribute.is_system ? (
+          <Lock className="size-3 text-zinc-300" aria-hidden />
+        ) : null}
         {attribute.is_required_in_group ? (
           <span
             className="text-rose-500"

--- a/apps/api/migrations/Version20260602100000.php
+++ b/apps/api/migrations/Version20260602100000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #1207 — blameable actor snapshot on `objects`.
+ *
+ * Adds nullable `created_by` / `updated_by` columns holding the e-mail of the
+ * actor who created / last updated the row, stamped by
+ * BlameableAssignmentListener on flush. A string snapshot (not a FK to users)
+ * is deliberate: "who created this" is a historical audit fact that must
+ * survive user rename/deletion, and it keeps the Catalog context free of a
+ * hard dependency on Identity. Existing rows stay NULL (no backfill) — they
+ * render "—" until next edit.
+ */
+final class Version20260602100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '#1207: add blameable created_by/updated_by (actor e-mail snapshot) to objects';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE objects ADD COLUMN created_by VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE objects ADD COLUMN updated_by VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE objects DROP COLUMN updated_by');
+        $this->addSql('ALTER TABLE objects DROP COLUMN created_by');
+    }
+}

--- a/apps/api/src/Catalog/Application/SystemAttributeReadOverlay.php
+++ b/apps/api/src/Catalog/Application/SystemAttributeReadOverlay.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use DateTimeInterface;
+
+/**
+ * #1207 — read-only overlay that injects the system attributes
+ * (`created_at`, `updated_at`, `created_by`, `updated_by`) into the
+ * `attributesIndexed` map returned by the item GET providers.
+ *
+ * These attributes are never stored as ObjectValue rows, so without this
+ * overlay they render as "—" on the detail page. The values are derived:
+ * timestamps from the entity, actor e-mails from the blameable columns.
+ *
+ * The overlay clones the object and uses the side-effect-free
+ * {@see CatalogObject::overlayAttributesIndexedForRead()} so it never touches
+ * `updatedAt`, records a domain event, or risks persistence on a GET — the
+ * same non-persisting contract the locale/channel overlay relies on.
+ */
+final readonly class SystemAttributeReadOverlay
+{
+    public function apply(CatalogObject $object): CatalogObject
+    {
+        $indexed = $object->getAttributesIndexed();
+
+        // Envelope shape `{value: …}` matches the JSONB contract the admin's
+        // `unwrapAttributesIndexed` lifts; created_at/updated_at render as
+        // datetime, created_by/updated_by as a plain string (reference→user).
+        $indexed['created_at'] = ['value' => $object->getCreatedAt()->format(DateTimeInterface::ATOM)];
+        $indexed['updated_at'] = ['value' => $object->getUpdatedAt()->format(DateTimeInterface::ATOM)];
+
+        $createdBy = $object->getCreatedBy();
+        if (null !== $createdBy) {
+            $indexed['created_by'] = ['value' => $createdBy];
+        }
+
+        $updatedBy = $object->getUpdatedBy();
+        if (null !== $updatedBy) {
+            $indexed['updated_by'] = ['value' => $updatedBy];
+        }
+
+        $copy = clone $object;
+        $copy->overlayAttributesIndexedForRead($indexed);
+
+        return $copy;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -10,6 +10,7 @@ use App\Catalog\Contracts\Event\ObjectCreated;
 use App\Catalog\Contracts\Event\ObjectEnabledChanged;
 use App\Catalog\Contracts\Event\ObjectPublished;
 use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\Blameable;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
@@ -50,13 +51,20 @@ use const ARRAY_FILTER_USE_BOTH;
  *   - `kind='product'` for variants (size/color of a parent SKU);
  *   - `kind='category'` for the tree (parent category in ltree).
  */
-class CatalogObject extends AggregateRoot implements TenantScoped
+class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
 {
     public const string STATUS_DRAFT = 'draft';
     public const string STATUS_PUBLISHED = 'published';
     public const string STATUS_ARCHIVED = 'archived';
     private Uuid $id;
     private ?Tenant $tenant = null;
+    /**
+     * #1207 — snapshot of the actor (e-mail) who created / last updated this
+     * row, stamped by {@see \App\Shared\Infrastructure\Doctrine\EventListener\BlameableAssignmentListener}.
+     * Null for rows written without a security context (CLI seeders, import).
+     */
+    private ?string $createdBy = null;
+    private ?string $updatedBy = null;
     private ObjectType $objectType;
     private ObjectKind $kind;
     #[Assert\NotBlank]
@@ -414,6 +422,40 @@ class CatalogObject extends AggregateRoot implements TenantScoped
     public function getUpdatedAt(): DateTimeImmutable
     {
         return $this->updatedAt;
+    }
+
+    public function getCreatedBy(): ?string
+    {
+        return $this->createdBy;
+    }
+
+    public function getUpdatedBy(): ?string
+    {
+        return $this->updatedBy;
+    }
+
+    public function stampCreatedBy(?string $actor): void
+    {
+        $this->createdBy = $actor;
+    }
+
+    public function stampUpdatedBy(?string $actor): void
+    {
+        $this->updatedBy = $actor;
+    }
+
+    /**
+     * #1207 / #1146 — replace the indexed map for a read-only response overlay
+     * (system attributes, locale/channel overlay). Unlike
+     * {@see updateAttributeIndex()} it does NOT touch `updatedAt` nor record a
+     * domain event, so it is safe to call on a detached clone inside a GET
+     * provider without spurious side effects or accidental persistence.
+     *
+     * @param array<string, mixed> $attributes
+     */
+    public function overlayAttributesIndexedForRead(array $attributes): void
+    {
+        $this->attributesIndexed = $attributes;
     }
 
     /**

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
@@ -7,6 +7,7 @@ namespace App\Catalog\Infrastructure\ApiPlatform\State;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use App\Catalog\Application\ObjectValueLocaleOverlay;
+use App\Catalog\Application\SystemAttributeReadOverlay;
 use App\Catalog\Domain\Entity\CatalogObject;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -32,6 +33,7 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
     public function __construct(
         private ProviderInterface $itemProvider,
         private ObjectValueLocaleOverlay $overlay,
+        private SystemAttributeReadOverlay $systemOverlay,
         private RequestStack $requestStack,
     ) {
     }
@@ -50,9 +52,11 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
         $locale = \is_string($localeParam) && '' !== $localeParam ? $localeParam : null;
         $channel = \is_string($channelParam) && '' !== $channelParam ? $channelParam : null;
         if (null !== $locale || null !== $channel) {
-            return $this->overlay->apply($object, $locale, $channel);
+            $object = $this->overlay->apply($object, $locale, $channel);
         }
 
-        return $object;
+        // #1207 — always surface the system attributes (created_at/updated_at +
+        // created_by/updated_by) so they render real values instead of "—".
+        return $this->systemOverlay->apply($object);
     }
 }

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -109,6 +109,11 @@
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
         <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
 
+        <!-- #1207 — blameable actor snapshot (e-mail), nullable for writes
+             with no security context (CLI seeders, import). -->
+        <field name="createdBy" type="string" length="255" column="created_by" nullable="true"/>
+        <field name="updatedBy" type="string" length="255" column="updated_by" nullable="true"/>
+
         <!-- MODR-10 (#932) — optimistic locking. Doctrine increments on every UPDATE. -->
         <field name="version" type="integer" column="version" version="true">
             <options>

--- a/apps/api/src/Shared/Application/Blameable.php
+++ b/apps/api/src/Shared/Application/Blameable.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+/**
+ * Marker interface for domain entities that record WHO created / last updated
+ * them, as a snapshot of the actor's identifier (e-mail) at write time.
+ *
+ * Implementing this opts an entity into
+ * {@see \App\Shared\Infrastructure\Doctrine\EventListener\BlameableAssignmentListener}:
+ *   - on insert it stamps both `createdBy` and `updatedBy`,
+ *   - on update it stamps `updatedBy`,
+ * using the current authenticated principal's identifier (Symfony Security).
+ *
+ * A SNAPSHOT STRING (not a User FK) is deliberate: "who created this" is a
+ * historical audit fact that must survive the user being renamed or deleted,
+ * and it keeps the owning bounded context free of a hard dependency on the
+ * Identity context (no cross-context association). Background writers with no
+ * security context (CLI seeders, async import) leave the fields `null`.
+ */
+interface Blameable
+{
+    public function getCreatedBy(): ?string;
+
+    public function getUpdatedBy(): ?string;
+
+    public function stampCreatedBy(?string $actor): void;
+
+    public function stampUpdatedBy(?string $actor): void;
+}

--- a/apps/api/src/Shared/Infrastructure/Doctrine/EventListener/BlameableAssignmentListener.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/EventListener/BlameableAssignmentListener.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine\EventListener;
+
+use App\Shared\Application\Blameable;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Stamps every {@see Blameable} entity with the current actor's identifier
+ * (e-mail) on write: both `createdBy` and `updatedBy` on insert, only
+ * `updatedBy` on update.
+ *
+ * Dispatches by interface like {@see TenantAssignmentListener} — entities opt
+ * in by implementing Blameable. Runs on `onFlush` (not pre-persist/pre-update)
+ * so a single hook covers inserts and updates and the changeset can be
+ * recomputed cleanly after mutating the fields.
+ *
+ * The actor comes from Symfony Security (a framework concern, available in
+ * every context), NOT from the Identity domain — so the owning context keeps
+ * no cross-context dependency. Writes with no security context (CLI seeders,
+ * async import workers) leave the fields untouched (null), which the read
+ * layer renders as "—".
+ */
+#[AsDoctrineListener(event: Events::onFlush)]
+final readonly class BlameableAssignmentListener
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+    ) {
+    }
+
+    public function onFlush(OnFlushEventArgs $event): void
+    {
+        $actor = $this->currentActor();
+        if (null === $actor) {
+            return;
+        }
+
+        $em = $event->getObjectManager();
+        $uow = $em->getUnitOfWork();
+
+        foreach ($uow->getScheduledEntityInsertions() as $entity) {
+            if (!$entity instanceof Blameable) {
+                continue;
+            }
+            if (null === $entity->getCreatedBy()) {
+                $entity->stampCreatedBy($actor);
+            }
+            $entity->stampUpdatedBy($actor);
+            $uow->recomputeSingleEntityChangeSet($em->getClassMetadata($entity::class), $entity);
+        }
+
+        foreach ($uow->getScheduledEntityUpdates() as $entity) {
+            if (!$entity instanceof Blameable) {
+                continue;
+            }
+            $entity->stampUpdatedBy($actor);
+            $uow->recomputeSingleEntityChangeSet($em->getClassMetadata($entity::class), $entity);
+        }
+    }
+
+    private function currentActor(): ?string
+    {
+        // UserInterface::getUserIdentifier() is the e-mail for this app's User.
+        // Null token / no user (CLI seeders, async import) → no stamp.
+        return $this->tokenStorage->getToken()?->getUser()?->getUserIdentifier();
+    }
+}

--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php
@@ -92,14 +92,19 @@ final class CatalogObjectPolyKindGetTest extends CatalogApiTestCase
 
         self::assertArrayHasKey('created_at', $indexed);
         self::assertArrayHasKey('updated_at', $indexed);
-        self::assertMatchesRegularExpression(
-            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/',
-            $indexed['created_at']['value'] ?? '',
-        );
 
-        self::assertArrayHasKey('created_by', $indexed);
-        self::assertSame(self::ADMIN_EMAIL, $indexed['created_by']['value'] ?? null);
-        self::assertSame(self::ADMIN_EMAIL, $indexed['updated_by']['value'] ?? null);
+        $createdAt = $indexed['created_at'];
+        self::assertIsArray($createdAt);
+        $createdAtValue = $createdAt['value'] ?? null;
+        self::assertIsString($createdAtValue);
+        self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/', $createdAtValue);
+
+        $createdBy = $indexed['created_by'] ?? null;
+        $updatedBy = $indexed['updated_by'] ?? null;
+        self::assertIsArray($createdBy);
+        self::assertIsArray($updatedBy);
+        self::assertSame(self::ADMIN_EMAIL, $createdBy['value'] ?? null);
+        self::assertSame(self::ADMIN_EMAIL, $updatedBy['value'] ?? null);
     }
 
     #[Test]

--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindGetTest.php
@@ -75,6 +75,34 @@ final class CatalogObjectPolyKindGetTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function getInjectsSystemAttributeValues(): void
+    {
+        // #1207 — created_at/updated_at + created_by/updated_by are surfaced in
+        // attributesIndexed at read time (they are never stored as ObjectValue
+        // rows). Creating authenticated stamps the blameable actor (e-mail).
+        $client = $this->authenticatedClient();
+        $id = $this->createObject($client, '/api/products', 'SKU-SYSTEM-ATTRS', ObjectKind::Product);
+
+        $response = $client->request('GET', '/api/objects/'.$id, [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+        self::assertResponseIsSuccessful();
+        $indexed = $response->toArray()['attributesIndexed'] ?? [];
+        self::assertIsArray($indexed);
+
+        self::assertArrayHasKey('created_at', $indexed);
+        self::assertArrayHasKey('updated_at', $indexed);
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/',
+            $indexed['created_at']['value'] ?? '',
+        );
+
+        self::assertArrayHasKey('created_by', $indexed);
+        self::assertSame(self::ADMIN_EMAIL, $indexed['created_by']['value'] ?? null);
+        self::assertSame(self::ADMIN_EMAIL, $indexed['updated_by']['value'] ?? null);
+    }
+
+    #[Test]
     public function getReturns404ForUnknownUuid(): void
     {
         $client = $this->authenticatedClient();


### PR DESCRIPTION
## Summary
Atrybuty systemowe `created_at` / `updated_at` / `created_by` / `updated_by` są traktowane jak zwykłe pola: znika badge „Zablokowane"/kłódka, a na szczegółach obiektu pokazują realną treść (kiedy/kto utworzył/zmienił) zamiast „—".

## Root cause
Badge/kłódka renderowały się dla `is_system`; te atrybuty nigdy nie trafiały do `object_values`/`attributesIndexed` (→ „—"), a creator/updater nie był nigdzie śledzony.

## Backend
- **`SystemAttributeReadOverlay`** (wpięty w `CatalogObjectLocaleOverlayProvider`, GET item) wstrzykuje do `attributesIndexed` envelope’y `{value}`: created_at/updated_at (timestampy encji, ISO) + created_by/updated_by (kolumny). Na **klonie**, przez `overlayAttributesIndexedForRead()` — bez `touch()`, domain-eventu i bez persystencji (jak istniejący locale overlay).
- **Blameable**: `Shared/Application/Blameable` + `BlameableAssignmentListener` (`onFlush`) stampuje e-mail aktora (Symfony Security) — insert: created_by+updated_by, update: updated_by. **Snapshot stringa, nie FK do User** → brak coupling Catalog↔Identity (Deptrac green), przeżywa rename/delete użytkownika. Zapisy bez kontekstu security (CLI/import) → null.
- **Migracja**: `objects` + `created_by`/`updated_by VARCHAR(255) NULL`.

## Frontend
- Usunięty `BuiltInLockBadge`/ikona `Lock` dla atrybutów systemowych w: liście atrybutów, `add-attributes-from-library-dialog`, `add-attributes-to-object-type-dialog`, `attr-row`. Pola zostają **read-only** (auto-wypełniane); datetime renderuje się natywnie, referencja(user) → e-mail.

## Świadome decyzje
- **Guard usuwania `is_system` zostaje** (to auto-pola systemowe; delete złamałby auto-treść). Usunięto tylko wizualny lock.
- Istniejące obiekty: created_by/updated_by = NULL (brak backfill) → „—" do następnej edycji.
- „Zmienić Langa" z opisu — niejasne, pominięte (do dopytania).

## Quality gates
- PHPStan max **0**. Deptrac **0 violations**. Biome **0**. tsc **0**. Vite build OK.
- PHPUnit: `CatalogObjectPolyKindGetTest::getInjectsSystemAttributeValues` + 19 lifecycle tests zielone (insert/update/delete/locale bez regresji).
- Playwright `1207-system-attributes.spec.ts` zielony lokalnie (lista System → brak „Zablokowane").
- OpenAPI: bez zmian (nowe kolumny nie są eksponowane).
- `composer audit` czerwony = pre-existing.

## Smoke test (live-stack, wykonany)
`POST /api/products` (auth) → `GET /api/objects/{id}` →
```
created_at => {"value":"2026-06-02T18:27:45+00:00"}
updated_at => {"value":"2026-06-02T18:27:45+00:00"}
created_by => {"value":"admin@demo.localhost"}
updated_by => {"value":"admin@demo.localhost"}
```

Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)