### PR TITLE
feat(modeling): drag-and-drop sortowanie grup atrybutów w ObjectType

### DIFF
--- a/apps/admin/e2e/1349-reorder-attribute-groups.spec.ts
+++ b/apps/admin/e2e/1349-reorder-attribute-groups.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1349 — drag-and-drop reordering of attribute groups on the ObjectType
+ * detail page (/modeling/object-types/{id}). The persisted `position`
+ * drives the left-to-right tab order on the object detail page.
+ *
+ * The spec attaches two fresh AttributeGroups to the built-in Product
+ * ObjectType, then keyboard-reorders the first one down via the dnd-kit
+ * handle (Space = pick up, ArrowDown = move, Space = drop) and asserts a
+ * `PATCH /groups/{id}` carrying `position` fires. Self-contained (creates
+ * + cleans up its own groups) so it does not depend on the ambient seed.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason
+ * (5 logins / 15 min) — dnd-kit keyboard sequences are also timing
+ * sensitive on the shared runner. Local cold-cache runs pass; the BE
+ * persistence is covered by ObjectTypeAttributeGroupDisplayModePatchApiTest.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: seeded UI spec + dnd timing on shared runner';
+
+test('reordering attribute groups persists position via PATCH', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(180_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const objectTypesResponse = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
+  const objectTypesBody = (await objectTypesResponse.json()) as {
+    member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+  };
+  const productType = (objectTypesBody.member ?? []).find(
+    (row) => row.kind === 'product' && row.codeImmutable,
+  );
+  if (productType === undefined) {
+    throw new Error('Built-in product ObjectType not seeded for demo tenant.');
+  }
+  const otId = productType.id;
+
+  const stamp = Date.now().toString(36).toLowerCase();
+  const codeA = `zz_reorder_a_${stamp}`;
+  const codeB = `zz_reorder_b_${stamp}`;
+  const createdGroupIds: string[] = [];
+
+  for (const [code, label] of [
+    [codeA, 'Reorder A'],
+    [codeB, 'Reorder B'],
+  ]) {
+    const created = await page.request.post('/api/attribute_groups', {
+      headers: { ...bearer, 'content-type': 'application/ld+json' },
+      data: { code, label: { pl: label, en: label } },
+    });
+    expect(created.status()).toBe(201);
+    const body = (await created.json()) as { id: string };
+    createdGroupIds.push(body.id);
+    const attached = await page.request.post(`/api/object_types/${otId}/groups/${body.id}`, {
+      headers: bearer,
+    });
+    expect(attached.status()).toBe(204);
+  }
+
+  await page.goto(`/modeling/object-types/${otId}`);
+  // Wait until the attached groups list resolves.
+  await page.waitForResponse(
+    (r) => r.url().includes(`/api/object_types/${otId}/attached_groups`) && r.ok(),
+    { timeout: 30_000 },
+  );
+
+  const handles = page.getByRole('button', {
+    name: /przeciągnij, aby zmienić kolejność|drag/i,
+  });
+  await expect(handles.first()).toBeVisible({ timeout: 15_000 });
+
+  // Keyboard reorder: focus first handle, pick up, move down, drop.
+  const patchPromise = page.waitForResponse(
+    (r) =>
+      /\/api\/object_types\/[0-9a-f-]+\/groups\/[0-9a-f-]+$/.test(r.url()) &&
+      r.request().method() === 'PATCH',
+    { timeout: 15_000 },
+  );
+  // dnd-kit KeyboardSensor needs a measuring tick between each step,
+  // otherwise the move is dropped before the collision is computed.
+  await handles.first().focus();
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(250);
+  await page.keyboard.press('ArrowDown');
+  await page.waitForTimeout(250);
+  await page.keyboard.press('Space');
+  await page.waitForTimeout(150);
+
+  const patch = await patchPromise;
+  const sentBody = patch.request().postDataJSON() as { position?: number };
+  expect(typeof sentBody.position).toBe('number');
+  expect(patch.status()).toBe(204);
+
+  // Cleanup — detach + delete the throwaway groups.
+  for (const groupId of createdGroupIds) {
+    await page.request.delete(`/api/object_types/${otId}/groups/${groupId}`, { headers: bearer });
+    await page.request.delete(`/api/attribute_groups/${groupId}`, { headers: bearer });
+  }
+});

--- a/apps/admin/src/components/modeling/group-card.tsx
+++ b/apps/admin/src/components/modeling/group-card.tsx
@@ -24,6 +24,12 @@ export interface AttachedGroup {
    * backwards compatibility with older payloads (defaults to `tab`).
    */
   displayMode?: GroupDisplayMode;
+  /**
+   * #1349 — persisted order of this group within the ObjectType. Drives
+   * the left-to-right tab order on the object detail page. Optional for
+   * backwards compatibility with older payloads (defaults to 0).
+   */
+  position?: number;
 }
 
 interface GroupCardProps {

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -1,6 +1,23 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useInvalidate, useOne } from '@refinedev/core';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Check, Copy, Library, Pencil, Plus, Trash2 } from 'lucide-react';
+import { ArrowLeft, Check, Copy, GripVertical, Library, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, Navigate, useNavigate, useParams } from 'react-router';
@@ -31,6 +48,7 @@ import { resolveLabel } from '@/features/catalog/attributes/list';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
 import { useCurrentWorkspace } from '@/lib/use-current-workspace';
+import { cn } from '@/lib/utils';
 
 interface ObjectTypeDetail {
   id: string;
@@ -73,6 +91,62 @@ interface AttachedAttribute {
 }
 
 /**
+ * #1349 — sortable wrapper around {@link GroupCard}. Adds a drag handle
+ * to the left of the card and wires the dnd-kit `useSortable` transform.
+ */
+function SortableGroupCard({
+  group,
+  language,
+  onEdit,
+  onRemove,
+  onDisplayModeChange,
+}: {
+  group: AttachedGroup;
+  language: string;
+  onEdit?: (group: AttachedGroup) => void;
+  onRemove?: (group: AttachedGroup) => void;
+  onDisplayModeChange?: (group: AttachedGroup, next: GroupDisplayMode) => void;
+}) {
+  const { t } = useTranslation();
+  const sortable = useSortable({ id: group.id });
+  const style = sortable.transform
+    ? {
+        transform: CSS.Transform.toString(sortable.transform),
+        transition: sortable.transition,
+      }
+    : undefined;
+
+  return (
+    <div
+      ref={sortable.setNodeRef}
+      style={style}
+      className={cn('flex items-stretch gap-2', sortable.isDragging && 'opacity-60')}
+    >
+      <button
+        type="button"
+        aria-label={t('object_types.group_card_drag', {
+          defaultValue: 'Przeciągnij, aby zmienić kolejność',
+        })}
+        {...sortable.attributes}
+        {...sortable.listeners}
+        className="mt-1 grid size-7 shrink-0 cursor-grab place-items-center rounded-lg text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-700 active:cursor-grabbing"
+      >
+        <GripVertical className="size-4" />
+      </button>
+      <div className="min-w-0 flex-1">
+        <GroupCard
+          group={group}
+          language={language}
+          onEdit={onEdit}
+          onRemove={onRemove}
+          onDisplayModeChange={onDisplayModeChange}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
  * VIEW-01 (#372) — pixel-perfect rebuild of the modeling Object Type
  * Detail view (object-types.jsx 89–244). Sections rendered in the
  * fixed order: header, Identyfikacja, Built-in groups, Custom groups,
@@ -85,6 +159,13 @@ export function ObjectTypeShowPage() {
   const id = params.id ?? '';
   const queryClient = useQueryClient();
   const invalidate = useInvalidate();
+
+  // #1349 — drag-and-drop reordering of attribute groups. Pointer for
+  // mouse/touch, keyboard for a11y (arrow keys move the focused row).
+  const dndSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   const { result, query } = useOne<ObjectTypeDetail>({
     resource: 'object_types',
@@ -199,6 +280,48 @@ export function ObjectTypeShowPage() {
       await refreshGroups();
     } catch (e) {
       setError(e instanceof HttpError ? `${e.status}` : e instanceof Error ? e.message : 'unknown');
+    }
+  };
+
+  // #1349 — persist a drag-and-drop reorder of the attribute groups. The
+  // new order is written to each junction's `position` (PATCH); the
+  // EffectiveAttributeGroupResolver orders by `position ASC`, so the
+  // left-to-right tab order on the object detail page follows this list.
+  const handleReorderGroups = async (event: DragEndEvent, ordered: AttachedGroup[]) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = ordered.findIndex((g) => g.id === active.id);
+    const newIndex = ordered.findIndex((g) => g.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+
+    const reordered = arrayMove(ordered, oldIndex, newIndex);
+    const positionById = new Map(reordered.map((g, index) => [g.id, index]));
+
+    // Optimistic: rewrite positions in the cached payload and re-sort it
+    // the same way the API does (position ASC, code ASC) so the list and
+    // SortableContext reflect the drop without waiting for the refetch.
+    queryClient.setQueryData<AttachedGroup[]>(['object_types', id, 'attached_groups'], (prev) =>
+      prev === undefined
+        ? prev
+        : [...prev]
+            .map((g) => (positionById.has(g.id) ? { ...g, position: positionById.get(g.id) } : g))
+            .sort((a, b) => (a.position ?? 0) - (b.position ?? 0) || a.code.localeCompare(b.code)),
+    );
+
+    setError(null);
+    try {
+      await Promise.all(
+        reordered.map((g, index) =>
+          jsonFetch(`/api/object_types/${id}/groups/${g.id}`, {
+            method: 'PATCH',
+            body: { position: index },
+          }),
+        ),
+      );
+      await refreshGroups();
+    } catch (e) {
+      setError(e instanceof HttpError ? `${e.status}` : e instanceof Error ? e.message : 'unknown');
+      await refreshGroups();
     }
   };
 
@@ -529,20 +652,31 @@ export function ObjectTypeShowPage() {
               })}
             </div>
           ) : (
-            <div className="space-y-2">
-              {editableGroups.map((g) => (
-                <GroupCard
-                  key={g.id}
-                  group={g}
-                  language={i18n.language}
-                  onEdit={
-                    g.system ? undefined : () => navigate(`/modeling/attribute-groups/${g.id}`)
-                  }
-                  onRemove={handleDetachGroup}
-                  onDisplayModeChange={handleDisplayModeChange}
-                />
-              ))}
-            </div>
+            <DndContext
+              sensors={dndSensors}
+              collisionDetection={closestCenter}
+              onDragEnd={(event) => void handleReorderGroups(event, editableGroups)}
+            >
+              <SortableContext
+                items={editableGroups.map((g) => g.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-2">
+                  {editableGroups.map((g) => (
+                    <SortableGroupCard
+                      key={g.id}
+                      group={g}
+                      language={i18n.language}
+                      onEdit={
+                        g.system ? undefined : () => navigate(`/modeling/attribute-groups/${g.id}`)
+                      }
+                      onRemove={handleDetachGroup}
+                      onDisplayModeChange={handleDisplayModeChange}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
           )}
         </CardContent>
       </Card>

--- a/apps/api/src/Catalog/Presentation/Controller/AttachObjectTypeAttributeGroupController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/AttachObjectTypeAttributeGroupController.php
@@ -138,15 +138,33 @@ final class AttachObjectTypeAttributeGroupController
         }
 
         $payload = json_decode($request->getContent(), true);
-        if (!\is_array($payload) || !\array_key_exists('display_mode', $payload)) {
-            throw new BadRequestHttpException('Body must contain `display_mode`.');
+        $hasDisplayMode = \is_array($payload) && \array_key_exists('display_mode', $payload);
+        $hasPosition = \is_array($payload) && \array_key_exists('position', $payload);
+        if (!$hasDisplayMode && !$hasPosition) {
+            throw new BadRequestHttpException('Body must contain `display_mode` and/or `position`.');
         }
-        $displayMode = $payload['display_mode'];
-        if (!\is_string($displayMode) || !\in_array($displayMode, ObjectTypeAttributeGroup::DISPLAY_MODES, true)) {
-            throw new BadRequestHttpException(\sprintf(
-                'display_mode must be one of: %s.',
-                implode(', ', ObjectTypeAttributeGroup::DISPLAY_MODES),
-            ));
+
+        $displayMode = null;
+        if ($hasDisplayMode) {
+            $displayMode = $payload['display_mode'];
+            if (!\is_string($displayMode) || !\in_array($displayMode, ObjectTypeAttributeGroup::DISPLAY_MODES, true)) {
+                throw new BadRequestHttpException(\sprintf(
+                    'display_mode must be one of: %s.',
+                    implode(', ', ObjectTypeAttributeGroup::DISPLAY_MODES),
+                ));
+            }
+        }
+
+        // #1349 — reordering attribute groups within an ObjectType. The
+        // persisted `position` drives the left-to-right tab order on the
+        // object detail page (EffectiveAttributeGroupResolver orders by
+        // `position ASC`).
+        $position = null;
+        if ($hasPosition) {
+            $position = $payload['position'];
+            if (!\is_int($position) || $position < 0) {
+                throw new BadRequestHttpException('position must be a non-negative integer.');
+            }
         }
 
         $junction = $this->em->find(ObjectTypeAttributeGroup::class, [
@@ -161,7 +179,12 @@ final class AttachObjectTypeAttributeGroupController
             ));
         }
 
-        $junction->changeDisplayMode($displayMode);
+        if (null !== $displayMode) {
+            $junction->changeDisplayMode($displayMode);
+        }
+        if (null !== $position) {
+            $junction->reorder($position);
+        }
         $this->em->flush();
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);

--- a/apps/api/src/Catalog/Presentation/Controller/ObjectTypeAttachedGroupsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ObjectTypeAttachedGroupsController.php
@@ -101,6 +101,7 @@ final class ObjectTypeAttachedGroupsController
                 'attrsCount' => \count($attrs),
                 'attrsPreview' => \array_slice($attrs, 0, self::ATTRS_PREVIEW_LIMIT),
                 'displayMode' => '' !== $displayMode ? $displayMode : 'tab',
+                'position' => \is_numeric($row['position'] ?? null) ? (int) $row['position'] : 0,
             ];
         }
 

--- a/apps/api/tests/Api/Catalog/ObjectTypeAttributeGroupDisplayModePatchApiTest.php
+++ b/apps/api/tests/Api/Catalog/ObjectTypeAttributeGroupDisplayModePatchApiTest.php
@@ -134,6 +134,78 @@ final class ObjectTypeAttributeGroupDisplayModePatchApiTest extends CatalogApiTe
         new ObjectTypeAttributeGroup($type, $group, 0, 'invalid_mode');
     }
 
+    #[Test]
+    public function patchUpdatesPosition(): void
+    {
+        $productId = $this->objectTypeIdFor(ObjectKind::Product);
+        $groupId = $this->attachGroupToProductType('position_patch');
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/object_types/'.$productId.'/groups/'.$groupId, [
+            'json' => ['position' => 7],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $response = $client->request('GET', '/api/object_types/'.$productId.'/attached_groups');
+        self::assertResponseIsSuccessful();
+        $patched = $this->findGroup($response->toArray(), $groupId);
+        self::assertSame(7, $patched['position']);
+    }
+
+    #[Test]
+    public function patchAcceptsPositionAndDisplayModeTogether(): void
+    {
+        $productId = $this->objectTypeIdFor(ObjectKind::Product);
+        $groupId = $this->attachGroupToProductType('position_and_mode');
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/object_types/'.$productId.'/groups/'.$groupId, [
+            'json' => ['position' => 3, 'display_mode' => 'stacked'],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
+
+        $patched = $this->findGroup(
+            $client->request('GET', '/api/object_types/'.$productId.'/attached_groups')->toArray(),
+            $groupId,
+        );
+        self::assertSame(3, $patched['position']);
+        self::assertSame('stacked', $patched['displayMode']);
+    }
+
+    #[Test]
+    public function patchRejectsNegativePosition(): void
+    {
+        $productId = $this->objectTypeIdFor(ObjectKind::Product);
+        $groupId = $this->attachGroupToProductType('position_negative');
+
+        $client = $this->authenticatedClient();
+        $client->request('PATCH', '/api/object_types/'.$productId.'/groups/'.$groupId, [
+            'json' => ['position' => -1],
+            'headers' => ['content-type' => 'application/json'],
+        ]);
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @param array<array-key, mixed> $entries
+     *
+     * @return array<array-key, mixed>
+     */
+    private function findGroup(array $entries, string $groupId): array
+    {
+        foreach ($entries as $entry) {
+            if (!\is_array($entry)) {
+                continue;
+            }
+            if (($entry['id'] ?? null) === $groupId) {
+                return $entry;
+            }
+        }
+        self::fail(\sprintf('Group "%s" not found in attached_groups response.', $groupId));
+    }
+
     private function attachGroupToProductType(string $code): string
     {
         $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);


### PR DESCRIPTION
## Summary
Sortowanie grup atrybutów na `/modeling/object-types/{id}` przez drag-and-drop. Zapisana kolejność (`position` na junction ObjectType↔grupa) steruje kolejnością zakładek na karcie wpisu — `EffectiveAttributeGroupResolver` już sortuje po `position ASC`.

## Backend
- `attached_groups` response zwraca `position`.
- `PATCH /api/object_types/{id}/groups/{groupId}` przyjmuje opcjonalny `position` (non-negative int) obok/zamiast `display_mode`. ApiTestCase: update position, łączny patch position+display_mode, walidacja 400 dla ujemnego.

## Frontend
- dnd-kit sortable lista z uchwytem (`GripVertical`) per karta grupy; po drop nowa kolejność leci PATCH-em per grupa, cache optymistycznie re-sortowany (position ASC, code ASC) zgodnie z serwerem.
- Keyboard sensor (a11y) + Playwright E2E (self-contained: tworzy 2 grupy, reorder klawiaturą, asercja PATCH `position`).

## Quality gates
- PHPStan max: 0
- PHPUnit: `ObjectTypeAttributeGroupDisplayModePatchApiTest` 8/8 (3 nowe)
- typecheck + Biome: 0, Vite build OK
- Playwright `1349-reorder-attribute-groups`: zielony lokalnie (`fixme` w CI — seeded UI + dnd timing, zgodnie z konwencją repo)

## Smoke test plan (po merge)
1. Login `admin@demo.localhost / changeme`.
2. `/modeling/object-types/{produkt}` → chwyć uchwyt grupy, przeciągnij → kolejność się zapisuje (reload trzyma).
3. Otwórz produkt → kolejność zakładek odpowiada kolejności grup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)