### PR TITLE
fix(modeling): grupy atrybutów honorują wszystkie skonfigurowane locale (PL/EN/DE)

### DIFF
--- a/apps/admin/e2e/1352-attributes-honor-configured-locales.spec.ts
+++ b/apps/admin/e2e/1352-attributes-honor-configured-locales.spec.ts
@@ -77,7 +77,9 @@ test('attribute name form honors all configured locales (PL/EN/DE)', async ({ pa
   await expect(deTab).toBeVisible();
 
   await deTab.click();
-  await expect(page.getByDisplayValue('Werkstoff')).toBeVisible();
+  // Playwright has no getByDisplayValue — target the LocaleTabsField input
+  // via its aria-label and assert the bound value.
+  await expect(page.getByLabel(/wartość dla de/i).first()).toHaveValue('Werkstoff');
 
   await page.request.delete(`/api/attributes/${attribute.id}`, { headers: bearer });
 });
@@ -113,4 +115,62 @@ test('attribute create form renders a locale tab per configured locale', async (
   await expect(localeTabs.getByRole('tab', { name: /pl/i })).toBeVisible();
   await expect(localeTabs.getByRole('tab', { name: /en/i })).toBeVisible();
   await expect(localeTabs.getByRole('tab', { name: /de/i })).toBeVisible();
+});
+
+test('attribute group forms honor all configured locales (PL/EN/DE)', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const wsBefore = await page.request.get('/api/workspaces/current', {
+    headers: { ...bearer, accept: 'application/json' },
+  });
+  const enabled = ((await wsBefore.json()) as { enabledLocales?: string[] }).enabledLocales ?? [];
+  if (!enabled.includes('de')) {
+    await page.request.post('/api/workspaces/current/locales', {
+      headers: { ...bearer, 'content-type': 'application/json' },
+      data: { locale: 'de' },
+    });
+  }
+
+  // Create form renders a tab per configured locale — no hardcoded pl/en.
+  await page.goto('/modeling/attribute-groups/new');
+  const createTabs = page.getByRole('tablist', { name: /wybór języka|language/i }).first();
+  await expect(createTabs).toBeVisible({ timeout: 15_000 });
+  await expect(createTabs.getByRole('tab', { name: /pl/i })).toBeVisible();
+  await expect(createTabs.getByRole('tab', { name: /en/i })).toBeVisible();
+  await expect(createTabs.getByRole('tab', { name: /de/i })).toBeVisible();
+
+  // Backend accepts + round-trips a DE label on the group; the edit form
+  // surfaces the DE tab with the stored translation.
+  const code = `zz_grp_${Date.now().toString(36).toLowerCase()}`;
+  const created = await page.request.post('/api/attribute_groups', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: {
+      code,
+      label: { pl: 'Wymiary', en: 'Dimensions', de: 'Abmessungen' },
+      position: 0,
+    },
+  });
+  expect(created.status(), await created.text()).toBe(201);
+  const group = (await created.json()) as { id: string };
+
+  await page.goto(`/modeling/attribute-groups/${group.id}`);
+  const editTabs = page.getByRole('tablist', { name: /wybór języka|language/i }).first();
+  await expect(editTabs).toBeVisible({ timeout: 15_000 });
+  const deTab = editTabs.getByRole('tab', { name: /de/i });
+  await expect(deTab).toBeVisible();
+  await deTab.click();
+  await expect(page.getByLabel(/wartość dla de/i).first()).toHaveValue('Abmessungen');
+
+  await page.request.delete(`/api/attribute_groups/${group.id}`, { headers: bearer });
 });

--- a/apps/admin/src/features/catalog/attribute-groups/create.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/create.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate } from 'react-router';
 
 import { ATTRIBUTE_GROUP_SWATCHES, ColorPicker } from '@/components/modeling/color-picker';
 import { ATTRIBUTE_GROUP_ICONS, IconPicker } from '@/components/modeling/icon-picker';
+import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { SettingToggleRow } from '@/components/modeling/setting-toggle-row';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -12,7 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { HttpError, jsonFetch } from '@/lib/http';
-import { cn } from '@/lib/utils';
+import { useCurrentWorkspace, useInvalidateCurrentWorkspace } from '@/lib/use-current-workspace';
 
 /**
  * VIEW-03b — pixel-perfect rebuild of `NewAttributeGroupView`
@@ -32,10 +33,9 @@ import { cn } from '@/lib/utils';
 
 interface CreatePayload {
   code: string;
-  labelPl: string;
-  labelEn: string;
-  descriptionPl: string;
-  descriptionEn: string;
+  /** Full per-locale maps — every workspace locale, not hardcoded PL/EN (#1352). */
+  label: Record<string, string>;
+  description: Record<string, string>;
   icon: string;
   color: string;
   requiredSection: boolean;
@@ -45,10 +45,8 @@ interface CreatePayload {
 
 const EMPTY: CreatePayload = {
   code: '',
-  labelPl: '',
-  labelEn: '',
-  descriptionPl: '',
-  descriptionEn: '',
+  label: {},
+  description: {},
   icon: ATTRIBUTE_GROUP_ICONS[0],
   color: ATTRIBUTE_GROUP_SWATCHES[0],
   requiredSection: false,
@@ -59,14 +57,19 @@ const EMPTY: CreatePayload = {
 export function AttributeGroupCreatePage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const workspace = useCurrentWorkspace();
+  const invalidateWorkspace = useInvalidateCurrentWorkspace();
+  const enabledLocales = workspace.data?.enabledLocales ?? ['pl', 'en'];
+  const primaryLocale = workspace.data?.primaryLocale ?? 'pl';
   const [values, setValues] = useState<CreatePayload>(EMPTY);
-  const [activeLocale, setActiveLocale] = useState<'pl' | 'en'>('pl');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const displayName =
-    values.labelPl.trim() ||
-    values.labelEn.trim() ||
+    (values.label[primaryLocale] ?? '').trim() ||
+    Object.values(values.label)
+      .map((v) => v.trim())
+      .find((v) => v !== '') ||
     t('modeling.attributeGroups.create.title_default', { defaultValue: 'Nazwa grupy' });
 
   const handleSubmit = async () => {
@@ -75,13 +78,13 @@ export function AttributeGroupCreatePage() {
     try {
       const body: Record<string, unknown> = {
         code: values.code,
-        label: stripEmpty({ pl: values.labelPl, en: values.labelEn }),
+        label: stripEmpty(values.label),
         position: 0,
         requiredSection: values.requiredSection,
         shared: values.shared,
         conditionalVisibility: values.conditionalVisibility,
       };
-      const description = stripEmpty({ pl: values.descriptionPl, en: values.descriptionEn });
+      const description = stripEmpty(values.description);
       if (Object.keys(description).length > 0) body.description = description;
       if (values.icon !== '') body.icon = values.icon;
       if (values.color !== '') body.color = values.color;
@@ -116,7 +119,8 @@ export function AttributeGroupCreatePage() {
     }
   };
 
-  const valid = values.code.trim().length > 0 && values.labelPl.trim().length > 0;
+  const valid =
+    values.code.trim().length > 0 && (values.label[primaryLocale] ?? '').trim().length > 0;
 
   return (
     <div className="space-y-6">
@@ -206,44 +210,16 @@ export function AttributeGroupCreatePage() {
                 <Label className="text-[11.5px] font-medium text-muted-foreground">
                   {t('modeling.attributeGroups.fields.name', { defaultValue: 'Nazwa' })}
                 </Label>
-                <div className="mt-1.5 flex items-center gap-1 border-b border-zinc-100">
-                  {(['pl', 'en'] as const).map((lc) => {
-                    const filled =
-                      (lc === 'pl' ? values.labelPl : values.labelEn).trim().length > 0;
-                    return (
-                      <button
-                        key={lc}
-                        type="button"
-                        onClick={() => setActiveLocale(lc)}
-                        className={cn(
-                          '-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-[12.5px] font-medium uppercase tracking-wider transition',
-                          activeLocale === lc
-                            ? 'border-zinc-900 text-foreground'
-                            : 'border-transparent text-muted-foreground hover:text-foreground',
-                        )}
-                      >
-                        <span>{lc === 'pl' ? '🇵🇱' : '🇬🇧'}</span>
-                        <span>{lc}</span>
-                        {!filled ? (
-                          <span className="size-1.5 rounded-full bg-amber-400" aria-hidden />
-                        ) : null}
-                      </button>
-                    );
-                  })}
+                <div className="mt-1.5">
+                  <LocaleTabsField
+                    values={values.label}
+                    enabledLocales={enabledLocales}
+                    primaryLocale={primaryLocale}
+                    onChange={(next) => setValues({ ...values, label: next })}
+                    onLocaleAdded={() => invalidateWorkspace()}
+                    placeholder="np. Wymiary"
+                  />
                 </div>
-                <Input
-                  className="mt-2"
-                  value={activeLocale === 'pl' ? values.labelPl : values.labelEn}
-                  onChange={(e) =>
-                    setValues({
-                      ...values,
-                      ...(activeLocale === 'pl'
-                        ? { labelPl: e.target.value }
-                        : { labelEn: e.target.value }),
-                    })
-                  }
-                  placeholder="np. Wymiary"
-                />
               </div>
 
               <div>
@@ -253,18 +229,27 @@ export function AttributeGroupCreatePage() {
                   })}
                 </Label>
                 <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
-                  <Textarea
-                    rows={2}
-                    value={values.descriptionPl}
-                    onChange={(e) => setValues({ ...values, descriptionPl: e.target.value })}
-                    placeholder="PL · krótki opis grupy"
-                  />
-                  <Textarea
-                    rows={2}
-                    value={values.descriptionEn}
-                    onChange={(e) => setValues({ ...values, descriptionEn: e.target.value })}
-                    placeholder="EN · short description"
-                  />
+                  {enabledLocales.map((lc) => (
+                    <Textarea
+                      key={lc}
+                      rows={2}
+                      value={values.description[lc] ?? ''}
+                      onChange={(e) =>
+                        setValues({
+                          ...values,
+                          description: { ...values.description, [lc]: e.target.value },
+                        })
+                      }
+                      aria-label={t('modeling.attributeGroups.fields.description_locale_aria', {
+                        defaultValue: 'Opis ({{locale}})',
+                        locale: lc.toUpperCase(),
+                      })}
+                      placeholder={t('modeling.attributeGroups.fields.description_locale', {
+                        defaultValue: '{{locale}} · krótki opis grupy',
+                        locale: lc.toUpperCase(),
+                      })}
+                    />
+                  ))}
                 </div>
               </div>
             </div>

--- a/apps/admin/src/features/catalog/attribute-groups/show.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/show.tsx
@@ -27,6 +27,7 @@ import { AuditLogIndicator } from '@/components/modeling/audit-log-indicator';
 import { BuiltInLockBadge } from '@/components/modeling/built-in-lock-badge';
 import { CreateAttributeInGroupDialog } from '@/components/modeling/create-attribute-in-group-dialog';
 import { DangerZoneCard } from '@/components/modeling/danger-zone-card';
+import { LocaleTabsField } from '@/components/modeling/locale-tabs-field';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -35,6 +36,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { resolveLabel } from '@/features/catalog/attributes/list';
 import { HttpError, jsonFetch } from '@/lib/http';
 import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
+import { useCurrentWorkspace, useInvalidateCurrentWorkspace } from '@/lib/use-current-workspace';
 import { cn } from '@/lib/utils';
 
 interface AttributeGroupDetail {
@@ -131,16 +133,18 @@ function Editor({
 }) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const workspace = useCurrentWorkspace();
+  const invalidateWorkspace = useInvalidateCurrentWorkspace();
+  const enabledLocales = workspace.data?.enabledLocales ?? ['pl', 'en'];
+  const primaryLocale = workspace.data?.primaryLocale ?? 'pl';
 
   const initialLabel = toLocaleMap(group.label);
   const initialDescription = toLocaleMap(group.description);
   const initialColor = group.color ?? '#71717a';
 
-  const [labelPl, setLabelPl] = useState(initialLabel.pl ?? '');
-  const [labelEn, setLabelEn] = useState(initialLabel.en ?? '');
-  const [descPl, setDescPl] = useState(initialDescription.pl ?? '');
+  const [label, setLabel] = useState<Record<string, string>>(initialLabel);
+  const [description, setDescription] = useState<Record<string, string>>(initialDescription);
   const [color, setColor] = useState(initialColor);
-  const [activeLocale, setActiveLocale] = useState<'pl' | 'en'>('pl');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -172,18 +176,14 @@ function Editor({
   const sortedMembers = [...members].sort((a, b) => a.position - b.position);
   const existingCodes = new Set(sortedMembers.map((m) => m.attribute.code));
 
-  const dirtyFields = [
-    labelPl !== (initialLabel.pl ?? ''),
-    labelEn !== (initialLabel.en ?? ''),
-    descPl !== (initialDescription.pl ?? ''),
-    color !== initialColor,
-  ].filter(Boolean).length;
+  const labelDirtyCount = countLocaleDiffs(label, initialLabel);
+  const descriptionDirtyCount = countLocaleDiffs(description, initialDescription);
+  const dirtyFields = labelDirtyCount + descriptionDirtyCount + (color !== initialColor ? 1 : 0);
   const dirty = dirtyFields > 0;
 
   const cancel = () => {
-    setLabelPl(initialLabel.pl ?? '');
-    setLabelEn(initialLabel.en ?? '');
-    setDescPl(initialDescription.pl ?? '');
+    setLabel(initialLabel);
+    setDescription(initialDescription);
     setColor(initialColor);
     setError(null);
   };
@@ -193,10 +193,11 @@ function Editor({
     setError(null);
     try {
       const body: Record<string, unknown> = {};
-      const nextLabel = stripEmpty({ pl: labelPl, en: labelEn });
-      if (JSON.stringify(nextLabel) !== JSON.stringify(initialLabel)) body.label = nextLabel;
-      const nextDescription = stripEmpty({ pl: descPl });
-      if (JSON.stringify(nextDescription) !== JSON.stringify(initialDescription))
+      const nextLabel = stripEmpty(label);
+      if (JSON.stringify(nextLabel) !== JSON.stringify(stripEmpty(initialLabel)))
+        body.label = nextLabel;
+      const nextDescription = stripEmpty(description);
+      if (JSON.stringify(nextDescription) !== JSON.stringify(stripEmpty(initialDescription)))
         body.description = nextDescription;
       if (!isLockedSystemGroup) {
         if (color !== initialColor) body.color = color;
@@ -224,14 +225,13 @@ function Editor({
     }
   }, [
     color,
-    descPl,
+    description,
     group.id,
     initialColor,
     initialDescription,
     initialLabel,
     isLockedSystemGroup,
-    labelEn,
-    labelPl,
+    label,
     onSaved,
     t,
   ]);
@@ -414,41 +414,19 @@ function Editor({
             <Label className="text-[11.5px] font-medium text-muted-foreground">
               {t('modeling.attributeGroups.fields.name', { defaultValue: 'Nazwa' })}
             </Label>
-            <div className="mt-1.5 flex items-center gap-1 border-b border-zinc-100">
-              {(['pl', 'en'] as const).map((lc) => {
-                const filled = (lc === 'pl' ? labelPl : labelEn).trim().length > 0;
-                return (
-                  <button
-                    key={lc}
-                    type="button"
-                    onClick={() => setActiveLocale(lc)}
-                    className={cn(
-                      '-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-[12.5px] font-medium uppercase tracking-wider transition',
-                      activeLocale === lc
-                        ? 'border-zinc-900 text-foreground'
-                        : 'border-transparent text-muted-foreground hover:text-foreground',
-                    )}
-                  >
-                    <span>{lc === 'pl' ? '🇵🇱' : '🇬🇧'}</span>
-                    <span>{lc}</span>
-                    {!filled ? (
-                      <span className="size-1.5 rounded-full bg-amber-400" aria-hidden />
-                    ) : null}
-                  </button>
-                );
-              })}
+            <div className="mt-1.5">
+              <LocaleTabsField
+                values={label}
+                enabledLocales={enabledLocales}
+                primaryLocale={primaryLocale}
+                onChange={setLabel}
+                onLocaleAdded={() => invalidateWorkspace()}
+                readOnly={isLockedSystemGroup}
+                placeholder={t('modeling.attributeGroups.fields.name_placeholder', {
+                  defaultValue: 'Nazwa grupy',
+                })}
+              />
             </div>
-            <Input
-              className="mt-2"
-              value={activeLocale === 'pl' ? labelPl : labelEn}
-              onChange={(e) =>
-                activeLocale === 'pl' ? setLabelPl(e.target.value) : setLabelEn(e.target.value)
-              }
-              disabled={isLockedSystemGroup}
-              placeholder={t('modeling.attributeGroups.fields.name_placeholder', {
-                defaultValue: 'Nazwa grupy',
-              })}
-            />
           </div>
 
           <div className="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2">
@@ -482,16 +460,25 @@ function Editor({
             <Label className="text-[11.5px] font-medium text-muted-foreground">
               {t('modeling.attributeGroups.fields.description', { defaultValue: 'Description' })}
             </Label>
-            <Textarea
-              rows={2}
-              value={descPl}
-              onChange={(e) => setDescPl(e.target.value)}
-              disabled={isLockedSystemGroup}
-              className="mt-1.5"
-              placeholder={t('modeling.attributeGroups.fields.description_placeholder', {
-                defaultValue: 'Krótki opis grupy — kiedy używać, jakie atrybuty zawiera.',
-              })}
-            />
+            <div className="mt-1.5 grid gap-2 sm:grid-cols-2">
+              {enabledLocales.map((lc) => (
+                <Textarea
+                  key={lc}
+                  rows={2}
+                  value={description[lc] ?? ''}
+                  onChange={(e) => setDescription({ ...description, [lc]: e.target.value })}
+                  disabled={isLockedSystemGroup}
+                  aria-label={t('modeling.attributeGroups.fields.description_locale_aria', {
+                    defaultValue: 'Opis ({{locale}})',
+                    locale: lc.toUpperCase(),
+                  })}
+                  placeholder={t('modeling.attributeGroups.fields.description_locale', {
+                    defaultValue: '{{locale}} · krótki opis grupy',
+                    locale: lc.toUpperCase(),
+                  })}
+                />
+              ))}
+            </div>
           </div>
         </Card>
 
@@ -884,18 +871,27 @@ function StatBox({ value, label }: { value: number | string; label: string }) {
   );
 }
 
-function toLocaleMap(value: Record<string, string> | string | null | undefined): {
-  pl?: string;
-  en?: string;
-} {
+function toLocaleMap(
+  value: Record<string, string> | string | null | undefined,
+): Record<string, string> {
   if (typeof value === 'string') return { pl: value };
   if (value && typeof value === 'object') {
-    const out: { pl?: string; en?: string } = {};
-    if (typeof value.pl === 'string') out.pl = value.pl;
-    if (typeof value.en === 'string') out.en = value.en;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (typeof v === 'string') out[k] = v;
+    }
     return out;
   }
   return {};
+}
+
+function countLocaleDiffs(next: Record<string, string>, initial: Record<string, string>): number {
+  const keys = new Set([...Object.keys(next), ...Object.keys(initial)]);
+  let count = 0;
+  for (const key of keys) {
+    if ((next[key] ?? '') !== (initial[key] ?? '')) count += 1;
+  }
+  return count;
 }
 
 function stripEmpty(record: Record<string, string>): Record<string, string> {


### PR DESCRIPTION
## Summary
Formularze tworzenia i edycji grup atrybutów renderują pola nazwy/opisu dla **wszystkich** języków skonfigurowanych w ustawieniach (workspace `enabledLocales`), zamiast hardkodowanych PL/EN. Domyka lukę z PR #1394, który naprawił tylko formularze atrybutów.

## Root cause
`attribute-groups/create.tsx` i `show.tsx` miały hardkod `['pl','en']` + state `labelPl/labelEn`; `toLocaleMap` gubił klucze spoza pl/en przy ładowaniu. Dodatkowo spec z #1394 używał `page.getByDisplayValue` — API testing-library, nieistniejące w Playwright — więc realnie nigdy nie przechodził.

## Backend changes
- Brak (JSONB label/description od zawsze przyjmuje dowolne locale).

## Frontend changes
- `attribute-groups/create.tsx` + `show.tsx`: `LocaleTabsField` + `useCurrentWorkspace()` (pattern z `attributes/new.tsx`), `label`/`description` jako pełne `Record<string,string>`, textarea opisu per skonfigurowany locale.
- `1352-...spec.ts`: nowy test dla grup + naprawa `getByDisplayValue` → `getByLabel(...).toHaveValue(...)`.

## Quality gates
- Biome strict: 0 błędów; tsc -b: clean.
- Playwright 1352: 3/3 zielone lokalnie (atrybuty edit, atrybuty create, grupy create+edit z DE).

## Smoke test plan
1. Ustawienia → Wersje językowe: włącz DE.
2. `/modeling/attribute-groups/new` → taby PL/EN/DE przy Nazwie, 3 textarea opisu.
3. `/modeling/attribute-groups/{id}` → edycja nazwy w DE → Zapisz zmiany → wartość round-tripuje.

## Świadome odejścia
- Przycisk „+ Dodaj język" w `LocaleTabsField` zostaje w tym PR — jego usunięcie to osobny ticket #1414 (PR 5 tego sprintu).

Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)