### PR TITLE
feat(catalog): egzekwowanie wymagalności atrybutów przy zapisie wpisu

### DIFF
--- a/apps/admin/e2e/1350-required-attribute-save-blocked.spec.ts
+++ b/apps/admin/e2e/1350-required-attribute-save-blocked.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin, uniqueSku } from './helpers/auth';
+
+/**
+ * #1350 (reopened) — an attribute flagged "Wymagany" in the attribute
+ * editor must actually be required on the entry card:
+ *   1. the row shows the red asterisk (is_required now serialized),
+ *   2. saving with the field empty is blocked client-side — both
+ *      "Zapisz zmiany" and "Zapisz i wróć do listy", no PATCH fires,
+ *      the row shows "Pole wymagane",
+ *   3. filling the field unblocks the save (PATCH 200),
+ *   4. the backend rejects an explicit emptying with 422 (defence in
+ *      depth — covered by RequiredAttributeValidationApiTest too).
+ *
+ * Runs on a CUSTOM ObjectType — proves the unified detail page (#1434)
+ * enforces the rule beyond /products.
+ *
+ * `fixme` in CI for the shared auth rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('required attribute blocks saving an empty value', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(150_000);
+
+  await loginAsAdmin(page);
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+  const json = { ...bearer, 'content-type': 'application/json' };
+  const ld = { ...bearer, 'content-type': 'application/ld+json' };
+
+  const ts = uniqueSku('REQ')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '_');
+  const slug = `req_${ts}`;
+
+  // Custom ObjectType + a REQUIRED text attribute.
+  const otResp = await page.request.post('/api/object_types', {
+    headers: json,
+    data: { code: slug, label: { pl: `Required ${ts}`, en: `Required ${ts}` } },
+  });
+  expect(otResp.status(), await otResp.text()).toBe(201);
+  const otId = ((await otResp.json()) as { id: string }).id;
+
+  const attrResp = await page.request.post('/api/attributes', {
+    headers: ld,
+    data: {
+      code: `req_note_${ts}`,
+      type: 'text',
+      label: { pl: 'Notatka obowiązkowa', en: 'Mandatory note' },
+      required: true,
+    },
+  });
+  expect(attrResp.status(), await attrResp.text()).toBe(201);
+  const attrId = ((await attrResp.json()) as { id: string }).id;
+  const attach = await page.request.post(`/api/object_types/${otId}/attributes/${attrId}`, {
+    headers: bearer,
+  });
+  expect([200, 201, 204]).toContain(attach.status());
+
+  // A dirty legacy object — created via API without the required value.
+  const objResp = await page.request.post('/api/objects', {
+    headers: ld,
+    data: { code: `REQ-${ts}`, objectTypeId: otId, attributes: { name: `Dirty ${ts}` } },
+  });
+  expect(objResp.status(), await objResp.text()).toBe(201);
+  const objId = ((await objResp.json()) as { id: string }).id;
+
+  await page.goto(`/objects/${slug}/${objId}`);
+  const saveButton = page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i });
+  await expect(saveButton).toBeVisible({ timeout: 20_000 });
+
+  // 1. The required row carries the asterisk.
+  const requiredLabel = page.getByText(/^(Notatka obowiązkowa|Mandatory note)$/).first();
+  await requiredLabel.scrollIntoViewIfNeeded();
+  const requiredRow = requiredLabel.locator(
+    'xpath=ancestor::div[contains(@class, "grid-cols")][1]',
+  );
+  await expect(requiredRow.getByText('*')).toBeVisible();
+
+  // 2. Save with the field empty → blocked, no PATCH, inline error.
+  let patched = false;
+  page.on('request', (r) => {
+    if (r.url().includes(`/api/objects/${objId}`) && r.method() === 'PATCH') patched = true;
+  });
+  await saveButton.click();
+  await expect(page.getByText(/pole wymagane/i).first()).toBeVisible({ timeout: 10_000 });
+  expect(patched).toBe(false);
+
+  // "Zapisz i wróć do listy" is blocked the same way (stays on the page).
+  await page.getByRole('button', { name: /zapisz i wróć do listy|save and return/i }).click();
+  expect(patched).toBe(false);
+  await expect(page).toHaveURL(new RegExp(`/objects/${slug}/${objId}`));
+
+  // 3. Filling the field unblocks the save.
+  await requiredRow.locator('input[type="text"], textarea').first().fill('uzupełnione');
+  const patchResponse = page.waitForResponse(
+    (r) => r.url().includes(`/api/objects/${objId}`) && r.request().method() === 'PATCH',
+  );
+  await saveButton.click();
+  expect((await patchResponse).status()).toBe(200);
+
+  // 4. Defence in depth: explicit emptying via API → 422.
+  const emptied = await page.request.patch(`/api/objects/${objId}`, {
+    headers: { ...bearer, 'content-type': 'application/merge-patch+json' },
+    data: { attributes: { [`req_note_${ts}`]: '' } },
+  });
+  expect(emptied.status()).toBe(422);
+
+  await page.request.delete(`/api/object_types/${otId}`, { headers: bearer });
+});

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -63,6 +63,11 @@ export interface AttrRowProps {
    * (e.g. "en" when requested "de" fell back to "en").
    */
   inheritedFrom?: string | null;
+  /**
+   * #1350 — set by the detail page when a save was blocked because this
+   * required attribute is empty: red highlight + "Pole wymagane" note.
+   */
+  requiredError?: boolean;
 }
 
 /**
@@ -86,6 +91,7 @@ export function AttrRow({
   channel = null,
   isInherited = false,
   inheritedFrom = null,
+  requiredError = false,
 }: AttrRowProps) {
   const { t, i18n } = useTranslation();
   const lang = i18n.language === 'pl' ? 'pl' : 'en';
@@ -119,6 +125,7 @@ export function AttrRow({
       className={cn(
         'grid grid-cols-[180px_minmax(0,1fr)_auto] items-start gap-3 rounded-xl px-3 py-2.5',
         'group transition-colors hover:bg-white/60',
+        requiredError && 'bg-rose-50/60 ring-1 ring-rose-300',
       )}
     >
       <div className="flex items-center gap-1.5 pt-1.5 text-[13px] font-medium text-zinc-600">
@@ -178,13 +185,18 @@ export function AttrRow({
         {isLocked && !attribute.is_system ? (
           <Lock className="size-3 text-zinc-300" aria-hidden />
         ) : null}
-        {attribute.is_required_in_group ? (
+        {attribute.is_required === true || attribute.is_required_in_group ? (
           <span
             className="text-rose-500"
             title={t('app.required', { defaultValue: 'wymagane' })}
             aria-hidden
           >
             *
+          </span>
+        ) : null}
+        {requiredError ? (
+          <span className="text-[11px] font-medium text-rose-600" role="alert">
+            {t('products.detail.validation.field_required', { defaultValue: 'Pole wymagane' })}
           </span>
         ) : null}
       </div>

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -192,6 +192,8 @@ export function ProductDetailPage({
   // "Zapisz i wróć do listy" action saves + returns to the list.
   const isEditing = true;
   const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
+  // #1350 — codes of required attributes that blocked the last save.
+  const [requiredErrors, setRequiredErrors] = useState<Set<string>>(new Set());
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
@@ -457,6 +459,12 @@ export function ProductDetailPage({
 
   const setFieldValue = (code: string, value: unknown): void => {
     setDirtyFields((prev) => ({ ...prev, [code]: value }));
+    setRequiredErrors((prev) => {
+      if (!prev.has(code)) return prev;
+      const next = new Set(prev);
+      next.delete(code);
+      return next;
+    });
   };
 
   const fieldValue = (code: string): unknown => {
@@ -466,8 +474,36 @@ export function ProductDetailPage({
     return attrs[code];
   };
 
+  // #1350 — full-state required check at save time: every `is_required`
+  // attribute across the effective groups must carry a non-empty CURRENT
+  // value (dirty edits included). Legacy dirty records are therefore
+  // enforced on their next save, exactly as the ticket specifies.
+  const collectRequiredViolations = (): string[] => {
+    const violations: string[] = [];
+    for (const group of groups) {
+      for (const attr of group.attributes) {
+        if (attr.is_required !== true) continue;
+        const current = fieldValue(attr.code);
+        if (isEmptyAttributeValue(current)) violations.push(attr.code);
+      }
+    }
+    return violations;
+  };
+
   const handleSave = async (returnToList = false): Promise<void> => {
     if (isSaving) return;
+    const violations = collectRequiredViolations();
+    if (violations.length > 0) {
+      setRequiredErrors(new Set(violations));
+      toast.error(
+        t('products.detail.validation.required_fields', {
+          defaultValue: 'Uzupełnij wymagane pola: {{fields}}',
+          fields: violations.join(', '),
+        }),
+      );
+      return;
+    }
+    setRequiredErrors(new Set());
     setIsSaving(true);
     try {
       if (mode === 'create') {
@@ -966,6 +1002,7 @@ export function ProductDetailPage({
                       scopeStatus[attr.code]?.inherited_from != null
                     }
                     inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
+                    requiredError={requiredErrors.has(attr.code)}
                   />
                 ))}
               </AttrGroupCard>
@@ -1157,6 +1194,21 @@ function tabBadge(
   const group = groups.find((g) => g.code === tab);
   if (!group) return null;
   return group.attributes.length === 0 ? null : group.attributes.length;
+}
+
+/**
+ * #1350 — mirrors the upserter's isEmptyEnvelope: null / '' (after trim) /
+ * empty arrays-objects count as empty; booleans and zeros are values.
+ */
+function isEmptyAttributeValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string') return value.trim() === '';
+  if (Array.isArray(value)) return value.every(isEmptyAttributeValue);
+  if (typeof value === 'object') {
+    const leaves = Object.values(value as Record<string, unknown>);
+    return leaves.length === 0 || leaves.every(isEmptyAttributeValue);
+  }
+  return false;
 }
 
 function stripAttributes(dirty: Record<string, unknown>): Record<string, unknown> {

--- a/apps/admin/src/features/catalog/products/components/types.ts
+++ b/apps/admin/src/features/catalog/products/components/types.ts
@@ -98,6 +98,13 @@ export interface AttributeMeta {
   is_scopable?: boolean;
   position: number;
   is_required_in_group: boolean;
+  /**
+   * #1350 — the global "Wymagany" flag from the attribute editor.
+   * Distinct from `is_required_in_group` (group-local/completeness):
+   * saving an empty value for an `is_required` attribute is blocked
+   * client-side and rejected 422 by the upserter.
+   */
+  is_required?: boolean;
   visible_when?: unknown;
   /**
    * Populated by the backend only for `select` / `multiselect` types

--- a/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
+++ b/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
@@ -117,6 +117,17 @@ final readonly class ObjectAttributesUpserter
 
             $jsonbValue = $this->wrapValue($rawValue);
 
+            // #1350 — a required attribute can never be explicitly emptied.
+            // Only codes present in the payload are checked: partial PATCHes
+            // and imports of legacy dirty records stay writable, while the
+            // admin form enforces the full-state rule client-side.
+            if ($attribute->isRequired() && self::isEmptyEnvelope($jsonbValue)) {
+                throw new UnprocessableEntityHttpException(\sprintf(
+                    'Attribute "%s" is required and cannot be empty.',
+                    $code,
+                ));
+            }
+
             // #1216 / #1261 — enforce per-type value validation (email format,
             // color hex/rgb, identifier shape, select/multiselect option
             // membership) on every write path. Empty values are skipped —
@@ -195,6 +206,30 @@ final readonly class ObjectAttributesUpserter
         $scalar = $jsonbValue['value'] ?? null;
 
         return null !== $scalar && '' !== $scalar;
+    }
+
+    /**
+     * #1350 — true when every leaf of the wrapped JSONB envelope is
+     * null / '' / [] (covers scalar `{value}`, select `{option_code}`,
+     * localized maps and structural shapes alike). Booleans and zeros
+     * are values — a required checkbox set to `false` passes.
+     */
+    private static function isEmptyEnvelope(mixed $value): bool
+    {
+        if (null === $value || '' === $value || [] === $value) {
+            return true;
+        }
+        if (\is_array($value)) {
+            foreach ($value as $leaf) {
+                if (!self::isEmptyEnvelope($leaf)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -524,6 +524,10 @@ final class ProductReadEndpointsController
             'is_scopable' => $attribute->isScopable(),
             'position' => $position,
             'is_required_in_group' => $isRequiredInGroup,
+            // #1350 — the global "Wymagany" flag from the attribute editor.
+            // Distinct from is_required_in_group (group-local/completeness):
+            // this one hard-blocks saving an empty value (FE + upserter).
+            'is_required' => $attribute->isRequired(),
             'visible_when' => $visibleWhen,
         ];
 

--- a/apps/api/tests/Api/Catalog/RequiredAttributeValidationApiTest.php
+++ b/apps/api/tests/Api/Catalog/RequiredAttributeValidationApiTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\ObjectKind;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * #1350 — the global Attribute.isRequired flag is enforced on the object
+ * write path: explicitly emptying a required attribute is rejected 422.
+ * Codes absent from the payload are untouched (partial PATCH / imports of
+ * legacy dirty records stay writable); the admin form enforces the
+ * full-state rule client-side.
+ */
+final class RequiredAttributeValidationApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function emptyingARequiredAttributeIsRejected(): void
+    {
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+
+        // Required text attribute attached to the Product ObjectType.
+        $attrResponse = $client->request('POST', '/api/attributes', [
+            'headers' => ['content-type' => 'application/ld+json', 'accept' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'req_val_test',
+                'type' => 'text',
+                'label' => ['pl' => 'Wymagany', 'en' => 'Required'],
+                'required' => true,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $attrId = $attrResponse->toArray()['id'];
+        \assert(\is_string($attrId));
+
+        $client->request('POST', '/api/object_types/'.$productOt.'/attributes/'.$attrId);
+        self::assertResponseStatusCodeSame(204);
+
+        // Creating WITH a value → 201.
+        $createResponse = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'REQ-OK',
+                'objectTypeId' => $productOt,
+                'attributes' => ['name' => 'Req ok', 'req_val_test' => 'filled'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $productId = $createResponse->toArray()['id'];
+        \assert(\is_string($productId));
+
+        // Explicitly emptying the required attribute → 422 with the code
+        // in the Problem Details `detail`.
+        $client->request('PATCH', '/api/products/'.$productId, [
+            'headers' => [
+                'content-type' => 'application/merge-patch+json',
+                'accept' => 'application/json',
+            ],
+            'body' => json_encode([
+                'attributes' => ['req_val_test' => ''],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+
+        // Null is just as empty.
+        $client->request('PATCH', '/api/products/'.$productId, [
+            'headers' => [
+                'content-type' => 'application/merge-patch+json',
+                'accept' => 'application/json',
+            ],
+            'body' => json_encode([
+                'attributes' => ['req_val_test' => null],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+
+        // A partial PATCH that does NOT touch the required code stays valid
+        // (legacy dirty records are enforced on their next full-form save,
+        // not on unrelated writes).
+        $client->request('PATCH', '/api/products/'.$productId, [
+            'headers' => [
+                'content-type' => 'application/merge-patch+json',
+                'accept' => 'application/json',
+            ],
+            'body' => json_encode([
+                'attributes' => ['name' => 'Renamed'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        // Overwriting with a fresh value works.
+        $client->request('PATCH', '/api/products/'.$productId, [
+            'headers' => [
+                'content-type' => 'application/merge-patch+json',
+                'accept' => 'application/json',
+            ],
+            'body' => json_encode([
+                'attributes' => ['req_val_test' => 'refilled'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    #[Test]
+    public function effectiveGroupsShipTheRequiredFlag(): void
+    {
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $attrResponse = $client->request('POST', '/api/attributes', [
+            'headers' => ['content-type' => 'application/ld+json', 'accept' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'req_flag_test',
+                'type' => 'text',
+                'label' => ['pl' => 'Flaga', 'en' => 'Flag'],
+                'required' => true,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $attrId = $attrResponse->toArray()['id'];
+        \assert(\is_string($attrId));
+
+        $client->request('POST', '/api/object_types/'.$productOt.'/attributes/'.$attrId);
+        self::assertResponseStatusCodeSame(204);
+
+        $createResponse = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'REQ-FLAG',
+                'objectTypeId' => $productOt,
+                'attributes' => ['name' => 'Flag carrier', 'req_flag_test' => 'x'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $productId = $createResponse->toArray()['id'];
+        \assert(\is_string($productId));
+
+        $groupsResponse = $client->request(
+            'GET',
+            '/api/objects/'.$productId.'/effective-attribute-groups',
+            ['headers' => ['accept' => 'application/json']],
+        );
+        self::assertResponseStatusCodeSame(200);
+        $groups = $groupsResponse->toArray()['groups'];
+        \assert(\is_array($groups));
+
+        $flag = null;
+        foreach ($groups as $group) {
+            \assert(\is_array($group) && \is_array($group['attributes']));
+            foreach ($group['attributes'] as $attribute) {
+                \assert(\is_array($attribute));
+                if ('req_flag_test' === $attribute['code']) {
+                    $flag = $attribute['is_required'];
+                }
+            }
+        }
+        self::assertTrue($flag, 'effective-attribute-groups must serialize is_required=true');
+    }
+}


### PR DESCRIPTION
## Summary
Atrybut z togglem „Wymagany" jest teraz realnie wymagany na karcie wpisu: gwiazdka przy polu, blokada zapisu z pustą wartością (oba przyciski, highlight + „Pole wymagane"), 422 z backendu przy explicit wyczyszczeniu. Dzięki unifikacji (#1434) działa dla products **i** custom ObjectTypes.

## Root cause (reopened #1350)
Toggle z #1368 zapisywał `Attribute.isRequired`, ale `effective-attribute-groups` nie serializował tej flagi (formularz czytał tylko `is_required_in_group` z junction grup), a wymagalności nie walidował nikt — ani frontend, ani `ObjectAttributesUpserter`.

## Backend changes
- `ProductReadEndpointsController::serializeAttribute` — dodane `is_required`.
- `ObjectAttributesUpserter` — 422 przy explicit pustej wartości required (rekurencyjny `isEmptyEnvelope`; bool/0 to wartości). Kody nieobecne w payloadzie nie są ruszane — importy/bulk/partial PATCH bez regresji (świadoma decyzja, egzekwowanie pełnego stanu robi formularz).
- Nowy `RequiredAttributeValidationApiTest` (422 na ''/null, partial PATCH OK, nadpisanie OK, flaga w effective-groups).

## Frontend changes
- `types.ts` + `attr-row.tsx` — `is_required`, gwiazdka (którakolwiek flaga), stan błędu wiersza.
- `product-detail-page.tsx` — walidacja **pełnego aktualnego stanu** pól `is_required` przed PATCH/POST (brudne rekordy egzekwowane przy następnym zapisie, per ticket); błąd czyszczony przy edycji pola.

## Quality gates
- PHPStan max 0 · celowane suity Api/Catalog 17/17 (pełen lokalny run katalogu ubija pre-existing 120s max_execution_time) · tsc/Biome clean · composer/pnpm audit 0 high/critical.
- Playwright `1350-required-attribute-save-blocked.spec.ts` zielony end-to-end na custom OT.
- OpenAPI: endpoint `effective-attribute-groups` to custom route poza snapshotem — brak regen.

## Smoke test plan
1. `/modeling/attributes/{id}` → toggle „Wymagany".
2. Karta wpisu: gwiazdka przy polu; zapis z pustym polem → blokada + „Pole wymagane" (oba przyciski).
3. Wypełnij → zapis 200. curl PATCH z `""` → 422.

Wymaga manualnego smoke przed zamknięciem #1350 (CLOSED MEANS CLOSED).

## Świadome odejścia
- BE waliduje tylko explicit emptying (nie pełny stan na każdy PATCH) — pełna walidacja łamałaby importy brudnych rekordów; backfill = #1416 (PR 7).
- `is_required_in_group`/`requiredForCompleteness` zostaje sygnałem completeness (jak dotąd).

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)