### PR TITLE
IMP2-0.2 — fix(imports,exports): topic Mercure z konfiguracji zamiast hardcoded pim.localhost

### DIFF
--- a/apps/admin/src/features/exports/hooks/useExportSessionsStream.ts
+++ b/apps/admin/src/features/exports/hooks/useExportSessionsStream.ts
@@ -49,7 +49,9 @@ export function useExportSessionsStream(userId: string | null): UseExportSession
       return;
     }
 
-    const topic = `https://pim.localhost/exports/${userId}`;
+    // Topic base = SPA origin (Caddy single-origin); BE publishers use the
+    // matching MERCURE_TOPIC_BASE env (IMP2-0.2 / #1461) — no hardcoded host.
+    const topic = `${window.location.origin}/exports/${userId}`;
     const url = `${window.location.origin}/.well-known/mercure?topic=${encodeURIComponent(topic)}`;
     const source = new EventSource(url, { withCredentials: true });
 

--- a/apps/admin/src/features/imports/hooks/useImportProgress.ts
+++ b/apps/admin/src/features/imports/hooks/useImportProgress.ts
@@ -71,7 +71,9 @@ export function useImportProgress(sessionId: string | null): ImportProgressState
       return;
     }
 
-    const topic = `https://pim.localhost/imports/${sessionId}`;
+    // Topic base = SPA origin (Caddy single-origin); BE publishers use the
+    // matching MERCURE_TOPIC_BASE env (IMP2-0.2 / #1461) — no hardcoded host.
+    const topic = `${window.location.origin}/imports/${sessionId}`;
     const url = `${window.location.origin}/.well-known/mercure?topic=${encodeURIComponent(topic)}`;
     const source = new EventSource(url, { withCredentials: true });
 

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -100,6 +100,10 @@ MERCURE_URL=https://example.com/.well-known/mercure
 MERCURE_PUBLIC_URL=https://example.com/.well-known/mercure
 # The secret used to sign the JWTs
 MERCURE_JWT_SECRET="!ChangeThisMercureHubJWTSecretKey!"
+# Base URI of Mercure topics published by import/export progress publishers.
+# Subscribers (admin SPA) build topics from window.location.origin, so this
+# must equal the public origin the SPA is served from.
+MERCURE_TOPIC_BASE=https://pim.localhost
 ###< symfony/mercure-bundle ###
 
 ###> symfony/lock ###

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -190,6 +190,16 @@ services:
             $url: '%env(default::MEILI_URL)%'
             $masterKey: '%env(default::MEILI_KEY)%'
 
+    # Mercure topic base for progress publishers (IMP2-0.2 / #1461).
+    # Subscribers (admin SPA) build the same topics from
+    # window.location.origin — the value must match the public origin.
+    App\Import\Application\Service\ImportProgressPublisher:
+        arguments:
+            $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+    App\Export\Application\Async\ExportProgressPublisher:
+        arguments:
+            $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+
     # Bind the named Flysystem storage for the Asset uploader. Without
     # this Symfony has multiple FilesystemOperator services (one per
     # named storage) and autowire can't pick. The named alias

--- a/apps/api/src/Export/Application/Async/ExportProgressPublisher.php
+++ b/apps/api/src/Export/Application/Async/ExportProgressPublisher.php
@@ -37,7 +37,7 @@ final class ExportProgressPublisher
 
     public function __construct(
         private readonly HubInterface $hub,
-        private readonly string $topicBase = 'https://pim.localhost',
+        private readonly string $topicBase,
         ?LoggerInterface $logger = null,
     ) {
         $this->logger = $logger ?? new NullLogger();

--- a/apps/api/src/Import/Application/Service/ImportProgressPublisher.php
+++ b/apps/api/src/Import/Application/Service/ImportProgressPublisher.php
@@ -31,7 +31,7 @@ final class ImportProgressPublisher
 
     public function __construct(
         private readonly HubInterface $hub,
-        private readonly string $topicBase = 'https://pim.localhost',
+        private readonly string $topicBase,
         ?LoggerInterface $logger = null,
     ) {
         $this->logger = $logger ?? new NullLogger();

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -113,6 +113,7 @@ services:
       MERCURE_URL: http://mercure/.well-known/mercure
       MERCURE_PUBLIC_URL: ${MERCURE_PUBLIC_URL:-https://pim.localhost/.well-known/mercure}
       MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:-!ChangeMercureKeyAtLeast256BitsLong!}
+      MERCURE_TOPIC_BASE: ${MERCURE_TOPIC_BASE:-https://pim.localhost}
       MEILI_URL: http://meilisearch:7700
       MEILI_KEY: ${MEILI_MASTER_KEY:-masterKeyPleaseChangeMe}
     # Worker entrypoint: drain `async` then exit cleanly. Docker restarts the


### PR DESCRIPTION
## Co i dlaczego

Oba publishery progresu (`ImportProgressPublisher`, `ExportProgressPublisher`) miały default `topicBase = 'https://pim.localhost'` w kodzie, a oba hooki SPA budowały topic na sztywno z tego samego hosta. Na innej domenie (prod) subskrypcja po cichu mija się z publikacją → live progress przestaje działać. Łamało regułę CLAUDE.md o hardcodowanych URL-ach.

## Zmiany
- BE: `$topicBase` wymagany przez DI, binding `%env(MERCURE_TOPIC_BASE)%` w `services.yaml` (oba publishery); default w kodzie usunięty.
- `apps/api/.env`: `MERCURE_TOPIC_BASE=https://pim.localhost` (dev); `docker-compose.prod.yml`: passthrough `${MERCURE_TOPIC_BASE:-…}`.
- FE: `useImportProgress` i `useExportSessionsStream` budują topic z `window.location.origin` (single-origin przez Caddy gwarantuje zgodność z BE).

## Smoke (live stack)
Subskrypcja URI-template `https://pim.localhost/imports/{id}` na realnym hubie + import przez API (po `docker compose restart api`):
```
data: {"type":"row_processed","session_id":"019ebd1c-…",…}
data: {"type":"completed","session_id":"019ebd1c-…","data":{"status":"partial",…}}
```
→ eventy publikowane przez BE z env-owego topicBase trafiają dokładnie w topic, który FE buduje z origin. Sesje smoke zrollbackowane.

Poza zakresem (pre-existing): hardcody `appBaseUrl` w Identity (UserCreateService/PasswordResetService/InvitationService) — inny obszar, nie dotykany.

Biome + tsc + php-cs-fixer czyste. PHPStan lokalnie zgłasza 1 pre-existing błąd w `tests/Api/Catalog/CatalogObjectPolyKindPatchDeleteTest.php:189` (cast mixed→string, plik nieruszany tym PR-em — najpewniej artefakt świeżo zinwalidowanego cache po bumpie vendora; CI rozstrzygnie).

Closes #1461