### PR TITLE
fix(asset): upload PDF >2MB — podniesione limity PHP do reklamowanych 25/50MB (#1214)

### DIFF
--- a/apps/admin/e2e/1214-asset-upload-large-pdf.spec.ts
+++ b/apps/admin/e2e/1214-asset-upload-large-pdf.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1214 — a real-world PDF (>2 MB) must upload. PHP's default
+ * upload_max_filesize=2M / post_max_size=8M truncated the multipart body
+ * before UploadAssetController ran, surfacing as a broken "HTTP 200" in the
+ * uploader. php.ini now raises the limits to match the advertised 50 MB PDF
+ * cap (apply with `docker compose build api`).
+ *
+ * Generates a ~3 MB PDF in-memory (no committed fixture) and posts it to the
+ * upload endpoint — should return 201, not the old truncated response.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other UI specs.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('a >2MB PDF uploads successfully (PHP upload limits raised)', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(60_000);
+
+  await loginAsAdmin(page);
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+
+  // ~3 MB PDF: minimal header + a large comment payload. Well over PHP's old
+  // 2 MB default, well under the 50 MB PDF cap.
+  const filler = Buffer.alloc(3 * 1024 * 1024, 0x41);
+  const pdf = Buffer.concat([
+    Buffer.from('%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n%'),
+    filler,
+    Buffer.from('\ntrailer<</Root 1 0 R/Size 2>>\n%%EOF\n'),
+  ]);
+
+  const response = await page.request.post('/api/assets/upload', {
+    headers: { Authorization: `Bearer ${accessToken}`, accept: 'application/json' },
+    multipart: {
+      file: { name: 'smoke-large.pdf', mimeType: 'application/pdf', buffer: pdf },
+    },
+  });
+
+  expect(response.status(), await response.text()).toBe(201);
+  const body = (await response.json()) as { id?: string; mimeType?: string };
+  expect(body.id).toBeTruthy();
+  expect(body.mimeType).toBe('application/pdf');
+});

--- a/apps/api/frankenphp/php.ini
+++ b/apps/api/frankenphp/php.ini
@@ -6,6 +6,14 @@ date.timezone = UTC
 memory_limit = 256M
 max_execution_time = 30
 
+; Asset uploads (#1214) — must accommodate the app-level limits enforced in
+; UploadAssetController (images 25 MB, PDF 50 MB). PHP's 2M/8M defaults truncate
+; the multipart body before the controller runs, surfacing as a broken upload
+; ("HTTP 200"). post_max_size must exceed upload_max_filesize to leave room for
+; multipart field overhead.
+upload_max_filesize = 50M
+post_max_size = 56M
+
 ; OPcache — JIT enabled for Symfony hot paths.
 opcache.enable = 1
 opcache.enable_cli = 0


### PR DESCRIPTION
## Summary
Wgranie realnego PDF (>2 MB) na `/assets` pokazywało czerwony „HTTP 200". Przyczyna: `php.ini` nie nadpisywał defaultów PHP (`upload_max_filesize=2M`, `post_max_size=8M`), a UI/BE reklamują 25 MB obrazy / 50 MB PDF. Plik >2 MB był ucinany przez PHP zanim dotarł do `UploadAssetController` → dziwna odpowiedź → FE traktuje jako błąd.

## Fix (config)
`apps/api/frankenphp/php.ini`: `upload_max_filesize = 50M`, `post_max_size = 56M` (post > upload na overhead multipart). App-level 413 nadal odrzuca obrazy >25 MB / PDF >50 MB.

## Smoke test (live, wykonany)
Po podniesieniu limitów: `POST /api/assets/upload` z PDF **3 MB** → **HTTP 201** + payload asset. Przed (2M) → ucięte.

## Quality gates
- Playwright `1214-asset-upload-large-pdf.spec.ts` (generuje ~3MB PDF in-memory → 201) zielony lokalnie. Biome 0.
- Config-only po stronie PHP — brak zmian PHP/TS kodu; CI buduje obraz api z nowym php.ini.
- **Uwaga deploy/local**: zmiana wchodzi po `docker compose build api` (php.ini jest bakowany w obraz, nie montowany). W tej sesji zastosowane runtime + zsmoke'owane.

## Świadome odejścia
- Pliki >56 MB (post_max) nadal ucinane przez PHP (poza reklamowanym 50 MB) — clean 413 dla skrajnego przypadku = osobny nice-to-have.

Closes #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)