### PR TITLE
fix(exports): deduplicate scopable attributes in column picker (#1278)

### DIFF
--- a/apps/admin/e2e/exports.spec.ts
+++ b/apps/admin/e2e/exports.spec.ts
@@ -211,6 +211,14 @@ test('#1278 scopable attribute appears once in column picker (no duplicate)', as
   // "Nowy eksport" link. This avoids a second full-page reload and keeps
   // the JWT alive so the attribute catalog API call is authenticated.
   await loginAsAdmin(page);
+
+  // Register the response listener BEFORE navigating so we don't miss
+  // the attributes fetch that fires immediately when the dialog mounts.
+  const attrsResponsePromise = page.waitForResponse(
+    (r) => r.url().includes('/api/attributes') && r.status() === 200,
+    { timeout: 30_000 },
+  );
+
   await page.goto('/integrations/exports');
   await page.getByRole('link', { name: /nowy eksport|new export/i }).click();
   await expect(page).toHaveURL(/\/integrations\/exports\/new$/);
@@ -218,20 +226,16 @@ test('#1278 scopable attribute appears once in column picker (no duplicate)', as
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible({ timeout: 10_000 });
 
-  // The DOSTĘPNE pane is the first <section> inside the ColumnPicker grid,
-  // identified by its aria-label so we don't accidentally grab the "Języki"
-  // or "Kanały" sections that the export form renders above the picker.
+  // The DOSTĘPNE pane is identified by its aria-label so we don't grab
+  // the "Języki" or "Kanały" sections that sit above the column picker.
   const available = dialog.getByRole('region', {
     name: /dostępne kolumny|available columns/i,
   });
   await expect(available).toBeVisible();
 
-  // Wait for the attributes fetch to succeed (fired by useExportColumnCatalog
-  // when the dialog mounts). After the first 401 jsonFetch retries via refresh;
-  // we wait for the final 200 response.
-  await page.waitForResponse((r) => r.url().includes('/api/attributes') && r.status() === 200, {
-    timeout: 15_000,
-  });
+  // Wait for the attributes fetch to complete (fired by useExportColumnCatalog
+  // on dialog mount; jsonFetch retries on 401 via silent refresh).
+  await attrsResponsePromise;
 
   // Once attributes are fetched, React re-renders the catalog. The "name"
   // code label (locale-group header) must be in the DOM; it may sit below

--- a/apps/admin/e2e/exports.spec.ts
+++ b/apps/admin/e2e/exports.spec.ts
@@ -198,3 +198,51 @@ test('#1244 grouped locale columns — expand group, select PL only lands in WYB
   await expect(dialog.getByText('description.pl')).toBeVisible();
   await expect(dialog.getByText('description.en')).not.toBeVisible();
 });
+
+test('#1278 scopable attribute appears once in column picker (no duplicate)', async ({ page }) => {
+  // Uses real DB data — demo fixture has 4 scopable attributes (name, price,
+  // short_description, color) and 1 channel (allegro). Before the fix,
+  // buildVisualGroups rendered scopable attrs as two separate flat items:
+  // a bare row (code "name") + a channel row (code "name.allegro").
+  // After the fix they are merged into one expandable group — the channel
+  // row (name.allegro) is collapsed inside the group and not directly visible.
+  //
+  // Mirrors the hub MVP test: loginAsAdmin → goto exports hub → click
+  // "Nowy eksport" link. This avoids a second full-page reload and keeps
+  // the JWT alive so the attribute catalog API call is authenticated.
+  await loginAsAdmin(page);
+  await page.goto('/integrations/exports');
+  await page.getByRole('link', { name: /nowy eksport|new export/i }).click();
+  await expect(page).toHaveURL(/\/integrations\/exports\/new$/);
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+  // The DOSTĘPNE pane is the first <section> inside the ColumnPicker grid,
+  // identified by its aria-label so we don't accidentally grab the "Języki"
+  // or "Kanały" sections that the export form renders above the picker.
+  const available = dialog.getByRole('region', {
+    name: /dostępne kolumny|available columns/i,
+  });
+  await expect(available).toBeVisible();
+
+  // Wait for the attributes fetch to succeed (fired by useExportColumnCatalog
+  // when the dialog mounts). After the first 401 jsonFetch retries via refresh;
+  // we wait for the final 200 response.
+  await page.waitForResponse((r) => r.url().includes('/api/attributes') && r.status() === 200, {
+    timeout: 15_000,
+  });
+
+  // Once attributes are fetched, React re-renders the catalog. The "name"
+  // code label (locale-group header) must be in the DOM; it may sit below
+  // the 60vh scroll fold so we use toBeAttached rather than toBeVisible.
+  await expect(available.locator('code').filter({ hasText: /^name$/ })).toBeAttached({
+    timeout: 5_000,
+  });
+
+  // WITH my fix: "name" (bare + locale cols + channel col) are merged into one
+  // locale-group → <code>name</code> appears exactly ONCE (the group header).
+  // WITHOUT the fix: bare "name" renders as a flat item (extra <code>name</code>),
+  // making it appear TWICE alongside the locale-group header.
+  await expect(available.locator('code').filter({ hasText: /^name$/ })).toHaveCount(1);
+});

--- a/apps/admin/src/features/exports/components/ColumnPicker.tsx
+++ b/apps/admin/src/features/exports/components/ColumnPicker.tsx
@@ -94,6 +94,18 @@ function buildVisualGroups(columns: ColumnOption[]): VisualItem[] {
       if (!byParent.has(parent)) {
         byParent.set(parent, []);
         order.push(parent);
+        // Scopable attributes emit [bare, ...channelCols]. If the bare key was
+        // already queued as __bare__X, absorb it as the first variant so that
+        // the attribute appears exactly once (as a group) rather than twice
+        // (flat bare + expandable channel group).
+        const bareKey = `__bare__${parent}`;
+        if (byParent.has(bareKey)) {
+          // biome-ignore lint/style/noNonNullAssertion: checked above
+          byParent.get(parent)!.push(...byParent.get(bareKey)!);
+          byParent.delete(bareKey);
+          const idx = order.indexOf(bareKey);
+          if (idx !== -1) order.splice(idx, 1);
+        }
       }
       // biome-ignore lint/style/noNonNullAssertion: guaranteed to exist
       byParent.get(parent)!.push(col);


### PR DESCRIPTION
## Summary

Atrybuty scopable (np. Nazwa, Cena) pojawiały się dwukrotnie w liście "DOSTĘPNE" w konfiguratorze eksportu — raz jako płaski checkbox i raz jako expandowalna grupa per-kanałowych wariantów. Po fixie każdy atrybut pojawia się dokładnie raz jako jedna expandowalna grupa.

## Root cause

`attrToOptions` poprawnie emituje `[bare, ...channelCols]` dla scopable atrybutów (bare = global/channel=null value). Błąd był w `buildVisualGroups` (`ColumnPicker.tsx`): bare key (bez `.`) lądował w buckecie `__bare__name`, a channel variants (`name.allegro` etc.) w buckecie `name`. Funkcja renderowała dwa osobne visual items zamiast jednego.

## Frontend changes

- **`ColumnPicker.tsx` – `buildVisualGroups`**: gdy napotkamy pierwszą channel variant i w bucketach istnieje już `__bare__X`, absorbujemy bare column jako pierwszy element grupy channel variants. Logika renderowania (locale-group vs flat) pozostaje bez zmian.
- **`exports.spec.ts`**: nowy test `#1278` weryfikujący że scopable atrybut `name` pojawia się dokładnie raz (`<code>name</code>` count=1 w DOSTĘPNE pane).

## Backend changes

Brak — bug był wyłącznie w warstwie renderowania UI.

## Quality gates

| Gate | Result |
|------|--------|
| Biome strict | ✅ 0 errors |
| Typecheck | ✅ 0 errors |
| Build | ✅ success |
| Playwright `exports.spec.ts` | ✅ 2 passed (hub MVP + #1278), 2 skipped, 1 pre-existing fail (`async 202` — auth refresh issue, niezwiązane z tą zmianą) |
| pnpm audit | ✅ 0 high/critical |

## Smoke test plan

- [ ] Login `admin@demo.localhost / changeme`
- [ ] Otwórz `/integrations/exports/new`
- [ ] W sekcji "Kolumny" → "DOSTĘPNE" — "Nazwa" i "Cena" pojawiają się dokładnie raz (nie 2x)
- [ ] Kliknij `>` przy "Nazwa" — rozwijają się warianty (globalna + per-locale + per-kanałowe)
- [ ] DevTools Console — brak czerwonych errorów

## Świadome odejścia

Brak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)