### PR TITLE
fix(catalog): walidacja option_code select/multiselect przeciw żywym attribute_options

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -107,7 +107,10 @@ services:
     # matching TypeValidator implementation.
     App\Catalog\Application\Validation\AttributeValueValidator:
         factory: ['App\Catalog\Application\Validation\AttributeValueValidator', 'default']
-        arguments: []
+        # #1261 — inject the option repository so Select/Multiselect validators
+        # enforce membership against the live `attribute_options` table.
+        arguments:
+            $optionRepository: '@App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface'
 
     # Kind-aware ApiResource hooks (#128). Built-in Product/Category/Asset
     # ship via dedicated sugar paths in #41; this layer holds the metadata

--- a/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
+++ b/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
@@ -57,6 +57,10 @@ final readonly class ObjectAttributesUpserter
         AttributeType::Email,
         AttributeType::Color,
         AttributeType::Identifier,
+        // #1261 — select/multiselect option codes are validated against the
+        // live attribute_options set (SelectValidator/MultiselectValidator).
+        AttributeType::Select,
+        AttributeType::Multiselect,
     ];
 
     public function __construct(
@@ -113,12 +117,12 @@ final readonly class ObjectAttributesUpserter
 
             $jsonbValue = $this->wrapValue($rawValue);
 
-            // #1216 — enforce per-type value validation (email format, color
-            // hex/rgb, identifier shape) on every write path. Empty values are
-            // skipped — clearing an attribute is always allowed.
-            $scalar = $jsonbValue['value'] ?? null;
+            // #1216 / #1261 — enforce per-type value validation (email format,
+            // color hex/rgb, identifier shape, select/multiselect option
+            // membership) on every write path. Empty values are skipped —
+            // clearing an attribute is always allowed.
             if (\in_array($attribute->getType(), self::VALUE_VALIDATED_TYPES, true)
-                && null !== $scalar && '' !== $scalar) {
+                && self::hasValidatableContent($attribute->getType(), $jsonbValue)) {
                 $errors = $this->valueValidator->validate($attribute, $jsonbValue);
                 if ([] !== $errors) {
                     throw new UnprocessableEntityHttpException(\sprintf(
@@ -164,6 +168,33 @@ final readonly class ObjectAttributesUpserter
             );
             $this->values->save($value);
         }
+    }
+
+    /**
+     * #1261 — whether a wrapped value carries content worth validating, per
+     * the type's JSONB envelope. Clearing a value (empty option_code / empty
+     * option_codes / null-or-empty scalar) skips validation so operators can
+     * always blank a field.
+     *
+     * @param array<string, mixed> $jsonbValue
+     */
+    private static function hasValidatableContent(AttributeType $type, array $jsonbValue): bool
+    {
+        if (AttributeType::Select === $type) {
+            $optionCode = $jsonbValue['option_code'] ?? null;
+
+            return \is_string($optionCode) && '' !== $optionCode;
+        }
+
+        if (AttributeType::Multiselect === $type) {
+            $optionCodes = $jsonbValue['option_codes'] ?? null;
+
+            return \is_array($optionCodes) && [] !== $optionCodes;
+        }
+
+        $scalar = $jsonbValue['value'] ?? null;
+
+        return null !== $scalar && '' !== $scalar;
     }
 
     /**

--- a/apps/api/src/Catalog/Application/Validation/AttributeValueValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/AttributeValueValidator.php
@@ -6,6 +6,7 @@ namespace App\Catalog\Application\Validation;
 
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 
 /**
  * Per-AttributeType validator dispatcher.
@@ -61,13 +62,13 @@ final readonly class AttributeValueValidator
         return $validator->validate($attribute, $value);
     }
 
-    public static function default(): self
+    public static function default(?AttributeOptionRepositoryInterface $optionRepository = null): self
     {
         return new self([
             AttributeType::Text->value => new TypeValidator\TextValidator(),
             AttributeType::Number->value => new TypeValidator\NumberValidator(),
-            AttributeType::Select->value => new TypeValidator\SelectValidator(),
-            AttributeType::Multiselect->value => new TypeValidator\MultiselectValidator(),
+            AttributeType::Select->value => new TypeValidator\SelectValidator($optionRepository),
+            AttributeType::Multiselect->value => new TypeValidator\MultiselectValidator($optionRepository),
             AttributeType::Date->value => new TypeValidator\DateValidator(),
             AttributeType::Boolean->value => new TypeValidator\BooleanValidator(),
             AttributeType::Asset->value => new TypeValidator\AssetValidator(),

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/MultiselectValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/MultiselectValidator.php
@@ -7,14 +7,23 @@ namespace App\Catalog\Application\Validation\TypeValidator;
 use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
 use App\Catalog\Application\Validation\ValidationError;
 use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 
 /**
  * `multiselect` AttributeType validator.
  *
  * Rules: `option_codes` (list<string>), `min_count` / `max_count` (int).
+ * #1261 — each picked code must exist in the attribute's canonical option
+ * set (live `attribute_options` table via {@see AttributeOptionRepositoryInterface}),
+ * falling back to `validation_rules['option_codes']` when no repo is wired.
  */
-final class MultiselectValidator implements AttributeValueValidatorInterface
+final readonly class MultiselectValidator implements AttributeValueValidatorInterface
 {
+    public function __construct(
+        private ?AttributeOptionRepositoryInterface $options = null,
+    ) {
+    }
+
     public function validate(Attribute $attribute, array $value): array
     {
         $codes = $value['option_codes'] ?? null;
@@ -29,16 +38,16 @@ final class MultiselectValidator implements AttributeValueValidatorInterface
             }
         }
 
-        $rules = $attribute->getValidationRules();
-        $allowed = $rules['option_codes'] ?? null;
-        if (\is_array($allowed)) {
+        $allowed = $this->resolveAllowedCodes($attribute);
+        if (null !== $allowed) {
             foreach ($codes as $i => $code) {
-                if (\is_string($code) && !\in_array($code, $allowed, true)) {
-                    $errors[] = new ValidationError(\sprintf('value.option_codes.%d', $i), 'multiselect.unknown_option', \sprintf('Option "%s" is not in the configured option_codes set.', $code));
+                if (\is_string($code) && '' !== $code && !\in_array($code, $allowed, true)) {
+                    $errors[] = new ValidationError(\sprintf('value.option_codes.%d', $i), 'multiselect.unknown_option', \sprintf('Option "%s" is not a valid option for this attribute.', $code));
                 }
             }
         }
 
+        $rules = $attribute->getValidationRules();
         $count = \count($codes);
         $min = $rules['min_count'] ?? null;
         if (\is_int($min) && $count < $min) {
@@ -50,5 +59,22 @@ final class MultiselectValidator implements AttributeValueValidatorInterface
         }
 
         return $errors;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function resolveAllowedCodes(Attribute $attribute): ?array
+    {
+        if (null !== $this->options) {
+            $dbCodes = $this->options->findCodesByAttribute($attribute);
+            if ([] !== $dbCodes) {
+                return $dbCodes;
+            }
+        }
+
+        $allowed = $attribute->getValidationRules()['option_codes'] ?? null;
+
+        return \is_array($allowed) ? array_values(array_filter($allowed, 'is_string')) : null;
     }
 }

--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/SelectValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/SelectValidator.php
@@ -7,17 +7,27 @@ namespace App\Catalog\Application\Validation\TypeValidator;
 use App\Catalog\Application\Validation\AttributeValueValidatorInterface;
 use App\Catalog\Application\Validation\ValidationError;
 use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 
 /**
  * `select` AttributeType validator.
  *
- * Rule: `option_codes` (list<string>) — when configured, the picked
- * value must match one of these. When the rule is missing the
- * validator only checks the shape; the API layer (#41) is expected to
- * cross-check against the live AttributeOption rows from the database.
+ * Rule: the picked `option_code` must exist in the attribute's canonical
+ * option set. #1261 — that set is the live `attribute_options` table
+ * (resolved via {@see AttributeOptionRepositoryInterface}); the legacy
+ * `validation_rules['option_codes']` mirror is used only as a fallback
+ * when no repository is wired (e.g. `AttributeValueValidator::default()`
+ * called bare in a unit test). When neither source lists any code the
+ * validator checks the shape only — a freshly created select with no
+ * options yet must not reject every write.
  */
-final class SelectValidator implements AttributeValueValidatorInterface
+final readonly class SelectValidator implements AttributeValueValidatorInterface
 {
+    public function __construct(
+        private ?AttributeOptionRepositoryInterface $options = null,
+    ) {
+    }
+
     public function validate(Attribute $attribute, array $value): array
     {
         $code = $value['option_code'] ?? null;
@@ -25,16 +35,36 @@ final class SelectValidator implements AttributeValueValidatorInterface
             return [new ValidationError('value.option_code', 'select.expected_string', 'Select value must include a non-empty option_code.')];
         }
 
-        $rules = $attribute->getValidationRules();
-        $allowed = $rules['option_codes'] ?? null;
-        if (\is_array($allowed) && !\in_array($code, $allowed, true)) {
+        $allowed = $this->resolveAllowedCodes($attribute);
+        if (null !== $allowed && !\in_array($code, $allowed, true)) {
             return [new ValidationError(
                 'value.option_code',
                 'select.unknown_option',
-                \sprintf('Option "%s" is not in the configured option_codes set.', $code),
+                \sprintf('Option "%s" is not a valid option for this attribute.', $code),
             )];
         }
 
         return [];
+    }
+
+    /**
+     * The canonical option set: live `attribute_options` rows when a repo is
+     * wired and the attribute has any options, otherwise the legacy
+     * `validation_rules['option_codes']`. `null` = nothing to enforce.
+     *
+     * @return list<string>|null
+     */
+    private function resolveAllowedCodes(Attribute $attribute): ?array
+    {
+        if (null !== $this->options) {
+            $dbCodes = $this->options->findCodesByAttribute($attribute);
+            if ([] !== $dbCodes) {
+                return $dbCodes;
+            }
+        }
+
+        $allowed = $attribute->getValidationRules()['option_codes'] ?? null;
+
+        return \is_array($allowed) ? array_values(array_filter($allowed, 'is_string')) : null;
     }
 }

--- a/apps/api/src/Catalog/Domain/Repository/AttributeOptionRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/AttributeOptionRepositoryInterface.php
@@ -18,6 +18,16 @@ interface AttributeOptionRepositoryInterface
     public function findByAttribute(Attribute $attribute): array;
 
     /**
+     * #1261 — lean query returning just the option codes for an attribute,
+     * used by Select/Multiselect value validation to enforce membership in
+     * the canonical option set (the `attribute_options` table) instead of
+     * the optional `validation_rules['option_codes']` mirror.
+     *
+     * @return list<string>
+     */
+    public function findCodesByAttribute(Attribute $attribute): array;
+
+    /**
      * Bulk variant of {@see findByAttribute}. Returns every option whose
      * parent Attribute is in `$attributes`, sorted by attribute then by
      * position. Used by the product detail / variants tab eager loader so

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineAttributeOptionRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineAttributeOptionRepository.php
@@ -37,6 +37,23 @@ class DoctrineAttributeOptionRepository extends ServiceEntityRepository implemen
     }
 
     /**
+     * @return list<string>
+     */
+    public function findCodesByAttribute(Attribute $attribute): array
+    {
+        /** @var list<string> $codes */
+        $codes = $this->createQueryBuilder('o')
+            ->select('o.code')
+            ->andWhere('o.attribute = :attribute')
+            ->setParameter('attribute', $attribute)
+            ->orderBy('o.position', 'ASC')
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return $codes;
+    }
+
+    /**
      * @param list<Attribute> $attributes
      *
      * @return list<AttributeOption>

--- a/apps/api/tests/Api/Catalog/CatalogSelectOptionValidationApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogSelectOptionValidationApiTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * #1261 — select/multiselect option_code must exist in the live
+ * `attribute_options` set; writing an unknown option is rejected with 422.
+ */
+final class CatalogSelectOptionValidationApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function unknownSelectOptionIsRejected(): void
+    {
+        $this->seedSelectWithOptions('spec_color', ['red', 'blue']);
+        $client = $this->authenticatedClient();
+        $otId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $ok = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'SEL-OK', 'objectTypeId' => $otId, 'attributes' => [
+                'spec_color' => ['option_code' => 'red'],
+            ]],
+        ]);
+        self::assertSame(201, $ok->getStatusCode());
+
+        $bad = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'SEL-BAD', 'objectTypeId' => $otId, 'attributes' => [
+                'spec_color' => ['option_code' => 'magenta'],
+            ]],
+        ]);
+        self::assertSame(422, $bad->getStatusCode());
+    }
+
+    #[Test]
+    public function unknownMultiselectOptionIsRejected(): void
+    {
+        $this->seedSelectWithOptions('spec_tags', ['new', 'sale'], AttributeType::Multiselect);
+        $client = $this->authenticatedClient();
+        $otId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $ok = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'MUL-OK', 'objectTypeId' => $otId, 'attributes' => [
+                'spec_tags' => ['option_codes' => ['new', 'sale']],
+            ]],
+        ]);
+        self::assertSame(201, $ok->getStatusCode());
+
+        $bad = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'MUL-BAD', 'objectTypeId' => $otId, 'attributes' => [
+                'spec_tags' => ['option_codes' => ['new', 'ghost']],
+            ]],
+        ]);
+        self::assertSame(422, $bad->getStatusCode());
+    }
+
+    #[Test]
+    public function clearingSelectValueIsAllowed(): void
+    {
+        $this->seedSelectWithOptions('spec_clear', ['a', 'b']);
+        $client = $this->authenticatedClient();
+        $otId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        // Empty option_code = clearing → no validation, 201.
+        $response = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'json' => ['code' => 'SEL-CLEAR', 'objectTypeId' => $otId, 'attributes' => [
+                'spec_clear' => ['option_code' => ''],
+            ]],
+        ]);
+        self::assertSame(201, $response->getStatusCode());
+    }
+
+    /**
+     * @param list<string> $optionCodes
+     */
+    private function seedSelectWithOptions(
+        string $code,
+        array $optionCodes,
+        AttributeType $type = AttributeType::Select,
+    ): void {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $product = self::getContainer()
+            ->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $attribute = new Attribute($code, ['pl' => $code, 'en' => $code], $type);
+        $em->persist($attribute);
+        $position = 0;
+        foreach ($optionCodes as $optionCode) {
+            $em->persist(new AttributeOption(
+                attribute: $attribute,
+                code: $optionCode,
+                label: ['pl' => ucfirst($optionCode), 'en' => ucfirst($optionCode)],
+                position: $position++,
+            ));
+        }
+        $em->persist(new ObjectTypeAttribute($product, $attribute, false, 1));
+        $em->flush();
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Validation/TypeValidator/SelectValidatorTest.php
+++ b/apps/api/tests/Unit/Catalog/Validation/TypeValidator/SelectValidatorTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Catalog\Validation\TypeValidator;
 use App\Catalog\Application\Validation\TypeValidator\SelectValidator;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -44,5 +45,29 @@ final class SelectValidatorTest extends TestCase
 
         self::assertSame([], $ok);
         self::assertSame('select.unknown_option', $bad[0]->code);
+    }
+
+    #[Test]
+    public function liveAttributeOptionsAreTheCanonicalAllowlist(): void
+    {
+        // #1261 — the DB option set wins over the (absent) validation_rules mirror.
+        $repo = $this->createStub(AttributeOptionRepositoryInterface::class);
+        $repo->method('findCodesByAttribute')->willReturn(['red', 'green']);
+        $validator = new SelectValidator($repo);
+
+        self::assertSame([], $validator->validate($this->attribute, ['option_code' => 'red']));
+        $bad = $validator->validate($this->attribute, ['option_code' => 'magenta']);
+        self::assertSame('select.unknown_option', $bad[0]->code);
+    }
+
+    #[Test]
+    public function emptyDbOptionsFallBackToShapeOnly(): void
+    {
+        // A select with no options yet must not reject every write.
+        $repo = $this->createStub(AttributeOptionRepositoryInterface::class);
+        $repo->method('findCodesByAttribute')->willReturn([]);
+        $validator = new SelectValidator($repo);
+
+        self::assertSame([], $validator->validate($this->attribute, ['option_code' => 'anything']));
     }
 }


### PR DESCRIPTION
## Summary
POST/PATCH `/api/products` z nieistniejącym `option_code` dla select/multiselect zwraca teraz 422 (był 200) — walidacja przeciw kanonicznemu zbiorowi opcji z tabeli `attribute_options`.

## Root cause
- `ObjectAttributesUpserter::VALUE_VALIDATED_TYPES` = [Email, Color, Identifier] — select/multiselect pominięte, więc `SelectValidator` nigdy nie odpalał.
- Guard `$jsonbValue['value']` pomijał select (envelope `option_code`, nie `value`).
- `SelectValidator` sprawdzał tylko `validation_rules['option_codes']` (mirror JSONB), nie żywych `attribute_options`.

## Backend changes
- `AttributeOptionRepositoryInterface::findCodesByAttribute()` + Doctrine impl (lean `getSingleColumnResult`).
- `SelectValidator`/`MultiselectValidator`: opcjonalny `AttributeOptionRepositoryInterface`, walidacja przeciw żywym opcjom (∪ fallback do rules gdy brak repo). Pusty zbiór DB → shape-only (świeży select nie odrzuca wszystkiego).
- `AttributeValueValidator::default(?repo)` + services.yaml inject repo.
- `ObjectAttributesUpserter`: Select/Multiselect w VALUE_VALIDATED_TYPES + type-aware `hasValidatableContent` (clearing = skip).

## Quality gates
- PHPStan max: 0. Deptrac: 0.
- PHPUnit: 70 istniejących validator testów green (backward compatible) + 2 nowe repo-aware case'y + ApiTestCase (valid→201, invalid→422, clear→201).

## Smoke test (live-stack pim.localhost)
```
POST /api/products color=red     → 201
POST /api/products color=magenta → 422
```

## Świadome odejścia
- Backfill istniejących `object_values` z nieprawidłowymi kodami: poza zakresem (read-side tolerancyjny).

Closes #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)