### PR TITLE
IMP2-1.10 — test(import): golden pełna matryca CSV+XLSX + pierwsze testy async

### DIFF
--- a/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
+++ b/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
@@ -20,14 +20,18 @@ use App\Export\Domain\Enum\ExportEntityType;
 use App\Export\Domain\Enum\ExportFormat;
 use App\Export\Domain\Enum\ExportSource;
 use App\Export\Domain\Enum\ExportTargetScope;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportSessionStatus;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Uid\Uuid;
 
 use const JSON_THROW_ON_ERROR;
+use const PATHINFO_EXTENSION;
 
 /**
  * IMP2-1.5 (#1467, ADR-0019) — GOLDEN ROUND-TRIP v0: the REAL exporter
@@ -72,8 +76,22 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         'gr_metric' => [AttributeType::Metric, ['value' => 0.75, 'unit' => 'kg']],
     ];
 
+    /**
+     * IMP2-1.10 — the full matrix rides BOTH serialisation formats through the
+     * real export → import engine. Same seeding, same envelope-equality
+     * contract; only the writer/reader (CSV vs PhpSpreadsheet xlsx) differ.
+     *
+     * @return iterable<string, array{ExportFormat}>
+     */
+    public static function formats(): iterable
+    {
+        yield 'csv' => [ExportFormat::Csv];
+        yield 'xlsx' => [ExportFormat::Xlsx];
+    }
+
     #[Test]
-    public function exportedCsvReimportsWithEnvelopeEquality(): void
+    #[DataProvider('formats')]
+    public function exportedFileReimportsWithEnvelopeEquality(ExportFormat $format): void
     {
         $client = $this->authenticatedClient();
         $tenant = $this->tenant();
@@ -162,10 +180,13 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
             array_keys(self::MATRIX),
             ['gr_name', 'gr_name.en', 'gr_chan', 'gr_chan.shopify', 'gr_chan.en.shopify', 'status', 'enabled'],
         );
-        $csv = $this->runProductExport($tenant, $columns, [$productId], ['shopify']);
-        self::assertStringContainsString('GR-001', $csv);
-        self::assertStringContainsString('249.99 PLN', $csv, 'price serialises as "amount CUR"');
-        self::assertStringContainsString('Chan EN shopify', $csv, 'combined locale+channel cell present in export');
+        $file = $this->exportToFile($tenant, $columns, [$productId], $format, ['shopify']);
+        $csv = ExportFormat::Csv === $format ? (string) file_get_contents($file) : '';
+        if (ExportFormat::Csv === $format) {
+            self::assertStringContainsString('GR-001', $csv);
+            self::assertStringContainsString('249.99 PLN', $csv, 'price serialises as "amount CUR"');
+            self::assertStringContainsString('Chan EN shopify', $csv, 'combined locale+channel cell present in export');
+        }
 
         // ── Act 2: real import (UPSERT) of that very file ──
         $mapping = ['sku' => 'sku', 'category' => '__category__'];
@@ -180,14 +201,24 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         $mapping['status'] = '__status__';
         $mapping['enabled'] = '__enabled__';
 
-        $body = $this->postImport($client, $csv, $objectType->getId()->toRfc4122(), $mapping);
+        $body = $this->postImportFile($client, $file, $objectType->getId()->toRfc4122(), $mapping);
+        @unlink($file);
         $sessionId = $body['id'];
         \assert(\is_string($sessionId));
         self::assertSame([], $this->reportRows($client, $sessionId), 'no findings expected');
-        self::assertSame('success', $body['status']);
-        self::assertSame(1, $body['success_count']);
-        self::assertSame(1, $body['updated_count'], 'UPSERT must update, not duplicate');
-        self::assertSame(0, $body['error_count']);
+
+        // Read the outcome from the persisted session, not the response body:
+        // xlsx routes through the async path (the controller can't pre-count
+        // xlsx rows), and although the sync transport completes it inline, the
+        // response carries the pre-dispatch `running` snapshot. The DB row is
+        // the contract for both formats.
+        $em->clear();
+        $session = $em->find(ImportSession::class, Uuid::fromString($sessionId));
+        \assert($session instanceof ImportSession);
+        self::assertSame(ImportSessionStatus::Success, $session->getStatus());
+        self::assertSame(1, $session->getSuccessCount());
+        self::assertSame(1, $session->getUpdatedCount(), 'UPSERT must update, not duplicate');
+        self::assertSame(0, $session->getErrorCount());
 
         // Same object — no duplicate row was created.
         $em->clear();
@@ -230,16 +261,20 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         self::assertFalse($reloaded->isEnabled());
 
         // ── Act 3: edit one cell → re-import updates exactly that value ──
-        $edited = str_replace('Uchwyt globalny', 'Uchwyt v2', $csv);
-        self::assertNotSame($csv, $edited);
-        $body2 = $this->postImport($client, $edited, $objectType->getId()->toRfc4122(), $mapping);
-        self::assertSame(1, $body2['updated_count']);
+        // CSV-only — the act edits the serialised text directly; the xlsx run
+        // already proved the binary round-trip above via envelope equality.
+        if (ExportFormat::Csv === $format) {
+            $edited = str_replace('Uchwyt globalny', 'Uchwyt v2', $csv);
+            self::assertNotSame($csv, $edited);
+            $body2 = $this->postImport($client, $edited, $objectType->getId()->toRfc4122(), $mapping);
+            self::assertSame(1, $body2['updated_count']);
 
-        $after = $this->envelopesOf($productId);
-        self::assertSame('Uchwyt v2', $after['gr_name||']['value'] ?? null);
-        unset($expected['gr_name||'], $after['gr_name||']);
-        foreach ($expected as $key => $envelope) {
-            self::assertEnvelopeEquals($envelope, $after[$key], $key.' (po edycji innej komórki)');
+            $after = $this->envelopesOf($productId);
+            self::assertSame('Uchwyt v2', $after['gr_name||']['value'] ?? null);
+            unset($expected['gr_name||'], $after['gr_name||']);
+            foreach ($expected as $key => $envelope) {
+                self::assertEnvelopeEquals($envelope, $after[$key], $key.' (po edycji innej komórki)');
+            }
         }
     }
 
@@ -489,6 +524,34 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         self::assertSame(['option_code' => 'red'], json_decode($redOption, true, 512, JSON_THROW_ON_ERROR));
     }
 
+    #[Test]
+    public function everyAttributeTypeHasGoldenCoverage(): void
+    {
+        // IMP2-1.10 (AC item 4) — every AttributeType is exercised by the
+        // golden suite, and the coverage is DERIVED (not a 17×4 cartesian):
+        //  - 14 value types ride the envelope matrix in both CSV + xlsx, each
+        //    with only the scopes its isLocalizable/isScopable flags permit
+        //    (gr_name adds locale rows, gr_chan adds channel + locale+channel);
+        //  - asset rides the 2-image gallery round-trip;
+        //  - relation + reference write object_relations (NOT object_values),
+        //    so they ride the relation round-trip instead of the envelope diff.
+        // A new AttributeType added without coverage flips this red.
+        $matrixTypes = array_map(static fn (array $entry): AttributeType => $entry[0], array_values(self::MATRIX));
+        $covered = array_merge($matrixTypes, [
+            AttributeType::Asset,
+            AttributeType::Relation,
+            AttributeType::Reference,
+        ]);
+
+        foreach (AttributeType::cases() as $type) {
+            self::assertContains(
+                $type,
+                $covered,
+                \sprintf('AttributeType "%s" has no golden round-trip coverage.', $type->value),
+            );
+        }
+    }
+
     /**
      * @param array<string, mixed> $expected
      * @param array<string, mixed> $actual
@@ -614,6 +677,80 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         } finally {
             @unlink($path);
         }
+    }
+
+    /**
+     * IMP2-1.10 — export the real file in the given format to a temp path with
+     * the matching extension. The caller owns the file (the format matrix needs
+     * the binary xlsx on disk for the import reader, not a string).
+     *
+     * @param list<string> $columns
+     * @param list<Uuid>   $ids
+     * @param list<string> $channels
+     */
+    private function exportToFile(Tenant $tenant, array $columns, array $ids, ExportFormat $format, array $channels = [], bool $includeVariants = true): string
+    {
+        $session = new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::CentralTab,
+            format: $format,
+            targetScope: ExportTargetScope::Selected,
+            selectedColumns: $columns,
+            entityType: ExportEntityType::Product,
+            selectedObjectIds: array_map(static fn (Uuid $id): string => $id->toRfc4122(), $ids),
+            channels: $channels,
+            includeVariants: $includeVariants,
+        );
+        $session->assignTenant($tenant);
+
+        $extension = ExportFormat::Xlsx === $format ? 'xlsx' : 'csv';
+        $path = tempnam(sys_get_temp_dir(), 'golden-').'.'.$extension;
+        $runner = self::getContainer()->get(SyncExportRunner::class);
+        $runner->runToFile($session, $path);
+
+        return $path;
+    }
+
+    /**
+     * IMP2-1.10 — import a previously-exported file (CSV or xlsx) by path. The
+     * reader picks the parser from the extension, so the same matrix rides both
+     * formats through the real engine.
+     *
+     * @param array<string, string> $mapping
+     *
+     * @return array<string, mixed>
+     */
+    private function postImportFile(
+        \ApiPlatform\Symfony\Bundle\Test\Client $client,
+        string $path,
+        string $objectTypeId,
+        array $mapping,
+    ): array {
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        $mime = 'xlsx' === $extension
+            ? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            : 'text/csv';
+
+        $client->request('POST', '/api/import-sessions', [
+            'extra' => [
+                'parameters' => [
+                    'target_object_type_id' => $objectTypeId,
+                    'mapping' => json_encode($mapping, JSON_THROW_ON_ERROR),
+                    'mode' => 'UPSERT',
+                ],
+                'files' => [
+                    'file' => new UploadedFile($path, 'golden.'.$extension, $mime, null, true),
+                ],
+            ],
+        ]);
+        self::assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        \assert(null !== $response);
+        $content = $response->getContent();
+        /** @var array<string, mixed> $body */
+        $body = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return $body;
     }
 
     /** @return list<string> */

--- a/apps/api/tests/Api/Import/ImportRunHandlerAsyncTest.php
+++ b/apps/api/tests/Api/Import/ImportRunHandlerAsyncTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Import\Application\Handler\ImportRunHandler;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportSessionStatus;
+use App\Import\Domain\Message\ImportRunMessage;
+use App\Shared\Application\BulkOperationLock;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP2-1.10 (#1473) — first tests for the async import path. The dev/test
+ * MESSENGER_IMPORT_TRANSPORT_DSN is `sync://`, so a routed ImportRunMessage
+ * still executes inline; these tests assert the ROUTING (the message targets
+ * the dedicated `import` transport), the end-to-end handler outcome for a
+ * file over the 50-row sync threshold, re-delivery idempotency, and the
+ * recoverable-retry contract on the per-tenant bulk lock.
+ */
+final class ImportRunHandlerAsyncTest extends CatalogApiTestCase
+{
+    private const int LARGE = 60; // > StartImportController::SYNC_THRESHOLD_ROWS
+
+    #[Test]
+    public function importRunMessageRoutesToDedicatedTransport(): void
+    {
+        // Audit MEDIUM-007 posture: the message must target an explicit
+        // transport (the dedicated `import` queue), never implicit default.
+        $locator = self::getContainer()->get('messenger.senders_locator');
+        self::assertInstanceOf(SendersLocatorInterface::class, $locator);
+
+        $message = new ReflectionClass(ImportRunMessage::class)->newInstanceWithoutConstructor();
+        $aliases = [];
+        foreach ($locator->getSenders(new Envelope($message)) as $alias => $_sender) {
+            $aliases[] = $alias;
+        }
+
+        self::assertContains('import', $aliases, 'ImportRunMessage must route to the dedicated import transport.');
+    }
+
+    #[Test]
+    public function largeFileImportsEndToEndViaAsyncPath(): void
+    {
+        // > 50 data rows → the controller routes through ImportRunMessage
+        // (the xlsx/large path); the sync transport completes it inline.
+        $this->seedSkuName();
+        $em = $this->em();
+
+        $rows = ['sku;name'];
+        for ($i = 1; $i <= self::LARGE; ++$i) {
+            $rows[] = \sprintf('ASYNC-%d;Product %d', $i, $i);
+        }
+        $sessionId = $this->upload(implode("\n", $rows)."\n");
+
+        $em->clear();
+        $session = $em->find(ImportSession::class, Uuid::fromString($sessionId));
+        \assert($session instanceof ImportSession);
+        self::assertSame(ImportSessionStatus::Success, $session->getStatus(), 'async-routed import completes');
+        self::assertSame(self::LARGE, $session->getSuccessCount());
+        self::assertSame(self::LARGE, $session->getTotalRows());
+
+        $persisted = $em->getConnection()->fetchOne("SELECT COUNT(*) FROM objects WHERE code LIKE 'ASYNC-%'");
+        self::assertSame(self::LARGE, (int) (\is_scalar($persisted) ? $persisted : 0));
+    }
+
+    #[Test]
+    public function reDeliveryIsIdempotentUnderUpsert(): void
+    {
+        // A re-delivered import (UPSERT) must not duplicate objects — the
+        // resilience contract the worker relies on after a crash/redeliver
+        // (full offset checkpoint is IMP2-2.3; UPSERT idempotency holds now).
+        $this->seedSkuName();
+        $em = $this->em();
+
+        $rows = ['sku;name'];
+        for ($i = 1; $i <= self::LARGE; ++$i) {
+            $rows[] = \sprintf('IDEM-%d;Product %d', $i, $i);
+        }
+        $csv = implode("\n", $rows)."\n";
+
+        $this->upload($csv);
+        $secondId = $this->upload($csv);
+
+        $em->clear();
+        $count = $em->getConnection()->fetchOne("SELECT COUNT(*) FROM objects WHERE code LIKE 'IDEM-%'");
+        self::assertSame(self::LARGE, (int) (\is_scalar($count) ? $count : 0), 're-delivery must not duplicate objects');
+
+        $second = $em->find(ImportSession::class, Uuid::fromString($secondId));
+        \assert($second instanceof ImportSession);
+        self::assertSame(self::LARGE, $second->getUpdatedCount(), 'second run updates every row');
+    }
+
+    #[Test]
+    public function bulkLockCollisionThrowsRecoverable(): void
+    {
+        // PROD-05 — a second concurrent import for the same tenant must surface
+        // as a recoverable Messenger failure (retry with backoff), never a
+        // dead-letter and never a corrupted session.
+        $this->seedSkuName();
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $productOt = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($productOt instanceof ObjectType);
+
+        $session = new ImportSession(
+            userId: Uuid::v7(),
+            targetObjectType: $productOt,
+            fileName: 'locked.csv',
+            fileSizeBytes: 64,
+        );
+        $session->assignTenant($tenant);
+        $session->setColumnMapping(['sku' => 'sku', 'name' => 'name']);
+        $em->persist($session);
+        $em->flush();
+        $sessionId = $session->getId();
+
+        // Hold the per-tenant bulk lock so the handler cannot acquire it.
+        $lock = self::getContainer()->get(BulkOperationLock::class)->acquire($tenant);
+        self::assertNotNull($lock, 'precondition: the test holds the bulk lock');
+
+        try {
+            $handler = self::getContainer()->get(ImportRunHandler::class);
+            $this->expectException(RecoverableMessageHandlingException::class);
+            $handler(new ImportRunMessage($sessionId, $tenant->getId()));
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function upload(string $csv): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pim-async-').'.csv';
+        file_put_contents($path, $csv);
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                        'mode' => 'UPSERT',
+                    ],
+                    'files' => ['file' => new UploadedFile($path, 'async.csv', 'text/csv', null, true)],
+                ],
+            ]);
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            $id = $body['id'];
+            \assert(\is_string($id));
+
+            return $id;
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    private function seedSkuName(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $product = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist(new ObjectTypeAttribute($product, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($product, $name, false, 2));
+        $em->flush();
+    }
+}


### PR DESCRIPTION
## Co dowozi (Closes #1473)

Siatka bezpieczeństwa Fali B: round-trip eksport→import pilnowany w CI dla obu formatów + pierwsze testy ścieżki async (dziś 0).

### Zakres (AC #1473)
- ✅ **Golden CSV+XLSX** — główny golden sparametryzowany nad `ExportFormat` (data provider): pełna matryca 17 typów × realne scope (z `isLocalizable`/`isScopable`, NIE kartezjan) + kategorie + status/enabled + warianty + relacje + galerie przechodzi przez realny `SyncExportRunner` → plik → import → równość envelope. XLSX dzieli ten sam silnik (różni się tylko writer/reader). Edit-cell act CSV-only (edytuje serializowany tekst).
- ✅ **Asercja per-typ** — guard `everyAttributeTypeHasGoldenCoverage`: każdy z 17 `AttributeType` ma pokrycie (14 w matrycy envelope, asset w galerii, relation/reference w `object_relations`); nowy typ bez pokrycia → czerwony. Komentarz wyprowadza pokrycie (nie kartezjan).
- ✅ **Testy async ImportRunHandler (4, pierwsze w repo)** — `ImportRunHandlerAsyncTest`: (a) `ImportRunMessage` routuje do dedykowanego transportu `import` (senders_locator), (b) plik >50 wierszy importuje się end-to-end ścieżką async, (c) re-delivery idempotentne pod UPSERT (brak duplikatów), (d) kolizja bulk-locka → `RecoverableMessageHandlingException`.
- ✅ **Izolacja błędu wiersza** — pokryta w IMP2-1.9 (`mixedRowsFinishPartialWithPerRowIsolation`, partial + spójne liczniki).
- ✅ **Fixtures syntetyczne** — zero plików z `Zrodla/Importy przykładowe` (CSV generowane w teście).
- ✅ **Determinizm** — sortowanie wierszy/kolumn + NULLS FIRST w `envelopesOf`, daty w ISO/UTC.

### Świadome odejście
- **Re-delivery z checkpointu offsetu (AC 3c „wznawia od checkpointu bez duplikatów")** — testowane jako **idempotencja UPSERT** (re-delivery całego importu nie duplikuje obiektów), bo pełny checkpoint offsetu jest explicite **IMP2-2.3** (#1479) i nie istnieje jeszcze jako kontrakt. Idempotencja UPSERT to gwarancja jaką worker ma DZIŚ.

### Dowód siatki (AC step 5, manualny)
Zmutowano `ValueSerializer::MULTI_VALUE_GLUE` `|`→`;` → golden zfailował (2 failures: multiselect drift w CSV i XLSX) → revert. Net łapie dryf serializera.

### Testy
`tests/{Api,Unit,Integration}/Import` → **172 passed**. Golden 5 case'ów (2× format matrix + fan-out + variant_axes + variants/relations/gallery + GenerateVariants + per-type guard), async 4.

### Bramki
PHPStan max `--memory-limit=1G` ✅ (też pliki testowe) · Deptrac 0 ✅ · cs-fixer ✅ · bez zmian API/UI (Playwright/OpenAPI n/d).

### Smoke
Live-stack round-trip demo (eksport → edycja 3 wartości + nowy wiersz + pusta komórka → import) na `https://pim.localhost` przed merge — dowód w komentarzu zamknięcia #1473.