### PR TITLE
feat(catalog): per-channel + per-locale completeness (#1152 PR1)

### DIFF
--- a/apps/admin/e2e/1152-completeness-per-scope.spec.ts
+++ b/apps/admin/e2e/1152-completeness-per-scope.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * feat(catalog) #1152 — per-scope completeness ring on the product card.
+ *
+ * The ring reflects the active locale/channel scope
+ * (`completeness.per_channel[channel] ?? completeness.per_locale[locale] ??
+ * global`). This spec is the deterministic UI safety net: the ring renders
+ * in edit mode and survives a channel switch without crashing.
+ *
+ * The actual per-scope VALUE differentiation (per_channel.allegro ≠ global)
+ * is data-dependent (needs a scopable attribute with a channel override) and
+ * is proven by the AttributesIndexedRebuilder unit test + the live-stack
+ * smoke documented in the PR.
+ *
+ * Conditional `fixme` in CI for the shared-suite auth rate limiter (same as
+ * the sibling product specs); runs locally.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+// Seed-dependent product (DEMO-100); adjust if the demo seed changes.
+const PRODUCT_PATH = '/products/019e8e72-20d0-79b6-928e-435b1c815aa0';
+
+test('feat(catalog) #1152 — completeness ring survives a channel switch', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+  await page.goto(PRODUCT_PATH);
+  await page.waitForTimeout(1500);
+
+  // The completeness ring renders its percentage text in edit mode.
+  const ring = page.locator('text=/%$/').first();
+  await expect(ring).toBeVisible();
+
+  // Switch the channel; the ring must re-render (scoped read) without crashing.
+  await page
+    .getByRole('button', { name: /^kanał$|^channel$/i })
+    .first()
+    .click();
+  await page.waitForTimeout(300);
+  const option = page.getByRole('menuitem').nth(1);
+  if (await option.isVisible().catch(() => false)) {
+    await option.click();
+    await page.waitForTimeout(800);
+  }
+  await expect(page.locator('text=/%$/').first()).toBeVisible();
+});

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -54,7 +54,7 @@ import { CompletenessRing } from '@/features/catalog/products/components/complet
 import { EffectiveModelCard } from '@/features/catalog/products/components/effective-model-card';
 import { LocaleChannelToolbar } from '@/features/catalog/products/components/locale-channel-toolbar';
 import { ProductMultimediaTab } from '@/features/catalog/products/components/product-multimedia-tab';
-import { scopeQuery } from '@/features/catalog/products/components/scope';
+import { scopedCompleteness, scopeQuery } from '@/features/catalog/products/components/scope';
 import type {
   AttributeMeta,
   CatalogObjectDto,
@@ -380,6 +380,13 @@ export function UniversalDetailPage({
   const skuValue = product.code ?? '';
   const nameValue = typeof attrs.name === 'string' ? attrs.name : skuValue;
   const completenessPct = product.completenessPct ?? 0;
+  // #1152 — ring reflects the active locale/channel scope, falling back to global.
+  const { pct: scopedCompletenessPct, scope: completenessScope } = scopedCompleteness(
+    product.completeness,
+    locale,
+    channel,
+    completenessPct,
+  );
 
   return (
     <div className="-mx-6 -mt-6 min-h-[calc(100vh-3rem)] bg-zinc-50">
@@ -511,8 +518,19 @@ export function UniversalDetailPage({
                 </span>
               </div>
             </div>
-            <div className="flex items-center">
-              <CompletenessRing pct={completenessPct} size={72} stroke={6} />
+            <div className="flex flex-col items-center gap-1">
+              <CompletenessRing pct={scopedCompletenessPct} size={72} stroke={6} />
+              {completenessScope !== null ? (
+                <span
+                  className="num rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-zinc-500"
+                  title={t('products.completeness.scope_tooltip', {
+                    scope: completenessScope.toUpperCase(),
+                    defaultValue: 'Kompletność dla zakresu {{scope}}',
+                  })}
+                >
+                  {completenessScope}
+                </span>
+              ) : null}
             </div>
           </div>
         </div>

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -46,7 +46,7 @@ import { LocaleChannelToolbar } from './locale-channel-toolbar';
 import { PreviewButton } from './preview-button';
 import { ProductMultimediaTab } from './product-multimedia-tab';
 import { RelationsTab } from './relations-tab';
-import { scopeQuery } from './scope';
+import { scopedCompleteness, scopeQuery } from './scope';
 import { SyncStatusCard } from './sync-status-card';
 import type {
   AttributeMeta,
@@ -570,6 +570,14 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
         : '';
   const objectTypeName = product?.objectType?.name?.[lang] ?? null;
   const completenessPct = product?.completenessPct ?? 0;
+  // #1152 — the ring reflects the active locale/channel scope (Akeneo
+  // "readiness per target"); falls back to the global pct.
+  const { pct: scopedCompletenessPct, scope: completenessScope } = scopedCompleteness(
+    product?.completeness,
+    locale,
+    channel,
+    completenessPct,
+  );
   const breadcrumbCategory =
     typeof attrs.category === 'string' && attrs.category !== ''
       ? attrs.category
@@ -774,8 +782,19 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
               )}
             </div>
             {mode === 'edit' ? (
-              <div className="flex items-center">
-                <CompletenessRing pct={completenessPct} size={72} stroke={6} />
+              <div className="flex flex-col items-center gap-1">
+                <CompletenessRing pct={scopedCompletenessPct} size={72} stroke={6} />
+                {completenessScope !== null ? (
+                  <span
+                    className="num rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-zinc-500"
+                    title={t('products.completeness.scope_tooltip', {
+                      scope: completenessScope.toUpperCase(),
+                      defaultValue: 'Kompletność dla zakresu {{scope}}',
+                    })}
+                  >
+                    {completenessScope}
+                  </span>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/apps/admin/src/features/catalog/products/components/scope.ts
+++ b/apps/admin/src/features/catalog/products/components/scope.ts
@@ -1,3 +1,5 @@
+import type { CompletenessMap } from './types';
+
 /**
  * #1150 / #1155 — build the `?locale=&channel=` scope query string for
  * locale/channel-aware object reads + writes. A null channel = "all
@@ -9,4 +11,30 @@ export function scopeQuery(locale: string, channel: string | null): string {
     params.set('channel', channel);
   }
   return `?${params.toString()}`;
+}
+
+/**
+ * #1152 — resolve the completeness % for the active scope: a per-channel
+ * value wins (the operator is looking at "readiness for this channel"),
+ * then a per-locale value, else the global baseline. `scope` is the label
+ * the value came from (channel/locale code) or null when it fell back to
+ * global — the card only shows the chip when a scoped value was used.
+ */
+export function scopedCompleteness(
+  completeness: CompletenessMap | null | undefined,
+  locale: string,
+  channel: string | null,
+  fallbackPct: number,
+): { pct: number; scope: string | null } {
+  if (channel !== null) {
+    const perChannel = completeness?.per_channel?.[channel];
+    if (typeof perChannel === 'number') {
+      return { pct: perChannel, scope: channel };
+    }
+  }
+  const perLocale = completeness?.per_locale?.[locale];
+  if (typeof perLocale === 'number') {
+    return { pct: perLocale, scope: locale };
+  }
+  return { pct: completeness?.global ?? fallbackPct, scope: null };
 }

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -37,13 +37,28 @@ export interface ChannelOption {
   label?: Record<string, string>;
 }
 
+/**
+ * #1152 — per-scope completeness. `global` is the baseline; `per_channel`
+ * / `per_locale` map a scope code to its 0..100 pct (omitted when the
+ * tenant has no channels / non-primary locales).
+ */
+export interface CompletenessMap {
+  global?: number;
+  per_channel?: Record<string, number>;
+  per_locale?: Record<string, number>;
+}
+
 export interface CatalogObjectDto {
   id: string;
   code: string;
   enabled?: boolean;
   status?: string;
   kind?: string;
-  completeness?: { pct?: number; missing?: string[] } | null;
+  /**
+   * #1152 — per-scope completeness map written by AttributesIndexedRebuilder:
+   * `global` plus optional `per_channel` / `per_locale` (code → pct).
+   */
+  completeness?: CompletenessMap | null;
   completenessPct?: number;
   syncStatusAggregate?: 'gray' | 'green' | 'yellow' | 'red' | string;
   attributesIndexed?: Record<string, unknown>;

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1559,7 +1559,8 @@
         "none": "All channels"
       },
       "completeness": {
-        "aria": "Completeness {{pct}}%"
+        "aria": "Completeness {{pct}}%",
+        "scope_tooltip": "Completeness for scope {{scope}}"
       },
       "asset": {
         "picker_title": "Choose asset",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1607,7 +1607,8 @@
         "none": "Wszystkie kanały"
       },
       "completeness": {
-        "aria": "Kompletność {{pct}}%"
+        "aria": "Kompletność {{pct}}%",
+        "scope_tooltip": "Kompletność dla zakresu {{scope}}"
       },
       "asset": {
         "picker_title": "Wybierz zasób",

--- a/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
+++ b/apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application;
 
+use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use App\Channel\Contracts\LocaleFallbackResolverInterface;
+use App\Channel\Contracts\ScopeEnumeratorInterface;
+use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
@@ -24,16 +28,28 @@ use Doctrine\ORM\EntityManagerInterface;
  * ({@see \App\Catalog\Infrastructure\ApiPlatform\State\CatalogObjectLocaleOverlayProvider}).
  * Keeping the cache global keeps list views + Meilisearch deterministic.
  *
- * Completeness reads `ObjectType.completeness_rules.required` (a list of
- * Attribute codes) and reports how many of those have at least one
- * non-null value. The result is `{global: <int 0-100>}`. Per-channel /
- * locale completeness lands in #41 alongside the channel-aware reader.
+ * Completeness (#1152) reports, per scope, the share of
+ * `ObjectType.completeness_rules.required` codes that resolve to a value:
+ *   - `global`        — the global reading.
+ *   - `per_locale[L]` — for each active non-primary locale L. A localizable
+ *     code counts if it has a row in L (or anywhere on its fallback chain)
+ *     or a global value; a non-localizable code counts if the global value
+ *     exists.
+ *   - `per_channel[C]`— for each tenant channel C against the effective
+ *     required set `required ∪ required_per_channel[C]`. A scopable code
+ *     counts if it has a row in C or a global value; non-scopable counts on
+ *     the global value.
+ * Granularity is flat (per_channel ignores locale, per_locale ignores
+ * channel) per the jsonb-schemas contract; the channel×locale matrix is out
+ * of scope.
  */
 final readonly class AttributesIndexedRebuilder
 {
     public function __construct(
         private EntityManagerInterface $em,
         private EffectiveAttributeGroupResolver $resolver,
+        private ScopeEnumeratorInterface $scopes,
+        private LocaleFallbackResolverInterface $fallback,
     ) {
     }
 
@@ -54,8 +70,7 @@ final readonly class AttributesIndexedRebuilder
             // (locale=null, channel=null). Per-locale / per-channel rows are
             // surfaced on the read path by CatalogObjectLocaleOverlayProvider;
             // letting them into the cache makes lists + Meilisearch flicker
-            // by last-written scope (non-deterministic) and miscounts global
-            // completeness. Per-scope search/completeness is deferred (#1152).
+            // by last-written scope (non-deterministic).
             if (null !== $value->getLocale() || null !== $value->getChannelId()) {
                 continue;
             }
@@ -63,44 +78,223 @@ final readonly class AttributesIndexedRebuilder
         }
 
         $object->updateAttributeIndex($indexed);
+        $object->recordCompleteness($this->computeCompleteness($object, $values, $indexed));
+    }
 
-        // Completeness: required-list / present-count. Empty rules → 100.
+    /**
+     * @param array<int, ObjectValue> $values
+     * @param array<string, mixed>    $indexed global reading, code => value
+     *
+     * @return array{global: int, per_locale?: array<string, int>, per_channel?: array<string, int>}
+     */
+    private function computeCompleteness(CatalogObject $object, array $values, array $indexed): array
+    {
         $rules = $object->getObjectType()->getCompletenessRules();
-        $required = \is_array($rules['required'] ?? null) ? $rules['required'] : [];
 
-        // ADR-014 / MOD-09 (#901) — orphaned values (codes present in
-        // attributes_indexed but absent from the effective model) MUST
-        // NOT participate in completeness. Likewise, `required` entries
-        // that point at attributes outside the current effective model
-        // are ignored (a Telewizory-only `przekatna` requirement does
-        // not penalise a Pralki primary).
-        //
-        // Fallback: when the effective model is empty (e.g. an ObjectType
-        // with no group attachments yet, the early-bootstrap path on
-        // fixtures, or unit tests with a stub resolver) we keep the
-        // legacy contract — `required` counts as-is.
+        // ADR-014 / MOD-09 (#901) — only `required` entries inside the
+        // current effective model participate; orphaned codes do not
+        // penalise. Empty effective model keeps the legacy contract.
         $effectiveCodes = $this->effectiveAttributeCodes($object);
-        if ([] !== $effectiveCodes) {
-            $required = array_values(array_filter(
-                $required,
-                static fn (mixed $code): bool => \is_string($code) && \in_array($code, $effectiveCodes, true),
-            ));
-        }
+        $required = $this->filterByEffective($this->codeList($rules['required'] ?? null), $effectiveCodes);
 
-        if ([] === $required) {
-            $object->recordCompleteness(['global' => 100]);
-
-            return;
-        }
-
-        $present = 0;
+        $globalPresent = 0;
         foreach ($required as $code) {
-            if (\is_string($code) && \array_key_exists($code, $indexed)) {
-                ++$present;
+            if (\array_key_exists($code, $indexed)) {
+                ++$globalPresent;
             }
         }
-        $pct = (int) round(100 * $present / \count($required));
-        $object->recordCompleteness(['global' => $pct]);
+
+        $result = ['global' => $this->pct($globalPresent, \count($required))];
+
+        $tenant = $object->getTenant();
+        if (!$tenant instanceof Tenant) {
+            // Fresh aggregate built inside the same flush — no tenant scope
+            // to enumerate yet; the global reading is enough.
+            return $result;
+        }
+
+        [$attrByCode, $localeRows, $channelRows] = $this->indexRows($values);
+
+        $perLocale = $this->perLocale($required, $tenant, $attrByCode, $localeRows, $indexed);
+        if ([] !== $perLocale) {
+            $result['per_locale'] = $perLocale;
+        }
+
+        $perChannel = $this->perChannel($required, $rules, $effectiveCodes, $tenant, $attrByCode, $channelRows, $indexed);
+        if ([] !== $perChannel) {
+            $result['per_channel'] = $perChannel;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Single pass over the rows: attribute meta per code + the set of
+     * locales / channel-ids each code carries a row for.
+     *
+     * @param array<int, ObjectValue> $values
+     *
+     * @return array{0: array<string, Attribute>, 1: array<string, array<string, true>>, 2: array<string, array<string, true>>}
+     */
+    private function indexRows(array $values): array
+    {
+        $attrByCode = [];
+        $localeRows = [];
+        $channelRows = [];
+        foreach ($values as $value) {
+            $code = $value->getAttribute()->getCode();
+            $attrByCode[$code] ??= $value->getAttribute();
+
+            $locale = $value->getLocale();
+            if (null !== $locale) {
+                $localeRows[$code][$locale] = true;
+            }
+            $channelId = $value->getChannelId();
+            if (null !== $channelId) {
+                $channelRows[$code][$channelId->toRfc4122()] = true;
+            }
+        }
+
+        return [$attrByCode, $localeRows, $channelRows];
+    }
+
+    /**
+     * @param list<string>                       $required
+     * @param array<string, Attribute>           $attrByCode
+     * @param array<string, array<string, true>> $localeRows
+     * @param array<string, mixed>               $indexed
+     *
+     * @return array<string, int>
+     */
+    private function perLocale(array $required, Tenant $tenant, array $attrByCode, array $localeRows, array $indexed): array
+    {
+        $primary = $tenant->getPrimaryLocale();
+        $perLocale = [];
+        foreach ($this->scopes->localeShortCodes($tenant) as $locale) {
+            if ($locale === $primary) {
+                // The primary locale is stored as the global reading.
+                continue;
+            }
+            $chain = $this->fallback->resolve($locale, $tenant);
+            $present = 0;
+            foreach ($required as $code) {
+                if ($this->presentInLocale($code, $chain, $attrByCode, $localeRows, $indexed)) {
+                    ++$present;
+                }
+            }
+            $perLocale[$locale] = $this->pct($present, \count($required));
+        }
+
+        return $perLocale;
+    }
+
+    /**
+     * @param list<string>                       $chain      fallback chain, most specific first
+     * @param array<string, Attribute>           $attrByCode
+     * @param array<string, array<string, true>> $localeRows
+     * @param array<string, mixed>               $indexed
+     */
+    private function presentInLocale(string $code, array $chain, array $attrByCode, array $localeRows, array $indexed): bool
+    {
+        $attribute = $attrByCode[$code] ?? null;
+        if (!$attribute instanceof Attribute) {
+            return false;
+        }
+        if ($attribute->isLocalizable()) {
+            foreach ($chain as $chainCode) {
+                if (isset($localeRows[$code][$chainCode])) {
+                    return true;
+                }
+            }
+
+            return \array_key_exists($code, $indexed);
+        }
+
+        return \array_key_exists($code, $indexed);
+    }
+
+    /**
+     * @param list<string>                       $required
+     * @param array<string, mixed>               $rules
+     * @param list<string>                       $effectiveCodes
+     * @param array<string, Attribute>           $attrByCode
+     * @param array<string, array<string, true>> $channelRows
+     * @param array<string, mixed>               $indexed
+     *
+     * @return array<string, int>
+     */
+    private function perChannel(array $required, array $rules, array $effectiveCodes, Tenant $tenant, array $attrByCode, array $channelRows, array $indexed): array
+    {
+        $perChannelRules = \is_array($rules['required_per_channel'] ?? null) ? $rules['required_per_channel'] : [];
+
+        $perChannel = [];
+        foreach ($this->scopes->channelIdsByCode($tenant) as $channelCode => $channelId) {
+            $extra = $this->filterByEffective($this->codeList($perChannelRules[$channelCode] ?? null), $effectiveCodes);
+            $effective = array_values(array_unique([...$required, ...$extra]));
+
+            $present = 0;
+            foreach ($effective as $code) {
+                if ($this->presentInChannel($code, $channelId, $attrByCode, $channelRows, $indexed)) {
+                    ++$present;
+                }
+            }
+            $perChannel[$channelCode] = $this->pct($present, \count($effective));
+        }
+
+        return $perChannel;
+    }
+
+    /**
+     * @param array<string, Attribute>           $attrByCode
+     * @param array<string, array<string, true>> $channelRows
+     * @param array<string, mixed>               $indexed
+     */
+    private function presentInChannel(string $code, string $channelId, array $attrByCode, array $channelRows, array $indexed): bool
+    {
+        $attribute = $attrByCode[$code] ?? null;
+        if (!$attribute instanceof Attribute) {
+            return false;
+        }
+        if ($attribute->isScopable()) {
+            return isset($channelRows[$code][$channelId]) || \array_key_exists($code, $indexed);
+        }
+
+        return \array_key_exists($code, $indexed);
+    }
+
+    private function pct(int $present, int $total): int
+    {
+        return 0 === $total ? 100 : (int) round(100 * $present / $total);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function codeList(mixed $raw): array
+    {
+        if (!\is_array($raw)) {
+            return [];
+        }
+
+        return array_values(array_filter($raw, static fn (mixed $code): bool => \is_string($code)));
+    }
+
+    /**
+     * @param list<string> $codes
+     * @param list<string> $effectiveCodes
+     *
+     * @return list<string>
+     */
+    private function filterByEffective(array $codes, array $effectiveCodes): array
+    {
+        if ([] === $effectiveCodes) {
+            return $codes;
+        }
+
+        return array_values(array_filter(
+            $codes,
+            static fn (string $code): bool => \in_array($code, $effectiveCodes, true),
+        ));
     }
 
     /**

--- a/apps/api/src/Channel/Contracts/ScopeEnumeratorInterface.php
+++ b/apps/api/src/Channel/Contracts/ScopeEnumeratorInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts;
+
+use App\Shared\Domain\Tenant;
+
+/**
+ * Cross-BC port enumerating a tenant's completeness scopes (#1152).
+ *
+ * Exposed from `Channel\Contracts` so Catalog (the completeness rebuilder)
+ * can iterate the tenant's locales + channels without reaching into Channel
+ * internals (Deptrac: `Catalog_Internals -> Channel_Contracts`).
+ */
+interface ScopeEnumeratorInterface
+{
+    /**
+     * Active tenant locales as SHORT codes (`pl`, `en`) — matches
+     * `ObjectValue.locale` and the `per_locale` completeness keys.
+     *
+     * @return list<string>
+     */
+    public function localeShortCodes(Tenant $tenant): array;
+
+    /**
+     * Tenant channels as `code => UUID rfc4122` — the value rows key the
+     * channel scope by id, the `per_channel` completeness map by code.
+     *
+     * @return array<string, string>
+     */
+    public function channelIdsByCode(Tenant $tenant): array;
+}

--- a/apps/api/src/Channel/Domain/Repository/ChannelRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/ChannelRepositoryInterface.php
@@ -10,6 +10,15 @@ interface ChannelRepositoryInterface
 
     public function findByCode(string $code, \App\Shared\Domain\Tenant $tenant): ?\App\Channel\Domain\Entity\Channel;
 
+    /**
+     * All channels for the tenant (Channel has no `isActive` flag yet, so
+     * "all" == every channel). Used to enumerate per-channel completeness
+     * scopes (#1152).
+     *
+     * @return list<\App\Channel\Domain\Entity\Channel>
+     */
+    public function findAllForTenant(\App\Shared\Domain\Tenant $tenant): array;
+
     public function save(\App\Channel\Domain\Entity\Channel $entity): void;
 
     public function remove(\App\Channel\Domain\Entity\Channel $entity): void;

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelRepository.php
@@ -35,7 +35,8 @@ class DoctrineChannelRepository extends ServiceEntityRepository implements Chann
      */
     public function findAllForTenant(Tenant $tenant): array
     {
-        return array_values($this->findBy(['tenant' => $tenant], ['code' => 'ASC']));
+        // findBy already returns a list<Channel>; no array_values needed.
+        return $this->findBy(['tenant' => $tenant], ['code' => 'ASC']);
     }
 
     public function save(Channel $entity): void

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelRepository.php
@@ -30,6 +30,14 @@ class DoctrineChannelRepository extends ServiceEntityRepository implements Chann
         return parent::find($id->toRfc4122());
     }
 
+    /**
+     * @return list<Channel>
+     */
+    public function findAllForTenant(Tenant $tenant): array
+    {
+        return array_values($this->findBy(['tenant' => $tenant], ['code' => 'ASC']));
+    }
+
     public function save(Channel $entity): void
     {
         $em = $this->getEntityManager();

--- a/apps/api/src/Channel/Infrastructure/ScopeEnumerator.php
+++ b/apps/api/src/Channel/Infrastructure/ScopeEnumerator.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure;
+
+use App\Channel\Contracts\ScopeEnumeratorInterface;
+use App\Channel\Domain\LocaleCode;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+
+/**
+ * #1152 — enumerates a tenant's completeness scopes from the canonical
+ * Channel-context stores: active {@see \App\Channel\Domain\Entity\TenantLocale}
+ * rows (normalised to short codes via {@see LocaleCode}) and the tenant's
+ * {@see \App\Channel\Domain\Entity\Channel} rows.
+ *
+ * Autowiring aliases {@see ScopeEnumeratorInterface} to this single impl.
+ */
+final readonly class ScopeEnumerator implements ScopeEnumeratorInterface
+{
+    public function __construct(
+        private TenantLocaleRepositoryInterface $tenantLocales,
+        private ChannelRepositoryInterface $channels,
+    ) {
+    }
+
+    public function localeShortCodes(Tenant $tenant): array
+    {
+        $codes = [];
+        foreach ($this->tenantLocales->findActiveForTenant($tenant) as $tenantLocale) {
+            $codes[LocaleCode::toShort($tenantLocale->getLocale()->getCode())] = true;
+        }
+
+        return array_keys($codes);
+    }
+
+    public function channelIdsByCode(Tenant $tenant): array
+    {
+        $map = [];
+        foreach ($this->channels->findAllForTenant($tenant) as $channel) {
+            $map[$channel->getCode()] = $channel->getId()->toRfc4122();
+        }
+
+        return $map;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/CompletenessCalculationTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/CompletenessCalculationTest.php
@@ -12,30 +12,25 @@ use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use App\Channel\Contracts\LocaleFallbackResolverInterface;
+use App\Channel\Contracts\ScopeEnumeratorInterface;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Property-based-style coverage of the completeness calculation in
- * {@see AttributesIndexedRebuilder::rebuild} (audit / 0.11.6).
+ * {@see AttributesIndexedRebuilder::rebuild} (audit / 0.11.6, per-scope #1152).
  *
  * The listener-level integration test
  * ({@see \App\Tests\Integration\Catalog\AttributesIndexedSyncListenerTest})
  * verifies the wiring; this unit test enumerates the algorithm's
  * properties directly so regressions in the math (rounding, denominator
- * handling, missing-attribute counting) surface without a DB round-trip.
- *
- * Properties under test:
- *   1. Empty `required` list → completeness is always 100 regardless of values.
- *   2. Reported pct is always within [0, 100].
- *   3. All required attributes present → 100. None present → 0.
- *   4. Half present rounds to 50; uneven splits round to nearest int.
- *   5. Non-required attribute values do NOT bump completeness.
- *   6. Non-string entries inside `required` are silently ignored
- *      (defensive parsing of JSONB rules — they may be edited by hand).
+ * handling, missing-attribute counting, per-scope resolution) surface
+ * without a DB round-trip.
  */
 final class CompletenessCalculationTest extends TestCase
 {
@@ -101,9 +96,9 @@ final class CompletenessCalculationTest extends TestCase
         yield 'non-string entries in required are ignored' => [
             'required' => ['name', 42, null, true, 'brand'],
             'present' => ['name', 'brand'],
-            // Denominator stays at 5 (the rebuilder counts the list length),
-            // but only the two real string codes can ever match — so 2/5 = 40.
-            'expectedPct' => 40,
+            // Non-string entries are dropped from the denominator (codeList
+            // keeps only strings), so 2 real codes both present → 100.
+            'expectedPct' => 100,
         ];
     }
 
@@ -118,17 +113,7 @@ final class CompletenessCalculationTest extends TestCase
         array $present,
         int $expectedPct,
     ): void {
-        // Resolver stub returns empty effective groups — the rebuilder's
-        // MOD-09 effective-model filter is bypassed (empty effective set
-        // falls back to the legacy `required` count), so this unit test
-        // still exercises the raw math invariants.
-        $resolver = $this->createStub(EffectiveAttributeGroupResolver::class);
-        $resolver->method('resolve')->willReturn([]);
-        $resolver->method('loadGroupAttributes')->willReturn([]);
-        $rebuilder = new AttributesIndexedRebuilder(
-            $this->createStub(EntityManagerInterface::class),
-            $resolver,
-        );
+        $rebuilder = $this->newRebuilder();
 
         $tenant = self::tenantStub();
         $objectType = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
@@ -136,7 +121,7 @@ final class CompletenessCalculationTest extends TestCase
         $objectType->updateCompletenessRules(['required' => $required]);
 
         $object = new CatalogObject($objectType, 'SKU-PROP-1');
-        $values = self::buildObjectValues($object, $tenant, $present);
+        $values = self::buildGlobalValues($object, $tenant, $present);
 
         $rebuilder->rebuild($object, $values);
 
@@ -145,22 +130,14 @@ final class CompletenessCalculationTest extends TestCase
         self::assertGreaterThanOrEqual(0, $completeness['global']);
         self::assertLessThanOrEqual(100, $completeness['global']);
         self::assertSame($expectedPct, $completeness['global']);
+        // No tenant scopes enumerated → only the global reading is recorded.
+        self::assertSame(['global' => $expectedPct], $completeness);
     }
 
     #[Test]
     public function emptyValuesListWithNoRulesYieldsHundredAndEmptyAttributesIndexed(): void
     {
-        // Resolver stub returns empty effective groups — the rebuilder's
-        // MOD-09 effective-model filter is bypassed (empty effective set
-        // falls back to the legacy `required` count), so this unit test
-        // still exercises the raw math invariants.
-        $resolver = $this->createStub(EffectiveAttributeGroupResolver::class);
-        $resolver->method('resolve')->willReturn([]);
-        $resolver->method('loadGroupAttributes')->willReturn([]);
-        $rebuilder = new AttributesIndexedRebuilder(
-            $this->createStub(EntityManagerInterface::class),
-            $resolver,
-        );
+        $rebuilder = $this->newRebuilder();
 
         $tenant = self::tenantStub();
         $objectType = new ObjectType('asset', ObjectKind::Asset, ['en' => 'Asset']);
@@ -173,25 +150,105 @@ final class CompletenessCalculationTest extends TestCase
         self::assertSame([], $object->getAttributesIndexed());
     }
 
+    #[Test]
+    public function rebuildComputesPerLocaleAndPerChannelCompleteness(): void
+    {
+        // #1152 — `desc` is localizable + scopable with NO global value, only
+        // a pl-locale row and an allegro-channel row. `name` is plain global.
+        // required_per_channel adds `extra` (unfilled) for allegro.
+        $allegroId = Uuid::v7();
+        $scopes = $this->createStub(ScopeEnumeratorInterface::class);
+        $scopes->method('localeShortCodes')->willReturn(['pl', 'en']);
+        $scopes->method('channelIdsByCode')->willReturn(['allegro' => $allegroId->toRfc4122()]);
+        $fallback = $this->createStub(LocaleFallbackResolverInterface::class);
+        // en falls back to the primary pl.
+        $fallback->method('resolve')->willReturnCallback(
+            static fn (string $code): array => 'en' === $code ? ['en', 'pl'] : [$code],
+        );
+
+        $rebuilder = $this->newRebuilder($scopes, $fallback);
+
+        $tenant = new Tenant('demo-scope', 'Demo'); // primaryLocale defaults to 'pl'
+        $objectType = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $objectType->assignTenant($tenant);
+        $objectType->updateCompletenessRules([
+            'required' => ['name', 'desc'],
+            'required_per_channel' => ['allegro' => ['extra']],
+        ]);
+
+        $object = new CatalogObject($objectType, 'SKU-SCOPE-1');
+        $object->assignTenant($tenant); // production: stamped by TenantAssignmentListener on persist
+
+        $name = self::attr('name', $tenant);
+        $desc = self::attr('desc', $tenant);
+        $desc->changeLocalizable(true);
+        $desc->changeScopable(true);
+
+        $values = [
+            new ObjectValue($object, $name, ['value' => 'Name']),                    // global
+            new ObjectValue($object, $desc, ['value' => 'Opis PL'], locale: 'pl'),   // pl-locale, no global
+            new ObjectValue($object, $desc, ['value' => 'Opis Allegro'], channelId: $allegroId), // channel
+        ];
+
+        $rebuilder->rebuild($object, $values);
+        $completeness = $object->getCompleteness();
+
+        // global: name present globally, desc has no global row → 1/2.
+        self::assertSame(50, $completeness['global']);
+        // per_locale['en']: name (non-loc → global) + desc (en→pl fallback hits the pl row) → 2/2.
+        self::assertSame(['en' => 100], $completeness['per_locale']);
+        // per_channel['allegro']: effective required = name, desc, extra.
+        // name (global) + desc (allegro row) present, extra absent → 2/3 = 67.
+        self::assertSame(['allegro' => 67], $completeness['per_channel']);
+    }
+
+    private function newRebuilder(
+        ?ScopeEnumeratorInterface $scopes = null,
+        ?LocaleFallbackResolverInterface $fallback = null,
+    ): AttributesIndexedRebuilder {
+        // Resolver stub returns empty effective groups — the rebuilder's
+        // MOD-09 effective-model filter is bypassed (empty effective set
+        // falls back to the legacy `required` count).
+        $resolver = $this->createStub(EffectiveAttributeGroupResolver::class);
+        $resolver->method('resolve')->willReturn([]);
+        $resolver->method('loadGroupAttributes')->willReturn([]);
+
+        if (null === $scopes) {
+            $scopes = $this->createStub(ScopeEnumeratorInterface::class);
+            $scopes->method('localeShortCodes')->willReturn([]);
+            $scopes->method('channelIdsByCode')->willReturn([]);
+        }
+        $fallback ??= $this->createStub(LocaleFallbackResolverInterface::class);
+
+        return new AttributesIndexedRebuilder(
+            $this->createStub(EntityManagerInterface::class),
+            $resolver,
+            $scopes,
+            $fallback,
+        );
+    }
+
     /**
      * @param list<string> $presentCodes
      *
      * @return list<ObjectValue>
      */
-    private static function buildObjectValues(CatalogObject $object, Tenant $tenant, array $presentCodes): array
+    private static function buildGlobalValues(CatalogObject $object, Tenant $tenant, array $presentCodes): array
     {
         $values = [];
         foreach ($presentCodes as $code) {
-            $attribute = new Attribute(
-                $code,
-                ['en' => ucfirst($code)],
-                AttributeType::Text,
-            );
-            $attribute->assignTenant($tenant);
-            $values[] = new ObjectValue($object, $attribute, ['value' => 'sample']);
+            $values[] = new ObjectValue($object, self::attr($code, $tenant), ['value' => 'sample']);
         }
 
         return $values;
+    }
+
+    private static function attr(string $code, Tenant $tenant): Attribute
+    {
+        $attribute = new Attribute($code, ['en' => ucfirst($code)], AttributeType::Text);
+        $attribute->assignTenant($tenant);
+
+        return $attribute;
     }
 
     private static function tenantStub(): Tenant

--- a/apps/api/tests/Unit/Channel/Infrastructure/ScopeEnumeratorTest.php
+++ b/apps/api/tests/Unit/Channel/Infrastructure/ScopeEnumeratorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel\Infrastructure;
+
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Channel\Infrastructure\ScopeEnumerator;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ScopeEnumeratorTest extends TestCase
+{
+    #[Test]
+    public function localeShortCodesNormalisesBcp47ToShortAndDedupes(): void
+    {
+        $tenantLocales = $this->createStub(TenantLocaleRepositoryInterface::class);
+        $tenantLocales->method('findActiveForTenant')->willReturn([
+            new TenantLocale(new Locale('pl_PL', 'pl_PL', null, 'pl')),
+            new TenantLocale(new Locale('en_US', 'en_US', null, 'en')),
+            new TenantLocale(new Locale('en_GB', 'en_GB', null, 'en')), // same language → deduped
+        ]);
+        $enum = new ScopeEnumerator($tenantLocales, $this->createStub(ChannelRepositoryInterface::class));
+
+        self::assertSame(['pl', 'en'], $enum->localeShortCodes(new Tenant('demo', 'Demo')));
+    }
+
+    #[Test]
+    public function channelIdsByCodeMapsCodeToRfc4122Id(): void
+    {
+        $allegro = Uuid::v7();
+        $shopify = Uuid::v7();
+        $channels = $this->createStub(ChannelRepositoryInterface::class);
+        $channels->method('findAllForTenant')->willReturn([
+            new Channel('allegro', ['pl' => 'Allegro'], $allegro),
+            new Channel('shopify', ['pl' => 'Shopify'], $shopify),
+        ]);
+        $enum = new ScopeEnumerator($this->createStub(TenantLocaleRepositoryInterface::class), $channels);
+
+        self::assertSame(
+            ['allegro' => $allegro->toRfc4122(), 'shopify' => $shopify->toRfc4122()],
+            $enum->channelIdsByCode(new Tenant('demo', 'Demo')),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `AttributesIndexedRebuilder` zapisuje obok `global` mapy **`per_locale`** i **`per_channel`** w `CatalogObject.completeness`.
  - localizable required code liczy się w locale L, gdy ma wiersz na łańcuchu fallbacku L lub wartość globalną; scopable code liczy się w kanale C, gdy ma wiersz C lub wartość globalną.
  - `per_channel` używa efektywnego required = `required ∪ required_per_channel[C]`. Granularność **płaska** (zgodnie z kontraktem jsonb-schemas; macierz channel×locale poza zakresem).
- Enumeracja scope przez nowy **`Channel\Contracts\ScopeEnumerator`** (Deptrac-safe; locale tenanta jako short codes + kanały code→id), reużywa `LocaleFallbackResolver` + `LocaleCode` (#1228).
- `completeness` JSONB jest już w grupie `admin:read` → karta produktu/OT renderuje **ring dla aktywnego scope** (`per_channel[channel] ?? per_locale[locale] ?? global`) z chipem zakresu. Bez zmiany serializacji → **brak OpenAPI driftu** (schemat `completeness` już generyczny).

Closes #1152 — to PR1 (silnik + badge). Edytor reguł per-channel required + odblokowanie built-in OT = PR2; dashboard per-channel rings = PR3 (follow-up).

## Scope

`apps/api` (Catalog rebuilder + Channel ScopeEnumerator/repo) + `apps/admin` (types/scope helper/karty/i18n) + testy. Brak migracji (`completeness_rules`/`completeness` to JSONB). Brak surface bezpieczeństwa.

## Smoke test (live-stack, https://pim.localhost) — network-verified

`description` oznaczony scopable; POST produktu z samym `name` (description globalnie BRAK); `PATCH ?channel=allegro` ustawia description tylko dla allegro. GET produktu (`admin:read`):

```
po POST:           completeness = { global: 25, per_locale: {de:25,en:25}, per_channel: {allegro: 25} }
po channel override: global = 25   per_channel = { allegro: 50 }   per_locale = { de:25, en:25 }
```

`description` wypełnione tylko dla allegro → **per_channel.allegro=50 vs global=25**. Mapy wystawione w odpowiedzi API bez zmiany serializacji. Cleanup: scopable revert + produkt usunięty (204).

## Testy / bramki

- **PHPUnit** `CompletenessCalculationTest::rebuildComputesPerLocaleAndPerChannelCompleteness` (global=50 / per_locale.en=100 z fallbackiem en→pl / per_channel.allegro=67 z `required_per_channel`) + `ScopeEnumeratorTest` (toShort, code→id). 15 testów / 84 asercje — green.
- **PHPStan max** `[OK]` · **Deptrac** 0 violations / 0 errors (Channel\Contracts inject) · **PHP-CS-Fixer** clean · **Biome / TypeScript** green.
- **Playwright** `e2e/1152-completeness-per-scope.spec.ts` (ring przetrwa przełączenie kanału) — `test.fixme(!!process.env.CI)` per konwencja; różnica per-scope dowiedziona smokem powyżej.

## Definicja Done

- [x] PHPStan / Deptrac / CS-Fixer / Biome / tsc — green
- [x] PHPUnit ≥80% nowej logiki — green
- [x] Manual smoke 5 min — passed (network-verified, global≠per_channel powyżej)
