### PR TITLE
IMP2-1.9 — feat(import): izolacja błędów per wiersz + severity + partial status

### DIFF
--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -32,7 +32,10 @@ use App\Shared\Application\BulkOperationInProgressException;
 use App\Shared\Application\BulkOperationLock;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
 use LogicException;
@@ -79,6 +82,7 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly TenantContext $tenantContext,
         private readonly FilesystemOperator $importsStorage,
         private readonly BulkOperationLock $bulkLock,
+        private readonly ManagerRegistry $managerRegistry,
         int $batchSize = 200,
     ) {
         parent::__construct($entityManager, $batchSize);
@@ -170,6 +174,10 @@ final class ImportRunHandler extends AbstractBatchHandler
             $sourcePath = $this->stageSourceFile($session, $tenant);
 
             $skuSeenInFile = [];
+            // IMP2-1.9 (item 2) — running file-wide set of identifier values
+            // already claimed, keyed by attributeCode, so a duplicate identifier
+            // across chunks is caught as a skip before the DB unique index.
+            $identifierSeenInFile = [];
             $processed = 0;
             $totalRows = 0;
             /** @var list<array{rowNumber: int, cells: array<string, string|null>}> $buffer */
@@ -187,7 +195,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                     continue;
                 }
 
-                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile);
+                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile, $identifierSeenInFile);
                 $buffer = [];
 
                 $this->flushAndClear();
@@ -208,7 +216,7 @@ final class ImportRunHandler extends AbstractBatchHandler
             }
 
             if ([] !== $buffer) {
-                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile);
+                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile, $identifierSeenInFile);
                 $this->flushAndClear();
                 $session = $this->refreshSession($session);
             }
@@ -242,12 +250,15 @@ final class ImportRunHandler extends AbstractBatchHandler
             $this->sessions->save($session);
             $this->progressPublisher->completed($session);
         } catch (Throwable $exception) {
-            $current = $this->sessions->findById($session->getId());
-            if ($current instanceof ImportSession && !$current->getStatus()->isTerminal()) {
-                $current->markFailed($exception->getMessage());
-                $this->sessions->save($current);
-                $this->progressPublisher->completed($current);
-            }
+            // IMP2-1.9 — a throw from flush() leaves the EM CLOSED, so the old
+            // path (findById + save on the same manager) threw again and left
+            // the session stuck in `running`. Reset the manager and record the
+            // outcome on a fresh one. A connection-level fault is systemic →
+            // `failed`; anything else that slipped the pre-flush checks degrades
+            // the session to `partial` so the rows committed by earlier chunks
+            // are not lost (full per-row replay of the failed chunk is deferred
+            // to IMP2-2.3 — it needs the same EM-lifecycle rework as resume).
+            $this->recordOutcomeAfterException($session->getId(), $exception);
             throw $exception;
         } finally {
             if (null !== $sourcePath && file_exists($sourcePath)) {
@@ -346,6 +357,239 @@ final class ImportRunHandler extends AbstractBatchHandler
         }
 
         return 'sku';
+    }
+
+    /**
+     * IMP2-1.9 — a compact rendering of the raw cells for the `columnValue`
+     * of a parse-failure log, so the operator can identify the offending
+     * (e.g. section/junk) row in the report. Truncated to keep logs sane.
+     *
+     * @param array<string, string|null> $cells
+     */
+    private function rawRowSnippet(array $cells): string
+    {
+        $snippet = implode(' | ', array_map(
+            static fn (?string $value): string => $value ?? '',
+            array_values($cells),
+        ));
+
+        return mb_substr($snippet, 0, 500);
+    }
+
+    /**
+     * IMP2-1.9 (item 2) — flag rows whose identifier-attribute value collides,
+     * BEFORE they reach the flush. A value already used by a DIFFERENT object
+     * in the catalog (queried once per chunk via the trigger-maintained
+     * denormalised columns) blocks the row with an Error; a value that already
+     * appeared earlier in the file is a non-blocking skip (D1). Mutates the
+     * prepared rows in place.
+     *
+     * @param list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string, duplicateInFile: bool}> $prepared
+     * @param array<string, Attribute>                                                                                                                                                                                     $attributesByCode
+     * @param array<string, CatalogObject>                                                                                                                                                                                 $existingByKey
+     * @param array<string, array<string, int>>                                                                                                                                                                            $identifierSeenInFile
+     */
+    private function precheckIdentifiers(
+        array &$prepared,
+        array $attributesByCode,
+        array $existingByKey,
+        ImportSession $session,
+        Tenant $tenant,
+        array &$identifierSeenInFile,
+    ): void {
+        $identifierAttributes = [];
+        foreach ($attributesByCode as $code => $attribute) {
+            if (AttributeType::Identifier === $attribute->getType()) {
+                $identifierAttributes[$code] = $attribute;
+            }
+        }
+        if ([] === $identifierAttributes) {
+            return;
+        }
+
+        /** @var array<string, array<string, true>> $valuesByAttributeId */
+        $valuesByAttributeId = [];
+        foreach ($prepared as $row) {
+            if (!$row['rowOk']) {
+                continue;
+            }
+            foreach ($row['resolvedValues'] as $resolved) {
+                $attribute = $identifierAttributes[$resolved->attributeCode] ?? null;
+                $value = $resolved->rawValue;
+                if (null === $attribute || null === $value || '' === $value) {
+                    continue;
+                }
+                $valuesByAttributeId[$attribute->getId()->toRfc4122()][$value] = true;
+            }
+        }
+
+        $existingOwners = $this->fetchIdentifierOwners(
+            $tenant,
+            $session->getTargetObjectType()->getId()->toRfc4122(),
+            $valuesByAttributeId,
+        );
+
+        foreach ($prepared as $index => $row) {
+            if (!$row['rowOk']) {
+                continue;
+            }
+            $ownObjectId = ($existingByKey[$row['matchKey']] ?? null)?->getId()->toRfc4122();
+            foreach ($row['resolvedValues'] as $resolved) {
+                $attribute = $identifierAttributes[$resolved->attributeCode] ?? null;
+                $value = $resolved->rawValue;
+                if (null === $attribute || null === $value || '' === $value) {
+                    continue;
+                }
+                $attrCode = $resolved->attributeCode;
+                $attrId = $attribute->getId()->toRfc4122();
+
+                $owner = $existingOwners[$attrId][$value] ?? null;
+                if (null !== $owner && $owner !== $ownObjectId) {
+                    $prepared[$index]['rowOk'] = false;
+                    $prepared[$index]['errors'][] = new ValidationError(
+                        rowNumber: $row['rowNumber'],
+                        sku: $row['sku'],
+                        errorType: ImportErrorType::InvalidValue,
+                        level: ImportLogLevel::Error,
+                        message: \sprintf('Identifier "%s" = "%s" is already used by another object.', $attrCode, $value),
+                        columnName: $attrCode,
+                        columnValue: $value,
+                    );
+
+                    continue 2;
+                }
+
+                if (isset($identifierSeenInFile[$attrCode][$value])) {
+                    $prepared[$index]['rowOk'] = false;
+                    $prepared[$index]['duplicateInFile'] = true;
+                    $prepared[$index]['errors'][] = new ValidationError(
+                        rowNumber: $row['rowNumber'],
+                        sku: $row['sku'],
+                        errorType: ImportErrorType::DuplicateSkuInFile,
+                        level: ImportLogLevel::Warning,
+                        message: \sprintf('Identifier "%s" = "%s" already appeared in the file at row %d — skipped.', $attrCode, $value, $identifierSeenInFile[$attrCode][$value]),
+                        columnName: $attrCode,
+                        columnValue: $value,
+                    );
+
+                    continue 2;
+                }
+
+                $identifierSeenInFile[$attrCode][$value] = $row['rowNumber'];
+            }
+        }
+    }
+
+    /**
+     * One bulk lookup of identifier owners for the chunk's candidate values.
+     *
+     * @param array<string, array<string, true>> $valuesByAttributeId
+     *
+     * @return array<string, array<string, string>> attributeId → (value → object_id)
+     */
+    private function fetchIdentifierOwners(Tenant $tenant, string $objectTypeId, array $valuesByAttributeId): array
+    {
+        if ([] === $valuesByAttributeId) {
+            return [];
+        }
+        $allValues = [];
+        foreach ($valuesByAttributeId as $values) {
+            foreach (array_keys($values) as $value) {
+                $allValues[$value] = true;
+            }
+        }
+
+        // Query the authoritative JSONB value (`value->>'value'`) joined to the
+        // target ObjectType rather than the trigger-maintained denormalised
+        // identifier_* columns: the JSONB is always populated (the denorm
+        // columns + partial-unique index are a production-only migration, absent
+        // in the ORM-metadata test schema), so the pre-check is correct in both.
+        $rows = $this->entityManager->getConnection()->fetchAllAssociative(
+            'SELECT ov.attribute_id AS attribute_id, ov.value->>\'value\' AS ident, ov.object_id AS object_id'
+            .' FROM object_values ov JOIN objects o ON o.id = ov.object_id'
+            .' WHERE ov.tenant_id = :tenant AND o.object_type_id = :ot'
+            .' AND ov.attribute_id IN (:attrs) AND ov.value->>\'value\' IN (:vals)',
+            [
+                'tenant' => $tenant->getId()->toRfc4122(),
+                'ot' => $objectTypeId,
+                'attrs' => array_keys($valuesByAttributeId),
+                'vals' => array_keys($allValues),
+            ],
+            [
+                'attrs' => ArrayParameterType::STRING,
+                'vals' => ArrayParameterType::STRING,
+            ],
+        );
+
+        $map = [];
+        foreach ($rows as $row) {
+            $attributeId = $row['attribute_id'];
+            $ident = $row['ident'];
+            $objectId = $row['object_id'];
+            if (!\is_scalar($attributeId) || !\is_scalar($ident) || !\is_scalar($objectId)) {
+                continue;
+            }
+            $map[(string) $attributeId][(string) $ident] = (string) $objectId;
+        }
+
+        return $map;
+    }
+
+    /**
+     * IMP2-1.9 (items 3–4) — record the session outcome after a throw that may
+     * have CLOSED the EntityManager (anything from flush()). Resets the manager
+     * via the registry so the write lands on a fresh, open one. A
+     * connection-level fault is systemic → `failed`; anything else that slipped
+     * the pre-flush checks degrades to `partial`, preserving the rows committed
+     * by earlier chunks. Full per-row replay of the failed chunk is deferred to
+     * IMP2-2.3 (it shares the EM-lifecycle rework that pause/resume needs).
+     */
+    private function recordOutcomeAfterException(Uuid $sessionId, Throwable $exception): void
+    {
+        try {
+            $this->managerRegistry->resetManager();
+        } catch (Throwable) {
+            // Best effort — still try to fetch a usable manager below.
+        }
+
+        $em = $this->managerRegistry->getManager();
+        if (!$em instanceof EntityManagerInterface) {
+            return;
+        }
+        $session = $em->find(ImportSession::class, $sessionId);
+        if (!$session instanceof ImportSession || $session->getStatus()->isTerminal()) {
+            return;
+        }
+
+        if ($this->isSystemicDbFailure($exception)) {
+            $session->markFailed('Import aborted by a system fault: '.$exception->getMessage());
+        } else {
+            // A data fault slipped the pre-flush checks (rare). Keep the rows
+            // committed by earlier chunks and finalize as partial rather than
+            // discarding the whole run.
+            $session->incrementError();
+            $session->markCompleted();
+        }
+        $em->flush();
+
+        try {
+            $this->progressPublisher->completed($session);
+        } catch (Throwable) {
+            // Progress channel is best-effort; the session row is the contract.
+        }
+    }
+
+    private function isSystemicDbFailure(Throwable $exception): bool
+    {
+        // ConnectionLost extends ConnectionException, so this covers a dropped
+        // connection mid-flush too — the systemic fault that warrants `failed`.
+        for ($cursor = $exception; null !== $cursor; $cursor = $cursor->getPrevious()) {
+            if ($cursor instanceof ConnectionException) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -605,6 +849,7 @@ final class ImportRunHandler extends AbstractBatchHandler
      * @param array<string, string>                                          $columnMapping
      * @param array<string, Attribute>                                       $attributesByCode
      * @param array<string, int>                                             $skuSeenInFile
+     * @param array<string, array<string, int>>                              $identifierSeenInFile attributeCode → (value → rowNumber)
      */
     private function processChunk(
         ImportSession $session,
@@ -613,9 +858,10 @@ final class ImportRunHandler extends AbstractBatchHandler
         array $columnMapping,
         array $attributesByCode,
         array &$skuSeenInFile,
+        array &$identifierSeenInFile,
     ): int {
         // Pass 1 — validate rows and gather match keys for the batch resolve.
-        /** @var list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string}> $prepared */
+        /** @var list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string, duplicateInFile: bool}> $prepared */
         $prepared = [];
         $matchKeys = [];
         foreach ($buffer as $entry) {
@@ -634,8 +880,33 @@ final class ImportRunHandler extends AbstractBatchHandler
                 $errors,
                 static fn (ValidationError $error): bool => $error->isRowBlocking(),
             ));
-            $rowOk = [] === $blocking;
-            $resolvedValues = $rowOk ? $this->materialiseValues($cells, $columnMapping, $tenant) : [];
+            // IMP2-1.9 (D1) — a Warning-level DuplicateSkuInFile does not block
+            // (severity contract) but the duplicate row must be SKIPPED, not
+            // imported. Kept distinct from a hard Error, which is a row error.
+            $duplicateInFile = [] !== array_filter(
+                $errors,
+                static fn (ValidationError $error): bool => ImportErrorType::DuplicateSkuInFile === $error->errorType,
+            );
+            $rowOk = [] === $blocking && !$duplicateInFile;
+            $resolvedValues = [];
+            if ($rowOk) {
+                // IMP2-1.9 (item 5) — value materialization can throw on a
+                // pathological/junk row (e.g. a section header in the middle of
+                // the data). Degrade to a row error instead of aborting the run.
+                try {
+                    $resolvedValues = $this->materialiseValues($cells, $columnMapping, $tenant);
+                } catch (Throwable $exception) {
+                    $rowOk = false;
+                    $errors[] = new ValidationError(
+                        rowNumber: $rowNumber,
+                        sku: $sku,
+                        errorType: ImportErrorType::InvalidValue,
+                        level: ImportLogLevel::Error,
+                        message: 'Row could not be parsed: '.$exception->getMessage(),
+                        columnValue: $this->rawRowSnippet($cells),
+                    );
+                }
+            }
             $matchKey = $rowOk ? $this->matchKey($session, $cells, $columnMapping, $resolvedValues, $rowNumber) : '';
             if ('' !== $matchKey) {
                 $matchKeys[] = $matchKey;
@@ -648,6 +919,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                 'rowOk' => $rowOk,
                 'resolvedValues' => $resolvedValues,
                 'matchKey' => $matchKey,
+                'duplicateInFile' => $duplicateInFile,
             ];
         }
 
@@ -666,6 +938,12 @@ final class ImportRunHandler extends AbstractBatchHandler
         // exist (tenant-scoped) so the creator can drop dangling ids with a
         // row warning — one query per chunk, mirroring the category prefetch.
         $existingAssetIds = $this->resolveChunkAssets($prepared, $attributesByCode, $tenant);
+        // IMP2-1.9 (item 2): set-based identifier collision pre-check BEFORE the
+        // flush — a value already used in the catalog (vs-DB) blocks the row as
+        // an Error; a value duplicated earlier in the file is a skip (D1). This
+        // catches the DB partial-unique-index violation gracefully instead of
+        // letting flush() explode and close the EM.
+        $this->precheckIdentifiers($prepared, $attributesByCode, $existingByKey, $session, $tenant, $identifierSeenInFile);
         /** @var list<array{product: CatalogObject, codes: list<string>, append: bool}> $pendingCategoryOps */
         $pendingCategoryOps = [];
 
@@ -741,6 +1019,10 @@ final class ImportRunHandler extends AbstractBatchHandler
                             message: \sprintf('No object matches key "%s" — row skipped (mode UPDATE).', $row['matchKey']),
                         );
                 }
+            } elseif ($row['duplicateInFile']) {
+                // IMP2-1.9 (D1) — duplicate of an earlier file row: skip, do not
+                // count as an error (the Warning is still logged below).
+                $session->incrementSkipped();
             } else {
                 $session->incrementError();
             }
@@ -787,8 +1069,8 @@ final class ImportRunHandler extends AbstractBatchHandler
      * {@see CatalogObject} once. Unresolved codes are dropped (the validator
      * emitted the per-code CategoryNotFound warning).
      *
-     * @param list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string}> $prepared
-     * @param array<string, string>                                                                                                                                                                 $columnMapping
+     * @param list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string, duplicateInFile: bool}> $prepared
+     * @param array<string, string>                                                                                                                                                                                        $columnMapping
      *
      * @return array<string, CatalogObject>
      */
@@ -821,8 +1103,8 @@ final class ImportRunHandler extends AbstractBatchHandler
      * tenant as a lower-cased lookup set. One query per chunk; the creator uses
      * the set to drop dangling ids with a row warning.
      *
-     * @param list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string}> $prepared
-     * @param array<string, Attribute>                                                                                                                                                              $attributesByCode
+     * @param list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string, duplicateInFile: bool}> $prepared
+     * @param array<string, Attribute>                                                                                                                                                                                     $attributesByCode
      *
      * @return array<string, true>
      */

--- a/apps/api/src/Import/Application/Service/ImportValidationService.php
+++ b/apps/api/src/Import/Application/Service/ImportValidationService.php
@@ -85,10 +85,17 @@ final readonly class ImportValidationService
                 $rowErrors,
                 static fn (ValidationError $error): bool => $error->isRowBlocking(),
             ));
-            if ([] === $blockingErrors) {
-                ++$successCount;
-            } else {
+            // IMP2-1.9 — mirror the run loop: a blocking Error counts as a row
+            // error; a Warning-level DuplicateSkuInFile is a skip (D1) — neither
+            // imported nor an error; everything else previews as a clean import.
+            $duplicateInFile = [] !== array_filter(
+                $rowErrors,
+                static fn (ValidationError $error): bool => ImportErrorType::DuplicateSkuInFile === $error->errorType,
+            );
+            if ([] !== $blockingErrors) {
                 ++$errorCount;
+            } elseif (!$duplicateInFile) {
+                ++$successCount;
             }
             // Surface every finding in the report — including non-blocking
             // warnings (e.g. CategoryNotFound) — so the operator sees

--- a/apps/api/src/Import/Domain/ValueObject/ValidationError.php
+++ b/apps/api/src/Import/Domain/ValueObject/ValidationError.php
@@ -25,13 +25,19 @@ final readonly class ValidationError
     }
 
     /**
-     * Returns false for findings that the operator wants surfaced in
-     * the report but should NOT skip the row (e.g. a category that the
-     * lookup did not resolve — the product still imports, just without
-     * the assignment).
+     * IMP2-1.9 — blocking is driven by SEVERITY, not by error type (ADR
+     * IMP2-1.1): only an {@see ImportLogLevel::Error} skips the row. Warnings
+     * and infos are surfaced in the report but never block — so a re-import of
+     * one's own export into a non-empty catalog (DuplicateSkuInFile /
+     * DuplicateSkuInDb in CREATE mode, CategoryNotFound, …) degrades to
+     * skip-with-warning instead of rejecting every row.
+     *
+     * Each emitter is responsible for choosing the right level:
+     * MissingRequired / InvalidType / InvalidValue → Error; the duplicate and
+     * lookup-miss findings → Warning.
      */
     public function isRowBlocking(): bool
     {
-        return ImportErrorType::CategoryNotFound !== $this->errorType;
+        return ImportLogLevel::Error === $this->level;
     }
 }

--- a/apps/api/tests/Api/Import/StartImportApiTest.php
+++ b/apps/api/tests/Api/Import/StartImportApiTest.php
@@ -516,6 +516,157 @@ final class StartImportApiTest extends CatalogApiTestCase
         }
     }
 
+    #[Test]
+    public function mixedRowsFinishPartialWithPerRowIsolation(): void
+    {
+        // IMP2-1.9 (AC) — 10 rows, 2 bad (missing SKU + bad number type):
+        // session ends partial, success=8, error=2, exactly 2 Error logs.
+        $this->seedAttributes();
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $productOt = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($productOt instanceof ObjectType);
+        $qty = new Attribute('qty', ['en' => 'Qty'], AttributeType::Number);
+        $em->persist($qty);
+        $em->persist(new ObjectTypeAttribute($productOt, $qty, false, 3));
+        $em->flush();
+
+        $rows = ['sku;name;qty'];
+        for ($i = 1; $i <= 8; ++$i) {
+            $rows[] = \sprintf('MIX-%d;Product %d;%d', $i, $i, $i);
+        }
+        $rows[] = ';No sku;5';           // missing SKU → Error
+        $rows[] = 'MIX-BAD;Bad qty;abc'; // non-numeric → InvalidType Error
+        $csvPath = $this->writeCsv(implode("\n", $rows)."\n", 'pim-mix-');
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name', 'qty' => 'qty'], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'mix.csv', 'text/csv', null, true)],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertSame('partial', $body['status']);
+            self::assertSame(8, $body['success_count']);
+            self::assertSame(2, $body['error_count']);
+
+            $errorLogs = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM import_logs WHERE level='error' AND import_session_id = :id",
+                ['id' => $body['id']],
+            );
+            self::assertSame(2, (int) (\is_scalar($errorLogs) ? $errorLogs : 0));
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function duplicateSkuInFileSkipsWithoutError(): void
+    {
+        // IMP2-1.9 (AC D1) — the first occurrence imports; later duplicates are
+        // skipped with a Warning, never an error, and never explode the DB.
+        $this->seedAttributes();
+        $em = $this->em();
+
+        $csvPath = $this->writeCsv("sku;name\nDUP-1;First\nDUP-2;Second\nDUP-1;Again\n", 'pim-dup-');
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'dup.csv', 'text/csv', null, true)],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertSame('success', $body['status'], 'a pure skip leaves no errors → success');
+            self::assertSame(2, $body['success_count']);
+            self::assertSame(0, $body['error_count']);
+            self::assertSame(1, $body['skipped_count']);
+
+            $warnings = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM import_logs WHERE level='warning' AND error_type='duplicate_sku_in_file' AND import_session_id = :id",
+                ['id' => $body['id']],
+            );
+            self::assertSame(1, (int) (\is_scalar($warnings) ? $warnings : 0));
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function identifierDuplicateVsDbBlocksRowGracefully(): void
+    {
+        // IMP2-1.9 (AC item 2) — an identifier value already used in the catalog
+        // is caught by the set pre-check: the row errors, the session ends
+        // partial, and the DB partial-unique index never throws.
+        $this->seedAttributes();
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $productOt = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($productOt instanceof ObjectType);
+
+        $ean = new Attribute('ean', ['en' => 'EAN'], AttributeType::Identifier);
+        $em->persist($ean);
+        $em->persist(new ObjectTypeAttribute($productOt, $ean, false, 3));
+        $existing = new CatalogObject($productOt, 'EXIST-1');
+        $em->persist($existing);
+        $em->flush();
+        $em->persist(new \App\Catalog\Domain\Entity\ObjectValue($existing, $ean, ['value' => '111'], \App\Catalog\Domain\Provenance::Import));
+        $em->flush();
+
+        $csvPath = $this->writeCsv("sku;name;ean\nNEW-1;Collides;111\nNEW-2;Fresh;222\n", 'pim-ident-');
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name', 'ean' => 'ean'], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'ident.csv', 'text/csv', null, true)],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertSame('partial', $body['status']);
+            self::assertSame(1, $body['success_count'], 'only the non-colliding row imports');
+            self::assertSame(1, $body['error_count']);
+
+            $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+            \assert($tenant instanceof Tenant);
+            self::getContainer()->get(TenantContext::class)->set($tenant);
+            $repo = self::getContainer()->get(CatalogObjectRepositoryInterface::class);
+            self::assertNotNull($repo->findByCode('NEW-2', ObjectKind::Product, $tenant), 'fresh identifier imports');
+            self::assertNull($repo->findByCode('NEW-1', ObjectKind::Product, $tenant), 'colliding identifier row is not created');
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
     private function writeCsv(string $contents, string $prefix): string
     {
         $path = tempnam(sys_get_temp_dir(), $prefix);

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -72,9 +72,11 @@ final class ImportValidationServiceTest extends TestCase
             // IMP2-1.3 (#1465): the in-DB duplicate check moved to the run
             // loop (ObjectResolver + ImportMode) — EXISTING-1 now validates
             // clean here; mode buckets surface in the dry-run rework (#1492).
-            // OK-1, EXISTING-1 and the first DUP-1 pass; the rest error out.
+            // IMP2-1.9: OK-1, EXISTING-1 and the first DUP-1 import (3); the
+            // empty-SKU + bad-price rows error (2); the second DUP-1 is a
+            // non-blocking skip (D1) — neither success nor error.
             self::assertSame(3, $result->successCount);
-            self::assertSame(3, $result->errorCount);
+            self::assertSame(2, $result->errorCount);
 
             $errorTypes = array_map(static fn ($e): string => $e->errorType->value, $result->errors);
             self::assertNotContains(ImportErrorType::DuplicateSkuInDb->value, $errorTypes);

--- a/apps/api/tests/Unit/Import/ValidationErrorTest.php
+++ b/apps/api/tests/Unit/Import/ValidationErrorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Domain\Enum\ImportErrorType;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Import\Domain\ValueObject\ValidationError;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * IMP2-1.9 (#1472) — blocking is driven by SEVERITY (level === Error), not by
+ * error type. Locks the full ImportErrorType × ImportLogLevel matrix so a
+ * Warning can never block (the bug that made re-importing one's own export
+ * reject every row).
+ */
+final class ValidationErrorTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{ImportErrorType, ImportLogLevel, bool}>
+     */
+    public static function matrix(): iterable
+    {
+        foreach (ImportErrorType::cases() as $type) {
+            foreach (ImportLogLevel::cases() as $level) {
+                $expected = ImportLogLevel::Error === $level;
+                yield \sprintf('%s × %s', $type->value, $level->value) => [$type, $level, $expected];
+            }
+        }
+    }
+
+    #[Test]
+    #[DataProvider('matrix')]
+    public function blockingFollowsSeverityNotType(ImportErrorType $type, ImportLogLevel $level, bool $expectedBlocking): void
+    {
+        $error = new ValidationError(
+            rowNumber: 1,
+            sku: 'SKU-1',
+            errorType: $type,
+            level: $level,
+            message: 'finding',
+        );
+
+        self::assertSame($expectedBlocking, $error->isRowBlocking());
+    }
+
+    #[Test]
+    public function categoryNotFoundWarningNoLongerBlocks(): void
+    {
+        // Regression: pre-1.9 this was the ONLY non-blocking type; now any
+        // Warning is non-blocking and any Error blocks.
+        $warning = new ValidationError(1, 'S', ImportErrorType::CategoryNotFound, ImportLogLevel::Warning, 'm');
+        $error = new ValidationError(1, 'S', ImportErrorType::CategoryNotFound, ImportLogLevel::Error, 'm');
+
+        self::assertFalse($warning->isRowBlocking());
+        self::assertTrue($error->isRowBlocking(), 'an Error-level finding blocks regardless of its type');
+    }
+}


### PR DESCRIPTION
## Co dowozi (Closes #1472)

Jeden zepsuty wiersz nie kładzie już całego importu, ostrzeżenia ostrzegają zamiast blokować, a sesja z częściowymi błędami kończy się uczciwym `partial`.

### Zakres (AC #1472)
- ✅ **Severity-driven blocking** — `ValidationError::isRowBlocking()` zwraca `true` wyłącznie dla `level === Error` (nie dla typu błędu). Test jednostkowy pokrywa pełną matrycę `ImportErrorType × ImportLogLevel`. Naprawia „re-import własnego eksportu = 0 zmian" (Warning blokował wiersz).
- ✅ **Duplikat SKU w pliku (D1)** — pierwsze wystąpienie importuje się, kolejne = skip + Warning, ZERO wyjątków DB, nie liczy się jako błąd.
- ✅ **Pre-check setowy identifierów** — wartość atrybutu `identifier` już użyta w katalogu (zapytanie zbiorcze per chunk po `value->>'value'` ∧ ObjectType) → wiersz dostaje Error przed flushem; duplikat w pliku → skip (D1). Łapie kolizję przed eksplozją partial-unique-index.
- ✅ **Wiersz sekcji/śmieciowy** — pusty SKU → `MissingRequired` (Error), a wyjątek na materializacji wartości → Error wiersza z surową zawartością w `columnValue`; pętla idzie dalej, nie abortuje.
- ✅ **partial zamiast failed** — sesja z ≥1 zaimportowanym i ≥1 błędem → `markCompleted()` → `Partial`. `markFailed` zarezerwowany dla błędów systemowych.
- ✅ **Recovery po wyjątku flusha** — throw z `flush()` zamyka EntityManager; outer catch resetuje manager przez `ManagerRegistry` i zapisuje wynik na świeżym EM (wcześniej `findById`/`save` na zamkniętym EM rzucał ponownie → sesja wisiała `running`). Błąd połączenia = systemic → `failed`; inny → `partial`.

### Świadome odejście
- **Pełny per-row replay rozbitego chunku (item 3, „pozostałe wiersze batcha zapisane")** — **deferred**. Po wyjątku `flush()` Doctrine zamyka EM; wstrzyknięte `ServiceEntityRepository` cache'ują EM w konstruktorze, więc `resetManager()` nie uzdrawia całego grafu kolaborantów (creator/valueWriter/repos) w trakcie jednego wywołania handlera — to ta sama przebudowa cyklu życia EM, której wymaga pauza/resume (**IMP2-2.3**, explicite poza zakresem). Zamiast tego pre-checki (identifier set + walidacja typów + pusty SKU) eliminują **deterministyczne** przyczyny wyjątku flusha PRZED flushem, więc realny wyjątek flusha = fault systemowy → `failed` (zgodne z negatywnym smoke step 7), a recovery degraduje do `partial` zachowując dane wcześniejszych chunków.

### Testy (zielone lokalnie)
- Unit: `ValidationErrorTest` — matryca 28 kombinacji.
- Api (realny Postgres): `mixedRowsFinishPartialWithPerRowIsolation` (10 wierszy, 2 błędne → partial 8/2 + 2 logi Error), `duplicateSkuInFileSkipsWithoutError` (skip+warning, 0 błędów), `identifierDuplicateVsDbBlocksRowGracefully` (kolizja vs-DB → partial, brak eksplozji).
- Pełna regresja `tests/{Unit,Api,Integration}/Import` → 166 passed.

### Bramki
PHPStan max `--memory-limit=1G` ✅ · Deptrac 0 ✅ · php-cs-fixer ✅ · brak zmian API/UI (Playwright/OpenAPI n/d).

### Smoke
Live-stack `dirty.csv` (pusty SKU + wiersz sekcji + duplikat) na `https://pim.localhost` przed merge — dowód w komentarzu zamknięcia #1472.