### PR TITLE
EXR-13: tab Profile Eksportu w nowym designie (#1389)

### DIFF
--- a/apps/admin/e2e/exr-13-profiles-tab.spec.ts
+++ b/apps/admin/e2e/exr-13-profiles-tab.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test';
+import { apiLogin } from './helpers/auth';
+
+/**
+ * EXR-13 (#1389) — Export Profiles tab: v2 table, run/edit/delete.
+ * Backend mocked; the full save → run → edit → delete cycle runs in
+ * the live smoke.
+ */
+
+const PROFILE = {
+  id: '22222222-2222-2222-2222-222222222222',
+  name: 'SEO PL+EN',
+  description: 'Cotygodniowy zrzut SEO',
+  entity_type: 'product',
+  object_type_id: null,
+  config: {
+    format: 'csv',
+    selected_columns: ['sku', 'meta_title.pl', 'meta_title.en'],
+    locales: ['pl', 'en'],
+    channels: null,
+    filter: { attr: 'brand', op: '=', value: 'Festo' },
+  },
+  last_run_at: '2026-06-09T10:00:00+00:00',
+  run_count: 4,
+  created_at: '2026-06-01T10:00:00+00:00',
+  updated_at: '2026-06-09T10:00:00+00:00',
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/exports/sessions', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], total: 0 }),
+    }),
+  );
+});
+
+test('profiles table renders config summary and runs a profile', async ({ page }) => {
+  await page.route('**/api/exports/profiles', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [PROFILE], total: 1 }),
+    }),
+  );
+  await page.route(`**/api/exports/profiles/${PROFILE.id}/run`, (route) =>
+    route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'sess-9', status: 'pending' }),
+    }),
+  );
+
+  await apiLogin(page);
+  await page.waitForTimeout(1200);
+  await page.goto('/integrations/exports/profiles', { waitUntil: 'commit' });
+  await page.waitForTimeout(1000);
+
+  await expect(page.getByText('SEO PL+EN')).toBeVisible();
+  await expect(page.getByText('CSV')).toBeVisible();
+  await expect(page.getByText('brand')).toBeVisible();
+  await expect(page.getByText('3', { exact: true })).toBeVisible(); // columns count
+  // tab counter wired to the real total
+  await expect(page.getByRole('tab', { name: /Profile/ })).toContainText('1');
+
+  await page.getByRole('button', { name: /Uruchom teraz|Run now/ }).click();
+  await expect(page).toHaveURL(/\/integrations\/exports\/sessions/);
+  await expect(page.getByText(/eksport uruchomiony|export started/)).toBeVisible();
+});
+
+test('edit opens the wizard prefilled from the profile', async ({ page }) => {
+  await page.route('**/api/exports/profiles', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [PROFILE], total: 1 }),
+    }),
+  );
+  await page.route(`**/api/exports/profiles/${PROFILE.id}`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(PROFILE),
+    }),
+  );
+  await page.route('**/api/exports/preflight', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: 5,
+        mode: 'sync',
+        threshold: 100,
+        soft_cap: 100000,
+        exceeds_cap: false,
+      }),
+    }),
+  );
+
+  await apiLogin(page);
+  await page.waitForTimeout(1200);
+  await page.goto(`/integrations/exports/new?profile=${PROFILE.id}`, { waitUntil: 'commit' });
+  await page.waitForTimeout(1000);
+
+  // step 1 prefilled: product selected
+  await expect(page.getByRole('radio', { name: /Produkty|Products/ })).toHaveAttribute(
+    'aria-checked',
+    'true',
+  );
+  // step 2 shows CSV selected
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await expect(page.getByRole('radio', { name: /^CSV/ })).toHaveAttribute('aria-checked', 'true');
+});
+
+test('delete confirms with the profile name and refetches', async ({ page }) => {
+  let deleted = false;
+  await page.route('**/api/exports/profiles', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(deleted ? { items: [], total: 0 } : { items: [PROFILE], total: 1 }),
+    }),
+  );
+  await page.route(`**/api/exports/profiles/${PROFILE.id}`, (route) => {
+    deleted = true;
+    route.fulfill({ status: 204, body: '' });
+  });
+
+  await apiLogin(page);
+  await page.waitForTimeout(1200);
+  await page.goto('/integrations/exports/profiles', { waitUntil: 'commit' });
+  await page.waitForTimeout(1000);
+
+  page.once('dialog', (dialog) => {
+    expect(dialog.message()).toContain('SEO PL+EN');
+    void dialog.accept();
+  });
+  await page.getByRole('button', { name: /Usuń profil|Delete profile/ }).click();
+  await expect(page.getByText(/Brak zapisanych profili|No saved profiles/)).toBeVisible();
+});

--- a/apps/admin/src/features/exports/profiles/ExportProfilesView.tsx
+++ b/apps/admin/src/features/exports/profiles/ExportProfilesView.tsx
@@ -1,15 +1,30 @@
-import { useApiUrl, useCustom, useCustomMutation } from '@refinedev/core';
+import { useGetIdentity } from '@refinedev/core';
+import { useQuery } from '@tanstack/react-query';
+import { Boxes, FolderTree, Layers, Package, Pencil, Play, Plus, Tags, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Link, useNavigate } from 'react-router';
+import { toast } from '@/components/ui/toast';
+import { EmptyState } from '@/components/ui-v2/empty-state';
+import { FormatPill } from '@/components/ui-v2/format-pill';
+import { type FilterDsl, isFilterGroup } from '@/lib/filters/filter-dsl';
+import { jsonFetch } from '@/lib/http';
+
+import { useInvalidateExportSessions } from '../hooks/useExportSessions';
+import { entityTypeLabelKey, formatStartedAt } from '../sessions/session-format';
 
 interface ExportProfileRow {
   id: string;
   name: string;
   description: string | null;
-  config: Record<string, unknown>;
+  entity_type: string;
+  object_type_id: string | null;
+  config: {
+    format?: string;
+    selected_columns?: string[];
+    filter?: FilterDsl | null;
+  };
   last_run_at: string | null;
   run_count: number;
-  created_at: string;
-  updated_at: string;
 }
 
 interface ProfilesResponse {
@@ -17,161 +32,222 @@ interface ProfilesResponse {
   total: number;
 }
 
+interface Identity {
+  name?: string;
+  email?: string;
+}
+
+const ENTITY_ICONS: Record<string, typeof Package> = {
+  product: Package,
+  custom_module: Boxes,
+  module_schema: Layers,
+  attributes_groups: Tags,
+  categories: FolderTree,
+};
+
+function filterChipsOf(profile: ExportProfileRow): string[] {
+  const dsl = profile.config.filter ?? null;
+  if (dsl === null) return [];
+  if (!isFilterGroup(dsl)) return [dsl.attr];
+  return dsl.conditions.flatMap((entry) => (isFilterGroup(entry) ? [] : [entry.attr]));
+}
+
 /**
- * EXP-14 (#593) — Saved profiles grid.
- *
- * `GET /api/exports/profiles` (per-user scope, PRD §3.3 punkt 2)
- * with per-row actions:
- *   - Run now → POST `/{id}/run` → toast + redirect to sessions tab
- *     so the user sees the freshly-dispatched session.
- *   - Delete → DELETE the profile (existing sessions keep their
- *     profile_id set to null per the DB cascade behavior).
- *
- * Edit (open the modal pre-filled) is a follow-up tied to EXP-11
- * modal landing — the modal is the only surface that knows how to
- * render the column picker, so duplicating that here would be
- * premature.
+ * EXR-13 (#1389) — Export Profiles tab in the v2 design: table with
+ * entity / format / columns / filters summary and per-row actions.
+ * "Uruchom teraz" uses the dedicated profile-run endpoint (async
+ * dispatch + run_count telemetry; the dev sync transport executes
+ * small jobs inline anyway). Edit opens the wizard prefilled via
+ * ?profile={id} (EXR-12 store init).
  */
 export function ExportProfilesView(): React.ReactElement {
   const { t } = useTranslation();
-  const apiUrl = useApiUrl();
+  const navigate = useNavigate();
+  const { data: identity } = useGetIdentity<Identity>();
+  const invalidateSessions = useInvalidateExportSessions();
 
-  const { result, query } = useCustom<ProfilesResponse>({
-    url: `${apiUrl}/exports/profiles`,
-    method: 'get',
-    queryOptions: { staleTime: 5000 },
+  const profilesQuery = useQuery<ProfilesResponse>({
+    queryKey: ['exports', 'profiles', 'list'],
+    queryFn: () =>
+      jsonFetch<ProfilesResponse>('/api/exports/profiles', { accept: 'application/json' }),
+    staleTime: 5_000,
   });
+  const profiles = profilesQuery.data?.items ?? [];
 
-  const { mutate: runNow } = useCustomMutation();
-  const { mutate: del } = useCustomMutation();
-
-  const profiles = result?.data?.items ?? [];
-
-  const onRun = (id: string, name: string) => {
-    runNow(
-      {
-        url: `${apiUrl}/exports/profiles/${id}/run`,
-        method: 'post',
-        values: {},
-        successNotification: () => ({
-          message: t('exports.profiles.run_success', {
-            name,
-            defaultValue: `Profile "${name}" — eksport rozpoczęty`,
-          }),
-          type: 'success',
-        }),
-      },
-      {
-        onSuccess: () => {
-          window.location.href = '/integrations/exports/sessions';
-        },
-      },
-    );
+  const onRun = async (profile: ExportProfileRow) => {
+    try {
+      const session = await jsonFetch<{ id: string }>(`/api/exports/profiles/${profile.id}/run`, {
+        method: 'POST',
+        accept: 'application/json',
+      });
+      invalidateSessions();
+      toast.success(t('exports.profiles.run_success', { name: profile.name }));
+      void navigate('/integrations/exports/sessions', {
+        state: { highlightSession: session.id },
+      });
+    } catch {
+      toast.error(t('exports.profiles.run_failed'));
+    }
   };
 
-  const onDelete = (id: string, name: string) => {
-    if (
-      !window.confirm(
-        t('exports.profiles.confirm_delete', {
-          name,
-          defaultValue: `Usunąć profil "${name}"? Historia eksportów uruchomionych z tego profilu pozostaje, ale tracą powiązanie.`,
-        }),
-      )
-    ) {
+  const onDelete = async (profile: ExportProfileRow) => {
+    if (!window.confirm(t('exports.profiles.confirm_delete', { name: profile.name }))) {
       return;
     }
-    del(
-      {
-        url: `${apiUrl}/exports/profiles/${id}`,
-        method: 'delete',
-        values: {},
-      },
-      {
-        onSuccess: () => {
-          void query.refetch();
-        },
-      },
-    );
+    try {
+      await jsonFetch(`/api/exports/profiles/${profile.id}`, {
+        method: 'DELETE',
+        accept: 'application/json',
+      });
+      void profilesQuery.refetch();
+      toast.success(t('exports.profiles.deleted', { name: profile.name }));
+    } catch {
+      toast.error(t('exports.profiles.delete_failed'));
+    }
   };
+
+  if (profilesQuery.isLoading) {
+    return <div className="h-40 animate-pulse rounded-2xl bg-zinc-100" aria-busy="true" />;
+  }
 
   if (profiles.length === 0) {
     return (
-      <div className="rounded-md border border-dashed bg-muted/30 p-8 text-center">
-        <h2 className="text-lg font-medium">
-          {t('exports.profiles.empty_title', { defaultValue: 'Brak zapisanych profili eksportu' })}
-        </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {t('exports.profiles.empty_subtitle', {
-            defaultValue:
-              'Zapisujesz profil w modalu Eksport — zaznacz "Zapisz jako profil" przed submit.',
-          })}
-        </p>
+      <div className="rounded-2xl border border-dashed border-zinc-200 bg-surface">
+        <EmptyState
+          title={t('exports.profiles.empty_title')}
+          description={t('exports.profiles.empty_subtitle')}
+          action={
+            <Link
+              to="/integrations/exports/new"
+              className="focus-ring inline-flex h-9 items-center gap-1.5 rounded-xl bg-cta px-3.5 text-[13px] font-semibold text-cta-foreground transition hover:bg-accent-hover"
+            >
+              <Plus className="size-4" aria-hidden />
+              {t('exports.new_cta')}
+            </Link>
+          }
+        />
       </div>
     );
   }
 
   return (
-    <div className="overflow-x-auto rounded-md border">
-      <table className="w-full text-sm">
-        <thead className="bg-muted/50 text-xs uppercase text-muted-foreground">
-          <tr>
-            <th className="px-3 py-2 text-left">
-              {t('exports.profiles.col_name', { defaultValue: 'Nazwa' })}
-            </th>
-            <th className="px-3 py-2 text-left">
-              {t('exports.profiles.col_created', { defaultValue: 'Utworzono' })}
-            </th>
-            <th className="px-3 py-2 text-left">
-              {t('exports.profiles.col_last_run', { defaultValue: 'Ostatnie uruchomienie' })}
-            </th>
-            <th className="px-3 py-2 text-right">
-              {t('exports.profiles.col_run_count', { defaultValue: 'Liczba uruchomień' })}
-            </th>
-            <th className="px-3 py-2 text-right">
-              {t('exports.profiles.col_actions', { defaultValue: 'Akcje' })}
-            </th>
-          </tr>
-        </thead>
-        <tbody className="divide-y">
-          {profiles.map((profile) => (
-            <tr key={profile.id} className="hover:bg-muted/30">
-              <td className="px-3 py-2">
-                <div className="font-medium">{profile.name}</div>
-                {profile.description !== null && profile.description !== '' && (
-                  <div className="mt-0.5 text-xs text-muted-foreground">{profile.description}</div>
-                )}
-              </td>
-              <td className="px-3 py-2 font-mono text-xs">
-                {new Date(profile.created_at).toLocaleDateString()}
-              </td>
-              <td className="px-3 py-2 font-mono text-xs">
-                {profile.last_run_at !== null
-                  ? new Date(profile.last_run_at).toLocaleString()
-                  : '—'}
-              </td>
-              <td className="px-3 py-2 text-right font-mono text-xs">{profile.run_count}</td>
-              <td className="px-3 py-2 text-right">
-                <div className="inline-flex gap-1">
-                  <button
-                    type="button"
-                    onClick={() => onRun(profile.id, profile.name)}
-                    className="rounded border border-input bg-background px-2 py-1 text-xs hover:bg-muted"
-                  >
-                    {t('exports.profiles.action_run', { defaultValue: 'Uruchom teraz' })}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onDelete(profile.id, profile.name)}
-                    className="rounded border border-rose-200 bg-rose-50 px-2 py-1 text-xs text-rose-900 hover:bg-rose-100"
-                  >
-                    {t('exports.profiles.action_delete', { defaultValue: 'Usuń' })}
-                  </button>
-                </div>
-              </td>
+    <div className="overflow-hidden rounded-2xl border border-zinc-200 bg-surface shadow-card">
+      <div className="overflow-x-auto">
+        <table className="w-full text-[13px]">
+          <thead>
+            <tr className="text-left">
+              {(
+                [
+                  'col_name',
+                  'col_entity',
+                  'col_format',
+                  'col_columns',
+                  'col_filters',
+                  'col_owner',
+                  'col_last_run',
+                  'col_runs',
+                ] as const
+              ).map((key) => (
+                <th
+                  key={key}
+                  className="px-4 py-3 text-[11px] font-medium tracking-wider text-zinc-400 uppercase"
+                >
+                  {t(`exports.profiles.${key}`)}
+                </th>
+              ))}
+              <th aria-hidden className="w-28" />
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="divide-y divide-zinc-100">
+            {profiles.map((profile) => {
+              const EntityIcon = ENTITY_ICONS[profile.entity_type] ?? Package;
+              const chips = filterChipsOf(profile);
+              return (
+                <tr key={profile.id} className="transition-colors hover:bg-zinc-50">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-ink">{profile.name}</div>
+                    {profile.description !== null && profile.description !== '' && (
+                      <div className="truncate text-[11.5px] text-zinc-400">
+                        {profile.description}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="flex items-center gap-2 text-zinc-600">
+                      <span className="grid h-6 w-6 shrink-0 place-items-center rounded-md bg-zinc-100 text-zinc-500">
+                        <EntityIcon className="size-3.5" aria-hidden />
+                      </span>
+                      {t(entityTypeLabelKey(profile.entity_type))}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <FormatPill format={profile.config.format ?? 'xlsx'} />
+                  </td>
+                  <td className="num px-4 py-3 font-mono text-zinc-600">
+                    {profile.config.selected_columns?.length ?? 0}
+                  </td>
+                  <td className="px-4 py-3">
+                    {chips.length === 0 ? (
+                      <span className="text-zinc-400">—</span>
+                    ) : (
+                      <span className="flex flex-wrap gap-1">
+                        {chips.slice(0, 2).map((chip) => (
+                          <span
+                            key={chip}
+                            className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10.5px] text-zinc-600"
+                          >
+                            {chip}
+                          </span>
+                        ))}
+                        {chips.length > 2 && (
+                          <span className="text-[11px] text-zinc-400">+{chips.length - 2}</span>
+                        )}
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-zinc-600">
+                    {identity?.name ?? identity?.email ?? '—'}
+                  </td>
+                  <td className="num px-4 py-3 font-mono text-[12px] text-zinc-600">
+                    {profile.last_run_at === null ? '—' : formatStartedAt(profile.last_run_at)}
+                  </td>
+                  <td className="num px-4 py-3 font-mono text-zinc-600">{profile.run_count}</td>
+                  <td className="px-2 py-3">
+                    <div className="flex items-center justify-end gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() => void onRun(profile)}
+                        aria-label={t('exports.profiles.action_run', { name: profile.name })}
+                        title={t('exports.profiles.action_run', { name: profile.name })}
+                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink"
+                      >
+                        <Play className="size-3.5" aria-hidden />
+                      </button>
+                      <Link
+                        to={`/integrations/exports/new?profile=${profile.id}`}
+                        aria-label={t('exports.profiles.action_edit', { name: profile.name })}
+                        title={t('exports.profiles.action_edit', { name: profile.name })}
+                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink"
+                      >
+                        <Pencil className="size-3.5" aria-hidden />
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() => void onDelete(profile)}
+                        aria-label={t('exports.profiles.action_delete', { name: profile.name })}
+                        title={t('exports.profiles.action_delete', { name: profile.name })}
+                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-brick-50 hover:text-brick-600"
+                      >
+                        <Trash2 className="size-3.5" aria-hidden />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
+++ b/apps/admin/src/features/exports/wizard/ExportWizardPage.tsx
@@ -1,10 +1,15 @@
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router';
 
 import { WizardStepper } from '@/components/ui-v2/wizard-stepper';
+import type { FilterDsl } from '@/lib/filters/filter-dsl';
+import { jsonFetch } from '@/lib/http';
 import { StepColumns } from './steps/StepColumns';
 import { StepEntityType } from './steps/StepEntityType';
 import { StepScopeFormat } from './steps/StepScopeFormat';
 import { StepSummary } from './steps/StepSummary';
+import type { ExportEntityType } from './types';
 import { WizardFooter } from './WizardFooter';
 import { useWizard, WizardProvider } from './wizard-store';
 
@@ -22,9 +27,55 @@ export function ExportWizardPage(): React.ReactElement {
   );
 }
 
+interface ProfilePayload {
+  id: string;
+  name: string;
+  entity_type: ExportEntityType;
+  object_type_id: string | null;
+  config: {
+    format?: string;
+    selected_columns?: string[];
+    locales?: string[] | null;
+    channels?: string[] | null;
+    filter?: FilterDsl | null;
+    default_target_scope?: string;
+  };
+}
+
 function WizardContent() {
   const { t } = useTranslation();
   const { state, dispatch } = useWizard();
+  const [searchParams] = useSearchParams();
+  const editProfileId = searchParams.get('profile');
+  const initialisedRef = useRef(false);
+
+  // EXR-13 — ?profile={id} opens the wizard prefilled for editing.
+  useEffect(() => {
+    if (editProfileId === null || initialisedRef.current) return;
+    initialisedRef.current = true;
+    jsonFetch<ProfilePayload>(`/api/exports/profiles/${editProfileId}`, {
+      accept: 'application/json',
+    })
+      .then((profile) => {
+        const filterDsl = profile.config.filter ?? null;
+        dispatch({
+          type: 'INIT_FROM_PROFILE',
+          profileId: profile.id,
+          profileName: profile.name,
+          entityType: profile.entity_type,
+          objectTypeId: profile.object_type_id,
+          format: profile.config.format === 'csv' ? 'csv' : 'xlsx',
+          columns: profile.config.selected_columns ?? [],
+          locales: profile.config.locales ?? null,
+          channels: profile.config.channels ?? null,
+          filterDsl,
+          targetScope: filterDsl === null ? 'all' : 'filter',
+        });
+      })
+      .catch(() => {
+        // Unknown profile id — fall back to the clean wizard.
+      });
+  }, [editProfileId, dispatch]);
 
   const steps = [
     {

--- a/apps/admin/src/features/exports/wizard/steps/StepSummary.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepSummary.tsx
@@ -10,7 +10,7 @@ import { HttpError } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 import { entityTypeLabelKey } from '../../sessions/session-format';
-import { type RunError, saveProfile, useRunExport } from '../use-run-export';
+import { type RunError, saveProfile, updateProfile, useRunExport } from '../use-run-export';
 import { useWizard } from '../wizard-store';
 
 const ENTITY_ICONS: Record<string, typeof Package> = {
@@ -32,7 +32,7 @@ export function StepSummary() {
   const navigate = useNavigate();
   const { state, dispatch } = useWizard();
   const { run, isRunning } = useRunExport();
-  const [profileNameInput, setProfileNameInput] = useState('');
+  const [profileNameInput, setProfileNameInput] = useState(state.profileName);
   const [profileError, setProfileError] = useState<string | null>(null);
   const [savingProfile, setSavingProfile] = useState(false);
 
@@ -69,7 +69,11 @@ export function StepSummary() {
     setSavingProfile(true);
     setProfileError(null);
     try {
-      await saveProfile(state, name);
+      if (state.editingProfileId !== null) {
+        await updateProfile(state, name, state.editingProfileId);
+      } else {
+        await saveProfile(state, name);
+      }
       dispatch({ type: 'SET_PROFILE_NAME', profileName: name });
       toast.success(t('exports.wizard.summary.profile_saved', { name }));
     } catch (error) {

--- a/apps/admin/src/features/exports/wizard/types.ts
+++ b/apps/admin/src/features/exports/wizard/types.ts
@@ -38,6 +38,8 @@ export interface WizardState {
   profileName: string;
   /** Last preflight probe for the current configuration (EXR-10). */
   preflight: PreflightResult | null;
+  /** EXR-13 — profile being edited (?profile={id}); save = PATCH. */
+  editingProfileId: string | null;
   /** Any user-made change — drives cancel/entity-switch confirmations. */
   dirty: boolean;
 }
@@ -55,6 +57,19 @@ export type WizardAction =
   | { type: 'SET_CHANNELS'; channels: string[] | null }
   | { type: 'SET_PROFILE_NAME'; profileName: string }
   | { type: 'SET_PREFLIGHT'; preflight: PreflightResult | null }
+  | {
+      type: 'INIT_FROM_PROFILE';
+      profileId: string;
+      profileName: string;
+      entityType: ExportEntityType;
+      objectTypeId: string | null;
+      format: ExportFormat;
+      columns: string[];
+      locales: string[] | null;
+      channels: string[] | null;
+      filterDsl: FilterDsl | null;
+      targetScope: ExportTargetScope;
+    }
   | {
       type: 'APPLY_PROFILE';
       profileId: string;
@@ -83,5 +98,6 @@ export const INITIAL_WIZARD_STATE: WizardState = {
   channels: null,
   profileName: '',
   preflight: null,
+  editingProfileId: null,
   dirty: false,
 };

--- a/apps/admin/src/features/exports/wizard/use-run-export.ts
+++ b/apps/admin/src/features/exports/wizard/use-run-export.ts
@@ -107,6 +107,26 @@ export function useRunExport() {
   return { run, isRunning };
 }
 
+/** EXR-13 — PATCH an existing profile from the wizard state. */
+export async function updateProfile(state: WizardState, name: string, id: string): Promise<void> {
+  await jsonFetch(`/api/exports/profiles/${id}`, {
+    method: 'PATCH',
+    accept: 'application/json',
+    body: {
+      name,
+      config: {
+        format: state.format,
+        selected_columns: state.columns,
+        locales: state.locales,
+        channels: state.channels,
+        include_variants: true,
+        default_target_scope: state.targetScope,
+        filter: state.filterDsl,
+      },
+    },
+  });
+}
+
 /** POST /api/exports/profiles from the wizard state (does NOT run). */
 export async function saveProfile(state: WizardState, name: string): Promise<void> {
   const payload: Record<string, unknown> = {

--- a/apps/admin/src/features/exports/wizard/wizard-store.tsx
+++ b/apps/admin/src/features/exports/wizard/wizard-store.tsx
@@ -57,6 +57,21 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       return { ...state, profileName: action.profileName, dirty: true };
     case 'SET_PREFLIGHT':
       return { ...state, preflight: action.preflight };
+    case 'INIT_FROM_PROFILE':
+      return {
+        ...INITIAL_WIZARD_STATE,
+        editingProfileId: action.profileId,
+        profileId: action.profileId,
+        profileName: action.profileName,
+        entityType: action.entityType,
+        objectTypeId: action.objectTypeId,
+        format: action.format,
+        columns: action.columns,
+        locales: action.locales,
+        channels: action.channels,
+        filterDsl: action.filterDsl,
+        targetScope: action.targetScope,
+      };
     case 'APPLY_PROFILE':
       return {
         ...state,

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2601,6 +2601,26 @@
     },
     "column_picker": {
       "group_structure": "Structure"
+    },
+    "profiles": {
+      "run_success": "Profile “{{name}}” — export started",
+      "run_failed": "Failed to run the profile export",
+      "confirm_delete": "Delete profile “{{name}}”? This cannot be undone.",
+      "deleted": "Profile “{{name}}” deleted",
+      "delete_failed": "Failed to delete the profile",
+      "empty_title": "No saved profiles",
+      "empty_subtitle": "Save a configuration in wizard Step 4 to reuse it with one click.",
+      "col_name": "Name",
+      "col_entity": "Entity",
+      "col_format": "Format",
+      "col_columns": "Columns",
+      "col_filters": "Filters",
+      "col_owner": "Owner",
+      "col_last_run": "Last run",
+      "col_runs": "Runs",
+      "action_run": "Run now: {{name}}",
+      "action_edit": "Edit profile {{name}}",
+      "action_delete": "Delete profile {{name}}"
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2655,6 +2655,26 @@
     },
     "column_picker": {
       "group_structure": "Struktura"
+    },
+    "profiles": {
+      "run_success": "Profil „{{name}}” — eksport uruchomiony",
+      "run_failed": "Nie udało się uruchomić eksportu z profilu",
+      "confirm_delete": "Usunąć profil „{{name}}”? Tej operacji nie można cofnąć.",
+      "deleted": "Usunięto profil „{{name}}”",
+      "delete_failed": "Nie udało się usunąć profilu",
+      "empty_title": "Brak zapisanych profili",
+      "empty_subtitle": "Zapisz konfigurację w Kroku 4 kreatora, aby wracać do niej jednym kliknięciem.",
+      "col_name": "Nazwa",
+      "col_entity": "Encja",
+      "col_format": "Format",
+      "col_columns": "Kolumny",
+      "col_filters": "Filtry",
+      "col_owner": "Właściciel",
+      "col_last_run": "Ostatnie uruchomienie",
+      "col_runs": "Uruchomienia",
+      "action_run": "Uruchom teraz: {{name}}",
+      "action_edit": "Edytuj profil {{name}}",
+      "action_delete": "Usuń profil {{name}}"
     }
   }
 }


### PR DESCRIPTION
## Zakres (EXR-13, #1389)
Tabela v2 profili: nazwa+opis, encja (ikona+label), `FormatPill`, liczba kolumn, chipy filtrów (+n), właściciel, ostatnie uruchomienie, run_count; dashed empty state z CTA. Licznik taba (EXR-08) już czyta realny total z tego samego endpointu.

**Akcje:** Uruchom teraz → `POST /api/exports/profiles/{id}/run` + redirect z highlight sesji; Edytuj → wizard `?profile={id}` (INIT_FROM_PROFILE prefilluje cały store — wszystkie 4 kroki odzwierciedlają profil, zapis w Kroku 4 robi PATCH zamiast create); Usuń → confirm z nazwą → refetch.

**BE:** PATCH + serializacja (entity_type/last_run_at/run_count) już istniały po EXR-04 — bez zmian backendu.

## Świadome odejście
Uruchomienie z profilu jest async-only (endpoint dispatchuje przez kolejkę — zachowuje run_count i telemetrię `saved_profile_run`; dev sync transport i tak wykonuje małe joby inline). Sync-download z profilu wymagałby rozgałęzienia endpointu — poza zakresem.

## Testy
E2E `exr-13-profiles-tab.spec.ts`: render configu + licznik taba, run → redirect + toast, edit → wizard prefilled (Krok 1 produkt, Krok 2 CSV), delete z confirm (nazwa w dialogu) → empty state.

## Live smoke ✅
Profil „Smoke profil EXR" w tabie z pełnym configiem (screenshot exr-smoke-08), Uruchom teraz → sesja w historii z kolumną PROFILE (exr-smoke-09/07).

Closes #1389