### PR TITLE
fix(catalog): PHPStan max — mixed→string cast w teście poly-kind (czerwony main)

### DIFF
--- a/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPatchDeleteTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectPolyKindPatchDeleteTest.php
@@ -186,6 +186,8 @@ final class CatalogObjectPolyKindPatchDeleteTest extends CatalogApiTestCase
         ]);
         self::assertResponseStatusCodeSame(409);
         $body = $response->toArray(false);
-        self::assertStringContainsString('DUP-409', (string) ($body['detail'] ?? ''));
+        $detail = $body['detail'] ?? '';
+        self::assertIsString($detail);
+        self::assertStringContainsString('DUP-409', $detail);
     }
 }


### PR DESCRIPTION
PHPStan max na main jest czerwony: `tests/Api/Catalog/CatalogObjectPolyKindPatchDeleteTest.php:189 — Cannot cast mixed to string` (ujawnione na PR #1501 i #1502, oba failują tym samym błędem mimo że go nie dotykają; #1443 wszedł zanim gate to łapał / ze stale cache).

Fix: `assertIsString($detail)` przed asercją zamiast `(string)` cast. Lokalnie pełny PHPStan: **No errors**. Blokuje merge #1501/#1502 — proszę o szybki przebieg.