### PR TITLE
IMP2-1.1 — docs(import): ADR-0019 kontrakty silnika importu + warstwy Deptrac Import/Export

### DIFF
--- a/Project Plan/01-architektura-pim.md
+++ b/Project Plan/01-architektura-pim.md
@@ -1252,7 +1252,7 @@ Opcja (Y) zachowuje killer feature ADR-012 (dziedziczenie grup atrybutów po drz
 
 **Referencje:** ADR-014 (rewidowany w zakresie scope drzewa; reszta — primary category overlay, cumulative resolution, EffectiveAttributeGroupResolver — w mocy). Plan implementacji: PR-A (#1118) schema+encja+create, PR-B API+resolver+walidacja przypisania, PR-C FE (dropdown all-categorizable + objectTypeId, list/new/show per drzewo, reword etykiety `is_categorizable` → „czy obiekty mogą być przypisane do drzewa").
 
-### ADR-0016, ADR-0017, ADR-0018 (per-file MADR)
+### ADR-0016, ADR-0017, ADR-0018, ADR-0019 (per-file MADR)
 
 Decyzje ADR-0016 (format kluczy API + Argon2id), ADR-0017 (BYOK AES-256-GCM) i ADR-0018 (ChannelPublicationProfile — per-channel attribute/locale allow-list, `?publication=<channel>` oddzielne od `?channel=`) są zarchiwizowane w plikach per-file MADR w `docs/adr/`. Streszczenie ADR-0018:
 
@@ -1260,6 +1260,8 @@ Decyzje ADR-0016 (format kluczy API + Argon2id), ADR-0017 (BYOK AES-256-GCM) i A
 - Param `?publication=<channel>` dedykowany dla filtrowania atrybutów do profilu — NIE przeciążamy `?channel=` (który nadal znaczy overlay wartości).
 - Cross-BC dostęp przez `Channel\Contracts\ChannelPublicationResolverInterface` (Deptrac-safe).
 - Bare UUID refs (`channel_id`, `object_type_id`) zgodnie z ADR-015.
+
+Streszczenie ADR-0019 (Import v2 — kontrakty silnika, epik IMP2 #1460–#1498): tryby importu `CREATE/UPDATE/UPSERT` (default upsert) z matchem po SKU lub atrybucie `identifier` per profil; semantyka komórek „pusta = nie ruszaj" + `clear_if_empty` opt-in per kolumna; kanon shape'ów JSONB `object_values.value` per typ (z migracją legacy `{value}`-selectów w #1464); gramatyka kolumn `code[.locale][.channel]` z rejestrami tenanta i precedencją locale; `import_session_id` wyłącznie jako marker created-by (rollback upsertów przez undo-log); mapping v2 kluczowany indeksem kolumny; transport Messenger `import` z workerem w dev i prod; reguły normalizacji golden testu (wersjonowane). Pełny plik: `docs/adr/0019-import-v2-engine-contracts.md`.
 
 ## 14. Roadmap rozwoju
 

--- a/Project Plan/UI/imports-v2-karta-prawdy.md
+++ b/Project Plan/UI/imports-v2-karta-prawdy.md
@@ -1,0 +1,21 @@
+# Imports v2 — karta prawdy UI (IMP2-1.1 / #1463)
+
+> Co w UI importów jest REALNE na danym etapie przebudowy (ADR-0019). Aktualizować przy merge ticketów IMP2.
+> Stan po NUI-10 (#1452) / NUI-11 (#1453): wizard 6 kroków i widok sesji istnieją NA STARYM silniku.
+
+| Element UI | Stan (2026-06-12) | Realne od |
+|---|---|---|
+| Wizard 6 kroków (Źródło→…→Start) | renderuje się; backend = stary silnik | — |
+| Tryby CREATE/UPDATE/UPSERT w kroku Reguły | **dekoracja** — silnik robi wyłącznie create, duplikat SKU blokuje wiersz | #1465 |
+| Kubełek „Aktualizacje" w Podglądzie | **kłamie** (silnik nie umie update) | #1465 + #1492 |
+| Dry-run pełnego pliku | sync, cały plik w jednym requeście | #1492 (dwupoziomowy) |
+| Pauza / wznów / anuluj | brak w UI (endpointy BE nieobsługiwane przez worker) | #1479 |
+| Rollback | działa dla CREATE; **nie cofa update'ów**; ghost-docs w Meili | #1480 |
+| Zdjęcia (URL/ZIP) | brak pobierania (pola martwe) | #1475 / #1476 |
+| Mapping: duplikaty/puste nagłówki | gubione (mapping po nazwie) | #1489 (po indeksie) |
+| Kolumny `code.channel` | **korupcja**: suffix zapisywany jako locale | #1469 |
+| Warianty / relacje / multi-kategorie | parent_sku skip; relacje bez ObjectRelation; 1 kategoria | #1470 / #1471 |
+| Profile: zapis z wizarda / prefill | niedziałające (stan lokalny) | #1491 |
+| Harmonogramy run-now / źródła SFTP | stemple bez sesji / stub „ok" | #1495 / #1496 |
+| Pobierz raport CSV / eksport profilu | ✅ działa (fetch+Bearer, #1500) | done |
+| Live progress (Mercure) | ✅ działa; topic z configu po #1502 | done |

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -104,6 +104,18 @@ parameters:
               - type: directory
                 value: 'src/ApiConfigurator/.*'
 
+        # ─── Import / Export (ADR-0019, IMP2-1.1 #1463) ────────────────
+        # Target ruleset: only *_Contracts + Shared. Existing reaches into
+        # Catalog_Internals are baselined below and burned down by #1466.
+        - name: Import
+          collectors:
+              - type: directory
+                value: 'src/Import/.*'
+        - name: Export
+          collectors:
+              - type: directory
+                value: 'src/Export/.*'
+
         # ─── Tooling — fixtures, benchmarks, foundry stories, PHPStan rules ───
         - name: Tooling
           collectors:
@@ -144,6 +156,19 @@ parameters:
             - Identity_Contracts
             - Shared
         Asset_Contracts:
+            - Shared
+
+        Import:
+            - Catalog_Contracts
+            - Channel_Contracts
+            - Asset_Contracts
+            - Identity_Contracts
+            - Shared
+        Export:
+            - Catalog_Contracts
+            - Channel_Contracts
+            - Asset_Contracts
+            - Identity_Contracts
             - Shared
 
         Identity_Internals:
@@ -199,6 +224,8 @@ parameters:
             - Identity_Internals
             - Identity_Contracts
             - Shared
+            - Import
+            - Export
 
     # Inline baseline of pre-existing cross-BC violations that the cleanup
     # tickets handle in follow-ups (see ADR-0013). Three clusters:
@@ -245,3 +272,127 @@ parameters:
             - App\Catalog\Domain\Entity\Attribute
         App\Identity\Infrastructure\Security\Prd\AttributeGroupVoter:
             - App\Catalog\Domain\Entity\AttributeGroup
+
+        # 3. IMP2-1.1 (#1463): Import/Export layers added with target ruleset
+        #    (*_Contracts + Shared only). Existing reaches into Catalog/Channel/
+        #    Identity internals + Identity voters importing Import entities are
+        #    baselined here; #1466 (shared writer core) burns the bulk down.
+        App\Export\Application\Builder\ExportBuilder:
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectValue
+            - App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectValueRepositoryInterface
+        App\Export\Application\Builder\Structural\AttributesGroupsExportBuilder:
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Entity\AttributeGroupAttribute
+            - App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface
+            - App\Catalog\Domain\Repository\AttributeRepositoryInterface
+            - App\Channel\Domain\Repository\TenantLocaleRepositoryInterface
+        App\Export\Application\Builder\Structural\CategoriesExportBuilder:
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\ObjectKind
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+            - App\Catalog\Domain\Repository\CategoryAttributeGroupRepositoryInterface
+            - App\Channel\Domain\Repository\TenantLocaleRepositoryInterface
+        App\Export\Application\Builder\Structural\ModuleSchemaExportBuilder:
+            - App\Catalog\Domain\Entity\AttributeGroup
+            - App\Catalog\Domain\Entity\AttributeGroupAttribute
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Entity\ObjectTypeAttributeGroup
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        App\Export\Application\Builder\ValueSerializer:
+            - App\Catalog\Domain\AttributeType
+            - App\Catalog\Domain\Entity\ObjectValue
+        App\Export\Application\Sync\SyncExportRunner:
+            - App\Catalog\Application\Filter\FilterDslResolver
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\ObjectKind
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        App\Export\Presentation\Controller\ExportPreflightController:
+            - App\Catalog\Application\Filter\FilterDslResolver
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\ObjectKind
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        App\Export\Presentation\Support\ExportEntityTypeResolver:
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        App\Identity\Infrastructure\Security\ImportProfileVoter:
+            - App\Import\Domain\Entity\ImportProfile
+        App\Identity\Infrastructure\Security\ImportScheduleVoter:
+            - App\Import\Domain\Entity\ImportSchedule
+        App\Identity\Infrastructure\Security\ImportSessionVoter:
+            - App\Import\Domain\Entity\ImportSession
+        App\Identity\Infrastructure\Security\ImportSourceVoter:
+            - App\Import\Domain\Entity\ImportSource
+        App\Import\Application\Service\ImportObjectCreator:
+            - App\Catalog\Domain\AttributeType
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectCategory
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Entity\ObjectValue
+            - App\Catalog\Domain\ObjectKind
+            - App\Catalog\Domain\Provenance
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+        App\Import\Application\Service\ImportValidationService:
+            - App\Catalog\Domain\AttributeType
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\ObjectKind
+            - App\Catalog\Domain\Repository\AttributeRepositoryInterface
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+        App\Import\Domain\Entity\ImportProfile:
+            - App\Catalog\Domain\Entity\ObjectType
+        App\Import\Domain\Entity\ImportSession:
+            - App\Catalog\Domain\Entity\ObjectType
+        App\Import\Infrastructure\ApiPlatform\State\ImportProfileProcessor:
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+            - App\Identity\Domain\Entity\User
+        App\Import\Infrastructure\ApiPlatform\State\ImportScheduleProcessor:
+            - App\Identity\Domain\Entity\User
+        App\Import\Infrastructure\ApiPlatform\State\ImportSourceProcessor:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\AutoMapController:
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\ObjectKind
+            - App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        App\Import\Presentation\Controller\DuplicateImportProfileController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ExportImportProfileController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\GetImportSessionController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ImportImportProfileController:
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ImportReportCsvController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ImportSessionStateController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ImportThroughputController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ListImportSessionsController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ListScheduleRunsController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ParsePreviewController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\RollbackImportController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ScheduleStateController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\StartImportController:
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\TestImportSourceConnectionController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\UpcomingSchedulesController:
+            - App\Identity\Domain\Entity\User
+        App\Import\Presentation\Controller\ValidateDryRunController:
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface

--- a/docs/adr/0019-import-v2-engine-contracts.md
+++ b/docs/adr/0019-import-v2-engine-contracts.md
@@ -1,0 +1,151 @@
+# 0019. Import v2 — engine contracts (modes, match key, cell semantics, JSONB canon)
+
+- **Status:** accepted
+- **Date:** 2026-06-12
+- **Deciders:** Marcin Lipiec, Senior Staff Engineer
+
+## Context and Problem Statement
+
+The import module is being rebuilt across ~39 tickets (epic IMP2, issues
+#1460–#1498; plan: `Project Plan/UI/feature-imports-v2.md`). Multiple agent
+sessions will implement it. Today the repo holds three contradictory versions
+of the truth about import modes (docblock says "always upserts", spec v1 says
+"ADD-only", the code does create-only with a blocking duplicate check), and
+`docs/api/jsonb-schemas.md` contradicts the value shapes the export serializer
+and the search flattener actually read. Every contract an implementer could
+guess differently must be pinned down here, once.
+
+Operator decisions recorded 2026-06-12 (plan §9) are binding inputs.
+
+## Decisions
+
+### D1 — Match key
+
+Row→object matching uses `objects.code` (SKU) by default; an import profile
+may select one attribute of type `identifier` (e.g. `ean`) instead. Matching
+is **case-sensitive** after `trim()` on the cell value. Duplicate match keys
+inside one file: the **first occurrence wins**, subsequent rows are skipped
+with a warning during pre-flight — never left for a DB unique constraint to
+explode mid-batch (Akeneo's historical failure mode).
+
+### D2 — Cell semantics (three states)
+
+| State | Behaviour |
+|---|---|
+| column absent from file/mapping | attribute untouched |
+| cell empty | attribute untouched (**default**) |
+| cell empty + `clear_if_empty` opt-in per column | value cleared (delete ObjectValue + rebuild caches) |
+
+Collections (multiselect, categories, galleries): `replace` is the default
+when the column is present; `append` is per-column opt-in. `clear_if_empty`
+does not reach the UI until the D7 migration is complete (legacy select rows
+export as empty cells — clearing on that signal would mass-delete data).
+Dry-run must show a "will clear N values" bucket; >20% of existing non-empty
+values cleared in one column requires an explicit confirm.
+
+### D3 — Modes
+
+`ImportMode` = `CREATE` | `UPDATE` | `UPSERT`, default **UPSERT**.
+MERGE/INCREMENT/DELETE are removed from the enum (they never had an
+implementation); existing `import_profiles.mode` rows are migrated
+(`ADD→CREATE`, `MERGE|INCREMENT|DELETE→UPSERT`) in the same PR that shrinks
+the enum (#1465). The session stores the mode chosen at start; profiles only
+pre-fill it.
+
+### D4/D5 — Round-trip scope and identifier resolution
+
+Baseline (etap 1) round-trips: all 17 attribute-type values, multi-categories,
+status/enabled, variants (`parent_sku`, two-pass), relations (as
+`ObjectRelation`, resolved by code), asset references (same-tenant
+`asset_id`). Structural exports (module_schema / attributes_groups /
+categories) stay one-way. Cross-environment relation/select resolution is by
+`code`; assets resolve by id (URL/path resolution arrives with media tickets).
+
+### D7 — JSONB value canon (object_values.value per AttributeType)
+
+| Types | Canonical shape |
+|---|---|
+| text, textarea, wysiwyg, number, date, datetime, boolean, color, email, identifier | `{"value": <scalar>}` |
+| select | `{"option_code": "<code>"}` |
+| multiselect | `{"option_codes": ["<code>", …]}` |
+| price | `{"amount": <number>, "currency": "<ISO>"}` |
+| metric | `{"value": <number>, "unit": "<code>"}` |
+| asset | `{"asset_id": "<uuid>"}` |
+| relation, reference | `{"object_id": "<uuid>"}` |
+
+Known legacy deviations to be migrated by #1464: admin-written selects as
+`{"value": code}` (blind `wrapValue`), variant axes stamped as `{"value": x}`
+by GenerateVariants, legacy price `{"value": n}` without currency. Writers
+normalise to canon; readers may keep a tolerant fallback only until the
+migration lands, then fallbacks are removed.
+
+### D8/D10 — Execution and limits
+
+Messenger transport `import` (doctrine, own queue) with a worker service in
+dev **and** prod compose; `redeliver_timeout` greater than the worst-case
+import duration. Inline sync path stays for files **≤ 50 rows** (counted in
+rows, not bytes). Dry-run is two-level: synchronous sample (~1000 rows) in
+the wizard + full async run with a `dryRun` flag. File caps: 100 MB / 200k
+rows per file (tenant-configurable). `.xls` (BIFF) is accepted read-only via
+PhpSpreadsheet up to 20 MB (D13); one sheet per session (D14).
+
+### D9/D12 — Profiles and mapping identity
+
+Profiles stay **per-user** (operator decision; tenant-sharing rejected for
+now). `columnMapping` v2 is a versioned list keyed by **column index** —
+`[{column_index, header_display, target, locale?, channel?, policy?,
+transforms?}]` — because real supplier files contain duplicate and empty
+headers (Bosch/IdoSell, Avapax `foto`×8). A v1 (header→code) compatibility
+reader must keep existing sessions/profiles loadable.
+
+### D11 — Session marker and concurrency
+
+`objects.import_session_id` means **created-by-this-session only**; it is
+never stamped on updated objects (a delete-rollback of an upsert session must
+not touch pre-existing catalog). Updates are tracked by the undo-log (#1480)
++ `provenance_meta.session_id` on values. `object_values` rows carry no
+optimistic lock: last-writer-wins is accepted and documented; the undo-log
+replay guards against clobbering manual edits via provenance/updated_at.
+
+### Column grammar
+
+`code` | `code.locale` | `code.channel` | `code.locale.channel`. A one-segment
+suffix is resolved against the tenant registries (active locales, channel
+codes). On a code collision (channel named like a locale) the **locale wins**
+and the import surfaces a warning; creating a channel whose code collides
+with an active locale (or activating such a locale) is rejected with 422.
+Attribute codes must match `[a-z0-9_]+` — the dot is reserved as the grammar
+separator. Unknown suffix = column-level validation error, never a silent
+`locale='<garbage>'` row.
+
+### Golden-test normalisation rules (v1)
+
+The golden round-trip test (#1467, #1473) compares envelopes after a minimal,
+versioned normalisation. **v1 allows only:**
+
+1. numeric string ↔ number for `number`/`price.amount`/`metric.value`
+   (`"1.50"` ≡ `1.5`),
+2. date/datetime rendered as ISO 8601 (timezone offset preserved),
+3. surrounding whitespace trimmed by the default `trim` transform.
+
+Anything else (key order aside — comparison is structural) is a failure.
+Extending this list requires bumping the rule version here and in the test.
+
+## Consequences
+
+- One authoritative document for every implementer; the conflicting docblock
+  (`ImportMode`), spec v1 statements and `jsonb-schemas.md` examples are
+  corrected to point here (#1474 sweeps the leftovers).
+- Deptrac gains `Import` and `Export` layers allowed to depend only on
+  `*_Contracts` + `Shared`; today's direct uses of `Catalog\Domain\Entity\*`
+  enter the baseline (`skip_violations`) and are burned down by #1466.
+- The wizard "karta prawdy" (`Project Plan/UI/imports-v2-karta-prawdy.md`)
+  tracks which UI affordances are real at any point of the rebuild.
+
+## Links
+
+- Plan + decisions: `Project Plan/UI/feature-imports-v2.md` (§4.4 D1–D14, §9)
+- Tickets: #1463 (this ADR), #1464 (D7 migration), #1465 (modes), #1466
+  (shared writer core), #1467/#1473 (golden tests), #1480 (undo-log)
+- Related ADRs: 0014 (ObjectRelation), 0015 (category trees), 0018
+  (publication profiles)

--- a/docs/api/jsonb-schemas.md
+++ b/docs/api/jsonb-schemas.md
@@ -57,9 +57,9 @@ Mapa `attribute.code → wartość`. Każda wartość to **envelope** (nie raw v
 ```json
 {
   "name":        { "value": "Buty sportowe Air Max 90" },
-  "color":       { "value": "red" },
-  "tags":        { "value": ["new", "sale"] },
-  "price":       { "value": { "amount": 299.00, "currency": "PLN" } },
+  "color":       { "option_code": "red" },
+  "tags":        { "option_codes": ["new", "sale"] },
+  "price":       { "amount": 299.00, "currency": "PLN" },
   "release_date":{ "value": "2027-03-15" },
   "in_stock":    { "value": true }
 }
@@ -270,3 +270,27 @@ Schema unionowa — pole `validation_rules` jest interpretowane przez validator 
 - `agent/lessons.md` "Patterns to Follow" → "`attributes_indexed` ma envelope `{value: ...}`" (PR #511).
 - [`apps/admin/src/lib/attributes-indexed.ts`](apps/admin/src/lib/attributes-indexed.ts) — shared reader helper.
 - [`apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php`](apps/api/src/Catalog/Application/AttributesIndexedRebuilder.php) — single writer dla cache.
+
+---
+
+## 6. `object_values.value` — kanon per `AttributeType` (ADR-0019)
+
+Cache `attributes_indexed` kopiuje envelope **verbatim** z `ObjectValue.value`
+— poniższe shape'y obowiązują w obu miejscach. Authoritative: ADR-0019
+(`docs/adr/0019-import-v2-engine-contracts.md`), egzekwowane przez wspólny
+rdzeń walidacji (IMP2-1.4 / #1466).
+
+| Typy | Shape |
+|---|---|
+| text, textarea, wysiwyg, number, date, datetime, boolean, color, email, identifier | `{"value": <scalar>}` |
+| select | `{"option_code": "<code>"}` |
+| multiselect | `{"option_codes": ["<code>", …]}` |
+| price | `{"amount": <number>, "currency": "<ISO>"}` |
+| metric | `{"value": <number>, "unit": "<code>"}` |
+| asset | `{"asset_id": "<uuid>"}` |
+| relation, reference | `{"object_id": "<uuid>"}` |
+
+Legacy odstępstwa (select `{"value": code}` z admina, osie wariantów
+`{"value": x}` z GenerateVariants, price `{"value": n}` bez waluty) migruje
+jednorazowo #1464; do tego czasu readery mogą mieć tolerancyjny fallback,
+po migracji fallbacki znikają.


### PR DESCRIPTION
## Zakres (#1463)
- **ADR-0019** (`docs/adr/0019-import-v2-engine-contracts.md`): D1 match key (SKU/identifier, case-sensitive+trim, dedup pre-flight), D2 trzy stany komórki (+ próg WYCZYŚCI >20%), D3 tryby z mapą migracji enuma, D7 kanon JSONB per 17 typów + lista legacy odstępstw, D8/D10 limity i transport, D9/D12 profile per-user + mapping po indeksie, D11 import_session_id=created-by-only, gramatyka kolumn z precedencją locale, **wersjonowane reguły normalizacji golden testu (v1)**.
- `docs/api/jsonb-schemas.md`: poprawione przykłady (select `{option_code}`, multiselect `{option_codes}`, price `{amount,currency}` — dotąd sprzeczne z ValueSerializer/DocumentFlattener) + nowa sekcja 6 z kanonem `object_values.value`.
- `Project Plan/01-architektura-pim.md` §13: streszczenie ADR-0019.
- **Deptrac**: warstwy `Import`/`Export` z docelowym rulesetem (*_Contracts + Shared); baseline inline **83 pary** (m.in. ImportObjectCreator→Catalog internals, 4 votery Identity importujące encje Import) — burn-down w #1466; Tooling może sięgać do Import/Export (benchmark eksportu).
- **Karta prawdy** `Project Plan/UI/imports-v2-karta-prawdy.md` — stan po NUI-10/11: co w UI jest realne, co dekoracją, z mapowaniem na tickety IMP2.

## Walidacja
`vendor/bin/deptrac analyse`: **Violations 0, Skipped 180, Errors 0** (przed zmianą: 164 violations po dodaniu warstw). Docs-only poza deptrac.yaml — bez zmian runtime.

Closes #1463