### PR TITLE
NUI-11: widok sesji importu v2 — pipeline faz, live log (Mercure), karta wyników

### DIFF
--- a/apps/admin/e2e/1430-import-session-v2.spec.ts
+++ b/apps/admin/e2e/1430-import-session-v2.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * NUI-11 (#1430) — import session view v2: header (status + duration),
+ * stage pipeline, results card with KPIs / ResultBar / report download.
+ * Uses the newest session from the history table; skips when the
+ * environment has no import sessions yet.
+ */
+test('NUI-11 — session view renders pipeline, summary and report link', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/integrations/imports/sessions');
+
+  // History rows are grid divs with an onClick navigate — click the
+  // filename cell and let the event bubble to the row handler.
+  const fileCell = page.getByText(/\.csv|\.xlsx/i).first();
+  const hasSession = await fileCell
+    .waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true)
+    .catch(() => false);
+  test.skip(!hasSession, 'No import sessions in this environment');
+
+  await fileCell.click();
+  await expect(page).toHaveURL(/\/integrations\/imports\/[0-9a-f-]{8,}/);
+
+  // Stage pipeline renders its stages.
+  await expect(page.getByText(/parsing/i).first()).toBeVisible();
+  await expect(page.getByText(/zapis|writing/i).first()).toBeVisible();
+
+  // Terminal session shows the results card with the report download.
+  await expect(page.getByText(/zaimportowano|imported/i).first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole('link', { name: /raport|report/i })).toBeVisible();
+});

--- a/apps/admin/src/features/imports/hooks/useImportProgress.ts
+++ b/apps/admin/src/features/imports/hooks/useImportProgress.ts
@@ -13,9 +13,19 @@ interface ProgressEvent {
   };
 }
 
+export interface ImportLogEntry {
+  id: number;
+  level: 'info' | 'error';
+  message: string;
+}
+
+const LOG_BUFFER_CAP = 200;
+
 export interface ImportProgressState {
   /** True until the first SSE event lands or the connection drops. */
   connecting: boolean;
+  /** NUI-11 — capped live-log buffer built from row_processed/error events. */
+  log: ImportLogEntry[];
   processedRows: number;
   totalRows: number;
   successCount: number;
@@ -34,6 +44,7 @@ export interface ImportProgressState {
 
 const INITIAL_STATE: ImportProgressState = {
   connecting: true,
+  log: [],
   processedRows: 0,
   totalRows: 0,
   successCount: 0,
@@ -68,19 +79,36 @@ export function useImportProgress(sessionId: string | null): ImportProgressState
       setState((prev) => ({ ...prev, connecting: false }));
     });
 
+    let logSeq = 0;
     source.addEventListener('message', (event) => {
       try {
         const raw = JSON.parse(event.data) as ProgressEvent;
-        setState((prev) => ({
-          ...prev,
-          connecting: false,
-          processedRows: raw.data.processed_rows ?? prev.processedRows,
-          totalRows: raw.data.total_rows ?? prev.totalRows,
-          successCount: raw.data.success_count ?? prev.successCount,
-          errorCount: raw.data.error_count ?? prev.errorCount,
-          currentSku: raw.data.current_sku ?? prev.currentSku,
-          status: (raw.data.status as ImportProgressState['status']) ?? prev.status,
-        }));
+        setState((prev) => {
+          let log = prev.log;
+          if (raw.type === 'row_processed' || raw.type === 'error') {
+            const sku = raw.data.current_sku ?? null;
+            const entry: ImportLogEntry = {
+              id: logSeq++,
+              level: raw.type === 'error' ? 'error' : 'info',
+              message:
+                raw.type === 'error'
+                  ? `✗ ${sku ?? 'row'} — error`
+                  : `✓ ${sku ?? 'row'} (${raw.data.processed_rows ?? '?'} / ${raw.data.total_rows ?? '?'})`,
+            };
+            log = [...prev.log.slice(-(LOG_BUFFER_CAP - 1)), entry];
+          }
+          return {
+            ...prev,
+            connecting: false,
+            log,
+            processedRows: raw.data.processed_rows ?? prev.processedRows,
+            totalRows: raw.data.total_rows ?? prev.totalRows,
+            successCount: raw.data.success_count ?? prev.successCount,
+            errorCount: raw.data.error_count ?? prev.errorCount,
+            currentSku: raw.data.current_sku ?? prev.currentSku,
+            status: (raw.data.status as ImportProgressState['status']) ?? prev.status,
+          };
+        });
       } catch {
         // Malformed Mercure payload — surface a console.warn on the
         // root error handler in dev only.

--- a/apps/admin/src/features/imports/show/ImportShowPage.tsx
+++ b/apps/admin/src/features/imports/show/ImportShowPage.tsx
@@ -1,13 +1,20 @@
 import { useApiUrl, useOne } from '@refinedev/core';
+import { Download, Eye } from 'lucide-react';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router';
 
 import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { Progress } from '@/components/ui/progress';
 import { RollbackButton } from '@/features/imports/components/RollbackButton';
 import { useImportProgress } from '@/features/imports/hooks/useImportProgress';
 import { type ImportStatus, StatusBadge } from '@/features/imports/list/StatusBadge';
+import {
+  type ImportStage,
+  ProgressBar,
+  ResultBar,
+  StagePipeline,
+} from '@/features/imports/primitives';
+import { cn } from '@/lib/utils';
 
 interface ImportSession {
   id: string;
@@ -26,14 +33,12 @@ interface ImportSession {
 }
 
 /**
- * Spec §5.6 + §5.7 — combined progress / results screen.
- *
- * The same page surfaces both because the wizard CTA navigates here
- * right after dispatch (status='pending'/'running'). Once Mercure /
- * polling updates the status to a terminal state, the layout
- * transitions to the results card with KPI counters + the
- * RollbackButton + report download. No router redirect needed —
- * the screen is symmetric.
+ * NUI-11 (#1430) — import session view v2 (design `Import-sesja.html`):
+ * header with status + duration + %, StagePipeline honestly derived from
+ * the session status (the backend stores no per-phase timestamps — done /
+ * active / pending only; backlog: Retrofit_v2/importy-do-oprogramowania.md),
+ * a Mercure-fed live log (capped buffer in `useImportProgress`) and the
+ * results card with KPI counters, ResultBar, report CSV and rollback.
  */
 export function ImportShowPage(): React.ReactElement {
   const { t } = useTranslation();
@@ -50,6 +55,12 @@ export function ImportShowPage(): React.ReactElement {
     },
   });
   const progress = useImportProgress(sessionId);
+  const logRef = React.useRef<HTMLDivElement | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll follows the log length
+  React.useEffect(() => {
+    logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
+  }, [progress.log.length]);
 
   if (sessionId === null || query.isLoading || session === undefined) {
     return (
@@ -66,19 +77,37 @@ export function ImportShowPage(): React.ReactElement {
     session.status === 'cancelled' ||
     session.status === 'rolled_back';
 
-  // Server is the source of truth; Mercure refines counters in
-  // realtime when REST poll has stale data.
+  // Server is the source of truth; Mercure refines counters in realtime.
   const processed = Math.max(progress.processedRows, session.success_count + session.error_count);
   const total = Math.max(progress.totalRows, session.total_rows ?? 0);
+  const pct = total > 0 ? Math.round((processed / total) * 100) : 0;
+
+  // Honest stage derivation — no per-phase timestamps exist on the session.
+  const stage: ImportStage = isTerminal
+    ? 'done'
+    : processed > 0
+      ? 'writing'
+      : session.status === 'running'
+        ? 'validating'
+        : 'parsing';
 
   return (
-    <div className="space-y-6">
-      <header className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">{session.file_name}</h1>
-          <p className="text-sm text-muted-foreground">
+    <div className="space-y-5">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h1 className="display truncate text-[24px] font-semibold tracking-tight">
+            {session.file_name}
+          </h1>
+          <div className="mt-1 flex flex-wrap items-center gap-2.5 text-sm text-zinc-500">
             <StatusBadge status={session.status} />
-          </p>
+            <span className="num font-mono text-[12px]">
+              {t('imports.show.duration', {
+                defaultValue: 'czas: {{value}}',
+                value: formatDuration(session.started_at, session.completed_at),
+              })}
+            </span>
+            {!isTerminal && <span className="num font-mono text-[12px]">{pct}%</span>}
+          </div>
         </div>
         <Button asChild variant="ghost">
           <Link to="/integrations/imports">
@@ -87,15 +116,16 @@ export function ImportShowPage(): React.ReactElement {
         </Button>
       </header>
 
+      <StagePipeline stage={stage} />
+
       {!isTerminal && (
-        <Card className="space-y-3 p-6">
+        <div className="space-y-4 rounded-2xl border border-zinc-100 bg-white p-6 shadow-sm">
           <div className="flex items-center justify-between text-sm">
-            <span className="font-medium">
-              {processed} / {total > 0 ? total : '?'} (
-              {total > 0 ? Math.round((processed / total) * 100) : 0}%)
+            <span className="num font-medium">
+              {processed} / {total > 0 ? total : '?'} ({pct}%)
             </span>
             {progress.currentSku !== null && (
-              <span className="font-mono text-xs text-muted-foreground">
+              <span className="font-mono text-xs text-zinc-500">
                 {t('imports.progress.current_sku', {
                   sku: progress.currentSku,
                   defaultValue: 'Aktualnie: {{sku}}',
@@ -103,21 +133,47 @@ export function ImportShowPage(): React.ReactElement {
               </span>
             )}
           </div>
-          <Progress
-            value={total > 0 ? (processed / total) * 100 : 0}
-            ariaLabel={t('imports.progress.title', { defaultValue: 'Import w toku' })}
-          />
-          <p className="text-xs text-muted-foreground">
+          <ProgressBar value={pct} />
+
+          <div>
+            <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wider text-zinc-400">
+              {t('imports.show.live_log', { defaultValue: 'Live log' })}
+            </div>
+            <div
+              ref={logRef}
+              className="max-h-56 overflow-y-auto rounded-xl bg-zinc-900 px-3.5 py-3 font-mono text-[11.5px] leading-relaxed text-zinc-200"
+              aria-live="polite"
+            >
+              {progress.log.length === 0 ? (
+                <span className="text-zinc-500">
+                  {t('imports.show.log_waiting', {
+                    defaultValue: '… oczekiwanie na zdarzenia (Mercure)',
+                  })}
+                </span>
+              ) : (
+                progress.log.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className={cn(entry.level === 'error' ? 'text-rose-400' : 'text-zinc-200')}
+                  >
+                    {entry.message}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <p className="text-xs text-zinc-500">
             💡{' '}
             {t('imports.progress.close_hint', {
               defaultValue: 'Możesz zamknąć tę kartę. System wyśle email po zakończeniu.',
             })}
           </p>
-        </Card>
+        </div>
       )}
 
       {isTerminal && (
-        <Card className="space-y-4 p-6">
+        <div className="space-y-4 rounded-2xl border border-zinc-100 bg-white p-6 shadow-sm">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             <Kpi
               label={t('imports.results.imported', {
@@ -142,6 +198,15 @@ export function ImportShowPage(): React.ReactElement {
             />
           </div>
 
+          {session.total_rows !== null && session.total_rows > 0 && (
+            <ResultBar
+              ok={session.success_count}
+              warn={0}
+              err={session.error_count}
+              total={session.total_rows}
+            />
+          )}
+
           {session.error_message !== null && (
             <p className="rounded-md border border-destructive/40 bg-destructive/10 p-2 text-sm text-destructive">
               {session.error_message}
@@ -151,12 +216,13 @@ export function ImportShowPage(): React.ReactElement {
           <div className="flex flex-wrap items-center gap-2">
             <Button asChild variant="outline">
               <a href={`${apiUrl}/import-sessions/${sessionId}/report.csv`}>
-                📥 {t('imports.results.download_report', { defaultValue: 'Pobierz raport CSV' })}
+                <Download className="size-4" />
+                {t('imports.results.download_report', { defaultValue: 'Pobierz raport CSV' })}
               </a>
             </Button>
             <Button asChild variant="outline">
               <Link to={`/products?import_session_id=${sessionId}`}>
-                👁{' '}
+                <Eye className="size-4" />
                 {t('imports.results.view_products', {
                   defaultValue: 'Zobacz zaimportowane produkty',
                 })}
@@ -170,7 +236,7 @@ export function ImportShowPage(): React.ReactElement {
               />
             )}
           </div>
-        </Card>
+        </div>
       )}
     </div>
   );
@@ -185,12 +251,12 @@ function Kpi({
 }): React.ReactElement {
   const palette =
     tone === 'ok'
-      ? 'border-green-500/40 bg-green-50'
+      ? 'border-emerald-500/40 bg-emerald-50'
       : tone === 'warn'
         ? 'border-amber-500/40 bg-amber-50'
-        : 'border-muted bg-muted/40';
+        : 'border-zinc-200 bg-zinc-50';
   return (
-    <div className={`rounded-md border p-4 text-center text-base font-semibold ${palette}`}>
+    <div className={`num rounded-xl border p-4 text-center text-base font-semibold ${palette}`}>
       {label}
     </div>
   );


### PR DESCRIPTION
## Zakres (NUI-11, #1430)

- **Header**: nazwa pliku, `StatusBadge`, czas trwania, % w trakcie biegu.
- **StagePipeline** wyprowadzony uczciwie ze statusu sesji (backend nie ma timestampów per faza — stany done/active/pending; terminal → wszystkie done + „Gotowe"). Backlog: timestampy faz (`Retrofit_v2/importy-do-oprogramowania.md`, wpis istnieje).
- **Live log (WIRE, Mercure)**: `useImportProgress` rozszerzony addytywnie o buforowany log (cap 200) z eventów `row_processed`/`error`; renderowany jako ciemna konsola z auto-scrollem w trakcie biegu sesji.
- **Karta wyników**: KPI (zaimportowane/pominięte/czas) + **ResultBar** + raport CSV (`ImportReportCsvController`) + „Zobacz zaimportowane produkty" + `RollbackButton` — logika bez zmian, restyle v2.

## Testy + smoke

- Nowy spec `e2e/1430-import-session-v2.spec.ts` — **1/1 passed na żywym stacku**: wejście z historii sesji → pipeline + karta wyników + link raportu (skip gdy środowisko bez sesji).
- **Live smoke (pim.localhost)**: login 200 → sesja `nui10.csv` (partial) renderuje pełny widok v2; screenshot zweryfikowany z `Import-sesja.html`; konsola czysta.
- Gates: tsc ✅, Biome ✅.

Plan: `Project Plan/UI/Retrofit_v2/plan-epik-NUI-retrofit-ui-v2.md` § NUI-11.

Closes #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)
