### PR TITLE
fix(catalog): przypisywanie kategorii dla custom kindów (#1209)

### DIFF
--- a/apps/admin/e2e/1209-category-picker-universal.spec.ts
+++ b/apps/admin/e2e/1209-category-picker-universal.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1209 — category assignment for custom kinds via the universal detail page.
+ *
+ * The CategoriesPanel used to render a read-only "UP-07 follow-up" placeholder;
+ * it now wires the generalised CategoryPickerDialog against the poly-kind
+ * `/api/objects/{id}/categories` endpoint with ADR-015 tree scoping.
+ *
+ * Full setup (the operator's actual case): a categorizable CUSTOM ObjectType +
+ * a category in its tree + a custom object, then drive the picker UI.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other UI specs.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('a custom kind can assign a category via the universal detail picker', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+  const json = { ...bearer, 'content-type': 'application/json' };
+  const ld = { ...bearer, 'content-type': 'application/ld+json' };
+
+  const ts = uniqueSku('SVC')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+  const slug = `svc_${ts}`;
+  const catName = `E2E Mycie ${ts}`;
+
+  // 1. Categorizable custom ObjectType.
+  const otResp = await page.request.post('/api/object_types', {
+    headers: json,
+    data: { code: slug, label: { pl: `Usługi ${ts}`, en: `Services ${ts}` } },
+  });
+  expect(otResp.status(), await otResp.text()).toBe(201);
+  const otId = ((await otResp.json()) as { id: string }).id;
+
+  const patchResp = await page.request.patch(`/api/object_types/${otId}`, {
+    headers: { ...bearer, 'content-type': 'application/merge-patch+json' },
+    data: { isCategorizable: true },
+  });
+  expect(patchResp.status()).toBe(200);
+
+  // 2. A category in the custom kind's tree (ADR-015).
+  const typesResp = await page.request.get('/api/object_types', { headers: bearer });
+  const typesBody = (await typesResp.json()) as {
+    member?: Array<{ id: string; kind: string }>;
+    'hydra:member'?: Array<{ id: string; kind: string }>;
+  };
+  const types = typesBody.member ?? typesBody['hydra:member'] ?? [];
+  const categoryOtId = types.find((t) => t.kind === 'category')?.id;
+  if (categoryOtId === undefined) throw new Error('Built-in category ObjectType not found.');
+
+  const catResp = await page.request.post('/api/categories', {
+    headers: ld,
+    data: {
+      code: `SVCCAT-${ts}`,
+      objectTypeId: categoryOtId,
+      categoryTargetObjectTypeId: otId,
+      attributes: { name: catName },
+    },
+  });
+  expect(catResp.status(), await catResp.text()).toBe(201);
+
+  // 3. A custom-kind object.
+  const objResp = await page.request.post('/api/objects', {
+    headers: ld,
+    data: { code: `SVC-OBJ-${ts}`, objectTypeId: otId, attributes: {} },
+  });
+  expect(objResp.status(), await objResp.text()).toBe(201);
+  const objId = ((await objResp.json()) as { id: string }).id;
+
+  // 4. Drive the universal detail page (custom kind → UniversalDetailPage).
+  await page.goto(`/objects/${slug}/${objId}`);
+  await page.getByRole('tab', { name: /kategorie/i }).click();
+
+  // The read-only "UP-07 follow-up" placeholder is gone; the edit button is wired.
+  const editButton = page.getByRole('button', { name: /edytuj kategorie/i });
+  await expect(editButton).toBeVisible();
+  await expect(page.getByText(/UP-07 follow-upie/i)).toHaveCount(0);
+
+  // 5. Picker opens, lists the tree-scoped category, assign it.
+  await editButton.click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByText(catName)).toBeVisible();
+
+  const putResponse = page.waitForResponse(
+    (r) => r.url().includes(`/api/objects/${objId}/categories`) && r.request().method() === 'PUT',
+  );
+  await dialog.getByRole('checkbox').first().check();
+  await dialog.getByRole('button', { name: /^zapisz$/i }).click();
+  expect((await putResponse).status()).toBe(200);
+
+  // 6. The assigned category surfaces as a chip.
+  await expect(page.getByText(`SVCCAT-${ts}`).first()).toBeVisible();
+});

--- a/apps/admin/src/components/catalog/category-picker-dialog.tsx
+++ b/apps/admin/src/components/catalog/category-picker-dialog.tsx
@@ -48,6 +48,20 @@ interface Props {
    * local state until the parent POST is fired.
    */
   onSelect?: (categoryIds: string[], primaryCategoryId: string | null) => void;
+  /**
+   * #1209 — which API surface to autosave against. `products` (default) keeps
+   * the legacy `/api/products/{id}/categories` behaviour for the product
+   * detail; `objects` targets the poly-kind `/api/objects/{id}/categories`
+   * so custom kinds (and any ObjectType) can assign categories too.
+   */
+  endpoint?: 'products' | 'objects';
+  /**
+   * #1209 — ADR-015 tree scope. When set, the picker only lists categories
+   * belonging to this ObjectType's tree (`?categoryTargetObjectType=`), so a
+   * custom kind never sees product categories (and the backend
+   * `assertSameTree` guard never rejects the save).
+   */
+  objectTypeId?: string;
 }
 
 /**
@@ -72,6 +86,8 @@ export function CategoryPickerDialog({
   currentAssignments,
   onSaved,
   onSelect,
+  endpoint = 'products',
+  objectTypeId,
 }: Props) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -101,11 +117,18 @@ export function CategoryPickerDialog({
   }, [open, currentAssignments]);
 
   const { data, isLoading } = useQuery({
-    queryKey: ['categories', 'picker'],
+    // #1209 — key by tree so a custom kind's scoped list does not collide
+    // with the product (all-trees) list in the cache.
+    queryKey: ['categories', 'picker', objectTypeId ?? 'all'],
     queryFn: async () => {
       // Refine convention: itemsPerPage with a generous cap; the picker
-      // is for admin-paced selection, not infinite-scroll.
-      return jsonFetch<CategoriesListResponse>('/api/categories?itemsPerPage=200');
+      // is for admin-paced selection, not infinite-scroll. When scoped to an
+      // ObjectType (ADR-015) only that tree's categories are listed.
+      const treeFilter =
+        objectTypeId !== undefined && objectTypeId !== ''
+          ? `&categoryTargetObjectType=${encodeURIComponent(objectTypeId)}`
+          : '';
+      return jsonFetch<CategoriesListResponse>(`/api/categories?itemsPerPage=200${treeFilter}`);
     },
     enabled: open,
     staleTime: 60_000,
@@ -187,20 +210,23 @@ export function CategoryPickerDialog({
         return;
       }
 
-      await jsonFetch(`/api/products/${productId}/categories`, {
+      await jsonFetch(`/api/${endpoint}/${productId}/categories`, {
         method: 'PUT',
         contentType: 'application/json',
         accept: 'application/json',
         body: { primaryCategoryId: primary, categoryIds },
       });
       // Burst the affected cache keys so the chip list, the effective
-      // schema, and any product-level reads pick up the change.
+      // schema, and any object-level reads pick up the change. The universal
+      // detail page (#1209) keys reads under `['object', id, …]`; the legacy
+      // product detail keys under `['products', id, …]`.
+      const base = endpoint === 'objects' ? 'object' : 'products';
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['products', productId, 'categories'] }),
+        queryClient.invalidateQueries({ queryKey: [base, productId, 'categories'] }),
         queryClient.invalidateQueries({
-          queryKey: ['products', productId, 'effective-attribute-groups'],
+          queryKey: [base, productId, 'effective-attribute-groups'],
         }),
-        queryClient.invalidateQueries({ queryKey: ['products', productId] }),
+        queryClient.invalidateQueries({ queryKey: [base, productId] }),
       ]);
       onSaved();
       onOpenChange(false);

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -34,6 +34,7 @@ import { ArrowLeft, MoreHorizontal, Pencil, Save, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
+import { CategoryPickerDialog } from '@/components/catalog/category-picker-dialog';
 import { DetailLoadingState } from '@/components/catalog/detail-loading-state';
 import { DetailNotFoundState } from '@/components/catalog/detail-not-found-state';
 import type { Provenance } from '@/components/provenance-badge';
@@ -101,7 +102,8 @@ export interface UniversalDetailPageProps {
 
 interface CategoryAssignment {
   categoryId: string;
-  code: string;
+  // The poly-kind endpoint returns `categoryCode` (not `code`).
+  categoryCode: string;
   isPrimary: boolean;
   position: number;
 }
@@ -115,7 +117,6 @@ interface CategoriesResponse {
 
 export function UniversalDetailPage({
   objectId,
-  objectTypeCode,
   objectTypeLabel,
   backHref,
   isCategorizable,
@@ -593,7 +594,11 @@ export function UniversalDetailPage({
                 <CategoriesPanel
                   data={categoriesQuery.data}
                   isLoading={categoriesQuery.isLoading}
-                  objectTypeCode={objectTypeCode}
+                  objectId={objectId}
+                  objectTypeId={product.objectType?.id}
+                  onChanged={() => {
+                    void categoriesQuery.refetch();
+                  }}
                 />
               );
             }
@@ -659,13 +664,19 @@ export function UniversalDetailPage({
 function CategoriesPanel({
   data,
   isLoading,
-  objectTypeCode,
+  objectId,
+  objectTypeId,
+  onChanged,
 }: {
   data: CategoriesResponse | undefined;
   isLoading: boolean;
-  objectTypeCode: string;
+  objectId: string;
+  objectTypeId: string | undefined;
+  onChanged: () => void;
 }) {
   const { t } = useTranslation();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
   if (isLoading) {
     return (
       <p className="text-[12.5px] text-muted-foreground">
@@ -673,32 +684,66 @@ function CategoriesPanel({
       </p>
     );
   }
+
   const assignments = data?.assignments ?? [];
+  // #1209 — CategoriesResponse assignments ({categoryId, isPrimary}) map 1:1
+  // to the picker's CurrentAssignment.
+  const currentAssignments = assignments.map((a) => ({
+    categoryId: a.categoryId,
+    isPrimary: a.isPrimary,
+  }));
+
+  const editButton = (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={() => {
+        setPickerOpen(true);
+      }}
+    >
+      {t('object_detail.categories.edit', { defaultValue: 'Edytuj kategorie' })}
+    </Button>
+  );
+
+  const picker = (
+    <CategoryPickerDialog
+      open={pickerOpen}
+      onOpenChange={setPickerOpen}
+      productId={objectId}
+      endpoint="objects"
+      objectTypeId={objectTypeId}
+      currentAssignments={currentAssignments}
+      onSaved={onChanged}
+    />
+  );
+
   if (assignments.length === 0) {
     return (
-      <div className="border-line bg-surface rounded-2xl border border-dashed p-6 text-center">
-        <p className="text-ink text-[13px] font-medium">
-          {t('object_detail.categories.empty', {
-            defaultValue: 'Brak przypisanych kategorii.',
-          })}
-        </p>
-        <p className="mt-1 text-[11.5px] text-muted-foreground">
-          {t('object_detail.categories.empty_hint', {
-            defaultValue:
-              'Edycja kategorii dla custom kindów dochodzi w UP-07 follow-upie (CategoryPickerDialog universal refactor).',
-          })}
-        </p>
-      </div>
+      <section className="space-y-3">
+        <div className="border-line bg-surface flex flex-col items-center gap-3 rounded-2xl border border-dashed p-6 text-center">
+          <p className="text-ink text-[13px] font-medium">
+            {t('object_detail.categories.empty', {
+              defaultValue: 'Brak przypisanych kategorii.',
+            })}
+          </p>
+          {editButton}
+        </div>
+        {picker}
+      </section>
     );
   }
+
   return (
     <section className="space-y-3">
-      <p className="text-[11.5px] text-muted-foreground">
-        {t('object_detail.categories.read_only_hint', {
-          defaultValue:
-            'Lista kategorii (read-only w UP-07 MVP — picker dialog dla custom kindów w follow-upie).',
-        })}
-      </p>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[11.5px] text-muted-foreground">
+          {t('object_detail.categories.assigned_hint', {
+            defaultValue: 'Przypisane kategorie (★ = główna).',
+          })}
+        </p>
+        {editButton}
+      </div>
       <ul className="flex flex-wrap gap-2">
         {assignments.map((a) => (
           <li
@@ -711,13 +756,11 @@ function CategoriesPanel({
             )}
           >
             {a.isPrimary ? <span aria-hidden>★</span> : null}
-            <span className="font-medium">{a.code}</span>
+            <span className="font-medium">{a.categoryCode}</span>
           </li>
         ))}
       </ul>
-      <p className="text-[11px] text-zinc-400">
-        objectType: <span className="font-mono">{objectTypeCode}</span>
-      </p>
+      {picker}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
Włącza przypisywanie kategorii dla custom kindów na uniwersalnej stronie szczegółów (znika placeholder „UP-07 follow-up"). Backend `/api/objects/{id}/categories` był już generyczny — gap był czysto FE.

## Root cause
`CategoryPickerDialog` był zahardkodowany na `/api/products/{id}/categories` + cache `['products', …]`; `CategoriesPanel` renderował read-only placeholder. Dodatkowo chip czytał `a.code`, a endpoint zwraca `categoryCode` → chipy były puste.

## Frontend changes
- `CategoryPickerDialog`: opcjonalne `endpoint` (`'products'`|`'objects'`, default `products` — produkty bez zmian) + `objectTypeId` (ADR-015 tree scoping `?categoryTargetObjectType=`, queryKey per drzewo). Dla `objects`: `PUT /api/objects/{id}/categories` + invalidacja `['object', id, …]`.
- `CategoriesPanel` (universal detail): przycisk „Edytuj kategorie" otwiera picker z `endpoint='objects'` + `objectTypeId = product.objectType?.id`; usunięty placeholder.
- Fix chipu: `categoryCode` zamiast `code`.

## Backend
Brak — endpoint generyczny + guard ADR-015 już są.

## Quality gates
- typecheck 0, Biome 0, build OK.
- Playwright `1209-category-picker-universal.spec.ts` **zielony lokalnie**: pełny custom-kind setup (categorizable OT → kategoria w drzewie → obiekt) → „Edytuj kategorie" (placeholder zniknął) → picker listuje tree-scoped kategorię → zaznacz → Zapisz → **PUT 200** → chip.
- `composer audit` czerwony = pre-existing.

## Smoke test (live-stack, wykonany)
Custom categorizable OT + kategoria w drzewie + obiekt; `PUT /api/objects/{id}/categories` → **200**; `GET` → `assignments: [{categoryCode: "SVCCAT-…", isPrimary: true}]`.

## Świadome odejścia
- Picker tree-scoped: jeśli OT nie ma kategorii w drzewie, lista pusta (poprawne).
- Uwaga: w bieżącym dev DB nie ma już custom OTs operatora (Usługi/Samochody) — wyglądają na zwipowane przez wcześniejszy `pim:db:reset`. Feature działa dla nowo utworzonych custom kindów.

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)