### PR TITLE
feat(catalog): detal wpisu od razu w trybie edycji + „Zapisz i wróć do listy"

### DIFF
--- a/apps/admin/e2e/1351-product-detail-edit-mode.spec.ts
+++ b/apps/admin/e2e/1351-product-detail-edit-mode.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1351 — the product detail page opens directly in edit mode (no
+ * read-only "Edytuj" toggle), "Zapisz zmiany" is always visible, and a
+ * new "Zapisz i wróć do listy" action saves and returns to the list
+ * while plain "Zapisz zmiany" keeps the row in edit mode.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('product detail opens in edit mode with save + save-and-return actions', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const objectTypesResponse = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
+  const types =
+    (
+      (await objectTypesResponse.json()) as {
+        member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+      }
+    ).member ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) throw new Error('Built-in product ObjectType not seeded.');
+
+  const sku = `ED1351-${Date.now().toString(36).toUpperCase()}`;
+  const created = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: sku, objectTypeId: productType.id, attributes: { name: `Edit mode ${sku}` } },
+  });
+  expect(created.status()).toBe(201);
+  const product = (await created.json()) as { id: string };
+
+  await page.goto(`/products/${product.id}`);
+
+  // Edit mode by default — "Zapisz zmiany" visible, no "Edytuj".
+  await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole('button', { name: /^(edytuj|edit)$/i })).toHaveCount(0);
+
+  // "Zapisz i wróć do listy" navigates back to the product list.
+  const saveAndReturn = page.getByRole('button', {
+    name: /zapisz i wróć do listy|save and return/i,
+  });
+  await expect(saveAndReturn).toBeVisible();
+  await saveAndReturn.click();
+  await expect(page).toHaveURL(/\/products$/, { timeout: 15_000 });
+
+  await page.request.delete(`/api/products/${product.id}`, { headers: bearer });
+});

--- a/apps/admin/e2e/products-date-and-variants-axis.spec.ts
+++ b/apps/admin/e2e/products-date-and-variants-axis.spec.ts
@@ -69,7 +69,7 @@ test('product detail date picker + variants axis combobox', async ({ page }) => 
   );
   await page.goto(`/products/${product.id}`);
   await groupsResponse;
-  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  // #1351 — detail opens directly in edit mode; no "Edytuj" click needed.
   await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible();
 
   // ---------- Part 1: date picker -----------
@@ -91,7 +91,8 @@ test('product detail date picker + variants axis combobox', async ({ page }) => 
   const datePatched = await datePatch;
   expect(datePatched.status()).toBe(200);
 
-  // Reload + assert read-only display shows the picked date.
+  // #1351 — the page reopens in edit mode, so the date renders as an
+  // editable input holding the saved value (no read-only text display).
   await page.reload();
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
   const reloadedDateLabel = page.getByText(/^(Data premiery|Release date)$/).first();
@@ -99,8 +100,8 @@ test('product detail date picker + variants axis combobox', async ({ page }) => 
   await expect(
     reloadedDateLabel
       .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]')
-      .getByText('2027-03-15'),
-  ).toBeVisible();
+      .locator('input[type="date"]'),
+  ).toHaveValue('2027-03-15');
 
   // ---------- Part 2: variants axis combobox ----------
   await page.getByRole('tab', { name: /^(warianty|variants)$/i }).click();

--- a/apps/admin/e2e/view-07-products-edit-create.spec.ts
+++ b/apps/admin/e2e/view-07-products-edit-create.spec.ts
@@ -56,17 +56,15 @@ test('VIEW-07 product detail + create + duplicate flow', async ({ page }) => {
   expect(created.status()).toBe(201);
   await expect(page).toHaveURL(/\/products\/[0-9a-f-]{36}$/, { timeout: 30_000 });
 
-  // Read-only by default — header shows "Edytuj"/"Edit" and the save
-  // button is absent until we toggle into edit mode.
-  const editToggle = page.getByRole('button', { name: /^(edytuj|edit)$/i });
-  await expect(editToggle).toBeVisible();
-  await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toHaveCount(
-    0,
-  );
-
-  await editToggle.click();
+  // #1351 — the detail page opens directly in edit mode: "Zapisz zmiany"
+  // + "Zapisz i wróć do listy" are visible immediately, there is no
+  // read-only "Edytuj" toggle.
   await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /^(edytuj|edit)$/i })).toHaveCount(0);
   await expect(page.getByRole('button', { name: /^(anuluj|cancel)$/i })).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /zapisz i wróć do listy|save and return/i }),
+  ).toBeVisible();
 
   // Duplicate uses the existing POST /api/products/{id}/duplicate
   // sugar endpoint and lands on the freshly minted /products/{newId}.

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -1,14 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-  ArrowLeft,
-  Clock,
-  Link2,
-  MoreHorizontal,
-  Pencil,
-  Save,
-  Sparkles,
-  Trash2,
-} from 'lucide-react';
+import { ArrowLeft, Clock, Link2, MoreHorizontal, Save, Sparkles, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router';
@@ -159,7 +150,10 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   const hasMultimediaCapability = schemaQuery.data?.objectType.has_multimedia ?? false;
 
   const [activeTab, setActiveTab] = useState<TabKey>('attributes');
-  const [isEditing, setIsEditing] = useState<boolean>(!isEditMode);
+  // #1351 — the detail page opens directly in edit mode; there is no
+  // read-only state anymore. "Zapisz zmiany" is always visible and a
+  // "Zapisz i wróć do listy" action saves + returns to the list.
+  const isEditing = true;
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [isSaving, setIsSaving] = useState<boolean>(false);
@@ -411,7 +405,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     return attrs[code];
   };
 
-  const handleSave = async (): Promise<void> => {
+  const handleSave = async (returnToList = false): Promise<void> => {
     if (isSaving) return;
     setIsSaving(true);
     try {
@@ -470,7 +464,8 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
         navigate(`/products/${created.id}`);
       } else {
         if (Object.keys(dirtyFields).length === 0) {
-          setIsEditing(false);
+          // Nothing to persist — "Zapisz i wróć do listy" still returns.
+          if (returnToList) navigate('/products');
           setIsSaving(false);
           return;
         }
@@ -485,8 +480,10 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
         });
         await productQuery.refetch();
         setDirtyFields({});
-        setIsEditing(false);
         toast.success(t('products.detail.save.success', { defaultValue: 'Zapisano zmiany' }));
+        // #1351 — "Zapisz zmiany" keeps the row in edit mode; only
+        // "Zapisz i wróć do listy" navigates back to the list.
+        if (returnToList) navigate('/products');
       }
     } catch (error) {
       // #1179 — surface the server's Problem Details `detail` (e.g. duplicate
@@ -502,8 +499,10 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   };
 
   const cancelEdit = (): void => {
+    // #1351 — no read-only mode anymore; "Anuluj" just discards unsaved
+    // edits and restores the persisted values.
     setDirtyFields({});
-    setIsEditing(false);
+    void productQuery.refetch();
   };
 
   const handleDelete = async (): Promise<void> => {
@@ -660,43 +659,44 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                 </Button>
               )}
               <span className="mx-1 h-6 w-px bg-zinc-200" />
-              {isEditing ? (
-                <>
-                  {mode === 'edit' ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={cancelEdit}
-                      disabled={isSaving}
-                      className="h-9 rounded-xl px-3 text-[12.5px] text-zinc-600"
-                    >
-                      {t('products.detail.actions.cancel', { defaultValue: 'Anuluj' })}
-                    </Button>
-                  ) : null}
-                  <Button
-                    type="button"
-                    onClick={() => void handleSave()}
-                    disabled={isSaving || (mode === 'create' && objectTypeId === null)}
-                    className="h-9 rounded-xl bg-zinc-900 px-4 text-[12.5px] font-medium text-white hover:bg-zinc-800"
-                  >
-                    <Save className="size-4" />
-                    {mode === 'create'
-                      ? t('products.detail.actions.create', { defaultValue: 'Utwórz produkt' })
-                      : t('products.detail.actions.save', { defaultValue: 'Zapisz zmiany' })}
-                  </Button>
-                </>
-              ) : (
+              {mode === 'edit' ? (
                 <Button
                   type="button"
-                  onClick={() => setIsEditing(true)}
-                  className="h-9 rounded-xl bg-zinc-900 px-4 text-[12.5px] font-medium text-white hover:bg-zinc-800"
-                  aria-pressed={isEditing}
+                  variant="ghost"
+                  size="sm"
+                  onClick={cancelEdit}
+                  disabled={isSaving}
+                  className="h-9 rounded-xl px-3 text-[12.5px] text-zinc-600"
                 >
-                  <Pencil className="size-4" />
-                  {t('products.detail.actions.edit', { defaultValue: 'Edytuj' })}
+                  {t('products.detail.actions.cancel', { defaultValue: 'Anuluj' })}
                 </Button>
-              )}
+              ) : null}
+              <Button
+                type="button"
+                onClick={() => void handleSave()}
+                disabled={isSaving || (mode === 'create' && objectTypeId === null)}
+                className="h-9 rounded-xl bg-zinc-900 px-4 text-[12.5px] font-medium text-white hover:bg-zinc-800"
+              >
+                <Save className="size-4" />
+                {mode === 'create'
+                  ? t('products.detail.actions.create', { defaultValue: 'Utwórz produkt' })
+                  : t('products.detail.actions.save', { defaultValue: 'Zapisz zmiany' })}
+              </Button>
+              {/* #1351 — save and return to the list (edit mode only). */}
+              {mode === 'edit' ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handleSave(true)}
+                  disabled={isSaving}
+                  className="h-9 rounded-xl px-4 text-[12.5px] font-medium"
+                >
+                  <Save className="size-4" />
+                  {t('products.detail.actions.save_and_return', {
+                    defaultValue: 'Zapisz i wróć do listy',
+                  })}
+                </Button>
+              ) : null}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
Detal produktu otwierał się read-only i wymagał kliknięcia „Edytuj". Per #1351 otwiera się **od razu w trybie edycji**: brak stanu read-only, „Zapisz zmiany" zawsze widoczny, nowy przycisk „Zapisz i wróć do listy" zapisuje i wraca do listy. „Zapisz zmiany" zostawia wpis w trybie edycji; „Anuluj" odrzuca niezapisane zmiany (refetch).

## Frontend changes
- `product-detail-page.tsx`: usunięty toggle read-only/„Edytuj" (`isEditing = true`); `handleSave(returnToList)` — po „Zapisz zmiany" zostaje w edycji, po „Zapisz i wróć do listy" → `navigate('/products')`. `cancelEdit` tylko czyści dirty + refetch.
- Zaktualizowane E2E `view-07` + `products-date-and-variants-axis` (asercje starego read-only → nowe always-edit) + nowy `1351-product-detail-edit-mode`.

## Quality gates
- typecheck + Biome: 0
- Playwright: `1351-product-detail-edit-mode` zielony lokalnie (`fixme` w CI — rate limiter)

## Smoke test plan (po merge)
1. Login → otwórz produkt → od razu edytowalne pola, „Zapisz zmiany" + „Zapisz i wróć do listy" widoczne, brak „Edytuj".
2. Zmień pole → „Zapisz zmiany" → zostaje w edycji. „Zapisz i wróć do listy" → wraca na `/products`.

## Świadome odejścia
- Zmiana dotyczy legacy `ProductDetailPage` (`/products/:id`). `UniversalDetailPage` (custom OT) — analogiczna zmiana w osobnym kroku jeśli operator potwierdzi (poza zakresem #1351).
- `view-07` ma pre-existing problem w części CREATE (wymóg kategorii #891 / rate-limiter) niezwiązany z tą zmianą; zaktualizowane są tylko asercje post-create (tryb edycji).

🤖 Generated with [Claude Code](https://claude.com/claude-code)