### PR TITLE
fix(channel): formularz kanału używa locale tenanta + fix scrolla modala locale

### DIFF
--- a/apps/admin/e2e/1280-channel-locales-modal-scroll.spec.ts
+++ b/apps/admin/e2e/1280-channel-locales-modal-scroll.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1280 — two settings-localization UX fixes:
+ *
+ *  1. The channel create form locale picker offers only the tenant's ACTIVE
+ *     locales (pl_PL + en_US for the demo tenant), not the global ISO catalog
+ *     (`de_DE` and friends must be absent).
+ *  2. The "Add locale" modal scroll container actually scrolls — the catalog
+ *     overflows its box (`scrollHeight > clientHeight`) and a deep row past the
+ *     popular section is reachable.
+ *
+ * `test.fixme` in CI for the shared auth-rate-limiter storageState gap (same
+ * pattern as #1263 / settings-channels-crud).
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test.describe('#1280 — channel locale picker + add-locale modal scroll', () => {
+  test('channel form locale picker lists only active tenant locales', async ({ page }) => {
+    test.fixme(!!process.env.CI, CI_BLOCKED);
+    test.setTimeout(120_000);
+
+    await loginAsAdmin(page);
+    await page.goto('/settings/channels/new');
+
+    const localesFieldset = page.locator('fieldset[aria-labelledby="channel-locales-label"]');
+    await expect(localesFieldset).toBeVisible();
+
+    // Demo tenant has pl_PL + en_US active.
+    await expect(localesFieldset.getByRole('button', { name: /pl_PL/ })).toBeVisible();
+    await expect(localesFieldset.getByRole('button', { name: /en_US/ })).toBeVisible();
+
+    // The global ISO catalog (de_DE, it_IT, fr_FR…) must NOT leak into the
+    // picker — only the tenant's activated subset is offered.
+    await expect(localesFieldset.getByRole('button', { name: /de_DE/ })).toHaveCount(0);
+    await expect(localesFieldset.getByRole('button', { name: /it_IT/ })).toHaveCount(0);
+  });
+
+  test('add-locale modal catalog scrolls past the popular section', async ({ page }) => {
+    test.fixme(!!process.env.CI, CI_BLOCKED);
+    test.setTimeout(120_000);
+
+    await loginAsAdmin(page);
+    await page.goto('/settings/locales');
+
+    await page.getByRole('button', { name: /dodaj lokalizacj|add locale/i }).click();
+
+    const scroll = page.getByTestId('locale-catalog-scroll');
+    await expect(scroll).toBeVisible();
+
+    // Catalog overflows its container → the box is genuinely scrollable.
+    const { scrollHeight, clientHeight } = await scroll.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+    expect(scrollHeight).toBeGreaterThan(clientHeight);
+
+    // The last catalog row is reachable by scrolling (the bug: it was clipped).
+    const lastRow = scroll.getByRole('button').last();
+    await lastRow.scrollIntoViewIfNeeded();
+    await expect(lastRow).toBeInViewport();
+  });
+});

--- a/apps/admin/src/features/channel/channels/locale-picker.tsx
+++ b/apps/admin/src/features/channel/channels/locale-picker.tsx
@@ -1,15 +1,14 @@
-import { useList } from '@refinedev/core';
+import { useQuery } from '@tanstack/react-query';
 import { Check, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
+import type {
+  TenantLocaleListItem,
+  TenantLocaleListResponse,
+} from '@/features/settings/locales/types';
+import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
-
-interface LocaleRow {
-  id: string;
-  code: string;
-  label: string;
-}
 
 interface LocalePickerProps {
   value: string[];
@@ -17,15 +16,27 @@ interface LocalePickerProps {
   ariaLabelledBy?: string;
 }
 
+/**
+ * Channel locale picker. Offers only the tenant's ACTIVE locales (configured
+ * under `/settings/locales`), not the global ISO catalog. The catalog lives at
+ * `GET /api/locales`; the tenant's activated subset is `GET /api/tenant-locales`
+ * (custom controller → `{items: [...]}`, hence `jsonFetch` rather than Refine's
+ * Hydra-shaped `useList`).
+ */
 export function LocalePicker({ value, onChange, ariaLabelledBy }: LocalePickerProps) {
-  const { t } = useTranslation();
-  const { result, query } = useList<LocaleRow>({
-    resource: 'locales',
-    pagination: { mode: 'off' },
+  const { t, i18n } = useTranslation();
+  const { data, isLoading } = useQuery({
+    queryKey: ['channel-form', 'tenant-locales'],
+    queryFn: () =>
+      jsonFetch<TenantLocaleListResponse>('/api/tenant-locales', {
+        accept: 'application/json',
+      }),
   });
 
-  const locales = result.data;
-  const isLoading = query.isLoading;
+  const locales = (data?.items ?? []).filter((l) => l.isActive);
+
+  const labelFor = (locale: TenantLocaleListItem) =>
+    locale.displayName?.[i18n.language] ?? locale.displayName?.en ?? locale.label;
 
   const toggle = (code: string) => {
     if (value.includes(code)) {
@@ -90,7 +101,7 @@ export function LocalePicker({ value, onChange, ariaLabelledBy }: LocalePickerPr
                 >
                   <Check className={cn('size-3.5', !checked && 'opacity-0')} />
                   <span>{locale.code}</span>
-                  <span className="ml-2 text-[11px] text-muted-foreground">{locale.label}</span>
+                  <span className="ml-2 text-[11px] text-muted-foreground">{labelFor(locale)}</span>
                 </Button>
               );
             })}

--- a/apps/admin/src/features/settings/locales/AddLocaleModal.tsx
+++ b/apps/admin/src/features/settings/locales/AddLocaleModal.tsx
@@ -155,13 +155,16 @@ export function AddLocaleModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[85vh] max-w-2xl overflow-hidden p-0">
+      <DialogContent className="flex max-h-[85vh] max-w-2xl flex-col overflow-hidden p-0">
         <DialogHeader className="border-b px-6 py-4">
           <DialogTitle>{t('settings.locales.add_modal.title')}</DialogTitle>
           <DialogDescription>{t('settings.locales.add_modal.intro')}</DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4 overflow-y-auto px-6 py-4">
+        <div
+          data-testid="locale-catalog-scroll"
+          className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4"
+        >
           <div className="relative">
             <Search
               className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"


### PR DESCRIPTION
## Summary

Dwie poprawki UX w ustawieniach lokalizacji (zgłoszone po manual smoke teście, #1280):

1. Formularz tworzenia kanału (`/settings/channels/new`) — picker wersji językowych pokazywał **pełny katalog ISO**; teraz oferuje **tylko aktywne locale tenanta** (skonfigurowane w `/settings/locales`).
2. Modal „Dodaj lokalizację" (`/settings/locales`) — lista **nie scrollowała się** (nie dało się wybrać nic poniżej `es_ES`); teraz scrolluje poprawnie.

## Root cause

- `LocalePicker` pobierał `useList({ resource: 'locales' })` → `GET /api/locales` (globalny katalog ISO, to samo źródło, którego modal dodawania używa z flagą `popular`). Aktywowane locale tenanta są pod `GET /api/tenant-locales`.
- `AddLocaleModal` — `DialogContent` miał `max-h-[85vh] overflow-hidden`, ale nie był `flex flex-col`, a scroll-div miał `overflow-y-auto` bez `flex-1`/`min-h-0` → kontener rozpychany treścią i przycinany.

## Frontend changes

- `locale-picker.tsx` — `useQuery` + `jsonFetch('/api/tenant-locales')`, filtr `isActive`, reużycie typu `TenantLocaleListItem`, label z `displayName[lang]`.
- `AddLocaleModal.tsx` — `DialogContent` → `flex … flex-col`; scroll-div → `flex-1 min-h-0 …` + `data-testid` dla testu.
- `e2e/1280-…spec.ts` — picker = tylko locale tenanta (brak `de_DE`/`it_IT`); modal `scrollHeight > clientHeight` + deep row osiągalny.

## Backend changes

Brak — czysto FE.

## Quality gates

- typecheck: 0; Biome lint: 0 (6 pre-existing warnings poza dotkniętymi plikami); build: OK.
- Playwright `e2e/1280`: **2/2 zielone** na żywym stacku (`scrollHeight 692 > clientHeight 404`, dialog 612px=85vh).
- pnpm audit: 0 high/critical (1 pre-existing moderate).

## Smoke test plan (operator po merge)

1. Login admin@demo.localhost / changeme.
2. `/settings/channels/new` → picker locale = tylko aktywne tenanta (pl_PL, en_US).
3. Aktywuj nowe locale w `/settings/locales` → pojawia się w pickerze kanału.
4. `/settings/locales` → „Dodaj lokalizację" → scroll poniżej es_ES działa, deep row klikalny.
5. DevTools Console bez błędów.

**Status: smoke-tested end-to-end** lokalnie przez Playwright na żywym stacku (oba flow). Operator-side manual smoke wg planu powyżej.

## Świadome odejścia

- RBAC: `GET /api/tenant-locales` gated `settings.locales.manage`. User z `settings.channels.manage` bez locale-manage dostałby 403 na pickerze — do osobnego RBAC ticketu (rozszerzenie GET do read-grant). Owner (obecny use case) ma oba uprawnienia.

Closes #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
