### PR TITLE
IMP2-1.8 — feat(import,export): warianty parent_sku + relacje ObjectRelation + fan-out + galerie + variant_axes

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -11,19 +11,26 @@
 - **Fala A — KOMPLETNA (8/8):** #1460–62 quick-winy, #1463 ADR-0019, #1464 kanon JSONB, #1465 tryby CREATE/UPDATE/UPSERT, #1466 ValueWriteCore+BatchValueWriter, #1467 golden round-trip v0, #1468/#1509 transport Messenger `import`+worker.
 - **Fala B — w toku:**
   - [x] **IMP2-1.6 (#1469)** — gramatyka kolumn `code.locale.channel` + zapis channelId. **MERGED** (PR #1510, `440a63a3`, 2026-06-13). Live smoke 3/3 na pim.localhost, issue zamknięte z dowodem. Grammar przez `Channel\Contracts\ScopeEnumerator` (deptrac-clean, channelId raz/sesja), export 3-segment + fan-out #1146 + R-47 preflight 422, kolizja kanał↔locale (oba kierunki), golden + kanały.
-  - [→] **IMP2-1.7 (#1470)** — multi-kategorie pipe-split + import status/enabled. Branch `feat/imp2-1.7-multicat-status`. **W TRAKCIE.**
-  - [ ] IMP2-1.8 (#1471) warianty/relacje · 1.9 (#1472) izolacja błędów · 1.10 (#1473) golden pełna matryca + async · 1.11+ (media, etap 2/3).
+  - [x] **IMP2-1.7 (#1470)** — multi-kategorie pipe-split + import status/enabled. **MERGED** (PR #1511, `5dd98b8c`, 2026-06-13). Live smoke 3/3, zamknięte z dowodem. CREATE multi-kat (primary+position), replace/append (D2), status/enabled z kolumn (`__status__`/`__enabled__`), FE StepMapping + Playwright, golden round-trip.
+  - [→] **IMP2-1.8 (#1471)** — warianty parent_sku two-pass + relacje ObjectRelation + fan-out. Branch `feat/imp2-1.8-variants-relations` (push'nięty). **CZĘŚCIOWE — parent_sku two-pass DONE** (commit `f8f22973`, NIE na main).
+  - [ ] 1.9 (#1472) izolacja błędów · 1.10 (#1473) golden pełna matryca + async · 1.11+ (media, etap 2/3).
 
 ## Ostatnie akcje
-1. IMP2-1.6 zaimplementowane, zmergowane (PR #1510) i zamknięte z live-smoke proof (#1469).
-2. Lekcje 1.6 → `lessons.md` + pamięć trwała (APP_ENV=test dla Api/*, assert status≠detail, ScopeEnumerator port).
-3. Start IMP2-1.7: branch + research backendu (SystemColumn, ReservedMappingTarget, extractCategoryCode).
+1. IMP2-1.6 + IMP2-1.7 zmergowane i zamknięte z live-smoke proof (#1469, #1470).
+2. Lekcje 1.6/1.7 → `lessons.md` + 2 wpisy pamięci trwałej. `current_status.md` zslimowany (2066→~40).
+3. Start IMP2-1.8: parent_sku two-pass (`RelationImportStep`) zacommitowany na branchu (f8f22973).
 
-## Następny krok
-Implementacja IMP2-1.7: `extractCategoryCodes()` pipe-split + `ObjectCategory` per kod (primary+position), polityka replace/append (D2), `status`/`enabled` z jawnych kolumn (`__status__`/`__enabled__`, usunięcie z `SystemColumn`), FE `StepMapping.tsx`, golden + ApiTest, PR → CI → merge → live smoke.
+## Następny krok — WZNOWIENIE IMP2-1.8 (świeży kontekst)
+Branch `feat/imp2-1.8-variants-relations` @ `f8f22973`. **Zrobione:** parent_sku two-pass (RelationImportStep buforuje child→parent po code, resolve po pass-1, cycle/self/missing guard; reserved target `__parent_sku__`; StartImportApiTest 5/5; PHPStan/deptrac/Unit zielone). **Pozostało (items #1471):**
+- **Relacje → ObjectRelation** (item 4): rozszerz `RelationImportStep` o relation-linki; Relation/Reference cele NIE piszą `ObjectValue{object_id}` (zmień `ImportObjectCreator::buildValuePayload`), pass-2 tworzy `ObjectRelation(source,target,attr,position)` z resolve targetów po code. **UWAGA: target może być w innym ObjectType** (`relationTargetObjectTypeIds` na atrybucie) — `findByCode` wymaga `kind`; trzeba iterować docelowe OT atrybutu. **Test izolacji cross-tenant** (target tylko w tenant B → 0 linków + błąd).
+- **Export relations-by-code** (item 5): `ExportBuilder` czyta `object_relations` (ObjectRelationRepositoryInterface, `findBySourceAndAttribute`) i emituje pipe-joined **kody** zamiast UUID.
+- **include_variants fan-out** (item 8): nowa metoda repo `findChildrenByParentIds(parentIds, tenant)` (brak jej w `CatalogObjectRepositoryInterface`); `SyncExportRunner::resolveTargets` przy true dokłada dzieci (master, potem warianty); przy false tylko mastery. Ścieżka krytyczna golden wariantów.
+- **variant_axes** (item 6): built-in kolumna; shape to `[{code, values}]`. **DECYZJA OPERATORA: pełny shape w eksporcie** (np. `color:red,blue|size:s,m`) — round-trip naprawdę identyczny (AC). Export serializuje code+values, import parsuje + `declareVariantAxes()` z walidacją że kody to atrybuty select.
+- **Galerie** (item 7): pipe-split `asset_id` + walidacja istnienia assetów tenant-scoped (prefetch per chunk).
+- **Checkpoint faza** (item 2, values/links) · **golden** (item 10: master+2warianty+relacja+galeria) · **testy integracyjne** (items 4,9, realny Postgres, no-mocking) · **zamknięcie #598** z dowodem.
 
 ## Aktywne blokery
-- Brak.
+- Brak (IMP2-1.8 pozostałe items to praca, nie bloker).
 
 ## Stałe przypomnienia (workflow IMP2)
 - Testy `Api/*`: `cache:clear --env=test` + `docker compose exec -T -e APP_ENV=test api php vendor/bin/phpunit ...` (inaczej `test.service_container` not found).

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -278,9 +278,13 @@ parameters:
         #    Identity internals + Identity voters importing Import entities are
         #    baselined here; #1466 (shared writer core) burns the bulk down.
         App\Export\Application\Builder\ExportBuilder:
+            - App\Catalog\Domain\AttributeType
+            - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Entity\CatalogObject
             - App\Catalog\Domain\Entity\ObjectValue
+            - App\Catalog\Domain\Repository\AttributeRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectValueRepositoryInterface
         App\Export\Application\Builder\Structural\AttributesGroupsExportBuilder:
             - App\Catalog\Domain\Entity\Attribute
@@ -328,8 +332,11 @@ parameters:
         # IMP2-1.8 (#1471) two-pass relation/parent linker
         App\Import\Application\Service\RelationImportStep:
             - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectRelation
             - App\Catalog\Domain\ObjectKind
+            - App\Catalog\Domain\Repository\AttributeRepositoryInterface
             - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface
         App\Import\Application\Service\ImportObjectCreator:
             - App\Catalog\Domain\AttributeType
             - App\Catalog\Domain\Entity\Attribute
@@ -406,6 +413,7 @@ parameters:
         # status/enabled write — per-chunk category resolve + replace/append.
         App\Import\Application\Handler\ImportRunHandler:
             - App\Catalog\Application\BatchValueWriter
+            - App\Catalog\Domain\AttributeType
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Entity\CatalogObject
             - App\Catalog\Domain\Entity\ObjectCategory

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -325,6 +325,11 @@ parameters:
             - App\Import\Domain\Entity\ImportSession
         App\Identity\Infrastructure\Security\ImportSourceVoter:
             - App\Import\Domain\Entity\ImportSource
+        # IMP2-1.8 (#1471) two-pass relation/parent linker
+        App\Import\Application\Service\RelationImportStep:
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\ObjectKind
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
         App\Import\Application\Service\ImportObjectCreator:
             - App\Catalog\Domain\AttributeType
             - App\Catalog\Domain\Entity\Attribute

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -420,6 +420,8 @@ parameters:
             - App\Catalog\Domain\ObjectKind
             - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface
+            # IMP2-1.8 galleries — per-chunk asset existence prefetch
+            - App\Asset\Domain\Repository\AssetRepositoryInterface
         # IMP2-1.4 (#1466) writer touchpoint
         App\Import\Application\Service\CreatedImportObject:
             - App\Catalog\Domain\Entity\CatalogObject

--- a/apps/api/src/Asset/Domain/Repository/AssetRepositoryInterface.php
+++ b/apps/api/src/Asset/Domain/Repository/AssetRepositoryInterface.php
@@ -14,6 +14,17 @@ interface AssetRepositoryInterface
 
     public function findByObjectId(\Symfony\Component\Uid\Uuid $objectId): ?\App\Asset\Domain\Entity\Asset;
 
+    /**
+     * Per-chunk existence prefetch for the importer (IMP2-1.8 galleries):
+     * returns the subset of the given RFC 4122 ids that exist for the tenant.
+     * One query for the whole chunk instead of a findById per cell.
+     *
+     * @param list<string> $rfc4122Ids
+     *
+     * @return list<string> existing ids, RFC 4122
+     */
+    public function existingIds(array $rfc4122Ids, \App\Shared\Domain\Tenant $tenant): array;
+
     public function save(\App\Asset\Domain\Entity\Asset $entity): void;
 
     public function remove(\App\Asset\Domain\Entity\Asset $entity): void;

--- a/apps/api/src/Asset/Infrastructure/Doctrine/Repository/DoctrineAssetRepository.php
+++ b/apps/api/src/Asset/Infrastructure/Doctrine/Repository/DoctrineAssetRepository.php
@@ -9,6 +9,7 @@ use App\Asset\Domain\Repository\AssetRepositoryInterface;
 use App\Shared\Domain\Tenant;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use Stringable;
 
 /**
  * @extends ServiceEntityRepository<Asset>
@@ -38,6 +39,28 @@ class DoctrineAssetRepository extends ServiceEntityRepository implements AssetRe
     public function findById(\Symfony\Component\Uid\Uuid $id): ?Asset
     {
         return parent::find($id->toRfc4122());
+    }
+
+    public function existingIds(array $rfc4122Ids, Tenant $tenant): array
+    {
+        if ([] === $rfc4122Ids) {
+            return [];
+        }
+
+        /** @var list<mixed> $rows */
+        $rows = $this->createQueryBuilder('a')
+            ->select('a.id')
+            ->where('a.id IN (:ids)')
+            ->andWhere('a.tenant = :tenant')
+            ->setParameter('ids', array_values(array_unique($rfc4122Ids)))
+            ->setParameter('tenant', $tenant)
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        return array_map(
+            static fn (mixed $id): string => $id instanceof Stringable || \is_scalar($id) ? (string) $id : '',
+            $rows,
+        );
     }
 
     public function save(Asset $entity): void

--- a/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
@@ -28,6 +28,29 @@ interface CatalogObjectRepositoryInterface
     public function findByCode(string $code, ObjectKind $kind, Tenant $tenant): ?CatalogObject;
 
     /**
+     * IMP2-1.8 (#1471) — resolve an object by `code` within a set of allowed
+     * ObjectTypes (a relation attribute's `relationTargetObjectTypeIds`),
+     * tenant-scoped. An empty `$objectTypeIds` matches any type in the
+     * tenant. Returns the first match or null. Used by the import relation
+     * step; the tenant filter guarantees a code that only exists in another
+     * tenant resolves to null (cross-tenant isolation).
+     *
+     * @param list<string> $objectTypeIds UUID strings; empty = any type
+     */
+    public function findByCodeInObjectTypes(string $code, array $objectTypeIds, Tenant $tenant): ?CatalogObject;
+
+    /**
+     * IMP2-1.8 (#1471) — children (variants) of the given parents,
+     * tenant-scoped, ordered by `code` ASC for a deterministic export
+     * fan-out. Drives `include_variants` on the export runner.
+     *
+     * @param list<string> $parentIdsRfc4122
+     *
+     * @return list<CatalogObject>
+     */
+    public function findChildrenByParentIds(array $parentIdsRfc4122, Tenant $tenant): array;
+
+    /**
      * @return list<CatalogObject>
      */
     public function findByKind(ObjectKind $kind, Tenant $tenant): array;

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
@@ -27,6 +27,49 @@ class DoctrineCatalogObjectRepository extends ServiceEntityRepository implements
         return $this->findOneBy(['code' => $code, 'kind' => $kind, 'tenant' => $tenant]);
     }
 
+    public function findByCodeInObjectTypes(string $code, array $objectTypeIds, Tenant $tenant): ?CatalogObject
+    {
+        $qb = $this->createQueryBuilder('o')
+            ->where('o.code = :code')
+            ->andWhere('o.tenant = :tenant')
+            ->setParameter('code', $code)
+            ->setParameter('tenant', $tenant)
+            ->setMaxResults(1);
+
+        if ([] !== $objectTypeIds) {
+            $qb->andWhere('o.objectType IN (:ots)')->setParameter('ots', $objectTypeIds);
+        }
+
+        /** @var ?CatalogObject $result */
+        $result = $qb->getQuery()->getOneOrNullResult();
+
+        return $result;
+    }
+
+    /**
+     * @param list<string> $parentIdsRfc4122
+     *
+     * @return list<CatalogObject>
+     */
+    public function findChildrenByParentIds(array $parentIdsRfc4122, Tenant $tenant): array
+    {
+        if ([] === $parentIdsRfc4122) {
+            return [];
+        }
+
+        /** @var list<CatalogObject> $rows */
+        $rows = $this->createQueryBuilder('o')
+            ->where('o.parent IN (:parents)')
+            ->andWhere('o.tenant = :tenant')
+            ->setParameter('parents', $parentIdsRfc4122)
+            ->setParameter('tenant', $tenant)
+            ->orderBy('o.code', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $rows;
+    }
+
     /**
      * @return list<CatalogObject>
      */

--- a/apps/api/src/Export/Application/Builder/ColumnResolver.php
+++ b/apps/api/src/Export/Application/Builder/ColumnResolver.php
@@ -47,6 +47,7 @@ final class ColumnResolver
         'updated_at' => 'updated_at',
         'status' => 'status',
         'enabled' => 'enabled',
+        'variant_axes' => 'variant_axes',
         'completeness_pct' => 'completeness_pct',
     ];
 

--- a/apps/api/src/Export/Application/Builder/ExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/ExportBuilder.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Export\Application\Builder;
 
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Channel\Contracts\ChannelResolverInterface;
 use App\Export\Domain\Entity\ExportSession;
+use App\Shared\Domain\Tenant;
 use Generator;
 use LogicException;
 
@@ -47,6 +50,8 @@ final class ExportBuilder
         private readonly ColumnResolver $columnResolver,
         private readonly ValueSerializer $serializer,
         private readonly ChannelResolverInterface $channels,
+        private readonly \App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface $relations,
+        private readonly \App\Catalog\Domain\Repository\AttributeRepositoryInterface $attributes,
     ) {
     }
 
@@ -84,10 +89,35 @@ final class ExportBuilder
         // defensive guard for a bypassed preflight.
         $this->assertChannelColumnsResolvable($columns, $channelIdByCode);
 
+        // IMP2-1.8: resolve the attribute behind each attribute column once so
+        // cellFor can route Relation/Reference columns to object_relations.
+        $attributeMap = $this->resolveColumnAttributes($columns, $tenant);
+
         $primaryLocale = $tenant->getPrimaryLocale();
         foreach ($objects as $object) {
-            yield $this->renderRow($object, $columns, $channelIdByCode, $primaryLocale);
+            yield $this->renderRow($object, $columns, $channelIdByCode, $primaryLocale, $attributeMap);
         }
+    }
+
+    /**
+     * @param array<int, ColumnDefinition> $columns
+     *
+     * @return array<string, Attribute>
+     */
+    private function resolveColumnAttributes(array $columns, Tenant $tenant): array
+    {
+        $map = [];
+        foreach ($columns as $column) {
+            if (!$column->isAttribute() || isset($map[$column->code])) {
+                continue;
+            }
+            $attribute = $this->attributes->findByCode($column->code, $tenant);
+            if (null !== $attribute) {
+                $map[$column->code] = $attribute;
+            }
+        }
+
+        return $map;
     }
 
     /**
@@ -111,16 +141,17 @@ final class ExportBuilder
     /**
      * @param array<int, ColumnDefinition> $columns
      * @param array<string, string>        $channelIdByCode channel code => UUID RFC 4122 (#1229)
+     * @param array<string, Attribute>     $attributeMap    attribute column code => Attribute (#1471)
      *
      * @return array<string, string>
      */
-    private function renderRow(CatalogObject $object, array $columns, array $channelIdByCode, string $primaryLocale): array
+    private function renderRow(CatalogObject $object, array $columns, array $channelIdByCode, string $primaryLocale, array $attributeMap): array
     {
         $valueIndex = $this->indexValuesByObject($object);
         $row = [];
 
         foreach ($columns as $column) {
-            $row[$column->key] = $this->cellFor($object, $column, $valueIndex, $channelIdByCode, $primaryLocale);
+            $row[$column->key] = $this->cellFor($object, $column, $valueIndex, $channelIdByCode, $primaryLocale, $attributeMap);
         }
 
         return $row;
@@ -152,6 +183,7 @@ final class ExportBuilder
     /**
      * @param array<string, ObjectValue> $valueIndex
      * @param array<string, string>      $channelIdByCode channel code => UUID RFC 4122 (#1229)
+     * @param array<string, Attribute>   $attributeMap    attribute column code => Attribute (#1471)
      */
     private function cellFor(
         CatalogObject $object,
@@ -159,9 +191,24 @@ final class ExportBuilder
         array $valueIndex,
         array $channelIdByCode,
         string $primaryLocale,
+        array $attributeMap,
     ): string {
         if ($column->isBuiltIn()) {
             return $this->builtIn($object, $column->code);
+        }
+
+        // IMP2-1.8 (D5): Relation/Reference columns emit pipe-joined target
+        // CODES read from object_relations (symmetry with the import, which
+        // writes relations there — not as ObjectValue).
+        $attribute = $attributeMap[$column->code] ?? null;
+        if ($attribute instanceof Attribute
+            && (AttributeType::Relation === $attribute->getType() || AttributeType::Reference === $attribute->getType())) {
+            $codes = [];
+            foreach ($this->relations->findBySourceAndAttribute($object, $attribute) as $relation) {
+                $codes[] = $relation->getTarget()->getCode();
+            }
+
+            return implode(ValueSerializer::MULTI_VALUE_GLUE, $codes);
         }
 
         // #1229: a channel-scoped column narrows the lookup to the channel's

--- a/apps/api/src/Export/Application/Builder/ExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/ExportBuilder.php
@@ -247,8 +247,37 @@ final class ExportBuilder
             'created_at' => $this->serializer->serializeScalar($object->getCreatedAt()),
             'updated_at' => $this->serializer->serializeScalar($object->getUpdatedAt()),
             'category' => $this->resolveCategories($object),
+            'variant_axes' => $this->serializeVariantAxes($object),
             default => '',
         };
+    }
+
+    /**
+     * IMP2-1.8 — serialise the master's variant axes to the round-trippable
+     * full shape `code:value,value|code:value`. Empty for non-masters /
+     * objects without declared axes.
+     */
+    private function serializeVariantAxes(CatalogObject $object): string
+    {
+        $axes = $object->getVariantAxes();
+        if (null === $axes || [] === $axes) {
+            return '';
+        }
+
+        $parts = [];
+        foreach ($axes as $axis) {
+            $code = $axis['code'] ?? null;
+            if (!\is_string($code) || '' === $code) {
+                continue;
+            }
+            $values = $axis['values'] ?? [];
+            $valueList = \is_array($values)
+                ? array_values(array_filter(array_map(static fn (mixed $v): string => \is_scalar($v) ? (string) $v : '', $values), static fn (string $v): bool => '' !== $v))
+                : [];
+            $parts[] = $code.':'.implode(',', $valueList);
+        }
+
+        return implode(ValueSerializer::MULTI_VALUE_GLUE, $parts);
     }
 
     private function resolveCategories(CatalogObject $object): string

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -99,11 +99,68 @@ final class SyncExportRunner
         // rather than the hardcoded Product kind.
         $objectType = $this->resolveObjectType($session, $tenant);
 
-        return match ($session->getTargetScope()) {
+        $base = match ($session->getTargetScope()) {
             ExportTargetScope::Selected => $this->resolveSelected($session),
             ExportTargetScope::All => $this->objects->findByObjectType($objectType, $tenant),
             ExportTargetScope::Filter => $this->resolveFilter($session, $tenant, $objectType),
         };
+
+        return $this->applyVariantFanout($base, $session, $tenant);
+    }
+
+    /**
+     * IMP2-1.8 (#1471) — `include_variants` fan-out. With the flag OFF the
+     * export carries masters only; with it ON each master is immediately
+     * followed by its variants (tenant-scoped child query), giving the export
+     * the deterministic `master, then its variants` order the variants golden
+     * relies on. A directly-selected variant whose master is absent is still
+     * emitted.
+     *
+     * @param list<CatalogObject> $base
+     *
+     * @return list<CatalogObject>
+     */
+    private function applyVariantFanout(array $base, ExportSession $session, Tenant $tenant): array
+    {
+        if (!$session->includesVariants()) {
+            return array_values(array_filter($base, static fn (CatalogObject $o): bool => null === $o->getParent()));
+        }
+
+        $masterIds = [];
+        foreach ($base as $object) {
+            if (null === $object->getParent()) {
+                $masterIds[] = $object->getId()->toRfc4122();
+            }
+        }
+
+        $childrenByParent = [];
+        foreach ($this->objects->findChildrenByParentIds($masterIds, $tenant) as $child) {
+            $parentId = $child->getParent()?->getId()->toRfc4122();
+            if (null !== $parentId) {
+                $childrenByParent[$parentId][] = $child;
+            }
+        }
+
+        $result = [];
+        $seen = [];
+        foreach ($base as $object) {
+            $id = $object->getId()->toRfc4122();
+            if (isset($seen[$id])) {
+                continue;
+            }
+            $result[] = $object;
+            $seen[$id] = true;
+
+            foreach ($childrenByParent[$id] ?? [] as $child) {
+                $childId = $child->getId()->toRfc4122();
+                if (!isset($seen[$childId])) {
+                    $result[] = $child;
+                    $seen[$childId] = true;
+                }
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Import\Application\Handler;
 
+use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectCategory;
@@ -439,6 +440,38 @@ final class ImportRunHandler extends AbstractBatchHandler
     }
 
     /**
+     * IMP2-1.8 — buffer relation links from Relation/Reference cells for
+     * pass 2. The values were NOT written as ObjectValue (the creator skips
+     * them); their pipe-separated target codes become object_relations rows.
+     *
+     * @param list<ResolvedImportValue> $resolvedValues
+     * @param array<string, Attribute>  $attributesByCode
+     */
+    private function recordRelationLinks(string $sourceSku, array $resolvedValues, array $attributesByCode, int $rowNumber): void
+    {
+        foreach ($resolvedValues as $resolved) {
+            $attribute = $attributesByCode[$resolved->attributeCode] ?? null;
+            if (!$attribute instanceof Attribute) {
+                continue;
+            }
+            if (AttributeType::Relation !== $attribute->getType() && AttributeType::Reference !== $attribute->getType()) {
+                continue;
+            }
+            $raw = $resolved->rawValue;
+            if (null === $raw || '' === $raw) {
+                continue;
+            }
+            $targetCodes = array_values(array_filter(
+                array_map('trim', explode('|', $raw)),
+                static fn (string $code): bool => '' !== $code,
+            ));
+            if ([] !== $targetCodes) {
+                $this->relationStep->recordRelation($sourceSku, $attribute->getCode(), $targetCodes, $rowNumber);
+            }
+        }
+    }
+
+    /**
      * First non-empty (trimmed) cell whose mapping targets the given reserved
      * marker, or null.
      *
@@ -616,9 +649,11 @@ final class ImportRunHandler extends AbstractBatchHandler
                     );
                     $issues = $created->issues;
                     $session->incrementSuccess();
-                    // IMP2-1.8: buffer the parent link; resolved in pass 2 once
-                    // every object exists (variant row may precede its master).
-                    $this->recordParentLink($this->skuFrom($row['resolvedValues'], $row['rowNumber']), $row['cells'], $columnMapping, $row['rowNumber']);
+                    // IMP2-1.8: buffer parent + relation links; resolved in
+                    // pass 2 once every object exists (target row may precede).
+                    $createdSku = $this->skuFrom($row['resolvedValues'], $row['rowNumber']);
+                    $this->recordParentLink($createdSku, $row['cells'], $columnMapping, $row['rowNumber']);
+                    $this->recordRelationLinks($createdSku, $row['resolvedValues'], $attributesByCode, $row['rowNumber']);
                 } elseif (ImportRowDecision::Update === $decision && null !== $existing) {
                     $issues = $this->creator->update(
                         $existing,
@@ -630,6 +665,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                     $session->incrementSuccess();
                     $session->incrementUpdated();
                     $this->recordParentLink($existing->getCode(), $row['cells'], $columnMapping, $row['rowNumber']);
+                    $this->recordRelationLinks($existing->getCode(), $row['resolvedValues'], $attributesByCode, $row['rowNumber']);
                     // IMP2-1.7: category replace/append runs after the value
                     // pass (replaceForProduct flushes around the primary index).
                     // Empty cell = untouched (D2), so only collect non-empty.

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -424,6 +424,43 @@ final class ImportRunHandler extends AbstractBatchHandler
     }
 
     /**
+     * IMP2-1.8 — parse the `__variant_axes__` cell (`code:v1,v2|code:v3`) into
+     * the stored shape, or null when absent/empty (D2 — do not touch).
+     *
+     * @param array<string, string|null> $cells
+     * @param array<string, string>      $columnMapping
+     *
+     * @return ?list<array{code: string, values: list<string>}>
+     */
+    private function extractVariantAxes(array $cells, array $columnMapping): ?array
+    {
+        $raw = $this->reservedCell($cells, $columnMapping, ReservedMappingTarget::VARIANT_AXES);
+        if (null === $raw) {
+            return null;
+        }
+
+        $axes = [];
+        foreach (explode('|', $raw) as $part) {
+            $part = trim($part);
+            if ('' === $part) {
+                continue;
+            }
+            [$code, $valuesRaw] = array_pad(explode(':', $part, 2), 2, '');
+            $code = trim($code);
+            if ('' === $code) {
+                continue;
+            }
+            $values = array_values(array_filter(
+                array_map('trim', explode(',', $valuesRaw)),
+                static fn (string $value): bool => '' !== $value,
+            ));
+            $axes[] = ['code' => $code, 'values' => $values];
+        }
+
+        return [] === $axes ? null : $axes;
+    }
+
+    /**
      * IMP2-1.8 — buffer a parent link for pass 2 when the row carries a
      * non-empty `__parent_sku__` cell. Existence / cycle validation happens
      * in pass 2 once every object is written.
@@ -646,6 +683,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                         categories: $this->resolveCategories($this->extractCategoryCodes($row['cells'], $columnMapping), $categoryByCode),
                         status: $this->extractStatus($row['cells'], $columnMapping),
                         enabled: $this->extractEnabled($row['cells'], $columnMapping),
+                        variantAxes: $this->extractVariantAxes($row['cells'], $columnMapping),
                     );
                     $issues = $created->issues;
                     $session->incrementSuccess();
@@ -661,6 +699,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                         $attributesByCode,
                         $this->extractStatus($row['cells'], $columnMapping),
                         $this->extractEnabled($row['cells'], $columnMapping),
+                        $this->extractVariantAxes($row['cells'], $columnMapping),
                     );
                     $session->incrementSuccess();
                     $session->incrementUpdated();

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -15,6 +15,7 @@ use App\Import\Application\Service\ImportRowDecision;
 use App\Import\Application\Service\ImportRowReader;
 use App\Import\Application\Service\ImportValidationService;
 use App\Import\Application\Service\ObjectResolver;
+use App\Import\Application\Service\RelationImportStep;
 use App\Import\Domain\Entity\ImportLog;
 use App\Import\Domain\Entity\ImportSession;
 use App\Import\Domain\Enum\ImportErrorType;
@@ -67,6 +68,7 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly ImportValidationService $validator,
         private readonly ImportObjectCreator $creator,
         private readonly ObjectResolver $objectResolver,
+        private readonly RelationImportStep $relationStep,
         private readonly ImportColumnGrammar $columnGrammar,
         private readonly \App\Catalog\Application\BatchValueWriter $valueWriter,
         private readonly \App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface $catalogObjects,
@@ -155,6 +157,10 @@ final class ImportRunHandler extends AbstractBatchHandler
             return;
         }
 
+        // IMP2-1.8: the cross-object link buffer accumulates across all chunks
+        // of THIS run; reset so a long-lived worker never carries stale tuples.
+        $this->relationStep->reset();
+
         $sourcePath = null;
         try {
             $columnMapping = $this->resolveColumnMapping($session);
@@ -205,8 +211,31 @@ final class ImportRunHandler extends AbstractBatchHandler
                 $session = $this->refreshSession($session);
             }
 
+            // IMP2-1.8 — pass 2: wire buffered cross-object links (parent →
+            // master) now that EVERY object exists, so variant rows may appear
+            // before or after their master. resolve() flush+clears in chunks.
+            if ($this->relationStep->hasWork()) {
+                $linkTenant = $session->getTenant();
+                if ($linkTenant instanceof Tenant) {
+                    $linkErrors = $this->relationStep->resolve($session->getTargetObjectType()->getKind(), $linkTenant);
+                    $session = $this->refreshSession($session);
+                    foreach ($linkErrors as $error) {
+                        $session->incrementError();
+                        $this->entityManager->persist(new ImportLog(
+                            importSession: $session,
+                            rowNumber: $error->rowNumber,
+                            level: $error->level,
+                            message: $error->message,
+                            sku: $error->sku,
+                            errorType: $error->errorType->value,
+                            columnName: $error->columnName,
+                            columnValue: $error->columnValue,
+                        ));
+                    }
+                }
+            }
+
             $session->setTotalRows($totalRows);
-            $session = $this->refreshSession($session);
             $session->markCompleted();
             $this->sessions->save($session);
             $this->progressPublisher->completed($session);
@@ -394,6 +423,22 @@ final class ImportRunHandler extends AbstractBatchHandler
     }
 
     /**
+     * IMP2-1.8 — buffer a parent link for pass 2 when the row carries a
+     * non-empty `__parent_sku__` cell. Existence / cycle validation happens
+     * in pass 2 once every object is written.
+     *
+     * @param array<string, string|null> $cells
+     * @param array<string, string>      $columnMapping
+     */
+    private function recordParentLink(string $childSku, array $cells, array $columnMapping, int $rowNumber): void
+    {
+        $parentSku = $this->reservedCell($cells, $columnMapping, ReservedMappingTarget::PARENT_SKU);
+        if (null !== $parentSku) {
+            $this->relationStep->recordParent($childSku, $parentSku, $rowNumber);
+        }
+    }
+
+    /**
      * First non-empty (trimmed) cell whose mapping targets the given reserved
      * marker, or null.
      *
@@ -571,6 +616,9 @@ final class ImportRunHandler extends AbstractBatchHandler
                     );
                     $issues = $created->issues;
                     $session->incrementSuccess();
+                    // IMP2-1.8: buffer the parent link; resolved in pass 2 once
+                    // every object exists (variant row may precede its master).
+                    $this->recordParentLink($this->skuFrom($row['resolvedValues'], $row['rowNumber']), $row['cells'], $columnMapping, $row['rowNumber']);
                 } elseif (ImportRowDecision::Update === $decision && null !== $existing) {
                     $issues = $this->creator->update(
                         $existing,
@@ -581,6 +629,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                     );
                     $session->incrementSuccess();
                     $session->incrementUpdated();
+                    $this->recordParentLink($existing->getCode(), $row['cells'], $columnMapping, $row['rowNumber']);
                     // IMP2-1.7: category replace/append runs after the value
                     // pass (replaceForProduct flushes around the primary index).
                     // Empty cell = untouched (D2), so only collect non-empty.

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -74,6 +74,7 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly \App\Catalog\Application\BatchValueWriter $valueWriter,
         private readonly \App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface $catalogObjects,
         private readonly \App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface $objectCategories,
+        private readonly \App\Asset\Domain\Repository\AssetRepositoryInterface $assets,
         private readonly ImportProgressPublisher $progressPublisher,
         private readonly TenantContext $tenantContext,
         private readonly FilesystemOperator $importsStorage,
@@ -661,6 +662,10 @@ final class ImportRunHandler extends AbstractBatchHandler
         // IMP2-1.7: resolve every distinct category code in the chunk once
         // (per-chunk prefetch — not one SELECT per code per row).
         $categoryByCode = $this->resolveChunkCategories($prepared, $columnMapping, $tenant);
+        // IMP2-1.8 galleries: prefetch which referenced asset ids actually
+        // exist (tenant-scoped) so the creator can drop dangling ids with a
+        // row warning — one query per chunk, mirroring the category prefetch.
+        $existingAssetIds = $this->resolveChunkAssets($prepared, $attributesByCode, $tenant);
         /** @var list<array{product: CatalogObject, codes: list<string>, append: bool}> $pendingCategoryOps */
         $pendingCategoryOps = [];
 
@@ -684,6 +689,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                         status: $this->extractStatus($row['cells'], $columnMapping),
                         enabled: $this->extractEnabled($row['cells'], $columnMapping),
                         variantAxes: $this->extractVariantAxes($row['cells'], $columnMapping),
+                        existingAssetIds: $existingAssetIds,
                     );
                     $issues = $created->issues;
                     $session->incrementSuccess();
@@ -700,6 +706,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                         $this->extractStatus($row['cells'], $columnMapping),
                         $this->extractEnabled($row['cells'], $columnMapping),
                         $this->extractVariantAxes($row['cells'], $columnMapping),
+                        $existingAssetIds,
                     );
                     $session->incrementSuccess();
                     $session->incrementUpdated();
@@ -806,6 +813,54 @@ final class ImportRunHandler extends AbstractBatchHandler
         }
 
         return $map;
+    }
+
+    /**
+     * IMP2-1.8 galleries — collect every asset id referenced by an Asset-type
+     * cell in the chunk (pipe-split) and return the subset that exists for the
+     * tenant as a lower-cased lookup set. One query per chunk; the creator uses
+     * the set to drop dangling ids with a row warning.
+     *
+     * @param list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string}> $prepared
+     * @param array<string, Attribute>                                                                                                                                                              $attributesByCode
+     *
+     * @return array<string, true>
+     */
+    private function resolveChunkAssets(array $prepared, array $attributesByCode, Tenant $tenant): array
+    {
+        $ids = [];
+        foreach ($prepared as $row) {
+            if (!$row['rowOk']) {
+                continue;
+            }
+            foreach ($row['resolvedValues'] as $resolved) {
+                $attribute = $attributesByCode[$resolved->attributeCode] ?? null;
+                if (!$attribute instanceof Attribute || AttributeType::Asset !== $attribute->getType()) {
+                    continue;
+                }
+                $raw = $resolved->rawValue;
+                if (null === $raw || '' === $raw) {
+                    continue;
+                }
+                foreach (explode('|', $raw) as $id) {
+                    $id = trim($id);
+                    if ('' !== $id) {
+                        $ids[$id] = true;
+                    }
+                }
+            }
+        }
+
+        if ([] === $ids) {
+            return [];
+        }
+
+        $set = [];
+        foreach ($this->assets->existingIds(array_keys($ids), $tenant) as $existing) {
+            $set[strtolower($existing)] = true;
+        }
+
+        return $set;
     }
 
     /**

--- a/apps/api/src/Import/Application/Service/AutoMapper.php
+++ b/apps/api/src/Import/Application/Service/AutoMapper.php
@@ -85,6 +85,7 @@ final readonly class AutoMapper
                 'status' => ReservedMappingTarget::STATUS,
                 'enabled' => ReservedMappingTarget::ENABLED,
                 'parentsku' => ReservedMappingTarget::PARENT_SKU,
+                'variantaxes' => ReservedMappingTarget::VARIANT_AXES,
                 default => null,
             };
             if (null !== $reservedTarget) {

--- a/apps/api/src/Import/Application/Service/AutoMapper.php
+++ b/apps/api/src/Import/Application/Service/AutoMapper.php
@@ -84,6 +84,7 @@ final readonly class AutoMapper
             $reservedTarget = match ($normalised) {
                 'status' => ReservedMappingTarget::STATUS,
                 'enabled' => ReservedMappingTarget::ENABLED,
+                'parentsku' => ReservedMappingTarget::PARENT_SKU,
                 default => null,
             };
             if (null !== $reservedTarget) {

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -52,6 +52,11 @@ final class ImportObjectCreator
      * @param ?string                                          $status           validated publication status (draft|published|archived) or null = untouched
      * @param ?bool                                            $enabled          parsed enabled flag or null = untouched
      * @param ?list<array{code: string, values: list<string>}> $variantAxes      parsed variant axes or null = untouched (IMP2-1.8)
+     * @param array<string, true>                              $existingAssetIds set of asset ids (lower-cased RFC 4122)
+     *                                                                           that exist for the tenant, prefetched per
+     *                                                                           chunk (IMP2-1.8). A gallery cell id absent
+     *                                                                           from the set is dropped with a row warning
+     *                                                                           instead of writing a dangling asset_id.
      */
     public function create(
         ObjectType $objectType,
@@ -63,17 +68,16 @@ final class ImportObjectCreator
         ?string $status = null,
         ?bool $enabled = null,
         ?array $variantAxes = null,
+        array $existingAssetIds = [],
     ): CreatedImportObject {
         $object = new CatalogObject($objectType, $sku);
         $object->assignImportSession($importSessionId);
         $this->applyState($object, $status, $enabled, $variantAxes);
         $this->em->persist($object);
 
-        $issues = $this->valueWriter->writeMany(
-            $object,
-            $this->buildWrites($resolvedValues, $attributesByCode),
-            Provenance::Import,
-        );
+        $assetIssues = [];
+        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues);
+        $issues = array_merge($assetIssues, $this->valueWriter->writeMany($object, $writes, Provenance::Import));
 
         // New object has no existing assignments, so batch-persist the
         // junction rows directly (no flush — the chunk handler owns it).
@@ -132,6 +136,7 @@ final class ImportObjectCreator
      * @param ?string                                          $status           validated status or null = untouched (IMP2-1.7)
      * @param ?bool                                            $enabled          parsed enabled flag or null = untouched (IMP2-1.7)
      * @param ?list<array{code: string, values: list<string>}> $variantAxes      parsed variant axes or null = untouched (IMP2-1.8)
+     * @param array<string, true>                              $existingAssetIds set of existing asset ids (IMP2-1.8)
      *
      * @return list<array{attributeCode: string, kind: string, message: string}>
      */
@@ -142,14 +147,14 @@ final class ImportObjectCreator
         ?string $status = null,
         ?bool $enabled = null,
         ?array $variantAxes = null,
+        array $existingAssetIds = [],
     ): array {
         $this->applyState($object, $status, $enabled, $variantAxes);
 
-        return $this->valueWriter->writeMany(
-            $object,
-            $this->buildWrites($resolvedValues, $attributesByCode),
-            Provenance::Import,
-        );
+        $assetIssues = [];
+        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues);
+
+        return array_merge($assetIssues, $this->valueWriter->writeMany($object, $writes, Provenance::Import));
     }
 
     /**
@@ -158,12 +163,15 @@ final class ImportObjectCreator
      * parsers cannot interpret are dropped here because the row validator
      * already emitted InvalidType for them.
      *
-     * @param list<ResolvedImportValue> $resolvedValues
-     * @param array<string, Attribute>  $attributesByCode
+     * @param list<ResolvedImportValue>                                         $resolvedValues
+     * @param array<string, Attribute>                                          $attributesByCode
+     * @param array<string, true>                                               $existingAssetIds
+     * @param list<array{attributeCode: string, kind: string, message: string}> $issues           collects per-cell warnings
+     *                                                                                            (dangling asset ids) — by ref
      *
      * @return list<array{attribute: Attribute, envelope: array<string, mixed>, locale: ?string, channelId: ?Uuid}>
      */
-    private function buildWrites(array $resolvedValues, array $attributesByCode): array
+    private function buildWrites(array $resolvedValues, array $attributesByCode, array $existingAssetIds, array &$issues): array
     {
         $writes = [];
         foreach ($resolvedValues as $resolved) {
@@ -175,7 +183,9 @@ final class ImportObjectCreator
             if (!$attribute instanceof Attribute) {
                 continue;
             }
-            $valuePayload = $this->buildValuePayload($attribute, $rawValue);
+            $valuePayload = AttributeType::Asset === $attribute->getType()
+                ? $this->assetPayload($attribute, $rawValue, $existingAssetIds, $issues)
+                : $this->buildValuePayload($attribute, $rawValue);
             if (null === $valuePayload) {
                 continue;
             }
@@ -209,13 +219,55 @@ final class ImportObjectCreator
             AttributeType::Boolean => ['value' => $this->parseBoolean($raw)],
             AttributeType::Select => ['option_code' => $raw],
             AttributeType::Multiselect => $this->multiSelectPayload($raw),
-            AttributeType::Asset => ['asset_id' => $raw],
+            // IMP2-1.8: Asset cells are handled by assetPayload() (pipe-split +
+            // tenant-scoped existence validation) before this match is reached.
             // IMP2-1.8: Relation/Reference cells are NOT written as
             // ObjectValue{object_id} anymore — the two-pass RelationImportStep
             // resolves their targets by code and writes object_relations rows.
             AttributeType::Relation, AttributeType::Reference => null,
             default => ['value' => $raw],
         };
+    }
+
+    /**
+     * IMP2-1.8 galleries — pipe-split an Asset cell (`id1|id2`) and validate
+     * every id against the per-chunk existence set (tenant-scoped). Missing ids
+     * are dropped with a row warning so a dangling id never lands in JSONB
+     * (ticket AC). A single surviving id keeps the scalar `{asset_id: <uuid>}`
+     * shape (round-trips with admin-authored single assets); two or more keep
+     * the list `{asset_id: [...]}` shape. Returns null when nothing survives.
+     *
+     * @param array<string, true>                                               $existingAssetIds
+     * @param list<array{attributeCode: string, kind: string, message: string}> $issues           by ref
+     *
+     * @return array{asset_id: string|list<string>}|null
+     */
+    private function assetPayload(Attribute $attribute, string $raw, array $existingAssetIds, array &$issues): ?array
+    {
+        $ids = array_values(array_filter(
+            array_map('trim', explode('|', $raw)),
+            static fn (string $id): bool => '' !== $id,
+        ));
+
+        $survivors = [];
+        foreach ($ids as $id) {
+            if (isset($existingAssetIds[strtolower($id)])) {
+                $survivors[] = $id;
+
+                continue;
+            }
+            $issues[] = [
+                'attributeCode' => $attribute->getCode(),
+                'kind' => 'invalid_value',
+                'message' => \sprintf('Asset "%s" does not exist for this tenant — skipped.', $id),
+            ];
+        }
+
+        if ([] === $survivors) {
+            return null;
+        }
+
+        return ['asset_id' => 1 === \count($survivors) ? $survivors[0] : $survivors];
     }
 
     /**

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -200,7 +200,10 @@ final class ImportObjectCreator
             AttributeType::Select => ['option_code' => $raw],
             AttributeType::Multiselect => $this->multiSelectPayload($raw),
             AttributeType::Asset => ['asset_id' => $raw],
-            AttributeType::Relation, AttributeType::Reference => ['object_id' => $raw],
+            // IMP2-1.8: Relation/Reference cells are NOT written as
+            // ObjectValue{object_id} anymore — the two-pass RelationImportStep
+            // resolves their targets by code and writes object_relations rows.
+            AttributeType::Relation, AttributeType::Reference => null,
             default => ['value' => $raw],
         };
     }

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -40,17 +40,18 @@ final class ImportObjectCreator
     }
 
     /**
-     * @param list<ResolvedImportValue> $resolvedValues   mapped cells with the locale parsed from
-     *                                                    their dotted header (`name.pl` → `pl`)
-     * @param array<string, Attribute>  $attributesByCode
-     * @param list<CatalogObject>       $categories       resolved category objects in cell order
-     *                                                    (IMP2-1.7) — first becomes primary,
-     *                                                    index drives `position`. The handler
-     *                                                    resolves codes once per chunk and emits
-     *                                                    a per-code CategoryNotFound warning for
-     *                                                    any that did not resolve.
-     * @param ?string                   $status           validated publication status (draft|published|archived) or null = untouched
-     * @param ?bool                     $enabled          parsed enabled flag or null = untouched
+     * @param list<ResolvedImportValue>                        $resolvedValues   mapped cells with the locale parsed from
+     *                                                                           their dotted header (`name.pl` → `pl`)
+     * @param array<string, Attribute>                         $attributesByCode
+     * @param list<CatalogObject>                              $categories       resolved category objects in cell order
+     *                                                                           (IMP2-1.7) — first becomes primary,
+     *                                                                           index drives `position`. The handler
+     *                                                                           resolves codes once per chunk and emits
+     *                                                                           a per-code CategoryNotFound warning for
+     *                                                                           any that did not resolve.
+     * @param ?string                                          $status           validated publication status (draft|published|archived) or null = untouched
+     * @param ?bool                                            $enabled          parsed enabled flag or null = untouched
+     * @param ?list<array{code: string, values: list<string>}> $variantAxes      parsed variant axes or null = untouched (IMP2-1.8)
      */
     public function create(
         ObjectType $objectType,
@@ -61,10 +62,11 @@ final class ImportObjectCreator
         array $categories = [],
         ?string $status = null,
         ?bool $enabled = null,
+        ?array $variantAxes = null,
     ): CreatedImportObject {
         $object = new CatalogObject($objectType, $sku);
         $object->assignImportSession($importSessionId);
-        $this->applyState($object, $status, $enabled);
+        $this->applyState($object, $status, $enabled, $variantAxes);
         $this->em->persist($object);
 
         $issues = $this->valueWriter->writeMany(
@@ -97,13 +99,19 @@ final class ImportObjectCreator
      * row's reserved columns. Null means "column absent or empty" (D2 — do
      * not touch). Values are pre-validated by {@see ImportValidationService}.
      */
-    private function applyState(CatalogObject $object, ?string $status, ?bool $enabled): void
+    /**
+     * @param ?list<array{code: string, values: list<string>}> $variantAxes
+     */
+    private function applyState(CatalogObject $object, ?string $status, ?bool $enabled, ?array $variantAxes): void
     {
         if (null !== $status) {
             $object->transitionTo($status);
         }
         if (null !== $enabled) {
             $object->changeEnabled($enabled);
+        }
+        if (null !== $variantAxes) {
+            $object->declareVariantAxes($variantAxes);
         }
     }
 
@@ -119,10 +127,11 @@ final class ImportObjectCreator
      * @param array<string, Attribute>  $attributesByCode
      */
     /**
-     * @param list<ResolvedImportValue> $resolvedValues
-     * @param array<string, Attribute>  $attributesByCode
-     * @param ?string                   $status           validated status or null = untouched (IMP2-1.7)
-     * @param ?bool                     $enabled          parsed enabled flag or null = untouched (IMP2-1.7)
+     * @param list<ResolvedImportValue>                        $resolvedValues
+     * @param array<string, Attribute>                         $attributesByCode
+     * @param ?string                                          $status           validated status or null = untouched (IMP2-1.7)
+     * @param ?bool                                            $enabled          parsed enabled flag or null = untouched (IMP2-1.7)
+     * @param ?list<array{code: string, values: list<string>}> $variantAxes      parsed variant axes or null = untouched (IMP2-1.8)
      *
      * @return list<array{attributeCode: string, kind: string, message: string}>
      */
@@ -132,8 +141,9 @@ final class ImportObjectCreator
         array $attributesByCode,
         ?string $status = null,
         ?bool $enabled = null,
+        ?array $variantAxes = null,
     ): array {
-        $this->applyState($object, $status, $enabled);
+        $this->applyState($object, $status, $enabled, $variantAxes);
 
         return $this->valueWriter->writeMany(
             $object,

--- a/apps/api/src/Import/Application/Service/ImportValidationService.php
+++ b/apps/api/src/Import/Application/Service/ImportValidationService.php
@@ -167,8 +167,10 @@ final readonly class ImportValidationService
                 continue;
             }
             // IMP2-1.8 — parent_sku is wired in the two-pass relation step
-            // (existence/cycle checked there, after all objects are written).
-            if (ReservedMappingTarget::PARENT_SKU === $attributeCode) {
+            // (existence/cycle checked there, after all objects are written);
+            // variant_axes is parsed + applied by the handler.
+            if (ReservedMappingTarget::PARENT_SKU === $attributeCode
+                || ReservedMappingTarget::VARIANT_AXES === $attributeCode) {
                 continue;
             }
             if (ReservedMappingTarget::isCategory($attributeCode)) {

--- a/apps/api/src/Import/Application/Service/ImportValidationService.php
+++ b/apps/api/src/Import/Application/Service/ImportValidationService.php
@@ -166,6 +166,11 @@ final readonly class ImportValidationService
             if (ReservedMappingTarget::SKIP === $attributeCode || '' === $attributeCode) {
                 continue;
             }
+            // IMP2-1.8 — parent_sku is wired in the two-pass relation step
+            // (existence/cycle checked there, after all objects are written).
+            if (ReservedMappingTarget::PARENT_SKU === $attributeCode) {
+                continue;
+            }
             if (ReservedMappingTarget::isCategory($attributeCode)) {
                 // IMP2-1.7: capture the raw (pipe-separated) category cell;
                 // per-code resolution + CategoryNotFound warnings run after

--- a/apps/api/src/Import/Application/Service/RelationImportStep.php
+++ b/apps/api/src/Import/Application/Service/RelationImportStep.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace App\Import\Application\Service;
 
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectRelation;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface;
 use App\Import\Domain\Enum\ImportErrorType;
 use App\Import\Domain\Enum\ImportLogLevel;
 use App\Import\Domain\ValueObject\ValidationError;
+use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -20,13 +24,20 @@ use Doctrine\ORM\EntityManagerInterface;
  * Pass 1 (the chunked object write in {@see ImportRunHandler}) buffers link
  * tuples as bare CODE strings — these survive `EntityManager::clear()`
  * because they reference no managed entity. Once pass 1 finishes (all
- * objects persisted, so a variant row may appear before OR after its
- * master), pass 2 resolves the codes tenant-scoped and persists the links
- * in chunks with flush+clear (memory contract — buffer is bounded to ~200k
- * tuples, D10).
+ * objects persisted, so a variant / relation target row may appear before
+ * OR after the source), pass 2 resolves the codes tenant-scoped and persists
+ * the links in chunks with flush+clear (memory contract, D10).
  *
- * Parent (variant → master) linking lands here first; relation attributes
- * (ObjectRelation rows) extend the same buffer in a follow-up of this ticket.
+ * Two kinds of links:
+ *   - parent (variant → master) via `parent_sku`;
+ *   - relations (Relation/Reference attribute cells) → {@see ObjectRelation}
+ *     rows (ADR-014), targets resolved by code within the attribute's allowed
+ *     ObjectTypes. The tenant filter guarantees a code that exists only in
+ *     another tenant resolves to null — never a cross-tenant link.
+ *
+ * After every clear() the active Tenant detaches, so it is re-fetched and
+ * re-published to {@see TenantContext} — otherwise the TenantAssignmentListener
+ * would stamp new ObjectRelation rows with a detached tenant.
  */
 final class RelationImportStep
 {
@@ -35,8 +46,16 @@ final class RelationImportStep
     /** @var list<array{childSku: string, parentSku: string, rowNumber: int}> */
     private array $parentLinks = [];
 
+    /** @var list<array{sourceSku: string, attributeCode: string, targetCodes: list<string>, rowNumber: int}> */
+    private array $relationLinks = [];
+
+    private ?Tenant $tenant = null;
+
     public function __construct(
         private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly ObjectRelationRepositoryInterface $relations,
+        private readonly AttributeRepositoryInterface $attributes,
+        private readonly TenantContext $tenantContext,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -44,6 +63,8 @@ final class RelationImportStep
     public function reset(): void
     {
         $this->parentLinks = [];
+        $this->relationLinks = [];
+        $this->tenant = null;
     }
 
     public function recordParent(string $childSku, string $parentSku, int $rowNumber): void
@@ -51,32 +72,61 @@ final class RelationImportStep
         $this->parentLinks[] = ['childSku' => $childSku, 'parentSku' => $parentSku, 'rowNumber' => $rowNumber];
     }
 
+    /**
+     * @param list<string> $targetCodes
+     */
+    public function recordRelation(string $sourceSku, string $attributeCode, array $targetCodes, int $rowNumber): void
+    {
+        $this->relationLinks[] = [
+            'sourceSku' => $sourceSku,
+            'attributeCode' => $attributeCode,
+            'targetCodes' => $targetCodes,
+            'rowNumber' => $rowNumber,
+        ];
+    }
+
     public function hasWork(): bool
     {
-        return [] !== $this->parentLinks;
+        return [] !== $this->parentLinks || [] !== $this->relationLinks;
     }
 
     /**
      * Pass 2 — resolve buffered links by code (tenant-scoped) and persist.
      * Returns row-level errors (logged by the handler; a non-empty result
-     * makes the session `partial`). Flushes + clears every {@see CHUNK}
-     * assignments; the caller re-merges its session afterwards.
+     * makes the session `partial`). Flushes + clears in chunks; the caller
+     * re-merges its session afterwards.
      *
      * @return list<ValidationError>
      */
     public function resolve(ObjectKind $kind, Tenant $tenant): array
     {
+        $this->tenant = $tenant;
+        $this->reattachTenant();
+
+        $errors = [...$this->resolveParents($kind), ...$this->resolveRelations($kind)];
+
+        $this->em->flush();
+        $this->reattachTenant();
+
+        return $errors;
+    }
+
+    /**
+     * @return list<ValidationError>
+     */
+    private function resolveParents(ObjectKind $kind): array
+    {
+        \assert($this->tenant instanceof Tenant);
         $errors = [];
         $written = 0;
 
         foreach ($this->parentLinks as $link) {
-            $child = $this->catalogObjects->findByCode($link['childSku'], $kind, $tenant);
+            $child = $this->catalogObjects->findByCode($link['childSku'], $kind, $this->tenant);
             if (null === $child) {
-                // The child row failed earlier in pass 1 — nothing to link.
                 continue;
             }
 
-            $parent = $this->catalogObjects->findByCode($link['parentSku'], $kind, $tenant);
+            $parent = $this->catalogObjects->findByCode($link['parentSku'], $kind, $this->tenant);
             if (null === $parent) {
                 $errors[] = $this->error($link['rowNumber'], $link['childSku'], \sprintf(
                     'parent_sku "%s" was not found — variant left unparented.',
@@ -101,20 +151,115 @@ final class RelationImportStep
 
             $child->assignParent($parent);
             if (0 === ++$written % self::CHUNK) {
-                $this->em->flush();
-                $this->em->clear();
+                $this->flushClearReattach();
             }
         }
 
-        $this->em->flush();
+        $this->flushClearReattach();
 
         return $errors;
     }
 
     /**
+     * @return list<ValidationError>
+     */
+    private function resolveRelations(ObjectKind $kind): array
+    {
+        \assert($this->tenant instanceof Tenant);
+        $errors = [];
+        // Cross-link dedupe of the unique (source, target, attribute) triple —
+        // catches the same relation declared in two rows before a flush makes
+        // it visible to findBySourceAndAttribute.
+        $seenTriples = [];
+        $linkCount = 0;
+
+        foreach ($this->relationLinks as $link) {
+            $source = $this->catalogObjects->findByCode($link['sourceSku'], $kind, $this->tenant);
+            $attribute = $this->attributes->findByCode($link['attributeCode'], $this->tenant);
+            if (null === $source || null === $attribute) {
+                continue;
+            }
+
+            $targetTypeIds = $attribute->getRelationTargetObjectTypeIds();
+            $sourceId = $source->getId()->toRfc4122();
+            $attributeId = $attribute->getId()->toRfc4122();
+
+            $position = 0;
+            $existingTargets = [];
+            foreach ($this->relations->findBySourceAndAttribute($source, $attribute) as $existing) {
+                $existingTargets[$existing->getTarget()->getId()->toRfc4122()] = true;
+                ++$position;
+            }
+
+            $seenInCell = [];
+            foreach ($link['targetCodes'] as $targetCode) {
+                if (isset($seenInCell[$targetCode])) {
+                    continue;
+                }
+                $seenInCell[$targetCode] = true;
+
+                $target = $this->catalogObjects->findByCodeInObjectTypes($targetCode, $targetTypeIds, $this->tenant);
+                if (null === $target) {
+                    $errors[] = $this->error($link['rowNumber'], $link['sourceSku'], \sprintf(
+                        'relation target "%s" (%s) was not found in this tenant.',
+                        $targetCode,
+                        $attribute->getCode(),
+                    ));
+
+                    continue;
+                }
+
+                $targetId = $target->getId()->toRfc4122();
+                if ($targetId === $sourceId) {
+                    $errors[] = $this->error($link['rowNumber'], $link['sourceSku'], \sprintf(
+                        'relation "%s" points to the row itself.',
+                        $attribute->getCode(),
+                    ));
+
+                    continue;
+                }
+
+                $triple = $sourceId.'|'.$attributeId.'|'.$targetId;
+                if (isset($existingTargets[$targetId]) || isset($seenTriples[$triple])) {
+                    continue;
+                }
+
+                $this->relations->add(new ObjectRelation($source, $target, $attribute, $position++));
+                $seenTriples[$triple] = true;
+            }
+
+            if (0 === ++$linkCount % self::CHUNK) {
+                $this->flushClearReattach();
+            }
+        }
+
+        return $errors;
+    }
+
+    private function flushClearReattach(): void
+    {
+        $this->em->flush();
+        $this->em->clear();
+        $this->reattachTenant();
+    }
+
+    /**
+     * Re-fetch the active tenant as a managed entity and re-publish it to the
+     * TenantContext so the assignment listener stamps new rows correctly.
+     */
+    private function reattachTenant(): void
+    {
+        \assert($this->tenant instanceof Tenant);
+        $managed = $this->em->find(Tenant::class, $this->tenant->getId()->toRfc4122());
+        if ($managed instanceof Tenant) {
+            $this->tenant = $managed;
+            $this->tenantContext->set($managed);
+        }
+    }
+
+    /**
      * True when making `$parent` the parent of `$child` would close a cycle —
-     * i.e. `$child` is already an ancestor of `$parent`. Earlier-chunk
-     * assignments are flushed, so the walk sees them.
+     * i.e. `$child` is already an ancestor of `$parent`.
      */
     private function wouldCycle(CatalogObject $child, CatalogObject $parent): bool
     {
@@ -126,7 +271,6 @@ final class RelationImportStep
                 return true;
             }
             if (++$guard > 1000) {
-                // Defensive: a pre-existing cycle in the data — treat as cycle.
                 return true;
             }
             $ancestor = $ancestor->getParent();

--- a/apps/api/src/Import/Application/Service/RelationImportStep.php
+++ b/apps/api/src/Import/Application/Service/RelationImportStep.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Import\Domain\Enum\ImportErrorType;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Import\Domain\ValueObject\ValidationError;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * IMP2-1.8 (#1471) — the "dedicated step" (Akeneo pattern) that wires
+ * cross-object links AFTER every object of the import is written.
+ *
+ * Pass 1 (the chunked object write in {@see ImportRunHandler}) buffers link
+ * tuples as bare CODE strings — these survive `EntityManager::clear()`
+ * because they reference no managed entity. Once pass 1 finishes (all
+ * objects persisted, so a variant row may appear before OR after its
+ * master), pass 2 resolves the codes tenant-scoped and persists the links
+ * in chunks with flush+clear (memory contract — buffer is bounded to ~200k
+ * tuples, D10).
+ *
+ * Parent (variant → master) linking lands here first; relation attributes
+ * (ObjectRelation rows) extend the same buffer in a follow-up of this ticket.
+ */
+final class RelationImportStep
+{
+    private const int CHUNK = 200;
+
+    /** @var list<array{childSku: string, parentSku: string, rowNumber: int}> */
+    private array $parentLinks = [];
+
+    public function __construct(
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public function reset(): void
+    {
+        $this->parentLinks = [];
+    }
+
+    public function recordParent(string $childSku, string $parentSku, int $rowNumber): void
+    {
+        $this->parentLinks[] = ['childSku' => $childSku, 'parentSku' => $parentSku, 'rowNumber' => $rowNumber];
+    }
+
+    public function hasWork(): bool
+    {
+        return [] !== $this->parentLinks;
+    }
+
+    /**
+     * Pass 2 — resolve buffered links by code (tenant-scoped) and persist.
+     * Returns row-level errors (logged by the handler; a non-empty result
+     * makes the session `partial`). Flushes + clears every {@see CHUNK}
+     * assignments; the caller re-merges its session afterwards.
+     *
+     * @return list<ValidationError>
+     */
+    public function resolve(ObjectKind $kind, Tenant $tenant): array
+    {
+        $errors = [];
+        $written = 0;
+
+        foreach ($this->parentLinks as $link) {
+            $child = $this->catalogObjects->findByCode($link['childSku'], $kind, $tenant);
+            if (null === $child) {
+                // The child row failed earlier in pass 1 — nothing to link.
+                continue;
+            }
+
+            $parent = $this->catalogObjects->findByCode($link['parentSku'], $kind, $tenant);
+            if (null === $parent) {
+                $errors[] = $this->error($link['rowNumber'], $link['childSku'], \sprintf(
+                    'parent_sku "%s" was not found — variant left unparented.',
+                    $link['parentSku'],
+                ));
+
+                continue;
+            }
+            if ($parent->getId()->equals($child->getId())) {
+                $errors[] = $this->error($link['rowNumber'], $link['childSku'], 'parent_sku points to the row itself.');
+
+                continue;
+            }
+            if ($this->wouldCycle($child, $parent)) {
+                $errors[] = $this->error($link['rowNumber'], $link['childSku'], \sprintf(
+                    'parent_sku "%s" would create a parent cycle.',
+                    $link['parentSku'],
+                ));
+
+                continue;
+            }
+
+            $child->assignParent($parent);
+            if (0 === ++$written % self::CHUNK) {
+                $this->em->flush();
+                $this->em->clear();
+            }
+        }
+
+        $this->em->flush();
+
+        return $errors;
+    }
+
+    /**
+     * True when making `$parent` the parent of `$child` would close a cycle —
+     * i.e. `$child` is already an ancestor of `$parent`. Earlier-chunk
+     * assignments are flushed, so the walk sees them.
+     */
+    private function wouldCycle(CatalogObject $child, CatalogObject $parent): bool
+    {
+        $childId = $child->getId();
+        $ancestor = $parent;
+        $guard = 0;
+        while (null !== $ancestor) {
+            if ($ancestor->getId()->equals($childId)) {
+                return true;
+            }
+            if (++$guard > 1000) {
+                // Defensive: a pre-existing cycle in the data — treat as cycle.
+                return true;
+            }
+            $ancestor = $ancestor->getParent();
+        }
+
+        return false;
+    }
+
+    private function error(int $rowNumber, string $sku, string $message): ValidationError
+    {
+        return new ValidationError(
+            rowNumber: $rowNumber,
+            sku: $sku,
+            errorType: ImportErrorType::InvalidValue,
+            level: ImportLogLevel::Error,
+            message: $message,
+        );
+    }
+}

--- a/apps/api/src/Import/Domain/ReservedMappingTarget.php
+++ b/apps/api/src/Import/Domain/ReservedMappingTarget.php
@@ -49,11 +49,19 @@ final class ReservedMappingTarget
     public const string ENABLED = '__enabled__';
 
     /**
+     * Link the row's object to its parent (variant → master) by the parent's
+     * `code` (IMP2-1.8). Resolved in the two-pass relation step after all
+     * objects are written, so variant rows may appear before OR after their
+     * master. An unresolved / self / cyclic parent is a row error.
+     */
+    public const string PARENT_SKU = '__parent_sku__';
+
+    /**
      * @return list<string>
      */
     public static function all(): array
     {
-        return [self::SKIP, self::CATEGORY, self::CATEGORY_APPEND, self::STATUS, self::ENABLED];
+        return [self::SKIP, self::CATEGORY, self::CATEGORY_APPEND, self::STATUS, self::ENABLED, self::PARENT_SKU];
     }
 
     /** Both category targets (replace + append). */

--- a/apps/api/src/Import/Domain/ReservedMappingTarget.php
+++ b/apps/api/src/Import/Domain/ReservedMappingTarget.php
@@ -57,11 +57,18 @@ final class ReservedMappingTarget
     public const string PARENT_SKU = '__parent_sku__';
 
     /**
+     * Set the master's variant axes (IMP2-1.8). Round-trippable full shape
+     * `code:value,value|code:value` — the axis attribute codes plus their
+     * option-code values. Applied via {@see \App\Catalog\Domain\Entity\CatalogObject::declareVariantAxes()}.
+     */
+    public const string VARIANT_AXES = '__variant_axes__';
+
+    /**
      * @return list<string>
      */
     public static function all(): array
     {
-        return [self::SKIP, self::CATEGORY, self::CATEGORY_APPEND, self::STATUS, self::ENABLED, self::PARENT_SKU];
+        return [self::SKIP, self::CATEGORY, self::CATEGORY_APPEND, self::STATUS, self::ENABLED, self::PARENT_SKU, self::VARIANT_AXES];
     }
 
     /** Both category targets (replace + append). */

--- a/apps/api/src/Import/Domain/SystemColumn.php
+++ b/apps/api/src/Import/Domain/SystemColumn.php
@@ -23,10 +23,10 @@ namespace App\Import\Domain;
 final class SystemColumn
 {
     /** @var list<string> */
-    // IMP2-1.7 (#1470): `status` / `enabled` removed — they are now explicit,
-    // mappable targets (ReservedMappingTarget::STATUS / ENABLED), not auto-skip.
+    // IMP2-1.7 (#1470): `status` / `enabled` removed — explicit mappable
+    // targets now. IMP2-1.8 (#1471): `parent_sku` removed — reserved target
+    // ReservedMappingTarget::PARENT_SKU (variant → master linking).
     private const array HEADERS = [
-        'parent_sku',
         'completeness_pct',
         'created_at',
         'updated_at',

--- a/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
+++ b/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
@@ -283,6 +283,51 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         self::assertStringNotContainsString('FAN-V2', $csvOff);
     }
 
+    #[Test]
+    public function variantAxesRoundTripsViaFullShape(): void
+    {
+        // IMP2-1.8 (AC) — variant_axes round-trips 1:1 via the full
+        // `code:value,value|code:value` shape.
+        $client = $this->authenticatedClient();
+        $tenant = $this->tenant();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $em = $this->em();
+        $productType = $em->getRepository(ObjectType::class)
+            ->find(Uuid::fromString($this->objectTypeIdFor(ObjectKind::Product)));
+        \assert($productType instanceof ObjectType);
+
+        $master = new CatalogObject($productType, 'VA-1');
+        $master->declareVariantAxes([
+            ['code' => 'color', 'values' => ['red', 'blue']],
+            ['code' => 'size', 'values' => ['m']],
+        ]);
+        $em->persist($master);
+        $em->flush();
+        $masterId = $master->getId();
+
+        $csv = $this->runProductExport($tenant, ['sku', 'variant_axes'], [$masterId]);
+        self::assertStringContainsString('color:red,blue', $csv);
+        self::assertStringContainsString('size:m', $csv);
+
+        // Re-import as a NEW object (rename the sku) → variant_axes parsed back.
+        $reimport = str_replace('VA-1', 'VA-2', $csv);
+        $this->postImport($client, $reimport, $productType->getId()->toRfc4122(), [
+            'sku' => 'sku',
+            'variant_axes' => '__variant_axes__',
+        ]);
+
+        $em->clear();
+        $stored = $em->getConnection()->fetchOne("SELECT variant_axes FROM objects WHERE code = 'VA-2'");
+        \assert(\is_string($stored));
+        self::assertSame(
+            [
+                ['code' => 'color', 'values' => ['red', 'blue']],
+                ['code' => 'size', 'values' => ['m']],
+            ],
+            json_decode($stored, true, 512, JSON_THROW_ON_ERROR),
+        );
+    }
+
     /**
      * @param array<string, mixed> $expected
      * @param array<string, mixed> $actual

--- a/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
+++ b/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
@@ -243,6 +243,46 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         }
     }
 
+    #[Test]
+    public function exportIncludeVariantsFansOutMasterBeforeItsVariants(): void
+    {
+        // IMP2-1.8 (AC) — include_variants=true emits each master followed by
+        // its variants (parent_sku filled); =false emits masters only.
+        $this->authenticatedClient();
+        $tenant = $this->tenant();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $em = $this->em();
+        $productType = $em->getRepository(ObjectType::class)
+            ->find(Uuid::fromString($this->objectTypeIdFor(ObjectKind::Product)));
+        \assert($productType instanceof ObjectType);
+
+        $master = new CatalogObject($productType, 'FAN-M');
+        $em->persist($master);
+        $v1 = new CatalogObject($productType, 'FAN-V1');
+        $v1->assignParent($master);
+        $v2 = new CatalogObject($productType, 'FAN-V2');
+        $v2->assignParent($master);
+        $em->persist($v1);
+        $em->persist($v2);
+        $em->flush();
+        $masterId = $master->getId();
+
+        $csvOn = $this->runProductExport($tenant, ['sku', 'parent_sku'], [$masterId], [], true);
+        self::assertStringContainsString('FAN-V1', $csvOn, 'variants exported when include_variants=true');
+        self::assertStringContainsString('FAN-V2', $csvOn);
+        self::assertMatchesRegularExpression('/FAN-V1\W+FAN-M/', $csvOn, 'variant row carries parent_sku');
+        self::assertLessThan(
+            (int) strpos($csvOn, 'FAN-V1'),
+            (int) strpos($csvOn, 'FAN-M'),
+            'master row precedes its variant rows',
+        );
+
+        $csvOff = $this->runProductExport($tenant, ['sku', 'parent_sku'], [$masterId], [], false);
+        self::assertStringContainsString('FAN-M', $csvOff);
+        self::assertStringNotContainsString('FAN-V1', $csvOff, 'variants excluded when include_variants=false');
+        self::assertStringNotContainsString('FAN-V2', $csvOff);
+    }
+
     /**
      * @param array<string, mixed> $expected
      * @param array<string, mixed> $actual
@@ -304,7 +344,7 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
      * @param list<Uuid>   $ids
      * @param list<string> $channels
      */
-    private function runProductExport(Tenant $tenant, array $columns, array $ids, array $channels = []): string
+    private function runProductExport(Tenant $tenant, array $columns, array $ids, array $channels = [], bool $includeVariants = true): string
     {
         $session = new ExportSession(
             userId: Uuid::v7(),
@@ -315,6 +355,7 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
             entityType: ExportEntityType::Product,
             selectedObjectIds: array_map(static fn (Uuid $id): string => $id->toRfc4122(), $ids),
             channels: $channels,
+            includeVariants: $includeVariants,
         );
         $session->assignTenant($tenant);
 

--- a/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
+++ b/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
@@ -328,6 +328,167 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         );
     }
 
+    #[Test]
+    public function goldenRoundTripCarriesVariantsRelationsAndGallery(): void
+    {
+        // IMP2-1.8 (AC item 10) — master + 2 variants + a relation + a 2-asset
+        // gallery survive export(include_variants=true) → import with their full
+        // structure: parent_id, object_relations (by code), and the asset list.
+        $client = $this->authenticatedClient();
+        $tenant = $this->tenant();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $em = $this->em();
+        $productType = $em->getRepository(ObjectType::class)
+            ->find(Uuid::fromString($this->objectTypeIdFor(ObjectKind::Product)));
+        \assert($productType instanceof ObjectType);
+
+        // Relation + gallery attributes on the product type.
+        $acc = new Attribute('acc', ['en' => 'Accessories'], AttributeType::Relation);
+        $acc->setRelationTargetObjectTypeIds([$productType->getId()->toRfc4122()]);
+        $acc->setRelationCardinality(\App\Catalog\Domain\RelationCardinality::Many);
+        $em->persist($acc);
+        $em->persist(new ObjectTypeAttribute($productType, $acc));
+        $gal = new Attribute('gal', ['en' => 'Gallery'], AttributeType::Asset);
+        $em->persist($gal);
+        $em->persist(new ObjectTypeAttribute($productType, $gal));
+
+        $assetA = new \App\Asset\Domain\Entity\Asset('G-A', 'a.jpg', 'image/jpeg', 10, 'p/a.jpg');
+        $assetB = new \App\Asset\Domain\Entity\Asset('G-B', 'b.jpg', 'image/jpeg', 10, 'p/b.jpg');
+        $em->persist($assetA);
+        $em->persist($assetB);
+
+        $master = new CatalogObject($productType, 'MA-M');
+        $v1 = new CatalogObject($productType, 'MA-V1');
+        $v1->assignParent($master);
+        $v2 = new CatalogObject($productType, 'MA-V2');
+        $v2->assignParent($master);
+        $relTarget = new CatalogObject($productType, 'MA-REL');
+        $em->persist($master);
+        $em->persist($v1);
+        $em->persist($v2);
+        $em->persist($relTarget);
+        $em->flush();
+
+        $idA = $assetA->getId()->toRfc4122();
+        $idB = $assetB->getId()->toRfc4122();
+        $em->persist(new \App\Catalog\Domain\Entity\ObjectRelation($master, $relTarget, $acc, 0));
+        $em->persist(new ObjectValue($master, $gal, ['asset_id' => [$idA, $idB]], Provenance::Manual));
+        $em->flush();
+        $masterId = $master->getId();
+        $relTargetId = $relTarget->getId();
+
+        // Export master + relation target (both selected) with variant fan-out.
+        $csv = $this->runProductExport($tenant, ['sku', 'parent_sku', 'acc', 'gal'], [$masterId, $relTargetId], [], true);
+        foreach (['MA-M', 'MA-V1', 'MA-V2', 'MA-REL'] as $code) {
+            self::assertStringContainsString($code, $csv, $code.' present in export');
+        }
+        self::assertStringContainsString($idA.'|'.$idB, $csv, 'gallery exported as pipe-joined asset ids');
+
+        // Re-import as a fresh tree (MA- → RT-): parent_sku + relation codes
+        // rename together; asset ids stay (the assets already exist).
+        $reimport = str_replace('MA-', 'RT-', $csv);
+        $body = $this->postImport($client, $reimport, $productType->getId()->toRfc4122(), [
+            'sku' => 'sku',
+            'parent_sku' => '__parent_sku__',
+            'acc' => 'acc',
+            'gal' => 'gal',
+        ]);
+        self::assertSame('success', $body['status']);
+        self::assertSame(4, $body['success_count']);
+
+        $em->clear();
+        // Variants point at the freshly-imported master (two-pass parent link).
+        $parents = $em->getConnection()->fetchAllKeyValue(
+            "SELECT o.code, p.code FROM objects o JOIN objects p ON p.id = o.parent_id WHERE o.code IN ('RT-V1','RT-V2') ORDER BY o.code",
+        );
+        self::assertSame(['RT-V1' => 'RT-M', 'RT-V2' => 'RT-M'], $parents);
+
+        // Relation resolved by code into object_relations (RT-M → RT-REL).
+        $relTargets = $em->getConnection()->fetchFirstColumn(
+            "SELECT t.code FROM object_relations r JOIN objects s ON s.id=r.source_object_id JOIN objects t ON t.id=r.target_object_id JOIN attributes a ON a.id=r.attribute_id WHERE s.code='RT-M' AND a.code='acc'",
+        );
+        self::assertSame(['RT-REL'], $relTargets);
+
+        // Gallery asset list survived intact and in order.
+        $galValue = $em->getConnection()->fetchOne(
+            "SELECT ov.value FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id JOIN objects o ON o.id=ov.object_id WHERE a.code='gal' AND o.code='RT-M'",
+        );
+        \assert(\is_string($galValue));
+        self::assertSame(['asset_id' => [$idA, $idB]], json_decode($galValue, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
+    public function generatedVariantsRoundTripOneToOne(): void
+    {
+        // IMP2-1.8 (AC item 9) — a master whose variants come from the REAL
+        // GenerateVariants endpoint (canonical select-axis shape, D7) exports
+        // with parent_sku + axes and re-imports 1:1.
+        $client = $this->authenticatedClient();
+        $tenant = $this->tenant();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $em = $this->em();
+        $productType = $em->getRepository(ObjectType::class)
+            ->find(Uuid::fromString($this->objectTypeIdFor(ObjectKind::Product)));
+        \assert($productType instanceof ObjectType);
+
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Select);
+        $em->persist($color);
+        $em->persist(new ObjectTypeAttribute($productType, $color));
+        $em->persist(new AttributeOption($color, 'red', ['en' => 'Red'], 1));
+        $em->persist(new AttributeOption($color, 'blue', ['en' => 'Blue'], 2));
+        $master = new CatalogObject($productType, 'GV-1');
+        $em->persist($master);
+        $em->flush();
+        $masterId = $master->getId();
+
+        // Generate two variants through the real endpoint.
+        $client->request('POST', '/api/products/'.$masterId->toRfc4122().'/generate-variants', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => json_encode(['axes' => ['color' => ['red', 'blue']]], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseIsSuccessful();
+
+        // Export master + its generated variants.
+        $csv = $this->runProductExport($tenant, ['sku', 'parent_sku', 'variant_axes', 'color'], [$masterId], [], true);
+        self::assertStringContainsString('GV-1-RED', $csv);
+        self::assertStringContainsString('GV-1-BLUE', $csv);
+        self::assertStringContainsString('color:red,blue', $csv, 'master carries the canonical axes definition');
+
+        // Re-import as a fresh tree (GV-1 → RT-1 renames master + variant skus
+        // + the parent_sku cell together; option codes stay).
+        $reimport = str_replace('GV-1', 'RT-1', $csv);
+        $body = $this->postImport($client, $reimport, $productType->getId()->toRfc4122(), [
+            'sku' => 'sku',
+            'parent_sku' => '__parent_sku__',
+            'variant_axes' => '__variant_axes__',
+            'color' => 'color',
+        ]);
+        self::assertSame('success', $body['status']);
+        self::assertSame(3, $body['success_count']);
+
+        $em->clear();
+        // Variants reparented to the freshly-imported master.
+        $parents = $em->getConnection()->fetchAllKeyValue(
+            "SELECT o.code, p.code FROM objects o JOIN objects p ON p.id = o.parent_id WHERE o.code IN ('RT-1-RED','RT-1-BLUE') ORDER BY o.code",
+        );
+        self::assertSame(['RT-1-BLUE' => 'RT-1', 'RT-1-RED' => 'RT-1'], $parents);
+
+        // Master axes definition survived intact.
+        $axes = $em->getConnection()->fetchOne("SELECT variant_axes FROM objects WHERE code = 'RT-1'");
+        \assert(\is_string($axes));
+        self::assertSame(
+            [['code' => 'color', 'values' => ['red', 'blue']]],
+            json_decode($axes, true, 512, JSON_THROW_ON_ERROR),
+        );
+
+        // Each variant kept its axis option code.
+        $redOption = $em->getConnection()->fetchOne(
+            "SELECT ov.value FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id JOIN objects o ON o.id=ov.object_id WHERE a.code='color' AND o.code='RT-1-RED'",
+        );
+        \assert(\is_string($redOption));
+        self::assertSame(['option_code' => 'red'], json_decode($redOption, true, 512, JSON_THROW_ON_ERROR));
+    }
+
     /**
      * @param array<string, mixed> $expected
      * @param array<string, mixed> $actual

--- a/apps/api/tests/Api/Import/StartImportApiTest.php
+++ b/apps/api/tests/Api/Import/StartImportApiTest.php
@@ -436,6 +436,86 @@ final class StartImportApiTest extends CatalogApiTestCase
         }
     }
 
+    #[Test]
+    public function importGalleryCellSplitsAssetsAndDropsDanglingIds(): void
+    {
+        // IMP2-1.8 (AC) — `id1|id2` in an Asset cell → envelope with a list;
+        // a non-existent asset id → row warning, nothing dangling in JSONB.
+        $this->seedAttributes();
+
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $productOt = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($productOt instanceof ObjectType);
+
+        $gallery = new Attribute('gallery', ['en' => 'Gallery'], AttributeType::Asset);
+        $em->persist($gallery);
+        $em->persist(new ObjectTypeAttribute($productOt, $gallery, false, 3));
+
+        $assetA = new \App\Asset\Domain\Entity\Asset('AST-A', 'a.jpg', 'image/jpeg', 10, 'p/a.jpg');
+        $assetB = new \App\Asset\Domain\Entity\Asset('AST-B', 'b.jpg', 'image/jpeg', 10, 'p/b.jpg');
+        $em->persist($assetA);
+        $em->persist($assetB);
+        $em->flush();
+        $idA = $assetA->getId()->toRfc4122();
+        $idB = $assetB->getId()->toRfc4122();
+        $bogus = '01914aaa-bbbb-7ccc-8ddd-eeeeeeeeeeee';
+
+        $csvPath = $this->writeCsv(
+            "sku;name;gallery\nGAL-1;Two assets;{$idA}|{$idB}\nGAL-2;One bad;{$idA}|{$bogus}\n",
+            'pim-gal-',
+        );
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode([
+                            'sku' => 'sku',
+                            'name' => 'name',
+                            'gallery' => 'gallery',
+                        ], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'gal.csv', 'text/csv', null, true)],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertSame(2, $body['success_count']);
+
+            // GAL-1 → both ids survive → list envelope.
+            $valueOne = $em->getConnection()->fetchOne(
+                "SELECT ov.value FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id JOIN objects o ON o.id=ov.object_id WHERE a.code='gallery' AND o.code='GAL-1'",
+            );
+            \assert(\is_string($valueOne));
+            self::assertSame(['asset_id' => [$idA, $idB]], json_decode($valueOne, true, 512, JSON_THROW_ON_ERROR));
+
+            // GAL-2 → only the existing id survives (scalar), bogus dropped.
+            $valueTwo = $em->getConnection()->fetchOne(
+                "SELECT ov.value FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id JOIN objects o ON o.id=ov.object_id WHERE a.code='gallery' AND o.code='GAL-2'",
+            );
+            \assert(\is_string($valueTwo));
+            $decodedTwo = json_decode($valueTwo, true, 512, JSON_THROW_ON_ERROR);
+            self::assertSame(['asset_id' => $idA], $decodedTwo);
+            self::assertStringNotContainsString($bogus, $valueTwo, 'dangling asset id must not reach JSONB');
+
+            // The dropped id surfaced as a row warning.
+            $warnings = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM import_logs WHERE level='warning' AND message LIKE '%does not exist for this tenant%'",
+            );
+            self::assertSame(1, (int) (\is_scalar($warnings) ? $warnings : 0));
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
     private function writeCsv(string $contents, string $prefix): string
     {
         $path = tempnam(sys_get_temp_dir(), $prefix);

--- a/apps/api/tests/Api/Import/StartImportApiTest.php
+++ b/apps/api/tests/Api/Import/StartImportApiTest.php
@@ -292,6 +292,73 @@ final class StartImportApiTest extends CatalogApiTestCase
         }
     }
 
+    #[Test]
+    public function importLinksVariantsToParentRegardlessOfRowOrder(): void
+    {
+        // IMP2-1.8 (AC) — two-pass parent linking: a variant row may appear
+        // BEFORE its master (VAR-2 → MST-2 which is a later row). A missing
+        // parent → row still imports, session partial, warning logged.
+        $this->seedAttributes();
+
+        $csvPath = $this->writeCsv(
+            "sku;name;parent_sku\n"
+            ."MST-1;Master 1;\n"
+            ."VAR-1;Variant 1;MST-1\n"
+            ."VAR-2;Variant 2;MST-2\n"
+            ."MST-2;Master 2;\n"
+            ."VAR-3;Variant 3;GHOST-MASTER\n",
+            'pim-parent-',
+        );
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode([
+                            'sku' => 'sku',
+                            'name' => 'name',
+                            'parent_sku' => '__parent_sku__',
+                        ], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'parent.csv', 'text/csv', null, true)],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertSame(5, $body['success_count'], 'all five rows create their object');
+            self::assertSame('partial', $body['status'], 'the GHOST parent makes the session partial');
+
+            $em = $this->em();
+            $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+            \assert($tenant instanceof Tenant);
+            self::getContainer()->get(TenantContext::class)->set($tenant);
+            $repo = self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+
+            $var1 = $repo->findByCode('VAR-1', ObjectKind::Product, $tenant);
+            \assert(null !== $var1);
+            self::assertSame('MST-1', $var1->getParent()?->getCode());
+
+            $var2 = $repo->findByCode('VAR-2', ObjectKind::Product, $tenant);
+            \assert(null !== $var2);
+            self::assertSame('MST-2', $var2->getParent()?->getCode(), 'parent resolved though its row came AFTER');
+
+            $var3 = $repo->findByCode('VAR-3', ObjectKind::Product, $tenant);
+            \assert(null !== $var3);
+            self::assertNull($var3->getParent(), 'missing parent → unparented but still imported');
+
+            $ghostWarning = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM import_logs WHERE message LIKE '%GHOST-MASTER%'",
+            );
+            self::assertSame(1, (int) (\is_scalar($ghostWarning) ? $ghostWarning : 0));
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
     private function writeCsv(string $contents, string $prefix): string
     {
         $path = tempnam(sys_get_temp_dir(), $prefix);

--- a/apps/api/tests/Api/Import/StartImportApiTest.php
+++ b/apps/api/tests/Api/Import/StartImportApiTest.php
@@ -10,8 +10,11 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\RelationCardinality;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
@@ -354,6 +357,80 @@ final class StartImportApiTest extends CatalogApiTestCase
                 "SELECT COUNT(*) FROM import_logs WHERE message LIKE '%GHOST-MASTER%'",
             );
             self::assertSame(1, (int) (\is_scalar($ghostWarning) ? $ghostWarning : 0));
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function importRelationCellCreatesObjectRelationsNotObjectValues(): void
+    {
+        // IMP2-1.8 (AC) — `REL-A|REL-B` in a Relation cell → 2 object_relations
+        // (position 0,1), and NO ObjectValue{object_id}. Targets follow the
+        // source row, so the two-pass resolves order-independently.
+        $this->seedAttributes();
+
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $productOt = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($productOt instanceof ObjectType);
+
+        $related = new Attribute('related', ['en' => 'Related'], AttributeType::Relation);
+        $related->setRelationTargetObjectTypeIds([$productOt->getId()->toRfc4122()]);
+        $related->setRelationCardinality(RelationCardinality::Many);
+        $em->persist($related);
+        $em->persist(new ObjectTypeAttribute($productOt, $related, false, 3));
+        $em->flush();
+
+        $csvPath = $this->writeCsv(
+            "sku;name;related\nSRC-1;Source;REL-A|REL-B\nREL-A;Target A;\nREL-B;Target B;\n",
+            'pim-rel-',
+        );
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode([
+                            'sku' => 'sku',
+                            'name' => 'name',
+                            'related' => 'related',
+                        ], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'rel.csv', 'text/csv', null, true)],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertSame('success', $body['status']);
+            self::assertSame(3, $body['success_count']);
+
+            $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+            \assert($tenant instanceof Tenant);
+            self::getContainer()->get(TenantContext::class)->set($tenant);
+            $repo = self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+            $relations = self::getContainer()->get(ObjectRelationRepositoryInterface::class);
+            $relAttr = self::getContainer()->get(AttributeRepositoryInterface::class)->findByCode('related', $tenant);
+            \assert(null !== $relAttr);
+
+            $src = $repo->findByCode('SRC-1', ObjectKind::Product, $tenant);
+            \assert(null !== $src);
+            $links = $relations->findBySourceAndAttribute($src, $relAttr);
+            self::assertCount(2, $links);
+            self::assertSame(['REL-A', 'REL-B'], array_map(static fn ($l): string => $l->getTarget()->getCode(), $links));
+            self::assertSame([0, 1], array_map(static fn ($l): int => $l->getPosition(), $links));
+
+            $ovCount = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id JOIN objects o ON o.id=ov.object_id WHERE a.code='related' AND o.code='SRC-1'",
+            );
+            self::assertSame(0, (int) (\is_scalar($ovCount) ? $ovCount : 1), 'a Relation cell must NOT write an ObjectValue');
         } finally {
             @unlink($csvPath);
         }

--- a/apps/api/tests/Integration/Import/ImportTenantIsolationTest.php
+++ b/apps/api/tests/Integration/Import/ImportTenantIsolationTest.php
@@ -7,10 +7,16 @@ namespace App\Tests\Integration\Import;
 use App\Backup\Domain\Entity\Backup;
 use App\Backup\Domain\Enum\BackupTriggerAction;
 use App\Backup\Domain\Repository\BackupRepositoryInterface;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\RelationCardinality;
+use App\Import\Application\Service\RelationImportStep;
 use App\Import\Domain\Entity\ImportProfile;
 use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportLogLevel;
 use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
 use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
 use App\Shared\Application\TenantContext;
@@ -115,6 +121,51 @@ final class ImportTenantIsolationTest extends KernelTestCase
         $this->activateTenantFilter($beta);
         $betaCount = $repo->countSince($alpha, new DateTimeImmutable('-1 hour'));
         self::assertSame(0, $betaCount, 'TenantFilter must hide alpha backups from beta context.');
+    }
+
+    #[Test]
+    public function relationTargetInAnotherTenantNeverLinks(): void
+    {
+        // IMP2-1.8 (AC) — a relation target whose code exists only in tenant
+        // beta must NOT link when resolved for tenant alpha: 0 object_relations
+        // + one row error. findByCodeInObjectTypes is tenant-scoped, so the
+        // cross-tenant code resolves to null — never a leaked link.
+        $alpha = $this->createTenant('alpha');
+        $beta = $this->createTenant('beta');
+        $em = $this->em();
+
+        $this->tenantContext()->set($alpha);
+        $type = $this->productObjectType($em);
+        $typeId = $type->getId()->toRfc4122();
+
+        $source = new CatalogObject($type, 'SRC-A');
+        $em->persist($source);
+        $attr = new Attribute('rel', ['en' => 'Rel'], AttributeType::Relation);
+        $attr->setRelationTargetObjectTypeIds([$typeId]);
+        $attr->setRelationCardinality(RelationCardinality::Many);
+        $em->persist($attr);
+        $em->flush();
+
+        // beta owns a product that shares the target CODE but not the tenant.
+        $this->tenantContext()->set($beta);
+        $betaTarget = new CatalogObject($type, 'CROSS-TGT');
+        $em->persist($betaTarget);
+        $em->flush();
+        $em->clear();
+
+        // Resolve the buffered relation in ALPHA's context.
+        $step = self::getContainer()->get(RelationImportStep::class);
+        $step->reset();
+        $step->recordRelation('SRC-A', 'rel', ['CROSS-TGT'], 7);
+        $errors = $step->resolve(ObjectKind::Product, $alpha);
+
+        self::assertCount(1, $errors, 'cross-tenant target must produce exactly one row error');
+        self::assertSame(7, $errors[0]->rowNumber);
+        self::assertSame(ImportLogLevel::Error, $errors[0]->level);
+        self::assertStringContainsString('CROSS-TGT', $errors[0]->message);
+
+        $linkCount = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM object_relations');
+        self::assertSame(0, (int) (\is_scalar($linkCount) ? $linkCount : 1), 'no object_relations row may be written');
     }
 
     /**

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
@@ -106,6 +106,16 @@ final class InMemoryCatalogObjectRepo implements CatalogObjectRepositoryInterfac
         throw new LogicException('not used in this test');
     }
 
+    public function findByCodeInObjectTypes(string $code, array $objectTypeIds, Tenant $tenant): ?CatalogObject
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function findChildrenByParentIds(array $parentIdsRfc4122, Tenant $tenant): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
     public function findByKind(ObjectKind $kind, Tenant $tenant): array
     {
         throw new LogicException('not used in this test');

--- a/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
@@ -8,10 +8,13 @@ use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectCategory;
+use App\Catalog\Domain\Entity\ObjectRelation;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Channel\Contracts\ChannelResolverInterface;
 use App\Export\Application\Builder\ColumnResolver;
@@ -262,17 +265,48 @@ final class ExportBuilderTest extends TestCase
         self::assertSame(['sku' => 'SKU-D', 'category' => 'CAT-A|CAT-B'], $rows[0]);
     }
 
+    #[Test]
+    public function rendersRelationColumnAsPipeJoinedTargetCodes(): void
+    {
+        // IMP2-1.8 (D5) — a Relation column emits pipe-joined target CODES
+        // read from object_relations, not a UUID from ObjectValue.
+        $product = $this->newProduct('SKU-R');
+        $related = $this->newAttribute('related', AttributeType::Relation);
+        $targetA = $this->newProduct('REL-A');
+        $targetB = $this->newProduct('REL-B');
+
+        $relA = $this->createStub(ObjectRelation::class);
+        $relA->method('getTarget')->willReturn($targetA);
+        $relB = $this->createStub(ObjectRelation::class);
+        $relB->method('getTarget')->willReturn($targetB);
+
+        $builder = $this->newBuilder(
+            valuesByObject: [],
+            categoriesByObject: [],
+            relationsBySource: [spl_object_id($product) => [$relA, $relB]],
+            attributesByCode: ['related' => $related],
+        );
+        $session = $this->newSessionWithTenant(['sku', 'related']);
+        $rows = iterator_to_array($builder->build([$product], $session));
+
+        self::assertSame(['sku' => 'SKU-R', 'related' => 'REL-A|REL-B'], $rows[0]);
+    }
+
     // ----- helpers -----
 
     /**
      * @param array<int, list<ObjectValue>>    $valuesByObject     keyed by spl_object_id($product)
      * @param array<int, list<ObjectCategory>> $categoriesByObject same
      * @param array<string, Uuid>              $channelIds         channel code => id (#1229)
+     * @param array<int, list<ObjectRelation>> $relationsBySource  keyed by spl_object_id($source) (#1471)
+     * @param array<string, Attribute>         $attributesByCode   attribute column code => Attribute (#1471)
      */
     private function newBuilder(
         array $valuesByObject,
         array $categoriesByObject,
         array $channelIds = [],
+        array $relationsBySource = [],
+        array $attributesByCode = [],
     ): ExportBuilder {
         $values = $this->createStub(ObjectValueRepositoryInterface::class);
         $values->method('findByObject')->willReturnCallback(
@@ -289,12 +323,24 @@ final class ExportBuilderTest extends TestCase
             static fn (string $code): ?Uuid => $channelIds[$code] ?? null
         );
 
+        $relations = $this->createStub(ObjectRelationRepositoryInterface::class);
+        $relations->method('findBySourceAndAttribute')->willReturnCallback(
+            static fn (CatalogObject $source): array => $relationsBySource[spl_object_id($source)] ?? []
+        );
+
+        $attributes = $this->createStub(AttributeRepositoryInterface::class);
+        $attributes->method('findByCode')->willReturnCallback(
+            static fn (string $code): ?Attribute => $attributesByCode[$code] ?? null
+        );
+
         return new ExportBuilder(
             values: $values,
             categories: $categories,
             columnResolver: new ColumnResolver(),
             serializer: new ValueSerializer(),
             channels: $channels,
+            relations: $relations,
+            attributes: $attributes,
         );
     }
 

--- a/apps/api/tests/Unit/Import/AutoMapperTest.php
+++ b/apps/api/tests/Unit/Import/AutoMapperTest.php
@@ -135,11 +135,11 @@ final class AutoMapperTest extends TestCase
             'sku' => ['aliases' => ['sku']],
         ]);
 
-        // IMP2-1.7: status / enabled are no longer system columns — they
-        // auto-map to reserved targets (covered by the test below).
+        // IMP2-1.7/1.8: status / enabled / parent_sku are no longer system
+        // columns — they auto-map to reserved targets (test below).
         $suggestions = $mapper->map(
             ['sku'],
-            ['sku', 'created_at', 'updated_at', 'completeness_pct', 'parent_sku'],
+            ['sku', 'created_at', 'updated_at', 'completeness_pct'],
             [],
         );
 
@@ -161,12 +161,15 @@ final class AutoMapperTest extends TestCase
         // reserved targets automatically.
         $mapper = $this->mapperWithDictionary(['sku' => ['aliases' => ['sku']]]);
 
-        $suggestions = $mapper->map(['sku'], ['status', 'enabled'], []);
+        $suggestions = $mapper->map(['sku'], ['status', 'enabled', 'parent_sku'], []);
 
         self::assertSame('__status__', $suggestions[0]->suggestedAttributeCode);
         self::assertSame(MappingConfidence::Auto, $suggestions[0]->confidence);
         self::assertSame('__enabled__', $suggestions[1]->suggestedAttributeCode);
         self::assertSame(MappingConfidence::Auto, $suggestions[1]->confidence);
+        // IMP2-1.8 — parent_sku auto-maps to its reserved target too.
+        self::assertSame('__parent_sku__', $suggestions[2]->suggestedAttributeCode);
+        self::assertSame(MappingConfidence::Auto, $suggestions[2]->confidence);
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -235,6 +235,16 @@ final class InMemoryCatalogObjectRepository implements CatalogObjectRepositoryIn
         return $this->bySku[$code] ?? null;
     }
 
+    public function findByCodeInObjectTypes(string $code, array $objectTypeIds, Tenant $tenant): ?CatalogObject
+    {
+        return $this->bySku[$code] ?? null;
+    }
+
+    public function findChildrenByParentIds(array $parentIdsRfc4122, Tenant $tenant): array
+    {
+        return [];
+    }
+
     public function findById(Uuid $id): ?CatalogObject
     {
         return null;


### PR DESCRIPTION
## Co dowozi (Closes #1471, #598)

Pełny round-trip eksport → import dla struktury produktów: hierarchia wariantów, relacje, galerie, osie wariantów. Wzorzec **dwuprzebiegowy** (Akeneo „dedicated step"): pass 1 zapisuje obiekty + buforuje krotki linków jako gołe kody (przeżywają `EntityManager::clear()`), pass 2 resolvuje po `objects.code` tenant-scoped po zapisaniu wszystkich obiektów — kolejność wierszy nieistotna.

### Zakres (AC #1471)
- ✅ **parent_sku two-pass** — warianty PRZED i PO wierszu mastera ustawiają `parent_id`; nieistniejący rodzic → błąd wiersza, sesja `partial`; guard self-parent + cykl.
- ✅ **Relacje → `object_relations`** (ADR-014) — komórka `REL-A|REL-B` tworzy wiersze `object_relations` (position 0,1), NIE `ObjectValue{object_id}`; dedupe po trójce `(source, target, attribute)`.
- ✅ **Izolacja cross-tenant** — target istniejący tylko w innym tenancie → 0 linków + błąd wiersza (`findByCodeInObjectTypes` tenant-scoped; test integracyjny w `tests/Integration/Import/`).
- ✅ **Eksport relacji po code (D5)** — `ExportBuilder` czyta `object_relations` i emituje pipe-joined kody zamiast UUID.
- ✅ **`include_variants` fan-out** — `SyncExportRunner::resolveTargets()` przy `true` dokłada dzieci każdego mastera (master przed wariantami); przy `false` tylko mastery. Ta sama ścieżka sync i async.
- ✅ **`variant_axes` round-trip** — kolumna built-in `code:value,value|code:value` (pełny shape, decyzja operatora dla 1:1) → import `declareVariantAxes`.
- ✅ **Galerie** — pipe-split `asset_id` z walidacją istnienia tenant-scoped (prefetch per chunk); nieistniejący id → warning wiersza, nic dangling w JSONB. Pojedynczy asset = skalar (round-trip z admin), wiele = lista.
- ✅ **GenerateVariants round-trip 1:1** — wariant z realnego endpointu eksportuje się z osiami + `parent_sku` i wraca importem identycznie.
- ✅ **Golden test rozszerzony** — master + 2 warianty + relacja + galeria 2 assetów, zielony.

### Świadome odejścia
- **Item 2 (pole fazy w checkpoincie)** — **deferred**. Premisa ticketu („checkpoint sesji z IMP2-1.6a") nie istnieje: #1509 dostarczyło wyłącznie transport Messengera + próg sync, bez struktury checkpoint/offset do rozszerzenia. Pełny offset-resume jest explicite **IMP2-2.3** (sekcja „Poza zakresem"). Dwuprzebieg jest już **redelivery-safe** bez pola fazy: upsert po code jest idempotentny, a relacje/rodzice dedupują się (trójka + idempotentny `assignParent`) — redelivery całego importu nie tworzy duplikatów linków. Dodanie martwego pola fazy bez konsumenta resume byłoby no-opem (reguła „component shipped ≠ feature done").

### Testy (wszystkie zielone lokalnie, `-e APP_ENV=test`)
`tests/Api/Import` + `tests/Integration/Import` + `tests/Unit/Import` + `tests/Unit/Export` → **206 passed**. Golden suite 4 testy / 97 asercji.

### Bramki
PHPStan max `--memory-limit=1G` ✅ · Deptrac 0 violations ✅ · php-cs-fixer ✅

### Smoke test
Live-stack smoke na `https://pim.localhost` przed merge (curl eksport `include_variants=true` → reimport renamed → psql weryfikacja `parent_id` + `object_relations` + galeria) — dowód w komentarzu zamknięcia #598.