### PR TITLE
docs(adr): ADR-0018 ChannelPublicationProfile — per-channel attribute allow-list

### DIFF
--- a/Project Plan/01-architektura-pim.md
+++ b/Project Plan/01-architektura-pim.md
@@ -262,7 +262,7 @@ System dzieli się na cztery główne konteksty domenowe (Bounded Contexts wg DD
 
 **Catalog Context** — typy obiektów domenowych (`ObjectType`), atrybuty, grupy atrybutów, instancje obiektów (produkty, kategorie, asocjacje), warianty. Rdzeń PIM po ADR-009. Encje: `ObjectType`, `ObjectTypeAttribute`, `Attribute`, `AttributeGroup`, `AttributeOption`, `Object` (poly: kind=`product`/`category`/`asset`/`custom`), `ObjectValue`, `ObjectVariant`, `Association`. Sub-context **Predefined Types** enkapsuluje predefiniowane fixture'y `Product`/`Category`/`Asset` (`is_built_in=true`) z dedykowanymi UX flow w admin UI i sugar paths w API. Pojęcie „Family" z poprzedniej iteracji jest deprecated — `ObjectType` przejmuje jego rolę i rozszerza ją na wszystkie byty domenowe.
 
-**Channel Context** — kanały sprzedaży, lokale, mappingi atrybutów per-kanał i per-`ObjectType`, completeness rules, publikacje. Encje: Channel, Locale, Currency, `ChannelObjectTypeMapping` (poly per `kind`), CompletenessRule.
+**Channel Context** — kanały sprzedaży, lokale, mappingi atrybutów per-kanał i per-`ObjectType`, completeness rules, publikacje. Encje: Channel, Locale, Currency, `ChannelObjectTypeMapping` (poly per `kind`), CompletenessRule, `ChannelPublicationProfile` (per-channel attribute/locale allow-list, ADR-0018).
 
 **Asset Context** — zarządzanie mediami (DAM), wersjonowanie, transformacje, metadane. Encje: Asset (predefined `ObjectType kind='asset'` + odrębna tabela storage), AssetVariant, AssetMetadata. User-defined metadata Asseta idzie przez `ObjectValue` (jednolity model atrybutów), storage szczegóły zostają w dedykowanych kolumnach `assets`.
 
@@ -1251,6 +1251,15 @@ Opcja (Y) zachowuje killer feature ADR-012 (dziedziczenie grup atrybutów po drz
 **Alternatywy odrzucone:** (a) status quo „jedno drzewo + multi-target" — nie spełnia żądania; (b) osobny category-kind ObjectType per drzewo — mnoży byty infrastrukturalne; (c) zachowanie współdzielenia kategorii między OT — niewykorzystane, komplikuje UX i unikalność ścieżek.
 
 **Referencje:** ADR-014 (rewidowany w zakresie scope drzewa; reszta — primary category overlay, cumulative resolution, EffectiveAttributeGroupResolver — w mocy). Plan implementacji: PR-A (#1118) schema+encja+create, PR-B API+resolver+walidacja przypisania, PR-C FE (dropdown all-categorizable + objectTypeId, list/new/show per drzewo, reword etykiety `is_categorizable` → „czy obiekty mogą być przypisane do drzewa").
+
+### ADR-0016, ADR-0017, ADR-0018 (per-file MADR)
+
+Decyzje ADR-0016 (format kluczy API + Argon2id), ADR-0017 (BYOK AES-256-GCM) i ADR-0018 (ChannelPublicationProfile — per-channel attribute/locale allow-list, `?publication=<channel>` oddzielne od `?channel=`) są zarchiwizowane w plikach per-file MADR w `docs/adr/`. Streszczenie ADR-0018:
+
+- Encja `ChannelPublicationProfile` w Channel BC (nie Catalog/Export); `published_attribute_codes=NULL` = publish-all (default).
+- Param `?publication=<channel>` dedykowany dla filtrowania atrybutów do profilu — NIE przeciążamy `?channel=` (który nadal znaczy overlay wartości).
+- Cross-BC dostęp przez `Channel\Contracts\ChannelPublicationResolverInterface` (Deptrac-safe).
+- Bare UUID refs (`channel_id`, `object_type_id`) zgodnie z ADR-015.
 
 ## 14. Roadmap rozwoju
 

--- a/docs/adr/0018-channel-publication-profile.md
+++ b/docs/adr/0018-channel-publication-profile.md
@@ -1,0 +1,122 @@
+# 0018. ChannelPublicationProfile — per-channel attribute/locale allow-list
+
+- **Status:** accepted
+- **Date:** 2026-06-04
+- **Deciders:** Marcin Lipiec, Senior Staff Engineer
+
+## Context and Problem Statement
+
+The export engine (epik EXP) and the API read path both need to know *which
+attributes* and *which locales* are relevant for a given distribution channel.
+Today every channel sees every attribute and every locale — correct for an
+unconfigured MVP but wrong for real integrations:
+
+- **Shopify** typically wants only 15-20 marketing attributes in EN+DE, not
+  all 200 internal fields in all 5 locales.
+- **Allegro** needs its own set of required attributes in PL only.
+- **Export CSV** without a channel filter produces files with hundreds of
+  columns that the operator must manually prune each time.
+
+Three concrete decisions were open before tickets #1232–#1235 could land:
+
+1. Where does the profile entity live (which Bounded Context)?
+2. How is publication-filtered reading exposed in the API — new param or
+   overloaded `?channel=`?
+3. How are cross-BC relationships expressed (Catalog + Export reading Channel
+   data)?
+
+## Decision Drivers
+
+- **Deptrac** enforces that `Catalog` and `Export` cannot import Channel
+  internals — only `Channel\Contracts` is allowed.
+- `?channel=` already has a well-established meaning: overlay per-channel
+  ObjectValue rows (value scoping). Adding a second semantic would break
+  all existing clients silently.
+- The default profile must be publish-all so that existing tenants with no
+  configured profiles see zero regression — all attributes, all locales.
+- Bare-UUID cross-BC references are the established pattern (ADR-015);
+  Doctrine associations between BCs are forbidden (ADR-015).
+
+## Considered Options
+
+1. **Option A — Entity in Channel BC, `?publication=<channel>` param**
+   — dedicated profile entity in `Channel/Domain`, resolver interface in
+   `Channel/Contracts`, `?publication=<channel>` as a distinct query param.
+
+2. **Option B — Entity in Catalog BC, reuse `?channel=` param**
+   — profile lives in Catalog next to ObjectType; channel filter and
+   publication filter share the same query parameter, disambiguated by
+   whether a profile row exists.
+
+3. **Option C — Entity in a new Publication BC, new API version**
+   — separate bounded context, versioned `/v2` API surface.
+
+## Decision Outcome
+
+Chosen option: **Option A**, because:
+
+- The profile *describes a channel's configuration* — it belongs in Channel BC
+  semantically and keeps Catalog clean.
+- A distinct `?publication=<channel>` param is unambiguous, preserves the
+  existing semantics of `?channel=`, and can evolve independently (e.g.
+  adding `?publication=<channel>@v2` in the future is safe).
+- A `Channel\Contracts` interface (`ChannelPublicationResolverInterface`) gives
+  Catalog and Export a Deptrac-clean call site with no direct dependency on
+  Channel internals.
+- Option B conflates two orthogonal concerns (value overlay vs. attribute
+  allow-list) under one parameter name — a recipe for subtle bugs.
+- Option C adds a fourth BC for ~4 domain classes; the overhead is not
+  justified at this stage.
+
+### Consequences
+
+- **Positive:**
+  - `?channel=` keeps its existing single meaning (value overlay).
+  - `?publication=<channel>` is additive — consumers that don't send it get
+    the same full response as before (publish-all default).
+  - `Channel\Contracts\ChannelPublicationResolverInterface` is Deptrac-safe
+    and reusable by both Catalog (API read) and Export (column planner).
+  - Auto-created default profile on `ChannelCreated` event → zero manual
+    setup cost for new tenants.
+
+- **Negative:**
+  - Two separate parameters (`?locale=`, `?channel=`, `?publication=`) increase
+    API surface; documented clearly in OpenAPI (#1230).
+  - A channel-keyed profile must be back-filled for existing channels on
+    migration (handled in the migration SQL for ticket #1232).
+
+- **Follow-ups:**
+  - #1232: entity + migration + seed
+  - #1233: `ChannelPublicationResolverInterface` + impl
+  - #1234: overlay provider reads `?publication=`, filters `attributes_indexed`
+  - #1235: `PublicationColumnPlanner` for export
+  - Faza 3: `?publication=<channel>` added to OpenAPI QueryParameter (#1230
+    already reserves the slot; actual param added when #1234 lands)
+
+## Entity shape (Channel BC)
+
+```
+channel_publication_profiles
+  id              UUID PK (v7)
+  tenant_id       UUID NOT NULL FK → tenants
+  channel_id      UUID NOT NULL  (bare ref, not FK — ADR-015)
+  object_type_id  UUID NOT NULL  (bare ref, not FK — ADR-015)
+  published_attribute_codes  text[] | NULL   (NULL = publish-all)
+  published_locales          text[] NOT NULL  (short codes; e.g. ['pl','en'])
+  column_aliases             jsonb NOT NULL DEFAULT '{}'
+  is_default      bool NOT NULL DEFAULT false
+  created_at      timestamptz NOT NULL
+  UNIQUE (tenant_id, channel_id, object_type_id)
+```
+
+`published_attribute_codes = NULL` means **publish-all** (the default profile
+created automatically on `ChannelCreated`). An empty array `[]` means
+publish-nothing — a valid but unusual configuration.
+
+## Links
+
+- ADR-009 — generic ObjectType (context for `object_type_id` bare ref)
+- ADR-015 — cross-BC FK policy (bare UUID refs, no Doctrine association)
+- ADR-011 — ORM XML mapping in Infrastructure
+- Related tickets: #1231 (this ADR), #1232, #1233, #1234, #1235
+- `Project Plan/01-architektura-pim.md` §5 Channel Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,8 @@ Why per-file ADRs alongside the narrative architecture in `Project Plan/01-archi
 - [0015-cross-bc-fk-policy.md](0015-cross-bc-fk-policy.md)
 
 ADRs 0001-0009 codify the existing decisions narrated in `Project Plan/01-architektura-pim.md` section 13. Lift-and-shift to per-file MADR is a follow-up housekeeping ticket — the canonical record stays in the Project Plan until that lands.
+
+- [0015-cross-bc-fk-policy.md](0015-cross-bc-fk-policy.md) — bare UUID references between BCs; no Doctrine cross-BC associations
+- [0016-api-configurator-key-format.md](0016-api-configurator-key-format.md) — API key format + Argon2id hashing
+- [0017-byok-encryption-strategy.md](0017-byok-encryption-strategy.md) — BYOK AES-256-GCM with versioned master key
+- [0018-channel-publication-profile.md](0018-channel-publication-profile.md) — per-channel attribute/locale allow-list; `?publication=<channel>` distinct from `?channel=`


### PR DESCRIPTION
## Summary

- Nowy plik ADR `docs/adr/0018-channel-publication-profile.md` (MADR 4.0).
- Rozstrzygnięcia:
  - Encja `ChannelPublicationProfile` w **Channel BC** (nie Catalog/Export).
  - Param `?publication=<channel>` jako **dedykowany** param — NIE przeciążamy `?channel=` (zachowanie semantyki overlay wartości bez zmian).
  - Bare-UUID refs (`channel_id`, `object_type_id`) zgodnie z ADR-015.
  - Profil domyślny `published_attribute_codes=NULL` = publish-all (zero regresji).
  - Cross-BC dostęp przez `Channel\Contracts\ChannelPublicationResolverInterface`.
- `docs/adr/README.md` — dodano wpisy ADR-0015..0018 do indeksu.
- `Project Plan/01-architektura-pim.md` — zaktualizowano §Channel Context (encje) + §13 (streszczenie ADR-0016/17/18).

## Scope

Docs only (`docs/adr/`, `Project Plan/`). Brak zmian kodu.

## Smoke test

- ships standalone docs change — brak kodu do smoke-testowania

Closes #1231