### PR TITLE
fix(modeling): usuń niedziałające przełączniki Unique / Indexed atrybutu

### DIFF
--- a/apps/admin/e2e/1355-attribute-no-unique-indexed.spec.ts
+++ b/apps/admin/e2e/1355-attribute-no-unique-indexed.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1355 / #1356 — the attribute create form carried "Unique" and
+ * "Indexed" toggles that were form-only (no backend column / enforcement)
+ * and only misled operators. Both were removed; "Required" and
+ * "Filtrowalny" stay.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('attribute create form has no Unique / Indexed toggles', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+  await page.goto('/modeling/attributes/new');
+
+  // Kept flags.
+  await expect(page.getByText(/^required$/i).first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(/^filtrowalny$/i).first()).toBeVisible();
+
+  // Removed flags.
+  await expect(page.getByText(/^unique$/i)).toHaveCount(0);
+  await expect(page.getByText(/^indexed$/i)).toHaveCount(0);
+});

--- a/apps/admin/src/features/catalog/attributes/new.tsx
+++ b/apps/admin/src/features/catalog/attributes/new.tsx
@@ -51,8 +51,6 @@ interface CreatePayload {
   helpEn: string;
   type: string;
   required: boolean;
-  unique: boolean;
-  indexed: boolean;
   filterable: boolean;
 }
 
@@ -64,8 +62,6 @@ const EMPTY: CreatePayload = {
   helpEn: '',
   type: 'text',
   required: false,
-  unique: false,
-  indexed: false,
   filterable: false,
 };
 
@@ -143,10 +139,6 @@ export function AttributeCreatePage() {
       };
       const help = stripEmpty({ pl: values.helpPl, en: values.helpEn });
       if (Object.keys(help).length > 0) body.help = help;
-      // `unique` is not in AttributeInput — surfaced via `validationRules`
-      // when the BE adds it. For now keep it form-only so the FE matches
-      // the mockup; submit-side stays no-op.
-      // `indexed` is similarly form-only (no `is_indexed` BE column yet).
 
       // #949 — relation config fields go through the same POST. Filter
       // empty advanced-field rows (the validator 422s them; the UX is
@@ -412,22 +404,11 @@ export function AttributeCreatePage() {
                 checked={values.required}
                 onChange={(next) => setValues({ ...values, required: next })}
               />
-              <SettingToggleRow
-                label={t('attributes.flags.unique_label', { defaultValue: 'Unique' })}
-                description={t('attributes.flags.unique_desc', {
-                  defaultValue: 'Wartość unikalna w obrębie ObjectType',
-                })}
-                checked={values.unique}
-                onChange={(next) => setValues({ ...values, unique: next })}
-              />
-              <SettingToggleRow
-                label={t('attributes.flags.indexed_label', { defaultValue: 'Indexed' })}
-                description={t('attributes.flags.indexed_desc', {
-                  defaultValue: 'Indeks dla wyszukiwania',
-                })}
-                checked={values.indexed}
-                onChange={(next) => setValues({ ...values, indexed: next })}
-              />
+              {/* #1355 / #1356 — the "Unique" and "Indexed" toggles were
+                  form-only (no backend column / enforcement) and only
+                  misled operators into thinking they did something. Removed
+                  until a real uniqueness validator / Meilisearch indexing
+                  flag is implemented as a dedicated feature. */}
               <SettingToggleRow
                 label={t('attributes.flags.filterable_label', { defaultValue: 'Filtrowalny' })}
                 description={t('attributes.flags.filterable_desc', {

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -137,7 +137,6 @@ function Editor({
   const [required, setRequired] = useState(attribute.required ?? false);
   const [localizable, setLocalizable] = useState(attribute.localizable ?? false);
   const [scopable, setScopable] = useState(attribute.scopable ?? false);
-  const [unique, setUnique] = useState(attribute.unique ?? false);
   const [filterable, setFilterable] = useState(attribute.filterable ?? false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -247,7 +246,6 @@ function Editor({
     required !== (attribute.required ?? false),
     localizable !== (attribute.localizable ?? false),
     scopable !== (attribute.scopable ?? false),
-    unique !== (attribute.unique ?? false),
     filterable !== (attribute.filterable ?? false),
     relationDirty,
   ].filter(Boolean).length;
@@ -264,7 +262,6 @@ function Editor({
     setRequired(attribute.required ?? false);
     setLocalizable(attribute.localizable ?? false);
     setScopable(attribute.scopable ?? false);
-    setUnique(attribute.unique ?? false);
     setFilterable(attribute.filterable ?? false);
     setError(null);
   };
@@ -284,9 +281,6 @@ function Editor({
         if (required !== (attribute.required ?? false)) body.required = required;
         if (localizable !== (attribute.localizable ?? false)) body.localizable = localizable;
         if (scopable !== (attribute.scopable ?? false)) body.scopable = scopable;
-        // `unique` has no backend flag yet — submit-side stays a no-op
-        // until #1355 decides whether to persist it. (Previously this was
-        // wrongly mapped onto `required`, corrupting the required flag.)
         if (filterable !== (attribute.filterable ?? false)) body.filterable = filterable;
       }
       if (attribute.type === 'relation' && relationDirty) {
@@ -553,14 +547,9 @@ function Editor({
                 })}
                 onChange={isSystem ? undefined : setScopable}
               />
-              <FlagPill
-                on={unique}
-                label={t('attributes.flags.unique_label', { defaultValue: 'Unique' })}
-                desc={t('attributes.flags.unique_desc', {
-                  defaultValue: 'unikalna wartość w obrębie typu',
-                })}
-                onChange={isSystem ? undefined : setUnique}
-              />
+              {/* #1355 — "Unique" removed: it was a form-only no-op (no
+                  backend uniqueness flag/validator). Re-add when a real
+                  uniqueness feature ships. */}
               <FlagPill
                 on={filterable}
                 label={t('attributes.flags.filterable_label', { defaultValue: 'Filtrowalny' })}


### PR DESCRIPTION
## Summary
Formularz tworzenia atrybutu miał przełączniki „Unique" i „Indexed", a formularz edycji pill „Unique" — żaden nie był podłączony do backendu (brak kolumny `is_unique`/`is_indexed`, brak walidatora unikalności, brak flagi indeksu Meilisearch). Były czystym form-state mylącym operatora (Unique dało się zaznaczyć nawet dla boolean). Usunięte do czasu prawdziwej implementacji; „Required" + „Filtrowalny" zostają.

## Decyzja operatora
Wybrano „usuń niedziałające toggle" (zamiast implementować pełny backend lub disable+tooltip). Prawdziwa unikalność/indeksowanie = osobny feature-ticket.

## Frontend changes
- `attributes/new.tsx`: usunięte SettingToggleRow Unique + Indexed + pola z `CreatePayload`/`EMPTY` + martwy komentarz.
- `attributes/show.tsx`: usunięty FlagPill „Unique" + state/dirty/cancel referencje.

## Quality gates
- typecheck + Biome + Vite build: 0
- Playwright: `1355-attribute-no-unique-indexed` zielony lokalnie (`fixme` w CI).

## Smoke test plan
1. Login → `/modeling/attributes/new` → brak „Unique"/„Indexed"; „Required"+„Filtrowalny" obecne.
2. `/modeling/attributes/{id}` → brak pill „Unique".

🤖 Generated with [Claude Code](https://claude.com/claude-code)