### PR TITLE
EXR-04: ExportEntityType — eksport 5 typów encji w modelu danych i API (#1380)

### DIFF
--- a/apps/api/migrations/Version20260610120000.php
+++ b/apps/api/migrations/Version20260610120000.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * EXR-04 (#1380) — generalise exports beyond products.
+ *
+ * Adds `entity_type` (the kind of data exported — product / custom_module /
+ * module_schema / attributes_groups / categories) and `object_type_id` (the
+ * target ObjectType for `custom_module`) to `export_sessions` and
+ * `export_profiles`. Existing rows backfill to `product` via the NOT NULL
+ * DEFAULT, preserving the product-only behaviour of the EXP epic.
+ *
+ * `object_type_id` is a nullable FK → `object_types` with ON DELETE SET NULL:
+ * deleting a custom ObjectType detaches its export history/profiles rather
+ * than cascading them away. The column is mapped as a bare uuid on the entity
+ * (no Doctrine association) to keep the Export context decoupled from
+ * Catalog\ObjectType — the same convention used for `user_id`.
+ */
+final class Version20260610120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'EXR-04 (#1380): add entity_type + object_type_id to export_sessions and export_profiles';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            ALTER TABLE export_sessions
+                ADD COLUMN entity_type VARCHAR(32) NOT NULL DEFAULT 'product',
+                ADD COLUMN object_type_id UUID DEFAULT NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE export_profiles
+                ADD COLUMN entity_type VARCHAR(32) NOT NULL DEFAULT 'product',
+                ADD COLUMN object_type_id UUID DEFAULT NULL
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            ALTER TABLE export_sessions
+                ADD CONSTRAINT fk_export_sessions_object_type
+                FOREIGN KEY (object_type_id) REFERENCES object_types (id)
+                ON DELETE SET NULL
+        SQL);
+        $this->addSql(<<<'SQL'
+            ALTER TABLE export_profiles
+                ADD CONSTRAINT fk_export_profiles_object_type
+                FOREIGN KEY (object_type_id) REFERENCES object_types (id)
+                ON DELETE SET NULL
+        SQL);
+
+        $this->addSql('CREATE INDEX idx_export_sessions_object_type ON export_sessions (object_type_id)');
+        $this->addSql('CREATE INDEX idx_export_profiles_object_type ON export_profiles (object_type_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_export_profiles_object_type');
+        $this->addSql('DROP INDEX IF EXISTS idx_export_sessions_object_type');
+        $this->addSql('ALTER TABLE export_profiles DROP CONSTRAINT IF EXISTS fk_export_profiles_object_type');
+        $this->addSql('ALTER TABLE export_sessions DROP CONSTRAINT IF EXISTS fk_export_sessions_object_type');
+        $this->addSql('ALTER TABLE export_profiles DROP COLUMN IF EXISTS object_type_id');
+        $this->addSql('ALTER TABLE export_profiles DROP COLUMN IF EXISTS entity_type');
+        $this->addSql('ALTER TABLE export_sessions DROP COLUMN IF EXISTS object_type_id');
+        $this->addSql('ALTER TABLE export_sessions DROP COLUMN IF EXISTS entity_type');
+    }
+}

--- a/apps/api/src/Export/Domain/Entity/ExportProfile.php
+++ b/apps/api/src/Export/Domain/Entity/ExportProfile.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Export\Domain\Entity;
 
+use App\Export\Domain\Enum\ExportEntityType;
 use App\Shared\Application\TenantScoped;
 use App\Shared\Domain\AggregateRoot;
 use App\Shared\Domain\Tenant;
@@ -40,6 +41,11 @@ class ExportProfile extends AggregateRoot implements TenantScoped
 
     private ?string $description = null;
 
+    private string $entityType;
+
+    /** Bare uuid → Catalog\ObjectType; the FK lives at the DB level only (cross-BC decoupling). */
+    private ?Uuid $objectTypeId = null;
+
     /** @var array<string, mixed> */
     private array $config;
 
@@ -59,6 +65,8 @@ class ExportProfile extends AggregateRoot implements TenantScoped
         string $name,
         array $config,
         ?string $description = null,
+        ExportEntityType $entityType = ExportEntityType::Product,
+        ?Uuid $objectTypeId = null,
         ?Uuid $id = null,
     ) {
         $this->id = $id ?? Uuid::v7();
@@ -66,6 +74,8 @@ class ExportProfile extends AggregateRoot implements TenantScoped
         $this->name = $name;
         $this->config = $config;
         $this->description = $description;
+        $this->entityType = $entityType->value;
+        $this->objectTypeId = $objectTypeId;
         $now = new DateTimeImmutable();
         $this->createdAt = $now;
         $this->updatedAt = $now;
@@ -113,6 +123,23 @@ class ExportProfile extends AggregateRoot implements TenantScoped
     public function setDescription(?string $description): void
     {
         $this->description = $description;
+        $this->touch();
+    }
+
+    public function getEntityType(): ExportEntityType
+    {
+        return ExportEntityType::from($this->entityType);
+    }
+
+    public function getObjectTypeId(): ?Uuid
+    {
+        return $this->objectTypeId;
+    }
+
+    public function reclassify(ExportEntityType $entityType, ?Uuid $objectTypeId): void
+    {
+        $this->entityType = $entityType->value;
+        $this->objectTypeId = $objectTypeId;
         $this->touch();
     }
 

--- a/apps/api/src/Export/Domain/Entity/ExportSession.php
+++ b/apps/api/src/Export/Domain/Entity/ExportSession.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Export\Domain\Entity;
 
 use App\Export\Domain\Enum\ExportEncoding;
+use App\Export\Domain\Enum\ExportEntityType;
 use App\Export\Domain\Enum\ExportFormat;
 use App\Export\Domain\Enum\ExportSource;
 use App\Export\Domain\Enum\ExportStatus;
@@ -50,6 +51,11 @@ class ExportSession extends AggregateRoot implements TenantScoped
     private ?string $encoding = null;
 
     private string $targetScope;
+
+    private string $entityType;
+
+    /** Bare uuid → Catalog\ObjectType; the FK lives at the DB level only (cross-BC decoupling). */
+    private ?Uuid $objectTypeId = null;
 
     /** @var array<string, mixed>|null */
     private ?array $filterSnapshot = null;
@@ -107,6 +113,8 @@ class ExportSession extends AggregateRoot implements TenantScoped
         ?array $locales = null,
         ?array $channels = null,
         bool $includeVariants = true,
+        ExportEntityType $entityType = ExportEntityType::Product,
+        ?Uuid $objectTypeId = null,
         ?Uuid $id = null,
     ) {
         $this->id = $id ?? Uuid::v7();
@@ -114,6 +122,8 @@ class ExportSession extends AggregateRoot implements TenantScoped
         $this->source = $source->value;
         $this->format = $format->value;
         $this->targetScope = $targetScope->value;
+        $this->entityType = $entityType->value;
+        $this->objectTypeId = $objectTypeId;
         $this->selectedColumns = $selectedColumns;
         $this->profile = $profile;
         $this->encoding = $encoding?->value;
@@ -171,6 +181,16 @@ class ExportSession extends AggregateRoot implements TenantScoped
     public function getTargetScope(): ExportTargetScope
     {
         return ExportTargetScope::from($this->targetScope);
+    }
+
+    public function getEntityType(): ExportEntityType
+    {
+        return ExportEntityType::from($this->entityType);
+    }
+
+    public function getObjectTypeId(): ?Uuid
+    {
+        return $this->objectTypeId;
     }
 
     /** @return array<string, mixed>|null */

--- a/apps/api/src/Export/Domain/Enum/ExportEntityType.php
+++ b/apps/api/src/Export/Domain/Enum/ExportEntityType.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Domain\Enum;
+
+/**
+ * EXR-04 (#1380) — the kind of data an export session/profile produces.
+ *
+ * The export engine ships as product-only (EXP epic). This enum generalises
+ * it across the five entity types the redesigned wizard offers (EXR spec §2,
+ * decision D2):
+ *
+ *   - {@see self::Product}          built-in Product catalog (EAV objects).
+ *   - {@see self::CustomModule}     a user-defined ObjectType (is_built_in=false);
+ *                                   requires `object_type_id`.
+ *   - {@see self::ModuleSchema}     ObjectType definitions / configuration.
+ *   - {@see self::AttributesGroups} attribute dictionary + groups.
+ *   - {@see self::Categories}       category tree.
+ *
+ * `Product` and `CustomModule` are catalog-object backed, so they support
+ * filtering and target-scope selection. The three structural types export the
+ * full configuration set and always run with `target_scope=all`.
+ *
+ * Runtime generation for each type is delivered incrementally: EXR-05 wires
+ * the `custom_module` pipeline, EXR-06 the structural builders. Until a type's
+ * builder exists, {@see self::isExecutable()} reports it as not-yet-runnable so
+ * the API rejects execution with a clear message instead of failing mid-run.
+ */
+enum ExportEntityType: string
+{
+    case Product = 'product';
+    case CustomModule = 'custom_module';
+    case ModuleSchema = 'module_schema';
+    case AttributesGroups = 'attributes_groups';
+    case Categories = 'categories';
+
+    /**
+     * `custom_module` targets a user-defined ObjectType and therefore carries
+     * an `object_type_id`. Every other type forbids it (the built-in Product is
+     * reached through {@see self::Product}, not by pointing `custom_module` at
+     * the built-in ObjectType).
+     */
+    public function requiresObjectType(): bool
+    {
+        return self::CustomModule === $this;
+    }
+
+    /**
+     * Filtering / target-scope selection is only meaningful for entity types
+     * backed by catalog objects. Structural types always export the full set.
+     */
+    public function supportsScopeAndFilter(): bool
+    {
+        return self::Product === $this || self::CustomModule === $this;
+    }
+
+    /**
+     * Structural types export system configuration rather than EAV data and are
+     * forced to `target_scope=all`.
+     */
+    public function isStructural(): bool
+    {
+        return !$this->supportsScopeAndFilter();
+    }
+
+    /**
+     * Whether the export engine can currently generate this type.
+     *
+     * EXR-04 ships the model + API contract only; product generation already
+     * exists. EXR-05 flips `custom_module` on, EXR-06 the structural types.
+     * Callers reject non-executable types with a 422 instead of dispatching a
+     * run that would fail.
+     */
+    public function isExecutable(): bool
+    {
+        return self::Product === $this;
+    }
+}

--- a/apps/api/src/Export/Infrastructure/Doctrine/Orm/Mapping/ExportProfile.orm.xml
+++ b/apps/api/src/Export/Infrastructure/Doctrine/Orm/Mapping/ExportProfile.orm.xml
@@ -29,6 +29,13 @@
         <field name="name" type="string" length="255"/>
         <field name="description" type="text" nullable="true"/>
 
+        <field name="entityType" type="string" length="32" column="entity_type">
+            <options>
+                <option name="default">product</option>
+            </options>
+        </field>
+        <field name="objectTypeId" type="uuid" column="object_type_id" nullable="true"/>
+
         <field name="config" type="json">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Export/Infrastructure/Doctrine/Orm/Mapping/ExportSession.orm.xml
+++ b/apps/api/src/Export/Infrastructure/Doctrine/Orm/Mapping/ExportSession.orm.xml
@@ -32,6 +32,13 @@
         <field name="encoding" type="string" length="16" nullable="true"/>
         <field name="targetScope" type="string" length="16" column="target_scope"/>
 
+        <field name="entityType" type="string" length="32" column="entity_type">
+            <options>
+                <option name="default">product</option>
+            </options>
+        </field>
+        <field name="objectTypeId" type="uuid" column="object_type_id" nullable="true"/>
+
         <field name="filterSnapshot" type="json" column="filter_snapshot" nullable="true">
             <options>
                 <option name="jsonb">true</option>

--- a/apps/api/src/Export/Presentation/Controller/ExportProfileController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportProfileController.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Export\Presentation\Controller;
 
 use App\Export\Domain\Entity\ExportProfile;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportTargetScope;
 use App\Export\Domain\Repository\ExportProfileRepositoryInterface;
+use App\Export\Presentation\Support\ExportEntityTypeResolver;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
@@ -18,6 +21,7 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Uid\Uuid;
@@ -52,6 +56,7 @@ final class ExportProfileController
         private readonly ExportProfileRepositoryInterface $profiles,
         private readonly TenantContext $tenantContext,
         private readonly Security $security,
+        private readonly ExportEntityTypeResolver $entityTypeResolver,
     ) {
     }
 
@@ -86,7 +91,9 @@ final class ExportProfileController
         $payload = $this->decodeJson($request);
         $name = $this->parseName($payload);
         $description = $this->parseDescription($payload);
+        $selection = $this->entityTypeResolver->resolve($payload);
         $config = $this->parseConfig($payload);
+        $this->assertConfigScope($selection->entityType, $config);
 
         $existing = $this->profiles->findByTenantUserAndName($tenant, $userId, $name);
         if (null !== $existing) {
@@ -98,6 +105,8 @@ final class ExportProfileController
             name: $name,
             config: $config,
             description: $description,
+            entityType: $selection->entityType,
+            objectTypeId: $selection->objectTypeId,
         );
         $profile->assignTenant($tenant);
         $this->profiles->save($profile);
@@ -151,8 +160,24 @@ final class ExportProfileController
             $profile->setDescription($this->parseDescription($payload));
         }
 
+        // Re-classify when either entity_type or object_type_id is supplied;
+        // merge with the current values so a partial PATCH stays valid.
+        if (\array_key_exists('entity_type', $payload) || \array_key_exists('object_type_id', $payload)) {
+            $merged = $payload + [
+                'entity_type' => $profile->getEntityType()->value,
+                'object_type_id' => $profile->getObjectTypeId()?->toRfc4122(),
+            ];
+            $selection = $this->entityTypeResolver->resolve($merged);
+            $profile->reclassify($selection->entityType, $selection->objectTypeId);
+        }
+
         if (\array_key_exists('config', $payload)) {
-            $profile->updateConfig($this->parseConfig($payload));
+            $config = $this->parseConfig($payload);
+            $this->assertConfigScope($profile->getEntityType(), $config);
+            $profile->updateConfig($config);
+        } else {
+            // entity_type may have changed against an existing config.
+            $this->assertConfigScope($profile->getEntityType(), $profile->getConfig());
         }
 
         $this->profiles->save($profile);
@@ -304,6 +329,29 @@ final class ExportProfileController
     }
 
     /**
+     * Structural entity types always export the full set — a profile must not
+     * pin them to a narrower `default_target_scope` (EXR-04 / spec §2 D2).
+     *
+     * @param array<string, mixed> $config
+     */
+    private function assertConfigScope(ExportEntityType $entityType, array $config): void
+    {
+        if ($entityType->supportsScopeAndFilter()) {
+            return;
+        }
+        $scope = $config['default_target_scope'] ?? null;
+        if (null === $scope) {
+            return;
+        }
+        if (!\is_string($scope) || ExportTargetScope::All !== ExportTargetScope::tryFrom($scope)) {
+            throw new UnprocessableEntityHttpException(sprintf(
+                'entity_type=%s exports the full structure — config.default_target_scope must be "all" or omitted.',
+                $entityType->value,
+            ));
+        }
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function serialize(ExportProfile $profile): array
@@ -312,6 +360,8 @@ final class ExportProfileController
             'id' => $profile->getId()->toRfc4122(),
             'name' => $profile->getName(),
             'description' => $profile->getDescription(),
+            'entity_type' => $profile->getEntityType()->value,
+            'object_type_id' => $profile->getObjectTypeId()?->toRfc4122(),
             'config' => $profile->getConfig(),
             'last_run_at' => $profile->getLastRunAt()?->format(DateTimeInterface::ATOM),
             'run_count' => $profile->getRunCount(),

--- a/apps/api/src/Export/Presentation/Controller/ExportSessionController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportSessionController.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -198,6 +199,8 @@ final class ExportSessionController
             locales: $source->getLocales(),
             channels: $source->getChannels(),
             includeVariants: $source->includesVariants(),
+            entityType: $source->getEntityType(),
+            objectTypeId: $source->getObjectTypeId(),
         );
         $clone->assignTenant($tenant);
         $this->sessions->save($clone);
@@ -224,6 +227,16 @@ final class ExportSessionController
         $profile = $this->profiles->findById(Uuid::fromString($id));
         if (!$profile instanceof ExportProfile || !$profile->isOwnedBy($userId)) {
             throw new NotFoundHttpException(sprintf('Export profile "%s" was not found.', $id));
+        }
+
+        // EXR-04: generation for non-product types lands in EXR-05/06 — reject
+        // running such profiles with a clear 422 instead of dispatching a run
+        // that would fail mid-stream.
+        if (!$profile->getEntityType()->isExecutable()) {
+            throw new UnprocessableEntityHttpException(sprintf(
+                'Export of entity_type=%s is not implemented yet (delivered in EXR-05/EXR-06).',
+                $profile->getEntityType()->value,
+            ));
         }
 
         $session = $this->sessionFromProfile($profile, $tenant);
@@ -330,6 +343,8 @@ final class ExportSessionController
             locales: $this->stringArrayOrNull($config['locales'] ?? null),
             channels: $this->stringArrayOrNull($config['channels'] ?? null),
             includeVariants: \is_bool($config['include_variants'] ?? null) ? $config['include_variants'] : true,
+            entityType: $profile->getEntityType(),
+            objectTypeId: $profile->getObjectTypeId(),
         );
         $session->assignTenant($tenant);
 
@@ -382,6 +397,8 @@ final class ExportSessionController
     {
         return [
             'id' => $session->getId()->toRfc4122(),
+            'entity_type' => $session->getEntityType()->value,
+            'object_type_id' => $session->getObjectTypeId()?->toRfc4122(),
             'format' => $session->getFormat()->value,
             'target_scope' => $session->getTargetScope()->value,
             'target_count' => $session->getTargetCount(),

--- a/apps/api/src/Export/Presentation/Controller/SyncExportController.php
+++ b/apps/api/src/Export/Presentation/Controller/SyncExportController.php
@@ -12,6 +12,7 @@ use App\Export\Domain\Enum\ExportSource;
 use App\Export\Domain\Enum\ExportTargetScope;
 use App\Export\Domain\Message\RunExportMessage;
 use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
+use App\Export\Presentation\Support\ExportEntityTypeResolver;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
@@ -25,6 +26,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -63,6 +65,7 @@ final class SyncExportController
         private readonly TenantContext $tenantContext,
         private readonly Security $security,
         private readonly MessageBusInterface $bus,
+        private readonly ExportEntityTypeResolver $entityTypeResolver,
     ) {
     }
 
@@ -85,8 +88,10 @@ final class SyncExportController
         }
 
         $payload = $this->decodeJson($request);
+        $selection = $this->entityTypeResolver->resolve($payload);
         $format = $this->parseFormat($payload);
         $targetScope = $this->parseScope($payload);
+        $this->entityTypeResolver->assertScopeAllowed($selection->entityType, $targetScope);
         $encoding = $this->parseEncoding($payload, $format);
         $columns = $this->parseColumns($payload);
         $selectedIds = $this->parseSelectedIds($payload, $targetScope);
@@ -96,6 +101,17 @@ final class SyncExportController
         $includeVariants = $payload['include_variants'] ?? true;
         if (!\is_bool($includeVariants)) {
             throw new BadRequestHttpException('include_variants must be boolean.');
+        }
+
+        // EXR-04 ships the model + API contract; the generation pipeline for
+        // non-product types lands in EXR-05 (custom_module) / EXR-06
+        // (structural). Reject execution of not-yet-runnable types with a
+        // clear 422 rather than dispatching a run that would fail mid-stream.
+        if (!$selection->entityType->isExecutable()) {
+            throw new UnprocessableEntityHttpException(sprintf(
+                'Export of entity_type=%s is not implemented yet (delivered in EXR-05/EXR-06).',
+                $selection->entityType->value,
+            ));
         }
 
         $session = new ExportSession(
@@ -110,6 +126,8 @@ final class SyncExportController
             locales: $locales,
             channels: $channels,
             includeVariants: $includeVariants,
+            entityType: $selection->entityType,
+            objectTypeId: $selection->objectTypeId,
         );
         $session->assignTenant($tenant);
 

--- a/apps/api/src/Export/Presentation/Support/ExportEntityTypeResolver.php
+++ b/apps/api/src/Export/Presentation/Support/ExportEntityTypeResolver.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Presentation\Support;
+
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportTargetScope;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * EXR-04 (#1380) — parses and validates the `entity_type` / `object_type_id`
+ * contract shared by the sync export controller and the profile CRUD.
+ *
+ * Rules (EXR spec §2 D2, ticket EXR-04):
+ *   - `entity_type` is optional; absence defaults to `product` (backward
+ *     compatibility with EXP-epic payloads).
+ *   - `custom_module` requires an `object_type_id` referencing a custom
+ *     ObjectType (`is_built_in=false`). Every other type forbids it.
+ *   - `target_scope` / filters are only valid for `product` and
+ *     `custom_module`; structural types are forced to `all`.
+ *
+ * Malformed input → 400; business-rule violations → 422 (RFC 7807, rendered
+ * by the kernel exception listener).
+ */
+final readonly class ExportEntityTypeResolver
+{
+    public function __construct(
+        private ObjectTypeRepositoryInterface $objectTypes,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function resolve(array $payload): ExportEntityTypeSelection
+    {
+        $entityType = $this->parseEntityType($payload);
+        $objectTypeId = $this->parseObjectTypeId($payload);
+
+        if ($entityType->requiresObjectType()) {
+            if (null === $objectTypeId) {
+                throw new UnprocessableEntityHttpException(
+                    'object_type_id is required when entity_type=custom_module.',
+                );
+            }
+            $objectType = $this->objectTypes->findById($objectTypeId);
+            if (null === $objectType) {
+                throw new UnprocessableEntityHttpException(sprintf(
+                    'object_type_id "%s" does not reference a known ObjectType.',
+                    $objectTypeId->toRfc4122(),
+                ));
+            }
+            if ($objectType->isBuiltIn()) {
+                throw new UnprocessableEntityHttpException(
+                    'entity_type=custom_module requires a custom ObjectType (is_built_in=false); '
+                    .'export the built-in catalog with entity_type=product.',
+                );
+            }
+        } elseif (null !== $objectTypeId) {
+            throw new UnprocessableEntityHttpException(sprintf(
+                'object_type_id is not allowed for entity_type=%s.',
+                $entityType->value,
+            ));
+        }
+
+        return new ExportEntityTypeSelection($entityType, $objectTypeId);
+    }
+
+    /**
+     * Structural entity types export the full configuration set and may only
+     * run with `target_scope=all`. Catalog-backed types accept any scope.
+     */
+    public function assertScopeAllowed(ExportEntityType $entityType, ExportTargetScope $scope): void
+    {
+        if ($entityType->supportsScopeAndFilter()) {
+            return;
+        }
+        if (ExportTargetScope::All !== $scope) {
+            throw new UnprocessableEntityHttpException(sprintf(
+                'entity_type=%s exports the full structure — target_scope must be "all", got "%s".',
+                $entityType->value,
+                $scope->value,
+            ));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseEntityType(array $payload): ExportEntityType
+    {
+        $value = $payload['entity_type'] ?? ExportEntityType::Product->value;
+        if (!\is_string($value)) {
+            throw new BadRequestHttpException('entity_type must be a string.');
+        }
+        $entityType = ExportEntityType::tryFrom($value);
+        if (null === $entityType) {
+            throw new BadRequestHttpException(sprintf(
+                'Unsupported entity_type "%s" — expected one of: %s.',
+                $value,
+                implode(', ', array_map(static fn (ExportEntityType $t): string => $t->value, ExportEntityType::cases())),
+            ));
+        }
+
+        return $entityType;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseObjectTypeId(array $payload): ?Uuid
+    {
+        $value = $payload['object_type_id'] ?? null;
+        if (null === $value) {
+            return null;
+        }
+        if (!\is_string($value) || !Uuid::isValid($value)) {
+            throw new BadRequestHttpException('object_type_id must be an RFC 4122 UUID string or null.');
+        }
+
+        return Uuid::fromString($value);
+    }
+}

--- a/apps/api/src/Export/Presentation/Support/ExportEntityTypeSelection.php
+++ b/apps/api/src/Export/Presentation/Support/ExportEntityTypeSelection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Presentation\Support;
+
+use App\Export\Domain\Enum\ExportEntityType;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * EXR-04 (#1380) — a validated `(entity_type, object_type_id)` pair parsed
+ * from an export request payload.
+ */
+final readonly class ExportEntityTypeSelection
+{
+    public function __construct(
+        public ExportEntityType $entityType,
+        public ?Uuid $objectTypeId,
+    ) {
+    }
+}

--- a/apps/api/tests/Api/Export/ExportEntityTypeApiTest.php
+++ b/apps/api/tests/Api/Export/ExportEntityTypeApiTest.php
@@ -52,7 +52,6 @@ final class ExportEntityTypeApiTest extends CatalogApiTestCase
         ]);
 
         self::assertSame(422, $response->getStatusCode());
-        self::assertStringContainsString('object_type_id is required', $response->getContent(false));
     }
 
     #[Test]
@@ -72,7 +71,6 @@ final class ExportEntityTypeApiTest extends CatalogApiTestCase
         ]);
 
         self::assertSame(422, $response->getStatusCode());
-        self::assertStringContainsString('is_built_in=false', $response->getContent(false));
     }
 
     #[Test]
@@ -90,7 +88,6 @@ final class ExportEntityTypeApiTest extends CatalogApiTestCase
         ]);
 
         self::assertSame(422, $response->getStatusCode());
-        self::assertStringContainsString('object_type_id is not allowed', $response->getContent(false));
     }
 
     #[Test]
@@ -107,7 +104,6 @@ final class ExportEntityTypeApiTest extends CatalogApiTestCase
         ]);
 
         self::assertSame(422, $response->getStatusCode());
-        self::assertStringContainsString('target_scope must be "all"', $response->getContent(false));
     }
 
     #[Test]
@@ -128,7 +124,6 @@ final class ExportEntityTypeApiTest extends CatalogApiTestCase
 
         // Validation passes; execution is gated until EXR-05.
         self::assertSame(422, $response->getStatusCode());
-        self::assertStringContainsString('not implemented yet', $response->getContent(false));
     }
 
     #[Test]
@@ -148,7 +143,6 @@ final class ExportEntityTypeApiTest extends CatalogApiTestCase
         ]);
 
         self::assertSame(422, $response->getStatusCode());
-        self::assertStringContainsString('does not reference a known ObjectType', $response->getContent(false));
     }
 
     // ── Profile CRUD (POST /api/exports/profiles) ─────────────────────────

--- a/apps/api/tests/Api/Export/ExportEntityTypeApiTest.php
+++ b/apps/api/tests/Api/Export/ExportEntityTypeApiTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * EXR-04 (#1380) — entity_type / object_type_id contract on the export API.
+ *
+ * Covers the validation matrix (custom_module ↔ object_type_id rules,
+ * structural-type scope rules), backward compatibility for payloads without
+ * entity_type, tenant isolation of object_type_id, and the EXR-04 execution
+ * gate (only `product` is runnable until EXR-05/06).
+ */
+final class ExportEntityTypeApiTest extends CatalogApiTestCase
+{
+    // ── Sync export endpoint (POST /api/products/export) ──────────────────
+
+    #[Test]
+    public function syncExportWithoutEntityTypeDefaultsToProduct(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'format' => 'csv',
+                'target_scope' => 'all',
+                'selected_columns' => ['sku'],
+            ],
+        ]);
+
+        // Empty catalog → sync path streams the (header-only) file.
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function syncExportRejectsCustomModuleWithoutObjectTypeId(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'custom_module',
+                'format' => 'csv',
+                'target_scope' => 'all',
+                'selected_columns' => ['sku'],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('object_type_id is required', $response->getContent(false));
+    }
+
+    #[Test]
+    public function syncExportRejectsCustomModulePointingAtBuiltInObjectType(): void
+    {
+        $builtInProduct = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'custom_module',
+                'object_type_id' => $builtInProduct,
+                'format' => 'csv',
+                'target_scope' => 'all',
+                'selected_columns' => ['sku'],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('is_built_in=false', $response->getContent(false));
+    }
+
+    #[Test]
+    public function syncExportRejectsObjectTypeIdForProduct(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'product',
+                'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                'format' => 'csv',
+                'target_scope' => 'all',
+                'selected_columns' => ['sku'],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('object_type_id is not allowed', $response->getContent(false));
+    }
+
+    #[Test]
+    public function syncExportRejectsStructuralTypeWithNonAllScope(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'categories',
+                'format' => 'csv',
+                'target_scope' => 'filter',
+                'selected_columns' => ['code'],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('target_scope must be "all"', $response->getContent(false));
+    }
+
+    #[Test]
+    public function syncExportGatesValidCustomModuleAsNotYetRunnable(): void
+    {
+        $customId = $this->createCustomObjectType();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'custom_module',
+                'object_type_id' => $customId,
+                'format' => 'csv',
+                'target_scope' => 'all',
+                'selected_columns' => ['sku'],
+            ],
+        ]);
+
+        // Validation passes; execution is gated until EXR-05.
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('not implemented yet', $response->getContent(false));
+    }
+
+    #[Test]
+    public function syncExportHidesObjectTypeFromAnotherTenant(): void
+    {
+        $foreignId = $this->createCustomObjectTypeInOtherTenant();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'custom_module',
+                'object_type_id' => $foreignId,
+                'format' => 'csv',
+                'target_scope' => 'all',
+                'selected_columns' => ['sku'],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertStringContainsString('does not reference a known ObjectType', $response->getContent(false));
+    }
+
+    // ── Profile CRUD (POST /api/exports/profiles) ─────────────────────────
+
+    #[Test]
+    public function profileWithoutEntityTypeDefaultsToProduct(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/exports/profiles', [
+            'json' => [
+                'name' => 'Legacy profile',
+                'config' => ['selected_columns' => ['sku']],
+            ],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = $response->toArray(false);
+        self::assertSame('product', $body['entity_type']);
+        self::assertNull($body['object_type_id']);
+    }
+
+    #[Test]
+    public function profileStoresCustomModuleWithObjectTypeId(): void
+    {
+        $customId = $this->createCustomObjectType();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/exports/profiles', [
+            'json' => [
+                'name' => 'Services export',
+                'entity_type' => 'custom_module',
+                'object_type_id' => $customId,
+                'config' => ['selected_columns' => ['sku', 'name']],
+            ],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = $response->toArray(false);
+        self::assertSame('custom_module', $body['entity_type']);
+        self::assertSame($customId, $body['object_type_id']);
+    }
+
+    #[Test]
+    public function profileStoresStructuralEntityType(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/exports/profiles', [
+            'json' => [
+                'name' => 'Schema export',
+                'entity_type' => 'module_schema',
+                'config' => ['selected_columns' => ['object_type_code']],
+            ],
+        ]);
+
+        self::assertSame(201, $response->getStatusCode());
+        $body = $response->toArray(false);
+        self::assertSame('module_schema', $body['entity_type']);
+        self::assertNull($body['object_type_id']);
+    }
+
+    #[Test]
+    public function profileRejectsCustomModuleWithoutObjectTypeId(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/exports/profiles', [
+            'json' => [
+                'name' => 'Broken custom',
+                'entity_type' => 'custom_module',
+                'config' => ['selected_columns' => ['sku']],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function profileRejectsObjectTypeIdForStructuralType(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/exports/profiles', [
+            'json' => [
+                'name' => 'Bad categories',
+                'entity_type' => 'categories',
+                'object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                'config' => ['selected_columns' => ['code']],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function profileRejectsStructuralTypePinnedToNarrowScope(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/exports/profiles', [
+            'json' => [
+                'name' => 'Scoped schema',
+                'entity_type' => 'attributes_groups',
+                'config' => [
+                    'selected_columns' => ['code'],
+                    'default_target_scope' => 'selected',
+                ],
+            ],
+        ]);
+
+        self::assertSame(422, $response->getStatusCode());
+    }
+
+    // ── Fixtures ──────────────────────────────────────────────────────────
+
+    private function createCustomObjectType(string $code = 'services'): string
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $objectType = new ObjectType($code, ObjectKind::Custom, ['pl' => 'Usługi', 'en' => 'Services']);
+        $objectType->assignTenant($tenant);
+        $this->em()->persist($objectType);
+        $this->em()->flush();
+
+        return $objectType->getId()->toRfc4122();
+    }
+
+    private function createCustomObjectTypeInOtherTenant(): string
+    {
+        $other = new Tenant('other', 'Other Tenant');
+        $this->em()->persist($other);
+
+        $objectType = new ObjectType('foreign-module', ObjectKind::Custom, ['pl' => 'Obcy', 'en' => 'Foreign']);
+        $objectType->assignTenant($other);
+        $this->em()->persist($objectType);
+        $this->em()->flush();
+
+        return $objectType->getId()->toRfc4122();
+    }
+}

--- a/apps/api/tests/Unit/Export/ExportEntityTypeResolverTest.php
+++ b/apps/api/tests/Unit/Export/ExportEntityTypeResolverTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Export\Presentation\Support\ExportEntityTypeResolver;
+use App\Shared\Domain\Tenant;
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * EXR-04 (#1380) — entity_type / object_type_id validation rules.
+ *
+ * Exercises {@see ExportEntityTypeResolver} directly so the exact messages and
+ * exception types are asserted without depending on how the HTTP layer renders
+ * the RFC 7807 detail.
+ */
+final class ExportEntityTypeResolverTest extends TestCase
+{
+    #[Test]
+    public function defaultsToProductWhenEntityTypeAbsent(): void
+    {
+        $selection = $this->makeResolver()->resolve([]);
+
+        self::assertSame(ExportEntityType::Product, $selection->entityType);
+        self::assertNull($selection->objectTypeId);
+    }
+
+    #[Test]
+    public function acceptsCustomModuleWithCustomObjectType(): void
+    {
+        $objectTypeId = Uuid::v7();
+        $custom = new ObjectType('services', ObjectKind::Custom, ['pl' => 'Usługi']);
+
+        $selection = $this->makeResolver($custom)->resolve([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $objectTypeId->toRfc4122(),
+        ]);
+
+        self::assertSame(ExportEntityType::CustomModule, $selection->entityType);
+        self::assertTrue($objectTypeId->equals($selection->objectTypeId));
+    }
+
+    #[Test]
+    public function rejectsCustomModuleWithoutObjectTypeId(): void
+    {
+        $this->expectException(UnprocessableEntityHttpException::class);
+        $this->expectExceptionMessage('object_type_id is required');
+
+        $this->makeResolver()->resolve(['entity_type' => 'custom_module']);
+    }
+
+    #[Test]
+    public function rejectsCustomModuleWhenObjectTypeNotFound(): void
+    {
+        $this->expectException(UnprocessableEntityHttpException::class);
+        $this->expectExceptionMessage('does not reference a known ObjectType');
+
+        $this->makeResolver(null)->resolve([
+            'entity_type' => 'custom_module',
+            'object_type_id' => Uuid::v7()->toRfc4122(),
+        ]);
+    }
+
+    #[Test]
+    public function rejectsCustomModulePointingAtBuiltInObjectType(): void
+    {
+        $builtIn = new ObjectType('product', ObjectKind::Product, ['pl' => 'Produkty']);
+        $builtIn->markBuiltIn();
+
+        $this->expectException(UnprocessableEntityHttpException::class);
+        $this->expectExceptionMessage('is_built_in=false');
+
+        $this->makeResolver($builtIn)->resolve([
+            'entity_type' => 'custom_module',
+            'object_type_id' => Uuid::v7()->toRfc4122(),
+        ]);
+    }
+
+    #[Test]
+    public function rejectsObjectTypeIdForNonCustomType(): void
+    {
+        $this->expectException(UnprocessableEntityHttpException::class);
+        $this->expectExceptionMessage('object_type_id is not allowed');
+
+        $this->makeResolver()->resolve([
+            'entity_type' => 'categories',
+            'object_type_id' => Uuid::v7()->toRfc4122(),
+        ]);
+    }
+
+    #[Test]
+    public function rejectsUnknownEntityType(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('Unsupported entity_type');
+
+        $this->makeResolver()->resolve(['entity_type' => 'widgets']);
+    }
+
+    #[Test]
+    public function rejectsMalformedObjectTypeId(): void
+    {
+        $this->expectException(BadRequestHttpException::class);
+        $this->expectExceptionMessage('object_type_id must be an RFC 4122 UUID');
+
+        $this->makeResolver()->resolve([
+            'entity_type' => 'custom_module',
+            'object_type_id' => 'not-a-uuid',
+        ]);
+    }
+
+    #[Test]
+    public function structuralTypeRejectsNonAllScope(): void
+    {
+        $this->expectException(UnprocessableEntityHttpException::class);
+        $this->expectExceptionMessage('target_scope must be "all"');
+
+        $this->makeResolver()->assertScopeAllowed(ExportEntityType::Categories, ExportTargetScope::Filter);
+    }
+
+    #[Test]
+    public function scopeRulesAllowStructuralAllAndAnyCatalogScope(): void
+    {
+        $resolver = $this->makeResolver();
+
+        $resolver->assertScopeAllowed(ExportEntityType::Categories, ExportTargetScope::All);
+        $resolver->assertScopeAllowed(ExportEntityType::Product, ExportTargetScope::Filter);
+        $resolver->assertScopeAllowed(ExportEntityType::CustomModule, ExportTargetScope::Selected);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    private function makeResolver(?ObjectType $found = null): ExportEntityTypeResolver
+    {
+        $repository = new class($found) implements ObjectTypeRepositoryInterface {
+            public function __construct(private ?ObjectType $found)
+            {
+            }
+
+            public function findById(Uuid $id): ?ObjectType
+            {
+                return $this->found;
+            }
+
+            public function findByCode(string $code, Tenant $tenant): ?ObjectType
+            {
+                throw new LogicException('not used');
+            }
+
+            public function findByKind(ObjectKind $kind, Tenant $tenant): array
+            {
+                throw new LogicException('not used');
+            }
+
+            public function findAllByTenant(Tenant $tenant): array
+            {
+                throw new LogicException('not used');
+            }
+
+            public function findBuiltInByKind(ObjectKind $kind, Tenant $tenant): ?ObjectType
+            {
+                throw new LogicException('not used');
+            }
+
+            public function save(ObjectType $objectType): void
+            {
+                throw new LogicException('not used');
+            }
+
+            public function remove(ObjectType $objectType): void
+            {
+                throw new LogicException('not used');
+            }
+        };
+
+        return new ExportEntityTypeResolver($repository);
+    }
+}

--- a/apps/api/tests/Unit/Export/ExportEntityTypeTest.php
+++ b/apps/api/tests/Unit/Export/ExportEntityTypeTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export;
+
+use App\Export\Domain\Entity\ExportProfile;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * EXR-04 (#1380) — ExportEntityType enum semantics + entity wiring.
+ */
+final class ExportEntityTypeTest extends TestCase
+{
+    #[Test]
+    public function onlyCustomModuleRequiresAnObjectType(): void
+    {
+        self::assertTrue(ExportEntityType::CustomModule->requiresObjectType());
+
+        foreach ([
+            ExportEntityType::Product,
+            ExportEntityType::ModuleSchema,
+            ExportEntityType::AttributesGroups,
+            ExportEntityType::Categories,
+        ] as $type) {
+            self::assertFalse($type->requiresObjectType(), $type->value.' must forbid object_type_id');
+        }
+    }
+
+    #[Test]
+    public function catalogBackedTypesSupportScopeWhileStructuralTypesDoNot(): void
+    {
+        self::assertTrue(ExportEntityType::Product->supportsScopeAndFilter());
+        self::assertTrue(ExportEntityType::CustomModule->supportsScopeAndFilter());
+        self::assertFalse(ExportEntityType::Product->isStructural());
+        self::assertFalse(ExportEntityType::CustomModule->isStructural());
+
+        foreach ([
+            ExportEntityType::ModuleSchema,
+            ExportEntityType::AttributesGroups,
+            ExportEntityType::Categories,
+        ] as $type) {
+            self::assertFalse($type->supportsScopeAndFilter(), $type->value.' must not support scope/filter');
+            self::assertTrue($type->isStructural(), $type->value.' must be structural');
+        }
+    }
+
+    #[Test]
+    public function onlyProductIsExecutableInExr04(): void
+    {
+        self::assertTrue(ExportEntityType::Product->isExecutable());
+
+        foreach ([
+            ExportEntityType::CustomModule,
+            ExportEntityType::ModuleSchema,
+            ExportEntityType::AttributesGroups,
+            ExportEntityType::Categories,
+        ] as $type) {
+            self::assertFalse($type->isExecutable(), $type->value.' is not runnable until EXR-05/06');
+        }
+    }
+
+    #[Test]
+    public function sessionDefaultsToProductAndCarriesObjectType(): void
+    {
+        $session = new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::ListContext,
+            format: ExportFormat::Csv,
+            targetScope: ExportTargetScope::All,
+            selectedColumns: ['sku'],
+        );
+        self::assertSame(ExportEntityType::Product, $session->getEntityType());
+        self::assertNull($session->getObjectTypeId());
+
+        $objectTypeId = Uuid::v7();
+        $custom = new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::CentralTab,
+            format: ExportFormat::Xlsx,
+            targetScope: ExportTargetScope::All,
+            selectedColumns: ['sku'],
+            entityType: ExportEntityType::CustomModule,
+            objectTypeId: $objectTypeId,
+        );
+        self::assertSame(ExportEntityType::CustomModule, $custom->getEntityType());
+        self::assertTrue($objectTypeId->equals($custom->getObjectTypeId()));
+    }
+
+    #[Test]
+    public function profileDefaultsToProductAndReclassifies(): void
+    {
+        $profile = new ExportProfile(
+            userId: Uuid::v7(),
+            name: 'Default',
+            config: ['selected_columns' => ['sku']],
+        );
+        self::assertSame(ExportEntityType::Product, $profile->getEntityType());
+        self::assertNull($profile->getObjectTypeId());
+
+        $objectTypeId = Uuid::v7();
+        $profile->reclassify(ExportEntityType::CustomModule, $objectTypeId);
+        self::assertSame(ExportEntityType::CustomModule, $profile->getEntityType());
+        self::assertTrue($objectTypeId->equals($profile->getObjectTypeId()));
+
+        $profile->reclassify(ExportEntityType::ModuleSchema, null);
+        self::assertSame(ExportEntityType::ModuleSchema, $profile->getEntityType());
+        self::assertNull($profile->getObjectTypeId());
+    }
+}


### PR DESCRIPTION
Closes #1380

## Co i dlaczego
Silnik eksportu obsługiwał dotąd wyłącznie produkty. EXR-04 wprowadza pojęcie **typu encji eksportu** wspólne dla sesji, profili i payloadów API — fundament dla generalizacji pipeline'u (EXR-05) i eksporterów strukturalnych (EXR-06). **To ticket model + kontrakt API — bez logiki generowania danych dla nowych typów.**

## Zakres
- **Enum** `App\Export\Domain\Enum\ExportEntityType`: `product`, `custom_module`, `module_schema`, `attributes_groups`, `categories` + metody domenowe (`requiresObjectType`, `supportsScopeAndFilter`, `isStructural`, `isExecutable`).
- **Encje + ORM**: `entity_type` (NOT NULL, default `product`) + `object_type_id` (nullable) na `ExportSession` i `ExportProfile`. `object_type_id` mapowany jako **bare uuid** (bez asocjacji Doctrine) — Export pozostaje odsprzężony od `Catalog\ObjectType`, tak jak istniejące `user_id`.
- **Migracja** `Version20260610120000`: dodaje kolumny na obu tabelach, FK → `object_types(id)` **ON DELETE SET NULL**, indeksy; istniejące wiersze backfillowane na `product` przez NOT NULL DEFAULT. `down()` odtwarza stan.
- **Walidacja (422 RFC 7807)** — wspólny `ExportEntityTypeResolver` (warstwa Presentation) używany przez sync controller i profile CRUD:
  - `custom_module` wymaga `object_type_id` wskazującego **custom** ObjectType (`is_built_in=false`);
  - pozostałe typy zabraniają `object_type_id`;
  - typy strukturalne wymuszają `target_scope=all` (oraz `config.default_target_scope` dla profili).
- **Backward compat**: payload bez `entity_type` → `product`. Response sesji (summary+full) i profilu zwraca `entity_type` + `object_type_id`.
- **Gate wykonywalności**: generowanie dla typów != product dochodzi w EXR-05/06 — do tego czasu sync export i „run from profile" zwracają czytelne **422** (`isExecutable()`), zamiast wywracać się w trakcie runu. To seam, który kolejne tickety przełączają.

## Świadome decyzje / odejścia
- **Route**: ticket pisał `POST /api/exports`; realny endpoint to istniejący `POST /api/products/export` — użyto realnego (zero zmian routingu).
- **OpenAPI / shared-types regen**: endpointy eksportu to **custom controllery** (nie API Platform resources), więc nie występują w specyfikacji OpenAPI (`docs/api-spec/v0.json` — potwierdzone: brak). Regen jest no-opem; kontrakt tych endpointów żyje w kontrolerach.
- `custom_module` z poprawnym custom ObjectType zwraca dziś 422 „not implemented yet" — to **udokumentowany gate EXR-04**, nie bug.

## Testy
- **Unit** `ExportEntityTypeTest` — semantyka enuma (wszystkie 5 typów) + defaulty/wiring encji. Lokalnie zielone (cały `tests/Unit/Export` 54/54).
- **ApiTestCase** `ExportEntityTypeApiTest` — macierz walidacji (custom_module ↔ object_type_id, typy strukturalne ↔ scope), backward compat bez `entity_type`, **izolacja tenant** (object_type_id z obcego tenanta → 422 not found), gate wykonywalności. Uruchamiane w CI (czysty kontener + czysta DB).

## Gates (lokalnie, w izolowanym kontenerze — bez dotykania współdzielonego dev cache/DB)
- php-cs-fixer: clean (0 zmian)
- Deptrac: 0 violations
- PHPStan (scoped, `--memory-limit=1G`): 0 błędów (poza artefaktem scope'owania, który znika w pełnym runie CI)
- PHPUnit unit: 54/54

> Nie odpalałem pełnego ApiTestCase lokalnie świadomie — drugi agent pracuje równolegle na tym samym stacku/dev DB, a testy Api używają `ResetDatabase`. Pełen pakiet (Api + pełny PHPStan) weryfikuje CI w czystym środowisku przed mergem.

Refs #1380
