### PR TITLE
fix(admin): zakładka wariantów scope-aware (follow parent locale/channel)

### DIFF
--- a/apps/admin/e2e/1226-variants-scope-aware.spec.ts
+++ b/apps/admin/e2e/1226-variants-scope-aware.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * fix(admin) #1226 — variants tab is scope-aware: it follows the parent
+ * product card's active locale/channel instead of the hardcoded
+ * `pl`/global. Verifies the FE wiring end-to-end:
+ *   - switching the header locale picker re-fetches the variant list with
+ *     `?locale=` (collection overlay, #1223), and
+ *   - saving a variant edit issues PATCH `/api/products/{id}?locale=`.
+ *
+ * The BE scope routing (localizable → locale row) is already covered by
+ * #1169; here we assert the request carries the scope, which is the bug
+ * #1226 fixes (previously the variants tab dropped it).
+ *
+ * Conditional `fixme` in CI for the shared-suite auth rate limiter (same
+ * as view-07-3-products-variants.spec.ts); runs locally.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('fix(admin) #1226 — variant list + PATCH carry the active locale scope', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  // Master product + two variants via API (UI create is covered elsewhere).
+  const sku = uniqueSku('SC1226');
+  const typesResponse = await page.request.get('/api/object_types');
+  const typesBody = (await typesResponse.json()) as {
+    member?: Array<{ id: string; kind: string }>;
+    'hydra:member'?: Array<{ id: string; kind: string }>;
+  };
+  const types = typesBody.member ?? typesBody['hydra:member'] ?? [];
+  // Exactly one `kind: 'product'` type exists (the built-in); the
+  // serialized `isBuiltIn` is omitted in JSON-LD, so match on kind.
+  const productType = types.find((t) => t.kind === 'product');
+  if (productType === undefined) {
+    throw new Error('Product ObjectType not found — demo seeder did not run.');
+  }
+
+  const masterResponse = await page.request.post('/api/products', {
+    headers: { 'content-type': 'application/ld+json' },
+    data: { code: sku, objectTypeId: productType.id, attributes: { name: `Master ${sku}` } },
+  });
+  expect(masterResponse.status()).toBe(201);
+  const master = (await masterResponse.json()) as { id: string };
+
+  const generateResponse = await page.request.post(`/api/products/${master.id}/generate-variants`, {
+    headers: { 'content-type': 'application/json' },
+    data: { axes: { color: ['red', 'blue'] } },
+  });
+  expect(generateResponse.status()).toBe(201);
+
+  await page.goto(`/products/${master.id}`);
+
+  // Switch the header locale picker to EN, then watch the scoped variant
+  // list read fire (collection overlay).
+  const listScoped = page.waitForResponse(
+    (r) =>
+      r.url().includes('/api/products?parent_id=') &&
+      r.url().includes('locale=en') &&
+      r.request().method() === 'GET',
+  );
+  await page
+    .getByRole('button', { name: /^język$|^language$/i })
+    .first()
+    .click();
+  await page.getByRole('menuitem').filter({ hasText: /en/i }).first().click();
+  await page.getByRole('tab', { name: /warianty|variants/i }).click();
+  await listScoped;
+
+  // Edit a variant attribute and save → PATCH must carry ?locale=en.
+  await page.getByRole('button', { name: /^(edytuj warianty|edit variants)$/i }).click();
+  await page.getByRole('button', { name: /rozwiń wszystkie|expand all/i }).click();
+  const firstInput = page.locator('input, textarea').filter({ visible: true }).first();
+  await firstInput.fill(`EN ${sku}`);
+
+  const patchScoped = page.waitForResponse(
+    (r) => /\/api\/products\/[^?]+\?.*locale=en/.test(r.url()) && r.request().method() === 'PATCH',
+  );
+  await page.getByRole('button', { name: /^(zapisz|save)$/i }).click();
+  const patch = await patchScoped;
+  expect(patch.status()).toBeLessThan(400);
+});

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -928,7 +928,9 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
             }
 
             if (mode === 'edit' && isSpecialTab(activeTab)) {
-              return <OtherTabs activeTab={activeTab} productId={id} />;
+              return (
+                <OtherTabs activeTab={activeTab} productId={id} locale={locale} channel={channel} />
+              );
             }
 
             return null;
@@ -1106,7 +1108,17 @@ function resolveProvenance(
   return 'manual';
 }
 
-function OtherTabs({ activeTab, productId }: { activeTab: SpecialTabKey; productId: string }) {
+function OtherTabs({
+  activeTab,
+  productId,
+  locale,
+  channel,
+}: {
+  activeTab: SpecialTabKey;
+  productId: string;
+  locale: ProductLocale;
+  channel: ProductChannel | null;
+}) {
   // UX bug fix #2 — Multimedia is back as a special tab gated by
   // `ObjectType.hasMultimedia` (UX-02 removed it from the AttributeGroup
   // dispatcher; mirroring the UniversalDetailPage gating brings the
@@ -1114,7 +1126,8 @@ function OtherTabs({ activeTab, productId }: { activeTab: SpecialTabKey; product
   if (activeTab === 'multimedia') return <ProductMultimediaTab productId={productId} />;
   if (activeTab === 'categories') return <CategoriesTab productId={productId} />;
   if (activeTab === 'history') return <HistoryStub />;
-  if (activeTab === 'variants') return <VariantsTabHost productId={productId} />;
+  if (activeTab === 'variants')
+    return <VariantsTabHost productId={productId} locale={locale} channel={channel} />;
   return null;
 }
 

--- a/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
+++ b/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
@@ -9,7 +9,8 @@ import { jsonFetch } from '@/lib/http';
 
 import { AttrGroupCard } from './attr-group-card';
 import { AttrRow } from './attr-row';
-import type { AttributeMeta, GroupMeta, ProductLocale } from './types';
+import { scopeQuery } from './scope';
+import type { AttributeMeta, GroupMeta, ProductChannel, ProductLocale } from './types';
 
 interface VariantRow {
   id: string;
@@ -25,6 +26,14 @@ interface VariantsResponse {
 
 export interface VariantsTabHostProps {
   productId: string;
+  /**
+   * #1226 — active locale from the parent product card. Scopes the variant
+   * value read + write so per-locale overrides land in the right row
+   * (localizable attrs route to that locale; others stay global).
+   */
+  locale: ProductLocale;
+  /** #1226 — active channel (null = all channels / global). */
+  channel: ProductChannel | null;
 }
 
 /**
@@ -36,7 +45,7 @@ export interface VariantsTabHostProps {
  * variants" action that replaces the ProvenanceBadge in the variant
  * RHS slot.
  */
-export function VariantsTabHost({ productId }: VariantsTabHostProps) {
+export function VariantsTabHost({ productId, locale, channel }: VariantsTabHostProps) {
   const { t } = useTranslation();
   const [variants, setVariants] = useState<VariantRow[]>([]);
   const [groups, setGroups] = useState<GroupMeta[]>([]);
@@ -46,12 +55,16 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [reloadKey, setReloadKey] = useState<number>(0);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is the intentional re-fetch trigger after Generate/Save (bumped via setReloadKey).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reloadKey is the intentional re-fetch trigger after Generate/Save (bumped via setReloadKey); locale/channel re-fetch the scoped variant values (#1226).
   useEffect(() => {
     let cancelled = false;
     if (productId === '') return;
+    // #1226 — the variant list goes through the collection locale/channel
+    // overlay (#1223), so the values reflect the active scope. The list URL
+    // already carries `?parent_id`, hence the leading `?` becomes `&`.
+    const scope = scopeQuery(locale, channel).replace('?', '&');
     Promise.all([
-      jsonFetch<VariantsResponse>(`/api/products?parent_id=${productId}`).then((body) => {
+      jsonFetch<VariantsResponse>(`/api/products?parent_id=${productId}${scope}`).then((body) => {
         if (cancelled) return;
         const list = body.member ?? body['hydra:member'] ?? [];
         const arr = Array.isArray(list) ? list : [];
@@ -68,7 +81,14 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
     return () => {
       cancelled = true;
     };
-  }, [productId, reloadKey]);
+  }, [productId, reloadKey, locale, channel]);
+
+  // #1226 — switching scope discards unsaved variant edits so an edit is
+  // never written to the wrong locale/channel (mirrors the product card).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset on scope change
+  useEffect(() => {
+    setDirtyByVariant({});
+  }, [locale, channel]);
 
   const variantAttributes = useMemo<AttributeMeta[]>(() => {
     return groups.flatMap((g) => g.attributes.filter((a) => !a.is_system));
@@ -141,7 +161,7 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
     setIsSaving(true);
     const results = await Promise.allSettled(
       targets.map(([id, attributes]) =>
-        jsonFetch(`/api/products/${id}`, {
+        jsonFetch(`/api/products/${id}${scopeQuery(locale, channel)}`, {
           method: 'PATCH',
           contentType: 'application/merge-patch+json',
           body: { attributes },
@@ -268,8 +288,8 @@ export function VariantsTabHost({ productId }: VariantsTabHostProps) {
                       attribute={attr}
                       value={fieldValue(variant.id, attr.code, baseAttrs)}
                       provenance={resolveProv(attr, variant.attributesIndexed)}
-                      locale={'pl' satisfies ProductLocale}
-                      channel={null}
+                      locale={locale}
+                      channel={channel}
                       isEditing={isEditing && !attr.is_system}
                       isLocked={attr.is_system}
                       onChange={(next) => setVariantField(variant.id, attr.code, next)}


### PR DESCRIPTION
## Summary

- Zakładka wariantów (`VariantsTabHost`) **śledzi aktywny locale/channel karty rodzica** zamiast hardkodowanego `pl`/global.
- `locale`/`channel` płyną z `ProductDetailPage` przez `OtherTabs` → `VariantsTabHost`; lista wariantów (GET) i zapis (PATCH) doklejają `scopeQuery(locale, channel)`.
- Przełączenie scope resetuje niezapisane edycje wariantów (parytet z kartą produktu). Backend bez zmian — read przez collection overlay (#1223), write przez upserter (#1169).

Closes #1226

## Scope

`apps/admin` — `variants-tab-host.tsx` (+ prop-threading w `product-detail-page.tsx`) + spec E2E. Brak surface bezpieczeństwa.

## Smoke test (live-stack, https://pim.localhost) — network-verified

Setup: master + 2 warianty (API). UI: login → `/products/{master}` → przełącz Język na **EN** → zakładka Warianty → edytuj + Zapisz. Przechwycone żądania:
- **Lista wariantów (GET):** `…/api/products?parent_id=019e8e28…&locale=en` ✅ (przed fixem: bez `locale`)
- **Zapis wariantu (PATCH):** `…/api/products/019e8e28-badf…?locale=en` i `…-badc…?locale=en` → status <400 ✅

Czyli wariant edytowany w EN trafia do scope EN, nie globalnie. Potwierdzone faktycznymi URL-ami z DevTools/Playwright network.

## Testy

- Spec `e2e/1226-variants-scope-aware.spec.ts` — używa tego samego setupu `page.request` co sibling `view-07-3-products-variants.spec.ts`, więc `test.fixme(!!process.env.CI)` (współdzielony auth rate-limiter + page.request korzysta z in-memory JWT — „Pending storageState rollout", env-level, nie ta zmiana). Zachowanie scope potwierdzone manualnym smokiem powyżej.

## Definicja Done

- [x] Biome strict — green
- [x] TypeScript noEmit — green
- [x] Manual smoke — passed (network-verified, URL-e powyżej)
