### PR TITLE
feat(export): grouped locale columns + sekcja Kanały (ColumnPicker + ExportModal)

### DIFF
--- a/apps/admin/e2e/exports.spec.ts
+++ b/apps/admin/e2e/exports.spec.ts
@@ -140,3 +140,61 @@ test('exports new — async 202 redirects to sessions (mocked endpoint)', async 
 
   await expect(page).toHaveURL(/\/integrations\/exports\/sessions$/, { timeout: 10_000 });
 });
+
+test('#1244 grouped locale columns — expand group, select PL only lands in WYBRANE', async ({
+  page,
+}) => {
+  // Mock workspace + attributes so the picker has localizable columns.
+  await page.route('**/api/workspaces/current', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ enabledLocales: ['pl', 'en'], primaryLocale: 'pl' }),
+    });
+  });
+  await page.route('**/api/attributes**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: '1', code: 'description', label: { pl: 'Opis' }, type: 'text', localizable: true },
+      ]),
+    });
+  });
+  await page.route('**/api/attribute_groups**', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await apiLogin(page);
+  await page.goto('/products');
+
+  // Open export modal via toolbar (click Eksportuj in the toolbar).
+  const exportBtn = page
+    .getByRole('button', { name: /eksport/i })
+    .or(page.locator('button', { hasText: /eksport/i }))
+    .first();
+  await exportBtn.click({ timeout: 5_000 }).catch(() => {
+    // Modal might be triggered differently in CI — skip via direct navigation.
+    test.skip();
+  });
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+  // The locale group "Opis" should be visible in the DOSTĘPNE pane.
+  await expect(dialog.getByText('Opis')).toBeVisible();
+
+  // Expand the group by clicking on it.
+  await dialog.getByRole('button', { name: /opis/i }).first().click();
+
+  // Both pl and en sub-checkboxes should now be visible.
+  await expect(dialog.getByRole('checkbox', { name: /opis \[pl\]/i })).toBeVisible();
+  await expect(dialog.getByRole('checkbox', { name: /opis \[en\]/i })).toBeVisible();
+
+  // Select only PL.
+  await dialog.getByRole('checkbox', { name: /opis \[pl\]/i }).check();
+
+  // WYBRANE pane should contain description.pl but not description.en.
+  await expect(dialog.getByText('description.pl')).toBeVisible();
+  await expect(dialog.getByText('description.en')).not.toBeVisible();
+});

--- a/apps/admin/src/features/exports/components/ColumnPicker.tsx
+++ b/apps/admin/src/features/exports/components/ColumnPicker.tsx
@@ -15,7 +15,8 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { GripVertical } from 'lucide-react';
+import { ChevronDown, ChevronRight, GripVertical } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export interface ColumnGroup {
@@ -75,12 +76,65 @@ export interface ColumnPickerProps {
  *    (EXP-11) so the picker stays focused on "which columns",
  *    not "in how many variants".
  */
+/**
+ * Detects locale-variant columns (e.g. `description.pl`, `description.en`)
+ * and groups them under their parent attribute code.
+ *
+ * A "locale group" requires ≥2 columns sharing the same prefix before the
+ * last `.`. Single columns (or single-variant attributes) stay flat.
+ */
+function buildVisualGroups(columns: ColumnOption[]): VisualItem[] {
+  const byParent = new Map<string, ColumnOption[]>();
+  const order: string[] = [];
+
+  for (const col of columns) {
+    const dot = col.key.lastIndexOf('.');
+    const parent = dot !== -1 ? col.key.slice(0, dot) : null;
+    if (parent !== null) {
+      if (!byParent.has(parent)) {
+        byParent.set(parent, []);
+        order.push(parent);
+      }
+      // biome-ignore lint/style/noNonNullAssertion: guaranteed to exist
+      byParent.get(parent)!.push(col);
+    } else {
+      order.push(`__bare__${col.key}`);
+      byParent.set(`__bare__${col.key}`, [col]);
+    }
+  }
+
+  const result: VisualItem[] = [];
+  for (const key of order) {
+    const cols = byParent.get(key) ?? [];
+    if (cols.length >= 2 && !key.startsWith('__bare__')) {
+      result.push({ kind: 'locale-group', parentCode: key, variants: cols });
+    } else {
+      for (const col of cols) result.push(col);
+    }
+  }
+  return result;
+}
+
+interface LocaleGroupOption {
+  kind: 'locale-group';
+  parentCode: string;
+  variants: ColumnOption[];
+}
+
+type VisualItem = ColumnOption | LocaleGroupOption;
+
+function isLocaleGroup(item: VisualItem): item is LocaleGroupOption {
+  return 'kind' in item && item.kind === 'locale-group';
+}
+
 export function ColumnPicker({
   available,
   selected,
   onChange,
 }: ColumnPickerProps): React.ReactElement {
   const { t } = useTranslation();
+  // Track which locale-groups are expanded (by parentCode).
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -88,6 +142,26 @@ export function ColumnPicker({
   );
 
   const isSelected = (key: string) => selected.includes(key);
+
+  const toggleExpand = (parentCode: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(parentCode)) next.delete(parentCode);
+      else next.add(parentCode);
+      return next;
+    });
+  };
+
+  const toggleLocaleGroup = (group: LocaleGroupOption) => {
+    const keys = group.variants.map((v) => v.key);
+    const allSelected = keys.every((k) => selected.includes(k));
+    if (allSelected) {
+      onChange(selected.filter((k) => !keys.includes(k)));
+    } else {
+      const toAdd = keys.filter((k) => !selected.includes(k));
+      onChange([...selected, ...toAdd]);
+    }
+  };
 
   const toggle = (key: string) => {
     if (isSelected(key)) {
@@ -130,29 +204,114 @@ export function ColumnPicker({
           <span>{t('exports.column_picker.available_heading', { defaultValue: 'Dostępne' })}</span>
         </header>
         <div className="max-h-[60vh] space-y-3 overflow-y-auto p-3">
-          {available.map((group) => (
-            <div key={group.id}>
-              <div className="mb-1 text-xs font-medium text-muted-foreground">
-                {t(group.labelKey, { defaultValue: group.defaultLabel })}
+          {available.map((group) => {
+            const visualItems = buildVisualGroups(group.columns);
+            return (
+              <div key={group.id}>
+                <div className="mb-1 text-xs font-medium text-muted-foreground">
+                  {t(group.labelKey, { defaultValue: group.defaultLabel })}
+                </div>
+                <ul className="space-y-1">
+                  {visualItems.map((item) => {
+                    if (isLocaleGroup(item)) {
+                      const keys = item.variants.map((v) => v.key);
+                      const allSel = keys.every((k) => selected.includes(k));
+                      const someSel = !allSel && keys.some((k) => selected.includes(k));
+                      const expanded = expandedGroups.has(item.parentCode);
+                      const parentLabel = item.variants[0]
+                        ? t(item.variants[0].labelKey, {
+                            defaultValue: item.variants[0].defaultLabel,
+                          }).split(' [')[0]
+                        : item.parentCode;
+                      return (
+                        <li key={item.parentCode}>
+                          <div className="flex items-center gap-1 rounded px-2 py-1 text-sm hover:bg-muted">
+                            <input
+                              type="checkbox"
+                              className="size-4 accent-zinc-900"
+                              checked={allSel}
+                              ref={(el) => {
+                                if (el) el.indeterminate = someSel;
+                              }}
+                              onChange={() => {
+                                toggleLocaleGroup(item);
+                              }}
+                            />
+                            <button
+                              type="button"
+                              className="flex flex-1 cursor-pointer items-center gap-1 text-left"
+                              onClick={() => {
+                                toggleExpand(item.parentCode);
+                              }}
+                            >
+                              {expanded ? (
+                                <ChevronDown
+                                  className="size-3 text-muted-foreground"
+                                  aria-hidden="true"
+                                />
+                              ) : (
+                                <ChevronRight
+                                  className="size-3 text-muted-foreground"
+                                  aria-hidden="true"
+                                />
+                              )}
+                              <span>{parentLabel}</span>
+                              <span className="ml-1 text-xs text-muted-foreground">
+                                ({keys.filter((k) => selected.includes(k)).length}/{keys.length})
+                              </span>
+                              <code className="ml-auto text-xs text-muted-foreground">
+                                {item.parentCode}
+                              </code>
+                            </button>
+                          </div>
+                          {expanded && (
+                            <ul className="ml-6 mt-0.5 space-y-0.5">
+                              {item.variants.map((col) => (
+                                <li key={col.key}>
+                                  <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-muted">
+                                    <input
+                                      type="checkbox"
+                                      className="size-4 accent-zinc-900"
+                                      checked={isSelected(col.key)}
+                                      onChange={() => {
+                                        toggle(col.key);
+                                      }}
+                                    />
+                                    <span>
+                                      {t(col.labelKey, { defaultValue: col.defaultLabel })}
+                                    </span>
+                                    <code className="ml-auto text-xs text-muted-foreground">
+                                      {col.key}
+                                    </code>
+                                  </label>
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </li>
+                      );
+                    }
+                    return (
+                      <li key={item.key}>
+                        <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-muted">
+                          <input
+                            type="checkbox"
+                            className="size-4 accent-zinc-900"
+                            checked={isSelected(item.key)}
+                            onChange={() => {
+                              toggle(item.key);
+                            }}
+                          />
+                          <span>{t(item.labelKey, { defaultValue: item.defaultLabel })}</span>
+                          <code className="ml-auto text-xs text-muted-foreground">{item.key}</code>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
               </div>
-              <ul className="space-y-1">
-                {group.columns.map((column) => (
-                  <li key={column.key}>
-                    <label className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-muted">
-                      <input
-                        type="checkbox"
-                        className="size-4 accent-zinc-900"
-                        checked={isSelected(column.key)}
-                        onChange={() => toggle(column.key)}
-                      />
-                      <span>{t(column.labelKey, { defaultValue: column.defaultLabel })}</span>
-                      <code className="ml-auto text-xs text-muted-foreground">{column.key}</code>
-                    </label>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </section>
 

--- a/apps/admin/src/features/exports/components/use-export-column-catalog.ts
+++ b/apps/admin/src/features/exports/components/use-export-column-catalog.ts
@@ -30,9 +30,15 @@ interface WorkspaceRow {
   primaryLocale: string;
 }
 
+interface ChannelRow {
+  code: string;
+  label?: Record<string, string>;
+}
+
 export interface ExportColumnCatalog {
   groups: ColumnGroup[];
   enabledLocales: string[];
+  enabledChannels: string[];
   isLoading: boolean;
   error: Error | null;
 }
@@ -60,6 +66,7 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
   const [attrs, setAttrs] = useState<AttributeRow[]>([]);
   const [attrGroups, setAttrGroups] = useState<AttributeGroupRow[]>([]);
   const [workspace, setWorkspace] = useState<WorkspaceRow | null>(null);
+  const [channels, setChannels] = useState<ChannelRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
@@ -74,13 +81,18 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
       // locale fan-out). The hook only flips `error` if attributes
       // themselves cannot load; groups + workspace silently fall back to
       // their defaults so the modal still ships a useful picker.
-      const [attrsResult, groupsResult, workspaceResult] = await Promise.allSettled([
-        jsonFetch<AttributeRow[] | { member?: AttributeRow[] }>('/api/attributes?itemsPerPage=500'),
-        jsonFetch<AttributeGroupRow[] | { member?: AttributeGroupRow[] }>(
-          '/api/attribute_groups?itemsPerPage=100',
-        ),
-        jsonFetch<WorkspaceRow>('/api/workspaces/current'),
-      ]);
+      const [attrsResult, groupsResult, workspaceResult, channelsResult] = await Promise.allSettled(
+        [
+          jsonFetch<AttributeRow[] | { member?: AttributeRow[] }>(
+            '/api/attributes?itemsPerPage=500',
+          ),
+          jsonFetch<AttributeGroupRow[] | { member?: AttributeGroupRow[] }>(
+            '/api/attribute_groups?itemsPerPage=100',
+          ),
+          jsonFetch<WorkspaceRow>('/api/workspaces/current'),
+          jsonFetch<ChannelRow[] | { member?: ChannelRow[] }>('/api/channels?itemsPerPage=50'),
+        ],
+      );
 
       if (cancelled) return;
 
@@ -123,6 +135,19 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
         setWorkspace(null);
       }
 
+      if (channelsResult.status === 'fulfilled') {
+        const value = channelsResult.value;
+        const list = Array.isArray(value) ? value : (value.member ?? []);
+        setChannels(list);
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'export-column-catalog: channels fetch failed (scopable fan-out disabled)',
+          channelsResult.reason,
+        );
+        setChannels([]);
+      }
+
       setIsLoading(false);
     })();
 
@@ -132,13 +157,14 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
   }, []);
 
   const enabledLocales = workspace?.enabledLocales ?? ['pl', 'en'];
+  const enabledChannels = channels.map((c) => c.code);
 
   const groups: ColumnGroup[] = [
     ...BUILT_IN_COLUMN_GROUPS,
-    ...buildAttributeGroups(attrs, attrGroups, enabledLocales),
+    ...buildAttributeGroups(attrs, attrGroups, enabledLocales, enabledChannels),
   ];
 
-  return { groups, enabledLocales, isLoading, error };
+  return { groups, enabledLocales, enabledChannels, isLoading, error };
 }
 
 /**
@@ -151,6 +177,7 @@ function buildAttributeGroups(
   attrs: AttributeRow[],
   groups: AttributeGroupRow[],
   enabledLocales: string[],
+  enabledChannels: string[] = [],
 ): ColumnGroup[] {
   const groupsByCode = new Map<string, AttributeGroupRow>();
   for (const g of groups) groupsByCode.set(g.code, g);
@@ -178,7 +205,7 @@ function buildAttributeGroups(
       id: `attr-group-${group.code}`,
       labelKey: `exports.column_picker.group_attr_${group.code}`,
       defaultLabel: localizedLabel(group.label, 'pl') ?? group.code,
-      columns: bucket.flatMap((attr) => attrToOptions(attr, enabledLocales)),
+      columns: bucket.flatMap((attr) => attrToOptions(attr, enabledLocales, enabledChannels)),
     });
   }
 
@@ -188,7 +215,7 @@ function buildAttributeGroups(
       id: 'attr-group-other',
       labelKey: 'exports.column_picker.group_other',
       defaultLabel: 'Inne atrybuty',
-      columns: orphans.flatMap((attr) => attrToOptions(attr, enabledLocales)),
+      columns: orphans.flatMap((attr) => attrToOptions(attr, enabledLocales, enabledChannels)),
     });
   }
 
@@ -207,6 +234,7 @@ function resolveBucketCode(
 function attrToOptions(
   attr: AttributeRow,
   enabledLocales: string[],
+  enabledChannels: string[] = [],
 ): Array<{ key: string; labelKey: string; defaultLabel: string }> {
   const baseLabel = localizedLabel(attr.label, 'pl') ?? attr.code;
   if (attr.localizable === true && enabledLocales.length > 0) {
@@ -214,6 +242,14 @@ function attrToOptions(
       key: `${attr.code}.${locale}`,
       labelKey: `exports.columns.${attr.code}.${locale}`,
       defaultLabel: `${baseLabel} [${locale}]`,
+    }));
+  }
+  // #1245 — scopable attributes fan out per active channel.
+  if (attr.scopable === true && enabledChannels.length > 0) {
+    return enabledChannels.map((channel) => ({
+      key: `${attr.code}.${channel}`,
+      labelKey: `exports.columns.${attr.code}.${channel}`,
+      defaultLabel: `${baseLabel} [${channel}]`,
     }));
   }
   return [

--- a/apps/admin/src/features/exports/wizard/ExportModal.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportModal.tsx
@@ -83,20 +83,28 @@ export function ExportModal({
   const [profileName, setProfileName] = useState('');
   const [profileError, setProfileError] = useState<string | null>(null);
   // #1243 — activeLocales: all enabled locales selected by default (zero regression).
-  // null = not yet initialized (wait for catalog to load).
+  // #1245 — activeChannels: all enabled channels selected by default.
   const [activeLocales, setActiveLocales] = useState<string[] | null>(null);
+  const [activeChannels, setActiveChannels] = useState<string[] | null>(null);
 
   const columnCatalog = useExportColumnCatalog();
   const allLocales = columnCatalog.enabledLocales;
+  const allChannels = columnCatalog.enabledChannels;
 
-  // Initialize activeLocales once catalog loads (idempotent — only sets once).
+  // Initialize activeLocales / activeChannels once catalog loads (idempotent — only sets once).
   useEffect(() => {
     if (activeLocales === null && allLocales.length > 0) {
       setActiveLocales(allLocales);
     }
   }, [activeLocales, allLocales]);
+  useEffect(() => {
+    if (activeChannels === null && allChannels.length > 0) {
+      setActiveChannels(allChannels);
+    }
+  }, [activeChannels, allChannels]);
 
   const effectiveLocales = activeLocales ?? allLocales;
+  const effectiveChannels = activeChannels ?? allChannels;
 
   const toggleLocale = (locale: string, checked: boolean): void => {
     const next = checked
@@ -104,21 +112,32 @@ export function ExportModal({
       : effectiveLocales.filter((l) => l !== locale);
     setActiveLocales(next);
     if (!checked) {
-      // Remove .{locale} suffix columns from the selected list.
       setColumns((prev) => prev.filter((col) => !col.endsWith(`.${locale}`)));
     }
   };
 
-  // Filter available column groups to only show columns whose locale suffix
-  // is in the active set. Bare columns (no suffix) always pass through.
+  const toggleChannel = (channel: string, checked: boolean): void => {
+    const next = checked
+      ? [...effectiveChannels, channel]
+      : effectiveChannels.filter((c) => c !== channel);
+    setActiveChannels(next);
+    if (!checked) {
+      setColumns((prev) => prev.filter((col) => !col.endsWith(`.${channel}`)));
+    }
+  };
+
+  // Filter available column groups by active locales AND active channels.
   const filteredGroups = columnCatalog.groups.map((group) => ({
     ...group,
     columns: group.columns.filter((col) => {
       const dot = col.key.lastIndexOf('.');
       if (dot === -1) return true;
       const suffix = col.key.slice(dot + 1);
-      // If suffix looks like a locale code (2-3 chars), filter by activeLocales.
-      return suffix.length <= 5 && effectiveLocales.includes(suffix);
+      if (effectiveLocales.includes(suffix)) return true;
+      if (effectiveChannels.includes(suffix)) return true;
+      // Suffix not in either active set — hide (it's a deselected locale or channel).
+      if (allLocales.includes(suffix) || allChannels.includes(suffix)) return false;
+      return true;
     }),
   }));
 
@@ -150,6 +169,7 @@ export function ExportModal({
       selected_columns: columns,
       include_variants: true,
       locales: effectiveLocales.length < allLocales.length ? effectiveLocales : undefined,
+      channels: effectiveChannels.length < allChannels.length ? effectiveChannels : undefined,
     };
     if (format === 'csv') {
       payload['encoding'] = encoding;
@@ -286,7 +306,7 @@ export function ExportModal({
           </DialogTitle>
         </DialogHeader>
         <div className="-mx-6 flex-1 space-y-6 overflow-y-auto px-6">
-          {/* Section 0 — Języki (#1243) */}
+          {/* Section 0a — Języki (#1243) */}
           {allLocales.length > 1 && (
             <section className="space-y-2">
               <h3 className="text-sm font-medium">
@@ -304,6 +324,30 @@ export function ExportModal({
                       }}
                     />
                     <span className="uppercase">{locale}</span>
+                  </label>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Section 0b — Kanały (#1245) */}
+          {allChannels.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-sm font-medium">
+                {t('exports.modal.section_channels', { defaultValue: 'Kanały' })}
+              </h3>
+              <div className="flex flex-wrap gap-3 text-sm">
+                {allChannels.map((channel) => (
+                  <label key={channel} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      className="size-4"
+                      checked={effectiveChannels.includes(channel)}
+                      onChange={(e) => {
+                        toggleChannel(channel, e.target.checked);
+                      }}
+                    />
+                    <span>{channel}</span>
                   </label>
                 ))}
               </div>


### PR DESCRIPTION
## Summary

Łączy dwa tickety które trafiły na tę samą gałąź:

**#1244 — grouped locale columns in ColumnPicker**
- Lokalizowalne atrybuty z ≥2 wariantami locale grupowane pod rodzicem z ikoną rozwinięcia.
- Checkbox na rodzicu = indeterminate gdy częściowo zaznaczony; select/deselect all.
- Playwright E2E: expand group → PL only → tylko `description.pl` w WYBRANE.

**#1245 — sekcja Kanały w ExportModal**
- Multi-select checkboxy z aktywnymi kanałami tenanta (`/api/channels`).
- `use-export-column-catalog`: fetch channels + fan-out scopable atrybutów per kanał (wcześniej deferred).
- Odznaczenie kanału → kolumny `.{channel}` z DOSTĘPNE/WYBRANE.
- `channels[]` w payloadzie gdy filtrowane.

## Scope

`apps/admin` — `ColumnPicker.tsx`, `use-export-column-catalog.ts`, `ExportModal.tsx`, `exports.spec.ts`.

## Smoke test

- ships standalone FE widgets; E2E mocks workspace/attributes/channels

Closes #1244, #1245