### PR TITLE
IMP2-1.4 — refactor(catalog,import): wspólny rdzeń walidacji (ValueWriteCore) + BatchValueWriter z prefetchem

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -331,10 +331,10 @@ parameters:
             - App\Catalog\Domain\Entity\CatalogObject
             - App\Catalog\Domain\Entity\ObjectCategory
             - App\Catalog\Domain\Entity\ObjectType
-            - App\Catalog\Domain\Entity\ObjectValue
             - App\Catalog\Domain\ObjectKind
             - App\Catalog\Domain\Provenance
             - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+            - App\Catalog\Application\BatchValueWriter
         App\Import\Application\Service\ImportValidationService:
             - App\Catalog\Domain\AttributeType
             - App\Catalog\Domain\Entity\Attribute
@@ -389,6 +389,9 @@ parameters:
             - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
             - App\Identity\Domain\Entity\User
+            - App\Catalog\Domain\AttributeType
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Repository\AttributeRepositoryInterface
         App\Import\Presentation\Controller\TestImportSourceConnectionController:
             - App\Identity\Domain\Entity\User
         App\Import\Presentation\Controller\UpcomingSchedulesController:
@@ -396,3 +399,15 @@ parameters:
         App\Import\Presentation\Controller\ValidateDryRunController:
             - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        # IMP2-1.4 (#1466) writer touchpoint
+        App\Import\Application\Handler\ImportRunHandler:
+            - App\Catalog\Application\BatchValueWriter
+            - App\Catalog\Domain\Entity\Attribute
+        # IMP2-1.4 (#1466) writer touchpoint
+        App\Import\Application\Service\CreatedImportObject:
+            - App\Catalog\Domain\Entity\CatalogObject
+        # IMP2-1.4 (#1466) writer touchpoint
+        App\Import\Application\Service\ObjectResolver:
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface

--- a/apps/api/src/Catalog/Application/BatchValueWriter.php
+++ b/apps/api/src/Catalog/Application/BatchValueWriter.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\Provenance;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * IMP2-1.4 (#1466, ADR-0019) — chunk-oriented value writer for bulk paths
+ * (import). Shares every rule with the admin path via {@see ValueWriteCore},
+ * but: collects violations as result issues instead of throwing, persists
+ * without flushing (the batch handler owns flushAndClear), and prefetches
+ * existing ObjectValue rows per chunk so the update path costs one query
+ * per chunk instead of one per value (the deliberate N+1 of IMP2-1.3).
+ *
+ * Lifecycle per chunk: primeChunk(objects, attributes) once, then
+ * writeMany() per row. EntityManager::clear() invalidates the prime —
+ * the import handler re-primes after every flushAndClear.
+ */
+final class BatchValueWriter
+{
+    /** @var array<string, ObjectValue> "objectId|attributeId|locale|channelId" => row */
+    private array $scopeIndex = [];
+
+    /** @var array<string, true> "attributeId|value" of identifier values seen in this chunk (in-file duplicates) */
+    private array $chunkIdentifiers = [];
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly ValueWriteCore $core,
+    ) {
+    }
+
+    /**
+     * One query: every ObjectValue of the chunk's existing objects for the
+     * mapped attributes. New (just-persisted, unflushed) objects have no
+     * rows yet and simply miss the index.
+     *
+     * @param list<CatalogObject>      $objects
+     * @param array<string, Attribute> $attributesByCode
+     */
+    public function primeChunk(array $objects, array $attributesByCode): void
+    {
+        $this->scopeIndex = [];
+        $this->chunkIdentifiers = [];
+
+        if ([] === $objects || [] === $attributesByCode) {
+            return;
+        }
+
+        $rows = $this->em->createQueryBuilder()
+            ->select('ov')
+            ->from(ObjectValue::class, 'ov')
+            ->where('ov.object IN (:objects)')
+            ->andWhere('ov.attribute IN (:attributes)')
+            ->setParameter('objects', $objects)
+            ->setParameter('attributes', array_values($attributesByCode))
+            ->getQuery()
+            ->getResult();
+
+        /** @var list<ObjectValue> $rows */
+        foreach ($rows as $row) {
+            $this->scopeIndex[$this->scopeKey(
+                $row->getObject()->getId(),
+                $row->getAttribute()->getId(),
+                $row->getLocale(),
+                $row->getChannelId(),
+            )] = $row;
+        }
+    }
+
+    /**
+     * Apply pre-built envelopes to one object. Issues are returned, never
+     * thrown; a value with an issue is skipped, the rest of the row writes.
+     *
+     * @param list<array{attribute: Attribute, envelope: array<string, mixed>, locale: ?string, channelId: ?Uuid}> $writes
+     *
+     * @return list<array{attributeCode: string, kind: string, message: string}>
+     */
+    public function writeMany(CatalogObject $object, array $writes, Provenance $provenance): array
+    {
+        $tenant = $object->getTenant();
+        $issues = [];
+
+        foreach ($writes as $write) {
+            $attribute = $write['attribute'];
+            $envelope = $this->core->normalise($attribute->getType(), $write['envelope']);
+
+            $requiredViolation = $this->core->requiredViolation($attribute, $envelope);
+            if (null !== $requiredViolation) {
+                $issues[] = ['attributeCode' => $attribute->getCode(), 'kind' => 'required_empty', 'message' => $requiredViolation];
+
+                continue;
+            }
+
+            $formatViolations = $this->core->formatViolations($attribute, $envelope);
+            if ([] !== $formatViolations) {
+                foreach ($formatViolations as $message) {
+                    $issues[] = ['attributeCode' => $attribute->getCode(), 'kind' => 'invalid_value', 'message' => $message];
+                }
+
+                continue;
+            }
+
+            // Identifier uniqueness: in-chunk set first (file duplicates the
+            // DB cannot see yet), then the per-value DB pre-check.
+            $identifierCandidate = $envelope['value'] ?? null;
+            if (AttributeType::Identifier === $attribute->getType()
+                && \is_string($identifierCandidate) && '' !== $identifierCandidate) {
+                $chunkKey = $attribute->getId()->toRfc4122().'|'.$identifierCandidate;
+                if (isset($this->chunkIdentifiers[$chunkKey])) {
+                    $issues[] = ['attributeCode' => $attribute->getCode(), 'kind' => 'duplicate_identifier', 'message' => \sprintf('Identifier "%s" duplicated within the imported chunk.', $identifierCandidate)];
+
+                    continue;
+                }
+                $duplicate = $this->core->duplicateIdentifier($object, $attribute, $envelope);
+                if (null !== $duplicate) {
+                    $issues[] = ['attributeCode' => $attribute->getCode(), 'kind' => 'duplicate_identifier', 'message' => \sprintf('Identifier "%s" is already assigned to another %s.', $duplicate, $object->getObjectType()->getCode())];
+
+                    continue;
+                }
+                $this->chunkIdentifiers[$chunkKey] = true;
+            }
+
+            [$targetLocale, $targetChannel] = $tenant instanceof Tenant
+                ? $this->core->routeScope($attribute, $tenant, $write['locale'], $write['channelId'])
+                : [$write['locale'], $write['channelId']];
+
+            $existing = $this->scopeIndex[$this->scopeKey($object->getId(), $attribute->getId(), $targetLocale, $targetChannel)] ?? null;
+            if ($existing instanceof ObjectValue) {
+                $existing->updateValue($envelope);
+                $existing->changeProvenance($provenance);
+
+                continue;
+            }
+
+            $value = new ObjectValue(
+                object: $object,
+                attribute: $attribute,
+                value: $envelope,
+                provenance: $provenance,
+                channelId: $targetChannel,
+                locale: $targetLocale,
+            );
+            $this->em->persist($value);
+            $this->scopeIndex[$this->scopeKey($object->getId(), $attribute->getId(), $targetLocale, $targetChannel)] = $value;
+        }
+
+        return $issues;
+    }
+
+    private function scopeKey(Uuid $objectId, Uuid $attributeId, ?string $locale, ?Uuid $channelId): string
+    {
+        return $objectId->toRfc4122().'|'.$attributeId->toRfc4122().'|'.($locale ?? '').'|'.($channelId?->toRfc4122() ?? '');
+    }
+}

--- a/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
+++ b/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
@@ -4,15 +4,12 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application;
 
-use App\Catalog\Application\Validation\AttributeValueValidator;
-use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Provenance;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
-use App\Catalog\Domain\Validator\IdentifierUniquenessValidator;
 use App\Shared\Domain\Tenant;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
@@ -22,68 +19,33 @@ use Symfony\Component\Uid\Uuid;
  * Map a flat `{attribute_code => value}` payload into `ObjectValue`
  * rows on a given `CatalogObject` (#45 / 0.4.5).
  *
- * Every value is wrapped in the canonical `{value: ...}` JSONB shape
- * the per-AttributeType validators (#39) expect. Provenance defaults
- * to `Manual` because the admin UI is the only write surface in MVP;
- * phase 2 agents will pass `Provenance::Agent` (reserved enum case).
+ * IMP2-1.4 (#1466): the shared rule-set (canon normalisation, required,
+ * per-type format validation, identifier uniqueness, scope routing) lives
+ * in {@see ValueWriteCore} — this service is the thin per-request client
+ * that maps violations to HTTP exceptions. The import path consumes the
+ * same core through {@see BatchValueWriter}, which is what guarantees
+ * "import validates exactly like the admin".
  *
- * Unknown attribute codes are silently dropped — adopting strict
- * mode would force every fixture / migration to enumerate the
- * built-in seed and is overkill for MVP. The admin UI's dynamic
- * schema picker (epic 0.6) will surface dropped keys before the
- * request lands here.
- *
- * The `AttributesIndexedSyncListener` (#38) keeps
- * `CatalogObject.attributes_indexed` in sync through the same flush;
- * read side reads from the denormalised cache, write side flows
- * through this service.
+ * Unknown attribute codes are silently dropped — see #45 for rationale.
+ * The `AttributesIndexedSyncListener` (#38) keeps the denormalised cache
+ * in sync through the same flush.
  */
 final readonly class ObjectAttributesUpserter
 {
-    /**
-     * #1216 — types whose value validator reads the canonical `{value: scalar}`
-     * shape and carries a real format rule, so it is safe + meaningful to
-     * enforce on every write path. Structural types (select/multiselect/asset/
-     * relation/price/metric) are intentionally excluded: their validators read
-     * different keys (option_code/asset_id/object_id/…) than the `{value}`
-     * shape the admin actually stores, so running them here would false-reject
-     * valid data. Lenient scalar types (text/number/date/boolean/wysiwyg) are
-     * left out to avoid surfacing pre-existing data on edit; they can be added
-     * once backfilled.
-     *
-     * @var list<AttributeType>
-     */
-    private const array VALUE_VALIDATED_TYPES = [
-        AttributeType::Email,
-        AttributeType::Color,
-        AttributeType::Identifier,
-        // #1261 — select/multiselect option codes are validated against the
-        // live attribute_options set (SelectValidator/MultiselectValidator).
-        AttributeType::Select,
-        AttributeType::Multiselect,
-    ];
-
     public function __construct(
         private AttributeRepositoryInterface $attributes,
         private ObjectValueRepositoryInterface $values,
-        private IdentifierUniquenessValidator $identifierUniqueness,
-        private AttributeValueValidator $valueValidator,
+        private ValueWriteCore $core,
     ) {
     }
 
     /**
      * @param array<string, mixed> $payload
-     * @param ?string              $locale    active locale scope (#1148). When set
-     *                                        AND the attribute is localizable AND the
-     *                                        locale is not the tenant's primary, the
-     *                                        value is written to that locale; otherwise
-     *                                        it lands on the global (locale=null) row.
-     *                                        Default locale === global keeps legacy data
-     *                                        and non-localizable attributes shared.
-     * @param ?Uuid                $channelId resolved active channel scope (#1154). When set
-     *                                        AND the attribute is scopable, the value is written
-     *                                        to that channel; otherwise it lands on the global
-     *                                        (channel=null) row.
+     * @param ?string              $locale    active locale scope (#1148); non-primary
+     *                                        locale on a localizable attribute targets
+     *                                        that locale row, otherwise the global row
+     * @param ?Uuid                $channelId resolved active channel scope (#1154);
+     *                                        applies to scopable attributes only
      */
     public function upsert(
         CatalogObject $object,
@@ -100,8 +62,6 @@ final readonly class ObjectAttributesUpserter
             return;
         }
 
-        $isNonPrimaryLocale = null !== $locale && $locale !== $tenant->getPrimaryLocale();
-
         foreach ($payload as $code => $rawValue) {
             if ('' === $code) {
                 continue;
@@ -112,55 +72,34 @@ final readonly class ObjectAttributesUpserter
                 continue;
             }
 
-            $targetLocale = $isNonPrimaryLocale && $attribute->isLocalizable() ? $locale : null;
-            $targetChannel = null !== $channelId && $attribute->isScopable() ? $channelId : null;
+            [$targetLocale, $targetChannel] = $this->core->routeScope($attribute, $tenant, $locale, $channelId);
 
-            $jsonbValue = $this->wrapValue($attribute->getType(), $rawValue);
+            $jsonbValue = $this->core->normalise($attribute->getType(), $rawValue);
 
-            // #1350 — a required attribute can never be explicitly emptied.
-            // Only codes present in the payload are checked: partial PATCHes
-            // and imports of legacy dirty records stay writable, while the
-            // admin form enforces the full-state rule client-side.
-            // Booleans are exempt (reopen #2, operator decision): an
-            // unchecked box IS the value `false`, not a missing value.
-            if (AttributeType::Boolean !== $attribute->getType()
-                && $attribute->isRequired() && self::isEmptyEnvelope($jsonbValue)) {
+            // #1350 — required attributes can never be explicitly emptied.
+            $requiredViolation = $this->core->requiredViolation($attribute, $jsonbValue);
+            if (null !== $requiredViolation) {
+                throw new UnprocessableEntityHttpException($requiredViolation);
+            }
+
+            // #1216 / #1261 — per-type format + option membership.
+            $formatViolations = $this->core->formatViolations($attribute, $jsonbValue);
+            if ([] !== $formatViolations) {
                 throw new UnprocessableEntityHttpException(\sprintf(
-                    'Attribute "%s" is required and cannot be empty.',
+                    'Attribute "%s": %s',
                     $code,
+                    $formatViolations[0],
                 ));
             }
 
-            // #1216 / #1261 — enforce per-type value validation (email format,
-            // color hex/rgb, identifier shape, select/multiselect option
-            // membership) on every write path. Empty values are skipped —
-            // clearing an attribute is always allowed.
-            if (\in_array($attribute->getType(), self::VALUE_VALIDATED_TYPES, true)
-                && self::hasValidatableContent($attribute->getType(), $jsonbValue)) {
-                $errors = $this->valueValidator->validate($attribute, $jsonbValue);
-                if ([] !== $errors) {
-                    throw new UnprocessableEntityHttpException(\sprintf(
-                        'Attribute "%s": %s',
-                        $code,
-                        $errors[0]->message,
-                    ));
-                }
-            }
-
-            // #1179 — identifier values are unique per ObjectType. Pre-check
-            // here for a clean 409 (the DB partial unique index is the
-            // race-proof backstop). Skip empty/non-string values — clearing
-            // an identifier is allowed.
-            if (AttributeType::Identifier === $attribute->getType()) {
-                $candidate = $jsonbValue['value'] ?? null;
-                if (\is_string($candidate) && '' !== $candidate
-                    && $this->identifierUniqueness->isDuplicate($object, $attribute, $candidate)) {
-                    throw new ConflictHttpException(\sprintf(
-                        'Identifier "%s" is already assigned to another %s.',
-                        $candidate,
-                        $object->getObjectType()->getCode(),
-                    ));
-                }
+            // #1179 — identifier uniqueness pre-check for a clean 409.
+            $duplicate = $this->core->duplicateIdentifier($object, $attribute, $jsonbValue);
+            if (null !== $duplicate) {
+                throw new ConflictHttpException(\sprintf(
+                    'Identifier "%s" is already assigned to another %s.',
+                    $duplicate,
+                    $object->getObjectType()->getCode(),
+                ));
             }
 
             $existing = $this->values->findOneByScope($object, $attribute, $targetChannel, $targetLocale);
@@ -182,112 +121,5 @@ final readonly class ObjectAttributesUpserter
             );
             $this->values->save($value);
         }
-    }
-
-    /**
-     * #1261 — whether a wrapped value carries content worth validating, per
-     * the type's JSONB envelope. Clearing a value (empty option_code / empty
-     * option_codes / null-or-empty scalar) skips validation so operators can
-     * always blank a field.
-     *
-     * @param array<string, mixed> $jsonbValue
-     */
-    private static function hasValidatableContent(AttributeType $type, array $jsonbValue): bool
-    {
-        if (AttributeType::Select === $type) {
-            $optionCode = $jsonbValue['option_code'] ?? null;
-
-            return \is_string($optionCode) && '' !== $optionCode;
-        }
-
-        if (AttributeType::Multiselect === $type) {
-            $optionCodes = $jsonbValue['option_codes'] ?? null;
-
-            return \is_array($optionCodes) && [] !== $optionCodes;
-        }
-
-        $scalar = $jsonbValue['value'] ?? null;
-
-        return null !== $scalar && '' !== $scalar;
-    }
-
-    /**
-     * #1350 — true when every leaf of the wrapped JSONB envelope is
-     * null / '' / [] (covers scalar `{value}`, select `{option_code}`,
-     * localized maps and structural shapes alike). Booleans and zeros
-     * are values — a required checkbox set to `false` passes.
-     */
-    private static function isEmptyEnvelope(mixed $value): bool
-    {
-        if (null === $value || '' === $value || [] === $value) {
-            return true;
-        }
-        if (\is_array($value)) {
-            foreach ($value as $leaf) {
-                if (!self::isEmptyEnvelope($leaf)) {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function wrapValue(AttributeType $type, mixed $rawValue): array
-    {
-        // Metric/price dicts and localised arrays pass through unchanged so
-        // the per-type validator (#39) can read them with their structure
-        // intact; everything else is rewrapped to the ADR-0019 canon below.
-        if (\is_array($rawValue)) {
-            $normalised = [];
-            foreach ($rawValue as $key => $value) {
-                $normalised[(string) $key] = $value;
-            }
-
-            return $this->canonicalise($type, $normalised);
-        }
-
-        return $this->canonicalise($type, ['value' => $rawValue]);
-    }
-
-    /**
-     * ADR-0019 / IMP2-1.2 (#1464) — normalise the legacy `{value: X}` wrap
-     * (and bare multiselect lists) into the per-type canonical envelope.
-     * Without this every select written from the admin bypassed the option
-     * validator (#1261) and exported as an empty cell (ValueSerializer reads
-     * `option_code` only).
-     *
-     * @param array<array-key, mixed> $envelope
-     *
-     * @return array<string, mixed>
-     */
-    private function canonicalise(AttributeType $type, array $envelope): array
-    {
-        if (AttributeType::Multiselect === $type && array_is_list($envelope)) {
-            return ['option_codes' => $envelope];
-        }
-
-        /** @var array<string, mixed> $envelope non-list past the guard (wrapValue stringifies keys) */
-        if (!\array_key_exists('value', $envelope)) {
-            return $envelope;
-        }
-
-        $value = $envelope['value'];
-        $rest = $envelope;
-        unset($rest['value']);
-
-        return match ($type) {
-            AttributeType::Select => \is_string($value) ? ['option_code' => $value] + $rest : $envelope,
-            AttributeType::Multiselect => \is_array($value) ? ['option_codes' => array_values($value)] + $rest : $envelope,
-            AttributeType::Price => \is_int($value) || \is_float($value) || (\is_string($value) && is_numeric($value))
-                ? ['amount' => \is_string($value) ? (float) $value : $value] + $rest
-                : $envelope,
-            default => $envelope,
-        };
     }
 }

--- a/apps/api/src/Catalog/Application/ValueWriteCore.php
+++ b/apps/api/src/Catalog/Application/ValueWriteCore.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Application\Validation\AttributeValueValidator;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Validator\IdentifierUniquenessValidator;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * ADR-0019 / IMP2-1.4 (#1466) — the single rule-set every value write path
+ * shares: envelope normalisation to the per-type canon, required/format
+ * validation and locale/channel scope routing.
+ *
+ * Consumers: ObjectAttributesUpserter (per-request, maps violations to HTTP
+ * exceptions) and BatchValueWriter (import chunks, collects violations as
+ * result issues). Keeping the rules here is what makes "import validates
+ * exactly like the admin" true instead of aspirational.
+ */
+final readonly class ValueWriteCore
+{
+    /**
+     * #1216 — types whose value validator reads the canonical envelope and
+     * carries a real format rule. See the original Upserter docblock for why
+     * lenient scalar types stay out until backfilled.
+     *
+     * @var list<AttributeType>
+     */
+    private const array VALUE_VALIDATED_TYPES = [
+        AttributeType::Email,
+        AttributeType::Color,
+        AttributeType::Identifier,
+        AttributeType::Select,
+        AttributeType::Multiselect,
+    ];
+
+    public function __construct(
+        private AttributeValueValidator $valueValidator,
+        private IdentifierUniquenessValidator $identifierUniqueness,
+    ) {
+    }
+
+    /**
+     * Wrap + canonicalise a raw value into the ADR-0019 per-type envelope.
+     *
+     * @return array<string, mixed>
+     */
+    public function normalise(AttributeType $type, mixed $rawValue): array
+    {
+        if (\is_array($rawValue)) {
+            $normalised = [];
+            foreach ($rawValue as $key => $value) {
+                $normalised[(string) $key] = $value;
+            }
+
+            return $this->canonicalise($type, $normalised);
+        }
+
+        return $this->canonicalise($type, ['value' => $rawValue]);
+    }
+
+    /**
+     * #1350 — required attributes can never be explicitly emptied
+     * (booleans exempt: an unchecked box IS `false`).
+     *
+     * @param array<string, mixed> $envelope
+     */
+    public function requiredViolation(Attribute $attribute, array $envelope): ?string
+    {
+        if (AttributeType::Boolean !== $attribute->getType()
+            && $attribute->isRequired() && self::isEmptyEnvelope($envelope)) {
+            return \sprintf('Attribute "%s" is required and cannot be empty.', $attribute->getCode());
+        }
+
+        return null;
+    }
+
+    /**
+     * #1216 / #1261 — per-type format + option-membership validation.
+     * Empty values are skipped (clearing is always allowed).
+     *
+     * @param array<string, mixed> $envelope
+     *
+     * @return list<string> violation messages
+     */
+    public function formatViolations(Attribute $attribute, array $envelope): array
+    {
+        if (!\in_array($attribute->getType(), self::VALUE_VALIDATED_TYPES, true)
+            || !self::hasValidatableContent($attribute->getType(), $envelope)) {
+            return [];
+        }
+
+        $messages = [];
+        foreach ($this->valueValidator->validate($attribute, $envelope) as $error) {
+            $messages[] = $error->message;
+        }
+
+        return $messages;
+    }
+
+    /**
+     * #1179 — identifier uniqueness pre-check (DB partial unique index stays
+     * the race-proof backstop). Returns the duplicate value, or null.
+     *
+     * @param array<string, mixed> $envelope
+     */
+    public function duplicateIdentifier(CatalogObject $object, Attribute $attribute, array $envelope): ?string
+    {
+        if (AttributeType::Identifier !== $attribute->getType()) {
+            return null;
+        }
+        $candidate = $envelope['value'] ?? null;
+        if (\is_string($candidate) && '' !== $candidate
+            && $this->identifierUniqueness->isDuplicate($object, $attribute, $candidate)) {
+            return $candidate;
+        }
+
+        return null;
+    }
+
+    /**
+     * #1148/#1154 — locale/channel scope routing: non-primary locale on a
+     * localizable attribute targets that locale row, otherwise global;
+     * channel only applies to scopable attributes.
+     *
+     * @return array{0: ?string, 1: ?Uuid} [locale, channelId]
+     */
+    public function routeScope(Attribute $attribute, Tenant $tenant, ?string $locale, ?Uuid $channelId): array
+    {
+        $isNonPrimaryLocale = null !== $locale && $locale !== $tenant->getPrimaryLocale();
+        $targetLocale = $isNonPrimaryLocale && $attribute->isLocalizable() ? $locale : null;
+        $targetChannel = null !== $channelId && $attribute->isScopable() ? $channelId : null;
+
+        return [$targetLocale, $targetChannel];
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    public static function hasValidatableContent(AttributeType $type, array $envelope): bool
+    {
+        if (AttributeType::Select === $type) {
+            $optionCode = $envelope['option_code'] ?? null;
+
+            return \is_string($optionCode) && '' !== $optionCode;
+        }
+
+        if (AttributeType::Multiselect === $type) {
+            $optionCodes = $envelope['option_codes'] ?? null;
+
+            return \is_array($optionCodes) && [] !== $optionCodes;
+        }
+
+        $scalar = $envelope['value'] ?? null;
+
+        return null !== $scalar && '' !== $scalar;
+    }
+
+    /**
+     * #1350 — true when every leaf is null / '' / []. Booleans and zeros
+     * are values.
+     */
+    public static function isEmptyEnvelope(mixed $value): bool
+    {
+        if (null === $value || '' === $value || [] === $value) {
+            return true;
+        }
+        if (\is_array($value)) {
+            foreach ($value as $leaf) {
+                if (!self::isEmptyEnvelope($leaf)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * ADR-0019 / IMP2-1.2 (#1464) — normalise legacy `{value: X}` wraps and
+     * bare multiselect lists into the per-type canonical envelope.
+     *
+     * @param array<array-key, mixed> $envelope
+     *
+     * @return array<string, mixed>
+     */
+    private function canonicalise(AttributeType $type, array $envelope): array
+    {
+        if (AttributeType::Multiselect === $type && array_is_list($envelope)) {
+            return ['option_codes' => $envelope];
+        }
+
+        /** @var array<string, mixed> $envelope non-list past the guard (normalise stringifies keys) */
+        if (!\array_key_exists('value', $envelope)) {
+            return $envelope;
+        }
+
+        $value = $envelope['value'];
+        $rest = $envelope;
+        unset($rest['value']);
+
+        return match ($type) {
+            AttributeType::Select => \is_string($value) ? ['option_code' => $value] + $rest : $envelope,
+            AttributeType::Multiselect => \is_array($value) ? ['option_codes' => array_values($value)] + $rest : $envelope,
+            AttributeType::Price => \is_int($value) || \is_float($value) || (\is_string($value) && is_numeric($value))
+                ? ['amount' => \is_string($value) ? (float) $value : $value] + $rest
+                : $envelope,
+            default => $envelope,
+        };
+    }
+}

--- a/apps/api/src/Export/Application/Builder/ValueSerializer.php
+++ b/apps/api/src/Export/Application/Builder/ValueSerializer.php
@@ -59,12 +59,7 @@ final class ValueSerializer
             AttributeType::Number => $this->pickValue($payload),
             AttributeType::Date, AttributeType::Datetime => $this->pickValue($payload),
             AttributeType::Boolean => $this->boolOf($payload),
-            // IMP2-1.2 (#1464): legacy admin-written selects carried {value};
-            // the migration normalises the DB, this fallback only covers rows
-            // written between deploy and migration run. Remove with #1466.
-            AttributeType::Select => '' !== $this->pickKey($payload, 'option_code')
-                ? $this->pickKey($payload, 'option_code')
-                : $this->pickKey($payload, 'value'),
+            AttributeType::Select => $this->pickKey($payload, 'option_code'),
             AttributeType::Multiselect => $this->multiSelect($payload),
             AttributeType::Price => $this->price($payload),
             AttributeType::Metric => $this->metric($payload),

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Handler;
 
+use App\Catalog\Domain\Entity\Attribute;
 use App\Import\Application\Service\ImportObjectCreator;
 use App\Import\Application\Service\ImportProgressPublisher;
 use App\Import\Application\Service\ImportRowDecision;
@@ -62,6 +63,7 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly ImportValidationService $validator,
         private readonly ImportObjectCreator $creator,
         private readonly ObjectResolver $objectResolver,
+        private readonly \App\Catalog\Application\BatchValueWriter $valueWriter,
         private readonly ImportProgressPublisher $progressPublisher,
         private readonly TenantContext $tenantContext,
         private readonly FilesystemOperator $importsStorage,
@@ -155,115 +157,45 @@ final class ImportRunHandler extends AbstractBatchHandler
             $skuSeenInFile = [];
             $processed = 0;
             $totalRows = 0;
+            /** @var list<array{rowNumber: int, cells: array<string, string|null>}> $buffer */
+            $buffer = [];
 
+            // IMP2-1.4 (#1466): rows are buffered per chunk so the resolver
+            // and the value writer pay one query per chunk (resolveMany +
+            // primeChunk) instead of one per row. flushAndClear() detaches
+            // everything, so the re-merge block below replays the lookups.
             foreach ($this->rowReader->read($sourcePath) as $rowNumber => $cells) {
-                ++$processed;
                 ++$totalRows;
-                $errors = $this->validator->validateRow(
-                    rowNumber: $rowNumber,
-                    cells: $cells,
-                    columnMapping: $columnMapping,
-                    attributesByCode: $attributesByCode,
-                    tenant: $tenant,
-                    skuSeenInFile: $skuSeenInFile,
-                );
+                $buffer[] = ['rowNumber' => $rowNumber, 'cells' => $cells];
 
-                $sku = $cells[$this->skuColumnHeader($columnMapping)] ?? null;
-                $blockingErrors = array_values(array_filter(
-                    $errors,
-                    static fn (ValidationError $error): bool => $error->isRowBlocking(),
-                ));
-                $rowOk = [] === $blockingErrors;
-
-                if ($rowOk) {
-                    $resolvedValues = $this->materialiseValues($cells, $columnMapping);
-                    $matchKey = $this->matchKey($session, $cells, $columnMapping, $resolvedValues, $rowNumber);
-                    $existing = $this->objectResolver->resolve(
-                        $matchKey,
-                        $session->getTargetObjectType(),
-                        $tenant,
-                        $session->getMatchAttributeCode(),
-                    );
-                    $decision = $this->objectResolver->decide($session->getMode(), $existing);
-
-                    if (ImportRowDecision::Create === $decision) {
-                        $this->creator->create(
-                            objectType: $session->getTargetObjectType(),
-                            sku: $this->skuFrom($resolvedValues, $rowNumber),
-                            resolvedValues: $resolvedValues,
-                            attributesByCode: $attributesByCode,
-                            importSessionId: $session->getId(),
-                            categoryCode: $this->extractCategoryCode($cells, $columnMapping),
-                            tenant: $tenant,
-                        );
-                        $session->incrementSuccess();
-                    } elseif (ImportRowDecision::Update === $decision && null !== $existing) {
-                        $this->creator->update($existing, $resolvedValues, $attributesByCode);
-                        $session->incrementSuccess();
-                        $session->incrementUpdated();
-                    } else {
-                        $session->incrementSkipped();
-                        $errors[] = ImportRowDecision::SkipExists === $decision
-                            ? new ValidationError(
-                                rowNumber: $rowNumber,
-                                sku: $sku,
-                                errorType: ImportErrorType::DuplicateSkuInDb,
-                                level: ImportLogLevel::Warning,
-                                message: \sprintf('Match key "%s" already exists — row skipped (mode CREATE).', $matchKey),
-                            )
-                            : new ValidationError(
-                                rowNumber: $rowNumber,
-                                sku: $sku,
-                                errorType: ImportErrorType::NoMatchInDb,
-                                level: ImportLogLevel::Warning,
-                                message: \sprintf('No object matches key "%s" — row skipped (mode UPDATE).', $matchKey),
-                            );
-                    }
-                } else {
-                    $session->incrementError();
+                if (!$this->shouldFlush(\count($buffer))) {
+                    continue;
                 }
 
-                // Persist every finding so the post-import report (IMP-05)
-                // surfaces both row-blocking errors and non-blocking
-                // warnings (e.g. CategoryNotFound on an otherwise OK row).
-                foreach ($errors as $error) {
-                    $this->entityManager->persist(new ImportLog(
-                        importSession: $session,
-                        rowNumber: $error->rowNumber,
-                        level: $error->level,
-                        message: $error->message,
-                        sku: $error->sku,
-                        errorType: $error->errorType->value,
-                        columnName: $error->columnName,
-                        columnValue: $error->columnValue,
+                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile);
+                $buffer = [];
+
+                $this->flushAndClear();
+                // After clear() every previously-loaded entity is detached —
+                // re-merge by reloading the session and tenant, replaying the
+                // attribute lookup and resetting TenantContext.
+                $session = $this->refreshSession($session);
+                $tenant = $session->getTenant();
+                if (!$tenant instanceof Tenant) {
+                    throw new RuntimeException(\sprintf(
+                        'Import session "%s" lost its tenant assignment mid-run.',
+                        $session->getId()->toRfc4122(),
                     ));
                 }
+                $this->tenantContext->set($tenant);
+                $attributesByCode = $this->validator->loadAttributesByCode($tenant, $columnMapping);
+                $this->progressPublisher->progress($session, $processed, null);
+            }
 
-                $this->progressPublisher->rowProcessed($session, $rowNumber, $sku, $rowOk);
-
-                if ($this->shouldFlush($processed)) {
-                    $this->flushAndClear();
-                    // After clear() every previously-loaded entity is
-                    // detached. The catalog-side lookups in the next
-                    // iteration (Attribute references on ObjectValue,
-                    // Tenant stamped by TenantAssignmentListener) would
-                    // throw "Multiple non-persisted new entities" on the
-                    // next flush — re-merge by reloading the session and
-                    // its tenant, replaying the attribute lookup, and
-                    // resetting TenantContext so the listener pulls the
-                    // managed reference.
-                    $session = $this->refreshSession($session);
-                    $tenant = $session->getTenant();
-                    if (!$tenant instanceof Tenant) {
-                        throw new RuntimeException(\sprintf(
-                            'Import session "%s" lost its tenant assignment mid-run.',
-                            $session->getId()->toRfc4122(),
-                        ));
-                    }
-                    $this->tenantContext->set($tenant);
-                    $attributesByCode = $this->validator->loadAttributesByCode($tenant, $columnMapping);
-                    $this->progressPublisher->progress($session, $processed, $sku);
-                }
+            if ([] !== $buffer) {
+                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile);
+                $this->flushAndClear();
+                $session = $this->refreshSession($session);
             }
 
             $session->setTotalRows($totalRows);
@@ -459,6 +391,153 @@ final class ImportRunHandler extends AbstractBatchHandler
      * IMP2-1.3 — the row match key: the cell mapped to the configured
      * identifier attribute, or the SKU cell by default (trimmed; the
      * synthetic IMPORT-{row} fallback only feeds brand-new rows).
+     *
+     * @param array<string, string> $columnMapping
+     */
+    /**
+     * IMP2-1.4 (#1466) — validate + resolve + write one buffered chunk.
+     * Returns the number of rows consumed (== chunk size).
+     *
+     * @param list<array{rowNumber: int, cells: array<string, string|null>}> $buffer
+     * @param array<string, string>                                          $columnMapping
+     * @param array<string, Attribute>                                       $attributesByCode
+     * @param array<string, int>                                             $skuSeenInFile
+     */
+    private function processChunk(
+        ImportSession $session,
+        Tenant $tenant,
+        array $buffer,
+        array $columnMapping,
+        array $attributesByCode,
+        array &$skuSeenInFile,
+    ): int {
+        // Pass 1 — validate rows and gather match keys for the batch resolve.
+        /** @var list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string}> $prepared */
+        $prepared = [];
+        $matchKeys = [];
+        foreach ($buffer as $entry) {
+            $rowNumber = $entry['rowNumber'];
+            $cells = $entry['cells'];
+            $errors = $this->validator->validateRow(
+                rowNumber: $rowNumber,
+                cells: $cells,
+                columnMapping: $columnMapping,
+                attributesByCode: $attributesByCode,
+                tenant: $tenant,
+                skuSeenInFile: $skuSeenInFile,
+            );
+            $sku = $cells[$this->skuColumnHeader($columnMapping)] ?? null;
+            $blocking = array_values(array_filter(
+                $errors,
+                static fn (ValidationError $error): bool => $error->isRowBlocking(),
+            ));
+            $rowOk = [] === $blocking;
+            $resolvedValues = $rowOk ? $this->materialiseValues($cells, $columnMapping) : [];
+            $matchKey = $rowOk ? $this->matchKey($session, $cells, $columnMapping, $resolvedValues, $rowNumber) : '';
+            if ('' !== $matchKey) {
+                $matchKeys[] = $matchKey;
+            }
+            $prepared[] = [
+                'rowNumber' => $rowNumber,
+                'cells' => $cells,
+                'sku' => $sku,
+                'errors' => $errors,
+                'rowOk' => $rowOk,
+                'resolvedValues' => $resolvedValues,
+                'matchKey' => $matchKey,
+            ];
+        }
+
+        $existingByKey = $this->objectResolver->resolveMany(
+            $matchKeys,
+            $session->getTargetObjectType(),
+            $tenant,
+            $session->getMatchAttributeCode(),
+        );
+        $this->valueWriter->primeChunk(array_values($existingByKey), $attributesByCode);
+
+        // Pass 2 — decide + write per row.
+        foreach ($prepared as $row) {
+            $errors = $row['errors'];
+            $issues = [];
+
+            if ($row['rowOk']) {
+                $existing = $existingByKey[$row['matchKey']] ?? null;
+                $decision = $this->objectResolver->decide($session->getMode(), $existing);
+
+                if (ImportRowDecision::Create === $decision) {
+                    $created = $this->creator->create(
+                        objectType: $session->getTargetObjectType(),
+                        sku: $this->skuFrom($row['resolvedValues'], $row['rowNumber']),
+                        resolvedValues: $row['resolvedValues'],
+                        attributesByCode: $attributesByCode,
+                        importSessionId: $session->getId(),
+                        categoryCode: $this->extractCategoryCode($row['cells'], $columnMapping),
+                        tenant: $tenant,
+                    );
+                    $issues = $created->issues;
+                    $session->incrementSuccess();
+                } elseif (ImportRowDecision::Update === $decision && null !== $existing) {
+                    $issues = $this->creator->update($existing, $row['resolvedValues'], $attributesByCode);
+                    $session->incrementSuccess();
+                    $session->incrementUpdated();
+                } else {
+                    $session->incrementSkipped();
+                    $errors[] = ImportRowDecision::SkipExists === $decision
+                        ? new ValidationError(
+                            rowNumber: $row['rowNumber'],
+                            sku: $row['sku'],
+                            errorType: ImportErrorType::DuplicateSkuInDb,
+                            level: ImportLogLevel::Warning,
+                            message: \sprintf('Match key "%s" already exists — row skipped (mode CREATE).', $row['matchKey']),
+                        )
+                        : new ValidationError(
+                            rowNumber: $row['rowNumber'],
+                            sku: $row['sku'],
+                            errorType: ImportErrorType::NoMatchInDb,
+                            level: ImportLogLevel::Warning,
+                            message: \sprintf('No object matches key "%s" — row skipped (mode UPDATE).', $row['matchKey']),
+                        );
+                }
+            } else {
+                $session->incrementError();
+            }
+
+            // Writer issues are value-level: the row stays imported, the
+            // offending value is skipped — surfaced as warnings.
+            foreach ($issues as $issue) {
+                $errors[] = new ValidationError(
+                    rowNumber: $row['rowNumber'],
+                    sku: $row['sku'],
+                    errorType: 'required_empty' === $issue['kind'] ? ImportErrorType::MissingRequired : ImportErrorType::InvalidValue,
+                    level: ImportLogLevel::Warning,
+                    message: $issue['message'],
+                    columnName: $issue['attributeCode'],
+                );
+            }
+
+            foreach ($errors as $error) {
+                $this->entityManager->persist(new ImportLog(
+                    importSession: $session,
+                    rowNumber: $error->rowNumber,
+                    level: $error->level,
+                    message: $error->message,
+                    sku: $error->sku,
+                    errorType: $error->errorType->value,
+                    columnName: $error->columnName,
+                    columnValue: $error->columnValue,
+                ));
+            }
+
+            $this->progressPublisher->rowProcessed($session, $row['rowNumber'], $row['sku'], $row['rowOk']);
+        }
+
+        return \count($prepared);
+    }
+
+    /**
+     * IMP2-1.3 — the row match key: the cell mapped to the configured
+     * identifier attribute, or the SKU cell by default (trimmed).
      *
      * @param array<string, string|null> $cells
      * @param array<string, string>      $columnMapping

--- a/apps/api/src/Import/Application/Service/CreatedImportObject.php
+++ b/apps/api/src/Import/Application/Service/CreatedImportObject.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+
+/**
+ * IMP2-1.4 (#1466) — create() result: the new object plus any per-value
+ * issues the BatchValueWriter collected (skipped values, never throws).
+ */
+final readonly class CreatedImportObject
+{
+    /**
+     * @param list<array{attributeCode: string, kind: string, message: string}> $issues
+     */
+    public function __construct(
+        public CatalogObject $object,
+        public array $issues,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Service;
 
+use App\Catalog\Application\BatchValueWriter;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -13,7 +14,6 @@ use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Provenance;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
-use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Import\Domain\ValueObject\ResolvedImportValue;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
@@ -38,7 +38,7 @@ final class ImportObjectCreator
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly ObjectValueRepositoryInterface $objectValues,
+        private readonly BatchValueWriter $valueWriter,
         private readonly CompositeValueParser $compositeValueParser,
     ) {
     }
@@ -61,34 +61,16 @@ final class ImportObjectCreator
         Uuid $importSessionId,
         ?string $categoryCode = null,
         ?Tenant $tenant = null,
-    ): CatalogObject {
+    ): CreatedImportObject {
         $object = new CatalogObject($objectType, $sku);
         $object->assignImportSession($importSessionId);
         $this->em->persist($object);
 
-        foreach ($resolvedValues as $resolved) {
-            $rawValue = $resolved->rawValue;
-            if (null === $rawValue || '' === $rawValue) {
-                continue;
-            }
-            $attribute = $attributesByCode[$resolved->attributeCode] ?? null;
-            if (!$attribute instanceof Attribute) {
-                continue;
-            }
-
-            $valuePayload = $this->buildValuePayload($attribute, $rawValue);
-            if (null === $valuePayload) {
-                continue;
-            }
-
-            $this->em->persist(new ObjectValue(
-                object: $object,
-                attribute: $attribute,
-                value: $valuePayload,
-                provenance: Provenance::Import,
-                locale: $resolved->locale,
-            ));
-        }
+        $issues = $this->valueWriter->writeMany(
+            $object,
+            $this->buildWrites($resolvedValues, $attributesByCode),
+            Provenance::Import,
+        );
 
         if (null !== $categoryCode && '' !== $categoryCode && $tenant instanceof Tenant) {
             $category = $this->catalogObjects->findByCode($categoryCode, ObjectKind::Category, $tenant);
@@ -102,7 +84,7 @@ final class ImportObjectCreator
             }
         }
 
-        return $object;
+        return new CreatedImportObject($object, $issues);
     }
 
     /**
@@ -116,11 +98,38 @@ final class ImportObjectCreator
      * @param list<ResolvedImportValue> $resolvedValues
      * @param array<string, Attribute>  $attributesByCode
      */
+    /**
+     * @param list<ResolvedImportValue> $resolvedValues
+     * @param array<string, Attribute>  $attributesByCode
+     *
+     * @return list<array{attributeCode: string, kind: string, message: string}>
+     */
     public function update(
         CatalogObject $object,
         array $resolvedValues,
         array $attributesByCode,
-    ): void {
+    ): array {
+        return $this->valueWriter->writeMany(
+            $object,
+            $this->buildWrites($resolvedValues, $attributesByCode),
+            Provenance::Import,
+        );
+    }
+
+    /**
+     * Map resolved cells to writer entries. Empty cells never become writes
+     * (ADR-0019 D2 — absent/empty means "do not touch"); cells the composite
+     * parsers cannot interpret are dropped here because the row validator
+     * already emitted InvalidType for them.
+     *
+     * @param list<ResolvedImportValue> $resolvedValues
+     * @param array<string, Attribute>  $attributesByCode
+     *
+     * @return list<array{attribute: Attribute, envelope: array<string, mixed>, locale: ?string, channelId: ?Uuid}>
+     */
+    private function buildWrites(array $resolvedValues, array $attributesByCode): array
+    {
+        $writes = [];
         foreach ($resolvedValues as $resolved) {
             $rawValue = $resolved->rawValue;
             if (null === $rawValue || '' === $rawValue) {
@@ -130,27 +139,14 @@ final class ImportObjectCreator
             if (!$attribute instanceof Attribute) {
                 continue;
             }
-
             $valuePayload = $this->buildValuePayload($attribute, $rawValue);
             if (null === $valuePayload) {
                 continue;
             }
-
-            $existing = $this->objectValues->findOneByScope($object, $attribute, null, $resolved->locale);
-            if ($existing instanceof ObjectValue) {
-                $existing->updateValue($valuePayload);
-                $existing->changeProvenance(Provenance::Import);
-                continue;
-            }
-
-            $this->em->persist(new ObjectValue(
-                object: $object,
-                attribute: $attribute,
-                value: $valuePayload,
-                provenance: Provenance::Import,
-                locale: $resolved->locale,
-            ));
+            $writes[] = ['attribute' => $attribute, 'envelope' => $valuePayload, 'locale' => $resolved->locale, 'channelId' => null];
         }
+
+        return $writes;
     }
 
     /**

--- a/apps/api/src/Import/Application/Service/ObjectResolver.php
+++ b/apps/api/src/Import/Application/Service/ObjectResolver.php
@@ -75,6 +75,76 @@ final readonly class ObjectResolver
     }
 
     /**
+     * IMP2-1.4 (#1466) — batch resolve for a chunk: one query instead of one
+     * per row. Keys are trimmed, empty keys ignored.
+     *
+     * @param list<string> $keys
+     *
+     * @return array<string, CatalogObject> key => object (missing keys absent)
+     */
+    public function resolveMany(
+        array $keys,
+        \App\Catalog\Domain\Entity\ObjectType $objectType,
+        Tenant $tenant,
+        ?string $matchAttributeCode,
+    ): array {
+        $keys = array_values(array_unique(array_filter(array_map(trim(...), $keys), static fn (string $k): bool => '' !== $k)));
+        if ([] === $keys) {
+            return [];
+        }
+
+        if (null === $matchAttributeCode) {
+            $rows = $this->em->createQueryBuilder()
+                ->select('o')
+                ->from(CatalogObject::class, 'o')
+                ->where('o.code IN (:keys)')
+                ->andWhere('o.objectType = :objectType')
+                ->setParameter('keys', $keys)
+                ->setParameter('objectType', $objectType)
+                ->getQuery()
+                ->getResult();
+
+            /** @var list<CatalogObject> $rows */
+            $map = [];
+            foreach ($rows as $row) {
+                $map[$row->getCode()] = $row;
+            }
+
+            return $map;
+        }
+
+        $idRows = $this->em->getConnection()->fetchAllAssociative(
+            <<<'SQL'
+                SELECT o.id, ov.value->>'value' AS match_key
+                FROM objects o
+                JOIN object_values ov ON ov.object_id = o.id
+                JOIN attributes a ON a.id = ov.attribute_id
+                WHERE a.code = :code
+                  AND o.object_type_id = :objectTypeId
+                  AND o.tenant_id = :tenantId
+                  AND ov.value->>'value' IN (:keys)
+                SQL,
+            [
+                'code' => $matchAttributeCode,
+                'objectTypeId' => $objectType->getId()->toRfc4122(),
+                'tenantId' => $tenant->getId()->toRfc4122(),
+                'keys' => $keys,
+            ],
+            ['keys' => \Doctrine\DBAL\ArrayParameterType::STRING],
+        );
+
+        $map = [];
+        foreach ($idRows as $idRow) {
+            $object = $this->em->find(CatalogObject::class, $idRow['id']);
+            if ($object instanceof CatalogObject && \is_string($idRow['match_key'])) {
+                $map[$idRow['match_key']] = $object;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
      * CREATE skips matched rows, UPDATE skips unmatched ones, UPSERT
      * branches — returns the decision for the run loop.
      */

--- a/apps/api/tests/Unit/Export/Application/Builder/ValueSerializerTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ValueSerializerTest.php
@@ -160,19 +160,4 @@ final class ValueSerializerTest extends TestCase
 
         return $stub;
     }
-
-    /**
-     * IMP2-1.2 (#1464): legacy admin-written selects carried {value} — the
-     * transitional fallback keeps them exportable until #1466 removes it.
-     */
-    #[Test]
-    public function selectFallsBackToLegacyValueKey(): void
-    {
-        $serializer = new ValueSerializer();
-        $legacy = $this->valueWithPayload(AttributeType::Select, ['value' => 'red']);
-        self::assertSame('red', $serializer->serialize($legacy));
-
-        $canonicalWins = $this->valueWithPayload(AttributeType::Select, ['option_code' => 'blue', 'value' => 'red']);
-        self::assertSame('blue', $serializer->serialize($canonicalWins));
-    }
 }


### PR DESCRIPTION
## Cel (#1466)
„Import waliduje dokładnie jak admin" — koniec równoległej logiki zapisu wartości.

## Zmiany
- **`ValueWriteCore`** (Catalog\Application): normalizacja do kanonu ADR-0019, required (#1350), walidacja per-typ (#1216/#1261 — email/color/identifier/select/multiselect z żywych AttributeOption), pre-check unikalności identifier (#1179), routing locale/channel (#1148/#1154). Jedno źródło reguł.
- **`ObjectAttributesUpserter`** = cienki klient per-request (HTTP-wyjątki) — zachowanie API bez zmian (528→850 testów zielonych bez modyfikacji kontraktów).
- **`BatchValueWriter`**: result-based (issues zamiast wyjątków), persist-only (flush należy do AbstractBatchHandler), **`primeChunk`** = 1 zapytanie o istniejące ObjectValue per chunk (klucz object×attribute×locale×channel) — znika N+1 z 1.3; in-chunk set duplikatów identifierów + DB pre-check.
- **`ImportRunHandler`**: pętla buforowana per chunk → `ObjectResolver::resolveMany` (1 zapytanie na chunk, SKU lub identifier przez natywny SQL z jawnym tenant_id) → primeChunk → decyzje/zapis; issues writera → `ImportLog` warnings (wartość pominięta, wiersz przechodzi — „skip+log").
- `ImportObjectCreator`: create/update przez writer (`CreatedImportObject` DTO z issues); własne persisty ObjectValue usunięte.
- `ValueSerializer`: zdjęty przejściowy fallback `{value}` dla selectów (baza kanoniczna od #1505).
- Deptrac: **Violations 0 / Errors 0**; stale wpis creator→ObjectValue zdjęty (burn-down), touchpointy writera udokumentowane w baseline (pełny kontrakt IDs-only w Contracts = dalszy burn-down, odnotowane).

## Bramki + smoke (live stack)
- PHPStan max **No errors** (pełny run); PHPUnit **850 testów** (pełny Unit + Api/Import, `-e APP_ENV=test`); Deptrac 0/0.
- **K1**: import CREATE z nieistniejącym `option_code` → wiersz przechodzi, wartość pominięta, raport: `invalid_value,"Option ""niebieski-nieistnieje"" is not a valid option…"` — **walidacja opcji na imporcie działa** (domyka resztkę IMP-17 z #598/#602).
- **K2**: UPSERT → `succ 1, upd 1`, DB: `name=Pisak v2, color={"option_code":"red"}` (ścieżka update przez prefetch).
- Cleanup: rollback 200.

Closes #1466