### PR TITLE
feat(channel): auto-assign channel placements from node mappings [CHC-07]

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -75,6 +75,13 @@ framework:
             # makes this a safe no-op enqueue until the CHC-04 handler lands.
             App\Catalog\Application\Message\CheckSchemaDriftForCategory: async
 
+            # CHC-07 (#1290) — when a product's primary master category is
+            # (re)assigned, the Channel handler auto-creates channel placements
+            # from that category's node mappings off the request thread. The
+            # event is recorded on the CatalogObject aggregate and dispatched
+            # post-flush; routing it async keeps the assignment request fast.
+            App\Catalog\Contracts\Event\ObjectPrimaryCategoryAssigned: async
+
             # DAM thumbnail pipeline (#438). The upload request returns
             # 201 immediately and the worker generates the 200×200 +
             # 800×800 WebP variants out-of-band. In dev / test the

--- a/apps/api/src/Catalog/Contracts/Event/ObjectPrimaryCategoryAssigned.php
+++ b/apps/api/src/Catalog/Contracts/Event/ObjectPrimaryCategoryAssigned.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts\Event;
+
+use App\Shared\Application\TenantAwareMessage;
+use App\Shared\Domain\DomainEvent;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Emitted when an object's primary master category is (re)assigned —
+ * i.e. whenever `ObjectCategoryRepository::replaceForProduct()` commits a
+ * non-null primary (CHC-07, #1290).
+ *
+ * The Channel context consumes this off-thread to auto-create channel
+ * placements from the node mappings of that master category
+ * ({@see \App\Channel\Application\Subscriber\AssignChannelPlacementsOnPrimaryCategoryAssigned}):
+ * the operator picks one master category and the product lands on every
+ * channel that mapped it — without touching each channel by hand.
+ *
+ * Carries `tenantId` so the async worker can rebind the tenant context
+ * ({@see TenantAwareMessage}); without it the consumer would run with no
+ * tenant filter and read across tenants.
+ */
+final readonly class ObjectPrimaryCategoryAssigned implements DomainEvent, TenantAwareMessage
+{
+    public function __construct(
+        public Uuid $objectId,
+        public Uuid $tenantId,
+        public Uuid $primaryCategoryId,
+        public DateTimeImmutable $occurredOn = new DateTimeImmutable(),
+    ) {
+    }
+
+    public function occurredOn(): DateTimeImmutable
+    {
+        return $this->occurredOn;
+    }
+
+    public function eventName(): string
+    {
+        return 'catalog.object.primary-category-assigned';
+    }
+
+    public function aggregateId(): string
+    {
+        return $this->objectId->toRfc4122();
+    }
+
+    public function tenantId(): Uuid
+    {
+        return $this->tenantId;
+    }
+}

--- a/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
+++ b/apps/api/src/Catalog/Domain/Entity/CatalogObject.php
@@ -8,6 +8,7 @@ use App\Catalog\Contracts\Event\ObjectArchived;
 use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
 use App\Catalog\Contracts\Event\ObjectEnabledChanged;
+use App\Catalog\Contracts\Event\ObjectPrimaryCategoryAssigned;
 use App\Catalog\Contracts\Event\ObjectPublished;
 use App\Catalog\Domain\ObjectKind;
 use App\Shared\Application\Blameable;
@@ -399,6 +400,27 @@ class CatalogObject extends AggregateRoot implements TenantScoped, Blameable
             objectId: $this->id,
             tenantId: $this->tenant->getId(),
             changedAttributeCodes: $changedCodes,
+        ));
+    }
+
+    /**
+     * Record that this object's primary master category is now
+     * `$primaryCategoryId` (CHC-07, #1290). Called by the assignment repository
+     * after it commits a non-null primary; the buffered event is dispatched by
+     * {@see \App\Shared\Infrastructure\Messenger\DomainEventDispatcher} once the
+     * surrounding flush succeeds, then drives channel-placement auto-assignment
+     * off-thread.
+     */
+    public function recordPrimaryCategoryAssigned(Uuid $primaryCategoryId): void
+    {
+        if (null === $this->tenant) {
+            throw new LogicException('Cannot record primary-category assignment before the tenant is set.');
+        }
+
+        $this->recordThat(new ObjectPrimaryCategoryAssigned(
+            objectId: $this->id,
+            tenantId: $this->tenant->getId(),
+            primaryCategoryId: $primaryCategoryId,
         ));
     }
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectCategoryRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectCategoryRepository.php
@@ -121,6 +121,14 @@ final class DoctrineObjectCategoryRepository extends ServiceEntityRepository imp
                 $em->persist($assignment);
             }
 
+            if (null !== $primaryId) {
+                // CHC-07 (#1290): record the primary-category assignment on the
+                // aggregate so DomainEventDispatcher dispatches it after this
+                // flush commits. Channel placements are then auto-created from
+                // the master category's node mappings, off the request thread.
+                $product->recordPrimaryCategoryAssigned($primaryId);
+            }
+
             $em->flush();
         });
     }

--- a/apps/api/src/Channel/Application/Subscriber/AssignChannelPlacementsOnPrimaryCategoryAssigned.php
+++ b/apps/api/src/Channel/Application/Subscriber/AssignChannelPlacementsOnPrimaryCategoryAssigned.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Application\Subscriber;
+
+use App\Catalog\Contracts\Event\ObjectPrimaryCategoryAssigned;
+use App\Channel\Domain\ChannelPlacementSource;
+use App\Channel\Domain\Repository\ChannelCategoryNodeMappingRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelCategoryNodeRepositoryInterface;
+use App\Channel\Domain\Repository\ObjectChannelPlacementRepositoryInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CHC-07 (#1290) — auto-assign channel placements from node mappings.
+ *
+ * On {@see ObjectPrimaryCategoryAssigned}: for every channel that mapped the
+ * product's new primary master category ({@see \App\Channel\Domain\Entity\ChannelCategoryNodeMapping},
+ * CHC-06), create or re-point an `object_channel_placements` row with
+ * `source='auto'`. The operator sets one master category and the product
+ * lands on every channel automatically.
+ *
+ * Manual placements win: a row the operator set by hand (`source='manual'`,
+ * CHC-03) is never overwritten — the operator's intent always overrides the
+ * mapping. Re-running is idempotent (upsert + manual skip).
+ *
+ * Runs on the async transport (see messenger.yaml); the event is
+ * {@see \App\Shared\Application\TenantAwareMessage} so the worker rebinds the
+ * tenant context before the tenant-filtered repositories run.
+ *
+ * Mapping is M:N on the channel side (one master → several channel nodes), a
+ * placement is single-node per (object, channel). When a mapping lists more
+ * than one node we place the product on the first; the operator can re-point
+ * by hand afterwards (manual then wins). Deliberate CHC-07 simplification —
+ * the split-view UI (CHC-08) makes the per-channel node explicit.
+ */
+#[AsMessageHandler]
+final readonly class AssignChannelPlacementsOnPrimaryCategoryAssigned
+{
+    public function __construct(
+        private ChannelCategoryNodeMappingRepositoryInterface $mappings,
+        private ChannelCategoryNodeRepositoryInterface $nodes,
+        private ObjectChannelPlacementRepositoryInterface $placements,
+    ) {
+    }
+
+    public function __invoke(ObjectPrimaryCategoryAssigned $event): void
+    {
+        $objectId = $event->objectId;
+
+        foreach ($this->mappings->findByMasterCategory($event->primaryCategoryId) as $mapping) {
+            $nodeIds = $mapping->getChannelNodeIds();
+            if ([] === $nodeIds) {
+                continue;
+            }
+
+            $node = $this->nodes->findById(Uuid::fromString($nodeIds[0]));
+            if (null === $node) {
+                // Stale mapping pointing at a deleted node — skip rather than fail.
+                continue;
+            }
+
+            $channel = $mapping->getChannel();
+            $existing = $this->placements->findByObjectAndChannel($objectId, $channel->getId());
+            if (null !== $existing && ChannelPlacementSource::Manual === $existing->getSource()) {
+                // Operator placed this product by hand — manual wins over auto.
+                continue;
+            }
+
+            $this->placements->upsert($objectId, $channel, $node, ChannelPlacementSource::Auto);
+        }
+    }
+}

--- a/apps/api/src/Channel/Domain/Repository/ChannelCategoryNodeMappingRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/ChannelCategoryNodeMappingRepositoryInterface.php
@@ -18,6 +18,14 @@ interface ChannelCategoryNodeMappingRepositoryInterface
     public function findByChannelAndMaster(Channel $channel, Uuid $masterCategoryId): ?ChannelCategoryNodeMapping;
 
     /**
+     * Every mapping of a master category across all channels — the fan-out
+     * source for placement auto-assignment (CHC-07).
+     *
+     * @return list<ChannelCategoryNodeMapping>
+     */
+    public function findByMasterCategory(Uuid $masterCategoryId): array;
+
+    /**
      * Create the (channel, master) mapping or replace its node set.
      *
      * @param list<string> $channelNodeIds

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelCategoryNodeMappingRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelCategoryNodeMappingRepository.php
@@ -42,6 +42,24 @@ class DoctrineChannelCategoryNodeMappingRepository extends ServiceEntityReposito
         return $result instanceof ChannelCategoryNodeMapping ? $result : null;
     }
 
+    /**
+     * @return list<ChannelCategoryNodeMapping>
+     */
+    public function findByMasterCategory(Uuid $masterCategoryId): array
+    {
+        /** @var list<ChannelCategoryNodeMapping> $rows */
+        $rows = $this->createQueryBuilder('m')
+            ->innerJoin('m.channel', 'c')
+            ->addSelect('c')
+            ->andWhere('m.masterCategoryId = :master')
+            ->setParameter('master', $masterCategoryId, 'uuid')
+            ->orderBy('c.code', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
     public function upsert(Channel $channel, Uuid $masterCategoryId, array $channelNodeIds): ChannelCategoryNodeMapping
     {
         $existing = $this->findByChannelAndMaster($channel, $masterCategoryId);

--- a/apps/api/tests/Integration/Channel/AutoAssignChannelPlacementsTest.php
+++ b/apps/api/tests/Integration/Channel/AutoAssignChannelPlacementsTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Channel;
+
+use App\Catalog\Application\BuiltInObjectTypeSeeder;
+use App\Catalog\Contracts\Event\ObjectPrimaryCategoryAssigned;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Application\Subscriber\AssignChannelPlacementsOnPrimaryCategoryAssigned;
+use App\Channel\Domain\ChannelPlacementSource;
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNode;
+use App\Channel\Domain\Repository\ChannelCategoryNodeMappingRepositoryInterface;
+use App\Channel\Domain\Repository\ObjectChannelPlacementRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * CHC-07 (#1290) — placement auto-assignment from node mappings, end-to-end
+ * over the real repositories + Postgres (the handler is invoked directly so
+ * the test does not depend on the async transport — same shape as
+ * {@see \App\Tests\Integration\Catalog\SchemaDriftTest}).
+ */
+final class AutoAssignChannelPlacementsTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $em = $this->em();
+        $this->tenant = new Tenant('demo', 'Demo');
+        $em->persist($this->tenant);
+        $em->flush();
+        $this->tenantContext()->set($this->tenant);
+
+        self::getContainer()->get(BuiltInObjectTypeSeeder::class)->seed($this->tenant);
+    }
+
+    #[Test]
+    public function createsAutoPlacementOnChannelThatMappedTheMasterCategory(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $category = $this->makeCategory('cat-tv');
+        $channel = $this->makeChannel('allegro');
+        $node = $this->makeNode($channel, 'rtv');
+        $this->mapMaster($channel, $category, [$node]);
+
+        $this->handler()(new ObjectPrimaryCategoryAssigned($product->getId(), $this->tenant->getId(), $category->getId()));
+
+        $placement = $this->placements()->findByObjectAndChannel($product->getId(), $channel->getId());
+        self::assertNotNull($placement);
+        self::assertTrue($placement->getNodeId()->equals($node->getId()));
+        self::assertSame(ChannelPlacementSource::Auto, $placement->getSource());
+    }
+
+    #[Test]
+    public function fansOutAcrossEveryChannelWithAMapping(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $category = $this->makeCategory('cat-tv');
+
+        $allegro = $this->makeChannel('allegro');
+        $shopify = $this->makeChannel('shopify');
+        $this->mapMaster($allegro, $category, [$this->makeNode($allegro, 'rtv')]);
+        $this->mapMaster($shopify, $category, [$this->makeNode($shopify, 'electronics')]);
+
+        $this->handler()(new ObjectPrimaryCategoryAssigned($product->getId(), $this->tenant->getId(), $category->getId()));
+
+        self::assertCount(2, $this->placements()->findByObject($product->getId()));
+    }
+
+    #[Test]
+    public function neverOverwritesAManualPlacement(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $category = $this->makeCategory('cat-tv');
+        $channel = $this->makeChannel('allegro');
+        $mapped = $this->makeNode($channel, 'rtv');
+        $manualNode = $this->makeNode($channel, 'agd');
+        $this->mapMaster($channel, $category, [$mapped]);
+
+        // Operator placed the product by hand on a different node.
+        $this->placements()->upsert($product->getId(), $channel, $manualNode, ChannelPlacementSource::Manual);
+
+        $this->handler()(new ObjectPrimaryCategoryAssigned($product->getId(), $this->tenant->getId(), $category->getId()));
+
+        $placement = $this->placements()->findByObjectAndChannel($product->getId(), $channel->getId());
+        self::assertNotNull($placement);
+        self::assertSame(ChannelPlacementSource::Manual, $placement->getSource());
+        self::assertTrue($placement->getNodeId()->equals($manualNode->getId()), 'manual node must be preserved');
+    }
+
+    #[Test]
+    public function repointsAnExistingAutoPlacement(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $category = $this->makeCategory('cat-tv');
+        $channel = $this->makeChannel('allegro');
+        $oldNode = $this->makeNode($channel, 'old');
+        $newNode = $this->makeNode($channel, 'new');
+        $this->mapMaster($channel, $category, [$newNode]);
+
+        $this->placements()->upsert($product->getId(), $channel, $oldNode, ChannelPlacementSource::Auto);
+
+        $this->handler()(new ObjectPrimaryCategoryAssigned($product->getId(), $this->tenant->getId(), $category->getId()));
+
+        $placement = $this->placements()->findByObjectAndChannel($product->getId(), $channel->getId());
+        self::assertNotNull($placement);
+        self::assertTrue($placement->getNodeId()->equals($newNode->getId()));
+        self::assertSame(ChannelPlacementSource::Auto, $placement->getSource());
+    }
+
+    #[Test]
+    public function doesNothingWhenCategoryHasNoMappings(): void
+    {
+        $product = $this->makeProduct('SKU-1');
+        $category = $this->makeCategory('cat-orphan');
+        $this->makeChannel('allegro');
+
+        $this->handler()(new ObjectPrimaryCategoryAssigned($product->getId(), $this->tenant->getId(), $category->getId()));
+
+        self::assertCount(0, $this->placements()->findByObject($product->getId()));
+    }
+
+    /**
+     * @param list<ChannelCategoryNode> $nodes
+     */
+    private function mapMaster(Channel $channel, CatalogObject $category, array $nodes): void
+    {
+        $this->mappings()->upsert(
+            $channel,
+            $category->getId(),
+            array_map(static fn (ChannelCategoryNode $n): string => $n->getId()->toRfc4122(), $nodes),
+        );
+    }
+
+    private function makeProduct(string $sku): CatalogObject
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $this->tenant);
+        \assert(null !== $type);
+        $product = new CatalogObject($type, $sku);
+        $this->em()->persist($product);
+        $this->em()->flush();
+
+        return $product;
+    }
+
+    private function makeCategory(string $code): CatalogObject
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Category, $this->tenant);
+        \assert(null !== $type);
+        $category = new CatalogObject($type, $code);
+        $this->em()->persist($category);
+        $this->em()->flush();
+
+        return $category;
+    }
+
+    private function makeChannel(string $code): Channel
+    {
+        $channel = new Channel($code, ['pl' => $code]);
+        $this->em()->persist($channel);
+        $this->em()->flush();
+
+        return $channel;
+    }
+
+    private function makeNode(Channel $channel, string $code): ChannelCategoryNode
+    {
+        $node = new ChannelCategoryNode($channel, $code, ['pl' => $code]);
+        $node->attachToPath($node->ltreeLabel());
+        $this->em()->persist($node);
+        $this->em()->flush();
+
+        return $node;
+    }
+
+    private function handler(): AssignChannelPlacementsOnPrimaryCategoryAssigned
+    {
+        return self::getContainer()->get(AssignChannelPlacementsOnPrimaryCategoryAssigned::class);
+    }
+
+    private function mappings(): ChannelCategoryNodeMappingRepositoryInterface
+    {
+        return self::getContainer()->get(ChannelCategoryNodeMappingRepositoryInterface::class);
+    }
+
+    private function placements(): ObjectChannelPlacementRepositoryInterface
+    {
+        return self::getContainer()->get(ObjectChannelPlacementRepositoryInterface::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}

--- a/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
+++ b/apps/api/tests/Integration/Configuration/MessengerRoutingTest.php
@@ -42,6 +42,11 @@ final class MessengerRoutingTest extends KernelTestCase
             \App\Catalog\Application\Message\ObjectValuesChangedMessage::class,
             'async',
         ];
+
+        yield 'catalog: primary category assigned (CHC-07 placement auto-assign)' => [
+            \App\Catalog\Contracts\Event\ObjectPrimaryCategoryAssigned::class,
+            'async',
+        ];
     }
 
     /**

--- a/apps/api/tests/Unit/Channel/AssignChannelPlacementsOnPrimaryCategoryAssignedTest.php
+++ b/apps/api/tests/Unit/Channel/AssignChannelPlacementsOnPrimaryCategoryAssignedTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Channel;
+
+use App\Catalog\Contracts\Event\ObjectPrimaryCategoryAssigned;
+use App\Channel\Application\Subscriber\AssignChannelPlacementsOnPrimaryCategoryAssigned;
+use App\Channel\Domain\ChannelPlacementSource;
+use App\Channel\Domain\Entity\Channel;
+use App\Channel\Domain\Entity\ChannelCategoryNode;
+use App\Channel\Domain\Entity\ChannelCategoryNodeMapping;
+use App\Channel\Domain\Entity\ObjectChannelPlacement;
+use App\Channel\Domain\Repository\ChannelCategoryNodeMappingRepositoryInterface;
+use App\Channel\Domain\Repository\ChannelCategoryNodeRepositoryInterface;
+use App\Channel\Domain\Repository\ObjectChannelPlacementRepositoryInterface;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CHC-07 (#1290) — unit coverage for placement auto-assignment from node
+ * mappings. The read repositories are stubs; the placement repository is a
+ * mock so the manual-wins rule and the fan-out are verified by call
+ * expectations.
+ */
+final class AssignChannelPlacementsOnPrimaryCategoryAssignedTest extends TestCase
+{
+    private Uuid $objectId;
+    private Uuid $masterCategoryId;
+    private Channel $channel;
+    private ChannelCategoryNode $node;
+
+    protected function setUp(): void
+    {
+        $this->objectId = Uuid::v7();
+        $this->masterCategoryId = Uuid::v7();
+        $this->channel = new Channel('allegro', ['pl' => 'Allegro']);
+        $this->node = new ChannelCategoryNode($this->channel, 'rtv', ['pl' => 'RTV']);
+    }
+
+    #[Test]
+    public function upsertsAutoPlacementForEachMappedChannel(): void
+    {
+        $placements = $this->placementsMock(existing: null);
+        $placements->expects(self::once())->method('upsert')
+            ->with($this->objectId, $this->channel, $this->node, ChannelPlacementSource::Auto);
+
+        $this->handler($this->mappingTo($this->node), $this->nodesReturn($this->node), $placements)($this->event());
+    }
+
+    #[Test]
+    public function neverOverwritesManualPlacement(): void
+    {
+        $manual = new ObjectChannelPlacement($this->objectId, $this->channel, $this->node, ChannelPlacementSource::Manual);
+        $placements = $this->placementsMock(existing: $manual);
+        $placements->expects(self::never())->method('upsert');
+
+        $this->handler($this->mappingTo($this->node), $this->nodesReturn($this->node), $placements)($this->event());
+    }
+
+    #[Test]
+    public function repointsExistingAutoPlacement(): void
+    {
+        $auto = new ObjectChannelPlacement($this->objectId, $this->channel, $this->node, ChannelPlacementSource::Auto);
+        $placements = $this->placementsMock(existing: $auto);
+        $placements->expects(self::once())->method('upsert')
+            ->with($this->objectId, $this->channel, $this->node, ChannelPlacementSource::Auto);
+
+        $this->handler($this->mappingTo($this->node), $this->nodesReturn($this->node), $placements)($this->event());
+    }
+
+    #[Test]
+    public function skipsMappingWithoutNodes(): void
+    {
+        $placements = $this->placementsMock(existing: null);
+        $placements->expects(self::never())->method('upsert');
+
+        $mappings = $this->createStub(ChannelCategoryNodeMappingRepositoryInterface::class);
+        $mappings->method('findByMasterCategory')
+            ->willReturn([new ChannelCategoryNodeMapping($this->channel, $this->masterCategoryId, [])]);
+
+        $this->handler($mappings, $this->nodesReturn(null), $placements)($this->event());
+    }
+
+    #[Test]
+    public function skipsStaleNodeReference(): void
+    {
+        $placements = $this->placementsMock(existing: null);
+        $placements->expects(self::never())->method('upsert');
+
+        $this->handler($this->mappingTo($this->node), $this->nodesReturn(null), $placements)($this->event());
+    }
+
+    #[Test]
+    public function doesNothingWhenCategoryHasNoMappings(): void
+    {
+        $placements = $this->placementsMock(existing: null);
+        $placements->expects(self::never())->method('upsert');
+
+        $mappings = $this->createStub(ChannelCategoryNodeMappingRepositoryInterface::class);
+        $mappings->method('findByMasterCategory')->willReturn([]);
+
+        $this->handler($mappings, $this->nodesReturn(null), $placements)($this->event());
+    }
+
+    private function mappingTo(ChannelCategoryNode $node): ChannelCategoryNodeMappingRepositoryInterface
+    {
+        $mappings = $this->createStub(ChannelCategoryNodeMappingRepositoryInterface::class);
+        $mappings->method('findByMasterCategory')
+            ->willReturn([new ChannelCategoryNodeMapping($this->channel, $this->masterCategoryId, [$node->getId()->toRfc4122()])]);
+
+        return $mappings;
+    }
+
+    private function nodesReturn(?ChannelCategoryNode $node): ChannelCategoryNodeRepositoryInterface
+    {
+        $nodes = $this->createStub(ChannelCategoryNodeRepositoryInterface::class);
+        $nodes->method('findById')->willReturn($node);
+
+        return $nodes;
+    }
+
+    private function placementsMock(?ObjectChannelPlacement $existing): ObjectChannelPlacementRepositoryInterface&MockObject
+    {
+        $placements = $this->createMock(ObjectChannelPlacementRepositoryInterface::class);
+        $placements->method('findByObjectAndChannel')->willReturn($existing);
+
+        return $placements;
+    }
+
+    private function handler(
+        ChannelCategoryNodeMappingRepositoryInterface $mappings,
+        ChannelCategoryNodeRepositoryInterface $nodes,
+        ObjectChannelPlacementRepositoryInterface $placements,
+    ): AssignChannelPlacementsOnPrimaryCategoryAssigned {
+        return new AssignChannelPlacementsOnPrimaryCategoryAssigned($mappings, $nodes, $placements);
+    }
+
+    private function event(): ObjectPrimaryCategoryAssigned
+    {
+        return new ObjectPrimaryCategoryAssigned($this->objectId, Uuid::v7(), $this->masterCategoryId);
+    }
+}


### PR DESCRIPTION
## Cel

CHC-07 (#1290, Faza 1) — przy 50k SKU ręczne ustawianie channel placement per produkt (CHC-03) jest niewykonalne. Gdy operator przypisuje **primary kategorię master** do produktu, system automatycznie tworzy placements na wszystkich kanałach, które zmapowały tę kategorię (node mappings z CHC-06). Operator nie dotyka każdego kanału ręcznie.

## Zakres

- **Event `ObjectPrimaryCategoryAssigned`** (`Catalog/Contracts/Event/`, `DomainEvent` + `TenantAwareMessage`) — ⚠ event nie istniał, utworzony zgodnie z notą korekty w treści ticketu.
- **Emisja**: nagrywana na agregacie `CatalogObject` przez `DoctrineObjectCategoryRepository::replaceForProduct()` zawsze gdy commitowany jest niepusty primary. `DomainEventDispatcher` dispatchuje po flushu. To jedyny lejek wszystkich zmian primary (oba kontrolery `Product*`/`Object*CategoryAssignmentController` + bulk).
- **Routing `async`** — assignment request zostaje szybki; w prod worker, w dev/test `sync://`.
- **Handler `AssignChannelPlacementsOnPrimaryCategoryAssigned`** (`Channel/Application/Subscriber/`): fan-out po `findByMasterCategory()`, per kanał upsert `object_channel_placements` z `source='auto'`. **Manual wygrywa** — placement ustawiony ręcznie nigdy nie jest nadpisywany. Idempotentny.
- **Repo**: nowa metoda `findByMasterCategory(Uuid): list` (mapowania master przez wszystkie kanały).

## Świadome odejścia

1. **Plain `#[AsMessageHandler]` zamiast `AbstractBatchHandler`** (ticket sugerował batch). Wzorzec z istniejącego `CreateDefaultPublicationProfilesOnChannelCreated`: jeden produkt dotyka kilku kanałów (brak batch-memory concern), a `clear()` z `AbstractBatchHandler` jest **niebezpieczny** gdy handler wykonuje się inline w `postFlush` pod transportem `sync://` (test) — re-entrant clear detachuje encje w trakcie iteracji identity map.
2. **Mapping M:N → placement single-node**: mapowanie kanałowe dopuszcza wiele węzłów na master; placement jest pojedynczy per (object, channel). Auto wybiera **pierwszy** węzeł; operator może ręcznie re-pointować (wtedy manual wygrywa). CHC-08 (split-view) uczyni węzeł per-kanał jawnym.
3. **Usunięcie primary nie kasuje auto-placements** (`primaryId === null` → brak eventu). Manual placements zostają; stare auto stają się nieaktywne ale nieszkodliwe. Cleanup poza zakresem CHC-07.

## Definicja Done (CI) — lokalnie zielone

- [x] `PHPStan max` 0 · `Deptrac` 0 (handler w `Channel_Internals` → `Catalog_Contracts`, dozwolone) · `PHP-CS-Fixer` 0
- [x] `PHPUnit`: unit handler (6 — manual-wins, repoint-auto, fan-out skip empty/stale/no-mapping) + integration (5, realne repo + Postgres) + routing assertion (`ObjectPrimaryCategoryAssigned` → async)
- [x] Brak zmian OpenAPI · brak zmian FE (event-driven backend; UI „Przywróć automatyczne" w CHC-08)

## Powiązania

- Refs #1290 · Blocked by #1289 (✅ CHC-06 merged), #1286 · Epik: `epik-CHC`
- Spec: `Project Plan/CHC-channel-categories-tickets.md` → CHC-07
