### PR TITLE
feat(channel): ChannelPublicationProfile entity + migration + seed (ADR-0018)

### DIFF
--- a/apps/api/migrations/Version20260604100000.php
+++ b/apps/api/migrations/Version20260604100000.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #1232 — ChannelPublicationProfile entity (ADR-0018).
+ *
+ * Adds `channel_publication_profiles` table: per (tenant, channel, objectType)
+ * allow-list of attributes and locales to publish. `published_attribute_codes
+ * = NULL` means publish-all (default).
+ *
+ * Backfill: creates one default publish-all profile per (channel, objectType)
+ * combination already in the database, so existing tenants see no behaviour
+ * change. The resolver (#1233) also falls back to publish-all when no row
+ * exists, making this backfill defensive-in-depth.
+ */
+final class Version20260604100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '#1232: add channel_publication_profiles table + backfill defaults';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE channel_publication_profiles (
+                id                       UUID         NOT NULL,
+                tenant_id                UUID         NOT NULL,
+                channel_id               UUID         NOT NULL,
+                object_type_id           UUID         NOT NULL,
+                published_attribute_codes JSONB        DEFAULT NULL,
+                published_locales        JSONB        NOT NULL DEFAULT '[]',
+                column_aliases           JSONB        NOT NULL DEFAULT '{}',
+                is_default               BOOLEAN      NOT NULL DEFAULT FALSE,
+                created_at               TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+                CONSTRAINT pk_channel_publication_profiles PRIMARY KEY (id),
+                CONSTRAINT fk_cpp_tenant  FOREIGN KEY (tenant_id)  REFERENCES tenants(id)      ON DELETE CASCADE,
+                CONSTRAINT fk_cpp_channel FOREIGN KEY (channel_id) REFERENCES channels(id)     ON DELETE CASCADE,
+                CONSTRAINT uq_cpp_tenant_channel_ot UNIQUE (tenant_id, channel_id, object_type_id)
+            )
+        SQL);
+
+        $this->addSql('CREATE INDEX idx_cpp_channel ON channel_publication_profiles (tenant_id, channel_id)');
+        $this->addSql('CREATE INDEX idx_cpp_tenant  ON channel_publication_profiles (tenant_id)');
+
+        // Backfill: one default publish-all profile per existing (channel, objectType).
+        // The cross product is intentional — each channel needs a profile row per OT
+        // so the operator can later configure per-OT overrides.
+        $this->addSql(<<<'SQL'
+            INSERT INTO channel_publication_profiles (
+                id, tenant_id, channel_id, object_type_id,
+                published_attribute_codes, published_locales, column_aliases,
+                is_default, created_at
+            )
+            SELECT
+                gen_random_uuid(),
+                c.tenant_id,
+                c.id,
+                ot.id,
+                NULL,
+                '[]',
+                '{}',
+                TRUE,
+                NOW()
+            FROM channels c
+            JOIN object_types ot ON ot.tenant_id = c.tenant_id
+            ON CONFLICT (tenant_id, channel_id, object_type_id) DO NOTHING
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS channel_publication_profiles');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -122,6 +122,7 @@ parameters:
               - src/Export/Domain/Entity/ExportProfile.php
               - src/Backup/Domain/Entity/Backup.php
               - src/Channel/Domain/Entity/TenantLocale.php
+              - src/Channel/Domain/Entity/ChannelPublicationProfile.php
         # Tenant aggregate exposes legacy `$enabledLocales` + `$primaryLocale`
         # marked `@deprecated` by #870 (LOC-02) until LOC-07 (#875) migrates
         # `/settings/tenant` to consume `tenant_locales`. The Tenant class

--- a/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
+++ b/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
@@ -46,6 +46,7 @@ final readonly class CreateDefaultPublicationProfilesOnChannelCreated
         );
 
         foreach ($objectTypeIds as $rawId) {
+            \assert(\is_string($rawId) && '' !== $rawId);
             $objectTypeId = Uuid::fromString($rawId);
             $existing = $this->profiles->findByChannelAndObjectType($channelId, $objectTypeId, $tenant);
             if (null !== $existing) {

--- a/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
+++ b/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Application\Subscriber;
+
+use App\Channel\Contracts\Event\ChannelCreated;
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * On {@see ChannelCreated}: provisions one publish-all default profile per
+ * ObjectType that belongs to the same tenant. ADR-0018.
+ *
+ * Uses raw DBAL to list ObjectType IDs — no Doctrine cross-BC entity
+ * reference (Deptrac-safe; Channel → Catalog_Contracts only).
+ */
+#[AsMessageHandler]
+final readonly class CreateDefaultPublicationProfilesOnChannelCreated
+{
+    public function __construct(
+        private ChannelPublicationProfileRepositoryInterface $profiles,
+        private EntityManagerInterface $entityManager,
+        private Connection $connection,
+    ) {
+    }
+
+    public function __invoke(ChannelCreated $event): void
+    {
+        $channelId = $event->channelId;
+        $tenantId = $event->tenantId->toRfc4122();
+
+        $tenant = $this->entityManager->find(Tenant::class, $event->tenantId->toRfc4122());
+        if (null === $tenant) {
+            return;
+        }
+
+        $objectTypeIds = $this->connection->fetchFirstColumn(
+            'SELECT id FROM object_types WHERE tenant_id = ?',
+            [$tenantId],
+        );
+
+        foreach ($objectTypeIds as $rawId) {
+            $objectTypeId = Uuid::fromString($rawId);
+            $existing = $this->profiles->findByChannelAndObjectType($channelId, $objectTypeId, $tenant);
+            if (null !== $existing) {
+                continue;
+            }
+            $this->profiles->save(new ChannelPublicationProfile(
+                channelId: $channelId,
+                objectTypeId: $objectTypeId,
+                publishedAttributeCodes: null,
+                publishedLocales: [],
+                columnAliases: [],
+                isDefault: true,
+                tenant: $tenant,
+            ));
+        }
+    }
+}

--- a/apps/api/src/Channel/Domain/Entity/ChannelPublicationProfile.php
+++ b/apps/api/src/Channel/Domain/Entity/ChannelPublicationProfile.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Per (tenant, channel, objectType) publication profile.
+ *
+ * Controls which attributes and locales are exported / surfaced when a
+ * consumer asks for `?publication=<channelCode>`. ADR-0018.
+ *
+ * - `publishedAttributeCodes = null` means publish-all (the default).
+ * - `publishedAttributeCodes = []` means publish-nothing.
+ * - `publishedLocales` filters per-locale values; defaults to all
+ *   tenant locales when empty (see resolver).
+ * - `isDefault = true` marks the auto-created publish-all profile that
+ *   is provisioned by {@see CreateDefaultPublicationProfilesOnChannelCreated}
+ *   on `ChannelCreated`; exactly one default per (tenant, channel, objectType).
+ *
+ * Cross-BC refs use bare UUID columns per ADR-015 — no Doctrine associations.
+ */
+class ChannelPublicationProfile implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Uuid $channelId;
+
+    private Uuid $objectTypeId;
+
+    /**
+     * null = publish-all; [] = publish-nothing; non-empty = allow-list.
+     *
+     * @var list<string>|null
+     */
+    private ?array $publishedAttributeCodes;
+
+    /**
+     * Short locale codes (e.g. 'pl', 'en'). Empty = use tenant locales.
+     *
+     * @var list<string>
+     */
+    private array $publishedLocales;
+
+    /**
+     * Optional per-attribute column header aliases for export.
+     *
+     * @var array<string, string>
+     */
+    private array $columnAliases;
+
+    private bool $isDefault;
+
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param list<string>|null    $publishedAttributeCodes
+     * @param list<string>         $publishedLocales
+     * @param array<string,string> $columnAliases
+     */
+    public function __construct(
+        Uuid $channelId,
+        Uuid $objectTypeId,
+        ?array $publishedAttributeCodes = null,
+        array $publishedLocales = [],
+        array $columnAliases = [],
+        bool $isDefault = false,
+        ?Tenant $tenant = null,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->channelId = $channelId;
+        $this->objectTypeId = $objectTypeId;
+        $this->publishedAttributeCodes = $publishedAttributeCodes;
+        $this->publishedLocales = $publishedLocales;
+        $this->columnAliases = $columnAliases;
+        $this->isDefault = $isDefault;
+        $this->tenant = $tenant;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getChannelId(): Uuid
+    {
+        return $this->channelId;
+    }
+
+    public function getObjectTypeId(): Uuid
+    {
+        return $this->objectTypeId;
+    }
+
+    /**
+     * @return list<string>|null null means publish-all
+     */
+    public function getPublishedAttributeCodes(): ?array
+    {
+        return $this->publishedAttributeCodes;
+    }
+
+    public function isPublishAll(): bool
+    {
+        return null === $this->publishedAttributeCodes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getPublishedLocales(): array
+    {
+        return $this->publishedLocales;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getColumnAliases(): array
+    {
+        return $this->columnAliases;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param list<string>|null $codes null restores publish-all
+     */
+    public function setPublishedAttributeCodes(?array $codes): void
+    {
+        $this->publishedAttributeCodes = $codes;
+    }
+
+    /**
+     * @param list<string> $locales
+     */
+    public function setPublishedLocales(array $locales): void
+    {
+        $this->publishedLocales = $locales;
+    }
+
+    /**
+     * @param array<string, string> $aliases
+     */
+    public function setColumnAliases(array $aliases): void
+    {
+        $this->columnAliases = $aliases;
+    }
+}

--- a/apps/api/src/Channel/Domain/Repository/ChannelPublicationProfileRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/ChannelPublicationProfileRepositoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Repository;
+
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+interface ChannelPublicationProfileRepositoryInterface
+{
+    public function findById(Uuid $id): ?ChannelPublicationProfile;
+
+    public function findByChannelAndObjectType(
+        Uuid $channelId,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?ChannelPublicationProfile;
+
+    /**
+     * @return list<ChannelPublicationProfile>
+     */
+    public function findForChannel(Uuid $channelId, Tenant $tenant): array;
+
+    /**
+     * @return list<ChannelPublicationProfile>
+     */
+    public function findForTenant(Tenant $tenant): array;
+
+    public function save(ChannelPublicationProfile $profile): void;
+
+    public function remove(ChannelPublicationProfile $profile): void;
+}

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ChannelPublicationProfile.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ChannelPublicationProfile.orm.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <!--
+        ADR-0015: cross-BC refs to channels and object_types carried as bare
+        UUID columns with DB-level FKs (ON DELETE CASCADE) — no Doctrine
+        targetEntity association. channel_id and object_type_id are plain
+        <field type="uuid"> entries.
+    -->
+    <entity name="App\Channel\Domain\Entity\ChannelPublicationProfile"
+            table="channel_publication_profiles"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\DoctrineChannelPublicationProfileRepository">
+
+        <unique-constraints>
+            <unique-constraint name="cpp_tenant_channel_ot_uniq" columns="tenant_id,channel_id,object_type_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="cpp_channel_idx" columns="tenant_id,channel_id"/>
+            <index name="cpp_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <!-- Bare UUID refs per ADR-015 — no Doctrine associations to Channel/ObjectType -->
+        <field name="channelId" column="channel_id" type="uuid" nullable="false"/>
+        <field name="objectTypeId" column="object_type_id" type="uuid" nullable="false"/>
+
+        <!--
+            NULL = publish-all (default profile created on ChannelCreated).
+            [] = publish-nothing.
+            Non-empty array = allow-list.
+            Stored as JSONB for GIN-indexable array queries in Phase 3.
+        -->
+        <field name="publishedAttributeCodes" column="published_attribute_codes" type="json" nullable="true"/>
+
+        <!-- Short locale codes, e.g. ["pl", "en"]. Empty = use tenant locales. -->
+        <field name="publishedLocales" column="published_locales" type="json" nullable="false"/>
+
+        <!-- Per-attribute column header aliases for export CSV/XLSX. -->
+        <field name="columnAliases" column="column_aliases" type="json" nullable="false"/>
+
+        <field name="isDefault" column="is_default" type="boolean"/>
+        <field name="createdAt" column="created_at" type="datetime_immutable"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelPublicationProfileRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelPublicationProfileRepository.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure\Doctrine\Repository;
+
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<ChannelPublicationProfile>
+ */
+class DoctrineChannelPublicationProfileRepository extends ServiceEntityRepository implements ChannelPublicationProfileRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ChannelPublicationProfile::class);
+    }
+
+    public function findById(Uuid $id): ?ChannelPublicationProfile
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    public function findByChannelAndObjectType(
+        Uuid $channelId,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?ChannelPublicationProfile {
+        return $this->findOneBy([
+            'channelId' => $channelId,
+            'objectTypeId' => $objectTypeId,
+            'tenant' => $tenant,
+        ]);
+    }
+
+    /**
+     * @return list<ChannelPublicationProfile>
+     */
+    public function findForChannel(Uuid $channelId, Tenant $tenant): array
+    {
+        /* @var list<ChannelPublicationProfile> */
+        return $this->findBy(['channelId' => $channelId, 'tenant' => $tenant]);
+    }
+
+    /**
+     * @return list<ChannelPublicationProfile>
+     */
+    public function findForTenant(Tenant $tenant): array
+    {
+        /* @var list<ChannelPublicationProfile> */
+        return $this->findBy(['tenant' => $tenant]);
+    }
+
+    public function save(ChannelPublicationProfile $profile): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($profile);
+        $em->flush();
+    }
+
+    public function remove(ChannelPublicationProfile $profile): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($profile);
+        $em->flush();
+    }
+}

--- a/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
@@ -32,8 +32,8 @@ final class ChannelPublicationProfileApiTest extends ChannelApiTestCase
         $channelId = $response->toArray()['id'];
         self::assertIsString($channelId);
 
+        /** @var ChannelPublicationProfileRepositoryInterface $repo */
         $repo = self::getContainer()->get(ChannelPublicationProfileRepositoryInterface::class);
-        \assert($repo instanceof ChannelPublicationProfileRepositoryInterface);
 
         $em = $this->em();
         $tenant = $em->getRepository(\App\Shared\Domain\Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);

--- a/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
@@ -32,8 +32,8 @@ final class ChannelPublicationProfileApiTest extends ChannelApiTestCase
         $channelId = $response->toArray()['id'];
         self::assertIsString($channelId);
 
-        /** @var ChannelPublicationProfileRepositoryInterface $repo */
         $repo = self::getContainer()->get(ChannelPublicationProfileRepositoryInterface::class);
+        self::assertInstanceOf(ChannelPublicationProfileRepositoryInterface::class, $repo);
 
         $em = $this->em();
         $tenant = $em->getRepository(\App\Shared\Domain\Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);

--- a/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Channel;
+
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * #1232 — ChannelPublicationProfile entity integration:
+ * on ChannelCreated, default publish-all profiles are auto-created
+ * for each ObjectType belonging to the same tenant.
+ */
+final class ChannelPublicationProfileApiTest extends ChannelApiTestCase
+{
+    #[Test]
+    public function creatingChannelProvisionesDefaultProfilesForAllObjectTypes(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/channels', [
+            'json' => [
+                'code' => 'pub_profile_test',
+                'label' => ['pl' => 'Test', 'en' => 'Test'],
+                'locales' => ['pl_PL'],
+                'currencies' => ['PLN'],
+            ],
+        ]);
+        self::assertSame(201, $response->getStatusCode());
+        $channelId = $response->toArray()['id'];
+        self::assertIsString($channelId);
+
+        /** @var ChannelPublicationProfileRepositoryInterface $repo */
+        $repo = self::getContainer()->get(ChannelPublicationProfileRepositoryInterface::class);
+
+        $em = $this->em();
+        $tenant = $em->getRepository(\App\Shared\Domain\Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        self::assertNotNull($tenant);
+        $profiles = $repo->findForChannel(\Symfony\Component\Uid\Uuid::fromString($channelId), $tenant);
+
+        self::assertNotEmpty($profiles, 'At least one default profile must be created per ObjectType.');
+
+        foreach ($profiles as $profile) {
+            self::assertInstanceOf(ChannelPublicationProfile::class, $profile);
+            self::assertTrue($profile->isDefault(), 'Auto-created profile must be marked as default.');
+            self::assertTrue($profile->isPublishAll(), 'Auto-created profile must be publish-all (null codes).');
+        }
+    }
+}

--- a/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
@@ -32,8 +32,8 @@ final class ChannelPublicationProfileApiTest extends ChannelApiTestCase
         $channelId = $response->toArray()['id'];
         self::assertIsString($channelId);
 
-        /** @var ChannelPublicationProfileRepositoryInterface $repo */
         $repo = self::getContainer()->get(ChannelPublicationProfileRepositoryInterface::class);
+        \assert($repo instanceof ChannelPublicationProfileRepositoryInterface);
 
         $em = $this->em();
         $tenant = $em->getRepository(\App\Shared\Domain\Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);

--- a/apps/api/tests/Unit/Channel/ChannelPublicationProfileTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelPublicationProfileTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel;
+
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ChannelPublicationProfileTest extends TestCase
+{
+    #[Test]
+    public function nullPublishedCodesSignifiesPublishAll(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+        );
+
+        self::assertTrue($profile->isPublishAll());
+        self::assertNull($profile->getPublishedAttributeCodes());
+    }
+
+    #[Test]
+    public function emptyArrayPublishedCodesSignifiesPublishNothing(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            publishedAttributeCodes: [],
+        );
+
+        self::assertFalse($profile->isPublishAll());
+        self::assertSame([], $profile->getPublishedAttributeCodes());
+    }
+
+    #[Test]
+    public function nonNullAllowListIsPreserved(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            publishedAttributeCodes: ['name', 'price', 'ean'],
+            publishedLocales: ['pl', 'en'],
+        );
+
+        self::assertFalse($profile->isPublishAll());
+        self::assertSame(['name', 'price', 'ean'], $profile->getPublishedAttributeCodes());
+        self::assertSame(['pl', 'en'], $profile->getPublishedLocales());
+    }
+
+    #[Test]
+    public function setPublishedAttributeCodesNullRestoresPublishAll(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            publishedAttributeCodes: ['name'],
+        );
+
+        $profile->setPublishedAttributeCodes(null);
+
+        self::assertTrue($profile->isPublishAll());
+    }
+
+    #[Test]
+    public function defaultProfileFlagCarriedThrough(): void
+    {
+        $channelId = Uuid::v7();
+        $objectTypeId = Uuid::v7();
+
+        $profile = new ChannelPublicationProfile(
+            channelId: $channelId,
+            objectTypeId: $objectTypeId,
+            isDefault: true,
+        );
+
+        self::assertTrue($profile->isDefault());
+        self::assertTrue($profile->getChannelId()->equals($channelId));
+        self::assertTrue($profile->getObjectTypeId()->equals($objectTypeId));
+    }
+
+    #[Test]
+    public function tenantCannotBeReassigned(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+        );
+
+        $tenant = new \App\Shared\Domain\Tenant('test-tenant', 'Test Tenant');
+        $profile->assignTenant($tenant);
+
+        $this->expectException(LogicException::class);
+        $profile->assignTenant($tenant);
+    }
+}


### PR DESCRIPTION
## Summary

- `ChannelPublicationProfile` encja w Channel BC — per `(tenant, channel, objectType)` allow-lista atrybutów i locale do publikacji (ADR-0018).
- `publishedAttributeCodes = null` = publish-all (default); `[]` = publish-nothing; non-empty = allow-lista.
- Bare UUID refs (`channelId`, `objectTypeId`) per ADR-015 — bez Doctrine cross-BC associations.
- Migracja `Version20260604100000`: tabela + FK constraints + backfill (jeden default publish-all profil per existing channel×objectType pair).
- Subscriber `CreateDefaultPublicationProfilesOnChannelCreated` na `ChannelCreated` event: auto-tworzy profile dla nowych kanałów używając DBAL (Deptrac-safe — bez Catalog_Internals zależności).
- PHPUnit: 6 unit tests + ApiTestCase integration test.

## Scope

`apps/api` — Channel BC (Domain + Application + Infrastructure) + migracja + testy.

## Smoke test

- ships standalone backend entity + migration; end-to-end integration w kolejnych PR-ach (#1233 resolver + #1234 API filter)

Closes #1232