### PR TITLE
fix(export): eksport cen dla localizable+scopable + plain-value envelope

### DIFF
--- a/apps/admin/src/features/exports/components/use-export-column-catalog.ts
+++ b/apps/admin/src/features/exports/components/use-export-column-catalog.ts
@@ -241,38 +241,45 @@ function attrToOptions(
   enabledChannels: string[] = [],
 ): Array<{ key: string; labelKey: string; defaultLabel: string }> {
   const baseLabel = localizedLabel(attr.label, 'pl') ?? attr.code;
-  if (attr.localizable === true && enabledLocales.length > 0) {
-    return enabledLocales.map((locale) => ({
-      key: `${attr.code}.${locale}`,
-      labelKey: `exports.columns.${attr.code}.${locale}`,
-      defaultLabel: `${baseLabel} [${locale}]`,
-    }));
+  const isLoc = attr.localizable === true && enabledLocales.length > 0;
+  const isScop = attr.scopable === true && enabledChannels.length > 0;
+
+  const bare = {
+    key: attr.code,
+    labelKey: `exports.columns.${attr.code}`,
+    defaultLabel: baseLabel,
+  };
+  const localeCols = enabledLocales.map((locale) => ({
+    key: `${attr.code}.${locale}`,
+    labelKey: `exports.columns.${attr.code}.${locale}`,
+    defaultLabel: `${baseLabel} [${locale}]`,
+  }));
+  const channelCols = enabledChannels.map((channel) => ({
+    key: `${attr.code}.${channel}`,
+    labelKey: `exports.columns.${attr.code}.${channel}`,
+    defaultLabel: `${baseLabel} [${channel}]`,
+  }));
+
+  // #1271 — an attribute that is BOTH localizable and scopable carries a
+  // global value, per-locale values, AND per-channel overrides. Emit the
+  // bare `code` (global) + per-locale + per-channel so none of the three
+  // scopes is dropped. Previously the localizable branch won and only the
+  // (often empty) per-locale columns shipped, hiding the global + channel
+  // values entirely.
+  if (isLoc && isScop) {
+    return [bare, ...localeCols, ...channelCols];
   }
-  // #1245 / #1267 — scopable attributes carry a global value (channel=null)
-  // AND per-channel overrides. Emit the bare `code` (global, gated by the
-  // "Wszystkie" channel option in the modal) plus one `code.{channel}` per
-  // active channel — the global column was previously dropped (#1267).
-  if (attr.scopable === true && enabledChannels.length > 0) {
-    return [
-      {
-        key: attr.code,
-        labelKey: `exports.columns.${attr.code}`,
-        defaultLabel: baseLabel,
-      },
-      ...enabledChannels.map((channel) => ({
-        key: `${attr.code}.${channel}`,
-        labelKey: `exports.columns.${attr.code}.${channel}`,
-        defaultLabel: `${baseLabel} [${channel}]`,
-      })),
-    ];
+  // Pure localizable: the primary locale === the global value, so only the
+  // per-locale columns ship (no redundant bare column).
+  if (isLoc) {
+    return localeCols;
   }
-  return [
-    {
-      key: attr.code,
-      labelKey: `exports.columns.${attr.code}`,
-      defaultLabel: baseLabel,
-    },
-  ];
+  // #1245 / #1267 — pure scopable: bare global (gated by "Wszystkie") +
+  // per-channel overrides.
+  if (isScop) {
+    return [bare, ...channelCols];
+  }
+  return [bare];
 }
 
 function localizedLabel(label: Record<string, string> | undefined, locale: string): string | null {

--- a/apps/api/src/Export/Application/Builder/ValueSerializer.php
+++ b/apps/api/src/Export/Application/Builder/ValueSerializer.php
@@ -167,7 +167,11 @@ final class ValueSerializer
      */
     private function price(array $payload): string
     {
-        $amount = $this->stringify($payload['amount'] ?? null);
+        // #1271 — the canonical price envelope is `{amount, currency}`, but the
+        // product card stores a plain `{value}` when the operator types a bare
+        // number into the (text) price field. Fall back to `value` so those
+        // prices export instead of rendering an empty cell.
+        $amount = $this->stringify($payload['amount'] ?? $payload['value'] ?? null);
         if ('' === $amount) {
             return '';
         }

--- a/apps/api/tests/Unit/Export/Application/Builder/ValueSerializerTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ValueSerializerTest.php
@@ -91,6 +91,16 @@ final class ValueSerializerTest extends TestCase
     }
 
     #[Test]
+    public function priceFallsBackToPlainValueEnvelope(): void
+    {
+        // #1271 — a price typed as a bare number on the product card is stored
+        // as `{value: "100"}`; it must export instead of an empty cell.
+        $serializer = new ValueSerializer();
+        $value = $this->valueWithPayload(AttributeType::Price, ['value' => '100']);
+        self::assertSame('100', $serializer->serialize($value));
+    }
+
+    #[Test]
     public function metricCombinesValueAndUnit(): void
     {
         $serializer = new ValueSerializer();


### PR DESCRIPTION
## Problem
Produkt z cenami (global 100, allegro 110, EN 200) → eksport zwracał PUSTE kolumny price. Dwie warstwy, jeden objaw.

## Root cause
1. **FE** (`use-export-column-catalog`): atrybut localizable AND scopable wpadał w branch localizable-first → tylko `code.{locale}` (często puste), gubiąc bare global + per-channel.
2. **BE** (`ValueSerializer::price`): kanoniczny envelope to `{amount, currency}`, ale karta produktu zapisuje `{value:"100"}` gdy operator wpisze gołą liczbę w pole price (attr-row renderuje price jako plain input) → serializer zwracał ''.

## Changes
- FE: loc+scop attr → bare `code` (global) + `code.{locale}` + `code.{channel}`. Pure-localizable / pure-scopable bez zmian.
- BE: `price()` fallback `amount ?? value`.

## Quality gates
- TypeScript noEmit 0, Biome strict 0, PHPStan max 0, 13 ValueSerializer unit testów green.

## Smoke test (live-stack pim.localhost)
```
POST /api/products/export sku;price;price.allegro;price.en
→ DEMO-100;100;110;200   (było: DEMO-100;;;)
```

## Świadome odejścia
- attr-row renderuje price jako plain input (nie amount+currency) — osobny UX ticket; ten fix sprawia że istniejące dane `{value}` eksportują się poprawnie.

Closes #1271

🤖 Generated with [Claude Code](https://claude.com/claude-code)