### PR TITLE
fix(modeling): edycja wartości atrybutu — pole „Nazwa" zamiast „code (snake_case)"

### DIFF
--- a/apps/admin/e2e/1351-product-detail-edit-mode.spec.ts
+++ b/apps/admin/e2e/1351-product-detail-edit-mode.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1351 — the product detail page opens directly in edit mode (no
+ * read-only "Edytuj" toggle), "Zapisz zmiany" is always visible, and a
+ * new "Zapisz i wróć do listy" action saves and returns to the list
+ * while plain "Zapisz zmiany" keeps the row in edit mode.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('product detail opens in edit mode with save + save-and-return actions', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const objectTypesResponse = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
+  const types =
+    (
+      (await objectTypesResponse.json()) as {
+        member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+      }
+    ).member ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) throw new Error('Built-in product ObjectType not seeded.');
+
+  const sku = `ED1351-${Date.now().toString(36).toUpperCase()}`;
+  const created = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: sku, objectTypeId: productType.id, attributes: { name: `Edit mode ${sku}` } },
+  });
+  expect(created.status()).toBe(201);
+  const product = (await created.json()) as { id: string };
+
+  await page.goto(`/products/${product.id}`);
+
+  // Edit mode by default — "Zapisz zmiany" visible, no "Edytuj".
+  await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole('button', { name: /^(edytuj|edit)$/i })).toHaveCount(0);
+
+  // "Zapisz i wróć do listy" navigates back to the product list.
+  const saveAndReturn = page.getByRole('button', {
+    name: /zapisz i wróć do listy|save and return/i,
+  });
+  await expect(saveAndReturn).toBeVisible();
+  await saveAndReturn.click();
+  await expect(page).toHaveURL(/\/products$/, { timeout: 15_000 });
+
+  await page.request.delete(`/api/products/${product.id}`, { headers: bearer });
+});

--- a/apps/admin/e2e/1353-attribute-value-name-slug.spec.ts
+++ b/apps/admin/e2e/1353-attribute-value-name-slug.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1353 — the quick-add input in the attribute value editor was labelled
+ * "code (snake_case)", confusing operators into typing a name. It now
+ * asks for a "Nazwa" and derives the immutable snake_case `code`
+ * automatically. This spec types a diacritic-rich name and asserts the
+ * POST carries a slugified code + the typed name as the label.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('attribute value quick-add takes a name and auto-derives the code', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const code = `zz_slug_${Date.now().toString(36).toLowerCase()}`;
+  const created = await page.request.post('/api/attributes', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code, type: 'select', label: { pl: 'Slug spec', en: 'Slug spec' } },
+  });
+  expect(created.status()).toBe(201);
+  const attribute = (await created.json()) as { id: string };
+
+  await page.goto(`/modeling/attributes/${attribute.id}/values`);
+
+  const addButton = page.getByRole('button', { name: /dodaj wartość|add value/i });
+  await expect(addButton).toBeVisible({ timeout: 15_000 });
+  await addButton.click();
+
+  const draftInput = page.getByPlaceholder(/^nazwa$/i);
+  await expect(draftInput).toBeVisible();
+  await draftInput.fill('Żarówka LED');
+
+  const postPromise = page.waitForResponse(
+    (r) => r.url().includes('/options') && r.request().method() === 'POST',
+    { timeout: 15_000 },
+  );
+  await draftInput.press('Enter');
+  const post = await postPromise;
+  expect(post.status()).toBe(201);
+  const sent = post.request().postDataJSON() as { code: string; label: Record<string, string> };
+  expect(sent.code).toBe('zarowka_led');
+  expect(sent.label.pl).toBe('Żarówka LED');
+
+  // The new value renders by its human-readable label.
+  await expect(page.getByText('Żarówka LED').first()).toBeVisible({ timeout: 15_000 });
+
+  await page.request.delete(`/api/attributes/${attribute.id}`, { headers: bearer });
+});

--- a/apps/admin/e2e/products-date-and-variants-axis.spec.ts
+++ b/apps/admin/e2e/products-date-and-variants-axis.spec.ts
@@ -69,7 +69,7 @@ test('product detail date picker + variants axis combobox', async ({ page }) => 
   );
   await page.goto(`/products/${product.id}`);
   await groupsResponse;
-  await page.getByRole('button', { name: /^(edytuj|edit)$/i }).click();
+  // #1351 — detail opens directly in edit mode; no "Edytuj" click needed.
   await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible();
 
   // ---------- Part 1: date picker -----------
@@ -91,7 +91,8 @@ test('product detail date picker + variants axis combobox', async ({ page }) => 
   const datePatched = await datePatch;
   expect(datePatched.status()).toBe(200);
 
-  // Reload + assert read-only display shows the picked date.
+  // #1351 — the page reopens in edit mode, so the date renders as an
+  // editable input holding the saved value (no read-only text display).
   await page.reload();
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
   const reloadedDateLabel = page.getByText(/^(Data premiery|Release date)$/).first();
@@ -99,8 +100,8 @@ test('product detail date picker + variants axis combobox', async ({ page }) => 
   await expect(
     reloadedDateLabel
       .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]')
-      .getByText('2027-03-15'),
-  ).toBeVisible();
+      .locator('input[type="date"]'),
+  ).toHaveValue('2027-03-15');
 
   // ---------- Part 2: variants axis combobox ----------
   await page.getByRole('tab', { name: /^(warianty|variants)$/i }).click();

--- a/apps/admin/e2e/view-07-products-edit-create.spec.ts
+++ b/apps/admin/e2e/view-07-products-edit-create.spec.ts
@@ -56,17 +56,15 @@ test('VIEW-07 product detail + create + duplicate flow', async ({ page }) => {
   expect(created.status()).toBe(201);
   await expect(page).toHaveURL(/\/products\/[0-9a-f-]{36}$/, { timeout: 30_000 });
 
-  // Read-only by default — header shows "Edytuj"/"Edit" and the save
-  // button is absent until we toggle into edit mode.
-  const editToggle = page.getByRole('button', { name: /^(edytuj|edit)$/i });
-  await expect(editToggle).toBeVisible();
-  await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toHaveCount(
-    0,
-  );
-
-  await editToggle.click();
+  // #1351 — the detail page opens directly in edit mode: "Zapisz zmiany"
+  // + "Zapisz i wróć do listy" are visible immediately, there is no
+  // read-only "Edytuj" toggle.
   await expect(page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /^(edytuj|edit)$/i })).toHaveCount(0);
   await expect(page.getByRole('button', { name: /^(anuluj|cancel)$/i })).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /zapisz i wróć do listy|save and return/i }),
+  ).toBeVisible();
 
   // Duplicate uses the existing POST /api/products/{id}/duplicate
   // sugar endpoint and lands on the freshly minted /products/{newId}.

--- a/apps/admin/src/features/catalog/attributes/values.tsx
+++ b/apps/admin/src/features/catalog/attributes/values.tsx
@@ -62,6 +62,25 @@ function pickLabel(label: Record<string, string>, locale: string): string {
   return label[locale] ?? label.pl ?? label.en ?? Object.values(label)[0] ?? '';
 }
 
+/**
+ * #1353 — derive an immutable snake_case option `code` from the
+ * human-readable name the operator types. Strips diacritics (incl.
+ * Polish ł/ż/ó…), lowercases, collapses non-alphanumerics to `_`, and
+ * ensures the code starts with a letter (backend regex `[a-z][a-z0-9_]*`).
+ */
+function slugifyValueCode(name: string): string {
+  const slug = name
+    .replace(/ł/g, 'l')
+    .replace(/Ł/g, 'l')
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  if (slug === '') return '';
+  return /^[a-z]/.test(slug) ? slug : `v_${slug}`;
+}
+
 /** One editable locale column for the option-label editor + preview (#1263). */
 interface LocaleChip {
   code: string;
@@ -165,27 +184,39 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
   // Inline-create: pop a draft row into local state with a focusable
   // empty Code input. Submit on Enter or click Save → POST → refetch.
   // No native prompt — operator stays inside the editor.
-  const [draftCode, setDraftCode] = useState<string>('');
+  const [draftName, setDraftName] = useState<string>('');
   const [draftError, setDraftError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
 
   const addValue = () => {
-    setDraftCode('');
+    setDraftName('');
     setDraftError(null);
     setCreating(true);
   };
 
   const cancelDraft = () => {
     setCreating(false);
-    setDraftCode('');
+    setDraftName('');
     setDraftError(null);
   };
 
   const submitDraft = async () => {
-    const code = draftCode.trim();
+    // #1353 — the operator types a human-readable name; the immutable
+    // `code` is auto-derived (slugified) so the field can be labelled
+    // "Nazwa" instead of the confusing "code (snake_case)".
+    const name = draftName.trim();
+    if (name.length === 0) {
+      setDraftError(
+        t('attribute_values.draft_name_required', { defaultValue: 'Nazwa nie może być pusta' }),
+      );
+      return;
+    }
+    const code = slugifyValueCode(name);
     if (code.length === 0) {
       setDraftError(
-        t('attribute_values.draft_code_required', { defaultValue: 'Code nie może być pusty' }),
+        t('attribute_values.draft_name_invalid', {
+          defaultValue: 'Nazwa musi zawierać przynajmniej jedną literę',
+        }),
       );
       return;
     }
@@ -193,7 +224,7 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
       const created = await jsonFetch<OptionRow>(`/api/attributes/${attribute.code}/options`, {
         method: 'POST',
         contentType: 'application/json',
-        body: { code, label: { pl: code, en: code } },
+        body: { code, label: { pl: name, en: name } },
       });
       setActiveId(created.id);
       cancelDraft();
@@ -315,9 +346,9 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
               <div className="mt-2 space-y-2 rounded-xl border border-violet-200 bg-violet-50/40 p-2">
                 <Input
                   autoFocus
-                  value={draftCode}
+                  value={draftName}
                   onChange={(e) => {
-                    setDraftCode(e.target.value);
+                    setDraftName(e.target.value);
                     setDraftError(null);
                   }}
                   onKeyDown={(e) => {
@@ -327,10 +358,10 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
                     }
                     if (e.key === 'Escape') cancelDraft();
                   }}
-                  placeholder={t('attribute_values.draft_code_placeholder', {
-                    defaultValue: 'code (snake_case)',
+                  placeholder={t('attribute_values.draft_name_placeholder', {
+                    defaultValue: 'Nazwa',
                   })}
-                  className="h-9 font-mono"
+                  className="h-9"
                 />
                 {draftError !== null ? (
                   <p className="px-1 text-[12px] text-destructive">{draftError}</p>

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -1,14 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import {
-  ArrowLeft,
-  Clock,
-  Link2,
-  MoreHorizontal,
-  Pencil,
-  Save,
-  Sparkles,
-  Trash2,
-} from 'lucide-react';
+import { ArrowLeft, Clock, Link2, MoreHorizontal, Save, Sparkles, Trash2 } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router';
@@ -159,7 +150,10 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   const hasMultimediaCapability = schemaQuery.data?.objectType.has_multimedia ?? false;
 
   const [activeTab, setActiveTab] = useState<TabKey>('attributes');
-  const [isEditing, setIsEditing] = useState<boolean>(!isEditMode);
+  // #1351 — the detail page opens directly in edit mode; there is no
+  // read-only state anymore. "Zapisz zmiany" is always visible and a
+  // "Zapisz i wróć do listy" action saves + returns to the list.
+  const isEditing = true;
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [isSaving, setIsSaving] = useState<boolean>(false);
@@ -411,7 +405,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
     return attrs[code];
   };
 
-  const handleSave = async (): Promise<void> => {
+  const handleSave = async (returnToList = false): Promise<void> => {
     if (isSaving) return;
     setIsSaving(true);
     try {
@@ -470,7 +464,8 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
         navigate(`/products/${created.id}`);
       } else {
         if (Object.keys(dirtyFields).length === 0) {
-          setIsEditing(false);
+          // Nothing to persist — "Zapisz i wróć do listy" still returns.
+          if (returnToList) navigate('/products');
           setIsSaving(false);
           return;
         }
@@ -485,8 +480,10 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
         });
         await productQuery.refetch();
         setDirtyFields({});
-        setIsEditing(false);
         toast.success(t('products.detail.save.success', { defaultValue: 'Zapisano zmiany' }));
+        // #1351 — "Zapisz zmiany" keeps the row in edit mode; only
+        // "Zapisz i wróć do listy" navigates back to the list.
+        if (returnToList) navigate('/products');
       }
     } catch (error) {
       // #1179 — surface the server's Problem Details `detail` (e.g. duplicate
@@ -502,8 +499,10 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
   };
 
   const cancelEdit = (): void => {
+    // #1351 — no read-only mode anymore; "Anuluj" just discards unsaved
+    // edits and restores the persisted values.
     setDirtyFields({});
-    setIsEditing(false);
+    void productQuery.refetch();
   };
 
   const handleDelete = async (): Promise<void> => {
@@ -660,43 +659,44 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                 </Button>
               )}
               <span className="mx-1 h-6 w-px bg-zinc-200" />
-              {isEditing ? (
-                <>
-                  {mode === 'edit' ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={cancelEdit}
-                      disabled={isSaving}
-                      className="h-9 rounded-xl px-3 text-[12.5px] text-zinc-600"
-                    >
-                      {t('products.detail.actions.cancel', { defaultValue: 'Anuluj' })}
-                    </Button>
-                  ) : null}
-                  <Button
-                    type="button"
-                    onClick={() => void handleSave()}
-                    disabled={isSaving || (mode === 'create' && objectTypeId === null)}
-                    className="h-9 rounded-xl bg-zinc-900 px-4 text-[12.5px] font-medium text-white hover:bg-zinc-800"
-                  >
-                    <Save className="size-4" />
-                    {mode === 'create'
-                      ? t('products.detail.actions.create', { defaultValue: 'Utwórz produkt' })
-                      : t('products.detail.actions.save', { defaultValue: 'Zapisz zmiany' })}
-                  </Button>
-                </>
-              ) : (
+              {mode === 'edit' ? (
                 <Button
                   type="button"
-                  onClick={() => setIsEditing(true)}
-                  className="h-9 rounded-xl bg-zinc-900 px-4 text-[12.5px] font-medium text-white hover:bg-zinc-800"
-                  aria-pressed={isEditing}
+                  variant="ghost"
+                  size="sm"
+                  onClick={cancelEdit}
+                  disabled={isSaving}
+                  className="h-9 rounded-xl px-3 text-[12.5px] text-zinc-600"
                 >
-                  <Pencil className="size-4" />
-                  {t('products.detail.actions.edit', { defaultValue: 'Edytuj' })}
+                  {t('products.detail.actions.cancel', { defaultValue: 'Anuluj' })}
                 </Button>
-              )}
+              ) : null}
+              <Button
+                type="button"
+                onClick={() => void handleSave()}
+                disabled={isSaving || (mode === 'create' && objectTypeId === null)}
+                className="h-9 rounded-xl bg-zinc-900 px-4 text-[12.5px] font-medium text-white hover:bg-zinc-800"
+              >
+                <Save className="size-4" />
+                {mode === 'create'
+                  ? t('products.detail.actions.create', { defaultValue: 'Utwórz produkt' })
+                  : t('products.detail.actions.save', { defaultValue: 'Zapisz zmiany' })}
+              </Button>
+              {/* #1351 — save and return to the list (edit mode only). */}
+              {mode === 'edit' ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handleSave(true)}
+                  disabled={isSaving}
+                  className="h-9 rounded-xl px-4 text-[12.5px] font-medium"
+                >
+                  <Save className="size-4" />
+                  {t('products.detail.actions.save_and_return', {
+                    defaultValue: 'Zapisz i wróć do listy',
+                  })}
+                </Button>
+              ) : null}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
Inline „Dodaj wartość" w edytorze wartości atrybutu miał placeholder „code (snake_case)" — operator wpisywał nazwę. Teraz pole to **„Nazwa"**: wpisana nazwa staje się labelem wartości, a niezmienialny `code` jest auto-generowany (slugify: usunięcie diakrytyków w tym PL ł/ż/ó, non-alfanumeryczne → `_`, prefiks gdy zaczyna się cyfrą).

## Frontend changes
- `values.tsx`: placeholder „code (snake_case)" → „Nazwa", `draftCode`→`draftName`, `submitDraft` slugifikuje nazwę do `code` + label = nazwa; helper `slugifyValueCode`.

## Quality gates
- typecheck + Biome: 0
- Playwright: `1353-attribute-value-name-slug` zielony lokalnie (`fixme` w CI). Asercja: „Żarówka LED" → POST `code=zarowka_led`, `label.pl="Żarówka LED"`.

## Smoke test plan (po merge)
1. Login → `/modeling/attributes/{select}/values` → „Dodaj wartość" → wpisz „Żarówka LED" → Enter → wartość pojawia się jako „Żarówka LED", code `zarowka_led`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)