### PR TITLE
fix(catalog): ukryj zakładkę „Atrybuty" w detalu wpisu gdy ObjectType nie ma atrybutów

### DIFF
--- a/apps/admin/e2e/1348-attributes-tab-hidden-when-empty.spec.ts
+++ b/apps/admin/e2e/1348-attributes-tab-hidden-when-empty.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1348 — the "Atrybuty" tab is the bucket for stacked/ungrouped
+ * attributes (synthetic default group + display_mode='stacked' groups).
+ * The built-in Product ObjectType ships only tab-mode groups (Grupa
+ * Uniwersalna, Logistyka, …) and no ungrouped attributes, so the
+ * "Atrybuty" tab used to render empty (just the ad-hoc adder). After
+ * the fix it must be dropped entirely while the tab-mode groups keep
+ * their own dedicated tabs.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason
+ * (5 logins / 15 min); local cold-cache runs pass.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('attributes tab is hidden when the object type has no stacked attributes', async ({
+  page,
+}) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const authHeaders = { Authorization: `Bearer ${accessToken}` };
+
+  const objectTypesResponse = await page.request.get('/api/object_types', {
+    headers: authHeaders,
+  });
+  const objectTypesBody = (await objectTypesResponse.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+    'hydra:member'?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const types = objectTypesBody.member ?? objectTypesBody['hydra:member'] ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not found — demo seeder did not run.');
+  }
+
+  const sku = uniqueSku('TAB1348');
+  const createResponse = await page.request.post('/api/products', {
+    headers: { ...authHeaders, 'content-type': 'application/ld+json' },
+    data: {
+      code: sku,
+      objectTypeId: productType.id,
+      attributes: { name: `Attr-tab spec ${sku}` },
+    },
+  });
+  expect(createResponse.status()).toBe(201);
+  const created = (await createResponse.json()) as { id: string };
+
+  const groupsResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes(`/api/products/${created.id}/effective-attribute-groups`) &&
+      response.request().method() === 'GET',
+    { timeout: 30_000 },
+  );
+  await page.goto(`/products/${created.id}`);
+  await groupsResponse;
+
+  const tablist = page.getByRole('tablist', { name: /zakładki produktu|product tabs/i });
+  await expect(tablist).toBeVisible();
+
+  // A tab-mode group keeps its dedicated tab (label falls back to the
+  // group code when the active UI locale has no translated label).
+  await expect(tablist.getByRole('tab', { name: /grupa[_ ]uniwersalna/i })).toBeVisible();
+
+  // The empty "Atrybuty" tab is gone.
+  await expect(tablist.getByRole('tab', { name: /^(atrybuty|attributes)$/i })).toHaveCount(0);
+
+  // Cleanup — keep the demo DB tidy (attributes/products leak into pickers).
+  await page.request.delete(`/api/products/${created.id}`, { headers: authHeaders });
+});

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -353,8 +353,14 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     const ensureRelations =
       shouldSurfaceRelationsTab && !fromGroups.includes('relations') ? ['relations'] : [];
     const multimedia: TabKey[] = hasMultimediaCapability ? ['multimedia' as const] : [];
+    // #1348 — the "Atrybuty" tab is the bucket for stacked/ungrouped
+    // attributes (synthetic default group + display_mode='stacked'
+    // groups). When the ObjectType has no such attributes the tab is
+    // empty (only the ad-hoc adder), so drop it entirely — tab-mode
+    // groups keep their own dedicated tabs.
+    const attributesTab: TabKey[] = stackedGroups.length > 0 ? ['attributes' as const] : [];
     return [
-      'attributes' as const,
+      ...attributesTab,
       ...fromGroups,
       ...ensureRelations,
       ...multimedia,
@@ -362,13 +368,15 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
       'history' as const,
       'variants' as const,
     ];
-  }, [mode, tabModeGroups, shouldSurfaceRelationsTab, hasMultimediaCapability]);
+  }, [mode, tabModeGroups, stackedGroups, shouldSurfaceRelationsTab, hasMultimediaCapability]);
 
   // Keep activeTab valid as group set changes (e.g. groups data arrives
-  // after first render or a tab→stacked switch in the wizard).
+  // after first render or a tab→stacked switch in the wizard). Falls back
+  // to the first visible tab — `attributes` may now be absent (#1348).
   useEffect(() => {
-    if (!visibleTabs.includes(activeTab)) {
-      setActiveTab('attributes');
+    const fallback = visibleTabs[0];
+    if (fallback !== undefined && !visibleTabs.includes(activeTab)) {
+      setActiveTab(fallback);
     }
   }, [activeTab, visibleTabs]);
 


### PR DESCRIPTION
## Summary
Zakładka „Atrybuty" w detalu wpisu to bucket dla atrybutów stacked/ungrouped (syntetyczna grupa default + grupy `display_mode='stacked'`). Gdy ObjectType ma wyłącznie grupy tab-mode i żadnych atrybutów ungrouped, zakładka renderowała się pusta (tylko „+ Dodaj grupę atrybutów ad-hoc"). Teraz znika, a grupy tab-mode zachowują własne zakładki.

## Root cause
`visibleTabs` zawsze wstawiało `'attributes'` na początek listy, niezależnie od tego czy są jakiekolwiek stacked/ungrouped atrybuty.

## Frontend changes
- `product-detail-page.tsx`: `'attributes'` dołączane do `visibleTabs` tylko gdy `stackedGroups.length > 0` (poza trybem `create`, który zostaje bez zmian — patrz #1357). `stackedGroups` dodane do deps `useMemo`.
- Fallback `activeTab` po zmianie zestawu zakładek wybiera pierwszą widoczną zakładkę zamiast zahardkodowanego `'attributes'`.

## Backend changes
N/A — zmiana czysto w warstwie render zakładek.

## Quality gates
- typecheck: 0 błędów
- Biome lint: 0 błędów (exit 0)
- Vite build: OK
- Playwright E2E: `1348-attributes-tab-hidden-when-empty.spec.ts` zielony (tworzy produkt przez API → detal → brak zakładki „Atrybuty", grupa tab-mode obecna; sprząta po sobie)

## Smoke test plan (po merge)
1. Login `admin@demo.localhost / changeme`.
2. Otwórz dowolny produkt demo (wszystkie mają grupy wyłącznie tab-mode) → brak zakładki „Atrybuty", widoczne grupy jako osobne zakładki.
3. DevTools Console — brak errorów.

## Świadome odejścia
- Tryb `create` (`/products/new`) zostawiony bez zmian — usunięcie ad-hoc addera z create to osobny ticket #1357.
- Pozytywny przypadek (OT z atrybutami stacked → zakładka obecna) nieobjęty E2E, bo demo data nie ma takich atrybutów; logika warunku symetryczna.

🤖 Generated with [Claude Code](https://claude.com/claude-code)