### PR TITLE
IMP2-1.2 — feat(catalog): kanon JSONB per AttributeType + migracja legacy shape'ów (ADR-0019)

### DIFF
--- a/apps/admin/src/lib/attributes-indexed.ts
+++ b/apps/admin/src/lib/attributes-indexed.ts
@@ -23,8 +23,20 @@ export function unwrapAttributesIndexed(
   if (raw === null || raw === undefined) return {};
   const out: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(raw)) {
-    if (entry !== null && typeof entry === 'object' && !Array.isArray(entry) && 'value' in entry) {
-      out[key] = (entry as { value: unknown }).value;
+    if (entry !== null && typeof entry === 'object' && !Array.isArray(entry)) {
+      const env = entry as Record<string, unknown>;
+      // ADR-0019 canonical envelopes (IMP2-1.2 / #1464): selects carry
+      // option_code, multiselects option_codes, prices {amount, currency}
+      // (kept whole — price renderers need both fields).
+      if ('value' in env) {
+        out[key] = env.value;
+      } else if ('option_code' in env) {
+        out[key] = env.option_code;
+      } else if ('option_codes' in env) {
+        out[key] = env.option_codes;
+      } else {
+        out[key] = entry;
+      }
     } else {
       out[key] = entry;
     }

--- a/apps/api/migrations/Version20260612210000.php
+++ b/apps/api/migrations/Version20260612210000.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * IMP2-1.2 (#1464, ADR-0019) — normalise legacy JSONB value envelopes to the
+ * per-AttributeType canon:
+ *
+ *   select       {value: "<code>"}   -> {option_code: "<code>"}
+ *   multiselect  {value: [...]}      -> {option_codes: [...]}
+ *   multiselect  bare array [...]    -> {option_codes: [...]}
+ *   price        {value: <number>}   -> {amount: <number>} (currency unknown —
+ *                                       left absent, the price validator asks
+ *                                       for it on the next manual edit)
+ *
+ * Both `object_values.value` and the denormalised `objects.attributes_indexed`
+ * cache (which copies envelopes verbatim) are rewritten. Run
+ * `pim:search:reindex` afterwards — Meilisearch documents flatten the same
+ * envelopes (deploy note in PR #1505).
+ */
+final class Version20260612210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'ADR-0019: migrate legacy {value} select/multiselect/price envelopes to canonical shapes (object_values + attributes_indexed)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // ── object_values ────────────────────────────────────────────────
+        $this->addSql(<<<'SQL'
+            UPDATE object_values ov
+            SET value = jsonb_build_object('option_code', ov.value->'value') || (ov.value - 'value')
+            FROM attributes a
+            WHERE a.id = ov.attribute_id
+              AND a.type = 'select'
+              AND jsonb_typeof(ov.value) = 'object'
+              AND jsonb_exists(ov.value, 'value')
+              AND NOT jsonb_exists(ov.value, 'option_code')
+              AND jsonb_typeof(ov.value->'value') = 'string'
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            UPDATE object_values ov
+            SET value = jsonb_build_object('option_codes', ov.value->'value') || (ov.value - 'value')
+            FROM attributes a
+            WHERE a.id = ov.attribute_id
+              AND a.type = 'multiselect'
+              AND jsonb_typeof(ov.value) = 'object'
+              AND jsonb_exists(ov.value, 'value')
+              AND NOT jsonb_exists(ov.value, 'option_codes')
+              AND jsonb_typeof(ov.value->'value') = 'array'
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            UPDATE object_values ov
+            SET value = jsonb_build_object('option_codes', ov.value)
+            FROM attributes a
+            WHERE a.id = ov.attribute_id
+              AND a.type = 'multiselect'
+              AND jsonb_typeof(ov.value) = 'array'
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            UPDATE object_values ov
+            SET value = jsonb_build_object('amount', ov.value->'value') || (ov.value - 'value')
+            FROM attributes a
+            WHERE a.id = ov.attribute_id
+              AND a.type = 'price'
+              AND jsonb_typeof(ov.value) = 'object'
+              AND jsonb_exists(ov.value, 'value')
+              AND NOT jsonb_exists(ov.value, 'amount')
+              AND jsonb_typeof(ov.value->'value') = 'number'
+        SQL);
+
+        // Edge shapes found in dev data: price {value: "100"} (numeric string)
+        // and multiselect {value: "single"} (bare string member).
+        $this->addSql(<<<'SQL'
+            UPDATE object_values ov
+            SET value = jsonb_build_object('amount', (ov.value->>'value')::numeric) || (ov.value - 'value')
+            FROM attributes a
+            WHERE a.id = ov.attribute_id
+              AND a.type = 'price'
+              AND jsonb_typeof(ov.value) = 'object'
+              AND jsonb_exists(ov.value, 'value')
+              AND NOT jsonb_exists(ov.value, 'amount')
+              AND jsonb_typeof(ov.value->'value') = 'string'
+              AND ov.value->>'value' ~ '^-?[0-9]+(\.[0-9]+)?$'
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            UPDATE object_values ov
+            SET value = jsonb_build_object('option_codes', jsonb_build_array(ov.value->'value')) || (ov.value - 'value')
+            FROM attributes a
+            WHERE a.id = ov.attribute_id
+              AND a.type = 'multiselect'
+              AND jsonb_typeof(ov.value) = 'object'
+              AND jsonb_exists(ov.value, 'value')
+              AND NOT jsonb_exists(ov.value, 'option_codes')
+              AND jsonb_typeof(ov.value->'value') = 'string'
+        SQL);
+
+        // ── objects.attributes_indexed (verbatim envelope copies) ────────
+        // One pass per affected attribute code; PL/pgSQL keeps it set-based
+        // per code while reusing the attribute -> type mapping.
+        $this->addSql(<<<'SQL'
+            DO $$
+            DECLARE attr RECORD;
+            BEGIN
+                FOR attr IN
+                    SELECT DISTINCT a.code, a.type
+                    FROM attributes a
+                    WHERE a.type IN ('select', 'multiselect', 'price')
+                LOOP
+                    IF attr.type = 'select' THEN
+                        EXECUTE format(
+                            'UPDATE objects SET attributes_indexed = jsonb_set(attributes_indexed, %L,
+                                jsonb_build_object(''option_code'', attributes_indexed#>%L) || ((attributes_indexed->%L) - ''value''))
+                             WHERE jsonb_typeof(attributes_indexed->%L) = ''object''
+                               AND jsonb_exists(attributes_indexed->%L, ''value'')
+                               AND NOT jsonb_exists(attributes_indexed->%L, ''option_code'')
+                               AND jsonb_typeof(attributes_indexed#>%L) = ''string''',
+                            ARRAY[attr.code], ARRAY[attr.code, 'value'], attr.code,
+                            attr.code, attr.code, attr.code, ARRAY[attr.code, 'value']
+                        );
+                    ELSIF attr.type = 'multiselect' THEN
+                        EXECUTE format(
+                            'UPDATE objects SET attributes_indexed = jsonb_set(attributes_indexed, %L,
+                                jsonb_build_object(''option_codes'', attributes_indexed#>%L) || ((attributes_indexed->%L) - ''value''))
+                             WHERE jsonb_typeof(attributes_indexed->%L) = ''object''
+                               AND jsonb_exists(attributes_indexed->%L, ''value'')
+                               AND NOT jsonb_exists(attributes_indexed->%L, ''option_codes'')
+                               AND jsonb_typeof(attributes_indexed#>%L) = ''array''',
+                            ARRAY[attr.code], ARRAY[attr.code, 'value'], attr.code,
+                            attr.code, attr.code, attr.code, ARRAY[attr.code, 'value']
+                        );
+                        EXECUTE format(
+                            'UPDATE objects SET attributes_indexed = jsonb_set(attributes_indexed, %L,
+                                jsonb_build_object(''option_codes'', attributes_indexed->%L))
+                             WHERE jsonb_typeof(attributes_indexed->%L) = ''array''',
+                            ARRAY[attr.code], attr.code, attr.code
+                        );
+                    ELSIF attr.type = 'price' THEN
+                        EXECUTE format(
+                            'UPDATE objects SET attributes_indexed = jsonb_set(attributes_indexed, %L,
+                                jsonb_build_object(''amount'', attributes_indexed#>%L) || ((attributes_indexed->%L) - ''value''))
+                             WHERE jsonb_typeof(attributes_indexed->%L) = ''object''
+                               AND jsonb_exists(attributes_indexed->%L, ''value'')
+                               AND NOT jsonb_exists(attributes_indexed->%L, ''amount'')
+                               AND jsonb_typeof(attributes_indexed#>%L) = ''number''',
+                            ARRAY[attr.code], ARRAY[attr.code, 'value'], attr.code,
+                            attr.code, attr.code, attr.code, ARRAY[attr.code, 'value']
+                        );
+                    END IF;
+                END LOOP;
+            END $$
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException(
+            'ADR-0019 canonicalisation is one-way; restore from the pre-migration dump (backups/pre-imp2-1.2-*.dump) instead.',
+        );
+    }
+}

--- a/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
+++ b/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
@@ -115,7 +115,7 @@ final readonly class ObjectAttributesUpserter
             $targetLocale = $isNonPrimaryLocale && $attribute->isLocalizable() ? $locale : null;
             $targetChannel = null !== $channelId && $attribute->isScopable() ? $channelId : null;
 
-            $jsonbValue = $this->wrapValue($rawValue);
+            $jsonbValue = $this->wrapValue($attribute->getType(), $rawValue);
 
             // #1350 — a required attribute can never be explicitly emptied.
             // Only codes present in the payload are checked: partial PATCHes
@@ -238,21 +238,56 @@ final readonly class ObjectAttributesUpserter
     /**
      * @return array<string, mixed>
      */
-    private function wrapValue(mixed $rawValue): array
+    private function wrapValue(AttributeType $type, mixed $rawValue): array
     {
-        // The canonical JSONB shape (per ObjectValue::$value docblock).
-        // Localised arrays (`{pl: '...', en: '...'}`) and metric/price
-        // dicts pass through unchanged so the per-type validator (#39)
-        // can read them with their structure intact.
+        // Metric/price dicts and localised arrays pass through unchanged so
+        // the per-type validator (#39) can read them with their structure
+        // intact; everything else is rewrapped to the ADR-0019 canon below.
         if (\is_array($rawValue)) {
             $normalised = [];
             foreach ($rawValue as $key => $value) {
                 $normalised[(string) $key] = $value;
             }
 
-            return $normalised;
+            return $this->canonicalise($type, $normalised);
         }
 
-        return ['value' => $rawValue];
+        return $this->canonicalise($type, ['value' => $rawValue]);
+    }
+
+    /**
+     * ADR-0019 / IMP2-1.2 (#1464) — normalise the legacy `{value: X}` wrap
+     * (and bare multiselect lists) into the per-type canonical envelope.
+     * Without this every select written from the admin bypassed the option
+     * validator (#1261) and exported as an empty cell (ValueSerializer reads
+     * `option_code` only).
+     *
+     * @param array<array-key, mixed> $envelope
+     *
+     * @return array<string, mixed>
+     */
+    private function canonicalise(AttributeType $type, array $envelope): array
+    {
+        if (AttributeType::Multiselect === $type && array_is_list($envelope)) {
+            return ['option_codes' => $envelope];
+        }
+
+        /** @var array<string, mixed> $envelope non-list past the guard (wrapValue stringifies keys) */
+        if (!\array_key_exists('value', $envelope)) {
+            return $envelope;
+        }
+
+        $value = $envelope['value'];
+        $rest = $envelope;
+        unset($rest['value']);
+
+        return match ($type) {
+            AttributeType::Select => \is_string($value) ? ['option_code' => $value] + $rest : $envelope,
+            AttributeType::Multiselect => \is_array($value) ? ['option_codes' => array_values($value)] + $rest : $envelope,
+            AttributeType::Price => \is_int($value) || \is_float($value) || (\is_string($value) && is_numeric($value))
+                ? ['amount' => \is_string($value) ? (float) $value : $value] + $rest
+                : $envelope,
+            default => $envelope,
+        };
     }
 }

--- a/apps/api/src/Catalog/Presentation/Controller/GenerateVariantsController.php
+++ b/apps/api/src/Catalog/Presentation/Controller/GenerateVariantsController.php
@@ -6,6 +6,7 @@ namespace App\Catalog\Presentation\Controller;
 
 use App\Catalog\Application\AttributesIndexedRebuilder;
 use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
@@ -250,7 +251,11 @@ final class GenerateVariantsController
                         $axisOV = new ObjectValue(
                             object: $variant,
                             attribute: $axisAttribute,
-                            value: ['value' => $axisValue],
+                            // ADR-0019: select axes stamp the canonical
+                            // {option_code} envelope, not a blind {value}.
+                            value: AttributeType::Select === $axisAttribute->getType()
+                                ? ['option_code' => $axisValue]
+                                : ['value' => $axisValue],
                             provenance: Provenance::Manual,
                         );
                         $this->em->persist($axisOV);

--- a/apps/api/src/Export/Application/Builder/ValueSerializer.php
+++ b/apps/api/src/Export/Application/Builder/ValueSerializer.php
@@ -59,7 +59,12 @@ final class ValueSerializer
             AttributeType::Number => $this->pickValue($payload),
             AttributeType::Date, AttributeType::Datetime => $this->pickValue($payload),
             AttributeType::Boolean => $this->boolOf($payload),
-            AttributeType::Select => $this->pickKey($payload, 'option_code'),
+            // IMP2-1.2 (#1464): legacy admin-written selects carried {value};
+            // the migration normalises the DB, this fallback only covers rows
+            // written between deploy and migration run. Remove with #1466.
+            AttributeType::Select => '' !== $this->pickKey($payload, 'option_code')
+                ? $this->pickKey($payload, 'option_code')
+                : $this->pickKey($payload, 'value'),
             AttributeType::Multiselect => $this->multiSelect($payload),
             AttributeType::Price => $this->price($payload),
             AttributeType::Metric => $this->metric($payload),

--- a/apps/api/tests/Unit/Export/Application/Builder/ValueSerializerTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ValueSerializerTest.php
@@ -160,4 +160,19 @@ final class ValueSerializerTest extends TestCase
 
         return $stub;
     }
+
+    /**
+     * IMP2-1.2 (#1464): legacy admin-written selects carried {value} — the
+     * transitional fallback keeps them exportable until #1466 removes it.
+     */
+    #[Test]
+    public function selectFallsBackToLegacyValueKey(): void
+    {
+        $serializer = new ValueSerializer();
+        $legacy = $this->valueWithPayload(AttributeType::Select, ['value' => 'red']);
+        self::assertSame('red', $serializer->serialize($legacy));
+
+        $canonicalWins = $this->valueWithPayload(AttributeType::Select, ['option_code' => 'blue', 'value' => 'red']);
+        self::assertSame('blue', $serializer->serialize($canonicalWins));
+    }
 }


### PR DESCRIPTION
## Problem (żywy bug)
Selecty zapisywane z admina lądowały jako `{value:'red'}` (ślepy `wrapValue`) → omijały walidator opcji (#1261) i **eksportowały się jako puste komórki** (ValueSerializer czyta tylko `option_code`). Do tego osie wariantów stampowane `{value}` i legacy price `{value}` bez waluty. Trzy shape'y tego samego typu w DB = round-trip niemożliwy do strzeżenia golden testem.

## Zmiany
- `ObjectAttributesUpserter::wrapValue` → Attribute-aware `canonicalise()` (select→`option_code`, multiselect→`option_codes` w tym gołe listy i pojedynczy string, price→`amount`).
- `GenerateVariantsController`: osie select stampowane `{option_code}`.
- `ValueSerializer`: przejściowy fallback `{value}` dla selectów (do zdjęcia w #1466) + test.
- **Migracja `Version20260612210000`**: 6 UPDATE na `object_values` + PL/pgSQL po `objects.attributes_indexed` (cache kopiuje envelope verbatim). Down = restore z dumpa (`backups/pre-imp2-1.2-*.dump` — wykonany przed migracją per decyzja operatora).
- FE `unwrapAttributesIndexed`: rozumie kanony (option_code/option_codes; price przechodzi całym envelope dla rendererów).

## Wykonane na dev (live stack)
- Dump: `backups/pre-imp2-1.2-jsonb-canon-20260612-2046.dump` (2.9 MB).
- Migracja: **146 selectów, 9 multiselectów (w tym 4 gołe tablice, 5 string), 16 prices** znormalizowane; weryfikacja SQL: `legacy_left = 0` (object_values i attributes_indexed).
- `pim:search:reindex`: 516 dokumentów.
- Smoke: `PATCH /api/products/{id}` z selectem → DB: `{"option_code": "red"}` (HTTP 200).

PHPStan: touched files **No errors** (pozostały 1 błąd to polykind-test z main — fix w #1504, po jego merge zrobię update-branch). PHPUnit Unit/Export+Catalog: **417 testów OK**. Biome+tsc zielone.

⚠️ Deploy note: po migracji uruchomić `pim:search:reindex`.

Closes #1464