### PR TITLE
NUI-07: modelowanie v2 — akcent orange zamiast violet, ink underline tabów

### DIFF
--- a/apps/admin/src/components/modeling/category-tree.tsx
+++ b/apps/admin/src/components/modeling/category-tree.tsx
@@ -145,7 +145,7 @@ function CategoryTreeRow({
 
   const rowVisualClass = isMulti
     ? isChecked
-      ? 'bg-violet-50/60 hover:bg-violet-50'
+      ? 'bg-orange-50/60 hover:bg-orange-50'
       : 'hover:bg-zinc-100/70'
     : isSelected
       ? 'bg-zinc-900 text-white'
@@ -167,7 +167,7 @@ function CategoryTreeRow({
             checked={isChecked}
             disabled={isDisabled}
             onChange={() => onToggleSelection?.(node.id)}
-            className="size-3.5 cursor-pointer accent-violet-600"
+            className="size-3.5 cursor-pointer accent-orange-600"
             aria-label={`Wybierz kategorię ${node.label}`}
             onClick={(e) => e.stopPropagation()}
           />

--- a/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-for-object-type-dialog.tsx
@@ -230,7 +230,7 @@ export function CreateAttributeForObjectTypeDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[88vh] max-w-[820px] flex-col gap-0 p-0">
         <div className="flex items-start gap-3 border-b border-zinc-100 px-7 pb-4 pt-6">
-          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-2xl bg-violet-100 text-violet-700">
+          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-2xl bg-orange-100 text-orange-700">
             <Zap className="size-4" />
           </div>
           <div className="min-w-0 flex-1">
@@ -354,9 +354,9 @@ export function CreateAttributeForObjectTypeDialog({
                 </div>
               ) : null}
               {showOptionsBanner ? (
-                <div className="flex items-start gap-2.5 rounded-xl border border-violet-200 bg-violet-50/60 px-4 py-3">
-                  <Info className="size-4 shrink-0 text-violet-700" />
-                  <div className="text-[12px] text-violet-900">
+                <div className="flex items-start gap-2.5 rounded-xl border border-orange-200 bg-orange-50/60 px-4 py-3">
+                  <Info className="size-4 shrink-0 text-orange-700" />
+                  <div className="text-[12px] text-orange-900">
                     Po utworzeniu atrybutu typu <span className="font-mono">{type}</span> będziesz
                     mógł zdefiniować wartości (z tłumaczeniami) w widoku „Zarządzaj wartościami".
                   </div>
@@ -441,7 +441,7 @@ export function CreateAttributeForObjectTypeDialog({
               <div className="flex flex-wrap items-center justify-end gap-1.5">
                 {required ? <Chip className="bg-rose-50 text-rose-700">required</Chip> : null}
                 {unique ? <Chip className="bg-blue-50 text-blue-700">unique</Chip> : null}
-                {localizable ? <Chip className="bg-violet-50 text-violet-700">i18n</Chip> : null}
+                {localizable ? <Chip className="bg-orange-50 text-orange-700">i18n</Chip> : null}
               </div>
             </div>
           </Section>

--- a/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-attribute-in-group-dialog.tsx
@@ -198,7 +198,7 @@ export function CreateAttributeInGroupDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[88vh] max-w-[820px] flex-col gap-0 p-0">
         <div className="flex items-start gap-3 border-b border-zinc-100 px-7 pb-4 pt-6">
-          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-2xl bg-violet-100 text-violet-700">
+          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-2xl bg-orange-100 text-orange-700">
             <Zap className="size-4" />
           </div>
           <div className="min-w-0 flex-1">
@@ -322,9 +322,9 @@ export function CreateAttributeInGroupDialog({
                 </div>
               ) : null}
               {showOptionsBanner ? (
-                <div className="flex items-start gap-2.5 rounded-xl border border-violet-200 bg-violet-50/60 px-4 py-3">
-                  <Info className="size-4 shrink-0 text-violet-700" />
-                  <div className="text-[12px] text-violet-900">
+                <div className="flex items-start gap-2.5 rounded-xl border border-orange-200 bg-orange-50/60 px-4 py-3">
+                  <Info className="size-4 shrink-0 text-orange-700" />
+                  <div className="text-[12px] text-orange-900">
                     Po utworzeniu atrybutu typu <span className="font-mono">{type}</span> będziesz
                     mógł zdefiniować wartości (z tłumaczeniami) w widoku „Zarządzaj wartościami".
                   </div>
@@ -409,7 +409,7 @@ export function CreateAttributeInGroupDialog({
               <div className="flex flex-wrap items-center justify-end gap-1.5">
                 {required ? <Chip className="bg-rose-50 text-rose-700">required</Chip> : null}
                 {unique ? <Chip className="bg-blue-50 text-blue-700">unique</Chip> : null}
-                {localizable ? <Chip className="bg-violet-50 text-violet-700">i18n</Chip> : null}
+                {localizable ? <Chip className="bg-orange-50 text-orange-700">i18n</Chip> : null}
               </div>
             </div>
           </Section>

--- a/apps/admin/src/components/modeling/create-group-inline-dialog.tsx
+++ b/apps/admin/src/components/modeling/create-group-inline-dialog.tsx
@@ -121,7 +121,7 @@ export function CreateGroupInlineDialog({ open, onOpenChange, onCreated }: Props
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[640px] gap-0 p-0">
         <div className="flex items-start gap-3 border-b border-zinc-100 px-7 pb-4 pt-6">
-          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-2xl bg-violet-100 text-violet-700">
+          <div className="grid h-10 w-10 shrink-0 place-items-center rounded-2xl bg-orange-100 text-orange-700">
             <FolderPlus className="size-4" />
           </div>
           <div className="min-w-0 flex-1">

--- a/apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/declare-attribute-group-dialog.tsx
@@ -229,14 +229,14 @@ export function DeclareAttributeGroupDialog({
                       isDisabled
                         ? 'cursor-not-allowed bg-zinc-50/60 opacity-60'
                         : 'hover:bg-zinc-50',
-                      isPicked && !isDisabled && 'bg-violet-50/60',
+                      isPicked && !isDisabled && 'bg-orange-50/60',
                     )}
                   >
                     <span
                       className={cn(
                         'grid size-5 place-items-center rounded border',
                         isPicked
-                          ? 'border-violet-500 bg-violet-500 text-white'
+                          ? 'border-orange-500 bg-orange-500 text-white'
                           : 'border-zinc-300 bg-white',
                       )}
                     >

--- a/apps/admin/src/components/modeling/declare-object-type-attribute-group-dialog.tsx
+++ b/apps/admin/src/components/modeling/declare-object-type-attribute-group-dialog.tsx
@@ -232,14 +232,14 @@ export function DeclareObjectTypeAttributeGroupDialog({
                       isAttached
                         ? 'cursor-not-allowed bg-zinc-50/60 opacity-60'
                         : 'hover:bg-zinc-50',
-                      isPicked && !isAttached && 'bg-violet-50/60',
+                      isPicked && !isAttached && 'bg-orange-50/60',
                     )}
                   >
                     <span
                       className={cn(
                         'grid size-5 place-items-center rounded border',
                         isPicked
-                          ? 'border-violet-500 bg-violet-500 text-white'
+                          ? 'border-orange-500 bg-orange-500 text-white'
                           : 'border-zinc-300 bg-white',
                       )}
                     >

--- a/apps/admin/src/components/modeling/object-type-wizard.tsx
+++ b/apps/admin/src/components/modeling/object-type-wizard.tsx
@@ -740,7 +740,7 @@ export function ObjectTypeWizard() {
                       })}{' '}
                       <Link
                         to="/settings/menu"
-                        className="text-accent-violet underline underline-offset-2 hover:text-accent-violet/80"
+                        className="text-orange-700 underline underline-offset-2 hover:text-orange-700/80"
                       >
                         {t('object_types.setting_expose_menu_link', {
                           defaultValue: 'Ustawienia → Menu',

--- a/apps/admin/src/components/modeling/relation-config-panel.tsx
+++ b/apps/admin/src/components/modeling/relation-config-panel.tsx
@@ -165,7 +165,7 @@ export function RelationConfigPanel({
                   onClick={() => toggleTarget(ot.id)}
                   className={
                     selected
-                      ? 'inline-flex items-center gap-1.5 rounded-full border border-accent-violet bg-accent-violet/10 px-3 py-1 text-[12px] font-medium text-accent-violet'
+                      ? 'inline-flex items-center gap-1.5 rounded-full border border-orange-600 bg-orange-500/10 px-3 py-1 text-[12px] font-medium text-orange-700'
                       : 'inline-flex items-center gap-1.5 rounded-full border border-zinc-300 bg-white px-3 py-1 text-[12px] text-zinc-600 hover:border-zinc-400'
                   }
                 >
@@ -188,7 +188,7 @@ export function RelationConfigPanel({
                 key={opt}
                 className={
                   value.cardinality === opt
-                    ? 'flex items-center gap-2 rounded-lg border border-accent-violet bg-accent-violet/5 px-3 py-2 text-[13px] text-accent-violet'
+                    ? 'flex items-center gap-2 rounded-lg border border-orange-600 bg-orange-500/5 px-3 py-2 text-[13px] text-orange-700'
                     : 'flex items-center gap-2 rounded-lg border border-zinc-200 bg-white px-3 py-2 text-[13px] text-zinc-700'
                 }
               >

--- a/apps/admin/src/features/catalog/attribute-groups/list.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/list.tsx
@@ -36,7 +36,7 @@ interface UsageResp {
  * VIEW-03b — pixel-perfect rebuild of `AttributeGroupsView`
  * (`groups-categories.jsx:3–80`):
  *
- *   - caption "{N} grup atrybutów" + violet ⭐ FIRST-CLASS ENTITY badge.
+ *   - caption "{N} grup atrybutów" + orange ⭐ FIRST-CLASS ENTITY badge.
  *   - title "Attribute Groups", description Pimcore/Akeneo positioning.
  *   - CTA "+ Nowa grupa" (zinc-900) → /modeling/attribute-groups/new.
  *   - Single Card with sticky search top, 2 sections:
@@ -92,7 +92,7 @@ export function AttributeGroupsListPage() {
                 count: groups.length,
               })}
             </span>
-            <span className="rounded bg-violet-100 px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-violet-700">
+            <span className="rounded bg-orange-100 px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-orange-700">
               {t('modeling.attributeGroups.list_first_class_badge', {
                 defaultValue: '⭐ first-class entity',
               })}

--- a/apps/admin/src/features/catalog/attribute-groups/show.tsx
+++ b/apps/admin/src/features/catalog/attribute-groups/show.tsx
@@ -512,7 +512,7 @@ function Editor({
                 type="button"
                 size="sm"
                 onClick={() => setCreateOpen(true)}
-                className="h-8 rounded-lg bg-violet-50 px-2.5 text-[12px] text-violet-700 hover:bg-violet-100"
+                className="h-8 rounded-lg bg-orange-50 px-2.5 text-[12px] text-orange-700 hover:bg-orange-100"
               >
                 <Plus className="size-3.5" />
                 {t('modeling.attributeGroups.members_create_new_action', {
@@ -526,7 +526,7 @@ function Editor({
             <button
               type="button"
               onClick={() => setPickerOpen(true)}
-              className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-200 py-2.5 text-[12.5px] font-medium text-muted-foreground transition hover:border-violet-300 hover:bg-violet-50/40 hover:text-violet-700"
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-200 py-2.5 text-[12.5px] font-medium text-muted-foreground transition hover:border-orange-300 hover:bg-orange-50/40 hover:text-orange-700"
             >
               <Plus className="size-4" />
               {t('modeling.attributeGroups.members_empty_action', {
@@ -571,20 +571,20 @@ function Editor({
               <SectionTitle as="span">
                 {t('modeling.attributeGroups.rules_title', { defaultValue: 'Visibility rules' })}
               </SectionTitle>
-              <span className="rounded bg-violet-100 px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-violet-700">
+              <span className="rounded bg-orange-100 px-1.5 py-0.5 text-[10.5px] font-semibold uppercase tracking-wider text-orange-700">
                 {t('modeling.attributeGroups.rules_visible_when_badge', {
                   defaultValue: 'visible_when',
                 })}
               </span>
             </div>
-            <div className="space-y-1 rounded-2xl border border-violet-200 bg-violet-50/40 p-4">
+            <div className="space-y-1 rounded-2xl border border-orange-200 bg-orange-50/40 p-4">
               {sortedMembers
                 .filter((m) => m.visible_when !== null)
                 .map((m) => (
                   <div key={m.attribute.id} className="flex items-center gap-3 py-1">
                     <span className="font-mono text-[12.5px] font-medium">{m.attribute.code}</span>
                     <span className="text-[11.5px] text-muted-foreground">visible_when</span>
-                    <span className="rounded border border-violet-200 bg-white px-2 py-0.5 font-mono text-[12.5px] text-violet-700">
+                    <span className="rounded border border-orange-200 bg-white px-2 py-0.5 font-mono text-[12.5px] text-orange-700">
                       {m.visible_when?.field}={String(m.visible_when?.value)}
                     </span>
                     <button
@@ -827,7 +827,7 @@ function SortableMemberRow({
         {row.attribute.type}
       </span>
       {row.visible_when ? (
-        <span className="inline-flex items-center gap-1.5 rounded-lg bg-violet-50 px-2 py-1 font-mono text-[11px] text-violet-700">
+        <span className="inline-flex items-center gap-1.5 rounded-lg bg-orange-50 px-2 py-1 font-mono text-[11px] text-orange-700">
           when {row.visible_when.field}={String(row.visible_when.value)}
         </span>
       ) : (

--- a/apps/admin/src/features/catalog/attributes/list.tsx
+++ b/apps/admin/src/features/catalog/attributes/list.tsx
@@ -61,7 +61,7 @@ type TypeFilter = (typeof TYPE_FILTERS)[number];
  *   - 8-col grid header (Code · nazwa | Type | Flagi | Used in | Groups
  *     | Instances | Wartości).
  *   - Body rows: shield/zap icon, code+name+lock+unique badges, TypeBadge,
- *     i18n/scope chips, usage counts, violet "N wartości" link for
+ *     i18n/scope chips, usage counts, orange "N wartości" link for
  *     select/multiselect.
  */
 export function AttributesListPage() {
@@ -275,9 +275,9 @@ function AttributeRowItem({
           <Link
             to={`/modeling/attributes/${row.id}/values`}
             onClick={(e) => e.stopPropagation()}
-            className="inline-flex h-7 items-center gap-1.5 rounded-lg bg-violet-50 px-2.5 text-[11.5px] font-medium text-violet-700 transition hover:bg-violet-100"
+            className="inline-flex h-7 items-center gap-1.5 rounded-lg bg-orange-50 px-2.5 text-[11.5px] font-medium text-orange-700 transition hover:bg-orange-100"
           >
-            <Layers className="size-3 text-violet-500" />
+            <Layers className="size-3 text-orange-500" />
             <span className="tabular-nums">{optionsCount ?? '—'}</span>
             <span className="hidden xl:inline">wartości</span>
           </Link>
@@ -300,7 +300,7 @@ function TypeBadge({ type }: { type: string }) {
           : type === 'date' || type === 'datetime'
             ? 'bg-accent-sky/10 text-accent-sky'
             : type === 'asset'
-              ? 'bg-accent-violet/10 text-accent-violet'
+              ? 'bg-orange-500/10 text-orange-700'
               : type === 'reference' || type === 'relation'
                 ? 'bg-accent-rose/10 text-accent-rose'
                 : type === 'identifier'

--- a/apps/admin/src/features/catalog/attributes/new.tsx
+++ b/apps/admin/src/features/catalog/attributes/new.tsx
@@ -458,7 +458,7 @@ export function AttributeCreatePage() {
                   type="button"
                   size="sm"
                   onClick={() => setCreateGroupOpen(true)}
-                  className="h-8 rounded-lg bg-violet-50 px-2.5 text-[12px] text-violet-700 hover:bg-violet-100"
+                  className="h-8 rounded-lg bg-orange-50 px-2.5 text-[12px] text-orange-700 hover:bg-orange-100"
                 >
                   <FolderPlus className="size-3.5" />
                   {t('modeling.attributes.attach_create_group_action', {

--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -69,7 +69,7 @@ interface AttributeDetail {
  *
  *   - Sticky header with shield/zap icon, mono code 26px, lock badge
  *     (system) + TypeBadge + label/unit subtitle. Right stack: Manage
- *     Values (violet, select/multiselect), Migrate Type (amber,
+ *     Values (orange, select/multiselect), Migrate Type (amber,
  *     non-system), Edit (zinc-900).
  *   - Card "Definicja": grid with locked Code + editable Nazwa
  *     PL/EN + locked Type + 3-column FlagPill row (Localizable /
@@ -444,7 +444,7 @@ function Editor({
               asChild
               size="sm"
               variant="outline"
-              className="h-9 rounded-xl bg-violet-50 text-violet-700 hover:bg-violet-100"
+              className="h-9 rounded-xl bg-orange-50 text-orange-700 hover:bg-orange-100"
             >
               <Link to={`/modeling/attributes/${attribute.id}/values`}>
                 <Layers className="size-4" />
@@ -1052,7 +1052,7 @@ function AttachedGroupsCard({ attribute, locale }: { attribute: AttributeDetail;
             type="button"
             size="sm"
             onClick={() => setCreateOpen(true)}
-            className="h-8 rounded-lg bg-violet-50 px-2.5 text-[12px] text-violet-700 hover:bg-violet-100"
+            className="h-8 rounded-lg bg-orange-50 px-2.5 text-[12px] text-orange-700 hover:bg-orange-100"
           >
             <FolderPlus className="size-3.5" />
             {t('modeling.attributes.attach_create_group_action', {

--- a/apps/admin/src/features/catalog/attributes/values.tsx
+++ b/apps/admin/src/features/catalog/attributes/values.tsx
@@ -293,7 +293,7 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
     <div className="space-y-6 px-4 py-6 sm:px-6 lg:px-10">
       <BackLink id={attribute.id} />
       <div className="flex items-start gap-3">
-        <div className="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-violet-50 text-violet-700">
+        <div className="grid h-12 w-12 shrink-0 place-items-center rounded-2xl bg-orange-50 text-orange-700">
           <Layers className="size-5" />
         </div>
         <div className="min-w-0 flex-1">
@@ -349,7 +349,7 @@ function ValuesEditor({ attribute, locale }: { attribute: AttributeDetail; local
               </SortableContext>
             </DndContext>
             {creating ? (
-              <div className="mt-2 space-y-2 rounded-xl border border-violet-200 bg-violet-50/40 p-2">
+              <div className="mt-2 space-y-2 rounded-xl border border-orange-200 bg-orange-50/40 p-2">
                 <Input
                   autoFocus
                   value={draftName}

--- a/apps/admin/src/features/catalog/categories/list.tsx
+++ b/apps/admin/src/features/catalog/categories/list.tsx
@@ -381,7 +381,7 @@ function CategoryDetailPanel({
             <button
               type="button"
               onClick={() => setDeclareOpen(true)}
-              className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-200 py-2 text-[12.5px] font-medium text-zinc-500 transition hover:border-violet-300 hover:bg-violet-50/40 hover:text-violet-700"
+              className="mt-2 flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-zinc-200 py-2 text-[12.5px] font-medium text-zinc-500 transition hover:border-orange-300 hover:bg-orange-50/40 hover:text-orange-700"
             >
               + {t('categories.detail.declare_group', { defaultValue: 'Declare group' })}
             </button>
@@ -428,13 +428,13 @@ function CategoryDetailPanel({
         </div>
       </Card>
 
-      <Card className="border border-violet-200 bg-violet-50/30 p-6">
+      <Card className="border border-orange-200 bg-orange-50/30 p-6">
         <div className="mb-3 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="text-[11px] font-semibold uppercase tracking-wider text-violet-700">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-orange-700">
               {t('categories.preview.title', { defaultValue: 'Effective preview' })}
             </span>
-            <span className="rounded bg-violet-100 px-1.5 py-0.5 text-[10.5px] font-medium text-violet-700">
+            <span className="rounded bg-orange-100 px-1.5 py-0.5 text-[10.5px] font-medium text-orange-700">
               {t('categories.preview.killer_feature_badge', { defaultValue: 'killer feature' })}
             </span>
           </div>
@@ -442,7 +442,7 @@ function CategoryDetailPanel({
             {targetType === 'product' ? (
               <Link
                 to={`/products/new?categories=${categoryId}&primary=${categoryId}`}
-                className="inline-flex items-center gap-1.5 text-[11.5px] font-medium text-violet-700 hover:text-violet-800 hover:underline"
+                className="inline-flex items-center gap-1.5 text-[11.5px] font-medium text-orange-700 hover:text-orange-800 hover:underline"
                 title={t('categories.preview.create_test_object_active_tooltip', {
                   defaultValue: 'Utwórz produkt pre-przypisany do tej kategorii',
                 })}
@@ -458,7 +458,7 @@ function CategoryDetailPanel({
                   type="button"
                   disabled
                   aria-disabled
-                  className="inline-flex cursor-not-allowed items-center gap-1.5 text-[11.5px] font-medium text-violet-500"
+                  className="inline-flex cursor-not-allowed items-center gap-1.5 text-[11.5px] font-medium text-orange-500"
                   title={t('categories.preview.create_test_object_mock_tooltip', {
                     defaultValue: 'Wymaga wizard tworzenia obiektu (Faza 1)',
                   })}
@@ -484,7 +484,7 @@ function CategoryDetailPanel({
             name: node?.label ?? '—',
           })}
         </p>
-        <div className="overflow-hidden rounded-2xl border border-violet-200 bg-white">
+        <div className="overflow-hidden rounded-2xl border border-orange-200 bg-white">
           {(effective?.effectiveGroups ?? []).length === 0 ? (
             <p className="px-4 py-6 text-center text-[12.5px] text-muted-foreground">
               {t('categories.preview.empty', { defaultValue: 'Brak grup do wyświetlenia.' })}
@@ -541,7 +541,7 @@ function FormPreviewRow({ group, locale }: { group: EffectiveGroup; locale: stri
 
   const sourceTone =
     group.source === 'declared_here'
-      ? 'bg-violet-100 text-violet-700'
+      ? 'bg-orange-100 text-orange-700'
       : group.source === 'inherited_from'
         ? 'bg-blue-100 text-blue-700'
         : 'bg-zinc-100 text-zinc-700';
@@ -553,7 +553,7 @@ function FormPreviewRow({ group, locale }: { group: EffectiveGroup; locale: stri
   const overflow = group.attributes.length > 3 ? '…' : '';
 
   return (
-    <div className="flex items-center gap-3 border-b border-violet-50 px-4 py-2.5 last:border-b-0">
+    <div className="flex items-center gap-3 border-b border-orange-50 px-4 py-2.5 last:border-b-0">
       <span
         className="grid size-7 place-items-center rounded-md text-[14px]"
         style={{

--- a/apps/admin/src/features/catalog/categories/show.tsx
+++ b/apps/admin/src/features/catalog/categories/show.tsx
@@ -213,10 +213,10 @@ function EffectiveAttributesPreview({ categoryId }: { categoryId: string }) {
   }, [categoryId, t]);
 
   return (
-    <Card className="border-accent-violet/30 bg-accent-violet/5 soft-shadow">
+    <Card className="border-orange-500/30 bg-orange-500/5 soft-shadow">
       <CardContent className="space-y-4 pt-6">
         <div className="space-y-1">
-          <div className="inline-flex items-center gap-1.5 rounded-full bg-accent-violet/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-accent-violet">
+          <div className="inline-flex items-center gap-1.5 rounded-full bg-orange-500/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-orange-700">
             effective preview
           </div>
           <h2 className="text-[15px] font-semibold text-ink">

--- a/apps/admin/src/features/catalog/modeling/layout.tsx
+++ b/apps/admin/src/features/catalog/modeling/layout.tsx
@@ -75,7 +75,7 @@ function TabBadge({ resource, isActive }: TabBadgeProps) {
     <span
       className={
         isActive
-          ? 'num ml-2 inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-accent-violet/10 px-1.5 text-[11px] font-medium text-accent-violet'
+          ? 'num ml-2 inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-ink/10 px-1.5 text-[11px] font-medium text-ink'
           : 'num ml-2 inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-muted px-1.5 text-[11px] font-medium text-muted-foreground'
       }
     >
@@ -112,7 +112,7 @@ export function ModelingLayout() {
               aria-controls={`modeling-panel-${tab.value}`}
               className={
                 isActive
-                  ? 'border-accent-violet text-foreground -mb-px flex items-center border-b-2 px-4 py-2 text-sm font-medium'
+                  ? 'border-ink text-foreground -mb-px flex items-center border-b-2 px-4 py-2 text-sm font-medium'
                   : 'text-muted-foreground hover:text-foreground -mb-px flex items-center border-b-2 border-transparent px-4 py-2 text-sm'
               }
             >

--- a/apps/admin/src/features/catalog/object-types/list.tsx
+++ b/apps/admin/src/features/catalog/object-types/list.tsx
@@ -145,7 +145,7 @@ export function ObjectTypesListPage() {
           <button
             type="button"
             onClick={() => navigate('/modeling/object-types/new')}
-            className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl border border-dashed border-line bg-surface px-6 py-4 text-[14px] font-medium text-ink-2 transition-colors hover:border-accent-violet/40 hover:bg-accent-violet/5 hover:text-ink"
+            className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl border border-dashed border-line bg-surface px-6 py-4 text-[14px] font-medium text-ink-2 transition-colors hover:border-orange-500/40 hover:bg-orange-500/5 hover:text-ink"
           >
             <Plus className="size-4" />
             {t('object_types.bottom_cta', {
@@ -184,7 +184,7 @@ function ObjectTypeListRow({ row, language, instanceCount, groupCount }: ObjectT
             </span>
           ) : null}
           {row.hierarchical ? (
-            <span className="rounded-md bg-accent-violet/10 px-1.5 py-0.5 text-[10.5px] font-medium uppercase tracking-wide text-accent-violet">
+            <span className="rounded-md bg-orange-500/10 px-1.5 py-0.5 text-[10.5px] font-medium uppercase tracking-wide text-orange-700">
               hierarchical
             </span>
           ) : null}

--- a/apps/admin/src/features/catalog/object-types/show.tsx
+++ b/apps/admin/src/features/catalog/object-types/show.tsx
@@ -833,7 +833,7 @@ export function ObjectTypeShowPage() {
                 })}{' '}
                 <Link
                   to="/settings/menu"
-                  className="text-accent-violet underline underline-offset-2 hover:text-accent-violet/80"
+                  className="text-orange-700 underline underline-offset-2 hover:text-orange-700/80"
                 >
                   {t('object_types.setting_expose_menu_link', {
                     defaultValue: 'Ustawienia → Menu',

--- a/apps/admin/src/features/catalog/products/components/agent-suggestions-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/agent-suggestions-card.tsx
@@ -61,7 +61,7 @@ export function AgentSuggestionsCard() {
     <section className="relative rounded-2xl border border-line bg-surface p-4 soft-shadow">
       <MockBadge variant="corner" tooltip={tooltip} />
       <header className="mb-3 flex items-center gap-2">
-        <Sparkles className="size-4 text-accent-violet" />
+        <Sparkles className="size-4 text-orange-700" />
         <h3 className="text-[13px] font-semibold text-ink">
           {t('products.agent.title', { defaultValue: 'Sugestie agenta' })}
         </h3>
@@ -71,7 +71,7 @@ export function AgentSuggestionsCard() {
           const Icon = s.icon;
           return (
             <li key={s.id} className="flex items-start gap-3 rounded-xl bg-surface-2/60 p-3">
-              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-accent-violet/10 text-accent-violet">
+              <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-orange-500/10 text-orange-700">
                 <Icon className="size-3.5" />
               </span>
               <div className="min-w-0 flex-1">

--- a/apps/admin/src/features/catalog/products/components/channel-node-picker-dialog.tsx
+++ b/apps/admin/src/features/catalog/products/components/channel-node-picker-dialog.tsx
@@ -114,7 +114,7 @@ export function ChannelNodePickerDialog({
     >
       <DialogContent className="max-w-xl">
         <header className="mb-3 flex items-center gap-2">
-          <FolderTree className="size-4 text-violet-600" />
+          <FolderTree className="size-4 text-orange-600" />
           <h2 className="text-base font-semibold">
             {t('products.detail.placements.picker_title', {
               defaultValue: 'Wybierz węzeł — {{channel}}',
@@ -144,7 +144,7 @@ export function ChannelNodePickerDialog({
                     style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
                     className={cn(
                       'flex w-full items-center gap-2 rounded-lg py-1.5 pr-2 text-left text-[12.5px] hover:bg-zinc-50',
-                      selected === node.id && 'bg-violet-50 text-violet-900',
+                      selected === node.id && 'bg-orange-50 text-orange-900',
                     )}
                     aria-pressed={selected === node.id}
                   >

--- a/apps/admin/src/features/catalog/products/components/channel-placements-section.tsx
+++ b/apps/admin/src/features/catalog/products/components/channel-placements-section.tsx
@@ -98,14 +98,14 @@ export function ChannelPlacementsSection({ productId }: Props) {
     <section className="space-y-3 border-t border-line pt-4">
       <header className="flex items-center justify-between">
         <h4 className="flex items-center gap-1.5 text-[12.5px] font-semibold text-ink">
-          <Radio className="size-3.5 text-violet-600" />
+          <Radio className="size-3.5 text-orange-600" />
           {t('products.detail.placements.title', { defaultValue: 'Gdzie trafia na kanałach' })}
         </h4>
         {collapsing && missingCount < rows.length ? (
           <button
             type="button"
             onClick={() => setExpanded(true)}
-            className="text-[11.5px] font-medium text-violet-600 hover:underline"
+            className="text-[11.5px] font-medium text-orange-600 hover:underline"
           >
             {t('products.detail.placements.show_all', {
               defaultValue: 'Pokaż wszystkie ({{count}})',

--- a/apps/admin/src/features/catalog/products/components/completeness-ring.tsx
+++ b/apps/admin/src/features/catalog/products/components/completeness-ring.tsx
@@ -16,7 +16,7 @@ interface CompletenessRingProps {
  * UI-03b detail-page completeness indicator (#366).
  *
  * Replaces the linear `<CompletenessBadge>` in the product show header
- * with an animated SVG ring. Color tracks the percent: violet 0–50,
+ * with an animated SVG ring. Color tracks the percent: rose 0–50,
  * amber 50–80, emerald 80–100. The stroke animates from 0 → target on
  * mount so the visual transition reads as "computing completeness".
  */
@@ -38,7 +38,7 @@ export function CompletenessRing({ pct, size = 56, stroke = 5, className }: Comp
       ? 'var(--color-accent-emerald)'
       : clamped >= 50
         ? 'var(--color-accent-amber)'
-        : 'var(--color-accent-violet)';
+        : 'var(--color-accent-rose)';
 
   return (
     <div

--- a/apps/admin/src/features/catalog/products/components/effective-model-card.tsx
+++ b/apps/admin/src/features/catalog/products/components/effective-model-card.tsx
@@ -56,7 +56,7 @@ export function EffectiveModelCard({
       </ul>
       <Link
         to="/modeling/object-types"
-        className="mt-2.5 block text-[11.5px] font-medium text-violet-700 hover:underline"
+        className="mt-2.5 block text-[11.5px] font-medium text-orange-700 hover:underline"
       >
         {t('products.detail.sidebar.effective_model.see_in_modeling', {
           defaultValue: 'Zobacz w Modelowanie →',

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -1409,7 +1409,7 @@ function HistoryStub() {
       who: 'Marcin Lipiec',
       when: '5 min temu',
       what: 'Zmieniono description.pl',
-      tone: 'bg-accent-violet/10 text-accent-violet',
+      tone: 'bg-orange-500/10 text-orange-700',
     },
     {
       who: 'agent.sonnet',


### PR DESCRIPTION
## Zakres (NUI-07, #1426)

Modelowanie funkcjonalnie odpowiadało designowi (VIEW-01..04/MODR budowane z tych samych mockupów), a wzorzec nagłówka (caption → tytuł → opis → **CTA pod opisem**) już był zgodny — realna delta to akcent kolorystyczny:

- **De-violet 25 plików** (`components/modeling/*`, `features/catalog/{object-types,attributes,attribute-groups,categories,modeling}/*` + współdzielone karty detalu produktu): klasy `violet-NNN` → `orange-NNN`, użycia tokenu `accent-violet` → odpowiedniki orange (mapowanie per-wzorzec, nie ślepy replace — `text-accent-violet`→`text-orange-700` itd.).
- **Wyjątki semantyczne** (świadome):
  - aktywny tab modelowania: podkreślenie **ink/czarne** (`border-ink`) zgodnie ze spec tabów designu („black bottom underline"), nie orange; badge licznika taba → `bg-ink/10 text-ink`;
  - `CompletenessRing` <50%: violet → **rose** (semantyka błędu, spójna z paskami kompletności listy).
- `grep violet` po przeczesanych katalogach = **0** (łącznie z komentarzami).
- SKIP: stopka „model schema rev" z mockupu — brak licznika rev w API (bez fałszywego numeru).

## Testy + smoke

- Specki modelowania: `1076-audit-group-no-lock` ✅, `1349-reorder-attribute-groups` ✅. `1177-attribute-types-simple` failuje **także na czystym main** (zweryfikowane przez stash — problem lokalnego środowiska/danych, nie tego PR-a; w CI przechodzi).
- **Live smoke (pim.localhost)**: login 200 → 4 taby modelowania renderują się z nowym akcentem (screenshoty zweryfikowane: nagłówki, chipy filtrów typów, tabela atrybutów, sekcje built-in/custom); konsola czysta.
- Gates: tsc ✅, Biome ✅, Vite build ✅.

Plan: `Project Plan/UI/Retrofit_v2/plan-epik-NUI-retrofit-ui-v2.md` § NUI-07.

Closes #1426

🤖 Generated with [Claude Code](https://claude.com/claude-code)
