### PR TITLE
fix(admin): brak nowych typów atrybutów na /modeling/attributes/new (#1211)

### DIFF
--- a/apps/admin/e2e/1211-attribute-new-types.spec.ts
+++ b/apps/admin/e2e/1211-attribute-new-types.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1210 follow-up — the standalone /modeling/attributes/new page lagged the
+ * create dialogs on the new attribute types (textarea/datetime/color/email/
+ * identifier, shipped #1177–#1179). It now shares CREATABLE_ATTRIBUTE_TYPES,
+ * so the data-type grid lists every creatable type.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other UI specs.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('the new-attribute page lists the recently added data types', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(60_000);
+
+  await loginAsAdmin(page);
+  await page.goto('/modeling/attributes/new');
+
+  const typeSection = page.getByText(/typ danych/i);
+  await expect(typeSection).toBeVisible();
+
+  // The types that were missing before this fix.
+  for (const type of ['textarea', 'datetime', 'identifier', 'color', 'email']) {
+    await expect(page.getByRole('button', { name: type, exact: true })).toBeVisible();
+  }
+
+  // `reference` is system-only and must NOT be offered for creation.
+  await expect(page.getByRole('button', { name: 'reference', exact: true })).toHaveCount(0);
+});

--- a/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { CREATABLE_ATTRIBUTE_TYPES } from '@/lib/attribute-types';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -34,25 +35,9 @@ interface ObjectTypePickerRow {
   label?: Record<string, string> | string | null;
 }
 
-const TYPES = [
-  'text',
-  'textarea',
-  'identifier',
-  'number',
-  'select',
-  'multiselect',
-  'date',
-  'datetime',
-  'boolean',
-  'asset',
-  'reference',
-  'relation',
-  'price',
-  'metric',
-  'wysiwyg',
-  'color',
-  'email',
-] as const;
+// #1210 follow-up — shared source of truth (drops the system-only `reference`
+// the create endpoint rejects; aligns this dialog with /modeling/attributes/new).
+const TYPES = CREATABLE_ATTRIBUTE_TYPES;
 
 interface Props {
   open: boolean;

--- a/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { CREATABLE_ATTRIBUTE_TYPES } from '@/lib/attribute-types';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -34,25 +35,9 @@ interface ObjectTypePickerRow {
   label?: Record<string, string> | string | null;
 }
 
-const TYPES = [
-  'text',
-  'textarea',
-  'identifier',
-  'number',
-  'select',
-  'multiselect',
-  'date',
-  'datetime',
-  'boolean',
-  'asset',
-  'reference',
-  'relation',
-  'price',
-  'metric',
-  'wysiwyg',
-  'color',
-  'email',
-] as const;
+// #1210 follow-up — shared source of truth (drops the system-only `reference`
+// the create endpoint rejects; aligns this dialog with /modeling/attributes/new).
+const TYPES = CREATABLE_ATTRIBUTE_TYPES;
 
 interface Props {
   open: boolean;

--- a/apps/admin/src/features/catalog/attributes/new.tsx
+++ b/apps/admin/src/features/catalog/attributes/new.tsx
@@ -17,6 +17,7 @@ import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { CREATABLE_ATTRIBUTE_TYPES } from '@/lib/attribute-types';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
@@ -89,19 +90,10 @@ interface ObjectTypePickerRow {
   label?: Record<string, string> | string | null;
 }
 
-const TYPES = [
-  'text',
-  'number',
-  'select',
-  'multiselect',
-  'date',
-  'boolean',
-  'asset',
-  'relation',
-  'price',
-  'metric',
-  'wysiwyg',
-] as const;
+// #1210 follow-up — shared with the create dialogs so the type grid never
+// drifts again (this page lagged the dialogs on textarea/datetime/color/email/
+// identifier).
+const TYPES = CREATABLE_ATTRIBUTE_TYPES;
 
 export function AttributeCreatePage() {
   const { t, i18n } = useTranslation();

--- a/apps/admin/src/lib/attribute-types.ts
+++ b/apps/admin/src/lib/attribute-types.ts
@@ -1,0 +1,37 @@
+/**
+ * #1209/#1210 follow-up — single source of truth for the user-creatable
+ * attribute types, mirroring the backend `AttributeInput` whitelist
+ * (`App\Catalog\Infrastructure\ApiPlatform\Resource\AttributeInput`).
+ *
+ * Every surface that lets an operator CREATE an attribute — the standalone
+ * `/modeling/attributes/new` page and the create-in-group /
+ * create-for-object-type dialogs — consumes this list, so a newly added type
+ * (textarea/datetime/color/email/identifier shipped in #1177–#1179) appears in
+ * exactly one place instead of drifting between hardcoded copies (the bug this
+ * fixes: `new.tsx` was never updated and lagged the dialogs).
+ *
+ * Intentionally excluded:
+ *   - `reference` — system-only (created_by/updated_by); the create endpoint
+ *     rejects it, so offering it in a creation UI is a dead option.
+ *   - `video` — not implemented in the backend enum yet (own feature ticket).
+ */
+export const CREATABLE_ATTRIBUTE_TYPES = [
+  'text',
+  'textarea',
+  'identifier',
+  'number',
+  'select',
+  'multiselect',
+  'date',
+  'datetime',
+  'boolean',
+  'asset',
+  'relation',
+  'price',
+  'metric',
+  'wysiwyg',
+  'color',
+  'email',
+] as const;
+
+export type CreatableAttributeType = (typeof CREATABLE_ATTRIBUTE_TYPES)[number];


### PR DESCRIPTION
## Summary
`/modeling/attributes/new` w gridzie „Typ danych" gubił nowe typy (textarea, datetime, identifier, color, email) — miał własną, nieaktualizowaną listę. Naprawa: jedna współdzielona stała typów.

## Root cause
Zduplikowane zahardkodowane listy: `new.tsx` miał osobną tablicę `TYPES` (11), której #1178/#1179 nie tknęły; dialogi miały pełną listę.

## Frontend changes
- Nowy `lib/attribute-types.ts` → `CREATABLE_ATTRIBUTE_TYPES` (single source of truth, lustro backendowego whitelist `AttributeInput`).
- `new.tsx` + `create-attribute-in-group-dialog` + `create-attribute-for-object-type-dialog` importują tę stałą → koniec driftu.
- Stała wyklucza `reference` (system-only, endpoint create go odrzuca — dialogi błędnie go oferowały) oraz `video` (brak w enumie backendu).

## Quality gates
- tsc 0, Biome 0, build OK.
- Playwright `1211-attribute-new-types.spec.ts` zielony lokalnie: przyciski textarea/datetime/identifier/color/email obecne; `reference` nieobecny.
- `composer audit` czerwony = pre-existing.

## Smoke test
Strona FE-only; E2E weryfikuje obecność przycisków na żywej stronie. Tworzenie atrybutu nowego typu działa (typy są w backend whitelist — potwierdzone w #1178/#1179).

## Świadome odejścia
- **`video`** NIE dodany — typ nie istnieje w backendzie (`AttributeType`). Wymaga osobnego feat ticketu (enum + validator + ewentualna migracja, wzorzec #1178/#1179). Sam przycisk bez backendu → 422 przy zapisie.

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)