### PR TITLE
EXR-05: generalizacja pipeline'u eksportu na dowolny ObjectType (custom_module) (#1381)

### DIFF
--- a/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Domain\Repository;
 
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
 use App\Shared\Domain\Tenant;
 use Symfony\Component\Uid\Uuid;
@@ -30,6 +31,17 @@ interface CatalogObjectRepositoryInterface
      * @return list<CatalogObject>
      */
     public function findByKind(ObjectKind $kind, Tenant $tenant): array;
+
+    /**
+     * Objects of a specific ObjectType within a tenant (EXR-05).
+     *
+     * Generalises {@see self::findByKind()} from the built-in Product kind to
+     * any ObjectType — products resolve their built-in type, custom modules
+     * their own. Tenant filter still applies.
+     *
+     * @return list<CatalogObject>
+     */
+    public function findByObjectType(ObjectType $objectType, Tenant $tenant): array;
 
     public function save(CatalogObject $object): void;
 

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Catalog\Infrastructure\Doctrine\Repository;
 
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Shared\Domain\Tenant;
@@ -33,6 +34,17 @@ class DoctrineCatalogObjectRepository extends ServiceEntityRepository implements
     {
         /** @var list<CatalogObject> $rows */
         $rows = $this->findBy(['kind' => $kind, 'tenant' => $tenant]);
+
+        return $rows;
+    }
+
+    /**
+     * @return list<CatalogObject>
+     */
+    public function findByObjectType(ObjectType $objectType, Tenant $tenant): array
+    {
+        /** @var list<CatalogObject> $rows */
+        $rows = $this->findBy(['objectType' => $objectType, 'tenant' => $tenant]);
 
         return $rows;
     }

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -6,12 +6,15 @@ namespace App\Export\Application\Sync;
 
 use App\Catalog\Application\Filter\FilterDslResolver;
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Export\Application\Builder\ExportBuilder;
 use App\Export\Application\Builder\PublicationColumnPlanner;
 use App\Export\Domain\Entity\ExportSession;
 use App\Export\Domain\Enum\ExportEncoding;
+use App\Export\Domain\Enum\ExportEntityType;
 use App\Export\Domain\Enum\ExportFormat;
 use App\Export\Domain\Enum\ExportTargetScope;
 use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
@@ -54,6 +57,7 @@ final class SyncExportRunner
         private readonly FilterDslResolver $filterDsl,
         private readonly Connection $connection,
         private readonly PublicationColumnPlanner $columnPlanner,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
     ) {
     }
 
@@ -69,11 +73,51 @@ final class SyncExportRunner
             throw new LogicException('Export session must carry a tenant before resolveTargets().');
         }
 
+        // EXR-05: the target set is scoped to the session's ObjectType
+        // (product → built-in Product type, custom_module → its own type)
+        // rather than the hardcoded Product kind.
+        $objectType = $this->resolveObjectType($session, $tenant);
+
         return match ($session->getTargetScope()) {
             ExportTargetScope::Selected => $this->resolveSelected($session),
-            ExportTargetScope::All => $this->objects->findByKind(ObjectKind::Product, $tenant),
-            ExportTargetScope::Filter => $this->resolveFilter($session, $tenant),
+            ExportTargetScope::All => $this->objects->findByObjectType($objectType, $tenant),
+            ExportTargetScope::Filter => $this->resolveFilter($session, $tenant, $objectType),
         };
+    }
+
+    /**
+     * Resolve the ObjectType backing a catalog-object export session.
+     *
+     * Product sessions resolve the tenant's built-in Product type; custom
+     * modules resolve their stored `object_type_id`. Structural entity types
+     * are not catalog-object backed and must never reach this path (they are
+     * rejected upstream by {@see ExportEntityType::isExecutable()}).
+     */
+    private function resolveObjectType(ExportSession $session, Tenant $tenant): ObjectType
+    {
+        return match ($session->getEntityType()) {
+            ExportEntityType::Product => $this->objectTypes->findBuiltInByKind(ObjectKind::Product, $tenant)
+                ?? throw new LogicException('Built-in Product ObjectType is not seeded for this tenant.'),
+            ExportEntityType::CustomModule => $this->resolveCustomObjectType($session),
+            default => throw new LogicException(sprintf(
+                'Export entity_type "%s" is not backed by catalog objects.',
+                $session->getEntityType()->value,
+            )),
+        };
+    }
+
+    private function resolveCustomObjectType(ExportSession $session): ObjectType
+    {
+        $id = $session->getObjectTypeId();
+        if (null === $id) {
+            throw new LogicException('custom_module export session is missing object_type_id.');
+        }
+        $objectType = $this->objectTypes->findById($id);
+        if (null === $objectType) {
+            throw new LogicException(sprintf('ObjectType "%s" was not found.', $id->toRfc4122()));
+        }
+
+        return $objectType;
     }
 
     /**
@@ -132,7 +176,7 @@ final class SyncExportRunner
      *
      * @return list<CatalogObject>
      */
-    private function resolveFilter(ExportSession $session, Tenant $tenant): array
+    private function resolveFilter(ExportSession $session, Tenant $tenant, ObjectType $objectType): array
     {
         $dsl = $session->getFilterSnapshot();
         if (null === $dsl || [] === $dsl) {
@@ -145,13 +189,15 @@ final class SyncExportRunner
         }
 
         $tenantId = $tenant->getId()->toRfc4122();
+        // EXR-05: scope by object_type_id (any ObjectType) instead of the
+        // hardcoded Product kind. The DSL itself stays ObjectType-agnostic.
         $sql = 'SELECT id FROM catalog_objects '
-            .'WHERE tenant_id = :tenant AND kind = :kind AND deleted_at IS NULL AND ('.$whereClause.')';
+            .'WHERE tenant_id = :tenant AND object_type_id = :otid AND deleted_at IS NULL AND ('.$whereClause.')';
 
         try {
             $rows = $this->connection->fetchAllAssociative(
                 $sql,
-                ['tenant' => $tenantId, 'kind' => ObjectKind::Product->value],
+                ['tenant' => $tenantId, 'otid' => $objectType->getId()->toRfc4122()],
             );
         } catch (Throwable $error) {
             throw new RuntimeException('Filter scope SQL execution failed: '.$error->getMessage(), previous: $error);

--- a/apps/api/src/Export/Domain/Enum/ExportEntityType.php
+++ b/apps/api/src/Export/Domain/Enum/ExportEntityType.php
@@ -67,13 +67,13 @@ enum ExportEntityType: string
     /**
      * Whether the export engine can currently generate this type.
      *
-     * EXR-04 ships the model + API contract only; product generation already
-     * exists. EXR-05 flips `custom_module` on, EXR-06 the structural types.
-     * Callers reject non-executable types with a 422 instead of dispatching a
-     * run that would fail.
+     * Product and custom modules share the catalog-object pipeline (EXR-05);
+     * the structural types (module_schema / attributes_groups / categories)
+     * land in EXR-06. Callers reject non-executable types with a 422 instead
+     * of dispatching a run that would fail.
      */
     public function isExecutable(): bool
     {
-        return self::Product === $this;
+        return self::Product === $this || self::CustomModule === $this;
     }
 }

--- a/apps/api/tests/Api/Export/CustomModuleExportApiTest.php
+++ b/apps/api/tests/Api/Export/CustomModuleExportApiTest.php
@@ -86,9 +86,7 @@ final class CustomModuleExportApiTest extends CatalogApiTestCase
      */
     private function runExport(Tenant $tenant, ObjectType $objectType, array $columns): string
     {
-        $tenantContext = self::getContainer()->get(TenantContext::class);
-        \assert($tenantContext instanceof TenantContext);
-        $tenantContext->set($tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
 
         $session = new ExportSession(
             userId: Uuid::v7(),
@@ -102,7 +100,6 @@ final class CustomModuleExportApiTest extends CatalogApiTestCase
         $session->assignTenant($tenant);
 
         $runner = self::getContainer()->get(SyncExportRunner::class);
-        \assert($runner instanceof SyncExportRunner);
 
         $path = tempnam(sys_get_temp_dir(), 'exr05-').'.csv';
         try {

--- a/apps/api/tests/Api/Export/CustomModuleExportApiTest.php
+++ b/apps/api/tests/Api/Export/CustomModuleExportApiTest.php
@@ -11,17 +11,30 @@ use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Provenance;
+use App\Export\Application\Sync\SyncExportRunner;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use App\Tests\Api\Catalog\CatalogApiTestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * EXR-05 (#1381) — the export pipeline generalised to any ObjectType.
  *
- * Exercises the custom_module path end-to-end through the real sync controller:
- * rows + attribute values come out, the target set is scoped to the requested
- * ObjectType, and a freshly-invented attribute exports with zero code change
- * (schema dynamism — the EAV requirement).
+ * Drives the real {@see SyncExportRunner} against a custom ObjectType fixture
+ * and inspects the produced file: rows + attribute values come out, the target
+ * set is scoped to the requested ObjectType, and a freshly-invented attribute
+ * exports with zero code change (schema dynamism — the EAV requirement).
+ *
+ * The content is read from the runner's output file rather than an HTTP
+ * response because the sync export streams a BinaryFileResponse whose body the
+ * API Platform test client does not buffer. The HTTP 200 contract for
+ * custom_module is covered by {@see ExportEntityTypeApiTest}.
  */
 final class CustomModuleExportApiTest extends CatalogApiTestCase
 {
@@ -41,7 +54,7 @@ final class CustomModuleExportApiTest extends CatalogApiTestCase
 
         $this->em()->flush();
 
-        $csv = $this->runSyncExport($services->getId()->toRfc4122(), ['sku', 'horsepower']);
+        $csv = $this->runExport($tenant, $services, ['sku', 'horsepower']);
 
         self::assertStringContainsString('SRV-1', $csv);
         self::assertStringContainsString('150', $csv);
@@ -62,7 +75,7 @@ final class CustomModuleExportApiTest extends CatalogApiTestCase
         $this->object($tenant, $collections, 'COL-1', $torque, '250');
         $this->em()->flush();
 
-        $csv = $this->runSyncExport($collections->getId()->toRfc4122(), ['sku', 'torque']);
+        $csv = $this->runExport($tenant, $collections, ['sku', 'torque']);
 
         self::assertStringContainsString('COL-1', $csv);
         self::assertStringContainsString('250', $csv);
@@ -71,22 +84,34 @@ final class CustomModuleExportApiTest extends CatalogApiTestCase
     /**
      * @param list<string> $columns
      */
-    private function runSyncExport(string $objectTypeId, array $columns): string
+    private function runExport(Tenant $tenant, ObjectType $objectType, array $columns): string
     {
-        $client = $this->authenticatedClient();
-        $response = $client->request('POST', '/api/products/export', [
-            'json' => [
-                'entity_type' => 'custom_module',
-                'object_type_id' => $objectTypeId,
-                'format' => 'csv',
-                'target_scope' => 'all',
-                'selected_columns' => $columns,
-            ],
-        ]);
+        $tenantContext = self::getContainer()->get(TenantContext::class);
+        \assert($tenantContext instanceof TenantContext);
+        $tenantContext->set($tenant);
 
-        self::assertSame(200, $response->getStatusCode());
+        $session = new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::CentralTab,
+            format: ExportFormat::Csv,
+            targetScope: ExportTargetScope::All,
+            selectedColumns: $columns,
+            entityType: ExportEntityType::CustomModule,
+            objectTypeId: $objectType->getId(),
+        );
+        $session->assignTenant($tenant);
 
-        return $response->getContent(false);
+        $runner = self::getContainer()->get(SyncExportRunner::class);
+        \assert($runner instanceof SyncExportRunner);
+
+        $path = tempnam(sys_get_temp_dir(), 'exr05-').'.csv';
+        try {
+            $runner->runToFile($session, $path);
+
+            return (string) file_get_contents($path);
+        } finally {
+            @unlink($path);
+        }
     }
 
     private function tenant(): Tenant

--- a/apps/api/tests/Api/Export/CustomModuleExportApiTest.php
+++ b/apps/api/tests/Api/Export/CustomModuleExportApiTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Provenance;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * EXR-05 (#1381) — the export pipeline generalised to any ObjectType.
+ *
+ * Exercises the custom_module path end-to-end through the real sync controller:
+ * rows + attribute values come out, the target set is scoped to the requested
+ * ObjectType, and a freshly-invented attribute exports with zero code change
+ * (schema dynamism — the EAV requirement).
+ */
+final class CustomModuleExportApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function exportsCustomModuleRowsScopedToItsObjectType(): void
+    {
+        $tenant = $this->tenant();
+
+        $services = $this->customObjectType($tenant, 'services');
+        $horsepower = $this->attribute($tenant, 'horsepower');
+        $this->object($tenant, $services, 'SRV-1', $horsepower, '150');
+        $this->object($tenant, $services, 'SRV-2', $horsepower, '200');
+
+        // A different custom ObjectType in the SAME tenant must not bleed in.
+        $salons = $this->customObjectType($tenant, 'salons');
+        $this->object($tenant, $salons, 'SAL-1', $horsepower, '999');
+
+        $this->em()->flush();
+
+        $csv = $this->runSyncExport($services->getId()->toRfc4122(), ['sku', 'horsepower']);
+
+        self::assertStringContainsString('SRV-1', $csv);
+        self::assertStringContainsString('150', $csv);
+        self::assertStringContainsString('SRV-2', $csv);
+        self::assertStringContainsString('200', $csv);
+        self::assertStringNotContainsString('SAL-1', $csv);
+        self::assertStringNotContainsString('999', $csv);
+    }
+
+    #[Test]
+    public function exportsAFreshlyAddedAttributeWithoutCodeChange(): void
+    {
+        $tenant = $this->tenant();
+
+        $collections = $this->customObjectType($tenant, 'collections');
+        // `torque` exists in no seed, fixture, or hardcode — it is invented here.
+        $torque = $this->attribute($tenant, 'torque');
+        $this->object($tenant, $collections, 'COL-1', $torque, '250');
+        $this->em()->flush();
+
+        $csv = $this->runSyncExport($collections->getId()->toRfc4122(), ['sku', 'torque']);
+
+        self::assertStringContainsString('COL-1', $csv);
+        self::assertStringContainsString('250', $csv);
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private function runSyncExport(string $objectTypeId, array $columns): string
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'custom_module',
+                'object_type_id' => $objectTypeId,
+                'format' => 'csv',
+                'target_scope' => 'all',
+                'selected_columns' => $columns,
+            ],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+
+        return $response->getContent(false);
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    private function customObjectType(Tenant $tenant, string $code): ObjectType
+    {
+        $objectType = new ObjectType($code, ObjectKind::Custom, ['pl' => ucfirst($code), 'en' => ucfirst($code)]);
+        $objectType->assignTenant($tenant);
+        $this->em()->persist($objectType);
+
+        return $objectType;
+    }
+
+    private function attribute(Tenant $tenant, string $code): Attribute
+    {
+        $attribute = new Attribute($code, ['pl' => ucfirst($code), 'en' => ucfirst($code)], AttributeType::Text);
+        $attribute->assignTenant($tenant);
+        $this->em()->persist($attribute);
+
+        return $attribute;
+    }
+
+    private function object(Tenant $tenant, ObjectType $objectType, string $code, Attribute $attribute, string $value): void
+    {
+        $object = new CatalogObject($objectType, $code);
+        $object->assignTenant($tenant);
+        $this->em()->persist($object);
+
+        $objectValue = new ObjectValue($object, $attribute, ['value' => $value], Provenance::Manual);
+        $objectValue->assignTenant($tenant);
+        $this->em()->persist($objectValue);
+    }
+}

--- a/apps/api/tests/Api/Export/ExportEntityTypeApiTest.php
+++ b/apps/api/tests/Api/Export/ExportEntityTypeApiTest.php
@@ -107,8 +107,10 @@ final class ExportEntityTypeApiTest extends CatalogApiTestCase
     }
 
     #[Test]
-    public function syncExportGatesValidCustomModuleAsNotYetRunnable(): void
+    public function syncExportRunsValidCustomModule(): void
     {
+        // EXR-05: custom_module now runs through the catalog-object pipeline.
+        // Empty custom catalog → sync path streams the header-only file.
         $customId = $this->createCustomObjectType();
 
         $client = $this->authenticatedClient();
@@ -122,8 +124,7 @@ final class ExportEntityTypeApiTest extends CatalogApiTestCase
             ],
         ]);
 
-        // Validation passes; execution is gated until EXR-05.
-        self::assertSame(422, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
@@ -111,6 +111,11 @@ final class InMemoryCatalogObjectRepo implements CatalogObjectRepositoryInterfac
         throw new LogicException('not used in this test');
     }
 
+    public function findByObjectType(ObjectType $objectType, Tenant $tenant): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
     public function save(CatalogObject $object): void
     {
         throw new LogicException('not used in this test');

--- a/apps/api/tests/Unit/Export/ExportEntityTypeTest.php
+++ b/apps/api/tests/Unit/Export/ExportEntityTypeTest.php
@@ -53,17 +53,19 @@ final class ExportEntityTypeTest extends TestCase
     }
 
     #[Test]
-    public function onlyProductIsExecutableInExr04(): void
+    public function catalogBackedTypesAreExecutableStructuralAreNotYet(): void
     {
+        // EXR-05: product + custom_module share the catalog-object pipeline.
         self::assertTrue(ExportEntityType::Product->isExecutable());
+        self::assertTrue(ExportEntityType::CustomModule->isExecutable());
 
+        // Structural builders land in EXR-06.
         foreach ([
-            ExportEntityType::CustomModule,
             ExportEntityType::ModuleSchema,
             ExportEntityType::AttributesGroups,
             ExportEntityType::Categories,
         ] as $type) {
-            self::assertFalse($type->isExecutable(), $type->value.' is not runnable until EXR-05/06');
+            self::assertFalse($type->isExecutable(), $type->value.' is not runnable until EXR-06');
         }
     }
 

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -233,6 +233,11 @@ final class InMemoryCatalogObjectRepository implements CatalogObjectRepositoryIn
         return [];
     }
 
+    public function findByObjectType(ObjectType $objectType, Tenant $tenant): array
+    {
+        return [];
+    }
+
     public function save(CatalogObject $object): void
     {
     }


### PR DESCRIPTION
Closes #1381

## Co i dlaczego
EXR-05 generalizuje silnik eksportu z „tylko produkty" na **dowolny ObjectType**. Custom moduły (`custom_module`) eksportują się tym samym pipelinem co produkty — różni je wyłącznie ObjectType, po którym scope'ujemy zbiór obiektów. To realizacja wymogu „dynamiczny schemat / EAV": zestaw kolumn wynika z atrybutów obiektu (JSONB `attributes_indexed` / `object_values`), nigdy z hardkodu.

## Zakres
- `SyncExportRunner` rozwiązuje **ObjectType sesji** (product → built-in Product type, `custom_module` → `object_type_id`) i pobiera cele przez nowe `CatalogObjectRepository::findByObjectType(...)` (scope=all) oraz filtr SQL scope'owany po `object_type_id` zamiast `kind = 'product'` (scope=filter). Scope=selected bez zmian.
- `CatalogObjectRepositoryInterface::findByObjectType(ObjectType, Tenant)` + impl Doctrine (mirror `findByKind`). Dwa in-memory test-double'y uzupełnione.
- `ExportEntityType::isExecutable()` → `product` **i** `custom_module` (zdejmuje gate EXR-04 dla custom modułów; typy strukturalne dalej 422 do EXR-06).
- **Bez zmian**: `ExportBuilder` / `ColumnResolver` / `ValueSerializer` były już ObjectType-agnostyczne (kolumna `category` zwraca pustą wartość dla obiektów bez kategorii). Ścieżki sync **i** async (ten sam `runToFile`) działają dla custom_module.

## Świadome decyzje / odejścia (per EPIK MARATHON RULE — minimum-viable z uzasadnieniem)
- **Rejestr builderów (`EntityExportBuilderInterface`) odłożony do EXR-06.** Product i custom_module dzielą JEDEN pipeline (catalog-object), więc rejestr nie wnosi wartości, dopóki nie istnieją builderzy strukturalni (config-based, fundamentalnie inni) do dispatchowania. EXR-06 wprowadzi rejestr dispatchujący catalog-object-vs-structural.
- **Dedykowany endpoint katalogu kolumn (`/api/exports/columns?...`) odłożony do EXR-11.** Obecny admin składa katalog z generycznych `/api/attributes` (nie istnieje „endpoint kolumn produktowych" do rozszerzenia), a kształt odpowiedzi najlepiej zdefiniuje jego konsument — wizard (EXR-11). Gwarancja dynamiczności schematu jest tu udowodniona ścieżką eksportu (świeżo dodany atrybut eksportuje się bez zmiany kodu — test `exportsAFreshlyAddedAttributeWithoutCodeChange`).
- **Optymalizacja kursorowa pamięci** (iterate zamiast findBy materializującego całość) — istniejąca ścieżka produktowa też materializuje (`findByKind`); `findByObjectType` zachowuje paritet. Realna optymalizacja + benchmark 100k = EXR-07/EXR-16. Brak nowej regresji pamięci.

## Testy
- **Unit**: `ExportEntityTypeTest` zaktualizowany (custom_module teraz executable; strukturalne nie). 69/69 unit (Export + dotknięte doubles) zielone lokalnie.
- **ApiTestCase** `CustomModuleExportApiTest`: custom_module eksportuje wiersze z wartościami atrybutów (text), **scoping per-ObjectType** (obiekty innego custom OT nie wyciekają), **dynamiczność schematu** (świeżo wymyślony atrybut `torque` eksportuje się bez zmiany kodu). `ExportEntityTypeApiTest` zaktualizowany (custom_module z poprawnym OT → 200 zamiast 422).
- Uruchamiane w CI (czysty kontener + czysta DB). Lokalnie nie odpalałem ApiTestCase (ResetDatabase) by nie ruszać współdzielonego dev DB.

## Gates lokalnie (izolowany kontener, izolowany `var`)
- php-cs-fixer: clean · PHPStan (scoped, 1G): 0 błędów (poza artefaktem scope'owania, znika w CI) · PHPUnit unit: 69/69 · Deptrac: (CI)

Refs #1381
