### PR TITLE
fix(admin): zapis Smart Preset pokazuje powod zamiast golego HTTP 400 (#1218)

### DIFF
--- a/apps/admin/src/components/catalog/save-as-smart-preset-modal.tsx
+++ b/apps/admin/src/components/catalog/save-as-smart-preset-modal.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import type { FilterDsl } from '@/lib/filters/filter-dsl';
 import type { SmartFilterPreset } from '@/lib/filters/use-smart-presets';
+import { httpErrorDetail } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 const ICON_CHOICES = ['🔧', '⚙️', '⚡', '🛠️', '🏷️', '📦', '🔍', '🌟', '🚀', '🎯', '💡', '📊'];
@@ -61,7 +62,10 @@ export function SaveAsSmartPresetModal({
       onSaved(preset);
       onClose();
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'unknown');
+      // #1218 — surface the server's Problem Details reason (e.g. "Operator
+      // '=' not supported for attribute 'created_by' of type 'reference'")
+      // instead of the opaque "HTTP 400", so the operator knows what to fix.
+      setError(httpErrorDetail(e) ?? (e instanceof Error ? e.message : 'unknown'));
     } finally {
       setIsPending(false);
     }


### PR DESCRIPTION
## Summary
Zapis Smart Preset z filtrem, ktory backend odrzuca (np. `created_by = admin`), pokazywal w modalu gole „HTTP 400". Teraz modal pokazuje konkretny powod z serwera.

## Root cause
Backend POPRAWNIE zwraca 400 z Problem Details `detail` (`created_by`/`updated_by` to typ `reference`, DSL wspiera dla nich tylko `IS EMPTY`/`IS NOT EMPTY`). `save-as-smart-preset-modal` ustawial `setError(e.message)` = „HTTP 400", gubiac `detail`.

## Frontend
`save-as-smart-preset-modal.tsx`: `setError(httpErrorDetail(e) ?? e.message)` — reuse helpera z #1179.

## Smoke test (live, wykonany)
`POST /api/smart-filter-presets` z `{query:{attr:created_by,op:"=",value:admin}}` → **400**, `detail`: „Operator \"=\" not supported for attribute \"created_by\" of type \"reference\". Valid operators: IS EMPTY, IS NOT EMPTY." Modal teraz pokazuje ten `detail`.

## Quality gates
- tsc 0, Biome 0, build OK. `composer audit` pre-existing.
- **Brak dedykowanego Playwright E2E**: type-aware panel filtrów nie potrafi zbudować nieprawidłowego warunku na atrybucie `reference` (oferuje tylko dozwolone operatory per typ), więc nie ma stabilnej ścieżki UI do odtworzenia 400. `httpErrorDetail` jest już pokryty E2E w #1179 (toast), backend `detail` potwierdzony curl-em.

## Świadome odejścia
- `created_by`/`updated_by` **nie są filtrowalne równością** (reference + nie w `attributes_indexed` po #1207 → filtr zwracał 0). Pełne filtrowanie wg twórcy (indeksacja) = osobny feature ticket. Ten fix daje czytelny komunikat.

Closes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)