### PR TITLE
feat(admin): karta „Warianty" w sidebarze karty custom ObjectType

### DIFF
--- a/apps/admin/e2e/1274-variants-sidebar-card-custom-object-type.spec.ts
+++ b/apps/admin/e2e/1274-variants-sidebar-card-custom-object-type.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1274 — the sidebar "Warianty" card (variant count + quick-nav) is present
+ * on the universal custom-ObjectType detail page, mirroring the product card.
+ * Depends on the #1273 basePath parametrization; here the card reads the
+ * master's children through the poly-kind `/api/objects?parent_id=` route.
+ *
+ * `test.fixme` in CI for the shared auth-rate-limiter storageState gap (same
+ * rationale as 1273-variants-custom-object-type.spec.ts); runs locally.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('#1274 — custom ObjectType sidebar lists variants + quick-nav', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const stamp = Date.now().toString(36);
+  const otCode = `uslugi_sb_${stamp}`;
+  const groupCode = `wariant_sb_grp_${stamp}`;
+  const axisCode = `wariant_sb_kolor_${stamp}`;
+
+  const otResp = await page.request.post('/api/object_types', {
+    data: {
+      code: otCode,
+      label: { pl: 'Usługi sidebar', en: 'Services sidebar' },
+      icon: '🧩',
+      color: '#0ea5e9',
+      hierarchical: false,
+      hasVariants: true,
+      abstract: false,
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(otResp.status(), await otResp.text()).toBe(201);
+  const objectTypeId = ((await otResp.json()) as { id: string }).id;
+
+  const groupResp = await page.request.post('/api/attribute_groups', {
+    data: { code: groupCode, label: { pl: 'Konfiguracja', en: 'Configuration' } },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(groupResp.status(), await groupResp.text()).toBe(201);
+  const groupId = ((await groupResp.json()) as { id: string }).id;
+
+  try {
+    const attrResp = await page.request.post('/api/attributes', {
+      data: {
+        code: axisCode,
+        type: 'select',
+        label: { pl: 'Kolor wariantu', en: 'Variant colour' },
+        required: false,
+      },
+      headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+    });
+    expect(attrResp.status(), await attrResp.text()).toBe(201);
+
+    for (const [code, pl, en] of [
+      ['red', 'Czerwony', 'Red'],
+      ['blue', 'Niebieski', 'Blue'],
+    ] as const) {
+      const optResp = await page.request.post(`/api/attributes/${axisCode}/options`, {
+        data: { code, label: { pl, en } },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      });
+      expect([200, 201]).toContain(optResp.status());
+    }
+
+    const attachAttr = await page.request.post(
+      `/api/attribute_groups/${groupId}/attributes/bulk-attach`,
+      {
+        data: { attributeCodes: [axisCode] },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      },
+    );
+    expect(attachAttr.status(), await attachAttr.text()).toBe(200);
+
+    const attachGroup = await page.request.post(
+      `/api/object_types/${objectTypeId}/groups/${groupId}`,
+      { headers: bearer },
+    );
+    expect(attachGroup.status()).toBe(204);
+
+    const masterCode = uniqueSku('USL1274');
+    const masterResp = await page.request.post('/api/objects', {
+      headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+      data: { code: masterCode, objectTypeId, attributes: {} },
+    });
+    expect(masterResp.status(), await masterResp.text()).toBe(201);
+    const masterId = ((await masterResp.json()) as { id: string }).id;
+
+    // Generate two variants via the poly-kind endpoint (UI generation is
+    // covered by #1273; this spec asserts the sidebar surfacing).
+    const genResp = await page.request.post(`/api/objects/${masterId}/generate-variants`, {
+      headers: { ...bearer, 'content-type': 'application/json' },
+      data: { axes: { [axisCode]: ['red', 'blue'] } },
+    });
+    expect(genResp.status(), await genResp.text()).toBeLessThan(400);
+
+    await page.goto(`/objects/${otCode}/${masterId}`);
+
+    // Sidebar "Warianty" card renders with the variant count.
+    const sidebarCard = page
+      .getByRole('complementary')
+      .filter({ hasText: /warianty|variants/i })
+      .first();
+    await expect(sidebarCard).toBeVisible();
+    // Two generated variants → the count badge shows 2.
+    await expect(sidebarCard.getByText('2', { exact: true })).toBeVisible();
+
+    // Quick-nav: clicking a variant row routes to its detail page.
+    const variantButton = sidebarCard
+      .getByRole('button')
+      .filter({ hasText: /red|blue/i })
+      .first();
+    await variantButton.click();
+    await expect(page).toHaveURL(new RegExp(`/objects/${otCode}/[0-9a-f-]+`));
+    // Landed on a different object than the master.
+    expect(page.url()).not.toContain(masterId);
+  } finally {
+    await page.request.delete(`/api/object_types/${objectTypeId}`, { headers: bearer });
+    await page.request.delete(`/api/attribute_groups/${groupId}`, { headers: bearer });
+  }
+});

--- a/apps/admin/src/components/objects/universal-detail-page.tsx
+++ b/apps/admin/src/components/objects/universal-detail-page.tsx
@@ -65,6 +65,7 @@ import type {
   ProductLocale,
   ScopeStatus,
 } from '@/features/catalog/products/components/types';
+import { VariantsListCard } from '@/features/catalog/products/components/variants-list-card';
 import { VariantsTabHost } from '@/features/catalog/products/components/variants-tab-host';
 import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
 import { httpErrorDetail, jsonFetch } from '@/lib/http';
@@ -119,6 +120,7 @@ interface CategoriesResponse {
 
 export function UniversalDetailPage({
   objectId,
+  objectTypeCode,
   objectTypeLabel,
   backHref,
   isCategorizable,
@@ -671,6 +673,14 @@ export function UniversalDetailPage({
           className="space-y-3"
           aria-label={t('object_detail.sidebar.aria', { defaultValue: 'Panel boczny' })}
         >
+          {hasVariants ? (
+            <VariantsListCard
+              masterProductId={objectId}
+              basePath="/api/objects"
+              onSelectVariant={(variantId) => navigate(`/objects/${objectTypeCode}/${variantId}`)}
+              onCreateVariant={() => setActiveTab('variants')}
+            />
+          ) : null}
           <EffectiveModelCard groups={groups} objectTypeName={objectTypeLabel} />
         </aside>
       </div>

--- a/apps/admin/src/features/catalog/products/components/variants-list-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/variants-list-card.tsx
@@ -22,6 +22,12 @@ export interface VariantsListCardProps {
   masterProductId: string;
   onSelectVariant?: (variantId: string) => void;
   onCreateVariant?: () => void;
+  /**
+   * #1274 — poly-kind base path. `/api/products` keeps the legacy product
+   * sidebar unchanged; the universal object card passes `/api/objects` so
+   * custom ObjectTypes list their variants the same way.
+   */
+  basePath?: string;
 }
 
 /**
@@ -35,6 +41,7 @@ export function VariantsListCard({
   masterProductId,
   onSelectVariant,
   onCreateVariant,
+  basePath = '/api/products',
 }: VariantsListCardProps) {
   const { t } = useTranslation();
   const [variants, setVariants] = useState<VariantRow[]>([]);
@@ -43,7 +50,7 @@ export function VariantsListCard({
   useEffect(() => {
     let cancelled = false;
     if (masterProductId === '') return;
-    jsonFetch<VariantsResponse>(`/api/products?parent_id=${masterProductId}`)
+    jsonFetch<VariantsResponse>(`${basePath}?parent_id=${masterProductId}`)
       .then((body) => {
         if (cancelled) return;
         const list = body.member ?? body['hydra:member'] ?? [];
@@ -56,7 +63,7 @@ export function VariantsListCard({
     return () => {
       cancelled = true;
     };
-  }, [masterProductId]);
+  }, [masterProductId, basePath]);
 
   return (
     <Card className="rounded-2xl border-line bg-surface p-5 soft-shadow">


### PR DESCRIPTION
## Kontekst
Closes #1274. Domyka parytet wariantów custom ObjectType zapoczątkowany w #1273 (PR #1275). **Bazuje na branchu #1273** — po jego merge'u base PR-a auto-retargetuje się na `main`.

Karta produktu ma w prawym sidebarze kartę „Warianty" (liczba + quick-nav + „Nowy wariant"). Karta custom ObjectType (`/objects/{slug}/{id}`) miała tylko `EffectiveModelCard`.

## Zmiany
- `variants-list-card.tsx`: nowy prop `basePath` (default `/api/products` — sidebar produktu bez zmiany). Repoint kolekcji `?parent_id` na `${basePath}`.
- `universal-detail-page.tsx`: w sidebarze renderuje `VariantsListCard` z `basePath="/api/objects"` gdy `hasVariants`. Quick-nav wiersza → `/objects/{objectTypeCode}/{variantId}`; „Nowy wariant" przełącza na zakładkę „Warianty" (gdzie jest generator z #1273).

## Test / smoke (na żywym stacku)
Nowy E2E `1274-variants-sidebar-card-custom-object-type.spec.ts` (zielony lokalnie): tworzy custom OT z `hasVariants` + master + 2 warianty przez `POST /api/objects/{master}/generate-variants` → nawiguje na kartę → asercja: karta „Warianty" w sidebarze pokazuje licznik `2`, klik wiersza wariantu routuje na `/objects/{slug}/{variantId}`.

Bramki: TypeScript `noEmit` 0, Biome strict 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)