### PR TITLE
EXR-02: pakiet primitives v2 — komponenty nowego designu + stack Vitest (#1378)

### DIFF
--- a/.github/workflows/quality-frontend.yml
+++ b/.github/workflows/quality-frontend.yml
@@ -79,6 +79,27 @@ jobs:
       - name: TypeScript typecheck
         run: pnpm --filter @pim/admin typecheck
 
+  unit:
+    name: Vitest unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Vitest
+        run: pnpm --filter @pim/admin test
+
   build:
     name: Vite build (smoke)
     runs-on: ubuntu-latest

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "biome check --write src e2e",
     "format": "biome format --write src e2e",
     "typecheck": "tsc -b --noEmit",
+    "test": "vitest run",
     "preview": "vite preview",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
@@ -59,14 +60,21 @@
     "@biomejs/biome": "^2.4.16",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/dompurify": "^3.2.0",
+    "@types/jest-axe": "^3.5.9",
     "@types/node": "^25.9.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "jest-axe": "^10.0.0",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "~6.0.2",
-    "vite": "^8.0.16"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   }
 }

--- a/apps/admin/src/components/ui-v2/README.md
+++ b/apps/admin/src/components/ui-v2/README.md
@@ -1,0 +1,67 @@
+# ui-v2 — primitives nowego design systemu (epik EXR)
+
+Komponenty nośne nowego look & feel (eksporty = pierwszy moduł, kolejne migrują
+w przyszłych epikach). Tailwind na tokenach z EXR-01 (`src/index.css`):
+granatowy neutral = skala `zinc`, CTA = skala `orange` / token `--cta`,
+błędy = skala `brick`, sukces = `emerald`.
+
+## Komponenty
+
+| Komponent | Plik | Zastosowanie |
+|---|---|---|
+| `PageHeader` | `page-header.tsx` | breadcrumb topbara + slot akcji (montowany globalnie w EXR-03) |
+| `PillTabs` | `pill-tabs.tsx` | taby strony Eksporty (aktywny = granatowy pill z licznikiem) |
+| `KpiCard` | `kpi-card.tsx` | pasek KPI (label uppercase, wartość 28px, sub-line, trend) |
+| `StatusPill` | `status-pill.tsx` | status sesji: kropka + label; mapowanie z `ExportStatus` w `status-maps.ts` |
+| `ResultBar` | `result-bar.tsx` | belka rozkładu OK/WARN/ERR (emerald/orange/brick) |
+| `ProgressBar` | `progress-bar.tsx` | animowany postęp async sesji (shimmer) |
+| `ModeBadge` | `mode-badge.tsx` | chip trybu operacji (UPDATE/CREATE/...) |
+| `FormatPill` | `format-pill.tsx` | chip formatu pliku (XLSX/CSV/...) |
+| `SelectableCard(+Group)` | `selectable-card.tsx` | kafelki wyboru (Krok 1 encje, Krok 2 formaty); radiogroup z klawiaturą |
+| `WizardStepper` | `wizard-stepper.tsx` | pasek 4 kroków wizarda (done/active/future) |
+| `EmptyState` | `empty-state.tsx` | pusty stan sekcji/tabeli z CTA |
+| `Sparkline` | `sparkline.tsx` | mini-trend SVG (port 1:1 z designu) |
+| `HealthDot` | `health-dot.tsx` | kropka zdrowia integracji (port 1:1 z designu) |
+
+Zasady: props z TSDoc, **labelki tłumaczone przez `t()`** (komponenty przyjmują
+przetłumaczone stringi albo same tłumaczą klucze z namespace `ui_v2`), a11y
+(role/aria + focus-ring), zero literałów PL/EN w kodzie.
+
+## Tabela v2 — wzorzec klas (nie komponent)
+
+Tabele nowego designu nie mają dedykowanego komponentu — stosuj klasy:
+
+- **nagłówek:** `text-[11px] uppercase tracking-wider text-zinc-400 font-medium`
+- **wiersz:** `hover:bg-zinc-50 transition-colors`
+- **separator wierszy:** `divide-y divide-zinc-100` (lub `border-b border-zinc-100`)
+- **liczby/kody:** `font-mono num` (tabular-nums z utility `.num`)
+- **karta-kontener:** `bg-surface border border-zinc-200 rounded-2xl shadow-card overflow-hidden`
+
+Przykład:
+
+```tsx
+<div className="overflow-hidden rounded-2xl border border-zinc-200 bg-surface shadow-card">
+  <table className="w-full text-[13px]">
+    <thead>
+      <tr className="text-left">
+        <th className="px-4 py-3 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">Plik</th>
+        <th className="px-4 py-3 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">Wiersze</th>
+      </tr>
+    </thead>
+    <tbody className="divide-y divide-zinc-100">
+      <tr className="transition-colors hover:bg-zinc-50">
+        <td className="px-4 py-3">products_2026-06.xlsx</td>
+        <td className="num px-4 py-3 font-mono">12 847</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+```
+
+## Testy
+
+`pnpm --filter @pim/admin test` — Vitest + Testing Library (jsdom) +
+jest-axe; specy w `src/components/ui-v2/__tests__/`.
+
+Poza zakresem (EXR-02): `StagePipeline` (specyficzny dla importów — przy
+redesignie importów), Storybook.

--- a/apps/admin/src/components/ui-v2/__tests__/axe.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/axe.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { EmptyState } from '../empty-state';
+import { FormatPill } from '../format-pill';
+import { HealthDot } from '../health-dot';
+import { KpiCard } from '../kpi-card';
+import { ModeBadge } from '../mode-badge';
+import { PageHeader } from '../page-header';
+import { PillTabs } from '../pill-tabs';
+import { ProgressBar } from '../progress-bar';
+import { ResultBar } from '../result-bar';
+import { SelectableCard, SelectableCardGroup } from '../selectable-card';
+import { StatusPill } from '../status-pill';
+import { WizardStepper } from '../wizard-stepper';
+
+expect.extend(toHaveNoViolations);
+
+/**
+ * Demo-page composition of every ui-v2 primitive — the axe acceptance
+ * gate from EXR-02 (test-only render instead of a dev route).
+ */
+function DemoPage() {
+  return (
+    <MemoryRouter>
+      <main>
+        <PageHeader
+          items={[{ label: 'Workspace', href: '/' }, { label: 'Eksporty' }]}
+          actions={<button type="button">Nowy eksport</button>}
+        />
+        <PillTabs
+          ariaLabel="Sekcje eksportów"
+          activeId="sessions"
+          onChange={() => {}}
+          items={[
+            { id: 'sessions', label: 'Sesje', count: 2 },
+            { id: 'targets', label: 'Cele', disabled: true },
+          ]}
+        />
+        <KpiCard label="Sesje 30 dni" value="12 847" sub="✓12 ⚠1 ✗0" trend={[1, 4, 2, 8]} />
+        <StatusPill variant="running" />
+        <ResultBar ok={10} warn={2} err={1} showCounts />
+        <ProgressBar value={0.4} ariaLabel="Postęp eksportu" />
+        <ModeBadge mode="UPDATE" />
+        <FormatPill format="csv" />
+        <HealthDot health="ok" label="Stan integracji: ok" />
+        <SelectableCardGroup ariaLabel="Typ encji">
+          <SelectableCard title="Produkty" description="Pełny konfigurator" selected />
+          <SelectableCard title="Usługi" disabled />
+        </SelectableCardGroup>
+        <WizardStepper
+          current={1}
+          steps={[
+            { id: 'type', label: 'Typ' },
+            { id: 'scope', label: 'Zakres' },
+          ]}
+        />
+        <EmptyState title="Brak aktywnych eksportów" description="Uruchom nowy eksport." />
+      </main>
+    </MemoryRouter>
+  );
+}
+
+describe('ui-v2 a11y', () => {
+  it('has no axe violations on the demo composition', async () => {
+    const { container } = render(<DemoPage />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/admin/src/components/ui-v2/__tests__/badges.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/badges.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { FormatPill } from '../format-pill';
+import { HealthDot } from '../health-dot';
+import { ModeBadge } from '../mode-badge';
+import { Sparkline } from '../sparkline';
+
+describe('ModeBadge', () => {
+  it('renders the mode code with a per-mode tint', () => {
+    render(<ModeBadge mode="UPDATE" />);
+    expect(screen.getByText('UPDATE')).toHaveClass('bg-sky-50');
+  });
+
+  it('falls back to the neutral tint for unknown modes', () => {
+    render(<ModeBadge mode="SOMETHING" />);
+    expect(screen.getByText('SOMETHING')).toHaveClass('bg-zinc-100');
+  });
+});
+
+describe('FormatPill', () => {
+  it('uppercases the format code', () => {
+    render(<FormatPill format="xlsx" />);
+    expect(screen.getByText('XLSX')).toHaveClass('bg-emerald-50');
+  });
+});
+
+describe('HealthDot', () => {
+  it('exposes an accessible label when given one', () => {
+    render(<HealthDot health="ok" label="Shopify: ok" />);
+    expect(screen.getByRole('img', { name: 'Shopify: ok' })).toHaveClass('bg-emerald-500');
+  });
+
+  it('is aria-hidden without a label', () => {
+    const { container } = render(<HealthDot health="off" />);
+    expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+describe('Sparkline', () => {
+  it('renders nothing for empty data', () => {
+    const { container } = render(<Sparkline data={[]} />);
+    expect(container.firstElementChild).toBeNull();
+  });
+
+  it('renders an svg path for data points', () => {
+    const { container } = render(<Sparkline data={[1, 5, 3]} />);
+    expect(container.querySelectorAll('path')).toHaveLength(2);
+  });
+});

--- a/apps/admin/src/components/ui-v2/__tests__/bars.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/bars.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ProgressBar } from '../progress-bar';
+import { ResultBar } from '../result-bar';
+
+describe('ResultBar', () => {
+  it('splits the bar proportionally and labels it for screen readers', () => {
+    render(<ResultBar ok={50} warn={25} err={25} />);
+    const bar = screen.getByRole('img');
+    expect(bar.getAttribute('aria-label')).toContain('50');
+    const segments = bar.children;
+    expect((segments[0] as HTMLElement).style.width).toBe('50%');
+    expect((segments[1] as HTMLElement).style.width).toBe('25%');
+  });
+
+  it('renders mono counts when showCounts is set', () => {
+    render(<ResultBar ok={1} warn={2} err={3} showCounts />);
+    expect(screen.getByText('✗3')).toBeInTheDocument();
+  });
+});
+
+describe('ProgressBar', () => {
+  it('clamps the value into 0..1 and exposes progressbar semantics', () => {
+    render(<ProgressBar value={1.4} ariaLabel="Postęp eksportu" />);
+    const bar = screen.getByRole('progressbar', { name: 'Postęp eksportu' });
+    expect(bar).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('drops the shimmer when not animated', () => {
+    const { container } = render(<ProgressBar value={0.5} animated={false} />);
+    expect(container.querySelector('.shimmer')).toBeNull();
+  });
+});

--- a/apps/admin/src/components/ui-v2/__tests__/kpi-empty.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/kpi-empty.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { EmptyState } from '../empty-state';
+import { KpiCard } from '../kpi-card';
+
+describe('KpiCard', () => {
+  it('renders label, value and sub-line', () => {
+    render(<KpiCard label="Sesje" value="12 847" sub="✓0 ⚠1 ✗0" />);
+    expect(screen.getByText('Sesje')).toBeInTheDocument();
+    expect(screen.getByText('12 847')).toBeInTheDocument();
+    expect(screen.getByText('✓0 ⚠1 ✗0')).toBeInTheDocument();
+  });
+
+  it('renders a trend sparkline only with 2+ points', () => {
+    const { container, rerender } = render(<KpiCard label="X" value="1" trend={[1, 2, 3]} />);
+    expect(container.querySelector('svg')).not.toBeNull();
+    rerender(<KpiCard label="X" value="1" trend={[1]} />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+});
+
+describe('EmptyState', () => {
+  it('renders title, description and the action slot', () => {
+    render(
+      <EmptyState
+        title="Brak aktywnych eksportów"
+        description="Uruchom nowy eksport, aby zobaczyć postęp."
+        action={<button type="button">Nowy eksport</button>}
+      />,
+    );
+    expect(screen.getByText('Brak aktywnych eksportów')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Nowy eksport' })).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/components/ui-v2/__tests__/page-header.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/page-header.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { PageHeader } from '../page-header';
+
+const ITEMS = [
+  { label: 'Workspace', href: '/' },
+  { label: 'Integracje', href: '/integrations' },
+  { label: 'Eksporty' },
+];
+
+describe('PageHeader', () => {
+  it('renders intermediate segments as links and the last as current page', () => {
+    render(
+      <MemoryRouter>
+        <PageHeader items={ITEMS} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('link', { name: 'Integracje' })).toHaveAttribute(
+      'href',
+      '/integrations',
+    );
+    const current = screen.getByText('Eksporty');
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(current.closest('nav')).toHaveAttribute('aria-label', 'breadcrumb');
+  });
+
+  it('renders the actions slot', () => {
+    render(
+      <MemoryRouter>
+        <PageHeader items={ITEMS} actions={<button type="button">Nowy eksport</button>} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('button', { name: 'Nowy eksport' })).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/components/ui-v2/__tests__/pill-tabs.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/pill-tabs.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type PillTabItem, PillTabs } from '../pill-tabs';
+
+const ITEMS: PillTabItem[] = [
+  { id: 'sessions', label: 'Sesje', count: 12 },
+  { id: 'profiles', label: 'Profile Eksportu', count: 3 },
+  { id: 'targets', label: 'Cele', disabled: true },
+];
+
+describe('PillTabs', () => {
+  it('marks the active tab and shows counts', () => {
+    render(<PillTabs items={ITEMS} activeId="sessions" onChange={() => {}} ariaLabel="Eksporty" />);
+    const active = screen.getByRole('tab', { name: /Sesje/ });
+    expect(active).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('fires onChange for enabled tabs only', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<PillTabs items={ITEMS} activeId="sessions" onChange={onChange} />);
+    await user.click(screen.getByRole('tab', { name: /Profile Eksportu/ }));
+    expect(onChange).toHaveBeenCalledWith('profiles');
+    await user.click(screen.getByRole('tab', { name: /Cele/ }));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the soon badge on disabled tabs', () => {
+    render(<PillTabs items={ITEMS} activeId="sessions" onChange={() => {}} />);
+    const disabled = screen.getByRole('tab', { name: /Cele/ });
+    expect(disabled).toHaveAttribute('aria-disabled', 'true');
+    expect(disabled).toHaveTextContent('wkrótce');
+  });
+});

--- a/apps/admin/src/components/ui-v2/__tests__/selectable-card.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/selectable-card.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SelectableCard, SelectableCardGroup } from '../selectable-card';
+
+describe('SelectableCard', () => {
+  it('shows the selected badge and aria-checked', () => {
+    render(<SelectableCard title="Produkty" selected onSelect={() => {}} />);
+    const radio = screen.getByRole('radio', { name: /Produkty/ });
+    expect(radio).toHaveAttribute('aria-checked', 'true');
+    expect(radio).toHaveTextContent('wybrane');
+  });
+
+  it('blocks selection and shows the soon badge when disabled', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<SelectableCard title="Google Sheets" disabled onSelect={onSelect} />);
+    const radio = screen.getByRole('radio', { name: /Google Sheets/ });
+    expect(radio).toHaveTextContent('wkrótce');
+    await user.click(radio);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe('SelectableCardGroup', () => {
+  it('moves selection with arrow keys (radiogroup keyboard model)', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <SelectableCardGroup ariaLabel="Typ encji">
+        <SelectableCard title="Produkty" selected onSelect={() => {}} />
+        <SelectableCard title="Kategorie" onSelect={onSelect} />
+      </SelectableCardGroup>,
+    );
+    screen.getByRole('radio', { name: /Produkty/ }).focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onSelect).toHaveBeenCalled();
+    expect(screen.getByRole('radio', { name: /Kategorie/ })).toHaveFocus();
+  });
+
+  it('skips disabled cards during arrow navigation', async () => {
+    const user = userEvent.setup();
+    const onSelectLast = vi.fn();
+    render(
+      <SelectableCardGroup ariaLabel="Format">
+        <SelectableCard title="CSV" selected onSelect={() => {}} />
+        <SelectableCard title="PDF" disabled onSelect={() => {}} />
+        <SelectableCard title="XLSX" onSelect={onSelectLast} />
+      </SelectableCardGroup>,
+    );
+    screen.getByRole('radio', { name: /CSV/ }).focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onSelectLast).toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/components/ui-v2/__tests__/status-pill.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/status-pill.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { exportStatusToPillVariant } from '../status-maps';
+import { StatusPill } from '../status-pill';
+
+describe('StatusPill', () => {
+  it('renders the translated label per variant', () => {
+    render(<StatusPill variant="success" />);
+    expect(screen.getByText('sukces')).toBeInTheDocument();
+  });
+
+  it('pulses the dot only for the running variant', () => {
+    const { container, rerender } = render(<StatusPill variant="running" />);
+    expect(container.querySelector('.pulse-dot')).not.toBeNull();
+    rerender(<StatusPill variant="error" />);
+    expect(container.querySelector('.pulse-dot')).toBeNull();
+  });
+
+  it('accepts a custom label override', () => {
+    render(<StatusPill variant="partial" label="50/100" />);
+    expect(screen.getByText('50/100')).toBeInTheDocument();
+  });
+});
+
+describe('exportStatusToPillVariant', () => {
+  it('maps backend ExportStatus values onto pill variants', () => {
+    expect(exportStatusToPillVariant('done')).toBe('success');
+    expect(exportStatusToPillVariant('running')).toBe('running');
+    expect(exportStatusToPillVariant('error')).toBe('error');
+    expect(exportStatusToPillVariant('pending')).toBe('queued');
+    expect(exportStatusToPillVariant('cancelled')).toBe('cancelled');
+  });
+});

--- a/apps/admin/src/components/ui-v2/__tests__/wizard-stepper.test.tsx
+++ b/apps/admin/src/components/ui-v2/__tests__/wizard-stepper.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type WizardStep, WizardStepper } from '../wizard-stepper';
+
+const STEPS: WizardStep[] = [
+  { id: 'type', label: 'Typ', hint: 'encja' },
+  { id: 'scope', label: 'Zakres', hint: 'filtr + format' },
+  { id: 'columns', label: 'Kolumny' },
+  { id: 'summary', label: 'Podsumowanie' },
+];
+
+describe('WizardStepper', () => {
+  it('marks the active step with aria-current', () => {
+    render(<WizardStepper steps={STEPS} current={1} />);
+    expect(screen.getByRole('button', { name: /Zakres/ })).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('lets the user go back to a done step but not forward', async () => {
+    const user = userEvent.setup();
+    const onStepClick = vi.fn();
+    render(<WizardStepper steps={STEPS} current={1} onStepClick={onStepClick} />);
+    await user.click(screen.getByRole('button', { name: /Typ/ }));
+    expect(onStepClick).toHaveBeenCalledWith(0);
+    expect(screen.getByRole('button', { name: /Kolumny/ })).toBeDisabled();
+  });
+});

--- a/apps/admin/src/components/ui-v2/empty-state.tsx
+++ b/apps/admin/src/components/ui-v2/empty-state.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface EmptyStateProps {
+  /** Icon rendered inside a muted rounded square. */
+  icon?: ReactNode;
+  /** Already-translated title. */
+  title: string;
+  /** Already-translated supporting copy. */
+  description?: string;
+  /** Call-to-action slot (button / link). */
+  action?: ReactNode;
+  className?: string;
+}
+
+/** Centered empty state ("W toku" with no running exports, empty tables). */
+export function EmptyState({ icon, title, description, action, className }: EmptyStateProps) {
+  return (
+    <div
+      className={cn('flex flex-col items-center justify-center px-6 py-12 text-center', className)}
+    >
+      {icon && (
+        <span
+          aria-hidden="true"
+          className="mb-3 grid h-12 w-12 place-items-center rounded-2xl bg-zinc-100 text-zinc-400"
+        >
+          {icon}
+        </span>
+      )}
+      <div className="text-[14px] font-semibold tracking-tight text-ink">{title}</div>
+      {description && (
+        <div className="mt-1 max-w-sm text-[12.5px] leading-relaxed text-zinc-500">
+          {description}
+        </div>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui-v2/format-pill.tsx
+++ b/apps/admin/src/components/ui-v2/format-pill.tsx
@@ -1,0 +1,31 @@
+import { cn } from '@/lib/utils';
+
+const FORMAT_CLASSES: Record<string, string> = {
+  XLSX: 'bg-emerald-50 text-emerald-700',
+  XLS: 'bg-emerald-50/70 text-emerald-700/80',
+  CSV: 'bg-sky-50 text-sky-700',
+  JSON: 'bg-orange-50 text-orange-700',
+  XML: 'bg-amber-50 text-amber-700',
+};
+
+interface FormatPillProps {
+  /** File format code, e.g. `xlsx` / `CSV` — rendered uppercase. */
+  format: string;
+  className?: string;
+}
+
+/** Small mono chip for a file format (XLSX / CSV / ...). */
+export function FormatPill({ format, className }: FormatPillProps) {
+  const code = format.toUpperCase();
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-1.5 py-0.5 font-mono text-[10.5px] font-semibold',
+        FORMAT_CLASSES[code] ?? 'bg-zinc-100 text-zinc-700',
+        className,
+      )}
+    >
+      {code}
+    </span>
+  );
+}

--- a/apps/admin/src/components/ui-v2/health-dot.tsx
+++ b/apps/admin/src/components/ui-v2/health-dot.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@/lib/utils';
+
+export type HealthDotHealth = 'ok' | 'warn' | 'error' | 'off';
+
+const HEALTH_CLASSES: Record<HealthDotHealth, string> = {
+  ok: 'bg-emerald-500',
+  warn: 'bg-amber-500',
+  error: 'bg-brick-500',
+  off: 'bg-zinc-300',
+};
+
+interface HealthDotProps {
+  health: HealthDotHealth;
+  /** Accessible description announced by screen readers. */
+  label?: string;
+  className?: string;
+}
+
+/** 8px health indicator dot (port of design primitives.jsx HealthDot). */
+export function HealthDot({ health, label, className }: HealthDotProps) {
+  const dotClassName = cn('inline-block h-2 w-2 rounded-full', HEALTH_CLASSES[health], className);
+  if (label) {
+    return <span role="img" aria-label={label} className={dotClassName} />;
+  }
+  return <span aria-hidden="true" className={dotClassName} />;
+}

--- a/apps/admin/src/components/ui-v2/kpi-card.tsx
+++ b/apps/admin/src/components/ui-v2/kpi-card.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+import { Sparkline } from './sparkline';
+
+interface KpiCardProps {
+  /** Uppercase 11px label above the value (already translated). */
+  label: string;
+  /** Main value, 28px bold — formatted by the caller (e.g. Intl.NumberFormat). */
+  value: ReactNode;
+  /** Secondary line under the value (e.g. `✓0 ⚠1 ✗0`, throughput). */
+  sub?: ReactNode;
+  /** Optional icon rendered in the top-right corner. */
+  icon?: ReactNode;
+  /** Optional mini trend sparkline data. */
+  trend?: number[];
+  className?: string;
+}
+
+/**
+ * KPI card for the exports page header strip (screen 1):
+ * white card, uppercase label, large mono-spaced value, optional sub-line,
+ * corner icon and trend sparkline.
+ */
+export function KpiCard({ label, value, sub, icon, trend, className }: KpiCardProps) {
+  return (
+    <div
+      className={cn(
+        'relative rounded-2xl border border-zinc-200 bg-surface p-5 shadow-card',
+        className,
+      )}
+    >
+      {icon && (
+        <span
+          aria-hidden="true"
+          className="absolute top-4 right-4 grid h-8 w-8 place-items-center rounded-xl bg-zinc-100 text-zinc-500"
+        >
+          {icon}
+        </span>
+      )}
+      <div className="text-[11px] font-medium tracking-wider text-zinc-400 uppercase">{label}</div>
+      <div className="num font-display mt-1 text-[28px] font-semibold tracking-tight text-ink">
+        {value}
+      </div>
+      {sub && <div className="mt-0.5 font-mono text-[11.5px] text-zinc-500">{sub}</div>}
+      {trend && trend.length > 1 && (
+        <div className="mt-2">
+          <Sparkline data={trend} width={120} height={24} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui-v2/mode-badge.tsx
+++ b/apps/admin/src/components/ui-v2/mode-badge.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@/lib/utils';
+
+export type ModeBadgeMode = 'ADD' | 'UPDATE' | 'UPSERT' | 'MERGE' | 'INCREMENT' | 'DELETE';
+
+const MODE_CLASSES: Record<ModeBadgeMode, { badge: string; dot: string }> = {
+  ADD: { badge: 'bg-zinc-100 text-zinc-700', dot: 'bg-zinc-400' },
+  UPDATE: { badge: 'bg-sky-50 text-sky-700', dot: 'bg-sky-500' },
+  UPSERT: { badge: 'bg-orange-50 text-orange-700', dot: 'bg-orange-500' },
+  MERGE: { badge: 'bg-emerald-50 text-emerald-700', dot: 'bg-emerald-500' },
+  INCREMENT: { badge: 'bg-amber-50 text-amber-800', dot: 'bg-amber-500' },
+  DELETE: { badge: 'bg-brick-50 text-brick-700', dot: 'bg-brick-500' },
+};
+
+interface ModeBadgeProps {
+  /** Operation mode; the label renders verbatim (uppercase technical code). */
+  mode: ModeBadgeMode | string;
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+/**
+ * Uppercase operation-mode chip with a colored dot (UPDATE / CREATE / ...).
+ * Unknown modes fall back to the neutral zinc tint.
+ */
+export function ModeBadge({ mode, size = 'sm', className }: ModeBadgeProps) {
+  const classes = MODE_CLASSES[mode as ModeBadgeMode] ?? MODE_CLASSES.ADD;
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 font-mono font-medium uppercase',
+        size === 'sm'
+          ? 'rounded px-1.5 py-0.5 text-[10.5px]'
+          : 'rounded-md px-2 py-0.5 text-[11.5px]',
+        classes.badge,
+        className,
+      )}
+    >
+      <span aria-hidden="true" className={cn('h-1.5 w-1.5 rounded-full', classes.dot)} />
+      {mode}
+    </span>
+  );
+}

--- a/apps/admin/src/components/ui-v2/page-header.tsx
+++ b/apps/admin/src/components/ui-v2/page-header.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+import { Link } from 'react-router';
+
+import { cn } from '@/lib/utils';
+
+export interface BreadcrumbItem {
+  /** Already-translated segment label. */
+  label: string;
+  /** Route target; the last segment usually has none (current page). */
+  href?: string;
+}
+
+interface PageHeaderProps {
+  /** Breadcrumb segments, e.g. Workspace / Integracje / Eksporty. */
+  items: BreadcrumbItem[];
+  /** Right-hand slot: page CTA + fixed icon actions (lang, history, bell). */
+  actions?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Topbar page header (design Topbar): breadcrumb where intermediate
+ * segments are links (zinc-400) and the last one is bold ink, plus an
+ * actions slot on the right. Mounted globally by the shell (EXR-03).
+ */
+export function PageHeader({ items, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn('flex h-[68px] items-center gap-4 px-10', className)}>
+      <nav aria-label="breadcrumb" className="min-w-0 flex-1">
+        <ol className="font-display flex items-center truncate text-[22px] font-semibold tracking-tight">
+          {items.map((item, index) => {
+            const last = index === items.length - 1;
+            return (
+              <li key={`${item.href ?? ''}|${item.label}`} className="flex min-w-0 items-center">
+                {index > 0 && (
+                  <span aria-hidden="true" className="mx-2 text-zinc-300">
+                    /
+                  </span>
+                )}
+                {item.href && !last ? (
+                  <Link
+                    to={item.href}
+                    className="focus-ring truncate rounded-md text-zinc-400 hover:text-ink"
+                  >
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span
+                    aria-current={last ? 'page' : undefined}
+                    className={cn('truncate', last ? 'text-ink' : 'text-zinc-400')}
+                  >
+                    {item.label}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+      {actions && <div className="flex shrink-0 items-center gap-1.5">{actions}</div>}
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui-v2/pill-tabs.tsx
+++ b/apps/admin/src/components/ui-v2/pill-tabs.tsx
@@ -1,0 +1,88 @@
+import { useTranslation } from 'react-i18next';
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+export interface PillTabItem {
+  id: string;
+  /** Already-translated tab label. */
+  label: string;
+  /** Optional count rendered in a lighter badge inside the pill. */
+  count?: number;
+  /** Disabled tab with a "coming soon" tooltip (D3: Cele / Harmonogram). */
+  disabled?: boolean;
+}
+
+interface PillTabsProps {
+  items: PillTabItem[];
+  activeId: string;
+  onChange: (id: string) => void;
+  /** Accessible name of the tablist. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Pill tabs from screen 1: active tab is a navy pill with a lighter count
+ * badge; inactive tabs are zinc-500 text; disabled tabs show a "soon"
+ * tooltip and are skipped by activation.
+ */
+export function PillTabs({ items, activeId, onChange, ariaLabel, className }: PillTabsProps) {
+  const { t } = useTranslation();
+  return (
+    <div role="tablist" aria-label={ariaLabel} className={cn('flex items-center gap-1', className)}>
+      {items.map((item) => {
+        const active = item.id === activeId;
+        const tab = (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            aria-disabled={item.disabled || undefined}
+            tabIndex={active ? 0 : -1}
+            onClick={() => {
+              if (!item.disabled) {
+                onChange(item.id);
+              }
+            }}
+            className={cn(
+              'focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl px-3.5 text-[13px] font-medium transition',
+              active && 'bg-zinc-900 text-white',
+              !active && !item.disabled && 'text-zinc-500 hover:bg-zinc-100 hover:text-ink',
+              item.disabled && 'cursor-not-allowed text-zinc-300',
+            )}
+          >
+            {item.label}
+            {item.count !== undefined && (
+              <span
+                className={cn(
+                  'num rounded-md px-1.5 py-0.5 font-mono text-[10.5px] font-semibold',
+                  active ? 'bg-white/15 text-white' : 'bg-zinc-100 text-zinc-500',
+                )}
+              >
+                {item.count}
+              </span>
+            )}
+            {item.disabled && (
+              <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-zinc-400 uppercase">
+                {t('ui_v2.soon')}
+              </span>
+            )}
+          </button>
+        );
+        if (!item.disabled) {
+          return tab;
+        }
+        return (
+          <TooltipProvider key={item.id}>
+            <Tooltip>
+              <TooltipTrigger asChild>{tab}</TooltipTrigger>
+              <TooltipContent>{t('ui_v2.soon_tooltip')}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui-v2/progress-bar.tsx
+++ b/apps/admin/src/components/ui-v2/progress-bar.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@/lib/utils';
+
+interface ProgressBarProps {
+  /** Progress in the 0..1 range; values outside are clamped. */
+  value: number;
+  height?: number;
+  /** Shimmer animation while the job is running. */
+  animated?: boolean;
+  /** Accessible label announced with the progressbar role. */
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Animated ink progress bar for async export sessions
+ * (port of design primitives.jsx ProgressBar; shimmer from index.css).
+ */
+export function ProgressBar({
+  value,
+  height = 8,
+  animated = true,
+  ariaLabel,
+  className,
+}: ProgressBarProps) {
+  const percent = Math.max(0, Math.min(1, value)) * 100;
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={Math.round(percent)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={ariaLabel}
+      className={cn('relative overflow-hidden rounded-full bg-zinc-100', className)}
+      style={{ height }}
+    >
+      <div
+        className="absolute inset-y-0 left-0 rounded-full bg-zinc-900 transition-all"
+        style={{ width: `${percent}%` }}
+      >
+        {animated && <div className="shimmer absolute inset-0" />}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui-v2/result-bar.tsx
+++ b/apps/admin/src/components/ui-v2/result-bar.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+interface ResultBarProps {
+  ok: number;
+  warn: number;
+  err: number;
+  /** Defaults to ok + warn + err when omitted. */
+  total?: number;
+  width?: number;
+  height?: number;
+  /** Render the `✓ok ⚠warn ✗err` counter next to the bar. */
+  showCounts?: boolean;
+  className?: string;
+}
+
+/**
+ * Horizontal OK/WARN/ERR distribution bar (emerald / orange / brick)
+ * with an optional mono counter (design: ResultBar + session table cells).
+ */
+export function ResultBar({
+  ok,
+  warn,
+  err,
+  total,
+  width = 140,
+  height = 8,
+  showCounts = false,
+  className,
+}: ResultBarProps) {
+  const { t } = useTranslation();
+  const sum = total ?? ok + warn + err;
+  const safeSum = sum > 0 ? sum : 1;
+  return (
+    <div className={cn('flex items-center gap-2', className)}>
+      <div
+        role="img"
+        aria-label={t('ui_v2.result_bar.aria', { ok, warn, err })}
+        className="flex overflow-hidden rounded-full bg-zinc-100"
+        style={{ width, height }}
+      >
+        <div className="bg-emerald-500" style={{ width: `${(ok / safeSum) * 100}%` }} />
+        <div className="bg-orange-400" style={{ width: `${(warn / safeSum) * 100}%` }} />
+        <div className="bg-brick-500" style={{ width: `${(err / safeSum) * 100}%` }} />
+      </div>
+      {showCounts && (
+        <span aria-hidden="true" className="font-mono text-[11px] text-zinc-500">
+          <span className="text-emerald-600">✓{ok}</span>{' '}
+          <span className="text-orange-600">⚠{warn}</span>{' '}
+          <span className="text-brick-600">✗{err}</span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui-v2/selectable-card.tsx
+++ b/apps/admin/src/components/ui-v2/selectable-card.tsx
@@ -1,0 +1,187 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type KeyboardEvent,
+  type ReactElement,
+  type ReactNode,
+  useRef,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface SelectableCardProps {
+  /** Icon shown in the rounded-xl square (navy when selected). */
+  icon?: ReactNode;
+  /** Already-translated title. */
+  title: string;
+  /** Already-translated 13px description. */
+  description?: string;
+  selected?: boolean;
+  /** Disabled card renders a "soon" badge + tooltip and cannot be chosen. */
+  disabled?: boolean;
+  onSelect?: () => void;
+  className?: string;
+  /** Managed by SelectableCardGroup — do not set manually. */
+  tabIndex?: number;
+}
+
+/**
+ * Selection tile (wizard step 1 entity / step 2 format). Use inside
+ * `<SelectableCardGroup>` which provides radiogroup keyboard semantics.
+ */
+export function SelectableCard({
+  icon,
+  title,
+  description,
+  selected = false,
+  disabled = false,
+  onSelect,
+  className,
+  tabIndex,
+}: SelectableCardProps) {
+  const { t } = useTranslation();
+  const card = (
+    // biome-ignore lint/a11y/useSemanticElements: rich card content (icon, badges, description) cannot live inside <input type="radio">; button+role=radio matches the Radix RadioGroup pattern
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      aria-disabled={disabled || undefined}
+      tabIndex={tabIndex ?? (selected ? 0 : -1)}
+      onClick={() => {
+        if (!disabled) {
+          onSelect?.();
+        }
+      }}
+      className={cn(
+        'focus-ring rounded-2xl border bg-surface p-5 text-left transition',
+        selected && 'soft-shadow border-zinc-900 ring-1 ring-zinc-900',
+        !selected && !disabled && 'border-zinc-200 hover:border-zinc-400',
+        disabled && 'cursor-not-allowed border-zinc-200 opacity-60',
+        className,
+      )}
+    >
+      {icon && (
+        <span
+          aria-hidden="true"
+          className={cn(
+            'grid h-12 w-12 place-items-center rounded-xl transition',
+            selected ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-600',
+          )}
+        >
+          {icon}
+        </span>
+      )}
+      <span
+        className={cn(
+          'flex items-center gap-2 text-[15px] font-semibold tracking-tight',
+          icon && 'mt-4',
+        )}
+      >
+        {title}
+        {selected && (
+          <span className="rounded bg-orange-500 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-zinc-900 uppercase">
+            {t('ui_v2.selected')}
+          </span>
+        )}
+        {disabled && (
+          <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-zinc-400 uppercase">
+            {t('ui_v2.soon')}
+          </span>
+        )}
+      </span>
+      {description && (
+        <span className="mt-1.5 block text-[12.5px] leading-relaxed text-zinc-500">
+          {description}
+        </span>
+      )}
+    </button>
+  );
+  if (!disabled) {
+    return card;
+  }
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{card}</TooltipTrigger>
+        <TooltipContent>{t('ui_v2.soon_tooltip')}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+interface SelectableCardGroupProps {
+  /** Accessible name of the radiogroup. */
+  ariaLabel: string;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Radiogroup wrapper for `<SelectableCard>` tiles: arrow keys move focus
+ * and select the focused card (standard radio-group keyboard model).
+ */
+export function SelectableCardGroup({ ariaLabel, children, className }: SelectableCardGroupProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp'].includes(event.key)) {
+      return;
+    }
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const radios = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[role="radio"]:not([aria-disabled="true"])'),
+    );
+    if (radios.length === 0) {
+      return;
+    }
+    event.preventDefault();
+    const forward = event.key === 'ArrowRight' || event.key === 'ArrowDown';
+    const currentIndex = radios.findIndex((radio) => radio === document.activeElement);
+    const base =
+      currentIndex === -1
+        ? radios.findIndex((r) => r.getAttribute('aria-checked') === 'true')
+        : currentIndex;
+    const next = ((base === -1 ? 0 : base) + (forward ? 1 : -1) + radios.length) % radios.length;
+    radios[next]?.focus();
+    radios[next]?.click();
+  };
+
+  // The selected card is the only tab stop; when none is selected the first
+  // enabled card takes it so keyboard users can enter the group.
+  let firstEnabledAssigned = false;
+  const anySelected = Children.toArray(children).some(
+    (child) => isValidElement<SelectableCardProps>(child) && child.props.selected,
+  );
+  const items = Children.map(children, (child) => {
+    if (!isValidElement<SelectableCardProps>(child)) {
+      return child;
+    }
+    let tabIndex = -1;
+    if (child.props.selected) {
+      tabIndex = 0;
+    } else if (!anySelected && !child.props.disabled && !firstEnabledAssigned) {
+      firstEnabledAssigned = true;
+      tabIndex = 0;
+    }
+    return cloneElement(child as ReactElement<SelectableCardProps>, { tabIndex });
+  });
+
+  return (
+    <div
+      ref={containerRef}
+      role="radiogroup"
+      aria-label={ariaLabel}
+      onKeyDown={handleKeyDown}
+      className={className}
+    >
+      {items}
+    </div>
+  );
+}

--- a/apps/admin/src/components/ui-v2/sparkline.tsx
+++ b/apps/admin/src/components/ui-v2/sparkline.tsx
@@ -1,0 +1,53 @@
+interface SparklineProps {
+  /** Data points, plotted left → right; renders nothing when empty. */
+  data: number[];
+  width?: number;
+  height?: number;
+  stroke?: string;
+  fill?: string;
+}
+
+/**
+ * Minimal SVG sparkline (port of design primitives.jsx Sparkline).
+ * Purely decorative — hidden from assistive technology.
+ */
+export function Sparkline({
+  data,
+  width = 96,
+  height = 28,
+  stroke = 'var(--ink)',
+  fill = 'rgba(22, 35, 63, 0.08)',
+}: SparklineProps) {
+  if (data.length === 0) {
+    return null;
+  }
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const points = data.map((value, index) => {
+    const x = data.length === 1 ? width : (index / (data.length - 1)) * width;
+    const y = height - ((value - min) / range) * height * 0.85 - height * 0.075;
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const path = `M${points.join(' L')}`;
+  const fillPath = `${path} L${width},${height} L0,${height} Z`;
+  return (
+    <svg
+      aria-hidden="true"
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="block"
+    >
+      <path d={fillPath} fill={fill} />
+      <path
+        d={path}
+        stroke={stroke}
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/admin/src/components/ui-v2/status-maps.ts
+++ b/apps/admin/src/components/ui-v2/status-maps.ts
@@ -1,0 +1,38 @@
+/**
+ * Single place mapping backend statuses onto ui-v2 visual variants.
+ * Spec: Project Plan/UI/feature-exports-redesign-tickets.md §EXR-02.
+ */
+
+/** Visual variants understood by `<StatusPill>`. */
+export type StatusPillVariant =
+  | 'success'
+  | 'warning'
+  | 'partial'
+  | 'error'
+  | 'cancelled'
+  | 'queued'
+  | 'running';
+
+/** Backend `ExportStatus` enum values (apps/api ExportStatus.php). */
+export type ExportStatus = 'pending' | 'running' | 'done' | 'error';
+
+/** Map an `ExportSession.status` onto a pill variant. */
+export function exportStatusToPillVariant(status: ExportStatus | string): StatusPillVariant {
+  switch (status) {
+    case 'done':
+      return 'success';
+    case 'running':
+      return 'running';
+    case 'error':
+      return 'error';
+    case 'cancelled':
+      return 'cancelled';
+    default:
+      return 'queued';
+  }
+}
+
+/** i18n key (in the `ui_v2.status` namespace) for a pill variant. */
+export function statusPillLabelKey(variant: StatusPillVariant): string {
+  return `ui_v2.status.${variant}`;
+}

--- a/apps/admin/src/components/ui-v2/status-pill.tsx
+++ b/apps/admin/src/components/ui-v2/status-pill.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+import { type StatusPillVariant, statusPillLabelKey } from './status-maps';
+
+const VARIANT_CLASSES: Record<StatusPillVariant, { pill: string; dot: string }> = {
+  success: { pill: 'bg-emerald-50 text-emerald-700', dot: 'bg-emerald-500' },
+  warning: { pill: 'bg-orange-50 text-orange-800', dot: 'bg-orange-500' },
+  partial: { pill: 'bg-orange-50 text-orange-800', dot: 'bg-orange-500' },
+  error: { pill: 'bg-brick-50 text-brick-700', dot: 'bg-brick-500' },
+  cancelled: { pill: 'bg-zinc-100 text-zinc-500', dot: 'bg-zinc-400' },
+  queued: { pill: 'bg-zinc-100 text-zinc-600', dot: 'bg-zinc-400' },
+  running: { pill: 'bg-zinc-100 text-zinc-700', dot: 'bg-zinc-500' },
+};
+
+interface StatusPillProps {
+  variant: StatusPillVariant;
+  /** Override the default translated label (e.g. backend-provided text). */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Dot + label status chip (ui-v2). The `running` variant pulses its dot.
+ * Map backend statuses through `exportStatusToPillVariant` in status-maps.ts.
+ */
+export function StatusPill({ variant, label, className }: StatusPillProps) {
+  const { t } = useTranslation();
+  const classes = VARIANT_CLASSES[variant];
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11.5px] font-medium',
+        classes.pill,
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          'h-1.5 w-1.5 rounded-full',
+          classes.dot,
+          variant === 'running' && 'pulse-dot',
+        )}
+      />
+      {label ?? t(statusPillLabelKey(variant))}
+    </span>
+  );
+}

--- a/apps/admin/src/components/ui-v2/wizard-stepper.tsx
+++ b/apps/admin/src/components/ui-v2/wizard-stepper.tsx
@@ -1,0 +1,83 @@
+import { Check } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export interface WizardStep {
+  id: string;
+  /** Already-translated step title. */
+  label: string;
+  /** Already-translated 11px subtitle. */
+  hint?: string;
+}
+
+interface WizardStepperProps {
+  steps: WizardStep[];
+  /** Index of the active step (0-based). */
+  current: number;
+  /**
+   * Called when the user clicks a DONE step (going back). Confirmation on
+   * dirty state is the wizard's responsibility (EXR-09), not the stepper's.
+   */
+  onStepClick?: (index: number) => void;
+  className?: string;
+}
+
+/**
+ * 4-step wizard bar (design Stepper): done = emerald tile with check,
+ * active = navy tile, future = white/zinc. Only done steps are clickable.
+ */
+export function WizardStepper({ steps, current, onStepClick, className }: WizardStepperProps) {
+  return (
+    <ol className={cn('flex items-stretch gap-1.5', className)}>
+      {steps.map((step, index) => {
+        const active = index === current;
+        const done = index < current;
+        return (
+          <li key={step.id} className="min-w-0 flex-1">
+            <button
+              type="button"
+              disabled={!done}
+              aria-current={active ? 'step' : undefined}
+              onClick={() => {
+                if (done) {
+                  onStepClick?.(index);
+                }
+              }}
+              className={cn(
+                'focus-ring w-full rounded-xl border px-3.5 py-3 text-left transition',
+                active && 'border-zinc-900 bg-zinc-900 text-white',
+                done && 'cursor-pointer border-emerald-200/70 bg-emerald-50/60 text-emerald-900',
+                !active && !done && 'cursor-default border-zinc-200 bg-surface text-zinc-500',
+              )}
+            >
+              <span className="flex items-center gap-2">
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'grid h-5 w-5 place-items-center rounded-full font-mono text-[10px] font-bold',
+                    active && 'bg-white text-zinc-900',
+                    done && 'bg-emerald-500 text-white',
+                    !active && !done && 'bg-zinc-100 text-zinc-400',
+                  )}
+                >
+                  {done ? <Check size={11} strokeWidth={3} /> : index + 1}
+                </span>
+                <span className="truncate text-[12.5px] font-semibold">{step.label}</span>
+              </span>
+              {step.hint && (
+                <span
+                  className={cn(
+                    'mt-1 block truncate text-[11px]',
+                    active ? 'text-white/70' : done ? 'text-emerald-700' : 'text-zinc-400',
+                  )}
+                >
+                  {step.hint}
+                </span>
+              )}
+            </button>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2384,5 +2384,22 @@
   },
   "object_detail": {
     "name_placeholder": "Name"
+  },
+  "ui_v2": {
+    "soon": "soon",
+    "soon_tooltip": "Coming soon",
+    "selected": "selected",
+    "status": {
+      "success": "success",
+      "warning": "with warnings",
+      "partial": "partial",
+      "error": "error",
+      "cancelled": "cancelled",
+      "queued": "queued",
+      "running": "running"
+    },
+    "result_bar": {
+      "aria": "Result: {{ok}} ok, {{warn}} warnings, {{err}} errors"
+    }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2434,5 +2434,22 @@
   },
   "object_detail": {
     "name_placeholder": "Nazwa"
+  },
+  "ui_v2": {
+    "soon": "wkrótce",
+    "soon_tooltip": "Funkcja dostępna wkrótce",
+    "selected": "wybrane",
+    "status": {
+      "success": "sukces",
+      "warning": "z ostrzeżeniami",
+      "partial": "częściowy",
+      "error": "błąd",
+      "cancelled": "anulowano",
+      "queued": "w kolejce",
+      "running": "w toku"
+    },
+    "result_bar": {
+      "aria": "Wynik: {{ok}} poprawnych, {{warn}} ostrzeżeń, {{err}} błędów"
+    }
   }
 }

--- a/apps/admin/src/types/vitest-matchers.d.ts
+++ b/apps/admin/src/types/vitest-matchers.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Vitest matcher augmentations for component tests:
+ * - jest-dom matchers (toBeInTheDocument, toHaveAttribute, ...)
+ * - jest-axe `toHaveNoViolations` (typed for vitest's Assertion, since
+ *   @types/jest-axe only augments the jest namespace)
+ */
+import '@testing-library/jest-dom/vitest';
+
+declare module 'vitest' {
+  interface Assertion<T> {
+    toHaveNoViolations(): T;
+  }
+}

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  esbuild: { jsx: 'automatic' },
+  resolve: {
+    alias: { '@': path.resolve(__dirname, 'src') },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+    globals: true,
+  },
+});

--- a/apps/admin/vitest.setup.ts
+++ b/apps/admin/vitest.setup.ts
@@ -1,0 +1,18 @@
+import '@testing-library/jest-dom/vitest';
+
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import en from './src/locales/en.json';
+import pl from './src/locales/pl.json';
+
+// Deterministic i18n for component tests — Polish, no browser detection.
+void i18n.use(initReactI18next).init({
+  lng: 'pl',
+  fallbackLng: 'pl',
+  interpolation: { escapeValue: false },
+  resources: {
+    pl: { translation: pl },
+    en: { translation: en },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,9 +160,21 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/dompurify':
         specifier: ^3.2.0
         version: 3.2.0
+      '@types/jest-axe':
+        specifier: ^3.5.9
+        version: 3.5.9
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -175,6 +187,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3))
+      jest-axe:
+        specifier: ^10.0.0
+        version: 10.0.0
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -187,6 +205,9 @@ importers:
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3))
 
   packages/shared-types:
     devDependencies:
@@ -198,6 +219,24 @@ importers:
         version: 6.0.3
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -267,6 +306,10 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@commitlint/cli@20.5.2':
     resolution: {integrity: sha512-IXr5xd3IX8SEG936P8gcpozRplkDeDSwJlt8UvoY1winwIy2udTbQ/cOCgbaaxcjdDqVoS29VUcz/wkwnSozbA==}
@@ -353,6 +396,42 @@ packages:
       conventional-commits-parser:
         optional: true
 
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
     peerDependencies:
@@ -383,6 +462,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -415,6 +503,34 @@ packages:
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
     peerDependencies:
       react-hook-form: ^7.55.0
+
+  '@jest/diff-sequences@30.4.0':
+    resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect-utils@30.4.1':
+    resolution: {integrity: sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/pattern@30.4.0':
+    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/schemas@30.4.1':
+    resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/types@30.4.1':
+    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1078,6 +1194,15 @@ packages:
     resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
     engines: {node: '>=18'}
 
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
+  '@sinclair/typebox@0.34.49':
+    resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -1183,6 +1308,35 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@turbo/darwin-64@2.9.16':
     resolution: {integrity: sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==}
     cpu: [x64]
@@ -1216,9 +1370,36 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/dompurify@3.2.0':
     resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
     deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
+
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
+
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/jest-axe@3.5.9':
+    resolution: {integrity: sha512-z98CzR0yVDalCEuhGXXO4/zN4HHuSebAukXDjTLJyjEAgoUf1H1i+sr7SUB/mz8CRS/03/XChsx0dcLjHkndoQ==}
+
+  '@types/jest@30.0.0':
+    resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
 
   '@types/node@25.9.2':
     resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
@@ -1231,8 +1412,17 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/stack-utils@2.0.3':
+    resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
   '@udecode/plate-basic-elements@49.0.0':
     resolution: {integrity: sha512-6Bv7eovWrGfM5PFEHQbSAHsYxkskjC5vkxn7vQuZlBUl8O8s5Z3OTGNQrEr0U6JJDinn+ylMGPG8rs3v7CHIVQ==}
@@ -1409,6 +1599,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1436,6 +1655,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -1447,11 +1670,33 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  axe-core@3.5.6:
+    resolution: {integrity: sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==}
+    engines: {node: '>=4'}
+
+  axe-core@4.10.2:
+    resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
+    engines: {node: '>=4'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
@@ -1468,8 +1713,20 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1530,6 +1787,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -1551,8 +1811,19 @@ packages:
       typescript:
         optional: true
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1562,6 +1833,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1574,9 +1848,19 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   direction@1.0.4:
     resolution: {integrity: sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==}
     hasBin: true
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dompurify@3.4.8:
     resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
@@ -1598,6 +1882,10 @@ packages:
   enhanced-resolve@5.21.3:
     resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -1621,6 +1909,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1629,8 +1920,23 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  expect@30.4.1:
+    resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1696,6 +2002,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -1703,6 +2013,10 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
@@ -1743,6 +2057,10 @@ packages:
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
@@ -1776,6 +2094,49 @@ packages:
   is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  jest-axe@10.0.0:
+    resolution: {integrity: sha512-9QR0M7//o5UVRnEUUm68IsGapHrcKGakYy9dKWWMX79LmeUKguDI6DREyljC5I13j78OUmtKLF5My6ccffLFBg==}
+    engines: {node: '>= 16.0.0'}
+
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-diff@30.4.1:
+    resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@29.2.2:
+    resolution: {integrity: sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-matcher-utils@30.4.1:
+    resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-message-util@30.4.1:
+    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-mock@30.4.1:
+    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-regex-util@30.4.0:
+    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-util@30.4.1:
+    resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1865,6 +2226,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -1970,6 +2340,9 @@ packages:
   lodash.mapvalues@4.6.0:
     resolution: {integrity: sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==}
 
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   lodash.mergewith@4.6.2:
     resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
@@ -1989,10 +2362,18 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lucide-react@1.17.0:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2001,6 +2382,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
@@ -2008,6 +2392,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
@@ -2037,6 +2425,10 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.2:
+    resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
+
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
@@ -2065,6 +2457,12 @@ packages:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2090,8 +2488,24 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  pretty-format@30.4.1:
+    resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   proxy-compare@2.6.0:
     resolution: {integrity: sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -2135,6 +2549,15 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-is@19.2.7:
+    resolution: {integrity: sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -2193,6 +2616,10 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2220,6 +2647,10 @@ packages:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2251,9 +2682,16 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
 
   slate-dom@0.114.0:
     resolution: {integrity: sha512-3LWIfiDPNQSY+SCPsvMTErCkx2gXTViLoWISisw6uM+unwiOkEF9ZmpHp88/SSmcq6k3P4aIquehUNeNUlkdiA==}
@@ -2314,8 +2752,18 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -2341,9 +2789,20 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -2364,6 +2823,9 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -2371,6 +2833,25 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2393,6 +2874,10 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@7.27.2:
+    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+    engines: {node: '>=20.18.1'}
 
   uri-js-replace@1.0.1:
     resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
@@ -2488,12 +2973,74 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   warn-once@0.1.1:
     resolution: {integrity: sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -2502,6 +3049,13 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -2560,6 +3114,28 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -2604,6 +3180,10 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.16':
     optional: true
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@commitlint/cli@20.5.2(@types/node@25.9.2)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
@@ -2732,6 +3312,30 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@dnd-kit/accessibility@3.1.1(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -2773,6 +3377,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@exodus/bytes@1.15.1': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -2806,6 +3412,37 @@ snapshots:
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.78.0(react@19.2.7)
+
+  '@jest/diff-sequences@30.4.0': {}
+
+  '@jest/expect-utils@30.4.1':
+    dependencies:
+      '@jest/get-type': 30.1.0
+
+  '@jest/get-type@30.1.0': {}
+
+  '@jest/pattern@30.4.0':
+    dependencies:
+      '@types/node': 25.9.2
+      jest-regex-util: 30.4.0
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
+
+  '@jest/schemas@30.4.1':
+    dependencies:
+      '@sinclair/typebox': 0.34.49
+
+  '@jest/types@30.4.1':
+    dependencies:
+      '@jest/pattern': 30.4.0
+      '@jest/schemas': 30.4.1
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 25.9.2
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3383,6 +4020,12 @@ snapshots:
 
   '@simple-libs/stream-utils@1.2.0': {}
 
+  '@sinclair/typebox@0.27.10': {}
+
+  '@sinclair/typebox@0.34.49': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.3.0':
@@ -3460,6 +4103,40 @@ snapshots:
       '@tanstack/query-core': 5.101.0
       react: 19.2.7
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@turbo/darwin-64@2.9.16':
     optional: true
 
@@ -3483,9 +4160,40 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/aria-query@5.0.4': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/dompurify@3.2.0':
     dependencies:
       dompurify: 3.4.8
+
+  '@types/estree@1.0.9': {}
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
+
+  '@types/istanbul-lib-report@3.0.3':
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.6
+
+  '@types/istanbul-reports@3.0.4':
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.3
+
+  '@types/jest-axe@3.5.9':
+    dependencies:
+      '@types/jest': 30.0.0
+      axe-core: 3.5.6
+
+  '@types/jest@30.0.0':
+    dependencies:
+      expect: 30.4.1
+      pretty-format: 30.4.1
 
   '@types/node@25.9.2':
     dependencies:
@@ -3499,8 +4207,16 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/stack-utils@2.0.3': {}
+
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
 
   '@udecode/plate-basic-elements@49.0.0(@udecode/plate@49.0.0(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -3802,6 +4518,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3)
 
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   agent-base@7.1.4: {}
 
   ajv@8.20.0:
@@ -3825,6 +4582,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
@@ -3833,9 +4592,25 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   array-ify@1.0.0: {}
 
+  assertion-error@2.0.1: {}
+
+  axe-core@3.5.6: {}
+
+  axe-core@4.10.2: {}
+
   balanced-match@1.0.2: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@2.1.0:
     dependencies:
@@ -3853,7 +4628,16 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  chai@6.2.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   change-case@5.4.4: {}
+
+  ci-info@4.4.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -3910,6 +4694,8 @@ snapshots:
       '@simple-libs/stream-utils': 1.2.0
       meow: 13.2.0
 
+  convert-source-map@2.0.0: {}
+
   cookie@1.1.1: {}
 
   cosmiconfig-typescript-loader@6.3.0(@types/node@25.9.2)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3):
@@ -3928,7 +4714,21 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -3936,13 +4736,21 @@ snapshots:
     optionalDependencies:
       supports-color: 10.2.2
 
+  decimal.js@10.6.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
+  diff-sequences@29.6.3: {}
+
   direction@1.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dompurify@3.4.8:
     optionalDependencies:
@@ -3967,6 +4775,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@8.0.0: {}
+
   env-paths@2.2.1: {}
 
   environment@1.1.0: {}
@@ -3983,13 +4793,32 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@2.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
+
+  expect@30.4.1:
+    dependencies:
+      '@jest/expect-utils': 30.4.1
+      '@jest/get-type': 30.1.0
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
 
   fast-deep-equal@3.1.3: {}
 
@@ -4047,11 +4876,19 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  has-flag@4.0.0: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-entities@2.6.0: {}
 
@@ -4087,6 +4924,8 @@ snapshots:
 
   import-meta-resolve@4.2.0: {}
 
+  indent-string@4.0.0: {}
+
   index-to-position@1.2.0: {}
 
   ini@6.0.0: {}
@@ -4106,6 +4945,75 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-plain-object@5.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  jest-axe@10.0.0:
+    dependencies:
+      axe-core: 4.10.2
+      chalk: 4.1.2
+      jest-matcher-utils: 29.2.2
+      lodash.merge: 4.6.2
+
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-diff@30.4.1:
+    dependencies:
+      '@jest/diff-sequences': 30.4.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.4.1
+
+  jest-get-type@29.6.3: {}
+
+  jest-matcher-utils@29.2.2:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-matcher-utils@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      jest-diff: 30.4.1
+      pretty-format: 30.4.1
+
+  jest-message-util@30.4.1:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@jest/types': 30.4.1
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-util: 30.4.1
+      picomatch: 4.0.4
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
+
+  jest-mock@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 25.9.2
+      jest-util: 30.4.1
+
+  jest-regex-util@30.4.0: {}
+
+  jest-util@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 25.9.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      graceful-fs: 4.2.11
+      picomatch: 4.0.4
 
   jiti@2.6.1: {}
 
@@ -4141,6 +5049,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.27.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-parse-even-better-errors@2.3.1: {}
 
@@ -4223,6 +5157,8 @@ snapshots:
 
   lodash.mapvalues@4.6.0: {}
 
+  lodash.merge@4.6.2: {}
+
   lodash.mergewith@4.6.2: {}
 
   lodash.snakecase@4.1.1: {}
@@ -4241,9 +5177,13 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  lru-cache@11.5.1: {}
+
   lucide-react@1.17.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4251,9 +5191,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.27.1: {}
+
   meow@13.2.0: {}
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@5.1.9:
     dependencies:
@@ -4270,6 +5214,8 @@ snapshots:
   nanoid@5.1.11: {}
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.2: {}
 
   onetime@7.0.0:
     dependencies:
@@ -4306,6 +5252,12 @@ snapshots:
       index-to-position: 1.2.0
       type-fest: 4.41.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -4326,7 +5278,28 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
+  pretty-format@30.4.1:
+    dependencies:
+      '@jest/schemas': 30.4.1
+      ansi-styles: 5.2.0
+      react-is-18: react-is@18.3.1
+      react-is-19: react-is@19.2.7
+
   proxy-compare@2.6.0: {}
+
+  punycode@2.3.1: {}
 
   qs@6.15.1:
     dependencies:
@@ -4360,6 +5333,12 @@ snapshots:
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
       typescript: 6.0.3
+
+  react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
+
+  react-is@19.2.7: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -4407,6 +5386,11 @@ snapshots:
 
   react@19.2.7: {}
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -4442,6 +5426,10 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.3
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -4481,7 +5469,11 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
+
+  slash@3.0.0: {}
 
   slate-dom@0.114.0(slate@0.114.0):
     dependencies:
@@ -4566,7 +5558,15 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
+
+  std-env@4.1.0: {}
 
   string-argv@0.3.2: {}
 
@@ -4595,7 +5595,17 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   supports-color@10.2.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
 
@@ -4609,12 +5619,30 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
+
+  tldts-core@7.4.2: {}
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
@@ -4634,6 +5662,8 @@ snapshots:
   typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
+
+  undici@7.27.2: {}
 
   uri-js-replace@1.0.1: {}
 
@@ -4685,9 +5715,58 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.8.3
 
+  vitest@4.1.8(@types/node@25.9.2)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.2)(jiti@2.7.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.2
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
   void-elements@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   warn-once@0.1.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -4700,6 +5779,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Zakres (EXR-02, #1378)

Nowy pakiet `apps/admin/src/components/ui-v2/` — 13 komponentów nośnych nowego look & feel (Tailwind na tokenach z EXR-01 / PR #1399):

`PageHeader` (breadcrumb + slot akcji), `PillTabs` (granatowy pill + licznik, disabled z tooltipem „wkrótce"), `KpiCard`, `StatusPill` + `status-maps.ts` (mapowanie `ExportStatus` → wariant w jednym miejscu), `ResultBar` (emerald/orange/brick), `ProgressBar` (shimmer), `ModeBadge`, `FormatPill`, `SelectableCard`+`SelectableCardGroup` (radiogroup z pełną obsługą klawiatury — strzałki, roving tabindex), `WizardStepper` (klik tylko w done-steps), `EmptyState`, `Sparkline` i `HealthDot` (porty 1:1 z `primitives.jsx`).

Wzorzec tabeli v2 (klasy, nie komponent) udokumentowany w `ui-v2/README.md` z przykładem.

## Infrastruktura testowa (nowość w apps/admin)

- **Vitest 4 + Testing Library + jsdom + jest-axe** — pierwszy setup unit testów w adminie (`pnpm --filter @pim/admin test`).
- **30 testów**: render + warianty stanów każdego komponentu (≥13 wymagane) + klawiatura (radiogroup, taby) + **axe-core bez naruszeń** na kompozycji wszystkich primitives (test-only render zamiast dev-route).
- Nowy job **Vitest unit** w `quality-frontend.yml`.

## i18n / a11y

- Zero literałów PL/EN w komponentach — labelki przez `t()` (nowy namespace `ui_v2`) albo przekazywane jako przetłumaczone propsy.
- role/aria: tablist/tab, radiogroup/radio, progressbar, breadcrumb nav, aria-current.

## Świadome ograniczenia (zgodnie z ticketem)

- `StagePipeline` — przeniesiemy przy redesignie importów.
- Storybook — poza zakresem.
- **Ships standalone components** — komponenty nie są jeszcze zamontowane w żadnym widoku; integracja zaczyna się w EXR-03 (shell) i EXR-08+ (eksporty). End-to-end smoke nastąpi tam.

## Gates

- Vitest: ✅ 30/30 (w tym axe)
- tsc: ✅ · Biome: ✅ (tylko pre-existing warningi/infos) · Vite build: ✅
- Playwright: CI

Closes #1378