### PR TITLE
feat(export): per-channel columns in export engine

### DIFF
--- a/apps/api/src/Export/Application/Builder/ColumnResolver.php
+++ b/apps/api/src/Export/Application/Builder/ColumnResolver.php
@@ -52,20 +52,26 @@ final class ColumnResolver
 
     /**
      * @param iterable<string> $selectedColumns
+     * @param list<string>     $channelCodes    channel codes active for the session (#1229);
+     *                                          a `code.modifier` whose modifier is one of these
+     *                                          resolves to a channel-scoped column, otherwise locale
      *
      * @return array<int, ColumnDefinition>
      */
-    public function resolve(iterable $selectedColumns): array
+    public function resolve(iterable $selectedColumns, array $channelCodes = []): array
     {
         $resolved = [];
         foreach ($selectedColumns as $key) {
-            $resolved[] = $this->resolveOne($key);
+            $resolved[] = $this->resolveOne($key, $channelCodes);
         }
 
         return $resolved;
     }
 
-    public function resolveOne(string $key): ColumnDefinition
+    /**
+     * @param list<string> $channelCodes
+     */
+    public function resolveOne(string $key, array $channelCodes = []): ColumnDefinition
     {
         if (\array_key_exists($key, self::BUILT_INS)) {
             return new ColumnDefinition(
@@ -85,10 +91,21 @@ final class ColumnResolver
 
         [$code, $modifier] = explode('.', $key, 2);
 
-        // PRD §5.3: locale codes are short (`pl`, `en`, `de`) and channels
-        // are kebab-cased identifiers (`shopify`, `baselinker`). The
-        // builder asks the row context to disambiguate when both are
-        // possible — channels know themselves by `code`.
+        // #1229: a modifier naming one of the session's active channels is a
+        // channel-scoped column (`description.shopify`); anything else is a
+        // locale (`description.pl`). Disambiguating by membership beats a
+        // "short = locale, kebab = channel" heuristic, which would collide on
+        // a 2-letter channel code. Combined notation (`description.pl.shopify`)
+        // stays deferred (PRD §5.3); `explode(..., 2)` keeps the tail intact.
+        if (\in_array($modifier, $channelCodes, true)) {
+            return new ColumnDefinition(
+                key: $key,
+                kind: ColumnDefinition::KIND_ATTRIBUTE,
+                code: $code,
+                channel: $modifier,
+            );
+        }
+
         return new ColumnDefinition(
             key: $key,
             kind: ColumnDefinition::KIND_ATTRIBUTE,

--- a/apps/api/src/Export/Application/Builder/ExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/ExportBuilder.php
@@ -8,6 +8,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelResolverInterface;
 use App\Export\Domain\Entity\ExportSession;
 use Generator;
 use LogicException;
@@ -45,6 +46,7 @@ final class ExportBuilder
         private readonly ObjectCategoryRepositoryInterface $categories,
         private readonly ColumnResolver $columnResolver,
         private readonly ValueSerializer $serializer,
+        private readonly ChannelResolverInterface $channels,
     ) {
     }
 
@@ -55,29 +57,44 @@ final class ExportBuilder
      */
     public function build(iterable $objects, ExportSession $session): Generator
     {
-        if (null === $session->getTenant()) {
+        $tenant = $session->getTenant();
+        if (null === $tenant) {
             throw new LogicException('Export session must carry a tenant before build().');
         }
 
-        $columns = $this->columnResolver->resolve($session->getSelectedColumns());
+        $channelCodes = $session->getChannels() ?? [];
+        $columns = $this->columnResolver->resolve($session->getSelectedColumns(), $channelCodes);
+
+        // #1229: ObjectValue rows key the channel scope by UUID, so resolve
+        // each session channel code to its id once up-front. A code with no
+        // matching tenant channel is dropped here and degrades to a blank
+        // cell in cellFor() (stale profile, R-47) rather than 500-ing.
+        $channelIdByCode = [];
+        foreach ($channelCodes as $code) {
+            $id = $this->channels->resolveId($code, $tenant);
+            if (null !== $id) {
+                $channelIdByCode[$code] = $id->toRfc4122();
+            }
+        }
 
         foreach ($objects as $object) {
-            yield $this->renderRow($object, $columns);
+            yield $this->renderRow($object, $columns, $channelIdByCode);
         }
     }
 
     /**
      * @param array<int, ColumnDefinition> $columns
+     * @param array<string, string>        $channelIdByCode channel code => UUID RFC 4122 (#1229)
      *
      * @return array<string, string>
      */
-    private function renderRow(CatalogObject $object, array $columns): array
+    private function renderRow(CatalogObject $object, array $columns, array $channelIdByCode): array
     {
         $valueIndex = $this->indexValuesByObject($object);
         $row = [];
 
         foreach ($columns as $column) {
-            $row[$column->key] = $this->cellFor($object, $column, $valueIndex);
+            $row[$column->key] = $this->cellFor($object, $column, $valueIndex, $channelIdByCode);
         }
 
         return $row;
@@ -108,19 +125,30 @@ final class ExportBuilder
 
     /**
      * @param array<string, ObjectValue> $valueIndex
+     * @param array<string, string>      $channelIdByCode channel code => UUID RFC 4122 (#1229)
      */
     private function cellFor(
         CatalogObject $object,
         ColumnDefinition $column,
         array $valueIndex,
+        array $channelIdByCode,
     ): string {
         if ($column->isBuiltIn()) {
             return $this->builtIn($object, $column->code);
         }
 
-        // Attribute lookup. Channel-scoped variant deferred to Faza 1
-        // (PRD §6.1) — MVP exports use locale-only narrowing.
-        $key = $this->indexKey($column->code, $column->locale, null);
+        // #1229: channel-scoped column (`description.shopify`) narrows the
+        // lookup to the channel's UUID; a channel that didn't resolve yields
+        // a blank cell rather than silently falling back to the global value.
+        $channelId = null;
+        if (null !== $column->channel) {
+            $channelId = $channelIdByCode[$column->channel] ?? null;
+            if (null === $channelId) {
+                return '';
+            }
+        }
+
+        $key = $this->indexKey($column->code, $column->locale, $channelId);
         $value = $valueIndex[$key] ?? null;
 
         // Stale profile / missing attribute (R-47 from PRD §14). Don't

--- a/apps/api/tests/Unit/Export/Application/Builder/ColumnResolverTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ColumnResolverTest.php
@@ -54,6 +54,28 @@ final class ColumnResolverTest extends TestCase
     }
 
     #[Test]
+    public function modifierMatchingASessionChannelResolvesAsChannel(): void
+    {
+        // #1229 — a modifier naming one of the session's channels is a
+        // channel-scoped column, not a locale.
+        $col = new ColumnResolver()->resolveOne('description.shopify', ['shopify', 'baselinker']);
+        self::assertTrue($col->isAttribute());
+        self::assertSame('description', $col->code);
+        self::assertSame('shopify', $col->channel);
+        self::assertNull($col->locale);
+    }
+
+    #[Test]
+    public function modifierNotAmongSessionChannelsStaysLocale(): void
+    {
+        // #1229 — disambiguation by membership: `pl` is not a channel, so it
+        // stays a locale even when channels are present.
+        $col = new ColumnResolver()->resolveOne('description.pl', ['shopify']);
+        self::assertSame('pl', $col->locale);
+        self::assertNull($col->channel);
+    }
+
+    #[Test]
     public function resolveArrayReturnsDefinitionsInOrder(): void
     {
         $resolver = new ColumnResolver();

--- a/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
@@ -13,6 +13,7 @@ use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelResolverInterface;
 use App\Export\Application\Builder\ColumnResolver;
 use App\Export\Application\Builder\ExportBuilder;
 use App\Export\Application\Builder\ValueSerializer;
@@ -92,6 +93,43 @@ final class ExportBuilderTest extends TestCase
     }
 
     #[Test]
+    public function rendersAttributeColumnsWithChannelScoping(): void
+    {
+        // #1229 — `description.shopify` resolves to the channel-scoped value;
+        // the bare `description` column still emits the global value, and a
+        // channel column whose channel does not resolve stays blank (it does
+        // NOT silently fall back to the global value).
+        $product = $this->newProduct('SKU-CH');
+        $desc = $this->newAttribute('description', AttributeType::Text);
+        $shopifyId = Uuid::v7();
+
+        $valuesByObject = [
+            spl_object_id($product) => [
+                new ObjectValue($product, $desc, ['value' => 'Global desc']),
+                new ObjectValue($product, $desc, ['value' => 'Shopify desc'], channelId: $shopifyId),
+            ],
+        ];
+
+        $builder = $this->newBuilder(
+            valuesByObject: $valuesByObject,
+            categoriesByObject: [],
+            channelIds: ['shopify' => $shopifyId],
+        );
+        $session = $this->newSessionWithTenant(
+            ['sku', 'description', 'description.shopify', 'description.allegro'],
+            channels: ['shopify', 'allegro'],
+        );
+        $rows = iterator_to_array($builder->build([$product], $session));
+
+        self::assertSame([
+            'sku' => 'SKU-CH',
+            'description' => 'Global desc',
+            'description.shopify' => 'Shopify desc',
+            'description.allegro' => '',
+        ], $rows[0]);
+    }
+
+    #[Test]
     public function missingAttributeYieldsBlankCell(): void
     {
         // R-47 from PRD §14 — profile references attribute that does not
@@ -156,9 +194,13 @@ final class ExportBuilderTest extends TestCase
     /**
      * @param array<int, list<ObjectValue>>    $valuesByObject     keyed by spl_object_id($product)
      * @param array<int, list<ObjectCategory>> $categoriesByObject same
+     * @param array<string, Uuid>              $channelIds         channel code => id (#1229)
      */
-    private function newBuilder(array $valuesByObject, array $categoriesByObject): ExportBuilder
-    {
+    private function newBuilder(
+        array $valuesByObject,
+        array $categoriesByObject,
+        array $channelIds = [],
+    ): ExportBuilder {
         $values = $this->createStub(ObjectValueRepositoryInterface::class);
         $values->method('findByObject')->willReturnCallback(
             static fn (CatalogObject $object): array => $valuesByObject[spl_object_id($object)] ?? []
@@ -169,11 +211,17 @@ final class ExportBuilderTest extends TestCase
             static fn (CatalogObject $object): array => $categoriesByObject[spl_object_id($object)] ?? []
         );
 
+        $channels = $this->createStub(ChannelResolverInterface::class);
+        $channels->method('resolveId')->willReturnCallback(
+            static fn (string $code): ?Uuid => $channelIds[$code] ?? null
+        );
+
         return new ExportBuilder(
             values: $values,
             categories: $categories,
             columnResolver: new ColumnResolver(),
             serializer: new ValueSerializer(),
+            channels: $channels,
         );
     }
 
@@ -203,9 +251,10 @@ final class ExportBuilderTest extends TestCase
     }
 
     /**
-     * @param list<string> $selectedColumns
+     * @param list<string>      $selectedColumns
+     * @param list<string>|null $channels
      */
-    private function newSession(array $selectedColumns): ExportSession
+    private function newSession(array $selectedColumns, ?array $channels = null): ExportSession
     {
         return new ExportSession(
             userId: Uuid::v7(),
@@ -213,15 +262,17 @@ final class ExportBuilderTest extends TestCase
             format: ExportFormat::Xlsx,
             targetScope: ExportTargetScope::Selected,
             selectedColumns: $selectedColumns,
+            channels: $channels,
         );
     }
 
     /**
-     * @param list<string> $selectedColumns
+     * @param list<string>      $selectedColumns
+     * @param list<string>|null $channels
      */
-    private function newSessionWithTenant(array $selectedColumns): ExportSession
+    private function newSessionWithTenant(array $selectedColumns, ?array $channels = null): ExportSession
     {
-        $session = $this->newSession($selectedColumns);
+        $session = $this->newSession($selectedColumns, $channels);
         $session->assignTenant(new Tenant('demo', 'Demo'));
 
         return $session;


### PR DESCRIPTION
## Summary

- Silnik eksportu obsługuje **kolumny per-channel** — `ExportBuilder` nie hardkoduje już `channel=null` w lookupie wartości (odroczenie z EXP-03).
- `<atrybut>.<channel>` (np. `seo_title.allegro`) zawęża do wartości kanałowej `ObjectValue`; `ColumnResolver` rozróżnia modyfikator przez **przynależność do kanałów sesji** (modyfikator = nazwa kanału → channel, inaczej locale; bez kruchej heurystyki short-vs-kebab).
- Kody kanałów → id raz na `build()` przez `ChannelResolverInterface` (`Channel\Contracts`, Deptrac-safe). Nierozwiązany kanał → pusta komórka, NIE fallback do globalnej.

Closes #1229

## Scope

`apps/api` — `Export/Application/Builder/{ColumnResolver,ExportBuilder}` + testy jednostkowe. `ColumnDefinition.channel` już istniał. Brak surface bezpieczeństwa.

## Smoke test (live-stack, https://pim.localhost) — network-verified

Setup: `seo_title` oznaczony scopable; DEMO-100 wartość globalna + override dla kanału `allegro` (przez `PATCH ?channel=allegro`). Eksport CSV przez realny `POST /api/products/export` (`channels:["allegro"]`, kolumny `sku, seo_title, seo_title.allegro`) → **HTTP 200**, plik:

```
sku;seo_title;seo_title.allegro
DEMO-100;"GLOBAL seo title";"ALLEGRO seo title"
```

Kolumna `seo_title` = wartość globalna, `seo_title.allegro` = **odrębny** override kanałowy. Po smoke: wartości wyczyszczone + `seo_title` z powrotem nie-scopable (stan demo przywrócony).

## Testy / bramki

- **PHPUnit** `ExportBuilderTest::rendersAttributeColumnsWithChannelScoping` (global vs channel vs nierozwiązany=blank) + `ColumnResolverTest` (dezambiguacja channel/locale). 14 testów / 55 asercji — green.
- **PHPStan max** `[OK]` · **Deptrac** 0 violations/0 errors (Channel\Contracts inject) · **PHP-CS-Fixer** clean.
- Notacja łączona `attr.pl.shopify` świadomie odroczona (PRD §5.3) — single-modifier grammar.

## Definicja Done

- [x] PHPStan max / Deptrac / PHP-CS-Fixer — green
- [x] PHPUnit ≥80% nowej logiki — green
- [x] Manual smoke 5 min — passed (network-verified CSV powyżej)
