### PR TITLE
IMP2-1.11 — chore(import): higiena backlogu importów

### DIFF
--- a/Project Plan/UI/feature-imports.md
+++ b/Project Plan/UI/feature-imports.md
@@ -1,5 +1,10 @@
 # Feature — Import produktów (CSV / Excel + zdjęcia)
 
+> ## ⚠️ SUPERSEDED (2026-06-12)
+> Silnik importu jest **przebudowywany** wg [`feature-imports-v2.md`](feature-imports-v2.md) (epik IMP2, #1499).
+> Sekcje silnika tego dokumentu (IMP-01..IMP-15) są **historyczne** — **nie implementować wg tej wersji**.
+> Aktualny kontrakt silnika (tryby CREATE/UPDATE/UPSERT, gramatyka kolumn `code.locale.channel`, envelope JSONB, warianty/relacje/galerie, izolacja błędów per wiersz, golden round-trip CSV+XLSX) opisuje `feature-imports-v2.md` i jest realizowany w ticketach IMP2-1.x. Mapa „stary ticket → następca IMP2-*" w komentarzu zbiorczym epika #1499.
+
 ## Status: 🟢 zaimplementowane (epik 0.13 / UI-09 — IMP-01..IMP-15 merged 2026-05-07)
 
 > **Część epiku 04 Publikacje** — sub-tab "Imports". Standalone dokument, bo feature jest na tyle obszerny, że zasługuje na własną iterację designu.


### PR DESCRIPTION
## Co dowozi (Closes #1474)

Porządek w backlogu importów: zamknięcie duplikatów i rzeczy zrobionych, sprostowanie fałszywych claimów, banner superseded na starym planie.

### Zmiana w repo
- ✅ **Banner SUPERSEDED** w `Project Plan/UI/feature-imports.md` (góra pliku) → link do `feature-imports-v2.md` + #1499; sekcje IMP-01..15 oznaczone jako historyczne.
- ℹ️ **Docblock `ImportMode.php`** — JUŻ poprawny (IMP2-1.3 #1465 usunął fałszywe „worker today always upserts"; opis odzwierciedla CREATE/UPDATE/UPSERT + migrację legacy). Bez zmiany kodu.

### Operacje na issue (poza PR, w trackerze)
- **#602/#603/#604/#605** → zamknięte `duplicate` (link do #598/#599/#600/#601 + mapa IMP2).
- **#599 (IMP-17 multiselect)** → zamknięte z dowodem: PR #1167 + `ImportObjectCreator::multiSelectPayload()` + live smoke (`eco|new` → `{"option_codes":["eco","new"]}`). Walidacja option_codes → IMP2-1.4.
- **#601 (IMP-19 multi-locale)** → zamknięte z dowodem (suffix `.locale` od #1130/#1167, gramatyka domknięta IMP2-1.6, golden round-trip `gr_name.en`).
- **#600 (IMP-18 media URL)** → komentarz-mapping do IMP2-1.12 (pozostaje OPEN).
- **#598 (IMP-16)** → już zamknięte przez IMP2-1.8 z dowodem.
- **#1130** → komentarz-sprostowanie (zamknięcie było na poziomie dry-run; realny round-trip dostarcza golden IMP2-1.5/1.10).
- **Mapa backlogu** → komentarz zbiorczy na #1499.

Efekt: OPEN tickety ze starego kompletu IMP-16..19 spadły z 8 do 1 (#600, czeka na IMP2-1.12).

### DoD
Zmiana ograniczona do dokumentacji (brak nowej logiki → brak testów). PHPStan/cs-fixer n/d dla .md. Closure'y z dowodem (CLOSED MEANS CLOSED).