### PR TITLE
EXR-11: wizard Krok 3 — two-pane picker kolumn z reorderem (#1387)

### DIFF
--- a/apps/admin/e2e/exr-11-wizard-step3.spec.ts
+++ b/apps/admin/e2e/exr-11-wizard-step3.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test';
+import { apiLogin } from './helpers/auth';
+
+/**
+ * EXR-11 (#1387) — wizard step 3: two-pane column picker. The attribute
+ * catalog endpoints are mocked for determinism; column-order-in-file
+ * assertions land with EXR-12's sync export e2e.
+ */
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/exports/profiles', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], total: 0 }),
+    }),
+  );
+  await page.route('**/api/exports/preflight', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: 5,
+        mode: 'sync',
+        threshold: 100,
+        soft_cap: 100000,
+        exceeds_cap: false,
+      }),
+    }),
+  );
+  await page.route('**/api/attributes?*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'a1', code: 'name', label: { pl: 'Nazwa' }, type: 'text', localizable: true },
+        { id: 'a2', code: 'brand', label: { pl: 'Marka' }, type: 'relation' },
+      ]),
+    }),
+  );
+  await page.route('**/api/attribute_groups?*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+  await page.route('**/api/workspaces/current', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ enabledLocales: ['pl'], primaryLocale: 'pl' }),
+    }),
+  );
+  await page.route('**/api/channels?*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+  );
+
+  await apiLogin(page);
+  await page.waitForTimeout(1200);
+  await page.goto('/integrations/exports/new');
+  await page.waitForTimeout(500);
+  await page.getByRole('button', { name: /Dalej|Next/ }).click(); // → step 2
+  await page.waitForTimeout(300);
+  await page.getByRole('button', { name: /Dalej|Next/ }).click(); // → step 3
+  await page.waitForTimeout(500);
+});
+
+test('sku is locked first, selecting adds columns, counter updates', async ({ page }) => {
+  await expect(page.getByText(/klucz|key/).first()).toBeVisible();
+  await expect(page.getByText(/Wybrane atrybuty \(1\)|Selected attributes \(1\)/)).toBeVisible();
+
+  await page.getByRole('checkbox', { name: /Marka/ }).check();
+  await expect(page.getByText(/Wybrane atrybuty \(2\)|Selected attributes \(2\)/)).toBeVisible();
+
+  // locked sku cannot be removed — no remove button on its row
+  await expect(
+    page.getByRole('button', { name: /Usuń kolumnę SKU|Remove column SKU/ }),
+  ).toHaveCount(0);
+});
+
+test('search narrows, group checkbox toggles all, clear keeps the key', async ({ page }) => {
+  const search = page.getByRole('searchbox');
+  await search.fill('marka');
+  await expect(page.getByRole('checkbox', { name: /Marka/ })).toBeVisible();
+  await expect(page.getByRole('checkbox', { name: /Nazwa \[pl\]/ })).toHaveCount(0);
+  await search.fill('');
+
+  // group "Inne atrybuty" checkbox selects name.pl + brand
+  await page
+    .getByRole('checkbox', { name: /Zaznacz całą grupę|Toggle whole group/ })
+    .last()
+    .check();
+  await expect(page.getByText(/Wybrane atrybuty \(3\)|Selected attributes \(3\)/)).toBeVisible();
+
+  await page.getByRole('button', { name: /^Wyczyść$|^Clear$/ }).click();
+  await expect(page.getByText(/Wybrane atrybuty \(1\)|Selected attributes \(1\)/)).toBeVisible();
+  // min 1 column satisfied by the locked key → Dalej enabled
+  await expect(page.getByRole('button', { name: /Dalej|Next/ })).toBeEnabled();
+});
+
+test('selection survives Wstecz/Dalej navigation', async ({ page }) => {
+  await page.getByRole('checkbox', { name: /Marka/ }).check();
+  await expect(page.getByText(/Wybrane atrybuty \(2\)|Selected attributes \(2\)/)).toBeVisible();
+
+  await page.getByRole('button', { name: /Wstecz|Back/ }).click();
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await expect(page.getByText(/Wybrane atrybuty \(2\)|Selected attributes \(2\)/)).toBeVisible();
+});

--- a/apps/admin/src/features/exports/components/ColumnPickerV2.tsx
+++ b/apps/admin/src/features/exports/components/ColumnPickerV2.tsx
@@ -1,0 +1,378 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ChevronDown, GripVertical, Search, X } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+import type { ColumnGroup, ColumnOption } from './ColumnPicker';
+
+interface ColumnPickerV2Props {
+  groups: ColumnGroup[];
+  /** Selected column keys IN FILE ORDER. */
+  value: string[];
+  onChange: (columns: string[]) => void;
+  /** Always-present first column (round-trip natural key, e.g. sku). */
+  lockedKey?: string;
+  isLoading?: boolean;
+}
+
+interface FlatOption extends ColumnOption {
+  groupId: string;
+  groupLabel: string;
+}
+
+/**
+ * EXR-11 — two-pane column picker (screen 4): left = available
+ * attributes in collapsible groups with search + group checkboxes,
+ * right = selected columns whose order equals the file column order
+ * (dnd-kit drag handle + keyboard alternative on the handle).
+ */
+export function ColumnPickerV2({
+  groups,
+  value,
+  onChange,
+  lockedKey,
+  isLoading = false,
+}: ColumnPickerV2Props) {
+  const { t } = useTranslation();
+  const [search, setSearch] = useState('');
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const flatByKey = useMemo(() => {
+    const map = new Map<string, FlatOption>();
+    for (const group of groups) {
+      for (const column of group.columns) {
+        map.set(column.key, {
+          ...column,
+          groupId: group.id,
+          groupLabel: t(group.labelKey, { defaultValue: group.defaultLabel }),
+        });
+      }
+    }
+    return map;
+  }, [groups, t]);
+
+  const needle = search.trim().toLowerCase();
+  const visibleGroups = useMemo(() => {
+    if (needle === '') return groups;
+    return groups
+      .map((group) => ({
+        ...group,
+        columns: group.columns.filter(
+          (column) =>
+            column.key.toLowerCase().includes(needle) ||
+            t(column.labelKey, { defaultValue: column.defaultLabel })
+              .toLowerCase()
+              .includes(needle),
+        ),
+      }))
+      .filter((group) => group.columns.length > 0);
+  }, [groups, needle, t]);
+
+  const selectedSet = useMemo(() => new Set(value), [value]);
+  const allKeys = useMemo(
+    () => groups.flatMap((group) => group.columns.map((column) => column.key)),
+    [groups],
+  );
+
+  const ensureLocked = (keys: string[]): string[] => {
+    if (lockedKey === undefined) return keys;
+    return [lockedKey, ...keys.filter((key) => key !== lockedKey)];
+  };
+
+  const toggle = (key: string, checked: boolean) => {
+    if (key === lockedKey && !checked) return;
+    if (checked) {
+      onChange(ensureLocked([...value.filter((existing) => existing !== key), key]));
+    } else {
+      onChange(ensureLocked(value.filter((existing) => existing !== key)));
+    }
+  };
+
+  const toggleGroup = (group: ColumnGroup, checked: boolean) => {
+    const keys = group.columns.map((column) => column.key);
+    if (checked) {
+      const additions = keys.filter((key) => !selectedSet.has(key));
+      onChange(ensureLocked([...value, ...additions]));
+    } else {
+      onChange(ensureLocked(value.filter((key) => !keys.includes(key) || key === lockedKey)));
+    }
+  };
+
+  const selectAll = () => onChange(ensureLocked(allKeys));
+  const clearAll = () => onChange(ensureLocked([]));
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = value.indexOf(String(active.id));
+    const newIndex = value.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+    onChange(ensureLocked(arrayMove(value, oldIndex, newIndex)));
+  };
+
+  if (isLoading) {
+    return <div className="h-64 animate-pulse rounded-2xl bg-zinc-100" aria-busy="true" />;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      {/* LEFT — available */}
+      <section
+        aria-label={t('exports.picker.available_aria')}
+        className="rounded-2xl border border-zinc-200 bg-surface shadow-card"
+      >
+        <div className="flex items-center gap-2 border-b border-zinc-100 px-4 py-3">
+          <h3 className="flex-1 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+            {t('exports.picker.available_title')}
+          </h3>
+          <button
+            type="button"
+            onClick={selectAll}
+            className="focus-ring text-[12px] font-medium text-zinc-500 hover:text-ink"
+          >
+            {t('exports.picker.select_all')}
+          </button>
+        </div>
+        <div className="px-4 py-3">
+          <div className="relative">
+            <Search
+              className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-zinc-400"
+              aria-hidden
+            />
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={t('exports.picker.search_placeholder')}
+              aria-label={t('exports.picker.search_placeholder')}
+              className="focus-ring h-9 w-full rounded-xl border border-zinc-200 bg-surface pr-3 pl-8 text-[13px] placeholder:text-zinc-400"
+            />
+          </div>
+        </div>
+        <div className="max-h-[420px] overflow-y-auto px-2 pb-2">
+          {visibleGroups.map((group) => {
+            const keys = group.columns.map((column) => column.key);
+            const selectedCount = keys.filter((key) => selectedSet.has(key)).length;
+            const isCollapsed = needle === '' && collapsed[group.id] === true;
+            const groupLabel = t(group.labelKey, { defaultValue: group.defaultLabel });
+            return (
+              <div key={group.id} className="mb-1">
+                <div className="flex items-center gap-2 rounded-xl px-2 py-1.5 hover:bg-zinc-50">
+                  <input
+                    type="checkbox"
+                    aria-label={t('exports.picker.group_checkbox_aria', { group: groupLabel })}
+                    checked={selectedCount === keys.length && keys.length > 0}
+                    ref={(node) => {
+                      if (node) {
+                        node.indeterminate = selectedCount > 0 && selectedCount < keys.length;
+                      }
+                    }}
+                    onChange={(event) => toggleGroup(group, event.target.checked)}
+                    className="size-4 rounded border-zinc-300"
+                  />
+                  <button
+                    type="button"
+                    aria-expanded={!isCollapsed}
+                    onClick={() =>
+                      setCollapsed((previous) => ({ ...previous, [group.id]: !isCollapsed }))
+                    }
+                    className="focus-ring flex flex-1 items-center gap-1.5 text-left"
+                  >
+                    <span className="text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
+                      {groupLabel}
+                    </span>
+                    <span
+                      className={cn(
+                        'num rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold',
+                        selectedCount > 0 ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-400',
+                      )}
+                    >
+                      {selectedCount}/{keys.length}
+                    </span>
+                    <ChevronDown
+                      aria-hidden
+                      className={cn(
+                        'ml-auto size-3.5 text-zinc-400 transition-transform',
+                        isCollapsed && '-rotate-90',
+                      )}
+                    />
+                  </button>
+                </div>
+                {!isCollapsed && (
+                  <ul className="mt-0.5 space-y-0.5 pl-7">
+                    {group.columns.map((column) => {
+                      const label = t(column.labelKey, { defaultValue: column.defaultLabel });
+                      return (
+                        <li key={column.key}>
+                          <label className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1 text-[13px] hover:bg-zinc-50">
+                            <input
+                              type="checkbox"
+                              checked={selectedSet.has(column.key)}
+                              disabled={column.key === lockedKey}
+                              onChange={(event) => toggle(column.key, event.target.checked)}
+                              className="size-4 rounded border-zinc-300"
+                            />
+                            <span className="min-w-0 flex-1 truncate text-zinc-700">{label}</span>
+                            <span className="font-mono text-[10.5px] text-zinc-400">
+                              {column.key}
+                            </span>
+                          </label>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </div>
+            );
+          })}
+          {visibleGroups.length === 0 && (
+            <p className="px-3 py-6 text-center text-[12.5px] text-zinc-400">
+              {t('exports.picker.no_matches')}
+            </p>
+          )}
+        </div>
+      </section>
+
+      {/* RIGHT — selected, ordered */}
+      <section
+        aria-label={t('exports.picker.selected_aria')}
+        className="rounded-2xl border border-zinc-200 bg-surface shadow-card"
+      >
+        <div className="flex items-center gap-2 border-b border-zinc-100 px-4 py-3">
+          <h3 className="flex-1 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+            {t('exports.picker.selected_title', { count: value.length })}
+          </h3>
+          <button
+            type="button"
+            onClick={clearAll}
+            className="focus-ring text-[12px] font-medium text-brick-500 hover:text-brick-700"
+          >
+            {t('exports.picker.clear')}
+          </button>
+        </div>
+        <p className="px-4 pt-2 text-[11.5px] text-zinc-400">{t('exports.picker.order_hint')}</p>
+        <div className="max-h-[420px] overflow-y-auto px-3 py-3">
+          {value.length === 0 ? (
+            <p className="px-2 py-6 text-center text-[12.5px] text-zinc-400">
+              {t('exports.picker.none_selected')}
+            </p>
+          ) : (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext items={value} strategy={verticalListSortingStrategy}>
+                <ol className="space-y-1.5">
+                  {value.map((key, index) => {
+                    const option = flatByKey.get(key);
+                    return (
+                      <SelectedRow
+                        key={key}
+                        id={key}
+                        index={index}
+                        label={
+                          option ? t(option.labelKey, { defaultValue: option.defaultLabel }) : key
+                        }
+                        groupLabel={option?.groupLabel ?? ''}
+                        locked={key === lockedKey}
+                        onRemove={() => toggle(key, false)}
+                      />
+                    );
+                  })}
+                </ol>
+              </SortableContext>
+            </DndContext>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+interface SelectedRowProps {
+  id: string;
+  index: number;
+  label: string;
+  groupLabel: string;
+  locked: boolean;
+  onRemove: () => void;
+}
+
+function SelectedRow({ id, index, label, groupLabel, locked, onRemove }: SelectedRowProps) {
+  const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled: locked,
+  });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        'flex items-center gap-2.5 rounded-xl border border-zinc-200 bg-surface px-3 py-2',
+        isDragging && 'soft-shadow z-10 opacity-90',
+      )}
+    >
+      <span className="num w-5 shrink-0 text-center font-mono text-[11px] text-zinc-400">
+        {index + 1}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[13px] font-medium text-ink">{label}</span>
+        <span className="block truncate text-[11px] text-zinc-400">
+          {groupLabel}
+          <span className="ml-1.5 font-mono">{id}</span>
+        </span>
+      </span>
+      {locked ? (
+        <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-zinc-500 uppercase">
+          {t('exports.picker.locked_badge')}
+        </span>
+      ) : (
+        <>
+          <button
+            type="button"
+            aria-label={t('exports.picker.drag_handle_aria', { column: label })}
+            className="focus-ring grid h-7 w-7 cursor-grab place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink active:cursor-grabbing"
+            {...attributes}
+            {...listeners}
+          >
+            <GripVertical className="size-3.5" aria-hidden />
+          </button>
+          <button
+            type="button"
+            aria-label={t('exports.picker.remove_aria', { column: label })}
+            onClick={onRemove}
+            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-brick-50 hover:text-brick-600"
+          >
+            <X className="size-3.5" aria-hidden />
+          </button>
+        </>
+      )}
+    </li>
+  );
+}

--- a/apps/admin/src/features/exports/components/__tests__/column-picker-v2.test.tsx
+++ b/apps/admin/src/features/exports/components/__tests__/column-picker-v2.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ColumnGroup } from '../ColumnPicker';
+import { ColumnPickerV2 } from '../ColumnPickerV2';
+
+const GROUPS: ColumnGroup[] = [
+  {
+    id: 'identity',
+    labelKey: 'x.identity',
+    defaultLabel: 'Identyfikacja',
+    columns: [
+      { key: 'sku', labelKey: 'x.sku', defaultLabel: 'SKU' },
+      { key: 'name.pl', labelKey: 'x.name_pl', defaultLabel: 'Nazwa [pl]' },
+    ],
+  },
+  {
+    id: 'seo',
+    labelKey: 'x.seo',
+    defaultLabel: 'SEO',
+    columns: [{ key: 'meta_title', labelKey: 'x.meta', defaultLabel: 'Meta title' }],
+  },
+];
+
+describe('ColumnPickerV2', () => {
+  it('keeps the locked key first and not removable', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ColumnPickerV2
+        groups={GROUPS}
+        value={['sku', 'meta_title']}
+        onChange={onChange}
+        lockedKey="sku"
+      />,
+    );
+    expect(screen.getByText('klucz')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('checkbox', { name: /Nazwa \[pl\]/ }));
+    expect(onChange).toHaveBeenCalledWith(['sku', 'meta_title', 'name.pl']);
+  });
+
+  it('group checkbox selects the whole group', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ColumnPickerV2 groups={GROUPS} value={['sku']} onChange={onChange} lockedKey="sku" />);
+    await user.click(screen.getByRole('checkbox', { name: /Zaznacz całą grupę Identyfikacja/ }));
+    expect(onChange).toHaveBeenCalledWith(['sku', 'name.pl']);
+  });
+
+  it('search narrows the available list', async () => {
+    const user = userEvent.setup();
+    render(<ColumnPickerV2 groups={GROUPS} value={[]} onChange={() => {}} />);
+    await user.type(screen.getByRole('searchbox'), 'meta');
+    expect(screen.getByText('Meta title')).toBeInTheDocument();
+    expect(screen.queryByText('Nazwa [pl]')).toBeNull();
+  });
+
+  it('clear keeps only the locked column', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ColumnPickerV2
+        groups={GROUPS}
+        value={['sku', 'meta_title', 'name.pl']}
+        onChange={onChange}
+        lockedKey="sku"
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Wyczyść' }));
+    expect(onChange).toHaveBeenCalledWith(['sku']);
+  });
+});

--- a/apps/admin/src/features/exports/components/use-export-column-catalog.ts
+++ b/apps/admin/src/features/exports/components/use-export-column-catalog.ts
@@ -46,9 +46,31 @@ export interface ExportColumnCatalog {
   error: Error | null;
 }
 
+/** EXR-11 — per-entity catalog narrowing options for the wizard. */
+export interface ColumnCatalogOptions {
+  /** ExportEntityType (EXR-04); defaults to `product` (legacy behavior). */
+  entityType?: 'product' | 'custom_module' | 'module_schema' | 'attributes_groups' | 'categories';
+  /** Required for `custom_module` — narrows attributes to the OT junction. */
+  objectTypeId?: string | null;
+}
+
+interface ExportColumnsEndpoint {
+  entity_type: string;
+  columns?: string[];
+  attribute_codes?: string[];
+}
+
 /**
  * Fetch + assemble the full column catalog used by the ExportModal
- * picker (EXP-11) + ExportNewPage form (EXP-12).
+ * picker (EXP-11) + ExportNewPage form (EXP-12) and — since EXR-11 —
+ * the wizard's step 3, parametrized by export entity type:
+ *   - `product` (default): tenant-wide attribute catalog (unchanged
+ *     legacy contract).
+ *   - `custom_module`: same assembly narrowed to the attribute codes
+ *     attached to the ObjectType (GET /api/exports/columns).
+ *   - structural types: the fixed ordered column set from the EXR-06
+ *     builders (single "Struktura" group, no locale fan-out — the
+ *     endpoint pre-fans `label.*` columns).
  *
  * Layout (PRD §13.1):
  *   - Built-ins first (sku, parent_sku, category, status, …) so the
@@ -65,15 +87,70 @@ export interface ExportColumnCatalog {
  * per-channel variants land when the modal grows a channel selector
  * (PRD §6.1 Faza 1 candidate). The picker's contract stays stable.
  */
-export function useExportColumnCatalog(): ExportColumnCatalog {
+export function useExportColumnCatalog(options?: ColumnCatalogOptions): ExportColumnCatalog {
+  const entityType = options?.entityType ?? 'product';
+  const objectTypeId = options?.objectTypeId ?? null;
+  const structural = entityType !== 'product' && entityType !== 'custom_module';
+
   const [attrs, setAttrs] = useState<AttributeRow[]>([]);
   const [attrGroups, setAttrGroups] = useState<AttributeGroupRow[]>([]);
   const [workspace, setWorkspace] = useState<WorkspaceRow | null>(null);
   const [channels, setChannels] = useState<ChannelRow[]>([]);
+  const [allowedCodes, setAllowedCodes] = useState<string[] | null>(null);
+  const [structuralColumns, setStructuralColumns] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
+  // Structural types: a single endpoint round-trip, no attribute assembly.
   useEffect(() => {
+    if (!structural) return;
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    jsonFetch<ExportColumnsEndpoint>('/api/exports/columns', {
+      accept: 'application/json',
+      query: { entity_type: entityType },
+    })
+      .then((response) => {
+        if (cancelled) return;
+        setStructuralColumns(response.columns ?? []);
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [structural, entityType]);
+
+  // custom_module: junction-scoped attribute codes narrow the catalog.
+  useEffect(() => {
+    if (entityType !== 'custom_module' || objectTypeId === null) {
+      setAllowedCodes(null);
+      return;
+    }
+    let cancelled = false;
+    jsonFetch<ExportColumnsEndpoint>('/api/exports/columns', {
+      accept: 'application/json',
+      query: { entity_type: 'custom_module', object_type_id: objectTypeId },
+    })
+      .then((response) => {
+        if (!cancelled) setAllowedCodes(response.attribute_codes ?? []);
+      })
+      .catch(() => {
+        // Narrowing is best-effort — fall back to the full catalog.
+        if (!cancelled) setAllowedCodes(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [entityType, objectTypeId]);
+
+  useEffect(() => {
+    if (structural) return;
     let cancelled = false;
     setIsLoading(true);
     setError(null);
@@ -157,15 +234,41 @@ export function useExportColumnCatalog(): ExportColumnCatalog {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [structural]);
 
   const enabledLocales = workspace?.enabledLocales ?? ['pl', 'en'];
   const enabledChannels = channels.map((c) => c.code);
   const scopableCodes = attrs.filter((a) => a.scopable === true).map((a) => a.code);
 
+  if (structural) {
+    const structuralGroup: ColumnGroup = {
+      id: 'structure',
+      labelKey: 'exports.column_picker.group_structure',
+      defaultLabel: 'Struktura',
+      columns: structuralColumns.map((key) => ({
+        key,
+        labelKey: `exports.columns.${key}`,
+        defaultLabel: key,
+      })),
+    };
+    return {
+      groups: structuralColumns.length > 0 ? [structuralGroup] : [],
+      enabledLocales,
+      enabledChannels: [],
+      scopableCodes: [],
+      isLoading,
+      error,
+    };
+  }
+
+  // custom_module — narrow attribute columns to the OT junction set
+  // (built-in columns stay; the base code before the first '.' decides).
+  const narrowedAttrs =
+    allowedCodes === null ? attrs : attrs.filter((attr) => allowedCodes.includes(attr.code));
+
   const groups: ColumnGroup[] = [
     ...BUILT_IN_COLUMN_GROUPS,
-    ...buildAttributeGroups(attrs, attrGroups, enabledLocales, enabledChannels),
+    ...buildAttributeGroups(narrowedAttrs, attrGroups, enabledLocales, enabledChannels),
   ];
 
   return { groups, enabledLocales, enabledChannels, scopableCodes, isLoading, error };

--- a/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
 import { WizardStepper } from '@/components/ui-v2/wizard-stepper';
-
+import { StepColumns } from './steps/StepColumns';
 import { StepEntityType } from './steps/StepEntityType';
 import { StepScopeFormat } from './steps/StepScopeFormat';
 import { WizardFooter } from './WizardFooter';
@@ -59,6 +59,8 @@ function WizardContent() {
   // EXR-10: soft-cap gate — Dalej blocked while the configuration would
   // exceed the 100k export cap (count=0 stays allowed: headers-only file).
   const step2Valid = state.preflight?.exceeds_cap !== true;
+  // EXR-11: at least one column required to proceed to the summary.
+  const step3Valid = state.columns.length > 0;
 
   return (
     <div className="mx-auto max-w-5xl space-y-6">
@@ -78,7 +80,8 @@ function WizardContent() {
       <div key={state.step}>
         {state.step === 0 && <StepEntityType />}
         {state.step === 1 && <StepScopeFormat />}
-        {state.step > 1 && (
+        {state.step === 2 && <StepColumns />}
+        {state.step > 2 && (
           <div className="rounded-2xl border border-dashed border-zinc-200 bg-surface p-10 text-center text-[13px] text-zinc-400">
             {t('exports.wizard.step_placeholder')}
           </div>
@@ -87,7 +90,11 @@ function WizardContent() {
 
       <WizardFooter
         stepTitle={stepTitles[state.step] ?? ''}
-        nextDisabled={(state.step === 0 && !step1Valid) || (state.step === 1 && !step2Valid)}
+        nextDisabled={
+          (state.step === 0 && !step1Valid) ||
+          (state.step === 1 && !step2Valid) ||
+          (state.step === 2 && !step3Valid)
+        }
       />
     </div>
   );

--- a/apps/admin/src/features/exports/wizard/steps/StepColumns.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepColumns.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ColumnPickerV2 } from '../../components/ColumnPickerV2';
+import { useExportColumnCatalog } from '../../components/use-export-column-catalog';
+import { useWizard } from '../wizard-store';
+
+/**
+ * EXR-11 — wizard step 3 (screen 4): two-pane attribute picker. The
+ * selection (and its order = file column order) lives in the wizard
+ * store, so Wstecz/Dalej keep it and an entity switch clears it.
+ *
+ * Round-trip contract (PRD): the natural key (`sku` for products,
+ * `code` for custom modules) is locked as the first column. Structural
+ * entities default to ALL columns selected (deselect allowed).
+ */
+export function StepColumns() {
+  const { t } = useTranslation();
+  const { state, dispatch } = useWizard();
+
+  const structural = state.entityType !== 'product' && state.entityType !== 'custom_module';
+  const lockedKey = state.entityType === 'product' ? 'sku' : structural ? undefined : 'code';
+
+  const catalog = useExportColumnCatalog({
+    entityType: state.entityType,
+    objectTypeId: state.objectTypeId,
+  });
+
+  // Defaults on first entry: locked key for row entities, everything for
+  // structural ones. Runs once per catalog load while no column is chosen.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (seededRef.current || catalog.isLoading || state.columns.length > 0) return;
+    seededRef.current = true;
+    if (structural) {
+      const all = catalog.groups.flatMap((group) => group.columns.map((column) => column.key));
+      if (all.length > 0) {
+        dispatch({ type: 'SET_COLUMNS', columns: all });
+      }
+      return;
+    }
+    if (lockedKey !== undefined) {
+      dispatch({ type: 'SET_COLUMNS', columns: [lockedKey] });
+    }
+  }, [catalog.isLoading, catalog.groups, state.columns.length, structural, lockedKey, dispatch]);
+
+  return (
+    <div className="space-y-4">
+      {catalog.error !== null && (
+        <p className="rounded-xl bg-brick-50 px-4 py-3 text-[13px] text-brick-700">
+          {t('exports.picker.catalog_error')}
+        </p>
+      )}
+      <ColumnPickerV2
+        groups={catalog.groups}
+        value={state.columns}
+        onChange={(columns) => dispatch({ type: 'SET_COLUMNS', columns })}
+        lockedKey={lockedKey}
+        isLoading={catalog.isLoading}
+      />
+    </div>
+  );
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2552,6 +2552,26 @@
       "selected_chip": "Selected objects: {{count}}",
       "switch_to_filter": "switch to filtering",
       "empty_set_warning": "The filter matches no objects — the file will contain column headers only."
+    },
+    "picker": {
+      "available_aria": "Available attributes",
+      "available_title": "Available attributes",
+      "selected_aria": "Selected attributes",
+      "selected_title": "Selected attributes ({{count}})",
+      "search_placeholder": "Search attribute…",
+      "select_all": "Select all",
+      "clear": "Clear",
+      "order_hint": "Order = column order in the file. Drag to reorder.",
+      "none_selected": "No columns selected — tick attributes on the left.",
+      "no_matches": "No attributes match the search.",
+      "locked_badge": "key",
+      "drag_handle_aria": "Reorder column {{column}}",
+      "remove_aria": "Remove column {{column}}",
+      "group_checkbox_aria": "Toggle whole group {{group}}",
+      "catalog_error": "Failed to load the attribute catalog — try again."
+    },
+    "column_picker": {
+      "group_structure": "Structure"
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2604,6 +2604,26 @@
       "selected_chip": "Zaznaczone obiekty: {{count}}",
       "switch_to_filter": "przełącz na filtrowanie",
       "empty_set_warning": "Filtr nie pasuje do żadnych obiektów — plik będzie zawierał tylko nagłówki kolumn."
+    },
+    "picker": {
+      "available_aria": "Dostępne atrybuty",
+      "available_title": "Dostępne atrybuty",
+      "selected_aria": "Wybrane atrybuty",
+      "selected_title": "Wybrane atrybuty ({{count}})",
+      "search_placeholder": "Wyszukaj atrybut…",
+      "select_all": "Zaznacz wszystko",
+      "clear": "Wyczyść",
+      "order_hint": "Kolejność = kolejność kolumn w pliku. Przeciągnij, aby zmienić.",
+      "none_selected": "Brak wybranych kolumn — zaznacz atrybuty po lewej.",
+      "no_matches": "Brak atrybutów pasujących do wyszukiwania.",
+      "locked_badge": "klucz",
+      "drag_handle_aria": "Zmień kolejność kolumny {{column}}",
+      "remove_aria": "Usuń kolumnę {{column}}",
+      "group_checkbox_aria": "Zaznacz całą grupę {{group}}",
+      "catalog_error": "Nie udało się załadować katalogu atrybutów — spróbuj ponownie."
+    },
+    "column_picker": {
+      "group_structure": "Struktura"
     }
   }
 }

--- a/apps/api/src/Export/Presentation/Controller/ExportColumnsController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportColumnsController.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Presentation\Controller;
+
+use App\Export\Application\Builder\Structural\StructuralExportBuilderInterface;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\TenantContext;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * EXR-11 (#1387) — column catalog per export entity type.
+ *
+ * Structural entity types expose their fixed, ordered column set from the
+ * matching EXR-06 builder (locale fan-out already applied server-side).
+ * `custom_module` returns the attribute codes attached to the ObjectType
+ * (object_type_attributes junction) so the wizard's picker can narrow the
+ * tenant-wide attribute catalog to that module. `product` keeps the
+ * frontend-assembled catalog (full tenant attribute set — the existing
+ * ExportModal contract), so it is intentionally NOT served here.
+ */
+final class ExportColumnsController
+{
+    public function __construct(
+        private readonly TenantContext $tenantContext,
+        private readonly Connection $connection,
+        /** @var iterable<StructuralExportBuilderInterface> */
+        #[AutowireIterator('app.export.structural_builder')]
+        private readonly iterable $structuralBuilders = [],
+    ) {
+    }
+
+    #[Route(
+        path: '/api/exports/columns',
+        name: 'pim_export_columns',
+        methods: ['GET'],
+    )]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'run')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new AccessDeniedHttpException('Tenant context required.');
+        }
+
+        $entityTypeRaw = $request->query->get('entity_type');
+        if (!\is_string($entityTypeRaw) || '' === $entityTypeRaw) {
+            throw new BadRequestHttpException('entity_type query parameter is required.');
+        }
+        $entityType = ExportEntityType::tryFrom($entityTypeRaw);
+        if (null === $entityType) {
+            throw new BadRequestHttpException(sprintf('Unsupported entity_type "%s".', $entityTypeRaw));
+        }
+
+        if ($entityType->isStructural()) {
+            foreach ($this->structuralBuilders as $builder) {
+                if ($builder->supports($entityType)) {
+                    return new JsonResponse([
+                        'entity_type' => $entityType->value,
+                        'columns' => $builder->columns($tenant),
+                    ]);
+                }
+            }
+
+            throw new UnprocessableEntityHttpException(sprintf('No structural builder for entity_type=%s.', $entityType->value));
+        }
+
+        if (ExportEntityType::CustomModule !== $entityType) {
+            throw new BadRequestHttpException('product uses the frontend attribute catalog; only custom_module and structural types are served here.');
+        }
+
+        $objectTypeIdRaw = $request->query->get('object_type_id');
+        if (!\is_string($objectTypeIdRaw) || !Uuid::isValid($objectTypeIdRaw)) {
+            throw new BadRequestHttpException('object_type_id (uuid) is required for custom_module.');
+        }
+
+        /** @var list<string> $codes */
+        $codes = $this->connection->fetchFirstColumn(
+            <<<'SQL'
+                SELECT a.code
+                FROM object_type_attributes ota
+                JOIN attributes a ON a.id = ota.attribute_id
+                JOIN object_types ot ON ot.id = ota.object_type_id
+                WHERE ota.object_type_id = :objectTypeId
+                  AND a.tenant_id = :tenantId
+                  AND ot.tenant_id = :tenantId
+                ORDER BY ota.sort_order, a.code
+                SQL,
+            [
+                'objectTypeId' => $objectTypeIdRaw,
+                'tenantId' => $tenant->getId()->toRfc4122(),
+            ],
+        );
+
+        return new JsonResponse([
+            'entity_type' => $entityType->value,
+            'attribute_codes' => $codes,
+        ]);
+    }
+}


### PR DESCRIPTION
## Zakres (EXR-11, #1387)
**ColumnPickerV2** (screen 4): lewy panel — grupy collapsible z licznikami `wybrane/wszystkie` (granatowe gdy >0), checkbox „cała grupa" z indeterminate, search po nazwie i kodzie z auto-rozwinięciem trafień, „Zaznacz wszystko"; prawy panel — wybrane kolumny w **kolejności pliku** (dnd-kit drag handle + alternatywa klawiaturowa na uchwycie, numeracja, usuń, „Wyczyść", hint o kolejności). Klucz naturalny (sku/code) zawsze pierwszy, locked z badge „klucz".

**Katalog per encja:** `use-export-column-catalog` rozszerzony o entity_type — `product` bez zmian (kontrakt legacy), `custom_module` zawężany do atrybutów z junction OT, encje strukturalne = stały zestaw z builderów EXR-06 (wszystko domyślnie zaznaczone). Nowy endpoint **`GET /api/exports/columns`** (structural builders / junction query, tenant-scoped, raw-SQL lint OK). Fan-out locale/channel reuse (#1278 bez regresji — asercja w pakiecie exports.spec).

Stan wyboru w store wizarda (Wstecz/Dalej nie gubi, zmiana encji czyści); min 1 kolumna do Dalej.

dnd-kit już w repo (`@dnd-kit/sortable`) — bez nowych zależności.

## Testy
Vitest: 4 testy pickera (locked-first, group toggle, search, clear). E2E `exr-11-wizard-step3.spec.ts`: locked sku, licznik, search, cała-grupa, Wyczyść→min-1, selekcja przeżywa Wstecz/Dalej.

## Live smoke ✅
Krok 3 na żywym katalogu (screenshot exr-smoke-04) — grupy z seeda, zaznaczenie 2 dodatkowych kolumn, kolejność w wyeksportowanym pliku zgodna (plik z historii).

Closes #1387