### PR TITLE
fix(channel): pasek języków z aktywnych tenant_locales — koniec widmowych locale

### DIFF
--- a/apps/admin/e2e/1352-deactivated-locale-disappears.spec.ts
+++ b/apps/admin/e2e/1352-deactivated-locale-disappears.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1352 (reopen #2) — a locale deactivated in Settings → Languages must
+ * disappear from every i18n form immediately. The strip used to read the
+ * legacy `Tenant.enabledLocales` JSONB, which the LOC-07 lifecycle never
+ * cleaned — a locale added once and later removed haunted the forms as a
+ * ghost tab (operator's "IT").
+ *
+ * Flow: activate it_IT via /api/tenant-locales → the IT tab appears on
+ * the attribute create form → deactivate it_IT → the tab is gone.
+ * Self-cleaning: the locale is purged at the end (no values were written).
+ *
+ * `fixme` in CI for the shared auth rate-limiter reason.
+ */
+const CI_BLOCKED = 'Pending storageState rollout: spec exhausts 5/15min auth rate limiter';
+
+test('deactivating a tenant locale removes its tab from i18n forms', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+  const json = { ...bearer, 'content-type': 'application/json' };
+
+  await apiLogin(page);
+
+  // Baseline: it must not be active (purge a leftover from failed runs).
+  const before = await page.request.get('/api/workspaces/current', {
+    headers: { ...bearer, accept: 'application/json' },
+  });
+  const baseline = ((await before.json()) as { enabledLocales?: string[] }).enabledLocales ?? [];
+  if (baseline.includes('it')) {
+    await page.request.delete('/api/tenant-locales/it_IT', { headers: bearer });
+  }
+
+  // 1. Activate it_IT through the LOC-07 lifecycle (Settings backend).
+  const createResp = await page.request.post('/api/tenant-locales', {
+    headers: json,
+    data: { code: 'it_IT' },
+  });
+  expect([201, 409]).toContain(createResp.status());
+  if (createResp.status() === 409) {
+    const reactivate = await page.request.post('/api/tenant-locales/it_IT/reactivate', {
+      headers: bearer,
+    });
+    expect(reactivate.status()).toBe(200);
+  }
+
+  try {
+    // The workspace strip now carries `it`.
+    const withIt = await page.request.get('/api/workspaces/current', {
+      headers: { ...bearer, accept: 'application/json' },
+    });
+    expect(((await withIt.json()) as { enabledLocales: string[] }).enabledLocales).toContain('it');
+
+    // …and the attribute create form renders an IT tab.
+    await page.goto('/modeling/attributes/new');
+    const tabs = page.getByRole('tablist', { name: /wybór języka|language/i }).first();
+    await expect(tabs).toBeVisible({ timeout: 15_000 });
+    await expect(tabs.getByRole('tab', { name: /\bit\b/i })).toBeVisible();
+
+    // 2. Deactivate in Settings → the tab disappears from the form.
+    const deleteResp = await page.request.delete('/api/tenant-locales/it_IT', {
+      headers: bearer,
+    });
+    expect(deleteResp.status()).toBe(204);
+
+    const without = await page.request.get('/api/workspaces/current', {
+      headers: { ...bearer, accept: 'application/json' },
+    });
+    const strip = ((await without.json()) as { enabledLocales: string[] }).enabledLocales;
+    expect(strip).not.toContain('it');
+
+    await page.reload();
+    const tabsAfter = page.getByRole('tablist', { name: /wybór języka|language/i }).first();
+    await expect(tabsAfter).toBeVisible({ timeout: 15_000 });
+    await expect(tabsAfter.getByRole('tab', { name: /\bit\b/i })).toHaveCount(0);
+  } finally {
+    // Self-clean: hard-remove the row so reruns start fresh (no values
+    // were written under `it`, the purge is safe).
+    await page.request.delete('/api/tenant-locales/it_IT/purge', {
+      headers: { ...bearer, 'X-Confirm-Purge': 'it_IT' },
+    });
+  }
+});

--- a/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/ProductReadEndpointsController.php
@@ -17,6 +17,7 @@ use App\Catalog\Domain\Service\EffectiveAttributeGroupResolver;
 use App\Channel\Contracts\ChannelResolverInterface;
 use App\Channel\Contracts\LocaleFallbackResolverInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\ActiveLocaleResolverInterface;
 use App\Shared\Domain\Tenant;
 use App\Shared\Infrastructure\Audit\CursorCodec;
 use Doctrine\DBAL\Connection;
@@ -76,6 +77,7 @@ final class ProductReadEndpointsController
         private readonly ObjectValueRepositoryInterface $objectValues,
         private readonly LocaleFallbackResolverInterface $localeFallback,
         private readonly ChannelResolverInterface $channels,
+        private readonly ActiveLocaleResolverInterface $activeLocales,
     ) {
     }
 
@@ -326,10 +328,18 @@ final class ProductReadEndpointsController
         if (!$tenant instanceof Tenant) {
             return [];
         }
-        $primary = $tenant->getPrimaryLocale();
+
+        // #1352 (reopen #2) — ACTIVE tenant_locales are the single source
+        // of truth; the legacy JSONB list is only a fallback for tenants
+        // without LOC-07 rows (it kept ghost locales after deactivation).
+        $languages = $this->activeLocales->languages($tenant);
+        $primary = $this->activeLocales->primaryLanguage($tenant) ?? $tenant->getPrimaryLocale();
+        if ([] === $languages) {
+            $languages = $tenant->getEnabledLocales();
+        }
 
         $locales = [];
-        foreach ($tenant->getEnabledLocales() as $code) {
+        foreach ($languages as $code) {
             $locales[] = ['code' => $code, 'is_default' => $code === $primary];
         }
         // Primary first so the picker defaults to it deterministically.

--- a/apps/api/src/Channel/Application/Service/ActiveLocaleResolver.php
+++ b/apps/api/src/Channel/Application/Service/ActiveLocaleResolver.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Channel\Application\Service;
+
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Channel\Domain\LocaleCode;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Shared\Application\ActiveLocaleResolverInterface;
+use App\Shared\Domain\Tenant;
+
+/**
+ * #1352 (reopen #2) — single source of truth for the tenant's UI locale
+ * strip. Two locale stores used to drift apart: the LOC-07
+ * `tenant_locales` lifecycle (Settings → Languages, soft-deactivate /
+ * reactivate / purge) and the legacy `Tenant.enabledLocales` JSONB
+ * (written by the retired "+ Dodaj język" dialog, never cleaned on
+ * deactivation). A locale added through the old dialog and then removed
+ * in Settings haunted every i18n form as a ghost tab (operator's "IT").
+ *
+ * Every read surface (workspace strip, detail-page locale picker) now
+ * derives short language codes from ACTIVE `tenant_locales` rows.
+ * Tenants with no rows at all (legacy/dev fixtures) fall back to the
+ * JSONB list so nothing regresses before LOC-07 seeding.
+ */
+final readonly class ActiveLocaleResolver implements ActiveLocaleResolverInterface
+{
+    public function __construct(
+        private TenantLocaleRepositoryInterface $tenantLocales,
+    ) {
+    }
+
+    /**
+     * Unique short language codes of the tenant's ACTIVE locales, default
+     * first then by sortOrder (e.g. `['pl', 'en', 'de']`). Empty when the
+     * tenant has no tenant_locales rows — caller applies its legacy
+     * fallback.
+     *
+     * @return list<string>
+     */
+    public function languages(Tenant $tenant): array
+    {
+        $rows = $this->tenantLocales->findActiveForTenant($tenant);
+        usort($rows, static function ($a, $b): int {
+            $byDefault = ($b->isDefault() ? 1 : 0) <=> ($a->isDefault() ? 1 : 0);
+
+            return 0 !== $byDefault ? $byDefault : $a->getSortOrder() <=> $b->getSortOrder();
+        });
+
+        $languages = [];
+        foreach ($rows as $row) {
+            $language = self::shortLanguage($row);
+            if ('' !== $language && !\in_array($language, $languages, true)) {
+                $languages[] = $language;
+            }
+        }
+
+        return $languages;
+    }
+
+    /**
+     * Short language code of the tenant's default locale, or null when no
+     * tenant_locales rows exist (caller falls back to
+     * `Tenant::getPrimaryLocale()`).
+     */
+    public function primaryLanguage(Tenant $tenant): ?string
+    {
+        $default = $this->tenantLocales->findDefaultForTenant($tenant);
+        if (null === $default) {
+            return null;
+        }
+        $language = self::shortLanguage($default);
+
+        return '' !== $language ? $language : null;
+    }
+
+    /**
+     * Legacy catalog rows may carry an empty `language` column — fall
+     * back to the BCP-47 code's language part (`pl_PL` -> `pl`).
+     */
+    private static function shortLanguage(TenantLocale $row): string
+    {
+        $language = $row->getLocale()->getLanguage();
+
+        return '' !== $language ? $language : LocaleCode::toShort($row->getLocale()->getCode());
+    }
+}

--- a/apps/api/src/Identity/Presentation/Controller/WorkspaceController.php
+++ b/apps/api/src/Identity/Presentation/Controller/WorkspaceController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Identity\Presentation\Controller;
 
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Shared\Application\ActiveLocaleResolverInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Exception\CannotDisablePrimaryLocaleException;
 use App\Shared\Domain\Exception\InvalidLocaleException;
@@ -48,6 +49,7 @@ final class WorkspaceController
         private readonly TenantContext $tenantContext,
         private readonly TenantRepositoryInterface $tenants,
         private readonly Connection $connection,
+        private readonly ActiveLocaleResolverInterface $activeLocales,
     ) {
     }
 
@@ -65,13 +67,19 @@ final class WorkspaceController
             throw new BadRequestHttpException('No tenant context.');
         }
 
+        // #1352 (reopen #2) — the locale strip derives from ACTIVE
+        // tenant_locales (LOC-07 lifecycle); the legacy JSONB list is only
+        // a fallback for tenants without rows. A locale deactivated in
+        // Settings disappears from every i18n form immediately.
+        $languages = $this->activeLocales->languages($tenant);
+
         return new JsonResponse([
             'id' => $tenant->getId()->toRfc4122(),
             'code' => $tenant->getCode(),
             'name' => $tenant->getName(),
             'plan' => $tenant->getPlan(),
-            'enabledLocales' => $tenant->getEnabledLocales(),
-            'primaryLocale' => $tenant->getPrimaryLocale(),
+            'enabledLocales' => [] !== $languages ? $languages : $tenant->getEnabledLocales(),
+            'primaryLocale' => $this->activeLocales->primaryLanguage($tenant) ?? $tenant->getPrimaryLocale(),
         ]);
     }
 
@@ -182,13 +190,19 @@ final class WorkspaceController
 
         $this->tenants->save($tenant);
 
+        // #1352 (reopen #2) — the locale strip derives from ACTIVE
+        // tenant_locales (LOC-07 lifecycle); the legacy JSONB list is only
+        // a fallback for tenants without rows. A locale deactivated in
+        // Settings disappears from every i18n form immediately.
+        $languages = $this->activeLocales->languages($tenant);
+
         return new JsonResponse([
             'id' => $tenant->getId()->toRfc4122(),
             'code' => $tenant->getCode(),
             'name' => $tenant->getName(),
             'plan' => $tenant->getPlan(),
-            'enabledLocales' => $tenant->getEnabledLocales(),
-            'primaryLocale' => $tenant->getPrimaryLocale(),
+            'enabledLocales' => [] !== $languages ? $languages : $tenant->getEnabledLocales(),
+            'primaryLocale' => $this->activeLocales->primaryLanguage($tenant) ?? $tenant->getPrimaryLocale(),
         ]);
     }
 }

--- a/apps/api/src/Shared/Application/ActiveLocaleResolverInterface.php
+++ b/apps/api/src/Shared/Application/ActiveLocaleResolverInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Application;
+
+use App\Shared\Domain\Tenant;
+
+/**
+ * Cross-BC contract for the tenant's ACTIVE UI locale strip (#1352).
+ *
+ * The LOC-07 `tenant_locales` lifecycle (Settings → Languages:
+ * soft-deactivate / reactivate / purge, owned by the Channel BC) is the
+ * single source of truth for which locales i18n forms and locale pickers
+ * may show. The contract lives in Shared — next to `Tenant` itself — so
+ * Identity (workspace strip) and Catalog (detail picker) can consume it
+ * without depending on Channel internals; Channel provides the
+ * implementation.
+ */
+interface ActiveLocaleResolverInterface
+{
+    /**
+     * Unique short language codes of the tenant's ACTIVE locales, default
+     * first then by sortOrder (e.g. `['pl', 'en', 'de']`). Empty when the
+     * tenant has no tenant_locales rows — caller applies its legacy
+     * fallback.
+     *
+     * @return list<string>
+     */
+    public function languages(Tenant $tenant): array;
+
+    /**
+     * Short language code of the tenant's default locale, or null when no
+     * tenant_locales rows exist (caller falls back to
+     * `Tenant::getPrimaryLocale()`).
+     */
+    public function primaryLanguage(Tenant $tenant): ?string;
+}

--- a/apps/api/tests/Api/Channel/GhostLocaleResolutionApiTest.php
+++ b/apps/api/tests/Api/Channel/GhostLocaleResolutionApiTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Channel;
+
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * #1352 (reopen #2) — the workspace locale strip derives from ACTIVE
+ * `tenant_locales`, not the legacy `Tenant.enabledLocales` JSONB. A
+ * locale enabled through the retired "+ Dodaj język" dialog and then
+ * deactivated (or never mirrored) in Settings must NOT haunt the i18n
+ * forms as a ghost tab.
+ */
+final class GhostLocaleResolutionApiTest extends ChannelApiTestCase
+{
+    #[Test]
+    public function workspaceStripIgnoresGhostAndDeactivatedLocales(): void
+    {
+        $em = $this->em();
+        $pl = $em->getRepository(Locale::class)->findOneBy(['code' => 'pl_PL']);
+        $en = $em->getRepository(Locale::class)->findOneBy(['code' => 'en_US']);
+        \assert($pl instanceof Locale && $en instanceof Locale);
+        $de = new Locale('de_DE', 'Niemiecki (Niemcy)', null, 'de', 'DE', ['pl' => 'Niemiecki (Niemcy)', 'en' => 'German (Germany)'], true);
+        $em->persist($de);
+
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        // Active rows: pl (default) + en. de is DEACTIVATED (soft delete).
+        $em->persist(new TenantLocale($pl, true, true, null, 0, $tenant));
+        $em->persist(new TenantLocale($en, false, false, $pl, 1, $tenant));
+        $deRow = new TenantLocale($de, false, false, $pl, 2, $tenant);
+        $deRow->deactivate();
+        $em->persist($deRow);
+
+        // Legacy JSONB carries a ghost "it" (added via the old dialog,
+        // never present in tenant_locales) plus the stale "de".
+        $tenant->enableLocale('pl');
+        $tenant->enableLocale('en');
+        $tenant->enableLocale('de');
+        $tenant->enableLocale('it');
+        $em->flush();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/workspaces/current', [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+
+        self::assertSame(['pl', 'en'], $payload['enabledLocales'], 'Ghost "it" and deactivated "de" must not surface.');
+        self::assertSame('pl', $payload['primaryLocale']);
+    }
+
+    #[Test]
+    public function workspaceStripFallsBackToLegacyListWithoutTenantLocaleRows(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        $tenant->enableLocale('pl');
+        $tenant->enableLocale('en');
+        $em->flush();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/workspaces/current', [
+            'headers' => ['accept' => 'application/json'],
+        ]);
+        self::assertSame(200, $response->getStatusCode());
+        $payload = $response->toArray();
+
+        // No tenant_locales rows at all (legacy/dev tenant) → the JSONB
+        // list keeps working so nothing regresses before LOC-07 seeding.
+        self::assertSame(['pl', 'en'], $payload['enabledLocales']);
+    }
+}


### PR DESCRIPTION
## Summary
Drugi reopen #1352: w ustawieniach PL/EN/DE, a w formularzach i pickerach straszyło widmowe **IT**. Root cause: dwa magazyny locale bez synchronizacji — lifecycle `tenant_locales` (Ustawienia → Wersje językowe) i legacy JSONB `Tenant.enabledLocales` (pisany przez wycofany dialog „+ Dodaj język", nigdy nie czyszczony). IT żyło tylko w JSONB, więc nie dało się go nawet usunąć z UI.

## Fix — jedno źródło prawdy
- Nowy kontrakt `Shared\Application\ActiveLocaleResolverInterface` (w Shared obok `Tenant`, bo Deptrac zabrania Identity→Channel_Contracts), implementacja w Channel na `TenantLocaleRepository`.
- `GET /api/workspaces/current` (zasila WSZYSTKIE formularze i18n) i lista locale detalu (`effective-attribute-groups.locales`) czytają **aktywne** wiersze `tenant_locales`: default pierwszy, unikalne krótkie kody, fallback z kodu BCP-47 dla wierszy z pustą kolumną language.
- Tenant bez wierszy `tenant_locales` (legacy/dev fixtures) → fallback do JSONB, zero regresji.
- Widmowe IT na żywym stacku znika automatycznie (derivacja) — bez migracji danych.

## Semantyka usuwania wersji językowej (pytanie operatora — model jak w Akeneo)
- **Deaktywacja** (Ustawienia → usuń): locale znika natychmiast ze wszystkich formularzy/pickerów; wartości w `object_values` ZOSTAJĄ niewidoczne.
- **Reaktywacja**: locale i jego dane wracają bez strat.
- **Purge** (hard delete z confirm-headerem): kasuje też wartości.
To dokładnie lifecycle LOC-07, który już istniał — bug polegał tylko na tym, że formularze czytały z innego magazynu.

## Quality gates
- PHPStan max 0 · **Deptrac 0 violations** · cs-fixer clean.
- `GhostLocaleResolutionApiTest` (ghost+deactivated wykluczone; legacy fallback) + `TenantLocalesApiTest` 18/18.
- Playwright `1352-deactivated-locale-disappears`: aktywacja it_IT → tab IT w formularzu → deaktywacja → tab znika (self-cleaning purge na końcu) + cała suita 1352 ✓.

## Smoke test plan
1. `/modeling/attributes/{id}` i `/values`, `/objects/uslugi/{id}` — tylko PL/EN/DE, **bez IT**.
2. Ustawienia → dodaj język → tab pojawia się; usuń → znika natychmiast.

## Świadome odejścia
- Legacy endpointy `POST/DELETE /api/workspaces/current/locales` zostają (RBAC-owane, nieużywane przez FE po #1435) — piszą tylko do JSONB; wpis w lessons, kandydat do wycięcia przy sprzątaniu Identity.

Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)