### PR TITLE
fix(modeling): drzewo kategorii pokazuje code zamiast Nazwy

### DIFF
--- a/apps/admin/e2e/1358-category-create-name-in-tree.spec.ts
+++ b/apps/admin/e2e/1358-category-create-name-in-tree.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1358 — the category tree showed the raw snake_case `code` because the
+ * create form captured a name but never sent it (the VIEW-04b upserter
+ * wiring was never finished). The create POST now carries
+ * `attributes.name`, so a freshly-created category renders by its name in
+ * the tree.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('creating a category persists its name and shows it in the tree', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const types =
+    (
+      (await (
+        await page.request.get('/api/object_types?itemsPerPage=200', {
+          headers: { ...bearer, accept: 'application/ld+json' },
+        })
+      ).json()) as { member?: Array<{ id: string; kind: string; codeImmutable: boolean }> }
+    ).member ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) throw new Error('Built-in product ObjectType not seeded.');
+
+  const code = `zz_cat_${Date.now().toString(36).toLowerCase()}`;
+  const name = `Kategoria E2E ${code}`;
+
+  // Wait for the object_types list so the create handler can resolve the
+  // built-in category ObjectType before we submit.
+  const objectTypesLoaded = page.waitForResponse(
+    (r) => r.url().includes('/api/object_types') && r.request().method() === 'GET',
+    { timeout: 30_000 },
+  );
+  await page.goto(`/modeling/categories/new?targetObjectTypeId=${productType.id}`);
+  await objectTypesLoaded;
+  // Let Refine commit the object_types list to state so the create
+  // handler resolves the built-in category ObjectType.
+  await page.waitForTimeout(2_500);
+  await page.locator('#cat-code').fill(code);
+  await page.locator('#cat-name-pl').fill(name);
+
+  const postPromise = page.waitForResponse(
+    (r) => r.url().endsWith('/api/categories') && r.request().method() === 'POST',
+    { timeout: 15_000 },
+  );
+  await page.getByRole('button', { name: /utwórz kategorię|create category/i }).click();
+  const post = await postPromise;
+  expect(post.status()).toBe(201);
+  const sent = post.request().postDataJSON() as { attributes?: { name?: string } };
+  expect(sent.attributes?.name).toBe(name);
+
+  // Back on the tree — the new node renders by its name, not its code.
+  await expect(page).toHaveURL(/\/modeling\/categories\?/, { timeout: 15_000 });
+  await expect(page.getByText(name).first()).toBeVisible({ timeout: 15_000 });
+
+  // Cleanup — find the created category by code and delete it.
+  const created = (await (
+    await page.request.get('/api/categories?itemsPerPage=200', {
+      headers: { ...bearer, accept: 'application/json' },
+    })
+  ).json()) as { member?: Array<{ id: string; code: string }> };
+  const row = (created.member ?? []).find((c) => c.code === code);
+  if (row) await page.request.delete(`/api/categories/${row.id}`, { headers: bearer });
+});

--- a/apps/admin/src/features/catalog/categories/new.tsx
+++ b/apps/admin/src/features/catalog/categories/new.tsx
@@ -122,6 +122,15 @@ export function CategoryCreatePage() {
         code,
         objectTypeId: categoryObjectTypeId,
       };
+      // #1358 — persist the typed name so the category tree shows a
+      // readable label instead of the raw snake_case code. Previously the
+      // name was captured but never sent (the VIEW-04b upserter wiring was
+      // never finished), so every operator-created category fell back to
+      // its code in the tree.
+      const name = namePl.trim() || nameEn.trim();
+      if (name !== '') {
+        body.attributes = { name };
+      }
       // ADR-015 — the categorizable ObjectType tree this category joins.
       if (targetObjectTypeId) {
         body.categoryTargetObjectTypeId = targetObjectTypeId;
@@ -163,10 +172,6 @@ export function CategoryCreatePage() {
       setSubmitting(false);
     }
   };
-
-  // Surface name/desc state so Biome doesn't flag them as unused before
-  // the attributes upserter wiring in VIEW-04b.
-  const _draftedAttrs = { namePl, nameEn, descPl };
 
   return (
     <div className="space-y-6">
@@ -327,11 +332,6 @@ export function CategoryCreatePage() {
           </Button>
         </div>
       </Card>
-
-      {/* keep namePl/nameEn/descPl referenced — wired in VIEW-04b */}
-      <span className="hidden" aria-hidden>
-        {JSON.stringify(_draftedAttrs)}
-      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Drzewo kategorii (`/modeling/categories`) pokazywało surowy `code` (snake_case), bo formularz tworzenia kategorii **captuje nazwę ale jej nie wysyłał** — wiring „attributes upserter" (VIEW-04b) został jako TODO. Teraz create POST niesie `attributes.name`; istniejący resolver drzewa (name-or-code) renderuje czytelną etykietę.

## Root cause
`categories/new.tsx`: `namePl/nameEn` były tylko trzymane lokalnie (`_draftedAttrs` hack), nie wchodziły do body POST → kategorie powstawały z samym `code`.

## Frontend changes
- `categories/new.tsx`: `body.attributes = { name }` (namePl || nameEn) w POST `/api/categories`. Usunięty obsoletny `_draftedAttrs`/ukryty span.

## Quality gates
- typecheck + Biome: 0
- Playwright: `1358-category-create-name-in-tree` zielony lokalnie (`fixme` w CI). POST niesie `attributes.name`, węzeł renderuje się po nazwie.
- Live: POST z `attributes:{name}` → `attributesIndexed.name={value:...}` ✅.

## Smoke test plan (po merge)
1. Login → `/modeling/categories` → „Nowa kategoria" → wpisz Kod + Nazwa PL → Utwórz → węzeł w drzewie pokazuje Nazwę.

## Świadome odejścia
- Istniejące kategorie bez nazwy (utworzone przed fixem) nadal pokazują code — operator nadaje im nazwę przez rename. Backfill poza zakresem.
- Per-locale nazwa (PL+EN naraz) — wysyłana jest jedna (PL→EN fallback); pełne per-locale w zakresie #1352.

🤖 Generated with [Claude Code](https://claude.com/claude-code)