### PR TITLE
fix(catalog): label „Nazwa" zamiast „Kod (np. CAR-001)" w tworzeniu custom obiektu

### DIFF
--- a/apps/admin/e2e/1102-relation-picker-in-create.spec.ts
+++ b/apps/admin/e2e/1102-relation-picker-in-create.spec.ts
@@ -207,7 +207,8 @@ test('UniversalCreatePage relation attribute renders picker and persists targets
       await page.locator('body').click({ position: { x: 10, y: 10 } });
 
       const newCarCode = `S_${stamp}`;
-      await page.getByPlaceholder(/kod \(np\. car-001\)/i).fill(newCarCode);
+      // #1361 — the custom-object identifier field is now labelled "Nazwa".
+      await page.getByPlaceholder(/^nazwa$/i).fill(newCarCode);
 
       // Capture the relation PUT so we can fail loud if it never fires
       // and inspect the body if the PUT lands but the relation does not

--- a/apps/admin/e2e/1361-object-create-name-label.spec.ts
+++ b/apps/admin/e2e/1361-object-create-name-label.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1361 — the custom-object create form (/objects/{slug}/new) labelled
+ * its single identifier field "Kod (np. CAR-001)" with a "must be unique
+ * … SKU" hint. For custom object types that field is the human-readable
+ * name (e.g. a service "Wniesienie"), so it now reads "Nazwa" and the
+ * code/uniqueness hint is gone.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason;
+ * it also needs a custom (kind!=product/category/asset) ObjectType, which
+ * only exists in operator dev data — skipped when none is present.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('custom object create form labels the identifier field "Nazwa"', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+
+  await apiLogin(page);
+
+  const types =
+    (
+      (await (
+        await page.request.get('/api/object_types?itemsPerPage=200', {
+          headers: { authorization: `Bearer ${token}`, accept: 'application/ld+json' },
+        })
+      ).json()) as { member?: Array<{ code: string; kind: string }> }
+    ).member ?? [];
+  const custom = types.find((t) => !['product', 'category', 'asset'].includes(t.kind));
+  test.skip(custom === undefined, 'No custom ObjectType seeded in this environment.');
+  if (custom === undefined) return;
+
+  await page.goto(`/objects/${custom.code}/new`);
+
+  await expect(page.getByPlaceholder(/^nazwa$/i)).toBeVisible({ timeout: 15_000 });
+  // The old "Kod (np. CAR-001)" placeholder + uniqueness hint are gone.
+  await expect(page.getByPlaceholder(/kod \(np\. CAR-001\)/i)).toHaveCount(0);
+  await expect(page.getByText(/kod musi być unikalny/i)).toHaveCount(0);
+});

--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -194,7 +194,7 @@ export function UniversalCreatePage({
     const trimmedCode = code.trim();
     if (trimmedCode === '') {
       toast.error(
-        t('object_create.validation.code_required', { defaultValue: 'Kod jest wymagany' }),
+        t('object_create.validation.name_required', { defaultValue: 'Nazwa jest wymagana' }),
       );
       return;
     }
@@ -348,21 +348,19 @@ export function UniversalCreatePage({
               ▣
             </div>
             <div className="min-w-0 flex-1 space-y-2">
+              {/* #1361 — this single identifier field is the object's
+                  human-readable name for custom object types (e.g. a
+                  service "Wniesienie"); label it "Nazwa" and drop the
+                  code/uniqueness hint that read like an SKU. */}
               <Input
                 autoFocus
-                placeholder={t('object_create.placeholder.code', {
-                  defaultValue: 'Kod (np. CAR-001)',
+                placeholder={t('object_create.placeholder.name', {
+                  defaultValue: 'Nazwa',
                 })}
                 value={code}
                 onChange={(event) => setCode(event.target.value)}
                 className="font-display h-10 rounded-lg border-zinc-200 bg-white text-[20px] font-semibold tracking-tight"
               />
-              <p className="text-[11.5px] text-muted-foreground">
-                {t('object_create.code_hint', {
-                  defaultValue:
-                    'Kod musi być unikalny w obrębie tego typu obiektu (np. SKU dla produktu).',
-                })}
-              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Na `/objects/{slug}/new` jedyne pole identyfikatora miało label „Kod (np. CAR-001)" + hint „Kod musi być unikalny … SKU dla produktu". Dla custom ObjectType to pole jest czytelną **nazwą** obiektu (np. usługa „Wniesienie"), więc placeholder → „Nazwa", hint usunięty, walidacja „Nazwa jest wymagana".

## Weryfikacja (per ticket)
Sprawdzone: pole mapuje się na `code` obiektu (jego identyfikator), który dla custom typów przyjmuje free-text (demo „Wniesienie" to dowodzi). Relabel jest spójny z tym jak operator używa pola; bez zmiany kontraktu API.

## Frontend changes
- `universal-create-page.tsx`: placeholder „Kod (np. CAR-001)"→„Nazwa", usunięty hint o unikalności kodu, toast walidacji „Nazwa jest wymagana".

## Quality gates
- typecheck + Biome: 0
- Playwright: `1361-object-create-name-label` zielony lokalnie (`fixme` w CI; skip gdy brak custom OT).

## Smoke test plan
1. Login → `/objects/{custom}/new` → pole „Nazwa", brak „Kod (np. CAR-001)" i hintu o unikalności.

🤖 Generated with [Claude Code](https://claude.com/claude-code)