### PR TITLE
NUI-06: karta produktu v2 — parytet po unifikacji #1434 + spec strażniczy

### DIFF
--- a/apps/admin/e2e/1425-product-detail-v2.spec.ts
+++ b/apps/admin/e2e/1425-product-detail-v2.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * NUI-06 (#1425) — design-parity guard for the unified product detail
+ * card. The structural v2 work shipped via the detail-unification
+ * series (#1434, #1351, #1440, #1442) and the NUI-07 de-violet sweep;
+ * this spec pins the design surface from `produkty/detail-view.jsx`:
+ * header (back + breadcrumb + actions + completeness ring), tabs with
+ * counts, collapsible attribute groups with fill counters, provenance
+ * badges, the locale/channel switcher and the right rail.
+ */
+test('NUI-06 — product detail renders the v2 design surface', async ({ page }) => {
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  await apiLogin(page);
+
+  const productsResponse = await page.request.get('/api/products?itemsPerPage=1', {
+    headers: { authorization: `Bearer ${token}`, accept: 'application/ld+json' },
+  });
+  const body = (await productsResponse.json()) as { member?: Array<{ id: string }> };
+  const productId = body.member?.[0]?.id;
+  test.skip(productId === undefined, 'No products in this environment seed');
+
+  await page.goto(`/products/${productId}`);
+  await page.waitForURL(/\/products\/[0-9a-f-]{8,}/, { timeout: 15_000 });
+
+  // Header: breadcrumb back-link, action buttons, completeness ring (%).
+  await expect(page.getByRole('link', { name: /produkty|products/i }).first()).toBeVisible();
+  await expect(page.getByRole('button', { name: /podgląd|preview/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /duplikuj|duplicate/i })).toBeVisible();
+  await expect(page.getByText(/^\d+%$/).first()).toBeVisible();
+
+  // Locale/channel switcher present (scope-aware reads, #1225/#1269).
+  await expect(page.getByRole('button', { name: /język|language/i }).first()).toBeVisible();
+
+  // Tabs with counts render (attribute groups as tabs + special tabs).
+  await expect(page.getByText(/media|multimedia/i).first()).toBeVisible();
+  await expect(page.getByText(/historia|history/i).first()).toBeVisible();
+
+  // Attribute group card: fill counter + provenance badge on rows.
+  await expect(page.getByText(/\d+ \/ \d+|filled/i).first()).toBeVisible();
+  await expect(page.getByText(/manual|import|agent|integration/i).first()).toBeVisible();
+
+  // Right rail: effective model + variants cards.
+  await expect(page.getByText(/effective model|model efektywny/i)).toBeVisible();
+  await expect(page.getByText(/variants|warianty/i).first()).toBeVisible();
+});


### PR DESCRIPTION
## Zakres (NUI-06, #1425) — rewizja po unifikacji detalu

**Kontekst rewizji**: między rozpisaniem epiku a tym ticketem równoległa seria PR-ów (#1434 unifikacja detalu, #1351 edit-mode default, #1440 SKU fix, #1442 identyfikator „ID") dostarczyła strukturalny zakres NUI-06: jest JEDNA strona detalu (universal-detail-page usunięty), header z back/breadcrumb/akcjami (Podgląd/Duplikuj/menu, Zapisz zmiany / Zapisz i wróć), **pierścień kompletności**, taby z licznikami (grupy + Media/Kategorie/Historia/Warianty), zwijane karty grup z licznikiem wypełnienia, **badge provenance** per wiersz, sticky selektor locale/kanału (#1225/#1269), prawa szyna (Kategorie / Publication status / Variants / Effective model). De-violet komponentów detalu wszedł w NUI-07. Screenshot weryfikacyjny w wątku issue.

**Świadoma decyzja (marathon)**: ZERO restyle'u kodu w tym PR — karta to najgoręcej bugfixowana powierzchnia tygodnia (5 PR-ów); ekstrakcja `DetailHeaderV2` z planu jest bezprzedmiotowa (jedna strona). Zamiast tego: **spec strażniczy** `e2e/1425-product-detail-v2.spec.ts` pinujący powierzchnię designu (header+ring, taby, fill counters, provenance, switcher, szyna) — parytet z `detail-view.jsx` egzekwowany w CI.

## Testy + smoke

- Nowy spec 1/1 ✅ na żywym stacku (wzorzec API-id z 1351).
- Live smoke: login 200 → `/products/{id}` renderuje pełną powierzchnię v2 (screenshot w issue).
- Gates: tsc ✅, Biome ✅.

Plan: `Project Plan/UI/Retrofit_v2/plan-epik-NUI-retrofit-ui-v2.md` § NUI-06 (korekta zakresu → NUI-13).

Closes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
