### PR TITLE
fix(channel): nazwy kategorii master w Kategorie kanału (nie „—")

### DIFF
--- a/apps/admin/e2e/chc-08-category-node-mapping.spec.ts
+++ b/apps/admin/e2e/chc-08-category-node-mapping.spec.ts
@@ -66,6 +66,13 @@ test('map a master category to a channel node from the channel mapping tab', asy
   await page.getByRole('button', { name: /Channel categories|Kategorie kanału/i }).click();
 
   await expect(page.getByTestId('chc-master-list')).toBeVisible();
+  // Master categories show their real name (from attributesIndexed), not "—".
+  await expect(
+    page
+      .getByTestId('chc-master-list')
+      .getByText(/Obuwie|Odzież|Bieganie|Outdoor/)
+      .first(),
+  ).toBeVisible();
   await expect(page.getByTestId('chc-channel-tree')).toBeVisible();
   await expect(page.getByText(/MAP08/i).first()).toBeVisible();
 

--- a/apps/admin/src/features/channel/channels/category-mapping-editor.tsx
+++ b/apps/admin/src/features/channel/channels/category-mapping-editor.tsx
@@ -16,13 +16,29 @@ import {
 import { MultiSelect } from '@/components/ui/multi-select';
 import { useToast } from '@/components/ui/toast';
 import { resolveLabel } from '@/features/catalog/attributes/list';
+import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
 import { jsonFetch } from '@/lib/http';
 
 interface MasterCategory {
   id: string;
   code: string;
-  label?: Record<string, string> | string | null;
+  attributesIndexed?: Record<string, unknown>;
   path?: string | null;
+}
+
+/**
+ * Display name of a master category. Categories (CatalogObject kind=category)
+ * carry no `label` field — the name lives in `attributesIndexed.name`
+ * (same source the modeling category tree uses). Falls back to `code`.
+ */
+function categoryName(master: MasterCategory, lang: string): string {
+  const name = unwrapAttributesIndexed(master.attributesIndexed).name;
+  if (typeof name === 'string' && name.trim() !== '') return name;
+  if (name !== null && typeof name === 'object') {
+    const map = name as Record<string, string>;
+    return map[lang] ?? map.pl ?? map.en ?? Object.values(map)[0] ?? master.code;
+  }
+  return master.code;
 }
 
 interface CategorizableObjectType {
@@ -276,9 +292,7 @@ export function ChannelCategoryMappingEditor({ channelId }: Props) {
                     <div className="min-w-0 space-y-0.5">
                       <div className="flex items-center gap-2 text-sm font-medium">
                         <FolderTree className="size-4 shrink-0 text-muted-foreground" />
-                        <span className="truncate">
-                          {resolveLabel(master.label ?? null, lang) ?? master.code}
-                        </span>
+                        <span className="truncate">{categoryName(master, lang)}</span>
                       </div>
                       {mapped.length > 0 ? (
                         <p className="pl-6 text-xs text-muted-foreground">
@@ -323,9 +337,7 @@ export function ChannelCategoryMappingEditor({ channelId }: Props) {
           <DialogHeader>
             <DialogTitle>
               {t('channels.category_mapping.dialog_title', {
-                category: dialogMaster
-                  ? (resolveLabel(dialogMaster.label ?? null, lang) ?? dialogMaster.code)
-                  : '',
+                category: dialogMaster ? categoryName(dialogMaster, lang) : '',
               })}
             </DialogTitle>
             <DialogDescription>{t('channels.category_mapping.dialog_hint')}</DialogDescription>


### PR DESCRIPTION
## Summary

Lewy panel „Twoje kategorie (master)" pokazywał „—" zamiast nazw. Kategorie (CatalogObject kind=category) nie mają pola `label` — nazwa jest w `attributesIndexed.name`. Edytor używał `resolveLabel(master.label)` (zwraca „—", więc fallback na `code` nigdy nie odpalał). Fix: nazwa przez `unwrapAttributesIndexed(attributesIndexed).name ?? code` — to samo źródło, co drzewo kategorii w Modelowaniu.

## Changes (FE-only)
- `category-mapping-editor.tsx`: `MasterCategory.attributesIndexed`, helper `categoryName()`, podmiana 2 użyć (lista master + tytuł dialogu „Mapuj").
- E2E `chc-08`: asercja, że realna nazwa (Obuwie/Odzież/…) się renderuje.

## Quality gates
Biome 0 · tsc 0 · Vite 0 · Playwright `chc-08` 1 passed (23.3s). Brak zmian BE.

Closes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
