### PR TITLE
refactor(channel): pojedyncza nazwa kanału zamiast dwujęzycznej etykiety

### DIFF
--- a/apps/admin/e2e/1153-channels-settings.spec.ts
+++ b/apps/admin/e2e/1153-channels-settings.spec.ts
@@ -29,12 +29,10 @@ test('operator creates a channel via the settings page', async ({ page }) => {
   await page.goto('/settings/channels/new');
   await expect(page.locator('#channel-code')).toBeVisible();
   await page.locator('#channel-code').fill(code);
-  await page.locator('#channel-label-pl').fill('Kanał E2E');
-  await page.locator('#channel-label-en').fill('E2E Channel');
+  await page.locator('#channel-name').fill('Kanał E2E');
 
-  // Pick one locale + one currency from the real catalogs.
+  // Pick one locale from the real catalog.
   await page.getByRole('button').filter({ hasText: /pl_PL/ }).first().click();
-  await page.getByRole('button').filter({ hasText: /PLN/ }).first().click();
 
   const createResponse = page.waitForResponse(
     (r) => r.url().includes('/api/channels') && r.request().method() === 'POST',

--- a/apps/admin/e2e/settings-channels-crud.spec.ts
+++ b/apps/admin/e2e/settings-channels-crud.spec.ts
@@ -43,14 +43,11 @@ test.describe('VIEW-06 — Settings · Channels · CRUD + mapping editor', () =>
     await page.getByRole('link', { name: /nowy kana[łl]|new channel/i }).click();
     await expect(page).toHaveURL(/\/settings\/channels\/new$/);
 
-    // 3. Fill form — code, label PL+EN, pick first locale + currency.
+    // 3. Fill form — code, name, pick first locale.
     await page.getByLabel(/^kod$|^code$/i).fill(uniqueCode);
-    await page.getByLabel(/etykieta \(pl\)|label \(pl\)/i).fill('E2E test');
-    await page.getByLabel(/label \(en\)/i).fill('E2E test');
+    await page.getByLabel(/^nazwa$|^name$/i).fill('E2E test');
     const localesFieldset = page.locator('fieldset[aria-labelledby="channel-locales-label"]');
     await localesFieldset.getByRole('button', { pressed: false }).first().click();
-    const currenciesFieldset = page.locator('fieldset[aria-labelledby="channel-currencies-label"]');
-    await currenciesFieldset.getByRole('button', { pressed: false }).first().click();
 
     // 4. Submit + redirect to detail page (UUID v7).
     await page.getByRole('button', { name: /utw[óo]rz kana[łl]|create channel/i }).click();

--- a/apps/admin/src/features/catalog/products/components/channel-placements-section.tsx
+++ b/apps/admin/src/features/catalog/products/components/channel-placements-section.tsx
@@ -18,7 +18,7 @@ interface Placement {
 interface PlacementRow {
   channelId: string;
   channelCode: string;
-  channelLabel: Record<string, string>;
+  channelName: string;
   placement: Placement | null;
 }
 
@@ -33,10 +33,6 @@ interface Props {
 
 const COLLAPSE_THRESHOLD = 5;
 
-function resolveLabel(label: Record<string, string>, lang: string, code: string): string {
-  return label[lang] ?? label.pl ?? label.en ?? Object.values(label)[0] ?? code;
-}
-
 /**
  * CHC-03 (#1286) — "Gdzie trafia na kanałach" section inside the product
  * "Kategorie" tab. One row per tenant channel showing the navigation node the
@@ -44,7 +40,7 @@ function resolveLabel(label: Record<string, string>, lang: string, code: string)
  * channels the list collapses to just the unmapped rows.
  */
 export function ChannelPlacementsSection({ productId }: Props) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [pickerChannel, setPickerChannel] = useState<{ id: string; name: string } | null>(null);
   const [busyChannelId, setBusyChannelId] = useState<string | null>(null);
@@ -126,7 +122,7 @@ export function ChannelPlacementsSection({ productId }: Props) {
       ) : (
         <ul className="divide-y divide-line/60 rounded-xl border border-line">
           {visibleRows.map((row) => {
-            const name = resolveLabel(row.channelLabel, i18n.language, row.channelCode);
+            const name = row.channelName || row.channelCode;
             const isBusy = busyChannelId === row.channelId;
             return (
               <li

--- a/apps/admin/src/features/catalog/products/components/locale-channel-toolbar.tsx
+++ b/apps/admin/src/features/catalog/products/components/locale-channel-toolbar.tsx
@@ -52,8 +52,7 @@ export function LocaleChannelToolbar({
   locales,
   channels,
 }: LocaleChannelToolbarProps) {
-  const { t, i18n } = useTranslation();
-  const lang = i18n.language === 'pl' ? 'pl' : 'en';
+  const { t } = useTranslation();
   const localeCodes: readonly string[] =
     locales !== undefined && locales.length > 0 ? locales.map((l) => l.code) : PRODUCT_LOCALES;
 
@@ -62,7 +61,7 @@ export function LocaleChannelToolbar({
   // picker offers just "Wszystkie kanały". No hardcoded mock fallback.
   const channelList: { code: string; label: string }[] = (channels ?? []).map((c) => ({
     code: c.code,
-    label: c.label?.[lang] ?? c.label?.en ?? c.code,
+    label: c.name ?? c.code,
   }));
   const channelLabel = (code: string): string =>
     channelList.find((c) => c.code === code)?.label ?? code;

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -29,7 +29,7 @@ export type ProductChannel = string;
 /** One tenant channel for the detail-page picker (#1155). */
 export interface ChannelOption {
   code: string;
-  label?: Record<string, string>;
+  name?: string | null;
 }
 
 /**

--- a/apps/admin/src/features/channel/channels/create.tsx
+++ b/apps/admin/src/features/channel/channels/create.tsx
@@ -24,7 +24,7 @@ export function ChannelCreatePage() {
         resource: 'channels',
         values: {
           code: values.code,
-          label: values.label,
+          name: values.name,
           locales: values.locales,
         },
       },

--- a/apps/admin/src/features/channel/channels/edit.tsx
+++ b/apps/admin/src/features/channel/channels/edit.tsx
@@ -5,20 +5,19 @@ import { Link, useNavigate, useParams } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/toast';
-import { resolveLabel } from '@/features/catalog/attributes/list';
 
 import { ChannelForm, type ChannelFormValues } from './form';
 
 interface ChannelDetail {
   id: string;
   code: string;
-  label?: Record<string, string> | null;
+  name?: string | null;
   locales?: Array<{ code: string }>;
   categoryTreeRootId?: string | null;
 }
 
 export function ChannelEditPage() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const toast = useToast();
   const { id } = useParams<{ id: string }>();
@@ -35,16 +34,11 @@ export function ChannelEditPage() {
 
   const defaultValues: Partial<ChannelFormValues> = {
     code: channel.code,
-    label: {
-      pl: channel.label?.pl ?? '',
-      en: channel.label?.en ?? '',
-    },
+    name: channel.name ?? '',
     locales: (channel.locales ?? []).map((l) => l.code),
   };
 
-  const headerTitle = `${t('channels.edit.title_prefix')} ${
-    resolveLabel(channel.label ?? null, i18n.language) ?? channel.code
-  }`;
+  const headerTitle = `${t('channels.edit.title_prefix')} ${channel.name ?? channel.code}`;
 
   const handleSubmit = (values: ChannelFormValues) => {
     doUpdate(
@@ -52,7 +46,7 @@ export function ChannelEditPage() {
         resource: 'channels',
         id: channel.id,
         values: {
-          label: values.label,
+          name: values.name,
           locales: values.locales,
         },
       },

--- a/apps/admin/src/features/channel/channels/form.tsx
+++ b/apps/admin/src/features/channel/channels/form.tsx
@@ -9,7 +9,7 @@ import { LocalePicker } from './locale-picker';
 
 export interface ChannelFormValues {
   code: string;
-  label: { pl: string; en: string };
+  name: string;
   locales: string[];
 }
 
@@ -23,7 +23,7 @@ interface ChannelFormProps {
 
 const EMPTY: ChannelFormValues = {
   code: '',
-  label: { pl: '', en: '' },
+  name: '',
   locales: [],
 };
 
@@ -40,14 +40,11 @@ export function ChannelForm({
   const [values, setValues] = useState<ChannelFormValues>({
     ...EMPTY,
     ...defaultValues,
-    label: {
-      pl: defaultValues?.label?.pl ?? '',
-      en: defaultValues?.label?.en ?? '',
-    },
+    name: defaultValues?.name ?? '',
     locales: defaultValues?.locales ?? [],
   });
 
-  const errors: Partial<Record<keyof ChannelFormValues | 'label_pl' | 'label_en', string>> = {};
+  const errors: Partial<Record<keyof ChannelFormValues, string>> = {};
   if (mode === 'create') {
     if (values.code.trim() === '') {
       errors.code = t('channels.form.validation.required');
@@ -55,11 +52,8 @@ export function ChannelForm({
       errors.code = t('channels.form.validation.code_format');
     }
   }
-  if (values.label.pl.trim() === '') {
-    errors.label_pl = t('channels.form.validation.required');
-  }
-  if (values.label.en.trim() === '') {
-    errors.label_en = t('channels.form.validation.required');
+  if (values.name.trim() === '') {
+    errors.name = t('channels.form.validation.required');
   }
   if (values.locales.length === 0) {
     errors.locales = t('channels.form.validation.locales_min');
@@ -102,41 +96,24 @@ export function ChannelForm({
             </div>
           ) : null}
 
-          <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <Label htmlFor="channel-label-pl">{t('channels.form.fields.label_pl')}</Label>
-              <Input
-                id="channel-label-pl"
-                value={values.label.pl}
-                onChange={(e) =>
-                  setValues({ ...values, label: { ...values.label, pl: e.target.value } })
-                }
-                aria-invalid={errors.label_pl ? 'true' : 'false'}
-                className="mt-1"
-              />
-              {errors.label_pl ? (
-                <p role="alert" className="mt-1 text-xs text-destructive">
-                  {errors.label_pl}
-                </p>
-              ) : null}
-            </div>
-            <div>
-              <Label htmlFor="channel-label-en">{t('channels.form.fields.label_en')}</Label>
-              <Input
-                id="channel-label-en"
-                value={values.label.en}
-                onChange={(e) =>
-                  setValues({ ...values, label: { ...values.label, en: e.target.value } })
-                }
-                aria-invalid={errors.label_en ? 'true' : 'false'}
-                className="mt-1"
-              />
-              {errors.label_en ? (
-                <p role="alert" className="mt-1 text-xs text-destructive">
-                  {errors.label_en}
-                </p>
-              ) : null}
-            </div>
+          <div>
+            <Label htmlFor="channel-name">{t('channels.form.fields.name')}</Label>
+            <Input
+              id="channel-name"
+              value={values.name}
+              onChange={(e) => setValues({ ...values, name: e.target.value })}
+              aria-invalid={errors.name ? 'true' : 'false'}
+              aria-describedby="channel-name-help"
+              className="mt-1"
+            />
+            <p id="channel-name-help" className="mt-1 text-xs text-muted-foreground">
+              {t('channels.form.fields.name_help')}
+            </p>
+            {errors.name ? (
+              <p role="alert" className="mt-1 text-xs text-destructive">
+                {errors.name}
+              </p>
+            ) : null}
           </div>
         </div>
       </div>

--- a/apps/admin/src/features/channel/channels/list.tsx
+++ b/apps/admin/src/features/channel/channels/list.tsx
@@ -20,7 +20,6 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { useToast } from '@/components/ui/toast';
-import { resolveLabel } from '@/features/catalog/attributes/list';
 
 import { ChannelDeleteConfirmDialog } from './delete-confirm-dialog';
 
@@ -33,13 +32,13 @@ interface LocaleRef {
 export interface ChannelRow {
   id: string;
   code: string;
-  label?: Record<string, string> | string | null;
+  name?: string | null;
   locales?: LocaleRef[];
   categoryTreeRootId?: string | null;
 }
 
 export function ChannelsListPage() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { result, query } = useList<ChannelRow>({
     resource: 'channels',
     pagination: { mode: 'off' },
@@ -87,7 +86,7 @@ export function ChannelsListPage() {
           <TableHeader>
             <TableRow>
               <TableHead className="w-[180px]">{t('channels.fields.code')}</TableHead>
-              <TableHead>{t('channels.fields.label')}</TableHead>
+              <TableHead>{t('channels.fields.name')}</TableHead>
               <TableHead className="w-[200px]">{t('channels.fields.locales')}</TableHead>
               <TableHead className="w-[120px] text-right">
                 <span className="sr-only">{t('channels.fields.actions')}</span>
@@ -114,9 +113,7 @@ export function ChannelsListPage() {
                     <Radio className="mr-1 inline size-3.5 text-muted-foreground" />
                     {row.code}
                   </TableCell>
-                  <TableCell className="font-medium">
-                    {resolveLabel(row.label, i18n.language)}
-                  </TableCell>
+                  <TableCell className="font-medium">{row.name ?? row.code}</TableCell>
                   <TableCell className="space-x-1 text-xs">
                     {(row.locales ?? []).map((loc) => (
                       <Tag key={loc.id ?? loc.code}>{loc.code}</Tag>
@@ -167,7 +164,7 @@ export function ChannelsListPage() {
 
       {pendingDelete ? (
         <ChannelDeleteConfirmDialog
-          channelLabel={resolveLabel(pendingDelete.label, i18n.language) ?? pendingDelete.code}
+          channelLabel={pendingDelete.name ?? pendingDelete.code}
           open={true}
           onClose={() => setPendingDelete(null)}
           onConfirm={() => handleDelete(pendingDelete)}

--- a/apps/admin/src/features/channel/channels/show.tsx
+++ b/apps/admin/src/features/channel/channels/show.tsx
@@ -6,7 +6,6 @@ import { Link, useParams } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { resolveLabel } from '@/features/catalog/attributes/list';
 import { cn } from '@/lib/utils';
 
 import { ChannelCategoryMappingEditor } from './category-mapping-editor';
@@ -21,7 +20,7 @@ interface LocaleRef {
 interface ChannelDetail {
   id: string;
   code: string;
-  label?: Record<string, string> | string | null;
+  name?: string | null;
   locales?: LocaleRef[];
   categoryTreeRootId?: string | null;
 }
@@ -31,7 +30,7 @@ type TabKey = 'overview' | 'locales' | 'channelTree' | 'categoryMapping' | 'prev
 const TABS: TabKey[] = ['overview', 'locales', 'channelTree', 'categoryMapping', 'preview'];
 
 export function ChannelShowPage() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const params = useParams<{ id: string }>();
   const id = params.id ?? '';
   const { result, query } = useOne<ChannelDetail>({
@@ -46,7 +45,7 @@ export function ChannelShowPage() {
   }
 
   const channel = result;
-  const label = resolveLabel(channel.label, i18n.language);
+  const label = channel.name ?? channel.code;
 
   return (
     <div className="space-y-6">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -1146,7 +1146,7 @@
     "empty": "No channels for the current tenant.",
     "fields": {
       "code": "Code",
-      "label": "Label",
+      "name": "Name",
       "locales": "Locales",
       "locales_count": "Locales count",
       "category_root": "Category tree root",
@@ -1188,8 +1188,8 @@
       "fields": {
         "code": "Code",
         "code_help": "Lowercase, characters: a-z, 0-9, _. Immutable after creation.",
-        "label_pl": "Label (PL)",
-        "label_en": "Label (EN)",
+        "name": "Name",
+        "name_help": "Internal channel name shown in the admin panel.",
         "locales": "Locales",
         "category_root": "Category tree root"
       },

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -1158,7 +1158,7 @@
     "empty": "Brak kanałów dla aktualnego najemcy.",
     "fields": {
       "code": "Kod",
-      "label": "Etykieta",
+      "name": "Nazwa",
       "locales": "Locale",
       "locales_count": "Liczba locale",
       "category_root": "Korzeń drzewa kategorii",
@@ -1200,8 +1200,8 @@
       "fields": {
         "code": "Kod",
         "code_help": "Lowercase, znaki: a-z, 0-9, _. Niezmienny po utworzeniu.",
-        "label_pl": "Etykieta (PL)",
-        "label_en": "Label (EN)",
+        "name": "Nazwa",
+        "name_help": "Wewnętrzna nazwa kanału widoczna w panelu admina.",
         "locales": "Wersje językowe",
         "category_root": "Korzeń kategorii"
       },

--- a/apps/api/migrations/Version20260607130000.php
+++ b/apps/api/migrations/Version20260607130000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #1316 — replace the bilingual channel `label` (JSONB `{pl, en}`) with a
+ * single scalar `name` (VARCHAR).
+ *
+ * The channel label was only ever an internal admin display name; nothing
+ * publishes it to a destination, so a multi-language envelope was needless
+ * over-engineering. The expand step backfills `name` from the existing
+ * `label` (pl → en → code) so live channels keep their display names, then
+ * the `label` column is dropped.
+ */
+final class Version20260607130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '#1316: channels.label (jsonb) -> channels.name (varchar), backfilled from label.pl/en/code';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE channels ADD name VARCHAR(255) DEFAULT NULL');
+        // tenant-safe: one-time data backfill across every channel row at
+        // migration time; the name is derived from each row's own label/code.
+        $this->addSql("UPDATE channels SET name = COALESCE(NULLIF(label->>'pl', ''), NULLIF(label->>'en', ''), code)");
+        $this->addSql('ALTER TABLE channels ALTER COLUMN name SET NOT NULL');
+        $this->addSql('ALTER TABLE channels DROP label');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE channels ADD label JSONB DEFAULT '{}' NOT NULL");
+        // tenant-safe: one-time reverse backfill; rebuilds the pl-keyed label
+        // envelope from each row's own name.
+        $this->addSql("UPDATE channels SET label = jsonb_build_object('pl', name)");
+        $this->addSql('ALTER TABLE channels DROP name');
+    }
+}

--- a/apps/api/src/Channel/Application/Command/CreateChannel/CreateChannelCommand.php
+++ b/apps/api/src/Channel/Application/Command/CreateChannel/CreateChannelCommand.php
@@ -7,12 +7,11 @@ namespace App\Channel\Application\Command\CreateChannel;
 final readonly class CreateChannelCommand
 {
     /**
-     * @param array<string, string> $label
-     * @param array<int, string>    $localeCodes
+     * @param array<int, string> $localeCodes
      */
     public function __construct(
         public string $code,
-        public array $label,
+        public string $name,
         public array $localeCodes,
         public ?string $categoryTreeRootId = null,
     ) {

--- a/apps/api/src/Channel/Application/Command/CreateChannel/CreateChannelHandler.php
+++ b/apps/api/src/Channel/Application/Command/CreateChannel/CreateChannelHandler.php
@@ -38,7 +38,7 @@ final readonly class CreateChannelHandler
             ));
         }
 
-        $channel = new Channel(code: $command->code, label: $command->label);
+        $channel = new Channel(code: $command->code, name: $command->name);
 
         foreach ($command->localeCodes as $code) {
             $locale = $this->locales->findByCode($code);

--- a/apps/api/src/Channel/Application/Command/UpdateChannel/UpdateChannelCommand.php
+++ b/apps/api/src/Channel/Application/Command/UpdateChannel/UpdateChannelCommand.php
@@ -9,13 +9,12 @@ use Symfony\Component\Uid\Uuid;
 final readonly class UpdateChannelCommand
 {
     /**
-     * @param array<string, string>|null $label
-     * @param array<int, string>|null    $localeCodes
-     * @param string|false|null          $categoryTreeRootId pass `false` to leave unchanged, `null` or `''` to clear, string UUID to set
+     * @param array<int, string>|null $localeCodes
+     * @param string|false|null       $categoryTreeRootId pass `false` to leave unchanged, `null` or `''` to clear, string UUID to set
      */
     public function __construct(
         public Uuid $id,
-        public ?array $label = null,
+        public ?string $name = null,
         public ?array $localeCodes = null,
         public string|false|null $categoryTreeRootId = false,
     ) {

--- a/apps/api/src/Channel/Application/Command/UpdateChannel/UpdateChannelHandler.php
+++ b/apps/api/src/Channel/Application/Command/UpdateChannel/UpdateChannelHandler.php
@@ -30,8 +30,8 @@ final readonly class UpdateChannelHandler
             ));
         }
 
-        if (null !== $command->label) {
-            $channel->rename($command->label);
+        if (null !== $command->name) {
+            $channel->rename($command->name);
         }
 
         if (null !== $command->localeCodes) {

--- a/apps/api/src/Channel/Domain/Entity/Channel.php
+++ b/apps/api/src/Channel/Domain/Entity/Channel.php
@@ -21,7 +21,8 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Examples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.
  * Each channel carries:
  *
- *   - a label (`{pl, en}`) — what admins see in the UI;
+ *   - a name (plain string) — what admins see in the UI. Internal-only,
+ *     never published to a destination, so it is intentionally single-language;
  *   - a set of supported `Locale` rows (M2M `channel_locales`);
  *   - an optional `category_tree_root_object_id` pointing at a
  *     `CatalogObject` of `kind=category` — the root of the category tree
@@ -43,11 +44,9 @@ class Channel extends AggregateRoot implements TenantScoped
     #[Assert\Length(max: 64)]
     private string $code;
 
-    /**
-     * @var array<string, string>
-     */
-    #[Assert\Type('array')]
-    private array $label;
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    private string $name;
 
     /**
      * @var Collection<int, Locale>
@@ -62,14 +61,11 @@ class Channel extends AggregateRoot implements TenantScoped
      */
     private ?Uuid $categoryTreeRootId = null;
 
-    /**
-     * @param array<string, string> $label
-     */
-    public function __construct(string $code, array $label, ?Uuid $id = null)
+    public function __construct(string $code, string $name, ?Uuid $id = null)
     {
         $this->id = $id ?? Uuid::v7();
         $this->code = $code;
-        $this->label = $label;
+        $this->name = $name;
         $this->locales = new ArrayCollection();
     }
 
@@ -105,20 +101,14 @@ class Channel extends AggregateRoot implements TenantScoped
         return $this->code;
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function getLabel(): array
+    public function getName(): string
     {
-        return $this->label;
+        return $this->name;
     }
 
-    /**
-     * @param array<string, string> $label
-     */
-    public function rename(array $label): void
+    public function rename(string $name): void
     {
-        $this->label = $label;
+        $this->name = $name;
     }
 
     /**

--- a/apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelInput.php
+++ b/apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelInput.php
@@ -21,15 +21,13 @@ final class ChannelInput
     public string $code = '';
 
     /**
-     * Multi-language label keyed by locale code. At least one entry required.
-     *
-     * @var array<string, string>
+     * Internal admin display name. Single-language by design — the channel
+     * name is never published to a destination.
      */
     #[Assert\NotBlank]
-    #[Assert\Type('array')]
-    #[Assert\Count(min: 1)]
+    #[Assert\Length(max: 255)]
     #[Groups(['channel:create'])]
-    public array $label = [];
+    public string $name = '';
 
     /**
      * Locale codes (BCP-47 shape, e.g. `pl_PL`).

--- a/apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelPatchInput.php
+++ b/apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelPatchInput.php
@@ -13,13 +13,10 @@ use Symfony\Component\Validator\Constraints as Assert;
  */
 final class ChannelPatchInput
 {
-    /**
-     * @var array<string, string>|null
-     */
-    #[Assert\Type('array')]
-    #[Assert\Count(min: 1)]
+    #[Assert\Length(max: 255)]
+    #[Assert\NotBlank(allowNull: true)]
     #[Groups(['channel:update'])]
-    public ?array $label = null;
+    public ?string $name = null;
 
     /**
      * @var array<int, string>|null

--- a/apps/api/src/Channel/Infrastructure/ApiPlatform/State/ChannelProcessor.php
+++ b/apps/api/src/Channel/Infrastructure/ApiPlatform/State/ChannelProcessor.php
@@ -73,7 +73,7 @@ final readonly class ChannelProcessor implements ProcessorInterface
 
         $command = new CreateChannelCommand(
             code: $data->code,
-            label: $data->label,
+            name: $data->name,
             localeCodes: $data->locales,
             categoryTreeRootId: null,
         );
@@ -114,7 +114,7 @@ final readonly class ChannelProcessor implements ProcessorInterface
         // endpoints (CHC-01, #1284), not channel PATCH — always unchanged here.
         $command = new UpdateChannelCommand(
             id: $id,
-            label: $data->label,
+            name: $data->name,
             localeCodes: $data->locales,
             categoryTreeRootId: false,
         );

--- a/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml
+++ b/apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml
@@ -25,11 +25,7 @@
         </many-to-one>
 
         <field name="code" type="string" length="64"/>
-        <field name="label" type="json">
-            <options>
-                <option name="jsonb">true</option>
-            </options>
-        </field>
+        <field name="name" type="string" length="255"/>
 
         <many-to-many field="locales" target-entity="App\Channel\Domain\Entity\Locale">
             <join-table name="channel_locales">

--- a/apps/api/src/Channel/Infrastructure/Serializer/Channel.xml
+++ b/apps/api/src/Channel/Infrastructure/Serializer/Channel.xml
@@ -16,7 +16,7 @@
             <group>integration:read</group>
             <group>public:read</group>
         </attribute>
-        <attribute name="label">
+        <attribute name="name">
             <group>admin:read</group>
             <group>admin:write</group>
             <group>integration:read</group>

--- a/apps/api/src/Channel/Presentation/Controller/ObjectChannelPlacementController.php
+++ b/apps/api/src/Channel/Presentation/Controller/ObjectChannelPlacementController.php
@@ -62,7 +62,7 @@ final class ObjectChannelPlacementController
             $rows[] = [
                 'channelId' => $channel->getId()->toRfc4122(),
                 'channelCode' => $channel->getCode(),
-                'channelLabel' => $channel->getLabel(),
+                'channelName' => $channel->getName(),
                 'placement' => null === $placement ? null : [
                     'nodeId' => $placement->getNodeId()->toRfc4122(),
                     'nodePath' => $this->labelPath($placement->getNode()),
@@ -93,7 +93,7 @@ final class ObjectChannelPlacementController
         return new JsonResponse([
             'channelId' => $channel->getId()->toRfc4122(),
             'channelCode' => $channel->getCode(),
-            'channelLabel' => $channel->getLabel(),
+            'channelName' => $channel->getName(),
             'placement' => [
                 'nodeId' => $placement->getNodeId()->toRfc4122(),
                 'nodePath' => $this->labelPath($placement->getNode()),

--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -205,7 +205,7 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
         // ChannelCreated subscriber provisions default publication profiles.
         $demoTenant = $tenants[0];
         \assert('demo' === $demoTenant->getCode());
-        $allegro = new Channel('allegro', ['pl' => 'Allegro', 'en' => 'Allegro']);
+        $allegro = new Channel('allegro', 'Allegro');
         $allegro->addLocale($plPL);
         $allegro->assignTenant($demoTenant);
         $manager->persist($allegro);

--- a/apps/api/tests/Api/Catalog/CatalogObjectChannelValuesApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectChannelValuesApiTest.php
@@ -149,8 +149,8 @@ final class CatalogObjectChannelValuesApiTest extends CatalogApiTestCase
             $em->persist(new ObjectTypeAttribute($product, $attribute, false, $position++));
         }
 
-        $em->persist(new Channel('shopify', ['en' => 'Shopify']));
-        $em->persist(new Channel('baselinker', ['en' => 'BaseLinker']));
+        $em->persist(new Channel('shopify', 'Shopify'));
+        $em->persist(new Channel('baselinker', 'BaseLinker'));
         $em->flush();
     }
 }

--- a/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPublicationFilterApiTest.php
@@ -80,7 +80,7 @@ final class CatalogObjectPublicationFilterApiTest extends CatalogApiTestCase
         $em = $this->em();
         $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
         \assert($tenant instanceof Tenant);
-        $channel = new Channel('pub_no_profile', ['pl' => 'Test Channel']);
+        $channel = new Channel('pub_no_profile', 'Test Channel');
         $channel->assignTenant($tenant);
         $em->persist($channel);
         $em->flush();
@@ -113,7 +113,7 @@ final class CatalogObjectPublicationFilterApiTest extends CatalogApiTestCase
         $this->seedThreeAttributes();
 
         $channelCode = 'pub_test_'.($allowedCodes === null ? 'all' : 'filtered');
-        $channel = new Channel($channelCode, ['pl' => 'Test Channel']);
+        $channel = new Channel($channelCode, 'Test Channel');
         $channel->assignTenant($tenant);
         $em->persist($channel);
         $em->flush();

--- a/apps/api/tests/Api/Channel/ChannelLocalesMatrixApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelLocalesMatrixApiTest.php
@@ -41,12 +41,12 @@ final class ChannelLocalesMatrixApiTest extends ChannelApiTestCase
         self::getContainer()->get(\App\Shared\Application\TenantContext::class)->set($tenant);
 
         // Two channels — one with two locales bound, one bare.
-        $shopify = new Channel('shopify_pl', ['pl' => 'Shopify PL']);
+        $shopify = new Channel('shopify_pl', 'Shopify PL');
         $shopify->addLocale($pl);
         $shopify->addLocale($en);
         $em->persist($shopify);
 
-        $allegro = new Channel('allegro_pl', ['pl' => 'Allegro PL']);
+        $allegro = new Channel('allegro_pl', 'Allegro PL');
         $em->persist($allegro);
 
         $em->flush();

--- a/apps/api/tests/Api/Channel/ChannelNavigationTreeApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelNavigationTreeApiTest.php
@@ -16,7 +16,7 @@ final class ChannelNavigationTreeApiTest extends ChannelApiTestCase
         $created = $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => $code,
-                'label' => ['pl' => 'Allegro', 'en' => 'Allegro'],
+                'name' => 'Allegro',
                 'locales' => ['pl_PL'],
             ],
         ]);

--- a/apps/api/tests/Api/Channel/ChannelNodeMappingApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelNodeMappingApiTest.php
@@ -23,7 +23,7 @@ final class ChannelNodeMappingApiTest extends ChannelApiTestCase
     private function createChannelWithNode(Client $client, string $code): array
     {
         $channel = $client->request('POST', '/api/channels', [
-            'json' => ['code' => $code, 'label' => ['pl' => $code], 'locales' => ['pl_PL']],
+            'json' => ['code' => $code, 'name' => $code, 'locales' => ['pl_PL']],
         ]);
         self::assertSame(201, $channel->getStatusCode());
         $channelId = self::extractId($channel->toArray());

--- a/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelPublicationProfileApiTest.php
@@ -23,7 +23,7 @@ final class ChannelPublicationProfileApiTest extends ChannelApiTestCase
         $response = $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => 'pub_profile_test',
-                'label' => ['pl' => 'Test', 'en' => 'Test'],
+                'name' => 'Test',
                 'locales' => ['pl_PL'],
             ],
         ]);

--- a/apps/api/tests/Api/Channel/ChannelsCrudApiTest.php
+++ b/apps/api/tests/Api/Channel/ChannelsCrudApiTest.php
@@ -20,7 +20,7 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
         $response = $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => 'shopify_pl',
-                'label' => ['pl' => 'Shopify PL', 'en' => 'Shopify PL'],
+                'name' => 'Shopify PL',
                 'locales' => ['pl_PL', 'en_US'],
             ],
         ]);
@@ -28,7 +28,7 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
         self::assertSame(201, $response->getStatusCode());
         $payload = $response->toArray();
         self::assertSame('shopify_pl', $payload['code']);
-        self::assertSame(['pl' => 'Shopify PL', 'en' => 'Shopify PL'], $payload['label']);
+        self::assertSame('Shopify PL', $payload['name']);
         $locales = $payload['locales'];
         \assert(\is_array($locales));
         self::assertCount(2, $locales);
@@ -43,14 +43,14 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
         $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => 'shopify_pl',
-                'label' => ['pl' => 'X', 'en' => 'X'],
+                'name' => 'X',
                 'locales' => ['pl_PL'],
             ],
         ]);
         $second = $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => 'shopify_pl',
-                'label' => ['pl' => 'Y', 'en' => 'Y'],
+                'name' => 'Y',
                 'locales' => ['pl_PL'],
             ],
         ]);
@@ -66,7 +66,23 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
         $response = $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => 'INVALID-WITH-DASH',
-                'label' => ['pl' => 'X', 'en' => 'X'],
+                'name' => 'X',
+                'locales' => ['pl_PL'],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function postRejectsBlankName(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/channels', [
+            'json' => [
+                'code' => 'shop',
+                'name' => '',
                 'locales' => ['pl_PL'],
             ],
         ]);
@@ -82,7 +98,7 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
         $response = $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => 'shop',
-                'label' => ['pl' => 'X', 'en' => 'X'],
+                'name' => 'X',
                 'locales' => ['xx_XX'],
             ],
         ]);
@@ -91,14 +107,14 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
     }
 
     #[Test]
-    public function patchUpdatesLabel(): void
+    public function patchUpdatesName(): void
     {
         $client = $this->authenticatedClient();
 
         $created = $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => 'shop',
-                'label' => ['pl' => 'Sklep', 'en' => 'Store'],
+                'name' => 'Sklep',
                 'locales' => ['pl_PL'],
             ],
         ]);
@@ -106,11 +122,11 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
 
         $patched = $client->request('PATCH', "/api/channels/{$id}", [
             'headers' => ['content-type' => 'application/merge-patch+json'],
-            'json' => ['label' => ['pl' => 'Sklep PL', 'en' => 'Store PL']],
+            'json' => ['name' => 'Sklep PL'],
         ]);
 
         self::assertSame(200, $patched->getStatusCode());
-        self::assertSame(['pl' => 'Sklep PL', 'en' => 'Store PL'], $patched->toArray()['label']);
+        self::assertSame('Sklep PL', $patched->toArray()['name']);
     }
 
     #[Test]
@@ -121,7 +137,7 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
         $created = $client->request('POST', '/api/channels', [
             'json' => [
                 'code' => 'shop',
-                'label' => ['pl' => 'Sklep', 'en' => 'Store'],
+                'name' => 'Sklep',
                 'locales' => ['pl_PL'],
             ],
         ]);
@@ -172,7 +188,7 @@ final class ChannelsCrudApiTest extends ChannelApiTestCase
 
         $response = $client->request('PATCH', "/api/channels/{$randomId}", [
             'headers' => ['content-type' => 'application/merge-patch+json'],
-            'json' => ['label' => ['pl' => 'X', 'en' => 'X']],
+            'json' => ['name' => 'X'],
         ]);
 
         self::assertSame(404, $response->getStatusCode());

--- a/apps/api/tests/Api/Channel/ObjectChannelPlacementApiTest.php
+++ b/apps/api/tests/Api/Channel/ObjectChannelPlacementApiTest.php
@@ -23,7 +23,7 @@ final class ObjectChannelPlacementApiTest extends ChannelApiTestCase
     private function createChannelWithNode(Client $client, string $code): array
     {
         $channel = $client->request('POST', '/api/channels', [
-            'json' => ['code' => $code, 'label' => ['pl' => $code], 'locales' => ['pl_PL']],
+            'json' => ['code' => $code, 'name' => $code, 'locales' => ['pl_PL']],
         ]);
         self::assertSame(201, $channel->getStatusCode());
         $channelId = self::extractId($channel->toArray());

--- a/apps/api/tests/Integration/Channel/AutoAssignChannelPlacementsTest.php
+++ b/apps/api/tests/Integration/Channel/AutoAssignChannelPlacementsTest.php
@@ -214,7 +214,7 @@ final class AutoAssignChannelPlacementsTest extends KernelTestCase
 
     private function makeChannel(string $code): Channel
     {
-        $channel = new Channel($code, ['pl' => $code]);
+        $channel = new Channel($code, $code);
         $this->em()->persist($channel);
         $this->em()->flush();
 

--- a/apps/api/tests/Integration/Channel/ObjectChannelPlacementRepositoryTest.php
+++ b/apps/api/tests/Integration/Channel/ObjectChannelPlacementRepositoryTest.php
@@ -125,7 +125,7 @@ final class ObjectChannelPlacementRepositoryTest extends KernelTestCase
 
     private function makeChannel(string $code): Channel
     {
-        $channel = new Channel($code, ['pl' => $code]);
+        $channel = new Channel($code, $code);
         $em = $this->em();
         $em->persist($channel);
         $em->flush();

--- a/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
+++ b/apps/api/tests/Unit/Channel/Application/ChannelPublicationResolverTest.php
@@ -117,7 +117,7 @@ final class ChannelPublicationResolverTest extends TestCase
 
     private function makeChannel(string $code): Channel
     {
-        $channel = new Channel(code: $code, label: ['pl' => $code]);
+        $channel = new Channel(code: $code, name: $code);
         $channel->assignTenant($this->tenant);
 
         return $channel;

--- a/apps/api/tests/Unit/Channel/ChannelCategoryRootValidatorTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelCategoryRootValidatorTest.php
@@ -30,7 +30,7 @@ final class ChannelCategoryRootValidatorTest extends TestCase
     #[Test]
     public function nullRootIsAllowed(): void
     {
-        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel = new Channel('shop', 'Sklep');
         $validator = new ChannelCategoryRootValidator(new InMemoryChannelCategoryNodeRepo());
 
         $validator->prePersist(new PrePersistEventArgs($channel, $this->em));
@@ -41,7 +41,7 @@ final class ChannelCategoryRootValidatorTest extends TestCase
     #[Test]
     public function rootNodeOfSameChannelIsAccepted(): void
     {
-        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel = new Channel('shop', 'Sklep');
         $root = new ChannelCategoryNode($channel, 'root', ['pl' => 'Root']);
         $channel->attachCategoryTreeRoot($root->getId());
 
@@ -57,7 +57,7 @@ final class ChannelCategoryRootValidatorTest extends TestCase
     #[Test]
     public function unknownRootThrows(): void
     {
-        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel = new Channel('shop', 'Sklep');
         $channel->attachCategoryTreeRoot(Uuid::v7());
 
         $validator = new ChannelCategoryRootValidator(new InMemoryChannelCategoryNodeRepo());
@@ -70,8 +70,8 @@ final class ChannelCategoryRootValidatorTest extends TestCase
     #[Test]
     public function nodeFromAnotherChannelThrows(): void
     {
-        $channelA = new Channel('a', ['pl' => 'A']);
-        $channelB = new Channel('b', ['pl' => 'B']);
+        $channelA = new Channel('a', 'A');
+        $channelB = new Channel('b', 'B');
         $foreignRoot = new ChannelCategoryNode($channelB, 'root', ['pl' => 'Root']);
         $channelA->attachCategoryTreeRoot($foreignRoot->getId());
 
@@ -87,7 +87,7 @@ final class ChannelCategoryRootValidatorTest extends TestCase
     #[Test]
     public function nonRootNodeThrows(): void
     {
-        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel = new Channel('shop', 'Sklep');
         $parent = new ChannelCategoryNode($channel, 'root', ['pl' => 'Root']);
         $child = new ChannelCategoryNode($channel, 'child', ['pl' => 'Child'], $parent);
         $channel->attachCategoryTreeRoot($child->getId());

--- a/apps/api/tests/Unit/Channel/ChannelTest.php
+++ b/apps/api/tests/Unit/Channel/ChannelTest.php
@@ -20,11 +20,11 @@ final class ChannelTest extends TestCase
     #[Test]
     public function constructorDefaultsAreEmpty(): void
     {
-        $channel = new Channel('ecommerce_pl', ['pl' => 'Sklep PL', 'en' => 'PL Storefront']);
+        $channel = new Channel('ecommerce_pl', 'Sklep PL');
 
         self::assertInstanceOf(Uuid::class, $channel->getId());
         self::assertSame('ecommerce_pl', $channel->getCode());
-        self::assertSame('Sklep PL', $channel->getLabel()['pl']);
+        self::assertSame('Sklep PL', $channel->getName());
         self::assertCount(0, $channel->getLocales());
         self::assertNull($channel->getCategoryTreeRootId());
         self::assertNull($channel->getTenant());
@@ -33,7 +33,7 @@ final class ChannelTest extends TestCase
     #[Test]
     public function localeM2mIsIdempotent(): void
     {
-        $channel = new Channel('ecommerce_pl', ['pl' => 'Sklep PL']);
+        $channel = new Channel('ecommerce_pl', 'Sklep PL');
         $pl = new Locale('pl_PL', 'Polski');
 
         $channel->addLocale($pl);
@@ -48,7 +48,7 @@ final class ChannelTest extends TestCase
     #[Test]
     public function categoryTreeRootStoresUuid(): void
     {
-        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel = new Channel('shop', 'Sklep');
         $categoryType = new ObjectType('category', ObjectKind::Category, ['pl' => 'Kategoria']);
         $root = new CatalogObject($categoryType, 'root');
 
@@ -60,7 +60,7 @@ final class ChannelTest extends TestCase
     #[Test]
     public function assignTenantStampsAndRefusesReassignment(): void
     {
-        $channel = new Channel('shop', ['pl' => 'Sklep']);
+        $channel = new Channel('shop', 'Sklep');
         $first = new Tenant('demo', 'Demo');
         $second = new Tenant('acme', 'Acme');
 

--- a/apps/api/tests/Unit/Channel/Infrastructure/ScopeEnumeratorTest.php
+++ b/apps/api/tests/Unit/Channel/Infrastructure/ScopeEnumeratorTest.php
@@ -38,8 +38,8 @@ final class ScopeEnumeratorTest extends TestCase
         $shopify = Uuid::v7();
         $channels = $this->createStub(ChannelRepositoryInterface::class);
         $channels->method('findAllForTenant')->willReturn([
-            new Channel('allegro', ['pl' => 'Allegro'], $allegro),
-            new Channel('shopify', ['pl' => 'Shopify'], $shopify),
+            new Channel('allegro', 'Allegro', $allegro),
+            new Channel('shopify', 'Shopify', $shopify),
         ]);
         $enum = new ScopeEnumerator($this->createStub(TenantLocaleRepositoryInterface::class), $channels);
 

--- a/apps/api/tests/Unit/Identity/Security/RbacVotersTest.php
+++ b/apps/api/tests/Unit/Identity/Security/RbacVotersTest.php
@@ -162,7 +162,7 @@ final class RbacVotersTest extends TestCase
     public function channelVoterRoutesToChannelResource(): void
     {
         $tenant = new Tenant('alpha', 'Alpha');
-        $channel = new Channel('ecommerce_pl', ['en' => 'Polish webstore']);
+        $channel = new Channel('ecommerce_pl', 'Polish webstore');
         $channel->assignTenant($tenant);
 
         $user = $this->userWithPermission($tenant, 'channel', 'read');

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -8378,7 +8378,7 @@
             },
             "Channel-admin.read": {
                 "type": "object",
-                "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a label (`{pl, en}`) \u2014 what admins see in the UI;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration.",
+                "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a name (plain string) \u2014 what admins see in the UI. Internal-only,\n    never published to a destination, so it is intentionally single-language;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration.",
                 "properties": {
                     "id": {
                         "type": [
@@ -8391,11 +8391,9 @@
                         "maxLength": 64,
                         "type": "string"
                     },
-                    "label": {
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
-                        }
+                    "name": {
+                        "maxLength": 255,
+                        "type": "string"
                     },
                     "locales": {
                         "type": "array",
@@ -8414,15 +8412,16 @@
                     }
                 },
                 "required": [
-                    "code"
+                    "code",
+                    "name"
                 ]
             },
             "Channel.ChannelInput-channel.create": {
                 "type": "object",
-                "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a label (`{pl, en}`) \u2014 what admins see in the UI;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration.",
+                "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a name (plain string) \u2014 what admins see in the UI. Internal-only,\n    never published to a destination, so it is intentionally single-language;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration.",
                 "required": [
                     "code",
-                    "label",
+                    "name",
                     "locales"
                 ],
                 "properties": {
@@ -8432,13 +8431,11 @@
                         "default": "",
                         "type": "string"
                     },
-                    "label": {
-                        "minItems": 1,
-                        "description": "Multi-language label keyed by locale code. At least one entry required.",
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "string"
-                        }
+                    "name": {
+                        "maxLength": 255,
+                        "description": "Internal admin display name. Single-language by design \u2014 the channel\nname is never published to a destination.",
+                        "default": "",
+                        "type": "string"
                     },
                     "locales": {
                         "minItems": 1,
@@ -8452,17 +8449,14 @@
             },
             "Channel.ChannelPatchInput-channel.update.jsonMergePatch": {
                 "type": "object",
-                "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a label (`{pl, en}`) \u2014 what admins see in the UI;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration.",
+                "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a name (plain string) \u2014 what admins see in the UI. Internal-only,\n    never published to a destination, so it is intentionally single-language;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration.",
                 "properties": {
-                    "label": {
-                        "minItems": 1,
+                    "name": {
+                        "maxLength": 255,
                         "type": [
-                            "object",
+                            "string",
                             "null"
-                        ],
-                        "additionalProperties": {
-                            "type": "string"
-                        }
+                        ]
                     },
                     "locales": {
                         "minItems": 1,
@@ -8495,11 +8489,9 @@
                                 "maxLength": 64,
                                 "type": "string"
                             },
-                            "label": {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                }
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
                             },
                             "locales": {
                                 "type": "array",
@@ -8518,11 +8510,12 @@
                             }
                         },
                         "required": [
-                            "code"
+                            "code",
+                            "name"
                         ]
                     }
                 ],
-                "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a label (`{pl, en}`) \u2014 what admins see in the UI;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration."
+                "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a name (plain string) \u2014 what admins see in the UI. Internal-only,\n    never published to a destination, so it is intentionally single-language;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration."
             },
             "ConstraintViolation": {
                 "type": "object",
@@ -10639,7 +10632,7 @@
         },
         {
             "name": "Channel",
-            "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a label (`{pl, en}`) \u2014 what admins see in the UI;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration."
+            "description": "Tenant-scoped sales / publication channel.\n\nExamples: `ecommerce_pl` (Polish webstore), `wholesale`, `b2b_export`.\nEach channel carries:\n\n  - a name (plain string) \u2014 what admins see in the UI. Internal-only,\n    never published to a destination, so it is intentionally single-language;\n  - a set of supported `Locale` rows (M2M `channel_locales`);\n  - an optional `category_tree_root_object_id` pointing at a\n    `CatalogObject` of `kind=category` \u2014 the root of the category tree\n    this channel publishes. Validation (\"the target must be a\n *     category\") lives in\n    {@see \\App\\Channel\\Infrastructure\\Doctrine\\EventListener\\ChannelCategoryRootValidator}.\n\nPer-channel attribute\u2192target-field mapping is not modelled here yet \u2014 it\nbelongs to the API integration configuration (Faza 1) and will be added\nwith the first real export integration."
         },
         {
             "name": "Locale",


### PR DESCRIPTION
## Summary

Etykieta kanału (`label` JSONB `{pl, en}`) była tylko **wewnętrzną nazwą w adminie** — nic nie publikuje jej na kanał docelowy, a formularz wymuszał dwa pola (PL+EN), zahardkodowane niezależnie od locale tenanta. Zwijam do pojedynczego `name` (VARCHAR) — czysto w schemacie, kontrakcie API i UI (wariant B wybrany przez operatora).

## Root cause

Wielojęzyczny `label` był over-engineeringiem dla nazwy używanej wyłącznie do wyświetlenia w panelu. Patrz dyskusja w #1316.

## Backend changes

- `Channel`: pole `array $label` → `string $name`; `getName()`, `rename(string)`, `#[Assert\NotBlank]` + `Length(max: 255)`.
- ORM: `channels.label` (jsonb) → `channels.name` (varchar 255).
- **Migracja** `Version20260607130000`: `ADD name` → backfill `COALESCE(label->>'pl', label->>'en', code)` → `SET NOT NULL` → `DROP label` (istniejące kanały zachowują nazwy; `down()` odwrotnie).
- Kontrakt: `ChannelInput`/`ChannelPatchInput` (`name`), `ChannelProcessor`, `CreateChannelCommand`/`UpdateChannelCommand`, serializer `Channel.xml`.
- `ObjectChannelPlacementController`: `channelLabel` → `channelName` w odpowiedzi placementów (etykieta węzła `getLabel()` bez zmian).
- Seed `AppFixtures`: `new Channel('allegro', 'Allegro')`.

## Frontend changes

- `form.tsx`: jedno pole „Nazwa" (required) zamiast PL+EN; walidacja `name`.
- `create`/`edit`/`show`/`list`: czytają/wysyłają `name` (usunięty `resolveLabel` dla kanału).
- `channel-placements-section.tsx` + `locale-channel-toolbar.tsx` + `types.ts`: `channelName`/`name` (string) zamiast `label` (object).
- i18n pl+en: `channels.form.fields.name` + `name_help`, `channels.fields.name` (zastępują `label_pl`/`label_en`/`label`).

## Quality gates (lokalnie)

- PHPStan max (`--memory-limit=1G`): **0**.
- Deptrac: **0 violations / 0 errors**.
- PHP-CS-Fixer: **0**.
- PHPUnit (Channel unit + Channel API + Catalog channel + integration, w tym nowy `postRejectsBlankName`): **146/146 zielone**.
- TypeScript noEmit: **0**. Biome: **0 errors**. Vite build: **OK**.
- OpenAPI `docs/api-spec/v0.json` zregenerowany (drift wyłącznie channel `label`→`name`).

## Smoke test plan (operator, po merge)

Wymaga smoke test przed claim „działa". Po merge zrobię: migracja na dev DB → restart api → `/settings/channels/new` (jedno pole „Nazwa") → utworzenie kanału → lista/edycja → weryfikacja, że `allegro`/`nowy_kanal` zachowały nazwy → produkt z placementem pokazuje nazwę kanału.

## Świadome odejścia

- `ChannelCategoryNode.label` (nazwa węzła drzewa, CHC-09, single-language) — poza zakresem, bez zmian.
- E2E `settings-channels-crud` / `1153-channels-settings` są `test.fixme(CI)` (rate-limiter storageState) — zaktualizowane do pola `name` (i przy okazji usunięto stale referencje walut z #1283), ale nie biegną w CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
