### PR TITLE
fix(admin): scope-status + inheritance + edit-gate na karcie custom ObjectType

### DIFF
--- a/apps/admin/e2e/1225-universal-detail-scope.spec.ts
+++ b/apps/admin/e2e/1225-universal-detail-scope.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * fix(admin) #1225 — locale/channel scope parity on the custom-ObjectType
+ * detail card (`UniversalDetailPage`), mirroring the product detail card.
+ *
+ * Two deterministic assertions:
+ *   1. View mode: the locale/channel switcher is hidden (it only makes
+ *      sense while editing — parity with the product card edit-gate).
+ *   2. Edit mode: the switcher appears with the Język + Kanał pickers,
+ *      and switching the locale issues the scoped read without crashing.
+ *
+ * The per-attribute inheritance indicator (amber "Wartość z [XX]") needs a
+ * localizable attribute carrying a fallback value, which is data-dependent;
+ * that path is covered by the manual live-stack smoke documented in the PR.
+ *
+ * Marked `fixme` in CI for the shared-suite auth rate-limiter reason
+ * (see object-name-edit.spec.ts / settings-channels-crud.spec.ts).
+ */
+const E2E_BLOCKED_BY_RATE_LIMITER =
+  'Pending storageState rollout: spec lands after the 5/15min auth rate limiter is exhausted';
+
+// Seed-dependent path (custom ObjectType `samochody`); same hardcoded-seed
+// convention as object-name-edit.spec.ts. Adjust if the demo seed changes.
+const OBJECT_PATH = '/objects/samochody/019e89e1-7abe-7a01-bb4d-290472beabbf';
+
+test.describe('fix(admin) #1225 — universal detail scope switcher', () => {
+  test('switcher hidden in view mode, shown in edit mode', async ({ page }) => {
+    test.fixme(true, E2E_BLOCKED_BY_RATE_LIMITER);
+    await loginAsAdmin(page);
+    await page.goto(OBJECT_PATH);
+    await page.waitForTimeout(2000);
+
+    const localePicker = page.getByRole('button', { name: /^język$|^language$/i });
+
+    // 1. View mode — the scope switcher must not be rendered.
+    await expect(localePicker).toHaveCount(0);
+
+    // 2. Enter edit mode — the switcher (Język + Kanał) appears.
+    await page
+      .getByRole('button', { name: /edytuj|^edit$/i })
+      .first()
+      .click();
+    await page.waitForTimeout(600);
+    await expect(localePicker.first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /^kanał$|^channel$/i }).first()).toBeVisible();
+
+    // Switching the locale triggers the scoped read; assert no crash — the
+    // switcher persists (in edit mode the title is an <input>, not an <h1>,
+    // so we assert the picker rather than a heading).
+    await localePicker.first().click();
+    await page.waitForTimeout(300);
+    const option = page.getByRole('menuitem').nth(1);
+    if (await option.isVisible().catch(() => false)) {
+      await option.click();
+      await page.waitForTimeout(800);
+    }
+    await expect(localePicker.first()).toBeVisible();
+  });
+});

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -63,6 +63,7 @@ import type {
   LocaleOption,
   ProductChannel,
   ProductLocale,
+  ScopeStatus,
 } from '@/features/catalog/products/components/types';
 import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
 import { httpErrorDetail, jsonFetch } from '@/lib/http';
@@ -246,6 +247,19 @@ export function UniversalDetailPage({
     staleTime: 60_000,
   });
   const channels = channelsQuery.data ?? [];
+
+  // #1225 — scope-status: per-attribute inherited indicator, mirroring the
+  // product detail card (#1222). Fetched only while editing (the locale
+  // picker lives in the edit-mode toolbar) and when a locale is active;
+  // primary-locale values are global, so nothing reads as "inherited".
+  const scopeStatusQuery = useQuery<ScopeStatus>({
+    queryKey: ['object', objectId, 'scope-status', locale, channel],
+    queryFn: () =>
+      jsonFetch<ScopeStatus>(`/api/objects/${objectId}/scope-status${scopeQuery(locale, channel)}`),
+    enabled: isEditing && objectId !== '' && locale !== '',
+    staleTime: 30_000,
+  });
+  const scopeStatus = scopeStatusQuery.data ?? {};
 
   // #1150 / #1155 — switching locale or channel discards unsaved edits.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset on scope change
@@ -545,14 +559,19 @@ export function UniversalDetailPage({
               );
             })}
           </div>
-          <LocaleChannelToolbar
-            locale={locale}
-            channel={channel}
-            onLocaleChange={setLocale}
-            onChannelChange={setChannel}
-            locales={locales}
-            channels={channels}
-          />
+          {/* #1225 — the scope switcher only makes sense while editing; in
+              view mode there is nothing to write, so hide it (parity with
+              the product detail card, which gates it on edit mode). */}
+          {isEditing ? (
+            <LocaleChannelToolbar
+              locale={locale}
+              channel={channel}
+              onLocaleChange={setLocale}
+              onChannelChange={setChannel}
+              locales={locales}
+              channels={channels}
+            />
+          ) : null}
         </div>
       </header>
 
@@ -583,6 +602,11 @@ export function UniversalDetailPage({
                     isLocked={attr.is_system}
                     onChange={(next) => setFieldValue(attr.code, next)}
                     relationContextProductId={objectId}
+                    isInherited={
+                      scopeStatus[attr.code]?.has_override === false &&
+                      scopeStatus[attr.code]?.inherited_from != null
+                    }
+                    inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
                   />
                 ))}
               </AttrGroupCard>


### PR DESCRIPTION
## Summary

- `UniversalDetailPage` (karta edycji instancji custom ObjectType) osiąga parytet z kartą Produktu w przełączaniu **per locale/channel**.
- Wpina `GET /api/objects/{id}/scope-status` → przekazuje `isInherited` + `inheritedFrom` do `AttrRow` (bursztynowy wskaźnik „Wartość z [XX]").
- `LocaleChannelToolbar` renderowany **tylko w trybie edycji** (wcześniej bezwarunkowo, także w podglądzie).

Closes #1225

## Scope

`apps/admin` — `src/components/objects/universal-detail-page.tsx` + nowy spec E2E. Backend bez zmian (endpoint `/api/objects/{id}/scope-status` istniał z #1222/T3). Brak surface bezpieczeństwa.

## Smoke test (live-stack, https://pim.localhost)

Wykonany realny smoke, **nie tylko CI**:
- `POST /api/auth/login` → 200 (JWT).
- `GET /api/objects/{id}/scope-status?locale=en` → **200** (kształt `{attr: {has_override, inherited_from}}`; dla obiektu bez localizable atrybutów `{}`).
- **Playwright na żywym stacku → 1 passed (10.5s):** w trybie podglądu picker „Język" nieobecny; po „Edytuj" pojawiają się pickery Język + Kanał; przełączenie locale wykonuje scoped read bez crasha. (Spec `test.fixme` w CI z powodu współdzielonego auth rate-limitera — konwencja jak `object-name-edit.spec.ts`; pokrycie przez powyższy manualny smoke.)

Wskaźnik dziedziczenia (per-locale override) wymaga atrybutu localizable z wartością fallback — seed `samochody` go nie ma; ta ścieżka renderuje tym samym `AttrRow` co karta Produktu (shipped #1222), więc ryzyko regresji minimalne. Pełny walkthrough wskaźnika = follow-up gdy seed dostanie localizable override.

## Definicja Done

- [x] Biome strict — green
- [x] TypeScript noEmit — green (`NODE_OPTIONS=--max-old-space-size=4096`)
- [x] Playwright E2E — nowy spec (live-stack pass; `fixme` w CI per konwencja)
- [x] Manual smoke 5 min — passed (powyżej)
