### PR TITLE
IMP2-1.6a — build(import): transport Messenger 'import' + worker w dev; próg sync po wierszach

### DIFF
--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2460,3 +2460,11 @@ Self-audit ujawnił 12 znalezisk; korekty wprowadzone w drugiej iteracji:
 - **Nowe pokrycie E2E odsłania stare bugi** — happy-path commitu importu (nigdy nietestowany w CI) wykrył FK violation `objects_import_session_fk` na ścieżce inline (tylko CI; #1455). Skip wyłącznie na dokładną sygnaturę znanego buga + osobny issue z diagnostyką — nie maskować szerokim catch-em.
 - **Rate limiter auth ogranicza lokalną pełną suitę** — ~140 speców × login > 50/15min; ogon suity failuje lokalnie (1177/1138/VIEW-09 itd.), te same specki pass w izolacji i w CI. Nie debugować ogona przed sprawdzeniem izolacji; storageState rollout pozostaje właściwym fixem.
 - **`gh pr merge` 401 (keyring)** — merge przez `gh api -X PUT .../pulls/N/merge -f merge_method=squash` działa zawsze (potwierdzone ×9 w epiku).
+
+## Lessons z IMP2 fala A (#1460–#1468, 2026-06-12)
+
+1. **PHPUnit w kontenerze ZAWSZE z `-e APP_ENV=test`** — kontener api ma `APP_ENV=dev` w compose i realne env wygrywa z phpunit `<server force="true">`: kernel bootuje DEV, Foundry `ResetDatabase` **zeruje dev DB** (incydent 2026-06-12, odtworzone z dumpa `backups/pre-imp2-1.2-*`). Kanon: `docker compose exec -T -e APP_ENV=test api vendor/bin/phpunit …`. Objaw-sygnatura: `Could not find service "test.service_container"`.
+2. **Test DB powstaje ze schematu ORM (Foundry reset: schema), nie z migracji** — kolumny trigger-maintained (np. `object_values.identifier_*` z Version20260531120000) muszą mieć read-only mapping w ORM XML (`insertable=false updatable=false`), inaczej każdy path który ich dotyka wybucha tylko w testach.
+3. **Operator JSONB `?` w Doctrine addSql koliduje z placeholderami** — w migracjach używać `jsonb_exists(col, 'key')`; dotyczy też DO-bloków (cały string idzie przez DBAL).
+4. **`docker compose exec` z cwd `apps/api` nie widzi serwisów** — compose root to katalog główny repo; objaw: `service "api" is not running` mimo zdrowego stacka.
+5. **Golden test (eksport→import→równość envelope) łapie luki, których testy kontraktowe nie widzą** — pierwsze uruchomienie wykryło hardcoded required `['sku','name']` i brak kolumn identifier w test DB. Wzorzec: matryca per `AttributeType` + scenariusz „edytuj jedną komórkę".

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -41,6 +41,8 @@ DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&ch
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 MESSENGER_TRANSPORT_DSN=doctrine://default?auto_setup=0
+# IMP2-1.6a — dedicated import queue (same Doctrine table, own queue_name).
+MESSENGER_IMPORT_TRANSPORT_DSN=doctrine://default?auto_setup=0
 ###< symfony/messenger ###
 
 ###> app/multi-tenancy ###

--- a/apps/api/.env.dev
+++ b/apps/api/.env.dev
@@ -8,6 +8,9 @@ APP_SECRET=e65fa14762532539948ae4ce3d479159
 # `doctrine://default?queue_name=async` so the FrankenPHP workers
 # drain the queue.
 MESSENGER_TRANSPORT_DSN=sync://
+# IMP2-1.6a — real async in dev: the compose `worker` service consumes the
+# `import` queue, so big files leave the HTTP request path (D8).
+MESSENGER_IMPORT_TRANSPORT_DSN=doctrine://default?auto_setup=1
 
 # RBAC Mailer dev: SMTP → Mailpit container (UI at https://mail.pim.localhost)
 MAILER_DSN=smtp://mailpit:1025

--- a/apps/api/.env.test
+++ b/apps/api/.env.test
@@ -18,3 +18,4 @@ APP_SECRET='$ecretf0rt3st'
 # the test asserts on. CI overrides this via a real env var to
 # `in-memory://` when individual tests need to introspect the queue.
 MESSENGER_TRANSPORT_DSN=sync://
+MESSENGER_IMPORT_TRANSPORT_DSN=sync://

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -33,6 +33,7 @@
         "stevenmaguire/oauth2-microsoft": "^2",
         "symfony/asset": "7.4.*",
         "symfony/console": "7.4.*",
+        "symfony/doctrine-messenger": "7.4.*",
         "symfony/dotenv": "7.4.*",
         "symfony/expression-language": "7.4.*",
         "symfony/flex": "^2.10",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e64e51ca26942f2087c6fcbdb889ceb2",
+    "content-hash": "8715ad91d74b817dae2384274eca221d",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -6518,6 +6518,82 @@
                 }
             ],
             "time": "2026-04-29T14:19:39+00:00"
+        },
+        {
+            "name": "symfony/doctrine-messenger",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/doctrine-messenger.git",
+                "reference": "a429cd95983eaea2371ea279bed3b8a93b9ecdd3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/doctrine-messenger/zipball/a429cd95983eaea2371ea279bed3b8a93b9ecdd3",
+                "reference": "a429cd95983eaea2371ea279bed3b8a93b9ecdd3",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.6|^4",
+                "php": ">=8.2",
+                "symfony/messenger": "^7.2|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "doctrine/persistence": "^1.3|^2|^3",
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0"
+            },
+            "type": "symfony-messenger-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\Bridge\\Doctrine\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Doctrine Messenger Bridge",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/doctrine-messenger/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T09:40:04+00:00"
         },
         {
             "name": "symfony/dotenv",

--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -20,6 +20,18 @@ framework:
             # worker pool drains the queue.
             async: '%env(MESSENGER_TRANSPORT_DSN)%'
 
+            # IMP2-1.6a (#1468, ADR-0019 D8) — dedicated import queue so a
+            # 200k-row import never starves UI-adjacent async jobs (Akeneo's
+            # ui_job / import_export_job split). Doctrine transport with a
+            # redeliver window safely above the worst-case import duration:
+            # the worker heartbeats per chunk, a crashed run is re-delivered
+            # and resumes idempotently (checkpoint lands in IMP2-2.3 #1479).
+            import:
+                dsn: '%env(MESSENGER_IMPORT_TRANSPORT_DSN)%'
+                options:
+                    queue_name: import
+                    redeliver_timeout: 14400
+
             failed: 'doctrine://default?queue_name=failed'
 
         buses:
@@ -98,7 +110,7 @@ framework:
             # row-by-row via {@see ImportRunHandler}. Sync small (<50
             # rows) imports bypass dispatch by calling `run()` directly
             # on the same handler from the controller.
-            App\Import\Domain\Message\ImportRunMessage: async
+            App\Import\Domain\Message\ImportRunMessage: import
 
             # Imports MVP (#447). pgBackRest snapshot can take 5-30
             # minutes — handler runs out-of-band so `POST /api/backups`

--- a/apps/api/config/reference.php
+++ b/apps/api/config/reference.php
@@ -128,7 +128,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * @psalm-type FrameworkConfig = array{
  *     secret?: scalar|Param|null,
  *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
- *     allowed_http_method_override?: list<string|Param>|null,
+ *     allowed_http_method_override?: null|list<string|Param>,
  *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
  *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
  *     test?: bool|Param,
@@ -136,9 +136,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
  *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
  *     enabled_locales?: list<scalar|Param|null>,
- *     trusted_hosts?: list<scalar|Param|null>,
+ *     trusted_hosts?: string|list<scalar|Param|null>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: list<scalar|Param|null>,
+ *     trusted_headers?: string|list<scalar|Param|null>,
  *     error_controller?: scalar|Param|null, // Default: "error_controller"
  *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
@@ -202,23 +202,23 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 property?: scalar|Param|null,
  *                 service?: scalar|Param|null,
  *             },
- *             supports?: list<scalar|Param|null>,
+ *             supports?: string|list<scalar|Param|null>,
  *             definition_validators?: list<scalar|Param|null>,
  *             support_strategy?: scalar|Param|null,
- *             initial_marking?: list<scalar|Param|null>,
- *             events_to_dispatch?: list<string|Param>|null,
- *             places?: list<array{ // Default: []
+ *             initial_marking?: \BackedEnum|string|list<scalar|Param|null>,
+ *             events_to_dispatch?: null|list<string|Param>,
+ *             places?: string|list<array{ // Default: []
  *                 name?: scalar|Param|null,
  *                 metadata?: array<string, mixed>,
  *             }>,
  *             transitions?: list<array{ // Default: []
  *                 name?: string|Param,
  *                 guard?: string|Param, // An expression to block the transition.
- *                 from?: list<array{ // Default: []
+ *                 from?: \BackedEnum|string|list<array{ // Default: []
  *                     place?: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
- *                 to?: list<array{ // Default: []
+ *                 to?: \BackedEnum|string|list<array{ // Default: []
  *                     place?: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
@@ -271,7 +271,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
  *         json_manifest_path?: scalar|Param|null, // Default: null
  *         base_path?: scalar|Param|null, // Default: ""
- *         base_urls?: list<scalar|Param|null>,
+ *         base_urls?: string|list<scalar|Param|null>,
  *         packages?: array<string, array{ // Default: []
  *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
  *             version_strategy?: scalar|Param|null, // Default: null
@@ -279,12 +279,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             version_format?: scalar|Param|null, // Default: null
  *             json_manifest_path?: scalar|Param|null, // Default: null
  *             base_path?: scalar|Param|null, // Default: ""
- *             base_urls?: list<scalar|Param|null>,
+ *             base_urls?: string|list<scalar|Param|null>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: false
- *         paths?: array<string, scalar|Param|null>,
+ *         paths?: string|array<string, scalar|Param|null>,
  *         excluded_patterns?: list<scalar|Param|null>,
  *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
  *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
@@ -303,7 +303,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     translator?: bool|array{ // Translator configuration
  *         enabled?: bool|Param, // Default: true
- *         fallbacks?: list<scalar|Param|null>,
+ *         fallbacks?: string|list<scalar|Param|null>,
  *         logging?: bool|Param, // Default: false
  *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
  *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
@@ -333,7 +333,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: true
  *         cache?: scalar|Param|null, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
  *         enable_attributes?: bool|Param, // Default: true
- *         static_method?: list<scalar|Param|null>,
+ *         static_method?: string|list<scalar|Param|null>,
  *         translation_domain?: scalar|Param|null, // Default: "validators"
  *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose"|Param, // Default: "html5"
  *         mapping?: array{
@@ -396,7 +396,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
  *         default_pdo_provider?: scalar|Param|null, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: list<scalar|Param|null>,
+ *             adapters?: string|list<scalar|Param|null>,
  *             tags?: scalar|Param|null, // Default: null
  *             public?: bool|Param, // Default: false
  *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
@@ -419,11 +419,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     lock?: bool|string|array{ // Lock configuration
  *         enabled?: bool|Param, // Default: true
- *         resources?: array<string, string|list<scalar|Param|null>>,
+ *         resources?: string|array<string, string|list<scalar|Param|null>>,
  *     },
  *     semaphore?: bool|string|array{ // Semaphore configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: array<string, scalar|Param|null>,
+ *         resources?: string|array<string, scalar|Param|null>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: true
@@ -453,7 +453,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
  *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: list<scalar|Param|null>,
+ *         stop_worker_on_signals?: int|string|list<scalar|Param|null>,
  *         default_bus?: scalar|Param|null, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
  *             default_middleware?: bool|string|array{
@@ -461,7 +461,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 allow_no_handlers?: bool|Param, // Default: false
  *                 allow_no_senders?: bool|Param, // Default: true
  *             },
- *             middleware?: list<string|array{ // Default: []
+ *             middleware?: string|list<string|array{ // Default: []
  *                 id?: scalar|Param|null,
  *                 arguments?: list<mixed>,
  *             }>,
@@ -510,9 +510,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
  *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: array<string, array{ // Default: []
+ *                 http_codes?: int|string|array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: list<string|Param>,
+ *                     methods?: string|list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -563,9 +563,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
  *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
- *                 http_codes?: array<string, array{ // Default: []
+ *                 http_codes?: int|string|array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: list<string|Param>,
+ *                     methods?: string|list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -582,8 +582,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         transports?: array<string, scalar|Param|null>,
  *         envelope?: array{ // Mailer Envelope configuration
  *             sender?: scalar|Param|null,
- *             recipients?: list<scalar|Param|null>,
- *             allowed_recipients?: list<scalar|Param|null>,
+ *             recipients?: string|list<scalar|Param|null>,
+ *             allowed_recipients?: string|list<scalar|Param|null>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
  *             value?: mixed,
@@ -635,7 +635,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
  *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
  *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: list<scalar|Param|null>,
+ *             limiters?: string|list<scalar|Param|null>,
  *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
  *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
@@ -658,20 +658,20 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
  *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
  *             allow_elements?: array<string, mixed>,
- *             block_elements?: list<string|Param>,
- *             drop_elements?: list<string|Param>,
+ *             block_elements?: string|list<string|Param>,
+ *             drop_elements?: string|list<string|Param>,
  *             allow_attributes?: array<string, mixed>,
  *             drop_attributes?: array<string, mixed>,
  *             force_attributes?: array<string, array<string, string|Param>>,
  *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: list<string|Param>,
- *             allowed_link_hosts?: list<string|Param>|null,
+ *             allowed_link_schemes?: string|list<string|Param>,
+ *             allowed_link_hosts?: null|string|list<string|Param>,
  *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: list<string|Param>,
- *             allowed_media_hosts?: list<string|Param>|null,
+ *             allowed_media_schemes?: string|list<string|Param>,
+ *             allowed_media_hosts?: null|string|list<string|Param>,
  *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: list<string|Param>,
- *             without_attribute_sanitizers?: list<string|Param>,
+ *             with_attribute_sanitizers?: string|list<string|Param>,
+ *             without_attribute_sanitizers?: string|list<string|Param>,
  *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
  *         }>,
  *     },
@@ -706,6 +706,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     jsonapi?: array{
  *         use_iri_as_id?: bool|Param, // Set to false to use entity identifiers instead of IRIs as the "id" field in JSON:API responses. // Default: true
+ *         allow_client_generated_id?: bool|Param, // Allow client-generated IDs on JSON:API POST per https://jsonapi.org/format/#crud-creating-client-ids. Off by default to prevent id spoofing on public endpoints. // Default: false
  *     },
  *     eager_loading?: bool|array{
  *         enabled?: bool|Param, // Default: true
@@ -1254,7 +1255,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     password_hashers?: array<string, string|array{ // Default: []
  *         algorithm?: scalar|Param|null,
- *         migrate_from?: list<scalar|Param|null>,
+ *         migrate_from?: string|list<scalar|Param|null>,
  *         hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
  *         key_length?: scalar|Param|null, // Default: 40
  *         ignore_case?: bool|Param, // Default: false
@@ -1268,7 +1269,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     providers?: array<string, array{ // Default: []
  *         id?: scalar|Param|null,
  *         chain?: array{
- *             providers?: list<scalar|Param|null>,
+ *             providers?: string|list<scalar|Param|null>,
  *         },
  *         entity?: array{
  *             class?: scalar|Param|null, // The full entity class name of your user class.
@@ -1278,7 +1279,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         memory?: array{
  *             users?: array<string, array{ // Default: []
  *                 password?: scalar|Param|null, // Default: null
- *                 roles?: list<scalar|Param|null>,
+ *                 roles?: string|list<scalar|Param|null>,
  *             }>,
  *         },
  *         ldap?: array{
@@ -1287,7 +1288,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             search_dn?: scalar|Param|null, // Default: null
  *             search_password?: scalar|Param|null, // Default: null
  *             extra_fields?: list<scalar|Param|null>,
- *             default_roles?: list<scalar|Param|null>,
+ *             default_roles?: string|list<scalar|Param|null>,
  *             role_fetcher?: scalar|Param|null, // Default: null
  *             uid_key?: scalar|Param|null, // Default: "sAMAccountName"
  *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
@@ -1300,7 +1301,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     firewalls?: array<string, array{ // Default: []
  *         pattern?: scalar|Param|null,
  *         host?: scalar|Param|null,
- *         methods?: list<scalar|Param|null>,
+ *         methods?: string|list<scalar|Param|null>,
  *         security?: bool|Param, // Default: true
  *         user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
  *         request_matcher?: scalar|Param|null,
@@ -1319,8 +1320,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             path?: scalar|Param|null, // Default: "/logout"
  *             target?: scalar|Param|null, // Default: "/"
  *             invalidate_session?: bool|Param, // Default: true
- *             clear_site_data?: list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
- *             delete_cookies?: array<string, array{ // Default: []
+ *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
+ *             delete_cookies?: string|array<string, array{ // Default: []
  *                 path?: scalar|Param|null, // Default: null
  *                 domain?: scalar|Param|null, // Default: null
  *                 secure?: scalar|Param|null, // Default: false
@@ -1462,7 +1463,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             success_handler?: scalar|Param|null,
  *             failure_handler?: scalar|Param|null,
  *             realm?: scalar|Param|null, // Default: null
- *             token_extractors?: list<scalar|Param|null>,
+ *             token_extractors?: string|list<scalar|Param|null>,
  *             token_handler?: string|array{
  *                 id?: scalar|Param|null,
  *                 oidc_user_info?: string|array{
@@ -1477,7 +1478,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 },
  *                 oidc?: array{
  *                     discovery?: array{ // Enable the OIDC discovery.
- *                         base_uri?: list<scalar|Param|null>,
+ *                         base_uri?: string|list<scalar|Param|null>,
  *                         cache?: array{
  *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
@@ -1520,7 +1521,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         remember_me?: array{
  *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
  *             service?: scalar|Param|null,
- *             user_providers?: list<scalar|Param|null>,
+ *             user_providers?: string|list<scalar|Param|null>,
  *             catch_exceptions?: bool|Param, // Default: true
  *             signature_properties?: list<scalar|Param|null>,
  *             token_provider?: string|array{
@@ -1548,12 +1549,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         path?: scalar|Param|null, // Use the urldecoded format. // Default: null
  *         host?: scalar|Param|null, // Default: null
  *         port?: int|Param, // Default: null
- *         ips?: list<scalar|Param|null>,
+ *         ips?: string|list<scalar|Param|null>,
  *         attributes?: array<string, scalar|Param|null>,
  *         route?: scalar|Param|null, // Default: null
- *         methods?: list<scalar|Param|null>,
+ *         methods?: string|list<scalar|Param|null>,
  *         allow_if?: scalar|Param|null, // Default: null
- *         roles?: list<scalar|Param|null>,
+ *         roles?: string|list<scalar|Param|null>,
  *     }>,
  *     role_hierarchy?: array<string, string|list<scalar|Param|null>>,
  * }
@@ -1618,7 +1619,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     auto_reload?: scalar|Param|null,
  *     optimizations?: int|Param,
  *     default_path?: scalar|Param|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
- *     file_name_pattern?: list<scalar|Param|null>,
+ *     file_name_pattern?: string|list<scalar|Param|null>,
  *     paths?: array<string, mixed>,
  *     date?: array{ // The default format options used by the date filter.
  *         format?: scalar|Param|null, // Default: "F j, Y H:i"

--- a/apps/api/src/Import/Presentation/Controller/StartImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/StartImportController.php
@@ -103,6 +103,16 @@ final class StartImportController
         if ('' === $originalName) {
             $originalName = 'upload.csv';
         }
+
+        // IMP2-1.6a (#1468, ADR-0019 D8): the sync/async split counts DATA
+        // ROWS, not bytes — a wide 20-row CSV stays inline, a narrow 500-row
+        // one goes to the worker. Counting stops at the threshold; the +1
+        // header line is excluded.
+        $dataRowCount = str_ends_with(strtolower($originalName), '.csv')
+            ? $this->countDataRows($file->getPathname(), self::SYNC_THRESHOLD_ROWS + 1)
+            // XLSX is a zip — line counting is meaningless; spreadsheets
+            // always take the worker path (cheap now that dev runs one).
+            : self::SYNC_THRESHOLD_ROWS + 1;
         $session = new ImportSession(
             userId: $user->getId(),
             targetObjectType: $objectType,
@@ -151,7 +161,7 @@ final class StartImportController
         // wait on a worker; `total_rows` is unknown until the handler
         // streams the file, so we use the request-time threshold based on
         // `file_size_bytes` heuristic (small files always sync).
-        if ($session->getFileSizeBytes() <= self::SYNC_THRESHOLD_ROWS * 1024) {
+        if ($dataRowCount <= self::SYNC_THRESHOLD_ROWS) {
             $reload = $this->sessions->findById($session->getId());
             if ($reload instanceof ImportSession) {
                 try {
@@ -290,5 +300,33 @@ final class StartImportController
         }
 
         return $code;
+    }
+
+    /**
+     * Counts non-empty data lines (header excluded), stopping at $cap —
+     * enough to answer "inline or worker?" without reading a huge file.
+     */
+    private function countDataRows(string $path, int $cap): int
+    {
+        $handle = @fopen($path, 'r');
+        if (false === $handle) {
+            return $cap;
+        }
+        $count = -1; // first line is the header
+        try {
+            while (false !== ($line = fgets($handle))) {
+                if ('' === trim($line)) {
+                    continue;
+                }
+                ++$count;
+                if ($count >= $cap) {
+                    return $count;
+                }
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return max(0, $count);
     }
 }

--- a/apps/api/src/Import/Presentation/Controller/StartImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/StartImportController.php
@@ -21,6 +21,7 @@ use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
 use App\Shared\Application\BulkOperationInProgressException;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Messenger\Stamp\TenantStamp;
 use DateTimeInterface;
 use InvalidArgumentException;
 use League\Flysystem\FilesystemException;
@@ -185,7 +186,7 @@ final class StartImportController
         $this->bus->dispatch(new ImportRunMessage(
             importSessionId: $session->getId(),
             tenantId: $tenant->getId(),
-        ));
+        ), [new TenantStamp($tenant->getId())]);
 
         return new JsonResponse($this->serialise($session), Response::HTTP_ACCEPTED);
     }

--- a/apps/api/src/Shared/Infrastructure/Messenger/IdempotencyMiddleware.php
+++ b/apps/api/src/Shared/Infrastructure/Messenger/IdempotencyMiddleware.php
@@ -12,6 +12,7 @@ use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * Drops duplicate-handle attempts on top of Doctrine's at-least-once
@@ -56,6 +57,13 @@ final readonly class IdempotencyMiddleware implements MiddlewareInterface
         $messageId = (string) $rawId;
         if ('' === $messageId) {
             return $stack->next()->handle($envelope, $stack);
+        }
+        // IMP2-1.6a (#1468): the doctrine transport hands out sequential
+        // bigint delivery ids, not UUIDs — the processed_messages PK is
+        // UUID, so derive a stable v5 from the id (sync/AMQP UUID ids pass
+        // through untouched).
+        if (!Uuid::isValid($messageId)) {
+            $messageId = Uuid::v5(Uuid::fromString(Uuid::NAMESPACE_OID), 'messenger:'.$messageId)->toRfc4122();
         }
 
         try {

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,7 @@
 #     (ObjectValuesChangedMessage, AssetThumbnailsRequested, ImportRunMessage,
 #     BackupSnapshotMessage) drain via the worker pool below instead of
 #     blocking the HTTP request thread.
-#   - Adds a dedicated `worker` service that runs `messenger:consume async`
+#   - Adds a dedicated `worker` service that runs `messenger:consume async import`
 #     with a per-process memory cap. Replicas scale the pool horizontally
 #     without touching the web container.
 #
@@ -129,6 +129,7 @@ services:
       - "bin/console"
       - "messenger:consume"
       - "async"
+      - "import"
       - "--memory-limit=256M"
       - "--time-limit=3600"
       - "--failure-limit=5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,10 @@ services:
       # `doctrine://default?queue_name=async` so the FrankenPHP worker
       # pool drains the queue (audit MEDIUM-007).
       MESSENGER_TRANSPORT_DSN: sync://
+      # IMP2-1.6a (#1468) — the import queue IS asynchronous in dev: the
+      # `worker` service below drains it, so big files leave the request
+      # path and pause/cancel (IMP2-2.3) have a real worker to act on.
+      MESSENGER_IMPORT_TRANSPORT_DSN: doctrine://default?auto_setup=1
       MERCURE_URL: http://mercure/.well-known/mercure
       MERCURE_PUBLIC_URL: https://pim.localhost/.well-known/mercure
       MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:-!ChangeMercureKeyAtLeast256BitsLong!}
@@ -167,6 +171,39 @@ services:
       timeout: 3s
       retries: 5
       start_period: 60s
+
+  # ─── Import queue worker (IMP2-1.6a #1468, ADR-0019 D8) ───────────────────
+  # Mirrors the api container (same image, same bind mounts) but runs the
+  # Messenger consumer for the dedicated `import` transport. time-limit
+  # recycles the process well under the redeliver window; failure stops
+  # the container and compose restarts it (crash → redelivery → resume).
+  worker:
+    build:
+      context: ./apps/api
+      dockerfile: Dockerfile
+    <<: *default_restart
+    depends_on:
+      database:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: php bin/console messenger:consume import --time-limit=3600 --memory-limit=256M
+    environment:
+      APP_ENV: ${APP_ENV:-dev}
+      APP_SECRET: ${APP_SECRET:-ChangeMeBeforeDeploy}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=16&charset=utf8
+      MESSENGER_TRANSPORT_DSN: sync://
+      MESSENGER_IMPORT_TRANSPORT_DSN: doctrine://default?auto_setup=1
+      MERCURE_URL: http://mercure/.well-known/mercure
+      MERCURE_PUBLIC_URL: https://pim.localhost/.well-known/mercure
+      MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:-!ChangeMercureKeyAtLeast256BitsLong!}
+      MERCURE_TOPIC_BASE: ${MERCURE_TOPIC_BASE:-https://pim.localhost}
+      MEILI_URL: http://meilisearch:7700
+      MEILI_KEY: ${MEILI_MASTER_KEY:-masterKeyPleaseChangeMe}
+    volumes:
+      - ./apps/api:/app
+      - api_var:/app/var
+      - api_vendor:/app/vendor
 
   # ─── Frontend admin (Vite dev server) ─────────────────────────────────────
   admin:


### PR DESCRIPTION
## Zakres (#1468, ADR-0019 D8)
- Transport `import` (doctrine, `queue_name=import`, `redeliver_timeout=14400` > worst-case run); routing `ImportRunMessage → import`.
- **Serwis `worker` w dev compose** (messenger:consume import, time/memory-limit, te same bind-mounty co api) — async import w dev naprawdę opuszcza request HTTP; pauza/cancel (#1479) dostaje realnego workera. Prod: istniejący consumer drenuje `async import`.
- Próg inline **≤50 WIERSZY** (zamiast mylącej heurystyki 50KB; komentarz vs kod z audytu) — szeroki 20-wierszowy CSV zostaje inline, wąski 500-wierszowy idzie do workera; **XLSX zawsze async** (liczenie linii w zipie nie ma sensu).
- ENV: `MESSENGER_IMPORT_TRANSPORT_DSN` (.env/.env.dev/.env.test/compose).
- Lessons fali A (w tym incydent `-e APP_ENV=test` + odtworzenie dev DB z dumpa).

## Smoke (live stack)
Dołączę po starcie kontenera `worker` (retry builda po przejściowym lease-error buildkita) — kryterium: 51-wierszowy CSV → HTTP 202, sesja przetworzona przez `worker` (logi konsumpcji z kolejki `import`), liczniki OK, rollback sprzątający.

Closes #1468