### PR TITLE
feat(channel): channel placements inline in product Kategorie tab [CHC-03]

### DIFF
--- a/apps/admin/e2e/chc-03-channel-placements.spec.ts
+++ b/apps/admin/e2e/chc-03-channel-placements.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * CHC-03 (#1286) — "Gdzie trafia na kanałach" section in the product
+ * "Kategorie" tab: assign a product to a channel navigation node.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other product
+ * detail UI specs (#1209) — runs locally against `pnpm stack:up`.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('assign a product to a channel navigation node from the Kategorie tab', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+  const json = { ...bearer, 'content-type': 'application/json', accept: 'application/json' };
+
+  // 1. A channel + a navigation tree (root + one node).
+  const channelsBody = (await (
+    await page.request.get('/api/channels', { headers: { ...bearer, accept: 'application/json' } })
+  ).json()) as { member?: Array<{ id: string }> } | Array<{ id: string }>;
+  const channels = Array.isArray(channelsBody) ? channelsBody : (channelsBody.member ?? []);
+  expect(channels.length).toBeGreaterThan(0);
+  const channelId = channels[0].id;
+
+  const rootResp = await page.request.post(`/api/channels/${channelId}/navigation-tree`, {
+    headers: json,
+    data: { label: { pl: 'Korzeń E2E' } },
+  });
+  // 201 on first run; 409 if a previous local run left a tree — reuse it then.
+  expect([201, 409]).toContain(rootResp.status());
+  const treeBody = (await (
+    await page.request.get(`/api/channels/${channelId}/navigation-tree`, {
+      headers: { ...bearer, accept: 'application/json' },
+    })
+  ).json()) as Array<{ id: string; parentId: string | null }>;
+  const rootId = treeBody.find((n) => n.parentId === null)?.id;
+  if (rootId === undefined) throw new Error('Navigation root missing after creation.');
+
+  await page.request.post(`/api/channels/${channelId}/navigation-tree/nodes`, {
+    headers: json,
+    data: { parentId: rootId, code: 'e2e_telewizory', label: { pl: 'E2E Telewizory' } },
+  });
+
+  // 2. A product to place.
+  const productsBody = (await (
+    await page.request.get('/api/products?itemsPerPage=1', {
+      headers: { ...bearer, accept: 'application/json' },
+    })
+  ).json()) as { member?: Array<{ id: string }> } | Array<{ id: string }>;
+  const products = Array.isArray(productsBody) ? productsBody : (productsBody.member ?? []);
+  expect(products.length).toBeGreaterThan(0);
+  const productId = products[0].id;
+
+  // 3. Open the product "Kategorie" tab.
+  await page.goto(`/products/${productId}`);
+  await page.getByRole('tab', { name: /kategorie/i }).click();
+
+  const section = page.getByText(/Gdzie trafia na kanałach/i);
+  await expect(section).toBeVisible();
+
+  // 4. Assign the node via the picker dialog.
+  await page
+    .getByRole('button', { name: /^(Przypisz|Nadpisz)$/ })
+    .first()
+    .click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: /E2E Telewizory/i }).click();
+
+  const putResponse = page.waitForResponse(
+    (r) => r.url().includes(`/channel-placements/${channelId}`) && r.request().method() === 'PUT',
+  );
+  await dialog.getByRole('button', { name: /^Przypisz$/ }).click();
+  expect((await putResponse).status()).toBe(200);
+
+  // 5. The placement breadcrumb + manual marker surface in the row.
+  await expect(page.getByText(/E2E Telewizory/i)).toBeVisible();
+  await expect(page.getByText(/\(ręcznie\)/i)).toBeVisible();
+
+  // cleanup — remove the navigation tree we created (cascade).
+  await page.request.delete(`/api/channels/${channelId}/navigation-tree/nodes/${rootId}`, {
+    headers: bearer,
+  });
+});

--- a/apps/admin/src/features/catalog/products/components/categories-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/categories-tab.tsx
@@ -11,6 +11,8 @@ import { Button } from '@/components/ui/button';
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
+import { ChannelPlacementsSection } from './channel-placements-section';
+
 interface AssignmentRow {
   categoryId: string;
   code: string;
@@ -216,6 +218,8 @@ export function CategoriesTab({ productId }: Props) {
           })}
         </ul>
       )}
+
+      <ChannelPlacementsSection productId={productId} />
 
       <CategoryPickerDialog
         open={pickerOpen}

--- a/apps/admin/src/features/catalog/products/components/channel-node-picker-dialog.tsx
+++ b/apps/admin/src/features/catalog/products/components/channel-node-picker-dialog.tsx
@@ -1,0 +1,173 @@
+import { useQuery } from '@tanstack/react-query';
+import { FolderTree } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+interface NavNode {
+  id: string;
+  parentId: string | null;
+  code: string;
+  label: Record<string, string>;
+  path: string;
+}
+
+interface TreeNode extends NavNode {
+  depth: number;
+  children: TreeNode[];
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  channelId: string | null;
+  channelName: string;
+  onPick: (nodeId: string) => void | Promise<void>;
+}
+
+function resolveLabel(label: Record<string, string>, lang: string, code: string): string {
+  return label[lang] ?? label.pl ?? label.en ?? Object.values(label)[0] ?? code;
+}
+
+function buildTree(nodes: NavNode[]): TreeNode[] {
+  const byId = new Map<string, TreeNode>();
+  for (const node of nodes) {
+    byId.set(node.id, { ...node, depth: 0, children: [] });
+  }
+  const roots: TreeNode[] = [];
+  for (const node of byId.values()) {
+    if (node.parentId !== null && byId.has(node.parentId)) {
+      const parent = byId.get(node.parentId);
+      if (parent) {
+        node.depth = parent.depth + 1;
+        parent.children.push(node);
+      }
+    } else {
+      roots.push(node);
+    }
+  }
+  return roots;
+}
+
+function flatten(nodes: TreeNode[]): TreeNode[] {
+  const out: TreeNode[] = [];
+  const walk = (list: TreeNode[]): void => {
+    for (const node of list) {
+      out.push(node);
+      walk(node.children);
+    }
+  };
+  walk(nodes);
+  return out;
+}
+
+/**
+ * CHC-03 (#1286) — modal that renders a channel's navigation tree
+ * (`GET /api/channels/{id}/navigation-tree`) and lets the operator pick the
+ * node a product should land in.
+ */
+export function ChannelNodePickerDialog({
+  open,
+  onOpenChange,
+  channelId,
+  channelName,
+  onPick,
+}: Props) {
+  const { t, i18n } = useTranslation();
+  const [selected, setSelected] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['channels', channelId, 'navigation-tree'],
+    queryFn: async () =>
+      jsonFetch<NavNode[]>(`/api/channels/${channelId}/navigation-tree`, {
+        accept: 'application/json',
+      }),
+    enabled: open && channelId !== null,
+  });
+
+  const rows = data ? flatten(buildTree(data)) : [];
+
+  const handlePick = async (): Promise<void> => {
+    if (selected === null || saving) return;
+    setSaving(true);
+    try {
+      await onPick(selected);
+      onOpenChange(false);
+      setSelected(null);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setSelected(null);
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent className="max-w-xl">
+        <header className="mb-3 flex items-center gap-2">
+          <FolderTree className="size-4 text-violet-600" />
+          <h2 className="text-base font-semibold">
+            {t('products.detail.placements.picker_title', {
+              defaultValue: 'Wybierz węzeł — {{channel}}',
+              channel: channelName,
+            })}
+          </h2>
+        </header>
+
+        <div className="max-h-[55vh] overflow-y-auto rounded-xl border border-zinc-100 bg-white p-2">
+          {isLoading ? (
+            <p className="p-3 text-[12.5px] text-muted-foreground">
+              {t('app.loading', { defaultValue: 'Ładowanie…' })}
+            </p>
+          ) : rows.length === 0 ? (
+            <p className="p-3 text-[12.5px] text-muted-foreground">
+              {t('products.detail.placements.empty_tree', {
+                defaultValue: 'Ten kanał nie ma jeszcze drzewa nawigacyjnego.',
+              })}
+            </p>
+          ) : (
+            <ul>
+              {rows.map((node) => (
+                <li key={node.id}>
+                  <button
+                    type="button"
+                    onClick={() => setSelected(node.id)}
+                    style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded-lg py-1.5 pr-2 text-left text-[12.5px] hover:bg-zinc-50',
+                      selected === node.id && 'bg-violet-50 text-violet-900',
+                    )}
+                    aria-pressed={selected === node.id}
+                  >
+                    <FolderTree className="size-3.5 shrink-0 text-zinc-400" />
+                    <span className="font-medium">
+                      {resolveLabel(node.label, i18n.language, node.code)}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <footer className="mt-4 flex items-center justify-end gap-2">
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={saving}>
+            {t('app.cancel', { defaultValue: 'Anuluj' })}
+          </Button>
+          <Button onClick={() => void handlePick()} disabled={selected === null || saving}>
+            {t('products.detail.placements.assign', { defaultValue: 'Przypisz' })}
+          </Button>
+        </footer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/channel-placements-section.tsx
+++ b/apps/admin/src/features/catalog/products/components/channel-placements-section.tsx
@@ -1,0 +1,200 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, Radio } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import { ChannelNodePickerDialog } from './channel-node-picker-dialog';
+
+interface Placement {
+  nodeId: string;
+  nodePath: string;
+  source: 'manual' | 'auto';
+}
+
+interface PlacementRow {
+  channelId: string;
+  channelCode: string;
+  channelLabel: Record<string, string>;
+  placement: Placement | null;
+}
+
+interface ListResponse {
+  member: PlacementRow[];
+  totalItems: number;
+}
+
+interface Props {
+  productId: string;
+}
+
+const COLLAPSE_THRESHOLD = 5;
+
+function resolveLabel(label: Record<string, string>, lang: string, code: string): string {
+  return label[lang] ?? label.pl ?? label.en ?? Object.values(label)[0] ?? code;
+}
+
+/**
+ * CHC-03 (#1286) — "Gdzie trafia na kanałach" section inside the product
+ * "Kategorie" tab. One row per tenant channel showing the navigation node the
+ * product lands in (or a ⚠ when unmapped). Above {@link COLLAPSE_THRESHOLD}
+ * channels the list collapses to just the unmapped rows.
+ */
+export function ChannelPlacementsSection({ productId }: Props) {
+  const { t, i18n } = useTranslation();
+  const queryClient = useQueryClient();
+  const [pickerChannel, setPickerChannel] = useState<{ id: string; name: string } | null>(null);
+  const [busyChannelId, setBusyChannelId] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['products', productId, 'channel-placements'],
+    queryFn: async () =>
+      jsonFetch<ListResponse>(`/api/products/${productId}/channel-placements`, {
+        accept: 'application/json',
+      }),
+    enabled: productId !== '',
+  });
+
+  const rows = useMemo(() => data?.member ?? [], [data]);
+  const missingCount = rows.filter((r) => r.placement === null).length;
+  const collapsing = rows.length >= COLLAPSE_THRESHOLD && !expanded;
+  const visibleRows = collapsing ? rows.filter((r) => r.placement === null) : rows;
+
+  const refresh = async (): Promise<void> => {
+    await queryClient.invalidateQueries({
+      queryKey: ['products', productId, 'channel-placements'],
+    });
+  };
+
+  const assign = async (channelId: string, nodeId: string): Promise<void> => {
+    await jsonFetch(`/api/products/${productId}/channel-placements/${channelId}`, {
+      method: 'PUT',
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: { nodeId },
+    });
+    await refresh();
+  };
+
+  const restoreAuto = async (channelId: string): Promise<void> => {
+    if (busyChannelId !== null) return;
+    setBusyChannelId(channelId);
+    try {
+      await jsonFetch(`/api/products/${productId}/channel-placements/${channelId}`, {
+        method: 'DELETE',
+        accept: 'application/json',
+      });
+      await refresh();
+    } finally {
+      setBusyChannelId(null);
+    }
+  };
+
+  if (!isLoading && rows.length === 0) {
+    return null; // no channels configured for the tenant — nothing to place
+  }
+
+  return (
+    <section className="space-y-3 border-t border-line pt-4">
+      <header className="flex items-center justify-between">
+        <h4 className="flex items-center gap-1.5 text-[12.5px] font-semibold text-ink">
+          <Radio className="size-3.5 text-violet-600" />
+          {t('products.detail.placements.title', { defaultValue: 'Gdzie trafia na kanałach' })}
+        </h4>
+        {collapsing && missingCount < rows.length ? (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            className="text-[11.5px] font-medium text-violet-600 hover:underline"
+          >
+            {t('products.detail.placements.show_all', {
+              defaultValue: 'Pokaż wszystkie ({{count}})',
+              count: rows.length,
+            })}
+          </button>
+        ) : null}
+      </header>
+
+      {isLoading ? (
+        <p className="text-[12px] text-muted-foreground">
+          {t('app.loading', { defaultValue: 'Ładowanie…' })}
+        </p>
+      ) : (
+        <ul className="divide-y divide-line/60 rounded-xl border border-line">
+          {visibleRows.map((row) => {
+            const name = resolveLabel(row.channelLabel, i18n.language, row.channelCode);
+            const isBusy = busyChannelId === row.channelId;
+            return (
+              <li
+                key={row.channelId}
+                className={cn(
+                  'flex items-center justify-between gap-3 px-3 py-2',
+                  isBusy && 'opacity-50',
+                )}
+              >
+                <div className="min-w-0">
+                  <p className="text-[12.5px] font-medium text-ink">{name}</p>
+                  {row.placement === null ? (
+                    <p className="flex items-center gap-1 text-[11.5px] text-amber-600">
+                      <AlertTriangle className="size-3" />
+                      {t('products.detail.placements.unmapped', { defaultValue: 'brak mapowania' })}
+                    </p>
+                  ) : (
+                    <p className="truncate text-[11.5px] text-muted-foreground">
+                      {row.placement.nodePath}{' '}
+                      <span className="text-zinc-400">
+                        {row.placement.source === 'manual'
+                          ? t('products.detail.placements.manual', { defaultValue: '(ręcznie)' })
+                          : t('products.detail.placements.auto', { defaultValue: '(auto)' })}
+                      </span>
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  {row.placement !== null ? (
+                    <button
+                      type="button"
+                      onClick={() => void restoreAuto(row.channelId)}
+                      disabled={isBusy}
+                      className="text-[11.5px] text-zinc-500 hover:text-red-600 hover:underline"
+                    >
+                      {t('products.detail.placements.restore_auto', {
+                        defaultValue: 'Przywróć automatyczne',
+                      })}
+                    </button>
+                  ) : null}
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setPickerChannel({ id: row.channelId, name })}
+                    disabled={isBusy}
+                  >
+                    {row.placement === null
+                      ? t('products.detail.placements.assign', { defaultValue: 'Przypisz' })
+                      : t('products.detail.placements.reassign', { defaultValue: 'Nadpisz' })}
+                  </Button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <ChannelNodePickerDialog
+        open={pickerChannel !== null}
+        onOpenChange={(next) => {
+          if (!next) setPickerChannel(null);
+        }}
+        channelId={pickerChannel?.id ?? null}
+        channelName={pickerChannel?.name ?? ''}
+        onPick={async (nodeId) => {
+          if (pickerChannel !== null) await assign(pickerChannel.id, nodeId);
+        }}
+      />
+    </section>
+  );
+}

--- a/apps/api/src/Channel/Presentation/Controller/ObjectChannelPlacementController.php
+++ b/apps/api/src/Channel/Presentation/Controller/ObjectChannelPlacementController.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Presentation\Controller;
+
+use App\Channel\Domain\ChannelPlacementSource;
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNode;
+use App\Channel\Domain\Repository\ChannelCategoryNodeRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Channel\Domain\Repository\ObjectChannelPlacementRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use JsonException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * CHC-03 (#1286) — per-channel placement of a product, surfaced inline in the
+ * product "Kategorie" tab ("Gdzie trafia na kanałach").
+ *
+ * Lives in the Channel context (it owns {@see \App\Channel\Domain\Entity\ObjectChannelPlacement});
+ * the product is referenced by bare Uuid so there is no cross-BC Catalog import.
+ * The master category assignment (`object_categories`) is a different surface
+ * and is untouched here.
+ */
+final class ObjectChannelPlacementController
+{
+    private const int MAX_LABEL_DEPTH = 50;
+
+    public function __construct(
+        private readonly ChannelRepositoryInterface $channels,
+        private readonly ChannelCategoryNodeRepositoryInterface $nodes,
+        private readonly ObjectChannelPlacementRepositoryInterface $placements,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    #[Route('/api/products/{id}/channel-placements', name: 'pim_products_channel_placements_list', methods: ['GET'], format: 'json')]
+    #[Route('/api/objects/{id}/channel-placements', name: 'pim_objects_channel_placements_list', methods: ['GET'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'view')]
+    public function list(string $id): JsonResponse
+    {
+        $objectId = $this->uuid($id);
+        $tenant = $this->requireTenant();
+
+        $rows = [];
+        foreach ($this->channels->findAllForTenant($tenant) as $channel) {
+            $placement = $this->placements->findByObjectAndChannel($objectId, $channel->getId());
+            $rows[] = [
+                'channelId' => $channel->getId()->toRfc4122(),
+                'channelCode' => $channel->getCode(),
+                'channelLabel' => $channel->getLabel(),
+                'placement' => null === $placement ? null : [
+                    'nodeId' => $placement->getNodeId()->toRfc4122(),
+                    'nodePath' => $this->labelPath($placement->getNode()),
+                    'source' => $placement->getSource()->value,
+                ],
+            ];
+        }
+
+        return new JsonResponse(['member' => $rows, 'totalItems' => \count($rows)]);
+    }
+
+    #[Route('/api/products/{id}/channel-placements/{channelId}', name: 'pim_products_channel_placements_put', methods: ['PUT'], format: 'json')]
+    #[Route('/api/objects/{id}/channel-placements/{channelId}', name: 'pim_objects_channel_placements_put', methods: ['PUT'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'edit')]
+    public function put(string $id, string $channelId, Request $request): JsonResponse
+    {
+        $objectId = $this->uuid($id);
+        $channel = $this->requireChannel($channelId);
+        $node = $this->requireNodeOfChannel($request, $channel);
+
+        try {
+            $placement = $this->placements->upsert($objectId, $channel, $node, ChannelPlacementSource::Manual);
+        } catch (ForeignKeyConstraintViolationException) {
+            throw new UnprocessableEntityHttpException(\sprintf('Object "%s" does not exist.', $objectId->toRfc4122()));
+        }
+
+        return new JsonResponse([
+            'channelId' => $channel->getId()->toRfc4122(),
+            'channelCode' => $channel->getCode(),
+            'channelLabel' => $channel->getLabel(),
+            'placement' => [
+                'nodeId' => $placement->getNodeId()->toRfc4122(),
+                'nodePath' => $this->labelPath($placement->getNode()),
+                'source' => $placement->getSource()->value,
+            ],
+        ]);
+    }
+
+    #[Route('/api/products/{id}/channel-placements/{channelId}', name: 'pim_products_channel_placements_delete', methods: ['DELETE'], format: 'json')]
+    #[Route('/api/objects/{id}/channel-placements/{channelId}', name: 'pim_objects_channel_placements_delete', methods: ['DELETE'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'edit')]
+    public function delete(string $id, string $channelId): Response
+    {
+        $placement = $this->placements->findByObjectAndChannel($this->uuid($id), $this->uuid($channelId));
+        if (null === $placement) {
+            throw new NotFoundHttpException('No placement for this product on the given channel.');
+        }
+
+        $this->placements->remove($placement);
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private function requireChannel(string $channelId): Channel
+    {
+        $channel = $this->channels->findById($this->uuid($channelId));
+        if (null === $channel) {
+            throw new NotFoundHttpException(\sprintf('Channel "%s" was not found.', $channelId));
+        }
+
+        return $channel;
+    }
+
+    private function requireNodeOfChannel(Request $request, Channel $channel): ChannelCategoryNode
+    {
+        $nodeIdRaw = $this->decodeNodeId($request);
+        $node = $this->nodes->findById($this->uuid($nodeIdRaw));
+        if (null === $node || !$node->getChannel()->getId()->equals($channel->getId())) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Node "%s" does not belong to channel "%s".',
+                $nodeIdRaw,
+                $channel->getCode(),
+            ));
+        }
+
+        return $node;
+    }
+
+    private function decodeNodeId(Request $request): string
+    {
+        $content = $request->getContent();
+        try {
+            $data = '' === $content ? [] : json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new BadRequestHttpException('Request body is not valid JSON.');
+        }
+        if (!\is_array($data) || !isset($data['nodeId']) || !\is_string($data['nodeId']) || '' === $data['nodeId']) {
+            throw new UnprocessableEntityHttpException('"nodeId" (string) is required.');
+        }
+
+        return $data['nodeId'];
+    }
+
+    /**
+     * Human-readable breadcrumb from the node's ancestry labels (pl → en → code).
+     */
+    private function labelPath(ChannelCategoryNode $node): string
+    {
+        $labels = [];
+        $current = $node;
+        $guard = 0;
+        while (null !== $current && $guard < self::MAX_LABEL_DEPTH) {
+            $label = $current->getLabel();
+            $labels[] = $label['pl'] ?? $label['en'] ?? (($first = reset($label)) !== false ? $first : $current->getCode());
+            $current = $current->getParent();
+            ++$guard;
+        }
+
+        return implode(' > ', array_reverse($labels));
+    }
+
+    private function requireTenant(): \App\Shared\Domain\Tenant
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new BadRequestHttpException('No tenant context.');
+        }
+
+        return $tenant;
+    }
+
+    private function uuid(string $value): Uuid
+    {
+        if (!Uuid::isValid($value)) {
+            throw new UnprocessableEntityHttpException(\sprintf('"%s" is not a valid UUID.', $value));
+        }
+
+        return Uuid::fromString($value);
+    }
+}

--- a/apps/api/tests/Api/Channel/ObjectChannelPlacementApiTest.php
+++ b/apps/api/tests/Api/Channel/ObjectChannelPlacementApiTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Channel;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * CHC-03 (#1286) — `/api/products/{id}/channel-placements` CRUD.
+ */
+final class ObjectChannelPlacementApiTest extends ChannelApiTestCase
+{
+    private function createChannelWithNode(\ApiPlatform\Symfony\Bundle\Test\Client $client, string $code): array
+    {
+        $channel = $client->request('POST', '/api/channels', [
+            'json' => ['code' => $code, 'label' => ['pl' => $code], 'locales' => ['pl_PL']],
+        ]);
+        self::assertSame(201, $channel->getStatusCode());
+        $channelId = self::extractId($channel->toArray());
+
+        $root = $client->request('POST', "/api/channels/{$channelId}/navigation-tree", [
+            'json' => ['label' => ['pl' => 'Korzeń']],
+        ]);
+        $rootId = self::extractId($root->toArray());
+
+        $node = $client->request('POST', "/api/channels/{$channelId}/navigation-tree/nodes", [
+            'json' => ['parentId' => $rootId, 'code' => 'telewizory', 'label' => ['pl' => 'Telewizory']],
+        ]);
+        $nodeId = self::extractId($node->toArray());
+
+        return ['channelId' => $channelId, 'nodeId' => $nodeId];
+    }
+
+    private function makeProductId(): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $productType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert(null !== $productType);
+
+        $product = new CatalogObject($productType, 'SKU-CHC03');
+        $em->persist($product);
+        $em->flush();
+
+        return $product->getId()->toRfc4122();
+    }
+
+    #[Test]
+    public function listReturnsEveryChannelWithNullPlacementByDefault(): void
+    {
+        $client = $this->authenticatedClient();
+        $this->createChannelWithNode($client, 'allegro');
+        $productId = $this->makeProductId();
+
+        $response = $client->request('GET', "/api/products/{$productId}/channel-placements", [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertSame(200, $response->getStatusCode());
+        $rows = $response->toArray()['member'];
+        self::assertCount(1, $rows);
+        self::assertSame('allegro', $rows[0]['channelCode']);
+        self::assertNull($rows[0]['placement']);
+    }
+
+    #[Test]
+    public function putAssignsPlacementThenGetReflectsIt(): void
+    {
+        $client = $this->authenticatedClient();
+        ['channelId' => $channelId, 'nodeId' => $nodeId] = $this->createChannelWithNode($client, 'allegro');
+        $productId = $this->makeProductId();
+
+        $put = $client->request('PUT', "/api/products/{$productId}/channel-placements/{$channelId}", [
+            'json' => ['nodeId' => $nodeId],
+        ]);
+        self::assertSame(200, $put->getStatusCode());
+        $body = $put->toArray();
+        self::assertSame($nodeId, $body['placement']['nodeId']);
+        self::assertSame('manual', $body['placement']['source']);
+        self::assertStringContainsString('Telewizory', $body['placement']['nodePath']);
+
+        $get = $client->request('GET', "/api/products/{$productId}/channel-placements", [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        $row = $get->toArray()['member'][0];
+        self::assertNotNull($row['placement']);
+        self::assertSame($nodeId, $row['placement']['nodeId']);
+    }
+
+    #[Test]
+    public function putRejectsNodeFromAnotherChannel(): void
+    {
+        $client = $this->authenticatedClient();
+        $a = $this->createChannelWithNode($client, 'allegro');
+        $b = $this->createChannelWithNode($client, 'shopify');
+        $productId = $this->makeProductId();
+
+        // Channel A placement pointing at channel B's node → 422.
+        $put = $client->request('PUT', "/api/products/{$productId}/channel-placements/{$a['channelId']}", [
+            'json' => ['nodeId' => $b['nodeId']],
+        ]);
+        self::assertSame(422, $put->getStatusCode());
+    }
+
+    #[Test]
+    public function deleteRemovesPlacement(): void
+    {
+        $client = $this->authenticatedClient();
+        ['channelId' => $channelId, 'nodeId' => $nodeId] = $this->createChannelWithNode($client, 'allegro');
+        $productId = $this->makeProductId();
+
+        $client->request('PUT', "/api/products/{$productId}/channel-placements/{$channelId}", [
+            'json' => ['nodeId' => $nodeId],
+        ]);
+
+        $delete = $client->request('DELETE', "/api/products/{$productId}/channel-placements/{$channelId}");
+        self::assertSame(204, $delete->getStatusCode());
+
+        $get = $client->request('GET', "/api/products/{$productId}/channel-placements", [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertNull($get->toArray()['member'][0]['placement']);
+    }
+
+    #[Test]
+    public function unauthenticatedIsRejected(): void
+    {
+        $client = static::createClient();
+        $response = $client->request('GET', '/api/products/0192ffff-ffff-7fff-8fff-ffffffffffff/channel-placements', [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertSame(401, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Cel

CHC-03 (#1286) — operator widzi w jednym miejscu: do jakiej kategorii **master** należy produkt (steruje formularzem) **oraz** gdzie ten produkt trafia na każdym **kanale** (nawigacja/syndykacja). Sekcja „Gdzie trafia na kanałach" inline w istniejącej zakładce **„Kategorie"** karty produktu — zero nowych zakładek.

## Zakres

**Backend** (`ObjectChannelPlacementController`, Channel BC; produkt po Uuid → brak importu Catalog, deptrac clean)
- `GET /api/products|objects/{id}/channel-placements` — lista per kanał tenanta: `channelId, channelCode, channelLabel, placement{nodeId, nodePath, source} | null`. `nodePath` to breadcrumb z labeli przodków węzła.
- `PUT …/{channelId}` — body `{nodeId}` → upsert placement `source='manual'`; walidacja że węzeł należy do tego kanału (→ 422).
- `DELETE …/{channelId}` — usuwa placement (→ 204).

**Frontend** (`categories-tab.tsx` + nowe `ChannelPlacementsSection` + `ChannelNodePickerDialog`)
- Sekcja „Gdzie trafia na kanałach" poniżej pickera master.
- Wiersz per kanał: nazwa, `path` węzła lub „⚠ brak mapowania", status `(ręcznie)`/`(auto)`.
- `[Przypisz]`/`[Nadpisz]` → modal tree-picker drzewa kanału (`GET /api/channels/{id}/navigation-tree`).
- `[Przywróć automatyczne]` → DELETE.
- Przy 5+ kanałach: sekcja zwinięta do wpisów „⚠" + `[Pokaż wszystkie (N)]`.

## Definicja Done (CI) — lokalnie zielone

- [x] `PHPStan max` 0 · `Deptrac` 0 (produkt po Uuid, brak cross-BC) · `PHP-CS-Fixer` stabilny · `raw-sql-lint` clean
- [x] `PHPUnit` — `ObjectChannelPlacementApiTest` 5/5 (19 asercji): list null-placement, PUT assign, GET reflects, PUT foreign-channel → 422, DELETE, 401
- [x] FE `tsc -b` + `biome` — czyste
- [x] **Playwright E2E** `chc-03-channel-placements.spec.ts` — **zielony lokalnie** (16.8s): nav-tree przez API → zakładka Kategorie → Przypisz → picker → PUT 200 → breadcrumb + „(ręcznie)". `fixme` w CI (auth rate-limiter, jak #1209) — weryfikacja lokalna.
- [x] OpenAPI snapshot bez zmian (custom controller, nie AP resource → nie w `api:openapi:export`)

## Powiązania

- Refs #1286 · Blocked by #1284, #1285 (✅ merged) · Related #1290 (CHC-07 auto-assign przywróci `source='auto'`)
- Epik: `epik-CHC` · Spec: `Project Plan/CHC-channel-categories-tickets.md` → CHC-03
