### PR TITLE
fix(admin): label opcji select per locale wartości (nie język interfejsu)

### DIFF
--- a/apps/admin/e2e/1262-select-option-label-per-locale.spec.ts
+++ b/apps/admin/e2e/1262-select-option-label-per-locale.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1262 — a select option's label is part of the VALUE, so it must follow
+ * the active value locale (the PL/EN toolbar), not the interface language.
+ *
+ *  1. Create a select attribute with per-locale option labels
+ *     (red → Czerwony / Red), attach to Product, seed a product with color=red.
+ *  2. Open detail under PL → the read-only value shows the Polish label.
+ *  3. Switch the locale picker to EN → the same value now shows the English
+ *     label (proving the option label re-resolves by value locale).
+ *
+ * `test.fixme` in CI for the shared auth-rate-limiter storageState gap
+ * (same rationale as products-channel-switch.spec.ts).
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('select option label follows the value locale, not the UI language', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+  const refresh = await page.request.post('/api/auth/refresh');
+  expect(refresh.status()).toBe(200);
+  const token = ((await refresh.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${token}` };
+
+  const ts = uniqueSku('SEL')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+  const attrCode = `selcolor_${ts}`;
+
+  const otResp = await page.request.get('/api/object_types', { headers: bearer });
+  const otBody = (await otResp.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const productType = (otBody.member ?? []).find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  // Select attribute with per-locale option labels.
+  const attrResp = await page.request.post('/api/attributes', {
+    data: {
+      code: attrCode,
+      type: 'select',
+      label: { pl: 'Kolor spec', en: 'Spec colour' },
+      required: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+  });
+  expect(attrResp.status(), await attrResp.text()).toBe(201);
+  const attrId = ((await attrResp.json()) as { id: string }).id;
+
+  const optResp = await page.request.post(`/api/attributes/${attrCode}/options`, {
+    data: { code: 'red', label: { pl: 'Czerwony', en: 'Red' } },
+    headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+  });
+  expect([200, 201]).toContain(optResp.status());
+
+  const attach = await page.request.post(
+    `/api/object_types/${productType.id}/attributes/${attrId}`,
+    { headers: bearer },
+  );
+  expect([200, 201, 204]).toContain(attach.status());
+
+  const sku = uniqueSku('SEL');
+  const createResponse = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: { name: `Select spec ${sku}`, [attrCode]: { option_code: 'red' } },
+    },
+  });
+  expect(createResponse.status(), await createResponse.text()).toBe(201);
+  const product = (await createResponse.json()) as { id: string };
+
+  await page.goto(`/products/${product.id}`);
+
+  // Read-only view under the default (PL) locale → Polish option label.
+  const fieldRow = () =>
+    page
+      .getByText(/^(Kolor spec|Spec colour)$/)
+      .first()
+      .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+  await fieldRow().scrollIntoViewIfNeeded();
+  await expect(fieldRow().getByText('Czerwony')).toBeVisible();
+
+  // Switch the locale picker to EN — the option label re-resolves to English.
+  await page.getByRole('button', { name: /^(język|language)$/i }).click();
+  await page.getByRole('menuitem', { name: /en/i }).click();
+
+  await expect(fieldRow().getByText('Red')).toBeVisible();
+  await expect(fieldRow().getByText('Czerwony')).toHaveCount(0);
+});

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -89,6 +89,11 @@ export function AttrRow({
 }: AttrRowProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
+  // #1262 — option labels are part of the VALUE, so they must follow the
+  // active value locale (the `locale` prop set by the PL/EN toolbar), not
+  // the interface language. The attribute NAME below stays on `lang`
+  // (UI chrome). Falls back to the interface lang when no scope is active.
+  const valueLang = locale ?? lang;
   const label = attribute.label[lang] ?? attribute.code;
   const editable = isEditing && !isLocked;
   const stringValue = typeof value === 'string' ? value : value == null ? '' : String(value);
@@ -297,7 +302,7 @@ export function AttrRow({
             />
           ) : attribute.type === 'select' ? (
             <Combobox
-              options={toComboboxOptions(selectOptions, lang)}
+              options={toComboboxOptions(selectOptions, valueLang)}
               value={typeof value === 'string' && value !== '' ? value : null}
               onChange={(next) => onChange(next)}
               placeholder={t('products.detail.field.select_placeholder', {
@@ -307,7 +312,7 @@ export function AttrRow({
             />
           ) : attribute.type === 'multiselect' ? (
             <MultiSelect
-              options={toMultiSelectOptions(selectOptions, lang)}
+              options={toMultiSelectOptions(selectOptions, valueLang)}
               value={readMultiselectValue(value)}
               onChange={(next) => onChange(next)}
               placeholder={t('products.detail.field.multiselect_placeholder', {
@@ -348,7 +353,7 @@ export function AttrRow({
               isLocked ? 'cursor-default text-zinc-700' : 'text-ink',
             )}
           >
-            {renderReadOnlyValue(attribute, value, selectOptions, lang) ?? (
+            {renderReadOnlyValue(attribute, value, selectOptions, valueLang) ?? (
               <span className="italic text-zinc-400">
                 {t('products.detail.field.empty', { defaultValue: '—' })}
               </span>
@@ -411,21 +416,18 @@ function isLocaleScoped(attribute: AttributeMeta): boolean {
   return attribute.is_localizable === true;
 }
 
-function optionLabel(option: AttributeOptionMeta, lang: 'pl' | 'en'): string {
+function optionLabel(option: AttributeOptionMeta, lang: string): string {
   return option.label[lang] ?? option.label.en ?? option.label.pl ?? option.code;
 }
 
-function toComboboxOptions(options: AttributeOptionMeta[], lang: 'pl' | 'en'): ComboboxOption[] {
+function toComboboxOptions(options: AttributeOptionMeta[], lang: string): ComboboxOption[] {
   return options.map((o) => ({
     value: o.code,
     label: optionLabel(o, lang),
   }));
 }
 
-function toMultiSelectOptions(
-  options: AttributeOptionMeta[],
-  lang: 'pl' | 'en',
-): MultiSelectOption[] {
+function toMultiSelectOptions(options: AttributeOptionMeta[], lang: string): MultiSelectOption[] {
   return options.map((o) => ({
     value: o.code,
     label: optionLabel(o, lang),
@@ -478,7 +480,7 @@ function renderReadOnlyValue(
   attribute: AttributeMeta,
   value: unknown,
   options: AttributeOptionMeta[],
-  lang: 'pl' | 'en',
+  lang: string,
 ): string | null {
   if (attribute.type === 'select') {
     if (typeof value !== 'string' || value === '') return null;

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -70,7 +70,10 @@ export interface CatalogObjectDto {
  */
 export interface AttributeOptionMeta {
   code: string;
-  label: { pl?: string; en?: string };
+  // #1262 — per-locale map keyed by any tenant locale (not just pl/en); the
+  // backend ships every enabled locale's label so the active value locale
+  // can resolve the option's display text.
+  label: Record<string, string>;
   color?: string | null;
   is_default?: boolean;
   is_deprecated?: boolean;


### PR DESCRIPTION
## Summary
Label wybranej opcji select/multiselect na karcie produktu podąża teraz za aktywnym locale wartości (toolbar PL/EN), nie za językiem interfejsu.

## Root cause
`attr-row.tsx:91` wyprowadzał `lang` z `i18n.language` (interfejs) i używał go do resolverowania labeli opcji (linie 300/310/351). Przełączenie locale wartości nie zmieniało labela.

## Frontend changes
- `attr-row.tsx`: `valueLang = locale ?? lang` przekazany do `toComboboxOptions`/`toMultiSelectOptions`/`renderReadOnlyValue`. Label NAZWY atrybutu zostaje na języku interfejsu.
- Helpery `optionLabel`/`toComboboxOptions`/`toMultiSelectOptions`/`renderReadOnlyValue`: `lang: 'pl' | 'en'` → `lang: string` (dowolne locale tenanta).
- `types.ts`: `AttributeOptionMeta.label` → `Record<string, string>`.
- E2E `1262-select-option-label-per-locale.spec.ts`: select z opcją red (Czerwony/Red) → PL pokazuje "Czerwony", EN "Red".

## Quality gates
- TypeScript noEmit: 0. Biome strict: 0.
- Playwright: spec 1262 (CI-fixme dla rate limiter, jak channel-switch).

## Smoke test plan (operator)
1. Login. 2. Karta DEMO-001 (color=green/...). 3. Wartość "Kolor" pokazuje label PL. 4. Toolbar Język PL→EN → label opcji zmienia się na EN. 5. Console bez errorów.

Live smoke (data path): `GET /api/objects/{id}/effective-attribute-groups` zwraca per-locale labele opcji (`red → {pl:Czerwony, en:Red}`).

## Świadome odejścia
- Label NAZWY atrybutu (Nazwa/Name) celowo zostaje na języku interfejsu (UI chrome, nie wartość).

Closes #1262

🤖 Generated with [Claude Code](https://claude.com/claude-code)