### PR TITLE
NUI-04: lista produktów v2 — tab rail, de-violet, szerokości wg designu

### DIFF
--- a/Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md
+++ b/Project Plan/UI/Wdrozenie_grafiki/produkty-do-oprogramowania.md
@@ -93,3 +93,9 @@
 - Epik 0.8 (BaseLinker) + 0.9 (Shopify) — sync status w detail-sidebar zależy od pełnej integracji (po Fazie 1).
 - Faza 2 (Agent layer) — wszystkie agent-related pozycje powyżej.
 - Epik 0.11 (Hardening) — audit log endpoints + import CSV mogą wpaść tutaj.
+
+## Dopisane przy NUI-04 (#1423, 2026-06-11) — luki vs design list-view-v2
+
+- **Wiersze locked/pinned** (`LOCK_SKUS`/`STAR_SKUS` w mocku — kłódka edycji + pin „flagowy") — brak modelu w backendzie; SKIP w NUI-04. Wymaga: pola lock/pin per obiekt + endpoint + uprawnienia.
+- **Liczniki per smart-preset** (design pokazuje count przy każdym presecie) — FE renderuje count gdy API go zwróci; dziś `/api/smart-presets` nie liczy trafień. Wymaga: tani endpoint zbiorczy `/api/smart-presets/counts` (cache 60 s).
+- **Dedykowany token wyszukiwania EAN** — placeholder obiecuje EAN; dziś leci przez wyszukiwanie pełnotekstowe. Opcjonalnie: jawny `ean:` qualifier w search API.

--- a/apps/admin/e2e/1423-products-list-v2.spec.ts
+++ b/apps/admin/e2e/1423-products-list-v2.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * NUI-04 (#1423) — products list v2 visual retrofit. Guards the shared
+ * surface: the saved-views tab rail, smart-filter row and grid render on
+ * BOTH `/products` (built-in) and `/objects/:slug` (custom ObjectType).
+ */
+
+test.describe('NUI-04 — products list v2', () => {
+  test('saved views rail + smart filters + grid render on /products', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/products');
+
+    const rail = page.getByRole('tablist', { name: /zapisane widoki|saved views/i });
+    await expect(rail).toBeVisible();
+
+    const smartRow = page.getByRole('tablist', { name: /smart filtry|smart filters/i });
+    await expect(smartRow).toBeVisible();
+
+    // Grid header in v2 typography renders the SKU column.
+    await expect(page.getByText('SKU', { exact: true }).first()).toBeVisible();
+    // Toolbar search keeps the EAN-aware placeholder semantics.
+    await expect(page.getByPlaceholder(/sku.*ean|szukaj|search/i)).toBeVisible();
+
+    // Preset interaction (chips + copy URL) is covered by 1205; here only
+    // assert the row exposes its tabs when presets exist in the env.
+    const presetCount = await smartRow.getByRole('tab').count();
+    if (presetCount > 0) {
+      await smartRow.getByRole('tab').first().click();
+      await expect(
+        page
+          .getByRole('button', { name: /skopiuj url|copy url/i })
+          .or(page.getByText(/aktywne filtry|active filters/i))
+          .first(),
+      ).toBeVisible({ timeout: 10_000 });
+    }
+  });
+
+  test('the same list surface serves a custom ObjectType', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/objects/uslugi');
+
+    const rail = page.getByRole('tablist', { name: /zapisane widoki|saved views/i });
+    const railVisible = await rail
+      .waitFor({ state: 'visible', timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+    test.skip(!railVisible, 'No custom ObjectType `uslugi` in this environment seed');
+
+    await expect(page.getByRole('tablist', { name: /smart filtry|smart filters/i })).toBeVisible();
+  });
+});

--- a/apps/admin/src/components/catalog/attribute-picker.tsx
+++ b/apps/admin/src/components/catalog/attribute-picker.tsx
@@ -310,7 +310,7 @@ function PickerRow({
     <div
       className={cn(
         'flex items-center gap-2 px-3 py-1.5 text-[12.5px]',
-        isActive ? 'bg-violet-50/60' : 'hover:bg-zinc-50',
+        isActive ? 'bg-orange-50/60' : 'hover:bg-zinc-50',
       )}
     >
       <button

--- a/apps/admin/src/components/catalog/bulk-bar.tsx
+++ b/apps/admin/src/components/catalog/bulk-bar.tsx
@@ -166,7 +166,7 @@ export function BulkBar({
             type="button"
             onClick={onOpenCmdK ?? placeholder('VIEW-05.5')}
             className={cn(
-              'text-[13px] font-medium px-3 py-1.5 rounded-xl bg-violet-500 hover:bg-violet-400 inline-flex items-center gap-1.5',
+              'text-[13px] font-medium px-3 py-1.5 rounded-xl bg-orange-500 hover:bg-orange-400 inline-flex items-center gap-1.5',
               'focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60',
             )}
           >

--- a/apps/admin/src/components/catalog/category-picker-dialog.tsx
+++ b/apps/admin/src/components/catalog/category-picker-dialog.tsx
@@ -245,7 +245,7 @@ export function CategoryPickerDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl">
         <header className="mb-3 flex items-center gap-2">
-          <FolderTree className="size-4 text-violet-600" />
+          <FolderTree className="size-4 text-orange-600" />
           <h2 className="text-base font-semibold">
             {t('categories.picker.title', { defaultValue: 'Wybierz kategorie' })}
           </h2>
@@ -260,7 +260,7 @@ export function CategoryPickerDialog({
             placeholder={t('categories.picker.search_placeholder', {
               defaultValue: 'Szukaj kategorii…',
             })}
-            className="w-full rounded-xl border border-zinc-200 bg-white py-2 pl-9 pr-3 text-[13px] focus:border-violet-300 focus:outline-none"
+            className="w-full rounded-xl border border-zinc-200 bg-white py-2 pl-9 pr-3 text-[13px] focus:border-orange-300 focus:outline-none"
           />
         </div>
 

--- a/apps/admin/src/components/catalog/products-grid.tsx
+++ b/apps/admin/src/components/catalog/products-grid.tsx
@@ -51,7 +51,7 @@ interface ProductsGridProps {
 }
 
 const GRID_TPL =
-  '44px 52px 130px minmax(240px,1.6fr) minmax(160px,1fr) 150px 150px 110px 70px 44px';
+  '44px 52px 150px minmax(260px,1.6fr) minmax(160px,1fr) 170px 150px 120px 70px 44px';
 
 const COL_KEYS = [
   'sel',
@@ -226,7 +226,7 @@ function ProductsGridRowView({
       data-testid={`products-grid-row-${row.sku}`}
       className={cn(
         'group relative grid items-center text-[13px] border-b border-zinc-50 last:border-b-0 transition',
-        isSelected ? 'bg-violet-50/60' : variant ? 'bg-zinc-50/40' : 'hover:bg-zinc-50/60',
+        isSelected ? 'bg-zinc-200/70' : variant ? 'bg-zinc-50/40' : 'hover:bg-zinc-50/60',
       )}
       style={style}
     >
@@ -306,7 +306,7 @@ function ProductsGridRowView({
           </Link>
         )}
         {hasVariants ? (
-          <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-violet-50 text-violet-700">
+          <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-orange-50 text-orange-700">
             {t('products.variants.count', {
               count: variantsCount,
               defaultValue: '{{count}} wariantów',

--- a/apps/admin/src/components/catalog/saved-views-rail.tsx
+++ b/apps/admin/src/components/catalog/saved-views-rail.tsx
@@ -116,7 +116,7 @@ export function SavedViewsRail({
       role="tablist"
       aria-label={t('products.saved_views.rail_aria', { defaultValue: 'Zapisane widoki' })}
       aria-orientation="horizontal"
-      className="scrollbar-thin flex items-center gap-1.5 overflow-x-auto"
+      className="scrollbar-thin -mb-px flex items-center gap-1.5 overflow-x-auto"
     >
       {views.map((view, index) => {
         const active = view.slug === activeSlug;
@@ -139,15 +139,15 @@ export function SavedViewsRail({
               handleKey(event, index);
             }}
             className={cn(
-              'shrink-0 inline-flex items-center gap-2 h-9 px-3 rounded-2xl text-[13px] font-medium transition focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900',
+              'shrink-0 inline-flex items-center gap-2 h-9 px-3.5 rounded-t-xl text-[13px] font-medium transition border-b-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900',
               active
-                ? 'bg-zinc-900 text-white'
-                : 'bg-white shadow-sm text-zinc-700 hover:bg-zinc-50',
+                ? 'bg-white border-zinc-900 text-zinc-900 shadow-sm'
+                : 'border-transparent text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50',
             )}
           >
             {view.is_system ? (
               <Eye
-                className={cn('size-3.5', active ? 'text-white/60' : 'text-zinc-400')}
+                className={cn('size-3.5', active ? 'text-zinc-700' : 'text-zinc-400')}
                 aria-label={t('products.saved_views.system_view_aria', {
                   defaultValue: 'Widok systemowy',
                 })}
@@ -155,7 +155,7 @@ export function SavedViewsRail({
             ) : null}
             <span>{view.name}</span>
             <span
-              className={cn('text-[11px] tabular-nums', active ? 'text-white/60' : 'text-zinc-400')}
+              className={cn('text-[11px] tabular-nums', active ? 'text-zinc-400' : 'text-zinc-300')}
             >
               {countLabel}
             </span>
@@ -165,7 +165,7 @@ export function SavedViewsRail({
       <button
         type="button"
         onClick={onSaveCurrent}
-        className="shrink-0 inline-flex items-center gap-1.5 h-9 px-3 rounded-2xl text-[13px] text-zinc-500 hover:text-zinc-900 hover:bg-zinc-100 border border-dashed border-zinc-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
+        className="shrink-0 inline-flex items-center gap-1.5 h-9 px-3 rounded-t-xl text-[13px] text-zinc-500 hover:text-zinc-900 hover:bg-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900"
       >
         <Plus className="size-3.5" aria-hidden="true" />
         <span>{t('products.saved_views.save_view', { defaultValue: 'Zapisz widok' })}</span>

--- a/apps/admin/src/components/catalog/smart-filter-presets-row.tsx
+++ b/apps/admin/src/components/catalog/smart-filter-presets-row.tsx
@@ -1,4 +1,4 @@
-import { Plus, Sparkles, X } from 'lucide-react';
+import { Plus, X, Zap } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import type { SmartFilterPreset } from '@/lib/filters/use-smart-presets';
@@ -59,7 +59,7 @@ export function SmartFilterPresetsRow({
           className="h-7 w-7 rounded-xl bg-zinc-900 text-white grid place-items-center"
           aria-hidden="true"
         >
-          <Sparkles className="size-3.5" />
+          <Zap className="size-3.5" />
         </span>
         <div className="leading-tight">
           <div className="text-[11.5px] font-semibold tracking-tight">

--- a/apps/admin/src/components/catalog/wysiwyg-editor.tsx
+++ b/apps/admin/src/components/catalog/wysiwyg-editor.tsx
@@ -100,7 +100,7 @@ export function WysiwygEditor({
             {...props}
             as="a"
             attributes={{ ...props.attributes, href: (props.element as { url?: string }).url }}
-            className="text-violet-700 underline"
+            className="text-orange-700 underline"
           >
             {props.children}
           </PlateElement>


### PR DESCRIPTION
## Zakres (NUI-04, #1423)

Lista była już funkcjonalnie kompletna i w większości pixel-perfect (komponenty budowane z tych samych mockupów w UI-09/VIEW) — ten PR domyka rozjazdy vs `produkty/list-view-v2.jsx`:

- **SavedViewsRail**: pills → **tab-rail v2** (rounded-t-xl, aktywny = biały z podkreśleniem border-b-2 zinc-900 + shadow, liczniki w jaśniejszym zinc, przycisk „Zapisz widok" bez dashed ramki).
- **Smart filtry**: ikona Zap zamiast Sparkles (Sparkles zarezerwowany dla agenta — spójnie z designem).
- **De-violet katalogu** (paleta v2 mapuje violet→orange): CTA „Zleć agentowi" w bulk-barze → orange, badge liczby wariantów → orange, zaznaczony wiersz → `zinc-200/70` (wg mockupu), akcenty w attribute-picker / category-picker / linki wysiwyg → orange. `grep violet components/catalog` = 0.
- **Szerokości kolumn grida** wg spec COLS: SKU 150px, Completeness 170px, Cena 120px, nazwa minmax(260px,1.6fr).
- **SKIP (backlog)**: wiersze locked/pinned (brak modelu BE), liczniki per-preset (brak endpointu), token EAN — dopisane do `Wdrozenie_grafiki/produkty-do-oprogramowania.md`.

Zero zmian w FilterDSL, payloadach, bulk akcjach, zapisanych widokach.

## Testy + smoke

- Nowy spec `e2e/1423-products-list-v2.spec.ts` — **2/2 passed**: rail+smart filtry+grid na `/products` ORAZ ta sama powierzchnia na `/objects/uslugi` (custom OT; seed-aware skip w CI).
- Istniejące specki listy: `1205-smart-filter-preset-delete` ✅, `1209-category-picker-universal` ✅.
- **Live smoke (pim.localhost)**: login 200 → `/products` renderuje rail/smart filtry/toolbar/grid z toggle'ami enabled; konsola czysta (poza pre-existing auth 401). Screenshot zweryfikowany z mockupem.
- Gates: tsc ✅, Biome ✅, Vite build ✅.

Plan: `Project Plan/UI/Retrofit_v2/plan-epik-NUI-retrofit-ui-v2.md` § NUI-04.

Closes #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
