### PR TITLE
feat(catalog): locale/channel scope gaps T1–T4 (#1220–#1223)

### DIFF
--- a/Project Plan/UI/feature-modeling-relations-option-y-tickets.md
+++ b/Project Plan/UI/feature-modeling-relations-option-y-tickets.md
@@ -1,0 +1,229 @@
+# Tickety — Modelowanie: Powiązania bez seedu (Option Y — korekta MODR-02/06/07)
+
+**Typ dokumentu:** Backlog ticketów — ready-to-paste GitHub Issues
+**Status:** Draft — supersedes MODR-02 (#924), MODR-06 (#928), MODR-07 (#929) z pliku [`feature-modeling-relations-ux-tickets.md`](feature-modeling-relations-ux-tickets.md)
+**Data:** 2026-05-26
+**Powiązane:**
+- [`feature-modeling-relations-ux-tickets.md`](feature-modeling-relations-ux-tickets.md) — pierwotny batch MODR-01..11 (część stale aktualna)
+- [ADR-014](../01-architektura-pim.md) — *„Model dystrybucji atrybutów + relacje obiekt↔obiekt"*
+- [`feature-modeling-data-model.md`](feature-modeling-data-model.md) — mini-spec implementacyjny (kontrakt, §3.5 — wymaga update'u)
+
+> **Cel:** decyzja **Option Y** — pełne odseedowanie grupy „Powiązania". User świadomie tworzy grupę atrybutów (dowolnej nazwy) z `display_mode=tab`, wrzuca atrybuty typu `relation`. Brak seedowanej systemowej grupy „Powiązania". Brak flagi `has_relations`. Brak „magicznego" pojawiania się zakładki. Pełna symetria z resztą atrybutów: relacja to typ atrybutu jak każdy inny — placement po grupie, grupa tworzona świadomie przez usera.
+>
+> **Kontekst decyzji (2026-05-26):** seedowana grupa Powiązań tworzyła problem discoverability — user nie miał jak odkryć, że dodanie atrybutu typu `relation` zmaterializuje zakładkę. Flaga `has_relations` zostałaby pułapką proliferacji flag (`has_pricing`, `has_translations`...). Y eliminuje magię — każda zakładka istnieje, bo grupa została świadomie utworzona z `display_mode=tab`.
+>
+> **POZA ZAKRESEM:** Multimedia (idzie ścieżką **Droga B — Moduł Media Library**, osobny refactor) i Kategorie (osobny System Module). Ten batch dotyczy WYŁĄCZNIE Powiązań.
+>
+> **4 tickety, ~13-20h** (~3-4 dni solo dev).
+
+---
+
+## Konwencje
+
+- Numer: `MODRC-NN`. Po utworzeniu w GitHub: dopisany numer issue.
+- Pola: Typ (Conventional Commits) / Epik / Estymacja / Dependencies / Supersedes / Risk flags / Cel / Scope / Acceptance criteria / Files affected / Testing / DoD.
+- Tytuł issue po angielsku (Conventional Commits), opis po polsku.
+- Labels: `modeling` + `adr-014` + `epik-ui-08` + `option-y` + risk flag jeśli dotyczy.
+- **Reguła testów:** każdy ticket w DoD ma WSZYSTKIE testy na zielono — co się da pokryć. Backend: PHPUnit + ApiTestCase. Frontend z widoczną zmianą: Vitest + Playwright E2E + manual smoke test (SMOKE TEST RULE, CLAUDE.md).
+
+## Graf zależności
+
+```
+MODRC-01 (kasuj seed grupy „Powiązania" — supersedes MODR-02 dla Powiązań) ── foundation
+        │
+        ├── MODRC-02 (konfigurator atrybutu relation: brak defaultu, inline create grupy)
+        │       (supersedes MODR-07)
+        │
+        ├── MODRC-03 (system section „Powiązania zwrotne" dla reverse relations)
+        │       (supersedes MODR-06)
+        │
+        └── MODRC-04 (docs: §3.5 + ADR-014 + lessons.md — decyzja Y)
+                (supersedes/extends MODR-11)
+```
+
+---
+
+## MODRC-01 / TBD: refactor(catalog): remove seeded "Powiązania" AttributeGroup — un-seed, supersedes MODR-02
+
+**Typ:** `refactor` | **Epik:** UI-08 | **Estymacja:** **2-4h**
+
+**Supersedes:** MODR-02 (#924) dla części Powiązań. (Część Multimedia z MODR-02 idzie osobnym torem przez Moduł Media Library — nie ten batch.)
+
+**Dependencies:** Blocks MODRC-02, MODRC-03. Blocked by — brak.
+
+**Risk flags:**
+- Jeśli seedowana grupa `relations` istnieje w bazie i ma przypięte atrybuty typu `relation` — migracja musi zdecydować, co z nimi zrobić: (a) zostawić atrybuty bez grupy (orphaned), (b) przepisać do grupy „Niezgrupowane" / „Default", (c) zostawić grupę ale zdjąć z niej built-in flag (user może ją usunąć ręcznie). Decyzja w pre-flight.
+- Pre-flight: zweryfikować obecny stan — czy MODR-02 (#924) został zmergowany? Jeśli tak, grupa `relations` jest w DB i trzeba ją odseedować. Jeśli nie — MODRC-01 po prostu odwołuje plan MODR-02 dla Powiązań.
+
+**Cel:** Usunąć systemową seedowaną grupę „Powiązania" jako built-in byt. Każda grupa atrybutów (w tym ta, w której user trzyma relacje) musi być utworzona świadomie przez usera. Brak hardcoded i brak seed dla Powiązań.
+
+**Scope:**
+- Jeśli MODR-02 zmergowane: migracja DOWN seedu grupy `relations` — usunąć grupę i jej built-in flag.
+- Jeśli MODR-02 niezmergowane: usuń scope „grupa relations" z planu MODR-02; zostaje (lub anuluj cały MODR-02 jeśli nic więcej w nim nie ma poza Multimedia, która idzie osobno).
+- Decyzja migracyjna dla istniejących atrybutów `relation` przypisanych do skasowanej grupy (jeden z wariantów a/b/c — udokumentuj wybór w PR description).
+- Built-in flag na żadnej grupie typu „Powiązania" nie istnieje po tym ticket.
+
+**Acceptance criteria:**
+- [ ] AC-1: Brak seedowanej grupy `relations`/„Powiązania" w bazie po migracji
+- [ ] AC-2: Brak built-in flagi na jakiejkolwiek grupie powiązanej z relacjami
+- [ ] AC-3: Istniejące atrybuty `relation` zachowane (nie skasowane) — przepisane do grupy default / zostawione orphaned, zgodnie z decyzją migracyjną
+- [ ] AC-4: Migracja DOWN przywraca poprzedni stan (lub udokumentowane czemu nieodwracalna)
+- [ ] AC-5: form-schema dla obiektów z atrybutami `relation` — atrybuty nadal renderują się (w nowej grupie lub orphaned, nie znikają)
+- [ ] AC-6: Cross-tenant — migracja izolowana per tenant (TenantFilter)
+
+**Files affected:** `src/Catalog/Doctrine/Migrations/Version*.php`, seed/fixtures AttributeGroup (usunąć wpis dla `relations`).
+
+**Testing:** Integration (migracja UP/DOWN + weryfikacja stanu) + ApiTestCase (form-schema renderuje atrybuty `relation` po migracji) + manual smoke test (otwórz produkt z atrybutami relation, sprawdź czy są widoczne).
+
+**DoD:** AC + wszystkie testy zielone + smoke test (paste przed/po form-schema) + PHPStan max + CI green + decyzja migracyjna udokumentowana w PR.
+
+---
+
+## MODRC-02 / TBD: feat(admin): relation attribute configurator — no default group, inline create-group action
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **3-5h**
+
+**Supersedes:** MODR-07 (#929).
+
+**Dependencies:** Blocked by MODRC-01, MOD-13 (#905 — konfigurator atrybutu relation istnieje).
+
+**Risk flags:**
+- Inline create grupy z poziomu konfiguratora atrybutu = mały sub-flow. Musi respektować walidacje nazwy grupy + `display_mode`.
+- Bez domyślnej grupy user może świadomie zostawić atrybut bez przypisania → atrybut „orphaned" w UI. Trzeba zdecydować, czy walidacja wymaga grupy.
+
+**Cel:** Konfigurator atrybutu typu `relation` w Modelowaniu **nie pre-selectuje żadnej grupy** — user wybiera z istniejących grup ObjectType, albo tworzy nową inline. Brak magicznego defaultu „Powiązania".
+
+**Scope:**
+- W konfiguratorze atrybutu (MOD-13), gdy `type = relation` — selektor grupy bez domyślnego wyboru. User musi świadomie wybrać.
+- Akcja „+ Utwórz nową grupę" w selektorze — otwiera inline mini-form (nazwa grupy + `display_mode` toggle tab/stacked + opcjonalnie position).
+- Po utworzeniu nowej grupy → grupa zapisana, atrybut auto-przypięty do niej.
+- Walidacja: atrybut musi mieć grupę (zapis bez grupy → 422). Brak orphaned atrybutów na poziomie persystencji.
+- i18n: stringi przez `t()`, brak literałów.
+- **Decyzja:** ten sam pattern stosuje się do KAŻDEGO typu atrybutu, nie tylko `relation`. Konsystencja — nie ma typu atrybutu z magicznym domyślnym przypisaniem do grupy.
+
+**Acceptance criteria:**
+- [ ] AC-1: Wybór typu `relation` → selektor grupy bez pre-selectu
+- [ ] AC-2: User wybiera istniejącą grupę → zapis OK
+- [ ] AC-3: User klika „+ Utwórz nową grupę" → inline form z nazwą + display_mode
+- [ ] AC-4: Nowa grupa zapisana, atrybut auto-podpięty do niej
+- [ ] AC-5: Zapis bez wybranej grupy → 422 z czytelnym komunikatem
+- [ ] AC-6: Stringi przez `t()` (brak literałów)
+- [ ] AC-7: E2E — pełen flow „utwórz atrybut relation → utwórz nową grupę inline → zapis → grupa i atrybut widoczne na karcie obiektu"
+
+**Files affected:** `apps/admin/src/components/modeling/RelationConfigPanel.tsx` (lub aktualny konfigurator), nowy `InlineCreateGroupForm.tsx`, walidator backend (`AttributeController` / serwis).
+
+**Testing:** Unit (Vitest — logika selektora + walidacja braku defaultu) + ApiTestCase (zapis atrybutu bez grupy → 422) + E2E Playwright (pełen flow z inline create grupy) + manual smoke test.
+
+**DoD:** AC + wszystkie testy zielone + E2E + smoke test + CI green.
+
+---
+
+## MODRC-03 / TBD: feat(admin): system "Powiązania zwrotne" section — auto-rendered when object is target of reverse relations
+
+**Typ:** `feat` | **Epik:** UI-08 | **Estymacja:** **6-8h**
+
+**Supersedes:** MODR-06 (#928).
+
+**Dependencies:** Blocked by MOD-07 (#899 — reverse relations endpoint), MODRC-01 (#TBD).
+
+**Risk flags:**
+- Reverse relations nie należą do żadnej user-managed grupy — wymagają systemowego domu. To jedyna „magiczna" sekcja w systemie, ale uzasadniona: user nie może z góry zaprojektować grupy dla powiązań, które dopiero inni do niego stworzą.
+- Sekcja jest **systemowa**, read-only, oddzielona wizualnie od user-defined zakładek.
+- Reverse lookup przy 200k+ SKU — performance po indeksie `idx_object_relations_target` (z MOD-02).
+
+**Cel:** Wprowadzić systemową sekcję „Powiązania zwrotne" (lub „Linki do tego obiektu") — pojawia się **tylko gdy obiekt jest celem przynajmniej jednej relacji**. Niezależna od user-defined grup atrybutów. Read-only.
+
+**Scope:**
+- Komponent `SystemReverseRelationsSection` — renderuje listę reverse pogrupowaną per (source ObjectType, atrybut źródłowy).
+- Renderuje się jako **wirtualna zakładka** „Powiązania zwrotne" (lub wizualnie oddzielona sekcja na końcu listy zakładek — alternatywa do rozważenia w PR description).
+- **Widoczność:** zakładka pojawia się gdy zapytanie `GET /api/objects/{id}/relations/reverse` zwraca ≥1 rekord. Brak reverse → brak zakładki.
+- **Wizualna distinguishability:** sekcja oznaczona ikoną „system" / inną stylistyką niż user-defined zakładki, żeby user widział: „to nie jest część mojego modelu, to systemowy widok".
+- Read-only: brak akcji edycji w tej sekcji (edycja po stronie źródła relacji).
+- Klik w pozycję reverse → otwiera obiekt źródłowy.
+- Performance — query po `idx_object_relations_target`, target <100ms dla dataset 50k+ powiązań.
+- i18n: nazwa zakładki i nagłówki sekcji przez `t()`.
+
+**Acceptance criteria:**
+- [ ] AC-1: Obiekt bez reverse → zakładka „Powiązania zwrotne" NIE pojawia się
+- [ ] AC-2: Obiekt z ≥1 reverse → zakładka „Powiązania zwrotne" pojawia się, renderuje listę
+- [ ] AC-3: Reverse pogrupowane per source ObjectType + atrybut źródłowy
+- [ ] AC-4: Sekcja wizualnie odróżnialna od user-defined zakładek (ikona/etykieta „system")
+- [ ] AC-5: Klik w pozycję reverse → nawigacja do obiektu źródłowego
+- [ ] AC-6: Brak akcji edycji w tej sekcji (read-only enforced)
+- [ ] AC-7: Performance — reverse lookup <100ms na dataset 50k+ powiązań
+- [ ] AC-8: E2E — utwórz obiekt A z relacją do B → otwórz B → zakładka „Powiązania zwrotne" widoczna z wpisem o A
+
+**Files affected:** `apps/admin/src/components/object-editor/SystemReverseRelationsSection.tsx` (nowy), integracja z rendererem karty obiektu (logika widoczności zakładki), ewentualnie lekki endpoint `GET /api/objects/{id}/relations/reverse/count` jeśli pełne pobranie po to tylko, by zdecydować o widoczności, jest zbyt drogie.
+
+**Testing:** Unit (Vitest — logika widoczności + render) + Integration/ApiTestCase (reverse endpoint) + Performance (benchmark) + E2E Playwright (US-MOD-005 analog) + manual smoke test + axe-core (sekcja systemowa dostępna).
+
+**DoD:** AC + wszystkie testy zielone + E2E + smoke test + benchmark w PR + axe-core pass + CI green.
+
+---
+
+## MODRC-04 / TBD: docs(modeling): §3.5 mini-spec + ADR-014 + lessons.md — Option Y (full un-seed)
+
+**Typ:** `docs` | **Epik:** UI-08 | **Estymacja:** **2-3h**
+
+**Supersedes/extends:** MODR-11 (#933).
+
+**Dependencies:** Równolegle z MODRC-01..03 (brak blokad implementacyjnych).
+
+**Cel:** Zaktualizować dokumentację, żeby odzwierciedlała finalną decyzję Option Y — brak seedu grupy Powiązania, brak flagi `has_relations`, systemowa sekcja „Powiązania zwrotne".
+
+**Scope:**
+- **`feature-modeling-data-model.md` §3.5** — przeredagować:
+  - Skreślić „seedowana grupa Powiązania" / „domyślna grupa dla relacji".
+  - Zapisać: relacja to zwykły typ atrybutu, placement po user-defined grupie + `display_mode`, ŻADNA grupa nie jest seedowana ani built-in dla relacji.
+  - Reverse relations renderują się w **systemowej sekcji „Powiązania zwrotne"** (jedyna wirtualna zakładka), widoczna gdy obiekt jest targetem.
+- **`feature-modeling-data-model.md` §11 (Poza zakresem)** — dopisać świadomie odrzucone:
+  - (a) Flaga `has_relations` na ObjectType — odrzucona jako pułapka proliferacji flag.
+  - (b) Seed grupy „Powiązania" jako built-in — odrzucony jako anti-pattern discoverability (magiczne pojawianie się zakładki).
+  - (c) „Magiczna" widoczność zakładki przy populacji — odrzucona.
+- **ADR-014** — krótka nota uzupełniająca: placement relacji rozstrzygnięty przez Option Y (full un-seed, system reverse section).
+- **`agent/lessons.md`** — wpis świadomego odejścia: „2026-05-26 — MODR-02/06/07 zastąpione przez MODRC-01..03 (Option Y). Decyzja: zero seedu/flag dla Powiązań; tylko systemowa sekcja `Powiązania zwrotne` jest auto-generowana. Powód: discoverability + symetria z innymi typami atrybutów."
+- **Cross-reference** do tego batcha (`feature-modeling-relations-option-y-tickets.md`) z `feature-modeling-relations-ux-tickets.md` (nota „MODR-02/06/07 superseded przez MODRC-01..03").
+
+**Acceptance criteria:**
+- [ ] AC-1: §3.5 przeredagowane — brak wzmianek o seedowanej grupie Powiązań
+- [ ] AC-2: §3.5 zawiera opis systemowej sekcji „Powiązania zwrotne" + warunki widoczności
+- [ ] AC-3: §11 zawiera 3 odrzucone alternatywy (flaga, seed, magiczna widoczność)
+- [ ] AC-4: ADR-014 ma notę o Option Y
+- [ ] AC-5: `agent/lessons.md` ma wpis świadomego odejścia z datą i powodem
+- [ ] AC-6: `feature-modeling-relations-ux-tickets.md` ma notę o supersedowaniu MODR-02/06/07
+
+**Files affected:** `Project Plan/UI/feature-modeling-data-model.md`, `Project Plan/01-architektura-pim.md` (ADR-014), `agent/lessons.md`, `Project Plan/UI/feature-modeling-relations-ux-tickets.md` (nota o supersede).
+
+**Testing:** N/A (dokumentacja) — review spójności z decyzjami.
+
+**DoD:** AC + review + merge.
+
+---
+
+## Podsumowanie
+
+| Ticket | Estymacja | Warstwa | Supersedes |
+|---|---|---|---|
+| MODRC-01 kasuj seed grupy Powiązania | 2-4h | Backend | MODR-02 (#924, część Powiązań) |
+| MODRC-02 konfigurator relacji bez defaultu + inline create | 3-5h | Frontend + backend walidacja | MODR-07 (#929) |
+| MODRC-03 system section „Powiązania zwrotne" | 6-8h | Frontend + perf | MODR-06 (#928) |
+| MODRC-04 docs §3.5 + ADR-014 + lessons | 2-3h | Docs | MODR-11 (#933) — rozszerza |
+| **TOTAL** | **~13-20h** | **4 tickety** | |
+
+~3-4 dni solo dev.
+
+**Sugerowana kolejność:** MODRC-01 (foundation, kasacja seedu) → MODRC-02 + MODRC-03 (równolegle, frontend) → MODRC-04 (docs, równolegle).
+
+**Co NIE wchodzi w ten batch:**
+- Multimedia → idzie ścieżką Droga B (Moduł Media Library) — osobny refactor.
+- Kategorie → osobny System Module (osobny refactor).
+- Multimedia/Powiązania jako AttributeGroup część MODR-02 — Multimedia idzie do Modułu, Powiązania kasowane tym batchem.
+
+**Decyzje świadomie odrzucone (zarejestrowane w MODRC-04):**
+- Flaga `has_relations` na ObjectType (proliferacja flag → Pimcore Classes anti-pattern).
+- Seed grupy „Powiązania" jako built-in (anti-pattern discoverability — magiczne tabs).
+- „Magiczna" widoczność zakładki przy populacji atrybutami (user nie ma jak odkryć tej reguły).
+
+---
+
+*Backlog wygenerowany 2026-05-26 jako korekta Option Y. Agent kodujący: utwórz GitHub Issues (tytuł = nagłówek `## MODRC-NN:` bez prefiksu, body = treść ticketu, labels `modeling`+`adr-014`+`epik-ui-08`+`option-y`+`supersedes`). Per ticket dotykający >3 plików — Plan Mode przed implementacją (CLAUDE.md). Każdy ticket: wszystkie testy zielone w DoD.*

--- a/Project Plan/UI/plan-audytu-code-review.md
+++ b/Project Plan/UI/plan-audytu-code-review.md
@@ -1,0 +1,118 @@
+# Plan audytu code review + checklista (read-only)
+
+**Data:** 2026-05-27  
+**Tryb pracy:** tylko przegląd i dokumentacja  
+**Bez automatycznego wdrażania:** TAK
+
+## 1. Cel audytu
+
+Celem audytu jest ocena jakości kodu i organizacji repozytorium PIM, ze szczególnym uwzględnieniem:
+- jakości architektury i zgodności z zasadami projektu,
+- bezpieczeństwa i multi-tenancy,
+- jakości testów i bramek CI,
+- struktury katalogów i plików oraz ich utrzymaniowości.
+
+## 2. Zakres audytu
+
+- `apps/api`
+- `apps/admin`
+- `packages/shared-types`
+- `docs/`
+- `Project Plan/`
+- `scripts/`
+- `tools/`
+- pliki konfiguracyjne root (`package.json`, `turbo.json`, `biome.json`, `pnpm-workspace.yaml`)
+
+## 3. Zasady wykonania
+
+- Audyt ma charakter **read-only**.
+- Brak zmian wdrożeniowych, brak auto-fixów, brak auto-merge.
+- Każde znalezisko musi zawierać:
+  - lokalizację (plik/folder),
+  - opis ryzyka,
+  - rekomendację,
+  - priorytet (`P0`, `P1`, `P2`).
+
+## 4. Priorytety i statusy
+
+**Priorytety**
+- `P0` — blokujące (security, data isolation, broken quality gates)
+- `P1` — ważne (stabilność, utrzymanie, spójność)
+- `P2` — usprawnienia i dług techniczny
+
+**Statusy checklisty**
+- `TODO`
+- `OK`
+- `UWAGA`
+- `BŁĄD`
+
+---
+
+## 5. Audit Sheet: Code Review + Repo Structure
+
+| Check | Status | Evidence (plik/folder + notatka) | Owner | Priority |
+|---|---|---|---|---|
+| Root: monorepo structure (`apps/`, `packages/`, `docs/`, `scripts/`, `tools/`) jest spójna | TODO |  |  | P1 |
+| Root: brak zbędnych katalogów/artefaktów tymczasowych w repo | TODO |  |  | P1 |
+| Root: konfiguracje (`package.json`, `turbo.json`, `biome.json`, `pnpm-workspace.yaml`) są spójne | TODO |  |  | P0 |
+| Root: brak nieuzasadnionej duplikacji konfiguracji między root i appkami | TODO |  |  | P1 |
+| Root: nazewnictwo plików/folderów kodu jest spójne i angielskie | TODO |  |  | P2 |
+| API: struktura bounded contexts/bundles zgodna z architekturą | TODO |  |  | P0 |
+| API: brak mieszania warstw (Domain/Application/Infrastructure/UI) | TODO |  |  | P1 |
+| API: endpointy mają spójną walidację i obsługę błędów | TODO |  |  | P0 |
+| API: multi-tenancy (`tenant_id`, filtry, izolacja) jest konsekwentnie egzekwowana | TODO |  |  | P0 |
+| API: batch/memory safety (`flush/clear`, brak ryzyk OOM) | TODO |  |  | P0 |
+| API: migracje są czytelne, odwracalne i bez „quick-fix SQL” bez uzasadnienia | TODO |  |  | P1 |
+| API: testy integracyjne pokrywają krytyczne flow auth/permissions | TODO |  |  | P0 |
+| Admin: struktura feature’ów i komponentów czytelna (brak „god components”) | TODO |  |  | P1 |
+| Admin: stany UI loading/empty/error są obecne i spójne | TODO |  |  | P1 |
+| Admin: i18n — brak hardcoded user-facing stringów, użycie `t()` | TODO |  |  | P1 |
+| Admin: permission gates / RBAC poprawnie ograniczają akcje i pola | TODO |  |  | P0 |
+| Admin: błędy API są obsługiwane i widoczne dla użytkownika | TODO |  |  | P1 |
+| Admin: E2E obejmuje krytyczne widoki/ścieżki po zmianach | TODO |  |  | P0 |
+| Shared-types: zgodność typów z OpenAPI i backend DTO | TODO |  |  | P0 |
+| Shared-types: brak nieuzasadnionych `any`/unsafe castów | TODO |  |  | P1 |
+| Docs: `docs/` i `Project Plan/` zgodne z rzeczywistą implementacją | TODO |  |  | P1 |
+| Docs: status „done vs in-progress/substrate” jest jednoznaczny | TODO |  |  | P1 |
+| Scripts/Tools: skrypty mają aktualny cel i opis użycia | TODO |  |  | P2 |
+| Scripts/Tools: brak martwych/nieużywanych skryptów | TODO |  |  | P2 |
+| Scripts/Tools: backup/restore/test-infra skrypty są aktualne i weryfikowalne | TODO |  |  | P1 |
+| Quality: lint/static analysis/test/build przechodzą dla aktualnego stanu | TODO |  |  | P0 |
+| Quality: dependency health (lockfile, drift, audyty) bez krytycznych ryzyk | TODO |  |  | P1 |
+| Maintainability: hotspoty (duże pliki/złożoność/duplikacje) zidentyfikowane | TODO |  |  | P2 |
+| Security: brak oczywistych naruszeń (sekrety w kodzie, bypass auth, data leaks) | TODO |  |  | P0 |
+| Smoke-test readiness: user-facing flow ma dowody testu manualnego (gdy claim „działa”) | TODO |  |  | P0 |
+
+---
+
+## 6. Rejestr znalezisk
+
+| ID | Obszar | Plik/folder | Opis problemu | Severity | Rekomendacja | Status |
+|---|---|---|---|---|---|---|
+| F-001 |  |  |  | P0/P1/P2 |  | Open |
+| F-002 |  |  |  | P0/P1/P2 |  | Open |
+| F-003 |  |  |  | P0/P1/P2 |  | Open |
+
+---
+
+## 7. Podsumowanie końcowe audytu
+
+- **Overall status:** Green / Yellow / Red  
+- **P0 (blokujące):** X  
+- **P1:** X  
+- **P2:** X  
+- **Decyzja:** Approve with changes / Changes required / Re-audit needed
+
+---
+
+## 8. Scope boundaries
+
+**W zakresie**
+- przegląd kodu,
+- przegląd struktury katalogów i plików,
+- dokumentacja znalezisk i rekomendacji.
+
+**Poza zakresem**
+- automatyczne wdrażanie,
+- automatyczny refaktor,
+- automatyczne mergowanie zmian.

--- a/Project Plan/conversation-compact-2026-05-28.md
+++ b/Project Plan/conversation-compact-2026-05-28.md
@@ -1,0 +1,324 @@
+# Compact rozmowy — PIM Architecture Decisions (2026-04 → 2026-05-28)
+
+> **Cel dokumentu:** pełen kontekst dla nowej sesji agenta — kto, co, dlaczego, gdzie jesteśmy, co dalej. Czytaj sekwencyjnie. Po przeczytaniu masz pełen pogląd bez konieczności wczytywania starych wątków.
+>
+> **Kontekst produktowy:** Cortex PIM — agentic-first SaaS PIM (alternatywa dla Akeneo/Pimcore). Solo dev (Marcin), ~60% zbudowany, tuż przed pierwszym klientem. Stack: PHP 8.4 + Symfony 7.4 LTS + API Platform 4 + Doctrine ORM 3.x + FrankenPHP worker mode; PostgreSQL 16 (JSONB+ltree+RLS), Meilisearch, Redis 7; React 19 + Vite 6 + Refine.dev + shadcn/ui; Mercure SSE; Anthropic SDK. Monorepo Turborepo (`apps/api`, `apps/admin`, `packages/shared-types`).
+>
+> **Autoryt sesyjny:** Senior Staff Backend/Full-Stack Engineer + architekt rozwiązań. CLAUDE.md to konstytucja, Project Plan to backlog, `agent/current_status.md` to single source of truth.
+
+---
+
+## 1. Filozofia operatora (utrwalona)
+
+- **Uniwersalny system z klocków** — Product/Category/Asset to wbudowane instancje `ObjectType` (ADR-009), custom ObjectType jest bytem pierwszej klasy.
+- **„Nie chcę być Pimcorem"** — predefiniowane = OK, hardcoded-immutable = problem. Sensible defaults to feature; magia za plecami usera to anti-pattern.
+- **Agentic-first** — agent (Faza 2) musi móc modyfikować schemat naturalnym językiem. Każdy hardcoded byt = hardcoded ograniczenie agenta.
+- **Solo dev przed pierwszym klientem** — minimal impact, find root causes, no over-engineering, no premature platformization.
+- **Discipline testowa** — wszystkie testy zielone w DoD, PHPStan max, E2E Playwright bez wyjątku, SMOKE TEST RULE przed claim „działa", CLOSED MEANS CLOSED RULE.
+
+---
+
+## 2. ADR map (stan na 2026-05-28)
+
+| ADR | Treść | Status |
+|---|---|---|
+| ADR-006 | Hybrid attribute model (`attributes` + junction + `object_values` + `attributes_indexed`) | Aktywne |
+| ADR-009 | `ObjectType` jako koncept pierwszej klasy; Product/Category/Asset = `is_built_in=true`; custom kindy w bazie, feature flag off w MVP | Aktywne — bazowa decyzja |
+| ADR-010 | Axis-driven variants | Aktywne |
+| ADR-011 | Per-tenant locale fallback | Aktywne |
+| ADR-012 | AttributeGroup first-class | Aktywne (zmodyfikowany przez ADR-014) |
+| ADR-013 | Pełen RBAC od dnia 1 (MVP-Alpha) — 10 ról, 3-state per-attribute permissions, 7 phase'ów, 89 ticketów | Aktywne — w trakcie implementacji |
+| ADR-014 | Model dystrybucji atrybutów + relacje obiekt↔obiekt; `provides_schema_overlay` capability; `object_relations` zastępuje `object_associations`; revert „Brand jako built-in" | Aktywne |
+
+---
+
+## 3. Chronologia kluczowych decyzji w rozmowie
+
+### Faza A — PRD'y (na początku rozmowy)
+
+1. **`feature-list-advanced.md`** dokończony, cross-referencowany z `epik-02-produkty.md`.
+2. **`PRD-PIM-list-advanced.md`** — zaawansowana lista produktów (search, AdvancedFilterBuilder, SavedViews, Excel-like grid, bulk actions).
+3. **`PRD-PIM-exports.md`** — export Excel round-trip (XLSX+CSV, SKU natural key, async hybrid <100 sync, MinIO storage, forever retention, two-pane attribute picker, saved profiles per-user).
+4. **`PRD-PIM-rbac.md`** v2.1 — master spec RBAC po grilled-discovery. Macierz §3.2 pure ✓/✗, §3.5 3-state positive grants (`restricted/view/edit`) z resolution order atrybut → grupa → role-default. Multi-tenancy management UI poza MVP (DB/code hooks zostają). §3.7 Ownership, §3.8 workflow-state policy.
+5. **`PRD-PIM-final-audit.md`** — placeholder na security/perf/quality audit (do uzupełnienia później).
+6. **`feature-locales.md`** — mini-spec `/settings/locales`.
+
+### Faza B — RBAC implementation plan (89 ticketów)
+
+7. **`07-rbac-implementation-plan.md`** v3.1 — 7 phase'ów, ~330-445h, 17-19 tygodni, testing strategy 4 layers, security tooling stack, red-team checklist.
+8. **`08-rbac-tickets-phase-1.md` … `14-rbac-tickets-phase-7.md`** — 89 ticketów (Issues #640-#728), milestones #9-#15.
+9. **Decyzja sekwencyjna:** RBAC robimy TERAZ w MVP-Alpha (nie odkładamy), pełen scope, „raz a dobrze", iterujemy ile trzeba. Trigger zmiany kierunku przeniósł RBAC z Fazy 1 do MVP-Alpha (ADR-013).
+
+### Faza C — Modeling burza mózgów (ADR-014)
+
+10. Operator zgłosił 4 nieścisłości w Modelowaniu przy ~60% systemu:
+    - Marka jako built-in ObjectType (niepotrzebna).
+    - Brak modelu relacji obiekt↔obiekt.
+    - Category jako ObjectType nie renderuje swoich atrybutów (#3-#28).
+    - Niejasność kategoryzowalności custom ObjectType.
+11. **ADR-014 dodany** do `Project Plan/01-architektura-pim.md`: REVERT Brand built-in; `category_attribute_groups` scoped do primary category; `EffectiveAttributeGroupResolver` bazowe źródło dla każdego ObjectType. Decyzja: **Opcja Y — Hybrid** (ObjectType base + primary category overlay cumulative). `object_relations` zastępuje `object_associations` (ADR-009 hardcoded enum → seedowane built-in atrybuty `relation`).
+12. **`feature-modeling-data-model.md`** — mini-spec, 14 sekcji. Schema delta: `object_types.show_in_main_menu`, `is_categorizable`; `object_categories.is_primary`; `attributes.relation_target_object_type_ids`, `relation_cardinality`, `relation_advanced`; tabela `object_relations`.
+13. **`feature-modeling-data-model-tickets.md`** — MOD-01..14, ~73-104h. Zrealizowane przez agenta kodującego (część zmergowana, część w toku).
+
+### Faza D — §3.5 relacje placement (MODR-01..11, Opcja 2)
+
+14. Operator wykrył babol: atrybut `relation` „Smoke test" wyrenderował się inline zamiast w zakładce „Powiązania". Diagnoza: §3.5 zawierał sprzeczność „relacja = atrybut" vs „fixed Powiązania tab".
+15. **Decyzja: Opcja 2** — placement zawsze decyduje AttributeGroup + `display_mode`. Relacja to zwykły atrybut. Zero hardkodu.
+16. **`feature-modeling-relations-ux-tickets.md`** — MODR-01..11 (~47-70h):
+    - MODR-01 #923: `display_mode` (`tab|stacked`) na junction ObjectType×AttributeGroup.
+    - MODR-02 #924: od-hardkodowanie Multimedia + Powiązania jako seedowane grupy.
+    - MODR-03 #925: renderer placement po grupie + `display_mode`.
+    - MODR-04 #926: przełącznik tab/stacked w wizardzie.
+    - MODR-05 #927: ikona/badge relacji inline.
+    - MODR-06 #928: widoczność zakładki „Powiązania" dla reverse.
+    - MODR-07 #929: konfigurator relacji — domyślna grupa „Powiązania".
+    - MODR-08/09/10 #930/931/932: widget relacji (rich-preview-card, inline create, inline expand/edit).
+    - MODR-11 #933: docs.
+
+### Faza E — Universal ObjectListView (shipped jako Epik UP)
+
+17. Operator zauważył: tylko Product ma widok listy (`/products`). Custom ObjectType (Samochody) nie ma. Wyróżnianie Producta sprzeczne z ADR-009.
+18. **`feature-universal-object-list.md`** — mini-spec, ULV-01..12 (~67-97h):
+    - Jeden komponent `ObjectListView(objectTypeId)`.
+    - Route generyczny `/objects/{slug}`, aliasy `/products|categories|assets`.
+    - Meilisearch single index `objects` z facetem `object_type_id`.
+    - Kolumny per ObjectType: systemowe + atrybutowe z `show_in_list` flag na junction `object_type_attributes`.
+    - RBAC sparametryzowany ObjectType (`object.view/create/edit/delete/export`).
+    - Funkcje warunkowe per capability flag.
+19. **Zrealizowane przez Epik UP** (UP-00..UP-11, 2026-05-25) — `UniversalListPage` + `UniversalDetailPage` + `UniversalCreatePage` mountowane na `/products` ORAZ `/objects/:slug`. ULV epik (parallel MVP) świadomie odrzucony jako „półśrodek".
+
+### Faza F — LLM Council Round 1 (hardcoded attributes + Category overlay)
+
+20. Operator pyta: które hardkody (wbudowane AttributeGroups Multimedia/Powiązania/Audyt; specjalna rola Category) naprawiać teraz vs odłożyć, i jak ująć „kategorię"?
+21. **Council Round 1 verdict:**
+    - Strongest: B (First Principles), 4/5 votes. Diagnoza: „Category robi 2 rzeczy — taksonomia + schema overlay — sklejone z legacy Akeneo/Pimcore. Schemat ≠ taksonomia. Cumulative overlay to capability `provides_schema_overlay` na relacji, nie hardcoded magic."
+    - Biggest blind spot: D (Contrarian), 3/5.
+    - Blind spots peer review: reversibility cheap (`is_built_in` + `kind` już istnieją), RBAC Phase 3 collision, DB schema vs app code asymmetry, nikt nie pytał klienta.
+    - **Chairman recommendation:** Hybryda B + Reviewer 4. Multimedia → seedowana AttributeGroup TERAZ. Category overlay → schema-level genericzność TERAZ (silnik `provides_schema_overlay`), UI universalizacja PÓŹNIEJ. AttributeGroups „Audyt"/„Powiązania" odłożyć. **Najpierw zadzwoń do klienta.**
+
+### Faza G — Moduły vs Obiekty reframe + Council Round 2
+
+22. Operator zaproponował reframe: usunąć Kategorie/Zasoby z „Modelowania → Obiekty", potraktować Kategorie/Multimedia/PDF jako osobne nieedytowalne **Moduły** (włączane per tenant, własne UI), w ObjectType tylko capability flags (`is_categorizable`, `has_media`, `has_variants`).
+23. **Council Round 2 verdict:**
+    - Strongest: D (Executor), **5/5 unanimous**. Plan: 2h schema (`system_module` enum lub reuse `is_built_in`) + 2h sidebar split + 4h capability flags. UP zostaje. Bez encji „Module", bez plugin systemu, bez ADR-014.
+    - Biggest blind spot: E (Expansionist marketplace/pricing tiers), **5/5 unanimous**.
+    - Blind spots peer review: brak feedbacku usera, RBAC × capability flags collision, **`is_built_in=true` JUŻ istnieje** → refactor ~2h sidebar filter (nie schema change), ADR-009 supersession needed if going schema route.
+    - **Chairman recommendation:** STOP refactor. Zadzwoń do klienta 30 min, 3 pytania (czy „Kategorie"/„Zdjęcia" to MIEJSCA w głowie usera; inne moduły w 6 miesiącach; czy widoczność Multimedia/zakładki ma znaczenie). Jeśli potwierdzi → **D zmodyfikowane przez Recenzenta 4: ~4-6h zamiast 16h** (sidebar split po `is_built_in` + capability flags). Multimedia odłożona do osobnej iteracji.
+
+### Faza H — Operator's UX worries → Option Y (Powiązania bez seedu)
+
+24. Operator wskazał: „magiczne" pojawianie się zakładki przy populacji grupy to anti-pattern discoverability. User nie ma jak odkryć tej reguły. Albo flaga na ObjectType, albo pełna user-freedom (sam tworzy grupę). Wolał drugie — większa elastyczność i spójność.
+25. Agent przyznał rację: Opcja Y (pełne odseedowanie) jest lepsza. Spójność z resztą systemu (każda grupa istnieje bo user ją utworzył), brak magii, brak flag.
+26. **`feature-modeling-relations-option-y-tickets.md`** — MODRC-01..04 (~13-20h):
+    - MODRC-01: kasuj seed grupy „Powiązania" (supersedes MODR-02 dla Powiązań).
+    - MODRC-02: konfigurator atrybutu `relation` bez pre-selectu grupy + akcja „+ Utwórz nową grupę" inline (supersedes MODR-07).
+    - MODRC-03: systemowa sekcja „Powiązania zwrotne" jako wirtualna zakładka (jedyna magia, uzasadniona — user nie zaprojektuje grupy dla powiązań, które dopiero inni do niego stworzą) (supersedes MODR-06).
+    - MODRC-04: docs §3.5 + ADR-014 + lessons.md.
+27. **MODR-02 #924, MODR-06 #928, MODR-07 #929 → superseded przez MODRC-01 #1080, MODRC-03 #1082, MODRC-02 #1081** (numery issue dopisane przez agenta kodującego).
+
+### Faza I — Multimedia → Module Library (decyzja B potwierdzona)
+
+28. Operator potwierdził: **Multimedia → Droga B (Module Library)**, jak Pimcore Assets. Centralna biblioteka mediów w sidebarze „Moduły → Multimedia", pliki współdzielone między ObjectType, podpinane przez relację. `has_media` flag na ObjectType = integracja z Modułem.
+29. **Spec do zrobienia osobno** — nie ma jeszcze dedykowanego mini-speca dla Media Library Module.
+
+### Faza J — Bounded capability flags pattern
+
+30. Operator obawiał się proliferacji flag (`has_pricing`, `has_translations` itd. → Pimcore Classes anti-pattern).
+31. **Wzorzec bounded:** flaga na ObjectType dozwolona TYLKO gdy znaczy „integracja z System Module" — nie „ma cechę X". Liczba flag = liczba Modułów, nie liczba feature'ów. Audyt → RBAC permission, nie flaga.
+32. Trzy klasy bytów:
+    - **Editable AttributeGroup** (Powiązania po Y, jakakolwiek user-defined): brak flagi, user tworzy świadomie.
+    - **System view/panel** (Audyt): RBAC permission `audit.view`, brak flagi.
+    - **System Module** (Kategorie/Media/Warianty/przyszłe Cennik/Translations): flaga `is_categorizable`/`has_media`/`has_variants` = integracja.
+
+---
+
+## 4. Pliki utworzone w rozmowie (mapa)
+
+### W `Project Plan/PRD/`
+- `PRD-PIM-list-advanced.md` — zaawansowana lista.
+- `PRD-PIM-exports.md` — Excel round-trip export.
+- `PRD-PIM-rbac.md` — master spec RBAC v2.1.
+- `PRD-PIM-final-audit.md` — placeholder audit.
+
+### W `Project Plan/`
+- `07-rbac-implementation-plan.md` v3.1.
+- `08-rbac-tickets-phase-1.md` … `14-rbac-tickets-phase-7.md` — 89 ticketów.
+- **`conversation-compact-2026-05-28.md`** — ten plik.
+
+### W `Project Plan/UI/`
+- `feature-list-advanced.md` (rozbudowany).
+- `feature-locales.md` — mini-spec `/settings/locales`.
+- `feature-modeling-data-model.md` — mini-spec ADR-014 (14 sekcji).
+- `feature-modeling-data-model-tickets.md` — MOD-01..14 (~73-104h).
+- `feature-modeling-relations-ux-tickets.md` — MODR-01..11 (~47-70h), **MODR-02/06/07 superseded**.
+- `feature-modeling-relations-option-y-tickets.md` — MODRC-01..04 (~13-20h), supersedes MODR-02/06/07.
+- `feature-universal-object-list.md` — mini-spec ULV (~67-97h), **zrealizowane przez Epik UP**.
+
+### Edytowane
+- `Project Plan/01-architektura-pim.md` — ADR-014 dodany, nota o object_associations → object_relations.
+- `Project Plan/UI/epik-02-produkty.md` — cross-references.
+- `Project Plan/UI/00-plan-ui.md` — linki do feature-list-advanced + feature-imports.
+
+---
+
+## 5. Stan ticketów (kompendium)
+
+### Active (w toku albo do zrobienia)
+
+| Batch | Plik | Status |
+|---|---|---|
+| MOD-01..14 | `feature-modeling-data-model-tickets.md` | W toku — część zmergowana (MOD-01 jako #893, MOD-02 jako #894, MOD-12 jako #904 itd.) |
+| MODR-01, 03, 04, 05, 08, 09, 10, 11 | `feature-modeling-relations-ux-tickets.md` | Active — pozostałe MODR-y nieosobane Y |
+| MODRC-01..04 | `feature-modeling-relations-option-y-tickets.md` | Issues #1080-#1082+ utworzone, do implementacji |
+| ULV-01..12 | `feature-universal-object-list.md` | **Zrealizowane** jako Epik UP (UP-00..UP-11) 2026-05-25 |
+| 89 RBAC ticketów Phase 1-7 | `08-rbac-tickets-phase-1.md` … `14-rbac-tickets-phase-7.md` | W toku — milestones #9-#15 |
+
+### Superseded
+- **MODR-02 #924** → MODRC-01 #1080 (kasacja seedu Powiązań; Multimedia idzie osobno przez Module Library).
+- **MODR-06 #928** → MODRC-03 #1082 (systemowa sekcja „Powiązania zwrotne").
+- **MODR-07 #929** → MODRC-02 #1081 (konfigurator relacji bez defaultu grupy + inline create).
+- **MODR-11 #933** → rozszerzone przez MODRC-04.
+
+---
+
+## 6. Decyzje świadomie odrzucone (zarejestrowane w lessons.md / mini-specach)
+
+| Odrzucone | Powód |
+|---|---|
+| Warstwa „Object Template" nad ObjectType | Potworek duplikujący ObjectType; ObjectType już JEST template |
+| Osobny krok „Objekty" w wizardzie ObjectType | Re-rozdziela relację od atrybutu, otwiera babola „Smoke test" |
+| Reguła „relacja zawsze zakładka" | Łamie Producent-inline use case (Brand relation w grupie tożsamości) |
+| Mechanizm embed/kompozycja w MVP | YAGNI; warianty/asset już mają dedicated mechanizmy |
+| Families à la Akeneo | Resolver `provides_schema_overlay` jako capability na relacji rozwiązuje to bez nowego bytu |
+| Flaga `has_relations` na ObjectType | Proliferacja flag → Pimcore Classes anti-pattern |
+| Seed grupy „Powiązania" jako built-in | Discoverability anti-pattern — magiczne pojawianie się zakładki |
+| „Magiczna" widoczność zakładki przy populacji | User nie ma jak odkryć tej reguły |
+| Encja „Module" / Module Registry / marketplace | Premature platformization pre-MVP-Alpha; brak ICP validation |
+| Pricing tiers / marketplace partnerów | Fantasy product strategy na podstawie 24h refleksji bez klienta |
+
+---
+
+## 7. Otwarte akcje (do zrobienia, w kolejności priorytetu)
+
+### Najważniejsza pojedyncza akcja (wskazana przez 2 niezależne rady)
+
+**Zadzwoń do pierwszego klienta. 30 minut. 3 pytania:**
+1. Czy „Kategorie" i „Zdjęcia" w jego głowie to MIEJSCA obok Produktów, czy typy obiektów wśród innych obiektów?
+2. Jakie inne „moduły" widzi w pierwszych 6 miesiącach (Cennik? Tłumaczenia? Katalogi PDF?)?
+3. Czy potrafi sensownie zamodelować swój katalog w 2h onboardingu?
+
+Bez tego telefonu każda decyzja architektoniczna jest spekulacją. Pół godziny zmieni pewność z 60% na 95%.
+
+### Po telefonie — implementacja decyzji
+
+- **Sidebar split „Obiekty" / „Moduły"** — filtr po `is_built_in` (juz istnieje od ADR-009). ~2h.
+- **Capability flags** `is_categorizable`, `has_media`, `has_variants` na ObjectType. ~2-4h.
+- **MODRC-01..04** — kasacja seedu Powiązań, systemowa sekcja reverse, konfigurator bez defaultu. ~13-20h.
+- **Multimedia → Media Library Module mini-spec** + tickets. Do napisania.
+- **RBAC × capability flags interakcja** — ustalić w voterze hierarchię: capability flag decyduje czy zakładka istnieje, RBAC decyduje co user widzi wewnątrz. 1-2h decyzji designerskiej.
+
+### Kontynuacja istniejących batchy
+
+- MOD-01..14 (Modelowanie data model + relacje backend) — w toku.
+- MODR-01, 03, 04, 05, 08, 09, 10, 11 (relations UX, części aktualne) — w toku.
+- 89 RBAC ticketów Phase 1-7 — w toku, MVP-Alpha + część MVP-Final.
+
+---
+
+## 8. Kluczowe wzorce do utrzymania
+
+### Z CLAUDE.md (konstytucja)
+
+- **EPIK MARATHON RULE** — gdy operator mówi „przez cały epik", agent nie deferuje, nie skipuje, nie bundle'uje.
+- **SMOKE TEST RULE** — bez manual smoke test na żywym backendzie nie wolno claim „działa" w PR.
+- **CLOSED MEANS CLOSED RULE** — `gh issue close` wymaga live-stack smoke test proof w comment.
+- **Memory management FrankenPHP** — każdy Messenger handler dziedziczy `AbstractBatchHandler` lub woła `EntityManager::clear()` po `flush()` w batchach.
+- **Single-origin przez Caddy** — nigdy nie konfiguruj CORS. Cały ruch przez `pim.localhost` / `pim.example.com`.
+- **Multi-tenancy** — `tenant_id UUID NOT NULL` na każdej tabeli domenowej. Doctrine TenantFilter + Postgres RLS jako defence in depth.
+- **Shopify throttling** — Exponential Backoff only, Leaky Bucket dopiero w Fazie 1.
+- **Agent security limits** — 50 tool calls/h, 10/run, 100k tokens/run, 500k/dzień, $20/dzień/tenant, $300/miesiąc.
+
+### Z PIM architecture (Reguły implementacyjne)
+
+1. Bounded Contexts: Catalog, Channel, Asset, Integration, Identity, Agent, ApiConfigurator.
+2. Każda integracja = bundle z Adapter/Client/MessageHandler/Webhook/ConfigForm.
+3. API jest produktem first-class — admin używa tych samych endpointów co integratorzy. Wszystko przez API Platform.
+4. Hybrid attribute model parametryzowany per ObjectType (ADR-006 + ADR-009). JSONB shapes per `docs/api/jsonb-schemas.md`.
+5. Provenance pole obowiązkowe: `manual | import | agent | integration` + meta JSONB.
+6. Approval flow dla agenta — `pending_changes` table, UI inbox/diff.
+7. Brak hardkodowanych URL/kluczy/sekretów w kodzie.
+8. i18n — wszystkie stringi UI przez `t()`. Label/help atrybutów jako JSONB `{"pl": ..., "en": ...}`.
+9. Cursor pagination dla list >1000. RFC 7807 Problem Details.
+10. ObjectType pierwszej klasy (ADR-009).
+
+### Z lessons.md per discovery
+
+- **„Sensible defaults to feature, hardcoded-immutable to problem"** — wzorzec rozróżnienia seedowanych built-in od hardkodów.
+- **Capability flag tylko jako integracja z System Module** — nie „ma cechę X".
+- **Każdy babol § wykryty w praktyce → reframe spec, nie patch kodu** — np. „Smoke test" babol odsłonił sprzeczność w §3.5.
+- **2 niezależne rady wskazują na to samo = zignorowany blocker** — jeśli rada drugi raz mówi „zadzwoń do klienta", to nie przypadek.
+- **Reversibility check** — sprawdź czy `is_built_in`/`kind` foundation już istnieje przed nową kolumną w schemacie.
+
+---
+
+## 9. Specyficzne case'y rozwiązane w rozmowie
+
+### Case: Salon Sprzedaży jako część Samochody
+
+- **Architektura:** Salon Sprzedaży = własny ObjectType z atrybutami (nazwa, adres, lokalizacja, zdjęcia). `show_in_main_menu=true`. Na Samochodzie atrybut typu `relation` → target Salon, cardinality `many`.
+- **Dwa poziomy:** Model (definicja atrybutu na ObjectType) + Instancja (wiersz w `object_relations` per powiązanie). Reverse dostajesz gratis.
+- **UX:** Widget relacji z rich-preview-card (nazwa + miasto + miniaturka), inline create targetu, inline expand/edit. Brak nowego konceptu.
+
+### Case: Powiązania ad-hoc
+
+- Ad hoc attributes = escape hatch + diagnostic signal (5th tripwire metric — przyrost ad hoc = sygnał brakującego modelu).
+- Governance: ścieżka promocji (gdy ten sam atrybut ad hoc pojawia się N razy → sugestia „dodać na stałe").
+- Pułapka: ad hoc maskuje pozostałe tripwire'y — user nie narzeka, tylko po cichu klepie ad hoc.
+
+### Case: tripwires dla rewizji modelu (kiedy rozważyć Families)
+
+4 metryki + 5-ta (ad hoc growth):
+1. **Eksplozja atrybutów na liściu** — mediana/p95 efektywnych atrybutów na obiekt. Próg: p95 > 150.
+2. **Ten sam atrybut/grupa w niespokrewnionych gałęziach** — % grup podpiętych w wielu miejscach. Próg: >30%.
+3. **Churn kategoryzacji** — liczba zmian primary category na obiekt w 30 dniach. Próg: mediana >1-2.
+4. **Completeness systematycznie niski** — rozkład per ObjectType. Próg: garbi się przy 60-70%.
+5. **Przyrost atrybutów ad hoc** — sygnał brakującego modelu.
+
+**Trigger Family:** 2 metryki nad progiem na ≥2 niezależnych tenantach.
+
+### Case: Pimcore comparison (gdy operator pytał czy Pimcore lepszy)
+
+- Pimcore: Class + Field Collections + Object Bricks + Classification Store. 4 koncepty, stroma krzywa, ale schema decoupled od category.
+- Akeneo: Family obowiązkowy per produkt, kategoria czysto nawigacyjna. Prostsze, mniej elastyczne.
+- Nasz: ObjectType base + primary category overlay cumulative. Pomiędzy — pod warunkiem że resolver pozostaje czystą abstrakcją źródeł nakładki.
+- Wniosek: nie kopiuj Pimcore (zbyt złożony), ale przejmij dekupling overlay od pojedynczego nośnika.
+
+---
+
+## 10. Co czytać dalej (jeśli nowy agent potrzebuje głębi)
+
+W kolejności priorytetu:
+
+1. **`CLAUDE.md`** (oba folderowe warianty — `/Users/mlipieclocal/dev/PIM/CLAUDE.md` i workspace) — konstytucja, twarde reguły.
+2. **`Project Plan/01-architektura-pim.md`** — pełen ADR list (1-14), reguły implementacyjne, schemat bazy.
+3. **`Project Plan/02-plan-projektu-pim.md`** — backlog i estymacje, checkboxy ticketów.
+4. **`agent/current_status.md`** — gdzie dokładnie jesteśmy (aktualna sub-faza, ticket, ostatnie akcje, blokery).
+5. **`agent/lessons.md`** — Patterns to Follow / Avoid / Decyzje świadome + per-ticket lessons.
+6. **Mini-speci w `Project Plan/UI/`** — `feature-modeling-data-model.md`, `feature-modeling-relations-option-y-tickets.md`, `feature-universal-object-list.md`.
+7. **`Project Plan/PRD/PRD-PIM-rbac.md`** — RBAC master spec.
+
+---
+
+## 11. Quick reference — najnowszy stan (one-liner per topic)
+
+- **Modeling placement relacji:** Option Y — user świadomie tworzy grupę, brak seedu, system reverse section gratis. MODRC-01..04 w toku.
+- **Multimedia:** Droga B (Module Library) — `has_media` flag = integracja. Spec do napisania.
+- **Kategorie:** osobny System Module w sidebarze, `is_categorizable` flag = integracja. ~2h sidebar split.
+- **Universal list:** **DONE** via Epik UP (UP-00..UP-11) 2026-05-25.
+- **RBAC:** Phase 1-7, 89 ticketów, w toku w MVP-Alpha + część MVP-Final.
+- **Capability flags bounded:** dozwolone TYLKO jako „integracja z System Module".
+- **Open critical action:** zadzwoń do klienta (3 pytania, 30 min) PRZED dalszymi decyzjami architektonicznymi.
+
+---
+
+*Compact wygenerowany 2026-05-28. Stan po: shipped Epik UP, supersedowaniu MODR-02/06/07 przez MODRC-01..03, decyzji Multimedia → Droga B (Moduł), bounded capability flags pattern. Dla nowej sesji: zacznij od tego pliku, potem CLAUDE.md, potem current_status.md.*

--- a/agent/conversation-handoff-2026-05-28.md
+++ b/agent/conversation-handoff-2026-05-28.md
@@ -1,0 +1,555 @@
+## 1. Gap analysis: oczekiwane vs obecne vs braki
+
+### Oczekiwane przez biznes
+- Domyślna wartość po zapisie ma trafiać do wszystkich locale i kanałów.
+- Każdy scope ma mieć możliwość nadpisania wartości.
+- UI ma pozwalać wygodnie przełączać locale/kanał i edytować odpowiedni wariant.
+- Export i API mają respektować konfigurację scope użytkownika.
+
+### Obecnie w systemie
+- UI ma przełącznik locale/kanału w `UniversalDetailPage` i `LocaleChannelToolbar`.
+- Backend czyta i zapisuje dane z uwzględnieniem `?locale=` i `?channel=`.
+- Istnieje matryca kanał↔locale oraz zarządzanie locale workspace.
+- Export przechowuje `locales` i `channels`, ale logika kanałowa jest jeszcze częściowo deferred.
+- `channels-status` dla produktu zwraca pustą listę.
+
+### Braki względem celu Akeneo-like
+- Brak pełnego mechanizmu dziedziczenia/fan-outu wartości na wszystkie scope po zapisie.
+- Brak jednolitej strategii override dla wszystkich typów pól.
+- Brak pełnego, spójnego modelu „effective value” dla read-path, export i API.
+- Brak realnych danych per-channel sync/status.
+- Export kanałowy nie jest jeszcze pełnoprawnie zaimplementowany.
+
+### Ryzyka
+- Rozjazd między UI, API i exportem.
+- Niejasne zachowanie dla pustej wartości vs override.
+- Trudność w utrzymaniu spójności przy dalszym rozwoju formularzy.
+
+## 2. Plan wdrożenia
+
+### Faza A — kontrakt domenowy
+1. Zdefiniować regułę zapisu: global default + per-scope override.
+2. Ustalić priorytet odczytu wartości effective.
+3. Rozróżnić localizable, scopable i globalne pola w jednym kontrakcie.
+
+### Faza B — backend
+1. Dodać mechanizm fan-out przy tworzeniu nowej wartości.
+2. Ujednolicić resolver effective values dla read/update/export.
+3. Wypełnić `channels-status` realnymi danymi.
+4. Dokończyć kanałowy export z respectowaniem konfiguracji scope.
+
+### Faza C — admin UI
+1. Ulepszyć UX przełącznika locale/kanału przy edycji.
+2. Pokazać, które pola są dziedziczone, a które nadpisane.
+3. Dodać czytelne stany: inherited / overridden / empty.
+
+### Faza D — testy i walidacja
+1. ApiTestCase dla reguł effective value.
+2. Playwright dla przełączania scope i override.
+3. Test eksportu dla locale/channel selection.
+4. Smoke test na żywym stacku przed zamknięciem ticketu.
+
+### Proponowana kolejność
+1. Kontrakt domenowy i resolver effective value.
+2. Backend write/read/export.
+3. UI scope UX.
+4. Testy E2E i smoke.
+# Conversation Handoff — Cortex PIM (architecture session, 2026-05-23 → 2026-05-28)
+
+**Typ dokumentu:** Brief startowy dla nowego agenta — pełen kontekst architektoniczny z wielodniowej rozmowy. Czytaj zanim podejmiesz decyzje dotyczące Modelowania, Relacji, listy uniwersalnej lub RBAC.
+**Data utworzenia:** 2026-05-28
+**Operator:** Marcin (solo dev, ~60% systemu zbudowane, tuż przed pierwszym klientem)
+
+---
+
+## 0. TL;DR — co musisz wiedzieć w 60 sekund
+
+Marcin buduje **Cortex PIM** — agentic-first SaaS PIM (alternatywa dla Akeneo/Pimcore), single-tenant deploy / multi-tenant ready, MVP-Alpha tuż przed pilotem. W ciągu ostatnich dni przeszliśmy długą sesję projektową obejmującą: feature-list-advanced, exports, RBAC, modelowanie obiektów, relacje, universal list view, Moduły vs Obiekty reframe, oraz dwie sesje LLM Council.
+
+**Najważniejszy outstanding action (jedyny blocker dalszych decyzji):**
+**Zadzwoń do pierwszego klienta. 30 min.** Dwie niezależne rady LLM wskazały na to samo — każda decyzja architektoniczna w tej rozmowie jest spekulacją do czasu tej rozmowy.
+
+**Aktualny stan implementacyjny (per system reminders):**
+- Epik UP (UP-00..UP-11) **shipped 2026-05-25** — uniwersalny list/detail/create dla wszystkich ObjectType
+- MOD-01..14 (ADR-014 implementation) — issues #893+ utworzone
+- MODR-01..11 (placement/UX relacji) — issues #923-933 utworzone, **MODR-02/06/07 częściowo superseded** przez MODRC-01..03 (#1080-1082, decyzja 2026-05-28)
+- RBAC Phase 1-7 — 89 ticketów rozpisane (Issues #640-#728, milestones #9-#15)
+
+---
+
+## 1. Kontekst projektu (na potrzeby handoff)
+
+**Cortex PIM** — patrz `CLAUDE.md` w root i `dev/PIM/CLAUDE.md`. Stack:
+- Backend: PHP 8.4 + Symfony 7.4 LTS + API Platform 4 + Doctrine ORM 3.x + FrankenPHP 2.x worker mode
+- DB: PostgreSQL 16 (JSONB+ltree+RLS), Meilisearch, Redis 7
+- Frontend: TypeScript 5 + React 19 + Vite 6 + Refine.dev + shadcn/ui
+- Agent layer: Anthropic SDK PHP (Faza 2)
+
+**Filozofia operatora (POWTARZAJĄCY SIĘ MOTYW — KRYTYCZNY):**
+- „Uniwersalny system z klocków, ale **NIE Pimcore**" (Pimcore = zbyt złożony, stroma krzywa uczenia)
+- „**Predefiniowane = OK, hardcoded-immutable = problem**"
+- Każda nowa flaga / koncept architektoniczny wymaga świadomej decyzji, nie odruchu
+- Agent-first w modelu mentalnym, choć agent layer fizycznie Faza 2
+
+**Reguły operacyjne (NIENEGOCJOWALNE — z CLAUDE.md):**
+- EPIK MARATHON RULE — gdy mówi „przez cały epik" = każdy ticket = osobny PR, bez deferrowania
+- SMOKE TEST RULE — przed claim „działa" w PR opisie wymagany manual smoke test na żywym stacku
+- CLOSED MEANS CLOSED RULE — `gh issue close` wymaga live-stack smoke testu jako proof w close comment
+- Testy zielone w DoD — backend PHPUnit + ApiTestCase, frontend Vitest + Playwright E2E (bez E2E ticket NIE jest done)
+
+---
+
+## 2. Mapa plików utworzonych/zmodyfikowanych w tej rozmowie
+
+### PRD-y (`Project Plan/PRD/`)
+| Plik | Status |
+|---|---|
+| `PRD-PIM-list-advanced.md` | Utworzony, finalny — feature-PRD listy zaawansowanej (16 sekcji) |
+| `PRD-PIM-exports.md` | Utworzony, finalny — po 5-wave wywiadzie (Excel round-trip, SKU key, XLSX+CSV, async hybrid <100, MinIO, forever retention) |
+| `PRD-PIM-rbac.md` | Utworzony v2.1 — master spec RBAC. §3.2 macierz pure ✓/✗, §3.5 rewrite na 3-state positive grants (`restricted`/`view`/`edit`) z resolution order attribute→group→role-default |
+| `PRD-PIM-final-audit.md` | Placeholder (security/performance/quality audit, nic teraz) |
+
+### Mini-speci i tickety modelowania (`Project Plan/UI/`)
+| Plik | Status |
+|---|---|
+| `feature-locales.md` | Utworzony — mini-spec `/settings/locales` |
+| `feature-modeling-data-model.md` | Utworzony, finalny — realizacja ADR-014. §3.5 wymaga aktualizacji per Opcja Y (MODRC-04) |
+| `feature-modeling-data-model-tickets.md` | MOD-01..14, ~73-104h, issues #893+ utworzone |
+| `feature-universal-object-list.md` | **Shipped via Epik UP (UP-00..UP-11) 2026-05-25.** ULV epik świadomie odrzucony przez operatora jako „półśrodek" |
+| `feature-modeling-relations-ux-tickets.md` | MODR-01..11, ~47-70h, issues #923-933. **MODR-02 (#924), MODR-06 (#928), MODR-07 (#929) superseded przez MODRC-01..03** |
+| `feature-modeling-relations-option-y-tickets.md` | **NAJNOWSZY (2026-05-28).** MODRC-01..04, ~13-20h. Decyzja Option Y — pełne odseedowanie grupy Powiązania |
+
+### RBAC backlog (`Project Plan/`)
+| Plik | Status |
+|---|---|
+| `07-rbac-implementation-plan.md` | v3.1 — 7 faz, testing strategy (4 layers), security tooling |
+| `08-rbac-tickets-phase-1.md` ... `14-rbac-tickets-phase-7.md` | 89 ticketów RBAC, Issues #640-#728, milestones #9-#15 |
+
+### Architektura i sterujące (`Project Plan/`)
+- `01-architektura-pim.md` — **ADR-014 dodany** („Model dystrybucji atrybutów + relacje obiekt↔obiekt"). Definiuje `object_relations` jako zastępca `object_associations`
+- `02-plan-projektu-pim.md` — backlog i estymacje (utrzymywane atomowo)
+
+---
+
+## 3. Chronologia decyzji architektonicznych — co się działo
+
+### Wątek A — feature-list-advanced + exports + RBAC + locales
+1. Operator poprosił o ukończenie `feature-list-advanced.md` + cross-reference z `epik-02-produkty.md`
+2. `/to-prd-md-pim` → `PRD-PIM-list-advanced.md`
+3. `/grill-me-prd-pim` dla eksportu (5 fal) → `PRD-PIM-exports.md`. Kluczowe decyzje: Excel round-trip primary, SKU as natural key, XLSX+CSV, two-pane attribute picker, saved profiles per-user, async hybrid threshold <100 sync, MinIO storage, forever retention
+4. `/grill-me-prd-pim` dla RBAC. **Konstraint operatora:** multi-tenancy management UI POMINIĘTY w MVP (ale DB/code hooks gdyby były potrzebne); podstawowe permissions
+5. Operator pyta: kiedy implementować RBAC? Wniosek: **TERAZ, full scope, „nic nie dzielimy na fazy, wszystko teraz, raz a dobrze, iterujemy tyle razy ile trzeba"**
+6. Operator wskazał: chcę Super Admina do zarządzania tenantami. Nie dzielić na fazy.
+7. Po refleksji nad macierzą §3.2: usunięto (own)/(view)/(per-X) magic notation — czyste ✓/✗
+8. Operator: workflow nie tworzymy, ale uprawnienia na atrybutach mają to wspierać (Jan dodaje, Maria uzupełnia tylko cenę)
+9. Po pokazaniu screenshotu — operator zaproponował przełączenie z negatywnego blacklistingu na **3-state positive grants** (restricted/view/edit), pogrupowane w grupy z komunikatem „Uprawnienia częściowe"
+10. Akceptacja: A. Macierz first → C. Inherit z macierzy → A. Visible w current view → B. Preview modal
+11. **`feature-locales.md`** — mini-spec dla `/settings/locales` (Opcja c Polish + b)
+
+### Wątek B — Modelowanie (sesja burzy mózgów 2026-05-23)
+Operator zaczął: „powstał kawał systemu, zaczynam widzieć nieścisłości w Modelowaniu". Wykryto 4 nieścisłości przy ~60% systemu:
+1. Marka jako built-in (po co?)
+2. Brak modelu relacji obiekt↔obiekt
+3. Category-jako-ObjectType nie renderuje swoich atrybutów (#3-#28)
+4. Niejasność kategoryzacji
+
+**Decyzje z Wave 1-4 wywiadu:**
+- Marka — REVERT z built-in, tenant decyduje (Y Hybrid)
+- Wzorzec dystrybucji: **(b) Y Hybrid — kategoria DODAJE, nie zastępuje** (cumulative po ścieżce)
+- Relacje — typ atrybutu (Pimcore-style), reverse generated, advanced=metadata na powiązaniu
+- Asset — pozostaje odrębny typ (a)
+- Fixed Powiązania tab (a) — z uwagą implementacyjną
+- Primary category zamiast Family (operator: „nie chcę Family, zbyt skomplikowane")
+- Orphaned values — wartości zostają w bazie, ukryte, reaktywowalne (a)
+- Walidacja unikalności kodów: blokuje (a) — trzeba dodać unikalne kody (`opis_telewizory`)
+- **ADR-014** utworzone + `feature-modeling-data-model.md` mini-spec + 14 ticketów MOD-01..14
+
+**Krytyczna decyzja architektoniczna:** `object_associations` (ADR-009 hardcoded enum cross_sell/up_sell/related/alternative/accessory) **ZASTĄPIONE przez `object_relations`** (relacja = typ atrybutu). 5 enum types → seedowane built-in `relation` attributes na Product.
+
+### Wątek C — Pytanie o Families (Akeneo) + Pimcore comparison
+- Czy gdyby drzewo nie działało, można zrobić Families à la Akeneo?
+- **Odpowiedź:** TAK, w dowolnym momencie. Scenariusz 1 (przed produkcją) = czysta zmiana kodu, ~tydzień. Scenariusz 2 (klienci) = backfill family_id per tenant, orphaned values, performance, RLS — kilka dni roboty migracyjnej + sam feature
+- **Tania polisa:** trzymać `EffectiveAttributeGroupResolver` jako single chokepoint (MOD-03 to robi). Plus opcjonalnie zarezerwować pustą migrację `objects.family_id`
+- **Pimcore comparison:** Pimcore ma Classification Store + Object Bricks + Field Collections. Klucz: w Pimce dystrybucja atrybutów jest ZDEKUPLOWANA od kategorii. To wyróżnik, ale Pimcore jest też notorycznie skomplikowany. Cortex może mieć podobną elastyczność BEZ złożoności — pod warunkiem że resolver pozostaje czystą abstrakcją źródeł nakładki
+
+### Wątek D — Kryteria rewizji modelu (tripwires)
+Operator: „kryterium 2h onboarding jest złe, bo wyjdzie przy 100k atrybutów i 200 kategorii". Wniosek: **4 metryki + 5-ta jako kontrola**:
+1. Eksplozja liczby efektywnych atrybutów na liściu (p95 >150 = formularz nie do użycia)
+2. Ten sam atrybut potrzebny w niespokrewnionych gałęziach (>30% grup = źle)
+3. Churn kategoryzacji (mediana zmian primary >1-2 w 30 dni = walka z systemem)
+4. Completeness systematycznie niski (rozkład garbi się przy 60-70%)
+5. **Przyrost atrybutów ad hoc** (jeśli >200/mc = model nietrafiony)
+
+**Trigger Family:** 2 metryki nad progiem na ≥2 niezależnych tenantach.
+
+**Pułapka do zapamiętania:** atrybuty ad hoc MASKUJĄ pozostałe tripwire'y (user zamiast narzekać klepie ad hoc). Czytać metrykę „przyrost ad hoc" RAZEM z pozostałymi, nie zamiast nich.
+
+### Wątek E — Ad hoc atrybuty (escape hatch + diagnostyka)
+- Pozwalają userowi dodawać atrybuty per-product (Akeneo/Pimcore tego nie mają)
+- ZALETY: rozładowuje eksplozję, lowers onboarding friction, jest zaworem bezpieczeństwa dla rigid modelu
+- WADY bez governance: fragmentacja danych, completeness break, channel export bypass, RBAC bypass, kula u nogi
+- Governance: badge widoczny, NOT counted to completeness, NOT in global filters, opt-in w eksporcie, separate permission do tworzenia, **ścieżka promocji** — gdy N produktów ma ten sam ad hoc, system sugeruje promocję
+
+### Wątek F — Salon Sprzedaży modeling (przykład relacji)
+Operator pyta: jak zorganizować „Salony Sprzedaży" jako część „Samochody"?
+- **Kluczowa korekta modelu mentalnego:** Salon NIE jest „zawarty w" samochodzie. Jest WSPÓŁDZIELONY (composition vs association)
+- **Architektura:** Salon = własny ObjectType z `show_in_main_menu=true` (lub false jeśli purely target), własne atrybuty (nazwa, adres, lokalizacja=geo, zdjęcia=asset gallery)
+- Na Samochodzie atrybut typu `relation` → target=Salon, cardinality=many
+- **Pokazane diagramem** (POZIOM MODELU + POZIOM INSTANCJI + object_relations row jako edge)
+- **Luka:** `geo`/map attribute type może nie istnieć — osobny ticket
+
+### Wątek G — Universal list view (uniwersalna lista każdego ObjectType)
+- Operator: tylko Product ma `/products`. Custom ObjectType (Samochody) nie ma. Cel: dowolny ObjectType ze `show_in_main_menu=true` → ten sam advanced list view co Produkty
+- Utworzony `feature-universal-object-list.md` (16 sekcji, ULV-01..12, ~67-97h)
+- **Krytyczny insight (peer review w Council):** `is_built_in=true` JUŻ istnieje od ADR-009. Refactor sidebar to ~2h, nie schema change
+- **STATUS: Shipped via Epik UP** (UP-00..UP-11) 2026-05-25. `/products/{list,show,create}` wydzielone do `UniversalListPage`/`UniversalDetailPage`/`UniversalCreatePage`, mountowane na `/products` ORAZ `/objects/:slug`. ULV epik świadomie odrzucony jako „półśrodek"
+
+### Wątek H — LLM Council Round 1 (hardcoded attributes / Category)
+**Pytanie:** które hardkody naprawiać teraz, które odłożyć?
+- **Najmocniejsza: B (First Principles)** — 4/5. Diagnoza: „Category robi 2 rzeczy — taksonomia + schema overlay — sklejone z legacy Akeneo/Pimcore. Cumulative overlay nie jest cechą Category, tylko cechą *relacji* `provides_schema_overlay`"
+- **Największy blind spot: A (Expansionist)** — sprzedaje viral demo moment bez dowodu, że pierwszy klient tego chce
+- **Chairman recommendation:** schema-level genericzność TERAZ (silnik) + UI universalizacja PÓŹNIEJ + **zadzwoń do klienta**
+- Blind spots wyłapane przez peer review: RBAC Phase 3 interaction, asymetria DB-schema vs app-code hardcodes, reversibility cheap (bo `is_built_in` istnieje), false dichotomy (refactor vs CSV hardening)
+
+### Wątek I — Reframe „Moduły vs Obiekty" (operator's counter-proposal)
+Operator po refleksji: usunąć Kategorie/Zasoby z „Modelowania → Obiekty"; potraktować Kategorie/Multimedia/Katalogi PDF jako osobne nieedytowalne **MODUŁY** (włącz/wyłącz per tenant, własne UI). W ObjectType tylko **capability flags** (`is_categorizable`, `has_media`, `has_variants`) → zakładki pojawiają się.
+
+### Wątek J — LLM Council Round 2 (Moduły vs Obiekty)
+- **Najmocniejsza: D (Executor) — 5/5 UNANIMOUS.** Konkretny plan: 2h sidebar split + 4h capability flags, NIE cofać UP, NIE encja „Module", używać istniejącego `is_built_in`
+- **Największy blind spot: E (Expansionist) — 5/5 UNANIMOUS.** Marketplace/pricing tiers/Module Registry = premature platformization 24h po shipping UP, bez ani jednego pilota
+- **Chairman recommendation:** STOP refactor, zadzwoń do klienta, potem D-zmodyfikowane przez Reviewer 4 (~2-6h zamiast 16h, używa istniejącego `is_built_in`)
+- **Nowe insighty z peer review:**
+  - `is_built_in=true` ALREADY EXISTS → refactor ~2h, NIE schema change
+  - RBAC × capability flags collision (dwa źródła prawdy: ObjectType flag vs per-attribute permission)
+  - Asymetria DB-schema vs app-code hardcodes
+  - Nikt nie pyta o pierwszego klienta
+
+### Wątek K — Capability flags bounded pattern + Audyt/Powiązania
+Operator pyta o pułapkę flag proliferation (`has_audit`, `has_pricing`...). Rozstrzygnięcie:
+- **Powiązania** = AttributeGroup (po MODR-02), nie wymaga flagi
+- **Audyt** = NIE flaga, ALE **RBAC permission `audit.view`** (system view, nie modeling)
+- **Multimedia** = droga A (AttributeGroup) ALBO droga B (Module Library) — **operator wybrał B**
+- **Bounded pattern:** flaga dozwolona TYLKO gdy znaczy „integracja z System Module". Liczba flag = liczba Modułów, nie liczba feature'ów. Naturalna bariera
+
+### Wątek L — Opcja Y dla Powiązań (finalna decyzja)
+Operator nie zaakceptował „seed everywhere + hide when empty" (Option Z) — odsłonił problem discoverability („skąd user ma wiedzieć że jak doda atrybut to magicznie pojawi się zakładka").
+
+**OPCJA Y (finalna):**
+- **Pełne odseedowanie grupy „Powiązania"** — żadnej seedowanej grupy, żadnej built-in
+- User świadomie tworzy grupę z `display_mode=tab` + wrzuca atrybuty `relation`
+- **Reverse relations** = systemowa wirtualna zakładka „Powiązania zwrotne" — jedyna magia, uzasadniona (user nie może z góry zaprojektować grupy dla powiązań, które inni dopiero stworzą)
+- Konfigurator atrybutu relation: bez defaultu grupy + akcja „+ Utwórz nową grupę" inline
+- **Spójność z resztą systemu:** każda grupa istnieje bo user ją utworzył, każda zakładka istnieje bo grupa ma `display_mode=tab`. Zero wyjątków
+- **`feature-modeling-relations-option-y-tickets.md` — MODRC-01..04** (~13-20h), supersedes MODR-02 (#924), MODR-06 (#928), MODR-07 (#929)
+
+---
+
+## 4. Kluczowe decyzje architektoniczne — kompendium
+
+### W kodzie (wprowadzone lub planowane)
+| # | Decyzja | Status |
+|---|---|---|
+| 1 | ObjectType = byt pierwszej klasy (ADR-009); Product/Category/Asset = built-in instancje | W systemie od dawna |
+| 2 | `is_built_in=true` flag różnicuje system entities od user entities | W systemie |
+| 3 | Capability flags na ObjectType: `show_in_main_menu`, `is_categorizable`, `has_variants`, (planowane: `has_media`) | Częściowo wdrożone (ADR-014) |
+| 4 | Hybrid attribute model (ADR-006) parametryzowany per ObjectType (ADR-009): base + cumulative primary category overlay | W systemie |
+| 5 | `object_relations` zastępuje `object_associations` (ADR-014) | MOD-02 #894 |
+| 6 | Relacja = typ atrybutu `relation` (Pimcore-style), placement po AttributeGroup + `display_mode` (Opcja 2) | MODR-01 #923 + MODR-03 #925 |
+| 7 | **Opcja Y dla Powiązań** — full un-seed, system reverse section | MODRC-01..04 (najnowsze) |
+| 8 | Universal list view: jeden `UniversalListPage` dla wszystkich ObjectType | **Shipped Epik UP** |
+| 9 | RBAC: 10 ról, 3-state per-attribute permissions, full scope w MVP-Alpha (ADR-013) | RBAC Phase 1-7 w toku |
+| 10 | RBAC permission model: generyczne `object.{view,create,edit,delete,export}` scope'owane per ObjectType | W planie (Phase 3) |
+| 11 | Audyt = RBAC permission `audit.view`, NIE flaga | Decyzja |
+| 12 | Multimedia → Droga B (Media Library Module), nie AttributeGroup | Decyzja, spec do zrobienia |
+
+### Filozoficzne (governance)
+| # | Reguła |
+|---|---|
+| 1 | „Predefiniowane ≠ hardcoded" — seedowane defaulty są OK, immutable code paths nie |
+| 2 | Flaga na ObjectType DOZWOLONA tylko gdy znaczy „integracja z System Module" (Kategorie, Media, Warianty, w przyszłości Cennik/Tłumaczenia). NIE „ma cechę X" |
+| 3 | Liczba flag = liczba Modułów (bounded), nie liczba feature'ów (unbounded slippery slope) |
+| 4 | Każda nowa flaga / koncept = świadoma decyzja po realnym sygnale, nie odruch |
+| 5 | „Magia" widoczności w UI = anty-wzorzec discoverability. Każde renderowanie ma świadomy „dlaczego" (user-defined) |
+| 6 | Wyjątek od reguły 5: systemowe widoki (reverse relations, audit log) — bo user nie może z góry projektować |
+| 7 | Sensible defaults > zero-config > magic — przy seedowaniu Producta na day-1 |
+
+---
+
+## 5. ADR-y dotknięte/utworzone w tej rozmowie
+
+| ADR | Status |
+|---|---|
+| ADR-009 (ObjectType first-class) | Bez zmian, ale interpretowany szerzej |
+| ADR-010 (axis-driven variants) | Bez zmian |
+| ADR-011 (per-tenant locale fallback) | Bez zmian |
+| ADR-012 (AttributeGroup first-class) | **REVERTed w 3 punktach przez ADR-014** |
+| ADR-013 (RBAC from day 1) | Bez zmian |
+| **ADR-014** | **UTWORZONY** — „Model dystrybucji atrybutów + relacje obiekt↔obiekt". REVERT Brand as 4th built-in, `category_attribute_groups` scoped to primary category, `EffectiveAttributeGroupResolver` base source dla każdego ObjectType. `object_relations` zastępuje `object_associations` |
+| ADR-014 update (planowany w MODRC-04) | Nota o Opcji Y (full un-seed Powiązań) |
+
+---
+
+## 6. Batche ticketów — status i zależności
+
+### MOD-01..14 (`feature-modeling-data-model-tickets.md`)
+Issues #893+ utworzone. Realizacja ADR-014. ~73-104h, ~2-3 tygodnie. Status per Sprint planning.
+
+**Krytyczne:**
+- MOD-01 #893 — schema delta (`is_categorizable`, relation config) ← `EffectiveAttributeGroupResolver` JUŻ istnieje
+- MOD-02 #894 — `object_relations` + drop `object_associations` (zero data, dormant tables)
+- MOD-03 — resolver fix #3-#28 (Category renderuje atrybuty)
+
+### MODR-01..11 (`feature-modeling-relations-ux-tickets.md`)
+Issues #923-933 utworzone. Opcja 2 (group decides placement). ~47-70h.
+
+**STATUS:** MODR-02 (#924), MODR-06 (#928), MODR-07 (#929) — **częściowo SUPERSEDED przez MODRC-01..03**. Pozostałe (01, 03, 04, 05, 08, 09, 10, 11) — wciąż ważne.
+
+### MODRC-01..04 (`feature-modeling-relations-option-y-tickets.md`)
+Issues #1080-1082 utworzone (MODRC-04 docs TBD). Decyzja Option Y. ~13-20h.
+
+- MODRC-01 #1080 — kasuj seed grupy Powiązania (refactor MODR-02)
+- MODRC-02 #1081 — konfigurator relacji bez defaultu + inline create grupy (refactor MODR-07)
+- MODRC-03 #1082 — system section „Powiązania zwrotne" (refactor MODR-06)
+- MODRC-04 — docs §3.5 + ADR-014 + lessons.md (rozszerza MODR-11)
+
+### ULV-01..12 (`feature-universal-object-list.md`)
+**Świadomie odrzucony epik** — Marcin uznał za „półśrodek". Zamiast tego:
+
+### Epik UP (UP-00..UP-11) — **SHIPPED 2026-05-25**
+`/products/{list,show,create}` wydzielone do `UniversalListPage` + `UniversalDetailPage` + `UniversalCreatePage`. Mountowane na `/products` ORAZ `/objects/:slug`. ADR-009 spłacony. Patrz `agent/current_status.md` per-PR record.
+
+### RBAC Phase 1-7 (89 ticketów, Issues #640-#728, milestones #9-#15)
+- Phase 1 (Foundation, milestone #9) — 10 ticketów: tooling, ADR-013, schema 10 tabel, seed, IdentityBundle skeleton, PHPStan rules
+- Phase 2 (Backend Auth, milestone #10) — 14 ticketów: JWT, email/password, API tokens, Tenant Context, Postgres RLS, Permission Resolver, MFA, SSO
+- Phase 3 (Permission Engine, milestone #11) — 14 ticketów: Voters, `#[RequiresPermission]`, 3-state attribute permissions, per-locale/channel scope, workflow-state policy, field-level filtering, audit, Super Admin bypass
+- Phase 4 (Frontend Core, milestone #12) — 13 ticketów
+- Phase 5 (Settings UI, milestone #13) — 22 tickety
+- Phase 6 (Refactor + Hardening, milestone #14) — 10 ticketów: retrofit `#[RequiresPermission]` do ~60 endpointów, CI gates lockdown
+- Phase 7 (Pentest + Launch, milestone #15) — 6 ticketów: red-team Marcina (15-point), optional external pentest, fix critical, user-facing docs (privacy/RODO), soft launch z 1-2 design partnerami
+
+---
+
+## 7. Sesje LLM Council — pełen rezultat
+
+### Round 1 (hardcoded attributes / Category)
+**Pytanie:** które bolączki naprawiać teraz vs odłożyć (Multimedia/Powiązania/Audyt hardcoded + Category cumulative overlay)?
+
+**Tally:**
+- Najmocniejsza: B (First Principles) — 4/5
+- Największy blind spot: D (Contrarian) — 3/5; A (Expansionist) — 2/5
+
+**Chairman verdict:**
+1. Multimedia → seedowana AttributeGroup. **TERAZ.** 1-2 dni. Jednogłośny kierunek
+2. Category overlay → **schema-level genericzność TERAZ (silnik `provides_schema_overlay`), UI universalizacja PÓŹNIEJ**. Tania rozdzielczość DB-schema vs UI
+3. AttributeGroups Audyt/Powiązania → ODŁÓŻ
+4. **Zadzwoń do klienta. 30 min.** Jedyna rzecz, której nikt z 5 doradców nie zrobił
+
+### Round 2 (Moduły vs Obiekty reframe + shipped UP)
+**Pytanie:** czy reframe jest dobrym rozwiązaniem czy regresją? Co z UP? Najmniejszy realny refactor?
+
+**Tally — UNANIMOUS:**
+- Najmocniejsza: D (Executor) — **5/5**
+- Największy blind spot: E (Expansionist) — **5/5**
+
+**Chairman verdict:**
+1. **STOP refactor. Zadzwoń do klienta.** Trzy pytania:
+   - Czy „Kategorie"/„Zdjęcia" w jego głowie to MIEJSCA obok Produktów, czy typy obiektów?
+   - Jakie inne „moduły" widzi w pierwszych 6 miesiącach (Cennik? Tłumaczenia? PDF?)?
+   - Czy ma znaczenie, że Kategorie są w sekcji „Modelowanie"?
+2. Jeśli klient potwierdza intuicję — D-zmodyfikowane przez Reviewer 4: ~4-6h zamiast 16h. Wykorzystaj istniejący `is_built_in=true`, NIE dodawaj `system_module` enum
+3. NIE rób: encji „Module", Module Registry, marketplace, pricing tierów. ADR-014 nie pisz — wystarczy notka w lessons.md
+4. **Koordynacja z RBAC Phase 3** — capability flag decyduje czy zakładka istnieje, RBAC decyduje co user widzi
+
+---
+
+## 8. Świadomie odrzucone alternatywy (zbiorczo)
+
+| # | Odrzucone | Powód |
+|---|---|---|
+| 1 | Warstwa „Object Template" nad ObjectType | Potworek duplikujący ObjectType, który już JEST template'em |
+| 2 | Osobny krok „Objekty" w wizardzie | Re-rozdziela relację od atrybutu (re-otwiera babol „Smoke test") |
+| 3 | Reguła „relacja zawsze zakładka" | Łamie Producent-inline use case (relacja do Brand w identity group) |
+| 4 | Mechanizm embed/kompozycji w MVP | YAGNI. Trigger: byt nigdy współdzielony bez własnej tożsamości |
+| 5 | Families à la Akeneo/Pimcore Classes teraz | Nie teraz. Trigger: tripwires (4+1 metryki). Resolver pozostaje czystą abstrakcją |
+| 6 | Flaga `has_relations` na ObjectType | Proliferacja flag → Pimcore Classes anti-pattern |
+| 7 | Seed grupy „Powiązania" jako built-in | Anti-pattern discoverability — magiczne tabs |
+| 8 | „Magiczna" widoczność zakładki przy populacji atrybutami | User nie ma jak odkryć tej reguły |
+| 9 | Encja „Module" / Module Registry / marketplace / pricing tiers w MVP | Premature platformization 24h po UP-ship bez pilota |
+| 10 | ADR-014 jako osobny ADR dla decyzji Module vs Object | Wystarczy nota w ADR-009 + lessons.md |
+| 11 | Multi-tab dla relacji (osobne „Powiązania handlowe"/"techniczne") | MVP: jedna zakładka. Furtka: zmiana seedu grup, nie architektury |
+| 12 | Multi-tenancy management UI w MVP | Świadoma decyzja operatora; DB/code hooks zachowane |
+| 13 | Mechanizm embed inline expand/edit jako default | Jako tryb opt-in widgetu relacji, nie default model |
+| 14 | „Audyt" jako capability flag | Audyt = RBAC permission, nie modeling decision |
+| 15 | Pełne uniwersalizowanie Category overlay w MVP (Wave A z R1) | UI-level repositioning + schema-level genericity OK, ale full universal odłożone |
+
+---
+
+## 9. Outstanding actions — co realnie czeka
+
+### Numer 1, blocker wszystkiego (powtórzone z 2 rad)
+**ZADZWOŃ DO PIERWSZEGO KLIENTA. 30 minut. Trzy pytania:**
+1. Jakie typy obiektów oprócz Produktów chce zarządzać w PIM w pierwszych 6 miesiącach?
+2. Czy ma use case użycia overlay atrybutów po kategorii dla czegoś poza produktem?
+3. Czy widoczność „Multimedia"/„Kategorie" jako stałych zakładek/sekcji vs konfigurowalnych ma dla niego znaczenie?
+
+Bez tej rozmowy każdy refactor jest spekulacją. Powtórzone 2x przez 2 niezależne rady.
+
+### Numer 2 — Multimedia jako Module Library
+Operator zdecydował: **Droga B**. Spec do zrobienia osobnym dokumentem. Module Library w sidebarze („Moduły → Multimedia"), pliki współdzielone między ObjectType, podpinane przez relację. `has_media` flag = integracja z Modułem.
+
+### Numer 3 — Kategorie jako System Module
+Analogicznie do Multimediów, Kategorie jako osobny Moduł (drzewo w sidebarze), nie jako jeden z ObjectType w „Modelowanie → Obiekty". Spec do zrobienia.
+
+### Numer 4 — Audyt jako RBAC permission
+Permission `audit.view` w PRD-PIM-rbac. Implementacja w RBAC Phase 3.
+
+### Numer 5 — Capability flag × RBAC collision resolution
+Zanim wprowadzisz `has_variants`/`has_media` jako flagi, ustal hierarchię w voterze: **capability flag decyduje czy zakładka istnieje, RBAC attribute permission decyduje co user widzi wewnątrz**. 1-2h decyzji designerskiej. Koordynacja z Phase 3 Permission Engine.
+
+### Numer 6 — `geo`/map attribute type
+Potencjalna luka. Zweryfikować czy `AttributeType` enum ma `geo`. Jeśli nie — osobny ticket (lokalizacja na mapie dla Salonu, dowolnego obiektu).
+
+### Numer 7 — MODRC-01..04 implementation
+4 tickety, ~13-20h, ~3-4 dni solo dev. Po fakcie: update §3.5 + ADR-014 + cross-ref w starym pliku ticketów.
+
+---
+
+## 10. Pułapki / gotchas dla nowego agenta
+
+1. **NIE confunduj „hardcoded" z „seedowane built-in".** Operator wielokrotnie wracał do tego. Seedowane = OK (Product to też seed). Hardcoded immutable code path = źle. Test: czy user może edytować zawartość? Czy może w przyszłości usunąć? Jeśli tak — to seed, nie hardcode
+
+2. **Jeśli sugerujesz seedowanie czegoś jako built-in — zastanów się czy nie powtarzasz Option Z** (seed + hide when empty). Operator JEDNOZNACZNIE odrzucił to jako anti-pattern discoverability. Option Y wymaga świadomego tworzenia przez usera
+
+3. **Capability flag bounded pattern:** flaga = integracja z System Module, NIE „ma cechę X". Każda nowa flaga wymaga, żeby pierwej powstał odpowiadający Moduł (z własnym UI/storage/API namespace). Inaczej wracasz do Pimcore Classes
+
+4. **NIE proponuj rozwiązań platformowych** (Module Registry, marketplace, pricing tiers, plugin system) **pre-MVP-Alpha bez pilota**. To E (Expansionist) blind spot — 5/5 unanimously flagged. Operator odrzuci. ADR-013 i CLAUDE.md zwalczają over-engineering
+
+5. **Operator MA RACJĘ co do flag proliferation.** Jeśli zauważasz w swoim rozwiązaniu trzecią flagę typu `has_X` — STOP. Możliwe, że proponujesz Pimcore-trap
+
+6. **Test discoverability każdej propozycji UX:**
+   - Skąd user ma wiedzieć, że X istnieje?
+   - Jak go odkryje? (eksploracja, dokumentacja, przypadek?)
+   - Jeśli „przypadek" — to anty-wzorzec
+
+7. **`is_built_in` JUŻ JEST** od ADR-009. Nie dodawaj `system_module` enum / nowej kolumny dla rozdzielenia system vs user entities. Reuse istniejący flag
+
+8. **UP epik shipped. NIE cofaj.** `/products` to `<UniversalListPage objectTypeId={productTypeId} />`. Dorób cienką warstwę nawigacji jeśli trzeba, ale silnik zostaje
+
+9. **Operator ma EPIK MARATHON RULE w CLAUDE.md.** Gdy mówi „przez cały epik" — każdy ticket osobny PR, bez deferrowania, bez bundle'owania. Powtarzające się ostrzeżenie z lessons.md (UI-02 marathon źródło)
+
+10. **SMOKE TEST RULE i CLOSED MEANS CLOSED RULE — NIENEGOCJOWALNE.** Przed claim „działa" w PR — manual smoke test. `gh issue close` — proof live-stack w close comment. Lessons z 2026-05-18 (RBAC re-audit, 9/14 ticketów źle zamkniętych, ~25h dorobionej pracy)
+
+11. **Zadzwoń do klienta = REAL blocker.** Jeśli operator nie zadzwonił, nie podejmuj kolejnych decyzji architektonicznych dotykających Modułów. Pchaj go do tego telefonu jak czarny pies
+
+12. **PRD-PIM-rbac §3.5 — 3-state positive grants** (restricted/view/edit). NIE proponuj negative blacklisting. Resolution order: attribute → group → role-default. Custom role builder w Phase 5
+
+13. **Multimedia idzie Drogą B** (Module Library), NIE A (AttributeGroup). Operator wyraźnie zdecydował. Niezależnie od ostatecznych decyzji o Powiązaniach
+
+14. **Komunikuj po polsku** (komentarze GH, dokumentacja, rozmowa z operatorem). Kod, branche, commits w angielskim (Conventional Commits, sekcja CLAUDE.md). Brak `Co-Authored-By` AI
+
+15. **Pliki utrzymywane atomowo** (per CLAUDE.md): `agent/current_status.md`, `agent/lessons.md`, `Project Plan/02-plan-projektu-pim.md`, `Project Plan/01-architektura-pim.md` (ADR), `Project Plan/06-sprint-0-findings.md`, `docs/api-spec/v{version}.json`, `Project Plan/UI/Wdrozenie_grafiki/`, RBAC backlog 08-14
+
+---
+
+## 11. Tripwires for model revision (do referencji)
+
+Kiedy podjąć decyzję o Families (lub innym refactorze podstawowej architektury):
+
+| # | Metryka | Tripwire |
+|---|---|---|
+| 1 | p95 liczby efektywnych atrybutów na obiekt | >150 |
+| 2 | % grup atrybutów podpiętych w wielu niespokrewnionych węzłach | >30% |
+| 3 | Mediana liczby zmian primary category obiektu w pierwszych 30 dniach | >1-2 |
+| 4 | Rozkład completeness per ObjectType | garbi się przy 60-70% |
+| 5 | Tempo tworzenia atrybutów ad hoc | >200/miesiąc/tenant |
+
+**Trigger refactoru:** ≥2 metryki nad progiem u ≥2 niezależnych tenantów.
+
+**Pułapka:** Ad hoc atrybuty (metryka 5) MASKUJĄ pozostałe. Czytać razem, nie zamiast.
+
+**Stress test przed produkcją** (świadoma decyzja operatora):
+Zamiast czekać na klienta — wygeneruj syntetyczny katalog: 200 kategorii, drzewo 5-6 poziomów, 100k+ atrybutów. Załaduj, otwórz formularz produktu na najgłębszym liściu. Mierz 4 metryki. Jeśli p95 wybucha — wiesz przed pierwszym klientem.
+
+---
+
+## 12. Mapa nazw / glossariusz
+
+| Termin | Znaczenie |
+|---|---|
+| ObjectType | byt pierwszej klasy (ADR-009); Product/Category/Asset = built-in instancje (`is_built_in=true`) |
+| ObjectType custom | user-defined ObjectType (Samochody, Dostawcy itp.); `is_built_in=false` |
+| AttributeGroup | grupa atrybutów; renderuje się jako zakładka (`display_mode=tab`) lub sekcja inline (`stacked`) |
+| `object_type_attributes` | junction ObjectType×Attribute; nosi `display_mode`, `show_in_list`, `list_position` |
+| `object_type_attribute_groups` | junction ObjectType×AttributeGroup; nosi `display_mode` per kontekst |
+| `object_relations` | tabela powiązań obiekt↔obiekt; zastępuje `object_associations` (ADR-014) |
+| `object_associations` | DEPRECATED — usuwane przez MOD-02 |
+| `EffectiveAttributeGroupResolver` | single chokepoint liczący efektywny zbiór grup atrybutów dla obiektu. Implementowany, czysty, nie hardcodować |
+| Primary category | jedyna kategoria z `is_primary=true` na obiekcie; sterowca cumulative overlay |
+| Secondary categories | dodatkowe kategorie obiektu; NIE wpływają na schemat |
+| Cumulative overlay | atrybuty z primary category dodawane kumulatywnie po ścieżce w drzewie |
+| Built-in flag | `is_built_in=true` — predefiniowane byty (Product, Category, Asset, system groups). Chronione przed deletion, ale edytowalne w zawartości |
+| Capability flag | flaga na ObjectType wyrażająca integrację z System Module (`is_categorizable`, `has_media`, `has_variants`) |
+| System Module | predefiniowany podsystem z własnym UI (Kategorie, Media Library, w przyszłości Cennik). Włączany per tenant. Wyłącznie kontrolowany przez kod platformy, nie przez usera |
+| User Entity | byt definiowany przez usera (Product instance, custom Samochód instance, AttributeGroup utworzona przez usera) |
+| System Entity | predefiniowany byt platformowy (Tenant, User, Role, Category jako Module, Asset jako Module) |
+| Provenance | pole `manual|import|agent|integration` na `object_values` z meta JSONB. UI pokazuje badge'e |
+| Powiązania zwrotne (reverse relations) | automatycznie generowane z `object_relations` po `target_object_id`. Read-only. Po Opcji Y: systemowa wirtualna zakładka |
+| Opcja 2 | placement po AttributeGroup + display_mode. Relacja to zwykły typ atrybutu. Decyzja z §3.5 mini-speca |
+| Opcja Y | rozszerzenie Opcji 2 — pełne odseedowanie grupy Powiązania. User świadomie tworzy grupę. Jedyna magia = system reverse section |
+
+---
+
+## 13. Pliki kluczowe do przeczytania PRZED kolejną decyzją
+
+Krytyczne (must read):
+1. `CLAUDE.md` (root + dev/PIM) — konstytucja projektu
+2. `Project Plan/01-architektura-pim.md` — ADR-014, sekcja 14 Roadmap
+3. `Project Plan/UI/feature-modeling-data-model.md` — mini-spec ADR-014 (UWAGA: §3.5 nieaktualne przed MODRC-04)
+4. `Project Plan/UI/feature-modeling-relations-option-y-tickets.md` — najnowsze tickety MODRC
+5. `Project Plan/PRD/PRD-PIM-rbac.md` v2.1 — RBAC master spec
+6. `agent/current_status.md` — gdzie jesteśmy
+
+Pomocnicze:
+- `Project Plan/UI/feature-universal-object-list.md` — shipped status UP
+- `Project Plan/UI/feature-modeling-data-model-tickets.md` — MOD-01..14
+- `Project Plan/UI/feature-modeling-relations-ux-tickets.md` — MODR-01..11 (z notą supersede)
+- `Project Plan/07-rbac-implementation-plan.md` + `08-rbac-tickets-phase-1.md..14-rbac-tickets-phase-7.md`
+- `agent/lessons.md` — wzorce sukcesu i porażki
+
+---
+
+## 14. Co teraz — recommended next steps
+
+W kolejności:
+
+1. **TELEFON DO KLIENTA** (30 min, 3 pytania, dziś)
+2. Update `feature-modeling-data-model.md` §3.5 + ADR-014 + lessons.md — Opcja Y (MODRC-04, 2-3h)
+3. Implementacja MODRC-01 (kasuj seed grupy Powiązania, 2-4h)
+4. Implementacja MODRC-02 + MODRC-03 (frontend, równolegle, 9-13h)
+5. Rozstrzygnięcie capability flag × RBAC collision (1-2h designerskie, koordynacja z Phase 3)
+6. Mini-spec dla Multimedia jako Media Library Module (jeśli klient potwierdza)
+7. Mini-spec dla Kategorii jako System Module (jeśli klient potwierdza)
+8. Powrót do RBAC Phase 2 / Phase 3 implementacji
+
+---
+
+## 15. Sygnały, że nowy kierunek jest dobry/zły
+
+**Dobre sygnały:**
+- Nowa decyzja redukuje liczbę konceptów (nie dodaje)
+- Wykorzystuje istniejący `is_built_in`, `display_mode`, capability flags zamiast nowych kolumn
+- User widzi w UI bez dokumentacji JAK to działa (discoverable)
+- Nie wprowadza encji „X-as-a-platform" przed pilotem
+- Spójne z istniejącym wzorcem (np. jeśli wszystkie grupy są user-defined, ta też)
+
+**Czerwone alarmy:**
+- Propozycja: czwarta flaga typu `has_X` w ciągu sesji
+- Propozycja: nowa encja architektoniczna („Module", „Template", „Plugin", „Registry")
+- Propozycja: „magicznie pojawia się" / „automatycznie wyświetla" / „intuicyjnie zrozumie"
+- Refactor shipped epiku bez sygnału z produkcji
+- Estymata >40h dla refactoru pre-MVP-Alpha bez pilota
+- Decyzja podejmowana 24h po shipping bez nowych danych
+
+---
+
+*Handoff utworzony 2026-05-28. Czytaj sekcję 0 i 9 minimum. Reszta na zawołanie.*

--- a/agent/handoff-marathon-2026-05-30.md
+++ b/agent/handoff-marathon-2026-05-30.md
@@ -1,0 +1,48 @@
+# Prompt startowy — kontynuacja marathonu bug-fix (smoke test 2026-05-30)
+
+> Wklej treść poniżej („=== PROMPT ===") jako pierwszą wiadomość w nowej sesji.
+> Zawiera pełen kontekst + gotchy, żeby nie odkrywać ich od nowa.
+
+---
+=== PROMPT ===
+
+Kontynuujemy batch bug-fix z manualnego smoke testu operatora (2026-05-30), issues #1130–#1147 w repo `malipie/PIM`.
+
+## Stan na teraz (zrobione w poprzedniej sesji)
+**14 z 18 zgłoszeń wdrożone na `main`** (PR-y #1157–#1166), każde z live-stack smoke + zielonym CI:
+- #1141 MFA enforcement przy logowaniu (KRYTYCZNE) · #1143 miniatury 403 · #1142 redirect /settings · #1144 przycisk „Dodaj" · #1136 systemowe atrybuty · #1145 presety Smart Filters scope · #1131/#1132/#1133 ObjectType wizard cleanup · #1134/#1135 widok kategorii · #1139/#1140 grupa atrybutów · #1137 zmiana nazwy kategorii.
+
+Stack lokalny jest UP na `main`, login `admin@demo.localhost / changeme` → 200, MFA posprzątane (admin niezablokowany).
+
+## Do zrobienia (4 pozostałe — pełne tickety już rozpisane w issue)
+1. **#1130 import round-trip** (duży, data-critical, BE). Root cause = 4 niezgodności:
+   - composite values: eksport pisze `"20.99 EUR"`/`"0.3 g"`, import `ImportValidationService::validateScalarType` (`apps/api/src/Import/Application/Service/ImportValidationService.php:277`) robi tylko `is_numeric` → odrzuca.
+   - kolumny lokalizowane: eksport `name.pl`, import wymaga gołego `name` (`ImportValidationService.php:37` REQUIRED=['sku','name']) + `AutoMapper` normalizuje `name.pl`→`namepl`≠`name` → unmapped → „Missing required name".
+   - kolumny systemowe (`created_at`…) w eksporcie → import powinien auto-SKIP.
+   - sparse cells: `ImportRowReader.php:69-84` mapuje pozycyjnie `headers[$i]=>cells[$i]` → mapować po cell-coordinate.
+   - Pliki: `Import/Application/Service/{ImportValidationService,ImportRowReader,AutoMapper}.php`, persistence handler, `Export/Application/Builder/{ColumnResolver,ValueSerializer}.php`. Plik testowy operatora: `Zrodla/importy/import pim-export-20260530-144844.xlsx`.
+2. **#1138 atrybut asset jako picker** (FE+BE). `attr-row.tsx` nie ma case'a `asset` → fallback do `<Input text>`. Istniejący `features/catalog/products/components/asset-library-picker.tsx` jest sprzężony z produktem (POST `/api/products/{id}/assets`, `onPicked()` nic nie zwraca) → trzeba wariant zwracający asset-id. Wartość = referencja asset id w envelope; podgląd przez `/api/assets/{id}/preview` (działa po #1143).
+3. **#1146 wersje językowe** (epik, parent + sub #1148–#1152) — **design-first / Plan Mode**. Cross-context: read/zapis wartości per-locale dla wszystkich ObjectType, dynamiczny picker z `/api/tenant-locales`, flaga `is_localizable`, completeness per-locale.
+4. **#1147 kanały** (epik, parent + sub #1153–#1156) — **design-first / Plan Mode**. Strona ustawień kanałów + `/api/channels`, read/zapis per-channel, picker dynamiczny.
+
+## Jak procedować
+- **Najpierw przeczytaj treść każdego issue** (`gh issue view <N>`) — mają pełny root cause + affected files + acceptance.
+- #1146/#1147 → **Plan Mode** (to epiki). #1130/#1138 → SKILL-BUG-FIX-TICKET.
+- Każdy ticket = własny branch + PR + CI + merge (marathon rules w CLAUDE.md). Tickety w tym samym pliku można grupować w 1 PR (udokumentuj w opisie).
+- Plan referencyjny wszystkich 18: `~/.claude/plans/efektem-planu-niech-b-d-enumerated-fox.md`.
+
+## Gotchy z poprzedniej sesji (NIE odkrywaj od nowa)
+- **`composer audit` czerwony w CI = PRE-EXISTING**, NIE blokuje merge: (a) krok CI odpala audit bez `composer install` („No installed packages"), (b) realne advisory `twig/twig` CVE-2026-46634 / CVE-2026-47732. `main` jest **nieprotected** (brak required checks) — te same czerwone na #1129 i wcześniej. → Osobny maintenance ticket: bump twig + fix kroku CI (`--locked` albo dodać install).
+- **`gh pr checks <pr>` bywa nieaktualne** (pokazuje „pending" gdy job już `completed success`). Weryfikuj przez `gh run view <run-id> --json jobs -q '.jobs[]|...'`.
+- **PHPUnit w CI ~17-18 min** (wolny). PR-y FE-only pomijają joby PHP (path filter) → szybsze.
+- **Stack**: `docker compose` już UP. Po `git checkout`/zmianie kodu API: `docker compose restart api` (FrankenPHP worker; ~6s warmup, pierwszy request może dać 502 zanim się rozgrzeje).
+- **PHPUnit Api/***: `docker compose exec -T -e APP_ENV=test api php bin/console cache:clear --env=test` PRZED runem (kolizja z dev DB — memory `feedback_phpunit_dev_db_collision.md`).
+- **Ścieżki w kontenerze api** są względne do `apps/api` (kontener `/app` = `apps/api`). PHPStan: `vendor/bin/phpstan analyse src/... tests/... --level=max`.
+- **Smoke TOTP** liczony pythonem (hmac-sha1 + base32, period 30). Po smoke MFA na adminie — ZAWSZE disable na końcu (inaczej blokada logowania).
+- **Admin typecheck/build**: `NODE_OPTIONS=--max-old-space-size=4096` (OOM — memory `feedback_tsc_memory_limit_pim.md`).
+- Komendy nie-readonly (docker/gh/git push) odpalaj z `dangerouslyDisableSandbox`.
+- Konwencje: `type(scope): subject` ang., PR body PL, BEZ `Co-Authored-By`, stopka `🤖 Generated with [Claude Code]`. PATCH atrybutów: `{attributes:{code: value}}` (upserter owija w `{value}`).
+
+Zacznij od przeczytania issue #1130, #1138, #1146, #1147 i zaproponuj kolejność (proponuję: #1130 → #1138 → Plan Mode #1146 → Plan Mode #1147), potem ruszaj marathonem.
+
+=== /PROMPT ===

--- a/agent/pimcore-akeneo-attribute-types.md
+++ b/agent/pimcore-akeneo-attribute-types.md
@@ -1,0 +1,220 @@
+# Typy atrybutów — Pimcore vs Akeneo
+
+> Źródła: docs.pimcore.com (2024.x/2025.x), help.akeneo.com (Serenity)
+> Data: 2026-05-31
+
+---
+
+## PIMCORE
+
+Pimcore organizuje typy danych w **kategorie**. Każdy typ to osobna klasa PHP dziedzicząca z `Pimcore\Model\DataObject\ClassDefinition\Data`. Typy mogą być używane wewnątrz Class Definition, Object Bricks, Field Collections i Classification Store.
+
+---
+
+### 1. Typy tekstowe (Text Types)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Input** | Jednolinijkowe pole tekstowe | Długość maksymalna (VARCHAR), wartość domyślna |
+| **Textarea** | Wielolinijkowy tekst bez formatowania | Kolumna TEXT w DB |
+| **WYSIWYG** | Edytor rich-text (HTML) — przechowuje HTML, obsługuje linki do assetów i dokumentów | Brak walidacji wbudowanej; zależności do assetów śledzone automatycznie |
+| **Password** | Pole hasła z ukrytymi znakami; hash algorytmem konfigurowalnym (bcrypt, argon2 itp.) | Algorytm hashowania; długość nie jest konfigurowalna (hash jest zawsze stały) |
+| **Input Quantity Value** | Tekst + jednostka miary (wariant Input Quantity Value dla wartości nie czysto numerycznych) | Lista dozwolonych jednostek (globalna lub per-pole) |
+
+---
+
+### 2. Typy numeryczne (Number Types)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Numeric** | Liczba całkowita lub dziesiętna (DOUBLE w DB) | Wartość domyślna, min/max (opcjonalne) |
+| **Numeric Range** | Dwa pola Numeric (minimum + maksimum) | Jak Numeric, para wartości |
+| **Slider** | Suwak poziomy lub pionowy (DOUBLE w DB) | **Wymagane**: wartość min, max, krok (step), precyzja dziesiętna; orientacja (horizontal/vertical) |
+| **Quantity Value** | Liczba + jednostka miary; obsługuje konwersję jednostek (np. km → m) | Lista globalnych jednostek; możliwość ograniczenia per-pole; konwersja przez bazową jednostkę + współczynnik + offset |
+| **Quantity Value Range** | Para pól Quantity Value (min + max) | Jak Quantity Value |
+
+---
+
+### 3. Typy wyboru (Select Types)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Select** | Lista rozwijana, jedna wartość (VARCHAR) | Opcje: wartość + etykieta wyświetlana; wartość domyślna |
+| **Multiselect** | Lista wielokrotnego wyboru (TEXT, wartości CSV) | Opcje: wartość + etykieta; tryb renderowania: list lub tags |
+| **Country** | Select z predefiniowanymi kodami krajów ISO | Brak dodatkowych walidacji |
+| **Country Multiselect** | Multiselect krajów ISO | Brak dodatkowych walidacji |
+| **Language** | Select z lokale systemowymi (ograniczone do aktywnych w systemie) | Opcjonalne: tylko języki aktywne |
+| **Language Multiselect** | Multiselect lokale systemowych | Jak Language |
+| **User** | Select użytkowników systemu Pimcore (powiązanie z user management) | Brak dodatkowych walidacji |
+
+---
+
+### 4. Typy daty i czasu (Date Types)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Date** | Pole daty (kalendarz w UI) | Wartość domyślna; zakres min/max (opcjonalne) |
+| **Datetime** | Data + godzina | Wartość domyślna; zakres min/max |
+| **Time** | Tylko godzina (format HH:MM:SS) | Min/max godzina |
+| **Date Range** | Para pól daty (from–to) | Jak Date, dwa pola |
+
+---
+
+### 5. Typy geograficzne (Geographic Types)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Geopoint** | Para lat/lng; widżet mapy w UI | Brak dodatkowych walidacji; przechowywane w dwóch kolumnach |
+| **Geobounds** | Prostokąt geograficzny: NE + SW punkt | Dwie pary lat/lng |
+| **Geopolygon** | Dowolna liczba punktów tworzących obszar (LONGTEXT, serialized array) | Brak dodatkowych walidacji |
+| **Geopolyline** | Dowolna liczba punktów tworzących linię (LONGTEXT, serialized array) | Brak dodatkowych walidacji |
+
+---
+
+### 6. Typy relacji (Relation Types)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Many-To-One Relation** | Relacja do jednego elementu Pimcore (dokument, asset, obiekt) | Konfigurowalny typ dozwolonych elementów (object/document/asset) i podtyp |
+| **Many-To-Many Relation** | Relacje do wielu elementów Pimcore (dowolny typ) | Konfigurowalny typ; lazy loading |
+| **Many-To-Many Object Relation** | Relacje do wielu obiektów (tylko obiekty, nie dokumenty/assety) | Ograniczenie do klas obiektów; lazy loading |
+| **Advanced Many-To-One Object Relation** | Relacja do obiektu + metadane na relacji (text, number, select, boolean); tylko jedna dozwolona klasa | Typy i liczba kolumn metadanych; jedna dozwolona klasa |
+| **Advanced Many-To-Many Relation** | Relacje do wielu elementów dowolnego typu + metadane (ElementMetadata) | Typy kolumn metadanych |
+
+---
+
+### 7. Typy mediów / obrazów (Media Types)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Image** | Pojedynczy obraz (link do assetu) | Konfigurowalny miniaturowy widok w UI |
+| **Image Gallery** | Kolekcja obrazów | Brak dodatkowej walidacji poza relacją do assetów |
+| **Hotspot Image** | Obraz z obszarami klikalnymi (hotspoty/markery z metadanymi) | Metadane hotspota: typ, pozycja, rozmiar |
+| **Video** | Link do wideo (asset lub zewnętrzny URL: YouTube, Vimeo, Dailymotion) | Typ źródła (asset/youtube/vimeo/url) |
+| **External Image** | Obraz z zewnętrznego URL (przechowuje URL, nie pobiera do assetu) | Brak walidacji URL |
+
+---
+
+### 8. Typy strukturalne (Structural / Container Types)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Block** | Tablica powtarzalnych grup prostych pól wewnątrz obiektu (przechowywane serializowane w DB, nie są oddzielnymi encjami) | Dowolne typy prostych pól wewnątrz; brak walidacji strukturalnej |
+| **Field Collections** | Predefiniowane zestawy pól wielokrotnego użytku; każda kolekcja to oddzielna tabela DB; dowolna liczba instancji per obiekt | Własna definicja klasy kolekcji; możliwość ograniczenia dozwolonych typów kolekcji |
+| **Object Bricks** | Dodatkowe zestawy atrybutów dokładane do obiektu; jedno na obiekt per typ bricka (w przeciwieństwie do Field Collections) | Własna definicja klasy bricka; możliwość włączenia/wyłączenia per obiekt |
+| **Classification Store** | Dynamiczne klucze atrybutów organizowane w grupy i kolekcje; klucz może należeć do wielu grup; przeznaczony do dużej liczby kategorii (>30) | Klucze: dowolny prosty typ danych; soft-delete kluczy (flaga enabled=0); wiele kolekcji per obiekt |
+| **Localized Fields** | Kontener dla pól tłumaczonych per locale; wartości przechowywane w osobnej tabeli `object_localized_fields_ID` | Obsługiwane typy wewnątrz: wszystkie proste typy oprócz relacyjnych |
+
+---
+
+### 9. Pozostałe typy (Others)
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Checkbox** | Pole logiczne (TINYINT 0/1) | Wartość domyślna (zaznaczony/odznaczony) |
+| **Boolean Select** | Trójstanowy checkbox (checked=1, unchecked=-1, empty=null) — rozwiązuje problem dziedziczenia zwykłego Checkbox | Konfigurowalne etykiety dla yes/no/empty |
+| **Link** | URL z tytułem, targetem i parametrami; przechowywany jako serialized TEXT | Brak wbudowanej walidacji URL |
+| **RGBA Color** | Kolor w formacie RGBA; picker w UI; hex w DB (dwie kolumny: RGB + Alpha) | Brak dodatkowych walidacji |
+| **Encrypted Field** | Szyfruje wartość dowolnego innego pola (AES-256 przez `defuse/php-encryption`) | Wymagany klucz szyfrowania w config; strict mode (exception gdy brak deszyfrowania) |
+| **URL Slug** | SEO-friendly URL dla obiektu; Pimcore obsługuje routing per slug | Niedozwolone znaki `?` i `#`; brak wbudowanej walidacji unikalności (globalna w Pimcore) |
+| **Table** | Prosta tabela wartości wewnątrz obiektu | Konfigurowalny rozmiar tabeli |
+| **Consent** | Zgoda GDPR z datą, timestampem i notką | Brak dodatkowych walidacji |
+
+---
+
+---
+
+## AKENEO (Serenity — wersja SaaS)
+
+Akeneo używa pojęcia **Family** (rodzina) — atrybuty są przypisywane do rodzin, a produkty należą do rodzin. W Serenity dostępnych jest **17 typów atrybutów**.
+
+Każdy atrybut może być:
+- **scopable** (różne wartości per kanał)
+- **localizable** (różne wartości per locale)
+- **locale-specific** (widoczny tylko dla wybranych lokali)
+- **read-only** *(Enterprise only)*
+- **mandatory** (wymagany przy tworzeniu/aktualizacji produktu; max 5 atrybutów)
+- **usable in grid** (jako kolumna lub filtr w liście produktów)
+
+---
+
+### Typy atrybutów Akeneo
+
+| Typ | Opis | Walidacje / konfiguracja |
+|---|---|---|
+| **Identifier** | Unikalny kod identyfikujący produkt; do 20 identyfikatorów per katalog; jeden z nich jest głównym (SKU by default) — obowiązkowy do tworzenia produktów | **GTIN**: 8, 12, 13 lub 14 cyfr + checksum; wartość unikalna per produkt (nienegocjowalne) |
+| **Text** | Jednolinijkowy tekst (VARCHAR 255) | Max liczba znaków (limit 255); reguła walidacji: URL / Email / Regex; **GTIN** (jak wyżej); przeszukiwalny w głównym pasku wyszukiwania (do 20 atrybutów) |
+| **Text Area** | Wielolinijkowy tekst (TEXT, do 65 535 znaków); opcjonalny edytor rich-text (WYSIWYG) | Max liczba znaków; rich text editor on/off; usuwanie formatowania HTML przy wklejaniu; lista niedozwolonych znaków (Unicode code points) |
+| **Simple Select** | Jednokrotny wybór z predefiniowanej listy opcji | Wartość domyślna; auto-tworzenie nowych opcji podczas importu (opcjonalne) |
+| **Multi Select** | Wielokrotny wybór z predefiniowanej listy opcji | Wartość domyślna; auto-tworzenie nowych opcji podczas importu |
+| **Yes/No** | Wartość logiczna (boolean) | Wartość domyślna (ustawiana przy tworzeniu produktu z przypisaną rodziną) |
+| **Date** | Data (picker kalendarzowy); format: tylko data `YYYY-MM-DD` lub data+czas `YYYY-MM-DD HH:MM` | Min date; max date; format (beta): date / datetime |
+| **Number** | Liczba (całkowita lub dziesiętna) | Allow decimals; allow negative values; min value; max value; strategia dziesiętna: zaokrąglenie / stała liczba miejsc / trim zer |
+| **Measurement** | Liczba + jednostka miary z przeliczaniem jednostek między kanałami | Allow decimals; allow negative values; min/max value; measurement family (waga, długość, obszar...); domyślna jednostka; strategia dziesiętna |
+| **Price** | Wartość ceny per waluta; wyświetlane waluty zależą od aktywnych walut w PIM | Allow decimals; min/max value; zawsze 2 miejsca dziesiętne w eksporcie |
+| **Image** | Wgrywany obraz (drag & drop) | Max rozmiar w MB; dozwolone rozszerzenia (gif, jfif, jpeg, jpg, pdf, png, psd, tif, tiff) |
+| **File** | Wgrywany plik (drag & drop) | Max rozmiar w MB; dozwolone rozszerzenia (csv, doc, docx, mp3, pdf, ppt, pptx, rtf, svg, txt, wav) |
+| **Asset Collection** *(Enterprise only)* | Kolekcja cyfrowych zasobów: obrazy, PDF, wideo (YouTube), łączona z rodziną assetów DAM | Max liczba elementów w kolekcji; powiązana rodzina assetów (asset family) |
+| **Reference Entity Simple Link** *(Enterprise only)* | Jeden link do rekordu Reference Entity (bogate dane strukturalne: tekst, obrazy) | Powiązana Reference Entity |
+| **Reference Entity Multiple Links** *(Enterprise only)* | Wiele linków do rekordów Reference Entity | Powiązana Reference Entity |
+| **Table** *(Enterprise + Growth)* | Wielowymiarowe dane w tabeli z konfigurowalnymi kolumnami różnych typów | Per kolumna: text (max 300 znaków), number (decimals, min/max, default), select (default) |
+| **Product Link** | Łączy produkty jako komponenty (Composable Products); nowość Serenity | Brak dodatkowych walidacji |
+
+---
+
+### Właściwości walidacji wspólne dla wszystkich atrybutów Akeneo
+
+| Właściwość | Typy atrybutów | Opis |
+|---|---|---|
+| Unique value | Identifier, Text, Number | Wartość musi być różna dla każdego produktu |
+| Value per channel | wszystkie oprócz Identifier | Różne wartości per kanał |
+| Value per locale | wszystkie oprócz Identifier, Price | Różne wartości per locale |
+| Read-only | wszystkie *(EE only)* | Edycja tylko przez import/API/reguły |
+| Mandatory | Identifier, Simple Select, Number, Ref Entity Single, Text, Text Area, Yes/No | Wymagane przy tworzeniu/aktualizacji; max 5 atrybutów |
+
+---
+
+### Konwersja i migracja typów (Akeneo Serenity, nowość 2025)
+
+Akeneo umożliwia zmianę typu atrybutu bez utraty danych w określonych ścieżkach:
+
+| Z | Na |
+|---|---|
+| Text | Text Area |
+| Number | Text, Text Area |
+| Identifier | Text (zachowuje unique) |
+| Simple Select | Text, Text Area, Multiselect, Ref Entity Simple/Multi |
+| Multiselect | Ref Entity Multi Link |
+| Ref Entity Simple | Ref Entity Multi Link |
+
+---
+
+## Podsumowanie porównawcze
+
+| Cecha | Pimcore | Akeneo |
+|---|---|---|
+| Liczba typów | ~30+ (łącznie z strukturalnymi) | 17 (Serenity); część tylko EE |
+| Typy geograficzne | ✅ Geopoint, Geobounds, Geopolygon, Geopolyline | ❌ Brak |
+| Rich text / WYSIWYG | ✅ Osobny typ | ✅ Opcja w Text Area |
+| Relacje obiekt↔obiekt | ✅ 5 typów z metadanymi | ✅ Reference Entity (EE), Product Link |
+| Dynamiczne atrybuty | ✅ Classification Store | ❌ Brak (stała struktura Family) |
+| Reusable sets of fields | ✅ Field Collections, Object Bricks | ❌ Brak |
+| Szyfrowanie pól | ✅ Encrypted Field | ❌ Brak |
+| GTIN walidacja | ❌ Brak wbudowanej | ✅ Na Identifier i Text |
+| Regex walidacja | ❌ Brak wbudowanej (custom validator) | ✅ Na Text |
+| Przeliczanie jednostek | ✅ Quantity Value (auto-konwersja) | ✅ Measurement (przeliczanie per kanał) |
+| Wielowalutowość | ❌ Brak dedykowanego typu | ✅ Price per currency |
+| Tłumaczenia atrybutów | ✅ Localized Fields (kontener) | ✅ Właściwość per atrybut (localizable) |
+| Zmiana typu atrybutu | ❌ Ręcznie (eksport → usuń → stwórz → import) | ✅ Migracja przez UI (wybrane ścieżki) |
+
+---
+
+*Źródła:*
+- [Pimcore Object Data Types](https://docs.pimcore.com/platform/Pimcore/Objects/Object_Classes/Data_Types/)
+- [Pimcore Number Types](https://pimcore.com/docs/platform/Pimcore/Objects/Object_Classes/Data_Types/Number_Types/)
+- [Pimcore Select Types](https://pimcore.com/docs/pimcore/current/Development_Documentation/Objects/Object_Classes/Data_Types/Select_Types.html)
+- [Pimcore Relation Types](https://docs.pimcore.com/pimcore/10.2/Development_Documentation/Objects/Object_Classes/Data_Types/Relation_Types.html)
+- [Pimcore Other Types](https://pimcore.com/docs/platform/Pimcore/Objects/Object_Classes/Data_Types/Others/)
+- [Pimcore Geographic Types](https://docs.pimcore.com/platform/Pimcore/Objects/Object_Classes/Data_Types/Geographic_Types/)
+- [Akeneo — What is an attribute?](https://help.akeneo.com/serenity-your-first-steps-with-akeneo/serenity-what-is-an-attribute)
+- [Akeneo — Manage your attributes](https://help.akeneo.com/serenity-build-your-catalog/serenity-manage-your-attributes)

--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -255,6 +255,7 @@ export function UniversalCreatePage({
           value={dirtyFields[attr.code]}
           provenance="manual"
           locale={locale}
+          channel={null}
           isEditing={true}
           isLocked={attr.is_system}
           onChange={(next) => setFieldValue(attr.code, next)}

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -248,6 +248,7 @@ export function UniversalDetailPage({
   const channels = channelsQuery.data ?? [];
 
   // #1150 / #1155 — switching locale or channel discards unsaved edits.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset on scope change
   useEffect(() => {
     setDirtyFields({});
   }, [locale, channel]);
@@ -577,6 +578,7 @@ export function UniversalDetailPage({
                     value={fieldValue(attr.code)}
                     provenance={resolveProvenance(attr, product)}
                     locale={locale}
+                    channel={channel}
                     isEditing={isEditing}
                     isLocked={attr.is_system}
                     onChange={(next) => setFieldValue(attr.code, next)}

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -1,4 +1,4 @@
-import { Copy, Link2, Lock } from 'lucide-react';
+import { Copy, CornerDownRight, Link2, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { WysiwygEditor } from '@/components/catalog/wysiwyg-editor';
 import { RelationCreateField } from '@/components/objects/relation-create-field';
@@ -46,6 +46,23 @@ export interface AttrRowProps {
    * after the main POST succeeds.
    */
   createMode?: boolean;
+  /**
+   * #1220 — active channel code (e.g. "shopify"). When provided and
+   * the attribute has `is_scopable=true`, a sky-coloured channel chip
+   * is rendered next to the label — mirroring the locale chip for
+   * `is_localizable` attributes.
+   */
+  channel?: string | null;
+  /**
+   * #1222 — when true the value shown is inherited from a fallback
+   * locale (not an exact match for the requested locale).
+   */
+  isInherited?: boolean;
+  /**
+   * #1222 — the locale code the value was inherited from
+   * (e.g. "en" when requested "de" fell back to "en").
+   */
+  inheritedFrom?: string | null;
 }
 
 /**
@@ -66,6 +83,9 @@ export function AttrRow({
   onCopyToOthers,
   relationContextProductId,
   createMode = false,
+  channel = null,
+  isInherited = false,
+  inheritedFrom = null,
 }: AttrRowProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
@@ -73,6 +93,7 @@ export function AttrRow({
   const editable = isEditing && !isLocked;
   const stringValue = typeof value === 'string' ? value : value == null ? '' : String(value);
   const localeChip = isLocaleScoped(attribute) ? locale : null;
+  const channelChip = attribute.is_scopable === true && channel ? channel : null;
   const isSelectLike = attribute.type === 'select' || attribute.type === 'multiselect';
   const selectOptions = isSelectLike ? (attribute.options ?? []) : [];
 
@@ -104,6 +125,35 @@ export function AttrRow({
             className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-[9px] uppercase text-zinc-500"
           >
             {localeChip}
+          </span>
+        ) : null}
+        {channelChip ? (
+          <span
+            title={t('products.detail.field.channel_aria', {
+              channel: channelChip.toUpperCase(),
+              defaultValue: 'Kanał {{channel}}',
+            })}
+            className="rounded bg-sky-100 px-1 py-0.5 font-mono text-[9px] uppercase text-sky-600"
+          >
+            {channelChip}
+          </span>
+        ) : null}
+        {isInherited && inheritedFrom ? (
+          <span
+            title={t('products.detail.field.inherited_from', {
+              locale: inheritedFrom.toUpperCase(),
+              defaultValue: 'Wartość z [{{locale}}]',
+            })}
+            className="inline-flex items-center text-amber-400"
+          >
+            <CornerDownRight
+              className="size-3"
+              aria-hidden
+              aria-label={t('products.detail.field.inherited_from', {
+                locale: inheritedFrom.toUpperCase(),
+                defaultValue: 'Wartość z [{{locale}}]',
+              })}
+            />
           </span>
         ) : null}
         {/* #1207 — system attributes (created_at/by, updated_at/by) stay

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -57,6 +57,7 @@ import type {
   ProductChannel,
   ProductDetailMode,
   ProductLocale,
+  ScopeStatus,
 } from './types';
 import { VariantsListCard } from './variants-list-card';
 import { VariantsTabHost } from './variants-tab-host';
@@ -287,8 +288,22 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   });
   const channels = channelsQuery.data ?? [];
 
+  // #1222 — scope-status: per-attribute inherited indicator.
+  // Only fetched in edit mode (detail page), not in create mode.
+  // Enabled only when a non-primary locale is active (primary locale
+  // values are global — nothing can be "inherited from another locale").
+  const scopeStatusQuery = useQuery<ScopeStatus>({
+    queryKey: ['products', id, 'scope-status', locale, channel],
+    queryFn: () =>
+      jsonFetch<ScopeStatus>(`/api/products/${id}/scope-status${scopeQuery(locale, channel)}`),
+    enabled: isEditMode && id !== '' && locale !== null,
+    staleTime: 30_000,
+  });
+  const scopeStatus = scopeStatusQuery.data ?? {};
+
   // #1150 / #1155 — switching locale or channel discards unsaved edits so an
   // edit is never written to the wrong scope; the operator saves first.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset on scope change
   useEffect(() => {
     setDirtyFields({});
   }, [locale, channel]);
@@ -849,10 +864,16 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                     value={fieldValue(attr.code)}
                     provenance={resolveProvenance(attr, product)}
                     locale={locale}
+                    channel={channel}
                     isEditing={isEditing}
                     isLocked={attr.is_system}
                     onChange={(next) => setFieldValue(attr.code, next)}
                     relationContextProductId={isEditMode ? id : undefined}
+                    isInherited={
+                      scopeStatus[attr.code]?.has_override === false &&
+                      scopeStatus[attr.code]?.inherited_from != null
+                    }
+                    inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
                   />
                 ))}
               </AttrGroupCard>

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -120,6 +120,21 @@ export interface EffectiveAttributeGroups {
   locales?: LocaleOption[];
 }
 
+/**
+ * #1222 — per-attribute scope status returned by
+ * `GET /api/products/{id}/scope-status?locale=&channel=`.
+ *
+ * - `has_override=true`  → an ObjectValue row exists for the exact requested scope.
+ * - `has_override=false, inherited_from="en"` → value comes from a fallback locale.
+ * - `has_override=false, inherited_from=null`  → global value used.
+ */
+export interface ScopeStatusEntry {
+  has_override: boolean;
+  inherited_from: string | null;
+}
+
+export type ScopeStatus = Record<string, ScopeStatusEntry>;
+
 export type ProductDetailMode = 'edit' | 'create';
 
 /**

--- a/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
+++ b/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
@@ -269,6 +269,7 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
                       value={fieldValue(variant.id, attr.code, baseAttrs)}
                       provenance={resolveProv(attr, variant.attributesIndexed)}
                       locale={'pl' satisfies ProductLocale}
+                      channel={null}
                       isEditing={isEditing && !attr.is_system}
                       isLocked={attr.is_system}
                       onChange={(next) => setVariantField(variant.id, attr.code, next)}

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -131,6 +131,12 @@ services:
         arguments:
             $itemProvider: '@api_platform.doctrine.orm.state.item_provider'
 
+    # #1223 — GetCollection provider that overlays per-locale/channel values
+    # on the full collection result page (N+1 prevention via batch load).
+    App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectCollectionLocaleOverlayProvider:
+        arguments:
+            $collectionProvider: '@api_platform.doctrine.orm.state.collection_provider'
+
     # Context-scope decorator (#42 / 0.4.2). Wraps the KindAware decorator
     # so the chain is: AP4 default → KindAware (per-kind groups, opt-in)
     # → ContextScope (?context=integration|public override). Explicit

--- a/apps/api/src/Catalog/Application/ObjectValueLocaleOverlay.php
+++ b/apps/api/src/Catalog/Application/ObjectValueLocaleOverlay.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Catalog\Application;
 
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Application\Locale\LocaleFallbackResolver;
 use App\Channel\Contracts\ChannelResolverInterface;
 use App\Shared\Domain\Tenant;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
- * Overlays per-locale / per-channel {@see \App\Catalog\Domain\Entity\ObjectValue}
+ * Overlays per-locale / per-channel {@see ObjectValue}
  * rows on top of an object's global `attributes_indexed` cache so a scoped
  * read (`?locale=en`, `?channel=shopify`, or both) returns the most
  * specific reading (#1146 / #1148 locale; #1147 / #1154 channel).
@@ -36,7 +38,120 @@ final readonly class ObjectValueLocaleOverlay
     public function __construct(
         private ObjectValueRepositoryInterface $values,
         private ChannelResolverInterface $channels,
+        private LocaleFallbackResolver $localeFallback,
     ) {
+    }
+
+    /**
+     * Batch variant of {@see apply()} for collection reads.
+     *
+     * Accepts a pre-loaded map of ObjectValue rows (keyed by object UUID) so
+     * the caller can issue a single `findByObjectIds()` query instead of one
+     * `findByObject()` call per item — preventing N+1 on list endpoints.
+     *
+     * @param list<CatalogObject>              $objects
+     * @param array<string, list<ObjectValue>> $valuesByObjectId keyed by UUID RFC 4122
+     *
+     * @return list<CatalogObject>
+     */
+    public function applyBatch(array $objects, array $valuesByObjectId, ?string $locale, ?string $channelCode = null): array
+    {
+        if ([] === $objects) {
+            return [];
+        }
+
+        // All objects share the same tenant in a single-tenant request.
+        $tenant = $objects[0]->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return $objects;
+        }
+
+        if (null !== $locale && !$tenant->isLocaleEnabled($locale)) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Locale "%s" is not enabled for this tenant.',
+                $locale,
+            ));
+        }
+        $effectiveLocale = null !== $locale && $locale !== $tenant->getPrimaryLocale() ? $locale : null;
+
+        $channelId = null;
+        if (null !== $channelCode) {
+            $channelId = $this->channels->resolveId($channelCode, $tenant);
+            if (null === $channelId) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Channel "%s" was not found for this tenant.',
+                    $channelCode,
+                ));
+            }
+        }
+
+        if (null === $effectiveLocale && null === $channelId) {
+            return $objects;
+        }
+
+        $localeChain = null !== $effectiveLocale
+            ? $this->localeFallback->resolve($effectiveLocale, $tenant)
+            : [];
+        $localeRankMap = [];
+        foreach ($localeChain as $pos => $chainCode) {
+            $localeRankMap[$chainCode] = $pos;
+        }
+        $maxChainLen = \count($localeChain);
+
+        $result = [];
+        foreach ($objects as $object) {
+            $objectKey = $object->getId()->toRfc4122();
+            $rows = $valuesByObjectId[$objectKey] ?? [];
+
+            $best = [];
+            foreach ($rows as $value) {
+                $valueLocale = $value->getLocale();
+                $valueChannel = $value->getChannelId();
+
+                if (null !== $valueLocale) {
+                    if (!isset($localeRankMap[$valueLocale])) {
+                        continue;
+                    }
+                    $localeRankContrib = ($maxChainLen - $localeRankMap[$valueLocale]) * 2;
+                } else {
+                    $localeRankContrib = 0;
+                }
+
+                if (null !== $valueChannel) {
+                    if (null === $channelId || !$valueChannel->equals($channelId)) {
+                        continue;
+                    }
+                    $channelRankContrib = 1;
+                } else {
+                    $channelRankContrib = 0;
+                }
+
+                $rank = $localeRankContrib + $channelRankContrib;
+                if (0 === $rank) {
+                    continue;
+                }
+
+                $code = $value->getAttribute()->getCode();
+                if (!isset($best[$code]) || $rank > $best[$code]['rank']) {
+                    $best[$code] = ['rank' => $rank, 'value' => $value->getValue()];
+                }
+            }
+
+            if ([] === $best) {
+                $result[] = $object;
+                continue;
+            }
+
+            $indexed = $object->getAttributesIndexed();
+            foreach ($best as $code => $entry) {
+                $indexed[$code] = $entry['value'];
+            }
+            $copy = clone $object;
+            $copy->updateAttributeIndex($indexed);
+            $result[] = $copy;
+        }
+
+        return $result;
     }
 
     public function apply(CatalogObject $object, ?string $locale, ?string $channelCode = null): CatalogObject
@@ -72,23 +187,61 @@ final readonly class ObjectValueLocaleOverlay
             return $object;
         }
 
+        // Build the locale fallback chain (most specific first).
+        // When no locale scope is active the chain is empty and locale
+        // matching degenerates to the channel-only / global path.
+        $localeChain = null !== $effectiveLocale
+            ? $this->localeFallback->resolve($effectiveLocale, $tenant)
+            : [];
+        // Index chain position for fast rank comparison: lower index = more specific.
+        $localeRankMap = [];
+        foreach ($localeChain as $pos => $chainCode) {
+            $localeRankMap[$chainCode] = $pos;
+        }
+
         // Per attribute, keep the most specific applicable row above global.
+        // Rank ordering (higher = wins):
+        //   (locale_chain_pos 0 + channel) > (locale_chain_pos 0) >
+        //   (locale_chain_pos 1 + channel) > (locale_chain_pos 1) > … >
+        //   (channel-only) > global (skipped — cache base)
+        //
+        // Encoded as: rank = (maxChainLen - chainPos) * 2 + hasChannel
+        $maxChainLen = \count($localeChain);
+        /** @var array<string, array{rank: int, value: mixed}> $best */
         $best = [];
         foreach ($this->values->findByObject($object) as $value) {
             $valueLocale = $value->getLocale();
             $valueChannel = $value->getChannelId();
 
-            $localeMatches = null === $valueLocale || (null !== $effectiveLocale && $valueLocale === $effectiveLocale);
-            $channelMatches = null === $valueChannel || (null !== $channelId && $valueChannel->equals($channelId));
-            if (!$localeMatches || !$channelMatches) {
+            // Determine locale rank contribution.
+            if (null !== $valueLocale) {
+                if (!isset($localeRankMap[$valueLocale])) {
+                    // This row belongs to a locale not in our chain — skip.
+                    continue;
+                }
+                $localeRankContrib = ($maxChainLen - $localeRankMap[$valueLocale]) * 2;
+            } else {
+                // locale-null row: only relevant when there is a channel scope.
+                $localeRankContrib = 0;
+            }
+
+            // Determine channel rank contribution.
+            if (null !== $valueChannel) {
+                if (null === $channelId || !$valueChannel->equals($channelId)) {
+                    // Row is for a different channel — skip.
+                    continue;
+                }
+                $channelRankContrib = 1;
+            } else {
+                $channelRankContrib = 0;
+            }
+
+            $rank = $localeRankContrib + $channelRankContrib;
+            if (0 === $rank) {
+                // Global row (locale=null, channel=null) — already the cache base.
                 continue;
             }
 
-            $rank = (null !== $valueLocale ? 2 : 0) + (null !== $valueChannel ? 1 : 0);
-            if (0 === $rank) {
-                // Global row — already the cache base.
-                continue;
-            }
             $code = $value->getAttribute()->getCode();
             if (!isset($best[$code]) || $rank > $best[$code]['rank']) {
                 $best[$code] = ['rank' => $rank, 'value' => $value->getValue()];

--- a/apps/api/src/Catalog/Application/ObjectValueLocaleOverlay.php
+++ b/apps/api/src/Catalog/Application/ObjectValueLocaleOverlay.php
@@ -7,8 +7,8 @@ namespace App\Catalog\Application;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
-use App\Channel\Application\Locale\LocaleFallbackResolver;
 use App\Channel\Contracts\ChannelResolverInterface;
+use App\Channel\Contracts\LocaleFallbackResolverInterface;
 use App\Shared\Domain\Tenant;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
@@ -38,7 +38,7 @@ final readonly class ObjectValueLocaleOverlay
     public function __construct(
         private ObjectValueRepositoryInterface $values,
         private ChannelResolverInterface $channels,
-        private LocaleFallbackResolver $localeFallback,
+        private LocaleFallbackResolverInterface $localeFallback,
     ) {
     }
 

--- a/apps/api/src/Catalog/Domain/Repository/ObjectValueRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/ObjectValueRepositoryInterface.php
@@ -18,6 +18,16 @@ interface ObjectValueRepositoryInterface
      */
     public function findByObject(CatalogObject $object): array;
 
+    /**
+     * Batch-load ObjectValue rows for multiple objects in a single query.
+     * Used by the collection overlay provider to avoid N+1 queries.
+     *
+     * @param list<Uuid> $objectIds
+     *
+     * @return array<string, list<ObjectValue>> keyed by object UUID (RFC 4122)
+     */
+    public function findByObjectIds(array $objectIds): array;
+
     public function findOneByScope(
         CatalogObject $object,
         Attribute $attribute,

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Resource/CatalogObject.xml
@@ -108,6 +108,7 @@
                        uriTemplate="/products{._format}"
                        name="products_get_collection"
                        paginationType="cursor"
+                       provider="App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectCollectionLocaleOverlayProvider"
                        security="is_granted('READ', 'App\\Catalog\\Domain\\Entity\\CatalogObject')">
                 <extraProperties>
                     <values>
@@ -192,6 +193,7 @@
                        uriTemplate="/categories{._format}"
                        name="categories_get_collection"
                        paginationType="cursor"
+                       provider="App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectCollectionLocaleOverlayProvider"
                        security="is_granted('READ', 'App\\Catalog\\Domain\\Entity\\CatalogObject')">
                 <extraProperties>
                     <values>
@@ -276,6 +278,7 @@
                        uriTemplate="/assets{._format}"
                        name="assets_get_collection"
                        paginationType="cursor"
+                       provider="App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectCollectionLocaleOverlayProvider"
                        security="is_granted('READ', 'App\\Catalog\\Domain\\Entity\\CatalogObject')">
                 <extraProperties>
                     <values>
@@ -317,6 +320,7 @@
                        uriTemplate="/objects{._format}"
                        name="objects_get_collection"
                        paginationType="cursor"
+                       provider="App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectCollectionLocaleOverlayProvider"
                        security="is_granted('READ', 'App\\Catalog\\Domain\\Entity\\CatalogObject')">
                 <paginationViaCursor>
                     <paginationField field="id" direction="DESC"/>

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\ApiPlatform\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\PaginatorInterface;
+use ApiPlatform\State\Pagination\TraversablePaginator;
+use ApiPlatform\State\ProviderInterface;
+use App\Catalog\Application\ObjectValueLocaleOverlay;
+use App\Catalog\Application\SystemAttributeReadOverlay;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use ArrayIterator;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Uid\Uuid;
+use Traversable;
+
+/**
+ * GetCollection provider for catalog sugar paths (`/api/products`,
+ * `/api/categories`, `/api/objects`). Delegates loading to the default
+ * Doctrine collection provider, then — when the request carries
+ * `?locale=<code>` and/or `?channel=<code>` — overlays per-locale /
+ * per-channel attribute readings before normalization (#1223 / T4).
+ *
+ * N+1 prevention: instead of calling `findByObject()` per item, the
+ * provider issues one `findByObjectIds()` batch query for the entire page,
+ * then passes the pre-loaded map to `ObjectValueLocaleOverlay::applyBatch()`.
+ *
+ * @implements ProviderInterface<CatalogObject>
+ */
+final readonly class CatalogObjectCollectionLocaleOverlayProvider implements ProviderInterface
+{
+    /**
+     * @param ProviderInterface<object> $collectionProvider the default Doctrine ORM collection provider
+     */
+    public function __construct(
+        private ProviderInterface $collectionProvider,
+        private ObjectValueLocaleOverlay $overlay,
+        private SystemAttributeReadOverlay $systemOverlay,
+        private ObjectValueRepositoryInterface $objectValues,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    /**
+     * @return iterable<CatalogObject>|CatalogObject|null
+     */
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|iterable|null
+    {
+        $result = $this->collectionProvider->provide($operation, $uriVariables, $context);
+
+        $request = $this->requestStack->getCurrentRequest();
+        $localeParam = $request?->query->get('locale');
+        $channelParam = $request?->query->get('channel');
+        $locale = \is_string($localeParam) && '' !== $localeParam ? $localeParam : null;
+        $channel = \is_string($channelParam) && '' !== $channelParam ? $channelParam : null;
+
+        // Collect CatalogObject items from the paginator or array result.
+        // API Platform may return an iterable paginator or a plain array.
+        $objects = [];
+        if (\is_array($result)) {
+            foreach ($result as $item) {
+                if ($item instanceof CatalogObject) {
+                    $objects[] = $item;
+                }
+            }
+        } elseif ($result instanceof Traversable) {
+            foreach ($result as $item) {
+                if ($item instanceof CatalogObject) {
+                    $objects[] = $item;
+                }
+            }
+        }
+
+        if ([] === $objects) {
+            return $result; // @phpstan-ignore-line (inner provider return type is wider)
+        }
+
+        // Always apply system overlay so created_at/updated_at render.
+        // When no locale/channel scope is active, skip the value overlay.
+        if (null === $locale && null === $channel) {
+            foreach ($objects as $object) {
+                $this->systemOverlay->apply($object);
+            }
+
+            return $result; // @phpstan-ignore-line (inner provider return type is wider)
+        }
+
+        // Batch-load all ObjectValue rows for the current page in one query.
+        $objectIds = array_map(
+            static fn (CatalogObject $o): Uuid => $o->getId(),
+            $objects,
+        );
+        $valuesByObjectId = $this->objectValues->findByObjectIds($objectIds);
+
+        // Apply locale/channel overlay on clones (no identity map mutation).
+        $overlaid = $this->overlay->applyBatch($objects, $valuesByObjectId, $locale, $channel);
+
+        // Apply system overlay on the (already cloned) overlaid objects.
+        $overlaid = array_map(
+            fn (CatalogObject $o): CatalogObject => $this->systemOverlay->apply($o),
+            $overlaid,
+        );
+
+        // Re-build the result preserving the paginator wrapper when present.
+        if (\is_array($result)) {
+            return $overlaid;
+        }
+
+        // For AP4 paginator results, wrap the overlaid items in a
+        // TraversablePaginator so the serializer still gets correct
+        // total-count / current-page metadata from the original paginator.
+        if ($result instanceof PaginatorInterface) {
+            return new TraversablePaginator(
+                new ArrayIterator($overlaid),
+                $result->getCurrentPage(),
+                $result->getItemsPerPage(),
+                $result->getTotalItems(),
+            );
+        }
+
+        return $overlaid;
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectValueRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectValueRepository.php
@@ -9,6 +9,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Uid\Uuid;
 
@@ -31,6 +32,35 @@ class DoctrineObjectValueRepository extends ServiceEntityRepository implements O
         $rows = $this->findBy(['object' => $object]);
 
         return $rows;
+    }
+
+    /**
+     * @param list<Uuid> $objectIds
+     *
+     * @return array<string, list<ObjectValue>> keyed by object UUID (RFC 4122)
+     */
+    public function findByObjectIds(array $objectIds): array
+    {
+        if ([] === $objectIds) {
+            return [];
+        }
+
+        $rfcIds = array_map(static fn (Uuid $id): string => $id->toRfc4122(), $objectIds);
+
+        /** @var list<ObjectValue> $rows */
+        $rows = $this->createQueryBuilder('v')
+            ->join('v.object', 'o', Join::WITH, 'o.id IN (:ids)')
+            ->setParameter('ids', $rfcIds)
+            ->getQuery()
+            ->getResult();
+
+        $byObject = [];
+        foreach ($rows as $row) {
+            $key = $row->getObject()->getId()->toRfc4122();
+            $byObject[$key][] = $row;
+        }
+
+        return $byObject;
     }
 
     public function findOneByScope(

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -14,8 +14,8 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
-use App\Channel\Application\Locale\LocaleFallbackResolver;
 use App\Channel\Contracts\ChannelResolverInterface;
+use App\Channel\Contracts\LocaleFallbackResolverInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Shared\Domain\Tenant;
 use App\Shared\Infrastructure\Audit\CursorCodec;
@@ -74,7 +74,7 @@ final class ProductReadEndpointsController
         private readonly ObjectTypeAttributeRepositoryInterface $objectTypeAttributes,
         private readonly AttributeOptionRepositoryInterface $attributeOptions,
         private readonly ObjectValueRepositoryInterface $objectValues,
-        private readonly LocaleFallbackResolver $localeFallback,
+        private readonly LocaleFallbackResolverInterface $localeFallback,
         private readonly ChannelResolverInterface $channels,
     ) {
     }

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -12,7 +12,10 @@ use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use App\Channel\Application\Locale\LocaleFallbackResolver;
+use App\Channel\Contracts\ChannelResolverInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Shared\Domain\Tenant;
 use App\Shared\Infrastructure\Audit\CursorCodec;
@@ -70,6 +73,9 @@ final class ProductReadEndpointsController
         private readonly Connection $connection,
         private readonly ObjectTypeAttributeRepositoryInterface $objectTypeAttributes,
         private readonly AttributeOptionRepositoryInterface $attributeOptions,
+        private readonly ObjectValueRepositoryInterface $objectValues,
+        private readonly LocaleFallbackResolver $localeFallback,
+        private readonly ChannelResolverInterface $channels,
     ) {
     }
 
@@ -330,6 +336,119 @@ final class ProductReadEndpointsController
         usort($locales, static fn (array $a, array $b): int => ($b['is_default'] ? 1 : 0) <=> ($a['is_default'] ? 1 : 0));
 
         return $locales;
+    }
+
+    /**
+     * #1222 — returns per-attribute scope status for a requested locale/channel.
+     *
+     * Response shape:
+     *   { "attribute_code": { "has_override": bool, "inherited_from": string|null } }
+     *
+     * - `has_override=true`  → an ObjectValue row exists for the exact requested locale/channel.
+     * - `has_override=false, inherited_from="en"` → value shown comes from a fallback locale.
+     * - `has_override=false, inherited_from=null`  → global value is used (primary locale or no locale scope).
+     */
+    #[Route(
+        '/api/products/{id}/scope-status',
+        name: 'pim_products_scope_status',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+        priority: 200,
+    )]
+    #[Route(
+        '/api/objects/{id}/scope-status',
+        name: 'pim_objects_scope_status',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+        priority: 200,
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function scopeStatus(string $id, Request $request): JsonResponse
+    {
+        $object = $this->mustFindObject($id);
+        $tenant = $object->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return new JsonResponse([]);
+        }
+
+        $requestedLocale = $request->query->get('locale');
+        $requestedChannel = $request->query->get('channel');
+
+        // Primary locale is stored as global (null) — treat as no locale scope.
+        $effectiveLocale = null !== $requestedLocale
+            && $requestedLocale !== $tenant->getPrimaryLocale()
+            ? $requestedLocale
+            : null;
+
+        $channelId = null;
+        if (null !== $requestedChannel) {
+            $channelId = $this->channels->resolveId($requestedChannel, $tenant);
+        }
+
+        // Build locale fallback chain for inheritance detection.
+        $localeChain = null !== $effectiveLocale
+            ? $this->localeFallback->resolve($effectiveLocale, $tenant)
+            : [];
+
+        // Index: locale code → chain position (0 = most specific).
+        $localeRankMap = [];
+        foreach ($localeChain as $pos => $code) {
+            $localeRankMap[$code] = $pos;
+        }
+
+        // Load all ObjectValue rows for this object.
+        $allValues = $this->objectValues->findByObject($object);
+
+        // Per attribute: find the best row and determine if it is exact or inherited.
+        $maxChainLen = \count($localeChain);
+        /** @var array<string, array{rank: int, locale: ?string}> $best */
+        $best = [];
+        foreach ($allValues as $value) {
+            $valueLocale = $value->getLocale();
+            $valueChannel = $value->getChannelId();
+
+            if (null !== $valueLocale) {
+                if (!isset($localeRankMap[$valueLocale])) {
+                    continue;
+                }
+                $localeRankContrib = ($maxChainLen - $localeRankMap[$valueLocale]) * 2;
+            } else {
+                $localeRankContrib = 0;
+            }
+
+            if (null !== $valueChannel) {
+                if (null === $channelId || !$valueChannel->equals($channelId)) {
+                    continue;
+                }
+                $channelRankContrib = 1;
+            } else {
+                $channelRankContrib = 0;
+            }
+
+            $rank = $localeRankContrib + $channelRankContrib;
+            if (0 === $rank) {
+                continue; // global row — not a scoped override
+            }
+
+            $code = $value->getAttribute()->getCode();
+            if (!isset($best[$code]) || $rank > $best[$code]['rank']) {
+                $best[$code] = ['rank' => $rank, 'locale' => $valueLocale];
+            }
+        }
+
+        // Build response: for each attribute with a scoped value, report
+        // whether it is an exact match or inherited from a fallback locale.
+        $result = [];
+        foreach ($best as $attrCode => $entry) {
+            $isExact = $entry['locale'] === $effectiveLocale;
+            $result[$attrCode] = [
+                'has_override' => $isExact,
+                'inherited_from' => $isExact ? null : $entry['locale'],
+            ];
+        }
+
+        return new JsonResponse($result);
     }
 
     private function mustFindProduct(string $id): CatalogObject

--- a/apps/api/src/Channel/Application/Locale/LocaleFallbackResolver.php
+++ b/apps/api/src/Channel/Application/Locale/LocaleFallbackResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Channel\Application\Locale;
 
+use App\Channel\Contracts\LocaleFallbackResolverInterface;
 use App\Channel\Domain\Entity\TenantLocale;
 use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
 use App\Shared\Domain\Tenant;
@@ -27,7 +28,7 @@ use App\Shared\Domain\Tenant;
  * memory map alone, and a Redis layer would add an invalidation surface
  * (`LocaleDeactivated`, `LocaleUpdated`, …) that LOC-04 should not own.
  */
-final class LocaleFallbackResolver
+final class LocaleFallbackResolver implements LocaleFallbackResolverInterface
 {
     /**
      * @var array<string, list<string>>

--- a/apps/api/src/Channel/Contracts/LocaleFallbackResolverInterface.php
+++ b/apps/api/src/Channel/Contracts/LocaleFallbackResolverInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts;
+
+use App\Shared\Domain\Tenant;
+
+/**
+ * Public contract for locale fallback chain resolution.
+ *
+ * Placed in Channel\Contracts so that other BCs (Catalog, Asset, …)
+ * can depend on this interface without reaching into Channel internals.
+ * The concrete implementation lives in Channel\Application\Locale\LocaleFallbackResolver.
+ *
+ * @see \App\Channel\Application\Locale\LocaleFallbackResolver
+ */
+interface LocaleFallbackResolverInterface
+{
+    /**
+     * Returns the fallback chain for `$code` on `$tenant` — most specific
+     * locale first, default locale last.
+     *
+     * @return list<string>
+     */
+    public function resolve(string $code, Tenant $tenant): array;
+
+    /**
+     * Returns the first chain entry for which `$hasValue($candidate)` is true,
+     * or null when every chain step is empty.
+     *
+     * @param callable(string): bool $hasValue
+     */
+    public function pickFirstAvailable(string $code, Tenant $tenant, callable $hasValue): ?string;
+}


### PR DESCRIPTION
## Zmiany

Cztery luki w obsłudze locale/channel — przybliżenie zachowania Akeneo.

### T1 — Channel chip w AttrRow dla `is_scopable` (#1220)
- Nowy prop `channel?: string | null` w `AttrRow` — gdy `attribute.is_scopable === true` i channel jest ustawiony, renderuje niebieski chip (`sky-100`) z kodem kanału.
- Nowe propsy `isInherited` / `inheritedFrom` — gdy atrybut dziedziczy wartość z innego locale, pokazuje bursztynową ikonę `CornerDownRight`.
- Wdrożony w 5 call site'ach: `product-detail-page`, `universal-detail-page`, `universal-create-page`, `variants-tab-host`.

### T2 — `LocaleFallbackResolver` w `ObjectValueLocaleOverlay` (#1221)
- Wstrzyknięto `LocaleFallbackResolver`; buduje mapę rang dla łańcucha locale per request.
- Dodano `applyBatch()` dla collection path — jedno zapytanie na stronę (brak N+1).
- Formuła rangi: `(maxLen - chainPos) * 2 + channelContrib`; wiersze spoza łańcucha pomijane.

### T3 — `GET /api/products/{id}/scope-status` + wskaźnik w UI (#1222)
- Nowa akcja `scopeStatus()` w `ProductReadEndpointsController`.
- Zwraca mapę `{has_override, inherited_from}` per atrybut.
- Typy `ScopeStatus` / `ScopeStatusEntry` dodane do `types.ts`.
- `scopeStatusQuery` wpięty w `product-detail-page`; `isInherited` + `inheritedFrom` przekazane do `AttrRow`.

### T4 — Overlay locale/channel na GetCollection (#1223)
- Nowy `CatalogObjectCollectionLocaleOverlayProvider` (dekoruje domyślny Doctrine collection provider).
- Batch-load `ObjectValue` przez `findByObjectIds()` — jedno zapytanie na stronę.
- Wynik owijany w `TraversablePaginator` — metadane paginacji zachowane.
- Wpięty w `services.yaml` + `CatalogObject.xml` dla `/api/products`, `/api/categories`, `/api/objects`.

## Quality gates
- ✅ `pnpm tsc --noEmit` — brak błędów
- ✅ Biome check — brak błędów/warningów
- ✅ PHPStan max — brak błędów (wszystkie zmienione pliki BE)
- ✅ PHP CS Fixer — brak zmian do naprawienia
- ✅ PHPUnit unit (10 testów, 11 asercji)

## Smoke test
Ships standalone component + wiring. End-to-end wymaga działającego stosu z produktami z wieloma locale/channel — do weryfikacji manualnej po merge.

Closes #1220, #1221, #1222, #1223