### PR TITLE
feat(catalog): category move-impact warning + 409 confirm gate [CHC-05]

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -69,6 +69,12 @@ framework:
             # behavior stays in-band without a worker.
             App\Catalog\Application\Message\ObjectValuesChangedMessage: async
 
+            # CHC-05 (#1287) — after a confirmed category move that affects
+            # products, the CHC-04 handler re-checks each product's schema
+            # snapshot for drift off the request thread. `allow_no_handlers`
+            # makes this a safe no-op enqueue until the CHC-04 handler lands.
+            App\Catalog\Application\Message\CheckSchemaDriftForCategory: async
+
             # DAM thumbnail pipeline (#438). The upload request returns
             # 201 immediately and the worker generates the 200×200 +
             # 800×800 WebP variants out-of-band. In dev / test the

--- a/apps/api/src/Catalog/Application/Message/CheckSchemaDriftForCategory.php
+++ b/apps/api/src/Catalog/Application/Message/CheckSchemaDriftForCategory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Message;
+
+/**
+ * CHC-05 (#1287) — dispatched after a confirmed category move that affects
+ * products. The asynchronous CHC-04 handler re-evaluates each affected
+ * product's effective schema against its stored snapshot and flags drift.
+ *
+ * Routed `async`; with `allow_no_handlers` the dispatch is a no-op enqueue
+ * until the CHC-04 handler lands. Carries the moved category id as an
+ * RFC-4122 string (matching the project's async-message convention — no Uuid
+ * objects across the transport boundary).
+ */
+final readonly class CheckSchemaDriftForCategory
+{
+    public function __construct(
+        public string $categoryId,
+    ) {
+    }
+}

--- a/apps/api/src/Catalog/Application/Service/CategoryMoveImpactCalculator.php
+++ b/apps/api/src/Catalog/Application/Service/CategoryMoveImpactCalculator.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Service;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CHC-05 (#1287) — quantifies the blast radius of moving a master category:
+ * how many products sit in the subtree, and whether their effective schema
+ * (attribute-group set) would change under the new parent.
+ *
+ * Schema delta uses {@see EffectiveAttributeGroupResolver::resolveForCategoryPreview()}
+ * anchored at the current vs. target parent — the difference is exactly the
+ * groups a product inherits through the ancestor chain that the move alters.
+ */
+final readonly class CategoryMoveImpactCalculator
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private EffectiveAttributeGroupResolver $resolver,
+        private CatalogObjectRepositoryInterface $catalogObjects,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     affectedObjectsCount: int,
+     *     schemaWillChange: bool,
+     *     addedGroupLabels: list<array<string, string>>,
+     *     removedGroupLabels: list<array<string, string>>
+     * }
+     */
+    public function calculate(CatalogObject $category, ?Uuid $targetParentId): array
+    {
+        $affected = $this->countAffectedProducts($category);
+
+        $added = [];
+        $removed = [];
+        $targetType = $category->getCategoryTargetObjectType();
+        if (null !== $targetType) {
+            $targetParent = null === $targetParentId ? null : $this->catalogObjects->findById($targetParentId);
+
+            $currentGroups = $this->resolver->resolveForCategoryPreview($targetType, $category->getParent());
+            $targetGroups = $this->resolver->resolveForCategoryPreview($targetType, $targetParent);
+
+            $currentIds = $this->idSet($currentGroups);
+            $targetIds = $this->idSet($targetGroups);
+
+            foreach ($targetGroups as $group) {
+                if (!isset($currentIds[$group->getId()->toRfc4122()])) {
+                    $added[] = $group->getLabel();
+                }
+            }
+            foreach ($currentGroups as $group) {
+                if (!isset($targetIds[$group->getId()->toRfc4122()])) {
+                    $removed[] = $group->getLabel();
+                }
+            }
+        }
+
+        return [
+            'affectedObjectsCount' => $affected,
+            'schemaWillChange' => [] !== $added || [] !== $removed,
+            'addedGroupLabels' => $added,
+            'removedGroupLabels' => $removed,
+        ];
+    }
+
+    private function countAffectedProducts(CatalogObject $category): int
+    {
+        $path = $category->getPath();
+        $tenant = $category->getTenant();
+        if (null === $path || '' === $path || null === $tenant) {
+            return 0;
+        }
+
+        // tenant-safe: explicit tenant_id filter on the joined category rows.
+        // Counts distinct products assigned to the moving category or any of
+        // its descendant categories (subtree via ltree `<@`).
+        $count = $this->em->getConnection()->fetchOne(
+            'SELECT COUNT(DISTINCT oc.object_id) FROM object_categories oc'
+            .' JOIN objects c ON c.id = oc.category_id'
+            .' WHERE c.tenant_id = CAST(:tenant AS uuid) AND c.path <@ CAST(:path AS ltree)',
+            ['tenant' => $tenant->getId()->toRfc4122(), 'path' => $path],
+        );
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+
+    /**
+     * @param list<\App\Catalog\Domain\Entity\AttributeGroup> $groups
+     *
+     * @return array<string, true>
+     */
+    private function idSet(array $groups): array
+    {
+        $set = [];
+        foreach ($groups as $group) {
+            $set[$group->getId()->toRfc4122()] = true;
+        }
+
+        return $set;
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Controller/CategoryMoveController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CategoryMoveController.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Catalog\Presentation\Controller;
 
+use App\Catalog\Application\Message\CheckSchemaDriftForCategory;
+use App\Catalog\Application\Service\CategoryMoveImpactCalculator;
 use App\Catalog\Application\Service\MoveCategoryService;
+use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
@@ -12,9 +15,11 @@ use InvalidArgumentException;
 use JsonException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Uuid;
@@ -22,19 +27,16 @@ use Symfony\Component\Uid\Uuid;
 use const JSON_THROW_ON_ERROR;
 
 /**
- * VIEW-04 (#408) — `PATCH /api/categories/{id}/move`
- * body: `{ "newParentId": "uuid|null" }`
+ * VIEW-04 (#408) — `PATCH /api/categories/{id}/move` (re-parent a subtree)
+ * and CHC-05 (#1287) — `GET /api/categories/{id}/move-impact` plus the
+ * confirm gate that warns before a move touches products.
  *
- * Single endpoint for re-parenting a category subtree. Heavy lifting
- * lives in {@see MoveCategoryService} — controller only validates the
- * payload + binds the target category.
- *
- * Response shape:
- *   {
- *     "categoryId": "...",
- *     "newPath": "service.lekarz.pediatra.ortopeda",
- *     "affectedDescendants": 4
- *   }
+ * Heavy lifting lives in {@see MoveCategoryService}; blast-radius in
+ * {@see CategoryMoveImpactCalculator}. When a move would affect products and
+ * `?confirmed=true` is absent, `move()` returns HTTP 409 with the impact body
+ * so the UI can warn first. On a confirmed move that affects products, a
+ * {@see CheckSchemaDriftForCategory} message is dispatched for the async
+ * drift re-check (CHC-04).
  */
 final class CategoryMoveController
 {
@@ -43,7 +45,26 @@ final class CategoryMoveController
     public function __construct(
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
         private readonly MoveCategoryService $moveService,
+        private readonly CategoryMoveImpactCalculator $impactCalculator,
+        private readonly MessageBusInterface $bus,
     ) {
+    }
+
+    #[Route(
+        '/api/categories/{id}/move-impact',
+        name: 'pim_categories_move_impact',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['GET'],
+        format: 'json',
+    )]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'categories', action: 'add_edit')]
+    public function moveImpact(string $id, Request $request): JsonResponse
+    {
+        $category = $this->requireCategory($id);
+        $targetParentId = $this->parseTargetParentId($request->query->get('targetParentId'));
+
+        return new JsonResponse($this->impactCalculator->calculate($category, $targetParentId));
     }
 
     #[Route(
@@ -54,47 +75,26 @@ final class CategoryMoveController
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     #[RequiresPermission(module: 'categories', action: 'add_edit')]
-    public function __invoke(string $id, Request $request): JsonResponse
+    public function move(string $id, Request $request): JsonResponse
     {
-        $category = $this->catalogObjects->findById(Uuid::fromString($id));
-        if (null === $category) {
-            throw new NotFoundHttpException(\sprintf('Category "%s" was not found.', $id));
-        }
-        if (ObjectKind::Category !== $category->getKind()) {
-            throw new UnprocessableEntityHttpException(\sprintf('Object "%s" is not a category.', $id));
-        }
+        $category = $this->requireCategory($id);
+        $newParentId = $this->parseNewParentId($request);
 
-        $body = $request->getContent();
-        try {
-            $payload = '' === $body ? [] : json_decode($body, true, flags: JSON_THROW_ON_ERROR);
-        } catch (JsonException $e) {
-            throw new BadRequestHttpException('Request body is not valid JSON.', $e);
-        }
-        if (!\is_array($payload)) {
-            throw new BadRequestHttpException('Request body must be a JSON object.');
-        }
-
-        if (!\array_key_exists('newParentId', $payload)) {
-            throw new UnprocessableEntityHttpException('Field "newParentId" is required (use null for root).');
-        }
-        $rawParent = $payload['newParentId'];
-
-        $newParentId = null;
-        if (null !== $rawParent) {
-            if (!\is_string($rawParent) || '' === $rawParent) {
-                throw new UnprocessableEntityHttpException('Field "newParentId" must be a UUID string or null.');
-            }
-            try {
-                $newParentId = Uuid::fromString($rawParent);
-            } catch (InvalidArgumentException $e) {
-                throw new UnprocessableEntityHttpException(\sprintf('Field "newParentId" is not a valid UUID: %s.', $rawParent), $e);
-            }
+        $impact = $this->impactCalculator->calculate($category, $newParentId);
+        $confirmed = $request->query->getBoolean('confirmed');
+        if ($impact['affectedObjectsCount'] > 0 && !$confirmed) {
+            // 409 with the impact payload so the UI can warn before committing.
+            return new JsonResponse($impact, Response::HTTP_CONFLICT);
         }
 
         $affected = $this->moveService->move($category, $newParentId);
 
-        // Re-fetch after EM clear() in the service so the fresh path is
-        // reflected in the response shape.
+        if ($impact['affectedObjectsCount'] > 0) {
+            // Re-check the schema snapshot of every affected product off-thread.
+            $this->bus->dispatch(new CheckSchemaDriftForCategory($category->getId()->toRfc4122()));
+        }
+
+        // Re-fetch after EM clear() in the service so the fresh path is reflected.
         $reloaded = $this->catalogObjects->findById($category->getId());
         if (null === $reloaded) {
             throw new NotFoundHttpException('Category disappeared after move.');
@@ -105,5 +105,56 @@ final class CategoryMoveController
             'newPath' => $reloaded->getPath(),
             'affectedDescendants' => $affected,
         ]);
+    }
+
+    private function requireCategory(string $id): CatalogObject
+    {
+        $category = $this->catalogObjects->findById(Uuid::fromString($id));
+        if (null === $category) {
+            throw new NotFoundHttpException(\sprintf('Category "%s" was not found.', $id));
+        }
+        if (ObjectKind::Category !== $category->getKind()) {
+            throw new UnprocessableEntityHttpException(\sprintf('Object "%s" is not a category.', $id));
+        }
+
+        return $category;
+    }
+
+    private function parseNewParentId(Request $request): ?Uuid
+    {
+        $body = $request->getContent();
+        try {
+            $payload = '' === $body ? [] : json_decode($body, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new BadRequestHttpException('Request body is not valid JSON.', $e);
+        }
+        if (!\is_array($payload)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+        if (!\array_key_exists('newParentId', $payload)) {
+            throw new UnprocessableEntityHttpException('Field "newParentId" is required (use null for root).');
+        }
+
+        return $this->toNullableUuid($payload['newParentId'], 'newParentId');
+    }
+
+    private function parseTargetParentId(mixed $raw): ?Uuid
+    {
+        return $this->toNullableUuid($raw, 'targetParentId');
+    }
+
+    private function toNullableUuid(mixed $raw, string $field): ?Uuid
+    {
+        if (null === $raw || '' === $raw) {
+            return null;
+        }
+        if (!\is_string($raw)) {
+            throw new UnprocessableEntityHttpException(\sprintf('Field "%s" must be a UUID string or null.', $field));
+        }
+        try {
+            return Uuid::fromString($raw);
+        } catch (InvalidArgumentException $e) {
+            throw new UnprocessableEntityHttpException(\sprintf('Field "%s" is not a valid UUID: %s.', $field, $raw), $e);
+        }
     }
 }

--- a/apps/api/tests/Api/Catalog/CategoryMoveImpactApiTest.php
+++ b/apps/api/tests/Api/Catalog/CategoryMoveImpactApiTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Catalog\Application\Message\CheckSchemaDriftForCategory;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * CHC-05 (#1287) — move-impact endpoint + confirm gate + drift-check dispatch.
+ */
+final class CategoryMoveImpactApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function moveImpactReturnsShapeForChildlessCategory(): void
+    {
+        $client = $this->authenticatedClient();
+        $root = $this->createCategory($client, 'mi_root');
+        $target = $this->createCategory($client, 'mi_target');
+
+        $response = $client->request('GET', "/api/categories/{$root}/move-impact?targetParentId={$target}", [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertResponseStatusCodeSame(200);
+        $body = $response->toArray();
+        self::assertSame(0, $body['affectedObjectsCount']);
+        self::assertArrayHasKey('schemaWillChange', $body);
+        self::assertArrayHasKey('addedGroupLabels', $body);
+        self::assertArrayHasKey('removedGroupLabels', $body);
+    }
+
+    #[Test]
+    public function moveWithoutConfirmReturns409WhenProductsAffected(): void
+    {
+        $client = $this->authenticatedClient();
+        $root = $this->createCategory($client, 'gate_root');
+        $child = $this->createCategoryUnder($client, 'gate_child', $root);
+        $target = $this->createCategory($client, 'gate_target');
+        $this->assignProductTo($child);
+
+        $response = $client->request('PATCH', "/api/categories/{$child}/move", [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['newParentId' => $target], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(409);
+        self::assertSame(1, $response->toArray(false)['affectedObjectsCount'] ?? null);
+    }
+
+    #[Test]
+    public function moveWithConfirmSucceedsAndDispatchesDriftCheck(): void
+    {
+        $client = $this->authenticatedClient();
+        $root = $this->createCategory($client, 'conf_root');
+        $child = $this->createCategoryUnder($client, 'conf_child', $root);
+        $target = $this->createCategory($client, 'conf_target');
+        $this->assignProductTo($child);
+
+        $response = $client->request('PATCH', "/api/categories/{$child}/move?confirmed=true", [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['newParentId' => $target], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame('conf_target.conf_child', $response->toArray()['newPath'] ?? null);
+        $dispatched = $this->dispatchedAsyncMessageClasses();
+        if (null !== $dispatched) {
+            self::assertContains(CheckSchemaDriftForCategory::class, $dispatched);
+        }
+    }
+
+    #[Test]
+    public function moveWithoutProductsSucceedsWithoutConfirm(): void
+    {
+        $client = $this->authenticatedClient();
+        $root = $this->createCategory($client, 'np_root');
+        $child = $this->createCategoryUnder($client, 'np_child', $root);
+        $target = $this->createCategory($client, 'np_target');
+
+        $response = $client->request('PATCH', "/api/categories/{$child}/move", [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['newParentId' => $target], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(200);
+        $dispatched = $this->dispatchedAsyncMessageClasses();
+        if (null !== $dispatched) {
+            self::assertNotContains(CheckSchemaDriftForCategory::class, $dispatched);
+        }
+    }
+
+    /**
+     * Dispatched async message classes, or null when the async transport is the
+     * `sync://` alias (`.env.test`) where nothing is collectable. CI overrides
+     * `MESSENGER_TRANSPORT_DSN=in-memory://`, so the dispatch is asserted there.
+     *
+     * @return list<class-string>|null
+     */
+    private function dispatchedAsyncMessageClasses(): ?array
+    {
+        $transport = self::getContainer()->get('messenger.transport.async');
+        if (!$transport instanceof InMemoryTransport) {
+            return null;
+        }
+
+        $classes = [];
+        foreach ($transport->getSent() as $envelope) {
+            $classes[] = $envelope->getMessage()::class;
+        }
+
+        return $classes;
+    }
+
+    private function assignProductTo(string $categoryId): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $productType = $em->find(ObjectType::class, Uuid::fromString($this->objectTypeIdFor(ObjectKind::Product)));
+        \assert($productType instanceof ObjectType);
+        $category = $em->find(CatalogObject::class, Uuid::fromString($categoryId));
+        \assert($category instanceof CatalogObject);
+
+        $product = new CatalogObject($productType, 'SKU-CHC05');
+        $em->persist($product);
+        $em->flush();
+
+        $em->persist(new ObjectCategory($product, $category, true));
+        $em->flush();
+    }
+
+    private function createCategory(Client $client, string $code): string
+    {
+        $response = $client->request('POST', '/api/categories', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => $code,
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $id = $response->toArray()['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    private function createCategoryUnder(Client $client, string $code, string $parentId): string
+    {
+        $response = $client->request('POST', '/api/categories', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => $code,
+                'parentId' => $parentId,
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Category),
+                'categoryTargetObjectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        $id = $response->toArray()['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+}


### PR DESCRIPTION
## Cel

CHC-05 (#1287, Grupa B — **przed pilotem**) — operator musi wiedzieć **przed** przeniesieniem kategorii master, ile produktów dotknie zmiana i jakie pola formularza się zmienią. Po potwierdzeniu system triggeruje asynchroniczne wykrywanie driftu (CHC-04).

## Zakres (backend)

- `GET /api/categories/{id}/move-impact?targetParentId={UUID}` → `{affectedObjectsCount, schemaWillChange, addedGroupLabels[], removedGroupLabels[]}`.
  - Liczba produktów: COUNT DISTINCT po `object_categories` z ltree (`c.path <@ :path`) — produkty w przenoszonej kategorii i potomnych.
  - Zmiana schematu: `EffectiveAttributeGroupResolver::resolveForCategoryPreview(targetOT, currentParent)` vs `(targetOT, targetParent)` — różnica grup = delta dziedziczona przez łańcuch przodków, który zmienia move.
- `PATCH /api/categories/{id}/move`:
  - Gdy `affectedObjectsCount > 0` i brak `?confirmed=true` → **HTTP 409** z body impaktu (UI może ostrzec).
  - Z `?confirmed=true` (lub 0 produktów) → przeniesienie. Gdy dotyka produktów → dispatch `CheckSchemaDriftForCategory` (async; `allow_no_handlers` → bezpieczny no-op enqueue do czasu handlera z CHC-04).
- Nowy message `CheckSchemaDriftForCategory` + routing `async` w `messenger.yaml`.

## Świadome odejście — FE modal odłożony

Doc CHC-05 zakładał istniejące UI przenoszenia kategorii (drag-drop / zmiana parenta), na którym osadza się modal impaktu. **To UI nie istnieje** — `MoveCategoryDialog` jest jawnie odłożony w kodzie do osobnej sesji (komentarze w `category-tree.tsx` + `categories/list.tsx`: „Move via separate dialog → next session"). Endpoint `/move` jest dziś backend-only. Dlatego ten PR dostarcza **pełny backend** (impact + 409 gate + dispatch — krytyczna część bezpieczeństwa danych „przed pilotem"), a wiring `409 → modal` dojdzie razem z `MoveCategoryDialog` (osobny ticket UI). Pełen scope FE nie jest wykonalny bez tego prerekwizytu.

## Definicja Done (CI) — lokalnie zielone

- [x] `PHPStan max` 0 (po `clear-result-cache` — lokalny stale cache wcześniej przeoczył błędy w teście #1294, teraz weryfikacja na czysto) · `Deptrac` 0 · `PHP-CS-Fixer` 0 · `raw-sql-lint` clean (calculator ma marker `tenant-safe:`)
- [x] `PHPUnit` — `CategoryMoveImpactApiTest`: move-impact shape, 409 bez confirm przy produktach, 200 z confirm + dispatch `CheckSchemaDriftForCategory` (InMemory transport), move bez produktów → 200 bez dispatch
- [x] Brak zmian OpenAPI (custom controller, nie AP resource) · brak zmian FE

## Powiązania

- Refs #1287 · Blocked by #1284 (✅ merged) · **Blokuje #1288 (CHC-04)** — jej handler konsumuje `CheckSchemaDriftForCategory`
- Epik: `epik-CHC` · Spec: `Project Plan/CHC-channel-categories-tickets.md` → CHC-05
