### PR TITLE
feat(modeling): toggle „Wymagany" w edycji atrybutu

### DIFF
--- a/apps/admin/e2e/1350-attribute-required-toggle.spec.ts
+++ b/apps/admin/e2e/1350-attribute-required-toggle.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1350 — the attribute edit form was missing a "Wymagany" (required)
+ * toggle even though `PATCH /api/attributes/{id}` already accepts the
+ * field. This spec creates a custom attribute via API, opens its edit
+ * page, flips Required on, saves, and asserts the PATCH carried
+ * `required: true` and the flag sticks after a reload.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason
+ * (5 logins / 15 min). BE persistence is covered by
+ * AttributesCrudApiTest::patchTogglesRequired.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('attribute edit form can toggle Required and persist it', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const code = `zz_required_${Date.now().toString(36).toLowerCase()}`;
+  const created = await page.request.post('/api/attributes', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code, type: 'text', label: { pl: 'Required spec', en: 'Required spec' } },
+  });
+  expect(created.status()).toBe(201);
+  const attribute = (await created.json()) as { id: string };
+
+  await page.goto(`/modeling/attributes/${attribute.id}`);
+
+  const requiredPill = page.getByRole('button', { name: /wymagany|required/i });
+  await expect(requiredPill).toBeVisible({ timeout: 15_000 });
+  await expect(requiredPill).toContainText(/off/i);
+  await requiredPill.click();
+
+  const patchPromise = page.waitForResponse(
+    (r) => r.url().includes(`/api/attributes/${attribute.id}`) && r.request().method() === 'PATCH',
+    { timeout: 15_000 },
+  );
+  await page
+    .getByRole('button', { name: /zapisz zmiany|save changes/i })
+    .first()
+    .click();
+  const patch = await patchPromise;
+  expect(patch.status()).toBe(200);
+  expect((patch.request().postDataJSON() as { required?: boolean }).required).toBe(true);
+
+  // The flag must read back as ON from the API (avoids SPA reload
+  // re-auth flakiness; the UI ON-state is already proven by the pill
+  // toggle + the PATCH payload above).
+  const reread = await page.request.get(`/api/attributes/${attribute.id}`, {
+    headers: { ...bearer, accept: 'application/json' },
+  });
+  expect(reread.status()).toBe(200);
+  expect((await reread.json()).required).toBe(true);
+
+  await page.request.delete(`/api/attributes/${attribute.id}`, { headers: bearer });
+});

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -134,6 +134,7 @@ function Editor({
   const [labelEn, setLabelEn] = useState(initialLabel.en ?? '');
   const [helpPl, setHelpPl] = useState(initialHelp.pl ?? '');
   const [helpEn, setHelpEn] = useState(initialHelp.en ?? '');
+  const [required, setRequired] = useState(attribute.required ?? false);
   const [localizable, setLocalizable] = useState(attribute.localizable ?? false);
   const [scopable, setScopable] = useState(attribute.scopable ?? false);
   const [unique, setUnique] = useState(attribute.unique ?? false);
@@ -243,6 +244,7 @@ function Editor({
   const dirtyFields = [
     labelPl !== (initialLabel.pl ?? '') || labelEn !== (initialLabel.en ?? ''),
     helpPl !== (initialHelp.pl ?? '') || helpEn !== (initialHelp.en ?? ''),
+    required !== (attribute.required ?? false),
     localizable !== (attribute.localizable ?? false),
     scopable !== (attribute.scopable ?? false),
     unique !== (attribute.unique ?? false),
@@ -259,6 +261,7 @@ function Editor({
     setLabelEn(initialLabel.en ?? '');
     setHelpPl(initialHelp.pl ?? '');
     setHelpEn(initialHelp.en ?? '');
+    setRequired(attribute.required ?? false);
     setLocalizable(attribute.localizable ?? false);
     setScopable(attribute.scopable ?? false);
     setUnique(attribute.unique ?? false);
@@ -276,9 +279,14 @@ function Editor({
       const nextHelp = stripEmpty({ pl: helpPl, en: helpEn });
       if (JSON.stringify(nextHelp) !== JSON.stringify(initialHelp)) body.help = nextHelp;
       if (!isSystem) {
+        // #1350 — `required` is now editable in-place (the edit form was
+        // missing the toggle even though PATCH already accepted it).
+        if (required !== (attribute.required ?? false)) body.required = required;
         if (localizable !== (attribute.localizable ?? false)) body.localizable = localizable;
         if (scopable !== (attribute.scopable ?? false)) body.scopable = scopable;
-        if (unique !== (attribute.unique ?? false)) body.required = unique; // BE has no `unique` flag yet
+        // `unique` has no backend flag yet — submit-side stays a no-op
+        // until #1355 decides whether to persist it. (Previously this was
+        // wrongly mapped onto `required`, corrupting the required flag.)
         if (filterable !== (attribute.filterable ?? false)) body.filterable = filterable;
       }
       if (attribute.type === 'relation' && relationDirty) {
@@ -521,6 +529,14 @@ function Editor({
               {t('attributes.flags_label', { defaultValue: 'Flagi' })}
             </div>
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <FlagPill
+                on={required}
+                label={t('attributes.flags.required_label', { defaultValue: 'Wymagany' })}
+                desc={t('attributes.flags.required_desc', {
+                  defaultValue: 'pole musi być wypełnione',
+                })}
+                onChange={isSystem ? undefined : setRequired}
+              />
               <FlagPill
                 on={localizable}
                 label={t('attributes.flags.localizable_label', { defaultValue: 'Localizable' })}

--- a/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
+++ b/apps/api/tests/Api/Catalog/AttributesCrudApiTest.php
@@ -113,6 +113,32 @@ final class AttributesCrudApiTest extends CatalogApiTestCase
         self::assertTrue($payload['localizable']);
     }
 
+    /**
+     * #1350 — the edit form gained a "Wymagany" toggle; assert PATCH
+     * actually flips `required` (and back), since the FE form was the
+     * only thing missing — the endpoint already accepted the field.
+     */
+    #[Test]
+    public function patchTogglesRequired(): void
+    {
+        $id = $this->seedAttribute('warranty_months', AttributeType::Number);
+        $client = $this->authenticatedClient();
+
+        $on = $client->request('PATCH', '/api/attributes/'.$id->toRfc4122(), [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['required' => true],
+        ]);
+        self::assertSame(200, $on->getStatusCode());
+        self::assertTrue($on->toArray()['required']);
+
+        $off = $client->request('PATCH', '/api/attributes/'.$id->toRfc4122(), [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['required' => false],
+        ]);
+        self::assertSame(200, $off->getStatusCode());
+        self::assertFalse($off->toArray()['required']);
+    }
+
     #[Test]
     public function deleteRemovesCustomAttribute(): void
     {


### PR DESCRIPTION
## Summary
Formularz edycji atrybutu (`/modeling/attributes/{id}`) nie miał przełącznika „Wymagany", mimo że `PATCH /api/attributes/{id}` już przyjmuje `required`. Dodatkowo formularz mapował form-only toggle `unique` na `body.required` — co psuło flagę required przy zapisie.

## Root cause
Brak toggla Required w edycji + `if (unique !== ...) body.required = unique` (linia ~281) nadpisywał required wartością unique.

## Frontend changes
- Nowy FlagPill „Wymagany" z własnym state + dirty-check + diff w PATCH.
- Usunięty błędny mapping `unique → required`; `unique` zostaje form-only no-op do czasu decyzji w #1355.

## Backend changes
- N/A (PATCH `required` już istniał). Dodany regresyjny ApiTest.

## Quality gates
- typecheck + Biome: 0, Vite build OK
- PHPUnit: `AttributesCrudApiTest::patchTogglesRequired` (round-trip true/false)
- Playwright: `1350-attribute-required-toggle` zielony lokalnie (`fixme` w CI — rate limiter)

## Smoke test plan (po merge)
1. Login `admin@demo.localhost / changeme`.
2. `/modeling/attributes/{custom}` → przełącz „Wymagany" → „Zapisz zmiany" → reload → ON trzyma.

## Świadome odejścia
- Walidacja wymagalności pól przy zapisie wpisu (highlight + blokada „Zapisz" na karcie produktu) — osobny, większy enhancement FE+BE. Ten PR dostarcza brakujący toggle (konkretny blocker operatora) + naprawia korupcję required. Egzekwowanie required przy zapisie obiektu → follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)