### PR TITLE
fix(catalog): formularze atrybutów honorują wszystkie skonfigurowane locale (PL/EN/DE)

### DIFF
--- a/apps/admin/e2e/1352-attributes-honor-configured-locales.spec.ts
+++ b/apps/admin/e2e/1352-attributes-honor-configured-locales.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1352 — attribute name + value-label forms were hardcoded to PL/EN even
+ * when the tenant enabled more locales (e.g. DE). They must render an input
+ * per configured locale, and the per-locale name must take effect.
+ *
+ * This spec enables DE on the workspace, creates an attribute carrying a DE
+ * name, and asserts:
+ *   1. the edit form's name field renders a DE locale tab (driven by the
+ *      workspace's enabled locales, not a hardcoded pl/en pair),
+ *   2. selecting the DE tab surfaces the DE translation,
+ *   3. the backend accepts + round-trips the DE label key.
+ *
+ * Marked `fixme` in CI for the shared `storageState` rate-limiter reason
+ * (5 logins / 15 min).
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('attribute name form honors all configured locales (PL/EN/DE)', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  // Ensure DE is enabled on the workspace (idempotent — tolerate the 4xx
+  // the endpoint returns when the locale is already enabled).
+  const wsBefore = await page.request.get('/api/workspaces/current', {
+    headers: { ...bearer, accept: 'application/json' },
+  });
+  const enabled = ((await wsBefore.json()) as { enabledLocales?: string[] }).enabledLocales ?? [];
+  if (!enabled.includes('de')) {
+    await page.request.post('/api/workspaces/current/locales', {
+      headers: { ...bearer, 'content-type': 'application/json' },
+      data: { locale: 'de' },
+    });
+  }
+
+  // Create an attribute with a full PL/EN/DE label — proves the backend
+  // accepts an arbitrary-locale JSONB map (no pl/en restriction).
+  const code = `zz_locale_${Date.now().toString(36).toLowerCase()}`;
+  const created = await page.request.post('/api/attributes', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: {
+      code,
+      type: 'text',
+      label: { pl: 'Materiał', en: 'Material', de: 'Werkstoff' },
+    },
+  });
+  expect(created.status()).toBe(201);
+  const attribute = (await created.json()) as { id: string };
+
+  // Backend round-trips the DE key.
+  const reread = await page.request.get(`/api/attributes/${attribute.id}`, {
+    headers: { ...bearer, accept: 'application/json' },
+  });
+  expect(reread.status()).toBe(200);
+  expect((await reread.json()).label.de).toBe('Werkstoff');
+
+  // Edit page: the name field renders a DE tab and shows the DE value.
+  await page.goto(`/modeling/attributes/${attribute.id}`);
+  const localeTabs = page.getByRole('tablist', { name: /wybór języka|language/i }).first();
+  await expect(localeTabs).toBeVisible({ timeout: 15_000 });
+  await expect(localeTabs.getByRole('tab', { name: /pl/i })).toBeVisible();
+  await expect(localeTabs.getByRole('tab', { name: /en/i })).toBeVisible();
+  const deTab = localeTabs.getByRole('tab', { name: /de/i });
+  await expect(deTab).toBeVisible();
+
+  await deTab.click();
+  await expect(page.getByDisplayValue('Werkstoff')).toBeVisible();
+
+  await page.request.delete(`/api/attributes/${attribute.id}`, { headers: bearer });
+});
+
+test('attribute create form renders a locale tab per configured locale', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(90_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const wsBefore = await page.request.get('/api/workspaces/current', {
+    headers: { ...bearer, accept: 'application/json' },
+  });
+  const enabled = ((await wsBefore.json()) as { enabledLocales?: string[] }).enabledLocales ?? [];
+  if (!enabled.includes('de')) {
+    await page.request.post('/api/workspaces/current/locales', {
+      headers: { ...bearer, 'content-type': 'application/json' },
+      data: { locale: 'de' },
+    });
+  }
+
+  await page.goto('/modeling/attributes/new');
+  const localeTabs = page.getByRole('tablist', { name: /wybór języka|language/i }).first();
+  await expect(localeTabs).toBeVisible({ timeout: 15_000 });
+  await expect(localeTabs.getByRole('tab', { name: /pl/i })).toBeVisible();
+  await expect(localeTabs.getByRole('tab', { name: /en/i })).toBeVisible();
+  await expect(localeTabs.getByRole('tab', { name: /de/i })).toBeVisible();
+});

--- a/apps/admin/src/features/catalog/attributes/new.tsx
+++ b/apps/admin/src/features/catalog/attributes/new.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router';
 
 import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inline-dialog';
+import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { PickGroupsForAttributeDialog } from '@/components/modeling/pick-groups-for-attribute-dialog';
 import {
   RelationConfigPanel,
@@ -19,6 +20,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { CREATABLE_ATTRIBUTE_TYPES } from '@/lib/attribute-types';
 import { HttpError, jsonFetch } from '@/lib/http';
+import { useCurrentWorkspace } from '@/lib/use-current-workspace';
 import { cn } from '@/lib/utils';
 
 /**
@@ -45,8 +47,10 @@ import { cn } from '@/lib/utils';
 
 interface CreatePayload {
   code: string;
-  labelPl: string;
-  labelEn: string;
+  // #1352 — attribute name is a JSONB i18n map keyed by every configured
+  // locale (pl/en/de/…), driven by the workspace's enabled locales rather
+  // than a hardcoded pl/en pair.
+  label: Record<string, string>;
   helpPl: string;
   helpEn: string;
   type: string;
@@ -56,8 +60,7 @@ interface CreatePayload {
 
 const EMPTY: CreatePayload = {
   code: '',
-  labelPl: '',
-  labelEn: '',
+  label: {},
   helpPl: '',
   helpEn: '',
   type: 'text',
@@ -96,6 +99,12 @@ export function AttributeCreatePage() {
   const navigate = useNavigate();
   const invalidate = useInvalidate();
   const queryClient = useQueryClient();
+  // #1352 — drive the name field's locale tabs from the tenant's enabled
+  // locales (Settings → Locales). Falls back to pl/en before the workspace
+  // resolves so the form is never blank.
+  const workspace = useCurrentWorkspace();
+  const enabledLocales = workspace.data?.enabledLocales ?? ['pl', 'en'];
+  const primaryLocale = workspace.data?.primaryLocale ?? 'pl';
   const [values, setValues] = useState<CreatePayload>(EMPTY);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -132,7 +141,7 @@ export function AttributeCreatePage() {
     try {
       const body: Record<string, unknown> = {
         code: values.code,
-        label: stripEmpty({ pl: values.labelPl, en: values.labelEn }),
+        label: stripEmpty(values.label),
         type: values.type,
         required: values.required,
         filterable: values.filterable,
@@ -222,7 +231,9 @@ export function AttributeCreatePage() {
 
   const valid =
     values.code.trim().length > 0 &&
-    values.labelPl.trim().length > 0 &&
+    // #1352 — the name is required in the primary locale (was hardcoded to
+    // PL); other locales remain optional translations.
+    (values.label[primaryLocale]?.trim().length ?? 0) > 0 &&
     (values.type !== 'relation' || relationConfig.targetObjectTypeIds.length > 0);
 
   return (
@@ -292,17 +303,22 @@ export function AttributeCreatePage() {
                   })}
                 </p>
               </div>
-              <LocaleField
-                label={t('attributes.fields.name', { defaultValue: 'Nazwa' })}
-                placeholder={t('attributes.fields.name_placeholder', {
-                  defaultValue: 'np. Gwarancja (msc)',
-                })}
-                values={{ pl: values.labelPl, en: values.labelEn }}
-                onChange={(locale, next) => {
-                  if (locale === 'pl') setValues({ ...values, labelPl: next });
-                  else setValues({ ...values, labelEn: next });
-                }}
-              />
+              <div>
+                <Label className="text-[11.5px] font-medium text-muted-foreground">
+                  {t('attributes.fields.name', { defaultValue: 'Nazwa' })}
+                </Label>
+                <div className="mt-1.5">
+                  <LocaleTabsField
+                    values={values.label}
+                    enabledLocales={enabledLocales}
+                    primaryLocale={primaryLocale}
+                    onChange={(next) => setValues({ ...values, label: next })}
+                    placeholder={t('attributes.fields.name_placeholder', {
+                      defaultValue: 'np. Gwarancja (msc)',
+                    })}
+                  />
+                </div>
+              </div>
               <div>
                 <Label className="text-[11.5px] font-medium text-muted-foreground">
                   {t('attributes.fields.help', { defaultValue: 'Opis (opcjonalny)' })}
@@ -508,7 +524,11 @@ export function AttributeCreatePage() {
                 </span>
               </div>
               <div className="text-[12px] text-muted-foreground">
-                {values.labelPl.trim() || values.labelEn.trim() || 'Nazwa atrybutu…'}
+                {values.label[primaryLocale]?.trim() ||
+                  Object.values(values.label)
+                    .find((v) => v.trim() !== '')
+                    ?.trim() ||
+                  'Nazwa atrybutu…'}
               </div>
             </div>
           </Card>
@@ -574,56 +594,4 @@ function stripEmpty(record: Record<string, string>): Record<string, string> {
     if (v.trim() !== '') out[k] = v;
   }
   return out;
-}
-
-const NEW_ATTRIBUTE_LOCALES: Array<{ code: 'pl' | 'en'; flag: string }> = [
-  { code: 'pl', flag: '🇵🇱' },
-  { code: 'en', flag: '🇬🇧' },
-];
-
-function LocaleField({
-  label,
-  placeholder,
-  values,
-  onChange,
-}: {
-  label: string;
-  placeholder?: string;
-  values: { pl: string; en: string };
-  onChange: (locale: 'pl' | 'en', next: string) => void;
-}) {
-  const [active, setActive] = useState<'pl' | 'en'>('pl');
-  return (
-    <div>
-      <Label className="text-[11.5px] font-medium text-muted-foreground">{label}</Label>
-      <div className="mt-1.5 flex items-center gap-1 border-b border-zinc-100">
-        {NEW_ATTRIBUTE_LOCALES.map(({ code, flag }) => {
-          const filled = values[code].trim().length > 0;
-          return (
-            <button
-              key={code}
-              type="button"
-              onClick={() => setActive(code)}
-              className={cn(
-                '-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-[12.5px] font-medium uppercase tracking-wider transition',
-                active === code
-                  ? 'border-zinc-900 text-foreground'
-                  : 'border-transparent text-muted-foreground hover:text-foreground',
-              )}
-            >
-              <span aria-hidden>{flag}</span>
-              <span>{code}</span>
-              {!filled ? <span className="size-1.5 rounded-full bg-amber-400" aria-hidden /> : null}
-            </button>
-          );
-        })}
-      </div>
-      <Input
-        className="mt-2"
-        value={values[active]}
-        onChange={(e) => onChange(active, e.target.value)}
-        placeholder={placeholder}
-      />
-    </div>
-  );
 }

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -21,6 +21,7 @@ import { Link, useNavigate, useParams } from 'react-router';
 import { AuditLogIndicator } from '@/components/modeling/audit-log-indicator';
 import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { CreateGroupInlineDialog } from '@/components/modeling/create-group-inline-dialog';
+import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { PickGroupsForAttributeDialog } from '@/components/modeling/pick-groups-for-attribute-dialog';
 import {
   type RelationAdvancedField,
@@ -31,11 +32,11 @@ import { WhereUsedList } from '@/components/modeling/where-used-list';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/toast';
 import { HttpError, jsonFetch } from '@/lib/http';
+import { useCurrentWorkspace } from '@/lib/use-current-workspace';
 import { cn } from '@/lib/utils';
 
 import { resolveLabel } from './list';
@@ -127,11 +128,16 @@ function Editor({
   onClose: () => void;
 }) {
   const { t } = useTranslation();
-  const initialLabel = toLocaleMap(attribute.label);
+  // #1352 — the name editor follows the tenant's enabled locales, so the
+  // label keeps ALL locale keys (not just pl/en). Help stays pl/en (out of
+  // ticket scope).
+  const workspace = useCurrentWorkspace();
+  const enabledLocales = workspace.data?.enabledLocales ?? ['pl', 'en'];
+  const primaryLocale = workspace.data?.primaryLocale ?? 'pl';
+  const initialLabel = toFullLocaleMap(attribute.label);
   const initialHelp = toLocaleMap(attribute.help);
 
-  const [labelPl, setLabelPl] = useState(initialLabel.pl ?? '');
-  const [labelEn, setLabelEn] = useState(initialLabel.en ?? '');
+  const [labelMap, setLabelMap] = useState<Record<string, string>>(initialLabel);
   const [helpPl, setHelpPl] = useState(initialHelp.pl ?? '');
   const [helpEn, setHelpEn] = useState(initialHelp.en ?? '');
   const [required, setRequired] = useState(attribute.required ?? false);
@@ -241,7 +247,7 @@ function Editor({
     attribute.type === 'relation' && JSON.stringify(relationConfig) !== initialRelationSnapshot;
 
   const dirtyFields = [
-    labelPl !== (initialLabel.pl ?? '') || labelEn !== (initialLabel.en ?? ''),
+    JSON.stringify(stripEmpty(labelMap)) !== JSON.stringify(initialLabel),
     helpPl !== (initialHelp.pl ?? '') || helpEn !== (initialHelp.en ?? ''),
     required !== (attribute.required ?? false),
     localizable !== (attribute.localizable ?? false),
@@ -255,8 +261,7 @@ function Editor({
   const isSystem = attribute.system === true;
 
   const cancel = () => {
-    setLabelPl(initialLabel.pl ?? '');
-    setLabelEn(initialLabel.en ?? '');
+    setLabelMap(initialLabel);
     setHelpPl(initialHelp.pl ?? '');
     setHelpEn(initialHelp.en ?? '');
     setRequired(attribute.required ?? false);
@@ -271,7 +276,7 @@ function Editor({
     setError(null);
     try {
       const body: Record<string, unknown> = {};
-      const nextLabel = stripEmpty({ pl: labelPl, en: labelEn });
+      const nextLabel = stripEmpty(labelMap);
       if (JSON.stringify(nextLabel) !== JSON.stringify(initialLabel)) body.label = nextLabel;
       const nextHelp = stripEmpty({ pl: helpPl, en: helpEn });
       if (JSON.stringify(nextHelp) !== JSON.stringify(initialHelp)) body.help = nextHelp;
@@ -501,19 +506,13 @@ function Editor({
             <FieldRow label={t('attributes.fields.type', { defaultValue: 'Type' })} mono lock>
               <span className="font-mono">{attribute.type}</span>
             </FieldRow>
-            <FieldRow label={t('attributes.fields.label_pl', { defaultValue: 'Nazwa (PL)' })}>
-              <Input
-                value={labelPl}
-                onChange={(e) => setLabelPl(e.target.value)}
-                disabled={isSystem}
-                className="font-medium"
-              />
-            </FieldRow>
-            <FieldRow label={t('attributes.fields.label_en', { defaultValue: 'Nazwa (EN)' })}>
-              <Input
-                value={labelEn}
-                onChange={(e) => setLabelEn(e.target.value)}
-                disabled={isSystem}
+            <FieldRow label={t('attributes.fields.name', { defaultValue: 'Nazwa' })}>
+              <LocaleTabsField
+                values={labelMap}
+                enabledLocales={enabledLocales}
+                primaryLocale={primaryLocale}
+                onChange={setLabelMap}
+                readOnly={isSystem}
               />
             </FieldRow>
           </div>
@@ -595,7 +594,7 @@ function Editor({
             </div>
             <div className="flex items-center gap-3">
               <Label className="w-24 text-[13px] font-medium text-foreground">
-                {labelPl || resolveLabel(attribute.label, locale)}
+                {labelMap[primaryLocale] || resolveLabel(attribute.label, locale)}
               </Label>
               <div className="flex h-10 flex-1 items-center gap-2 rounded-xl border border-zinc-200 bg-zinc-50 px-3">
                 <span className="text-[13px] text-muted-foreground">
@@ -776,6 +775,25 @@ function toLocaleMap(value: Record<string, string> | string | null | undefined):
     const out: { pl?: string; en?: string } = {};
     if (typeof value.pl === 'string') out.pl = value.pl;
     if (typeof value.en === 'string') out.en = value.en;
+    return out;
+  }
+  return {};
+}
+
+/**
+ * #1352 — unlike {@see toLocaleMap}, preserves EVERY locale key on the
+ * JSONB label map (pl/en/de/…) so the editor can surface a DE tab. A bare
+ * string (legacy single-locale shape) maps onto the primary `pl` slot.
+ */
+function toFullLocaleMap(
+  value: Record<string, string> | string | null | undefined,
+): Record<string, string> {
+  if (typeof value === 'string') return { pl: value };
+  if (value && typeof value === 'object') {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (typeof v === 'string') out[k] = v;
+    }
     return out;
   }
   return {};

--- a/apps/admin/src/features/catalog/attributes/values.tsx
+++ b/apps/admin/src/features/catalog/attributes/values.tsx
@@ -221,10 +221,16 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
       return;
     }
     try {
+      // #1352 — seed the new option's label for EVERY enabled locale
+      // (pl/en/de/…), not a hardcoded pl/en pair, so a DE-enabled tenant
+      // gets a DE column to edit instead of a missing translation.
+      const seededLabel: Record<string, string> = Object.fromEntries(
+        localeChips.map((chip) => [chip.code, name]),
+      );
       const created = await jsonFetch<OptionRow>(`/api/attributes/${attribute.code}/options`, {
         method: 'POST',
         contentType: 'application/json',
-        body: { code, label: { pl: name, en: name } },
+        body: { code, label: seededLabel },
       });
       setActiveId(created.id);
       cancelDraft();

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -90,11 +90,23 @@ export function AttrRow({
   const { t, i18n } = useTranslation();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
   // #1262 — option labels are part of the VALUE, so they must follow the
-  // active value locale (the `locale` prop set by the PL/EN toolbar), not
-  // the interface language. The attribute NAME below stays on `lang`
-  // (UI chrome). Falls back to the interface lang when no scope is active.
+  // active value locale (the `locale` prop set by the locale toolbar), not
+  // the interface language. Falls back to the interface lang when no scope
+  // is active.
   const valueLang = locale ?? lang;
-  const label = attribute.label[lang] ?? attribute.code;
+  // #1352 — the attribute NAME on the card now follows the selected display
+  // language too: previously it was pinned to the UI chrome `lang` (pl/en),
+  // so a DE name never showed and the EN name appeared to "have no effect"
+  // when another locale was selected. Resolve against the selected locale
+  // first, then degrade through the UI language and any available
+  // translation before the raw code.
+  const label =
+    attribute.label[valueLang] ??
+    attribute.label[lang] ??
+    attribute.label.en ??
+    attribute.label.pl ??
+    Object.values(attribute.label)[0] ??
+    attribute.code;
   const editable = isEditing && !isLocked;
   const stringValue = typeof value === 'string' ? value : value == null ? '' : String(value);
   const localeChip = isLocaleScoped(attribute) ? locale : null;

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -83,7 +83,10 @@ export interface AttributeMeta {
   id: string;
   code: string;
   type: string;
-  label: { pl?: string; en?: string };
+  // #1352 — labels are a JSONB i18n map keyed by ANY configured locale
+  // (pl/en/de/…), not just pl/en. The backend already returns the full
+  // map; narrowing it here dropped DE/extra-locale names on the card.
+  label: Record<string, string>;
   is_system: boolean;
   /**
    * #1151 — whether the attribute carries a distinct value per locale.


### PR DESCRIPTION
## Problem (UAT #1352)
W ustawieniach włączone 3 języki (PL/EN/DE), ale formularz atrybutu i edytor wartości miały tylko PL/EN — brak DE. Dodatkowo „Nazwa (EN)" nie miała wpływu na kartę wpisu ObjectType (nazwa renderowała się zawsze wg języka interfejsu, nie wybranego języka danych).

## Przyczyna
Backend już przechowuje etykiety jako JSONB i18n o dowolnych kluczach locale — **tylko frontend** zawężał je do twardego `pl/en`.

## Rozwiązanie (FE-only)
- **Tworzenie + edycja atrybutu** (`attributes/new.tsx`, `attributes/show.tsx`) — pole „Nazwa" przez współdzielony `LocaleTabsField` sterowany `useCurrentWorkspace().enabledLocales` (+ `primaryLocale`). Fallback `pl/en` zanim workspace się rozwiąże.
- **Edytor wartości** (`attributes/values.tsx`) — nowa opcja seeduje etykietę dla **każdego** włączonego locale, nie hardkodowanego `{pl,en}`.
- **Karta wpisu** (`products/components/attr-row.tsx`) — nazwa atrybutu rozwiązywana wg wybranego języka wyświetlania z łańcuchem fallbacków (`valueLang → UI lang → en → pl → dowolny → code`); to naprawia „EN/DE nie ma wpływu".
- **Typ** (`products/components/types.ts`) — `AttributeMeta.label` poszerzone z `{pl?,en?}` do `Record<string,string>`.
- Usunięto hardkodowany `LocaleField`/`NEW_ATTRIBUTE_LOCALES` i wąski `toLocaleMap` dla etykiety (nowy `toFullLocaleMap` zachowuje wszystkie klucze).

## DoD
- typecheck (`tsc -b`) + biome strict: zielone.
- **E2E** `1352-attributes-honor-configured-locales.spec.ts`: (1) edycja — pole nazwy ma taby PL/EN/**DE**, klik DE pokazuje tłumaczenie; (2) tworzenie — taby per locale; backend round-trips klucz `de`. `fixme` w CI (wzorzec storageState), uruchamiane lokalnie.
- Brak zmian BE → PHPStan/PHPUnit bez nowej logiki (CI no-op pass). a11y: reużyty dostępny `LocaleTabsField` (role=tablist/tab, aria-selected).

## Smoke (live, `https://pim.localhost`)
- `POST /api/workspaces/current/locales {locale:"de"}` → `enabledLocales: [pl,en,de]`, HTTP 201.
- `POST /api/attributes {label:{pl,en,de}}` → HTTP 201, label round-trips `de:"Werkstoff"`.
- `GET /api/attributes/{id}` → `label.de = "Werkstoff"`. Cleanup 204.

> Uwaga: smoke włączył DE na workspace demo (reversible w Ustawieniach). Pełny przeklik UI pokryty E2E; backend zweryfikowany live na realnych payloadach.

Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)