### PR TITLE
EXR-16: bramka jakości epiku — E2E, a11y, benchmark 100k, dokumentacja (#1392)

### DIFF
--- a/Project Plan/PRD/PRD-PIM-exports.md
+++ b/Project Plan/PRD/PRD-PIM-exports.md
@@ -5,13 +5,28 @@
 **Pozycjonowanie:** Alternatywa dla Akeneo / Pimcore / BaseLinker — operator cockpit + workflow-grade czystość + Cmd+K agent
 **Producent:** Marcin Lipiec (projekt prywatny; equity / model biznesowy poza zakresem tego dokumentu)
 **Data utworzenia:** 2026-05-14
-**Wersja dokumentu:** 1.0
+**Wersja dokumentu:** 1.1 (rewizja EXR 2026-06)
 **Autor:** Marcin Lipiec (synteza brainstormingu 5-falowego 2026-05-14)
 **Status:** Implemented (MVP) 2026-05-15 — marathon EXP-01..EXP-16 (PR #597..#619). 4 follow-upy IMP-16..IMP-19 (#602..#605) blokują pełen round-trip per EXP-02 audit (`agent/exp-02-imp-audit.md`). Lista świadomych odejść w `Project Plan/02-plan-projektu-pim.md` epik EXP. Validation z Magdą + Tomaszem oraz dogfooding Marcin 50k SKU — manualne follow-up sesje per `agent/exp-15-smoke-report.md`.
 
 > **Nota o scope dokumentu.** To **feature-PRD** dla *jednego* obszaru produktu (eksport produktów z dwoma entry points: kontekstowy z listy + centralny `/integrations/exports`). Pełen product-PRD dla Cortex PIM (pozycjonowanie, ICP, model biznesowy, multitenant SaaS, pricing) — patrz `Zrodla/PRD/PRD-PIM.md`. Sekcje 3, 4, 11, 12 niniejszego dokumentu zawierają wyciąg / odniesienia do master PRD; sekcje 5–10, 13–14 są feature-specific.
 >
 > **Bliźniaczy feature:** [`feature-imports.md`](../UI/feature-imports.md) — importy CSV/XLS/XLSX (🟢 zaimplementowane IMP-01..IMP-15 merged 2026-05-07). Ten PRD bezpośrednio reuse'uje import pipeline dla round-trip semantyki.
+
+---
+
+## Rewizja 2026-06 (epik EXR — #1377–#1392)
+
+Eksporty zostały przemodelowane jako **pierwszy moduł nowego look & feel** (spec: `Project Plan/UI/feature-exports-redesign-tickets.md`). Zmiany względem v1.0:
+
+- **Encje eksportu (D2):** już nie tylko produkty — 5 typów `ExportEntityType`: `product`, `custom_module` (treści custom ObjectType), `module_schema`, `attributes_groups`, `categories`. Encje strukturalne mają uproszczoną ścieżkę (bez query buildera, pełna struktura, kolumny z builderów EXR-06).
+- **Preflight (EXR-07):** `POST /api/exports/preflight` — count + routing `sync|async` + `exceeds_cap` przed uruchomieniem; UI nigdy nie hardkoduje progu 100 (źródło prawdy: `SyncExportController::SYNC_THRESHOLD`).
+- **Wycofanie modala (D5):** `ExportModal` + paste-JSON `ExportNewPage` usunięte (EXR-14). Jedyny flow konfiguracji = pełnostronicowy 4-krokowy wizard `/integrations/exports/new` (Typ → Zakres i format → Kolumny → Podsumowanie). Wejścia kontekstowe z listy (zaznaczone / wynik filtra) nawigują do wizarda z kontekstem w router state.
+- **Reużywalna wyszukiwarka (EXR-10):** sekcja filtrów wizarda osadza TEN SAM `AdvancedFilterPanel` + `useFilterDslState` co lista produktów — zero drugiej implementacji DSL.
+- **Formaty (D1):** payload przyjmuje wyłącznie `xlsx|csv`; kafelki XML/JSON/Google Sheets/PDF widoczne jako disabled „wkrótce".
+- **Taby (D3):** Sesje + Profile Eksportu działające; Cele i Harmonogram disabled „wkrótce" (osobny epik).
+- **Async UX (EXR-15):** progres per chunk (Mercure), **anulowanie** (`POST /api/exports/sessions/{id}/cancel`, nowy status `cancelled`), in-app inbox przy dzwonku (bez persystencji BE — świadome MVP).
+- **Sesje sync w historii:** sync zapisuje wpis `ExportSession` (file_path=null — plik temp jest kasowany po wysyłce; download tylko dla sesji async z plikiem w MinIO).
 
 ---
 

--- a/Project Plan/UI/Wdrozenie_grafiki/plan-handoff-wdrozenie.md
+++ b/Project Plan/UI/Wdrozenie_grafiki/plan-handoff-wdrozenie.md
@@ -443,3 +443,16 @@ End-to-end test scenariusza operatora:
 1. **#1 Dashboard + tokens** — pierwszy, bo wprowadza globalne tokeny. Operator manualnie waliduje całość admina po merge.
 2. **#2 Modelowanie** + **#3 Produkty** — równolegle (oba startują na main z #1 zmergowanym), bo nie kolidują plikowo.
 3. Po merge'u trzech ticketów: utworzenie kolejnych ticketów z plików `.md` w `Project Plan/handoff-modelowanie/` jako osobne issues z linkami do konkretnych pozycji backlogu.
+
+
+---
+
+## Notka 2026-06-10 — eksporty = pierwszy moduł nowego look & feel (epik EXR)
+
+Epik EXR (#1377–#1392) wdrożył **design system v2** (granatowy neutral + pomarańczowy CTA, `Zrodla/Front_Claude_Design/NOWY UI/PIM-nowoczesny/`) zaczynając od modułu eksportów:
+
+- **Tokeny (EXR-01, `apps/admin/src/index.css`):** skale `zinc` (granat), `orange` (CTA), `brick` (błędy), `emerald` (sukces) nadpisane globalnie w Tailwind `@theme`; semantyka `--cta`/`--accent-hover`/`--accent-soft`, statusy, `--shadow-card`, radiusy 8/12/16. **To jest baza dla redesignu kolejnych modułów** — nowe widoki używają klas `zinc-*`/`orange-*` 1:1 z designem HTML.
+- **Primitives (EXR-02, `apps/admin/src/components/ui-v2/`):** 13 komponentów (PageHeader, PillTabs, KpiCard, StatusPill, ResultBar, ProgressBar, ModeBadge, FormatPill, SelectableCard, WizardStepper, EmptyState, Sparkline, HealthDot) + wzorzec tabeli v2 w README — reuse przy migracji importów/dashboardu.
+- **Shell (EXR-03):** sidebar z menu II poziomu + topbar v2 (`PageHeader` + `PageActionsContext`) działa globalnie — kolejne moduły rejestrują swoje CTA przez `usePageActions`.
+
+Kolejność migracji pozostałych modułów: wg planu handoff (dashboard / modelowanie / produkty) — teraz na tokenach v2 zamiast handoff-owych.

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -1,5 +1,22 @@
 # Current Status
 
+## 2026-06-10 (wieczór): ✅ Epik EXR DOMKNIĘTY — 16/16 ticketów, eksporty = pierwszy moduł nowego look & feel
+
+**Marathon zakończony.** Wszystkie tickety #1377–#1392 zamknięte; PR-y #1399–#1410 zmergowane (każdy: CI green + live smoke proof w komentarzu).
+
+- **Grupa A (fundament):** EXR-01 tokeny v2 (granat+orange, `--cta`, shadow-card) · EXR-02 `ui-v2/` 13 primitives + **stack Vitest/Testing Library/jest-axe** (nowy job CI) · EXR-03 sidebar II poziomu + topbar (`PageHeader`+`PageActionsContext`, `useNavCounts`).
+- **Grupa B (backend, wcześniej):** EXR-04..07 — ExportEntityType (5 encji), pipeline per ObjectType, eksportery strukturalne, preflight.
+- **Grupa C (frontend eksportów):** EXR-08 strona Sesje (KPI/W toku/Historia) · EXR-09..12 pełny 4-krokowy wizard (reuse `AdvancedFilterPanel` przez `useFilterDslState`, ColumnPickerV2 + `GET /api/exports/columns`, run sync/async wg odpowiedzi BE) · EXR-13 Profile v2 (edit przez `?profile=`) · EXR-14 wejścia z listy + **usunięty ExportModal/ExportNewPage/ColumnPicker** · EXR-15 live progress per chunk + **anulowanie** (status `cancelled`, endpoint cancel, graceful stop) + inbox przy dzwonku.
+- **Grupa D:** EXR-16 — axe-gate WCAG A/AA (sesje+4 kroki+profile), e2e wszystkich encji, **benchmark 100k×22 kol.: 46,5 s, 0,465 ms/wiersz, wzrost pamięci 0.00 MB** (454 MB to baseline kernela CLI dev), docs (PRD-exports 1.1, notka handoff, lessons). Screencast 5 min = operator.
+- **Bug fix po drodze:** `FilterDslResolver` mapował `sku`→`co.sku` (kolumna nie istnieje; fizyczna to `code`) — każdy filtr sku w preflight/eksporcie dawał 500. Fix + `ExportCancelApiTest`.
+
+### Incydent 2026-06-10 (wyciągnięte wnioski — patrz lessons + memory)
+Lokalny PHPUnit bez `APP_ENV=test` wyczyścił bazę dev. Pierwsza reakcja (wielogodzinny PITR z archiwum WAL) była błędna dla środowiska dev — **polityka od teraz: dump z `backups/` → fixtures; nigdy WAL-replay na dev**. Baza przywrócona z dumpa operatora (08.06) + migracje + reindex. Follow-up tickety: martwy cron pełnych backupów pgBackRest (od 28.04), guard wymuszający APP_ENV=test dla PHPUnit.
+
+### Następny krok
+Operator: screencast 5 min (zasada sub-faz). Dalej wg planu — kolejne moduły migrują na tokeny v2 (importy/dashboard/modelowanie); fundament w `ui-v2/README.md`.
+
+
 ## 2026-06-10: 🚧 Epik EXR w realizacji — A zamknięta (EXR-01/02/03 merged), B była zamknięta wcześniej, C w toku (EXR-08 na PR)
 
 **Marathon mode (operator: „kontynuuj prace")** — jeden ticket = branch + PR + CI + merge, po kolei.

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2418,3 +2418,12 @@ Self-audit ujawnił 12 znalezisk; korekty wprowadzone w drugiej iteracji:
 4. **shadcn `--accent` ≠ ticketowe „accent".** Design v2 chciał `--accent` = orange-600, ale shadcn używa `--accent` jako muted hover (64 użycia) — podmiana łamałaby AA. CTA wystawione jako skala `orange-*` + token `--cta`; `--accent` pozostał muted. Przy kolejnych redesignach sprawdzać kolizje semantyk shadcn przed podmianą tokenów.
 5. **`networkidle` w Playwright nigdy nie nastąpi przy Mercure SSE** — używać selektorów/timeoutów zamiast `waitForLoadState('networkidle')`.
 6. **Lokalna baza dev może nie mieć kolumn z już zmergowanych migracji** (dev nie trackuje `doctrine_migration_versions` — schema z fixtures). Po merge'u PR-a z migracją odpalić ją punktowo: `doctrine:migrations:execute 'DoctrineMigrations\VersionX' --up` zamiast `migrate` (migrate wywala się na istniejących tabelach).
+
+## Lessons z EXR-09..16 (wizard + async UX, 2026-06-10)
+
+1. **Stacked branches przy squash-merge**: każdy ticket na branchu od poprzedniego; po merge'u PR-a bazowego `git stash push -u` → `rebase origin/main` → `stash pop`. Uwaga: stash z untracked plikami operatora (`reference.php`) konfliktuje przy pop — bezpieczniej `git checkout stash@{0} -- <ścieżki>` selektywnie.
+2. **Backend enum values ≠ intuicja FE**: `ExportEntityType` to `product`/`attributes_groups` (singular/underscore), nie `products`/`attributes`. Przy syncu typów FE↔BE zawsze czytać enum z PHP, nie zgadywać z nazw ticketów.
+3. **Sesje sync miały wiszący `file_path`** do skasowanego pliku temp — `markDone()` w runnerze zapisuje targetPath; sync path musi po streamingu zrobić `setFilePath(null)`. FE gate'uje download na `file_path !== null`, nie na statusie.
+4. **Profile-run jest async-only** (dispatch + run_count); sync-download z profilu wymagałby zmiany w endpointzie — świadomie odłożone, odnotowane w PR EXR-13.
+5. **Live progress wymagał callbacka w runnerze** — publisher był wołany tylko po zakończeniu; `onChunk` co 500 wierszy + odczyt PERSISTED statusu z DBAL (encja w pamięci jest stale w długiej pętli) daje i progres, i graceful cancel bez nowej kolumny.
+6. **biome `useSemanticElements`**: `role="group"` → `<fieldset>`; `role="radio"` na button wymaga biome-ignore z uzasadnieniem (wzorzec Radix).

--- a/apps/admin/e2e/exr-16-a11y.spec.ts
+++ b/apps/admin/e2e/exr-16-a11y.spec.ts
@@ -1,0 +1,117 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page, test } from '@playwright/test';
+import { apiLogin } from './helpers/auth';
+
+/**
+ * EXR-16 (#1392) — axe-core gate (WCAG A/AA) over the exports redesign:
+ * sessions page, all four wizard steps, profiles tab. Data mocked so the
+ * scan sees fully-rendered states.
+ */
+
+async function expectNoViolations(page: Page) {
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa'])
+    // The scan covers the exports surface; the global shell (sidebar,
+    // topbar) is included implicitly and must stay clean too.
+    .analyze();
+  expect(results.violations.map((violation) => `${violation.id}: ${violation.help}`)).toEqual([]);
+}
+
+const SESSION = {
+  id: '00000000-0000-0000-0000-000000000001',
+  entity_type: 'product',
+  object_type_id: null,
+  format: 'xlsx',
+  target_scope: 'all',
+  target_count: 100,
+  success_count: 100,
+  status: 'done',
+  source: 'central_tab',
+  started_at: new Date().toISOString(),
+  completed_at: new Date().toISOString(),
+  profile_name: null,
+  file_path: 'exports/a11y.xlsx',
+  duration_ms: 1000,
+  error_message: null,
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/exports/sessions', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [SESSION], total: 1 }),
+    }),
+  );
+  await page.route('**/api/exports/profiles', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], total: 0 }),
+    }),
+  );
+  await page.route('**/api/exports/preflight', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: 5,
+        mode: 'sync',
+        threshold: 100,
+        soft_cap: 100000,
+        exceeds_cap: false,
+      }),
+    }),
+  );
+  await page.route('**/api/attributes?*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([{ id: 'a1', code: 'brand', label: { pl: 'Marka' }, type: 'relation' }]),
+    }),
+  );
+  for (const url of ['**/api/attribute_groups?*', '**/api/channels?*'] as const) {
+    await page.route(url, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    );
+  }
+  await page.route('**/api/workspaces/current', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ enabledLocales: ['pl'], primaryLocale: 'pl' }),
+    }),
+  );
+  await apiLogin(page);
+  await page.waitForTimeout(1200);
+});
+
+test('a11y: sessions page', async ({ page }) => {
+  await page.goto('/integrations/exports/sessions', { waitUntil: 'commit' });
+  await expect(page.getByText('a11y.xlsx')).toBeVisible();
+  await expectNoViolations(page);
+});
+
+test('a11y: profiles tab (empty state)', async ({ page }) => {
+  await page.goto('/integrations/exports/profiles', { waitUntil: 'commit' });
+  await expect(page.getByText(/Brak zapisanych profili|No saved profiles/)).toBeVisible();
+  await expectNoViolations(page);
+});
+
+test('a11y: wizard steps 1-4', async ({ page }) => {
+  await page.goto('/integrations/exports/new', { waitUntil: 'commit' });
+  await expect(page.getByRole('radiogroup')).toBeVisible();
+  await expectNoViolations(page); // step 1
+
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await expect(page.getByTestId('preflight-badge')).toBeVisible();
+  await expectNoViolations(page); // step 2
+
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await expect(page.getByText(/Dostępne atrybuty|Available attributes/)).toBeVisible();
+  await expectNoViolations(page); // step 3
+
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+  await expect(page.getByText(/Podsumowanie konfiguracji|Configuration summary/)).toBeVisible();
+  await expectNoViolations(page); // step 4
+});

--- a/apps/admin/e2e/exr-16-a11y.spec.ts
+++ b/apps/admin/e2e/exr-16-a11y.spec.ts
@@ -9,12 +9,24 @@ import { apiLogin } from './helpers/auth';
  */
 
 async function expectNoViolations(page: Page) {
+  // Let CSS transitions finish — axe samples computed colors and a
+  // mid-transition tile (navy → emerald) reads as an illegible blend.
+  await page.waitForTimeout(350);
   const results = await new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa'])
     // The scan covers the exports surface; the global shell (sidebar,
     // topbar) is included implicitly and must stay clean too.
     .analyze();
-  expect(results.violations.map((violation) => `${violation.id}: ${violation.help}`)).toEqual([]);
+  expect(
+    results.violations.flatMap((violation) =>
+      violation.nodes
+        .slice(0, 4)
+        .map(
+          (node) =>
+            `${violation.id} @ ${node.target.join(' ')} :: ${node.failureSummary?.split('\n')[1]?.trim() ?? ''}`,
+        ),
+    ),
+  ).toEqual([]);
 }
 
 const SESSION = {
@@ -36,6 +48,15 @@ const SESSION = {
 };
 
 test.beforeEach(async ({ page }) => {
+  // Color-contrast sampling races CSS transitions (axe reads a mid-blend
+  // of the stepper tile animating navy → emerald). Standard practice for
+  // a11y scans: freeze animations/transitions for the whole run.
+  await page.addInitScript(() => {
+    const style = document.createElement('style');
+    style.textContent =
+      '*, *::before, *::after { transition: none !important; animation: none !important; }';
+    document.documentElement.appendChild(style);
+  });
   await page.route('**/api/exports/sessions', (route) =>
     route.fulfill({
       status: 200,

--- a/apps/admin/e2e/exr-16-entities.spec.ts
+++ b/apps/admin/e2e/exr-16-entities.spec.ts
@@ -1,0 +1,155 @@
+import { expect, test } from '@playwright/test';
+import { apiLogin } from './helpers/auth';
+
+/**
+ * EXR-16 (#1392) — wizard happy path for every non-product entity type
+ * (D2: all five working). Endpoints mocked for CI determinism; the
+ * real-file assertions run in the live smoke + benchmark.
+ */
+
+const CUSTOM_OT = {
+  id: '11111111-1111-1111-1111-111111111111',
+  code: 'producers',
+  kind: 'custom',
+  builtIn: false,
+  label: { pl: 'Producenci', en: 'Producers' },
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/exports/profiles', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], total: 0 }),
+    }),
+  );
+  await page.route('**/api/exports/preflight', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        count: 42,
+        mode: 'sync',
+        threshold: 100,
+        soft_cap: 100000,
+        exceeds_cap: false,
+      }),
+    }),
+  );
+  await page.route('**/api/object_types', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/ld+json',
+      body: JSON.stringify({ member: [CUSTOM_OT], totalItems: 1 }),
+    }),
+  );
+  await page.route('**/api/exports/columns?*', (route) => {
+    const url = new URL(route.request().url());
+    if (url.searchParams.get('entity_type') === 'custom_module') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ entity_type: 'custom_module', attribute_codes: ['name'] }),
+      });
+      return;
+    }
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        entity_type: url.searchParams.get('entity_type'),
+        columns: ['code', 'label.pl', 'label.en', 'position'],
+      }),
+    });
+  });
+  await page.route('**/api/attributes?*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'a1', code: 'name', label: { pl: 'Nazwa' }, type: 'text' },
+        { id: 'a2', code: 'only_products', label: { pl: 'Tylko produkty' }, type: 'text' },
+      ]),
+    }),
+  );
+  for (const url of ['**/api/attribute_groups?*', '**/api/channels?*'] as const) {
+    await page.route(url, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }),
+    );
+  }
+  await page.route('**/api/workspaces/current', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ enabledLocales: ['pl'], primaryLocale: 'pl' }),
+    }),
+  );
+
+  await apiLogin(page);
+  await page.waitForTimeout(1200);
+  await page.goto('/integrations/exports/new');
+  await page.waitForTimeout(500);
+});
+
+for (const entity of [
+  { radio: /Schemat modułów|Module schema/, payload: 'module_schema' },
+  { radio: /Atrybuty i grupy|Attributes & groups/, payload: 'attributes_groups' },
+  { radio: /Kategorie|Categories/, payload: 'categories' },
+]) {
+  test(`structural happy path: ${entity.payload}`, async ({ page }) => {
+    await page.getByRole('radio', { name: entity.radio }).click();
+    await page.getByRole('button', { name: /Dalej|Next/ }).click();
+
+    // step 2: no query builder, full-structure note with the preflight count
+    await expect(page.getByText(/Eksport pełnej struktury|Full structure export/)).toBeVisible();
+    await expect(page.getByRole('button', { name: /dodaj warunek/i })).toHaveCount(0);
+    await page.getByRole('button', { name: /Dalej|Next/ }).click();
+
+    // step 3: builder columns preselected (all)
+    await expect(page.getByText(/Wybrane atrybuty \(4\)|Selected attributes \(4\)/)).toBeVisible({
+      timeout: 5_000,
+    });
+    await page.getByRole('button', { name: /Dalej|Next/ }).click();
+
+    // step 4: summary with full-structure scope; payload check on run
+    await expect(page.getByText(/Pełna struktura|Full structure/)).toBeVisible();
+    let sentEntity: string | null = null;
+    await page.route('**/api/products/export', (route) => {
+      const body = route.request().postDataJSON() as { entity_type: string };
+      sentEntity = body.entity_type;
+      route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'sess-x', status: 'pending' }),
+      });
+    });
+    await page.route('**/api/exports/sessions', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [], total: 0 }),
+      }),
+    );
+    await page.getByTestId('run-export').click();
+    await expect(page).toHaveURL(/\/integrations\/exports\/sessions/);
+    expect(sentEntity).toBe(entity.payload);
+  });
+}
+
+test('custom_module happy path: ObjectType select + junction-narrowed columns', async ({
+  page,
+}) => {
+  await page.getByRole('radio', { name: /Moduły własne|Custom modules/ }).click();
+  await page.getByLabel(/Moduł własny|Custom module/).selectOption(CUSTOM_OT.id);
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+
+  // step 2: query builder available for custom modules
+  await expect(page.getByRole('button', { name: /dodaj warunek/i })).toBeVisible();
+  await page.getByRole('button', { name: /Dalej|Next/ }).click();
+
+  // step 3: junction narrowing — 'name' offered, 'only_products' not
+  await expect(page.getByRole('checkbox', { name: /Nazwa/ })).toBeVisible();
+  await expect(page.getByRole('checkbox', { name: /Tylko produkty/ })).toHaveCount(0);
+  // locked natural key for custom modules = code
+  await expect(page.getByText(/klucz|key/).first()).toBeVisible();
+});

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -57,6 +57,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@biomejs/biome": "^2.4.16",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.0",

--- a/apps/admin/src/components/catalog/advanced-filter-panel.tsx
+++ b/apps/admin/src/components/catalog/advanced-filter-panel.tsx
@@ -228,7 +228,7 @@ export function AdvancedFilterPanel({
           {t('products.advanced_filter.title', { defaultValue: 'Filtr zaawansowany' })}
         </span>
         <div className="ml-auto flex items-center gap-2">
-          <span className="text-[11.5px] text-zinc-400 tabular-nums">
+          <span className="text-[11.5px] text-zinc-500 tabular-nums">
             {t('products.advanced_filter.condition_count', {
               count: draftConditions.length,
               defaultValue: `${draftConditions.length} warunków`,
@@ -269,7 +269,7 @@ export function AdvancedFilterPanel({
               // biome-ignore lint/suspicious/noArrayIndexKey: see comment
               <div key={`cond-${idx}`} className="flex items-center gap-2">
                 {idx === 0 ? (
-                  <span className="text-[11px] uppercase tracking-wider font-semibold text-zinc-400 w-12">
+                  <span className="text-[11px] uppercase tracking-wider font-semibold text-zinc-500 w-12">
                     {t('products.advanced_filter.where_label', { defaultValue: 'Gdzie' })}
                   </span>
                 ) : (
@@ -420,7 +420,7 @@ export function AdvancedFilterPanel({
         </div>
 
         {draftConditions.length > 0 && (
-          <span className="text-[11.5px] text-zinc-400 inline-flex items-center gap-1.5">
+          <span className="text-[11.5px] text-zinc-500 inline-flex items-center gap-1.5">
             <Link2 className="size-3.5" />
             <span>
               {t('products.advanced_filter.url_updated', { defaultValue: 'URL zaktualizowany' })}

--- a/apps/admin/src/components/ui-v2/empty-state.tsx
+++ b/apps/admin/src/components/ui-v2/empty-state.tsx
@@ -23,7 +23,7 @@ export function EmptyState({ icon, title, description, action, className }: Empt
       {icon && (
         <span
           aria-hidden="true"
-          className="mb-3 grid h-12 w-12 place-items-center rounded-2xl bg-zinc-100 text-zinc-400"
+          className="mb-3 grid h-12 w-12 place-items-center rounded-2xl bg-zinc-100 text-zinc-500"
         >
           {icon}
         </span>

--- a/apps/admin/src/components/ui-v2/kpi-card.tsx
+++ b/apps/admin/src/components/ui-v2/kpi-card.tsx
@@ -38,7 +38,7 @@ export function KpiCard({ label, value, sub, icon, trend, className }: KpiCardPr
           {icon}
         </span>
       )}
-      <div className="text-[11px] font-medium tracking-wider text-zinc-400 uppercase">{label}</div>
+      <div className="text-[11px] font-medium tracking-wider text-zinc-500 uppercase">{label}</div>
       <div className="num font-display mt-1 text-[28px] font-semibold tracking-tight text-ink">
         {value}
       </div>

--- a/apps/admin/src/components/ui-v2/page-header.tsx
+++ b/apps/admin/src/components/ui-v2/page-header.tsx
@@ -40,14 +40,14 @@ export function PageHeader({ items, actions, className }: PageHeaderProps) {
                 {item.href && !last ? (
                   <Link
                     to={item.href}
-                    className="focus-ring truncate rounded-md text-zinc-400 hover:text-ink"
+                    className="focus-ring truncate rounded-md text-zinc-500 hover:text-ink"
                   >
                     {item.label}
                   </Link>
                 ) : (
                   <span
                     aria-current={last ? 'page' : undefined}
-                    className={cn('truncate', last ? 'text-ink' : 'text-zinc-400')}
+                    className={cn('truncate', last ? 'text-ink' : 'text-zinc-500')}
                   >
                     {item.label}
                   </span>

--- a/apps/admin/src/components/ui-v2/pill-tabs.tsx
+++ b/apps/admin/src/components/ui-v2/pill-tabs.tsx
@@ -58,14 +58,14 @@ export function PillTabs({ items, activeId, onChange, ariaLabel, className }: Pi
               <span
                 className={cn(
                   'num rounded-md px-1.5 py-0.5 font-mono text-[10.5px] font-semibold',
-                  active ? 'bg-white/15 text-white' : 'bg-zinc-100 text-zinc-500',
+                  active ? 'bg-white/15 text-white' : 'bg-zinc-100 text-zinc-600',
                 )}
               >
                 {item.count}
               </span>
             )}
             {item.disabled && (
-              <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-zinc-400 uppercase">
+              <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-zinc-600 uppercase">
                 {t('ui_v2.soon')}
               </span>
             )}

--- a/apps/admin/src/components/ui-v2/selectable-card.tsx
+++ b/apps/admin/src/components/ui-v2/selectable-card.tsx
@@ -88,7 +88,7 @@ export function SelectableCard({
           </span>
         )}
         {disabled && (
-          <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-zinc-400 uppercase">
+          <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9.5px] font-semibold tracking-wider text-zinc-600 uppercase">
             {t('ui_v2.soon')}
           </span>
         )}

--- a/apps/admin/src/components/ui-v2/status-pill.tsx
+++ b/apps/admin/src/components/ui-v2/status-pill.tsx
@@ -8,7 +8,7 @@ const VARIANT_CLASSES: Record<StatusPillVariant, { pill: string; dot: string }> 
   warning: { pill: 'bg-orange-50 text-orange-800', dot: 'bg-orange-500' },
   partial: { pill: 'bg-orange-50 text-orange-800', dot: 'bg-orange-500' },
   error: { pill: 'bg-brick-50 text-brick-700', dot: 'bg-brick-500' },
-  cancelled: { pill: 'bg-zinc-100 text-zinc-500', dot: 'bg-zinc-400' },
+  cancelled: { pill: 'bg-zinc-100 text-zinc-600', dot: 'bg-zinc-400' },
   queued: { pill: 'bg-zinc-100 text-zinc-600', dot: 'bg-zinc-400' },
   running: { pill: 'bg-zinc-100 text-zinc-700', dot: 'bg-zinc-500' },
 };

--- a/apps/admin/src/components/ui-v2/wizard-stepper.tsx
+++ b/apps/admin/src/components/ui-v2/wizard-stepper.tsx
@@ -46,7 +46,7 @@ export function WizardStepper({ steps, current, onStepClick, className }: Wizard
               className={cn(
                 'focus-ring w-full rounded-xl border px-3.5 py-3 text-left transition',
                 active && 'border-zinc-900 bg-zinc-900 text-white',
-                done && 'cursor-pointer border-emerald-200/70 bg-emerald-50/60 text-emerald-900',
+                done && 'cursor-pointer border-emerald-200 bg-emerald-50 text-emerald-900',
                 !active && !done && 'cursor-default border-zinc-200 bg-surface text-zinc-500',
               )}
             >
@@ -57,7 +57,7 @@ export function WizardStepper({ steps, current, onStepClick, className }: Wizard
                     'grid h-5 w-5 place-items-center rounded-full font-mono text-[10px] font-bold',
                     active && 'bg-white text-zinc-900',
                     done && 'bg-emerald-500 text-white',
-                    !active && !done && 'bg-zinc-100 text-zinc-400',
+                    !active && !done && 'bg-zinc-100 text-zinc-600',
                   )}
                 >
                   {done ? <Check size={11} strokeWidth={3} /> : index + 1}
@@ -68,7 +68,7 @@ export function WizardStepper({ steps, current, onStepClick, className }: Wizard
                 <span
                   className={cn(
                     'mt-1 block truncate text-[11px]',
-                    active ? 'text-white/70' : done ? 'text-emerald-700' : 'text-zinc-400',
+                    active ? 'text-white/70' : done ? 'text-emerald-700' : 'text-zinc-500',
                   )}
                 >
                   {step.hint}

--- a/apps/admin/src/features/exports/components/ColumnPickerV2.tsx
+++ b/apps/admin/src/features/exports/components/ColumnPickerV2.tsx
@@ -145,7 +145,7 @@ export function ColumnPickerV2({
         className="rounded-2xl border border-zinc-200 bg-surface shadow-card"
       >
         <div className="flex items-center gap-2 border-b border-zinc-100 px-4 py-3">
-          <h3 className="flex-1 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+          <h3 className="flex-1 text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
             {t('exports.picker.available_title')}
           </h3>
           <button
@@ -159,7 +159,7 @@ export function ColumnPickerV2({
         <div className="px-4 py-3">
           <div className="relative">
             <Search
-              className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-zinc-400"
+              className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-zinc-500"
               aria-hidden
             />
             <input
@@ -168,7 +168,7 @@ export function ColumnPickerV2({
               onChange={(event) => setSearch(event.target.value)}
               placeholder={t('exports.picker.search_placeholder')}
               aria-label={t('exports.picker.search_placeholder')}
-              className="focus-ring h-9 w-full rounded-xl border border-zinc-200 bg-surface pr-3 pl-8 text-[13px] placeholder:text-zinc-400"
+              className="focus-ring h-9 w-full rounded-xl border border-zinc-200 bg-surface pr-3 pl-8 text-[13px] placeholder:text-zinc-500"
             />
           </div>
         </div>
@@ -207,7 +207,7 @@ export function ColumnPickerV2({
                     <span
                       className={cn(
                         'num rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold',
-                        selectedCount > 0 ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-400',
+                        selectedCount > 0 ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-600',
                       )}
                     >
                       {selectedCount}/{keys.length}
@@ -215,7 +215,7 @@ export function ColumnPickerV2({
                     <ChevronDown
                       aria-hidden
                       className={cn(
-                        'ml-auto size-3.5 text-zinc-400 transition-transform',
+                        'ml-auto size-3.5 text-zinc-500 transition-transform',
                         isCollapsed && '-rotate-90',
                       )}
                     />
@@ -236,7 +236,7 @@ export function ColumnPickerV2({
                               className="size-4 rounded border-zinc-300"
                             />
                             <span className="min-w-0 flex-1 truncate text-zinc-700">{label}</span>
-                            <span className="font-mono text-[10.5px] text-zinc-400">
+                            <span className="font-mono text-[10.5px] text-zinc-500">
                               {column.key}
                             </span>
                           </label>
@@ -249,7 +249,7 @@ export function ColumnPickerV2({
             );
           })}
           {visibleGroups.length === 0 && (
-            <p className="px-3 py-6 text-center text-[12.5px] text-zinc-400">
+            <p className="px-3 py-6 text-center text-[12.5px] text-zinc-500">
               {t('exports.picker.no_matches')}
             </p>
           )}
@@ -262,7 +262,7 @@ export function ColumnPickerV2({
         className="rounded-2xl border border-zinc-200 bg-surface shadow-card"
       >
         <div className="flex items-center gap-2 border-b border-zinc-100 px-4 py-3">
-          <h3 className="flex-1 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+          <h3 className="flex-1 text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
             {t('exports.picker.selected_title', { count: value.length })}
           </h3>
           <button
@@ -273,10 +273,10 @@ export function ColumnPickerV2({
             {t('exports.picker.clear')}
           </button>
         </div>
-        <p className="px-4 pt-2 text-[11.5px] text-zinc-400">{t('exports.picker.order_hint')}</p>
+        <p className="px-4 pt-2 text-[11.5px] text-zinc-500">{t('exports.picker.order_hint')}</p>
         <div className="max-h-[420px] overflow-y-auto px-3 py-3">
           {value.length === 0 ? (
-            <p className="px-2 py-6 text-center text-[12.5px] text-zinc-400">
+            <p className="px-2 py-6 text-center text-[12.5px] text-zinc-500">
               {t('exports.picker.none_selected')}
             </p>
           ) : (
@@ -338,12 +338,12 @@ function SelectedRow({ id, index, label, groupLabel, locked, onRemove }: Selecte
         isDragging && 'soft-shadow z-10 opacity-90',
       )}
     >
-      <span className="num w-5 shrink-0 text-center font-mono text-[11px] text-zinc-400">
+      <span className="num w-5 shrink-0 text-center font-mono text-[11px] text-zinc-500">
         {index + 1}
       </span>
       <span className="min-w-0 flex-1">
         <span className="block truncate text-[13px] font-medium text-ink">{label}</span>
-        <span className="block truncate text-[11px] text-zinc-400">
+        <span className="block truncate text-[11px] text-zinc-500">
           {groupLabel}
           <span className="ml-1.5 font-mono">{id}</span>
         </span>
@@ -357,7 +357,7 @@ function SelectedRow({ id, index, label, groupLabel, locked, onRemove }: Selecte
           <button
             type="button"
             aria-label={t('exports.picker.drag_handle_aria', { column: label })}
-            className="focus-ring grid h-7 w-7 cursor-grab place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink active:cursor-grabbing"
+            className="focus-ring grid h-7 w-7 cursor-grab place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-ink active:cursor-grabbing"
             {...attributes}
             {...listeners}
           >
@@ -367,7 +367,7 @@ function SelectedRow({ id, index, label, groupLabel, locked, onRemove }: Selecte
             type="button"
             aria-label={t('exports.picker.remove_aria', { column: label })}
             onClick={onRemove}
-            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-brick-50 hover:text-brick-600"
+            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-500 hover:bg-brick-50 hover:text-brick-600"
           >
             <X className="size-3.5" aria-hidden />
           </button>

--- a/apps/admin/src/features/exports/profiles/ExportProfilesView.tsx
+++ b/apps/admin/src/features/exports/profiles/ExportProfilesView.tsx
@@ -150,7 +150,7 @@ export function ExportProfilesView(): React.ReactElement {
               ).map((key) => (
                 <th
                   key={key}
-                  className="px-4 py-3 text-[11px] font-medium tracking-wider text-zinc-400 uppercase"
+                  className="px-4 py-3 text-[11px] font-medium tracking-wider text-zinc-500 uppercase"
                 >
                   {t(`exports.profiles.${key}`)}
                 </th>
@@ -167,7 +167,7 @@ export function ExportProfilesView(): React.ReactElement {
                   <td className="px-4 py-3">
                     <div className="font-medium text-ink">{profile.name}</div>
                     {profile.description !== null && profile.description !== '' && (
-                      <div className="truncate text-[11.5px] text-zinc-400">
+                      <div className="truncate text-[11.5px] text-zinc-500">
                         {profile.description}
                       </div>
                     )}
@@ -188,7 +188,7 @@ export function ExportProfilesView(): React.ReactElement {
                   </td>
                   <td className="px-4 py-3">
                     {chips.length === 0 ? (
-                      <span className="text-zinc-400">—</span>
+                      <span className="text-zinc-500">—</span>
                     ) : (
                       <span className="flex flex-wrap gap-1">
                         {chips.slice(0, 2).map((chip) => (
@@ -200,7 +200,7 @@ export function ExportProfilesView(): React.ReactElement {
                           </span>
                         ))}
                         {chips.length > 2 && (
-                          <span className="text-[11px] text-zinc-400">+{chips.length - 2}</span>
+                          <span className="text-[11px] text-zinc-500">+{chips.length - 2}</span>
                         )}
                       </span>
                     )}
@@ -219,7 +219,7 @@ export function ExportProfilesView(): React.ReactElement {
                         onClick={() => void onRun(profile)}
                         aria-label={t('exports.profiles.action_run', { name: profile.name })}
                         title={t('exports.profiles.action_run', { name: profile.name })}
-                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink"
+                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-ink"
                       >
                         <Play className="size-3.5" aria-hidden />
                       </button>
@@ -227,7 +227,7 @@ export function ExportProfilesView(): React.ReactElement {
                         to={`/integrations/exports/new?profile=${profile.id}`}
                         aria-label={t('exports.profiles.action_edit', { name: profile.name })}
                         title={t('exports.profiles.action_edit', { name: profile.name })}
-                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink"
+                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-ink"
                       >
                         <Pencil className="size-3.5" aria-hidden />
                       </Link>
@@ -236,7 +236,7 @@ export function ExportProfilesView(): React.ReactElement {
                         onClick={() => void onDelete(profile)}
                         aria-label={t('exports.profiles.action_delete', { name: profile.name })}
                         title={t('exports.profiles.action_delete', { name: profile.name })}
-                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-brick-50 hover:text-brick-600"
+                        className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-500 hover:bg-brick-50 hover:text-brick-600"
                       >
                         <Trash2 className="size-3.5" aria-hidden />
                       </button>

--- a/apps/admin/src/features/exports/sessions/ActiveSessions.tsx
+++ b/apps/admin/src/features/exports/sessions/ActiveSessions.tsx
@@ -54,7 +54,7 @@ export function ActiveSessions({
   if (sessions.length === 0) {
     return (
       <section aria-label={t('exports.active.title')}>
-        <h2 className="mb-2 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+        <h2 className="mb-2 text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
           {t('exports.active.title')}
         </h2>
         <div className="rounded-2xl border border-dashed border-zinc-200 bg-surface">
@@ -78,7 +78,7 @@ export function ActiveSessions({
 
   return (
     <section aria-label={t('exports.active.title')}>
-      <h2 className="mb-2 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+      <h2 className="mb-2 text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
         {t('exports.active.title')}
       </h2>
       <div className="space-y-3">
@@ -121,7 +121,7 @@ export function ActiveSessions({
                   onClick={() => void cancelSession()}
                   aria-label={t('exports.active.cancel')}
                   title={t('exports.active.cancel')}
-                  className="focus-ring inline-flex h-7 items-center gap-1 rounded-md px-2 text-[12px] font-medium text-zinc-400 hover:bg-brick-50 hover:text-brick-600"
+                  className="focus-ring inline-flex h-7 items-center gap-1 rounded-md px-2 text-[12px] font-medium text-zinc-500 hover:bg-brick-50 hover:text-brick-600"
                 >
                   <XCircle className="size-3.5" aria-hidden />
                   {t('exports.active.cancel')}

--- a/apps/admin/src/features/exports/sessions/HistoryTable.tsx
+++ b/apps/admin/src/features/exports/sessions/HistoryTable.tsx
@@ -116,13 +116,13 @@ export function HistoryTable({
   return (
     <section aria-label={t('exports.history.title')}>
       <div className="mb-2 flex flex-wrap items-center gap-3">
-        <h2 className="text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+        <h2 className="text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
           {t('exports.history.title', { count: filtered.length })}
         </h2>
         <div className="ml-auto flex flex-wrap items-center gap-2">
           <div className="relative">
             <Search
-              className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-zinc-400"
+              className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-zinc-500"
               aria-hidden
             />
             <input
@@ -134,7 +134,7 @@ export function HistoryTable({
               }}
               placeholder={t('exports.history.search_placeholder')}
               aria-label={t('exports.history.search_placeholder')}
-              className="focus-ring h-9 rounded-xl border border-zinc-200 bg-surface pr-3 pl-8 text-[13px] placeholder:text-zinc-400"
+              className="focus-ring h-9 rounded-xl border border-zinc-200 bg-surface pr-3 pl-8 text-[13px] placeholder:text-zinc-500"
             />
           </div>
           <fieldset
@@ -189,7 +189,7 @@ export function HistoryTable({
                   ).map((key) => (
                     <th
                       key={key}
-                      className="px-4 py-3 text-[11px] font-medium tracking-wider text-zinc-400 uppercase"
+                      className="px-4 py-3 text-[11px] font-medium tracking-wider text-zinc-500 uppercase"
                     >
                       {t(`exports.history.${key}`)}
                     </th>
@@ -216,7 +216,7 @@ export function HistoryTable({
                             <div className="truncate font-mono text-[12.5px] font-medium text-ink">
                               {fileName ?? '—'}
                             </div>
-                            <div className="truncate text-[11px] text-zinc-400">
+                            <div className="truncate text-[11px] text-zinc-500">
                               {t(entityTypeLabelKey(session.entity_type))}
                             </div>
                           </div>
@@ -242,7 +242,7 @@ export function HistoryTable({
                         <div className="num font-mono text-[12px] text-zinc-600">
                           {formatStartedAt(session.started_at)}
                         </div>
-                        <div className="text-[11px] text-zinc-400">
+                        <div className="text-[11px] text-zinc-500">
                           {formatDuration(session.duration_ms)}
                         </div>
                       </td>
@@ -258,7 +258,7 @@ export function HistoryTable({
                               onClick={() => onDownload(session.id)}
                               aria-label={t('exports.history.action_download')}
                               title={t('exports.history.action_download')}
-                              className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink"
+                              className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-ink"
                             >
                               <Download className="size-3.5" aria-hidden />
                             </button>
@@ -268,7 +268,7 @@ export function HistoryTable({
                             onClick={() => onRerun(session.id)}
                             aria-label={t('exports.history.action_rerun')}
                             title={t('exports.history.action_rerun')}
-                            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink"
+                            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-ink"
                           >
                             <RefreshCw className="size-3.5" aria-hidden />
                           </button>
@@ -277,14 +277,14 @@ export function HistoryTable({
                             onClick={() => onDelete(session.id)}
                             aria-label={t('exports.history.action_delete')}
                             title={t('exports.history.action_delete')}
-                            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-brick-50 hover:text-brick-600"
+                            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-500 hover:bg-brick-50 hover:text-brick-600"
                           >
                             <Trash2 className="size-3.5" aria-hidden />
                           </button>
                           <Link
                             to={`/integrations/exports/sessions/${session.id}`}
                             aria-label={t('exports.history.action_details')}
-                            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-400 hover:bg-zinc-100 hover:text-ink"
+                            className="focus-ring grid h-7 w-7 place-items-center rounded-md text-zinc-500 hover:bg-zinc-100 hover:text-ink"
                           >
                             <ChevronRight className="size-4" aria-hidden />
                           </Link>

--- a/apps/admin/src/features/exports/show/ExportSessionShowPage.tsx
+++ b/apps/admin/src/features/exports/show/ExportSessionShowPage.tsx
@@ -95,7 +95,7 @@ export function ExportSessionShowPage(): React.ReactElement {
         <dl className="mt-4 grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
           {rows.map(([label, value]) => (
             <div key={label} className="flex items-baseline justify-between gap-4 sm:justify-start">
-              <dt className="w-36 shrink-0 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+              <dt className="w-36 shrink-0 text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
                 {label}
               </dt>
               <dd className="min-w-0 truncate text-[13px] text-zinc-700">{value}</dd>

--- a/apps/admin/src/features/exports/wizard/WizardFooter.tsx
+++ b/apps/admin/src/features/exports/wizard/WizardFooter.tsx
@@ -34,7 +34,7 @@ export function WizardFooter({ stepTitle, nextDisabled = false, onNext }: Wizard
 
   return (
     <div className="flex items-center gap-3 border-t border-zinc-100 pt-4">
-      <div className="num flex-1 font-mono text-[11.5px] text-zinc-400">
+      <div className="num flex-1 font-mono text-[11.5px] text-zinc-500">
         {t('exports.wizard.step_indicator', {
           step: state.step + 1,
           total: WIZARD_STEP_COUNT,
@@ -70,7 +70,7 @@ export function WizardFooter({ stepTitle, nextDisabled = false, onNext }: Wizard
           className={cn(
             'focus-ring h-10 rounded-xl px-5 text-[13px] font-semibold transition',
             nextDisabled
-              ? 'cursor-not-allowed bg-zinc-100 text-zinc-400'
+              ? 'cursor-not-allowed bg-zinc-100 text-zinc-500'
               : 'bg-cta text-cta-foreground hover:bg-accent-hover',
           )}
         >

--- a/apps/admin/src/features/exports/wizard/steps/StepEntityType.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepEntityType.tsx
@@ -98,7 +98,7 @@ export function StepEntityType() {
         <div className="mt-5 rounded-xl border border-zinc-200 bg-surface-muted p-4">
           <label
             htmlFor="wizard-custom-object-type"
-            className="block text-[11px] font-medium tracking-wider text-zinc-400 uppercase"
+            className="block text-[11px] font-medium tracking-wider text-zinc-500 uppercase"
           >
             {t('exports.wizard.custom_object_type_label')}
           </label>

--- a/apps/admin/src/features/exports/wizard/steps/StepScopeFormat.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepScopeFormat.tsx
@@ -134,7 +134,7 @@ export function StepScopeFormat() {
         <div className="mt-4 max-w-md">
           <label
             htmlFor="wizard-profile-select"
-            className="block text-[11px] font-medium tracking-wider text-zinc-400 uppercase"
+            className="block text-[11px] font-medium tracking-wider text-zinc-500 uppercase"
           >
             {t('exports.wizard.profile_label')}
           </label>
@@ -153,10 +153,10 @@ export function StepScopeFormat() {
               </option>
             ))}
           </select>
-          <p className="mt-1.5 text-[12px] text-zinc-400">{t('exports.wizard.profile_hint')}</p>
+          <p className="mt-1.5 text-[12px] text-zinc-500">{t('exports.wizard.profile_hint')}</p>
         </div>
 
-        <h3 className="mt-6 text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+        <h3 className="mt-6 text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
           {t('exports.wizard.format_label')}
         </h3>
         <SelectableCardGroup

--- a/apps/admin/src/features/exports/wizard/steps/StepSummary.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepSummary.tsx
@@ -173,7 +173,7 @@ export function StepSummary() {
             </span>
           ))}
           {state.columns.length > 12 && (
-            <span className="text-[11.5px] text-zinc-400">+{state.columns.length - 12}</span>
+            <span className="text-[11.5px] text-zinc-500">+{state.columns.length - 12}</span>
           )}
         </span>
       ),
@@ -198,7 +198,7 @@ export function StepSummary() {
         <dl className="mt-5 grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
           {cards.map((card) => (
             <div key={card.key}>
-              <dt className="text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+              <dt className="text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
                 {card.title}
               </dt>
               <dd className="mt-1.5">{card.body}</dd>
@@ -208,7 +208,7 @@ export function StepSummary() {
       </section>
 
       <section className="rounded-2xl border border-zinc-200 bg-surface p-7 shadow-card">
-        <h3 className="text-[11px] font-medium tracking-wider text-zinc-400 uppercase">
+        <h3 className="text-[11px] font-medium tracking-wider text-zinc-500 uppercase">
           {t('exports.wizard.summary.save_profile_title')}
         </h3>
         <div className="mt-3 flex max-w-lg flex-wrap items-start gap-2">
@@ -224,7 +224,7 @@ export function StepSummary() {
               placeholder={t('exports.wizard.summary.profile_name_placeholder')}
               aria-label={t('exports.wizard.summary.profile_name_placeholder')}
               className={cn(
-                'focus-ring h-10 w-full rounded-xl border bg-surface px-3 text-[13px] placeholder:text-zinc-400',
+                'focus-ring h-10 w-full rounded-xl border bg-surface px-3 text-[13px] placeholder:text-zinc-500',
                 profileError === null ? 'border-zinc-200' : 'border-brick-300',
               )}
             />
@@ -244,12 +244,12 @@ export function StepSummary() {
             {t('exports.wizard.summary.save_profile_cta')}
           </button>
         </div>
-        <p className="mt-2 text-[11.5px] text-zinc-400">
+        <p className="mt-2 text-[11.5px] text-zinc-500">
           {t('exports.wizard.summary.save_profile_hint')}
         </p>
       </section>
 
-      <div className="rounded-2xl border border-emerald-200/70 bg-emerald-50/60 px-5 py-4 text-[13px] text-emerald-800">
+      <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-[13px] text-emerald-800">
         {mode === 'sync'
           ? t('exports.wizard.summary.note_sync')
           : t('exports.wizard.summary.note_async')}

--- a/apps/admin/src/index.css
+++ b/apps/admin/src/index.css
@@ -144,9 +144,11 @@
   --ink-2: #43536e;
   --line: #d7dfeb;
 
-  /* v2 CTA accent (orange) */
-  --cta: #df5b16;
-  --cta-hover: #ef6a1f;
+  /* v2 CTA accent (orange) — one step deeper than the design's
+   * orange-600: white 13px text on #df5b16 is 3.7:1 (fails WCAG AA);
+   * orange-700/800 keep the hue and pass (5.2:1 / 7.3:1). */
+  --cta: #b9491a;
+  --cta-hover: #933c19;
   --cta-soft: #fef4ec;
 
   /* shadcn-mapped tokens — remapped onto handoff palette */
@@ -183,8 +185,8 @@
   --ink-2: #d7dfeb;
   --line: #1d2c47;
 
-  --cta: #ef6a1f;
-  --cta-hover: #f3823f;
+  --cta: #b9491a;
+  --cta-hover: #933c19;
   --cta-soft: #3a1709;
 
   --background: var(--bg);

--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -176,7 +176,7 @@ const customLeafClass = cn(
   'border border-dashed border-violet-300/70 bg-violet-50/50 text-violet-900 hover:bg-violet-100/70',
 );
 
-const disabledLeafClass = cn(baseLeafClass, 'cursor-not-allowed text-zinc-400');
+const disabledLeafClass = cn(baseLeafClass, 'cursor-not-allowed text-zinc-500');
 
 const leafLinkClass = ({ isActive }: { isActive: boolean }): string =>
   cn(baseLeafClass, isActive ? 'bg-zinc-900 text-white' : 'text-zinc-700 hover:bg-zinc-100');
@@ -220,7 +220,7 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
       <span
         className={cn(
           'num ml-auto font-mono text-[11px] font-medium',
-          active ? 'text-white/70' : 'text-zinc-400',
+          active ? 'text-white/70' : 'text-zinc-500',
         )}
       >
         {formatNavCount(value)}
@@ -254,14 +254,14 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
           <Icon
             className={cn(
               'size-4',
-              integrationsRouteActive && !integrationsOpen ? 'text-white/90' : 'text-zinc-400',
+              integrationsRouteActive && !integrationsOpen ? 'text-white/90' : 'text-zinc-500',
             )}
           />
           <span className="flex-1 text-left">{labelText}</span>
           <ChevronDown
             aria-hidden="true"
             className={cn(
-              'size-3.5 text-zinc-400 transition-transform',
+              'size-3.5 text-zinc-500 transition-transform',
               integrationsOpen && 'rotate-180',
             )}
           />
@@ -303,7 +303,7 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
     if (item.comingSoon || item.route === null) {
       return (
         <span key={item.id} className={disabledLeafClass} aria-disabled="true">
-          <Icon className="size-4 text-zinc-400" />
+          <Icon className="size-4 text-zinc-500" />
           <span className="flex-1">{labelText}</span>
           <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9.5px] font-semibold uppercase tracking-wider text-zinc-500">
             {t('nav.soon')}
@@ -343,7 +343,7 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
       >
         {({ isActive }) => (
           <>
-            <Icon className={cn('size-4', isActive ? 'text-white/90' : 'text-zinc-400')} />
+            <Icon className={cn('size-4', isActive ? 'text-white/90' : 'text-zinc-500')} />
             <span className="flex-1">{labelText}</span>
             {renderCountBadge(item.id, isActive)}
           </>
@@ -386,7 +386,7 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
               defaultValue: 'Zapytaj agenta lub szukaj...',
             })}
           >
-            <Search className="size-4 shrink-0 text-zinc-400" aria-hidden />
+            <Search className="size-4 shrink-0 text-zinc-500" aria-hidden />
             <span className="flex-1 truncate text-[13px] text-zinc-500">
               {t('topbar.search_agent_placeholder', {
                 defaultValue: 'Zapytaj agenta lub szukaj...',
@@ -402,7 +402,7 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
       </Tooltip>
 
       <nav className="mt-5 flex-1 overflow-y-auto">
-        <div className="px-3 pb-1.5 text-[11px] font-medium uppercase tracking-wider text-zinc-400">
+        <div className="px-3 pb-1.5 text-[11px] font-medium uppercase tracking-wider text-zinc-500">
           {t('nav.workspace_label', { defaultValue: 'Workspace' })}
         </div>
         <div className="flex flex-col gap-0.5">{items.map(renderLeaf)}</div>
@@ -412,7 +412,7 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
           onClick={onNavigate}
           className="mt-3 flex w-full items-center gap-3 rounded-xl border border-dashed border-zinc-200 px-3 py-2 text-[13px] text-zinc-500 transition hover:border-violet-300 hover:bg-violet-50/60 hover:text-violet-700"
         >
-          <Plus className="size-4 text-zinc-400" aria-hidden />
+          <Plus className="size-4 text-zinc-500" aria-hidden />
           <span className="flex-1 text-left">
             {t('nav.add_custom_module', { defaultValue: 'Dodaj własny moduł' })}
           </span>

--- a/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
+++ b/apps/api/src/Catalog/Application/Filter/FilterDslResolver.php
@@ -171,7 +171,10 @@ final class FilterDslResolver
     private const array COLUMN_MAP = [
         'completeness_pct' => 'co.completeness_pct',
         'enabled' => 'co.enabled',
-        'sku' => 'co.sku',
+        // 'sku' is the UI alias for the natural key; the physical column on
+        // objects is 'code' (EXR-16 fix — the wizard's preflight/export SQL
+        // path 500'd on any sku condition).
+        'sku' => 'co.code',
     ];
 
     public function __construct(

--- a/apps/api/tests/Api/Export/ExportCancelApiTest.php
+++ b/apps/api/tests/Api/Export/ExportCancelApiTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export;
+
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportStatus;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * EXR-15 (#1391) — POST /api/exports/sessions/{id}/cancel.
+ *
+ * The endpoint persists the terminal `cancelled` status; the async
+ * handler polls it between chunks and stops gracefully. Contract under
+ * test: pending/running → 200 + cancelled, terminal states → 409.
+ * The mid-run graceful stop itself needs a real queue worker (dev runs
+ * the sync transport inline), so it is exercised by the chunk-callback
+ * logic in {@see \App\Export\Application\Async\ExportJobHandler} and
+ * verified manually on a worker-backed stack.
+ */
+final class ExportCancelApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function cancelsPendingSessionAndRejectsSecondCancel(): void
+    {
+        $session = $this->session();
+        $this->em()->persist($session);
+        $this->em()->flush();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request(
+            'POST',
+            sprintf('/api/exports/sessions/%s/cancel', $session->getId()->toRfc4122()),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        /** @var array<string, mixed> $body */
+        $body = $response->toArray(false);
+        self::assertSame('cancelled', $body['status']);
+
+        // Second cancel hits a terminal state → 409.
+        $conflict = $client->request(
+            'POST',
+            sprintf('/api/exports/sessions/%s/cancel', $session->getId()->toRfc4122()),
+        );
+        self::assertSame(409, $conflict->getStatusCode());
+    }
+
+    #[Test]
+    public function rejectsCancellingCompletedSession(): void
+    {
+        $session = $this->session();
+        $session->markRunning();
+        $session->markDone(5, 'tenant/file.csv', 123);
+        $this->em()->persist($session);
+        $this->em()->flush();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request(
+            'POST',
+            sprintf('/api/exports/sessions/%s/cancel', $session->getId()->toRfc4122()),
+        );
+
+        self::assertSame(409, $response->getStatusCode());
+
+        $row = $this->em()->getConnection()->fetchOne(
+            'SELECT status FROM export_sessions WHERE id = :id',
+            ['id' => $session->getId()->toRfc4122()],
+        );
+        self::assertSame(ExportStatus::Done->value, $row);
+    }
+
+    private function session(): ExportSession
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail(self::ADMIN_EMAIL);
+        \assert(null !== $user);
+
+        $session = new ExportSession(
+            userId: $user->getId(),
+            source: ExportSource::CentralTab,
+            format: ExportFormat::Csv,
+            targetScope: ExportTargetScope::All,
+            selectedColumns: ['sku'],
+            encoding: null,
+            filterSnapshot: null,
+            selectedObjectIds: null,
+            locales: null,
+            channels: null,
+            includeVariants: true,
+            entityType: ExportEntityType::Product,
+            objectTypeId: null,
+        );
+        $session->assignTenant($tenant);
+
+        return $session;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.60.0)
       '@biomejs/biome':
         specifier: ^2.4.16
         version: 2.4.16
@@ -237,6 +240,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1692,6 +1700,10 @@ packages:
     resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
     engines: {node: '>=4'}
 
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -3135,6 +3147,11 @@ snapshots:
   '@asamuzakjp/generational-cache@1.0.1': {}
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.60.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4605,6 +4622,8 @@ snapshots:
   axe-core@3.5.6: {}
 
   axe-core@4.10.2: {}
+
+  axe-core@4.11.4: {}
 
   balanced-match@1.0.2: {}
 


### PR DESCRIPTION
## Zakres (EXR-16, #1392)

### E2E — pakiet exports-redesign
Łącznie w epiku: `exr-08` (KPI/segmenty/szczegół), `exr-09` (Krok 1 + walidacje), `exr-10` (formaty/preflight/cap), `exr-11` (picker), `exr-12` (sync download/async/profil), `exr-13` (profile run/edit/delete), `exr-03` (menu II poziomu), `exports.spec` (scenariusze biznesowe EXP przepisane na wizard, kontrakt #1244/#1278) + **nowe w tym PR:** `exr-16-entities` (happy path 4 pozostałych encji z payload-asercją entity_type) i `exr-16-a11y`.

### a11y
**@axe-core/playwright** (nowa dev-zależność + lockfile): skan WCAG A/AA na stronie sesji, 4 krokach wizarda i profilach — 0 violations.

### i18n
Audyt literałów PL w `features/exports` + `ui-v2` + `layout`: 0 (poza fixture'ami testów); klucze komplet pl/en.

### Benchmark skali (wymóg spec)
Seed 100 420 obiektów (pim:benchmark:bulk-import) → `pim:export:benchmark`, **100 000 wierszy × 22 kolumny (built-ins + 14 EAV)**:
| metryka | wynik |
|---|---|
| czas | 46 547 ms (0,465 ms/wiersz) |
| **przyrost pamięci w trakcie przebiegu** | **0.00 MB** (chunk+clear działa; reguła worker-mode z CLAUDE.md) |
| peak (absolutny) | 454-456 MB — **baseline kernela CLI w dev** (identyczny przy 1k/50k/100k wierszy, więc nie skaluje z eksportem) |
| ekstrapolacja 50k SKU (MVP) | 23,3 s |

Pomiar = przejście ExportBuilder (bez zapisu MinIO — tak działa komenda EXP-04). Pełny zapis pliku zweryfikowany w smoke'ach EXR-12 (realne XLSX/CSV).

### Bug fix wykryty benchmarkiem
`FilterDslResolver` mapował `sku` → `co.sku` — kolumna nie istnieje (fizyczna: `code`); każdy filtr sku w preflight/eksporcie kończył się SQLSTATE 42703. Fix + weryfikacja live (`{count:7500, mode:async}` na seedzie). Lista produktów nie trafiała w ten kod (filtry idą przez Meilisearch).

### Test API anulowania (uzupełnienie EXR-15)
`ExportCancelApiTest`: pending→200+cancelled; powtórny cancel i sesja done→409 (2 testy/5 asercji, zielone z APP_ENV=test).

### Dokumentacja
PRD-PIM-exports **1.1** (sekcja „Rewizja 2026-06 (EXR)"), notka w planie handoff (eksporty = pierwszy moduł na tokenach v2 + wskazanie bazy dla kolejnych), lessons epiku w `agent/lessons.md`, finalny wpis w `agent/current_status.md`. OpenAPI snapshot — zgodnie z procesem release (CI przy tagu), bez akcji w tym PR.

### Poza PR (dla operatora)
Screencast 5 min (zasada sub-faz z CLAUDE.md): menu II poziomu → strona eksportów → pełny wizard → profil.

Closes #1392