### PR TITLE
fix(catalog): 409 zamiast 500 dla duplikatu ID przy poly-create

### DIFF
--- a/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectHandler.php
+++ b/apps/api/src/Catalog/Application/Command/CreateCatalogObject/CreateCatalogObjectHandler.php
@@ -10,6 +10,8 @@ use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -55,6 +57,22 @@ final readonly class CreateCatalogObjectHandler
                 'ObjectType kind "%s" does not match the operation kind "%s".',
                 $objectType->getKind()->value,
                 $command->expectedKind->value,
+            ));
+        }
+
+        // #1415 — duplicate IDs used to surface as a raw 500 from the
+        // (tenant, kind, code) unique constraint on the poly-kind create.
+        // Pre-check for a clean 409; the DB index stays as the race-proof
+        // backstop. Categories are skipped — their codes are unique per
+        // tree, not per kind, and the constraint excludes them.
+        $tenant = $objectType->getTenant();
+        if (ObjectKind::Category !== $objectType->getKind()
+            && $tenant instanceof Tenant
+            && $this->catalogObjects->findByCode($command->code, $objectType->getKind(), $tenant) instanceof CatalogObject) {
+            throw new ConflictHttpException(\sprintf(
+                'ID "%s" is already used by another "%s" entry.',
+                $command->code,
+                $objectType->getCode(),
             ));
         }
 

--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPatchDeleteTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPatchDeleteTest.php
@@ -159,4 +159,33 @@ final class CatalogObjectPolyKindPatchDeleteTest extends CatalogApiTestCase
 
         return $ot->getId()->toRfc4122();
     }
+
+    #[Test]
+    public function duplicateCodeOnPolyCreateReturnsConflict(): void
+    {
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+
+        $payload = json_encode([
+            'code' => 'DUP-409',
+            'objectTypeId' => $productOt,
+            'attributes' => ['name' => 'First'],
+        ], JSON_THROW_ON_ERROR);
+        $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => $payload,
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        // #1415 — the duplicate used to bubble up as a raw 500 from the
+        // (tenant, kind, code) unique index; now a clean 409 with the ID
+        // in the Problem Details detail.
+        $response = $client->request('POST', '/api/objects', [
+            'headers' => ['content-type' => 'application/ld+json', 'accept' => 'application/json'],
+            'body' => $payload,
+        ]);
+        self::assertResponseStatusCodeSame(409);
+        $body = $response->toArray(false);
+        self::assertStringContainsString('DUP-409', (string) ($body['detail'] ?? ''));
+    }
 }


### PR DESCRIPTION
## Summary
Wyłapane w live smoke #1442: duplikat ID na `POST /api/objects` kończył się **500** z gołym SQL-em w `detail` (unique index `(tenant, kind, code)`). Handler robi teraz pre-check i zwraca czyste **409**: `ID "X" is already used by another "uslugi" entry.` Index DB zostaje jako race-proof backstop. Kategorie pominięte (kody unikalne per drzewo, poza constraintem).

## Quality gates
- PHPStan max 0 · `CatalogObjectPolyKindPatchDeleteTest` 6/6 (nowy case duplicate-409).
- Live: `POST /api/objects` z zajętym ID → **409** + czytelny detail (operator widzi komunikat w formularzu przez httpErrorDetail).

Refs #1415

🤖 Generated with [Claude Code](https://claude.com/claude-code)