### PR TITLE
feat(channel): helper LocaleCode (short <-> BCP-47)

### DIFF
--- a/apps/api/src/Channel/Application/Locale/LocaleCodeResolver.php
+++ b/apps/api/src/Channel/Application/Locale/LocaleCodeResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Application\Locale;
+
+use App\Channel\Contracts\LocaleCodeResolverInterface;
+use App\Channel\Domain\LocaleCode;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+
+/**
+ * Locales feature (#1228) — resolves the tenant-ambiguous SHORT -> BCP-47
+ * direction against a tenant's active locales.
+ *
+ * The SHORT direction delegates to the pure {@see LocaleCode}; the reverse
+ * walks `findActiveForTenant` (ordered by sortOrder) and returns the first
+ * active locale whose language matches. Matching is done on the catalog
+ * code via {@see LocaleCode::toShort} rather than `Locale::$language`,
+ * which is unpopulated for older seed rows.
+ *
+ * Per-request memoised through `$cache` keyed by `tenantId|short`; nulls
+ * are cached too (a missing match is a stable answer for the request).
+ */
+final class LocaleCodeResolver implements LocaleCodeResolverInterface
+{
+    /**
+     * @var array<string, string|null>
+     */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly TenantLocaleRepositoryInterface $tenantLocales,
+    ) {
+    }
+
+    public function toShort(string $code): string
+    {
+        return LocaleCode::toShort($code);
+    }
+
+    public function toBcp47(string $short, Tenant $tenant): ?string
+    {
+        $needle = LocaleCode::toShort($short);
+        $cacheKey = $tenant->getId()->toRfc4122().'|'.$needle;
+        if (\array_key_exists($cacheKey, $this->cache)) {
+            return $this->cache[$cacheKey];
+        }
+
+        $resolved = null;
+        foreach ($this->tenantLocales->findActiveForTenant($tenant) as $tenantLocale) {
+            $code = $tenantLocale->getLocale()->getCode();
+            if (LocaleCode::toShort($code) === $needle) {
+                $resolved = $code;
+                break;
+            }
+        }
+
+        $this->cache[$cacheKey] = $resolved;
+
+        return $resolved;
+    }
+}

--- a/apps/api/src/Channel/Contracts/LocaleCodeResolverInterface.php
+++ b/apps/api/src/Channel/Contracts/LocaleCodeResolverInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts;
+
+use App\Shared\Domain\Tenant;
+
+/**
+ * Cross-BC contract for locale code normalization (#1228).
+ *
+ * Exposed from `Channel\Contracts` (not `Channel\Internals`) so consumers
+ * in other bounded contexts — completeness per-locale (#1152), the channel
+ * publication profile + export (T3.x) — can convert between the SHORT
+ * (`pl`) and BCP-47 (`pl_PL`) shapes without reaching into Channel
+ * internals (Deptrac: `*_Internals -> Channel_Contracts` is allowed).
+ *
+ * The SHORT direction is pure ({@see \App\Channel\Domain\LocaleCode}); the
+ * reverse needs the tenant's enabled locales to disambiguate
+ * (`de` -> `de_DE` | `de_AT`), hence a tenant-scoped resolver.
+ */
+interface LocaleCodeResolverInterface
+{
+    /**
+     * Short (language-only) form of any locale code: `pl_PL` -> `pl`.
+     */
+    public function toShort(string $code): string;
+
+    /**
+     * BCP-47 form of a short code, resolved against the tenant's active
+     * locales: `pl` -> `pl_PL`. Returns null when no active tenant locale
+     * matches the language. When several active locales share the language
+     * (`de_DE` + `de_AT`), the first by sort order wins.
+     */
+    public function toBcp47(string $short, Tenant $tenant): ?string;
+}

--- a/apps/api/src/Channel/Domain/LocaleCode.php
+++ b/apps/api/src/Channel/Domain/LocaleCode.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain;
+
+/**
+ * Locale code normalization (#1228).
+ *
+ * The codebase carries locales in two shapes and silently mixing them
+ * mis-keys per-locale rows:
+ *   - SHORT (ISO 639-1, e.g. `pl`) — {@see \App\Shared\Domain\Tenant::$primaryLocale},
+ *     `Tenant::$enabledLocales`, `ObjectValue::$locale`, the `?locale=`
+ *     query param, and the `per_locale` completeness keys.
+ *   - BCP-47 (e.g. `pl_PL`) — the global {@see Entity\Locale} catalog and
+ *     `Channel::$locales`.
+ *
+ * This value helper owns the SHORT direction (the high-frequency one:
+ * turning a full catalog / Channel code into the short code used
+ * everywhere else). The tenant-ambiguous reverse (`de` -> `de_DE` | `de_AT`)
+ * lives in {@see \App\Channel\Contracts\LocaleCodeResolverInterface}, which
+ * resolves against the tenant's enabled locales.
+ *
+ * Pure + stateless so it is safe to call from hot paths (the read overlay,
+ * completeness rebuild) without a service round-trip.
+ */
+final class LocaleCode
+{
+    /**
+     * Short (language-only) form of a locale code, lower-cased.
+     *
+     * `pl_PL` -> `pl`, `en-US` -> `en`, `pl` -> `pl`, `PL` -> `pl`.
+     * Accepts either `_` or `-` as the region separator.
+     */
+    public static function toShort(string $code): string
+    {
+        $separator = self::separatorPos($code);
+        $language = null === $separator ? $code : substr($code, 0, $separator);
+
+        return strtolower($language);
+    }
+
+    /**
+     * Region subtag (upper-cased) or null when the code carries none.
+     *
+     * `pl_PL` -> `PL`, `en-us` -> `US`, `pl` -> null, `pl_` -> null.
+     */
+    public static function region(string $code): ?string
+    {
+        $separator = self::separatorPos($code);
+        if (null === $separator) {
+            return null;
+        }
+        $region = substr($code, $separator + 1);
+
+        return '' === $region ? null : strtoupper($region);
+    }
+
+    /**
+     * Whether the code carries a region subtag (`pl_PL` true, `pl` false).
+     */
+    public static function hasRegion(string $code): bool
+    {
+        return null !== self::region($code);
+    }
+
+    /**
+     * Position of the first `_` / `-` region separator, or null when the
+     * code is language-only.
+     */
+    private static function separatorPos(string $code): ?int
+    {
+        $underscore = strpos($code, '_');
+        $hyphen = strpos($code, '-');
+
+        if (false === $underscore && false === $hyphen) {
+            return null;
+        }
+        if (false === $underscore) {
+            return $hyphen;
+        }
+        if (false === $hyphen) {
+            return $underscore;
+        }
+
+        return min($underscore, $hyphen);
+    }
+}

--- a/apps/api/tests/Unit/Channel/Application/Locale/LocaleCodeResolverTest.php
+++ b/apps/api/tests/Unit/Channel/Application/Locale/LocaleCodeResolverTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel\Application\Locale;
+
+use App\Channel\Application\Locale\LocaleCodeResolver;
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class LocaleCodeResolverTest extends TestCase
+{
+    #[Test]
+    public function toShortDelegatesToThePureHelper(): void
+    {
+        $resolver = new LocaleCodeResolver($this->repo([]));
+
+        self::assertSame('pl', $resolver->toShort('pl_PL'));
+        self::assertSame('en', $resolver->toShort('en-US'));
+    }
+
+    #[Test]
+    public function toBcp47ResolvesAShortCodeAgainstActiveTenantLocales(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $resolver = new LocaleCodeResolver(
+            $this->repo([$this->tenantLocale('pl_PL', 'pl'), $this->tenantLocale('en_US', 'en')]),
+        );
+
+        self::assertSame('pl_PL', $resolver->toBcp47('pl', $tenant));
+        self::assertSame('en_US', $resolver->toBcp47('en', $tenant));
+    }
+
+    #[Test]
+    public function toBcp47AcceptsAFullCodeAndNormalisesItFirst(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $resolver = new LocaleCodeResolver($this->repo([$this->tenantLocale('pl_PL', 'pl')]));
+
+        self::assertSame('pl_PL', $resolver->toBcp47('pl_PL', $tenant));
+    }
+
+    #[Test]
+    public function toBcp47ReturnsNullWhenNoActiveLocaleMatches(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        $resolver = new LocaleCodeResolver($this->repo([$this->tenantLocale('pl_PL', 'pl')]));
+
+        self::assertNull($resolver->toBcp47('fr', $tenant));
+    }
+
+    #[Test]
+    public function toBcp47ReturnsTheFirstMatchBySortOrderWhenALanguageIsAmbiguous(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+        // de_AT first (sortOrder 0), de_DE second — first by order wins.
+        $resolver = new LocaleCodeResolver(
+            $this->repo([$this->tenantLocale('de_AT', 'de'), $this->tenantLocale('de_DE', 'de')]),
+        );
+
+        self::assertSame('de_AT', $resolver->toBcp47('de', $tenant));
+    }
+
+    private function tenantLocale(string $code, string $language): TenantLocale
+    {
+        return new TenantLocale(new Locale($code, $code, null, $language));
+    }
+
+    /**
+     * @param list<TenantLocale> $active
+     */
+    private function repo(array $active): TenantLocaleRepositoryInterface
+    {
+        return new class($active) implements TenantLocaleRepositoryInterface {
+            /**
+             * @param list<TenantLocale> $active
+             */
+            public function __construct(private array $active)
+            {
+            }
+
+            public function findById(Uuid $id): ?TenantLocale
+            {
+                return null;
+            }
+
+            public function findByTenantAndLocale(Tenant $tenant, Locale $locale): ?TenantLocale
+            {
+                return null;
+            }
+
+            public function findByTenantAndCode(Tenant $tenant, string $code): ?TenantLocale
+            {
+                return null;
+            }
+
+            public function findActiveForTenant(Tenant $tenant): array
+            {
+                return $this->active;
+            }
+
+            public function findAllForTenant(Tenant $tenant): array
+            {
+                return $this->active;
+            }
+
+            public function findDefaultForTenant(Tenant $tenant): ?TenantLocale
+            {
+                return $this->active[0] ?? null;
+            }
+
+            public function save(TenantLocale $entity): void
+            {
+            }
+
+            public function remove(TenantLocale $entity): void
+            {
+            }
+        };
+    }
+}

--- a/apps/api/tests/Unit/Channel/Domain/LocaleCodeTest.php
+++ b/apps/api/tests/Unit/Channel/Domain/LocaleCodeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel\Domain;
+
+use App\Channel\Domain\LocaleCode;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class LocaleCodeTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function shortCases(): iterable
+    {
+        yield 'bcp-47 underscore' => ['pl_PL', 'pl'];
+        yield 'bcp-47 hyphen' => ['en-US', 'en'];
+        yield 'already short' => ['pl', 'pl'];
+        yield 'uppercase short' => ['PL', 'pl'];
+        yield 'uppercase language with region' => ['DE_DE', 'de'];
+        yield 'trailing separator' => ['pl_', 'pl'];
+    }
+
+    #[Test]
+    #[DataProvider('shortCases')]
+    public function toShortStripsAndLowercasesTheRegion(string $code, string $expected): void
+    {
+        self::assertSame($expected, LocaleCode::toShort($code));
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null}>
+     */
+    public static function regionCases(): iterable
+    {
+        yield 'underscore region' => ['pl_PL', 'PL'];
+        yield 'hyphen lowercase region' => ['en-us', 'US'];
+        yield 'language only' => ['pl', null];
+        yield 'empty region' => ['pl_', null];
+    }
+
+    #[Test]
+    #[DataProvider('regionCases')]
+    public function regionIsUppercasedOrNull(string $code, ?string $expected): void
+    {
+        self::assertSame($expected, LocaleCode::region($code));
+    }
+
+    #[Test]
+    public function hasRegionReflectsPresenceOfARegionSubtag(): void
+    {
+        self::assertTrue(LocaleCode::hasRegion('pl_PL'));
+        self::assertTrue(LocaleCode::hasRegion('en-US'));
+        self::assertFalse(LocaleCode::hasRegion('pl'));
+        self::assertFalse(LocaleCode::hasRegion('pl_'));
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -9248,7 +9248,7 @@
                     },
                     "status": {
                         "type": [
-                            "number",
+                            "integer",
                             "null"
                         ],
                         "examples": [
@@ -9297,7 +9297,7 @@
                             },
                             "status": {
                                 "type": [
-                                    "number",
+                                    "integer",
                                     "null"
                                 ],
                                 "examples": [


### PR DESCRIPTION
## Summary

- `Channel\Domain\LocaleCode` — czysty helper: `toShort('pl_PL') → 'pl'`, `region()`, `hasRegion()` (akceptuje `_` i `-`). Stateless, bezpieczny na hot-pathach.
- `Channel\Contracts\LocaleCodeResolverInterface` + `Channel\Application\Locale\LocaleCodeResolver` — tenant-aware kierunek odwrotny `toBcp47('pl', tenant) → 'pl_PL'`, rozwiązywany po aktywnych locale tenanta (memoizowany; pierwszy po sortOrder przy ambiwalencji `de_DE`/`de_AT`).

Centralizuje konwersję short↔BCP-47, usuwając cichą minę: `ObjectValue.locale`/`Tenant` używają kodów krótkich, a katalog `Locale`/`Channel.locales` — pełnych. Kontrakt w `Channel\Contracts` (Deptrac-safe) — odblokowuje completeness per-locale (#1152) i profil publikacji (T3.x).

Closes #1228

## Scope

`apps/api` — Channel BC (Domain + Contracts + Application) + testy jednostkowe. Brak konsumenta w tym PR (infrastruktura pod Fazę 2/3). Autowiring aliasuje interfejs → impl (jak `LocaleFallbackResolver`). Brak surface bezpieczeństwa.

## Testy / bramki

- **PHPUnit** — `LocaleCodeTest` (toShort/region/hasRegion, data-provider) + `LocaleCodeResolverTest` (toBcp47 z fake repo: match, full-input, brak dopasowania = null, ambiwalencja = pierwszy po order). 16 testów / 21 asercji — green.
- **PHPStan max** — green · **Deptrac** — 0 errors / 0 warnings (zero nowych `skip_violations`) · **PHP-CS-Fixer** — clean · **composer audit** — (CI).
- **Bez E2E** — pure helper bez UI/endpointu (zgodnie z treścią ticketu). Live-stack smoke nie dotyczy (brak user-facing flow); zachowanie pokryte testami jednostkowymi.

## Definicja Done

- [x] PHPStan max — green
- [x] Deptrac — green (0/0)
- [x] PHPUnit ≥80% nowej logiki — green (16 testów)
- [x] PHP-CS-Fixer — clean
- [x] Bez E2E (pure helper, brak UI) — uzasadnione w treści
