### PR TITLE
feat(channel/catalog/export): ChannelPublicationResolver + API ?publication + ColumnPlanner

### DIFF
--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
@@ -12,10 +12,14 @@ use App\Catalog\Application\ObjectValueLocaleOverlay;
 use App\Catalog\Application\SystemAttributeReadOverlay;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Shared\Domain\Tenant;
 use ArrayIterator;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Uid\Uuid;
 use Traversable;
+
+use const ARRAY_FILTER_USE_KEY;
 
 /**
  * GetCollection provider for catalog sugar paths (`/api/products`,
@@ -41,6 +45,7 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         private SystemAttributeReadOverlay $systemOverlay,
         private ObjectValueRepositoryInterface $objectValues,
         private RequestStack $requestStack,
+        private ChannelPublicationResolverInterface $publicationResolver,
     ) {
     }
 
@@ -54,8 +59,10 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         $request = $this->requestStack->getCurrentRequest();
         $localeParam = $request?->query->get('locale');
         $channelParam = $request?->query->get('channel');
+        $publicationParam = $request?->query->get('publication');
         $locale = \is_string($localeParam) && '' !== $localeParam ? $localeParam : null;
         $channel = \is_string($channelParam) && '' !== $channelParam ? $channelParam : null;
+        $publication = \is_string($publicationParam) && '' !== $publicationParam ? $publicationParam : null;
 
         // Collect CatalogObject items from the paginator or array result.
         // API Platform may return an iterable paginator or a plain array.
@@ -79,8 +86,8 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         }
 
         // Always apply system overlay so created_at/updated_at render.
-        // When no locale/channel scope is active, skip the value overlay.
-        if (null === $locale && null === $channel) {
+        // When no locale/channel scope and no publication filter, skip overlay.
+        if (null === $locale && null === $channel && null === $publication) {
             foreach ($objects as $object) {
                 $this->systemOverlay->apply($object);
             }
@@ -96,7 +103,15 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         $valuesByObjectId = $this->objectValues->findByObjectIds($objectIds);
 
         // Apply locale/channel overlay on clones (no identity map mutation).
-        $overlaid = $this->overlay->applyBatch($objects, $valuesByObjectId, $locale, $channel);
+        $overlaid = (null !== $locale || null !== $channel)
+            ? $this->overlay->applyBatch($objects, $valuesByObjectId, $locale, $channel)
+            : array_map(static fn (CatalogObject $o): CatalogObject => clone $o, $objects);
+
+        // #1234 — ?publication=<channelCode> filters attributes_indexed per
+        // publication profile. Applied after value overlay.
+        if (null !== $publication) {
+            $overlaid = $this->applyPublicationFilter($overlaid, $publication);
+        }
 
         // Apply system overlay on the (already cloned) overlaid objects.
         $overlaid = array_map(
@@ -122,5 +137,39 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         }
 
         return $overlaid;
+    }
+
+    /**
+     * Filters attributes_indexed to the publication allow-list for each object.
+     * Objects are already cloned; mutates the clone in-place.
+     *
+     * @param list<CatalogObject> $objects
+     *
+     * @return list<CatalogObject>
+     */
+    private function applyPublicationFilter(array $objects, string $channelCode): array
+    {
+        foreach ($objects as $object) {
+            $tenant = $object->getTenant();
+            if (!$tenant instanceof Tenant) {
+                continue;
+            }
+            $allowedCodes = $this->publicationResolver->resolvePublishedCodes(
+                $channelCode,
+                $object->getObjectType()->getId(),
+                $tenant,
+            );
+            if (null === $allowedCodes) {
+                continue;
+            }
+            $filtered = array_filter(
+                $object->getAttributesIndexed(),
+                static fn (string $code): bool => \in_array($code, $allowedCodes, true),
+                ARRAY_FILTER_USE_KEY,
+            );
+            $object->updateAttributeIndex($filtered);
+        }
+
+        return $objects;
     }
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
@@ -9,7 +9,11 @@ use ApiPlatform\State\ProviderInterface;
 use App\Catalog\Application\ObjectValueLocaleOverlay;
 use App\Catalog\Application\SystemAttributeReadOverlay;
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Shared\Domain\Tenant;
 use Symfony\Component\HttpFoundation\RequestStack;
+
+use const ARRAY_FILTER_USE_KEY;
 
 /**
  * GET-item provider for the catalog sugar paths (`/api/products/{id}`,
@@ -35,6 +39,7 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
         private ObjectValueLocaleOverlay $overlay,
         private SystemAttributeReadOverlay $systemOverlay,
         private RequestStack $requestStack,
+        private ChannelPublicationResolverInterface $publicationResolver,
     ) {
     }
 
@@ -49,14 +54,53 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
         $request = $this->requestStack->getCurrentRequest();
         $localeParam = $request?->query->get('locale');
         $channelParam = $request?->query->get('channel');
+        $publicationParam = $request?->query->get('publication');
         $locale = \is_string($localeParam) && '' !== $localeParam ? $localeParam : null;
         $channel = \is_string($channelParam) && '' !== $channelParam ? $channelParam : null;
+        $publication = \is_string($publicationParam) && '' !== $publicationParam ? $publicationParam : null;
+
         if (null !== $locale || null !== $channel) {
             $object = $this->overlay->apply($object, $locale, $channel);
+        }
+
+        // #1234 — ?publication=<channelCode> filters attributes_indexed to the
+        // channel's publication allow-list. Applied after value overlay so the
+        // returned values are already locale/channel-resolved.
+        if (null !== $publication) {
+            $object = $this->applyPublicationFilter($object, $publication);
         }
 
         // #1207 — always surface the system attributes (created_at/updated_at +
         // created_by/updated_by) so they render real values instead of "—".
         return $this->systemOverlay->apply($object);
+    }
+
+    private function applyPublicationFilter(CatalogObject $object, string $channelCode): CatalogObject
+    {
+        $tenant = $object->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return $object;
+        }
+
+        $allowedCodes = $this->publicationResolver->resolvePublishedCodes(
+            $channelCode,
+            $object->getObjectType()->getId(),
+            $tenant,
+        );
+
+        if (null === $allowedCodes) {
+            return $object;
+        }
+
+        $filtered = array_filter(
+            $object->getAttributesIndexed(),
+            static fn (string $code): bool => \in_array($code, $allowedCodes, true),
+            ARRAY_FILTER_USE_KEY,
+        );
+
+        $copy = clone $object;
+        $copy->updateAttributeIndex($filtered);
+
+        return $copy;
     }
 }

--- a/apps/api/src/Channel/Contracts/ChannelPublicationResolverInterface.php
+++ b/apps/api/src/Channel/Contracts/ChannelPublicationResolverInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Contracts;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Cross-BC interface for reading a channel's publication profile.
+ *
+ * Catalog and Export BCs call this to filter which attributes/locales to
+ * expose when a consumer provides `?publication=<channelCode>`. ADR-0018.
+ *
+ * Implementations are in `Channel\Infrastructure`; Catalog and Export only
+ * import this interface (Deptrac-safe: Channel_Contracts is allowed from
+ * both Catalog_Internals and Export_Internals).
+ */
+interface ChannelPublicationResolverInterface
+{
+    /**
+     * Returns the allow-list of attribute codes for the given channel +
+     * objectType combination. `null` means publish-all (no filtering).
+     *
+     * @return list<string>|null null = publish-all; [] = publish-nothing
+     */
+    public function resolvePublishedCodes(
+        string $channelCode,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?array;
+
+    /**
+     * Returns the list of short locale codes configured for the channel
+     * profile. Empty array means "use tenant locales" (no filtering).
+     *
+     * @return list<string>
+     */
+    public function resolvePublishedLocales(
+        string $channelCode,
+        Tenant $tenant,
+    ): array;
+}

--- a/apps/api/src/Channel/Infrastructure/ChannelPublicationResolver.php
+++ b/apps/api/src/Channel/Infrastructure/ChannelPublicationResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure;
+
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Resolves a channel's publication profile for cross-BC consumers.
+ *
+ * Falls back to publish-all (null) when no profile row exists for the
+ * given (channelCode, objectTypeId, tenant) triple — providing zero-config
+ * behaviour for tenants that haven't configured explicit profiles.
+ *
+ * Autowiring aliases {@see ChannelPublicationResolverInterface} to this impl.
+ */
+final readonly class ChannelPublicationResolver implements ChannelPublicationResolverInterface
+{
+    public function __construct(
+        private ChannelRepositoryInterface $channels,
+        private ChannelPublicationProfileRepositoryInterface $profiles,
+    ) {
+    }
+
+    /**
+     * @return list<string>|null null = publish-all
+     */
+    public function resolvePublishedCodes(
+        string $channelCode,
+        Uuid $objectTypeId,
+        Tenant $tenant,
+    ): ?array {
+        $channel = $this->channels->findByCode($channelCode, $tenant);
+        if (null === $channel) {
+            return null;
+        }
+        $profile = $this->profiles->findByChannelAndObjectType($channel->getId(), $objectTypeId, $tenant);
+        if (null === $profile) {
+            return null;
+        }
+
+        return $profile->getPublishedAttributeCodes();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function resolvePublishedLocales(string $channelCode, Tenant $tenant): array
+    {
+        $channel = $this->channels->findByCode($channelCode, $tenant);
+        if (null === $channel) {
+            return [];
+        }
+
+        $profiles = $this->profiles->findForChannel($channel->getId(), $tenant);
+        if ([] === $profiles) {
+            return [];
+        }
+
+        // Collect published locales across all profiles for this channel.
+        // If any profile has an empty published_locales, it signals "use tenant locales".
+        $locales = [];
+        foreach ($profiles as $profile) {
+            foreach ($profile->getPublishedLocales() as $locale) {
+                $locales[$locale] = true;
+            }
+        }
+
+        return array_keys($locales);
+    }
+}

--- a/apps/api/src/Export/Application/Builder/PublicationColumnPlanner.php
+++ b/apps/api/src/Export/Application/Builder/PublicationColumnPlanner.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder;
+
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Export\Domain\Entity\ExportSession;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Generates export column keys from a channel's publication profile when
+ * the operator hasn't manually picked columns.
+ *
+ * When `ExportSession.selectedColumns` is empty and the session carries at
+ * least one channel, this service queries the publication profile of the
+ * first session channel and expands it into a flat list of column keys
+ * (`code`, `code.locale`, `code.channel`) that the {@see ColumnResolver}
+ * understands. ADR-0018.
+ *
+ * Falls back to `null` (no generated columns) when:
+ *   - The profile has no explicit allow-list (`publishedAttributeCodes = null`
+ *     → publish-all; we can't enumerate "all attribute codes" without a DB
+ *     query and a Catalog dependency).
+ *   - The session has no channels configured.
+ *   - The objectType ID is unknown.
+ *
+ * In these cases the caller should preserve existing behaviour (require
+ * manual `selectedColumns` or throw).
+ */
+final readonly class PublicationColumnPlanner
+{
+    public function __construct(
+        private ChannelPublicationResolverInterface $publicationResolver,
+    ) {
+    }
+
+    /**
+     * Returns generated column keys or null if the profile cannot provide
+     * a definitive list.
+     *
+     * @param list<string> $objectTypeIds UUID strings of object types in the session
+     *
+     * @return list<string>|null null = can't generate (operator must supply selectedColumns)
+     */
+    public function plan(ExportSession $session, array $objectTypeIds): ?array
+    {
+        $tenant = $session->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return null;
+        }
+
+        $sessionChannels = $session->getChannels() ?? [];
+        if ([] === $sessionChannels) {
+            return null;
+        }
+
+        // Use the first channel as the publication profile source.
+        $channelCode = $sessionChannels[0];
+
+        $sessionLocales = $session->getLocales() ?? [];
+
+        $columns = [];
+        foreach ($objectTypeIds as $rawId) {
+            $objectTypeId = Uuid::fromString($rawId);
+            $allowedCodes = $this->publicationResolver->resolvePublishedCodes(
+                $channelCode,
+                $objectTypeId,
+                $tenant,
+            );
+
+            if (null === $allowedCodes) {
+                // Publish-all → can't generate a finite column list.
+                return null;
+            }
+
+            foreach ($allowedCodes as $code) {
+                // Bare column (global value)
+                $columns[] = $code;
+
+                // Per-locale columns for each session locale.
+                foreach ($sessionLocales as $locale) {
+                    $columns[] = "{$code}.{$locale}";
+                }
+
+                // Per-channel columns for each session channel.
+                foreach ($sessionChannels as $channel) {
+                    $columns[] = "{$code}.{$channel}";
+                }
+            }
+        }
+
+        // De-duplicate while preserving order (bare code + qualified variants
+        // share the same code prefix; duplicates appear when multiple OTs
+        // share attribute codes).
+        $seen = [];
+        $unique = [];
+        foreach ($columns as $col) {
+            if (!isset($seen[$col])) {
+                $seen[$col] = true;
+                $unique[] = $col;
+            }
+        }
+
+        return [] === $unique ? null : $unique;
+    }
+}

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -9,6 +9,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Export\Application\Builder\ExportBuilder;
+use App\Export\Application\Builder\PublicationColumnPlanner;
 use App\Export\Domain\Entity\ExportSession;
 use App\Export\Domain\Enum\ExportEncoding;
 use App\Export\Domain\Enum\ExportFormat;
@@ -52,6 +53,7 @@ final class SyncExportRunner
         private readonly ExportSessionRepositoryInterface $sessions,
         private readonly FilterDslResolver $filterDsl,
         private readonly Connection $connection,
+        private readonly PublicationColumnPlanner $columnPlanner,
     ) {
     }
 
@@ -83,13 +85,21 @@ final class SyncExportRunner
      */
     public function runToFile(ExportSession $session, string $targetPath): int
     {
-        $columns = $session->getSelectedColumns();
-        if ([] === $columns) {
-            throw new InvalidArgumentException('Export session must list at least one column.');
-        }
-
         $targets = $this->resolveTargets($session);
         $session->setTargetCount(\count($targets));
+
+        $columns = $session->getSelectedColumns();
+        if ([] === $columns) {
+            // #1235 — when no manual columns, try to derive from publication profile.
+            $objectTypeIds = $this->collectObjectTypeIds($targets);
+            $planned = $objectTypeIds !== []
+                ? $this->columnPlanner->plan($session, $objectTypeIds)
+                : null;
+            if (null === $planned) {
+                throw new InvalidArgumentException('Export session must list at least one column.');
+            }
+            $columns = $planned;
+        }
 
         $writer = $this->openWriter($session->getFormat(), $session, $targetPath);
         $writer->writeHeaders($columns);
@@ -173,6 +183,24 @@ final class SyncExportRunner
         $uuids = array_map(static fn (string $id): Uuid => Uuid::fromString($id), $ids);
 
         return $this->objects->findByIds(array_map(static fn (Uuid $u): string => $u->toRfc4122(), $uuids));
+    }
+
+    /**
+     * Collects unique ObjectType IDs (as UUID RFC strings) from a set of objects.
+     *
+     * @param list<CatalogObject> $objects
+     *
+     * @return list<string>
+     */
+    private function collectObjectTypeIds(array $objects): array
+    {
+        $ids = [];
+        foreach ($objects as $object) {
+            $id = $object->getObjectType()->getId()->toRfc4122();
+            $ids[$id] = $id;
+        }
+
+        return array_values($ids);
     }
 
     private function openWriter(ExportFormat $format, ExportSession $session, string $path): RowWriter

--- a/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
@@ -123,15 +123,27 @@ final class CatalogObjectPublicationFilterApiTest extends CatalogApiTestCase
             ->findBuiltInByKind(ObjectKind::Product, $tenant);
         \assert($product instanceof ObjectType);
 
-        $profile = new ChannelPublicationProfile(
-            channelId: $channel->getId(),
-            objectTypeId: $product->getId(),
-            publishedAttributeCodes: $allowedCodes,
-            isDefault: true,
-        );
-        $profile->assignTenant($tenant);
-        $em->persist($profile);
-        $em->flush();
+        // The channel POST above triggers CreateDefaultPublicationProfilesOnChannelCreated
+        // which already creates a default profile. Upsert: update existing profile's allow-list.
+        $existing = $em->getRepository(ChannelPublicationProfile::class)->findOneBy([
+            'channelId' => $channel->getId(),
+            'objectTypeId' => $product->getId(),
+            'tenant' => $tenant,
+        ]);
+        if ($existing instanceof ChannelPublicationProfile) {
+            $existing->setPublishedAttributeCodes($allowedCodes);
+            $em->flush();
+        } else {
+            $profile = new ChannelPublicationProfile(
+                channelId: $channel->getId(),
+                objectTypeId: $product->getId(),
+                publishedAttributeCodes: $allowedCodes,
+                isDefault: true,
+            );
+            $profile->assignTenant($tenant);
+            $em->persist($profile);
+            $em->flush();
+        }
 
         $client = $this->authenticatedClient();
         $create = $client->request('POST', '/api/products', [

--- a/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #1234 — ?publication=<channelCode> filters attributes_indexed to the
+ * channel's publication allow-list.
+ *
+ * Tests: allow-list reduces attributes, publish-all profile returns all,
+ * missing profile falls back to publish-all (null), ?locale+?publication
+ * can coexist.
+ */
+final class CatalogObjectPublicationFilterApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function publicationAllowListFiltersAttributesIndexed(): void
+    {
+        $client = $this->authenticatedClient();
+        [$id, $channelCode] = $this->seedProductWithPublicationProfile(['name', 'ean']);
+
+        $response = $client->request('GET', "/api/products/{$id}?publication={$channelCode}");
+        self::assertSame(200, $response->getStatusCode());
+
+        $indexed = $this->decodeIndexed($response->getContent());
+        self::assertArrayHasKey('name', $indexed, 'name is in allow-list');
+        self::assertArrayHasKey('ean', $indexed, 'ean is in allow-list');
+        self::assertArrayNotHasKey('internal_notes', $indexed, 'internal_notes is NOT in allow-list');
+    }
+
+    #[Test]
+    public function publicationPublishAllProfileReturnsAllAttributes(): void
+    {
+        $client = $this->authenticatedClient();
+        [$id, $channelCode] = $this->seedProductWithPublicationProfile(null);
+
+        $response = $client->request('GET', "/api/products/{$id}?publication={$channelCode}");
+        self::assertSame(200, $response->getStatusCode());
+
+        $indexed = $this->decodeIndexed($response->getContent());
+        // publish-all = all three attributes present
+        self::assertArrayHasKey('name', $indexed);
+        self::assertArrayHasKey('ean', $indexed);
+        self::assertArrayHasKey('internal_notes', $indexed);
+    }
+
+    #[Test]
+    public function missingPublicationProfileFallsBackToPublishAll(): void
+    {
+        $client = $this->authenticatedClient();
+        $otId = $this->objectTypeIdFor(ObjectKind::Product);
+        $this->seedThreeAttributes();
+
+        $create = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'PUB-FALLBACK-1', 'objectTypeId' => $otId, 'attributes' => [
+                'name' => 'Test', 'ean' => '123', 'internal_notes' => 'secret',
+            ]],
+        ]);
+        self::assertSame(201, $create->getStatusCode());
+        $id = $this->decode($create->getContent())['id'];
+        self::assertIsString($id);
+
+        // Use a channel that exists but has no profile for this objectType
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $channel = new Channel('pub_no_profile', ['pl' => 'Test Channel']);
+        $channel->assignTenant($tenant);
+        $em->persist($channel);
+        $em->flush();
+
+        $response = $client->request('GET', "/api/products/{$id}?publication=pub_no_profile");
+        self::assertSame(200, $response->getStatusCode());
+
+        $indexed = $this->decodeIndexed($response->getContent());
+        // No profile row → publish-all fallback
+        self::assertArrayHasKey('name', $indexed);
+        self::assertArrayHasKey('ean', $indexed);
+        self::assertArrayHasKey('internal_notes', $indexed);
+    }
+
+    /**
+     * Seeds a product with three attributes and a channel + publication profile.
+     * Returns [productId, channelCode].
+     *
+     * @param list<string>|null $allowedCodes null = publish-all
+     *
+     * @return array{0: string, 1: string}
+     */
+    private function seedProductWithPublicationProfile(?array $allowedCodes): array
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $this->seedThreeAttributes();
+
+        $channelCode = 'pub_test_'.($allowedCodes === null ? 'all' : 'filtered');
+        $channel = new Channel($channelCode, ['pl' => 'Test Channel']);
+        $channel->assignTenant($tenant);
+        $em->persist($channel);
+        $em->flush();
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $profile = new ChannelPublicationProfile(
+            channelId: $channel->getId(),
+            objectTypeId: $product->getId(),
+            publishedAttributeCodes: $allowedCodes,
+            isDefault: true,
+        );
+        $profile->assignTenant($tenant);
+        $em->persist($profile);
+        $em->flush();
+
+        $client = $this->authenticatedClient();
+        $create = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'PUB-PROD-'.uniqid(), 'objectTypeId' => $product->getId()->toRfc4122(), 'attributes' => [
+                'name' => 'Test Product', 'ean' => '1234567890', 'internal_notes' => 'secret note',
+            ]],
+        ]);
+        self::assertSame(201, $create->getStatusCode());
+        $id = $this->decode($create->getContent())['id'];
+        self::assertIsString($id);
+
+        return [$id, $channelCode];
+    }
+
+    private function seedThreeAttributes(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        foreach (['name' => 'Name', 'ean' => 'EAN', 'internal_notes' => 'Notes'] as $code => $label) {
+            $attr = new Attribute($code, ['en' => $label, 'pl' => $label], AttributeType::Text);
+            $em->persist($attr);
+            $em->persist(new ObjectTypeAttribute($product, $attr, false, 1));
+        }
+        $em->flush();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeIndexed(string $body): array
+    {
+        $decoded = $this->decode($body);
+        $raw = $decoded['attributesIndexed'] ?? [];
+        \assert(\is_array($raw));
+        /** @var array<string, mixed> $indexed */
+        $indexed = $raw;
+
+        return $indexed;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(string $json): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+}

--- a/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
+++ b/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel\Application;
+
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelPublicationProfile;
+use App\Channel\Domain\Repository\ChannelPublicationProfileRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Channel\Infrastructure\ChannelPublicationResolver;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+#[AllowMockObjectsWithoutExpectations]
+final class ChannelPublicationResolverTest extends TestCase
+{
+    /** @var MockObject&ChannelRepositoryInterface */
+    private MockObject $channels;
+    /** @var MockObject&ChannelPublicationProfileRepositoryInterface */
+    private MockObject $profiles;
+    private ChannelPublicationResolver $resolver;
+    private Tenant $tenant;
+    private Uuid $objectTypeId;
+
+    protected function setUp(): void
+    {
+        $this->channels = $this->createMock(ChannelRepositoryInterface::class);
+        $this->profiles = $this->createMock(ChannelPublicationProfileRepositoryInterface::class);
+        $this->resolver = new ChannelPublicationResolver($this->channels, $this->profiles);
+        $this->tenant = new Tenant('demo', 'Demo Tenant');
+        $this->objectTypeId = Uuid::v7();
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullForUnknownChannel(): void
+    {
+        $this->channels->method('findByCode')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedCodes('unknown', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullWhenNoProfileExists(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result, 'No profile row → publish-all fallback.');
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsNullForDefaultPublishAllProfile(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profile = new ChannelPublicationProfile($channel->getId(), $this->objectTypeId, null, [], [], true);
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn($profile);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertNull($result, 'Explicit publish-all profile → null return.');
+    }
+
+    #[Test]
+    public function resolvePublishedCodesReturnsAllowListWhenProfileHasCodes(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profile = new ChannelPublicationProfile(
+            $channel->getId(),
+            $this->objectTypeId,
+            ['name', 'price', 'ean'],
+        );
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findByChannelAndObjectType')->willReturn($profile);
+
+        $result = $this->resolver->resolvePublishedCodes('shopify', $this->objectTypeId, $this->tenant);
+
+        self::assertSame(['name', 'price', 'ean'], $result);
+    }
+
+    #[Test]
+    public function resolvePublishedLocalesReturnsEmptyForUnknownChannel(): void
+    {
+        $this->channels->method('findByCode')->willReturn(null);
+
+        $result = $this->resolver->resolvePublishedLocales('unknown', $this->tenant);
+
+        self::assertSame([], $result);
+    }
+
+    #[Test]
+    public function resolvePublishedLocalesMergesLocalesAcrossProfiles(): void
+    {
+        $channel = $this->makeChannel('shopify');
+        $profiles = [
+            new ChannelPublicationProfile($channel->getId(), Uuid::v7(), null, ['pl', 'en']),
+            new ChannelPublicationProfile($channel->getId(), Uuid::v7(), null, ['pl', 'de']),
+        ];
+        $this->channels->method('findByCode')->willReturn($channel);
+        $this->profiles->method('findForChannel')->willReturn($profiles);
+
+        $result = $this->resolver->resolvePublishedLocales('shopify', $this->tenant);
+
+        sort($result);
+        self::assertSame(['de', 'en', 'pl'], $result);
+    }
+
+    private function makeChannel(string $code): Channel
+    {
+        $channel = new Channel(code: $code, label: ['pl' => $code]);
+        $channel->assignTenant($this->tenant);
+
+        return $channel;
+    }
+}

--- a/apps/api/tests/Unit/Export/Application/PublicationColumnPlannerTest.php
+++ b/apps/api/tests/Unit/Export/Application/PublicationColumnPlannerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export\Application;
+
+use App\Channel\Contracts\ChannelPublicationResolverInterface;
+use App\Export\Application\Builder\PublicationColumnPlanner;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+#[AllowMockObjectsWithoutExpectations]
+final class PublicationColumnPlannerTest extends TestCase
+{
+    /** @var MockObject&ChannelPublicationResolverInterface */
+    private MockObject $resolver;
+    private PublicationColumnPlanner $planner;
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        $this->resolver = $this->createMock(ChannelPublicationResolverInterface::class);
+        $this->planner = new PublicationColumnPlanner($this->resolver);
+        $this->tenant = new Tenant('demo', 'Demo Tenant');
+    }
+
+    #[Test]
+    public function returnsNullWhenNoChannelInSession(): void
+    {
+        $session = $this->makeSession(channels: [], locales: ['pl']);
+
+        $result = $this->planner->plan($session, [Uuid::v7()->toRfc4122()]);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function returnsNullForPublishAllProfile(): void
+    {
+        $this->resolver->method('resolvePublishedCodes')->willReturn(null);
+        $session = $this->makeSession(channels: ['shopify'], locales: ['pl']);
+
+        $result = $this->planner->plan($session, [Uuid::v7()->toRfc4122()]);
+
+        self::assertNull($result, 'Publish-all profile cannot generate a finite column list.');
+    }
+
+    #[Test]
+    public function generatesBareCodeAndLocaleSuffixedColumns(): void
+    {
+        $this->resolver->method('resolvePublishedCodes')->willReturn(['name', 'price']);
+        $session = $this->makeSession(channels: ['shopify'], locales: ['pl', 'en']);
+
+        $result = $this->planner->plan($session, [Uuid::v7()->toRfc4122()]);
+
+        self::assertNotNull($result);
+        self::assertContains('name', $result);
+        self::assertContains('name.pl', $result);
+        self::assertContains('name.en', $result);
+        self::assertContains('price', $result);
+        self::assertContains('price.shopify', $result);
+    }
+
+    #[Test]
+    public function deduplicatesColumnsAcrossMultipleObjectTypes(): void
+    {
+        $this->resolver->method('resolvePublishedCodes')->willReturn(['name', 'ean']);
+        $session = $this->makeSession(channels: ['shopify'], locales: ['pl']);
+
+        $ot1 = Uuid::v7()->toRfc4122();
+        $ot2 = Uuid::v7()->toRfc4122();
+
+        $result = $this->planner->plan($session, [$ot1, $ot2]);
+
+        self::assertNotNull($result);
+        self::assertCount(\count(array_unique($result)), $result, 'No duplicates in result.');
+    }
+
+    #[Test]
+    public function returnsNullWhenObjectTypeIdsIsEmpty(): void
+    {
+        $session = $this->makeSession(channels: ['shopify'], locales: ['pl']);
+
+        $result = $this->planner->plan($session, []);
+
+        self::assertNull($result);
+    }
+
+    /**
+     * @param list<string> $channels
+     * @param list<string> $locales
+     */
+    private function makeSession(array $channels, array $locales): ExportSession
+    {
+        $session = new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::ListContext,
+            format: ExportFormat::Csv,
+            targetScope: ExportTargetScope::All,
+            selectedColumns: [],
+            locales: $locales,
+            channels: $channels,
+        );
+        $session->assignTenant($this->tenant);
+
+        return $session;
+    }
+}


### PR DESCRIPTION
## Summary

Łączy 3 tickety po uproszczeniu chain-PR podejścia:

**#1233 — ChannelPublicationResolverInterface + impl**
- Kontrakt cross-BC w `Channel\Contracts` (Deptrac-safe).
- `ChannelPublicationResolver`: szuka profilu po (channelCode, objectTypeId, tenant); null = publish-all.
- PHPUnit: 6 unit tests.

**#1234 — API read `?publication=<channel>`**
- Oba overlay providerzy (item + collection) czytają `?publication=<channelCode>`.
- `attributes_indexed` filtrowany do allow-listy profilu po overlay.
- null profile = publish-all fallback.
- ApiTestCase: allow-lista redukuje atrybuty, publish-all zwraca wszystkie.

**#1235 — PublicationColumnPlanner**
- Gdy `ExportSession.selectedColumns = []` i sesja ma kanały → generuje kolumny z profilu publikacji.
- `SyncExportRunner` używa plannera jako pre-flight.
- PHPUnit: 5 unit tests.

## Scope

`apps/api` — Channel BC Contracts+Infrastructure, Catalog providers, Export Builder+Runner + testy.

## Smoke test

- ships standalone backend features; end-to-end smoke po merge gdy FE (sekcja Kanały #1245) jest też w main

Closes #1233, #1234, #1235