### PR TITLE
fix(catalog): SKU nie znika po zapisie + wymagalność pomija booleany

### DIFF
--- a/apps/admin/e2e/1350-required-attribute-save-blocked.spec.ts
+++ b/apps/admin/e2e/1350-required-attribute-save-blocked.spec.ts
@@ -112,3 +112,101 @@ test('required attribute blocks saving an empty value', async ({ page }) => {
 
   await page.request.delete(`/api/object_types/${otId}`, { headers: bearer });
 });
+
+test('editing the sku attribute persists (no header-strip collision)', async ({ page }) => {
+  test.fixme(!!process.env.CI, CI_BLOCKED);
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+  const refreshResponse = await page.request.post('/api/auth/refresh');
+  expect(refreshResponse.status()).toBe(200);
+  const accessToken = ((await refreshResponse.json()) as { token: string }).token;
+  const bearer = { Authorization: `Bearer ${accessToken}` };
+  const ld = { ...bearer, 'content-type': 'application/ld+json' };
+
+  // Built-in product OT carries the demo `sku` attribute whose code
+  // collides with the create-mode header key — the strip used to drop it
+  // from every edit-mode PATCH (#1350 reopen #2: "SKU robi się puste").
+  const typesResp = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: bearer,
+  });
+  const types =
+    ((await typesResp.json()) as { member?: Array<{ id: string; kind: string }> }).member ?? [];
+  const productType = types.find((t) => t.kind === 'product');
+  if (productType === undefined) throw new Error('Built-in product ObjectType not found.');
+
+  const code = uniqueSku('SKUFIX');
+  const created = await page.request.post('/api/products', {
+    headers: ld,
+    data: {
+      code,
+      objectTypeId: productType.id,
+      attributes: { name: `Sku strip fix ${code}` },
+    },
+  });
+  expect(created.status(), await created.text()).toBe(201);
+  const productId = ((await created.json()) as { id: string }).id;
+
+  // Neutralize unrelated required gaps via API first: the demo OT may
+  // carry operator-toggled required flags (e.g. dimensions_length) that
+  // would block the full-state validation before our sku assertion.
+  const groupsResp = await page.request.get(
+    `/api/objects/${productId}/effective-attribute-groups`,
+    { headers: bearer },
+  );
+  const groupsBody = (await groupsResp.json()) as {
+    groups: Array<{
+      attributes: Array<{ code: string; type: string; is_required?: boolean }>;
+    }>;
+  };
+  const gapFill: Record<string, unknown> = {};
+  for (const group of groupsBody.groups) {
+    for (const attr of group.attributes) {
+      if (attr.is_required === true && attr.code !== 'sku' && attr.type !== 'boolean') {
+        gapFill[attr.code] = '1';
+      }
+    }
+  }
+  delete gapFill.name; // already filled at create
+  if (Object.keys(gapFill).length > 0) {
+    const fillResp = await page.request.patch(`/api/objects/${productId}`, {
+      headers: { ...bearer, 'content-type': 'application/merge-patch+json' },
+      data: { attributes: gapFill },
+    });
+    expect(fillResp.status(), await fillResp.text()).toBe(200);
+  }
+
+  await page.goto(`/products/${productId}`);
+  const saveButton = page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i });
+  await expect(saveButton).toBeVisible({ timeout: 20_000 });
+
+  // The demo `sku` attribute lives in the tab-mode `grupa_uniwersalna`.
+  await page.getByRole('tab', { name: /grupa[_ ]uniwersalna/i }).click();
+  const skuRow = page
+    .getByText(/^(SKU|sku)$/)
+    .first()
+    .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+  await skuRow.scrollIntoViewIfNeeded();
+  const skuInput = skuRow.locator('input[type="text"]').first();
+  await skuInput.fill(code);
+
+  const patchResponse = page.waitForResponse(
+    (r) => r.url().includes(`/api/objects/${productId}`) && r.request().method() === 'PATCH',
+  );
+  await saveButton.click();
+  const patch = await patchResponse;
+  expect(patch.status()).toBe(200);
+  // The payload must actually carry the sku attribute…
+  const body = patch.request().postDataJSON() as { attributes?: Record<string, unknown> };
+  expect(body.attributes?.sku).toBe(code);
+
+  // …and the field survives a reload instead of going blank.
+  await page.reload();
+  await page.getByRole('tab', { name: /grupa[_ ]uniwersalna/i }).click();
+  const reloadedRow = page
+    .getByText(/^(SKU|sku)$/)
+    .first()
+    .locator('xpath=ancestor::div[contains(@class, "grid-cols")][1]');
+  await reloadedRow.scrollIntoViewIfNeeded();
+  await expect(reloadedRow.locator('input[type="text"]').first()).toHaveValue(code);
+});

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -185,7 +185,10 @@ export function AttrRow({
         {isLocked && !attribute.is_system ? (
           <Lock className="size-3 text-zinc-300" aria-hidden />
         ) : null}
-        {attribute.is_required === true || attribute.is_required_in_group ? (
+        {/* #1350 reopen #2 — no asterisk for booleans: requiredness is
+            meaningless when "unchecked" is itself a value. */}
+        {(attribute.is_required === true && attribute.type !== 'boolean') ||
+        attribute.is_required_in_group ? (
           <span
             className="text-rose-500"
             title={t('app.required', { defaultValue: 'wymagane' })}

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -501,6 +501,10 @@ export function ProductDetailPage({
     for (const group of groups) {
       for (const attr of group.attributes) {
         if (attr.is_required !== true) continue;
+        // #1350 (reopen #2) — requiredness is meaningless for booleans:
+        // an unchecked box IS the value `false`, not a missing value.
+        // Operator decision: a required boolean always passes.
+        if (attr.type === 'boolean') continue;
         const current = fieldValue(attr.code);
         if (isEmptyAttributeValue(current)) violations.push(attr.code);
       }
@@ -622,7 +626,12 @@ export function ProductDetailPage({
           setIsSaving(false);
           return;
         }
-        const attributes = stripAttributes(dirtyFields);
+        // #1350 (reopen #2) — in edit mode every dirty key IS an attribute
+        // code; stripping 'sku'/'code' here silently dropped edits to a
+        // real `sku` attribute (field emptied after save). The strip only
+        // belongs to create mode, where the header SKU input doubles as
+        // the object code.
+        const attributes = { ...dirtyFields };
         // #1150 / #1155 — write in the active locale + channel: localizable
         // / scopable attributes land on that scope's row, others stay
         // global (BE decides per flag).

--- a/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
+++ b/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
@@ -121,7 +121,10 @@ final readonly class ObjectAttributesUpserter
             // Only codes present in the payload are checked: partial PATCHes
             // and imports of legacy dirty records stay writable, while the
             // admin form enforces the full-state rule client-side.
-            if ($attribute->isRequired() && self::isEmptyEnvelope($jsonbValue)) {
+            // Booleans are exempt (reopen #2, operator decision): an
+            // unchecked box IS the value `false`, not a missing value.
+            if (AttributeType::Boolean !== $attribute->getType()
+                && $attribute->isRequired() && self::isEmptyEnvelope($jsonbValue)) {
                 throw new UnprocessableEntityHttpException(\sprintf(
                     'Attribute "%s" is required and cannot be empty.',
                     $code,

--- a/apps/api/tests/Api/Catalog/RequiredAttributeValidationApiTest.php
+++ b/apps/api/tests/Api/Catalog/RequiredAttributeValidationApiTest.php
@@ -107,6 +107,65 @@ final class RequiredAttributeValidationApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function requiredBooleanIsExemptFromEnforcement(): void
+    {
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $attrResponse = $client->request('POST', '/api/attributes', [
+            'headers' => ['content-type' => 'application/ld+json', 'accept' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'req_bool_test',
+                'type' => 'boolean',
+                'label' => ['pl' => 'Zgodny', 'en' => 'Compliant'],
+                'required' => true,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $attrId = $attrResponse->toArray()['id'];
+        \assert(\is_string($attrId));
+        $client->request('POST', '/api/object_types/'.$productOt.'/attributes/'.$attrId);
+        self::assertResponseStatusCodeSame(204);
+
+        // #1350 reopen #2 — an unchecked box IS `false`, not a missing
+        // value: creating without it and explicitly nulling it both pass.
+        $createResponse = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'REQ-BOOL',
+                'objectTypeId' => $productOt,
+                'attributes' => ['name' => 'Bool carrier'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $productId = $createResponse->toArray()['id'];
+        \assert(\is_string($productId));
+
+        $client->request('PATCH', '/api/products/'.$productId, [
+            'headers' => [
+                'content-type' => 'application/merge-patch+json',
+                'accept' => 'application/json',
+            ],
+            'body' => json_encode([
+                'attributes' => ['req_bool_test' => null],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        // `false` is a value too.
+        $client->request('PATCH', '/api/products/'.$productId, [
+            'headers' => [
+                'content-type' => 'application/merge-patch+json',
+                'accept' => 'application/json',
+            ],
+            'body' => json_encode([
+                'attributes' => ['req_bool_test' => false],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    #[Test]
     public function effectiveGroupsShipTheRequiredFlag(): void
     {
         $client = $this->authenticatedClient();


### PR DESCRIPTION
## Summary
Dwa problemy z drugiego reopena #1350:

**1. „Pole SKU po zapisaniu robi się puste"** — edit-mode save reużywał create-mode'owego `stripAttributes()`, który wycina klucze `sku`/`code` (w create input SKU w nagłówku to KOD obiektu). W edycji każdy dirty-klucz to kod atrybutu, więc edycja realnego atrybutu `sku` była po cichu wycinana z PATCHa → pole pustoszało po zapisie, a walidacja required blokowała formularz na amen. Edit wysyła teraz dirty fields 1:1.

**2. Wymagany boolean (doradztwo + decyzja)** — semantycznie odznaczony checkbox to wartość `false`, nie brak wartości. Tak też robi Akeneo (boolean zawsze „wypełniony", nie ma pojęcia pustego boola). Wybrana opcja 3 z Twojej listy: flaga „Wymagany" na boolean **nie blokuje zapisu** (FE + upserter pomijają typ boolean), gwiazdka dla takich pól znika (gwiazdka completeness z grup zostaje). Flagi w modelowaniu nie ruszamy — gdybyś kiedyś chciał twardo „musi być na TAK", to będzie reguła walidacyjna per-atrybut (value=true), nie wymagalność.

## Quality gates
- PHPStan max 0 · `RequiredAttributeValidationApiTest` 3/3 (nowy case boolean: create bez wartości 201, explicit null 200, false 200).
- tsc/Biome clean · Playwright 1350 2/2 — nowy spec sku-persistence: PATCH payload zawiera `attributes.sku`, wartość przeżywa reload (luki wymagalności z UAT neutralizowane przez API, spec niezależny od danych).

## Smoke test plan
1. `/products/{id}` → grupa z polem SKU → wpisz symbol → Zapisz zmiany → reload → wartość JEST.
2. Produkt z wymaganym `rohs_compliant` → zapis przechodzi bez zaznaczania; checkbox bez gwiazdki.

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)