### PR TITLE
feat(catalog): custom OT — kategoria wymagana + przypisanie przy tworzeniu

### DIFF
--- a/apps/admin/e2e/1359-universal-create-category-required.spec.ts
+++ b/apps/admin/e2e/1359-universal-create-category-required.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1359 — a categorizable custom ObjectType could be created without a
+ * category, and the create form had no category picker at all. The
+ * universal create page now renders a category selector for categorizable
+ * types and blocks save until at least one category is assigned (same
+ * rule /products/new enforces).
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('categorizable custom object create requires a category', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(150_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+  const jsonHeaders = {
+    ...bearer,
+    accept: 'application/ld+json',
+    'content-type': 'application/json',
+  };
+
+  await apiLogin(page);
+
+  const stamp = Date.now().toString(36);
+  const otCode = `catz_${stamp}`;
+
+  // Custom, categorizable ObjectType.
+  const otResp = await page.request.post('/api/object_types', {
+    data: {
+      code: otCode,
+      label: { pl: 'Catz', en: 'Catz' },
+      icon: '📦',
+      color: '#10b981',
+      hierarchical: false,
+      hasVariants: false,
+      abstract: false,
+    },
+    headers: jsonHeaders,
+  });
+  expect(otResp.status(), await otResp.text()).toBe(201);
+  const ot = (await otResp.json()) as { id: string };
+  const patchResp = await page.request.patch(`/api/object_types/${ot.id}`, {
+    data: { isCategorizable: true },
+    headers: {
+      ...bearer,
+      accept: 'application/ld+json',
+      'content-type': 'application/merge-patch+json',
+    },
+  });
+  expect(patchResp.status()).toBe(200);
+
+  // A category in this ObjectType's tree.
+  const catOtResp = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
+  const catOt = (
+    ((await catOtResp.json()) as { member?: Array<{ id: string; kind: string }> }).member ?? []
+  ).find((t) => t.kind === 'category');
+  if (catOt === undefined) throw new Error('No built-in category ObjectType.');
+  const catResp = await page.request.post('/api/categories', {
+    data: {
+      code: `cat_${stamp}`,
+      objectTypeId: catOt.id,
+      categoryTargetObjectTypeId: ot.id,
+      attributes: { name: `Kat ${stamp}` },
+    },
+    headers: jsonHeaders,
+  });
+  expect(catResp.status(), await catResp.text()).toBe(201);
+
+  await page.goto(`/objects/${otCode}/new`);
+
+  // Category picker is present for categorizable types.
+  await expect(page.getByText(/przypisz kategorię|brak kategorii|kategorie/i).first()).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Try to create without a category → blocked with a toast, no POST fires.
+  // The identifier field placeholder is "Nazwa" (#1361) — fall back to the
+  // older "Kod (np. CAR-001)" so the spec passes before/after that merge.
+  await page.getByPlaceholder(/^nazwa$|kod \(np\. car-001\)/i).fill(`Obj ${stamp}`);
+  let posted = false;
+  page.on('request', (r) => {
+    if (r.url().endsWith('/api/objects') && r.method() === 'POST') posted = true;
+  });
+  await page.getByRole('button', { name: /^utwórz$/i }).click();
+  await expect(page.getByText(/przypisz przynajmniej jedną kategorię/i)).toBeVisible({
+    timeout: 10_000,
+  });
+  expect(posted).toBe(false);
+
+  // Cleanup OT (cascades) — delete via API.
+  await page.request.delete(`/api/object_types/${ot.id}`, { headers: bearer });
+});

--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -27,6 +27,7 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/components/ui/toast';
 import { AttrGroupCard } from '@/features/catalog/products/components/attr-group-card';
 import { AttrRow } from '@/features/catalog/products/components/attr-row';
+import { CategorySelectorCard } from '@/features/catalog/products/components/category-selector-card';
 import type {
   GroupMeta,
   LocaleOption,
@@ -51,6 +52,12 @@ export interface UniversalCreatePageProps {
    * in modeling matches what the operator sees here.
    */
   hasMultimedia?: boolean;
+  /**
+   * #1359 — when the ObjectType is categorizable, the create form shows a
+   * category picker and requires at least one category before save (same
+   * rule products enforce). Non-categorizable types skip it entirely.
+   */
+  isCategorizable?: boolean;
 }
 
 const GROUP_ICONS: Record<string, string> = {
@@ -76,11 +83,16 @@ export function UniversalCreatePage({
   backHref,
   detailPathFor,
   hasMultimedia = false,
+  isCategorizable = false,
 }: UniversalCreatePageProps) {
   const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
   const [code, setCode] = useState('');
+  // #1359 — create-mode category selection (stashed in local state, sent
+  // with the POST /api/objects body), mirroring /products/new.
+  const [categoryIds, setCategoryIds] = useState<string[]>([]);
+  const [primaryCategoryId, setPrimaryCategoryId] = useState<string | null>(null);
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [isSaving, setIsSaving] = useState(false);
@@ -189,12 +201,46 @@ export function UniversalCreatePage({
     setDirtyFields((prev) => ({ ...prev, [codeKey]: value }));
   };
 
+  // #1359 — resolve category codes for chip rendering (same shared cache
+  // key as the products create flow + the picker dialog).
+  const categoriesListQuery = useQuery({
+    queryKey: ['categories', 'picker'],
+    queryFn: () =>
+      jsonFetch<{
+        'hydra:member'?: Array<{ id: string; code: string }>;
+        member?: Array<{ id: string; code: string }>;
+      }>('/api/categories?itemsPerPage=200'),
+    enabled: isCategorizable && categoryIds.length > 0,
+    staleTime: 60_000,
+  });
+  const categorySummaries = useMemo(() => {
+    const rows =
+      categoriesListQuery.data?.['hydra:member'] ?? categoriesListQuery.data?.member ?? [];
+    const codeById = new Map<string, string>();
+    for (const row of rows) codeById.set(row.id, row.code);
+    return categoryIds.map((cid) => ({
+      categoryId: cid,
+      code: codeById.get(cid) ?? cid.slice(0, 8),
+      isPrimary: cid === primaryCategoryId,
+    }));
+  }, [categoryIds, primaryCategoryId, categoriesListQuery.data]);
+
   const handleCreate = async (): Promise<void> => {
     if (isSaving) return;
     const trimmedCode = code.trim();
     if (trimmedCode === '') {
       toast.error(
         t('object_create.validation.name_required', { defaultValue: 'Nazwa jest wymagana' }),
+      );
+      return;
+    }
+    // #1359 — categorizable types must carry at least one category, the
+    // same rule /products/new enforces.
+    if (isCategorizable && categoryIds.length === 0) {
+      toast.error(
+        t('object_create.validation.categories_required', {
+          defaultValue: 'Przypisz przynajmniej jedną kategorię',
+        }),
       );
       return;
     }
@@ -212,6 +258,14 @@ export function UniversalCreatePage({
         code: trimmedCode,
       };
       if (Object.keys(normal).length > 0) body.attributes = normal;
+      // #1359 — atomic category assignment for categorizable types.
+      if (isCategorizable && categoryIds.length > 0) {
+        body.categoryIds = categoryIds;
+        body.primaryCategoryId =
+          primaryCategoryId !== null && categoryIds.includes(primaryCategoryId)
+            ? primaryCategoryId
+            : categoryIds[0];
+      }
       const created = await jsonFetch<{ id: string }>('/api/objects', {
         method: 'POST',
         contentType: 'application/ld+json',
@@ -458,6 +512,20 @@ export function UniversalCreatePage({
               <span className="font-mono">{objectTypeCode}</span>
             </p>
           </div>
+          {/* #1359 — category picker for categorizable types (required). */}
+          {isCategorizable ? (
+            <CategorySelectorCard
+              mode="create"
+              objectTypeId={objectTypeId}
+              selectedCategoryIds={categoryIds}
+              primaryCategoryId={primaryCategoryId}
+              selectedCategories={categorySummaries}
+              onChange={(ids, primary) => {
+                setCategoryIds(ids);
+                setPrimaryCategoryId(primary);
+              }}
+            />
+          ) : null}
         </aside>
       </div>
     </div>

--- a/apps/admin/src/features/catalog/objects/create-page.tsx
+++ b/apps/admin/src/features/catalog/objects/create-page.tsx
@@ -95,6 +95,8 @@ export function ObjectCreatePage() {
   // `false` if the schema query failed so a transient BE error never
   // hides the rest of the create form.
   const hasMultimedia = schemaQuery.data?.objectType.has_multimedia ?? false;
+  // #1359 — categorizable types require a category at create time.
+  const isCategorizable = schemaQuery.data?.objectType.is_categorizable ?? false;
 
   return (
     <UniversalCreatePage
@@ -104,6 +106,7 @@ export function ObjectCreatePage() {
       backHref={`/objects/${code}`}
       detailPathFor={(id) => `/objects/${code}/${id}`}
       hasMultimedia={hasMultimedia}
+      isCategorizable={isCategorizable}
     />
   );
 }

--- a/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectHandler.php
+++ b/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectHandler.php
@@ -129,10 +129,11 @@ final readonly class CreateCatalogObjectHandler
             $this->attributesUpserter->upsert($object, $command->attributes);
         }
 
-        // #891 — atomic category assignment for product creates. Validate
+        // #891 / #1359 — atomic category assignment for any categorizable
+        // ObjectType (products + custom categorizable kinds). Validate
         // every id resolves to a tenant-scoped `kind=category` BEFORE the
         // junction write so the row never lands partially populated.
-        if (ObjectKind::Product === $command->expectedKind && null !== $command->categoryIds) {
+        if ($object->getObjectType()->isCategorizable() && null !== $command->categoryIds) {
             if ([] === $command->categoryIds) {
                 throw new UnprocessableEntityHttpException('"categoryIds" must contain at least one category.');
             }


### PR DESCRIPTION
## Summary
Custom **kategoryzowalny** ObjectType dało się utworzyć bez kategorii, a strona tworzenia (`/objects/{slug}/new`) nie miała w ogóle pickera kategorii — tylko produkty wymuszały „Przypisz przynajmniej jedną kategorię". Teraz reguła obowiązuje każdy `isCategorizable` typ.

## Backend
- `CreateCatalogObjectHandler`: walidacja + przypisanie kategorii dla KAŻDEGO `isCategorizable` ObjectType (nie tylko `kind=product`). Ścieżka `replaceForProduct` jest już poly-kind. Pokrycie: istniejące `ProductsApiTest`/`ProductCategoryAssignmentApiTest` (produkt JEST categorizable → ta sama gałąź `isCategorizable`), 28/28 zielone.

## Frontend
- `universal-create-page.tsx`: renderuje `CategorySelectorCard` dla typów categorizable, blokuje zapis bez kategorii (toast), wysyła `categoryIds`/`primaryCategoryId` w POST `/api/objects`.
- `objects/create-page.tsx`: przekazuje `is_categorizable` ze schematu.

## Quality gates
- PHPStan max: 0, typecheck + Biome: 0
- PHPUnit: ProductsApiTest + ProductCategoryAssignmentApiTest 28/28 (regresja)
- Playwright: `1359-universal-create-category-required` zielony lokalnie (`fixme` w CI; tworzy categorizable custom OT + kategorię, sprawdza blokadę bez kategorii)
- Live smoke: POST custom obiekt z `categoryIds` → assignment persystuje (DB row=1).

## Smoke test plan
1. `/objects/{categorizable}/new` → karta „Kategorie" obecna; „Utwórz" bez kategorii → toast „Przypisz przynajmniej jedną kategorię"; po przypisaniu → tworzy + kategoria zapisana.

## Świadome odejścia
- Serwer wymusza kategorię „gdy podane" (jak produkty) + blokada po stronie klienta. Twarde serwerowe „categorizable → zawsze wymagane" (dla integracji omijających UI) = osobny hardening (nie łamie istniejących testów produktów).

🤖 Generated with [Claude Code](https://claude.com/claude-code)