### PR TITLE
feat(catalog): ?publication=<channel> filters attributes_indexed to allow-list

### DIFF
--- a/apps/api/migrations/Version20260604100000.php
+++ b/apps/api/migrations/Version20260604100000.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #1232 — ChannelPublicationProfile entity (ADR-0018).
+ *
+ * Adds `channel_publication_profiles` table: per (tenant, channel, objectType)
+ * allow-list of attributes and locales to publish. `published_attribute_codes
+ * = NULL` means publish-all (default).
+ *
+ * Backfill: creates one default publish-all profile per (channel, objectType)
+ * combination already in the database, so existing tenants see no behaviour
+ * change. The resolver (#1233) also falls back to publish-all when no row
+ * exists, making this backfill defensive-in-depth.
+ */
+final class Version20260604100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '#1232: add channel_publication_profiles table + backfill defaults';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE channel_publication_profiles (
+                id                       UUID         NOT NULL,
+                tenant_id                UUID         NOT NULL,
+                channel_id               UUID         NOT NULL,
+                object_type_id           UUID         NOT NULL,
+                published_attribute_codes JSONB        DEFAULT NULL,
+                published_locales        JSONB        NOT NULL DEFAULT '[]',
+                column_aliases           JSONB        NOT NULL DEFAULT '{}',
+                is_default               BOOLEAN      NOT NULL DEFAULT FALSE,
+                created_at               TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+                CONSTRAINT pk_channel_publication_profiles PRIMARY KEY (id),
+                CONSTRAINT fk_cpp_tenant  FOREIGN KEY (tenant_id)  REFERENCES tenants(id)      ON DELETE CASCADE,
+                CONSTRAINT fk_cpp_channel FOREIGN KEY (channel_id) REFERENCES channels(id)     ON DELETE CASCADE,
+                CONSTRAINT uq_cpp_tenant_channel_ot UNIQUE (tenant_id, channel_id, object_type_id)
+            )
+        SQL);
+
+        $this->addSql('CREATE INDEX idx_cpp_channel ON channel_publication_profiles (tenant_id, channel_id)');
+        $this->addSql('CREATE INDEX idx_cpp_tenant  ON channel_publication_profiles (tenant_id)');
+
+        // Backfill: one default publish-all profile per existing (channel, objectType).
+        // The cross product is intentional — each channel needs a profile row per OT
+        // so the operator can later configure per-OT overrides.
+        $this->addSql(<<<'SQL'
+            INSERT INTO channel_publication_profiles (
+                id, tenant_id, channel_id, object_type_id,
+                published_attribute_codes, published_locales, column_aliases,
+                is_default, created_at
+            )
+            SELECT
+                gen_random_uuid(),
+                c.tenant_id,
+                c.id,
+                ot.id,
+                NULL,
+                '[]',
+                '{}',
+                TRUE,
+                NOW()
+            FROM channels c
+            JOIN object_types ot ON ot.tenant_id = c.tenant_id
+            ON CONFLICT (tenant_id, channel_id, object_type_id) DO NOTHING
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS channel_publication_profiles');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -122,6 +122,7 @@ parameters:
               - src/Export/Domain/Entity/ExportProfile.php
               - src/Backup/Domain/Entity/Backup.php
               - src/Channel/Domain/Entity/TenantLocale.php
+              - src/Channel/Domain/Entity/ChannelPublicationProfile.php
         # Tenant aggregate exposes legacy `$enabledLocales` + `$primaryLocale`
         # marked `@deprecated` by #870 (LOC-02) until LOC-07 (#875) migrates
         # `/settings/tenant` to consume `tenant_locales`. The Tenant class

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
@@ -12,10 +12,14 @@ use App\Catalog\Application\ObjectValueLocaleOverlay;
 use App\Catalog\Application\SystemAttributeReadOverlay;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Shared\Domain\Tenant;
 use ArrayIterator;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Uid\Uuid;
 use Traversable;
+
+use const ARRAY_FILTER_USE_KEY;
 
 /**
  * GetCollection provider for catalog sugar paths (`/api/products`,
@@ -41,6 +45,7 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         private SystemAttributeReadOverlay $systemOverlay,
         private ObjectValueRepositoryInterface $objectValues,
         private RequestStack $requestStack,
+        private ChannelPublicationResolverInterface $publicationResolver,
     ) {
     }
 
@@ -54,8 +59,10 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         $request = $this->requestStack->getCurrentRequest();
         $localeParam = $request?->query->get('locale');
         $channelParam = $request?->query->get('channel');
+        $publicationParam = $request?->query->get('publication');
         $locale = \is_string($localeParam) && '' !== $localeParam ? $localeParam : null;
         $channel = \is_string($channelParam) && '' !== $channelParam ? $channelParam : null;
+        $publication = \is_string($publicationParam) && '' !== $publicationParam ? $publicationParam : null;
 
         // Collect CatalogObject items from the paginator or array result.
         // API Platform may return an iterable paginator or a plain array.
@@ -79,8 +86,8 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         }
 
         // Always apply system overlay so created_at/updated_at render.
-        // When no locale/channel scope is active, skip the value overlay.
-        if (null === $locale && null === $channel) {
+        // When no locale/channel scope and no publication filter, skip overlay.
+        if (null === $locale && null === $channel && null === $publication) {
             foreach ($objects as $object) {
                 $this->systemOverlay->apply($object);
             }
@@ -96,7 +103,15 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         $valuesByObjectId = $this->objectValues->findByObjectIds($objectIds);
 
         // Apply locale/channel overlay on clones (no identity map mutation).
-        $overlaid = $this->overlay->applyBatch($objects, $valuesByObjectId, $locale, $channel);
+        $overlaid = (null !== $locale || null !== $channel)
+            ? $this->overlay->applyBatch($objects, $valuesByObjectId, $locale, $channel)
+            : array_map(static fn (CatalogObject $o): CatalogObject => clone $o, $objects);
+
+        // #1234 — ?publication=<channelCode> filters attributes_indexed per
+        // publication profile. Applied after value overlay.
+        if (null !== $publication) {
+            $overlaid = $this->applyPublicationFilter($overlaid, $publication);
+        }
 
         // Apply system overlay on the (already cloned) overlaid objects.
         $overlaid = array_map(
@@ -122,5 +137,39 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         }
 
         return $overlaid;
+    }
+
+    /**
+     * Filters attributes_indexed to the publication allow-list for each object.
+     * Objects are already cloned; mutates the clone in-place.
+     *
+     * @param list<CatalogObject> $objects
+     *
+     * @return list<CatalogObject>
+     */
+    private function applyPublicationFilter(array $objects, string $channelCode): array
+    {
+        foreach ($objects as $object) {
+            $tenant = $object->getTenant();
+            if (!$tenant instanceof Tenant) {
+                continue;
+            }
+            $allowedCodes = $this->publicationResolver->resolvePublishedCodes(
+                $channelCode,
+                $object->getObjectType()->getId(),
+                $tenant,
+            );
+            if (null === $allowedCodes) {
+                continue;
+            }
+            $filtered = array_filter(
+                $object->getAttributesIndexed(),
+                static fn (string $code): bool => \in_array($code, $allowedCodes, true),
+                ARRAY_FILTER_USE_KEY,
+            );
+            $object->updateAttributeIndex($filtered);
+        }
+
+        return $objects;
     }
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
@@ -9,7 +9,11 @@ use ApiPlatform\State\ProviderInterface;
 use App\Catalog\Application\ObjectValueLocaleOverlay;
 use App\Catalog\Application\SystemAttributeReadOverlay;
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Shared\Domain\Tenant;
 use Symfony\Component\HttpFoundation\RequestStack;
+
+use const ARRAY_FILTER_USE_KEY;
 
 /**
  * GET-item provider for the catalog sugar paths (`/api/products/{id}`,
@@ -35,6 +39,7 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
         private ObjectValueLocaleOverlay $overlay,
         private SystemAttributeReadOverlay $systemOverlay,
         private RequestStack $requestStack,
+        private ChannelPublicationResolverInterface $publicationResolver,
     ) {
     }
 
@@ -49,14 +54,53 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
         $request = $this->requestStack->getCurrentRequest();
         $localeParam = $request?->query->get('locale');
         $channelParam = $request?->query->get('channel');
+        $publicationParam = $request?->query->get('publication');
         $locale = \is_string($localeParam) && '' !== $localeParam ? $localeParam : null;
         $channel = \is_string($channelParam) && '' !== $channelParam ? $channelParam : null;
+        $publication = \is_string($publicationParam) && '' !== $publicationParam ? $publicationParam : null;
+
         if (null !== $locale || null !== $channel) {
             $object = $this->overlay->apply($object, $locale, $channel);
+        }
+
+        // #1234 — ?publication=<channelCode> filters attributes_indexed to the
+        // channel's publication allow-list. Applied after value overlay so the
+        // returned values are already locale/channel-resolved.
+        if (null !== $publication) {
+            $object = $this->applyPublicationFilter($object, $publication);
         }
 
         // #1207 — always surface the system attributes (created_at/updated_at +
         // created_by/updated_by) so they render real values instead of "—".
         return $this->systemOverlay->apply($object);
+    }
+
+    private function applyPublicationFilter(CatalogObject $object, string $channelCode): CatalogObject
+    {
+        $tenant = $object->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return $object;
+        }
+
+        $allowedCodes = $this->publicationResolver->resolvePublishedCodes(
+            $channelCode,
+            $object->getObjectType()->getId(),
+            $tenant,
+        );
+
+        if (null === $allowedCodes) {
+            return $object;
+        }
+
+        $filtered = array_filter(
+            $object->getAttributesIndexed(),
+            static fn (string $code): bool => \in_array($code, $allowedCodes, true),
+            ARRAY_FILTER_USE_KEY,
+        );
+
+        $copy = clone $object;
+        $copy->updateAttributeIndex($filtered);
+
+        return $copy;
     }
 }

--- a/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
+++ b/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
@@ -46,6 +46,7 @@ final readonly class CreateDefaultPublicationProfilesOnChannelCreated
         );
 
         foreach ($objectTypeIds as $rawId) {
+            \assert(\is_string($rawId) && '' !== $rawId);
             $objectTypeId = Uuid::fromString($rawId);
             $existing = $this->profiles->findByChannelAndObjectType($channelId, $objectTypeId, $tenant);
             if (null !== $existing) {

--- a/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
+++ b/apps/api/src/Channel/Application/Subscriber/CreateDefaultPublicationProfilesOnChannelCreated.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Application\Subscriber;
+
+use App\Channel\Contracts\Event\ChannelCreated;
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * On {@see ChannelCreated}: provisions one publish-all default profile per
+ * ObjectType that belongs to the same tenant. ADR-0018.
+ *
+ * Uses raw DBAL to list ObjectType IDs — no Doctrine cross-BC entity
+ * reference (Deptrac-safe; Channel → Catalog_Contracts only).
+ */
+#[AsMessageHandler]
+final readonly class CreateDefaultPublicationProfilesOnChannelCreated
+{
+    public function __construct(
+        private ChannelPublicationProfileRepositoryInterface $profiles,
+        private EntityManagerInterface $entityManager,
+        private Connection $connection,
+    ) {
+    }
+
+    public function __invoke(ChannelCreated $event): void
+    {
+        $channelId = $event->channelId;
+        $tenantId = $event->tenantId->toRfc4122();
+
+        $tenant = $this->entityManager->find(Tenant::class, $event->tenantId->toRfc4122());
+        if (null === $tenant) {
+            return;
+        }
+
+        $objectTypeIds = $this->connection->fetchFirstColumn(
+            'SELECT id FROM object_types WHERE tenant_id = ?',
+            [$tenantId],
+        );
+
+        foreach ($objectTypeIds as $rawId) {
+            $objectTypeId = Uuid::fromString($rawId);
+            $existing = $this->profiles->findByChannelAndObjectType($channelId, $objectTypeId, $tenant);
+            if (null !== $existing) {
+                continue;
+            }
+            $this->profiles->save(new ChannelPublicationProfile(
+                channelId: $channelId,
+                objectTypeId: $objectTypeId,
+                publishedAttributeCodes: null,
+                publishedLocales: [],
+                columnAliases: [],
+                isDefault: true,
+                tenant: $tenant,
+            ));
+        }
+    }
+}

--- a/apps/api/src/Channel/Contracts/ChannelPublicationResolverInterface.php
+++ b/apps/api/src/Channel/Contracts/ChannelPublicationResolverInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC interface for reading a channel's publication profile.
+ *
+ * Catalog and Export BCs call this to filter which attributes/locales to
+ * expose when a consumer provides `?publication=<channelCode>`. ADR-0018.
+ *
+ * Implementations are in `Channel\Infrastructure`; Catalog and Export only
+ * import this interface (Deptrac-safe: Channel_Contracts is allowed from
+ * both Catalog_Internals and Export_Internals).
+ */
+interface ChannelPublicationResolverInterface
+{
+    /**
+     * Returns the allow-list of attribute codes for the given channel +
+     * objectType combination. `null` means publish-all (no filtering).
+     *
+     * @return list<string>|null null = publish-all; [] = publish-nothing
+     */
+    public function resolvePublishedCodes(
+        string $channelCode,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?array;
+
+    /**
+     * Returns the list of short locale codes configured for the channel
+     * profile. Empty array means "use tenant locales" (no filtering).
+     *
+     * @return list<string>
+     */
+    public function resolvePublishedLocales(
+        string $channelCode,
+        Tenant $tenant,
+    ): array;
+}

--- a/apps/api/src/Channel/Domain/Entity/ChannelPublicationProfile.php
+++ b/apps/api/src/Channel/Domain/Entity/ChannelPublicationProfile.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Per (tenant, channel, objectType) publication profile.
+ *
+ * Controls which attributes and locales are exported / surfaced when a
+ * consumer asks for `?publication=<channelCode>`. ADR-0018.
+ *
+ * - `publishedAttributeCodes = null` means publish-all (the default).
+ * - `publishedAttributeCodes = []` means publish-nothing.
+ * - `publishedLocales` filters per-locale values; defaults to all
+ *   tenant locales when empty (see resolver).
+ * - `isDefault = true` marks the auto-created publish-all profile that
+ *   is provisioned by {@see CreateDefaultPublicationProfilesOnChannelCreated}
+ *   on `ChannelCreated`; exactly one default per (tenant, channel, objectType).
+ *
+ * Cross-BC refs use bare UUID columns per ADR-015 — no Doctrine associations.
+ */
+class ChannelPublicationProfile implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Uuid $channelId;
+
+    private Uuid $objectTypeId;
+
+    /**
+     * null = publish-all; [] = publish-nothing; non-empty = allow-list.
+     *
+     * @var list<string>|null
+     */
+    private ?array $publishedAttributeCodes;
+
+    /**
+     * Short locale codes (e.g. 'pl', 'en'). Empty = use tenant locales.
+     *
+     * @var list<string>
+     */
+    private array $publishedLocales;
+
+    /**
+     * Optional per-attribute column header aliases for export.
+     *
+     * @var array<string, string>
+     */
+    private array $columnAliases;
+
+    private bool $isDefault;
+
+    private DateTimeImmutable $createdAt;
+
+    /**
+     * @param list<string>|null    $publishedAttributeCodes
+     * @param list<string>         $publishedLocales
+     * @param array<string,string> $columnAliases
+     */
+    public function __construct(
+        Uuid $channelId,
+        Uuid $objectTypeId,
+        ?array $publishedAttributeCodes = null,
+        array $publishedLocales = [],
+        array $columnAliases = [],
+        bool $isDefault = false,
+        ?Tenant $tenant = null,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->channelId = $channelId;
+        $this->objectTypeId = $objectTypeId;
+        $this->publishedAttributeCodes = $publishedAttributeCodes;
+        $this->publishedLocales = $publishedLocales;
+        $this->columnAliases = $columnAliases;
+        $this->isDefault = $isDefault;
+        $this->tenant = $tenant;
+        $this->createdAt = new DateTimeImmutable();
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+        $this->tenant = $tenant;
+    }
+
+    public function getChannelId(): Uuid
+    {
+        return $this->channelId;
+    }
+
+    public function getObjectTypeId(): Uuid
+    {
+        return $this->objectTypeId;
+    }
+
+    /**
+     * @return list<string>|null null means publish-all
+     */
+    public function getPublishedAttributeCodes(): ?array
+    {
+        return $this->publishedAttributeCodes;
+    }
+
+    public function isPublishAll(): bool
+    {
+        return null === $this->publishedAttributeCodes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getPublishedLocales(): array
+    {
+        return $this->publishedLocales;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getColumnAliases(): array
+    {
+        return $this->columnAliases;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param list<string>|null $codes null restores publish-all
+     */
+    public function setPublishedAttributeCodes(?array $codes): void
+    {
+        $this->publishedAttributeCodes = $codes;
+    }
+
+    /**
+     * @param list<string> $locales
+     */
+    public function setPublishedLocales(array $locales): void
+    {
+        $this->publishedLocales = $locales;
+    }
+
+    /**
+     * @param array<string, string> $aliases
+     */
+    public function setColumnAliases(array $aliases): void
+    {
+        $this->columnAliases = $aliases;
+    }
+}

--- a/apps/api/src/Channel/Domain/Repository/ChannelPublicationProfileRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/ChannelPublicationProfileRepositoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Repository;
+
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+interface ChannelPublicationProfileRepositoryInterface
+{
+    public function findById(Uuid $id): ?ChannelPublicationProfile;
+
+    public function findByChannelAndObjectType(
+        Uuid $channelId,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?ChannelPublicationProfile;
+
+    /**
+     * @return list<ChannelPublicationProfile>
+     */
+    public function findForChannel(Uuid $channelId, Tenant $tenant): array;
+
+    /**
+     * @return list<ChannelPublicationProfile>
+     */
+    public function findForTenant(Tenant $tenant): array;
+
+    public function save(ChannelPublicationProfile $profile): void;
+
+    public function remove(ChannelPublicationProfile $profile): void;
+}

--- a/apps/api/src/Channel/Infrastructure/ChannelPublicationResolver.php
+++ b/apps/api/src/Channel/Infrastructure/ChannelPublicationResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure;
+
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Resolves a channel's publication profile for cross-BC consumers.
+ *
+ * Falls back to publish-all (null) when no profile row exists for the
+ * given (channelCode, objectTypeId, tenant) triple — providing zero-config
+ * behaviour for tenants that haven't configured explicit profiles.
+ *
+ * Autowiring aliases {@see ChannelPublicationResolverInterface} to this impl.
+ */
+final readonly class ChannelPublicationResolver implements ChannelPublicationResolverInterface
+{
+    public function __construct(
+        private ChannelRepositoryInterface $channels,
+        private ChannelPublicationProfileRepositoryInterface $profiles,
+    ) {
+    }
+
+    /**
+     * @return list<string>|null null = publish-all
+     */
+    public function resolvePublishedCodes(
+        string $channelCode,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?array {
+        $channel = $this->channels->findByCode($channelCode, $tenant);
+        if (null === $channel) {
+            return null;
+        }
+        $profile = $this->profiles->findByChannelAndObjectType($channel->getId(), $objectTypeId, $tenant);
+        if (null === $profile) {
+            return null;
+        }
+
+        return $profile->getPublishedAttributeCodes();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resolvePublishedLocales(string $channelCode, Tenant $tenant): array
+    {
+        $channel = $this->channels->findByCode($channelCode, $tenant);
+        if (null === $channel) {
+            return [];
+        }
+
+        $profiles = $this->profiles->findForChannel($channel->getId(), $tenant);
+        if ([] === $profiles) {
+            return [];
+        }
+
+        // Collect published locales across all profiles for this channel.
+        // If any profile has an empty published_locales, it signals "use tenant locales".
+        $locales = [];
+        foreach ($profiles as $profile) {
+            foreach ($profile->getPublishedLocales() as $locale) {
+                $locales[$locale] = true;
+            }
+        }
+
+        return array_keys($locales);
+    }
+}

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ChannelPublicationProfile.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ChannelPublicationProfile.orm.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <!--
+        ADR-0015: cross-BC refs to channels and object_types carried as bare
+        UUID columns with DB-level FKs (ON DELETE CASCADE) — no Doctrine
+        targetEntity association. channel_id and object_type_id are plain
+        <field type="uuid"> entries.
+    -->
+    <entity name="App\Channel\Domain\Entity\ChannelPublicationProfile"
+            table="channel_publication_profiles"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\DoctrineChannelPublicationProfileRepository">
+
+        <unique-constraints>
+            <unique-constraint name="cpp_tenant_channel_ot_uniq" columns="tenant_id,channel_id,object_type_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="cpp_channel_idx" columns="tenant_id,channel_id"/>
+            <index name="cpp_tenant_idx" columns="tenant_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <!-- Bare UUID refs per ADR-015 — no Doctrine associations to Channel/ObjectType -->
+        <field name="channelId" column="channel_id" type="uuid" nullable="false"/>
+        <field name="objectTypeId" column="object_type_id" type="uuid" nullable="false"/>
+
+        <!--
+            NULL = publish-all (default profile created on ChannelCreated).
+            [] = publish-nothing.
+            Non-empty array = allow-list.
+            Stored as JSONB for GIN-indexable array queries in Phase 3.
+        -->
+        <field name="publishedAttributeCodes" column="published_attribute_codes" type="json" nullable="true"/>
+
+        <!-- Short locale codes, e.g. ["pl", "en"]. Empty = use tenant locales. -->
+        <field name="publishedLocales" column="published_locales" type="json" nullable="false"/>
+
+        <!-- Per-attribute column header aliases for export CSV/XLSX. -->
+        <field name="columnAliases" column="column_aliases" type="json" nullable="false"/>
+
+        <field name="isDefault" column="is_default" type="boolean"/>
+        <field name="createdAt" column="created_at" type="datetime_immutable"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelPublicationProfileRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelPublicationProfileRepository.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure\Doctrine\Repository;
+
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<ChannelPublicationProfile>
+ */
+class DoctrineChannelPublicationProfileRepository extends ServiceEntityRepository implements ChannelPublicationProfileRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ChannelPublicationProfile::class);
+    }
+
+    public function findById(Uuid $id): ?ChannelPublicationProfile
+    {
+        return parent::find($id->toRfc4122());
+    }
+
+    public function findByChannelAndObjectType(
+        Uuid $channelId,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?ChannelPublicationProfile {
+        return $this->findOneBy([
+            'channelId' => $channelId,
+            'objectTypeId' => $objectTypeId,
+            'tenant' => $tenant,
+        ]);
+    }
+
+    /**
+     * @return list<ChannelPublicationProfile>
+     */
+    public function findForChannel(Uuid $channelId, Tenant $tenant): array
+    {
+        /* @var list<ChannelPublicationProfile> */
+        return $this->findBy(['channelId' => $channelId, 'tenant' => $tenant]);
+    }
+
+    /**
+     * @return list<ChannelPublicationProfile>
+     */
+    public function findForTenant(Tenant $tenant): array
+    {
+        /* @var list<ChannelPublicationProfile> */
+        return $this->findBy(['tenant' => $tenant]);
+    }
+
+    public function save(ChannelPublicationProfile $profile): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($profile);
+        $em->flush();
+    }
+
+    public function remove(ChannelPublicationProfile $profile): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($profile);
+        $em->flush();
+    }
+}

--- a/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
@@ -123,15 +123,27 @@ final class CatalogObjectPublicationFilterApiTest extends CatalogApiTestCase
             ->findBuiltInByKind(ObjectKind::Product, $tenant);
         \assert($product instanceof ObjectType);
 
-        $profile = new ChannelPublicationProfile(
-            channelId: $channel->getId(),
-            objectTypeId: $product->getId(),
-            publishedAttributeCodes: $allowedCodes,
-            isDefault: true,
-        );
-        $profile->assignTenant($tenant);
-        $em->persist($profile);
-        $em->flush();
+        // The channel POST above triggers CreateDefaultPublicationProfilesOnChannelCreated
+        // which already creates a default profile. Upsert: update existing profile's allow-list.
+        $existing = $em->getRepository(ChannelPublicationProfile::class)->findOneBy([
+            'channelId' => $channel->getId(),
+            'objectTypeId' => $product->getId(),
+            'tenant' => $tenant,
+        ]);
+        if ($existing instanceof ChannelPublicationProfile) {
+            $existing->setPublishedAttributeCodes($allowedCodes);
+            $em->flush();
+        } else {
+            $profile = new ChannelPublicationProfile(
+                channelId: $channel->getId(),
+                objectTypeId: $product->getId(),
+                publishedAttributeCodes: $allowedCodes,
+                isDefault: true,
+            );
+            $profile->assignTenant($tenant);
+            $em->persist($profile);
+            $em->flush();
+        }
 
         $client = $this->authenticatedClient();
         $create = $client->request('POST', '/api/products', [

--- a/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #1234 — ?publication=<channelCode> filters attributes_indexed to the
+ * channel's publication allow-list.
+ *
+ * Tests: allow-list reduces attributes, publish-all profile returns all,
+ * missing profile falls back to publish-all (null), ?locale+?publication
+ * can coexist.
+ */
+final class CatalogObjectPublicationFilterApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function publicationAllowListFiltersAttributesIndexed(): void
+    {
+        $client = $this->authenticatedClient();
+        [$id, $channelCode] = $this->seedProductWithPublicationProfile(['name', 'ean']);
+
+        $response = $client->request('GET', "/api/products/{$id}?publication={$channelCode}");
+        self::assertSame(200, $response->getStatusCode());
+
+        $indexed = $this->decodeIndexed($response->getContent());
+        self::assertArrayHasKey('name', $indexed, 'name is in allow-list');
+        self::assertArrayHasKey('ean', $indexed, 'ean is in allow-list');
+        self::assertArrayNotHasKey('internal_notes', $indexed, 'internal_notes is NOT in allow-list');
+    }
+
+    #[Test]
+    public function publicationPublishAllProfileReturnsAllAttributes(): void
+    {
+        $client = $this->authenticatedClient();
+        [$id, $channelCode] = $this->seedProductWithPublicationProfile(null);
+
+        $response = $client->request('GET', "/api/products/{$id}?publication={$channelCode}");
+        self::assertSame(200, $response->getStatusCode());
+
+        $indexed = $this->decodeIndexed($response->getContent());
+        // publish-all = all three attributes present
+        self::assertArrayHasKey('name', $indexed);
+        self::assertArrayHasKey('ean', $indexed);
+        self::assertArrayHasKey('internal_notes', $indexed);
+    }
+
+    #[Test]
+    public function missingPublicationProfileFallsBackToPublishAll(): void
+    {
+        $client = $this->authenticatedClient();
+        $otId = $this->objectTypeIdFor(ObjectKind::Product);
+        $this->seedThreeAttributes();
+
+        $create = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'PUB-FALLBACK-1', 'objectTypeId' => $otId, 'attributes' => [
+                'name' => 'Test', 'ean' => '123', 'internal_notes' => 'secret',
+            ]],
+        ]);
+        self::assertSame(201, $create->getStatusCode());
+        $id = $this->decode($create->getContent())['id'];
+        self::assertIsString($id);
+
+        // Use a channel that exists but has no profile for this objectType
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $channel = new Channel('pub_no_profile', ['pl' => 'Test Channel']);
+        $channel->assignTenant($tenant);
+        $em->persist($channel);
+        $em->flush();
+
+        $response = $client->request('GET', "/api/products/{$id}?publication=pub_no_profile");
+        self::assertSame(200, $response->getStatusCode());
+
+        $indexed = $this->decodeIndexed($response->getContent());
+        // No profile row → publish-all fallback
+        self::assertArrayHasKey('name', $indexed);
+        self::assertArrayHasKey('ean', $indexed);
+        self::assertArrayHasKey('internal_notes', $indexed);
+    }
+
+    /**
+     * Seeds a product with three attributes and a channel + publication profile.
+     * Returns [productId, channelCode].
+     *
+     * @param list<string>|null $allowedCodes null = publish-all
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function seedProductWithPublicationProfile(?array $allowedCodes): array
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $this->seedThreeAttributes();
+
+        $channelCode = 'pub_test_'.($allowedCodes === null ? 'all' : 'filtered');
+        $channel = new Channel($channelCode, ['pl' => 'Test Channel']);
+        $channel->assignTenant($tenant);
+        $em->persist($channel);
+        $em->flush();
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $profile = new ChannelPublicationProfile(
+            channelId: $channel->getId(),
+            objectTypeId: $product->getId(),
+            publishedAttributeCodes: $allowedCodes,
+            isDefault: true,
+        );
+        $profile->assignTenant($tenant);
+        $em->persist($profile);
+        $em->flush();
+
+        $client = $this->authenticatedClient();
+        $create = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'PUB-PROD-'.uniqid(), 'objectTypeId' => $product->getId()->toRfc4122(), 'attributes' => [
+                'name' => 'Test Product', 'ean' => '1234567890', 'internal_notes' => 'secret note',
+            ]],
+        ]);
+        self::assertSame(201, $create->getStatusCode());
+        $id = $this->decode($create->getContent())['id'];
+        self::assertIsString($id);
+
+        return [$id, $channelCode];
+    }
+
+    private function seedThreeAttributes(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        foreach (['name' => 'Name', 'ean' => 'EAN', 'internal_notes' => 'Notes'] as $code => $label) {
+            $attr = new Attribute($code, ['en' => $label, 'pl' => $label], AttributeType::Text);
+            $em->persist($attr);
+            $em->persist(new ObjectTypeAttribute($product, $attr, false, 1));
+        }
+        $em->flush();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeIndexed(string $body): array
+    {
+        $decoded = $this->decode($body);
+        $raw = $decoded['attributesIndexed'] ?? [];
+        \assert(\is_array($raw));
+        /** @var array<string, mixed> $indexed */
+        $indexed = $raw;
+
+        return $indexed;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(string $json): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+}

--- a/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
@@ -32,8 +32,8 @@ final class ChannelPublicationProfileApiTest extends ChannelApiTestCase
         $channelId = $response->toArray()['id'];
         self::assertIsString($channelId);
 
-        /** @var ChannelPublicationProfileRepositoryInterface $repo */
         $repo = self::getContainer()->get(ChannelPublicationProfileRepositoryInterface::class);
+        self::assertInstanceOf(ChannelPublicationProfileRepositoryInterface::class, $repo);
 
         $em = $this->em();
         $tenant = $em->getRepository(\App\Shared\Domain\Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);

--- a/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Channel;
+
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * #1232 — ChannelPublicationProfile entity integration:
+ * on ChannelCreated, default publish-all profiles are auto-created
+ * for each ObjectType belonging to the same tenant.
+ */
+final class ChannelPublicationProfileApiTest extends ChannelApiTestCase
+{
+    #[Test]
+    public function creatingChannelProvisionesDefaultProfilesForAllObjectTypes(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/channels', [
+            'json' => [
+                'code' => 'pub_profile_test',
+                'label' => ['pl' => 'Test', 'en' => 'Test'],
+                'locales' => ['pl_PL'],
+                'currencies' => ['PLN'],
+            ],
+        ]);
+        self::assertSame(201, $response->getStatusCode());
+        $channelId = $response->toArray()['id'];
+        self::assertIsString($channelId);
+
+        /** @var ChannelPublicationProfileRepositoryInterface $repo */
+        $repo = self::getContainer()->get(ChannelPublicationProfileRepositoryInterface::class);
+
+        $em = $this->em();
+        $tenant = $em->getRepository(\App\Shared\Domain\Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        self::assertNotNull($tenant);
+        $profiles = $repo->findForChannel(\Symfony\Component\Uid\Uuid::fromString($channelId), $tenant);
+
+        self::assertNotEmpty($profiles, 'At least one default profile must be created per ObjectType.');
+
+        foreach ($profiles as $profile) {
+            self::assertInstanceOf(ChannelPublicationProfile::class, $profile);
+            self::assertTrue($profile->isDefault(), 'Auto-created profile must be marked as default.');
+            self::assertTrue($profile->isPublishAll(), 'Auto-created profile must be publish-all (null codes).');
+        }
+    }
+}

--- a/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
+++ b/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel\Application;
+
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Channel\Infrastructure\ChannelPublicationResolver;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ChannelPublicationResolverTest extends TestCase
+{
+    private ChannelRepositoryInterface $channels;
+    private ChannelPublicationProfileRepositoryInterface $profiles;
+    private ChannelPublicationResolver $resolver;
+    private Tenant $tenant;
+    private Uuid $objectTypeId;
+
+    protected function setUp(): void
+    {
+        $this->channels = $this->createStub(ChannelRepositoryInterface::class);
+        $this->profiles = $this->createStub(ChannelPublicationProfileRepositoryInterface::class);
+        $this->resolver = new ChannelPublicationResolver($this->channels, $this->profiles);
+        $this->tenant = new Tenant('demo', 'Demo Tenant');
+        $this->objectTypeId = Uuid::v7();
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullForUnknownChannel(): void
+    {
+        $this->channels->method('findByCode')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedCodes('unknown', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullWhenNoProfileExists(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result, 'No profile row → publish-all fallback.');
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullForDefaultPublishAllProfile(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profile = new ChannelPublicationProfile($channel->getId(), $this->objectTypeId, null, [], [], true);
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn($profile);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result, 'Explicit publish-all profile → null return.');
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsAllowListWhenProfileHasCodes(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profile = new ChannelPublicationProfile(
+            $channel->getId(),
+            $this->objectTypeId,
+            ['name', 'price', 'ean'],
+        );
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn($profile);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertSame(['name', 'price', 'ean'], $result);
+    }
+
+    #[Test]
+    public function resolvePublishedLocalesReturnsEmptyForUnknownChannel(): void
+    {
+        $this->channels->method('findByCode')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedLocales('unknown', $this->tenant);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function resolvePublishedLocalesMergesLocalesAcrossProfiles(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profiles = [
+            new ChannelPublicationProfile($channel->getId(), Uuid::v7(), null, ['pl', 'en']),
+            new ChannelPublicationProfile($channel->getId(), Uuid::v7(), null, ['pl', 'de']),
+        ];
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findForChannel')->willReturn($profiles);
+
+        $result = $this->resolver->resolvePublishedLocales('shopify', $this->tenant);
+
+        sort($result);
+        self::assertSame(['de', 'en', 'pl'], $result);
+    }
+
+    private function makeChannel(string $code): Channel
+    {
+        $channel = new Channel(code: $code, label: ['pl' => $code]);
+        $channel->assignTenant($this->tenant);
+
+        return $channel;
+    }
+}

--- a/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
+++ b/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
@@ -10,22 +10,27 @@ use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
 use App\Channel\Domain\Repository\ChannelRepositoryInterface;
 use App\Channel\Infrastructure\ChannelPublicationResolver;
 use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ChannelPublicationResolverTest extends TestCase
 {
-    private ChannelRepositoryInterface $channels;
-    private ChannelPublicationProfileRepositoryInterface $profiles;
+    /** @var MockObject&ChannelRepositoryInterface */
+    private MockObject $channels;
+    /** @var MockObject&ChannelPublicationProfileRepositoryInterface */
+    private MockObject $profiles;
     private ChannelPublicationResolver $resolver;
     private Tenant $tenant;
     private Uuid $objectTypeId;
 
     protected function setUp(): void
     {
-        $this->channels = $this->createStub(ChannelRepositoryInterface::class);
-        $this->profiles = $this->createStub(ChannelPublicationProfileRepositoryInterface::class);
+        $this->channels = $this->createMock(ChannelRepositoryInterface::class);
+        $this->profiles = $this->createMock(ChannelPublicationProfileRepositoryInterface::class);
         $this->resolver = new ChannelPublicationResolver($this->channels, $this->profiles);
         $this->tenant = new Tenant('demo', 'Demo Tenant');
         $this->objectTypeId = Uuid::v7();

--- a/apps/api/tests/Unit/Channel/ChannelPublicationProfileTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelPublicationProfileTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel;
+
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class ChannelPublicationProfileTest extends TestCase
+{
+    #[Test]
+    public function nullPublishedCodesSignifiesPublishAll(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+        );
+
+        self::assertTrue($profile->isPublishAll());
+        self::assertNull($profile->getPublishedAttributeCodes());
+    }
+
+    #[Test]
+    public function emptyArrayPublishedCodesSignifiesPublishNothing(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            publishedAttributeCodes: [],
+        );
+
+        self::assertFalse($profile->isPublishAll());
+        self::assertSame([], $profile->getPublishedAttributeCodes());
+    }
+
+    #[Test]
+    public function nonNullAllowListIsPreserved(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            publishedAttributeCodes: ['name', 'price', 'ean'],
+            publishedLocales: ['pl', 'en'],
+        );
+
+        self::assertFalse($profile->isPublishAll());
+        self::assertSame(['name', 'price', 'ean'], $profile->getPublishedAttributeCodes());
+        self::assertSame(['pl', 'en'], $profile->getPublishedLocales());
+    }
+
+    #[Test]
+    public function setPublishedAttributeCodesNullRestoresPublishAll(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+            publishedAttributeCodes: ['name'],
+        );
+
+        $profile->setPublishedAttributeCodes(null);
+
+        self::assertTrue($profile->isPublishAll());
+    }
+
+    #[Test]
+    public function defaultProfileFlagCarriedThrough(): void
+    {
+        $channelId = Uuid::v7();
+        $objectTypeId = Uuid::v7();
+
+        $profile = new ChannelPublicationProfile(
+            channelId: $channelId,
+            objectTypeId: $objectTypeId,
+            isDefault: true,
+        );
+
+        self::assertTrue($profile->isDefault());
+        self::assertTrue($profile->getChannelId()->equals($channelId));
+        self::assertTrue($profile->getObjectTypeId()->equals($objectTypeId));
+    }
+
+    #[Test]
+    public function tenantCannotBeReassigned(): void
+    {
+        $profile = new ChannelPublicationProfile(
+            channelId: Uuid::v7(),
+            objectTypeId: Uuid::v7(),
+        );
+
+        $tenant = new \App\Shared\Domain\Tenant('test-tenant', 'Test Tenant');
+        $profile->assignTenant($tenant);
+
+        $this->expectException(LogicException::class);
+        $profile->assignTenant($tenant);
+    }
+}


### PR DESCRIPTION
## Summary

- Oba overlay providerzy (`CatalogObjectLocaleOverlayProvider` + `CatalogObjectCollectionLocaleOverlayProvider`) odczytują nowy param `?publication=<channelCode>` z request.
- Po locale/channel value overlay: `attributes_indexed` filtrowane do allow-listy profilu publikacji via `ChannelPublicationResolverInterface::resolvePublishedCodes(...)`.
- Null allow-list (publish-all lub brak profilu) → bez filtrowania (zero regresji).
- `?publication` coexistuje z `?locale=` i `?channel=` (parametry ortogonalne).
- ApiTestCase: allow-lista redukuje atrybuty, publish-all zwraca wszystkie, brak profilu = fallback publish-all.

## Scope

`apps/api` — `CatalogObjectLocaleOverlayProvider` + `CatalogObjectCollectionLocaleOverlayProvider` + ApiTestCase.

## Smoke test

- ships standalone backend feature, end-to-end nieprzetestowany lokalnie (known local docker test.service_container issue); CI ApiTestCase cover it

Closes #1234