### PR TITLE
chore(deps): bump guzzlehttp/psr7 do 2.11.0 (CVE-2026-48998, CVE-2026-49214)

### DIFF
--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d9e98500bcac229721d7b60907c87cba",
+    "content-hash": "e64e51ca26942f2087c6fcbdb889ceb2",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -3163,23 +3163,25 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.10.1",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
-                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -3260,7 +3262,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -3276,7 +3278,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T09:27:36+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "lcobucci/jwt",


### PR DESCRIPTION
Świeże advisory (2026-06-11) na `guzzlehttp/psr7 <2.10.2` wywróciły gate `composer audit` na każdym PR (pierwszy raz widoczne na #1500 — zmiana czysto FE).

- `composer update guzzlehttp/psr7 --with-all-dependencies` → **2.11.0** (zmiana tylko w composer.lock, +10/-8 linii)
- Lokalnie: `composer audit --no-dev --abandoned=fail --locked` → **No security vulnerability advisories found**
- Smoke po `docker compose restart api`: login na live stacku → HTTP 200