### PR TITLE
feat(channel): object_channel_placements table + repository [CHC-02]

### DIFF
--- a/apps/api/migrations/Version20260606130000.php
+++ b/apps/api/migrations/Version20260606130000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * CHC-02 (#1285) — object_channel_placements.
+ *
+ * Where a product lands in a channel's navigation tree. Separate from the
+ * master `object_categories` pivot (different semantics). One placement per
+ * (object, channel); `source` distinguishes manual vs auto-assigned (CHC-07).
+ */
+final class Version20260606130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'CHC-02: create object_channel_placements (product → channel navigation node)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE object_channel_placements (id UUID NOT NULL, tenant_id UUID NOT NULL, object_id UUID NOT NULL, channel_id UUID NOT NULL, channel_category_node_id UUID NOT NULL, source VARCHAR(16) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('ALTER TABLE object_channel_placements ADD CONSTRAINT ocp_tenant_fk FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE object_channel_placements ADD CONSTRAINT ocp_object_fk FOREIGN KEY (object_id) REFERENCES objects (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE object_channel_placements ADD CONSTRAINT ocp_channel_fk FOREIGN KEY (channel_id) REFERENCES channels (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE object_channel_placements ADD CONSTRAINT ocp_node_fk FOREIGN KEY (channel_category_node_id) REFERENCES channel_category_nodes (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE UNIQUE INDEX object_channel_placements_tenant_object_channel_uniq ON object_channel_placements (tenant_id, object_id, channel_id)');
+        $this->addSql('CREATE INDEX ocp_object_idx ON object_channel_placements (object_id)');
+        $this->addSql('CREATE INDEX ocp_channel_idx ON object_channel_placements (channel_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE object_channel_placements');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -108,6 +108,7 @@ parameters:
               - src/Catalog/Domain/Entity/BulkSession.php
               - src/Channel/Domain/Entity/Channel.php
               - src/Channel/Domain/Entity/ChannelCategoryNode.php
+              - src/Channel/Domain/Entity/ObjectChannelPlacement.php
               - src/Asset/Domain/Entity/Asset.php
               - src/ApiConfigurator/Domain/Entity/ApiProfile.php
               - src/ApiConfigurator/Domain/Entity/ApiKey.php

--- a/apps/api/src/Channel/Domain/ChannelPlacementSource.php
+++ b/apps/api/src/Channel/Domain/ChannelPlacementSource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain;
+
+/**
+ * Provenance of an {@see Entity\ObjectChannelPlacement}
+ * (CHC-02). `manual` placements are operator-set and win over `auto` ones
+ * created by node-mapping auto-assignment (CHC-07).
+ */
+enum ChannelPlacementSource: string
+{
+    case Manual = 'manual';
+    case Auto = 'auto';
+}

--- a/apps/api/src/Channel/Domain/Entity/ObjectChannelPlacement.php
+++ b/apps/api/src/Channel/Domain/Entity/ObjectChannelPlacement.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Entity;
+
+use App\Channel\Domain\ChannelPlacementSource;
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Where a product lands in a channel's navigation tree (CHC-02).
+ *
+ * A separate concept from master category assignment (`object_categories`):
+ * different semantics, different table. Tells the integration which channel
+ * navigation node a product belongs to. One placement per (object, channel).
+ *
+ * `objectId` is a soft FK to `objects.id` (a Catalog `CatalogObject`) — kept
+ * as a bare Uuid so the Channel context stays free of cross-BC entity imports
+ * (deptrac); the schema-level FK still keeps orphans out.
+ */
+class ObjectChannelPlacement implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Uuid $objectId;
+
+    private Channel $channel;
+
+    private ChannelCategoryNode $node;
+
+    private ChannelPlacementSource $source;
+
+    private DateTimeImmutable $createdAt;
+
+    private DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Uuid $objectId,
+        Channel $channel,
+        ChannelCategoryNode $node,
+        ChannelPlacementSource $source = ChannelPlacementSource::Manual,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->objectId = $objectId;
+        $this->channel = $channel;
+        $this->node = $node;
+        $this->source = $source;
+        $now = new DateTimeImmutable();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getObjectId(): Uuid
+    {
+        return $this->objectId;
+    }
+
+    public function getChannel(): Channel
+    {
+        return $this->channel;
+    }
+
+    public function getChannelId(): Uuid
+    {
+        return $this->channel->getId();
+    }
+
+    public function getNode(): ChannelCategoryNode
+    {
+        return $this->node;
+    }
+
+    public function getNodeId(): Uuid
+    {
+        return $this->node->getId();
+    }
+
+    public function getSource(): ChannelPlacementSource
+    {
+        return $this->source;
+    }
+
+    public function reassign(ChannelCategoryNode $node, ChannelPlacementSource $source): void
+    {
+        $this->node = $node;
+        $this->source = $source;
+        $this->updatedAt = new DateTimeImmutable();
+    }
+
+    public function getCreatedAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+}

--- a/apps/api/src/Channel/Domain/Repository/ObjectChannelPlacementRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/ObjectChannelPlacementRepositoryInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Repository;
+
+use App\Channel\Domain\ChannelPlacementSource;
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNode;
+use App\Channel\Domain\Entity\ObjectChannelPlacement;
+use Symfony\Component\Uid\Uuid;
+
+interface ObjectChannelPlacementRepositoryInterface
+{
+    /**
+     * All placements of a product across every channel.
+     *
+     * @return list<ObjectChannelPlacement>
+     */
+    public function findByObject(Uuid $objectId): array;
+
+    public function findByObjectAndChannel(Uuid $objectId, Uuid $channelId): ?ObjectChannelPlacement;
+
+    /**
+     * Create the (object, channel) placement or re-point an existing one.
+     */
+    public function upsert(
+        Uuid $objectId,
+        Channel $channel,
+        ChannelCategoryNode $node,
+        ChannelPlacementSource $source,
+    ): ObjectChannelPlacement;
+
+    public function save(ObjectChannelPlacement $placement): void;
+
+    public function remove(ObjectChannelPlacement $placement): void;
+}

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ObjectChannelPlacement.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ObjectChannelPlacement.orm.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Channel\Domain\Entity\ObjectChannelPlacement"
+            table="object_channel_placements"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\DoctrineObjectChannelPlacementRepository">
+
+        <unique-constraints>
+            <unique-constraint name="object_channel_placements_tenant_object_channel_uniq" columns="tenant_id,object_id,channel_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="ocp_object_idx" columns="object_id"/>
+            <index name="ocp_channel_idx" columns="channel_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="channel" target-entity="App\Channel\Domain\Entity\Channel">
+            <join-column name="channel_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="node" target-entity="App\Channel\Domain\Entity\ChannelCategoryNode">
+            <join-column name="channel_category_node_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="objectId" type="uuid" column="object_id"/>
+        <field name="source" type="string" length="16" enum-type="App\Channel\Domain\ChannelPlacementSource"/>
+        <field name="createdAt" type="datetime_immutable" column="created_at"/>
+        <field name="updatedAt" type="datetime_immutable" column="updated_at"/>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineObjectChannelPlacementRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineObjectChannelPlacementRepository.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure\Doctrine\Repository;
+
+use App\Channel\Domain\ChannelPlacementSource;
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNode;
+use App\Channel\Domain\Entity\ObjectChannelPlacement;
+use App\Channel\Domain\Repository\ObjectChannelPlacementRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<ObjectChannelPlacement>
+ */
+class DoctrineObjectChannelPlacementRepository extends ServiceEntityRepository implements ObjectChannelPlacementRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ObjectChannelPlacement::class);
+    }
+
+    /**
+     * @return list<ObjectChannelPlacement>
+     */
+    public function findByObject(Uuid $objectId): array
+    {
+        return $this->findBy(['objectId' => $objectId], ['channel' => 'ASC']);
+    }
+
+    public function findByObjectAndChannel(Uuid $objectId, Uuid $channelId): ?ObjectChannelPlacement
+    {
+        $result = $this->createQueryBuilder('p')
+            ->andWhere('p.objectId = :objectId')
+            ->andWhere('IDENTITY(p.channel) = :channelId')
+            ->setParameter('objectId', $objectId, 'uuid')
+            ->setParameter('channelId', $channelId, 'uuid')
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof ObjectChannelPlacement ? $result : null;
+    }
+
+    public function upsert(
+        Uuid $objectId,
+        Channel $channel,
+        ChannelCategoryNode $node,
+        ChannelPlacementSource $source,
+    ): ObjectChannelPlacement {
+        $existing = $this->findByObjectAndChannel($objectId, $channel->getId());
+        if (null !== $existing) {
+            $existing->reassign($node, $source);
+            $this->save($existing);
+
+            return $existing;
+        }
+
+        $placement = new ObjectChannelPlacement($objectId, $channel, $node, $source);
+        $this->save($placement);
+
+        return $placement;
+    }
+
+    public function save(ObjectChannelPlacement $placement): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($placement);
+        $em->flush();
+    }
+
+    public function remove(ObjectChannelPlacement $placement): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($placement);
+        $em->flush();
+    }
+}

--- a/apps/api/tests/Integration/Channel/ObjectChannelPlacementRepositoryTest.php
+++ b/apps/api/tests/Integration/Channel/ObjectChannelPlacementRepositoryTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Channel;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Domain\ChannelPlacementSource;
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNode;
+use App\Channel\Domain\Repository\ObjectChannelPlacementRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * CHC-02 (#1285) — ObjectChannelPlacement repository behaviour.
+ */
+final class ObjectChannelPlacementRepositoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($this->tenant);
+    }
+
+    #[Test]
+    public function upsertCreatesPlacement(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $channel = $this->makeChannel('allegro');
+        $node = $this->makeRoot($channel);
+
+        $placement = $this->repo()->upsert($product->getId(), $channel, $node, ChannelPlacementSource::Manual);
+
+        self::assertTrue($placement->getObjectId()->equals($product->getId()));
+        self::assertTrue($placement->getNodeId()->equals($node->getId()));
+        self::assertSame(ChannelPlacementSource::Manual, $placement->getSource());
+
+        $found = $this->repo()->findByObjectAndChannel($product->getId(), $channel->getId());
+        self::assertNotNull($found);
+        self::assertTrue($found->getId()->equals($placement->getId()));
+    }
+
+    #[Test]
+    public function upsertOnSameObjectAndChannelUpdatesWithoutDuplicating(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $channel = $this->makeChannel('allegro');
+        $root = $this->makeRoot($channel);
+        $child = $this->makeChild($channel, $root, 'telewizory');
+
+        $this->repo()->upsert($product->getId(), $channel, $root, ChannelPlacementSource::Manual);
+        $this->repo()->upsert($product->getId(), $channel, $child, ChannelPlacementSource::Auto);
+
+        $all = $this->repo()->findByObject($product->getId());
+        self::assertCount(1, $all);
+        self::assertTrue($all[0]->getNodeId()->equals($child->getId()));
+        self::assertSame(ChannelPlacementSource::Auto, $all[0]->getSource());
+    }
+
+    #[Test]
+    public function findByObjectReturnsEveryChannelPlacement(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $allegro = $this->makeChannel('allegro');
+        $shopify = $this->makeChannel('shopify');
+
+        $this->repo()->upsert($product->getId(), $allegro, $this->makeRoot($allegro), ChannelPlacementSource::Manual);
+        $this->repo()->upsert($product->getId(), $shopify, $this->makeRoot($shopify), ChannelPlacementSource::Manual);
+
+        self::assertCount(2, $this->repo()->findByObject($product->getId()));
+    }
+
+    #[Test]
+    public function removeDeletesPlacement(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $channel = $this->makeChannel('allegro');
+        $placement = $this->repo()->upsert($product->getId(), $channel, $this->makeRoot($channel), ChannelPlacementSource::Manual);
+
+        $this->repo()->remove($placement);
+
+        self::assertNull($this->repo()->findByObjectAndChannel($product->getId(), $channel->getId()));
+        self::assertCount(0, $this->repo()->findByObject($product->getId()));
+    }
+
+    private function repo(): ObjectChannelPlacementRepositoryInterface
+    {
+        return self::getContainer()->get(ObjectChannelPlacementRepositoryInterface::class);
+    }
+
+    private function makeProduct(string $sku): CatalogObject
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $this->tenant);
+        \assert(null !== $type);
+        $product = new CatalogObject($type, $sku);
+        $em = $this->em();
+        $em->persist($product);
+        $em->flush();
+
+        return $product;
+    }
+
+    private function makeChannel(string $code): Channel
+    {
+        $channel = new Channel($code, ['pl' => $code]);
+        $em = $this->em();
+        $em->persist($channel);
+        $em->flush();
+
+        return $channel;
+    }
+
+    private function makeRoot(Channel $channel): ChannelCategoryNode
+    {
+        $node = new ChannelCategoryNode($channel, 'root', ['pl' => 'Root']);
+        $node->attachToPath($node->ltreeLabel());
+        $em = $this->em();
+        $em->persist($node);
+        $em->flush();
+
+        return $node;
+    }
+
+    private function makeChild(Channel $channel, ChannelCategoryNode $parent, string $code): ChannelCategoryNode
+    {
+        $node = new ChannelCategoryNode($channel, $code, ['pl' => $code], $parent);
+        $node->attachToPath($parent->getPath().'.'.$node->ltreeLabel());
+        $em = $this->em();
+        $em->persist($node);
+        $em->flush();
+
+        return $node;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}


### PR DESCRIPTION
## Cel

CHC-02 (#1285) — produkt musi wiedzieć, w którym węźle nawigacyjnym kanału się znajduje (żeby integracja wiedziała, gdzie go wysłać). To **odrębny byt** od przypisania do kategorii master — inna semantyka, osobna tabela `object_channel_placements`. Tabela `object_categories` pozostaje **nietknięta**. Substrate pod CHC-03 (inline w zakładce „Kategorie") i CHC-07 (auto-assignment).

## Zakres

- Encja `ObjectChannelPlacement` (`TenantScoped`) + enum `ChannelPlacementSource` (`manual`/`auto`) + ORM XML.
- Migracja `Version20260606130000`: tabela z FK tenant/object/channel/`channel_category_node` (`ON DELETE CASCADE`), `UNIQUE (tenant_id, object_id, channel_id)` (jeden placement per produkt per kanał), indeksy na `object_id` + `channel_id`.
- `object_id` to **soft FK Uuid** do `objects.id` — Channel BC nie importuje encji Catalog (deptrac clean, bez nowych skipów); FK schematu trzyma spójność.
- Repozytorium `ObjectChannelPlacementRepository`: `findByObject(Uuid)`, `findByObjectAndChannel(Uuid, Uuid)`, `upsert(...)` (create-or-repoint).
- `object_categories` / `ObjectCategoryRepository::findPrimary()` — **zero zmian**.

## Definicja Done (CI) — lokalnie zielone

- [x] `PHPStan max` — 0 errors
- [x] `Deptrac` — 0 violations (bez nowych skipów; `object_id` jako Uuid utrzymuje izolację Channel↔Catalog)
- [x] `PHP-CS-Fixer` — stabilny · `raw-sql-lint` — clean
- [x] `PHPUnit` — `ObjectChannelPlacementRepositoryTest` 4/4 (11 asercji): upsert create/update, multi-channel, remove, invariant jeden-per-(object,channel)
- [x] Brak zmian API (encja nie jest AP resource) → OpenAPI snapshot bez zmian · brak zmian FE

## Powiązania

- Refs #1285 · Blocked by #1284 (✅ merged) · Blokuje #1286 (CHC-03)
- Epik: `epik-CHC` · Spec: `Project Plan/CHC-channel-categories-tickets.md` → CHC-02
