### PR TITLE
EXR-10: wizard Krok 2 — Zakres i format z REUŻYWALNĄ wyszukiwarką (#1386)

### DIFF
--- a/apps/admin/e2e/exr-09-wizard-step1.spec.ts
+++ b/apps/admin/e2e/exr-09-wizard-step1.spec.ts
@@ -43,9 +43,8 @@ test('every entity tile is selectable and Dalej advances', async ({ page }) => {
   }
 
   await page.getByRole('button', { name: /Dalej|Next/ }).click();
-  await expect(page.getByText(/EXR-10\/11\/12/)).toBeVisible();
 
-  // stepper: step 1 done, step 2 active
+  // stepper: step 1 done, step 2 active (step content owned by EXR-10+)
   await expect(page.getByRole('button', { name: /Zakres|Scope/ })).toHaveAttribute(
     'aria-current',
     'step',
@@ -61,7 +60,10 @@ test('custom module requires an ObjectType before Dalej', async ({ page }) => {
   await page.getByLabel(/Moduł własny|Custom module/).selectOption(CUSTOM_OT.id);
   await expect(page.getByRole('button', { name: /Dalej|Next/ })).toBeEnabled();
   await page.getByRole('button', { name: /Dalej|Next/ }).click();
-  await expect(page.getByText(/EXR-10\/11\/12/)).toBeVisible();
+  await expect(page.getByRole('button', { name: /Zakres|Scope/ })).toHaveAttribute(
+    'aria-current',
+    'step',
+  );
 });
 
 test('cancel asks for confirmation when dirty and returns to sessions', async ({ page }) => {

--- a/apps/admin/e2e/exr-10-wizard-step2.spec.ts
+++ b/apps/admin/e2e/exr-10-wizard-step2.spec.ts
@@ -51,7 +51,7 @@ test('format tiles: XLSX/CSV selectable, soon formats disabled', async ({ page }
   const pdf = group.getByRole('radio', { name: /PDF/ });
   await expect(pdf).toHaveAttribute('aria-disabled', 'true');
   await expect(pdf).toContainText(/wkrótce|soon/);
-  await pdf.click();
+  await pdf.click({ force: true });
   await expect(pdf).toHaveAttribute('aria-checked', 'false');
 });
 
@@ -64,7 +64,7 @@ test('preflight badge shows the count and reacts to filter changes', async ({ pa
   // like the product list; only then the preflight re-probes.
   preflightCount = 7;
   await page.getByRole('button', { name: /dodaj warunek/i }).click();
-  await expect(page.getByLabel('Atrybut').first()).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Usuń warunek' }).first()).toBeVisible();
   await page
     .getByPlaceholder(/wpisz wartość/i)
     .first()

--- a/apps/admin/e2e/exr-10-wizard-step2.spec.ts
+++ b/apps/admin/e2e/exr-10-wizard-step2.spec.ts
@@ -59,7 +59,9 @@ test('preflight badge shows the count and reacts to filter changes', async ({ pa
   const badge = page.getByTestId('preflight-badge');
   await expect(badge).toContainText('42');
 
-  // build a condition through the REUSED AdvancedFilterPanel
+  // build a condition through the REUSED AdvancedFilterPanel — the
+  // panel commits its draft on „Zastosuj filtr" (VIEW-22a), exactly
+  // like the product list; only then the preflight re-probes.
   preflightCount = 7;
   await page.getByRole('button', { name: /dodaj warunek/i }).click();
   await expect(page.getByLabel('Atrybut').first()).toBeVisible();
@@ -67,6 +69,7 @@ test('preflight badge shows the count and reacts to filter changes', async ({ pa
     .getByPlaceholder(/wpisz wartość/i)
     .first()
     .fill('Festo');
+  await page.getByRole('button', { name: /zastosuj filtr/i }).click();
   await expect(badge).toContainText('7', { timeout: 5_000 });
 });
 
@@ -77,6 +80,7 @@ test('exceeding the soft cap blocks Dalej', async ({ page }) => {
     .getByPlaceholder(/wpisz wartość/i)
     .first()
     .fill('x');
+  await page.getByRole('button', { name: /zastosuj filtr/i }).click();
 
   await expect(page.getByTestId('preflight-badge')).toContainText(/Przekroczono|exceeded/, {
     timeout: 5_000,

--- a/apps/admin/e2e/exr-10-wizard-step2.spec.ts
+++ b/apps/admin/e2e/exr-10-wizard-step2.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from '@playwright/test';
+import { apiLogin } from './helpers/auth';
+
+/**
+ * EXR-10 (#1386) — wizard step 2: format radio-cards (D1: only XLSX/CSV
+ * active), reused AdvancedFilterPanel and the debounced preflight badge.
+ * Preflight + profiles are mocked for determinism; the cross-check
+ * against the product list count runs in the live smoke.
+ */
+
+let preflightCount = 42;
+
+test.beforeEach(async ({ page }) => {
+  preflightCount = 42;
+  await page.route('**/api/exports/profiles', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], total: 0 }),
+    }),
+  );
+  await page.route('**/api/exports/preflight', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: preflightCount,
+        mode: preflightCount >= 100 ? 'async' : 'sync',
+        threshold: 100,
+        soft_cap: 100_000,
+        exceeds_cap: preflightCount > 100_000,
+      }),
+    }),
+  );
+  await apiLogin(page);
+  await page.waitForTimeout(1200);
+  await page.goto('/integrations/exports/new');
+  await page.waitForTimeout(600);
+  // step 1 → step 2 (products preselected)
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await page.waitForTimeout(300);
+});
+
+test('format tiles: XLSX/CSV selectable, soon formats disabled', async ({ page }) => {
+  const group = page.getByRole('radiogroup', { name: /Format pliku|File format/ });
+  await expect(group.getByRole('radio')).toHaveCount(6);
+
+  await group.getByRole('radio', { name: /^CSV/ }).click();
+  await expect(group.getByRole('radio', { name: /^CSV/ })).toHaveAttribute('aria-checked', 'true');
+
+  const pdf = group.getByRole('radio', { name: /PDF/ });
+  await expect(pdf).toHaveAttribute('aria-disabled', 'true');
+  await expect(pdf).toContainText(/wkrótce|soon/);
+  await pdf.click();
+  await expect(pdf).toHaveAttribute('aria-checked', 'false');
+});
+
+test('preflight badge shows the count and reacts to filter changes', async ({ page }) => {
+  const badge = page.getByTestId('preflight-badge');
+  await expect(badge).toContainText('42');
+
+  // build a condition through the REUSED AdvancedFilterPanel
+  preflightCount = 7;
+  await page.getByRole('button', { name: /dodaj warunek/i }).click();
+  await expect(page.getByLabel('Atrybut').first()).toBeVisible();
+  await page
+    .getByPlaceholder(/wpisz wartość/i)
+    .first()
+    .fill('Festo');
+  await expect(badge).toContainText('7', { timeout: 5_000 });
+});
+
+test('exceeding the soft cap blocks Dalej', async ({ page }) => {
+  preflightCount = 250_000;
+  await page.getByRole('button', { name: /dodaj warunek/i }).click();
+  await page
+    .getByPlaceholder(/wpisz wartość/i)
+    .first()
+    .fill('x');
+
+  await expect(page.getByTestId('preflight-badge')).toContainText(/Przekroczono|exceeded/, {
+    timeout: 5_000,
+  });
+  await expect(page.getByRole('button', { name: /Dalej|Next/ })).toBeDisabled();
+});
+
+test('structural entity shows full-structure note instead of the panel', async ({ page }) => {
+  // go back to step 1 and pick a structural entity
+  await page
+    .getByRole('button', { name: /Typ|Type/ })
+    .first()
+    .click();
+  await page.getByRole('radio', { name: /Kategorie|Categories/ }).click();
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+
+  await expect(page.getByText(/Eksport pełnej struktury|Full structure export/)).toBeVisible();
+  await expect(page.getByRole('button', { name: /dodaj warunek/i })).not.toBeVisible();
+});

--- a/apps/admin/src/components/objects/universal-list-page.tsx
+++ b/apps/admin/src/components/objects/universal-list-page.tsx
@@ -63,12 +63,9 @@ import {
   useCatalogSearch,
 } from '@/features/catalog/search/use-catalog-search';
 import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
-import {
-  conditionsToDsl,
-  dslToFlatConditions,
-  type FilterCondition,
-} from '@/lib/filters/filter-dsl';
+import { dslToFlatConditions } from '@/lib/filters/filter-dsl';
 import { dslToBase64 } from '@/lib/filters/url-serializer';
+import { useFilterDslState } from '@/lib/filters/use-filter-dsl-state';
 import { type SmartFilterPreset, useSmartPresets } from '@/lib/filters/use-smart-presets';
 import { jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
@@ -284,8 +281,14 @@ export function UniversalListPage({
   const [activeSmartPresetId, setActiveSmartPresetId] = useState<string | null>(null);
   const [presetToDelete, setPresetToDelete] = useState<SmartFilterPreset | null>(null);
   const [advancedPanelOpen, setAdvancedPanelOpen] = useState(false);
-  const [panelConditions, setPanelConditions] = useState<FilterCondition[]>([]);
-  const [matchOperator, setMatchOperator] = useState<'AND' | 'OR'>('AND');
+  // EXR-10 — shared filter-DSL state (same hook the export wizard uses).
+  const {
+    conditions: panelConditions,
+    setConditions: setPanelConditions,
+    matchOperator,
+    setMatchOperator,
+    dsl: panelDsl,
+  } = useFilterDslState();
   const [showSaveAsPresetModal, setShowSaveAsPresetModal] = useState(false);
 
   const { searchFilters, rangeFilters } = useMemo(() => {
@@ -306,15 +309,13 @@ export function UniversalListPage({
     : undefined;
   const filterBlob = useMemo<string | undefined>(() => {
     if (activePreset !== undefined) return undefined;
-    if (panelConditions.length === 0) return undefined;
-    const dsl = conditionsToDsl(panelConditions, matchOperator);
-    if (dsl === null) return undefined;
+    if (panelDsl === null) return undefined;
     try {
-      return dslToBase64(dsl);
+      return dslToBase64(panelDsl);
     } catch {
       return undefined;
     }
-  }, [activePreset, panelConditions, matchOperator]);
+  }, [activePreset, panelDsl]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — `setPage` is stable
   useEffect(() => {
@@ -1029,7 +1030,7 @@ export function UniversalListPage({
 
       {showSaveAsPresetModal ? (
         <SaveAsSmartPresetModal
-          query={conditionsToDsl(panelConditions, matchOperator)}
+          query={panelDsl}
           create={createSmartPreset}
           onClose={() => setShowSaveAsPresetModal(false)}
           onSaved={(preset) => {

--- a/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { WizardStepper } from '@/components/ui-v2/wizard-stepper';
 
 import { StepEntityType } from './steps/StepEntityType';
+import { StepScopeFormat } from './steps/StepScopeFormat';
 import { WizardFooter } from './WizardFooter';
 import { useWizard, WizardProvider } from './wizard-store';
 
@@ -55,6 +56,9 @@ function WizardContent() {
   ];
 
   const step1Valid = state.entityType !== 'custom_module' || state.objectTypeId !== null;
+  // EXR-10: soft-cap gate — Dalej blocked while the configuration would
+  // exceed the 100k export cap (count=0 stays allowed: headers-only file).
+  const step2Valid = state.preflight?.exceeds_cap !== true;
 
   return (
     <div className="mx-auto max-w-5xl space-y-6">
@@ -73,7 +77,8 @@ function WizardContent() {
 
       <div key={state.step}>
         {state.step === 0 && <StepEntityType />}
-        {state.step > 0 && (
+        {state.step === 1 && <StepScopeFormat />}
+        {state.step > 1 && (
           <div className="rounded-2xl border border-dashed border-zinc-200 bg-surface p-10 text-center text-[13px] text-zinc-400">
             {t('exports.wizard.step_placeholder')}
           </div>
@@ -82,7 +87,7 @@ function WizardContent() {
 
       <WizardFooter
         stepTitle={stepTitles[state.step] ?? ''}
-        nextDisabled={state.step === 0 && !step1Valid}
+        nextDisabled={(state.step === 0 && !step1Valid) || (state.step === 1 && !step2Valid)}
       />
     </div>
   );

--- a/apps/admin/src/features/exports/wizard/steps/StepScopeFormat.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepScopeFormat.tsx
@@ -1,0 +1,262 @@
+import { useQuery } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { lazy, Suspense, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from '@/components/ui/toast';
+import { SelectableCard, SelectableCardGroup } from '@/components/ui-v2/selectable-card';
+import type { FilterDsl } from '@/lib/filters/filter-dsl';
+import { useFilterDslState } from '@/lib/filters/use-filter-dsl-state';
+import { jsonFetch } from '@/lib/http';
+import { cn } from '@/lib/utils';
+
+import type { ExportFormat } from '../types';
+import { useExportPreflight } from '../use-export-preflight';
+import { useWizard } from '../wizard-store';
+
+// EXR-10 CRITICAL REUSE: the export wizard embeds the SAME panel the
+// product/universal list uses — no second filter implementation.
+const AdvancedFilterPanel = lazy(() =>
+  import('@/components/catalog/advanced-filter-panel').then((m) => ({
+    default: m.AdvancedFilterPanel,
+  })),
+);
+
+interface ProfileRow {
+  id: string;
+  name: string;
+  entity_type: string;
+  object_type_id: string | null;
+  config: {
+    format?: string;
+    selected_columns?: string[];
+    locales?: string[] | null;
+    channels?: string[] | null;
+    default_target_scope?: string;
+    filter?: FilterDsl | null;
+  };
+}
+
+interface ProfilesResponse {
+  items: ProfileRow[];
+  total: number;
+}
+
+const ACTIVE_FORMATS: Array<{ id: ExportFormat; descKey: string }> = [
+  { id: 'xlsx', descKey: 'exports.wizard.format_desc.xlsx' },
+  { id: 'csv', descKey: 'exports.wizard.format_desc.csv' },
+];
+
+/** D1 — visible but disabled format tiles ("wkrótce"), never sent in payloads. */
+const SOON_FORMATS = ['xml', 'json', 'gsheets', 'pdf'] as const;
+
+/**
+ * EXR-10 — wizard step 2 (screen 3): saved profile select, format
+ * radio-cards (XLSX/CSV active, rest D1-disabled) and the data-scope
+ * section embedding the shared AdvancedFilterPanel for product /
+ * custom_module entities. Structural entities show a full-structure
+ * info card instead. A debounced preflight probe (EXR-07) feeds the
+ * "Do wyeksportowania: N" badge and the sync/async routing for step 4.
+ */
+export function StepScopeFormat() {
+  const { t } = useTranslation();
+  const { state, dispatch } = useWizard();
+
+  const filterable = state.entityType === 'product' || state.entityType === 'custom_module';
+  const selectedMode = state.targetScope === 'selected';
+
+  const filterState = useFilterDslState(state.filterDsl);
+  const { dsl } = filterState;
+
+  // Push panel changes into the wizard store (scope follows DSL presence).
+  useEffect(() => {
+    if (!filterable || selectedMode) return;
+    const targetScope = dsl === null ? 'all' : 'filter';
+    if (dsl !== state.filterDsl || targetScope !== state.targetScope) {
+      dispatch({ type: 'SET_FILTER', filterDsl: dsl, targetScope });
+    }
+  }, [dsl, filterable, selectedMode, state.filterDsl, state.targetScope, dispatch]);
+
+  const preflight = useExportPreflight({
+    entityType: state.entityType,
+    objectTypeId: state.objectTypeId,
+    targetScope: state.targetScope,
+    filterDsl: state.filterDsl,
+    selectedIds: state.selectedIds,
+    enabled: state.entityType !== 'custom_module' || state.objectTypeId !== null,
+  });
+
+  // Surface the preflight result to the footer (cap gate) and step 4.
+  useEffect(() => {
+    dispatch({ type: 'SET_PREFLIGHT', preflight: preflight.result });
+  }, [preflight.result, dispatch]);
+
+  const profilesQuery = useQuery<ProfilesResponse>({
+    queryKey: ['exports', 'profiles', 'list'],
+    staleTime: 30_000,
+    queryFn: () =>
+      jsonFetch<ProfilesResponse>('/api/exports/profiles', { accept: 'application/json' }),
+  });
+  const matchingProfiles = (profilesQuery.data?.items ?? []).filter(
+    (profile) =>
+      profile.entity_type === state.entityType &&
+      (state.entityType !== 'custom_module' || profile.object_type_id === state.objectTypeId),
+  );
+
+  const applyProfile = (profileId: string) => {
+    const profile = matchingProfiles.find((row) => row.id === profileId);
+    if (!profile) return;
+    const format = profile.config.format === 'csv' ? 'csv' : 'xlsx';
+    const filterDsl = profile.config.filter ?? null;
+    dispatch({
+      type: 'APPLY_PROFILE',
+      profileId: profile.id,
+      profileName: profile.name,
+      format,
+      columns: profile.config.selected_columns ?? [],
+      locales: profile.config.locales ?? null,
+      channels: profile.config.channels ?? null,
+      filterDsl,
+      targetScope: filterDsl === null ? 'all' : 'filter',
+    });
+    filterState.setConditions([]);
+    toast.success(t('exports.wizard.profile_loaded', { name: profile.name }));
+  };
+
+  const count = preflight.result?.count ?? null;
+  const exceedsCap = preflight.result?.exceeds_cap === true;
+
+  return (
+    <div className="space-y-5">
+      <section className="rounded-2xl border border-zinc-200 bg-surface p-7 shadow-card">
+        <h2 className="text-[16px] font-semibold tracking-tight text-ink">
+          {t('exports.wizard.step2_profile_title')}
+        </h2>
+        <div className="mt-4 max-w-md">
+          <label
+            htmlFor="wizard-profile-select"
+            className="block text-[11px] font-medium tracking-wider text-zinc-400 uppercase"
+          >
+            {t('exports.wizard.profile_label')}
+          </label>
+          <select
+            id="wizard-profile-select"
+            value={state.profileId ?? ''}
+            onChange={(event) => {
+              if (event.target.value !== '') applyProfile(event.target.value);
+            }}
+            className="focus-ring mt-2 h-10 w-full rounded-xl border border-zinc-200 bg-surface px-3 text-[13px]"
+          >
+            <option value="">{t('exports.wizard.profile_placeholder')}</option>
+            {matchingProfiles.map((profile) => (
+              <option key={profile.id} value={profile.id}>
+                {profile.name}
+              </option>
+            ))}
+          </select>
+          <p className="mt-1.5 text-[12px] text-zinc-400">{t('exports.wizard.profile_hint')}</p>
+        </div>
+
+        <h3 className="mt-6 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+          {t('exports.wizard.format_label')}
+        </h3>
+        <SelectableCardGroup
+          ariaLabel={t('exports.wizard.format_group_aria')}
+          className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
+        >
+          {[
+            ...ACTIVE_FORMATS.map(({ id, descKey }) => (
+              <SelectableCard
+                key={id}
+                title={id.toUpperCase()}
+                description={t(descKey)}
+                selected={state.format === id}
+                onSelect={() => dispatch({ type: 'SET_FORMAT', format: id })}
+              />
+            )),
+            ...SOON_FORMATS.map((id) => (
+              <SelectableCard
+                key={id}
+                title={t(`exports.wizard.format_soon.${id}`)}
+                description={t(`exports.wizard.format_soon_desc.${id}`)}
+                disabled
+              />
+            )),
+          ]}
+        </SelectableCardGroup>
+      </section>
+
+      <section className="rounded-2xl border border-zinc-200 bg-surface p-7 shadow-card">
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="text-[16px] font-semibold tracking-tight text-ink">
+            {t('exports.wizard.step2_scope_title')}
+          </h2>
+          <span
+            data-testid="preflight-badge"
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-[11.5px] font-medium',
+              exceedsCap ? 'bg-brick-50 text-brick-700' : 'bg-zinc-100 text-zinc-600',
+            )}
+          >
+            {preflight.isLoading && <Loader2 className="size-3 animate-spin" aria-hidden />}
+            {exceedsCap
+              ? t('exports.wizard.cap_exceeded', {
+                  cap: preflight.result?.soft_cap.toLocaleString('pl-PL'),
+                })
+              : t('exports.wizard.preflight_badge', {
+                  count: count === null ? '—' : count.toLocaleString('pl-PL'),
+                })}
+          </span>
+        </div>
+
+        {!filterable && (
+          <p className="mt-3 text-[13px] text-zinc-500">
+            {t('exports.wizard.structural_scope', {
+              count: count ?? 0,
+            })}
+          </p>
+        )}
+
+        {filterable && selectedMode && (
+          <div className="mt-4 flex items-center gap-3">
+            <span className="inline-flex items-center rounded-md bg-zinc-100 px-2 py-1 text-[12.5px] font-medium text-zinc-700">
+              {t('exports.wizard.selected_chip', { count: state.selectedIds?.length ?? 0 })}
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                dispatch({ type: 'SET_SELECTED_IDS', selectedIds: null });
+                dispatch({ type: 'SET_FILTER', filterDsl: null, targetScope: 'all' });
+              }}
+              className="focus-ring text-[12.5px] font-medium text-zinc-500 underline-offset-2 hover:text-ink hover:underline"
+            >
+              {t('exports.wizard.switch_to_filter')}
+            </button>
+          </div>
+        )}
+
+        {filterable && !selectedMode && (
+          <div className="mt-4">
+            {count === 0 && !preflight.isLoading && (
+              <p className="mb-3 text-[12.5px] text-orange-700">
+                {t('exports.wizard.empty_set_warning')}
+              </p>
+            )}
+            <Suspense fallback={<div className="h-24 animate-pulse rounded-xl bg-zinc-100" />}>
+              <AdvancedFilterPanel
+                open
+                conditions={filterState.conditions}
+                setConditions={filterState.setConditions}
+                matchOperator={filterState.matchOperator}
+                setMatchOperator={filterState.setMatchOperator}
+                onApply={() => {}}
+                onClose={() => {}}
+                onClear={() => filterState.clear()}
+                resultCount={count ?? undefined}
+              />
+            </Suspense>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/admin/src/features/exports/wizard/types.ts
+++ b/apps/admin/src/features/exports/wizard/types.ts
@@ -1,4 +1,4 @@
-import type { FilterGroup } from '@/lib/filters/filter-dsl';
+import type { FilterDsl } from '@/lib/filters/filter-dsl';
 
 /** Export entity types — synced with backend ExportEntityType (EXR-04). */
 export type ExportEntityType =
@@ -12,6 +12,15 @@ export type ExportFormat = 'xlsx' | 'csv';
 
 export type ExportTargetScope = 'all' | 'filter' | 'selected';
 
+/** Result of POST /api/exports/preflight (EXR-07). */
+export interface PreflightResult {
+  count: number;
+  mode: 'sync' | 'async';
+  threshold: number;
+  soft_cap: number;
+  exceeds_cap: boolean;
+}
+
 /** Whole-wizard state (EXR-09); steps 2-4 fill the optional fields. */
 export interface WizardState {
   step: number;
@@ -20,13 +29,15 @@ export interface WizardState {
   objectTypeId: string | null;
   profileId: string | null;
   format: ExportFormat;
-  filterDsl: FilterGroup | null;
+  filterDsl: FilterDsl | null;
   selectedIds: string[] | null;
   targetScope: ExportTargetScope;
   columns: string[];
   locales: string[] | null;
   channels: string[] | null;
   profileName: string;
+  /** Last preflight probe for the current configuration (EXR-10). */
+  preflight: PreflightResult | null;
   /** Any user-made change — drives cancel/entity-switch confirmations. */
   dirty: boolean;
 }
@@ -37,12 +48,24 @@ export type WizardAction =
   | { type: 'GO_TO_STEP'; step: number }
   | { type: 'SET_FORMAT'; format: ExportFormat }
   | { type: 'SET_PROFILE'; profileId: string | null }
-  | { type: 'SET_FILTER'; filterDsl: FilterGroup | null; targetScope: ExportTargetScope }
+  | { type: 'SET_FILTER'; filterDsl: FilterDsl | null; targetScope: ExportTargetScope }
   | { type: 'SET_SELECTED_IDS'; selectedIds: string[] | null }
   | { type: 'SET_COLUMNS'; columns: string[] }
   | { type: 'SET_LOCALES'; locales: string[] | null }
   | { type: 'SET_CHANNELS'; channels: string[] | null }
-  | { type: 'SET_PROFILE_NAME'; profileName: string };
+  | { type: 'SET_PROFILE_NAME'; profileName: string }
+  | { type: 'SET_PREFLIGHT'; preflight: PreflightResult | null }
+  | {
+      type: 'APPLY_PROFILE';
+      profileId: string;
+      profileName: string;
+      format: ExportFormat;
+      columns: string[];
+      locales: string[] | null;
+      channels: string[] | null;
+      filterDsl: FilterDsl | null;
+      targetScope: ExportTargetScope;
+    };
 
 export const WIZARD_STEP_COUNT = 4;
 
@@ -59,5 +82,6 @@ export const INITIAL_WIZARD_STATE: WizardState = {
   locales: null,
   channels: null,
   profileName: '',
+  preflight: null,
   dirty: false,
 };

--- a/apps/admin/src/features/exports/wizard/use-export-preflight.ts
+++ b/apps/admin/src/features/exports/wizard/use-export-preflight.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { FilterDsl } from '@/lib/filters/filter-dsl';
+import { jsonFetch } from '@/lib/http';
+
+import type { ExportEntityType, ExportTargetScope, PreflightResult } from './types';
+
+interface PreflightInput {
+  entityType: ExportEntityType;
+  objectTypeId: string | null;
+  targetScope: ExportTargetScope;
+  filterDsl: FilterDsl | null;
+  selectedIds: string[] | null;
+  /** Skip probing (e.g. custom_module without a chosen ObjectType). */
+  enabled?: boolean;
+}
+
+interface PreflightState {
+  result: PreflightResult | null;
+  isLoading: boolean;
+  error: boolean;
+}
+
+const DEBOUNCE_MS = 500;
+
+/**
+ * EXR-10 — debounced POST /api/exports/preflight (EXR-07) on every
+ * configuration change. Stale responses are discarded by sequence id.
+ */
+export function useExportPreflight(input: PreflightInput): PreflightState {
+  const [state, setState] = useState<PreflightState>({
+    result: null,
+    isLoading: false,
+    error: false,
+  });
+  const seqRef = useRef(0);
+
+  const { entityType, objectTypeId, targetScope, filterDsl, selectedIds, enabled = true } = input;
+  const filterKey = JSON.stringify(filterDsl);
+  const selectedKey = JSON.stringify(selectedIds);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: filterDsl/selectedIds tracked via their JSON keys
+  useEffect(() => {
+    if (!enabled) {
+      setState({ result: null, isLoading: false, error: false });
+      return;
+    }
+    const seq = ++seqRef.current;
+    setState((prev) => ({ ...prev, isLoading: true, error: false }));
+    const timer = setTimeout(() => {
+      const payload: Record<string, unknown> = {
+        entity_type: entityType,
+        target_scope: targetScope,
+      };
+      if (objectTypeId !== null) payload.object_type_id = objectTypeId;
+      if (targetScope === 'filter' && filterDsl !== null) payload.filter = filterDsl;
+      if (targetScope === 'selected') payload.selected_object_ids = selectedIds ?? [];
+
+      jsonFetch<PreflightResult>('/api/exports/preflight', {
+        method: 'POST',
+        accept: 'application/json',
+        body: payload,
+      })
+        .then((result) => {
+          if (seqRef.current === seq) {
+            setState({ result, isLoading: false, error: false });
+          }
+        })
+        .catch(() => {
+          if (seqRef.current === seq) {
+            setState({ result: null, isLoading: false, error: true });
+          }
+        });
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [entityType, objectTypeId, targetScope, filterKey, selectedKey, enabled]);
+
+  return state;
+}

--- a/apps/admin/src/features/exports/wizard/wizard-store.tsx
+++ b/apps/admin/src/features/exports/wizard/wizard-store.tsx
@@ -55,6 +55,21 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       return { ...state, channels: action.channels, dirty: true };
     case 'SET_PROFILE_NAME':
       return { ...state, profileName: action.profileName, dirty: true };
+    case 'SET_PREFLIGHT':
+      return { ...state, preflight: action.preflight };
+    case 'APPLY_PROFILE':
+      return {
+        ...state,
+        profileId: action.profileId,
+        profileName: action.profileName,
+        format: action.format,
+        columns: action.columns,
+        locales: action.locales,
+        channels: action.channels,
+        filterDsl: action.filterDsl,
+        targetScope: action.targetScope,
+        dirty: true,
+      };
     default:
       return state;
   }

--- a/apps/admin/src/lib/filters/__tests__/use-filter-dsl-state.test.tsx
+++ b/apps/admin/src/lib/filters/__tests__/use-filter-dsl-state.test.tsx
@@ -1,0 +1,34 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { FilterCondition, FilterGroup } from '../filter-dsl';
+import { useFilterDslState } from '../use-filter-dsl-state';
+
+const COND_A: FilterCondition = { attr: 'brand', op: '=', value: 'Festo' };
+const COND_B: FilterCondition = { attr: 'enabled', op: '=', value: true };
+
+describe('useFilterDslState', () => {
+  it('starts empty and composes DSL as conditions are added', () => {
+    const { result } = renderHook(() => useFilterDslState());
+    expect(result.current.dsl).toBeNull();
+
+    act(() => result.current.setConditions([COND_A]));
+    expect(result.current.dsl).toEqual(COND_A);
+
+    act(() => result.current.setConditions([COND_A, COND_B]));
+    expect(result.current.dsl).toEqual({ operator: 'AND', conditions: [COND_A, COND_B] });
+  });
+
+  it('hydrates from an initial group (operator preserved)', () => {
+    const initial: FilterGroup = { operator: 'OR', conditions: [COND_A, COND_B] };
+    const { result } = renderHook(() => useFilterDslState(initial));
+    expect(result.current.matchOperator).toBe('OR');
+    expect(result.current.conditions).toEqual([COND_A, COND_B]);
+  });
+
+  it('clear() empties the composed DSL', () => {
+    const { result } = renderHook(() => useFilterDslState(COND_A));
+    act(() => result.current.clear());
+    expect(result.current.dsl).toBeNull();
+  });
+});

--- a/apps/admin/src/lib/filters/use-filter-dsl-state.ts
+++ b/apps/admin/src/lib/filters/use-filter-dsl-state.ts
@@ -1,0 +1,48 @@
+import { useMemo, useState } from 'react';
+
+import {
+  conditionsToDsl,
+  dslToFlatConditions,
+  type FilterCondition,
+  type FilterDsl,
+  isFilterGroup,
+} from './filter-dsl';
+
+export interface FilterDslState {
+  conditions: FilterCondition[];
+  setConditions: (conditions: FilterCondition[]) => void;
+  matchOperator: 'AND' | 'OR';
+  setMatchOperator: (operator: 'AND' | 'OR') => void;
+  /** Composed DSL (single condition stays unwrapped) — `null` when empty. */
+  dsl: FilterDsl | null;
+  clear: () => void;
+}
+
+/**
+ * EXR-10 — shared state holder for `AdvancedFilterPanel` (Single Source
+ * of Truth for filtering): the universal list page and the export
+ * wizard hold the same conditions/operator pair and derive the composed
+ * FilterDSL from one place. The panel itself stays fully props-driven.
+ */
+export function useFilterDslState(initial?: FilterDsl | null): FilterDslState {
+  const [conditions, setConditions] = useState<FilterCondition[]>(
+    () => dslToFlatConditions(initial ?? null) ?? [],
+  );
+  const [matchOperator, setMatchOperator] = useState<'AND' | 'OR'>(
+    initial && isFilterGroup(initial) ? initial.operator : 'AND',
+  );
+
+  const dsl = useMemo(
+    () => conditionsToDsl(conditions, matchOperator),
+    [conditions, matchOperator],
+  );
+
+  return {
+    conditions,
+    setConditions,
+    matchOperator,
+    setMatchOperator,
+    dsl,
+    clear: () => setConditions([]),
+  };
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2521,7 +2521,37 @@
       "custom_object_type_label": "Custom module",
       "custom_object_type_placeholder": "Choose a module…",
       "custom_object_type_required": "Choose a custom module to continue.",
-      "step_placeholder": "This step's content lands in upcoming tickets (EXR-10/11/12)."
+      "step_placeholder": "This step's content lands in upcoming tickets (EXR-10/11/12).",
+      "step2_profile_title": "Profile & file format",
+      "profile_label": "Saved profile (optional)",
+      "profile_placeholder": "Choose a saved profile…",
+      "profile_hint": "Loading a profile overrides the current format and filter settings.",
+      "profile_loaded": "Profile {{name}} loaded",
+      "format_label": "Target format",
+      "format_group_aria": "File format",
+      "format_desc": {
+        "xlsx": "Excel spreadsheet",
+        "csv": "Comma-separated values"
+      },
+      "format_soon": {
+        "xml": "XML",
+        "json": "JSON",
+        "gsheets": "Google Sheets",
+        "pdf": "PDF"
+      },
+      "format_soon_desc": {
+        "xml": "Hierarchical feed",
+        "json": "Structured data / API",
+        "gsheets": "Cloud spreadsheet",
+        "pdf": "Catalog / price list"
+      },
+      "step2_scope_title": "Data scope (filtering)",
+      "preflight_badge": "To export: {{count}}",
+      "cap_exceeded": "Limit of {{cap}} exceeded — narrow the filters",
+      "structural_scope": "Full structure export — {{count}} rows.",
+      "selected_chip": "Selected objects: {{count}}",
+      "switch_to_filter": "switch to filtering",
+      "empty_set_warning": "The filter matches no objects — the file will contain column headers only."
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2573,7 +2573,37 @@
       "custom_object_type_label": "Moduł własny",
       "custom_object_type_placeholder": "Wybierz moduł…",
       "custom_object_type_required": "Wybierz moduł własny, aby przejść dalej.",
-      "step_placeholder": "Treść tego kroku pojawi się w kolejnych ticketach (EXR-10/11/12)."
+      "step_placeholder": "Treść tego kroku pojawi się w kolejnych ticketach (EXR-10/11/12).",
+      "step2_profile_title": "Profil i format pliku",
+      "profile_label": "Zapisany profil (opcjonalnie)",
+      "profile_placeholder": "Wybierz zapisany profil…",
+      "profile_hint": "Użycie profilu nadpisze aktualne ustawienia formatu i filtrów.",
+      "profile_loaded": "Załadowano profil {{name}}",
+      "format_label": "Format docelowy",
+      "format_group_aria": "Format pliku",
+      "format_desc": {
+        "xlsx": "Arkusz kalkulacyjny Excel",
+        "csv": "Wartości rozdzielane przecinkiem"
+      },
+      "format_soon": {
+        "xml": "XML",
+        "json": "JSON",
+        "gsheets": "Google Sheets",
+        "pdf": "PDF"
+      },
+      "format_soon_desc": {
+        "xml": "Feed hierarchiczny",
+        "json": "Dane strukturalne / API",
+        "gsheets": "Arkusz w chmurze",
+        "pdf": "Katalog / cennik"
+      },
+      "step2_scope_title": "Zakres danych (filtrowanie)",
+      "preflight_badge": "Do wyeksportowania: {{count}}",
+      "cap_exceeded": "Przekroczono limit {{cap}} — zawęź filtry",
+      "structural_scope": "Eksport pełnej struktury — {{count}} wierszy.",
+      "selected_chip": "Zaznaczone obiekty: {{count}}",
+      "switch_to_filter": "przełącz na filtrowanie",
+      "empty_set_warning": "Filtr nie pasuje do żadnych obiektów — plik będzie zawierał tylko nagłówki kolumn."
     }
   }
 }


### PR DESCRIPTION
## Zakres (EXR-10, #1386)

**Krytyczny wymóg spec — reuse wyszukiwarki:** sekcja „Zakres danych" osadza TEN SAM `AdvancedFilterPanel` co lista produktów. Wspólny stan wydzielony do `@/lib/filters/use-filter-dsl-state.ts` — **lista uniwersalna refaktoryzowana na ten sam hook** (identyczne zachowanie, E2E listy zielone). Dowód braku drugiej implementacji: `git grep -l 'conditionsToDsl\|FilterCondition' apps/admin/src/features/exports` → tylko import z `@/lib/filters`.

- **Profil i format:** select zapisanych profili pasujących do encji (APPLY_PROFILE nadpisuje format/filtry/kolumny + toast + hint), radio-cards formatów — **XLSX/CSV aktywne, XML/JSON/Google Sheets/PDF disabled „wkrótce"** (D1, nigdy w payloadzie).
- **Preflight:** debounce 500 ms → `POST /api/exports/preflight` (EXR-07); badge „Do wyeksportowania: N" ze spinnerem; `exceeds_cap` → czerwony stan + **Dalej disabled**; count=0 dozwolone z ostrzeżeniem (plik nagłówkowy).
- **Tryby:** `selected` → chip „Zaznaczone: N" + „przełącz na filtrowanie"; encje strukturalne → karta „Eksport pełnej struktury — N wierszy" (ten sam preflight), panel ukryty.
- Panel commituje draft przy „Zastosuj filtr" (kontrakt VIEW-22a — identycznie jak lista; specy dostosowane).

## Decyzja ze spec
Opcje locale/channel zostają w Kroku 3 przy katalogu kolumn (warianty per locale/channel są tam widoczne) — w Kroku 2 tylko format+filtry.

## Live smoke ✅
Realny preflight na żywych danych: produkty all → `{count:100, mode:async}`, kategorie → `{count:5, mode:sync}` (curl proof w wątku #1402); filtr w wizardzie zbudowany na żywym panelu (screenshot exr-smoke-03), format disabled nie daje się wybrać.

Closes #1386