### PR TITLE
fix(catalog): picker kategorii filtruje po drzewie ObjectType + czytelny błąd create

### DIFF
--- a/apps/admin/e2e/1413-create-category-picker-tree-scoped.spec.ts
+++ b/apps/admin/e2e/1413-create-category-picker-tree-scoped.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1413 — the category picker on the universal create page listed
+ * categories from EVERY ObjectType tree, so the operator could pick a
+ * foreign category (e.g. a product-tree one) and the create POST failed
+ * with an opaque "Nie udało się utworzyć obiektu" toast.
+ *
+ * CategorySelectorCard now forwards `objectTypeId` to CategoryPickerDialog
+ * (ADR-015 tree scoping via `categoryTargetObjectType`), and the create
+ * page surfaces the RFC 7807 `detail` when the backend rejects.
+ *
+ * `fixme` in CI for the same auth rate-limiter reason as the other UI specs.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('create-page category picker only lists the ObjectType tree', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(150_000);
+
+  await loginAsAdmin(page);
+
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+  const json = { ...bearer, 'content-type': 'application/json' };
+  const ld = { ...bearer, 'content-type': 'application/ld+json' };
+
+  const ts = uniqueSku('SVC')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+  const slug = `svc_${ts}`;
+  const ownCatName = `E2E Wlasna ${ts}`;
+  const foreignCatName = `E2E Obca ${ts}`;
+
+  // 1. Categorizable custom ObjectType.
+  const otResp = await page.request.post('/api/object_types', {
+    headers: json,
+    data: { code: slug, label: { pl: `Usługi ${ts}`, en: `Services ${ts}` } },
+  });
+  expect(otResp.status(), await otResp.text()).toBe(201);
+  const otId = ((await otResp.json()) as { id: string }).id;
+
+  const patchResp = await page.request.patch(`/api/object_types/${otId}`, {
+    headers: { ...bearer, 'content-type': 'application/merge-patch+json' },
+    data: { isCategorizable: true },
+  });
+  expect(patchResp.status()).toBe(200);
+
+  // 2. ObjectType ids needed for the two category trees.
+  const typesResp = await page.request.get('/api/object_types', { headers: bearer });
+  const typesBody = (await typesResp.json()) as {
+    member?: Array<{ id: string; kind: string }>;
+    'hydra:member'?: Array<{ id: string; kind: string }>;
+  };
+  const types = typesBody.member ?? typesBody['hydra:member'] ?? [];
+  const categoryOtId = types.find((t) => t.kind === 'category')?.id;
+  const productOtId = types.find((t) => t.kind === 'product')?.id;
+  if (categoryOtId === undefined) throw new Error('Built-in category ObjectType not found.');
+  if (productOtId === undefined) throw new Error('Built-in product ObjectType not found.');
+
+  // 3. One category in the custom kind's tree, one in the product tree.
+  const ownCatResp = await page.request.post('/api/categories', {
+    headers: ld,
+    data: {
+      code: `OWNCAT-${ts}`,
+      objectTypeId: categoryOtId,
+      categoryTargetObjectTypeId: otId,
+      attributes: { name: ownCatName },
+    },
+  });
+  expect(ownCatResp.status(), await ownCatResp.text()).toBe(201);
+
+  const foreignCatResp = await page.request.post('/api/categories', {
+    headers: ld,
+    data: {
+      code: `FORCAT-${ts}`,
+      objectTypeId: categoryOtId,
+      categoryTargetObjectTypeId: productOtId,
+      attributes: { name: foreignCatName },
+    },
+  });
+  expect(foreignCatResp.status(), await foreignCatResp.text()).toBe(201);
+
+  // 4. Open the create page and the category picker.
+  await page.goto(`/objects/${slug}/new`);
+  const pickerButton = page.getByRole('button', {
+    name: /przypisz kategorię|edytuj kategorie/i,
+  });
+  await expect(pickerButton).toBeVisible({ timeout: 15_000 });
+
+  const categoriesRequest = page.waitForRequest(
+    (r) => r.url().includes('/api/categories') && r.method() === 'GET',
+  );
+  await pickerButton.click();
+  // The picker query must be tree-scoped (ADR-015).
+  expect((await categoriesRequest).url()).toContain(
+    `categoryTargetObjectType=${encodeURIComponent(otId)}`,
+  );
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByText(ownCatName)).toBeVisible();
+  await expect(dialog.getByText(foreignCatName)).toHaveCount(0);
+
+  // 5. Assign the in-tree category and create — POST succeeds end-to-end.
+  await dialog.getByRole('checkbox').first().check();
+  await dialog.getByRole('button', { name: /^zapisz$/i }).click();
+
+  await page.getByPlaceholder(/^nazwa$|kod \(np\. car-001\)/i).fill(`Obj ${ts}`);
+  const createResponse = page.waitForResponse(
+    (r) => r.url().endsWith('/api/objects') && r.request().method() === 'POST',
+  );
+  await page.getByRole('button', { name: /^utwórz$/i }).click();
+  expect((await createResponse).status()).toBe(201);
+
+  // Cleanup OT (cascades).
+  await page.request.delete(`/api/object_types/${otId}`, { headers: bearer });
+});

--- a/apps/admin/src/components/objects/universal-create-page.tsx
+++ b/apps/admin/src/components/objects/universal-create-page.tsx
@@ -33,7 +33,7 @@ import type {
   LocaleOption,
   ProductLocale,
 } from '@/features/catalog/products/components/types';
-import { jsonFetch } from '@/lib/http';
+import { httpErrorDetail, jsonFetch } from '@/lib/http';
 import { cn } from '@/lib/utils';
 
 export interface UniversalCreatePageProps {
@@ -302,8 +302,11 @@ export function UniversalCreatePage({
         );
       }
       navigate(detailPathFor(created.id));
-    } catch {
-      toast.error(t('object_create.failed', { defaultValue: 'Nie udało się utworzyć obiektu' }));
+    } catch (e) {
+      toast.error(
+        httpErrorDetail(e) ??
+          t('object_create.failed', { defaultValue: 'Nie udało się utworzyć obiektu' }),
+      );
     } finally {
       setIsSaving(false);
     }

--- a/apps/admin/src/features/catalog/products/components/categories-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/categories-tab.tsx
@@ -29,6 +29,8 @@ interface ListResponse {
 
 interface Props {
   productId: string;
+  /** ObjectType owning the object — scopes the picker to its category tree (#1413). */
+  objectTypeId?: string | null;
 }
 
 /**
@@ -44,7 +46,7 @@ interface Props {
  * needs to know that picking a category is what activates the
  * category-driven group set on the form (PCAT-03).
  */
-export function CategoriesTab({ productId }: Props) {
+export function CategoriesTab({ productId, objectTypeId }: Props) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -228,6 +230,7 @@ export function CategoriesTab({ productId }: Props) {
         open={pickerOpen}
         onOpenChange={setPickerOpen}
         productId={productId}
+        objectTypeId={objectTypeId ?? undefined}
         currentAssignments={currentAssignments}
         onSaved={() => undefined}
       />

--- a/apps/admin/src/features/catalog/products/components/category-selector-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/category-selector-card.tsx
@@ -319,6 +319,7 @@ export function CategorySelectorCard(props: Props) {
         open={pickerOpen}
         onOpenChange={setPickerOpen}
         productId={productId}
+        objectTypeId={props.objectTypeId ?? undefined}
         currentAssignments={currentPickerAssignments}
         onSaved={() => undefined}
         onSelect={

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -931,7 +931,13 @@ export function ProductDetailPage({ mode, productId }: ProductDetailPageProps) {
 
             if (mode === 'edit' && isSpecialTab(activeTab)) {
               return (
-                <OtherTabs activeTab={activeTab} productId={id} locale={locale} channel={channel} />
+                <OtherTabs
+                  activeTab={activeTab}
+                  productId={id}
+                  objectTypeId={objectTypeId}
+                  locale={locale}
+                  channel={channel}
+                />
               );
             }
 
@@ -1113,11 +1119,13 @@ function resolveProvenance(
 function OtherTabs({
   activeTab,
   productId,
+  objectTypeId,
   locale,
   channel,
 }: {
   activeTab: SpecialTabKey;
   productId: string;
+  objectTypeId: string | null;
   locale: ProductLocale;
   channel: ProductChannel | null;
 }) {
@@ -1126,7 +1134,8 @@ function OtherTabs({
   // dispatcher; mirroring the UniversalDetailPage gating brings the
   // legacy product card back in sync with the capability flag).
   if (activeTab === 'multimedia') return <ProductMultimediaTab productId={productId} />;
-  if (activeTab === 'categories') return <CategoriesTab productId={productId} />;
+  if (activeTab === 'categories')
+    return <CategoriesTab productId={productId} objectTypeId={objectTypeId} />;
   if (activeTab === 'history') return <HistoryStub />;
   if (activeTab === 'variants')
     return <VariantsTabHost productId={productId} locale={locale} channel={channel} />;

--- a/apps/admin/src/features/catalog/products/components/relations-tab.tsx
+++ b/apps/admin/src/features/catalog/products/components/relations-tab.tsx
@@ -841,6 +841,7 @@ function ObjectPickerDialog({
         open={categoryPickerOpen}
         onOpenChange={setCategoryPickerOpen}
         productId=""
+        objectTypeId={createObjectTypeId ?? undefined}
         currentAssignments={createCategoryIds.map((id) => ({
           categoryId: id,
           isPrimary: id === createPrimaryCategoryId,


### PR DESCRIPTION
## Summary
Picker kategorii (create wpisu custom OT, zakładka Kategorie, sidebar, create obiektu z poziomu relacji) pokazywał kategorie ze WSZYSTKICH drzew ObjectType. Wybór obcej kategorii kończył się generycznym toastem „Nie udało się utworzyć obiektu". Teraz picker jest ograniczony do drzewa właściwego ObjectType, a błąd create pokazuje `detail` z RFC 7807.

## Root cause
`CategorySelectorCard` / `CategoriesTab` / create-flow w `relations-tab` nie przekazywały `objectTypeId` do `CategoryPickerDialog` — filtr BE (`CategoryTreeFilter`, `categoryTargetObjectType`) istniał i działał, ale FE go nie używał. Dodatkowo `universal-create-page.tsx` połykał treść błędu 422 z `CategoryTreeAssignmentGuard`.

## Backend changes
- Brak (filtr + walidacja istniały).

## Frontend changes
- `category-selector-card.tsx`, `categories-tab.tsx`, `relations-tab.tsx`, `product-detail-page.tsx` — przekazanie `objectTypeId` do pickera we wszystkich call sites.
- `universal-create-page.tsx` — `httpErrorDetail(e)` w catch (pattern z product create).

## Quality gates
- Biome strict: 0 błędów; tsc -b: clean.
- Playwright `1413-create-category-picker-tree-scoped.spec.ts`: zielony lokalnie (picker tree-scoped, obca kategoria niewidoczna, create 201 end-to-end).
- pnpm audit: 0 high/critical.

## Smoke test plan
1. Login admin@demo.localhost.
2. `/objects/uslugi/new` → „Przypisz kategorię" → lista zawiera tylko kategorie drzewa „uslugi".
3. Wybór kategorii + Utwórz → 201, redirect do detalu.

## Świadome odejścia
- Brak — pełen scope ticketu.

Closes #1413

🤖 Generated with [Claude Code](https://claude.com/claude-code)