### PR TITLE
EXR-15: async UX live — postęp per chunk, anulowanie, powiadomienia (#1391)

### DIFF
--- a/apps/admin/e2e/exr-12-wizard-step4.spec.ts
+++ b/apps/admin/e2e/exr-12-wizard-step4.spec.ts
@@ -67,10 +67,16 @@ test.beforeEach(async ({ page }) => {
   await page.waitForTimeout(1200);
   await page.goto('/integrations/exports/new');
   await page.waitForTimeout(500);
-  for (let step = 0; step < 3; step += 1) {
-    await page.getByRole('button', { name: /Dalej|Next/ }).click();
-    await page.waitForTimeout(400);
-  }
+  // step 1 → 2
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  // deterministic: wait for the (mocked) preflight to land in the store
+  // before leaving step 2 — the probe is debounced 500 ms and the sync
+  // note on step 4 depends on it.
+  await expect(page.getByTestId('preflight-badge')).toContainText('5', { timeout: 10_000 });
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await page.waitForTimeout(400);
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await page.waitForTimeout(400);
 });
 
 test('summary shows the configuration and sync run downloads a file', async ({ page }) => {

--- a/apps/admin/src/features/exports/hooks/ExportsLiveBridge.tsx
+++ b/apps/admin/src/features/exports/hooks/ExportsLiveBridge.tsx
@@ -1,0 +1,64 @@
+import { useGetIdentity } from '@refinedev/core';
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useNotificationsInboxOptional } from '@/layout/notifications-context';
+import { useInvalidateExportSessions } from './useExportSessions';
+import { useExportSessionsStream } from './useExportSessionsStream';
+
+interface Identity {
+  id: string;
+}
+
+/**
+ * EXR-15 — shell-mounted subscriber: terminal export events land in the
+ * in-app inbox (bell badge) and invalidate the sessions cache even when
+ * the user is elsewhere in the app. Render-less.
+ */
+export function ExportsLiveBridge(): null {
+  const { t } = useTranslation();
+  const { data: identity } = useGetIdentity<Identity>();
+  const inbox = useNotificationsInboxOptional();
+  const invalidate = useInvalidateExportSessions();
+  const { lastEvent } = useExportSessionsStream(identity?.id ?? null);
+  const seenRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (lastEvent === null || lastEvent.event !== 'status') return;
+    const status = lastEvent.status;
+    if (status !== 'done' && status !== 'error' && status !== 'cancelled') return;
+
+    invalidate();
+
+    const key = `${lastEvent.session_id}:${status}`;
+    if (seenRef.current.has(key) || inbox === null) return;
+    seenRef.current.add(key);
+
+    if (status === 'done') {
+      inbox.add({
+        id: key,
+        level: 'success',
+        title: t('exports.notifications.done_title'),
+        body: t('exports.notifications.done_body', { count: lastEvent.success_count ?? 0 }),
+        href: `/integrations/exports/sessions/${lastEvent.session_id}`,
+      });
+    } else if (status === 'cancelled') {
+      inbox.add({
+        id: key,
+        level: 'warning',
+        title: t('exports.notifications.cancelled_title'),
+        href: `/integrations/exports/sessions/${lastEvent.session_id}`,
+      });
+    } else {
+      inbox.add({
+        id: key,
+        level: 'error',
+        title: t('exports.notifications.error_title'),
+        body: lastEvent.error_message ?? undefined,
+        href: `/integrations/exports/sessions/${lastEvent.session_id}`,
+      });
+    }
+  }, [lastEvent, inbox, invalidate, t]);
+
+  return null;
+}

--- a/apps/admin/src/features/exports/hooks/useExportSessions.ts
+++ b/apps/admin/src/features/exports/hooks/useExportSessions.ts
@@ -17,7 +17,7 @@ export interface ExportSessionRow {
   target_scope: string;
   target_count: number;
   success_count: number;
-  status: 'pending' | 'running' | 'done' | 'error';
+  status: 'pending' | 'running' | 'done' | 'error' | 'cancelled';
   source: string;
   started_at: string;
   completed_at: string | null;

--- a/apps/admin/src/features/exports/hooks/useExportSessionsStream.ts
+++ b/apps/admin/src/features/exports/hooks/useExportSessionsStream.ts
@@ -7,7 +7,7 @@ interface ExportEvent {
   rows_total?: number;
   progress_pct?: number;
   estimated_seconds_remaining?: number | null;
-  status?: 'pending' | 'running' | 'done' | 'error';
+  status?: 'pending' | 'running' | 'done' | 'error' | 'cancelled';
   success_count?: number;
   error_message?: string | null;
 }

--- a/apps/admin/src/features/exports/sessions/ActiveSessions.tsx
+++ b/apps/admin/src/features/exports/sessions/ActiveSessions.tsx
@@ -1,21 +1,34 @@
-import { Download } from 'lucide-react';
+import { Download, XCircle } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
+import { toast } from '@/components/ui/toast';
 import { EmptyState } from '@/components/ui-v2/empty-state';
 import { FormatPill } from '@/components/ui-v2/format-pill';
 import { ProgressBar } from '@/components/ui-v2/progress-bar';
 import { exportStatusToPillVariant } from '@/components/ui-v2/status-maps';
 import { StatusPill } from '@/components/ui-v2/status-pill';
+import { jsonFetch } from '@/lib/http';
 
 import type { ExportSessionRow } from '../hooks/useExportSessions';
 import { entityTypeLabelKey, fileNameOf } from './session-format';
+
+export interface LiveProgress {
+  rowsDone: number;
+  rowsTotal: number;
+  /** rows/s computed from consecutive progress events. */
+  throughput: number | null;
+}
 
 interface ActiveSessionsProps {
   sessions: ExportSessionRow[];
   /** EXR-12 — session id to scroll to + pulse after the async redirect. */
   highlightId?: string | null;
+  /** EXR-15 — Mercure progress overlay keyed by session id. */
+  liveProgress?: Record<string, LiveProgress>;
+  /** EXR-15 — called after a successful cancel POST. */
+  onCancelled?: () => void;
 }
 
 /**
@@ -23,7 +36,12 @@ interface ActiveSessionsProps {
  * session, or a dashed empty state with the CTA. Cancellation lands in
  * EXR-15 (no cancel endpoint yet).
  */
-export function ActiveSessions({ sessions, highlightId = null }: ActiveSessionsProps) {
+export function ActiveSessions({
+  sessions,
+  highlightId = null,
+  liveProgress = {},
+  onCancelled,
+}: ActiveSessionsProps) {
   const { t } = useTranslation();
   const highlightRef = useRef<HTMLDivElement>(null);
 
@@ -65,8 +83,23 @@ export function ActiveSessions({ sessions, highlightId = null }: ActiveSessionsP
       </h2>
       <div className="space-y-3">
         {sessions.map((session) => {
-          const progress =
-            session.target_count > 0 ? session.success_count / session.target_count : 0;
+          const live = liveProgress[session.id];
+          const done = live?.rowsDone ?? session.success_count;
+          const total = live?.rowsTotal ?? session.target_count;
+          const progress = total > 0 ? done / total : 0;
+          const cancelSession = async () => {
+            if (!window.confirm(t('exports.active.cancel_confirm'))) return;
+            try {
+              await jsonFetch(`/api/exports/sessions/${session.id}/cancel`, {
+                method: 'POST',
+                accept: 'application/json',
+              });
+              toast.success(t('exports.active.cancelled_toast'));
+              onCancelled?.();
+            } catch {
+              toast.error(t('exports.active.cancel_failed'));
+            }
+          };
           return (
             <div
               key={session.id}
@@ -83,6 +116,16 @@ export function ActiveSessions({ sessions, highlightId = null }: ActiveSessionsP
                 </span>
                 <FormatPill format={session.format} />
                 <StatusPill variant={exportStatusToPillVariant(session.status)} />
+                <button
+                  type="button"
+                  onClick={() => void cancelSession()}
+                  aria-label={t('exports.active.cancel')}
+                  title={t('exports.active.cancel')}
+                  className="focus-ring inline-flex h-7 items-center gap-1 rounded-md px-2 text-[12px] font-medium text-zinc-400 hover:bg-brick-50 hover:text-brick-600"
+                >
+                  <XCircle className="size-3.5" aria-hidden />
+                  {t('exports.active.cancel')}
+                </button>
               </div>
               <div className="mt-3">
                 <ProgressBar
@@ -91,11 +134,13 @@ export function ActiveSessions({ sessions, highlightId = null }: ActiveSessionsP
                   animated={session.status === 'running'}
                 />
               </div>
-              <div className="num mt-2 font-mono text-[11.5px] text-zinc-500">
-                {t('exports.active.progress', {
-                  done: session.success_count,
-                  total: session.target_count,
-                })}
+              <div className="num mt-2 flex items-center gap-3 font-mono text-[11.5px] text-zinc-500">
+                <span>{t('exports.active.progress', { done, total })}</span>
+                {live?.throughput != null && live.throughput > 0 && (
+                  <span>
+                    {t('exports.active.throughput', { value: Math.round(live.throughput) })}
+                  </span>
+                )}
               </div>
             </div>
           );

--- a/apps/admin/src/features/exports/sessions/ExportSessionsView.tsx
+++ b/apps/admin/src/features/exports/sessions/ExportSessionsView.tsx
@@ -1,5 +1,5 @@
 import { useGetIdentity } from '@refinedev/core';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 
@@ -8,7 +8,7 @@ import { getAccessToken, jsonFetch } from '@/lib/http';
 
 import { useExportSessions, useInvalidateExportSessions } from '../hooks/useExportSessions';
 import { useExportSessionsStream } from '../hooks/useExportSessionsStream';
-import { ActiveSessions } from './ActiveSessions';
+import { ActiveSessions, type LiveProgress } from './ActiveSessions';
 import { HistoryTable } from './HistoryTable';
 import { KpiStrip } from './KpiStrip';
 
@@ -37,11 +37,45 @@ export function ExportSessionsView(): React.ReactElement {
   const sessionsQuery = useExportSessions();
   const invalidate = useInvalidateExportSessions();
 
-  const { lastEvent } = useExportSessionsStream(identity?.id ?? null);
+  const { lastEvent, connected } = useExportSessionsStream(identity?.id ?? null);
+  const [liveProgress, setLiveProgress] = useState<Record<string, LiveProgress>>({});
+  const lastTickRef = useRef<Record<string, { rows: number; at: number }>>({});
   useEffect(() => {
     if (lastEvent === null) return;
+    if (lastEvent.event === 'progress') {
+      // EXR-15 — smooth in-place progress without a REST round-trip;
+      // throughput from the delta between consecutive ticks.
+      const previous = lastTickRef.current[lastEvent.session_id];
+      const now = Date.now();
+      const rowsDone = lastEvent.rows_done ?? 0;
+      const throughput =
+        previous && now > previous.at
+          ? ((rowsDone - previous.rows) / (now - previous.at)) * 1000
+          : null;
+      lastTickRef.current[lastEvent.session_id] = { rows: rowsDone, at: now };
+      setLiveProgress((current) => ({
+        ...current,
+        [lastEvent.session_id]: {
+          rowsDone,
+          rowsTotal: lastEvent.rows_total ?? 0,
+          throughput,
+        },
+      }));
+      return;
+    }
+    // status events: completed/cancelled/error rows move to history.
     invalidate();
   }, [lastEvent, invalidate]);
+
+  // EXR-15 — degrade to 5 s polling only while the hub is unreachable
+  // (the shared query's 30 s refetch stays as the slow baseline).
+  useEffect(() => {
+    if (connected) return;
+    // biome-ignore lint/suspicious/noConsole: spec EXR-15 — degradation is logged to the console, not surfaced in the UI
+    console.info('exports: Mercure unavailable — falling back to 5s polling');
+    const timer = setInterval(() => invalidate(), 5_000);
+    return () => clearInterval(timer);
+  }, [connected, invalidate]);
 
   const all = sessionsQuery.data?.items ?? [];
   const cutoff = Date.now() - THIRTY_DAYS_MS;
@@ -132,7 +166,12 @@ export function ExportSessionsView(): React.ReactElement {
   return (
     <div className="space-y-6">
       <KpiStrip sessions={sessions} />
-      <ActiveSessions sessions={active} highlightId={highlightId} />
+      <ActiveSessions
+        sessions={active}
+        highlightId={highlightId}
+        liveProgress={liveProgress}
+        onCancelled={invalidate}
+      />
       <HistoryTable
         sessions={history}
         userName={identity?.name ?? identity?.email ?? '—'}

--- a/apps/admin/src/features/exports/sessions/HistoryTable.tsx
+++ b/apps/admin/src/features/exports/sessions/HistoryTable.tsx
@@ -26,12 +26,13 @@ import { entityTypeLabelKey, fileNameOf, formatDuration, formatStartedAt } from 
 
 const PAGE_SIZE = 20;
 
-type Segment = 'all' | 'success' | 'errors' | 'running';
+type Segment = 'all' | 'success' | 'errors' | 'cancelled' | 'running';
 
 const SEGMENTS: Array<{ id: Segment; labelKey: string }> = [
   { id: 'all', labelKey: 'exports.history.segment_all' },
   { id: 'success', labelKey: 'exports.history.segment_success' },
   { id: 'errors', labelKey: 'exports.history.segment_errors' },
+  { id: 'cancelled', labelKey: 'exports.history.segment_cancelled' },
   { id: 'running', labelKey: 'exports.history.segment_running' },
 ];
 
@@ -41,6 +42,8 @@ function matchesSegment(session: ExportSessionRow, segment: Segment): boolean {
       return session.status === 'done';
     case 'errors':
       return session.status === 'error';
+    case 'cancelled':
+      return session.status === 'cancelled';
     case 'running':
       return session.status === 'running' || session.status === 'pending';
     default:

--- a/apps/admin/src/layout/AppLayout.tsx
+++ b/apps/admin/src/layout/AppLayout.tsx
@@ -7,7 +7,10 @@ import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
+import { ExportsLiveBridge } from '@/features/exports/hooks/ExportsLiveBridge';
+
 import { AppFooter } from './app-footer';
+import { NotificationsInboxProvider } from './notifications-context';
 import { PageActionsProvider } from './page-actions-context';
 import { SidebarNav } from './sidebar-nav';
 import { TopbarV2 } from './topbar-v2';
@@ -19,46 +22,49 @@ export function AppLayout() {
   return (
     <TooltipProvider delayDuration={150}>
       <PageActionsProvider>
-        <div className="flex min-h-screen bg-background">
-          <aside className="sticky top-0 hidden h-screen w-[260px] shrink-0 flex-col px-4 py-5 md:flex">
-            <SidebarNav />
-          </aside>
+        <NotificationsInboxProvider>
+          <ExportsLiveBridge />
+          <div className="flex min-h-screen bg-background">
+            <aside className="sticky top-0 hidden h-screen w-[260px] shrink-0 flex-col px-4 py-5 md:flex">
+              <SidebarNav />
+            </aside>
 
-          <div className="flex min-w-0 flex-1 flex-col">
-            <header className="glass-strong sticky top-0 z-30 flex items-center gap-1 border-b border-zinc-100 pl-3 md:pl-0">
-              <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
-                <SheetTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="md:hidden"
-                    aria-label={t('app.toggle_nav', { defaultValue: 'Toggle navigation' })}
+            <div className="flex min-w-0 flex-1 flex-col">
+              <header className="glass-strong sticky top-0 z-30 flex items-center gap-1 border-b border-zinc-100 pl-3 md:pl-0">
+                <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+                  <SheetTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="md:hidden"
+                      aria-label={t('app.toggle_nav', { defaultValue: 'Toggle navigation' })}
+                    >
+                      <Menu className="size-4" />
+                    </Button>
+                  </SheetTrigger>
+                  <SheetContent
+                    side="left"
+                    className="w-[260px] bg-background p-4"
+                    closeLabel={t('app.close', { defaultValue: 'Close' })}
                   >
-                    <Menu className="size-4" />
-                  </Button>
-                </SheetTrigger>
-                <SheetContent
-                  side="left"
-                  className="w-[260px] bg-background p-4"
-                  closeLabel={t('app.close', { defaultValue: 'Close' })}
-                >
-                  <SheetTitle className="sr-only">{t('app.title')}</SheetTitle>
-                  <SidebarNav onNavigate={() => setMobileOpen(false)} />
-                </SheetContent>
-              </Sheet>
+                    <SheetTitle className="sr-only">{t('app.title')}</SheetTitle>
+                    <SidebarNav onNavigate={() => setMobileOpen(false)} />
+                  </SheetContent>
+                </Sheet>
 
-              <div className="min-w-0 flex-1">
-                <TopbarV2 />
-              </div>
-            </header>
+                <div className="min-w-0 flex-1">
+                  <TopbarV2 />
+                </div>
+              </header>
 
-            <main className="flex-1 overflow-auto p-4 md:p-6">
-              <Outlet />
-            </main>
+              <main className="flex-1 overflow-auto p-4 md:p-6">
+                <Outlet />
+              </main>
 
-            <AppFooter />
+              <AppFooter />
+            </div>
           </div>
-        </div>
+        </NotificationsInboxProvider>
       </PageActionsProvider>
     </TooltipProvider>
   );

--- a/apps/admin/src/layout/notifications-bell.tsx
+++ b/apps/admin/src/layout/notifications-bell.tsx
@@ -1,5 +1,6 @@
 import { Bell } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -11,6 +12,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
+import { useNotificationsInboxOptional } from './notifications-context';
 import { useNotifications } from './use-notifications';
 
 /**
@@ -24,11 +26,17 @@ import { useNotifications } from './use-notifications';
 export function NotificationsBell() {
   const { t, i18n } = useTranslation();
   const { entries, unreadCount, markAllRead } = useNotifications();
+  // EXR-15 — exports in-app inbox merges into the bell (badge + list).
+  const inbox = useNotificationsInboxOptional();
+  const totalUnread = unreadCount + (inbox?.unread ?? 0);
 
   return (
     <DropdownMenu
       onOpenChange={(open) => {
-        if (open) markAllRead();
+        if (open) {
+          markAllRead();
+          inbox?.markAllRead();
+        }
       }}
     >
       <DropdownMenuTrigger asChild>
@@ -39,12 +47,12 @@ export function NotificationsBell() {
           className="relative"
         >
           <Bell className="size-4" />
-          {unreadCount > 0 ? (
+          {totalUnread > 0 ? (
             <span
               className="absolute right-1 top-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold text-primary-foreground"
               aria-live="polite"
             >
-              {unreadCount > 9 ? '9+' : unreadCount}
+              {totalUnread > 9 ? '9+' : totalUnread}
             </span>
           ) : null}
         </Button>
@@ -54,7 +62,36 @@ export function NotificationsBell() {
           {t('notifications.title', { defaultValue: 'Recent activity' })}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        {entries.length === 0 ? (
+        {(inbox?.entries.length ?? 0) > 0 && (
+          <>
+            {inbox?.entries.slice(0, 6).map((entry) => (
+              <DropdownMenuItem
+                key={entry.id}
+                asChild
+                className="flex flex-col items-start gap-0.5 whitespace-normal"
+              >
+                <Link to={entry.href ?? '/integrations/exports/sessions'}>
+                  <span
+                    className={
+                      entry.level === 'error'
+                        ? 'text-sm font-medium text-brick-600'
+                        : entry.level === 'warning'
+                          ? 'text-sm font-medium text-orange-700'
+                          : 'text-sm font-medium text-emerald-700'
+                    }
+                  >
+                    {entry.title}
+                  </span>
+                  {entry.body !== undefined && (
+                    <span className="text-xs text-muted-foreground">{entry.body}</span>
+                  )}
+                </Link>
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+          </>
+        )}
+        {entries.length === 0 && (inbox?.entries.length ?? 0) === 0 ? (
           <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             {t('notifications.empty', { defaultValue: 'No recent events.' })}
           </div>

--- a/apps/admin/src/layout/notifications-context.tsx
+++ b/apps/admin/src/layout/notifications-context.tsx
@@ -1,0 +1,71 @@
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+
+/**
+ * EXR-15 — simple client-side in-app inbox. Exports are the first
+ * writer; the shape is module-agnostic so future modules (imports,
+ * sync) can push entries through the same context. Deliberately NO
+ * backend persistence in MVP — reload clears the inbox.
+ */
+export interface InboxNotification {
+  id: string;
+  level: 'success' | 'warning' | 'error';
+  /** Already-translated title. */
+  title: string;
+  /** Already-translated secondary line. */
+  body?: string;
+  /** In-app link target (e.g. session detail). */
+  href?: string;
+  receivedAt: number;
+}
+
+interface NotificationsInboxValue {
+  entries: InboxNotification[];
+  unread: number;
+  add: (entry: Omit<InboxNotification, 'receivedAt'>) => void;
+  markAllRead: () => void;
+}
+
+const MAX_ENTRIES = 20;
+
+const NotificationsInboxContext = createContext<NotificationsInboxValue | null>(null);
+
+export function NotificationsInboxProvider({ children }: { children: ReactNode }) {
+  const [entries, setEntries] = useState<InboxNotification[]>([]);
+  const [unread, setUnread] = useState(0);
+
+  const add = useCallback((entry: Omit<InboxNotification, 'receivedAt'>) => {
+    setEntries((previous) => {
+      if (previous.some((existing) => existing.id === entry.id)) {
+        return previous;
+      }
+      return [{ ...entry, receivedAt: Date.now() }, ...previous].slice(0, MAX_ENTRIES);
+    });
+    setUnread((count) => count + 1);
+  }, []);
+
+  const markAllRead = useCallback(() => setUnread(0), []);
+
+  const value = useMemo(
+    () => ({ entries, unread, add, markAllRead }),
+    [entries, unread, add, markAllRead],
+  );
+
+  return (
+    <NotificationsInboxContext.Provider value={value}>
+      {children}
+    </NotificationsInboxContext.Provider>
+  );
+}
+
+export function useNotificationsInbox(): NotificationsInboxValue {
+  const context = useContext(NotificationsInboxContext);
+  if (!context) {
+    throw new Error('useNotificationsInbox must be used inside <NotificationsInboxProvider>');
+  }
+  return context;
+}
+
+/** Null-safe variant for components that may render outside the shell. */
+export function useNotificationsInboxOptional(): NotificationsInboxValue | null {
+  return useContext(NotificationsInboxContext);
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2440,7 +2440,12 @@
       "empty_title": "No active exports",
       "empty_subtitle": "Start with “New export” — small batches download instantly, bulk jobs land here with a progress bar.",
       "progress": "{{done}} / {{total}} rows",
-      "progress_aria": "Export progress"
+      "progress_aria": "Export progress",
+      "cancel": "Cancel",
+      "cancel_confirm": "Cancel this export? The partial file will be discarded.",
+      "cancelled_toast": "Export cancelled",
+      "cancel_failed": "Failed to cancel the export",
+      "throughput": "{{value}} rows/s"
     },
     "history": {
       "title": "History · last 30 days",
@@ -2469,7 +2474,8 @@
       "action_details": "Details",
       "download_failed": "Download failed",
       "rerun_failed": "Rerun failed",
-      "delete_failed": "Delete failed"
+      "delete_failed": "Delete failed",
+      "segment_cancelled": "cancelled"
     },
     "sessions": {
       "confirm_delete": "Delete this export? The MinIO file will be removed as well."
@@ -2622,6 +2628,16 @@
       "action_run": "Run now: {{name}}",
       "action_edit": "Edit profile {{name}}",
       "action_delete": "Delete profile {{name}}"
+    },
+    "notifications": {
+      "done_title": "Export finished — download the file",
+      "done_body_one": "{{count}} row exported",
+      "done_body_other": "{{count}} rows exported",
+      "cancelled_title": "Export cancelled",
+      "error_title": "Export failed"
+    },
+    "status": {
+      "cancelled": "cancelled"
     }
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2492,7 +2492,12 @@
       "empty_title": "Brak aktywnych eksportów",
       "empty_subtitle": "Zacznij od „Nowy eksport” — małe paczki pobierzesz od razu, masowe trafią tutaj z paskiem postępu.",
       "progress": "{{done}} / {{total}} wierszy",
-      "progress_aria": "Postęp eksportu"
+      "progress_aria": "Postęp eksportu",
+      "cancel": "Anuluj",
+      "cancel_confirm": "Anulować ten eksport? Częściowy plik zostanie odrzucony.",
+      "cancelled_toast": "Eksport anulowany",
+      "cancel_failed": "Nie udało się anulować eksportu",
+      "throughput": "{{value}} wier/s"
     },
     "history": {
       "title": "Historia · ostatnie 30 dni",
@@ -2521,7 +2526,8 @@
       "action_details": "Szczegóły",
       "download_failed": "Pobieranie nie powiodło się",
       "rerun_failed": "Ponowne uruchomienie nie powiodło się",
-      "delete_failed": "Usunięcie nie powiodło się"
+      "delete_failed": "Usunięcie nie powiodło się",
+      "segment_cancelled": "anulowane"
     },
     "sessions": {
       "confirm_delete": "Usunąć ten eksport? Plik z MinIO zostanie również usunięty."
@@ -2676,6 +2682,18 @@
       "action_run": "Uruchom teraz: {{name}}",
       "action_edit": "Edytuj profil {{name}}",
       "action_delete": "Usuń profil {{name}}"
+    },
+    "notifications": {
+      "done_title": "Eksport zakończony — pobierz plik",
+      "done_body_one": "{{count}} wiersz wyeksportowany",
+      "done_body_few": "{{count}} wiersze wyeksportowane",
+      "done_body_many": "{{count}} wierszy wyeksportowanych",
+      "done_body_other": "{{count}} wierszy wyeksportowanych",
+      "cancelled_title": "Eksport anulowany",
+      "error_title": "Eksport zakończony błędem"
+    },
+    "status": {
+      "cancelled": "anulowano"
     }
   }
 }

--- a/apps/api/src/Export/Application/Async/ExportCancelledException.php
+++ b/apps/api/src/Export/Application/Async/ExportCancelledException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Async;
+
+use RuntimeException;
+
+/**
+ * EXR-15 — thrown by the per-chunk progress callback when the persisted
+ * session status flipped to `cancelled` (user pressed Anuluj). The async
+ * handler catches it, removes the partial temp file and exits without
+ * marking the session as error.
+ */
+final class ExportCancelledException extends RuntimeException
+{
+}

--- a/apps/api/src/Export/Application/Async/ExportJobHandler.php
+++ b/apps/api/src/Export/Application/Async/ExportJobHandler.php
@@ -12,6 +12,7 @@ use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
 use App\Shared\Application\AbstractBatchHandler;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
@@ -64,6 +65,7 @@ final class ExportJobHandler extends AbstractBatchHandler
         private readonly FilesystemOperator $exportsStorage,
         private readonly ExportProgressPublisher $progress,
         private readonly TenantContext $tenantContext,
+        private readonly Connection $connection,
         ?LoggerInterface $logger = null,
         int $batchSize = 1000,
     ) {
@@ -109,10 +111,40 @@ final class ExportJobHandler extends AbstractBatchHandler
 
         $tempPath = $this->prepareTempFile($session);
         try {
-            $this->runner->runToFile($session, $tempPath);
+            // EXR-15 — live progress every chunk + graceful cancellation:
+            // the cancel endpoint flips the PERSISTED status; we read it
+            // straight from the DB (the in-memory entity is stale inside
+            // the long-running loop).
+            $startedAt = microtime(true);
+            $onChunk = function (int $rowsDone) use ($session, $startedAt): void {
+                $elapsed = microtime(true) - $startedAt;
+                $rate = $elapsed > 0 ? $rowsDone / $elapsed : 0.0;
+                $remaining = max(0, $session->getTargetCount() - $rowsDone);
+                $eta = $rate > 0 ? (int) ceil($remaining / $rate) : null;
+                $this->progress->progress($session, $rowsDone, $eta);
+
+                $statusNow = $this->connection->fetchOne(
+                    'SELECT status FROM export_sessions WHERE id = :id',
+                    ['id' => $session->getId()->toRfc4122()],
+                );
+                if (ExportStatus::Cancelled->value === $statusNow) {
+                    throw new ExportCancelledException('Export cancelled by the user.');
+                }
+            };
+
+            $this->runner->runToFile($session, $tempPath, $onChunk);
             $this->uploadToMinio($session, $tenant, $tempPath);
             $this->progress->progress($session, $session->getSuccessCount(), estimatedSecondsRemaining: 0);
             $this->progress->status($session);
+        } catch (ExportCancelledException) {
+            // EXR-15 — the cancel endpoint already persisted the terminal
+            // status; refresh the stale entity and notify subscribers so
+            // the card drops out of "W toku" instantly.
+            $this->entityManager->refresh($session);
+            $this->progress->status($session);
+            $this->logger->info('Export job cancelled by user', [
+                'session_id' => $session->getId()->toRfc4122(),
+            ]);
         } catch (Throwable $error) {
             // markError throws if the session has already transitioned to
             // 'done' (e.g. runToFile completed but MinIO upload failed

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -52,6 +52,8 @@ use Throwable;
  */
 final class SyncExportRunner
 {
+    public const int PROGRESS_CHUNK = 500;
+
     public function __construct(
         private readonly ExportBuilder $builder,
         private readonly CatalogObjectRepositoryInterface $objects,
@@ -145,11 +147,16 @@ final class SyncExportRunner
      * Caller (the controller) is responsible for streaming the file to
      * the HTTP response and deleting it afterwards. We split execution
      * from delivery so the same runner can later land async output.
+     *
+     * @param callable(int): void|null $onChunk EXR-15 — invoked every
+     *                                          PROGRESS_CHUNK rows with rows-done; throwing
+     *                                          {@see \App\Export\Application\Async\ExportCancelledException}
+     *                                          aborts the run gracefully
      */
-    public function runToFile(ExportSession $session, string $targetPath): int
+    public function runToFile(ExportSession $session, string $targetPath, ?callable $onChunk = null): int
     {
         if ($session->getEntityType()->isStructural()) {
-            return $this->runStructuralToFile($session, $targetPath);
+            return $this->runStructuralToFile($session, $targetPath, $onChunk);
         }
 
         $targets = $this->resolveTargets($session);
@@ -180,6 +187,9 @@ final class SyncExportRunner
                 }
                 $writer->writeRow($values);
                 ++$rows;
+                if (null !== $onChunk && 0 === $rows % self::PROGRESS_CHUNK) {
+                    $onChunk($rows);
+                }
             }
         } finally {
             $writer->close();
@@ -279,7 +289,10 @@ final class SyncExportRunner
      * categories) stream a flat config table from the matching builder rather
      * than the catalog-object pipeline.
      */
-    private function runStructuralToFile(ExportSession $session, string $targetPath): int
+    /**
+     * @param callable(int): void|null $onChunk
+     */
+    private function runStructuralToFile(ExportSession $session, string $targetPath, ?callable $onChunk = null): int
     {
         $tenant = $this->requireTenant($session);
         $builder = $this->structuralBuilderFor($session->getEntityType());
@@ -301,6 +314,9 @@ final class SyncExportRunner
                 }
                 $writer->writeRow($values);
                 ++$rows;
+                if (null !== $onChunk && 0 === $rows % self::PROGRESS_CHUNK) {
+                    $onChunk($rows);
+                }
             }
         } finally {
             $writer->close();

--- a/apps/api/src/Export/Domain/Entity/ExportSession.php
+++ b/apps/api/src/Export/Domain/Entity/ExportSession.php
@@ -313,6 +313,14 @@ class ExportSession extends AggregateRoot implements TenantScoped
         $this->durationMs = ($this->completedAt->getTimestamp() - $this->startedAt->getTimestamp()) * 1000;
     }
 
+    public function markCancelled(): void
+    {
+        $this->ensureTransitionable([ExportStatus::Pending, ExportStatus::Running]);
+        $this->status = ExportStatus::Cancelled->value;
+        $this->completedAt = new DateTimeImmutable();
+        $this->durationMs = ($this->completedAt->getTimestamp() - $this->startedAt->getTimestamp()) * 1000;
+    }
+
     public function markError(string $message): void
     {
         $this->ensureTransitionable([ExportStatus::Pending, ExportStatus::Running]);

--- a/apps/api/src/Export/Domain/Enum/ExportStatus.php
+++ b/apps/api/src/Export/Domain/Enum/ExportStatus.php
@@ -8,9 +8,10 @@ namespace App\Export\Domain\Enum;
  * Lifecycle of a single export session (PRD §5.1).
  *
  * `pending` is the row's default right after dispatch; the worker
- * transitions through `running` to a terminal state. No paused/cancelled
- * states in MVP — exports are read-only operations that either complete
- * or fail, there is nothing to roll back.
+ * transitions through `running` to a terminal state. `cancelled` (EXR-15)
+ * is user-requested: the async handler checks the persisted status
+ * between chunks and stops gracefully — exports are read-only, so there
+ * is nothing to roll back beyond removing the partial temp file.
  */
 enum ExportStatus: string
 {
@@ -18,11 +19,12 @@ enum ExportStatus: string
     case Running = 'running';
     case Done = 'done';
     case Error = 'error';
+    case Cancelled = 'cancelled';
 
     public function isTerminal(): bool
     {
         return match ($this) {
-            self::Done, self::Error => true,
+            self::Done, self::Error, self::Cancelled => true,
             default => false,
         };
     }

--- a/apps/api/src/Export/Presentation/Controller/ExportSessionController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportSessionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Export\Presentation\Controller;
 
+use App\Export\Application\Async\ExportProgressPublisher;
 use App\Export\Domain\Entity\ExportLog;
 use App\Export\Domain\Entity\ExportProfile;
 use App\Export\Domain\Entity\ExportSession;
@@ -63,6 +64,7 @@ final class ExportSessionController
         private readonly Security $security,
         private readonly MessageBusInterface $bus,
         private readonly FilesystemOperator $exportsStorage,
+        private readonly ExportProgressPublisher $progress,
     ) {
     }
 
@@ -211,6 +213,36 @@ final class ExportSessionController
             status: Response::HTTP_ACCEPTED,
             headers: ['Location' => sprintf('/api/exports/sessions/%s', $clone->getId()->toRfc4122())],
         );
+    }
+
+    /**
+     * EXR-15 — user-requested cancellation. Persists the terminal status;
+     * the async handler polls it between chunks and stops gracefully
+     * (partial temp file removed, no error state).
+     */
+    #[Route(
+        path: '/api/exports/sessions/{id}/cancel',
+        name: 'pim_export_sessions_cancel',
+        requirements: ['id' => self::UUID_REGEX],
+        methods: ['POST'],
+    )]
+    #[IsGranted('ROLE_USER')]
+    #[RequiresPermission(module: 'exports', action: 'run')]
+    public function cancel(string $id): JsonResponse
+    {
+        $session = $this->loadOwnedOrFail($id);
+        if ($session->getStatus()->isTerminal()) {
+            throw new ConflictHttpException(sprintf(
+                'Export session is already %s and cannot be cancelled.',
+                $session->getStatus()->value,
+            ));
+        }
+
+        $session->markCancelled();
+        $this->sessions->save($session);
+        $this->progress->status($session);
+
+        return new JsonResponse($this->serializeSummary($session));
     }
 
     #[Route(


### PR DESCRIPTION
## Zakres (EXR-15, #1391)

**Backend:**
- `SyncExportRunner::runToFile` przyjmuje callback `onChunk` (co 500 wierszy, ścieżka katalogowa i strukturalna).
- `ExportJobHandler` publikuje per-chunk **progress z ETA** do Mercure i odpytuje PERSISTED status sesji między chunkami (encja w pamięci jest stale w długiej pętli).
- **Anulowanie:** nowy status `cancelled` w `ExportStatus` + `markCancelled()` + **`POST /api/exports/sessions/{id}/cancel`** (owner-only; 409 na stanach terminalnych). Handler przerywa graceful przez `ExportCancelledException` (partial temp usunięty, bez stanu error) i republikuje status.

**Frontend:**
- Karty „W toku" konsumują stream bezpośrednio (rows + throughput z delty ticków — bez REST per tick) + przycisk **Anuluj** z confirm.
- Historia: segment „anulowane" (status istnieje od teraz).
- Fallback: Mercure niedostępny → polling 5 s (nota w konsoli, nie w UI — zgodnie ze spec).
- **In-app inbox**: `NotificationsInboxProvider` (moduł-agnostyczny, max 20 wpisów, bez persystencji BE — świadome MVP) + render-less `ExportsLiveBridge` w shellu: terminalne zdarzenia eksportu → wpis z linkiem do szczegółu + invalidacja cache; dzwonek topbara scala inbox z istniejącym feedem (wspólny badge unread).

## Testy / smoke
- Kontrakt cancel pokryty testem API (`ExportCancelApiTest`, na branchu EXR-16: pending→200+cancelled; powtórka i done→409).
- **Live smoke:** dzwonek z badge'em 1 po realnym async (screenshot exr-smoke-07 — widać badge), toast „Eksport zakończony". 
- **Świadome ograniczenie:** mid-run cancel i live progress bar wymagają realnego workera kolejki — dev transport `sync://` wykonuje joby inline (sesja nigdy nie jest widziana w stanie running). Logika chunk-callback pokryta na poziomie handlera; pełny smoke na stacku z workerem = Faza 1 (prod transport doctrine).

Closes #1391