### PR TITLE
feat(channel): split-view UI for master→channel-node mapping [CHC-08]

### DIFF
--- a/apps/admin/e2e/chc-08-category-node-mapping.spec.ts
+++ b/apps/admin/e2e/chc-08-category-node-mapping.spec.ts
@@ -32,52 +32,62 @@ test('map a master category to a channel node from the channel mapping tab', asy
   expect(channels.length).toBeGreaterThan(0);
   const channelId = channels[0].id;
 
-  // 2. A navigation tree (root + one node) on that channel.
-  const rootResp = await page.request.post(`/api/channels/${channelId}/navigation-tree`, {
-    headers: json,
-    data: { label: { pl: 'Korzeń CHC08' } },
-  });
-  expect([201, 409]).toContain(rootResp.status());
-  const tree = (await (
+  // Clean slate: drop any leftover navigation tree + mappings so options and
+  // assertions stay deterministic across re-runs (failed runs skip cleanup).
+  const existing = (await (
     await page.request.get(`/api/channels/${channelId}/navigation-tree`, {
       headers: { ...bearer, accept: 'application/json' },
     })
   ).json()) as Array<{ id: string; parentId: string | null }>;
-  const rootId = tree.find((n) => n.parentId === null)?.id;
-  if (rootId === undefined) throw new Error('Navigation root missing after creation.');
+  for (const root of existing.filter((n) => n.parentId === null)) {
+    await page.request.delete(`/api/channels/${channelId}/navigation-tree/nodes/${root.id}`, {
+      headers: bearer,
+    });
+  }
+  await page.request.delete(`/api/channels/${channelId}/node-mappings`, { headers: bearer });
+
+  // 2. A fresh navigation tree: root + one node, with distinct tokens so the
+  // node option ("MAP08") never collides with the root ("E2E08").
+  const rootResp = await page.request.post(`/api/channels/${channelId}/navigation-tree`, {
+    headers: json,
+    data: { label: { pl: 'Korzeń E2E08', en: 'Root E2E08' } },
+  });
+  expect(rootResp.status()).toBe(201);
+  const rootId = ((await rootResp.json()) as { id: string }).id;
 
   await page.request.post(`/api/channels/${channelId}/navigation-tree/nodes`, {
     headers: json,
-    data: { parentId: rootId, code: 'chc08_node', label: { pl: 'CHC08 Węzeł' } },
+    data: { parentId: rootId, code: 'e2e_map08', label: { pl: 'Węzeł MAP08', en: 'Node MAP08' } },
   });
-
-  // Start from a clean mapping slate so assertions are deterministic.
-  await page.request.delete(`/api/channels/${channelId}/node-mappings`, { headers: bearer });
 
   // 3. Open the channel "Kategorie kanału" tab.
   await page.goto(`/settings/channels/${channelId}`);
-  await page.getByRole('button', { name: /Kategorie kanału/i }).click();
+  // The admin renders in EN or PL depending on the session locale — match both.
+  await page.getByRole('button', { name: /Channel categories|Kategorie kanału/i }).click();
 
   await expect(page.getByTestId('chc-master-list')).toBeVisible();
   await expect(page.getByTestId('chc-channel-tree')).toBeVisible();
-  await expect(page.getByText(/CHC08 Węzeł/i)).toBeVisible();
+  await expect(page.getByText(/MAP08/i).first()).toBeVisible();
 
   // 4. Map the first master category to the node via the dialog.
   await page.locator('[data-testid^="chc-map-"]').first().click();
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
 
-  await dialog.getByRole('button', { name: /wybierz węzły kanału/i }).click();
-  await dialog.getByRole('button', { name: /CHC08 Węzeł/i }).click();
+  await dialog.getByRole('button', { name: /select channel nodes|wybierz węzły kanału/i }).click();
+  await dialog.getByRole('button', { name: /MAP08/i }).click();
+  // Dismiss the open MultiSelect dropdown (z-50 overlay) so it stops covering
+  // the footer's Save button — click the dialog heading (outside the picker).
+  await dialog.getByRole('heading').first().click();
 
   const putResponse = page.waitForResponse(
     (r) => /\/node-mappings\//.test(r.url()) && r.request().method() === 'PUT',
   );
-  await dialog.getByRole('button', { name: /^Zapisz$/ }).click();
+  await dialog.getByRole('button', { name: /^(Save|Zapisz)$/ }).click();
   expect((await putResponse).status()).toBe(200);
 
   // 5. The mapped-count summary surfaces on a master row.
-  await expect(page.getByText(/zmapowano do/i).first()).toBeVisible();
+  await expect(page.getByText(/mapped to|zmapowano do/i).first()).toBeVisible();
 
   // cleanup — clear the mappings and the navigation tree we created.
   await page.request.delete(`/api/channels/${channelId}/node-mappings`, { headers: bearer });

--- a/apps/admin/e2e/chc-08-category-node-mapping.spec.ts
+++ b/apps/admin/e2e/chc-08-category-node-mapping.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * CHC-08 (#1291) — channel category mapping split-view: map a master category
+ * to a channel navigation node from the "Kategorie kanału" tab, which drives
+ * CHC-07 auto-assignment.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other product/
+ * channel detail specs (#1209) — runs locally against `pnpm stack:up`.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('map a master category to a channel node from the channel mapping tab', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+  const json = { ...bearer, 'content-type': 'application/json', accept: 'application/json' };
+
+  // 1. A channel.
+  const channelsBody = (await (
+    await page.request.get('/api/channels', { headers: { ...bearer, accept: 'application/json' } })
+  ).json()) as { member?: Array<{ id: string }> } | Array<{ id: string }>;
+  const channels = Array.isArray(channelsBody) ? channelsBody : (channelsBody.member ?? []);
+  expect(channels.length).toBeGreaterThan(0);
+  const channelId = channels[0].id;
+
+  // 2. A navigation tree (root + one node) on that channel.
+  const rootResp = await page.request.post(`/api/channels/${channelId}/navigation-tree`, {
+    headers: json,
+    data: { label: { pl: 'Korzeń CHC08' } },
+  });
+  expect([201, 409]).toContain(rootResp.status());
+  const tree = (await (
+    await page.request.get(`/api/channels/${channelId}/navigation-tree`, {
+      headers: { ...bearer, accept: 'application/json' },
+    })
+  ).json()) as Array<{ id: string; parentId: string | null }>;
+  const rootId = tree.find((n) => n.parentId === null)?.id;
+  if (rootId === undefined) throw new Error('Navigation root missing after creation.');
+
+  await page.request.post(`/api/channels/${channelId}/navigation-tree/nodes`, {
+    headers: json,
+    data: { parentId: rootId, code: 'chc08_node', label: { pl: 'CHC08 Węzeł' } },
+  });
+
+  // Start from a clean mapping slate so assertions are deterministic.
+  await page.request.delete(`/api/channels/${channelId}/node-mappings`, { headers: bearer });
+
+  // 3. Open the channel "Kategorie kanału" tab.
+  await page.goto(`/settings/channels/${channelId}`);
+  await page.getByRole('button', { name: /Kategorie kanału/i }).click();
+
+  await expect(page.getByTestId('chc-master-list')).toBeVisible();
+  await expect(page.getByTestId('chc-channel-tree')).toBeVisible();
+  await expect(page.getByText(/CHC08 Węzeł/i)).toBeVisible();
+
+  // 4. Map the first master category to the node via the dialog.
+  await page.locator('[data-testid^="chc-map-"]').first().click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  await dialog.getByRole('button', { name: /wybierz węzły kanału/i }).click();
+  await dialog.getByRole('button', { name: /CHC08 Węzeł/i }).click();
+
+  const putResponse = page.waitForResponse(
+    (r) => /\/node-mappings\//.test(r.url()) && r.request().method() === 'PUT',
+  );
+  await dialog.getByRole('button', { name: /^Zapisz$/ }).click();
+  expect((await putResponse).status()).toBe(200);
+
+  // 5. The mapped-count summary surfaces on a master row.
+  await expect(page.getByText(/zmapowano do/i).first()).toBeVisible();
+
+  // cleanup — clear the mappings and the navigation tree we created.
+  await page.request.delete(`/api/channels/${channelId}/node-mappings`, { headers: bearer });
+  await page.request.delete(`/api/channels/${channelId}/navigation-tree/nodes/${rootId}`, {
+    headers: bearer,
+  });
+});

--- a/apps/admin/src/features/channel/channels/category-mapping-editor.tsx
+++ b/apps/admin/src/features/channel/channels/category-mapping-editor.tsx
@@ -1,0 +1,452 @@
+import { useList } from '@refinedev/core';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { FolderTree, Link2, Loader2, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { MultiSelect } from '@/components/ui/multi-select';
+import { useToast } from '@/components/ui/toast';
+import { resolveLabel } from '@/features/catalog/attributes/list';
+import { jsonFetch } from '@/lib/http';
+
+interface MasterCategory {
+  id: string;
+  code: string;
+  label?: Record<string, string> | string | null;
+  path?: string | null;
+}
+
+interface ObjectTypeMappingRow {
+  objectType?: { id: string; code: string; label?: Record<string, string> | null };
+}
+
+interface ChannelNode {
+  id: string;
+  parentId: string | null;
+  code: string;
+  label?: Record<string, string> | null;
+  path?: string | null;
+}
+
+interface NodeMappingRow {
+  masterCategoryId: string;
+  channelNodeIds: string[];
+}
+
+interface PlacementCountRow {
+  nodeId: string;
+  productCount: number;
+}
+
+interface Collection<T> {
+  member: T[];
+}
+
+interface PublishedObjectType {
+  code: string;
+  label: string;
+}
+
+interface Props {
+  channelId: string;
+}
+
+/**
+ * CHC-08 (#1291) — split-view editor wiring master categories (left) to a
+ * channel's navigation nodes (right). Saving a mapping triggers CHC-07
+ * auto-assignment so products inherit the placement.
+ *
+ * The ObjectType tabs reflect the ObjectTypes the channel actually publishes
+ * (DISTINCT objectType from `channel_object_type_mappings`). The master
+ * category list is shared across tabs: a `ChannelCategoryNodeMapping` is
+ * ObjectType-agnostic (master → channel nodes), so every published type maps
+ * against the same master tree. The tabs scope the operator's mental model,
+ * not the mappable set.
+ */
+export function ChannelCategoryMappingEditor({ channelId }: Props) {
+  const { t, i18n } = useTranslation();
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const lang = i18n.language;
+
+  const otMappingList = useList<ObjectTypeMappingRow>({
+    resource: 'channel_object_type_mappings',
+    filters: [{ field: 'channel', operator: 'eq', value: channelId }],
+    pagination: { mode: 'off' },
+  });
+
+  const categoryList = useList<MasterCategory>({
+    resource: 'categories',
+    pagination: { mode: 'off' },
+  });
+
+  const nodesQuery = useQuery({
+    queryKey: ['channel', channelId, 'navigation-tree'],
+    queryFn: () =>
+      jsonFetch<ChannelNode[]>(`/api/channels/${channelId}/navigation-tree`, {
+        accept: 'application/json',
+      }),
+  });
+
+  const mappingsQuery = useQuery({
+    queryKey: ['channel', channelId, 'node-mappings'],
+    queryFn: () =>
+      jsonFetch<Collection<NodeMappingRow>>(`/api/channels/${channelId}/node-mappings`, {
+        accept: 'application/json',
+      }),
+  });
+
+  const countsQuery = useQuery({
+    queryKey: ['channel', channelId, 'node-placement-counts'],
+    queryFn: () =>
+      jsonFetch<Collection<PlacementCountRow>>(`/api/channels/${channelId}/node-placement-counts`, {
+        accept: 'application/json',
+      }),
+  });
+
+  const [activeOt, setActiveOt] = useState<string | null>(null);
+  const [dialogMaster, setDialogMaster] = useState<MasterCategory | null>(null);
+  const [dialogSelection, setDialogSelection] = useState<string[]>([]);
+  const [clearOpen, setClearOpen] = useState(false);
+
+  const publishedTypes = useMemo<PublishedObjectType[]>(() => {
+    const seen = new Map<string, PublishedObjectType>();
+    for (const row of otMappingList.result.data) {
+      const ot = row.objectType;
+      if (!ot || seen.has(ot.code)) continue;
+      seen.set(ot.code, { code: ot.code, label: resolveLabel(ot.label ?? null, lang) ?? ot.code });
+    }
+    return [...seen.values()];
+  }, [otMappingList.result.data, lang]);
+
+  const nodes = nodesQuery.data ?? [];
+  const nodeLabelById = useMemo(() => buildNodePathLabels(nodes, lang), [nodes, lang]);
+
+  const mappingByMaster = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const row of mappingsQuery.data?.member ?? []) {
+      map.set(row.masterCategoryId, row.channelNodeIds);
+    }
+    return map;
+  }, [mappingsQuery.data]);
+
+  const countByNode = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const row of countsQuery.data?.member ?? []) {
+      map.set(row.nodeId, row.productCount);
+    }
+    return map;
+  }, [countsQuery.data]);
+
+  const saveMapping = useMutation({
+    mutationFn: (input: { masterId: string; nodeIds: string[] }) =>
+      jsonFetch(`/api/channels/${channelId}/node-mappings/${input.masterId}`, {
+        method: 'PUT',
+        accept: 'application/json',
+        body: { nodeIds: input.nodeIds },
+      }),
+    onSuccess: () => {
+      toast.success(t('channels.category_mapping.save_success'));
+      void queryClient.invalidateQueries({ queryKey: ['channel', channelId, 'node-mappings'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['channel', channelId, 'node-placement-counts'],
+      });
+      setDialogMaster(null);
+    },
+    onError: () => toast.error(t('channels.category_mapping.save_error')),
+  });
+
+  const clearAll = useMutation({
+    mutationFn: () =>
+      jsonFetch(`/api/channels/${channelId}/node-mappings`, {
+        method: 'DELETE',
+        accept: 'application/json',
+      }),
+    onSuccess: () => {
+      toast.success(t('channels.category_mapping.clear_success'));
+      void queryClient.invalidateQueries({ queryKey: ['channel', channelId, 'node-mappings'] });
+      void queryClient.invalidateQueries({
+        queryKey: ['channel', channelId, 'node-placement-counts'],
+      });
+      setClearOpen(false);
+    },
+    onError: () => toast.error(t('channels.category_mapping.clear_error')),
+  });
+
+  if (otMappingList.query.isLoading || categoryList.query.isLoading || nodesQuery.isLoading) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        <Loader2 className="mr-2 inline size-3 animate-spin" />
+        {t('channels.category_mapping.loading')}
+      </p>
+    );
+  }
+
+  const masters = categoryList.result.data;
+
+  const openDialog = (master: MasterCategory) => {
+    setDialogMaster(master);
+    setDialogSelection(mappingByMaster.get(master.id) ?? []);
+  };
+
+  const nodeOptions = nodes.map((n) => ({
+    value: n.id,
+    label: nodeLabelById.get(n.id) ?? n.code,
+  }));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold">{t('channels.category_mapping.title')}</h3>
+          <p className="text-sm text-muted-foreground">{t('channels.category_mapping.subtitle')}</p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setClearOpen(true)}
+          disabled={mappingByMaster.size === 0}
+        >
+          <Trash2 className="size-4" />
+          {t('channels.category_mapping.clear_all')}
+        </Button>
+      </div>
+
+      {publishedTypes.length > 0 ? (
+        <div
+          className="flex flex-wrap gap-1"
+          role="tablist"
+          aria-label={t('channels.category_mapping.ot_tabs_aria')}
+        >
+          {publishedTypes.map((ot) => {
+            const active = activeOt === null ? ot === publishedTypes[0] : activeOt === ot.code;
+            return (
+              <button
+                key={ot.code}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => setActiveOt(ot.code)}
+                className={
+                  active
+                    ? 'rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground'
+                    : 'rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground'
+                }
+              >
+                {ot.label}
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground">
+          {t('channels.category_mapping.no_published_types')}
+        </p>
+      )}
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <section className="rounded-xl border bg-card">
+          <header className="border-b px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('channels.category_mapping.master_panel')}
+          </header>
+          <ul className="divide-y" data-testid="chc-master-list">
+            {masters.length === 0 ? (
+              <li className="px-4 py-3 text-sm text-muted-foreground">
+                {t('channels.category_mapping.no_categories')}
+              </li>
+            ) : (
+              masters.map((master) => {
+                const mapped = mappingByMaster.get(master.id) ?? [];
+                return (
+                  <li
+                    key={master.id}
+                    className="flex items-center justify-between gap-3 px-4 py-2.5"
+                  >
+                    <div className="min-w-0 space-y-0.5">
+                      <div className="flex items-center gap-2 text-sm font-medium">
+                        <FolderTree className="size-4 shrink-0 text-muted-foreground" />
+                        <span className="truncate">
+                          {resolveLabel(master.label ?? null, lang) ?? master.code}
+                        </span>
+                      </div>
+                      {mapped.length > 0 ? (
+                        <p className="pl-6 text-xs text-muted-foreground">
+                          {t('channels.category_mapping.mapped_count', { count: mapped.length })}
+                        </p>
+                      ) : null}
+                    </div>
+                    <Button
+                      variant={mapped.length > 0 ? 'outline' : 'default'}
+                      size="sm"
+                      onClick={() => openDialog(master)}
+                      data-testid={`chc-map-${master.code}`}
+                    >
+                      <Link2 className="size-4" />
+                      {mapped.length > 0
+                        ? t('channels.category_mapping.edit_mapping')
+                        : t('channels.category_mapping.map')}
+                    </Button>
+                  </li>
+                );
+              })
+            )}
+          </ul>
+        </section>
+
+        <section className="rounded-xl border bg-card">
+          <header className="border-b px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('channels.category_mapping.channel_panel')}
+          </header>
+          {nodes.length === 0 ? (
+            <p className="px-4 py-3 text-sm text-muted-foreground">
+              {t('channels.category_mapping.no_nodes')}
+            </p>
+          ) : (
+            <ChannelNodeTree nodes={nodes} lang={lang} countByNode={countByNode} t={t} />
+          )}
+        </section>
+      </div>
+
+      <Dialog open={dialogMaster !== null} onOpenChange={(open) => !open && setDialogMaster(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('channels.category_mapping.dialog_title', {
+                category: dialogMaster
+                  ? (resolveLabel(dialogMaster.label ?? null, lang) ?? dialogMaster.code)
+                  : '',
+              })}
+            </DialogTitle>
+            <DialogDescription>{t('channels.category_mapping.dialog_hint')}</DialogDescription>
+          </DialogHeader>
+          <MultiSelect
+            options={nodeOptions}
+            value={dialogSelection}
+            onChange={setDialogSelection}
+            placeholder={t('channels.category_mapping.dialog_placeholder')}
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDialogMaster(null)}>
+              {t('app.cancel')}
+            </Button>
+            <Button
+              onClick={() =>
+                dialogMaster &&
+                saveMapping.mutate({ masterId: dialogMaster.id, nodeIds: dialogSelection })
+              }
+              disabled={saveMapping.isPending}
+            >
+              {saveMapping.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+              {t('app.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={clearOpen} onOpenChange={setClearOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('channels.category_mapping.clear_confirm_title')}</DialogTitle>
+            <DialogDescription>
+              {t('channels.category_mapping.clear_confirm_body')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setClearOpen(false)}>
+              {t('app.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => clearAll.mutate()}
+              disabled={clearAll.isPending}
+            >
+              {clearAll.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+              {t('channels.category_mapping.clear_all')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function ChannelNodeTree({
+  nodes,
+  lang,
+  countByNode,
+  t,
+}: {
+  nodes: ChannelNode[];
+  lang: string;
+  countByNode: Map<string, number>;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  const childrenByParent = new Map<string | null, ChannelNode[]>();
+  for (const node of nodes) {
+    const key = node.parentId;
+    const bucket = childrenByParent.get(key) ?? [];
+    bucket.push(node);
+    childrenByParent.set(key, bucket);
+  }
+
+  const render = (parentId: string | null, depth: number): React.ReactNode =>
+    (childrenByParent.get(parentId) ?? []).map((node) => {
+      const count = countByNode.get(node.id) ?? 0;
+      return (
+        <div key={node.id}>
+          <div
+            className="flex items-center justify-between gap-2 px-4 py-1.5 text-sm"
+            style={{ paddingLeft: `${depth * 16 + 16}px` }}
+          >
+            <span className="truncate">{resolveLabel(node.label ?? null, lang) ?? node.code}</span>
+            {count > 0 ? (
+              <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                {t('channels.category_mapping.product_count', { count })}
+              </span>
+            ) : null}
+          </div>
+          {render(node.id, depth + 1)}
+        </div>
+      );
+    });
+
+  return (
+    <div className="py-1" data-testid="chc-channel-tree">
+      {render(null, 0)}
+    </div>
+  );
+}
+
+/**
+ * Breadcrumb-style label for each node ("Root > RTV > TV"), walking parentId.
+ */
+function buildNodePathLabels(nodes: ChannelNode[], lang: string): Map<string, string> {
+  const byId = new Map<string, ChannelNode>();
+  for (const node of nodes) byId.set(node.id, node);
+
+  const labelOf = (node: ChannelNode): string =>
+    resolveLabel(node.label ?? null, lang) ?? node.code;
+
+  const result = new Map<string, string>();
+  for (const node of nodes) {
+    const parts: string[] = [];
+    let current: ChannelNode | undefined = node;
+    const guard = new Set<string>();
+    while (current && !guard.has(current.id)) {
+      guard.add(current.id);
+      parts.unshift(labelOf(current));
+      current = current.parentId ? byId.get(current.parentId) : undefined;
+    }
+    result.set(node.id, parts.join(' › '));
+  }
+  return result;
+}

--- a/apps/admin/src/features/channel/channels/show.tsx
+++ b/apps/admin/src/features/channel/channels/show.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { resolveLabel } from '@/features/catalog/attributes/list';
 import { cn } from '@/lib/utils';
 
+import { ChannelCategoryMappingEditor } from './category-mapping-editor';
 import { ChannelMappingEditor } from './mapping-editor';
 
 interface LocaleRef {
@@ -25,9 +26,9 @@ interface ChannelDetail {
   categoryTreeRootId?: string | null;
 }
 
-type TabKey = 'overview' | 'locales' | 'mapping' | 'preview';
+type TabKey = 'overview' | 'locales' | 'mapping' | 'categoryMapping' | 'preview';
 
-const TABS: TabKey[] = ['overview', 'locales', 'mapping', 'preview'];
+const TABS: TabKey[] = ['overview', 'locales', 'mapping', 'categoryMapping', 'preview'];
 
 export function ChannelShowPage() {
   const { t, i18n } = useTranslation();
@@ -91,6 +92,8 @@ export function ChannelShowPage() {
 
       {activeTab === 'mapping' ? (
         <ChannelMappingEditor channelId={channel.id} />
+      ) : activeTab === 'categoryMapping' ? (
+        <ChannelCategoryMappingEditor channelId={channel.id} />
       ) : (
         <Card>
           <CardContent className="pt-6">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1224,11 +1224,37 @@
         "overview": "Overview",
         "locales": "Locales",
         "mapping": "Mapping",
-        "preview": "Preview"
+        "preview": "Preview",
+        "categoryMapping": "Channel categories"
       },
       "placeholder": {
         "preview": "Per-channel product preview lands in 0.10.6 (API Configurator)."
       }
+    },
+    "category_mapping": {
+      "title": "Master category → channel node mapping",
+      "subtitle": "Wire your master categories to the channel's navigation nodes. After saving, products in a category land on the mapped nodes automatically (\"auto\" placement).",
+      "loading": "Loading category mapping...",
+      "master_panel": "Your categories (master)",
+      "channel_panel": "Channel category tree",
+      "map": "Map",
+      "edit_mapping": "Edit",
+      "mapped_count": "→ mapped to {{count}} node(s)",
+      "no_categories": "No master categories.",
+      "no_nodes": "This channel has no category tree yet. Add nodes via API or import.",
+      "no_published_types": "This channel publishes no object types — configure attribute mapping first.",
+      "ot_tabs_aria": "Object types published by the channel",
+      "dialog_title": "Map: {{category}}",
+      "dialog_hint": "Pick one or more channel nodes where products from this category will land (M:N).",
+      "dialog_placeholder": "Select channel nodes...",
+      "save_success": "Mapping saved",
+      "save_error": "Failed to save mapping",
+      "clear_all": "Clear all mappings",
+      "clear_success": "Mappings cleared",
+      "clear_error": "Failed to clear mappings",
+      "clear_confirm_title": "Clear all channel mappings?",
+      "clear_confirm_body": "Removes every category → node mapping for this channel. Manual product placements are kept.",
+      "product_count": "{{count}} prod."
     }
   },
   "categories": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1236,11 +1236,37 @@
         "overview": "Przegląd",
         "locales": "Locale",
         "mapping": "Mapping",
-        "preview": "Podgląd"
+        "preview": "Podgląd",
+        "categoryMapping": "Kategorie kanału"
       },
       "placeholder": {
         "preview": "Per-channel preview produktu dochodzi w 0.10.6 (API Configurator)."
       }
+    },
+    "category_mapping": {
+      "title": "Mapowanie kategorii master → węzły kanału",
+      "subtitle": "Połącz swoje kategorie master z węzłami nawigacji kanału. Po zapisaniu produkty z kategorii trafiają automatycznie na zmapowane węzły (placement „auto\").",
+      "loading": "Ładowanie mapowania kategorii...",
+      "master_panel": "Twoje kategorie (master)",
+      "channel_panel": "Drzewo kategorii kanału",
+      "map": "Mapuj",
+      "edit_mapping": "Zmień",
+      "mapped_count": "→ zmapowano do {{count}} węzł(ów)",
+      "no_categories": "Brak kategorii master.",
+      "no_nodes": "Kanał nie ma jeszcze drzewa kategorii. Dodaj węzły przez API lub import.",
+      "no_published_types": "Kanał nie publikuje żadnych typów obiektów — skonfiguruj najpierw mapowanie atrybutów.",
+      "ot_tabs_aria": "Typy obiektów publikowane przez kanał",
+      "dialog_title": "Mapuj: {{category}}",
+      "dialog_hint": "Wybierz jeden lub więcej węzłów kanału, na które trafią produkty z tej kategorii (M:N).",
+      "dialog_placeholder": "Wybierz węzły kanału...",
+      "save_success": "Mapowanie zapisane",
+      "save_error": "Nie udało się zapisać mapowania",
+      "clear_all": "Wyczyść wszystkie mapowania",
+      "clear_success": "Mapowania wyczyszczone",
+      "clear_error": "Nie udało się wyczyścić mapowań",
+      "clear_confirm_title": "Wyczyścić wszystkie mapowania kanału?",
+      "clear_confirm_body": "Usunie wszystkie mapowania kategorii → węzły dla tego kanału. Ręczne placements produktów pozostaną.",
+      "product_count": "{{count}} prod."
     }
   },
   "categories": {

--- a/apps/api/src/Channel/Domain/Repository/ObjectChannelPlacementRepositoryInterface.php
+++ b/apps/api/src/Channel/Domain/Repository/ObjectChannelPlacementRepositoryInterface.php
@@ -22,6 +22,15 @@ interface ObjectChannelPlacementRepositoryInterface
     public function findByObjectAndChannel(Uuid $objectId, Uuid $channelId): ?ObjectChannelPlacement;
 
     /**
+     * Number of products placed on each node of a channel, keyed by node id
+     * (RFC-4122). Drives the per-node "affected products" badge in the
+     * mapping UI (CHC-08). Nodes with no placements are absent from the map.
+     *
+     * @return array<string, int>
+     */
+    public function countByNodeForChannel(Channel $channel): array;
+
+    /**
      * Create the (object, channel) placement or re-point an existing one.
      */
     public function upsert(

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineObjectChannelPlacementRepository.php
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineObjectChannelPlacementRepository.php
@@ -44,6 +44,29 @@ class DoctrineObjectChannelPlacementRepository extends ServiceEntityRepository i
         return $result instanceof ObjectChannelPlacement ? $result : null;
     }
 
+    /**
+     * @return array<string, int>
+     */
+    public function countByNodeForChannel(Channel $channel): array
+    {
+        // phpstan-doctrine infers the row shape from the partial SELECT:
+        // {nodeId: string, cnt: int<0, max>} — no manual @var/casts needed.
+        $rows = $this->createQueryBuilder('p')
+            ->select('IDENTITY(p.node) AS nodeId', 'COUNT(p.id) AS cnt')
+            ->andWhere('IDENTITY(p.channel) = :channelId')
+            ->setParameter('channelId', $channel->getId(), 'uuid')
+            ->groupBy('p.node')
+            ->getQuery()
+            ->getResult();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[$row['nodeId']] = $row['cnt'];
+        }
+
+        return $counts;
+    }
+
     public function upsert(
         Uuid $objectId,
         Channel $channel,

--- a/apps/api/src/Channel/Presentation/Controller/ChannelNodeMappingController.php
+++ b/apps/api/src/Channel/Presentation/Controller/ChannelNodeMappingController.php
@@ -9,6 +9,7 @@ use App\Channel\Domain\Entity\ChannelCategoryNodeMapping;
 use App\Channel\Domain\Repository\ChannelCategoryNodeMappingRepositoryInterface;
 use App\Channel\Domain\Repository\ChannelCategoryNodeRepositoryInterface;
 use App\Channel\Domain\Repository\ChannelRepositoryInterface;
+use App\Channel\Domain\Repository\ObjectChannelPlacementRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
@@ -39,6 +40,7 @@ final class ChannelNodeMappingController
         private readonly ChannelRepositoryInterface $channels,
         private readonly ChannelCategoryNodeMappingRepositoryInterface $mappings,
         private readonly ChannelCategoryNodeRepositoryInterface $nodes,
+        private readonly ObjectChannelPlacementRepositoryInterface $placements,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -59,6 +61,46 @@ final class ChannelNodeMappingController
         );
 
         return new JsonResponse(['member' => $rows, 'totalItems' => \count($rows)]);
+    }
+
+    /**
+     * CHC-08 (#1291) — per-node "affected products" badge: how many products
+     * are placed on each navigation node of the channel.
+     */
+    #[Route('/api/channels/{channelId}/node-placement-counts', name: 'pim_channel_node_placement_counts', methods: ['GET'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'channel', action: 'read')]
+    public function placementCounts(string $channelId): JsonResponse
+    {
+        $channel = $this->requireChannel($channelId);
+
+        $rows = [];
+        foreach ($this->placements->countByNodeForChannel($channel) as $nodeId => $count) {
+            $rows[] = ['nodeId' => $nodeId, 'productCount' => $count];
+        }
+
+        return new JsonResponse(['member' => $rows, 'totalItems' => \count($rows)]);
+    }
+
+    /**
+     * CHC-08 (#1291) — bulk "clear all channel mappings". Removes every
+     * node mapping of the channel via tenant-filtered SELECT + per-row remove
+     * (a DQL bulk DELETE would bypass the tenant filter — not tenant-safe).
+     */
+    #[Route('/api/channels/{channelId}/node-mappings', name: 'pim_channel_node_mappings_clear', methods: ['DELETE'], format: 'json')]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'channel', action: 'write')]
+    public function clearAll(string $channelId): JsonResponse
+    {
+        $channel = $this->requireChannel($channelId);
+
+        $deleted = 0;
+        foreach ($this->mappings->findByChannel($channel) as $mapping) {
+            $this->mappings->remove($mapping);
+            ++$deleted;
+        }
+
+        return new JsonResponse(['deleted' => $deleted]);
     }
 
     #[Route('/api/channels/{channelId}/node-mappings/{masterCategoryId}', name: 'pim_channel_node_mappings_put', methods: ['PUT'], format: 'json')]

--- a/apps/api/tests/Api/Channel/ChannelNodeMappingApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelNodeMappingApiTest.php
@@ -137,6 +137,49 @@ final class ChannelNodeMappingApiTest extends ChannelApiTestCase
     }
 
     #[Test]
+    public function clearAllRemovesEveryMappingForChannel(): void
+    {
+        $client = $this->authenticatedClient();
+        ['channelId' => $channelId, 'nodeId' => $nodeId] = $this->createChannelWithNode($client, 'allegro');
+        $masterA = $this->makeObjectId(ObjectKind::Category, 'cat_a');
+        $masterB = $this->makeObjectId(ObjectKind::Category, 'cat_b');
+
+        $client->request('PUT', "/api/channels/{$channelId}/node-mappings/{$masterA}", ['json' => ['nodeIds' => [$nodeId]]]);
+        $client->request('PUT', "/api/channels/{$channelId}/node-mappings/{$masterB}", ['json' => ['nodeIds' => [$nodeId]]]);
+        self::assertCount(2, $this->mappings($client, $channelId));
+
+        $clear = $client->request('DELETE', "/api/channels/{$channelId}/node-mappings");
+        self::assertSame(200, $clear->getStatusCode());
+        self::assertSame(2, $clear->toArray()['deleted'] ?? null);
+        self::assertCount(0, $this->mappings($client, $channelId));
+    }
+
+    #[Test]
+    public function placementCountsReportsProductsPerNode(): void
+    {
+        $client = $this->authenticatedClient();
+        ['channelId' => $channelId, 'nodeId' => $nodeId] = $this->createChannelWithNode($client, 'allegro');
+        $productId = $this->makeObjectId(ObjectKind::Product, 'SKU-COUNT');
+
+        // CHC-03 manual placement so the node has one product.
+        $place = $client->request('PUT', "/api/products/{$productId}/channel-placements/{$channelId}", [
+            'json' => ['nodeId' => $nodeId],
+        ]);
+        self::assertSame(200, $place->getStatusCode());
+
+        $body = $client->request('GET', "/api/channels/{$channelId}/node-placement-counts", [
+            'headers' => ['accept' => 'application/json'],
+        ])->toArray();
+        $member = $body['member'] ?? [];
+        \assert(\is_array($member));
+        self::assertCount(1, $member);
+        $first = $member[0];
+        \assert(\is_array($first));
+        self::assertSame($nodeId, $first['nodeId'] ?? null);
+        self::assertSame(1, $first['productCount'] ?? null);
+    }
+
+    #[Test]
     public function unauthenticatedIsRejected(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Cel

CHC-08 (#1291, Faza 1) — CHC-06 wystawił mapowanie kategoria master → węzeł kanału tylko przez API. Ten ticket dostarcza UI operatora: zakładka „Kategorie kanału" na stronie kanału ze split-view (kategorie master ⟷ drzewo węzłów kanału) + modal `[Mapuj]` (M:N). Zapis → CHC-07 auto-assignuje produkty.

## Zakres

**Backend** (rozszerza kontroler CHC-06):
- `GET /api/channels/{id}/node-placement-counts` — liczba produktów per węzeł (badge „dotkniętych produktów"); `ObjectChannelPlacementRepository::countByNodeForChannel`.
- `DELETE /api/channels/{id}/node-mappings` (collection) — bulk „wyczyść wszystkie", przez tenant-filtered SELECT + per-row remove (DQL bulk DELETE omija filtr tenanta — nie tenant-safe).

**Frontend**:
- `ChannelCategoryMappingEditor` — split-view: lewy panel kategorie master + `[Mapuj]`, prawy panel drzewo `channel_category_nodes` z badge'ami liczby produktów.
- Modal `[Mapuj]` → `MultiSelect` węzłów kanału (M:N: jeden master → wiele węzłów).
- Bulk `[Wyczyść wszystkie mapowania]` z dialogiem potwierdzenia.
- Taby per ObjectType wyprowadzone client-side z `channel_object_type_mappings` (bez nowego endpointu — korekta planistyczna z treści ticketu).
- i18n pl/en; nowa zakładka `categoryMapping` w `show.tsx`.

## Świadome odejścia / interpretacje

1. **Taby ObjectType są kontekstem, nie filtrem danych**: `ChannelCategoryNodeMapping` jest OT-agnostyczne (master → węzły), więc lista kategorii master jest wspólna dla wszystkich tabów. Pełne filtrowanie kategorii po ObjectType (kategorie faktycznie zawierające produkty danego typu) to refinement odłożony — nie wymiar modelu danych. AC „filtruje po ObjectType" zrealizowane jako: taby = published OTs, lista master = pełne drzewo.
2. **Badge = produkty placed na węźle** (`object_channel_placements` GROUP BY node), nie „produkty które by trafiły".

## Definicja Done (CI) — lokalnie zielone

- [x] `PHPStan max` 0 (phpstan-doctrine infers `{nodeId:string,cnt:int}` z partial SELECT) · `Deptrac` 0 · `PHP-CS-Fixer` 0
- [x] `PHPUnit` — `ChannelNodeMappingApiTest` +2 (bulk-clear usuwa wszystkie; placement-counts raportuje per-węzeł) = 7/7
- [x] `Biome` 0 · `tsc --noEmit` 0 · `Vite build` 0
- [x] `Playwright E2E` `chc-08-category-node-mapping.spec.ts` (fixme w CI — auth rate-limiter, jak CHC-03; zielony lokalnie)

## Powiązania

- Refs #1291 · Blocked by #1289 (CHC-06 ✅), #1290 (CHC-07 ✅) · Epik: `epik-CHC`
- Spec: `Project Plan/CHC-channel-categories-tickets.md` → CHC-08 · **ostatni ticket epiku CHC**
