### PR TITLE
fix(catalog): filtr zaawansowany pokazuje wyłącznie atrybuty filterable

### DIFF
--- a/apps/admin/e2e/1354-advanced-filter-respects-filterable.spec.ts
+++ b/apps/admin/e2e/1354-advanced-filter-respects-filterable.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1354 — the advanced filter panel must offer ONLY attributes flagged
+ * `is_filterable=true`. Previously the AttributePicker fetched the full
+ * tenant attribute list, so an operator could build a condition on a
+ * non-filterable attribute (e.g. `description`, `short_description`) that
+ * the search index silently ignored — the list just emptied with no
+ * explanation.
+ *
+ * The demo seeder marks a sensible product subset filterable
+ * (brand/color/size/tags/price/weight/height/in_stock/release_date); the
+ * remaining product attributes (name/sku/description/short_description/
+ * main_image/related_to) stay non-filterable and MUST NOT appear in the
+ * picker.
+ *
+ * Marked `fixme` in CI for the shared `storageState` auth-quota reason
+ * the other UI-seeded specs use.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec reuses the shared auth rate-limiter quota.';
+
+test('advanced filter picker lists only filterable attributes', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(90_000);
+
+  await loginAsAdmin(page);
+  await page.goto('/products');
+
+  // Open the push-down advanced filter panel.
+  await page.getByRole('button', { name: /filtruj zaawansowane/i }).click();
+  const panel = page.locator('section[aria-label*="Filtr"]');
+  await expect(panel).toBeVisible();
+
+  // Add a condition row → its AttributePicker trigger appears.
+  await page.getByRole('button', { name: /dodaj warunek/i }).click();
+  const pickerTrigger = panel.locator('button[aria-haspopup="listbox"]').first();
+  await expect(pickerTrigger).toBeVisible();
+  await pickerTrigger.click();
+
+  // The portal dropdown is searchable; the option rows render label + code.
+  const search = page.getByPlaceholder(/szukaj atrybutu/i);
+  await expect(search).toBeVisible();
+
+  // Filterable attributes MUST be offered.
+  await expect(page.getByText('brand', { exact: true })).toBeVisible();
+  await expect(page.getByText('color', { exact: true })).toBeVisible();
+  await expect(page.getByText('price', { exact: true })).toBeVisible();
+
+  // Non-filterable product attributes MUST NOT appear in the picker.
+  await expect(page.getByText('short_description', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('description_html', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('related_to', { exact: true })).toHaveCount(0);
+
+  // Narrowing the search to a non-filterable code yields the empty state,
+  // proving the gate runs before the text filter.
+  await search.fill('short_description');
+  await expect(page.getByText(/brak atrybutów/i)).toBeVisible();
+});

--- a/apps/admin/src/components/catalog/advanced-filter-panel.tsx
+++ b/apps/admin/src/components/catalog/advanced-filter-panel.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from '@tanstack/react-query';
 import { Link2, Plus, Trash2, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +12,7 @@ import {
   type FilterCondition,
   type FilterOperator,
 } from '@/lib/filters/filter-dsl';
+import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 /**
@@ -38,11 +40,11 @@ const FIRST_PANEL_ATTR: PanelAttr = {
 };
 
 /**
- * Default product-flavoured attribute catalog for the panel. Kept as
- * the fallback so the legacy /products list keeps its rich type
- * inference (brand=relation, price=metric, …) without a downstream
- * schema fetch on every render. UP-06 universal list passes a
- * schema-derived `panelAttrs` prop instead.
+ * Loading/empty fallback catalog. Since #1354 the live filterable
+ * attribute set (fetched below) is the source of truth for type-badge /
+ * operator inference; this static list only fills the gap while that
+ * fetch is in flight (or returns nothing) so the panel never renders a
+ * dead picker on first open. An explicit `panelAttrs` prop still wins.
  */
 const PANEL_ATTRS: ReadonlyArray<PanelAttr> = [
   FIRST_PANEL_ATTR,
@@ -57,6 +59,43 @@ const PANEL_ATTRS: ReadonlyArray<PanelAttr> = [
   { code: 'meta_description', name: 'Meta description', type: 'text' },
   { code: 'tags', name: 'Tagi', type: 'multiselect' },
 ];
+
+/**
+ * #1354 — map the backend AttributeType enum onto the panel's operator
+ * buckets. Types without a dedicated bucket (color, email, identifier,
+ * textarea) behave as plain string equality filters → `text`.
+ */
+const FILTER_TYPE_BY_ATTR_TYPE: Record<string, keyof typeof FILTER_OPERATORS_BY_TYPE> = {
+  text: 'text',
+  wysiwyg: 'wysiwyg',
+  textarea: 'text',
+  number: 'number',
+  metric: 'metric',
+  price: 'price',
+  date: 'date',
+  datetime: 'datetime',
+  select: 'select',
+  multiselect: 'multiselect',
+  boolean: 'boolean',
+  relation: 'relation',
+  reference: 'reference',
+  asset: 'asset',
+  color: 'text',
+  email: 'text',
+  identifier: 'text',
+};
+
+function toFilterType(attrType: string | undefined): keyof typeof FILTER_OPERATORS_BY_TYPE {
+  return (attrType !== undefined ? FILTER_TYPE_BY_ATTR_TYPE[attrType] : undefined) ?? 'text';
+}
+
+interface AttributeApiRow {
+  id: string;
+  code: string;
+  label?: Record<string, string> | string | null;
+  type?: string;
+  filterable?: boolean;
+}
 
 interface AdvancedFilterPanelProps {
   open: boolean;
@@ -95,10 +134,41 @@ export function AdvancedFilterPanel({
   resultCount,
   panelAttrs,
 }: AdvancedFilterPanelProps) {
-  const effectivePanelAttrs: ReadonlyArray<PanelAttr> =
-    panelAttrs && panelAttrs.length > 0 ? panelAttrs : PANEL_ATTRS;
-  const firstPanelAttr = effectivePanelAttrs[0] ?? FIRST_PANEL_ATTR;
   const { t } = useTranslation();
+
+  // #1354 — strict filterable catalog. The panel offers ONLY attributes
+  // flagged `is_filterable=true`; this drives the type-badge / operator
+  // inference for the conditions, while the AttributePicker below applies
+  // the same gate (`filterableOnly`) to its dropdown. An explicit
+  // `panelAttrs` prop (per-ObjectType override) still wins; the hardcoded
+  // PANEL_ATTRS only acts as the loading/empty fallback so the panel never
+  // renders a dead picker mid-fetch.
+  const { data: liveFilterableAttrs } = useQuery({
+    queryKey: ['attributes', 'filterable-panel'],
+    staleTime: 5 * 60 * 1000,
+    queryFn: async (): Promise<PanelAttr[]> => {
+      const res = await jsonFetch<{
+        'hydra:member'?: AttributeApiRow[];
+        member?: AttributeApiRow[];
+      }>('/api/attributes?itemsPerPage=200');
+      const rows = res['hydra:member'] ?? res.member ?? [];
+      return rows
+        .filter((r) => r.filterable === true)
+        .map<PanelAttr>((r) => ({
+          code: r.code,
+          name: typeof r.label === 'string' ? r.label : (r.label?.pl ?? r.label?.en ?? r.code),
+          type: toFilterType(r.type),
+        }));
+    },
+  });
+
+  const effectivePanelAttrs: ReadonlyArray<PanelAttr> =
+    panelAttrs && panelAttrs.length > 0
+      ? panelAttrs
+      : liveFilterableAttrs && liveFilterableAttrs.length > 0
+        ? liveFilterableAttrs
+        : PANEL_ATTRS;
+  const firstPanelAttr = effectivePanelAttrs[0] ?? FIRST_PANEL_ATTR;
   // VIEW-22a (#553) — draft state. Panel edits go into draftConditions and
   // are committed to the parent (and thereby to the search) ONLY when the
   // operator clicks „Zastosuj filtr". This stops the previous auto-apply
@@ -216,6 +286,7 @@ export function AdvancedFilterPanel({
 
                 <AttributePicker
                   value={cond.attr}
+                  filterableOnly
                   onChange={(picked) => {
                     if (picked === null) return;
                     const nextAttrMeta = effectivePanelAttrs.find((a) => a.code === picked.code);

--- a/apps/admin/src/components/catalog/attribute-picker.tsx
+++ b/apps/admin/src/components/catalog/attribute-picker.tsx
@@ -27,6 +27,7 @@ interface AttributeRow {
   code: string;
   label: Record<string, string> | string | null;
   type?: string;
+  filterable?: boolean;
 }
 
 interface AttributeListResponse {
@@ -43,6 +44,14 @@ export interface AttributePickerProps {
    * `number` / `metric` only).
    */
   allowedTypes?: ReadonlyArray<string>;
+  /**
+   * #1354 — when true, restrict the list to attributes flagged
+   * `is_filterable=true`. The advanced filter panel sets this so the
+   * operator can only build conditions on attributes the search index
+   * actually filters on; picking a non-filterable attribute previously
+   * produced a silently-empty result set.
+   */
+  filterableOnly?: boolean;
   placeholder?: string;
   className?: string;
 }
@@ -57,6 +66,7 @@ export function AttributePicker({
   value,
   onChange,
   allowedTypes,
+  filterableOnly,
   placeholder,
   className,
 }: AttributePickerProps) {
@@ -134,9 +144,15 @@ export function AttributePicker({
   }, [open]);
 
   const allowedRows = useMemo(() => {
-    if (!allowedTypes || allowedTypes.length === 0) return attributes;
-    return attributes.filter((row) => !row.type || allowedTypes.includes(row.type));
-  }, [attributes, allowedTypes]);
+    let rows = attributes;
+    // #1354 — strict filterable gate. Applied before the type filter so
+    // a consumer can combine both (e.g. filterable numeric attributes).
+    if (filterableOnly) {
+      rows = rows.filter((row) => row.filterable === true);
+    }
+    if (!allowedTypes || allowedTypes.length === 0) return rows;
+    return rows.filter((row) => !row.type || allowedTypes.includes(row.type));
+  }, [attributes, allowedTypes, filterableOnly]);
 
   const filteredRows = useMemo(() => {
     const needle = query.trim().toLowerCase();

--- a/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
+++ b/apps/api/src/Catalog/Application/DemoCatalogSeeder.php
@@ -126,6 +126,13 @@ final readonly class DemoCatalogSeeder
             $attribute->changeRequired($def['required'] ?? false);
             $attribute->changeLocalizable($def['localizable'] ?? false);
             $attribute->changeScopable($def['scopable'] ?? false);
+            // #1354 — flag demo attributes as filterable so they appear in
+            // the advanced filter panel (the picker now shows ONLY
+            // `is_filterable=true` attributes) AND actually resolve in
+            // Meilisearch (the index settings union `is_filterable` codes
+            // into `filterableAttributes`). Without this the strict panel
+            // would render an empty attribute picker on the demo data.
+            $attribute->changeFilterable($def['filterable'] ?? false);
             $attribute->updateValidationRules($def['rules'] ?? []);
             $attribute->reorder($position++);
             $this->em->persist($attribute);
@@ -396,7 +403,7 @@ final readonly class DemoCatalogSeeder
     }
 
     /**
-     * @return array<string, array{label: array<string, string>, type: AttributeType, required?: bool, localizable?: bool, scopable?: bool, rules?: array<string, mixed>, options?: list<array{0: string, 1: array<string, string>, 2?: string|null, 3?: bool, 4?: bool}>}>
+     * @return array<string, array{label: array<string, string>, type: AttributeType, required?: bool, localizable?: bool, scopable?: bool, filterable?: bool, rules?: array<string, mixed>, options?: list<array{0: string, 1: array<string, string>, 2?: string|null, 3?: bool, 4?: bool}>}>
      */
     private static function attributeDefinitions(): array
     {
@@ -439,6 +446,7 @@ final readonly class DemoCatalogSeeder
             'brand' => [
                 'label' => ['pl' => 'Marka', 'en' => 'Brand'],
                 'type' => AttributeType::Text,
+                'filterable' => true,
             ],
             'color' => [
                 'label' => ['pl' => 'Kolor', 'en' => 'Color'],
@@ -447,6 +455,7 @@ final readonly class DemoCatalogSeeder
                 // Values editor swatch dot renders next to each label, and
                 // `red` is the default option (one default per attribute,
                 // partial unique index on attribute_options).
+                'filterable' => true,
                 'options' => [
                     ['red', ['pl' => 'Czerwony', 'en' => 'Red'], '#EF4444', true, false],
                     ['green', ['pl' => 'Zielony', 'en' => 'Green'], '#10B981', false, false],
@@ -458,6 +467,7 @@ final readonly class DemoCatalogSeeder
             'size' => [
                 'label' => ['pl' => 'Rozmiar', 'en' => 'Size'],
                 'type' => AttributeType::Select,
+                'filterable' => true,
                 'options' => [
                     ['XS', ['pl' => 'XS', 'en' => 'XS']],
                     ['S', ['pl' => 'S', 'en' => 'S']],
@@ -469,6 +479,7 @@ final readonly class DemoCatalogSeeder
             'tags' => [
                 'label' => ['pl' => 'Tagi', 'en' => 'Tags'],
                 'type' => AttributeType::Multiselect,
+                'filterable' => true,
                 'rules' => ['max_count' => 5],
                 'options' => [
                     ['new', ['pl' => 'Nowość', 'en' => 'New']],
@@ -484,25 +495,30 @@ final readonly class DemoCatalogSeeder
                 // (Allegro charges a different amount); makes the channel picker
                 // on the product card show a real difference, not a mock.
                 'scopable' => true,
+                'filterable' => true,
                 'rules' => ['min_amount' => 0, 'currencies' => ['PLN', 'EUR', 'USD']],
             ],
             'weight' => [
                 'label' => ['pl' => 'Waga', 'en' => 'Weight'],
                 'type' => AttributeType::Metric,
+                'filterable' => true,
                 'rules' => ['units' => ['kg', 'g', 'cm'], 'min' => 0],
             ],
             'height' => [
                 'label' => ['pl' => 'Wysokość', 'en' => 'Height'],
                 'type' => AttributeType::Number,
+                'filterable' => true,
                 'rules' => ['min' => 0],
             ],
             'in_stock' => [
                 'label' => ['pl' => 'Na stanie', 'en' => 'In stock'],
                 'type' => AttributeType::Boolean,
+                'filterable' => true,
             ],
             'release_date' => [
                 'label' => ['pl' => 'Data premiery', 'en' => 'Release date'],
                 'type' => AttributeType::Date,
+                'filterable' => true,
             ],
             'main_image' => [
                 'label' => ['pl' => 'Zdjęcie główne', 'en' => 'Main image'],

--- a/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
+++ b/apps/api/tests/Integration/Catalog/DemoCatalogSeederTest.php
@@ -105,6 +105,35 @@ final class DemoCatalogSeederTest extends KernelTestCase
     }
 
     #[Test]
+    public function marksSensibleProductAttributesFilterable(): void
+    {
+        // #1354 — the advanced filter panel offers ONLY `is_filterable`
+        // attributes. The demo must therefore seed a usable filterable
+        // subset (otherwise the panel renders an empty picker on demo
+        // data) while leaving long-form / system fields non-filterable.
+        $seeder = self::getContainer()->get(DemoCatalogSeeder::class);
+        $seeder->seed($this->tenant);
+
+        $em = $this->em();
+        $em->clear();
+
+        $repo = self::getContainer()->get(\App\Catalog\Domain\Repository\AttributeRepositoryInterface::class);
+
+        foreach (['brand', 'color', 'size', 'tags', 'price', 'weight', 'height', 'in_stock', 'release_date'] as $code) {
+            $attribute = $repo->findByCode($code, $this->tenant);
+            self::assertNotNull($attribute, \sprintf('Attribute "%s" should be seeded.', $code));
+            self::assertTrue($attribute->isFilterable(), \sprintf('Attribute "%s" must be filterable.', $code));
+        }
+
+        // Long-form / identifier fields stay out of the filter picker.
+        foreach (['description', 'short_description', 'description_html', 'sku'] as $code) {
+            $attribute = $repo->findByCode($code, $this->tenant);
+            self::assertNotNull($attribute);
+            self::assertFalse($attribute->isFilterable(), \sprintf('Attribute "%s" must NOT be filterable.', $code));
+        }
+    }
+
+    #[Test]
     public function categorySchemaIncludesOwnUserDefinedAttributes(): void
     {
         // Proof of ADR-009: categories carry their own user-defined fields,


### PR DESCRIPTION
## Problem (UAT #1354 „Filtrowalny")
Panel „Filtr zaawansowany" pozwalał wybrać **dowolny** atrybut — picker pobierał pełną listę `/api/attributes` i ignorował flagę `is_filterable`. Po wybraniu atrybutu nie-filterowalnego Meilisearch po cichu pomijał warunek, a lista pustoszała bez wyjaśnienia.

## Rozwiązanie (decyzja operatora: ściśle tylko `filterable`)
- **`AttributePicker`** — nowy prop `filterableOnly`; gdy ustawiony, lista zawężona do atrybutów z `filterable === true`.
- **`AdvancedFilterPanel`** — źródłem katalogu (type-badge + operatory) jest teraz **żywy zbiór filterable** (`/api/attributes`, cache 5 min), a nie hardkodowane `PANEL_ATTRS` (zostaje jedynie jako fallback na czas ładowania). Picker dostaje `filterableOnly`.
- **`DemoCatalogSeeder`** — oznacza sensowny podzbiór atrybutów produktu jako `filterable`: `brand, color, size, tags, price, weight, height, in_stock, release_date`. Dzięki temu picker nie jest pusty na danych demo, a te klauzule **realnie filtrują** (indeks unionuje `is_filterable` do `filterableAttributes`). Pola długie/identyfikatory (`description`, `short_description`, `sku`, …) pozostają nie-filterowalne.

## DoD
- **Backend test**: `DemoCatalogSeederTest::marksSensibleProductAttributesFilterable` — 9 atrybutów filterable + 4 nie-filterable. Cały plik 7/7 zielony.
- Logika schematu (schema zwraca tylko filterable) już pokryta w `GetObjectTypeListSchemaHandlerTest`.
- **Frontend test (E2E)**: `1354-advanced-filter-respects-filterable.spec.ts` — picker pokazuje brand/color/price, ukrywa `short_description/description_html/related_to`; `fixme` w CI (wzorzec storageState dla UI-seeded specs), uruchamiany lokalnie.
- typecheck + biome lint zielone; PHPStan (`--memory-limit=1G`, `APP_DEBUG=1`) zielony.

## Smoke (live, `https://pim.localhost`)
- `GET /api/attributes` zwraca pole `filterable`; dokładnie 9 filterable, 28 nie-filterable.
- `GET /api/search/products?filter[brand]=Acme` → **HTTP 200, 3 trafienia, wszystkie brand=Acme** (filterowalny atrybut działa w indeksie).
- `GET /api/search/products?filter[description]=foo` → 200, **0 trafień** (Meili po cichu ignoruje nie-filterowalny atrybut — dokładnie pułapka, którą picker teraz eliminuje).

> Uwaga: pełny przeklik UI pokryty E2E (lokalnie/`fixme` w CI); backend zweryfikowany live na realnych payloadach.

Closes #1354

🤖 Generated with [Claude Code](https://claude.com/claude-code)