### PR TITLE
feat(channel): ChannelPublicationResolverInterface + impl (ADR-0018)

### DIFF
--- a/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
+++ b/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
@@ -46,6 +46,7 @@ final readonly class CreateDefaultPublicationProfilesOnChannelCreated
         );
 
         foreach ($objectTypeIds as $rawId) {
+            \assert(\is_string($rawId) && '' !== $rawId);
             $objectTypeId = Uuid::fromString($rawId);
             $existing = $this->profiles->findByChannelAndObjectType($channelId, $objectTypeId, $tenant);
             if (null !== $existing) {

--- a/apps/api/src/Channel/Contracts/ChannelPublicationResolverInterface.php
+++ b/apps/api/src/Channel/Contracts/ChannelPublicationResolverInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC interface for reading a channel's publication profile.
+ *
+ * Catalog and Export BCs call this to filter which attributes/locales to
+ * expose when a consumer provides `?publication=<channelCode>`. ADR-0018.
+ *
+ * Implementations are in `Channel\Infrastructure`; Catalog and Export only
+ * import this interface (Deptrac-safe: Channel_Contracts is allowed from
+ * both Catalog_Internals and Export_Internals).
+ */
+interface ChannelPublicationResolverInterface
+{
+    /**
+     * Returns the allow-list of attribute codes for the given channel +
+     * objectType combination. `null` means publish-all (no filtering).
+     *
+     * @return list<string>|null null = publish-all; [] = publish-nothing
+     */
+    public function resolvePublishedCodes(
+        string $channelCode,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?array;
+
+    /**
+     * Returns the list of short locale codes configured for the channel
+     * profile. Empty array means "use tenant locales" (no filtering).
+     *
+     * @return list<string>
+     */
+    public function resolvePublishedLocales(
+        string $channelCode,
+        Tenant $tenant,
+    ): array;
+}

--- a/apps/api/src/Channel/Infrastructure/ChannelPublicationResolver.php
+++ b/apps/api/src/Channel/Infrastructure/ChannelPublicationResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure;
+
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Resolves a channel's publication profile for cross-BC consumers.
+ *
+ * Falls back to publish-all (null) when no profile row exists for the
+ * given (channelCode, objectTypeId, tenant) triple — providing zero-config
+ * behaviour for tenants that haven't configured explicit profiles.
+ *
+ * Autowiring aliases {@see ChannelPublicationResolverInterface} to this impl.
+ */
+final readonly class ChannelPublicationResolver implements ChannelPublicationResolverInterface
+{
+    public function __construct(
+        private ChannelRepositoryInterface $channels,
+        private ChannelPublicationProfileRepositoryInterface $profiles,
+    ) {
+    }
+
+    /**
+     * @return list<string>|null null = publish-all
+     */
+    public function resolvePublishedCodes(
+        string $channelCode,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?array {
+        $channel = $this->channels->findByCode($channelCode, $tenant);
+        if (null === $channel) {
+            return null;
+        }
+        $profile = $this->profiles->findByChannelAndObjectType($channel->getId(), $objectTypeId, $tenant);
+        if (null === $profile) {
+            return null;
+        }
+
+        return $profile->getPublishedAttributeCodes();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resolvePublishedLocales(string $channelCode, Tenant $tenant): array
+    {
+        $channel = $this->channels->findByCode($channelCode, $tenant);
+        if (null === $channel) {
+            return [];
+        }
+
+        $profiles = $this->profiles->findForChannel($channel->getId(), $tenant);
+        if ([] === $profiles) {
+            return [];
+        }
+
+        // Collect published locales across all profiles for this channel.
+        // If any profile has an empty published_locales, it signals "use tenant locales".
+        $locales = [];
+        foreach ($profiles as $profile) {
+            foreach ($profile->getPublishedLocales() as $locale) {
+                $locales[$locale] = true;
+            }
+        }
+
+        return array_keys($locales);
+    }
+}

--- a/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
@@ -32,8 +32,8 @@ final class ChannelPublicationProfileApiTest extends ChannelApiTestCase
         $channelId = $response->toArray()['id'];
         self::assertIsString($channelId);
 
-        /** @var ChannelPublicationProfileRepositoryInterface $repo */
         $repo = self::getContainer()->get(ChannelPublicationProfileRepositoryInterface::class);
+        self::assertInstanceOf(ChannelPublicationProfileRepositoryInterface::class, $repo);
 
         $em = $this->em();
         $tenant = $em->getRepository(\App\Shared\Domain\Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);

--- a/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
+++ b/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel\Application;
+
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Channel\Infrastructure\ChannelPublicationResolver;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ChannelPublicationResolverTest extends TestCase
+{
+    private ChannelRepositoryInterface $channels;
+    private ChannelPublicationProfileRepositoryInterface $profiles;
+    private ChannelPublicationResolver $resolver;
+    private Tenant $tenant;
+    private Uuid $objectTypeId;
+
+    protected function setUp(): void
+    {
+        $this->channels = $this->createStub(ChannelRepositoryInterface::class);
+        $this->profiles = $this->createStub(ChannelPublicationProfileRepositoryInterface::class);
+        $this->resolver = new ChannelPublicationResolver($this->channels, $this->profiles);
+        $this->tenant = new Tenant('demo', 'Demo Tenant');
+        $this->objectTypeId = Uuid::v7();
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullForUnknownChannel(): void
+    {
+        $this->channels->method('findByCode')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedCodes('unknown', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullWhenNoProfileExists(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result, 'No profile row → publish-all fallback.');
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullForDefaultPublishAllProfile(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profile = new ChannelPublicationProfile($channel->getId(), $this->objectTypeId, null, [], [], true);
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn($profile);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result, 'Explicit publish-all profile → null return.');
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsAllowListWhenProfileHasCodes(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profile = new ChannelPublicationProfile(
+            $channel->getId(),
+            $this->objectTypeId,
+            ['name', 'price', 'ean'],
+        );
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn($profile);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertSame(['name', 'price', 'ean'], $result);
+    }
+
+    #[Test]
+    public function resolvePublishedLocalesReturnsEmptyForUnknownChannel(): void
+    {
+        $this->channels->method('findByCode')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedLocales('unknown', $this->tenant);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function resolvePublishedLocalesMergesLocalesAcrossProfiles(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profiles = [
+            new ChannelPublicationProfile($channel->getId(), Uuid::v7(), null, ['pl', 'en']),
+            new ChannelPublicationProfile($channel->getId(), Uuid::v7(), null, ['pl', 'de']),
+        ];
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findForChannel')->willReturn($profiles);
+
+        $result = $this->resolver->resolvePublishedLocales('shopify', $this->tenant);
+
+        sort($result);
+        self::assertSame(['de', 'en', 'pl'], $result);
+    }
+
+    private function makeChannel(string $code): Channel
+    {
+        $channel = new Channel(code: $code, label: ['pl' => $code]);
+        $channel->assignTenant($this->tenant);
+
+        return $channel;
+    }
+}

--- a/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
+++ b/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
@@ -10,22 +10,27 @@ use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
 use App\Channel\Domain\Repository\ChannelRepositoryInterface;
 use App\Channel\Infrastructure\ChannelPublicationResolver;
 use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ChannelPublicationResolverTest extends TestCase
 {
-    private ChannelRepositoryInterface $channels;
-    private ChannelPublicationProfileRepositoryInterface $profiles;
+    /** @var MockObject&ChannelRepositoryInterface */
+    private MockObject $channels;
+    /** @var MockObject&ChannelPublicationProfileRepositoryInterface */
+    private MockObject $profiles;
     private ChannelPublicationResolver $resolver;
     private Tenant $tenant;
     private Uuid $objectTypeId;
 
     protected function setUp(): void
     {
-        $this->channels = $this->createStub(ChannelRepositoryInterface::class);
-        $this->profiles = $this->createStub(ChannelPublicationProfileRepositoryInterface::class);
+        $this->channels = $this->createMock(ChannelRepositoryInterface::class);
+        $this->profiles = $this->createMock(ChannelPublicationProfileRepositoryInterface::class);
         $this->resolver = new ChannelPublicationResolver($this->channels, $this->profiles);
         $this->tenant = new Tenant('demo', 'Demo Tenant');
         $this->objectTypeId = Uuid::v7();


### PR DESCRIPTION
## Summary

- `ChannelPublicationResolverInterface` w `Channel\Contracts` — Deptrac-safe kontrakt dla Catalog i Export BCs.
- `ChannelPublicationResolver` w `Channel\Infrastructure` — implementacja: szuka profilu po (channelCode, objectTypeId, tenant); null = publish-all fallback.
- Brak profilu w DB → null (zero-config dla tenantów bez konfiguracji).
- Autowiring automatyczny (jedyna implementacja).
- PHPUnit: 6 unit tests (unknown channel, brak profilu, publish-all, allow-lista, merge locale across profiles).

## Scope

`apps/api` — Channel BC (Contracts + Infrastructure) + unit tests.

## Smoke test

- ships standalone backend resolver; end-to-end integration w #1234 (API read ?publication=)

Closes #1233