### PR TITLE
feat(catalog): identyfikator systemowy jako „ID" wszędzie + deduplikacja pola Nazwa

### DIFF
--- a/apps/admin/e2e/1102-relation-picker-in-create.spec.ts
+++ b/apps/admin/e2e/1102-relation-picker-in-create.spec.ts
@@ -208,7 +208,7 @@ test('UniversalCreatePage relation attribute renders picker and persists targets
 
       const newCarCode = `S_${stamp}`;
       // #1415 unified create: a "Kod" identifier input + a "Nazwa" input.
-      await page.getByPlaceholder(/^(kod|sku)$/i).fill(newCarCode);
+      await page.getByPlaceholder(/^(id|kod|sku)$/i).fill(newCarCode);
       await page.getByPlaceholder(/^nazwa$|nazwa produktu/i).fill(newCarCode);
 
       // Capture the relation PUT so we can fail loud if it never fires

--- a/apps/admin/e2e/1357-products-new-no-marka-adhoc.spec.ts
+++ b/apps/admin/e2e/1357-products-new-no-marka-adhoc.spec.ts
@@ -19,7 +19,8 @@ test('new product form has no Marka input and no ad-hoc group adder', async ({ p
   await page.goto('/products/new');
 
   // SKU + name inputs stay.
-  await expect(page.getByPlaceholder('SKU')).toBeVisible({ timeout: 15_000 });
+  // #1415 — the identifier is labelled "ID" for every ObjectType.
+  await expect(page.getByPlaceholder(/^id$/i)).toBeVisible({ timeout: 15_000 });
   await expect(page.getByPlaceholder(/nazwa produktu|product name/i)).toBeVisible();
 
   // "Marka" input is gone.

--- a/apps/admin/e2e/1359-universal-create-category-required.spec.ts
+++ b/apps/admin/e2e/1359-universal-create-category-required.spec.ts
@@ -88,7 +88,7 @@ test('categorizable custom object create requires a category', async ({ page }) 
 
   // Try to create without a category → blocked with a toast, no POST fires.
   // #1415 unified create: a code ("Kod") input + a name input.
-  await page.getByPlaceholder(/^(kod|sku)$/i).fill(`OBJ-${stamp}`);
+  await page.getByPlaceholder(/^(id|kod|sku)$/i).fill(`OBJ-${stamp}`);
   await page.getByPlaceholder(/^nazwa$|nazwa produktu/i).fill(`Obj ${stamp}`);
   let posted = false;
   page.on('request', (r) => {

--- a/apps/admin/e2e/1413-create-category-picker-tree-scoped.spec.ts
+++ b/apps/admin/e2e/1413-create-category-picker-tree-scoped.spec.ts
@@ -110,7 +110,7 @@ test('create-page category picker only lists the ObjectType tree', async ({ page
   await dialog.getByRole('button', { name: /^zapisz$/i }).click();
 
   // #1415 unified create: fill the code ("Kod") + name inputs.
-  await page.getByPlaceholder(/^(kod|sku)$/i).fill(`OBJ-${ts}`);
+  await page.getByPlaceholder(/^(id|kod|sku)$/i).fill(`OBJ-${ts}`);
   await page.getByPlaceholder(/^nazwa$|nazwa produktu/i).fill(`Obj ${ts}`);
   const createResponse = page.waitForResponse(
     (r) => r.url().endsWith('/api/objects') && r.request().method() === 'POST',

--- a/apps/admin/e2e/view-07-products-edit-create.spec.ts
+++ b/apps/admin/e2e/view-07-products-edit-create.spec.ts
@@ -43,7 +43,7 @@ test('VIEW-07 product detail + create + duplicate flow', async ({ page }) => {
   await expect(page.getByRole('button', { name: /utwórz produkt|create product/i })).toBeVisible();
   await expect(page.getByText(/krok|step/i)).toHaveCount(0);
 
-  await page.getByPlaceholder('SKU').fill(sku);
+  await page.getByPlaceholder(/^id$/i).fill(sku); // #1415 — unified ID label
   await page.getByPlaceholder(/nazwa produktu|product name/i).fill(`Playwright VIEW-07 ${sku}`);
   // #1357 — the "Marka" field was removed from the new-entry form.
 

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -301,8 +301,17 @@ export function ProductDetailPage({
   // Empty groups (no attributes after field-level filtering) render as
   // bare headers with zero rows — drop them, consistent with #1348's
   // "no empty Atrybuty tab" rule.
+  // #1415 — the header already carries a dedicated input for the `name`
+  // attribute; the duplicated group row confused operators (two inputs,
+  // one storage), so it is hidden from every group.
   const groups = useMemo(
-    () => (groupsQuery.data?.groups ?? []).filter((g) => g.attributes.length > 0),
+    () =>
+      (groupsQuery.data?.groups ?? [])
+        .map((g) => ({
+          ...g,
+          attributes: g.attributes.filter((attr) => attr.code !== 'name'),
+        }))
+        .filter((g) => g.attributes.length > 0),
     [groupsQuery.data],
   );
 
@@ -532,11 +541,10 @@ export function ProductDetailPage({
         const skuRaw = dirtyFields.sku ?? dirtyFields.code ?? '';
         const sku = typeof skuRaw === 'string' ? skuRaw.trim() : '';
         if (sku === '') {
-          toast.error(
-            kind === 'product'
-              ? t('products.detail.validation.sku_required', { defaultValue: 'SKU jest wymagane' })
-              : t('object_create.code_required', { defaultValue: 'Kod jest wymagany' }),
-          );
+          // #1415 — the system identifier is labelled "ID" for every
+          // ObjectType (operator decision); custom identifiers live as
+          // ordinary attributes.
+          toast.error(t('object_create.id_required', { defaultValue: 'ID jest wymagane' }));
           setIsSaving(false);
           return;
         }
@@ -888,11 +896,7 @@ export function ProductDetailPage({
                   <div className="flex items-center gap-2.5 text-[12px] text-zinc-500">
                     <Input
                       autoFocus
-                      placeholder={
-                        kind === 'product'
-                          ? t('products.detail.create.placeholder.sku', { defaultValue: 'SKU' })
-                          : t('object_create.code_placeholder', { defaultValue: 'Kod' })
-                      }
+                      placeholder={t('object_create.id_placeholder', { defaultValue: 'ID' })}
                       value={skuValue}
                       onChange={(event) => setFieldValue('sku', event.target.value)}
                       className="h-7 w-32 rounded-lg border-zinc-200 bg-white px-2 font-mono text-[12px]"


### PR DESCRIPTION
## Summary
Decyzja operatora w #1415 (model Akeneo, bez auto-podpowiadania):
- Pole identyfikatora w formularzu tworzenia ma label **„ID"** dla KAŻDEGO ObjectType (było: „SKU" na produktach, „Kod" na custom). Kto chce innego identyfikatora / innej nazwy — modeluje go atrybutem.
- User zawsze wpisuje ID sam; unikalność pilnowana przy zapisie (409 z czytelnym komunikatem — bez zmian), po utworzeniu wartość niezmienialna (read-only w nagłówku — bez zmian).
- **Deduplikacja**: wiersz atrybutu `name` znika z grup — nagłówek ma już dedykowany input piszący to samo `attributes.name` (dwa inputy nad jedną wartością myliły).

## Frontend changes
- `product-detail-page.tsx`: jednolity placeholder/komunikat `ID` (`object_create.id_placeholder` / `id_required`), filtr wiersza `name` z grup (create + edit, wszystkie kindy).
- Specy: placeholdery SKU/Kod → ID (5 plików).

## Quality gates
- tsc -b clean · Biome strict 0 błędów.
- Playwright: 10/10 baterii create+detail zielone lokalnie (1102, 1350×2, 1357, 1359, 1361, 1413, objects-detail-unified×2, view-07).

## Smoke test plan
1. `/products/new` i `/objects/uslugi/new` — pole „ID" (puste, bez podpowiedzi), „Nazwa" niżej; w grupach NIE ma drugiego wiersza Nazwa.
2. Utwórz z duplikatem ID → czytelny błąd 409; po utworzeniu ID read-only w nagłówku.

Closes #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)