### PR TITLE
fix(catalog): usuń pole „Marka" i „Dodaj grupę atrybutów ad-hoc" z nowego wpisu

### DIFF
--- a/apps/admin/e2e/1357-products-new-no-marka-adhoc.spec.ts
+++ b/apps/admin/e2e/1357-products-new-no-marka-adhoc.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1357 — the new-product form (/products/new) carried a "Marka" input
+ * and a non-functional "Dodaj grupę atrybutów ad-hoc" stub. Both were
+ * removed per operator request; SKU + name stay.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('new product form has no Marka input and no ad-hoc group adder', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+  await page.goto('/products/new');
+
+  // SKU + name inputs stay.
+  await expect(page.getByPlaceholder('SKU')).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByPlaceholder(/nazwa produktu|product name/i)).toBeVisible();
+
+  // "Marka" input is gone.
+  await expect(page.getByPlaceholder(/^marka$/i)).toHaveCount(0);
+  // The ad-hoc group adder is gone.
+  await expect(
+    page.getByRole('button', { name: /dodaj grupę atrybutów ad-hoc|ad-hoc/i }),
+  ).toHaveCount(0);
+});

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -729,14 +729,7 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
                     onChange={(event) => setFieldValue('name', event.target.value)}
                     className="font-display h-10 rounded-lg border-zinc-200 bg-white text-[20px] font-semibold tracking-tight"
                   />
-                  <Input
-                    placeholder={t('products.detail.create.placeholder.brand', {
-                      defaultValue: 'Marka',
-                    })}
-                    value={brandValue}
-                    onChange={(event) => setFieldValue('brand', event.target.value)}
-                    className="h-8 w-64 rounded-lg border-zinc-200 bg-white text-[12px]"
-                  />
+                  {/* #1357 — "Marka" removed from the new-entry form. */}
                 </div>
               ) : (
                 <>
@@ -907,27 +900,9 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
             );
 
             if (activeTab === 'attributes') {
-              return (
-                <>
-                  {stackedGroups.map(renderStackedGroup)}
-                  <button
-                    type="button"
-                    onClick={() =>
-                      toast.info(
-                        t('products.detail.add_attribute_group.unavailable', {
-                          defaultValue: 'Custom grupy ad-hoc — follow-up',
-                        }),
-                      )
-                    }
-                    className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-2xl border border-dashed border-zinc-300 text-[13px] font-medium text-zinc-500 hover:bg-white hover:text-zinc-900"
-                  >
-                    +{' '}
-                    {t('products.detail.add_attribute_group.label', {
-                      defaultValue: 'Dodaj grupę atrybutów ad-hoc',
-                    })}
-                  </button>
-                </>
-              );
+              // #1357 — the non-functional "Dodaj grupę atrybutów ad-hoc"
+              // stub was removed from this view per operator request.
+              return <>{stackedGroups.map(renderStackedGroup)}</>;
             }
 
             // Tab-mode AttributeGroup → render only that group, with


### PR DESCRIPTION
## Summary
Formularz `/products/new` miał pole „Marka" oraz niefunkcjonalny przycisk „Dodaj grupę atrybutów ad-hoc" (toast stub). Oba usunięte (#1357); SKU + Nazwa zostają.

## Frontend changes
- `product-detail-page.tsx`: usunięty input „Marka" w trybie create + usunięty stub „Dodaj grupę atrybutów ad-hoc" z zakładki Atrybuty. `brand` nadal wyświetlany w nagłówku detalu gdy ustawiony.

## Quality gates
- typecheck + Biome: 0
- Playwright: `1357-products-new-no-marka-adhoc` zielony lokalnie (`fixme` w CI).

## Smoke test plan
1. Login → `/products/new` → brak „Marka", brak „Dodaj grupę atrybutów ad-hoc"; SKU + Nazwa obecne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)