### PR TITLE
EXR-09: wizard eksportu — szkielet, store, Krok 1 (Typ) (#1385)

### DIFF
--- a/apps/admin/e2e/exports.spec.ts
+++ b/apps/admin/e2e/exports.spec.ts
@@ -36,13 +36,14 @@ test('exports hub MVP — tabs + new flow smoke', async ({ page }) => {
   await expect(page.getByRole('tab', { name: /sessions|sesje/i }).first()).toBeVisible();
   await expect(page.getByRole('tab', { name: /profiles|profile/i }).first()).toBeVisible();
 
-  // "Nowy eksport" CTA opens the standalone full-page form.
+  // EXR-09: the CTA opens the v2 wizard; the legacy paste-JSON page
+  // stays at /new-legacy until EXR-14 removes it.
   await page
     .getByRole('link', { name: /nowy eksport|new export/i })
     .first()
     .click();
   await expect(page).toHaveURL(/\/integrations\/exports\/new$/);
-  await expect(page.getByRole('dialog')).toBeVisible();
+  await expect(page.getByRole('radiogroup')).toBeVisible();
 });
 
 test('exports modal — sync XLSX download from list + save-as-profile lifecycle', async ({
@@ -135,7 +136,8 @@ test('exports new — async 202 redirects to sessions (mocked endpoint)', async 
     });
   });
 
-  await page.goto('/integrations/exports/new');
+  // EXR-09: legacy full-page form moved to /new-legacy until EXR-14.
+  await page.goto('/integrations/exports/new-legacy');
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
 
@@ -223,12 +225,9 @@ test('#1278 scopable attribute appears once in column picker (no duplicate)', as
     { timeout: 30_000 },
   );
 
-  await page.goto('/integrations/exports');
-  await page
-    .getByRole('link', { name: /nowy eksport|new export/i })
-    .first()
-    .click();
-  await expect(page).toHaveURL(/\/integrations\/exports\/new$/);
+  // EXR-09: the legacy column-picker page lives at /new-legacy until
+  // EXR-14 removes it together with the modal.
+  await page.goto('/integrations/exports/new-legacy');
 
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible({ timeout: 10_000 });

--- a/apps/admin/e2e/exr-08-exports-page.spec.ts
+++ b/apps/admin/e2e/exr-08-exports-page.spec.ts
@@ -13,7 +13,7 @@ const NOW = Date.now();
 function session(overrides: Record<string, unknown>): Record<string, unknown> {
   return {
     id: '00000000-0000-0000-0000-000000000001',
-    entity_type: 'products',
+    entity_type: 'product',
     object_type_id: null,
     format: 'xlsx',
     target_scope: 'all',

--- a/apps/admin/e2e/exr-09-wizard-step1.spec.ts
+++ b/apps/admin/e2e/exr-09-wizard-step1.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import { apiLogin } from './helpers/auth';
+
+/**
+ * EXR-09 (#1385) — export wizard shell + step 1. Object types are
+ * mocked so the custom-module flow is deterministic.
+ */
+
+const CUSTOM_OT = {
+  id: '11111111-1111-1111-1111-111111111111',
+  code: 'producers',
+  kind: 'custom',
+  builtIn: false,
+  label: { pl: 'Producenci', en: 'Producers' },
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/object_types', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [CUSTOM_OT], totalItems: 1 }),
+    }),
+  );
+  await apiLogin(page);
+  await page.waitForTimeout(1200);
+  await page.goto('/integrations/exports/new');
+  await page.waitForTimeout(800);
+});
+
+test('every entity tile is selectable and Dalej advances', async ({ page }) => {
+  const group = page.getByRole('radiogroup');
+  await expect(group.getByRole('radio')).toHaveCount(5);
+
+  // products selected by default with the WYBRANE badge
+  const products = group.getByRole('radio', { name: /Produkty|Products/ });
+  await expect(products).toHaveAttribute('aria-checked', 'true');
+  await expect(products).toContainText(/wybrane|selected/);
+
+  for (const name of [/Schemat|Module schema/, /Atrybuty|Attributes/, /Kategorie|Categories/]) {
+    await group.getByRole('radio', { name }).click();
+    await expect(group.getByRole('radio', { name })).toHaveAttribute('aria-checked', 'true');
+  }
+
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await expect(page.getByText(/EXR-10\/11\/12/)).toBeVisible();
+
+  // stepper: step 1 done, step 2 active
+  await expect(page.getByRole('button', { name: /Zakres|Scope/ })).toHaveAttribute(
+    'aria-current',
+    'step',
+  );
+});
+
+test('custom module requires an ObjectType before Dalej', async ({ page }) => {
+  await page.getByRole('radio', { name: /Moduły własne|Custom modules/ }).click();
+
+  await expect(page.getByText(/Wybierz moduł własny|Choose a custom module/)).toBeVisible();
+  await expect(page.getByRole('button', { name: /Dalej|Next/ })).toBeDisabled();
+
+  await page.getByLabel(/Moduł własny|Custom module/).selectOption(CUSTOM_OT.id);
+  await expect(page.getByRole('button', { name: /Dalej|Next/ })).toBeEnabled();
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await expect(page.getByText(/EXR-10\/11\/12/)).toBeVisible();
+});
+
+test('cancel asks for confirmation when dirty and returns to sessions', async ({ page }) => {
+  await page.getByRole('radio', { name: /Kategorie|Categories/ }).click();
+
+  page.once('dialog', (dialog) => void dialog.dismiss());
+  await page.getByRole('button', { name: /Anuluj|Cancel/ }).click();
+  await expect(page).toHaveURL(/\/integrations\/exports\/new/);
+
+  page.once('dialog', (dialog) => void dialog.accept());
+  await page.getByRole('button', { name: /Anuluj|Cancel/ }).click();
+  await expect(page).toHaveURL(/\/integrations\/exports\/sessions/);
+});

--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -203,6 +203,10 @@ const ExportSessionShowPage = lazyPage(
   () => import('@/features/exports/show/ExportSessionShowPage'),
   'ExportSessionShowPage',
 );
+const ExportWizardPage = lazyPage(
+  () => import('@/features/exports/wizard/ExportWizardPage'),
+  'ExportWizardPage',
+);
 const IntegrationsLayout = lazyPage(
   () => import('@/features/integration-hub/IntegrationsLayout'),
   'IntegrationsLayout',
@@ -539,7 +543,11 @@ function App() {
                   path="/integrations/exports/sessions/:id"
                   element={<ExportSessionShowPage />}
                 />
-                <Route path="/integrations/exports/new" element={<ExportNewPage />} />
+                {/* EXR-09 — v2 wizard replaces the paste-JSON page; the
+                    legacy form stays reachable at /new-legacy only until
+                    EXR-14 removes it. */}
+                <Route path="/integrations/exports/new" element={<ExportWizardPage />} />
+                <Route path="/integrations/exports/new-legacy" element={<ExportNewPage />} />
                 <Route path="/integrations" element={<IntegrationsLayout />}>
                   <Route index element={<Navigate to="/integrations/imports" replace />} />
                   {/* VIEW-IMP-00 (#493) — Importy hub with 4 tabs. Old flat

--- a/apps/admin/src/features/exports/hooks/useExportSessions.ts
+++ b/apps/admin/src/features/exports/hooks/useExportSessions.ts
@@ -6,10 +6,10 @@ import { jsonFetch } from '@/lib/http';
 export interface ExportSessionRow {
   id: string;
   entity_type:
-    | 'products'
+    | 'product'
     | 'custom_module'
     | 'module_schema'
-    | 'attributes'
+    | 'attributes_groups'
     | 'categories'
     | string;
   object_type_id: string | null;

--- a/apps/admin/src/features/exports/sessions/session-format.ts
+++ b/apps/admin/src/features/exports/sessions/session-format.ts
@@ -10,18 +10,18 @@ export function fileNameOf(session: ExportSessionRow): string | null {
 /** i18n label key for an export entity type (EXR-04 enum). */
 export function entityTypeLabelKey(entityType: string): string {
   switch (entityType) {
-    case 'products':
-      return 'exports.entity.products';
+    case 'product':
+      return 'exports.entity.product';
     case 'custom_module':
       return 'exports.entity.custom_module';
     case 'module_schema':
       return 'exports.entity.module_schema';
-    case 'attributes':
-      return 'exports.entity.attributes';
+    case 'attributes_groups':
+      return 'exports.entity.attributes_groups';
     case 'categories':
       return 'exports.entity.categories';
     default:
-      return 'exports.entity.products';
+      return 'exports.entity.product';
   }
 }
 

--- a/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from 'react-i18next';
+
+import { WizardStepper } from '@/components/ui-v2/wizard-stepper';
+
+import { StepEntityType } from './steps/StepEntityType';
+import { WizardFooter } from './WizardFooter';
+import { useWizard, WizardProvider } from './wizard-store';
+
+/**
+ * EXR-09 (#1385) — full-page 4-step export wizard at
+ * /integrations/exports/new (screen 2). This ticket ships the shell,
+ * the store and step 1; steps 2-4 render placeholders until
+ * EXR-10/11/12 fill them in.
+ */
+export function ExportWizardPage(): React.ReactElement {
+  return (
+    <WizardProvider>
+      <WizardContent />
+    </WizardProvider>
+  );
+}
+
+function WizardContent() {
+  const { t } = useTranslation();
+  const { state, dispatch } = useWizard();
+
+  const steps = [
+    {
+      id: 'type',
+      label: t('exports.wizard.steps.type'),
+      hint: t('exports.wizard.steps.type_hint'),
+    },
+    {
+      id: 'scope',
+      label: t('exports.wizard.steps.scope'),
+      hint: t('exports.wizard.steps.scope_hint'),
+    },
+    {
+      id: 'columns',
+      label: t('exports.wizard.steps.columns'),
+      hint: t('exports.wizard.steps.columns_hint'),
+    },
+    {
+      id: 'summary',
+      label: t('exports.wizard.steps.summary'),
+      hint: t('exports.wizard.steps.summary_hint'),
+    },
+  ];
+
+  const stepTitles = [
+    t('exports.wizard.steps.type'),
+    t('exports.wizard.steps.scope'),
+    t('exports.wizard.steps.columns'),
+    t('exports.wizard.steps.summary'),
+  ];
+
+  const step1Valid = state.entityType !== 'custom_module' || state.objectTypeId !== null;
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6">
+      <header>
+        <h1 className="display text-[24px] font-semibold tracking-tight text-ink">
+          {t('exports.wizard.title')}
+        </h1>
+        <p className="mt-1 text-[13px] text-zinc-500">{t('exports.wizard.lead')}</p>
+      </header>
+
+      <WizardStepper
+        steps={steps}
+        current={state.step}
+        onStepClick={(step) => dispatch({ type: 'GO_TO_STEP', step })}
+      />
+
+      <div key={state.step}>
+        {state.step === 0 && <StepEntityType />}
+        {state.step > 0 && (
+          <div className="rounded-2xl border border-dashed border-zinc-200 bg-surface p-10 text-center text-[13px] text-zinc-400">
+            {t('exports.wizard.step_placeholder')}
+          </div>
+        )}
+      </div>
+
+      <WizardFooter
+        stepTitle={stepTitles[state.step] ?? ''}
+        nextDisabled={state.step === 0 && !step1Valid}
+      />
+    </div>
+  );
+}
+
+export default ExportWizardPage;

--- a/apps/admin/src/features/exports/wizard/WizardFooter.tsx
+++ b/apps/admin/src/features/exports/wizard/WizardFooter.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+
+import { cn } from '@/lib/utils';
+
+import { WIZARD_STEP_COUNT } from './types';
+import { useWizard } from './wizard-store';
+
+interface WizardFooterProps {
+  /** Already-translated short title of the current step (mono line). */
+  stepTitle: string;
+  /** Step 1 validation gate — disables "Dalej" with a reason tooltip. */
+  nextDisabled?: boolean;
+  /** Called instead of plain step++ when the step needs custom advance. */
+  onNext?: () => void;
+}
+
+/**
+ * EXR-09 — wizard footer: mono `krok N z 4 · <title>` + Anuluj (confirm
+ * when dirty) / Wstecz / Dalej (orange CTA).
+ */
+export function WizardFooter({ stepTitle, nextDisabled = false, onNext }: WizardFooterProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { state, dispatch } = useWizard();
+  const last = state.step === WIZARD_STEP_COUNT - 1;
+
+  const handleCancel = () => {
+    if (state.dirty && !window.confirm(t('exports.wizard.cancel_confirm'))) {
+      return;
+    }
+    void navigate('/integrations/exports/sessions');
+  };
+
+  return (
+    <div className="flex items-center gap-3 border-t border-zinc-100 pt-4">
+      <div className="num flex-1 font-mono text-[11.5px] text-zinc-400">
+        {t('exports.wizard.step_indicator', {
+          step: state.step + 1,
+          total: WIZARD_STEP_COUNT,
+          title: stepTitle,
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={handleCancel}
+        className="focus-ring h-10 rounded-xl px-4 text-[13px] font-medium text-zinc-500 transition hover:bg-zinc-100 hover:text-ink"
+      >
+        {t('exports.wizard.cancel')}
+      </button>
+      <button
+        type="button"
+        disabled={state.step === 0}
+        onClick={() => dispatch({ type: 'GO_TO_STEP', step: state.step - 1 })}
+        className="focus-ring h-10 rounded-xl border border-zinc-200 bg-surface px-4 text-[13px] font-medium text-zinc-700 transition enabled:hover:border-zinc-400 disabled:cursor-not-allowed disabled:text-zinc-300"
+      >
+        {t('exports.wizard.back')}
+      </button>
+      {!last && (
+        <button
+          type="button"
+          disabled={nextDisabled}
+          onClick={() => {
+            if (onNext) {
+              onNext();
+              return;
+            }
+            dispatch({ type: 'GO_TO_STEP', step: state.step + 1 });
+          }}
+          className={cn(
+            'focus-ring h-10 rounded-xl px-5 text-[13px] font-semibold transition',
+            nextDisabled
+              ? 'cursor-not-allowed bg-zinc-100 text-zinc-400'
+              : 'bg-cta text-cta-foreground hover:bg-accent-hover',
+          )}
+        >
+          {t('exports.wizard.next')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/features/exports/wizard/__tests__/wizard-store.test.ts
+++ b/apps/admin/src/features/exports/wizard/__tests__/wizard-store.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { INITIAL_WIZARD_STATE, type WizardState } from '../types';
+import { hasDownstreamConfig, wizardReducer } from '../wizard-store';
+
+const CONFIGURED: WizardState = {
+  ...INITIAL_WIZARD_STATE,
+  step: 2,
+  format: 'csv',
+  columns: ['sku', 'name'],
+  filterDsl: { operator: 'AND', conditions: [] },
+  targetScope: 'filter',
+  dirty: true,
+};
+
+describe('wizardReducer', () => {
+  it('resets steps 2-4 when the entity type changes', () => {
+    const next = wizardReducer(CONFIGURED, {
+      type: 'SET_ENTITY_TYPE',
+      entityType: 'categories',
+    });
+    expect(next.entityType).toBe('categories');
+    expect(next.columns).toEqual([]);
+    expect(next.filterDsl).toBeNull();
+    expect(next.targetScope).toBe('all');
+    expect(next.step).toBe(2);
+    expect(next.dirty).toBe(true);
+  });
+
+  it('is a no-op when re-selecting the same entity', () => {
+    const next = wizardReducer(CONFIGURED, {
+      type: 'SET_ENTITY_TYPE',
+      entityType: 'products',
+    });
+    expect(next).toBe(CONFIGURED);
+  });
+
+  it('clamps GO_TO_STEP into 0..3', () => {
+    expect(wizardReducer(CONFIGURED, { type: 'GO_TO_STEP', step: 9 }).step).toBe(3);
+    expect(wizardReducer(CONFIGURED, { type: 'GO_TO_STEP', step: -2 }).step).toBe(0);
+  });
+});
+
+describe('hasDownstreamConfig', () => {
+  it('detects configured later steps', () => {
+    expect(hasDownstreamConfig(INITIAL_WIZARD_STATE)).toBe(false);
+    expect(hasDownstreamConfig(CONFIGURED)).toBe(true);
+  });
+});

--- a/apps/admin/src/features/exports/wizard/__tests__/wizard-store.test.ts
+++ b/apps/admin/src/features/exports/wizard/__tests__/wizard-store.test.ts
@@ -30,7 +30,7 @@ describe('wizardReducer', () => {
   it('is a no-op when re-selecting the same entity', () => {
     const next = wizardReducer(CONFIGURED, {
       type: 'SET_ENTITY_TYPE',
-      entityType: 'products',
+      entityType: 'product',
     });
     expect(next).toBe(CONFIGURED);
   });

--- a/apps/admin/src/features/exports/wizard/steps/StepEntityType.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepEntityType.tsx
@@ -1,0 +1,132 @@
+import { useQuery } from '@tanstack/react-query';
+import { Boxes, FolderTree, Layers, Package, Tags } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { SelectableCard, SelectableCardGroup } from '@/components/ui-v2/selectable-card';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import type { ExportEntityType } from '../types';
+import { hasDownstreamConfig, useWizard } from '../wizard-store';
+
+interface ObjectTypeRow {
+  id: string;
+  code: string;
+  kind?: string;
+  builtIn?: boolean;
+  label?: Record<string, string>;
+}
+
+interface ObjectTypesResponse {
+  member?: ObjectTypeRow[];
+  'hydra:member'?: ObjectTypeRow[];
+}
+
+const ENTITY_DEFS: Array<{ id: ExportEntityType; icon: typeof Package }> = [
+  { id: 'products', icon: Package },
+  { id: 'custom_module', icon: Boxes },
+  { id: 'module_schema', icon: Layers },
+  { id: 'attributes', icon: Tags },
+  { id: 'categories', icon: FolderTree },
+];
+
+/** Custom (non-built-in) ObjectTypes for the custom_module second row. */
+function useCustomObjectTypes() {
+  return useQuery({
+    queryKey: ['object-types', 'custom'],
+    staleTime: 60_000,
+    queryFn: async (): Promise<ObjectTypeRow[]> => {
+      const response = await jsonFetch<ObjectTypesResponse>('/api/object_types');
+      const rows = response.member ?? response['hydra:member'] ?? [];
+      return rows.filter((row) => row.kind === 'custom' || row.builtIn === false);
+    },
+  });
+}
+
+/**
+ * EXR-09 — wizard step 1 (screen 2): 3+2 grid of entity tiles. Picking
+ * "Moduły własne" reveals an ObjectType select (custom OTs only); the
+ * tile is disabled with a tooltip when the tenant has none. Switching
+ * entity after configuring later steps asks for confirmation and resets
+ * steps 2-4 (reducer handles the reset).
+ */
+export function StepEntityType() {
+  const { t, i18n } = useTranslation();
+  const { state, dispatch } = useWizard();
+  const customTypes = useCustomObjectTypes();
+
+  const customAvailable = (customTypes.data?.length ?? 0) > 0;
+
+  const selectEntity = (entityType: ExportEntityType) => {
+    if (entityType === state.entityType) return;
+    if (hasDownstreamConfig(state) && !window.confirm(t('exports.wizard.entity_switch_confirm'))) {
+      return;
+    }
+    dispatch({ type: 'SET_ENTITY_TYPE', entityType });
+  };
+
+  const labelOf = (row: ObjectTypeRow): string => {
+    const labels = row.label ?? {};
+    return labels[i18n.language] ?? labels.pl ?? labels.en ?? row.code;
+  };
+
+  return (
+    <div className="rounded-2xl border border-zinc-200 bg-surface p-7 shadow-card">
+      <h2 className="text-[16px] font-semibold tracking-tight text-ink">
+        {t('exports.wizard.step1_title')}
+      </h2>
+      <p className="mt-1 text-[13px] text-zinc-500">{t('exports.wizard.step1_subtitle')}</p>
+
+      <SelectableCardGroup
+        ariaLabel={t('exports.wizard.entity_group_aria')}
+        className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
+      >
+        {ENTITY_DEFS.map(({ id, icon: Icon }) => (
+          <SelectableCard
+            key={id}
+            icon={<Icon className="size-5" aria-hidden />}
+            title={t(`exports.entity.${id}`)}
+            description={t(`exports.wizard.entity_desc.${id}`)}
+            selected={state.entityType === id}
+            disabled={id === 'custom_module' && !customAvailable && !customTypes.isLoading}
+            onSelect={() => selectEntity(id)}
+          />
+        ))}
+      </SelectableCardGroup>
+
+      {state.entityType === 'custom_module' && (
+        <div className="mt-5 rounded-xl border border-zinc-200 bg-surface-muted p-4">
+          <label
+            htmlFor="wizard-custom-object-type"
+            className="block text-[11px] font-medium tracking-wider text-zinc-400 uppercase"
+          >
+            {t('exports.wizard.custom_object_type_label')}
+          </label>
+          <select
+            id="wizard-custom-object-type"
+            value={state.objectTypeId ?? ''}
+            onChange={(event) => {
+              dispatch({ type: 'SET_OBJECT_TYPE_ID', objectTypeId: event.target.value || null });
+            }}
+            className={cn(
+              'focus-ring mt-2 h-10 w-full max-w-md rounded-xl border bg-surface px-3 text-[13px]',
+              state.objectTypeId === null ? 'border-brick-300' : 'border-zinc-200',
+            )}
+          >
+            <option value="">{t('exports.wizard.custom_object_type_placeholder')}</option>
+            {(customTypes.data ?? []).map((row) => (
+              <option key={row.id} value={row.id}>
+                {labelOf(row)}
+              </option>
+            ))}
+          </select>
+          {state.objectTypeId === null && (
+            <p className="mt-1.5 text-[12px] text-brick-600">
+              {t('exports.wizard.custom_object_type_required')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/src/features/exports/wizard/steps/StepEntityType.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepEntityType.tsx
@@ -23,10 +23,10 @@ interface ObjectTypesResponse {
 }
 
 const ENTITY_DEFS: Array<{ id: ExportEntityType; icon: typeof Package }> = [
-  { id: 'products', icon: Package },
+  { id: 'product', icon: Package },
   { id: 'custom_module', icon: Boxes },
   { id: 'module_schema', icon: Layers },
-  { id: 'attributes', icon: Tags },
+  { id: 'attributes_groups', icon: Tags },
   { id: 'categories', icon: FolderTree },
 ];
 

--- a/apps/admin/src/features/exports/wizard/types.ts
+++ b/apps/admin/src/features/exports/wizard/types.ts
@@ -1,0 +1,63 @@
+import type { FilterGroup } from '@/lib/filters/filter-dsl';
+
+/** Export entity types — synced with backend ExportEntityType (EXR-04). */
+export type ExportEntityType =
+  | 'products'
+  | 'custom_module'
+  | 'module_schema'
+  | 'attributes'
+  | 'categories';
+
+export type ExportFormat = 'xlsx' | 'csv';
+
+export type ExportTargetScope = 'all' | 'filter' | 'selected';
+
+/** Whole-wizard state (EXR-09); steps 2-4 fill the optional fields. */
+export interface WizardState {
+  step: number;
+  entityType: ExportEntityType;
+  /** Required when entityType=custom_module — the chosen custom ObjectType. */
+  objectTypeId: string | null;
+  profileId: string | null;
+  format: ExportFormat;
+  filterDsl: FilterGroup | null;
+  selectedIds: string[] | null;
+  targetScope: ExportTargetScope;
+  columns: string[];
+  locales: string[] | null;
+  channels: string[] | null;
+  profileName: string;
+  /** Any user-made change — drives cancel/entity-switch confirmations. */
+  dirty: boolean;
+}
+
+export type WizardAction =
+  | { type: 'SET_ENTITY_TYPE'; entityType: ExportEntityType }
+  | { type: 'SET_OBJECT_TYPE_ID'; objectTypeId: string | null }
+  | { type: 'GO_TO_STEP'; step: number }
+  | { type: 'SET_FORMAT'; format: ExportFormat }
+  | { type: 'SET_PROFILE'; profileId: string | null }
+  | { type: 'SET_FILTER'; filterDsl: FilterGroup | null; targetScope: ExportTargetScope }
+  | { type: 'SET_SELECTED_IDS'; selectedIds: string[] | null }
+  | { type: 'SET_COLUMNS'; columns: string[] }
+  | { type: 'SET_LOCALES'; locales: string[] | null }
+  | { type: 'SET_CHANNELS'; channels: string[] | null }
+  | { type: 'SET_PROFILE_NAME'; profileName: string };
+
+export const WIZARD_STEP_COUNT = 4;
+
+export const INITIAL_WIZARD_STATE: WizardState = {
+  step: 0,
+  entityType: 'products',
+  objectTypeId: null,
+  profileId: null,
+  format: 'xlsx',
+  filterDsl: null,
+  selectedIds: null,
+  targetScope: 'all',
+  columns: [],
+  locales: null,
+  channels: null,
+  profileName: '',
+  dirty: false,
+};

--- a/apps/admin/src/features/exports/wizard/types.ts
+++ b/apps/admin/src/features/exports/wizard/types.ts
@@ -2,10 +2,10 @@ import type { FilterGroup } from '@/lib/filters/filter-dsl';
 
 /** Export entity types — synced with backend ExportEntityType (EXR-04). */
 export type ExportEntityType =
-  | 'products'
+  | 'product'
   | 'custom_module'
   | 'module_schema'
-  | 'attributes'
+  | 'attributes_groups'
   | 'categories';
 
 export type ExportFormat = 'xlsx' | 'csv';
@@ -48,7 +48,7 @@ export const WIZARD_STEP_COUNT = 4;
 
 export const INITIAL_WIZARD_STATE: WizardState = {
   step: 0,
-  entityType: 'products',
+  entityType: 'product',
   objectTypeId: null,
   profileId: null,
   format: 'xlsx',

--- a/apps/admin/src/features/exports/wizard/wizard-store.tsx
+++ b/apps/admin/src/features/exports/wizard/wizard-store.tsx
@@ -1,0 +1,92 @@
+import { createContext, type Dispatch, type ReactNode, useContext, useReducer } from 'react';
+
+import {
+  INITIAL_WIZARD_STATE,
+  WIZARD_STEP_COUNT,
+  type WizardAction,
+  type WizardState,
+} from './types';
+
+/**
+ * EXR-09 — single source of truth for the 4-step export wizard.
+ * Plain context + reducer (repo has no store library; spec default).
+ *
+ * Switching the entity type resets steps 2-4 (filters/columns are
+ * per-entity) — the confirmation dialog lives in StepEntityType, the
+ * reducer just performs the reset deterministically.
+ */
+export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
+  switch (action.type) {
+    case 'SET_ENTITY_TYPE': {
+      if (action.entityType === state.entityType) {
+        return state;
+      }
+      return {
+        ...INITIAL_WIZARD_STATE,
+        step: state.step,
+        entityType: action.entityType,
+        dirty: true,
+      };
+    }
+    case 'SET_OBJECT_TYPE_ID':
+      return { ...state, objectTypeId: action.objectTypeId, dirty: true };
+    case 'GO_TO_STEP': {
+      const step = Math.max(0, Math.min(WIZARD_STEP_COUNT - 1, action.step));
+      return { ...state, step };
+    }
+    case 'SET_FORMAT':
+      return { ...state, format: action.format, dirty: true };
+    case 'SET_PROFILE':
+      return { ...state, profileId: action.profileId, dirty: true };
+    case 'SET_FILTER':
+      return {
+        ...state,
+        filterDsl: action.filterDsl,
+        targetScope: action.targetScope,
+        dirty: true,
+      };
+    case 'SET_SELECTED_IDS':
+      return { ...state, selectedIds: action.selectedIds, dirty: true };
+    case 'SET_COLUMNS':
+      return { ...state, columns: action.columns, dirty: true };
+    case 'SET_LOCALES':
+      return { ...state, locales: action.locales, dirty: true };
+    case 'SET_CHANNELS':
+      return { ...state, channels: action.channels, dirty: true };
+    case 'SET_PROFILE_NAME':
+      return { ...state, profileName: action.profileName, dirty: true };
+    default:
+      return state;
+  }
+}
+
+interface WizardContextValue {
+  state: WizardState;
+  dispatch: Dispatch<WizardAction>;
+}
+
+const WizardContext = createContext<WizardContextValue | null>(null);
+
+export function WizardProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(wizardReducer, INITIAL_WIZARD_STATE);
+  return <WizardContext.Provider value={{ state, dispatch }}>{children}</WizardContext.Provider>;
+}
+
+export function useWizard(): WizardContextValue {
+  const context = useContext(WizardContext);
+  if (!context) {
+    throw new Error('useWizard must be used inside <WizardProvider>');
+  }
+  return context;
+}
+
+/** Has the user configured anything beyond step 1? (entity-switch confirm) */
+export function hasDownstreamConfig(state: WizardState): boolean {
+  return (
+    state.filterDsl !== null ||
+    state.selectedIds !== null ||
+    state.columns.length > 0 ||
+    state.profileId !== null ||
+    state.profileName !== ''
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2428,11 +2428,11 @@
       "unknown_error": "unknown error"
     },
     "entity": {
-      "products": "Products",
       "custom_module": "Custom modules",
       "module_schema": "Module schema",
-      "attributes": "Attributes & groups",
-      "categories": "Categories"
+      "categories": "Categories",
+      "product": "Products",
+      "attributes_groups": "Attributes & groups"
     },
     "active": {
       "title": "Running",
@@ -2512,11 +2512,11 @@
       "step1_subtitle": "Pick the main entity type to generate the output file from.",
       "entity_group_aria": "Export entity type",
       "entity_desc": {
-        "products": "Export the main product catalog, variants, prices and related media.",
         "custom_module": "Export data from user-defined custom modules (e.g. Manufacturers, Collections).",
         "module_schema": "Download module definitions, relations and configuration settings.",
-        "attributes": "Export the attribute dictionary, default values, types and group assignments.",
-        "categories": "Category tree structure, name translations and inheritance rules."
+        "categories": "Category tree structure, name translations and inheritance rules.",
+        "product": "Export the main product catalog, variants, prices and related media.",
+        "attributes_groups": "Export the attribute dictionary, default values, types and group assignments."
       },
       "custom_object_type_label": "Custom module",
       "custom_object_type_placeholder": "Choose a module…",

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2488,6 +2488,40 @@
       "file": "File",
       "size": "Size",
       "error": "Error"
+    },
+    "wizard": {
+      "title": "Export wizard",
+      "lead": "Configure the export — format, scope and target columns.",
+      "steps": {
+        "type": "Type",
+        "type_hint": "what to export",
+        "scope": "Scope & format",
+        "scope_hint": "profile · format · filters",
+        "columns": "Columns",
+        "columns_hint": "attribute selection",
+        "summary": "Summary",
+        "summary_hint": "review & run"
+      },
+      "step_indicator": "step {{step}} of {{total}} · {{title}}",
+      "cancel": "Cancel",
+      "back": "← Back",
+      "next": "Next →",
+      "cancel_confirm": "Abandon this export configuration? Unsaved changes will be lost.",
+      "entity_switch_confirm": "Changing the data type clears steps 2-4 (filters and columns are entity-specific). Continue?",
+      "step1_title": "Step 1: Choose the data to export",
+      "step1_subtitle": "Pick the main entity type to generate the output file from.",
+      "entity_group_aria": "Export entity type",
+      "entity_desc": {
+        "products": "Export the main product catalog, variants, prices and related media.",
+        "custom_module": "Export data from user-defined custom modules (e.g. Manufacturers, Collections).",
+        "module_schema": "Download module definitions, relations and configuration settings.",
+        "attributes": "Export the attribute dictionary, default values, types and group assignments.",
+        "categories": "Category tree structure, name translations and inheritance rules."
+      },
+      "custom_object_type_label": "Custom module",
+      "custom_object_type_placeholder": "Choose a module…",
+      "custom_object_type_required": "Choose a custom module to continue.",
+      "step_placeholder": "This step's content lands in upcoming tickets (EXR-10/11/12)."
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2480,11 +2480,11 @@
       "unknown_error": "nieznany błąd"
     },
     "entity": {
-      "products": "Produkty",
       "custom_module": "Moduły własne",
       "module_schema": "Schemat modułów",
-      "attributes": "Atrybuty i grupy",
-      "categories": "Kategorie"
+      "categories": "Kategorie",
+      "product": "Produkty",
+      "attributes_groups": "Atrybuty i grupy"
     },
     "active": {
       "title": "W toku",
@@ -2564,11 +2564,11 @@
       "step1_subtitle": "Wybierz główny typ encji, z którego chcesz wygenerować plik wyjściowy.",
       "entity_group_aria": "Typ encji eksportu",
       "entity_desc": {
-        "products": "Eksportuj główny katalog produktów, warianty, ceny i powiązane multimedia.",
         "custom_module": "Eksportuj dane ze zdefiniowanych przez użytkownika modułów niestandardowych (np. Producenci, Kolekcje).",
         "module_schema": "Pobierz strukturę definicji, relacje i ustawienia konfiguracyjne modułów.",
-        "attributes": "Eksport słownika atrybutów, ich wartości domyślnych, typów oraz podziału na grupy.",
-        "categories": "Struktura drzewa kategorii, tłumaczenia nazw oraz przypisane reguły dziedziczenia."
+        "categories": "Struktura drzewa kategorii, tłumaczenia nazw oraz przypisane reguły dziedziczenia.",
+        "product": "Eksportuj główny katalog produktów, warianty, ceny i powiązane multimedia.",
+        "attributes_groups": "Eksport słownika atrybutów, ich wartości domyślnych, typów oraz podziału na grupy."
       },
       "custom_object_type_label": "Moduł własny",
       "custom_object_type_placeholder": "Wybierz moduł…",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2540,6 +2540,40 @@
       "file": "Plik",
       "size": "Rozmiar",
       "error": "Błąd"
+    },
+    "wizard": {
+      "title": "Kreator eksportu",
+      "lead": "Skonfiguruj parametry eksportu danych — format, zakres i docelowe kolumny.",
+      "steps": {
+        "type": "Typ",
+        "type_hint": "co eksportujesz",
+        "scope": "Zakres i format",
+        "scope_hint": "profil · format · filtry",
+        "columns": "Kolumny",
+        "columns_hint": "wybór atrybutów",
+        "summary": "Podsumowanie",
+        "summary_hint": "sprawdź i uruchom"
+      },
+      "step_indicator": "krok {{step}} z {{total}} · {{title}}",
+      "cancel": "Anuluj",
+      "back": "← Wstecz",
+      "next": "Dalej →",
+      "cancel_confirm": "Porzucić konfigurację eksportu? Niezapisane zmiany przepadną.",
+      "entity_switch_confirm": "Zmiana typu danych wyczyści ustawienia kroków 2-4 (filtry i kolumny są zależne od encji). Kontynuować?",
+      "step1_title": "Krok 1: Wybierz dane do eksportu",
+      "step1_subtitle": "Wybierz główny typ encji, z którego chcesz wygenerować plik wyjściowy.",
+      "entity_group_aria": "Typ encji eksportu",
+      "entity_desc": {
+        "products": "Eksportuj główny katalog produktów, warianty, ceny i powiązane multimedia.",
+        "custom_module": "Eksportuj dane ze zdefiniowanych przez użytkownika modułów niestandardowych (np. Producenci, Kolekcje).",
+        "module_schema": "Pobierz strukturę definicji, relacje i ustawienia konfiguracyjne modułów.",
+        "attributes": "Eksport słownika atrybutów, ich wartości domyślnych, typów oraz podziału na grupy.",
+        "categories": "Struktura drzewa kategorii, tłumaczenia nazw oraz przypisane reguły dziedziczenia."
+      },
+      "custom_object_type_label": "Moduł własny",
+      "custom_object_type_placeholder": "Wybierz moduł…",
+      "custom_object_type_required": "Wybierz moduł własny, aby przejść dalej.",
+      "step_placeholder": "Treść tego kroku pojawi się w kolejnych ticketach (EXR-10/11/12)."
     }
   }
 }


### PR DESCRIPTION
## Zakres (EXR-09, #1385)
Pełnostronicowy 4-krokowy kreator na `/integrations/exports/new` (screen 2): `WizardStepper` (klik tylko w done-steps), stopka z mono `krok N z 4`, Anuluj (confirm przy dirty), store context+reducer (`wizard-store.tsx`, brak biblioteki store w repo — default ze spec), typy zsynchronizowane z enumami EXR-04 (`product`/`attributes_groups`!).

**Krok 1:** 5 kafelków `SelectableCard` w radiogroup (Produkty default + badge WYBRANE); „Moduły własne" odsłania select custom ObjectType (kind=custom) z walidacją inline blokującą Dalej i disabled z tooltipem przy braku modułów. Zmiana encji po konfiguracji dalszych kroków → confirm + reset (reducer). Legacy paste-JSON page przeniesiony na `/new-legacy` do czasu EXR-14.

## Testy
- Vitest: reducer (reset przy zmianie encji, clamp kroków, no-op) — 34 testy łącznie.
- E2E `exr-09-wizard-step1.spec.ts`: 5 kafelków wybieralnych + Dalej, walidacja custom module, Anuluj z confirm (mock OT).

## Live smoke ✅ (pim.localhost, realny backend)
Wejście z CTA „Nowy eksport" → Krok 1 renderuje 5 kafelków, pełny przepływ przez 4 kroki wykonany w ramach smoke'a całego epiku (screenshots exr-smoke-02..05), konsola czysta.

Closes #1385