### PR TITLE
feat(catalog): schema-drift detection on category move [CHC-04]

### DIFF
--- a/apps/admin/src/features/catalog/products/components/categories-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/categories-tab.tsx
@@ -12,6 +12,7 @@ import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 import { ChannelPlacementsSection } from './channel-placements-section';
+import { SchemaDriftBanner } from './schema-drift-banner';
 
 interface AssignmentRow {
   categoryId: string;
@@ -111,6 +112,8 @@ export function CategoriesTab({ productId }: Props) {
 
   return (
     <section className="space-y-4">
+      <SchemaDriftBanner productId={productId} />
+
       <header className="flex items-center justify-between">
         <div>
           <h3 className="text-[13.5px] font-semibold text-ink">

--- a/apps/admin/src/features/catalog/products/components/schema-drift-banner.tsx
+++ b/apps/admin/src/features/catalog/products/components/schema-drift-banner.tsx
@@ -1,0 +1,75 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { jsonFetch } from '@/lib/http';
+
+interface Props {
+  productId: string;
+}
+
+/**
+ * CHC-04 (#1288) — banner shown in the product "Kategorie" tab when a category
+ * move changed the product's effective schema since it was last filled
+ * (`schemaDrift`). Acknowledging clears the flag and re-baselines the snapshot.
+ */
+export function SchemaDriftBanner({ productId }: Props) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [busy, setBusy] = useState(false);
+
+  const { data } = useQuery({
+    queryKey: ['products', productId, 'schema-drift'],
+    queryFn: async () =>
+      jsonFetch<{ schemaDrift?: boolean }>(`/api/products/${productId}`, {
+        accept: 'application/json',
+      }),
+    enabled: productId !== '',
+  });
+
+  if (data?.schemaDrift !== true) {
+    return null;
+  }
+
+  const acknowledge = async (): Promise<void> => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await jsonFetch(`/api/products/${productId}/schema-drift/acknowledge`, {
+        method: 'POST',
+        accept: 'application/json',
+      });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['products', productId, 'schema-drift'] }),
+        queryClient.invalidateQueries({ queryKey: ['products', productId] }),
+      ]);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-amber-200 bg-amber-50 p-3" role="alert">
+      <p className="flex items-center gap-1.5 text-[12.5px] font-medium text-amber-900">
+        <AlertTriangle className="size-4 shrink-0" />
+        {t('products.detail.schema_drift.title', {
+          defaultValue:
+            'Schemat tego produktu zmienił się po ostatnim wypełnieniu. Sprawdź czy wszystkie dane są kompletne.',
+        })}
+      </p>
+      <Button
+        size="sm"
+        variant="outline"
+        className="mt-2 border-amber-300 text-amber-900 hover:bg-amber-100"
+        onClick={() => void acknowledge()}
+        disabled={busy}
+      >
+        {t('products.detail.schema_drift.acknowledge', {
+          defaultValue: 'Rozumiem, zaktualizuj schemat',
+        })}
+      </Button>
+    </div>
+  );
+}

--- a/apps/api/migrations/Version20260606140000.php
+++ b/apps/api/migrations/Version20260606140000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * CHC-04 (#1288) — schema-drift tracking columns on `objects`.
+ *
+ * `schema_snapshot` captures the effective attribute-group ids a product had
+ * when first filled; `schema_drift` is flagged by the async
+ * CheckSchemaDriftHandler when a category move changes that effective set, and
+ * cleared when the operator acknowledges. Both default to "no snapshot / no
+ * drift" so existing rows are inert until first touched.
+ */
+final class Version20260606140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'CHC-04: add objects.schema_snapshot (jsonb) + objects.schema_drift (bool)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE objects ADD COLUMN schema_snapshot JSONB DEFAULT NULL');
+        $this->addSql('ALTER TABLE objects ADD COLUMN schema_drift BOOLEAN DEFAULT FALSE NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE objects DROP COLUMN schema_snapshot');
+        $this->addSql('ALTER TABLE objects DROP COLUMN schema_drift');
+    }
+}

--- a/apps/api/src/Catalog/Application/Handler/CheckSchemaDriftHandler.php
+++ b/apps/api/src/Catalog/Application/Handler/CheckSchemaDriftHandler.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Handler;
+
+use App\Catalog\Application\Message\CheckSchemaDriftForCategory;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use App\Shared\Application\AbstractBatchHandler;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CHC-04 (#1288) — asynchronous schema-drift detection after a category move.
+ *
+ * Triggered by {@see CheckSchemaDriftForCategory} (dispatched on a confirmed
+ * move that affects products). For every product assigned to the moved
+ * category or any descendant, it recomputes the effective attribute-group set
+ * and compares it with the captured snapshot; a difference flags
+ * `schema_drift`. Off the request thread, batched to stay worker-memory-safe.
+ */
+#[AsMessageHandler]
+final class CheckSchemaDriftHandler extends AbstractBatchHandler
+{
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private readonly EffectiveAttributeGroupResolver $resolver,
+    ) {
+        parent::__construct($entityManager);
+    }
+
+    public function __invoke(CheckSchemaDriftForCategory $message): void
+    {
+        $category = $this->entityManager->find(CatalogObject::class, Uuid::fromString($message->categoryId));
+        if (!$category instanceof CatalogObject) {
+            return;
+        }
+        $path = $category->getPath();
+        $tenant = $category->getTenant();
+        if (null === $path || '' === $path || null === $tenant) {
+            return;
+        }
+
+        $processed = 0;
+        foreach ($this->affectedProductIds($tenant->getId()->toRfc4122(), $path) as $productId) {
+            $product = $this->entityManager->find(CatalogObject::class, Uuid::fromString($productId));
+            if (!$product instanceof CatalogObject) {
+                continue;
+            }
+            if ($this->hasDrifted($product)) {
+                $product->flagSchemaDrift(true);
+            }
+
+            ++$processed;
+            if ($this->shouldFlush($processed)) {
+                $this->flushAndClear();
+            }
+        }
+
+        $this->flushAndClear();
+    }
+
+    private function hasDrifted(CatalogObject $product): bool
+    {
+        $snapshot = $product->getSchemaSnapshot();
+        if (null === $snapshot) {
+            return false; // no baseline captured — nothing to compare against
+        }
+
+        $snapshotIds = [];
+        $raw = $snapshot['attributeGroupIds'] ?? null;
+        if (\is_array($raw)) {
+            foreach ($raw as $value) {
+                if (\is_string($value)) {
+                    $snapshotIds[] = $value;
+                }
+            }
+        }
+
+        $current = array_map(
+            static fn (AttributeGroup $group): string => $group->getId()->toRfc4122(),
+            $this->resolver->resolve($product),
+        );
+
+        sort($snapshotIds);
+        sort($current);
+
+        return $snapshotIds !== $current;
+    }
+
+    /**
+     * RFC-4122 ids of products assigned to the moved category subtree.
+     *
+     * @return list<string>
+     */
+    private function affectedProductIds(string $tenantId, string $path): array
+    {
+        // tenant-safe: explicit tenant_id filter on the joined category rows;
+        // subtree via ltree `<@`.
+        $rows = $this->entityManager->getConnection()->fetchFirstColumn(
+            'SELECT DISTINCT oc.object_id FROM object_categories oc'
+            .' JOIN objects c ON c.id = oc.category_id'
+            .' WHERE c.tenant_id = CAST(:tenant AS uuid) AND c.path <@ CAST(:path AS ltree)',
+            ['tenant' => $tenantId, 'path' => $path],
+        );
+
+        $ids = [];
+        foreach ($rows as $row) {
+            if (\is_string($row)) {
+                $ids[] = $row;
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/apps/api/src/Catalog/Application/Message/CheckSchemaDriftForCategory.php
+++ b/apps/api/src/Catalog/Application/Message/CheckSchemaDriftForCategory.php
@@ -4,20 +4,30 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application\Message;
 
+use App\Shared\Application\TenantAwareMessage;
+use Symfony\Component\Uid\Uuid;
+
 /**
  * CHC-05 (#1287) — dispatched after a confirmed category move that affects
- * products. The asynchronous CHC-04 handler re-evaluates each affected
- * product's effective schema against its stored snapshot and flags drift.
+ * products. The asynchronous CHC-04 handler ({@see \App\Catalog\Application\Handler\CheckSchemaDriftHandler})
+ * re-evaluates each affected product's effective schema against its stored
+ * snapshot and flags drift.
  *
- * Routed `async`; with `allow_no_handlers` the dispatch is a no-op enqueue
- * until the CHC-04 handler lands. Carries the moved category id as an
- * RFC-4122 string (matching the project's async-message convention — no Uuid
- * objects across the transport boundary).
+ * Routed `async`. Carries category + tenant ids as RFC-4122 strings (no Uuid
+ * objects across the transport boundary). Implements {@see TenantAwareMessage}
+ * so the worker rebinds TenantContext on consume (there is no dispatch-side
+ * TenantStamp writer in this codebase).
  */
-final readonly class CheckSchemaDriftForCategory
+final readonly class CheckSchemaDriftForCategory implements TenantAwareMessage
 {
     public function __construct(
         public string $categoryId,
+        public string $tenantId,
     ) {
+    }
+
+    public function tenantId(): Uuid
+    {
+        return Uuid::fromString($this->tenantId);
     }
 }

--- a/apps/api/src/Catalog/Application/Service/SchemaSnapshotFactory.php
+++ b/apps/api/src/Catalog/Application/Service/SchemaSnapshotFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Service;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
+use DateTimeImmutable;
+
+use const DATE_ATOM;
+
+/**
+ * CHC-04 (#1288) — builds the `schema_snapshot` payload (effective
+ * attribute-group ids + capture time + master category) for a product.
+ * Shared by the first-fill listener and the acknowledge endpoint so both
+ * produce the identical shape the drift handler compares against.
+ */
+final readonly class SchemaSnapshotFactory
+{
+    public function __construct(
+        private EffectiveAttributeGroupResolver $resolver,
+        private ObjectCategoryRepositoryInterface $categories,
+    ) {
+    }
+
+    /**
+     * @return array{attributeGroupIds: list<string>, capturedAt: string, masterCategoryId: string|null}
+     */
+    public function build(CatalogObject $object): array
+    {
+        $groupIds = array_map(
+            static fn (AttributeGroup $group): string => $group->getId()->toRfc4122(),
+            $this->resolver->resolve($object),
+        );
+
+        $primary = $this->categories->findPrimary($object);
+
+        return [
+            'attributeGroupIds' => $groupIds,
+            'capturedAt' => new DateTimeImmutable()->format(DATE_ATOM),
+            'masterCategoryId' => $primary?->getCategory()->getId()->toRfc4122(),
+        ];
+    }
+}

--- a/apps/api/src/Catalog/Application/Subscriber/SchemaSnapshotListener.php
+++ b/apps/api/src/Catalog/Application/Subscriber/SchemaSnapshotListener.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Subscriber;
+
+use App\Catalog\Application\Service\SchemaSnapshotFactory;
+use App\Catalog\Contracts\Event\ObjectAttributesChanged;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * CHC-04 (#1288) — captures a product's effective attribute-group set the first
+ * time its values are filled. Synchronous + idempotent: writes the snapshot
+ * only when none exists yet, so it never overwrites the baseline the async
+ * drift check ({@see \App\Catalog\Application\Handler\CheckSchemaDriftHandler})
+ * compares against after a category move.
+ *
+ * Listens to {@see ObjectAttributesChanged} (already emitted on every
+ * `attributes_indexed` write). Snapshotting `schema_snapshot` does not emit
+ * that event, so there is no re-trigger loop.
+ */
+#[AsMessageHandler]
+final class SchemaSnapshotListener
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly SchemaSnapshotFactory $snapshots,
+    ) {
+    }
+
+    public function __invoke(ObjectAttributesChanged $event): void
+    {
+        $object = $this->em->find(CatalogObject::class, $event->objectId);
+        if (!$object instanceof CatalogObject || ObjectKind::Product !== $object->getKind()) {
+            return;
+        }
+        if (null !== $object->getSchemaSnapshot()) {
+            return; // baseline already captured — keep it
+        }
+
+        $object->recordSchemaSnapshot($this->snapshots->build($object));
+        $this->em->flush();
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -122,6 +122,22 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
     private ?string $path = null;
 
     /**
+     * CHC-04 (#1288) — effective attribute-group snapshot captured on first
+     * fill: {"attributeGroupIds": ["uuid", ...], "capturedAt": ISO8601,
+     * "masterCategoryId": "uuid"|null}. The async drift handler compares it
+     * after a category move; null until the product is first filled.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $schemaSnapshot = null;
+
+    /**
+     * CHC-04 (#1288) — true when a category move changed this product's
+     * effective schema vs its snapshot; cleared on operator acknowledge.
+     */
+    private bool $schemaDrift = false;
+
+    /**
      * UI-02.6 (#296) — axis definition on a master product row, e.g.
      * `[{"code":"color","attribute_id":"...","values":["red","blue"]}]`.
      * NULL on variant + non-master rows. Only writable on `kind=product`.
@@ -395,6 +411,32 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
     {
         $this->path = $path;
         $this->touch();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function getSchemaSnapshot(): ?array
+    {
+        return $this->schemaSnapshot;
+    }
+
+    /**
+     * @param array<string, mixed>|null $snapshot
+     */
+    public function recordSchemaSnapshot(?array $snapshot): void
+    {
+        $this->schemaSnapshot = $snapshot;
+    }
+
+    public function getSchemaDrift(): bool
+    {
+        return $this->schemaDrift;
+    }
+
+    public function flagSchemaDrift(bool $drifted): void
+    {
+        $this->schemaDrift = $drifted;
     }
 
     /**

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -94,7 +94,11 @@
                 <option name="jsonb">true</option>
             </options>
         </field>
-        <field name="schemaDrift" type="boolean" column="schema_drift"/>
+        <field name="schemaDrift" type="boolean" column="schema_drift">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
         <field name="variantAxes" type="json" column="variant_axes" nullable="true">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Orm/Mapping/CatalogObject.orm.xml
@@ -89,6 +89,12 @@
             </options>
         </field>
         <field name="path" type="ltree" nullable="true"/>
+        <field name="schemaSnapshot" type="json" column="schema_snapshot" nullable="true">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+        <field name="schemaDrift" type="boolean" column="schema_drift"/>
         <field name="variantAxes" type="json" column="variant_axes" nullable="true">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Catalog/Infrastructure/Serializer/CatalogObject.xml
+++ b/apps/api/src/Catalog/Infrastructure/Serializer/CatalogObject.xml
@@ -31,6 +31,9 @@
             <group>integration:read</group>
             <group>public:read</group>
         </attribute>
+        <attribute name="schemaDrift">
+            <group>admin:read</group>
+        </attribute>
         <attribute name="code">
             <group>admin:read</group>
             <group>admin:write</group>

--- a/apps/api/src/Catalog/Presentation/Controller/CategoryMoveController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/CategoryMoveController.php
@@ -91,7 +91,12 @@ final class CategoryMoveController
 
         if ($impact['affectedObjectsCount'] > 0) {
             // Re-check the schema snapshot of every affected product off-thread.
-            $this->bus->dispatch(new CheckSchemaDriftForCategory($category->getId()->toRfc4122()));
+            $tenant = $category->getTenant();
+            \assert(null !== $tenant);
+            $this->bus->dispatch(new CheckSchemaDriftForCategory(
+                $category->getId()->toRfc4122(),
+                $tenant->getId()->toRfc4122(),
+            ));
         }
 
         // Re-fetch after EM clear() in the service so the fresh path is reflected.

--- a/apps/api/src/Catalog/Presentation/Controller/SchemaDriftAcknowledgeController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/SchemaDriftAcknowledgeController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Controller;
+
+use App\Catalog\Application\Service\SchemaSnapshotFactory;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CHC-04 (#1288) — operator acknowledges a product's schema drift: clears the
+ * `schema_drift` flag and re-baselines the snapshot to the current effective
+ * attribute-group set, so future moves are measured against what the operator
+ * just confirmed.
+ */
+final class SchemaDriftAcknowledgeController
+{
+    private const string UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $objects,
+        private readonly SchemaSnapshotFactory $snapshots,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    #[Route('/api/products/{id}/schema-drift/acknowledge', name: 'pim_products_schema_drift_acknowledge', requirements: ['id' => self::UUID_REGEX], methods: ['POST'], format: 'json')]
+    #[Route('/api/objects/{id}/schema-drift/acknowledge', name: 'pim_objects_schema_drift_acknowledge', requirements: ['id' => self::UUID_REGEX], methods: ['POST'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'products', action: 'edit')]
+    public function __invoke(string $id): JsonResponse
+    {
+        try {
+            $uuid = Uuid::fromString($id);
+        } catch (InvalidArgumentException $e) {
+            throw new NotFoundHttpException(\sprintf('Object "%s" was not found.', $id), $e);
+        }
+
+        $object = $this->objects->findById($uuid);
+        if (null === $object) {
+            throw new NotFoundHttpException(\sprintf('Object "%s" was not found.', $id));
+        }
+
+        $object->recordSchemaSnapshot($this->snapshots->build($object));
+        $object->flagSchemaDrift(false);
+        $this->em->flush();
+
+        return new JsonResponse(['schemaDrift' => false]);
+    }
+}

--- a/apps/api/tests/Api/Catalog/SchemaDriftAcknowledgeApiTest.php
+++ b/apps/api/tests/Api/Catalog/SchemaDriftAcknowledgeApiTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CHC-04 (#1288) — `POST /api/products/{id}/schema-drift/acknowledge`.
+ */
+final class SchemaDriftAcknowledgeApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function acknowledgeClearsDriftFlag(): void
+    {
+        $client = $this->authenticatedClient();
+        $productId = $this->makeDriftedProduct();
+
+        $before = $client->request('GET', "/api/products/{$productId}", [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertTrue($before->toArray()['schemaDrift'] ?? null);
+
+        $ack = $client->request('POST', "/api/products/{$productId}/schema-drift/acknowledge", [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertSame(200, $ack->getStatusCode());
+        self::assertFalse($ack->toArray()['schemaDrift'] ?? null);
+
+        $after = $client->request('GET', "/api/products/{$productId}", [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertFalse($after->toArray()['schemaDrift'] ?? null);
+    }
+
+    #[Test]
+    public function unknownObjectReturns404(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/0192ffff-ffff-7fff-8fff-ffffffffffff/schema-drift/acknowledge', [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function unauthenticatedReturns401(): void
+    {
+        $client = static::createClient();
+        $response = $client->request('POST', '/api/products/0192ffff-ffff-7fff-8fff-ffffffffffff/schema-drift/acknowledge', [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    private function makeDriftedProduct(): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $productType = $em->find(ObjectType::class, Uuid::fromString($this->objectTypeIdFor(ObjectKind::Product)));
+        \assert($productType instanceof ObjectType);
+
+        $product = new CatalogObject($productType, 'SKU-DRIFT');
+        $product->recordSchemaSnapshot(['attributeGroupIds' => [], 'capturedAt' => 'x', 'masterCategoryId' => null]);
+        $product->flagSchemaDrift(true);
+        $em->persist($product);
+        $em->flush();
+
+        return $product->getId()->toRfc4122();
+    }
+}

--- a/apps/api/tests/Integration/Catalog/SchemaDriftTest.php
+++ b/apps/api/tests/Integration/Catalog/SchemaDriftTest.php
@@ -112,10 +112,10 @@ final class SchemaDriftTest extends KernelTestCase
 
         // Snapshot == current effective set → no drift.
         $current = array_map(
-            static fn ($g) => $g->getId()->toRfc4122(),
+            static fn (\App\Catalog\Domain\Entity\AttributeGroup $g): string => $g->getId()->toRfc4122(),
             self::getContainer()->get(\App\Catalog\Domain\Service\EffectiveAttributeGroupResolver::class)->resolve($product),
         );
-        $product->recordSchemaSnapshot(['attributeGroupIds' => array_values($current), 'capturedAt' => 'x', 'masterCategoryId' => null]);
+        $product->recordSchemaSnapshot(['attributeGroupIds' => $current, 'capturedAt' => 'x', 'masterCategoryId' => null]);
         $this->em()->flush();
 
         $this->handler()(new CheckSchemaDriftForCategory(

--- a/apps/api/tests/Integration/Catalog/SchemaDriftTest.php
+++ b/apps/api/tests/Integration/Catalog/SchemaDriftTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Catalog;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Application\Handler\CheckSchemaDriftHandler;
+use App\Catalog\Application\Message\CheckSchemaDriftForCategory;
+use App\Catalog\Application\Subscriber\SchemaSnapshotListener;
+use App\Catalog\Contracts\Event\ObjectAttributesChanged;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * CHC-04 (#1288) — snapshot capture + async drift detection.
+ */
+final class SchemaDriftTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($this->tenant);
+    }
+
+    #[Test]
+    public function listenerCapturesSnapshotOnFirstFill(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+
+        $this->listener()(new ObjectAttributesChanged($product->getId(), $this->tenant->getId()));
+
+        $this->em()->clear();
+        $reloaded = $this->em()->find(CatalogObject::class, $product->getId());
+        \assert($reloaded instanceof CatalogObject);
+        $snapshot = $reloaded->getSchemaSnapshot();
+        self::assertNotNull($snapshot);
+        self::assertArrayHasKey('attributeGroupIds', $snapshot);
+    }
+
+    #[Test]
+    public function listenerDoesNotOverwriteExistingSnapshot(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $product->recordSchemaSnapshot(['attributeGroupIds' => ['frozen'], 'capturedAt' => 'x', 'masterCategoryId' => null]);
+        $this->em()->flush();
+
+        $this->listener()(new ObjectAttributesChanged($product->getId(), $this->tenant->getId()));
+
+        $this->em()->clear();
+        $reloaded = $this->em()->find(CatalogObject::class, $product->getId());
+        \assert($reloaded instanceof CatalogObject);
+        self::assertSame(['frozen'], $reloaded->getSchemaSnapshot()['attributeGroupIds'] ?? null);
+    }
+
+    #[Test]
+    public function handlerFlagsDriftWhenSnapshotDiffersFromCurrent(): void
+    {
+        $category = $this->makeCategory('driftcat');
+        $product = $this->makeProduct('SKU-1');
+        $this->assign($product, $category);
+
+        // Snapshot references a group id that the product's current effective
+        // set does not contain → drift.
+        $product->recordSchemaSnapshot([
+            'attributeGroupIds' => [Uuid::v7()->toRfc4122()],
+            'capturedAt' => 'x',
+            'masterCategoryId' => null,
+        ]);
+        $this->em()->flush();
+
+        $this->handler()(new CheckSchemaDriftForCategory(
+            $category->getId()->toRfc4122(),
+            $this->tenant->getId()->toRfc4122(),
+        ));
+
+        $this->em()->clear();
+        $reloaded = $this->em()->find(CatalogObject::class, $product->getId());
+        \assert($reloaded instanceof CatalogObject);
+        self::assertTrue($reloaded->getSchemaDrift());
+    }
+
+    #[Test]
+    public function handlerLeavesNoDriftWhenSnapshotMatches(): void
+    {
+        $category = $this->makeCategory('matchcat');
+        $product = $this->makeProduct('SKU-1');
+        $this->assign($product, $category);
+
+        // Snapshot == current effective set → no drift.
+        $current = array_map(
+            static fn ($g) => $g->getId()->toRfc4122(),
+            self::getContainer()->get(\App\Catalog\Domain\Service\EffectiveAttributeGroupResolver::class)->resolve($product),
+        );
+        $product->recordSchemaSnapshot(['attributeGroupIds' => array_values($current), 'capturedAt' => 'x', 'masterCategoryId' => null]);
+        $this->em()->flush();
+
+        $this->handler()(new CheckSchemaDriftForCategory(
+            $category->getId()->toRfc4122(),
+            $this->tenant->getId()->toRfc4122(),
+        ));
+
+        $this->em()->clear();
+        $reloaded = $this->em()->find(CatalogObject::class, $product->getId());
+        \assert($reloaded instanceof CatalogObject);
+        self::assertFalse($reloaded->getSchemaDrift());
+    }
+
+    private function makeProduct(string $sku): CatalogObject
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $this->tenant);
+        \assert(null !== $type);
+        $product = new CatalogObject($type, $sku);
+        $this->em()->persist($product);
+        $this->em()->flush();
+
+        return $product;
+    }
+
+    private function makeCategory(string $code): CatalogObject
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Category, $this->tenant);
+        \assert(null !== $type);
+        $category = new CatalogObject($type, $code);
+        $this->em()->persist($category);
+        $this->em()->flush();
+
+        return $category;
+    }
+
+    private function assign(CatalogObject $product, CatalogObject $category): void
+    {
+        $this->em()->persist(new ObjectCategory($product, $category, true));
+        $this->em()->flush();
+    }
+
+    private function listener(): SchemaSnapshotListener
+    {
+        return self::getContainer()->get(SchemaSnapshotListener::class);
+    }
+
+    private function handler(): CheckSchemaDriftHandler
+    {
+        return self::getContainer()->get(CheckSchemaDriftHandler::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -8399,6 +8399,12 @@
                             "null"
                         ]
                     },
+                    "schemaDrift": {
+                        "readOnly": true,
+                        "description": "CHC-04 (#1288) \u2014 true when a category move changed this product's\neffective schema vs its snapshot; cleared on operator acknowledge.",
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "createdAt": {
                         "readOnly": true,
                         "type": "string",
@@ -8658,6 +8664,12 @@
                             "string",
                             "null"
                         ]
+                    },
+                    "schemaDrift": {
+                        "readOnly": true,
+                        "description": "CHC-04 (#1288) \u2014 true when a category move changed this product's\neffective schema vs its snapshot; cleared on operator acknowledge.",
+                        "default": false,
+                        "type": "boolean"
                     },
                     "createdAt": {
                         "readOnly": true,


### PR DESCRIPTION
## Cel

CHC-04 (#1288, Grupa B — **przed pilotem**) — gdy ktoś przeniesie kategorię master, schemat produktów w niej może się zmienić (nowe/znikłe pola). Dane w starych polach zostają w bazie, ale formularz ich nie pokazuje. Operator powinien o tym wiedzieć. **Wykrywanie driftu jest asynchroniczne** — triggerowane zdarzeniem przeniesienia (CHC-05), NIE przy każdym otwarciu karty (zero wpływu na wydajność).

## Zakres

- **Schema**: `objects.schema_snapshot JSONB` + `objects.schema_drift BOOLEAN DEFAULT false` (migracja `Version20260606140000`).
- **Snapshot (sync, jednorazowy)**: `SchemaSnapshotListener` na `ObjectAttributesChanged` — przy pierwszym wypełnieniu produktu zapisuje `{attributeGroupIds, capturedAt, masterCategoryId}` (tylko gdy `schema_snapshot IS NULL`). `SchemaSnapshotFactory` buduje kształt (współdzielony z acknowledge).
- **Drift (async)**: `CheckSchemaDriftHandler` (`AbstractBatchHandler`, konsumuje `CheckSchemaDriftForCategory` z CHC-05) — dla każdego produktu w przeniesionym poddrzewie (ltree) porównuje `snapshot.attributeGroupIds` z bieżącym `EffectiveAttributeGroupResolver::resolve()`; różnica → `schema_drift = true`. `CheckSchemaDriftForCategory` implementuje teraz `TenantAwareMessage` (worker rebinduje TenantContext — brak dispatch-side TenantStamp w repo).
- **API**: `GET /api/objects|products/{id}` zwraca `schemaDrift`; `POST /api/objects|products/{id}/schema-drift/acknowledge` zeruje flagę + re-baseline snapshotu.
- **FE**: bursztynowy baner w górnej części zakładki „Kategorie" gdy `schemaDrift=true` + „Rozumiem, zaktualizuj schemat" → acknowledge → baner znika. Baner sam pobiera stan (zero dodatkowych zapytań przy otwarciu produktu bez driftu — query enabled, ale render warunkowy).

## Definicja Done (CI) — lokalnie zielone

- [x] `PHPStan max` 0 (po `clear-result-cache`) · `Deptrac` 0 · `PHP-CS-Fixer` 0 · `raw-sql-lint` clean (handler ma marker `tenant-safe:`)
- [x] `PHPUnit` — `SchemaDriftTest` (integ): listener zapisuje snapshot raz, NIE nadpisuje, handler flaguje drift gdy różnica / nie flaguje gdy zgodne; `SchemaDriftAcknowledgeApiTest`: acknowledge zeruje flagę + GET odzwierciedla; regresja `CategoryMoveImpactApiTest` (dispatch z `tenantId`) zielona
- [x] FE `tsc -b` + `biome`
- [x] OpenAPI snapshot zregenerowany (dodane pole `schemaDrift` w schemacie CatalogObject; acknowledge to custom controller — nie w AP export)

## Powiązania

- Refs #1288 · Blocked by #1287 (✅ merged — dostarczył message + dispatch)
- Epik: `epik-CHC` · Spec: `Project Plan/CHC-channel-categories-tickets.md` → CHC-04
