### PR TITLE
feat(channel): channel category node-mappings + CRUD API [CHC-06]

### DIFF
--- a/apps/api/migrations/Version20260606150000.php
+++ b/apps/api/migrations/Version20260606150000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * CHC-06 (#1289) — channel_category_node_mappings.
+ *
+ * One row per (tenant, channel, master category): the set of channel
+ * navigation nodes a master category maps to (M:N on the channel side, stored
+ * as a JSONB id array). Drives CHC-07 auto-assignment of products.
+ */
+final class Version20260606150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'CHC-06: create channel_category_node_mappings (master category → channel nodes)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE channel_category_node_mappings (id UUID NOT NULL, tenant_id UUID NOT NULL, channel_id UUID NOT NULL, master_cat_id UUID NOT NULL, channel_node_ids JSONB NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('ALTER TABLE channel_category_node_mappings ADD CONSTRAINT ccnm_tenant_fk FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE channel_category_node_mappings ADD CONSTRAINT ccnm_channel_fk FOREIGN KEY (channel_id) REFERENCES channels (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE channel_category_node_mappings ADD CONSTRAINT ccnm_master_fk FOREIGN KEY (master_cat_id) REFERENCES objects (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE UNIQUE INDEX ccnm_tenant_channel_master_uniq ON channel_category_node_mappings (tenant_id, channel_id, master_cat_id)');
+        $this->addSql('CREATE INDEX ccnm_channel_idx ON channel_category_node_mappings (channel_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE channel_category_node_mappings');
+    }
+}

--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -109,6 +109,7 @@ parameters:
               - src/Channel/Domain/Entity/Channel.php
               - src/Channel/Domain/Entity/ChannelCategoryNode.php
               - src/Channel/Domain/Entity/ObjectChannelPlacement.php
+              - src/Channel/Domain/Entity/ChannelCategoryNodeMapping.php
               - src/Asset/Domain/Entity/Asset.php
               - src/ApiConfigurator/Domain/Entity/ApiProfile.php
               - src/ApiConfigurator/Domain/Entity/ApiKey.php

--- a/apps/api/src/Channel/Domain/Entity/ChannelCategoryNodeMapping.php
+++ b/apps/api/src/Channel/Domain/Entity/ChannelCategoryNodeMapping.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Entity;
+
+use App\Shared\Application\TenantScoped;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CHC-06 (#1289) — maps a master category to one-or-many channel navigation
+ * nodes, so auto-assignment (CHC-07) can place every product of that category
+ * onto the channel without per-product manual work.
+ *
+ * `masterCategoryId` is a soft FK to a master `objects` (kind=category) row,
+ * kept as a bare Uuid so the Channel context never imports Catalog entities
+ * (deptrac). `channelNodeIds` is the M:N target set on the channel side
+ * (one master → many channel nodes), stored as a JSONB list of node ids.
+ */
+class ChannelCategoryNodeMapping implements TenantScoped
+{
+    private Uuid $id;
+
+    private ?Tenant $tenant = null;
+
+    private Channel $channel;
+
+    private Uuid $masterCategoryId;
+
+    /**
+     * @var list<string> RFC-4122 ids of ChannelCategoryNode targets
+     */
+    private array $channelNodeIds;
+
+    /**
+     * @param list<string> $channelNodeIds
+     */
+    public function __construct(
+        Channel $channel,
+        Uuid $masterCategoryId,
+        array $channelNodeIds,
+        ?Uuid $id = null,
+    ) {
+        $this->id = $id ?? Uuid::v7();
+        $this->channel = $channel;
+        $this->masterCategoryId = $masterCategoryId;
+        $this->channelNodeIds = $channelNodeIds;
+    }
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getTenant(): ?Tenant
+    {
+        return $this->tenant;
+    }
+
+    /**
+     * @internal stamped by TenantAssignmentListener on prePersist
+     */
+    public function assignTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant) {
+            throw new LogicException('Tenant is already assigned and cannot be reassigned.');
+        }
+
+        $this->tenant = $tenant;
+    }
+
+    public function getChannel(): Channel
+    {
+        return $this->channel;
+    }
+
+    public function getChannelId(): Uuid
+    {
+        return $this->channel->getId();
+    }
+
+    public function getMasterCategoryId(): Uuid
+    {
+        return $this->masterCategoryId;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getChannelNodeIds(): array
+    {
+        return $this->channelNodeIds;
+    }
+
+    /**
+     * @param list<string> $channelNodeIds
+     */
+    public function replaceNodes(array $channelNodeIds): void
+    {
+        $this->channelNodeIds = $channelNodeIds;
+    }
+}

--- a/apps/api/src/Channel/Domain/Repository/ChannelCategoryNodeMappingRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/ChannelCategoryNodeMappingRepositoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Domain\Repository;
+
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNodeMapping;
+use Symfony\Component\Uid\Uuid;
+
+interface ChannelCategoryNodeMappingRepositoryInterface
+{
+    /**
+     * @return list<ChannelCategoryNodeMapping>
+     */
+    public function findByChannel(Channel $channel): array;
+
+    public function findByChannelAndMaster(Channel $channel, Uuid $masterCategoryId): ?ChannelCategoryNodeMapping;
+
+    /**
+     * Create the (channel, master) mapping or replace its node set.
+     *
+     * @param list<string> $channelNodeIds
+     */
+    public function upsert(Channel $channel, Uuid $masterCategoryId, array $channelNodeIds): ChannelCategoryNodeMapping;
+
+    public function save(ChannelCategoryNodeMapping $mapping): void;
+
+    public function remove(ChannelCategoryNodeMapping $mapping): void;
+}

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ChannelCategoryNodeMapping.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/ChannelCategoryNodeMapping.orm.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="App\Channel\Domain\Entity\ChannelCategoryNodeMapping"
+            table="channel_category_node_mappings"
+            repository-class="App\Channel\Infrastructure\Doctrine\Repository\DoctrineChannelCategoryNodeMappingRepository">
+
+        <unique-constraints>
+            <unique-constraint name="ccnm_tenant_channel_master_uniq" columns="tenant_id,channel_id,master_cat_id"/>
+        </unique-constraints>
+
+        <indexes>
+            <index name="ccnm_channel_idx" columns="channel_id"/>
+        </indexes>
+
+        <id name="id" type="uuid" column="id">
+            <generator strategy="NONE"/>
+        </id>
+
+        <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+            <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <many-to-one field="channel" target-entity="App\Channel\Domain\Entity\Channel">
+            <join-column name="channel_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
+        </many-to-one>
+
+        <field name="masterCategoryId" type="uuid" column="master_cat_id"/>
+        <field name="channelNodeIds" type="json" column="channel_node_ids">
+            <options>
+                <option name="jsonb">true</option>
+            </options>
+        </field>
+
+    </entity>
+
+</doctrine-mapping>

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelCategoryNodeMappingRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelCategoryNodeMappingRepository.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Infrastructure\Doctrine\Repository;
+
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNodeMapping;
+use App\Channel\Domain\Repository\ChannelCategoryNodeMappingRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @extends ServiceEntityRepository<ChannelCategoryNodeMapping>
+ */
+class DoctrineChannelCategoryNodeMappingRepository extends ServiceEntityRepository implements ChannelCategoryNodeMappingRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ChannelCategoryNodeMapping::class);
+    }
+
+    /**
+     * @return list<ChannelCategoryNodeMapping>
+     */
+    public function findByChannel(Channel $channel): array
+    {
+        return $this->findBy(['channel' => $channel], ['masterCategoryId' => 'ASC']);
+    }
+
+    public function findByChannelAndMaster(Channel $channel, Uuid $masterCategoryId): ?ChannelCategoryNodeMapping
+    {
+        $result = $this->createQueryBuilder('m')
+            ->andWhere('IDENTITY(m.channel) = :channelId')
+            ->andWhere('m.masterCategoryId = :master')
+            ->setParameter('channelId', $channel->getId(), 'uuid')
+            ->setParameter('master', $masterCategoryId, 'uuid')
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof ChannelCategoryNodeMapping ? $result : null;
+    }
+
+    public function upsert(Channel $channel, Uuid $masterCategoryId, array $channelNodeIds): ChannelCategoryNodeMapping
+    {
+        $existing = $this->findByChannelAndMaster($channel, $masterCategoryId);
+        if (null !== $existing) {
+            $existing->replaceNodes($channelNodeIds);
+            $this->save($existing);
+
+            return $existing;
+        }
+
+        $mapping = new ChannelCategoryNodeMapping($channel, $masterCategoryId, $channelNodeIds);
+        $this->save($mapping);
+
+        return $mapping;
+    }
+
+    public function save(ChannelCategoryNodeMapping $mapping): void
+    {
+        $em = $this->getEntityManager();
+        $em->persist($mapping);
+        $em->flush();
+    }
+
+    public function remove(ChannelCategoryNodeMapping $mapping): void
+    {
+        $em = $this->getEntityManager();
+        $em->remove($mapping);
+        $em->flush();
+    }
+}

--- a/apps/api/src/Channel/Presentation/Controller/ChannelNodeMappingController.php
+++ b/apps/api/src/Channel/Presentation/Controller/ChannelNodeMappingController.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Presentation\Controller;
+
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNodeMapping;
+use App\Channel\Domain\Repository\ChannelCategoryNodeMappingRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelCategoryNodeRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * CHC-06 (#1289) — node-mapping CRUD: "master category → channel navigation
+ * node(s)". Drives CHC-07 auto-assignment so products inherit a channel
+ * placement from their master category without per-product work.
+ *
+ * Lives in the Channel context; the master category is referenced by Uuid
+ * (no cross-BC Catalog import). Master kind is validated with a tenant-scoped
+ * raw query on `objects` (table access, not an entity dependency).
+ */
+final class ChannelNodeMappingController
+{
+    public function __construct(
+        private readonly ChannelRepositoryInterface $channels,
+        private readonly ChannelCategoryNodeMappingRepositoryInterface $mappings,
+        private readonly ChannelCategoryNodeRepositoryInterface $nodes,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    #[Route('/api/channels/{channelId}/node-mappings', name: 'pim_channel_node_mappings_list', methods: ['GET'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'channel', action: 'read')]
+    public function list(string $channelId): JsonResponse
+    {
+        $channel = $this->requireChannel($channelId);
+
+        $rows = array_map(
+            static fn (ChannelCategoryNodeMapping $m): array => [
+                'masterCategoryId' => $m->getMasterCategoryId()->toRfc4122(),
+                'channelNodeIds' => $m->getChannelNodeIds(),
+            ],
+            $this->mappings->findByChannel($channel),
+        );
+
+        return new JsonResponse(['member' => $rows, 'totalItems' => \count($rows)]);
+    }
+
+    #[Route('/api/channels/{channelId}/node-mappings/{masterCategoryId}', name: 'pim_channel_node_mappings_put', methods: ['PUT'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'channel', action: 'write')]
+    public function put(string $channelId, string $masterCategoryId, Request $request): JsonResponse
+    {
+        $channel = $this->requireChannel($channelId);
+        $masterId = $this->uuid($masterCategoryId);
+        $this->assertMasterIsCategory($channel, $masterId);
+
+        $nodeIds = $this->decodeNodeIds($request);
+        foreach ($nodeIds as $nodeId) {
+            $node = $this->nodes->findById($this->uuid($nodeId));
+            if (null === $node || !$node->getChannel()->getId()->equals($channel->getId())) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Node "%s" does not belong to channel "%s".',
+                    $nodeId,
+                    $channel->getCode(),
+                ));
+            }
+        }
+
+        $mapping = $this->mappings->upsert($channel, $masterId, $nodeIds);
+
+        return new JsonResponse([
+            'masterCategoryId' => $mapping->getMasterCategoryId()->toRfc4122(),
+            'channelNodeIds' => $mapping->getChannelNodeIds(),
+        ]);
+    }
+
+    #[Route('/api/channels/{channelId}/node-mappings/{masterCategoryId}', name: 'pim_channel_node_mappings_delete', methods: ['DELETE'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'channel', action: 'write')]
+    public function delete(string $channelId, string $masterCategoryId): Response
+    {
+        $channel = $this->requireChannel($channelId);
+        $mapping = $this->mappings->findByChannelAndMaster($channel, $this->uuid($masterCategoryId));
+        if (null === $mapping) {
+            throw new NotFoundHttpException('No node mapping for this master category on the channel.');
+        }
+
+        $this->mappings->remove($mapping);
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+
+    private function requireChannel(string $channelId): Channel
+    {
+        $channel = $this->channels->findById($this->uuid($channelId));
+        if (null === $channel) {
+            throw new NotFoundHttpException(\sprintf('Channel "%s" was not found.', $channelId));
+        }
+
+        return $channel;
+    }
+
+    private function assertMasterIsCategory(Channel $channel, Uuid $masterId): void
+    {
+        $tenant = $channel->getTenant();
+        if (null === $tenant) {
+            throw new UnprocessableEntityHttpException('Channel has no tenant.');
+        }
+
+        // tenant-safe: explicit tenant_id filter; reads master object kind only.
+        $kind = $this->em->getConnection()->fetchOne(
+            'SELECT kind FROM objects WHERE id = CAST(:id AS uuid) AND tenant_id = CAST(:tenant AS uuid)',
+            ['id' => $masterId->toRfc4122(), 'tenant' => $tenant->getId()->toRfc4122()],
+        );
+        if ('category' !== $kind) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Object "%s" is not a master category.',
+                $masterId->toRfc4122(),
+            ));
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function decodeNodeIds(Request $request): array
+    {
+        $content = $request->getContent();
+        try {
+            $data = '' === $content ? [] : json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new BadRequestHttpException('Request body is not valid JSON.');
+        }
+        if (!\is_array($data) || !isset($data['nodeIds']) || !\is_array($data['nodeIds'])) {
+            throw new UnprocessableEntityHttpException('"nodeIds" (array of UUID strings) is required.');
+        }
+
+        $ids = [];
+        foreach ($data['nodeIds'] as $id) {
+            if (!\is_string($id) || '' === $id) {
+                throw new UnprocessableEntityHttpException('"nodeIds" must contain only non-empty UUID strings.');
+            }
+            $ids[] = $id;
+        }
+
+        return $ids;
+    }
+
+    private function uuid(string $value): Uuid
+    {
+        if (!Uuid::isValid($value)) {
+            throw new UnprocessableEntityHttpException(\sprintf('"%s" is not a valid UUID.', $value));
+        }
+
+        return Uuid::fromString($value);
+    }
+}

--- a/apps/api/tests/Api/Channel/ChannelNodeMappingApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelNodeMappingApiTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Channel;
+
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * CHC-06 (#1289) — `/api/channels/{channelId}/node-mappings` CRUD.
+ */
+final class ChannelNodeMappingApiTest extends ChannelApiTestCase
+{
+    /**
+     * @return array{channelId: string, nodeId: string}
+     */
+    private function createChannelWithNode(Client $client, string $code): array
+    {
+        $channel = $client->request('POST', '/api/channels', [
+            'json' => ['code' => $code, 'label' => ['pl' => $code], 'locales' => ['pl_PL']],
+        ]);
+        self::assertSame(201, $channel->getStatusCode());
+        $channelId = self::extractId($channel->toArray());
+
+        $root = $client->request('POST', "/api/channels/{$channelId}/navigation-tree", [
+            'json' => ['label' => ['pl' => 'Korzeń']],
+        ]);
+        $rootId = self::extractId($root->toArray());
+
+        $node = $client->request('POST', "/api/channels/{$channelId}/navigation-tree/nodes", [
+            'json' => ['parentId' => $rootId, 'code' => 'telewizory', 'label' => ['pl' => 'Telewizory']],
+        ]);
+
+        return ['channelId' => $channelId, 'nodeId' => self::extractId($node->toArray())];
+    }
+
+    private function makeObjectId(ObjectKind $kind, string $code): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)->findBuiltInByKind($kind, $tenant);
+        \assert(null !== $type);
+        $object = new CatalogObject($type, $code);
+        $em->persist($object);
+        $em->flush();
+
+        return $object->getId()->toRfc4122();
+    }
+
+    /**
+     * @return list<array<array-key, mixed>>
+     */
+    private function mappings(Client $client, string $channelId): array
+    {
+        $body = $client->request('GET', "/api/channels/{$channelId}/node-mappings", [
+            'headers' => ['accept' => 'application/json'],
+        ])->toArray();
+        $member = $body['member'] ?? [];
+        \assert(\is_array($member));
+        $out = [];
+        foreach ($member as $row) {
+            \assert(\is_array($row));
+            $out[] = $row;
+        }
+
+        return $out;
+    }
+
+    #[Test]
+    public function putThenGetReturnsMapping(): void
+    {
+        $client = $this->authenticatedClient();
+        ['channelId' => $channelId, 'nodeId' => $nodeId] = $this->createChannelWithNode($client, 'allegro');
+        $masterId = $this->makeObjectId(ObjectKind::Category, 'cat_tv');
+
+        $put = $client->request('PUT', "/api/channels/{$channelId}/node-mappings/{$masterId}", [
+            'json' => ['nodeIds' => [$nodeId]],
+        ]);
+        self::assertSame(200, $put->getStatusCode());
+
+        $rows = $this->mappings($client, $channelId);
+        self::assertCount(1, $rows);
+        self::assertSame($masterId, $rows[0]['masterCategoryId']);
+        self::assertSame([$nodeId], $rows[0]['channelNodeIds']);
+    }
+
+    #[Test]
+    public function putRejectsNonCategoryMaster(): void
+    {
+        $client = $this->authenticatedClient();
+        ['channelId' => $channelId, 'nodeId' => $nodeId] = $this->createChannelWithNode($client, 'allegro');
+        $productId = $this->makeObjectId(ObjectKind::Product, 'SKU-NODEMAP');
+
+        $put = $client->request('PUT', "/api/channels/{$channelId}/node-mappings/{$productId}", [
+            'json' => ['nodeIds' => [$nodeId]],
+        ]);
+        self::assertSame(422, $put->getStatusCode());
+    }
+
+    #[Test]
+    public function putRejectsNodeFromAnotherChannel(): void
+    {
+        $client = $this->authenticatedClient();
+        $a = $this->createChannelWithNode($client, 'allegro');
+        $b = $this->createChannelWithNode($client, 'shopify');
+        $masterId = $this->makeObjectId(ObjectKind::Category, 'cat_tv');
+
+        $put = $client->request('PUT', "/api/channels/{$a['channelId']}/node-mappings/{$masterId}", [
+            'json' => ['nodeIds' => [$b['nodeId']]],
+        ]);
+        self::assertSame(422, $put->getStatusCode());
+    }
+
+    #[Test]
+    public function deleteRemovesMapping(): void
+    {
+        $client = $this->authenticatedClient();
+        ['channelId' => $channelId, 'nodeId' => $nodeId] = $this->createChannelWithNode($client, 'allegro');
+        $masterId = $this->makeObjectId(ObjectKind::Category, 'cat_tv');
+
+        $client->request('PUT', "/api/channels/{$channelId}/node-mappings/{$masterId}", [
+            'json' => ['nodeIds' => [$nodeId]],
+        ]);
+
+        $delete = $client->request('DELETE', "/api/channels/{$channelId}/node-mappings/{$masterId}");
+        self::assertSame(204, $delete->getStatusCode());
+        self::assertCount(0, $this->mappings($client, $channelId));
+    }
+
+    #[Test]
+    public function unauthenticatedIsRejected(): void
+    {
+        $client = static::createClient();
+        $response = $client->request('GET', '/api/channels/0192ffff-ffff-7fff-8fff-ffffffffffff/node-mappings', [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertSame(401, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Cel

CHC-06 (#1289, Faza 1) — przy 50k produktów ręczne ustawianie channel placement per produkt (CHC-03) jest niewykonalne. Node mapping definiuje raz: „kategoria master Telewizory → węzeł Allegro RTV > Telewizory". System auto-assignuje produkty (CHC-07). Ten ticket dostarcza tabelę + CRUD API (substrate pod CHC-07/CHC-08).

## Zakres

- Encja `ChannelCategoryNodeMapping` (`TenantScoped`) + migracja `Version20260606150000`: `UNIQUE (tenant_id, channel_id, master_cat_id)`; FK `master_cat_id → objects`, `channel_id → channels`, `tenant_id → tenants` (`ON DELETE CASCADE`).
- `channel_node_ids` jako **JSONB** lista id (M:N po stronie kanału — jeden master → wiele węzłów). Doc pisał `UUID[]`; JSONB to równoważnik bez custom Doctrine array-type (świadome odejście, ta sama semantyka).
- `masterCategoryId` to **soft FK Uuid** (brak importu encji Catalog → deptrac clean); kind mastera walidowany tenant-scoped raw query na `objects` (dostęp do tabeli, nie zależność klasowa).
- `ChannelNodeMappingController`: `GET /node-mappings`, `PUT /node-mappings/{masterCategoryId}` body `{nodeIds:[...]}`, `DELETE /node-mappings/{masterCategoryId}`. Walidacje: master nie-kategoria → 422, węzeł z innego kanału → 422.
- Repozytorium `ChannelCategoryNodeMappingRepository`: `findByChannel`, `findByChannelAndMaster`, `upsert` (create-or-replace node set).

## Definicja Done (CI) — lokalnie zielone

- [x] `PHPStan max` 0 · `Deptrac` 0 (master po Uuid, brak cross-BC) · `PHP-CS-Fixer` 0 · `raw-sql-lint` clean (kind-check ma marker `tenant-safe:`)
- [x] `PHPUnit` — `ChannelNodeMappingApiTest`: PUT+GET, 422 non-category master, 422 node z innego kanału, DELETE, 401
- [x] Brak zmian OpenAPI (custom controller, nie AP resource) · brak zmian FE

## Powiązania

- Refs #1289 · Blocked by #1284 (✅ merged — `channel_category_nodes`) · **Blokuje #1290 (CHC-07), #1291 (CHC-08)**
- Epik: `epik-CHC` · Spec: `Project Plan/CHC-channel-categories-tickets.md` → CHC-06
