### PR TITLE
feat(channel): UI editor for the channel navigation tree [CHC-09]

### DIFF
--- a/apps/admin/e2e/chc-09-channel-tree-editor.spec.ts
+++ b/apps/admin/e2e/chc-09-channel-tree-editor.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * CHC-09 (#1302) — manual channel category-tree editor on the "Drzewo kanału"
+ * tab: create tree → add sub-nodes → edit (name + external id) → move → delete.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other channel
+ * detail specs (#1209) — runs locally against `pnpm stack:up`.
+ *
+ * Actions target the root via `.first()` (the root row renders first, so its
+ * action buttons are first in DOM order); "move" targets the first non-root.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('build, edit, move and delete a channel navigation tree from the UI', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+
+  // A channel + a clean slate (failed runs skip cleanup).
+  const channelsBody = (await (
+    await page.request.get('/api/channels', { headers: { ...bearer, accept: 'application/json' } })
+  ).json()) as { member?: Array<{ id: string }> } | Array<{ id: string }>;
+  const channels = Array.isArray(channelsBody) ? channelsBody : (channelsBody.member ?? []);
+  expect(channels.length).toBeGreaterThan(0);
+  const channelId = channels[0].id;
+
+  const existing = (await (
+    await page.request.get(`/api/channels/${channelId}/navigation-tree`, {
+      headers: { ...bearer, accept: 'application/json' },
+    })
+  ).json()) as Array<{ id: string; parentId: string | null }>;
+  for (const root of existing.filter((n) => n.parentId === null)) {
+    await page.request.delete(`/api/channels/${channelId}/navigation-tree/nodes/${root.id}`, {
+      headers: bearer,
+    });
+  }
+
+  await page.goto(`/settings/channels/${channelId}`);
+  await page.getByRole('button', { name: /Drzewo kanału|Channel tree/i }).click();
+
+  const saveName = async (name: string, external?: string) => {
+    const dialog = page.getByRole('dialog');
+    await dialog.locator('#chc-node-name').fill(name);
+    if (external !== undefined) await dialog.locator('#chc-node-external').fill(external);
+    await dialog.getByRole('button', { name: /^(Save|Zapisz)$/ }).click();
+  };
+
+  // 1. Create the tree (root).
+  await page.getByRole('button', { name: /Utwórz drzewo|Create tree/i }).click();
+  await saveName('ROOT09');
+  const editor = page.getByTestId('chc-tree-editor');
+  await expect(editor).toBeVisible();
+  await expect(editor.getByText('ROOT09')).toBeVisible();
+
+  // 2. Edit the root (first edit button) — rename + set external id.
+  await editor
+    .getByRole('button', { name: /^(Edit|Edytuj)$/ })
+    .first()
+    .click();
+  await saveName('ROOT09X', '999');
+  await expect(editor.getByText('ROOT09X')).toBeVisible();
+  await expect(editor.getByText('#999')).toBeVisible();
+
+  // 3. Add two sub-nodes under the root (root's add button is first).
+  await editor
+    .getByRole('button', { name: /Add sub-node|Dodaj podpozycję/i })
+    .first()
+    .click();
+  await saveName('NODEA09');
+  await expect(editor.getByText('NODEA09')).toBeVisible();
+  await editor
+    .getByRole('button', { name: /Add sub-node|Dodaj podpozycję/i })
+    .first()
+    .click();
+  await saveName('NODEB09');
+  await expect(editor.getByText('NODEB09')).toBeVisible();
+
+  // 4. Move NODEA09 (first non-root → first move button) under NODEB09.
+  await editor
+    .getByRole('button', { name: /^(Move|Przenieś)$/ })
+    .first()
+    .click();
+  const moveResponse = page.waitForResponse(
+    (r) => /\/nodes\/.+\/move$/.test(r.url()) && r.request().method() === 'PATCH',
+  );
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: /NODEB09/i })
+    .click();
+  expect((await moveResponse).status()).toBe(200);
+
+  // 5. Delete the whole tree (root's delete → cascade) and land back on empty state.
+  await editor
+    .getByRole('button', { name: /^(Delete|Usuń)$/ })
+    .first()
+    .click();
+  const deleteResponse = page.waitForResponse(
+    (r) => /\/navigation-tree\/nodes\//.test(r.url()) && r.request().method() === 'DELETE',
+  );
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: /^(Delete|Usuń)$/ })
+    .click();
+  expect((await deleteResponse).status()).toBe(204);
+  await expect(page.getByRole('button', { name: /Utwórz drzewo|Create tree/i })).toBeVisible();
+
+  // cleanup — ensure no leftover tree.
+  const after = (await (
+    await page.request.get(`/api/channels/${channelId}/navigation-tree`, {
+      headers: { ...bearer, accept: 'application/json' },
+    })
+  ).json()) as Array<{ id: string; parentId: string | null }>;
+  for (const root of after.filter((n) => n.parentId === null)) {
+    await page.request.delete(`/api/channels/${channelId}/navigation-tree/nodes/${root.id}`, {
+      headers: bearer,
+    });
+  }
+});

--- a/apps/admin/src/features/channel/channels/channel-tree-editor.tsx
+++ b/apps/admin/src/features/channel/channels/channel-tree-editor.tsx
@@ -1,0 +1,459 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { FolderPlus, FolderTree, Loader2, MoveRight, Pencil, Plus, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/components/ui/toast';
+import { resolveLabel } from '@/features/catalog/attributes/list';
+import type { TenantLocaleListResponse } from '@/features/settings/locales/types';
+import { jsonFetch } from '@/lib/http';
+
+interface ChannelNode {
+  id: string;
+  parentId: string | null;
+  code: string;
+  label?: Record<string, string> | null;
+  path?: string | null;
+  externalCode?: string | null;
+}
+
+type FormState =
+  | { mode: 'addRoot' }
+  | { mode: 'addChild'; parentId: string }
+  | { mode: 'edit'; node: ChannelNode };
+
+interface Props {
+  channelId: string;
+}
+
+/**
+ * CHC-09 (#1302) — manual editor for a channel's navigation tree: create the
+ * tree (root), add sub-nodes, edit (name + target-channel node id), move a
+ * node under a different parent, delete (cascades to descendants).
+ *
+ * Separate from the CHC-08 "Kategorie kanału" tab (which MAPS master
+ * categories onto these nodes). A node carries only a name and an external id;
+ * the name is stored in the multilingual `label` under the tenant's locale and
+ * read back via {@link resolveLabel} (its first-value fallback covers any UI
+ * language). The internal `code` slug is auto-defaulted server-side.
+ */
+export function ChannelTreeEditor({ channelId }: Props) {
+  const { t, i18n } = useTranslation();
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const lang = i18n.language;
+
+  const treeQuery = useQuery({
+    queryKey: ['channel', channelId, 'navigation-tree'],
+    queryFn: () =>
+      jsonFetch<ChannelNode[]>(`/api/channels/${channelId}/navigation-tree`, {
+        accept: 'application/json',
+      }),
+  });
+
+  const localesQuery = useQuery({
+    queryKey: ['channel-tree', 'tenant-locales'],
+    queryFn: () =>
+      jsonFetch<TenantLocaleListResponse>('/api/tenant-locales', { accept: 'application/json' }),
+  });
+
+  const nodes = useMemo(() => treeQuery.data ?? [], [treeQuery.data]);
+  const storageLocale = (localesQuery.data?.items ?? []).find((l) => l.isActive)?.code ?? 'pl';
+
+  const childrenByParent = useMemo(() => {
+    const map = new Map<string | null, ChannelNode[]>();
+    for (const node of nodes) {
+      const bucket = map.get(node.parentId) ?? [];
+      bucket.push(node);
+      map.set(node.parentId, bucket);
+    }
+    return map;
+  }, [nodes]);
+
+  const root = nodes.find((n) => n.parentId === null) ?? null;
+
+  const [form, setForm] = useState<FormState | null>(null);
+  const [formName, setFormName] = useState('');
+  const [formExternal, setFormExternal] = useState('');
+  const [moveTarget, setMoveTarget] = useState<ChannelNode | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ChannelNode | null>(null);
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ['channel', channelId, 'navigation-tree'] });
+
+  const saveMutation = useMutation({
+    mutationFn: () => {
+      const body = {
+        label: { [storageLocale]: formName.trim() },
+        externalCode: formExternal.trim() === '' ? null : formExternal.trim(),
+      };
+      if (form?.mode === 'addRoot') {
+        return jsonFetch(`/api/channels/${channelId}/navigation-tree`, {
+          method: 'POST',
+          accept: 'application/json',
+          body,
+        });
+      }
+      if (form?.mode === 'addChild') {
+        return jsonFetch(`/api/channels/${channelId}/navigation-tree/nodes`, {
+          method: 'POST',
+          accept: 'application/json',
+          body: { ...body, parentId: form.parentId },
+        });
+      }
+      const nodeId = form?.mode === 'edit' ? form.node.id : '';
+      return jsonFetch(`/api/channels/${channelId}/navigation-tree/nodes/${nodeId}`, {
+        method: 'PATCH',
+        accept: 'application/json',
+        body,
+      });
+    },
+    onSuccess: () => {
+      toast.success(t('channels.channel_tree.saved'));
+      void invalidate();
+      setForm(null);
+    },
+    onError: () => toast.error(t('channels.channel_tree.save_error')),
+  });
+
+  const moveMutation = useMutation({
+    mutationFn: (input: { nodeId: string; newParentId: string }) =>
+      jsonFetch(`/api/channels/${channelId}/navigation-tree/nodes/${input.nodeId}/move`, {
+        method: 'PATCH',
+        accept: 'application/json',
+        body: { newParentId: input.newParentId },
+      }),
+    onSuccess: () => {
+      toast.success(t('channels.channel_tree.moved'));
+      void invalidate();
+      setMoveTarget(null);
+    },
+    onError: () => toast.error(t('channels.channel_tree.move_error')),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (nodeId: string) =>
+      jsonFetch(`/api/channels/${channelId}/navigation-tree/nodes/${nodeId}`, {
+        method: 'DELETE',
+        accept: 'application/json',
+      }),
+    onSuccess: () => {
+      toast.success(t('channels.channel_tree.deleted'));
+      void invalidate();
+      setDeleteTarget(null);
+    },
+    onError: () => toast.error(t('channels.channel_tree.delete_error')),
+  });
+
+  const openAddRoot = () => {
+    setForm({ mode: 'addRoot' });
+    setFormName('');
+    setFormExternal('');
+  };
+  const openAddChild = (parentId: string) => {
+    setForm({ mode: 'addChild', parentId });
+    setFormName('');
+    setFormExternal('');
+  };
+  const openEdit = (node: ChannelNode) => {
+    setForm({ mode: 'edit', node });
+    setFormName(resolveLabel(node.label ?? null, lang).replace('—', ''));
+    setFormExternal(node.externalCode ?? '');
+  };
+
+  const subtreeIds = (nodeId: string): Set<string> => {
+    const ids = new Set<string>([nodeId]);
+    const stack = [nodeId];
+    for (let cur = stack.pop(); cur !== undefined; cur = stack.pop()) {
+      for (const child of childrenByParent.get(cur) ?? []) {
+        ids.add(child.id);
+        stack.push(child.id);
+      }
+    }
+    return ids;
+  };
+
+  if (treeQuery.isLoading) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        <Loader2 className="mr-2 inline size-3 animate-spin" />
+        {t('channels.channel_tree.loading')}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h3 className="text-base font-semibold">{t('channels.channel_tree.title')}</h3>
+        <p className="text-sm text-muted-foreground">{t('channels.channel_tree.subtitle')}</p>
+      </div>
+
+      {root === null ? (
+        <div className="rounded-xl border border-dashed px-4 py-8 text-center">
+          <p className="mb-3 text-sm text-muted-foreground">{t('channels.channel_tree.empty')}</p>
+          <Button onClick={openAddRoot}>
+            <FolderPlus className="size-4" />
+            {t('channels.channel_tree.create_tree')}
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-xl border bg-card py-1" data-testid="chc-tree-editor">
+          <TreeRows
+            node={root}
+            depth={0}
+            childrenByParent={childrenByParent}
+            lang={lang}
+            t={t}
+            onAddChild={openAddChild}
+            onEdit={openEdit}
+            onMove={setMoveTarget}
+            onDelete={setDeleteTarget}
+          />
+        </div>
+      )}
+
+      {/* Add / edit dialog — 2 fields only: name + external id. */}
+      <Dialog open={form !== null} onOpenChange={(open) => !open && setForm(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {form?.mode === 'edit'
+                ? t('channels.channel_tree.edit_title')
+                : form?.mode === 'addChild'
+                  ? t('channels.channel_tree.add_child_title')
+                  : t('channels.channel_tree.create_tree')}
+            </DialogTitle>
+            <DialogDescription>{t('channels.channel_tree.form_hint')}</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <Label htmlFor="chc-node-name">{t('channels.channel_tree.name_label')}</Label>
+              <Input
+                id="chc-node-name"
+                value={formName}
+                onChange={(e) => setFormName(e.target.value)}
+                placeholder={t('channels.channel_tree.name_placeholder')}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="chc-node-external">{t('channels.channel_tree.external_label')}</Label>
+              <Input
+                id="chc-node-external"
+                value={formExternal}
+                onChange={(e) => setFormExternal(e.target.value)}
+                placeholder={t('channels.channel_tree.external_placeholder')}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setForm(null)}>
+              {t('app.cancel')}
+            </Button>
+            <Button
+              onClick={() => saveMutation.mutate()}
+              disabled={saveMutation.isPending || formName.trim() === ''}
+            >
+              {saveMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+              {t('app.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Move dialog — pick a new parent (excluding self + descendants). */}
+      <Dialog open={moveTarget !== null} onOpenChange={(open) => !open && setMoveTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {t('channels.channel_tree.move_title', {
+                name: moveTarget ? resolveLabel(moveTarget.label ?? null, lang) : '',
+              })}
+            </DialogTitle>
+            <DialogDescription>{t('channels.channel_tree.move_hint')}</DialogDescription>
+          </DialogHeader>
+          <div className="max-h-72 space-y-1 overflow-auto">
+            {moveTarget
+              ? moveCandidates(root, childrenByParent, subtreeIds(moveTarget.id)).map((c) => (
+                  <button
+                    key={c.node.id}
+                    type="button"
+                    onClick={() =>
+                      moveTarget &&
+                      moveMutation.mutate({ nodeId: moveTarget.id, newParentId: c.node.id })
+                    }
+                    disabled={moveMutation.isPending || c.node.id === moveTarget.parentId}
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-accent disabled:opacity-40"
+                    style={{ paddingLeft: `${c.depth * 16 + 8}px` }}
+                  >
+                    <FolderTree className="size-4 shrink-0 text-muted-foreground" />
+                    {resolveLabel(c.node.label ?? null, lang)}
+                  </button>
+                ))
+              : null}
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setMoveTarget(null)}>
+              {t('app.cancel')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirm — warns about descendant cascade. */}
+      <Dialog open={deleteTarget !== null} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('channels.channel_tree.delete_title')}</DialogTitle>
+            <DialogDescription>
+              {deleteTarget?.parentId === null
+                ? t('channels.channel_tree.delete_root_body')
+                : t('channels.channel_tree.delete_body')}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setDeleteTarget(null)}>
+              {t('app.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => deleteTarget && deleteMutation.mutate(deleteTarget.id)}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+              {t('channels.channel_tree.delete_confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function TreeRows({
+  node,
+  depth,
+  childrenByParent,
+  lang,
+  t,
+  onAddChild,
+  onEdit,
+  onMove,
+  onDelete,
+}: {
+  node: ChannelNode;
+  depth: number;
+  childrenByParent: Map<string | null, ChannelNode[]>;
+  lang: string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  onAddChild: (parentId: string) => void;
+  onEdit: (node: ChannelNode) => void;
+  onMove: (node: ChannelNode) => void;
+  onDelete: (node: ChannelNode) => void;
+}) {
+  const children = childrenByParent.get(node.id) ?? [];
+  const isRoot = node.parentId === null;
+  return (
+    <div>
+      <div
+        className="group flex items-center justify-between gap-2 px-3 py-1.5 hover:bg-muted/40"
+        style={{ paddingLeft: `${depth * 20 + 12}px` }}
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          <FolderTree className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate text-sm font-medium">
+            {resolveLabel(node.label ?? null, lang)}
+          </span>
+          {node.externalCode ? (
+            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+              #{node.externalCode}
+            </span>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-center gap-0.5 opacity-60 group-hover:opacity-100">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => onAddChild(node.id)}
+            title={t('channels.channel_tree.add_child')}
+          >
+            <Plus className="size-4" />
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => onEdit(node)}
+            title={t('channels.channel_tree.edit')}
+          >
+            <Pencil className="size-4" />
+          </Button>
+          {isRoot ? null : (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onMove(node)}
+              title={t('channels.channel_tree.move')}
+            >
+              <MoveRight className="size-4" />
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => onDelete(node)}
+            title={t('channels.channel_tree.delete')}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+      </div>
+      {children.map((child) => (
+        <TreeRows
+          key={child.id}
+          node={child}
+          depth={depth + 1}
+          childrenByParent={childrenByParent}
+          lang={lang}
+          t={t}
+          onAddChild={onAddChild}
+          onEdit={onEdit}
+          onMove={onMove}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Flattened candidate parents for the move dialog, in tree order, excluding the
+ * moving node and its whole subtree.
+ */
+function moveCandidates(
+  root: ChannelNode | null,
+  childrenByParent: Map<string | null, ChannelNode[]>,
+  excluded: Set<string>,
+): Array<{ node: ChannelNode; depth: number }> {
+  if (root === null) return [];
+  const out: Array<{ node: ChannelNode; depth: number }> = [];
+  const walk = (node: ChannelNode, depth: number) => {
+    if (excluded.has(node.id)) return;
+    out.push({ node, depth });
+    for (const child of childrenByParent.get(node.id) ?? []) {
+      walk(child, depth + 1);
+    }
+  };
+  walk(root, 0);
+  return out;
+}

--- a/apps/admin/src/features/channel/channels/show.tsx
+++ b/apps/admin/src/features/channel/channels/show.tsx
@@ -10,6 +10,7 @@ import { resolveLabel } from '@/features/catalog/attributes/list';
 import { cn } from '@/lib/utils';
 
 import { ChannelCategoryMappingEditor } from './category-mapping-editor';
+import { ChannelTreeEditor } from './channel-tree-editor';
 import { ChannelMappingEditor } from './mapping-editor';
 
 interface LocaleRef {
@@ -26,9 +27,16 @@ interface ChannelDetail {
   categoryTreeRootId?: string | null;
 }
 
-type TabKey = 'overview' | 'locales' | 'mapping' | 'categoryMapping' | 'preview';
+type TabKey = 'overview' | 'locales' | 'mapping' | 'channelTree' | 'categoryMapping' | 'preview';
 
-const TABS: TabKey[] = ['overview', 'locales', 'mapping', 'categoryMapping', 'preview'];
+const TABS: TabKey[] = [
+  'overview',
+  'locales',
+  'mapping',
+  'channelTree',
+  'categoryMapping',
+  'preview',
+];
 
 export function ChannelShowPage() {
   const { t, i18n } = useTranslation();
@@ -92,6 +100,8 @@ export function ChannelShowPage() {
 
       {activeTab === 'mapping' ? (
         <ChannelMappingEditor channelId={channel.id} />
+      ) : activeTab === 'channelTree' ? (
+        <ChannelTreeEditor channelId={channel.id} />
       ) : activeTab === 'categoryMapping' ? (
         <ChannelCategoryMappingEditor channelId={channel.id} />
       ) : (

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1225,7 +1225,8 @@
         "locales": "Locales",
         "mapping": "Mapping",
         "preview": "Preview",
-        "categoryMapping": "Channel categories"
+        "categoryMapping": "Channel categories",
+        "channelTree": "Channel tree"
       },
       "placeholder": {
         "preview": "Per-channel product preview lands in 0.10.6 (API Configurator)."
@@ -1255,6 +1256,36 @@
       "clear_confirm_title": "Clear all channel mappings?",
       "clear_confirm_body": "Removes every category → node mapping for this channel. Manual product placements are kept.",
       "product_count": "{{count}} prod."
+    },
+    "channel_tree": {
+      "title": "Channel category tree",
+      "subtitle": "Build the channel category structure by hand. A node = a name (to tell it apart) + the target-channel node id. These nodes are the mapping targets in the \"Channel categories\" tab.",
+      "loading": "Loading tree...",
+      "empty": "This channel has no category tree yet.",
+      "create_tree": "Create tree",
+      "add_child": "Add sub-node",
+      "edit": "Edit",
+      "move": "Move",
+      "delete": "Delete",
+      "add_child_title": "Add sub-node",
+      "edit_title": "Edit node",
+      "form_hint": "The name tells the node apart in the structure. The target-channel id is optional — you can fill it in later.",
+      "name_label": "Name",
+      "name_placeholder": "e.g. TVs",
+      "external_label": "Target-channel node id (optional)",
+      "external_placeholder": "e.g. 12345 — the category id in the channel",
+      "move_title": "Move \"{{name}}\" to…",
+      "move_hint": "Pick a new parent. A node cannot be moved into itself or its own descendant.",
+      "delete_title": "Delete node?",
+      "delete_body": "The node and all its sub-nodes will be removed. Mappings and placements that reference them will disappear.",
+      "delete_root_body": "This deletes the ENTIRE category tree of this channel (root + all nodes). This cannot be undone.",
+      "delete_confirm": "Delete",
+      "saved": "Saved",
+      "save_error": "Failed to save",
+      "moved": "Moved",
+      "move_error": "Failed to move",
+      "deleted": "Deleted",
+      "delete_error": "Failed to delete"
     }
   },
   "categories": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1237,7 +1237,8 @@
         "locales": "Locale",
         "mapping": "Mapping",
         "preview": "Podgląd",
-        "categoryMapping": "Kategorie kanału"
+        "categoryMapping": "Kategorie kanału",
+        "channelTree": "Drzewo kanału"
       },
       "placeholder": {
         "preview": "Per-channel preview produktu dochodzi w 0.10.6 (API Configurator)."
@@ -1267,6 +1268,36 @@
       "clear_confirm_title": "Wyczyścić wszystkie mapowania kanału?",
       "clear_confirm_body": "Usunie wszystkie mapowania kategorii → węzły dla tego kanału. Ręczne placements produktów pozostaną.",
       "product_count": "{{count}} prod."
+    },
+    "channel_tree": {
+      "title": "Drzewo kategorii kanału",
+      "subtitle": "Zbuduj strukturę kategorii kanału ręcznie. Węzeł = nazwa (do rozróżnienia) + ID w kanale docelowym. Te węzły są celami mapowania w zakładce „Kategorie kanału\".",
+      "loading": "Ładowanie drzewa...",
+      "empty": "Ten kanał nie ma jeszcze drzewa kategorii.",
+      "create_tree": "Utwórz drzewo",
+      "add_child": "Dodaj podpozycję",
+      "edit": "Edytuj",
+      "move": "Przenieś",
+      "delete": "Usuń",
+      "add_child_title": "Dodaj podpozycję",
+      "edit_title": "Edytuj węzeł",
+      "form_hint": "Nazwa służy do rozróżnienia w strukturze. ID w kanale docelowym jest opcjonalne — możesz uzupełnić je później.",
+      "name_label": "Nazwa",
+      "name_placeholder": "np. Telewizory",
+      "external_label": "ID w kanale docelowym (opcjonalne)",
+      "external_placeholder": "np. 12345 — ID kategorii w kanale",
+      "move_title": "Przenieś „{{name}}\" do…",
+      "move_hint": "Wybierz nowego rodzica. Nie można przenieść węzła do samego siebie ani do swojego potomka.",
+      "delete_title": "Usunąć węzeł?",
+      "delete_body": "Węzeł i wszystkie jego podpozycje zostaną usunięte. Mapowania i placements odwołujące się do nich znikną.",
+      "delete_root_body": "To usunie CAŁE drzewo kategorii tego kanału (root + wszystkie węzły). Operacji nie można cofnąć.",
+      "delete_confirm": "Usuń",
+      "saved": "Zapisano",
+      "save_error": "Nie udało się zapisać",
+      "moved": "Przeniesiono",
+      "move_error": "Nie udało się przenieść",
+      "deleted": "Usunięto",
+      "delete_error": "Nie udało się usunąć"
     }
   },
   "categories": {

--- a/apps/api/src/Channel/Application/Command/AddChannelCategoryNode/AddChannelCategoryNodeCommand.php
+++ b/apps/api/src/Channel/Application/Command/AddChannelCategoryNode/AddChannelCategoryNodeCommand.php
@@ -10,11 +10,14 @@ final readonly class AddChannelCategoryNodeCommand
 {
     /**
      * @param array<string, string> $label
+     * @param string|null           $code  null/empty → handler defaults it to the new node's
+     *                                     uuid-hex (CHC-09: the tree editor never sends a code;
+     *                                     it is an internal slug, unique per channel)
      */
     public function __construct(
         public Uuid $channelId,
         public Uuid $parentId,
-        public string $code,
+        public ?string $code,
         public array $label,
         public ?string $externalCode = null,
     ) {

--- a/apps/api/src/Channel/Application/Command/AddChannelCategoryNode/AddChannelCategoryNodeHandler.php
+++ b/apps/api/src/Channel/Application/Command/AddChannelCategoryNode/AddChannelCategoryNodeHandler.php
@@ -40,12 +40,21 @@ final readonly class AddChannelCategoryNodeHandler
             ));
         }
 
+        // CHC-09: the tree editor sends only name + externalId, no code. Pre-generate
+        // the node id so an absent code can default to its uuid-hex — guaranteed unique
+        // per (tenant, channel) without the operator ever seeing a slug.
+        $id = Uuid::v7();
+        $code = (null === $command->code || '' === trim($command->code))
+            ? str_replace('-', '', $id->toRfc4122())
+            : $command->code;
+
         $node = new ChannelCategoryNode(
             channel: $channel,
-            code: $command->code,
+            code: $code,
             label: $command->label,
             parent: $parent,
             externalCode: $command->externalCode,
+            id: $id,
         );
 
         $parentPath = $parent->getPath();

--- a/apps/api/src/Channel/Application/Command/MoveChannelCategoryNode/MoveChannelCategoryNodeCommand.php
+++ b/apps/api/src/Channel/Application/Command/MoveChannelCategoryNode/MoveChannelCategoryNodeCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Application\Command\MoveChannelCategoryNode;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * CHC-09 (#1302) — re-parent a channel navigation node under a different node,
+ * rewriting the ltree path of the node and all its descendants.
+ */
+final readonly class MoveChannelCategoryNodeCommand
+{
+    public function __construct(
+        public Uuid $channelId,
+        public Uuid $nodeId,
+        public Uuid $newParentId,
+    ) {
+    }
+}

--- a/apps/api/src/Channel/Application/Command/MoveChannelCategoryNode/MoveChannelCategoryNodeHandler.php
+++ b/apps/api/src/Channel/Application/Command/MoveChannelCategoryNode/MoveChannelCategoryNodeHandler.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Application\Command\MoveChannelCategoryNode;
+
+use App\Channel\Domain\Repository\ChannelCategoryNodeRepositoryInterface;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Throwable;
+
+/**
+ * CHC-09 (#1302) — re-parent a channel navigation node and rewrite the ltree
+ * path of the node + every descendant in one transaction.
+ *
+ * Mirrors {@see \App\Catalog\Application\Service\MoveCategoryService} (the
+ * master-category move) but scoped to a single channel and tenant. Placements
+ * (CHC-02) and node mappings (CHC-06) reference nodes by id, never by path, so
+ * a move has no blast radius beyond the tree itself — hence no confirm gate.
+ */
+#[AsMessageHandler]
+final readonly class MoveChannelCategoryNodeHandler
+{
+    public function __construct(
+        private ChannelCategoryNodeRepositoryInterface $nodes,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    public function __invoke(MoveChannelCategoryNodeCommand $command): void
+    {
+        $node = $this->nodes->findById($command->nodeId);
+        if (null === $node || !$node->getChannel()->getId()->equals($command->channelId)) {
+            throw new NotFoundHttpException(\sprintf(
+                'Navigation node "%s" was not found in this channel.',
+                $command->nodeId->toRfc4122(),
+            ));
+        }
+
+        $newParent = $this->nodes->findById($command->newParentId);
+        if (null === $newParent || !$newParent->getChannel()->getId()->equals($command->channelId)) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Target parent "%s" does not belong to this channel.',
+                $command->newParentId->toRfc4122(),
+            ));
+        }
+        if ($newParent->getId()->equals($node->getId())) {
+            throw new UnprocessableEntityHttpException('A node cannot be its own parent.');
+        }
+
+        $oldPath = $node->getPath();
+        $parentPath = $newParent->getPath();
+        if (null === $oldPath || '' === $oldPath || null === $parentPath || '' === $parentPath) {
+            throw new UnprocessableEntityHttpException('Node or target parent has no ltree path.');
+        }
+
+        // Cycle guard: the target parent must not be the node itself or any of
+        // its descendants. ltree descendant-or-equal = path prefix on dot
+        // boundaries.
+        if ($parentPath === $oldPath || str_starts_with($parentPath, $oldPath.'.')) {
+            throw new UnprocessableEntityHttpException('Cannot move a node into its own subtree.');
+        }
+
+        $newPath = $parentPath.'.'.$node->ltreeLabel();
+        if ($newPath === $oldPath) {
+            return; // already under this parent — no-op
+        }
+
+        $tenant = $node->getTenant();
+        \assert(null !== $tenant);
+
+        $connection = $this->em->getConnection();
+        $connection->beginTransaction();
+        try {
+            // tenant-safe: WHERE id = :id — id is a tenant-scoped UUID resolved
+            // through ChannelCategoryNodeRepository (TenantFilter applied), so it
+            // can only match a row in the current tenant.
+            $connection->executeStatement(
+                'UPDATE channel_category_nodes SET path = CAST(:newPath AS ltree), parent_id = :parentId WHERE id = :id',
+                [
+                    'newPath' => $newPath,
+                    'parentId' => $newParent->getId()->toRfc4122(),
+                    'id' => $node->getId()->toRfc4122(),
+                ],
+                ['parentId' => Types::STRING, 'id' => Types::STRING],
+            );
+
+            // tenant-safe: explicit tenant_id + channel_id filter — the ltree
+            // subtree match (`path <@ :oldPath`) alone would touch rows of other
+            // tenants/channels sharing the namespace.
+            $connection->executeStatement(
+                'UPDATE channel_category_nodes'
+                .' SET path = CAST(:newPath AS ltree) || subpath(path, :oldDepth)'
+                .' WHERE tenant_id = :tenantId AND channel_id = :channelId'
+                .'   AND path <@ CAST(:oldPath AS ltree) AND id <> :id',
+                [
+                    'newPath' => $newPath,
+                    'oldDepth' => $this->ltreeDepth($oldPath),
+                    'tenantId' => $tenant->getId()->toRfc4122(),
+                    'channelId' => $node->getChannelId()->toRfc4122(),
+                    'oldPath' => $oldPath,
+                    'id' => $node->getId()->toRfc4122(),
+                ],
+                ['oldDepth' => Types::INTEGER, 'tenantId' => Types::STRING, 'channelId' => Types::STRING, 'id' => Types::STRING],
+            );
+
+            $connection->commit();
+        } catch (Throwable $e) {
+            $connection->rollBack();
+            throw $e;
+        }
+
+        // Evict so the next read re-hydrates the rewritten paths.
+        $this->em->clear();
+    }
+
+    private function ltreeDepth(string $path): int
+    {
+        return '' === $path ? 0 : substr_count($path, '.') + 1;
+    }
+}

--- a/apps/api/src/Channel/Presentation/Controller/ChannelNavigationTreeController.php
+++ b/apps/api/src/Channel/Presentation/Controller/ChannelNavigationTreeController.php
@@ -7,6 +7,7 @@ namespace App\Channel\Presentation\Controller;
 use App\Channel\Application\Command\AddChannelCategoryNode\AddChannelCategoryNodeCommand;
 use App\Channel\Application\Command\CreateNavigationTreeRoot\CreateNavigationTreeRootCommand;
 use App\Channel\Application\Command\DeleteChannelCategoryNode\DeleteChannelCategoryNodeCommand;
+use App\Channel\Application\Command\MoveChannelCategoryNode\MoveChannelCategoryNodeCommand;
 use App\Channel\Application\Command\UpdateChannelCategoryNode\UpdateChannelCategoryNodeCommand;
 use App\Channel\Domain\Entity\Channel;
 use App\Channel\Domain\Entity\ChannelCategoryNode;
@@ -93,20 +94,42 @@ final class ChannelNavigationTreeController
         if (null === $parentId) {
             throw new UnprocessableEntityHttpException('"parentId" is required.');
         }
-        $code = $this->optionalString($data, 'code');
-        if (null === $code || '' === $code) {
-            throw new UnprocessableEntityHttpException('"code" is required.');
-        }
 
+        // CHC-09: `code` is optional — the tree editor sends only name + externalId;
+        // the handler defaults an absent code to the node's uuid-hex.
         $id = $this->dispatchForId(new AddChannelCategoryNodeCommand(
             channelId: $this->uuid($channelId),
             parentId: $this->uuid($parentId),
-            code: $code,
+            code: $this->optionalString($data, 'code'),
             label: $this->labelMap($data['label'] ?? []),
             externalCode: $this->optionalString($data, 'externalCode'),
         ));
 
         return new JsonResponse($this->serialize($this->requireNode($id)), Response::HTTP_CREATED);
+    }
+
+    /**
+     * CHC-09 (#1302) — re-parent a node (and its subtree) under a different node.
+     */
+    #[Route('/api/channels/{channelId}/navigation-tree/nodes/{nodeId}/move', name: 'pim_channel_navtree_move_node', methods: ['PATCH'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    #[RequiresPermission(module: 'channel', action: 'write')]
+    public function moveNode(string $channelId, string $nodeId, Request $request): JsonResponse
+    {
+        $data = $this->decode($request);
+        $newParentId = $this->optionalString($data, 'newParentId');
+        if (null === $newParentId) {
+            throw new UnprocessableEntityHttpException('"newParentId" is required.');
+        }
+        $nodeUuid = $this->uuid($nodeId);
+
+        $this->dispatch(new MoveChannelCategoryNodeCommand(
+            channelId: $this->uuid($channelId),
+            nodeId: $nodeUuid,
+            newParentId: $this->uuid($newParentId),
+        ));
+
+        return new JsonResponse($this->serialize($this->requireNode($nodeUuid)));
     }
 
     #[Route('/api/channels/{channelId}/navigation-tree/nodes/{nodeId}', name: 'pim_channel_navtree_patch_node', methods: ['PATCH'])]

--- a/apps/api/tests/Api/Channel/ChannelNavigationTreeApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelNavigationTreeApiTest.php
@@ -166,6 +166,118 @@ final class ChannelNavigationTreeApiTest extends ChannelApiTestCase
     }
 
     #[Test]
+    public function moveReparentsNodeAndRewritesDescendantPaths(): void
+    {
+        $client = $this->authenticatedClient();
+        $channelId = $this->createChannel($client);
+        $rootId = self::extractId($client->request('POST', "/api/channels/{$channelId}/navigation-tree", [
+            'json' => ['label' => ['pl' => 'Root']],
+        ])->toArray());
+        $aId = $this->addNode($client, $channelId, $rootId, 'A');
+        $a1Id = $this->addNode($client, $channelId, $aId, 'A1');
+        $bId = $this->addNode($client, $channelId, $rootId, 'B');
+
+        $moved = $client->request('PATCH', "/api/channels/{$channelId}/navigation-tree/nodes/{$aId}/move", [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['newParentId' => $bId],
+        ]);
+        self::assertSame(200, $moved->getStatusCode());
+        self::assertSame($bId, $moved->toArray()['parentId'] ?? null);
+
+        $paths = $this->pathsById($client, $channelId);
+        self::assertStringStartsWith($paths[$bId].'.', $paths[$aId], 'A now sits under B');
+        self::assertStringStartsWith($paths[$aId].'.', $paths[$a1Id], 'A1 follows A (descendant rewrite)');
+    }
+
+    #[Test]
+    public function moveIntoOwnSubtreeIsRejected(): void
+    {
+        $client = $this->authenticatedClient();
+        $channelId = $this->createChannel($client);
+        $rootId = self::extractId($client->request('POST', "/api/channels/{$channelId}/navigation-tree", [
+            'json' => ['label' => ['pl' => 'Root']],
+        ])->toArray());
+        $aId = $this->addNode($client, $channelId, $rootId, 'A');
+        $a1Id = $this->addNode($client, $channelId, $aId, 'A1');
+
+        $rejected = $client->request('PATCH', "/api/channels/{$channelId}/navigation-tree/nodes/{$aId}/move", [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['newParentId' => $a1Id],
+        ]);
+        self::assertSame(422, $rejected->getStatusCode());
+    }
+
+    #[Test]
+    public function moveToForeignChannelParentIsRejected(): void
+    {
+        $client = $this->authenticatedClient();
+        $channelA = $this->createChannel($client, 'allegro');
+        $channelB = $this->createChannel($client, 'shopify');
+        $rootA = self::extractId($client->request('POST', "/api/channels/{$channelA}/navigation-tree", [
+            'json' => ['label' => ['pl' => 'Root A']],
+        ])->toArray());
+        $aId = $this->addNode($client, $channelA, $rootA, 'A');
+        $rootB = self::extractId($client->request('POST', "/api/channels/{$channelB}/navigation-tree", [
+            'json' => ['label' => ['pl' => 'Root B']],
+        ])->toArray());
+
+        $rejected = $client->request('PATCH', "/api/channels/{$channelA}/navigation-tree/nodes/{$aId}/move", [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['newParentId' => $rootB],
+        ]);
+        self::assertSame(422, $rejected->getStatusCode());
+    }
+
+    #[Test]
+    public function addNodeWithoutCodeGeneratesOne(): void
+    {
+        $client = $this->authenticatedClient();
+        $channelId = $this->createChannel($client);
+        $rootId = self::extractId($client->request('POST', "/api/channels/{$channelId}/navigation-tree", [
+            'json' => ['label' => ['pl' => 'Root']],
+        ])->toArray());
+
+        $node = $client->request('POST', "/api/channels/{$channelId}/navigation-tree/nodes", [
+            'json' => ['parentId' => $rootId, 'label' => ['pl' => 'Bez kodu']],
+        ]);
+        self::assertSame(201, $node->getStatusCode());
+        $code = $node->toArray()['code'] ?? null;
+        self::assertIsString($code);
+        self::assertNotSame('', $code);
+    }
+
+    private function addNode(\ApiPlatform\Symfony\Bundle\Test\Client $client, string $channelId, string $parentId, string $name): string
+    {
+        $node = $client->request('POST', "/api/channels/{$channelId}/navigation-tree/nodes", [
+            'json' => ['parentId' => $parentId, 'label' => ['pl' => $name]],
+        ]);
+        self::assertSame(201, $node->getStatusCode());
+
+        return self::extractId($node->toArray());
+    }
+
+    /**
+     * @return array<string, string> node id → ltree path
+     */
+    private function pathsById(\ApiPlatform\Symfony\Bundle\Test\Client $client, string $channelId): array
+    {
+        $nodes = $client->request('GET', "/api/channels/{$channelId}/navigation-tree", [
+            'headers' => ['accept' => 'application/json'],
+        ])->toArray();
+
+        $paths = [];
+        foreach ($nodes as $node) {
+            \assert(\is_array($node));
+            $id = $node['id'] ?? null;
+            $path = $node['path'] ?? null;
+            \assert(\is_string($id) && \is_string($path));
+            $paths[$id] = $path;
+        }
+
+        return $paths;
+    }
+
+    #[Test]
     public function unauthenticatedAccessIsRejected(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
## Cel

CHC-09 (#1302) — drzewo kategorii kanału było tylko API (CHC-01); „zaciąganie z API" (sync z zewnętrznego kanału) nie będzie istniało długo, więc operator musi budować drzewo ręcznie. Nowa zakładka **„Drzewo kanału"** na stronie kanału: utwórz drzewo, dodawaj podpozycje, edytuj (nazwa + ID w kanale docelowym), przenoś węzły, usuwaj (kaskada).

## Zakres

**Backend** (rozszerza kontroler nav-tree z CHC-01):
- `PATCH /api/channels/{id}/navigation-tree/nodes/{nodeId}/move` — reparent przez `MoveChannelCategoryNode`; przepisuje ścieżkę ltree węzła + wszystkich potomków w jednej transakcji (tenant+channel-scoped, wzorzec `MoveCategoryService`). Cykl (move-to-descendant) i obcy kanał → 422.
- `addNode` `code` jest teraz **opcjonalny** — edytor wysyła tylko nazwę + external id; handler defaultuje brakujący `code` do uuid-hex węzła.

**Frontend**:
- `ChannelTreeEditor` — rekurencyjne drzewo, akcje per węzeł: dodaj podpozycję / edytuj / przenieś / usuń. Dialog „Przenieś do…" (picker rodzica, bez self+potomków). Usuń z potwierdzeniem (ostrzeżenie o kaskadzie). Formularz węzła = **2 pola** (Nazwa + ID w kanale docelowym); nazwa zapisywana w `label` pod locale tenanta.
- i18n pl/en; Playwright E2E (fixme w CI jak CHC-03).

## Decyzje (z planu, zatwierdzone)

- **Minimalny model, bez migracji**: kolumny `label` (jsonb) + `code` zostają w schemacie, ale edytor pokazuje tylko 2 pola; `code` auto z uuid-hex. Brak zmian CHC-03/06/07/08.
- Reparent przez **dialog „Przenieś do…"** (bez drag&drop).
- Brak confirm-gate przy move (placements/mappingi referują węzeł po ID, nie po path → zero blast-radius).
- Potwierdzono audytem: **brak kodu ingestion/sync** z zewnętrznego API — nic do usunięcia.

## Definicja Done (CI) — lokalnie zielone

- [x] `PHPStan max` 0 · `Deptrac` 0 · `PHP-CS-Fixer` 0 · `raw-sql-lint` (move = raw ltree UPDATE z markerami `// tenant-safe:`)
- [x] `PHPUnit` `ChannelNavigationTreeApiTest` 11/11 (reparent + descendant path rewrite, cykl→422, obcy kanał→422, POST node bez code→201)
- [x] `Biome` 0 · `tsc` 0 · `Vite` 0
- [x] `Playwright` `chc-09-channel-tree-editor.spec.ts` — **1 passed (14.2s)** lokalnie (fixme w CI)

## Powiązania

- Closes #1302 · Epik `epik-CHC` · Blocked by #1284 (CHC-01), #1291 (CHC-08)
