### PR TITLE
NUI-03: globalna paleta ⌘K — realna nawigacja, sekcja agenta jako mock (Faza 2)

### DIFF
--- a/apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts
+++ b/apps/admin/e2e/1420-sidebar-settings-subtree.spec.ts
@@ -53,8 +53,12 @@ test.describe('NUI-01 — settings subtree in main sidebar', () => {
     // Class-level check needs a custom ObjectType in the menu. The operator's
     // local DB ships "Usługi"; CI fixtures seed no custom OT — skip there.
     const customLink = nav.getByRole('link', { name: /usługi/i });
-    const customCount = await customLink.count();
-    test.skip(customCount === 0, 'No custom ObjectType in this environment seed');
+    // The effective menu loads async — give the custom OT entry a beat.
+    const hasCustom = await customLink
+      .waitFor({ state: 'visible', timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+    test.skip(!hasCustom, 'No custom ObjectType in this environment seed');
 
     const className = (await customLink.getAttribute('class')) ?? '';
     expect(className).not.toContain('violet');

--- a/apps/admin/e2e/1422-global-cmdk.spec.ts
+++ b/apps/admin/e2e/1422-global-cmdk.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * NUI-03 (#1422) — global ⌘K palette: real navigation (static routes +
+ * settings sub-pages), agent section mocked. The sidebar pill opens the
+ * palette; on the universal list routes the list-scoped palette keeps
+ * the shortcut (no double binding).
+ */
+test('NUI-03 — global palette navigates and mocks the agent section', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/dashboard');
+  // Wait for the app shell to hydrate before firing the shortcut.
+  await expect(
+    page.getByRole('button', { name: /zapytaj agenta|ask the agent/i }).first(),
+  ).toBeVisible();
+
+  // Open via keyboard.
+  await page.keyboard.press('ControlOrMeta+k');
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  // Agent section renders (mock suggestions + MOCK badge).
+  await expect(dialog.getByText('Generuj opisy SEO')).toBeVisible();
+  await expect(dialog.getByText('MOCK', { exact: true }).first()).toBeVisible();
+
+  // Type to filter and navigate to settings users.
+  await page.keyboard.type('Użytkow');
+  const usersEntry = dialog.getByRole('button', { name: /użytkownicy|users/i }).first();
+  const hasPl = await usersEntry.isVisible().catch(() => false);
+  if (!hasPl) {
+    // EN UI — retype the English label.
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.type('Users');
+  }
+  await dialog
+    .getByRole('button', { name: /użytkownicy|users/i })
+    .first()
+    .click();
+  await expect(page).toHaveURL(/\/settings\/users$/);
+
+  // Sidebar pill re-opens the palette from any page.
+  await page
+    .getByRole('button', { name: /zapytaj agenta|ask the agent/i })
+    .first()
+    .click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  await page.keyboard.press('Escape');
+});

--- a/apps/admin/src/components/agent/global-cmd-k.tsx
+++ b/apps/admin/src/components/agent/global-cmd-k.tsx
@@ -1,0 +1,241 @@
+import { ArrowRight, CornerDownLeft, Search, Sparkles } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router';
+
+import { MockBadge } from '@/components/ui/mock-badge';
+import { SETTINGS_NAV_GROUPS } from '@/layout/settings-nav-data';
+import { isMenuRefVisible, useIdentity } from '@/lib/identity';
+import { useEffectiveMenu } from '@/lib/use-effective-menu';
+import { cn } from '@/lib/utils';
+
+/** Custom event the sidebar pill dispatches to open the palette. */
+export const OPEN_CMDK_EVENT = 'pim:open-cmdk';
+
+interface NavEntry {
+  label: string;
+  route: string;
+  group: string;
+}
+
+const AGENT_SUGGESTIONS = [
+  'Dodaj atrybut',
+  'Generuj opisy SEO',
+  'Bulk update kategorii',
+  'Tłumaczenia PL→DE',
+];
+
+/**
+ * NUI-03 (#1422) — global ⌘K palette (design `Dashboard.html` CmdK).
+ * The navigation section is REAL: static routes + ObjectTypes from the
+ * effective menu + settings sub-pages, fuzzy-filtered, keyboard-driven.
+ * The agent section stays a MOCK until epik 0.7 / Faza 2 — suggestions
+ * render with a badge and never call the API.
+ *
+ * On the universal list routes (`/products`, `/objects/:slug`) the
+ * list-scoped CmdKPalette (VIEW-19, bulk intents) owns the mod+k
+ * shortcut — this host stays silent there to avoid a double binding;
+ * the sidebar pill still opens the global palette everywhere.
+ */
+export function GlobalCmdK() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { data: menu } = useEffectiveMenu();
+  const { identity } = useIdentity();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const listOwnsShortcut = pathname === '/products' || pathname.startsWith('/objects/');
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        if (listOwnsShortcut) return;
+        event.preventDefault();
+        setOpen((prev) => !prev);
+      }
+      if (event.key === 'Escape') setOpen(false);
+    };
+    const onOpenEvent = () => setOpen(true);
+    window.addEventListener('keydown', onKey);
+    window.addEventListener(OPEN_CMDK_EVENT, onOpenEvent);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener(OPEN_CMDK_EVENT, onOpenEvent);
+    };
+  }, [listOwnsShortcut]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setCursor(0);
+      window.requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const navEntries: NavEntry[] = useMemo(() => {
+    const groupNav = t('cmdk.group_nav', { defaultValue: 'Nawigacja' });
+    const groupSettings = t('cmdk.group_settings', { defaultValue: 'Ustawienia' });
+    const entries: NavEntry[] = [
+      { label: t('nav.dashboard'), route: '/dashboard', group: groupNav },
+      { label: t('nav.modeling'), route: '/modeling', group: groupNav },
+      { label: t('nav.multimedia'), route: '/assets', group: groupNav },
+      { label: t('nav.imports'), route: '/integrations/imports/sessions', group: groupNav },
+      { label: t('nav.exports'), route: '/integrations/exports/sessions', group: groupNav },
+      {
+        label: t('nav.api_configurator'),
+        route: '/integrations/api-configurator',
+        group: groupNav,
+      },
+    ];
+    for (const item of menu?.visible ?? []) {
+      if (item.route === null || item.comingSoon) continue;
+      if (!isMenuRefVisible(identity, item.ref)) continue;
+      if (item.kind !== 'object_type') continue;
+      entries.push({
+        label: item.label ?? (item.labelKey ? t(item.labelKey) : item.ref),
+        route: item.route,
+        group: groupNav,
+      });
+    }
+    if (isMenuRefVisible(identity, 'settings')) {
+      for (const group of SETTINGS_NAV_GROUPS) {
+        for (const item of group.items) {
+          entries.push({ label: t(item.labelKey), route: item.to, group: groupSettings });
+        }
+      }
+    }
+    return entries;
+  }, [menu, identity, t]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (needle === '') return navEntries.slice(0, 8);
+    return navEntries.filter((entry) => entry.label.toLowerCase().includes(needle)).slice(0, 8);
+  }, [navEntries, query]);
+
+  if (!open) return null;
+
+  const go = (route: string): void => {
+    setOpen(false);
+    void navigate(route);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[55] grid place-items-start bg-zinc-900/40 pt-24 backdrop-blur-sm">
+      <button
+        type="button"
+        aria-label={t('app.close', { defaultValue: 'Zamknij' })}
+        onClick={() => setOpen(false)}
+        className="absolute inset-0 cursor-default"
+      />
+      <div
+        className="relative mx-auto flex w-[640px] max-w-[94vw] flex-col overflow-hidden rounded-3xl bg-white shadow-2xl"
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('cmdk.title', { defaultValue: 'Szukaj lub przejdź' })}
+      >
+        <div className="flex h-14 items-center gap-3 border-b border-zinc-100 px-5">
+          <Search className="size-4 shrink-0 text-zinc-400" aria-hidden />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setCursor(0);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setCursor((c) => Math.min(c + 1, filtered.length - 1));
+              } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setCursor((c) => Math.max(c - 1, 0));
+              } else if (e.key === 'Enter') {
+                const target = filtered[cursor];
+                if (target) go(target.route);
+              }
+            }}
+            placeholder={t('cmdk.placeholder', {
+              defaultValue: 'Przejdź do… (np. Użytkownicy, Modelowanie, Importy)',
+            })}
+            className="h-full flex-1 text-[14px] outline-none placeholder:text-zinc-400"
+          />
+          <kbd className="rounded border border-zinc-200 bg-zinc-50 px-1.5 py-0.5 font-mono text-[10px] text-zinc-500">
+            esc
+          </kbd>
+        </div>
+
+        <div className="max-h-[420px] space-y-4 overflow-y-auto p-4">
+          <div>
+            <div className="px-2 pb-1 text-[10.5px] font-semibold uppercase tracking-wider text-zinc-400">
+              {t('cmdk.section_nav', { defaultValue: 'Przejdź do' })}
+            </div>
+            {filtered.length === 0 ? (
+              <p className="px-2 py-2 text-[12.5px] text-zinc-400">
+                {t('cmdk.no_results', { defaultValue: 'Brak pasujących stron.' })}
+              </p>
+            ) : (
+              <ul>
+                {filtered.map((entry, index) => (
+                  <li key={entry.route}>
+                    <button
+                      type="button"
+                      onClick={() => go(entry.route)}
+                      onMouseEnter={() => setCursor(index)}
+                      className={cn(
+                        'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[13px]',
+                        index === cursor ? 'bg-zinc-100 text-zinc-900' : 'text-zinc-700',
+                      )}
+                    >
+                      <ArrowRight className="size-3.5 shrink-0 text-zinc-400" aria-hidden />
+                      <span className="flex-1 truncate">{entry.label}</span>
+                      <span className="text-[10.5px] uppercase tracking-wider text-zinc-400">
+                        {entry.group}
+                      </span>
+                      {index === cursor ? (
+                        <CornerDownLeft className="size-3.5 text-zinc-400" aria-hidden />
+                      ) : null}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div>
+            <div className="flex items-center gap-1.5 px-2 pb-1 text-[10.5px] font-semibold uppercase tracking-wider text-zinc-400">
+              <Sparkles className="size-3 text-orange-500" aria-hidden />
+              {t('cmdk.section_agent', { defaultValue: 'Agent' })}
+              <MockBadge
+                tooltip={t('cmdk.agent_mock_tooltip', {
+                  defaultValue: 'MOCK — agent layer wymaga oprogramowania (epik 0.7, Faza 2)',
+                })}
+              />
+            </div>
+            <ul className="opacity-60">
+              {AGENT_SUGGESTIONS.map((suggestion) => (
+                <li key={suggestion}>
+                  <div className="flex w-full cursor-not-allowed items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[13px] text-zinc-500">
+                    <Sparkles className="size-3.5 shrink-0 text-zinc-300" aria-hidden />
+                    <span className="flex-1 truncate">{suggestion}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 border-t border-zinc-100 bg-zinc-50/60 px-5 py-2.5 text-[10.5px] text-zinc-400">
+          <span>↑↓ {t('cmdk.kbd_navigate', { defaultValue: 'nawiguj' })}</span>
+          <span>↵ {t('cmdk.kbd_open', { defaultValue: 'otwórz' })}</span>
+          <span>esc {t('cmdk.kbd_close', { defaultValue: 'zamknij' })}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/layout/AppLayout.tsx
+++ b/apps/admin/src/layout/AppLayout.tsx
@@ -2,11 +2,10 @@ import { Menu } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Outlet } from 'react-router';
-
+import { GlobalCmdK } from '@/components/agent/global-cmd-k';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { TooltipProvider } from '@/components/ui/tooltip';
-
 import { ExportsLiveBridge } from '@/features/exports/hooks/ExportsLiveBridge';
 
 import { AppFooter } from './app-footer';
@@ -24,6 +23,7 @@ export function AppLayout() {
       <PageActionsProvider>
         <NotificationsInboxProvider>
           <ExportsLiveBridge />
+          <GlobalCmdK />
           <div className="flex min-h-screen bg-background">
             <aside className="sticky top-0 hidden h-screen w-[260px] shrink-0 flex-col px-4 py-5 md:flex">
               <SidebarNav />

--- a/apps/admin/src/layout/sidebar-nav.tsx
+++ b/apps/admin/src/layout/sidebar-nav.tsx
@@ -430,8 +430,8 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
   const brandSubtitle =
     refineIdentity?.tenant?.name ?? t('app.brand_subtitle_fallback', { defaultValue: 'Workspace' });
 
-  const agentTooltip = t('topbar.agent_mock_tooltip', {
-    defaultValue: 'MOCK · Agent layer wymaga oprogramowania (epik 0.7, Faza 2)',
+  const agentTooltip = t('topbar.agent_pill_tooltip', {
+    defaultValue: 'Nawigacja ⌘K działa; sekcja agenta = MOCK (epik 0.7, Faza 2)',
   });
 
   return (
@@ -455,8 +455,8 @@ export function SidebarNav({ onNavigate }: SidebarNavProps) {
         <TooltipTrigger asChild>
           <button
             type="button"
-            disabled
-            className="mt-1 flex w-full cursor-not-allowed items-center gap-2 rounded-2xl bg-white px-3 py-2.5 text-left shadow-[0_1px_2px_rgba(0,0,0,0.04),0_4px_12px_rgba(0,0,0,0.04)] transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => window.dispatchEvent(new CustomEvent('pim:open-cmdk'))}
+            className="mt-1 flex w-full items-center gap-2 rounded-2xl bg-white px-3 py-2.5 text-left shadow-[0_1px_2px_rgba(0,0,0,0.04),0_4px_12px_rgba(0,0,0,0.04)] transition hover:bg-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label={t('topbar.search_agent_placeholder', {
               defaultValue: 'Zapytaj agenta lub szukaj...',
             })}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -932,7 +932,8 @@
     "agent_mock_tooltip": "MOCK · Agent layer requires implementation (epic 0.7, Phase 2)",
     "audit_log": "Audit log",
     "audit_log_tooltip": "MOCK · Audit log requires BE endpoint",
-    "history": "History"
+    "history": "History",
+    "agent_pill_tooltip": "⌘K navigation works; the agent section is a MOCK (epic 0.7, Phase 2)"
   },
   "mock": {
     "label": "MOCK",
@@ -2672,5 +2673,18 @@
     "status": {
       "cancelled": "cancelled"
     }
+  },
+  "cmdk": {
+    "group_nav": "Navigation",
+    "group_settings": "Settings",
+    "title": "Search or jump to",
+    "placeholder": "Jump to… (e.g. Users, Modeling, Imports)",
+    "section_nav": "Jump to",
+    "no_results": "No matching pages.",
+    "section_agent": "Agent",
+    "agent_mock_tooltip": "MOCK — the agent layer ships in epic 0.7 (Phase 2)",
+    "kbd_navigate": "navigate",
+    "kbd_open": "open",
+    "kbd_close": "close"
   }
 }

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -942,7 +942,8 @@
     "agent_mock_tooltip": "MOCK · Agent layer wymaga oprogramowania (epik 0.7, Faza 2)",
     "audit_log": "Audit log",
     "audit_log_tooltip": "MOCK · Audit log wymaga endpointu BE",
-    "history": "Historia"
+    "history": "Historia",
+    "agent_pill_tooltip": "Nawigacja ⌘K działa; sekcja agenta = MOCK (epik 0.7, Faza 2)"
   },
   "mock": {
     "label": "MOCK",
@@ -2728,5 +2729,18 @@
     "status": {
       "cancelled": "anulowano"
     }
+  },
+  "cmdk": {
+    "group_nav": "Nawigacja",
+    "group_settings": "Ustawienia",
+    "title": "Szukaj lub przejdź",
+    "placeholder": "Przejdź do… (np. Użytkownicy, Modelowanie, Importy)",
+    "section_nav": "Przejdź do",
+    "no_results": "Brak pasujących stron.",
+    "section_agent": "Agent",
+    "agent_mock_tooltip": "MOCK — agent layer wymaga oprogramowania (epik 0.7, Faza 2)",
+    "kbd_navigate": "nawiguj",
+    "kbd_open": "otwórz",
+    "kbd_close": "zamknij"
   }
 }


### PR DESCRIPTION
## Zakres (NUI-03, #1422)

- **Nowy `GlobalCmdK`** w AppLayout (design `Dashboard.html` CmdK): sekcja **„Przejdź do" REALNA** — trasy statyczne + ObjectTypes z effective menu (z gatingiem `isMenuRefVisible`) + podstrony Ustawień (`settings-nav-data`), fuzzy-filter, pełna obsługa klawiatury (↑↓ ↵ esc), footer ze skrótami.
- **Sekcja Agent = MOCK** z badge („epik 0.7, Faza 2") — sugestie renderują się disabled, zero wywołań API.
- **Brak double-bindingu**: na trasach universal listy (`/products`, `/objects/*`) skrót zostaje przy palecie kontekstowej VIEW-19 (bulk-intencje, nietknięta); globalny host tam milczy. Pill w sidebarze **odblokowany** — otwiera globalną paletę wszędzie (custom event), tooltip uczciwie opisuje zakres.
- Świadome odejście: zamiast rozszerzać paletę listy (ryzyko regresji VIEW-19) — osobny komponent globalny; modal „Plan zmian" z mockupu pominięty (sekcja agenta i tak disabled — pełny plan-preview wróci z epikiem 0.7).

## Testy + smoke

- Nowy spec `e2e/1422-global-cmdk.spec.ts` — **1/1 passed na żywym stacku**: ⌘K na dashboardzie → dialog; sekcja agenta z MOCK badge; filtr „Użytkownicy/Users" → nawigacja do `/settings/users`; pill ponownie otwiera paletę.
- Regresja: `1420-sidebar-settings-subtree` ✅ (+utwardzenie flaky skipa custom OT — czeka na async menu), spec VIEW-19 nietknięty.
- Gates: tsc ✅, Biome ✅, Vite build ✅.

Plan: `Project Plan/UI/Retrofit_v2/plan-epik-NUI-retrofit-ui-v2.md` § NUI-03.

Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)
