### PR TITLE
chore(deps): sync root @biomejs/biome specifier to lockfile (2.4.16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.13",
+    "@biomejs/biome": "^2.4.16",
     "@commitlint/cli": "^20.5.2",
     "@commitlint/config-conventional": "^21.0.2",
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary

- Root `package.json` deklarowało `@biomejs/biome: ^2.4.13`, ale `apps/admin/package.json` i `pnpm-lock.yaml` mają `^2.4.16` → `pnpm install --frozen-lockfile` (krok każdego FE joba CI) failuje na mismatchu specifier-ów.
- Sync root manifestu do `^2.4.16` (już zalokowana, najnowsza stabilna). Lockfile bez zmian.

## Scope

Toolchain/maintenance. Odblokowuje wszystkie frontendowe joby CI (Biome / TypeScript / Vite / Playwright), które dziś są czerwone na main z tego powodu. Brak surface bezpieczeństwa.

## Smoke test

- `pnpm install --frozen-lockfile` lokalnie → **"Lockfile is up to date, Already up to date"** (wcześniej: `ERR specifiers in the lockfile don't match`).
