### PR TITLE
fix(admin): empty channel select + seed real demo channel/locale data

### DIFF
--- a/apps/admin/src/features/catalog/products/components/locale-channel-toolbar.tsx
+++ b/apps/admin/src/features/catalog/products/components/locale-channel-toolbar.tsx
@@ -14,7 +14,6 @@ import {
 import {
   type ChannelOption,
   type LocaleOption,
-  PRODUCT_CHANNELS,
   PRODUCT_LOCALES,
   type ProductChannel,
   type ProductLocale,
@@ -31,17 +30,13 @@ export interface LocaleChannelToolbarProps {
    */
   locales?: LocaleOption[];
   /**
-   * #1155 — the tenant's channels (from `/api/channels`). Falls back to the
-   * static PRODUCT_CHANNELS on first paint / when absent.
+   * #1155 — the tenant's channels (from `/api/channels`). #1259 — when the
+   * tenant has no channels the picker shows ONLY "Wszystkie kanały"; we no
+   * longer fall back to a hardcoded shopify/baselinker/allegro list, which
+   * looked like real channels but was a mock.
    */
   channels?: ChannelOption[];
 }
-
-const CHANNEL_LABELS: Record<string, string> = {
-  shopify: 'Shopify',
-  baselinker: 'BaseLinker',
-  allegro: 'Allegro',
-};
 
 /**
  * VIEW-07 (#420) — toolbar replacing the prototype's segmented PL/EN/DE/CS
@@ -62,14 +57,15 @@ export function LocaleChannelToolbar({
   const localeCodes: readonly string[] =
     locales !== undefined && locales.length > 0 ? locales.map((l) => l.code) : PRODUCT_LOCALES;
 
-  // #1155 — channel options from the tenant's real channels, falling back
-  // to the static list before /api/channels resolves.
-  const channelList: { code: string; label: string }[] =
-    channels !== undefined && channels.length > 0
-      ? channels.map((c) => ({ code: c.code, label: c.label?.[lang] ?? c.label?.en ?? c.code }))
-      : PRODUCT_CHANNELS.map((c) => ({ code: c, label: CHANNEL_LABELS[c] ?? c }));
+  // #1155 / #1259 — channel options come ONLY from the tenant's real
+  // channels (`/api/channels`). No tenant channels → empty list, so the
+  // picker offers just "Wszystkie kanały". No hardcoded mock fallback.
+  const channelList: { code: string; label: string }[] = (channels ?? []).map((c) => ({
+    code: c.code,
+    label: c.label?.[lang] ?? c.label?.en ?? c.code,
+  }));
   const channelLabel = (code: string): string =>
-    channelList.find((c) => c.code === code)?.label ?? CHANNEL_LABELS[code] ?? code;
+    channelList.find((c) => c.code === code)?.label ?? code;
 
   return (
     <div className="flex items-center gap-2">

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -21,15 +21,10 @@ export interface LocaleOption {
 }
 
 // #1155 — a channel code is whatever the tenant configured (Settings →
-// Channels), not a fixed union. The real list comes from `/api/channels`;
-// PRODUCT_CHANNELS is only a static fallback before that loads.
+// Channels), not a fixed union. The real list comes from `/api/channels`.
+// #1259 — removed the PRODUCT_CHANNELS static fallback: an empty channel
+// list must render an empty picker, never a hardcoded mock trio.
 export type ProductChannel = string;
-
-export const PRODUCT_CHANNELS: readonly ProductChannel[] = [
-  'shopify',
-  'baselinker',
-  'allegro',
-] as const;
 
 /** One tenant channel for the detail-page picker (#1155). */
 export interface ChannelOption {

--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -21,6 +21,7 @@ use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Idempotent demo dataset seeder for ticket #40 (0.3.10).
@@ -56,7 +57,13 @@ final readonly class DemoCatalogSeeder
     ) {
     }
 
-    public function seed(Tenant $tenant): void
+    /**
+     * @param ?Uuid $demoChannelId when provided, a handful of demo products get
+     *                             per-channel `price` overrides for this channel
+     *                             (#1259 — makes the channel picker show a real
+     *                             difference instead of a hardcoded mock)
+     */
+    public function seed(Tenant $tenant, ?Uuid $demoChannelId = null): void
     {
         $previous = $this->tenantContext->get();
         $this->tenantContext->set($tenant);
@@ -89,7 +96,7 @@ final readonly class DemoCatalogSeeder
             $assets = $this->seedAssets($assetType, $tenant, $attributes);
             $this->em->flush();
 
-            $this->seedProducts($productType, $categories, $assets, $attributes);
+            $this->seedProducts($productType, $categories, $assets, $attributes, $demoChannelId);
             $this->em->flush();
         } finally {
             $this->bulkContext->setBulk(false);
@@ -118,6 +125,7 @@ final readonly class DemoCatalogSeeder
             $attribute = new Attribute($code, $def['label'], $def['type']);
             $attribute->changeRequired($def['required'] ?? false);
             $attribute->changeLocalizable($def['localizable'] ?? false);
+            $attribute->changeScopable($def['scopable'] ?? false);
             $attribute->updateValidationRules($def['rules'] ?? []);
             $attribute->reorder($position++);
             $this->em->persist($attribute);
@@ -278,7 +286,7 @@ final readonly class DemoCatalogSeeder
      * @param list<CatalogObject>      $categories
      * @param list<Asset>              $assets
      */
-    private function seedProducts(ObjectType $type, array $categories, array $assets, array $attributes): void
+    private function seedProducts(ObjectType $type, array $categories, array $assets, array $attributes, ?Uuid $demoChannelId = null): void
     {
         $brands = ['Acme', 'Globex', 'Soylent', 'Initech', 'Hooli', 'Festo', 'Bosch'];
         $colors = ['red', 'green', 'blue', 'black', 'white'];
@@ -328,11 +336,47 @@ final readonly class DemoCatalogSeeder
             $product->updateAttributeIndex($indexed);
             $product->recordCompleteness(['global' => 100]);
             $this->em->persist($product);
+
+            // #1259 — give the first few products real per-locale + per-channel
+            // overrides so the product card's locale/channel pickers show a
+            // visible difference (not just a fallback to the global value).
+            // Only a small slice (i <= 5) keeps the demo light while still
+            // proving the overlay works end-to-end after a DB reset.
+            if ($i <= 5) {
+                $this->em->persist(new ObjectValue(
+                    $product,
+                    $attributes['name'],
+                    ['value' => \sprintf('Demo product %03d (EN)', $i)],
+                    Provenance::Import,
+                    null,
+                    'en',
+                ));
+                $this->em->persist(new ObjectValue(
+                    $product,
+                    $attributes['description'],
+                    ['value' => \sprintf('English description for SKU %s, brand %s.', $sku, $brand)],
+                    Provenance::Import,
+                    null,
+                    'en',
+                ));
+
+                if (null !== $demoChannelId) {
+                    // Allegro charges a different price — per-channel override.
+                    $this->em->persist(new ObjectValue(
+                        $product,
+                        $attributes['price'],
+                        ['amount' => 24.99 + $i, 'currency' => $currency],
+                        Provenance::Import,
+                        $demoChannelId,
+                        null,
+                    ));
+                }
+            }
         }
     }
 
     /**
-     * @return array<string, array{label: array<string, string>, type: AttributeType, required?: bool, localizable?: bool, rules?: array<string, mixed>, options?: list<array{0: string, 1: array<string, string>, 2?: string|null, 3?: bool, 4?: bool}>}>
+     * @return array<string, array{label: array<string, string>, type: AttributeType, required?: bool, localizable?: bool, scopable?: bool, rules?: array<string, mixed>, options?: list<array{0: string, 1: array<string, string>, 2?: string|null, 3?: bool, 4?: bool}>}>
      */
     private static function attributeDefinitions(): array
     {
@@ -411,6 +455,10 @@ final readonly class DemoCatalogSeeder
             'price' => [
                 'label' => ['pl' => 'Cena', 'en' => 'Price'],
                 'type' => AttributeType::Price,
+                // #1259 — scopable so the demo carries per-channel price overrides
+                // (Allegro charges a different amount); makes the channel picker
+                // on the product card show a real difference, not a mock.
+                'scopable' => true,
                 'rules' => ['min_amount' => 0, 'currencies' => ['PLN', 'EUR', 'USD']],
             ],
             'weight' => [

--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -343,6 +343,7 @@ final readonly class DemoCatalogSeeder
             // Only a small slice (i <= 5) keeps the demo light while still
             // proving the overlay works end-to-end after a DB reset.
             if ($i <= 5) {
+                // Per-locale (EN) overrides — locale switch shows different text.
                 $this->em->persist(new ObjectValue(
                     $product,
                     $attributes['name'],
@@ -359,6 +360,14 @@ final readonly class DemoCatalogSeeder
                     null,
                     'en',
                 ));
+                $this->em->persist(new ObjectValue(
+                    $product,
+                    $attributes['short_description'],
+                    ['value' => \sprintf('Short EN tagline for %s.', $sku)],
+                    Provenance::Import,
+                    null,
+                    'en',
+                ));
 
                 if (null !== $demoChannelId) {
                     // Allegro charges a different price — per-channel override.
@@ -366,6 +375,17 @@ final readonly class DemoCatalogSeeder
                         $product,
                         $attributes['price'],
                         ['amount' => 24.99 + $i, 'currency' => $currency],
+                        Provenance::Import,
+                        $demoChannelId,
+                        null,
+                    ));
+                    // short_description is localizable AND scopable — give it an
+                    // Allegro-specific tagline so the row shows both a PL chip and
+                    // an Allegro chip with genuinely different content.
+                    $this->em->persist(new ObjectValue(
+                        $product,
+                        $attributes['short_description'],
+                        ['value' => \sprintf('Allegro tagline for %s.', $sku)],
                         Provenance::Import,
                         $demoChannelId,
                         null,
@@ -408,7 +428,12 @@ final readonly class DemoCatalogSeeder
             'short_description' => [
                 'label' => ['pl' => 'Krótki opis', 'en' => 'Short description'],
                 'type' => AttributeType::Text,
+                // #1259 — both localizable AND scopable: marketing copy differs
+                // per language and per channel. On the product card this row
+                // shows a PL chip + an Allegro chip side by side once a channel
+                // is selected — the exact "channel next to locale" affordance.
                 'localizable' => true,
+                'scopable' => true,
                 'rules' => ['max_length' => 280],
             ],
             'brand' => [

--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -13,6 +13,7 @@ use App\Catalog\Application\DemoCatalogSeeder;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Domain\Entity\Channel;
 use App\Channel\Domain\Entity\Currency;
 use App\Channel\Domain\Entity\Locale;
 use App\Channel\Domain\Entity\TenantLocale;
@@ -96,13 +97,19 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
             $manager->persist($locale);
             $localesByCode[$entry['code']] = $locale;
         }
+        $pln = null;
         foreach ([
             ['PLN', 'zł', 'Polish złoty'],
             ['EUR', '€', 'Euro'],
             ['USD', '$', 'United States dollar'],
         ] as [$code, $symbol, $label]) {
-            $manager->persist(new Currency($code, $symbol, $label));
+            $currency = new Currency($code, $symbol, $label);
+            $manager->persist($currency);
+            if ('PLN' === $code) {
+                $pln = $currency;
+            }
         }
+        \assert($pln instanceof Currency);
 
         $tenants = [
             new Tenant('demo', 'Demo Tenant'),
@@ -205,12 +212,25 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
         }
         $manager->flush();
 
-        // Demo tenant: full ADR-009 dataset (#40). 100 products + 5
-        // categories with own user-defined attributes + 10 assets +
-        // ~19 attributes spanning all 10 AttributeType cases.
+        // #1259 — seed one real demo channel (Allegro) for the demo tenant so
+        // the product card's channel picker has actual data after a DB reset,
+        // instead of falling back to a hardcoded mock list on the frontend.
+        // Built-in ObjectTypes already exist (builtInSeeder above), so the
+        // ChannelCreated subscriber provisions default publication profiles.
         $demoTenant = $tenants[0];
         \assert('demo' === $demoTenant->getCode());
-        $this->demoCatalogSeeder->seed($demoTenant);
+        $allegro = new Channel('allegro', ['pl' => 'Allegro', 'en' => 'Allegro']);
+        $allegro->addLocale($plPL);
+        $allegro->addCurrency($pln);
+        $allegro->assignTenant($demoTenant);
+        $manager->persist($allegro);
+        $manager->flush();
+
+        // Full ADR-009 dataset (#40). 100 products + 5 categories with own
+        // user-defined attributes + 10 assets + ~19 attributes spanning all
+        // 10 AttributeType cases. Passing the Allegro channel id seeds
+        // per-channel price overrides on the first few products (#1259).
+        $this->demoCatalogSeeder->seed($demoTenant, $allegro->getId());
 
         // Acme tenant: minimal smoke dataset (3 SKUs, no attribute graph).
         // Existing isolation tests + admin e2e probes assume the legacy shape;

--- a/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
@@ -64,9 +64,9 @@ final class DemoCatalogSeederTest extends KernelTestCase
         $junctions = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM object_type_attributes');
         self::assertSame(23, (int) (\is_scalar($junctions) ? $junctions : 0));
         // 100 × 15 + 5 × 3 + 10 × 2 = 1535 global ObjectValue rows
-        // + #1259: first 5 products each get a per-locale EN `name` + `description`
-        //   (5 × 2 = 10). No channelId passed here → no per-channel rows.
-        self::assertSame(1545, (int) $em->createQuery('SELECT COUNT(v) FROM '.ObjectValue::class.' v')->getSingleScalarResult());
+        // + #1259: first 5 products each get per-locale EN name + description +
+        //   short_description (5 × 3 = 15). No channelId here → no per-channel rows.
+        self::assertSame(1550, (int) $em->createQuery('SELECT COUNT(v) FROM '.ObjectValue::class.' v')->getSingleScalarResult());
     }
 
     #[Test]
@@ -149,17 +149,17 @@ final class DemoCatalogSeederTest extends KernelTestCase
 
         $em = $this->em();
 
-        // First 5 products each get name(EN) + description(EN) → 10 per-locale rows.
+        // First 5 products each get name + description + short_description (EN) → 15 rows.
         $perLocale = (int) $em->createQuery(
             'SELECT COUNT(v) FROM '.ObjectValue::class." v WHERE v.locale = 'en'",
         )->getSingleScalarResult();
-        self::assertSame(10, $perLocale, 'First 5 products carry EN name + description.');
+        self::assertSame(15, $perLocale, 'First 5 products carry EN name + description + short_description.');
 
-        // First 5 products each get a per-channel price override → 5 rows.
+        // First 5 products each get a per-channel price + short_description override → 10 rows.
         $perChannel = (int) $em->createQuery(
             'SELECT COUNT(v) FROM '.ObjectValue::class.' v WHERE v.channelId = :ch',
         )->setParameter('ch', $channelId->toRfc4122())->getSingleScalarResult();
-        self::assertSame(5, $perChannel, 'First 5 products carry an Allegro price override.');
+        self::assertSame(10, $perChannel, 'First 5 products carry an Allegro price + short_description override.');
     }
 
     #[Test]

--- a/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
@@ -63,8 +63,10 @@ final class DemoCatalogSeederTest extends KernelTestCase
         // Composite PK on ObjectTypeAttribute prevents DQL COUNT — drop to DBAL.
         $junctions = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM object_type_attributes');
         self::assertSame(23, (int) (\is_scalar($junctions) ? $junctions : 0));
-        // 100 × 15 + 5 × 3 + 10 × 2 = 1535 ObjectValue rows.
-        self::assertSame(1535, (int) $em->createQuery('SELECT COUNT(v) FROM '.ObjectValue::class.' v')->getSingleScalarResult());
+        // 100 × 15 + 5 × 3 + 10 × 2 = 1535 global ObjectValue rows
+        // + #1259: first 5 products each get a per-locale EN `name` + `description`
+        //   (5 × 2 = 10). No channelId passed here → no per-channel rows.
+        self::assertSame(1545, (int) $em->createQuery('SELECT COUNT(v) FROM '.ObjectValue::class.' v')->getSingleScalarResult());
     }
 
     #[Test]
@@ -136,6 +138,28 @@ final class DemoCatalogSeederTest extends KernelTestCase
 
         self::assertSame($beforeProducts, $this->countObjects(ObjectKind::Product));
         self::assertSame($beforeAttributes, (int) $this->em()->createQuery('SELECT COUNT(a) FROM '.Attribute::class.' a')->getSingleScalarResult());
+    }
+
+    #[Test]
+    public function seedsPerLocaleAndPerChannelDemoValues(): void
+    {
+        $channelId = \Symfony\Component\Uid\Uuid::v7();
+        $seeder = self::getContainer()->get(DemoCatalogSeeder::class);
+        $seeder->seed($this->tenant, $channelId);
+
+        $em = $this->em();
+
+        // First 5 products each get name(EN) + description(EN) → 10 per-locale rows.
+        $perLocale = (int) $em->createQuery(
+            'SELECT COUNT(v) FROM '.ObjectValue::class." v WHERE v.locale = 'en'",
+        )->getSingleScalarResult();
+        self::assertSame(10, $perLocale, 'First 5 products carry EN name + description.');
+
+        // First 5 products each get a per-channel price override → 5 rows.
+        $perChannel = (int) $em->createQuery(
+            'SELECT COUNT(v) FROM '.ObjectValue::class.' v WHERE v.channelId = :ch',
+        )->setParameter('ch', $channelId->toRfc4122())->getSingleScalarResult();
+        self::assertSame(5, $perChannel, 'First 5 products carry an Allegro price override.');
     }
 
     #[Test]


### PR DESCRIPTION
## Problem

Po `pim:db:reset` przełączanie locale/channel na karcie produktu wyglądało jak mock:
1. `/api/channels` zwracał `[]` → FE pokazywał hardcoded `shopify/baselinker/allegro`.
2. Brak per-locale/per-channel `object_values` → przełączanie nie pokazywało różnic.
3. Brak atrybutu localizable+scopable → chip kanału nie pojawiał się obok chipa PL.

## Rozwiązanie

**FE** (`locale-channel-toolbar.tsx`): usunięty fallback `PRODUCT_CHANNELS`. Pusty `/api/channels` → pusty picker (tylko "Wszystkie kanały"). Usunięta stała `PRODUCT_CHANNELS`.

**BE** (`DemoCatalogSeeder` + `AppFixtures`): seed realnych danych demo:
- `AppFixtures` tworzy kanał **Allegro** dla demo tenanta.
- `price` scopable → pierwsze 5 produktów ma override ceny Allegro (24.99+i).
- `name` + `description` localizable → pierwsze 5 produktów ma EN values.
- `short_description` **localizable I scopable** → wiersz "Krótki opis" pokazuje chip **PL + Allegro razem** (dokładnie zachowanie z pamięci operatora).

## Smoke test (live-stack pim.localhost) — network-verified

```
SMOKE 1 — GET /api/channels → [{code: allegro, ...}]  (realny, nie mock)
SMOKE 2 — name: PL "Demo product 001" vs EN "Demo product 001 (EN)"
SMOKE 3 — price: global 20.99 EUR vs allegro 25.99 EUR
SMOKE 4 — short_description: is_localizable=True + is_scopable=True;
          global "Short tagline..." / EN "Short EN tagline..." / allegro "Allegro tagline..."
```

Channel chip na AttrRow (linia 96 attr-row.tsx) NIE był zmieniony przez marathon #1227-1245 (ostatnio #1224). Chip wymaga atrybutu scopable + wybranego kanału — demo nigdy nie miało scopable attrs do #1259.

## Definicja Done (CI)

- [x] PHPStan max, Deptrac, TypeScript noEmit, Biome — green lokalnie
- [x] PHPUnit `DemoCatalogSeederTest` (1535→1550 + per-locale/channel test) — CI verifies
- [x] Manual smoke 4× — realny kanał + locale/channel/both switch pokazują różne wartości

Closes #1259