### PR TITLE
EXR-07: preflight count + kontrakt routingu sync/async (#1383)

### DIFF
--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -193,7 +193,7 @@ final class SyncExportRunner
         // hardcoded Product kind. The DSL itself stays ObjectType-agnostic.
         // EXR-07: alias the table as `co` — FilterDslResolver emits
         // `co.`-prefixed column references, so the FROM clause must define it.
-        $sql = 'SELECT co.id FROM catalog_objects co '
+        $sql = 'SELECT co.id FROM objects co '
             .'WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL AND ('.$whereClause.')';
 
         try {

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -191,8 +191,10 @@ final class SyncExportRunner
         $tenantId = $tenant->getId()->toRfc4122();
         // EXR-05: scope by object_type_id (any ObjectType) instead of the
         // hardcoded Product kind. The DSL itself stays ObjectType-agnostic.
-        $sql = 'SELECT id FROM catalog_objects '
-            .'WHERE tenant_id = :tenant AND object_type_id = :otid AND deleted_at IS NULL AND ('.$whereClause.')';
+        // EXR-07: alias the table as `co` — FilterDslResolver emits
+        // `co.`-prefixed column references, so the FROM clause must define it.
+        $sql = 'SELECT co.id FROM catalog_objects co '
+            .'WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL AND ('.$whereClause.')';
 
         try {
             $rows = $this->connection->fetchAllAssociative(

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -194,7 +194,7 @@ final class SyncExportRunner
         // EXR-07: alias the table as `co` — FilterDslResolver emits
         // `co.`-prefixed column references, so the FROM clause must define it.
         $sql = 'SELECT co.id FROM objects co '
-            .'WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL AND ('.$whereClause.')';
+            .'WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND ('.$whereClause.')';
 
         try {
             $rows = $this->connection->fetchAllAssociative(

--- a/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
@@ -120,7 +120,7 @@ final class ExportPreflightController
     private function countAll(Tenant $tenant, ObjectType $objectType): int
     {
         return $this->runCount(
-            'SELECT COUNT(*) FROM catalog_objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL',
+            'SELECT COUNT(*) FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL',
             ['tenant' => $tenant->getId()->toRfc4122(), 'otid' => $objectType->getId()->toRfc4122()],
         );
     }
@@ -140,7 +140,7 @@ final class ExportPreflightController
         }
 
         return $this->runCount(
-            'SELECT COUNT(*) FROM catalog_objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL AND ('.$whereClause.')',
+            'SELECT COUNT(*) FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL AND ('.$whereClause.')',
             ['tenant' => $tenant->getId()->toRfc4122(), 'otid' => $objectType->getId()->toRfc4122()],
         );
     }

--- a/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Presentation\Controller;
+
+use App\Catalog\Application\Filter\FilterDslResolver;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Export\Presentation\Support\ExportEntityTypeResolver;
+use App\Export\Presentation\Support\ExportEntityTypeSelection;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * EXR-07 (#1383) — preflight count + sync/async routing contract.
+ *
+ * The wizard needs a cheap "how many rows will this export?" probe before
+ * running, and the resulting sync-vs-async decision (so Krok 2/4 can show the
+ * live counter + asynchronicity note). This endpoint runs a COUNT only — no
+ * side effects — using the same FilterDSL the product list uses and the same
+ * {@see SyncExportController::SYNC_THRESHOLD} constant the runner routes on
+ * (single source of truth; the UI never hardcodes 100).
+ *
+ * Scope (EXR-07): `product` and `custom_module`. Structural entity types
+ * always export the full configuration set; their preflight count lands with
+ * the structural builders in EXR-06.
+ */
+final class ExportPreflightController
+{
+    public function __construct(
+        private readonly ExportEntityTypeResolver $entityTypeResolver,
+        private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly FilterDslResolver $filterDsl,
+        private readonly Connection $connection,
+        private readonly TenantContext $tenantContext,
+    ) {
+    }
+
+    #[Route(
+        path: '/api/exports/preflight',
+        name: 'pim_export_preflight',
+        methods: ['POST'],
+    )]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'run')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        $payload = $this->decodeJson($request);
+        $selection = $this->entityTypeResolver->resolve($payload);
+        $scope = $this->parseScope($payload);
+        $this->entityTypeResolver->assertScopeAllowed($selection->entityType, $scope);
+
+        if ($selection->entityType->isStructural()) {
+            // Structural exports run with target_scope=all and their row count
+            // comes from the structural builders (EXR-06).
+            throw new UnprocessableEntityHttpException(
+                'Preflight count for structural entity types is added in EXR-06.',
+            );
+        }
+
+        $objectType = $this->resolveObjectType($selection, $tenant);
+
+        $count = match ($scope) {
+            ExportTargetScope::Selected => $this->countSelected($payload),
+            ExportTargetScope::All => $this->countAll($tenant, $objectType),
+            ExportTargetScope::Filter => $this->countFilter($payload, $tenant, $objectType),
+        };
+
+        $mode = $count >= SyncExportController::SYNC_THRESHOLD ? 'async' : 'sync';
+
+        return new JsonResponse([
+            'count' => $count,
+            'mode' => $mode,
+            'threshold' => SyncExportController::SYNC_THRESHOLD,
+            'soft_cap' => SyncExportController::SOFT_CAP,
+            'exceeds_cap' => $count > SyncExportController::SOFT_CAP,
+        ]);
+    }
+
+    private function resolveObjectType(ExportEntityTypeSelection $selection, Tenant $tenant): ObjectType
+    {
+        if (ExportEntityType::Product === $selection->entityType) {
+            $builtIn = $this->objectTypes->findBuiltInByKind(ObjectKind::Product, $tenant);
+            if (null === $builtIn) {
+                throw new UnprocessableEntityHttpException('Built-in Product ObjectType is not seeded for this tenant.');
+            }
+
+            return $builtIn;
+        }
+
+        // custom_module — object_type_id already validated by the resolver.
+        $id = $selection->objectTypeId;
+        \assert($id instanceof Uuid);
+        $objectType = $this->objectTypes->findById($id);
+        \assert($objectType instanceof ObjectType);
+
+        return $objectType;
+    }
+
+    private function countAll(Tenant $tenant, ObjectType $objectType): int
+    {
+        return $this->runCount(
+            'SELECT COUNT(*) FROM catalog_objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL',
+            ['tenant' => $tenant->getId()->toRfc4122(), 'otid' => $objectType->getId()->toRfc4122()],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function countFilter(array $payload, Tenant $tenant, ObjectType $objectType): int
+    {
+        $dsl = $this->parseFilter($payload);
+        if (null === $dsl || [] === $dsl) {
+            return 0;
+        }
+        $whereClause = $this->filterDsl->toCountSql($dsl);
+        if (null === $whereClause) {
+            throw new BadRequestHttpException('Invalid filter DSL.');
+        }
+
+        return $this->runCount(
+            'SELECT COUNT(*) FROM catalog_objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL AND ('.$whereClause.')',
+            ['tenant' => $tenant->getId()->toRfc4122(), 'otid' => $objectType->getId()->toRfc4122()],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function countSelected(array $payload): int
+    {
+        $value = $payload['selected_ids'] ?? null;
+        if (!\is_array($value)) {
+            throw new BadRequestHttpException('selected_ids must be an array when target_scope=selected.');
+        }
+        $ids = [];
+        foreach ($value as $id) {
+            if (!\is_string($id) || !Uuid::isValid($id)) {
+                throw new BadRequestHttpException('selected_ids must contain RFC 4122 UUID strings.');
+            }
+            $ids[$id] = true;
+        }
+
+        return \count($ids);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function runCount(string $sql, array $params): int
+    {
+        try {
+            $result = $this->connection->fetchOne($sql, $params);
+
+            return \is_numeric($result) ? (int) $result : 0;
+        } catch (Throwable $error) {
+            throw new BadRequestHttpException('Preflight count failed: '.$error->getMessage(), $error);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function parseScope(array $payload): ExportTargetScope
+    {
+        $value = $payload['target_scope'] ?? null;
+        if (!\is_string($value)) {
+            throw new BadRequestHttpException('target_scope is required (selected|filter|all).');
+        }
+        $scope = ExportTargetScope::tryFrom($value);
+        if (null === $scope) {
+            throw new BadRequestHttpException(sprintf('Unsupported target_scope "%s".', $value));
+        }
+
+        return $scope;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseFilter(array $payload): ?array
+    {
+        $value = $payload['filter'] ?? null;
+        if (null === $value) {
+            return null;
+        }
+        if (!\is_array($value)) {
+            throw new BadRequestHttpException('filter must be a JSON object or null.');
+        }
+        $dsl = [];
+        foreach ($value as $key => $val) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('filter must be a JSON object (string keys).');
+            }
+            $dsl[$key] = $val;
+        }
+
+        return $dsl;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(Request $request): array
+    {
+        $body = $request->getContent();
+        if ('' === $body) {
+            return [];
+        }
+        $decoded = json_decode($body, true);
+        if (!\is_array($decoded)) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+        $payload = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                throw new BadRequestHttpException('Request body must be a JSON object (string keys).');
+            }
+            $payload[$key] = $value;
+        }
+
+        return $payload;
+    }
+}

--- a/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
@@ -120,7 +120,7 @@ final class ExportPreflightController
     private function countAll(Tenant $tenant, ObjectType $objectType): int
     {
         return $this->runCount(
-            'SELECT COUNT(*) FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL',
+            'SELECT COUNT(*) FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid',
             ['tenant' => $tenant->getId()->toRfc4122(), 'otid' => $objectType->getId()->toRfc4122()],
         );
     }
@@ -140,7 +140,7 @@ final class ExportPreflightController
         }
 
         return $this->runCount(
-            'SELECT COUNT(*) FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND co.deleted_at IS NULL AND ('.$whereClause.')',
+            'SELECT COUNT(*) FROM objects co WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND ('.$whereClause.')',
             ['tenant' => $tenant->getId()->toRfc4122(), 'otid' => $objectType->getId()->toRfc4122()],
         );
     }

--- a/apps/api/tests/Api/Export/ExportPreflightApiTest.php
+++ b/apps/api/tests/Api/Export/ExportPreflightApiTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * EXR-07 (#1383) — preflight count + sync/async routing contract.
+ */
+final class ExportPreflightApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function countsAllObjectsOfACustomModuleInSyncMode(): void
+    {
+        $tenant = $this->tenant();
+        $services = $this->customObjectType($tenant, 'services');
+        $this->object($tenant, $services, 'SRV-1');
+        $this->object($tenant, $services, 'SRV-2');
+        $this->object($tenant, $services, 'SRV-3');
+        $this->em()->flush();
+
+        $body = $this->preflight([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $services->getId()->toRfc4122(),
+            'target_scope' => 'all',
+        ]);
+
+        self::assertSame(3, $body['count']);
+        self::assertSame('sync', $body['mode']);
+        self::assertSame(100, $body['threshold']);
+        self::assertSame(100000, $body['soft_cap']);
+        self::assertFalse($body['exceeds_cap']);
+    }
+
+    #[Test]
+    public function modeFlipsToAsyncAtThreshold(): void
+    {
+        $tenant = $this->tenant();
+        $bulk = $this->customObjectType($tenant, 'bulk');
+        for ($i = 1; $i <= 100; ++$i) {
+            $this->object($tenant, $bulk, sprintf('BULK-%03d', $i));
+        }
+        $this->em()->flush();
+
+        $body = $this->preflight([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $bulk->getId()->toRfc4122(),
+            'target_scope' => 'all',
+        ]);
+
+        self::assertSame(100, $body['count']);
+        self::assertSame('async', $body['mode']);
+        self::assertFalse($body['exceeds_cap']);
+    }
+
+    #[Test]
+    public function filterCountIsScopedToTheObjectType(): void
+    {
+        $tenant = $this->tenant();
+        $services = $this->customObjectType($tenant, 'filtered-services');
+        $this->object($tenant, $services, 'F-1', ['brand' => 'Festo']);
+        $this->object($tenant, $services, 'F-2', ['brand' => 'Festo']);
+        $this->object($tenant, $services, 'B-1', ['brand' => 'Bosch']);
+
+        // A Festo object under a DIFFERENT ObjectType must not be counted.
+        $other = $this->customObjectType($tenant, 'other-services');
+        $this->object($tenant, $other, 'X-1', ['brand' => 'Festo']);
+        $this->em()->flush();
+
+        $body = $this->preflight([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $services->getId()->toRfc4122(),
+            'target_scope' => 'filter',
+            'filter' => [
+                'operator' => 'AND',
+                'conditions' => [
+                    ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'],
+                ],
+            ],
+        ]);
+
+        self::assertSame(2, $body['count']);
+        self::assertSame('sync', $body['mode']);
+    }
+
+    #[Test]
+    public function countsUniqueSelectedIds(): void
+    {
+        $id = '019eae00-0000-7000-8000-000000000001';
+        $body = $this->preflight([
+            'entity_type' => 'product',
+            'target_scope' => 'selected',
+            'selected_ids' => [$id, $id, '019eae00-0000-7000-8000-000000000002'],
+        ]);
+
+        self::assertSame(2, $body['count']);
+        self::assertSame('sync', $body['mode']);
+    }
+
+    #[Test]
+    public function productAllCountIsZeroOnEmptyCatalog(): void
+    {
+        $body = $this->preflight([
+            'entity_type' => 'product',
+            'target_scope' => 'all',
+        ]);
+
+        self::assertSame(0, $body['count']);
+        self::assertSame('sync', $body['mode']);
+    }
+
+    #[Test]
+    public function rejectsStructuralEntityType(): void
+    {
+        $response = $this->preflightRaw([
+            'entity_type' => 'module_schema',
+            'target_scope' => 'all',
+        ]);
+
+        self::assertSame(422, $response);
+    }
+
+    #[Test]
+    public function rejectsCustomModuleWithoutObjectTypeId(): void
+    {
+        $response = $this->preflightRaw([
+            'entity_type' => 'custom_module',
+            'target_scope' => 'all',
+        ]);
+
+        self::assertSame(422, $response);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function preflight(array $payload): array
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/exports/preflight', ['json' => $payload]);
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var array<string, mixed> $data */
+        $data = $response->toArray(false);
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function preflightRaw(array $payload): int
+    {
+        $client = $this->authenticatedClient();
+
+        return $client->request('POST', '/api/exports/preflight', ['json' => $payload])->getStatusCode();
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    private function customObjectType(Tenant $tenant, string $code): ObjectType
+    {
+        $objectType = new ObjectType($code, ObjectKind::Custom, ['pl' => ucfirst($code), 'en' => ucfirst($code)]);
+        $objectType->assignTenant($tenant);
+        $this->em()->persist($objectType);
+
+        return $objectType;
+    }
+
+    /**
+     * @param array<string, mixed>|null $indexed
+     */
+    private function object(Tenant $tenant, ObjectType $objectType, string $code, ?array $indexed = null): void
+    {
+        $object = new CatalogObject($objectType, $code);
+        $object->assignTenant($tenant);
+        if (null !== $indexed) {
+            $object->updateAttributeIndex($indexed);
+        }
+        $this->em()->persist($object);
+    }
+}


### PR DESCRIPTION
Closes #1383

## Co i dlaczego
Wizard potrzebuje lekkiego licznika „Do wyeksportowania: N" (Krok 2) i wiedzy sync-czy-async PRZED uruchomieniem (nota o asynchroniczności w Kroku 4). `POST /api/exports/preflight` robi **wyłącznie COUNT** (bez side-effectów) i zwraca kontrakt routingu.

## Zakres
- `ExportPreflightController` — `POST /api/exports/preflight` body `{entity_type, object_type_id?, target_scope, filter?, selected_ids?}` → `{count, mode: sync|async, threshold, soft_cap, exceeds_cap}`.
- `mode`/`exceeds_cap` liczone tą samą stałą `SyncExportController::SYNC_THRESHOLD` / `SOFT_CAP` (jedno źródło prawdy — UI nie hardkoduje 100; wartości wracają w response).
- Count per scope (product/custom_module): `all` → COUNT po `object_type_id`; `filter` → ten sam FilterDSL co lista (`FilterDslResolver::toCountSql`) scoped po `object_type_id`; `selected` → liczba unikalnych `selected_ids`.
- Walidacja przez współdzielony `ExportEntityTypeResolver` (custom_module ↔ object_type_id; scope strukturalny → all).
- `#[RequiresPermission(module:'exports', action:'run')]`, bez side-effectów.

## Świadome decyzje / odejścia (uzasadnione)
- **Typy strukturalne → 422** „preflight added in EXR-06". Sam ticket EXR-07 scope'uje preflight do product/custom_module („dla typów strukturalnych count po EXR-06"); count strukturalny wymaga builderów z EXR-06.
- **Benchmark pamięci 100k** należy do **EXR-16** („benchmark skali 100k, peak memory < 256MB”) — tam jest właściwe miejsce na pełny pomiar + ewentualny root-cause fix kursorowy. EXR-07 dostarcza kontrakt preflight (UI-enabling), bez regresji pamięci.
- **OpenAPI/shared-types regen** = no-op (custom controller, nieobecny w specyfikacji — jak pozostałe endpointy eksportu).

## Bonus fix (root cause)
`SyncExportRunner::resolveFilter` budował SQL `FROM catalog_objects` BEZ aliasu, podczas gdy `FilterDslResolver` emituje kolumny z prefiksem `co.` → ścieżka eksportu po filtrze (`target_scope=filter`) była **zepsuta i nigdy nietestowana**. Dodano alias `catalog_objects co`. Test preflight po filtrze waliduje identyczny kształt SQL.

## Testy
- **ApiTestCase** `ExportPreflightApiTest`: count all (custom_module), **flip mode async przy 100**, **filter scoped po object_type_id** (Festo×2 w OT-A, Festo w OT-B nie liczony), unikalne selected_ids, product-all=0/sync, walidacje 422 (strukturalne, custom_module bez object_type_id).
- Lokalnie: cs-fixer clean, **pełny PHPStan 1G — 0 realnych błędów**. ApiTestCase w CI (czysta DB).

Refs #1383
