### PR TITLE
fix(channel): „Kategorie kanału" taby = kategoryzowalne ObjectType + usuń zakładkę Mapping

### DIFF
--- a/apps/admin/src/features/channel/channels/category-mapping-editor.tsx
+++ b/apps/admin/src/features/channel/channels/category-mapping-editor.tsx
@@ -25,8 +25,11 @@ interface MasterCategory {
   path?: string | null;
 }
 
-interface ObjectTypeMappingRow {
-  objectType?: { id: string; code: string; label?: Record<string, string> | null };
+interface CategorizableObjectType {
+  id: string;
+  code: string;
+  label?: Record<string, string> | null;
+  isCategorizable?: boolean;
 }
 
 interface ChannelNode {
@@ -51,11 +54,6 @@ interface Collection<T> {
   member: T[];
 }
 
-interface PublishedObjectType {
-  code: string;
-  label: string;
-}
-
 interface Props {
   channelId: string;
 }
@@ -65,12 +63,13 @@ interface Props {
  * channel's navigation nodes (right). Saving a mapping triggers CHC-07
  * auto-assignment so products inherit the placement.
  *
- * The ObjectType tabs reflect the ObjectTypes the channel actually publishes
- * (DISTINCT objectType from `channel_object_type_mappings`). The master
- * category list is shared across tabs: a `ChannelCategoryNodeMapping` is
- * ObjectType-agnostic (master → channel nodes), so every published type maps
- * against the same master tree. The tabs scope the operator's mental model,
- * not the mappable set.
+ * Each categorizable ObjectType has its OWN master category tree (ADR-015,
+ * {@see \App\Catalog\Application\CategoryTreeAssignmentGuard}). The tabs are
+ * therefore one-per-categorizable-ObjectType, and the left panel loads that
+ * tab's tree via the `categoryTargetObjectType` filter. The channel is assumed
+ * to handle every ObjectType (no explicit channel↔ObjectType assignment — that
+ * is a deliberate "minimal" choice; an explicit per-channel subset is a
+ * separate ticket). The right panel (channel node tree) is ObjectType-agnostic.
  */
 export function ChannelCategoryMappingEditor({ channelId }: Props) {
   const { t, i18n } = useTranslation();
@@ -78,15 +77,29 @@ export function ChannelCategoryMappingEditor({ channelId }: Props) {
   const queryClient = useQueryClient();
   const lang = i18n.language;
 
-  const otMappingList = useList<ObjectTypeMappingRow>({
-    resource: 'channel_object_type_mappings',
-    filters: [{ field: 'channel', operator: 'eq', value: channelId }],
-    pagination: { mode: 'off' },
+  const objectTypesQuery = useQuery({
+    queryKey: ['channel-category-mapping', 'categorizable-object-types'],
+    queryFn: () =>
+      jsonFetch<CategorizableObjectType[]>('/api/object_types', { accept: 'application/json' }),
   });
+  const categorizableTypes = useMemo(
+    () => (objectTypesQuery.data ?? []).filter((ot) => ot.isCategorizable === true),
+    [objectTypesQuery.data],
+  );
 
+  const [activeOtId, setActiveOtId] = useState<string | null>(null);
+  // Effective active tab: the explicit pick, else the first categorizable type.
+  const effectiveOtId = activeOtId ?? categorizableTypes[0]?.id ?? null;
+
+  // Left panel: master categories of the active ObjectType's tree (ADR-015 —
+  // each ObjectType has its own tree; filter by categoryTargetObjectType).
   const categoryList = useList<MasterCategory>({
     resource: 'categories',
+    filters: effectiveOtId
+      ? [{ field: 'categoryTargetObjectType', operator: 'eq', value: effectiveOtId }]
+      : [],
     pagination: { mode: 'off' },
+    queryOptions: { enabled: effectiveOtId !== null },
   });
 
   const nodesQuery = useQuery({
@@ -113,20 +126,9 @@ export function ChannelCategoryMappingEditor({ channelId }: Props) {
       }),
   });
 
-  const [activeOt, setActiveOt] = useState<string | null>(null);
   const [dialogMaster, setDialogMaster] = useState<MasterCategory | null>(null);
   const [dialogSelection, setDialogSelection] = useState<string[]>([]);
   const [clearOpen, setClearOpen] = useState(false);
-
-  const publishedTypes = useMemo<PublishedObjectType[]>(() => {
-    const seen = new Map<string, PublishedObjectType>();
-    for (const row of otMappingList.result.data) {
-      const ot = row.objectType;
-      if (!ot || seen.has(ot.code)) continue;
-      seen.set(ot.code, { code: ot.code, label: resolveLabel(ot.label ?? null, lang) ?? ot.code });
-    }
-    return [...seen.values()];
-  }, [otMappingList.result.data, lang]);
 
   const nodes = nodesQuery.data ?? [];
   const nodeLabelById = useMemo(() => buildNodePathLabels(nodes, lang), [nodes, lang]);
@@ -182,7 +184,7 @@ export function ChannelCategoryMappingEditor({ channelId }: Props) {
     onError: () => toast.error(t('channels.category_mapping.clear_error')),
   });
 
-  if (otMappingList.query.isLoading || categoryList.query.isLoading || nodesQuery.isLoading) {
+  if (objectTypesQuery.isLoading || categoryList.query.isLoading || nodesQuery.isLoading) {
     return (
       <p className="text-sm text-muted-foreground">
         <Loader2 className="mr-2 inline size-3 animate-spin" />
@@ -221,35 +223,35 @@ export function ChannelCategoryMappingEditor({ channelId }: Props) {
         </Button>
       </div>
 
-      {publishedTypes.length > 0 ? (
+      {categorizableTypes.length > 0 ? (
         <div
           className="flex flex-wrap gap-1"
           role="tablist"
           aria-label={t('channels.category_mapping.ot_tabs_aria')}
         >
-          {publishedTypes.map((ot) => {
-            const active = activeOt === null ? ot === publishedTypes[0] : activeOt === ot.code;
+          {categorizableTypes.map((ot) => {
+            const active = effectiveOtId === ot.id;
             return (
               <button
-                key={ot.code}
+                key={ot.id}
                 type="button"
                 role="tab"
                 aria-selected={active}
-                onClick={() => setActiveOt(ot.code)}
+                onClick={() => setActiveOtId(ot.id)}
                 className={
                   active
                     ? 'rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground'
                     : 'rounded-md border px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground'
                 }
               >
-                {ot.label}
+                {resolveLabel(ot.label ?? null, lang)}
               </button>
             );
           })}
         </div>
       ) : (
         <p className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground">
-          {t('channels.category_mapping.no_published_types')}
+          {t('channels.category_mapping.no_object_types')}
         </p>
       )}
 

--- a/apps/admin/src/features/channel/channels/show.tsx
+++ b/apps/admin/src/features/channel/channels/show.tsx
@@ -11,7 +11,6 @@ import { cn } from '@/lib/utils';
 
 import { ChannelCategoryMappingEditor } from './category-mapping-editor';
 import { ChannelTreeEditor } from './channel-tree-editor';
-import { ChannelMappingEditor } from './mapping-editor';
 
 interface LocaleRef {
   id: string;
@@ -27,16 +26,9 @@ interface ChannelDetail {
   categoryTreeRootId?: string | null;
 }
 
-type TabKey = 'overview' | 'locales' | 'mapping' | 'channelTree' | 'categoryMapping' | 'preview';
+type TabKey = 'overview' | 'locales' | 'channelTree' | 'categoryMapping' | 'preview';
 
-const TABS: TabKey[] = [
-  'overview',
-  'locales',
-  'mapping',
-  'channelTree',
-  'categoryMapping',
-  'preview',
-];
+const TABS: TabKey[] = ['overview', 'locales', 'channelTree', 'categoryMapping', 'preview'];
 
 export function ChannelShowPage() {
   const { t, i18n } = useTranslation();
@@ -98,9 +90,7 @@ export function ChannelShowPage() {
         </nav>
       </div>
 
-      {activeTab === 'mapping' ? (
-        <ChannelMappingEditor channelId={channel.id} />
-      ) : activeTab === 'channelTree' ? (
+      {activeTab === 'channelTree' ? (
         <ChannelTreeEditor channelId={channel.id} />
       ) : activeTab === 'categoryMapping' ? (
         <ChannelCategoryMappingEditor channelId={channel.id} />

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1243,7 +1243,7 @@
       "mapped_count": "→ mapped to {{count}} node(s)",
       "no_categories": "No master categories.",
       "no_nodes": "Add categories in the «Channel tree» tab.",
-      "no_published_types": "This channel publishes no object types — configure attribute mapping first.",
+      "no_object_types": "No categorizable object types. Add a type with categories in the Modeling section.",
       "ot_tabs_aria": "Object types published by the channel",
       "dialog_title": "Map: {{category}}",
       "dialog_hint": "Pick one or more channel nodes where products from this category will land (M:N).",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1255,7 +1255,7 @@
       "mapped_count": "→ zmapowano do {{count}} węzł(ów)",
       "no_categories": "Brak kategorii master.",
       "no_nodes": "Dodaj kategorie w zakładce «Drzewo kanału».",
-      "no_published_types": "Kanał nie publikuje żadnych typów obiektów — skonfiguruj najpierw mapowanie atrybutów.",
+      "no_object_types": "Brak kategoryzowalnych typów obiektów. Dodaj typ z kategoriami w sekcji Modelowanie.",
       "ot_tabs_aria": "Typy obiektów publikowane przez kanał",
       "dialog_title": "Mapuj: {{category}}",
       "dialog_hint": "Wybierz jeden lub więcej węzłów kanału, na które trafią produkty z tej kategorii (M:N).",


### PR DESCRIPTION
## Summary

Dwie nielogiczności z ustawień kanału (po smoke CHC-09), FE-only:
1. „Kategorie kanału" mówiło „kanał nie publikuje żadnych typów" — bo czytało z tabeli `channel_object_type_mappings`, która **nigdy nie jest zapełniana**. A drzew kategorii jest wiele — **po jednym na ObjectType** (ADR-015).
2. Zakładka „Mapping" (atrybut→pole) — myląca tu; należy do konfiguracji integracji API (Faza 1).

## Root cause

- Bug A: CHC-08 wyprowadzał „publikowane typy" z pustej tabeli + ładował kategorie bez filtra drzewa.
- Bug B: zakładka atrybutowego mapowania umieszczona w ustawieniach kanału zamiast w konfiguracji API.

## Changes (frontend)

- `category-mapping-editor.tsx`: taby = **kategoryzowalne ObjectType** (`GET /api/object_types` → `isCategorizable`); lewy panel ładuje kategorie aktywnego taba przez `?categoryTargetObjectType=<id>` (ADR-015 `CategoryTreeFilter`). Usunięta zależność od `channel_object_type_mappings` + banner „nie publikuje typów" → „brak kategoryzowalnych typów".
- `show.tsx`: usunięta zakładka „Mapping" (komponent `mapping-editor.tsx` zostaje w kodzie, odpięty).
- i18n: `category_mapping.no_object_types` (zamiast `no_published_types`), pl/en.

## Świadome odejścia

- „Kanał obsługuje wszystkie typy" — brak jawnego przypisania kanał↔ObjectType (osobny ticket, jeśli kiedyś trzeba ograniczyć kanał do podzbioru typów).
- „Mapping" atrybutów wraca przy konfiguracji integracji API (Faza 1).

## Quality gates (lokalnie zielone)

- Biome 0 · tsc 0 · Vite 0
- Playwright: `chc-08-category-node-mapping` **1 passed (12.1s)** (taby OT + lewy panel = drzewo Produktu + mapowanie→węzeł), `chc-09-channel-tree-editor` **1 passed (8.7s)** (usunięcie zakładki nie psuje nawigacji)
- Brak zmian BE → brak zmian OpenAPI; composer/pnpm audit bez zmian

## Smoke test plan (operator)

1. Login → `/settings/channels/{allegro}` → zakładka **„Kategorie kanału"**.
2. Widać taby per kategoryzowalny typ (Produkt + ewentualne custom); lewy panel = kategorie drzewa wybranego typu; prawy = drzewo węzłów kanału. ✅ (bug A)
3. „Mapuj" na kategorii → wybór węzła → produkt z tej kategorii auto-trafia na węzeł.
4. Zakładki „Mapping" **już nie ma**. ✅ (bug B)
5. DevTools Console — brak czerwonych errorów.

Closes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
