### PR TITLE
fix(catalog): hasMultimedia flippable on built-in Product (revert UP-07b lock)

### DIFF
--- a/apps/api/src/Catalog/Application/ObjectTypeService.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeService.php
@@ -200,17 +200,13 @@ final readonly class ObjectTypeService
             $objectType->setCategorizable($isCategorizable);
         }
         if (null !== $hasMultimedia) {
-            // UP-07b (#1022): built-in Product is locked TRUE (legacy
-            // multimedia tab behaviour). Other kinds (built-in + custom)
-            // are free to flip. Toggle gates the Multimedia tab on
-            // UniversalDetailPage (UP-07).
-            if (
-                $isBuiltIn
-                && ObjectKind::Product === $objectType->getKind()
-                && $objectType->hasMultimedia() !== $hasMultimedia
-            ) {
-                throw BuiltInObjectTypeException::fieldLocked($objectType, 'hasMultimedia');
-            }
+            // UX-03 (#1049): capability flags (hasVariants / isCategorizable /
+            // hasMultimedia) gate *which tabs* the operator sees, not the
+            // entity model — so they stay flippable on built-in rows too,
+            // otherwise built-in Product is forever stuck on its seed value.
+            // (Reverts the UP-07b built-in-Product lock, which regressed this
+            // contract and broke updateUnlocksCapabilityFlagsOnBuiltInProduct.)
+            //
             // UX-03: Asset is itself a multimedia object; promoting an Asset
             // ObjectType to host a Multimedia tab creates a recursive UI
             // (the multimedia tab would list assets pointing at assets).

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -9248,7 +9248,7 @@
                     },
                     "status": {
                         "type": [
-                            "number",
+                            "integer",
                             "null"
                         ],
                         "examples": [
@@ -9297,7 +9297,7 @@
                             },
                             "status": {
                                 "type": [
-                                    "number",
+                                    "integer",
                                     "null"
                                 ],
                                 "examples": [


### PR DESCRIPTION
## Summary

- Usuwa lock z UP-07b (#1036), który blokował `hasMultimedia` na built-in Product.
- Przywraca kontrakt UX-03 (#1049): capability flagi (`hasVariants` / `isCategorizable` / `hasMultimedia`) są przełączalne na built-in rows — gatują *które zakładki* widzi operator, nie model encji. Asset-exclusion (prawdziwy invariant modelu) zostaje.

## Tło

`ObjectTypeServiceTest::updateUnlocksCapabilityFlagsOnBuiltInProduct` (z #1049) padał na main od czasu #1036 (`BuiltInObjectTypeException: hasMultimedia cannot be edited`). Bramki PHP są **path-filtered na `apps/api`/`docs/api-spec`**, więc czerwony PHPUnit nie ujawniał się przy PR-ach FE-only — wyszedł dopiero przy pierwszym PR dotykającym `apps/api` od czasu #1036. Ten fix odblokowuje main dla wszystkich takich PR-ów.

Decyzja operatora: lock z UP-07b to regresja → zdjąć (UX-03 jest właściwe).

## Scope

`apps/api` — `ObjectTypeService.php` (usunięcie jednego bloku `if`). Bez zmian w testach (żaden nie asertował locka; istniejący test UX-03 teraz przechodzi). Brak surface bezpieczeństwa.

## Testy / bramki

- **PHPUnit** — naprawia `updateUnlocksCapabilityFlagsOnBuiltInProduct` (weryfikacja w CI; lokalny dev-kontener nie startuje test-kernela — `framework.test`). `updateStillLocksStructuralFlagsOnBuiltInProduct` i `updateRejectsHasMultimediaTrueOnAsset` pozostają zielone (locki strukturalne + Asset-exclusion nietknięte).
- **PHPStan max** — green (lokalnie `[OK] No errors`) · **PHP-CS-Fixer** — clean · **Deptrac** — 0/0.

## Definicja Done

- [x] PHPStan max — green
- [x] PHP-CS-Fixer / Deptrac — clean
- [ ] PHPUnit — zielony test w CI (potwierdzenie po runie)
