### PR TITLE
feat(export): sekcja Kanały w ExportModal — channel filter + scopable fan-out

### DIFF
--- a/apps/admin/src/features/exports/components/use-export-column-catalog.ts
+++ b/apps/admin/src/features/exports/components/use-export-column-catalog.ts
@@ -30,9 +30,15 @@ interface WorkspaceRow {
   primaryLocale: string;
 }
 
+interface ChannelRow {
+  code: string;
+  label?: Record<string, string>;
+}
+
 export interface ExportColumnCatalog {
   groups: ColumnGroup[];
   enabledLocales: string[];
+  enabledChannels: string[];
   isLoading: boolean;
   error: Error | null;
 }
@@ -60,6 +66,7 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
   const [attrs, setAttrs] = useState<AttributeRow[]>([]);
   const [attrGroups, setAttrGroups] = useState<AttributeGroupRow[]>([]);
   const [workspace, setWorkspace] = useState<WorkspaceRow | null>(null);
+  const [channels, setChannels] = useState<ChannelRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -74,13 +81,18 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
       // locale fan-out). The hook only flips `error` if attributes
       // themselves cannot load; groups + workspace silently fall back to
       // their defaults so the modal still ships a useful picker.
-      const [attrsResult, groupsResult, workspaceResult] = await Promise.allSettled([
-        jsonFetch<AttributeRow[] | { member?: AttributeRow[] }>('/api/attributes?itemsPerPage=500'),
-        jsonFetch<AttributeGroupRow[] | { member?: AttributeGroupRow[] }>(
-          '/api/attribute_groups?itemsPerPage=100',
-        ),
-        jsonFetch<WorkspaceRow>('/api/workspaces/current'),
-      ]);
+      const [attrsResult, groupsResult, workspaceResult, channelsResult] = await Promise.allSettled(
+        [
+          jsonFetch<AttributeRow[] | { member?: AttributeRow[] }>(
+            '/api/attributes?itemsPerPage=500',
+          ),
+          jsonFetch<AttributeGroupRow[] | { member?: AttributeGroupRow[] }>(
+            '/api/attribute_groups?itemsPerPage=100',
+          ),
+          jsonFetch<WorkspaceRow>('/api/workspaces/current'),
+          jsonFetch<ChannelRow[] | { member?: ChannelRow[] }>('/api/channels?itemsPerPage=50'),
+        ],
+      );
 
       if (cancelled) return;
 
@@ -123,6 +135,19 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
         setWorkspace(null);
       }
 
+      if (channelsResult.status === 'fulfilled') {
+        const value = channelsResult.value;
+        const list = Array.isArray(value) ? value : (value.member ?? []);
+        setChannels(list);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'export-column-catalog: channels fetch failed (scopable fan-out disabled)',
+          channelsResult.reason,
+        );
+        setChannels([]);
+      }
+
       setIsLoading(false);
     })();
 
@@ -132,13 +157,14 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
   }, []);
 
   const enabledLocales = workspace?.enabledLocales ?? ['pl', 'en'];
+  const enabledChannels = channels.map((c) => c.code);
 
   const groups: ColumnGroup[] = [
     ...BUILT_IN_COLUMN_GROUPS,
-    ...buildAttributeGroups(attrs, attrGroups, enabledLocales),
+    ...buildAttributeGroups(attrs, attrGroups, enabledLocales, enabledChannels),
   ];
 
-  return { groups, enabledLocales, isLoading, error };
+  return { groups, enabledLocales, enabledChannels, isLoading, error };
 }
 
 /**
@@ -151,6 +177,7 @@ function buildAttributeGroups(
   attrs: AttributeRow[],
   groups: AttributeGroupRow[],
   enabledLocales: string[],
+  enabledChannels: string[] = [],
 ): ColumnGroup[] {
   const groupsByCode = new Map<string, AttributeGroupRow>();
   for (const g of groups) groupsByCode.set(g.code, g);
@@ -178,7 +205,7 @@ function buildAttributeGroups(
       id: `attr-group-${group.code}`,
       labelKey: `exports.column_picker.group_attr_${group.code}`,
       defaultLabel: localizedLabel(group.label, 'pl') ?? group.code,
-      columns: bucket.flatMap((attr) => attrToOptions(attr, enabledLocales)),
+      columns: bucket.flatMap((attr) => attrToOptions(attr, enabledLocales, enabledChannels)),
     });
   }
 
@@ -188,7 +215,7 @@ function buildAttributeGroups(
       id: 'attr-group-other',
       labelKey: 'exports.column_picker.group_other',
       defaultLabel: 'Inne atrybuty',
-      columns: orphans.flatMap((attr) => attrToOptions(attr, enabledLocales)),
+      columns: orphans.flatMap((attr) => attrToOptions(attr, enabledLocales, enabledChannels)),
     });
   }
 
@@ -207,6 +234,7 @@ function resolveBucketCode(
 function attrToOptions(
   attr: AttributeRow,
   enabledLocales: string[],
+  enabledChannels: string[] = [],
 ): Array<{ key: string; labelKey: string; defaultLabel: string }> {
   const baseLabel = localizedLabel(attr.label, 'pl') ?? attr.code;
   if (attr.localizable === true && enabledLocales.length > 0) {
@@ -214,6 +242,14 @@ function attrToOptions(
       key: `${attr.code}.${locale}`,
       labelKey: `exports.columns.${attr.code}.${locale}`,
       defaultLabel: `${baseLabel} [${locale}]`,
+    }));
+  }
+  // #1245 — scopable attributes fan out per active channel.
+  if (attr.scopable === true && enabledChannels.length > 0) {
+    return enabledChannels.map((channel) => ({
+      key: `${attr.code}.${channel}`,
+      labelKey: `exports.columns.${attr.code}.${channel}`,
+      defaultLabel: `${baseLabel} [${channel}]`,
     }));
   }
   return [

--- a/apps/admin/src/features/exports/wizard/ExportModal.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportModal.tsx
@@ -83,20 +83,28 @@ export function ExportModal({
   const [profileName, setProfileName] = useState('');
   const [profileError, setProfileError] = useState<string | null>(null);
   // #1243 — activeLocales: all enabled locales selected by default (zero regression).
-  // null = not yet initialized (wait for catalog to load).
+  // #1245 — activeChannels: all enabled channels selected by default.
   const [activeLocales, setActiveLocales] = useState<string[] | null>(null);
+  const [activeChannels, setActiveChannels] = useState<string[] | null>(null);
 
   const columnCatalog = useExportColumnCatalog();
   const allLocales = columnCatalog.enabledLocales;
+  const allChannels = columnCatalog.enabledChannels;
 
-  // Initialize activeLocales once catalog loads (idempotent — only sets once).
+  // Initialize activeLocales / activeChannels once catalog loads (idempotent — only sets once).
   useEffect(() => {
     if (activeLocales === null && allLocales.length > 0) {
       setActiveLocales(allLocales);
     }
   }, [activeLocales, allLocales]);
+  useEffect(() => {
+    if (activeChannels === null && allChannels.length > 0) {
+      setActiveChannels(allChannels);
+    }
+  }, [activeChannels, allChannels]);
 
   const effectiveLocales = activeLocales ?? allLocales;
+  const effectiveChannels = activeChannels ?? allChannels;
 
   const toggleLocale = (locale: string, checked: boolean): void => {
     const next = checked
@@ -104,21 +112,32 @@ export function ExportModal({
       : effectiveLocales.filter((l) => l !== locale);
     setActiveLocales(next);
     if (!checked) {
-      // Remove .{locale} suffix columns from the selected list.
       setColumns((prev) => prev.filter((col) => !col.endsWith(`.${locale}`)));
     }
   };
 
-  // Filter available column groups to only show columns whose locale suffix
-  // is in the active set. Bare columns (no suffix) always pass through.
+  const toggleChannel = (channel: string, checked: boolean): void => {
+    const next = checked
+      ? [...effectiveChannels, channel]
+      : effectiveChannels.filter((c) => c !== channel);
+    setActiveChannels(next);
+    if (!checked) {
+      setColumns((prev) => prev.filter((col) => !col.endsWith(`.${channel}`)));
+    }
+  };
+
+  // Filter available column groups by active locales AND active channels.
   const filteredGroups = columnCatalog.groups.map((group) => ({
     ...group,
     columns: group.columns.filter((col) => {
       const dot = col.key.lastIndexOf('.');
       if (dot === -1) return true;
       const suffix = col.key.slice(dot + 1);
-      // If suffix looks like a locale code (2-3 chars), filter by activeLocales.
-      return suffix.length <= 5 && effectiveLocales.includes(suffix);
+      if (effectiveLocales.includes(suffix)) return true;
+      if (effectiveChannels.includes(suffix)) return true;
+      // Suffix not in either active set — hide (it's a deselected locale or channel).
+      if (allLocales.includes(suffix) || allChannels.includes(suffix)) return false;
+      return true;
     }),
   }));
 
@@ -150,6 +169,7 @@ export function ExportModal({
       selected_columns: columns,
       include_variants: true,
       locales: effectiveLocales.length < allLocales.length ? effectiveLocales : undefined,
+      channels: effectiveChannels.length < allChannels.length ? effectiveChannels : undefined,
     };
     if (format === 'csv') {
       payload['encoding'] = encoding;
@@ -286,7 +306,7 @@ export function ExportModal({
           </DialogTitle>
         </DialogHeader>
         <div className="-mx-6 flex-1 space-y-6 overflow-y-auto px-6">
-          {/* Section 0 — Języki (#1243) */}
+          {/* Section 0a — Języki (#1243) */}
           {allLocales.length > 1 && (
             <section className="space-y-2">
               <h3 className="text-sm font-medium">
@@ -304,6 +324,30 @@ export function ExportModal({
                       }}
                     />
                     <span className="uppercase">{locale}</span>
+                  </label>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Section 0b — Kanały (#1245) */}
+          {allChannels.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-medium">
+                {t('exports.modal.section_channels', { defaultValue: 'Kanały' })}
+              </h3>
+              <div className="flex flex-wrap gap-3 text-sm">
+                {allChannels.map((channel) => (
+                  <label key={channel} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="size-4"
+                      checked={effectiveChannels.includes(channel)}
+                      onChange={(e) => {
+                        toggleChannel(channel, e.target.checked);
+                      }}
+                    />
+                    <span>{channel}</span>
                   </label>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

- Nowa sekcja „Kanały" w `ExportModal.tsx` — analogiczna do „Języki" (#1243), multi-select checkboxy z aktywnymi kanałami tenanta.
- `use-export-column-catalog.ts`: fetch `/api/channels` + fan-out scopable atrybutów per kanał (`price.shopify`, `price.allegro` zamiast płaskiego `price`). Realizuje TODO "deferred to Faza 1".
- Odznaczenie kanału → kolumny `.{channel}` znikają z DOSTĘPNE i są usuwane z WYBRANE.
- `filteredGroups` filtruje zarówno wg activeLocales jak i activeChannels.
- Payload `channels[]` wysyłany tylko gdy operator odznaczył ≥1 kanał.
- Sekcja nie wyświetla się gdy tenant nie ma aktywnych kanałów.

## Scope

`apps/admin` — `ExportModal.tsx` + `use-export-column-catalog.ts`. BE bez zmian (SyncExportController już akceptuje `channels`).

## Smoke test

- ships standalone FE widgets + channel data fetching; end-to-end smoke wymaga tenanta z aktywnym scopable atrybutem + kanałem

Closes #1245