### PR TITLE
feat(admin): generator + edytowalna lista wariantów na karcie custom ObjectType

### DIFF
--- a/apps/admin/e2e/1273-variants-custom-object-type.spec.ts
+++ b/apps/admin/e2e/1273-variants-custom-object-type.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1273 — the full variants editor (axis generator + matrix) is available on
+ * the universal custom-ObjectType detail page, not just the legacy product
+ * card. The poly-kind backend (`POST /api/objects/{master}/generate-variants`,
+ * gated only by `ObjectType.hasVariants`) shipped in UP-04 (#1021); this spec
+ * proves the FE wiring: on a custom OT with `hasVariants=true` the "Warianty"
+ * tab renders `VariantsTabHost` (read-only `ObjectVariantsPanel` removed) and
+ * generation hits `/api/objects/...` (not `/api/products/...`).
+ *
+ * `test.fixme` in CI for the shared auth-rate-limiter storageState gap (same
+ * rationale as 1226-variants-scope-aware.spec.ts); runs locally.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('#1273 — custom ObjectType variants tab generates via /api/objects', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const stamp = Date.now().toString(36);
+  const otCode = `uslugi_e2e_${stamp}`;
+  const groupCode = `wariant_grp_${stamp}`;
+  const axisCode = `wariant_kolor_${stamp}`;
+
+  // 1. Custom ObjectType with variants enabled (kind defaults to 'custom').
+  const otResp = await page.request.post('/api/object_types', {
+    data: {
+      code: otCode,
+      label: { pl: 'Usługi E2E', en: 'Services E2E' },
+      icon: '🧩',
+      color: '#0ea5e9',
+      hierarchical: false,
+      hasVariants: true,
+      abstract: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(otResp.status(), await otResp.text()).toBe(201);
+  const objectTypeId = ((await otResp.json()) as { id: string }).id;
+
+  // 2. AttributeGroup so the axis attribute surfaces in effective-attribute-groups
+  //    (the generator combobox reads that response).
+  const groupResp = await page.request.post('/api/attribute_groups', {
+    data: { code: groupCode, label: { pl: 'Konfiguracja', en: 'Configuration' } },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(groupResp.status(), await groupResp.text()).toBe(201);
+  const groupId = ((await groupResp.json()) as { id: string }).id;
+
+  try {
+    // 3. Select attribute with two options — the axis the generator iterates.
+    const attrResp = await page.request.post('/api/attributes', {
+      data: {
+        code: axisCode,
+        type: 'select',
+        label: { pl: 'Kolor wariantu', en: 'Variant colour' },
+        required: false,
+      },
+      headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+    });
+    expect(attrResp.status(), await attrResp.text()).toBe(201);
+
+    for (const [code, pl, en] of [
+      ['red', 'Czerwony', 'Red'],
+      ['blue', 'Niebieski', 'Blue'],
+    ] as const) {
+      const optResp = await page.request.post(`/api/attributes/${axisCode}/options`, {
+        data: { code, label: { pl, en } },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      });
+      expect([200, 201]).toContain(optResp.status());
+    }
+
+    // 4. Attach attr → group → ObjectType.
+    const attachAttr = await page.request.post(
+      `/api/attribute_groups/${groupId}/attributes/bulk-attach`,
+      {
+        data: { attributeCodes: [axisCode] },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      },
+    );
+    expect(attachAttr.status(), await attachAttr.text()).toBe(200);
+
+    const attachGroup = await page.request.post(
+      `/api/object_types/${objectTypeId}/groups/${groupId}`,
+      { headers: bearer },
+    );
+    expect(attachGroup.status()).toBe(204);
+
+    // 5. Master object (poly-kind POST /api/objects).
+    const masterCode = uniqueSku('USL1273');
+    const masterResp = await page.request.post('/api/objects', {
+      headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+      data: { code: masterCode, objectTypeId, attributes: {} },
+    });
+    expect(masterResp.status(), await masterResp.text()).toBe(201);
+    const masterId = ((await masterResp.json()) as { id: string }).id;
+
+    // 6. UI: open the custom OT detail and the Warianty tab → full generator.
+    await page.goto(`/objects/${otCode}/${masterId}`);
+
+    const variantsTab = page.getByRole('tab', { name: /^(warianty|variants)$/i });
+    await expect(variantsTab).toBeVisible();
+    await variantsTab.click();
+
+    // The full host renders the generator (read-only panel had no button).
+    const generateButton = page.getByRole('button', {
+      name: /^(generate variants|wygeneruj warianty|generuj warianty|generate)/i,
+    });
+    await expect(generateButton).toBeVisible();
+
+    // 7. Pick the axis attribute in the first axis-row combobox, then add both
+    //    option values from the suggestion chips.
+    await page.getByRole('button', { name: /wybierz atrybut osi|pick axis attribute/i }).click();
+    await page.getByPlaceholder(/szukaj atrybutu|search/i).fill('Kolor wariantu');
+    await page.getByRole('button', { name: /kolor wariantu|variant colour/i }).click();
+    await page.getByRole('button', { name: '+red' }).click();
+    await page.getByRole('button', { name: '+blue' }).click();
+
+    // 8. Generate → the POST must go to the poly-kind /api/objects route.
+    const genResponse = page.waitForResponse(
+      (r) =>
+        /\/api\/objects\/[^/]+\/generate-variants/.test(r.url()) && r.request().method() === 'POST',
+    );
+    await generateButton.click();
+    const gen = await genResponse;
+    expect(gen.status(), await gen.text()).toBeLessThan(400);
+
+    // 9. The generated variant lands in the list below.
+    await expect(page.getByText(/1 wariant|2 wariant|variants?/i).first()).toBeVisible();
+    await expect(page.getByText(new RegExp(masterCode, 'i')).first()).toBeVisible();
+  } finally {
+    await page.request.delete(`/api/object_types/${objectTypeId}`, { headers: bearer });
+    await page.request.delete(`/api/attribute_groups/${groupId}`, { headers: bearer });
+  }
+});

--- a/apps/admin/src/components/catalog/variants-tab.tsx
+++ b/apps/admin/src/components/catalog/variants-tab.tsx
@@ -58,9 +58,17 @@ function buildDefaultSkuTemplate(axes: AxisDraft[]): string {
 export function VariantsTab({
   masterProductId,
   onGenerated,
+  basePath = '/api/products',
 }: {
   masterProductId: string;
   onGenerated?: () => void;
+  /**
+   * UP-04 follow-up (#1273) — poly-kind base path. `/api/products` keeps the
+   * legacy product detail working unchanged; the universal object card passes
+   * `/api/objects` so custom ObjectTypes with `hasVariants=true` reach the
+   * same generator endpoint.
+   */
+  basePath?: string;
 }) {
   const { t } = useTranslation();
   const [axes, setAxes] = useState<AxisDraft[]>([{ code: 'color', values: [] }]);
@@ -69,7 +77,7 @@ export function VariantsTab({
   useEffect(() => {
     let cancelled = false;
     jsonFetch<{ groups: SchemaGroup[] }>(
-      `/api/products/${masterProductId}/effective-attribute-groups`,
+      `${basePath}/${masterProductId}/effective-attribute-groups`,
     )
       .then((body) => {
         if (cancelled) return;
@@ -80,7 +88,7 @@ export function VariantsTab({
     return () => {
       cancelled = true;
     };
-  }, [masterProductId]);
+  }, [masterProductId, basePath]);
   const [skuTemplate, setSkuTemplate] = useState('');
   const [isPending, setIsPending] = useState(false);
   const [response, setResponse] = useState<GenerateVariantsResponse | null>(null);
@@ -135,7 +143,7 @@ export function VariantsTab({
         skuTemplate.trim() !== '' ? skuTemplate.trim() : buildDefaultSkuTemplate(axes);
       body.sku_template = template;
       const result = await jsonFetch<GenerateVariantsResponse>(
-        `/api/products/${masterProductId}/generate-variants`,
+        `${basePath}/${masterProductId}/generate-variants`,
         { method: 'POST', body },
       );
       setResponse(result);

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -65,6 +65,7 @@ import type {
   ProductLocale,
   ScopeStatus,
 } from '@/features/catalog/products/components/types';
+import { VariantsTabHost } from '@/features/catalog/products/components/variants-tab-host';
 import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
 import { httpErrorDetail, jsonFetch } from '@/lib/http';
 import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
@@ -651,7 +652,14 @@ export function UniversalDetailPage({
               return <ObjectMultimediaPanel objectId={objectId} />;
             }
             if (activeTab === 'variants') {
-              return <ObjectVariantsPanel objectId={objectId} />;
+              return (
+                <VariantsTabHost
+                  productId={objectId}
+                  basePath="/api/objects"
+                  locale={locale}
+                  channel={channel}
+                />
+              );
             }
             const tabGroup = tabModeGroups.find((g) => g.code === activeTab);
             if (tabGroup) return renderStackedGroup(tabGroup);
@@ -882,72 +890,4 @@ function resolveProvenance(
  */
 function ObjectMultimediaPanel({ objectId }: { objectId: string }) {
   return <ProductMultimediaTab productId={objectId} />;
-}
-
-interface VariantSummary {
-  id: string;
-  code?: string;
-  attributesIndexed?: Record<string, unknown>;
-}
-
-/**
- * UX-08 — Variants tab driven by `ObjectType.hasVariants`.
- *
- * Minimal poly-kind list: queries `/api/objects?parent_id={objectId}`
- * for direct children and links each one back to the detail page via
- * its ObjectType slug. Full editor (axis matrix, generator) stays on
- * the legacy Product detail for now — the universal generator endpoint
- * landed in UP-04 but a generic editor UI is a follow-up.
- */
-function ObjectVariantsPanel({ objectId }: { objectId: string }) {
-  const { t } = useTranslation();
-  const query = useQuery({
-    queryKey: ['object', objectId, 'variants'],
-    enabled: objectId !== '',
-    staleTime: 30_000,
-    queryFn: async () => {
-      const data = await jsonFetch<{
-        member?: VariantSummary[];
-        'hydra:member'?: VariantSummary[];
-      }>(`/api/objects?parent_id=${objectId}&itemsPerPage=200`, { accept: 'application/ld+json' });
-      return data.member ?? data['hydra:member'] ?? [];
-    },
-  });
-
-  if (query.isLoading) {
-    return <p className="text-sm text-muted-foreground">{t('app.loading')}</p>;
-  }
-
-  const variants = query.data ?? [];
-  if (variants.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        {t('object_detail.variants.empty', {
-          defaultValue:
-            'Ten obiekt nie ma jeszcze wariantów. Generator wariantów ląduje w następnej iteracji.',
-        })}
-      </p>
-    );
-  }
-
-  return (
-    <ul className="space-y-2">
-      {variants.map((variant) => {
-        const indexed = variant.attributesIndexed ?? {};
-        const sku =
-          typeof variant.code === 'string' && variant.code.length > 0 ? variant.code : variant.id;
-        return (
-          <li key={variant.id} className="rounded-md border bg-card px-3 py-2 text-sm">
-            <div className="font-mono text-[12px] text-ink">{sku}</div>
-            <div className="text-[11px] text-muted-foreground">
-              {Object.entries(indexed)
-                .map(([k, v]) => `${k}: ${typeof v === 'string' ? v : JSON.stringify(v)}`)
-                .slice(0, 3)
-                .join(' · ')}
-            </div>
-          </li>
-        );
-      })}
-    </ul>
-  );
 }

--- a/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
+++ b/apps/admin/src/features/catalog/products/components/variants-tab-host.tsx
@@ -34,6 +34,12 @@ export interface VariantsTabHostProps {
   locale: ProductLocale;
   /** #1226 — active channel (null = all channels / global). */
   channel: ProductChannel | null;
+  /**
+   * #1273 — poly-kind base path. `/api/products` keeps the legacy product
+   * detail working unchanged; the universal object card passes `/api/objects`
+   * so custom ObjectTypes share the same variant list + generator + editor.
+   */
+  basePath?: string;
 }
 
 /**
@@ -45,7 +51,12 @@ export interface VariantsTabHostProps {
  * variants" action that replaces the ProvenanceBadge in the variant
  * RHS slot.
  */
-export function VariantsTabHost({ productId, locale, channel }: VariantsTabHostProps) {
+export function VariantsTabHost({
+  productId,
+  locale,
+  channel,
+  basePath = '/api/products',
+}: VariantsTabHostProps) {
   const { t } = useTranslation();
   const [variants, setVariants] = useState<VariantRow[]>([]);
   const [groups, setGroups] = useState<GroupMeta[]>([]);
@@ -64,14 +75,14 @@ export function VariantsTabHost({ productId, locale, channel }: VariantsTabHostP
     // already carries `?parent_id`, hence the leading `?` becomes `&`.
     const scope = scopeQuery(locale, channel).replace('?', '&');
     Promise.all([
-      jsonFetch<VariantsResponse>(`/api/products?parent_id=${productId}${scope}`).then((body) => {
+      jsonFetch<VariantsResponse>(`${basePath}?parent_id=${productId}${scope}`).then((body) => {
         if (cancelled) return;
         const list = body.member ?? body['hydra:member'] ?? [];
         const arr = Array.isArray(list) ? list : [];
         setVariants(arr);
       }),
       jsonFetch<{ groups?: GroupMeta[] }>(
-        `/api/products/${productId}/effective-attribute-groups`,
+        `${basePath}/${productId}/effective-attribute-groups`,
       ).then((body) => {
         // Defensive — see saved-views-rail comment. Empty groups is a
         // valid state (product whose ObjectType has no attached groups).
@@ -81,7 +92,7 @@ export function VariantsTabHost({ productId, locale, channel }: VariantsTabHostP
     return () => {
       cancelled = true;
     };
-  }, [productId, reloadKey, locale, channel]);
+  }, [productId, reloadKey, locale, channel, basePath]);
 
   // #1226 — switching scope discards unsaved variant edits so an edit is
   // never written to the wrong locale/channel (mirrors the product card).
@@ -161,7 +172,7 @@ export function VariantsTabHost({ productId, locale, channel }: VariantsTabHostP
     setIsSaving(true);
     const results = await Promise.allSettled(
       targets.map(([id, attributes]) =>
-        jsonFetch(`/api/products/${id}${scopeQuery(locale, channel)}`, {
+        jsonFetch(`${basePath}/${id}${scopeQuery(locale, channel)}`, {
           method: 'PATCH',
           contentType: 'application/merge-patch+json',
           body: { attributes },
@@ -202,7 +213,11 @@ export function VariantsTabHost({ productId, locale, channel }: VariantsTabHostP
   return (
     <div className="space-y-3">
       <div className="rounded-2xl border border-zinc-100 bg-zinc-50/40 p-1">
-        <VariantsTab masterProductId={productId} onGenerated={() => setReloadKey((k) => k + 1)} />
+        <VariantsTab
+          masterProductId={productId}
+          basePath={basePath}
+          onGenerated={() => setReloadKey((k) => k + 1)}
+        />
       </div>
 
       <div>


### PR DESCRIPTION
## Kontekst
Closes #1273.

Pełny edytor wariantów (generator osi + macierz kombinacji + edytowalna lista z inline-edit) był podpięty wyłącznie na legacy karcie produktu i zahardkodowany na `/api/products/*`. Karta custom ObjectType (`/objects/{slug}/{id}`, np. Usługi) dostawała tylko read-only `ObjectVariantsPanel` — mimo że produkt jest tylko built-in instancją ObjectType, a backendowy endpoint generacji jest poly-kind od UP-04 (#1021): `POST /api/objects/{master}/generate-variants`, bramkowany wyłącznie capability flagiem `ObjectType.hasVariants()` (bez sprawdzania `kind='product'`).

## Zmiany
- `variants-tab.tsx`, `variants-tab-host.tsx`: nowy prop `basePath` (default `/api/products` — karta produktu bez zmiany zachowania). Repoint `effective-attribute-groups`, kolekcji `?parent_id`, `generate-variants` i PATCH zapisu na `${basePath}/...`.
- `universal-detail-page.tsx`: zakładka „Warianty" renderuje `VariantsTabHost` z `basePath="/api/objects"` (+ aktywne `locale`/`channel`). Usunięty martwy read-only `ObjectVariantsPanel`.
- Kolekcja `/api/objects` honoruje już filtr `parent_id` oraz overlay locale/channel (#1223), więc lista wariantów, generator i inline-edit PATCH działają na poly-kind route.

## Test / smoke (na żywym stacku)
Nowy E2E `1273-variants-custom-object-type.spec.ts` (zielony lokalnie): login → tworzy custom OT z `hasVariants=true` + atrybut select z opcjami + master przez `POST /api/objects` → nawiguje na kartę → zakładka „Warianty" → wybiera oś, dodaje wartości, klika **Generuj** → asercja `POST /api/objects/{id}/generate-variants` zwraca 2xx → wygenerowany wariant widoczny na liście.

Bramki: TypeScript `noEmit` 0, Biome strict 0.

**Świadome odejście:** dwa istniejące produktowe specy wariantów (`1226-variants-scope-aware`, `view-07-3-products-variants`) failują w fazie setup (querowanie `/api/object_types`) — zweryfikowane jako **pre-existing na czystym main**, nie regresja tego PR (`test.fixme` w CI z powodu auth rate-limitera).

🤖 Generated with [Claude Code](https://claude.com/claude-code)