### PR TITLE
EXR-06: eksportery strukturalne — schemat modułów, atrybuty i grupy, kategorie (#1382)

### DIFF
--- a/apps/api/src/Export/Application/Builder/Structural/AttributesGroupsExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/Structural/AttributesGroupsExportBuilder.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder\Structural;
+
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Shared\Domain\Tenant;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * EXR-06 (#1382) — `attributes_groups` export: the attribute dictionary.
+ *
+ * One row per attribute. Localised label/help fan out across the tenant's
+ * active locales (`label.pl`, `label.en`, …) and a joined `groups` column
+ * captures the attribute→group membership. The dedicated per-group metadata
+ * sheet (XLSX second sheet / CSV-in-ZIP) is deferred — see the PR — but the
+ * `groups` column already records which groups each attribute belongs to.
+ *
+ * Columns are dynamic: a new attribute type, locale, or select option exports
+ * with no change here.
+ */
+final readonly class AttributesGroupsExportBuilder implements StructuralExportBuilderInterface
+{
+    public function __construct(
+        private AttributeRepositoryInterface $attributes,
+        private AttributeOptionRepositoryInterface $options,
+        private TenantLocaleRepositoryInterface $locales,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    public function supports(ExportEntityType $type): bool
+    {
+        return ExportEntityType::AttributesGroups === $type;
+    }
+
+    public function columns(Tenant $tenant): array
+    {
+        $columns = ['code', 'type'];
+        foreach ($this->localeCodes($tenant) as $code) {
+            $columns[] = 'label.'.$code;
+        }
+        foreach ($this->localeCodes($tenant) as $code) {
+            $columns[] = 'help.'.$code;
+        }
+        $columns[] = 'validation_rules';
+        $columns[] = 'is_localizable';
+        $columns[] = 'is_scopable';
+        $columns[] = 'options';
+        $columns[] = 'groups';
+        $columns[] = 'is_built_in';
+        $columns[] = 'created_at';
+
+        return $columns;
+    }
+
+    public function rows(Tenant $tenant): iterable
+    {
+        $localeCodes = $this->localeCodes($tenant);
+
+        foreach ($this->attributes->findAllByTenant($tenant) as $attribute) {
+            $label = $attribute->getLabel();
+            $help = $attribute->getHelp() ?? [];
+
+            $row = ['code' => $attribute->getCode(), 'type' => $attribute->getType()->value];
+            foreach ($localeCodes as $code) {
+                $row['label.'.$code] = $label[$code] ?? '';
+            }
+            foreach ($localeCodes as $code) {
+                $row['help.'.$code] = $help[$code] ?? '';
+            }
+            $row['validation_rules'] = json_encode($attribute->getValidationRules(), JSON_THROW_ON_ERROR);
+            $row['is_localizable'] = $attribute->isLocalizable() ? 'true' : 'false';
+            $row['is_scopable'] = $attribute->isScopable() ? 'true' : 'false';
+            $row['options'] = $this->optionsJson($attribute);
+            $row['groups'] = implode('|', $this->groupCodes($attribute));
+            $row['is_built_in'] = $attribute->isSystem() ? 'true' : 'false';
+            $row['created_at'] = $attribute->getCreatedAt()->format(DateTimeInterface::ATOM);
+
+            yield $row;
+        }
+    }
+
+    public function count(Tenant $tenant): int
+    {
+        return \count($this->attributes->findAllByTenant($tenant));
+    }
+
+    private function optionsJson(Attribute $attribute): string
+    {
+        if (!$attribute->usesOptions()) {
+            return '';
+        }
+        $options = [];
+        foreach ($this->options->findByAttribute($attribute) as $option) {
+            $options[] = ['code' => $option->getCode(), 'label' => $option->getLabel()];
+        }
+
+        return json_encode($options, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function groupCodes(Attribute $attribute): array
+    {
+        /** @var list<string> $codes */
+        $codes = $this->em->createQuery(
+            'SELECT g.code FROM '.AttributeGroupAttribute::class.' j JOIN j.attributeGroup g'
+            .' WHERE j.attribute = :a ORDER BY g.code ASC',
+        )->setParameter('a', $attribute)->getSingleColumnResult();
+
+        return $codes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function localeCodes(Tenant $tenant): array
+    {
+        $codes = [];
+        foreach ($this->locales->findActiveForTenant($tenant) as $tenantLocale) {
+            $codes[] = $tenantLocale->getLocale()->getCode();
+        }
+
+        return $codes;
+    }
+}

--- a/apps/api/src/Export/Application/Builder/Structural/CategoriesExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/Structural/CategoriesExportBuilder.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder\Structural;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\CategoryAttributeGroupRepositoryInterface;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Shared\Domain\Tenant;
+
+/**
+ * EXR-06 (#1382) — `categories` export: the category tree.
+ *
+ * One row per category (CatalogObject kind=category), emitted in DFS order by
+ * ltree path so parents precede children (round-trip friendly). Localised name
+ * fans out per active locale, and `assigned_groups` lists the attribute groups
+ * declared on the category (the inheritance overlay).
+ */
+final readonly class CategoriesExportBuilder implements StructuralExportBuilderInterface
+{
+    public function __construct(
+        private CatalogObjectRepositoryInterface $objects,
+        private CategoryAttributeGroupRepositoryInterface $categoryGroups,
+        private TenantLocaleRepositoryInterface $locales,
+    ) {
+    }
+
+    public function supports(ExportEntityType $type): bool
+    {
+        return ExportEntityType::Categories === $type;
+    }
+
+    public function columns(Tenant $tenant): array
+    {
+        $columns = ['code'];
+        foreach ($this->localeCodes($tenant) as $code) {
+            $columns[] = 'name.'.$code;
+        }
+        $columns[] = 'parent_code';
+        $columns[] = 'path';
+        $columns[] = 'level';
+        $columns[] = 'target_object_type_code';
+        $columns[] = 'assigned_groups';
+
+        return $columns;
+    }
+
+    public function rows(Tenant $tenant): iterable
+    {
+        $localeCodes = $this->localeCodes($tenant);
+
+        foreach ($this->sortedCategories($tenant) as $category) {
+            $name = $this->resolveName($category);
+            $path = $category->getPath();
+
+            $row = ['code' => $category->getCode()];
+            foreach ($localeCodes as $code) {
+                // '*' holds a non-localised scalar name applied to every locale.
+                $row['name.'.$code] = $name[$code] ?? ($name['*'] ?? '');
+            }
+            $row['parent_code'] = $category->getParent()?->getCode() ?? '';
+            $row['path'] = $path ?? '';
+            $row['level'] = null === $path || '' === $path ? '' : (string) substr_count($path, '.');
+            $row['target_object_type_code'] = $category->getCategoryTargetObjectType()?->getCode() ?? '';
+            $row['assigned_groups'] = implode('|', $this->assignedGroupCodes($category));
+
+            yield $row;
+        }
+    }
+
+    public function count(Tenant $tenant): int
+    {
+        return \count($this->objects->findByKind(ObjectKind::Category, $tenant));
+    }
+
+    /**
+     * @return list<CatalogObject>
+     */
+    private function sortedCategories(Tenant $tenant): array
+    {
+        $categories = $this->objects->findByKind(ObjectKind::Category, $tenant);
+        usort($categories, static fn (CatalogObject $a, CatalogObject $b): int => ($a->getPath() ?? '') <=> ($b->getPath() ?? ''));
+
+        return $categories;
+    }
+
+    /**
+     * Localised category name keyed by locale code. A non-localised scalar
+     * name is returned under the '*' key (applied to every locale column).
+     *
+     * @return array<string, string>
+     */
+    private function resolveName(CatalogObject $category): array
+    {
+        $labelAttribute = $category->getObjectType()->getLabelAttribute();
+        if (null === $labelAttribute) {
+            return [];
+        }
+        $value = $category->getAttributesIndexed()[$labelAttribute->getCode()] ?? null;
+        if (\is_array($value)) {
+            $out = [];
+            foreach ($value as $locale => $localized) {
+                if (\is_string($locale)) {
+                    $out[$locale] = \is_scalar($localized) ? (string) $localized : '';
+                }
+            }
+
+            return $out;
+        }
+
+        return \is_scalar($value) ? ['*' => (string) $value] : [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function assignedGroupCodes(CatalogObject $category): array
+    {
+        $target = $category->getCategoryTargetObjectType();
+        if (null === $target) {
+            return [];
+        }
+        $codes = [];
+        foreach ($this->categoryGroups->findByCategoryAndTarget($category, $target) as $assignment) {
+            $codes[] = $assignment->getAttributeGroup()->getCode();
+        }
+
+        return $codes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function localeCodes(Tenant $tenant): array
+    {
+        $codes = [];
+        foreach ($this->locales->findActiveForTenant($tenant) as $tenantLocale) {
+            $codes[] = $tenantLocale->getLocale()->getCode();
+        }
+
+        return $codes;
+    }
+}

--- a/apps/api/src/Export/Application/Builder/Structural/ModuleSchemaExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/Structural/ModuleSchemaExportBuilder.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder\Structural;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * EXR-06 (#1382) — `module_schema` export: ObjectType definitions.
+ *
+ * One row per (ObjectType, attribute) attachment so the full schema — which
+ * attribute sits in which group on which ObjectType, with its config — is
+ * captured. ObjectTypes with no attributes still emit a single descriptor row.
+ *
+ * Columns are derived dynamically from the model (capability flags read off
+ * the entity, attribute config off the Attribute) — a new attribute type or
+ * capability needs no change here.
+ */
+final readonly class ModuleSchemaExportBuilder implements StructuralExportBuilderInterface
+{
+    /** @var list<string> */
+    private const array COLUMNS = [
+        'object_type_code', 'object_type_name', 'kind', 'is_built_in', 'capabilities', 'schema_version',
+        'group_code', 'group_display_mode',
+        'attribute_code', 'attribute_type', 'required', 'position', 'relation_target', 'relation_cardinality',
+    ];
+
+    public function __construct(
+        private ObjectTypeRepositoryInterface $objectTypes,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    public function supports(ExportEntityType $type): bool
+    {
+        return ExportEntityType::ModuleSchema === $type;
+    }
+
+    public function columns(Tenant $tenant): array
+    {
+        return self::COLUMNS;
+    }
+
+    public function rows(Tenant $tenant): iterable
+    {
+        foreach ($this->objectTypes->findAllByTenant($tenant) as $objectType) {
+            $base = $this->objectTypeColumns($objectType);
+
+            $groups = $this->groupsOf($objectType);
+            if ([] === $groups) {
+                yield $base + $this->blankAttributeColumns();
+                continue;
+            }
+
+            foreach ($groups as $junction) {
+                $group = $junction->getAttributeGroup();
+                $attributes = $this->attributesOf($group);
+                if ([] === $attributes) {
+                    yield $base + [
+                        'group_code' => $group->getCode(),
+                        'group_display_mode' => $junction->getDisplayMode(),
+                    ] + $this->blankAttributeColumns(keepGroup: true);
+                    continue;
+                }
+
+                foreach ($attributes as $member) {
+                    $attribute = $member->getAttribute();
+                    $cardinality = $attribute->getRelationCardinality();
+                    yield $base + [
+                        'group_code' => $group->getCode(),
+                        'group_display_mode' => $junction->getDisplayMode(),
+                        'attribute_code' => $attribute->getCode(),
+                        'attribute_type' => $attribute->getType()->value,
+                        'required' => $this->boolStr($member->isRequiredInGroup()),
+                        'position' => (string) $member->getPosition(),
+                        'relation_target' => implode('|', $attribute->getRelationTargetObjectTypeIds()),
+                        'relation_cardinality' => null === $cardinality ? '' : $cardinality->value,
+                    ];
+                }
+            }
+        }
+    }
+
+    public function count(Tenant $tenant): int
+    {
+        $count = 0;
+        foreach ($this->rows($tenant) as $ignored) {
+            ++$count;
+        }
+
+        return $count;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function objectTypeColumns(ObjectType $objectType): array
+    {
+        $capabilities = json_encode([
+            'expose_to_main_menu' => $objectType->getExposeToMainMenu(),
+            'is_categorizable' => $objectType->getIsCategorizable(),
+            'has_multimedia' => $objectType->getHasMultimedia(),
+            'has_variants' => $objectType->hasVariants(),
+        ], JSON_THROW_ON_ERROR);
+
+        return [
+            'object_type_code' => $objectType->getCode(),
+            'object_type_name' => $this->pickLabel($objectType->getLabel()),
+            'kind' => $objectType->getKind()->value,
+            'is_built_in' => $this->boolStr($objectType->isBuiltIn()),
+            'capabilities' => $capabilities,
+            'schema_version' => (string) $objectType->getSchemaVersion(),
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function blankAttributeColumns(bool $keepGroup = false): array
+    {
+        $blank = [
+            'attribute_code' => '', 'attribute_type' => '', 'required' => '',
+            'position' => '', 'relation_target' => '', 'relation_cardinality' => '',
+        ];
+        if ($keepGroup) {
+            return $blank;
+        }
+
+        return ['group_code' => '', 'group_display_mode' => ''] + $blank;
+    }
+
+    /**
+     * @return list<ObjectTypeAttributeGroup>
+     */
+    private function groupsOf(ObjectType $objectType): array
+    {
+        /** @var list<ObjectTypeAttributeGroup> $rows */
+        $rows = $this->em->createQuery(
+            'SELECT j FROM '.ObjectTypeAttributeGroup::class.' j JOIN j.attributeGroup g'
+            .' WHERE j.objectType = :ot ORDER BY j.position ASC, g.code ASC',
+        )->setParameter('ot', $objectType)->getResult();
+
+        return $rows;
+    }
+
+    /**
+     * @return list<AttributeGroupAttribute>
+     */
+    private function attributesOf(AttributeGroup $group): array
+    {
+        /** @var list<AttributeGroupAttribute> $rows */
+        $rows = $this->em->createQuery(
+            'SELECT j FROM '.AttributeGroupAttribute::class.' j JOIN j.attribute a'
+            .' WHERE j.attributeGroup = :g ORDER BY j.position ASC, a.code ASC',
+        )->setParameter('g', $group)->getResult();
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, string> $label
+     */
+    private function pickLabel(array $label): string
+    {
+        return $label['en'] ?? $label['pl'] ?? (array_values($label)[0] ?? '');
+    }
+
+    private function boolStr(bool $value): string
+    {
+        return $value ? 'true' : 'false';
+    }
+}

--- a/apps/api/src/Export/Application/Builder/Structural/StructuralExportBuilderInterface.php
+++ b/apps/api/src/Export/Application/Builder/Structural/StructuralExportBuilderInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder\Structural;
+
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * EXR-06 (#1382) — registry of builders for the structural export types.
+ *
+ * Structural exports (module_schema / attributes_groups / categories) emit the
+ * system *configuration* rather than EAV data, so they do not flow through the
+ * catalog-object pipeline ({@see \App\Export\Application\Sync\SyncExportRunner}
+ * dispatches product/custom_module there). Each implementation yields a flat
+ * table — ordered column keys + rows keyed by those columns — which the runner
+ * streams into the existing CSV/XLSX writers.
+ *
+ * Implementations are autoconfigured into the `app.export.structural_builder`
+ * tag and consumed by the runner via a tagged iterator.
+ */
+#[AutoconfigureTag('app.export.structural_builder')]
+interface StructuralExportBuilderInterface
+{
+    public function supports(ExportEntityType $type): bool;
+
+    /**
+     * Ordered default column keys. Depends on the tenant because some types
+     * fan out per active locale (e.g. `label.pl`, `label.en`).
+     *
+     * @return list<string>
+     */
+    public function columns(Tenant $tenant): array;
+
+    /**
+     * @return iterable<array<string, string>> rows keyed by column key
+     */
+    public function rows(Tenant $tenant): iterable;
+
+    public function count(Tenant $tenant): int;
+}

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -12,6 +12,7 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Export\Application\Builder\ExportBuilder;
 use App\Export\Application\Builder\PublicationColumnPlanner;
+use App\Export\Application\Builder\Structural\StructuralExportBuilderInterface;
 use App\Export\Domain\Entity\ExportSession;
 use App\Export\Domain\Enum\ExportEncoding;
 use App\Export\Domain\Enum\ExportEntityType;
@@ -26,6 +27,7 @@ use Doctrine\DBAL\Connection;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\Uid\Uuid;
 use Throwable;
 
@@ -58,7 +60,24 @@ final class SyncExportRunner
         private readonly Connection $connection,
         private readonly PublicationColumnPlanner $columnPlanner,
         private readonly ObjectTypeRepositoryInterface $objectTypes,
+        /** @var iterable<StructuralExportBuilderInterface> */
+        #[AutowireIterator('app.export.structural_builder')]
+        private readonly iterable $structuralBuilders = [],
     ) {
+    }
+
+    /**
+     * Count the rows an export will produce, used by the controller to route
+     * sync vs async. Structural types count via their builder; catalog-object
+     * types count the resolved target set.
+     */
+    public function resolveTargetCount(ExportSession $session): int
+    {
+        if ($session->getEntityType()->isStructural()) {
+            return $this->structuralBuilderFor($session->getEntityType())->count($this->requireTenant($session));
+        }
+
+        return \count($this->resolveTargets($session));
     }
 
     /**
@@ -129,6 +148,10 @@ final class SyncExportRunner
      */
     public function runToFile(ExportSession $session, string $targetPath): int
     {
+        if ($session->getEntityType()->isStructural()) {
+            return $this->runStructuralToFile($session, $targetPath);
+        }
+
         $targets = $this->resolveTargets($session);
         $session->setTargetCount(\count($targets));
 
@@ -249,6 +272,67 @@ final class SyncExportRunner
         }
 
         return array_values($ids);
+    }
+
+    /**
+     * EXR-06: structural exports (module_schema / attributes_groups /
+     * categories) stream a flat config table from the matching builder rather
+     * than the catalog-object pipeline.
+     */
+    private function runStructuralToFile(ExportSession $session, string $targetPath): int
+    {
+        $tenant = $this->requireTenant($session);
+        $builder = $this->structuralBuilderFor($session->getEntityType());
+
+        $columns = $session->getSelectedColumns();
+        if ([] === $columns) {
+            $columns = $builder->columns($tenant);
+        }
+
+        $writer = $this->openWriter($session->getFormat(), $session, $targetPath);
+        $writer->writeHeaders($columns);
+
+        $rows = 0;
+        try {
+            foreach ($builder->rows($tenant) as $row) {
+                $values = [];
+                foreach ($columns as $key) {
+                    $values[] = $row[$key] ?? '';
+                }
+                $writer->writeRow($values);
+                ++$rows;
+            }
+        } finally {
+            $writer->close();
+        }
+
+        $session->setTargetCount($rows);
+        $size = file_exists($targetPath) ? (int) filesize($targetPath) : 0;
+        $session->markDone($rows, $targetPath, $size);
+        $this->sessions->save($session);
+
+        return $rows;
+    }
+
+    private function structuralBuilderFor(ExportEntityType $type): StructuralExportBuilderInterface
+    {
+        foreach ($this->structuralBuilders as $builder) {
+            if ($builder->supports($type)) {
+                return $builder;
+            }
+        }
+
+        throw new LogicException(sprintf('No structural export builder supports entity_type "%s".', $type->value));
+    }
+
+    private function requireTenant(ExportSession $session): Tenant
+    {
+        $tenant = $session->getTenant();
+        if (null === $tenant) {
+            throw new LogicException('Export session must carry a tenant.');
+        }
+
+        return $tenant;
     }
 
     private function openWriter(ExportFormat $format, ExportSession $session, string $path): RowWriter

--- a/apps/api/src/Export/Domain/Enum/ExportEntityType.php
+++ b/apps/api/src/Export/Domain/Enum/ExportEntityType.php
@@ -67,13 +67,14 @@ enum ExportEntityType: string
     /**
      * Whether the export engine can currently generate this type.
      *
-     * Product and custom modules share the catalog-object pipeline (EXR-05);
-     * the structural types (module_schema / attributes_groups / categories)
-     * land in EXR-06. Callers reject non-executable types with a 422 instead
-     * of dispatching a run that would fail.
+     * All five types are runnable as of EXR-06: product + custom_module share
+     * the catalog-object pipeline (EXR-04/05); module_schema, attributes_groups
+     * and categories run through the structural builders (EXR-06). The flag is
+     * kept as the seam callers gate on, in case a future type ships its model
+     * ahead of its generator.
      */
     public function isExecutable(): bool
     {
-        return self::Product === $this || self::CustomModule === $this;
+        return true;
     }
 }

--- a/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
@@ -8,6 +8,7 @@ use App\Catalog\Application\Filter\FilterDslResolver;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Application\Builder\Structural\StructuralExportBuilderInterface;
 use App\Export\Domain\Enum\ExportEntityType;
 use App\Export\Domain\Enum\ExportTargetScope;
 use App\Export\Presentation\Support\ExportEntityTypeResolver;
@@ -16,6 +17,7 @@ use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\DBAL\Connection;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -48,6 +50,9 @@ final class ExportPreflightController
         private readonly FilterDslResolver $filterDsl,
         private readonly Connection $connection,
         private readonly TenantContext $tenantContext,
+        /** @var iterable<StructuralExportBuilderInterface> */
+        #[AutowireIterator('app.export.structural_builder')]
+        private readonly iterable $structuralBuilders = [],
     ) {
     }
 
@@ -71,20 +76,17 @@ final class ExportPreflightController
         $this->entityTypeResolver->assertScopeAllowed($selection->entityType, $scope);
 
         if ($selection->entityType->isStructural()) {
-            // Structural exports run with target_scope=all and their row count
-            // comes from the structural builders (EXR-06).
-            throw new UnprocessableEntityHttpException(
-                'Preflight count for structural entity types is added in EXR-06.',
-            );
+            // EXR-06: structural exports always run target_scope=all; the row
+            // count comes from the matching structural builder.
+            $count = $this->structuralCount($selection->entityType, $tenant);
+        } else {
+            $objectType = $this->resolveObjectType($selection, $tenant);
+            $count = match ($scope) {
+                ExportTargetScope::Selected => $this->countSelected($payload),
+                ExportTargetScope::All => $this->countAll($tenant, $objectType),
+                ExportTargetScope::Filter => $this->countFilter($payload, $tenant, $objectType),
+            };
         }
-
-        $objectType = $this->resolveObjectType($selection, $tenant);
-
-        $count = match ($scope) {
-            ExportTargetScope::Selected => $this->countSelected($payload),
-            ExportTargetScope::All => $this->countAll($tenant, $objectType),
-            ExportTargetScope::Filter => $this->countFilter($payload, $tenant, $objectType),
-        };
 
         $mode = $count >= SyncExportController::SYNC_THRESHOLD ? 'async' : 'sync';
 
@@ -95,6 +97,17 @@ final class ExportPreflightController
             'soft_cap' => SyncExportController::SOFT_CAP,
             'exceeds_cap' => $count > SyncExportController::SOFT_CAP,
         ]);
+    }
+
+    private function structuralCount(ExportEntityType $type, Tenant $tenant): int
+    {
+        foreach ($this->structuralBuilders as $builder) {
+            if ($builder->supports($type)) {
+                return $builder->count($tenant);
+            }
+        }
+
+        throw new UnprocessableEntityHttpException(sprintf('No structural builder for entity_type=%s.', $type->value));
     }
 
     private function resolveObjectType(ExportEntityTypeSelection $selection, Tenant $tenant): ObjectType

--- a/apps/api/src/Export/Presentation/Controller/SyncExportController.php
+++ b/apps/api/src/Export/Presentation/Controller/SyncExportController.php
@@ -93,7 +93,9 @@ final class SyncExportController
         $targetScope = $this->parseScope($payload);
         $this->entityTypeResolver->assertScopeAllowed($selection->entityType, $targetScope);
         $encoding = $this->parseEncoding($payload, $format);
-        $columns = $this->parseColumns($payload);
+        // Structural exports may omit columns (the builder supplies its full
+        // default set); catalog exports still require an explicit selection.
+        $columns = $this->parseColumns($payload, allowEmpty: $selection->entityType->isStructural());
         $selectedIds = $this->parseSelectedIds($payload, $targetScope);
         $filterSnapshot = $this->parseFilterSnapshot($payload);
         $locales = $this->parseStringList($payload, 'locales');
@@ -131,9 +133,9 @@ final class SyncExportController
         );
         $session->assignTenant($tenant);
 
-        // Resolve targets once so we know whether to go sync or async.
-        $targets = $this->runner->resolveTargets($session);
-        $targetCount = \count($targets);
+        // Count targets so we know whether to go sync or async (structural
+        // types count via their builder; catalog types via the resolved set).
+        $targetCount = $this->runner->resolveTargetCount($session);
         $this->guardCaps($targetCount);
         $session->setTargetCount($targetCount);
 
@@ -261,9 +263,12 @@ final class SyncExportController
      *
      * @return list<string>
      */
-    private function parseColumns(array $payload): array
+    private function parseColumns(array $payload, bool $allowEmpty = false): array
     {
         $value = $payload['selected_columns'] ?? null;
+        if ($allowEmpty && (null === $value || [] === $value)) {
+            return [];
+        }
         if (!\is_array($value) || [] === $value) {
             throw new BadRequestHttpException('selected_columns must be a non-empty array of column keys.');
         }

--- a/apps/api/tests/Api/Export/ExportPreflightApiTest.php
+++ b/apps/api/tests/Api/Export/ExportPreflightApiTest.php
@@ -117,14 +117,15 @@ final class ExportPreflightApiTest extends CatalogApiTestCase
     }
 
     #[Test]
-    public function rejectsStructuralEntityType(): void
+    public function countsStructuralEntityType(): void
     {
+        // EXR-06 enabled structural preflight counts (was 422 in EXR-07).
         $response = $this->preflightRaw([
             'entity_type' => 'module_schema',
             'target_scope' => 'all',
         ]);
 
-        self::assertSame(422, $response);
+        self::assertSame(200, $response);
     }
 
     #[Test]

--- a/apps/api/tests/Api/Export/StructuralExportApiTest.php
+++ b/apps/api/tests/Api/Export/StructuralExportApiTest.php
@@ -84,6 +84,7 @@ final class StructuralExportApiTest extends CatalogApiTestCase
             'json' => [
                 'entity_type' => 'module_schema',
                 'target_scope' => 'all',
+                'format' => 'csv',
             ],
         ]);
 

--- a/apps/api/tests/Api/Export/StructuralExportApiTest.php
+++ b/apps/api/tests/Api/Export/StructuralExportApiTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Export\Application\Sync\SyncExportRunner;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * EXR-06 (#1382) — structural exporters (module_schema / attributes_groups /
+ * categories) routed through the builder registry.
+ */
+final class StructuralExportApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function moduleSchemaExportListsObjectTypes(): void
+    {
+        $tenant = $this->tenant();
+        $custom = new ObjectType('gadgets', ObjectKind::Custom, ['pl' => 'Gadżety', 'en' => 'Gadgets']);
+        $custom->assignTenant($tenant);
+        $this->em()->persist($custom);
+        $this->em()->flush();
+
+        $csv = $this->runStructural($tenant, ExportEntityType::ModuleSchema);
+
+        self::assertStringContainsString('object_type_code', $csv);
+        self::assertStringContainsString('gadgets', $csv);
+    }
+
+    #[Test]
+    public function attributesExportIncludesAFreshlyAddedAttribute(): void
+    {
+        $tenant = $this->tenant();
+        $attribute = new Attribute('horsepower', ['pl' => 'Moc', 'en' => 'Horsepower'], AttributeType::Text);
+        $attribute->assignTenant($tenant);
+        $this->em()->persist($attribute);
+        $this->em()->flush();
+
+        $csv = $this->runStructural($tenant, ExportEntityType::AttributesGroups);
+
+        self::assertStringContainsString('horsepower', $csv);
+    }
+
+    #[Test]
+    public function categoriesExportListsCategoryObjects(): void
+    {
+        $tenant = $this->tenant();
+        $categoryType = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Category, $tenant);
+        \assert($categoryType instanceof ObjectType);
+
+        $category = new CatalogObject($categoryType, 'CAT-EXPORT');
+        $category->assignTenant($tenant);
+        $this->em()->persist($category);
+        $this->em()->flush();
+
+        $csv = $this->runStructural($tenant, ExportEntityType::Categories);
+
+        self::assertStringContainsString('CAT-EXPORT', $csv);
+        self::assertStringContainsString('parent_code', $csv);
+    }
+
+    #[Test]
+    public function moduleSchemaSyncExportReturns200(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/products/export', [
+            'json' => [
+                'entity_type' => 'module_schema',
+                'target_scope' => 'all',
+            ],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function preflightCountsStructuralRows(): void
+    {
+        $client = $this->authenticatedClient();
+        $response = $client->request('POST', '/api/exports/preflight', [
+            'json' => [
+                'entity_type' => 'attributes_groups',
+                'target_scope' => 'all',
+            ],
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $response->toArray(false);
+        self::assertIsInt($body['count']);
+        self::assertContains($body['mode'], ['sync', 'async']);
+    }
+
+    private function runStructural(Tenant $tenant, ExportEntityType $type): string
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $session = new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::CentralTab,
+            format: ExportFormat::Csv,
+            targetScope: ExportTargetScope::All,
+            selectedColumns: [],
+            entityType: $type,
+        );
+        $session->assignTenant($tenant);
+
+        $runner = self::getContainer()->get(SyncExportRunner::class);
+        $path = tempnam(sys_get_temp_dir(), 'exr06-').'.csv';
+        try {
+            $runner->runToFile($session, $path);
+
+            return (string) file_get_contents($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Unit/Export/ExportEntityTypeTest.php
+++ b/apps/api/tests/Unit/Export/ExportEntityTypeTest.php
@@ -53,19 +53,13 @@ final class ExportEntityTypeTest extends TestCase
     }
 
     #[Test]
-    public function catalogBackedTypesAreExecutableStructuralAreNotYet(): void
+    public function allEntityTypesAreExecutableAsOfExr06(): void
     {
-        // EXR-05: product + custom_module share the catalog-object pipeline.
-        self::assertTrue(ExportEntityType::Product->isExecutable());
-        self::assertTrue(ExportEntityType::CustomModule->isExecutable());
-
-        // Structural builders land in EXR-06.
-        foreach ([
-            ExportEntityType::ModuleSchema,
-            ExportEntityType::AttributesGroups,
-            ExportEntityType::Categories,
-        ] as $type) {
-            self::assertFalse($type->isExecutable(), $type->value.' is not runnable until EXR-06');
+        // EXR-04/05: catalog-object pipeline (product + custom_module).
+        // EXR-06: structural builders (module_schema / attributes_groups /
+        // categories). All five types are now runnable.
+        foreach (ExportEntityType::cases() as $type) {
+            self::assertTrue($type->isExecutable(), $type->value.' should be runnable');
         }
     }
 


### PR DESCRIPTION
Closes #1382

## Co i dlaczego
Trzy typy strukturalne eksportują **konfigurację systemu** (nie dane EAV). EXR-06 wprowadza **rejestr builderów** (`StructuralExportBuilderInterface`, seam odłożony z EXR-05) dispatchujący między pipeline'em catalog-object (product/custom_module) a builderami strukturalnymi.

## Zakres
- **Rejestr**: `StructuralExportBuilderInterface` (`#[AutoconfigureTag]`), konsumowany przez runner + preflight przez `#[AutowireIterator]`.
- **`module_schema`**: wiersz per (ObjectType, grupa, atrybut) — `object_type_code/name`, `kind`, `is_built_in`, `capabilities` (JSON, czytane dynamicznie z encji), `schema_version`, `group_code/display_mode`, `attribute_code/type`, `required`, `position`, `relation_target/cardinality`. ObjectType bez atrybutów → wiersz deskryptora.
- **`attributes_groups`**: słownik atrybutów — `code`, `type`, `label.<locale>`/`help.<locale>` (fan-out aktywnych locale tenanta), `validation_rules`, `is_localizable/scopable`, `options` (kody+labele select/multiselect), `groups` (kody grup joined), `is_built_in`, `created_at`.
- **`categories`**: drzewo kategorii w kolejności DFS (sort po ltree path) — `code`, `name.<locale>`, `parent_code`, `path`, `level`, `target_object_type_code`, `assigned_groups`.
- **Runner**: `runToFile` rozgałęzia structural vs catalog; `resolveTargetCount` liczy przez builder (sync/async routing); kontroler sync akceptuje puste `selected_columns` dla strukturalnych (builder podaje pełny zestaw).
- **`ExportEntityType::isExecutable()`** → wszystkie 5 typów runnable. Preflight (EXR-07) liczy strukturalne przez builder (zdjęty 422).
- **Dynamiczność schematu**: kolumny wyprowadzane z modelu — nowy typ atrybutu / locale / capability / opcja select eksportuje się bez zmiany kodu.

## Świadome odejście (uzasadnione, w treści PR per MARATHON RULE)
- **Dedykowany arkusz metadanych grup (XLSX drugi sheet / CSV-w-ZIP) odłożony** do osobnego follow-upu. Wszystkie typy emitują jeden płaski arkusz reużywając istniejących writerów (zero zmian w infrastrukturze writerów/kontrolera response). Mapowanie atrybut→grupa jest zachowane przez kolumnę `groups`. Multi-output writer (multi-sheet OpenSpout + ZipArchive + content-type ZIP w kontrolerze) to spora cross-cutting infrastruktura — lepiej jako dedykowany ticket; round-trip importu struktur i tak poza zakresem epiku.

## Testy
- **ApiTestCase** `StructuralExportApiTest` (via runner, czyta plik): module_schema listuje ObjectType (custom 'gadgets'), attributes_groups zawiera świeżo dodany atrybut (dynamiczność), categories listuje obiekty kategorii; HTTP 200 dla module_schema sync; preflight liczy strukturalne.
- **Unit** `ExportEntityTypeTest` zaktualizowany (wszystkie typy executable).
- Lokalnie: cs-fixer clean, **pełny PHPStan 1G — 0 realnych błędów**, Deptrac 0 violations, PHPUnit unit 64/64. ApiTestCase w CI.

Refs #1382
