### PR TITLE
feat(catalog): wyjaśnij regułę osi wariantów (select/multiselect) w pickerze

### DIFF
--- a/apps/admin/e2e/products-date-and-variants-axis.spec.ts
+++ b/apps/admin/e2e/products-date-and-variants-axis.spec.ts
@@ -110,6 +110,8 @@ test('product detail date picker + variants axis combobox', async ({ page }) => 
   // Combobox opens its option list on a single click instead.
   const axisTrigger = page.locator('button[aria-haspopup="listbox"]').first();
   await expect(axisTrigger).toBeVisible();
+  // #1360 — the selector explains which attribute types qualify as an axis.
+  await expect(page.getByText(/osią wariantów mogą być tylko atrybuty/i)).toBeVisible();
   await axisTrigger.click();
 
   // The popover shows attribute labels for select/multiselect attrs

--- a/apps/admin/src/components/catalog/variants-tab.tsx
+++ b/apps/admin/src/components/catalog/variants-tab.tsx
@@ -286,6 +286,13 @@ function AxisRow({
             defaultValue: 'Brak atrybutów typu select/multiselect',
           })}
         />
+        {/* #1360 — explain what makes an attribute eligible as a variant
+            axis so the operator isn't left guessing why only some show. */}
+        <p className="mt-1 text-[10.5px] leading-tight text-muted-foreground">
+          {t('products.variants.axis_hint', {
+            defaultValue: 'Osią wariantów mogą być tylko atrybuty typu select / multiselect.',
+          })}
+        </p>
       </div>
       <div className="flex-1 space-y-1">
         <div className="flex flex-wrap gap-1">


### PR DESCRIPTION
## Summary
Selektor osi wariantów JUŻ ogranicza do atrybutów `select`/`multiselect` (generator iteruje ich predefiniowane opcje), ale nic na ekranie nie wyjaśniało dlaczego pojawiają się tylko niektóre — operator pytał „co decyduje który atrybut może generować warianty". Dodany krótki hint pod Comboboxem osi.

## Weryfikacja (per ticket)
Reguła = atrybuty typu **select / multiselect** ([variants-tab.tsx:265](apps/admin/src/components/catalog/variants-tab.tsx)). Dotąd komunikowana tylko emptyText-em (gdy brak kandydatów). Teraz proaktywny hint zawsze widoczny.

## Frontend changes
- `variants-tab.tsx`: hint „Osią wariantów mogą być tylko atrybuty typu select / multiselect." pod selektorem osi.
- `products-date-and-variants-axis` E2E: asercja hintu.

## Quality gates
- typecheck + Biome: 0
- Playwright: asercja dodana do istniejącego `products-date-and-variants-axis` (fixme w CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)