### PR TITLE
IMP2-1.12 — feat(import,asset): pobieranie zdjęć z URL-i (media część 1)

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -112,6 +112,11 @@ framework:
             # on the same handler from the controller.
             App\Import\Domain\Message\ImportRunMessage: import
 
+            # IMP2-1.12 (#1475). Image-download batches buffered by the import
+            # run and dispatched after the row phase. Same dedicated `import`
+            # queue so media never starves UI-adjacent async jobs.
+            App\Import\Domain\Message\ImageDownloadMessage: import
+
             # Imports MVP (#447). pgBackRest snapshot can take 5-30
             # minutes — handler runs out-of-band so `POST /api/backups`
             # returns 202 immediately and the wizard polls

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -229,6 +229,20 @@ services:
         arguments:
             $importsStorage: '@imports.storage'
 
+    # IMP2-1.12 — SSRF-safe HTTP client for image downloads. Wraps the default
+    # client in Symfony's NoPrivateNetworkHttpClient, which validates the
+    # ACTUALLY-connected peer IP on every progress tick AND every redirect hop
+    # (closing the DNS-rebinding TOCTOU + redirect-to-private gaps that a
+    # one-shot pre-resolution cannot). SsrfGuard stays as a cheap early reject.
+    import.ssrf_safe_http_client:
+        class: Symfony\Component\HttpClient\NoPrivateNetworkHttpClient
+        arguments:
+            - '@http_client'
+
+    App\Import\Application\Handler\ImageDownloadHandler:
+        arguments:
+            $httpClient: '@import.ssrf_safe_http_client'
+
     # EXP-06 (#585) — async export worker. Same named-storage binding so
     # the handler can write the generated XLSX/CSV to MinIO under
     # `<tenant_id>/<session_id>.<format>` (PRD §11.1).

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -422,6 +422,18 @@ parameters:
             - App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface
             # IMP2-1.8 galleries — per-chunk asset existence prefetch
             - App\Asset\Domain\Repository\AssetRepositoryInterface
+        # IMP2-1.12 media — the download handler writes the {asset_id} envelope
+        # + links assets. Asset INGEST is clean via Asset\Contracts; the value
+        # write reuses the same Catalog-domain touchpoints as ImportRunHandler.
+        App\Import\Application\Handler\ImageDownloadHandler:
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectValue
+            - App\Catalog\Domain\Provenance
+            - App\Catalog\Domain\Repository\AttributeRepositoryInterface
+            - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectValueRepositoryInterface
+            - App\Asset\Domain\Repository\AssetRepositoryInterface
         # IMP2-1.4 (#1466) writer touchpoint
         App\Import\Application\Service\CreatedImportObject:
             - App\Catalog\Domain\Entity\CatalogObject

--- a/apps/api/migrations/Version20260614120000.php
+++ b/apps/api/migrations/Version20260614120000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * IMP2-1.12 (#1475) — media-from-URL completion gating.
+ *
+ * Adds the two counters the import run needs to defer finalization until
+ * every dispatched image-download batch has finished: `pending_image_batches`
+ * (decremented by each media handler) and `row_phase_complete` (set once the
+ * row-write phase dispatched its last batch). The session only transitions to
+ * its terminal state when the row phase is done AND no batch is pending.
+ */
+final class Version20260614120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'IMP2-1.12: import_sessions media completion gating (pending_image_batches, row_phase_complete)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import_sessions ADD pending_image_batches INT NOT NULL DEFAULT 0');
+        $this->addSql('ALTER TABLE import_sessions ADD row_phase_complete BOOLEAN NOT NULL DEFAULT false');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import_sessions DROP COLUMN pending_image_batches');
+        $this->addSql('ALTER TABLE import_sessions DROP COLUMN row_phase_complete');
+    }
+}

--- a/apps/api/src/Asset/Application/AssetIngestor.php
+++ b/apps/api/src/Asset/Application/AssetIngestor.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Application;
+
+use App\Asset\Application\Exception\DuplicateAssetException;
+use App\Asset\Contracts\AssetIngestorInterface;
+use App\Asset\Contracts\AssetIngestResult;
+use App\Asset\Contracts\Exception\UnsupportedMediaFormatException;
+use App\Asset\Domain\Repository\AssetRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\File\File;
+
+use const PATHINFO_FILENAME;
+
+/**
+ * IMP2-1.12 — default {@see AssetIngestorInterface}: magic-byte validation
+ * (jpg/png/webp only, content sniff — never trusts the source's declared
+ * type), content-hash dedup, and storage via {@see AssetUploader} (which
+ * owns the bucket write + Asset row + catalog mirror + thumbnail dispatch).
+ *
+ * Dedup is checked up front so a repeated URL returns `reused=true` without
+ * touching the bucket; the DuplicateAssetException catch covers the race
+ * where two concurrent ingests hash-collide between the pre-check and the
+ * uploader's own guard.
+ */
+final readonly class AssetIngestor implements AssetIngestorInterface
+{
+    /** Accepted image magic numbers → canonical extension. */
+    private const string EXT_JPEG = 'jpg';
+    private const string EXT_PNG = 'png';
+    private const string EXT_WEBP = 'webp';
+
+    public function __construct(
+        private AssetUploader $uploader,
+        private AssetRepositoryInterface $assets,
+        private TenantContext $tenantContext,
+    ) {
+    }
+
+    public function ingest(string $absolutePath, string $originalFilename): AssetIngestResult
+    {
+        $extension = $this->sniffExtension($absolutePath, $originalFilename);
+
+        $tenant = $this->tenantContext->get();
+        if (null === $tenant) {
+            throw new RuntimeException('AssetIngestor requires an active TenantContext.');
+        }
+
+        $hash = hash_file('sha256', $absolutePath);
+        if (false === $hash) {
+            throw new RuntimeException(\sprintf('Failed to hash media file "%s".', $absolutePath));
+        }
+        $existing = $this->assets->findByContentHash($hash, $tenant);
+        if (null !== $existing) {
+            return new AssetIngestResult($existing->getId(), true);
+        }
+
+        // AssetUploader derives the stored filename + extension from the
+        // File path, so stage a copy named after the source with the
+        // sniffed extension (a raw download temp path has neither).
+        $base = pathinfo($originalFilename, PATHINFO_FILENAME);
+        $safeBase = preg_replace('/[^A-Za-z0-9_-]+/', '-', $base) ?? '';
+        $safeBase = trim($safeBase, '-');
+        if ('' === $safeBase) {
+            $safeBase = 'image';
+        }
+        $tmpDir = sys_get_temp_dir().'/pim-ingest-'.bin2hex(random_bytes(8));
+        if (!mkdir($tmpDir) && !is_dir($tmpDir)) {
+            throw new RuntimeException(\sprintf('Failed to create ingest temp dir "%s".', $tmpDir));
+        }
+        $staged = $tmpDir.'/'.$safeBase.'.'.$extension;
+
+        try {
+            if (!copy($absolutePath, $staged)) {
+                throw new RuntimeException(\sprintf('Failed to stage media file "%s".', $absolutePath));
+            }
+            $asset = $this->uploader->upload(new File($staged));
+
+            return new AssetIngestResult($asset->getId(), false);
+        } catch (DuplicateAssetException $exception) {
+            // Race: another ingest stored the same bytes between the
+            // pre-check and the uploader's guard — reuse it.
+            return new AssetIngestResult($exception->existingAssetId, true);
+        } finally {
+            if (is_file($staged)) {
+                @unlink($staged);
+            }
+            if (is_dir($tmpDir)) {
+                @rmdir($tmpDir);
+            }
+        }
+    }
+
+    /**
+     * Content-sniff the accepted image formats by magic bytes. The source's
+     * declared content-type / URL extension is never trusted.
+     *
+     * @throws UnsupportedMediaFormatException
+     */
+    private function sniffExtension(string $absolutePath, string $originalFilename): string
+    {
+        $handle = fopen($absolutePath, 'r');
+        if (false === $handle) {
+            throw new RuntimeException(\sprintf('Failed to open media file "%s".', $absolutePath));
+        }
+        try {
+            $head = fread($handle, 16);
+        } finally {
+            fclose($handle);
+        }
+        if (false === $head || \strlen($head) < 12) {
+            throw UnsupportedMediaFormatException::forFilename($originalFilename);
+        }
+
+        if (str_starts_with($head, "\xFF\xD8\xFF")) {
+            return self::EXT_JPEG;
+        }
+        if (str_starts_with($head, "\x89PNG\r\n\x1A\n")) {
+            return self::EXT_PNG;
+        }
+        if (str_starts_with($head, 'RIFF') && 'WEBP' === substr($head, 8, 4)) {
+            return self::EXT_WEBP;
+        }
+
+        throw UnsupportedMediaFormatException::forFilename($originalFilename);
+    }
+}

--- a/apps/api/src/Asset/Contracts/AssetIngestResult.php
+++ b/apps/api/src/Asset/Contracts/AssetIngestResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Contracts;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * IMP2-1.12 — outcome of ingesting a binary into the asset library via
+ * {@see AssetIngestorInterface}. Carries only the asset id (not the Asset
+ * entity) so consumers in other bounded contexts stay decoupled from
+ * Asset\Domain. `reused` is true when content-hash dedup matched an
+ * existing asset (no new row / bytes written).
+ */
+final readonly class AssetIngestResult
+{
+    public function __construct(
+        public Uuid $assetId,
+        public bool $reused,
+    ) {
+    }
+}

--- a/apps/api/src/Asset/Contracts/AssetIngestorInterface.php
+++ b/apps/api/src/Asset/Contracts/AssetIngestorInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Contracts;
+
+use App\Asset\Contracts\Exception\UnsupportedMediaFormatException;
+
+/**
+ * IMP2-1.12 — the shared "binary → Asset" ingest seam: magic-byte image
+ * validation, SHA-256 content-hash dedup, and storage. The single entry
+ * point every media source funnels through — HTTP download (IMP2-1.12),
+ * ZIP extraction (IMP2-1.13), prefix/suffix URL build (IMP2-3.4) — so the
+ * dedup + storage contract lives in one place. Lives in Asset\Contracts so
+ * the Import context depends only on the port (deptrac: Import → Asset_Contracts),
+ * never on Asset\Application internals.
+ *
+ * The active tenant is taken from the TenantContext (the implementation
+ * stamps storage + the Asset row tenant-scoped).
+ */
+interface AssetIngestorInterface
+{
+    /**
+     * Validate + dedup + store the binary at $absolutePath.
+     *
+     * @param string $absolutePath     local path to the already-fetched bytes
+     * @param string $originalFilename filename to record on the Asset (e.g. URL basename)
+     *
+     * @throws UnsupportedMediaFormatException when the bytes are not jpg/png/webp
+     */
+    public function ingest(string $absolutePath, string $originalFilename): AssetIngestResult;
+}

--- a/apps/api/src/Asset/Contracts/Exception/UnsupportedMediaFormatException.php
+++ b/apps/api/src/Asset/Contracts/Exception/UnsupportedMediaFormatException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Contracts\Exception;
+
+use RuntimeException;
+
+/**
+ * IMP2-1.12 — thrown by {@see \App\Asset\Contracts\AssetIngestorInterface}
+ * when the supplied bytes are not an accepted image (magic-byte sniff:
+ * only jpg/jpeg, png, webp are ingestible by the import media path). The
+ * import handler maps this to an `image_format_unsupported` row finding.
+ */
+final class UnsupportedMediaFormatException extends RuntimeException
+{
+    public static function forFilename(string $filename): self
+    {
+        return new self(\sprintf('File "%s" is not an accepted image (jpg/png/webp expected).', $filename));
+    }
+}

--- a/apps/api/src/Import/Application/Handler/ImageDownloadHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImageDownloadHandler.php
@@ -134,31 +134,43 @@ final class ImageDownloadHandler extends AbstractBatchHandler
         if (!$session instanceof ImportSession) {
             return;
         }
-
-        for ($i = 0; $i < $downloaded; ++$i) {
-            $session->incrementImagesDownloaded();
-        }
-        for ($i = 0; $i < $failed; ++$i) {
-            $session->incrementImagesFailed();
-        }
         foreach ($pendingLogs as $entry) {
             $this->persistLog($session, $entry['job'], $entry['type'], $entry['message'], $entry['value']);
         }
         foreach ($pendingWrites as $write) {
             $this->applyWrite($session, $write['job'], $write['downloaded'], $tenant);
         }
-
-        $session->decrementPendingImageBatches();
-        $finalize = $session->canFinalizeMedia() && !$session->getStatus()->isTerminal();
-        if ($finalize) {
-            $session->markCompleted();
-        }
+        // The session entity is intentionally NOT mutated here — its counters
+        // and the batch gate move via ONE atomic SQL statement below, so
+        // concurrent media batches (multiple `import` consumers) cannot lose an
+        // increment or a decrement and strand the session non-terminal.
         $this->flushAndClear();
 
-        if ($finalize) {
-            $reloaded = $this->sessions->findById($message->importSessionId);
-            if ($reloaded instanceof ImportSession) {
-                $this->progressPublisher->completed($reloaded);
+        $row = $this->entityManager->getConnection()->fetchAssociative(
+            'UPDATE import_sessions'
+            .' SET images_downloaded = images_downloaded + :d,'
+            .'     images_failed = images_failed + :f,'
+            .'     pending_image_batches = GREATEST(0, pending_image_batches - 1)'
+            .' WHERE id = :id'
+            .' RETURNING pending_image_batches, row_phase_complete',
+            [
+                'd' => $downloaded,
+                'f' => $failed,
+                'id' => $message->importSessionId->toRfc4122(),
+            ],
+        );
+        $pendingRaw = \is_array($row) ? $row['pending_image_batches'] : 1;
+        $pending = \is_scalar($pendingRaw) ? (int) $pendingRaw : 1;
+        $rowPhaseDone = \is_array($row) && (bool) $row['row_phase_complete'];
+
+        // The batch that drives the counter to zero AFTER the row phase is done
+        // finalizes the session (success / partial).
+        if (0 === $pending && $rowPhaseDone) {
+            $session = $this->sessions->findById($message->importSessionId);
+            if ($session instanceof ImportSession && !$session->getStatus()->isTerminal()) {
+                $session->markCompleted();
+                $this->sessions->save($session);
+                $this->progressPublisher->completed($session);
             }
         }
     }

--- a/apps/api/src/Import/Application/Handler/ImageDownloadHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImageDownloadHandler.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Handler;
+
+use App\Asset\Contracts\AssetIngestorInterface;
+use App\Asset\Contracts\Exception\UnsupportedMediaFormatException;
+use App\Asset\Domain\Repository\AssetRepositoryInterface;
+use App\Catalog\Contracts\Service\ProductAssetLinker;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Import\Application\Service\ImportProgressPublisher;
+use App\Import\Application\Service\Media\SsrfGuard;
+use App\Import\Domain\Entity\ImportLog;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportErrorType;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Import\Domain\Message\ImageDownloadJob;
+use App\Import\Domain\Message\ImageDownloadMessage;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Shared\Application\AbstractBatchHandler;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Throwable;
+
+use const PHP_URL_PATH;
+
+/**
+ * IMP2-1.12 (#1475) — downloads image URLs from Asset-attribute cells, ingests
+ * them into the asset library (dedup by content-hash via the shared
+ * {@see AssetIngestorInterface}), writes the canonical `{asset_id}` envelope
+ * and links the assets to the product. Runs on the dedicated `import`
+ * transport, one message per buffered chunk batch.
+ *
+ * Hard limits: only http/https + SSRF-guarded hosts ({@see SsrfGuard}), 30s
+ * timeout, ≤3 redirects, ≤10 MB/file (aborted mid-stream), magic-byte format
+ * sniff in the ingestor (jpg/png/webp). A repeated URL in the batch downloads
+ * once. Media failures NEVER fail the session — they raise `image_not_found` /
+ * `image_format_unsupported` row warnings and bump `imagesFailed`.
+ *
+ * Two phases, because {@see AssetIngestorInterface::ingest()} → AssetUploader
+ * may flush + dispatch thumbnail work that CLEARS the shared EntityManager:
+ *   1. DOWNLOAD — fetch + ingest every URL, keeping only primitives (asset id
+ *      strings, counts, pending log/write data). No managed entity is held
+ *      across an ingest call.
+ *   2. APPLY — reload the session + re-attach the tenant on the (possibly
+ *      cleared) EM, then write counters, logs, envelopes, links in one flush.
+ *
+ * Completion: the batch decrements the session's pending-batch counter and,
+ * when it reaches zero AND the row phase is done, finalizes the session.
+ */
+#[AsMessageHandler]
+final class ImageDownloadHandler extends AbstractBatchHandler
+{
+    private const int TIMEOUT_SECONDS = 30;
+    private const int MAX_REDIRECTS = 3;
+    private const int MAX_BYTES = 10 * 1024 * 1024;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly HttpClientInterface $httpClient,
+        private readonly SsrfGuard $ssrfGuard,
+        private readonly AssetIngestorInterface $assetIngestor,
+        private readonly ProductAssetLinker $assetLinker,
+        private readonly AssetRepositoryInterface $assets,
+        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        private readonly AttributeRepositoryInterface $attributes,
+        private readonly ObjectValueRepositoryInterface $objectValues,
+        private readonly TenantContext $tenantContext,
+        private readonly ImportProgressPublisher $progressPublisher,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct($entityManager);
+    }
+
+    public function __invoke(ImageDownloadMessage $message): void
+    {
+        $session = $this->sessions->findById($message->importSessionId);
+        if (!$session instanceof ImportSession) {
+            return;
+        }
+        $tenant = $session->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return;
+        }
+        $this->tenantContext->set($tenant);
+
+        // ── Phase 1: DOWNLOAD (primitives only; ingest may clear the EM) ──
+        $downloaded = 0;
+        $failed = 0;
+        /** @var list<array{job: ImageDownloadJob, type: ImportErrorType, message: string, value: string}> $pendingLogs */
+        $pendingLogs = [];
+        /** @var list<array{job: ImageDownloadJob, downloaded: list<string>}> $pendingWrites */
+        $pendingWrites = [];
+        $urlCache = [];
+
+        foreach ($message->jobs as $job) {
+            $ids = [];
+            foreach ($job->urls as $url) {
+                if (isset($urlCache[$url])) {
+                    $ids[] = $urlCache[$url];
+
+                    continue;
+                }
+                $assetId = $this->fetchAndIngest($job, $url, $pendingLogs);
+                if (null === $assetId) {
+                    ++$failed;
+
+                    continue;
+                }
+                $urlCache[$url] = $assetId;
+                $ids[] = $assetId;
+                ++$downloaded;
+            }
+            $pendingWrites[] = ['job' => $job, 'downloaded' => $ids];
+        }
+
+        // ── Phase 2: APPLY (EM may have been cleared by ingest) ──
+        $tenant = $this->reattachTenant($message->tenantId);
+        $session = $this->sessions->findById($message->importSessionId);
+        if (!$session instanceof ImportSession) {
+            return;
+        }
+
+        for ($i = 0; $i < $downloaded; ++$i) {
+            $session->incrementImagesDownloaded();
+        }
+        for ($i = 0; $i < $failed; ++$i) {
+            $session->incrementImagesFailed();
+        }
+        foreach ($pendingLogs as $entry) {
+            $this->persistLog($session, $entry['job'], $entry['type'], $entry['message'], $entry['value']);
+        }
+        foreach ($pendingWrites as $write) {
+            $this->applyWrite($session, $write['job'], $write['downloaded'], $tenant);
+        }
+
+        $session->decrementPendingImageBatches();
+        $finalize = $session->canFinalizeMedia() && !$session->getStatus()->isTerminal();
+        if ($finalize) {
+            $session->markCompleted();
+        }
+        $this->flushAndClear();
+
+        if ($finalize) {
+            $reloaded = $this->sessions->findById($message->importSessionId);
+            if ($reloaded instanceof ImportSession) {
+                $this->progressPublisher->completed($reloaded);
+            }
+        }
+    }
+
+    /**
+     * @param list<array{job: ImageDownloadJob, type: ImportErrorType, message: string, value: string}> $pendingLogs by ref
+     */
+    private function fetchAndIngest(ImageDownloadJob $job, string $url, array &$pendingLogs): ?string
+    {
+        if (!$this->ssrfGuard->isAllowed($url)) {
+            $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageNotFound, 'message' => \sprintf('URL "%s" rejected: non-public or unsupported host.', $url), 'value' => $url];
+
+            return null;
+        }
+
+        $localPath = tempnam(sys_get_temp_dir(), 'pim-dl-');
+        if (false === $localPath) {
+            return null;
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'timeout' => self::TIMEOUT_SECONDS,
+                'max_redirects' => self::MAX_REDIRECTS,
+            ]);
+            if ($response->getStatusCode() >= 400) {
+                $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageNotFound, 'message' => \sprintf('URL "%s" returned HTTP %d.', $url, $response->getStatusCode()), 'value' => $url];
+
+                return null;
+            }
+
+            $handle = fopen($localPath, 'w');
+            if (false === $handle) {
+                return null;
+            }
+            $bytes = 0;
+            try {
+                foreach ($this->httpClient->stream($response) as $chunk) {
+                    $content = $chunk->getContent();
+                    $bytes += \strlen($content);
+                    if ($bytes > self::MAX_BYTES) {
+                        $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageFormatUnsupported, 'message' => \sprintf('URL "%s" exceeds the %d MB limit.', $url, self::MAX_BYTES >> 20), 'value' => $url];
+
+                        return null;
+                    }
+                    fwrite($handle, $content);
+                }
+            } finally {
+                fclose($handle);
+            }
+
+            return $this->assetIngestor->ingest($localPath, $this->filenameFor($url))->assetId->toRfc4122();
+        } catch (UnsupportedMediaFormatException $exception) {
+            $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageFormatUnsupported, 'message' => \sprintf('URL "%s": %s', $url, $exception->getMessage()), 'value' => $url];
+
+            return null;
+        } catch (Throwable $exception) {
+            $this->logger->warning('Import image download failed.', ['url' => $url, 'exception' => $exception]);
+            $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageNotFound, 'message' => \sprintf('URL "%s" could not be downloaded: %s', $url, $exception->getMessage()), 'value' => $url];
+
+            return null;
+        } finally {
+            if (is_file($localPath)) {
+                @unlink($localPath);
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $downloaded asset ids (RFC 4122) fetched for this job
+     */
+    private function applyWrite(ImportSession $session, ImageDownloadJob $job, array $downloaded, Tenant $tenant): void
+    {
+        // Validate the cell's existing-asset UUIDs tenant-scoped; drop (with a
+        // warning) any that do not belong to this tenant (cross-tenant / gone).
+        $validExisting = [];
+        if ([] !== $job->existingUuids) {
+            $existsSet = [];
+            foreach ($this->assets->existingIds($job->existingUuids, $tenant) as $id) {
+                $existsSet[strtolower($id)] = true;
+            }
+            foreach ($job->existingUuids as $uuid) {
+                if (isset($existsSet[strtolower($uuid)])) {
+                    $validExisting[] = $uuid;
+                } else {
+                    $this->persistLog($session, $job, ImportErrorType::ImageNotFound, \sprintf('Asset "%s" does not exist for this tenant — skipped.', $uuid), $uuid);
+                }
+            }
+        }
+
+        $merged = [];
+        foreach ([...$validExisting, ...$downloaded] as $id) {
+            $merged[strtolower($id)] = $id;
+        }
+        $merged = array_values($merged);
+        if ([] === $merged) {
+            return;
+        }
+
+        $object = $this->catalogObjects->findById(Uuid::fromString($job->objectId));
+        if (!$object instanceof CatalogObject) {
+            return;
+        }
+        $attribute = $this->attributes->findByCode($job->attributeCode, $tenant);
+        if (!$attribute instanceof Attribute) {
+            return;
+        }
+
+        $channelId = null !== $job->channelId ? Uuid::fromString($job->channelId) : null;
+        // IMP2-1.8 gallery shape: scalar for a single asset, list for a gallery.
+        $envelope = ['asset_id' => 1 === \count($merged) ? $merged[0] : $merged];
+
+        $existing = $this->objectValues->findOneByScope($object, $attribute, $channelId, $job->locale);
+        if ($existing instanceof ObjectValue) {
+            $existing->updateValue($envelope);
+            $existing->changeProvenance(Provenance::Import);
+            $this->objectValues->save($existing);
+        } else {
+            $this->objectValues->save(new ObjectValue($object, $attribute, $envelope, Provenance::Import, $channelId, $job->locale));
+        }
+
+        $this->assetLinker->linkAssetsToProduct(
+            $object->getId(),
+            array_map(static fn (string $id): Uuid => Uuid::fromString($id), $merged),
+        );
+    }
+
+    /**
+     * Re-fetch the active tenant as a managed entity on the (possibly cleared)
+     * EM and re-publish it to the TenantContext so the assignment listener
+     * stamps new ObjectValue rows with a managed tenant.
+     */
+    private function reattachTenant(Uuid $tenantId): Tenant
+    {
+        $tenant = $this->entityManager->find(Tenant::class, $tenantId->toRfc4122());
+        if (!$tenant instanceof Tenant) {
+            throw new RuntimeException(\sprintf('Tenant "%s" not found while applying media downloads.', $tenantId->toRfc4122()));
+        }
+        $this->tenantContext->set($tenant);
+
+        return $tenant;
+    }
+
+    private function filenameFor(string $url): string
+    {
+        $path = parse_url($url, PHP_URL_PATH);
+        $base = \is_string($path) ? basename($path) : '';
+
+        return '' !== $base ? $base : 'image';
+    }
+
+    private function persistLog(ImportSession $session, ImageDownloadJob $job, ImportErrorType $type, string $message, string $value): void
+    {
+        $this->entityManager->persist(new ImportLog(
+            importSession: $session,
+            rowNumber: $job->rowNumber,
+            level: ImportLogLevel::Warning,
+            message: $message,
+            sku: $job->sku,
+            errorType: $type->value,
+            columnName: $job->attributeCode,
+            columnValue: $value,
+        ));
+    }
+}

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -15,12 +15,15 @@ use App\Import\Application\Service\ImportProgressPublisher;
 use App\Import\Application\Service\ImportRowDecision;
 use App\Import\Application\Service\ImportRowReader;
 use App\Import\Application\Service\ImportValidationService;
+use App\Import\Application\Service\Media\AssetUrlResolver;
 use App\Import\Application\Service\ObjectResolver;
 use App\Import\Application\Service\RelationImportStep;
 use App\Import\Domain\Entity\ImportLog;
 use App\Import\Domain\Entity\ImportSession;
 use App\Import\Domain\Enum\ImportErrorType;
 use App\Import\Domain\Enum\ImportLogLevel;
+use App\Import\Domain\Message\ImageDownloadJob;
+use App\Import\Domain\Message\ImageDownloadMessage;
 use App\Import\Domain\Message\ImportRunMessage;
 use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
 use App\Import\Domain\ReservedMappingTarget;
@@ -42,6 +45,7 @@ use LogicException;
 use RuntimeException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Uid\Uuid;
 use Throwable;
 
@@ -65,6 +69,9 @@ use const PATHINFO_EXTENSION;
 #[AsMessageHandler]
 final class ImportRunHandler extends AbstractBatchHandler
 {
+    /** IMP2-1.12 — image-download jobs per dispatched media batch. */
+    private const int MEDIA_BATCH_SIZE = 50;
+
     public function __construct(
         EntityManagerInterface $entityManager,
         private readonly ImportSessionRepositoryInterface $sessions,
@@ -83,6 +90,8 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly FilesystemOperator $importsStorage,
         private readonly BulkOperationLock $bulkLock,
         private readonly ManagerRegistry $managerRegistry,
+        private readonly AssetUrlResolver $assetUrlResolver,
+        private readonly MessageBusInterface $messageBus,
         int $batchSize = 200,
     ) {
         parent::__construct($entityManager, $batchSize);
@@ -178,6 +187,13 @@ final class ImportRunHandler extends AbstractBatchHandler
             // already claimed, keyed by attributeCode, so a duplicate identifier
             // across chunks is caught as a skip before the DB unique index.
             $identifierSeenInFile = [];
+            // IMP2-1.12 — image-download jobs (Asset cells carrying URLs) are
+            // buffered across ALL chunks as plain DTOs (survive clear) and
+            // dispatched AFTER the row phase: dispatching mid-loop would let a
+            // sync-transport ImageDownloadHandler clear the EM under the row
+            // loop's feet.
+            /** @var list<ImageDownloadJob> $mediaJobs */
+            $mediaJobs = [];
             $processed = 0;
             $totalRows = 0;
             /** @var list<array{rowNumber: int, cells: array<string, string|null>}> $buffer */
@@ -195,7 +211,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                     continue;
                 }
 
-                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile, $identifierSeenInFile);
+                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile, $identifierSeenInFile, $mediaJobs);
                 $buffer = [];
 
                 $this->flushAndClear();
@@ -216,7 +232,7 @@ final class ImportRunHandler extends AbstractBatchHandler
             }
 
             if ([] !== $buffer) {
-                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile, $identifierSeenInFile);
+                $processed += $this->processChunk($session, $tenant, $buffer, $columnMapping, $attributesByCode, $skuSeenInFile, $identifierSeenInFile, $mediaJobs);
                 $this->flushAndClear();
                 $session = $this->refreshSession($session);
             }
@@ -246,9 +262,23 @@ final class ImportRunHandler extends AbstractBatchHandler
             }
 
             $session->setTotalRows($totalRows);
-            $session->markCompleted();
             $this->sessions->save($session);
-            $this->progressPublisher->completed($session);
+
+            // IMP2-1.12 — dispatch the buffered media batches now (after the
+            // row phase + relation links), then defer finalization: the last
+            // download batch to finish finalizes the session, or this handler
+            // does it right here when there is no media / sync already drained
+            // the batches.
+            $session = $this->dispatchMediaBatches($session, $mediaJobs);
+            $session->markRowPhaseComplete();
+            if ($session->canFinalizeMedia() && !$session->getStatus()->isTerminal()) {
+                $session->markCompleted();
+                $this->sessions->save($session);
+                $this->progressPublisher->completed($session);
+            } else {
+                $this->sessions->save($session);
+                $this->progressPublisher->progress($session, $processed, null);
+            }
         } catch (Throwable $exception) {
             // IMP2-1.9 — a throw from flush() leaves the EM CLOSED, so the old
             // path (findById + save on the same manager) threw again and left
@@ -754,6 +784,76 @@ final class ImportRunHandler extends AbstractBatchHandler
     }
 
     /**
+     * IMP2-1.12 — buffer an image-download job for each Asset-attribute cell on
+     * the row that carries http(s) URLs. Existing-asset UUIDs in the same cell
+     * ride along so the handler writes ONE merged `{asset_id}` envelope. The
+     * object id is captured as a string so the buffered job survives
+     * flushAndClear.
+     *
+     * @param list<ImageDownloadJob>                                                                                                                                                                                 $mediaJobs        by ref
+     * @param array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string, duplicateInFile: bool} $row
+     * @param array<string, Attribute>                                                                                                                                                                               $attributesByCode
+     */
+    private function collectMediaJobs(array &$mediaJobs, Uuid $objectId, array $row, array $attributesByCode): void
+    {
+        foreach ($row['resolvedValues'] as $resolved) {
+            $attribute = $attributesByCode[$resolved->attributeCode] ?? null;
+            if (!$attribute instanceof Attribute || AttributeType::Asset !== $attribute->getType()) {
+                continue;
+            }
+            $raw = $resolved->rawValue;
+            if (null === $raw || '' === $raw) {
+                continue;
+            }
+            $classified = $this->assetUrlResolver->classify($raw);
+            if ([] === $classified['urls']) {
+                continue; // pure UUID / unresolved cell — handled by the value writer
+            }
+            $mediaJobs[] = new ImageDownloadJob(
+                objectId: $objectId->toRfc4122(),
+                attributeCode: $resolved->attributeCode,
+                locale: $resolved->locale,
+                channelId: $resolved->channelId?->toRfc4122(),
+                existingUuids: $classified['uuids'],
+                urls: $classified['urls'],
+                rowNumber: $row['rowNumber'],
+                sku: $row['sku'],
+            );
+        }
+    }
+
+    /**
+     * IMP2-1.12 — dispatch buffered media jobs in batches to the `import`
+     * transport, bumping the session's pending-batch counter per batch so the
+     * run is not finalized until every batch reports back. Returns a fresh
+     * managed session (a sync-transport handler may have cleared the EM).
+     *
+     * @param list<ImageDownloadJob> $mediaJobs
+     */
+    private function dispatchMediaBatches(ImportSession $session, array $mediaJobs): ImportSession
+    {
+        if ([] === $mediaJobs) {
+            return $session;
+        }
+        foreach (array_chunk($mediaJobs, self::MEDIA_BATCH_SIZE) as $batch) {
+            $session = $this->refreshSession($session);
+            $tenant = $session->getTenant();
+            if (!$tenant instanceof Tenant) {
+                break;
+            }
+            $session->incrementPendingImageBatches();
+            $this->sessions->save($session);
+            $this->messageBus->dispatch(new ImageDownloadMessage(
+                $session->getId(),
+                $tenant->getId(),
+                $batch,
+            ));
+        }
+
+        return $this->refreshSession($session);
+    }
+
+    /**
      * First non-empty (trimmed) cell whose mapping targets the given reserved
      * marker, or null.
      *
@@ -850,6 +950,7 @@ final class ImportRunHandler extends AbstractBatchHandler
      * @param array<string, Attribute>                                       $attributesByCode
      * @param array<string, int>                                             $skuSeenInFile
      * @param array<string, array<string, int>>                              $identifierSeenInFile attributeCode → (value → rowNumber)
+     * @param list<ImageDownloadJob>                                         $mediaJobs            accumulated across chunks (IMP2-1.12), by ref
      */
     private function processChunk(
         ImportSession $session,
@@ -859,6 +960,7 @@ final class ImportRunHandler extends AbstractBatchHandler
         array $attributesByCode,
         array &$skuSeenInFile,
         array &$identifierSeenInFile,
+        array &$mediaJobs,
     ): int {
         // Pass 1 — validate rows and gather match keys for the batch resolve.
         /** @var list<array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string, duplicateInFile: bool}> $prepared */
@@ -976,6 +1078,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                     $createdSku = $this->skuFrom($row['resolvedValues'], $row['rowNumber']);
                     $this->recordParentLink($createdSku, $row['cells'], $columnMapping, $row['rowNumber']);
                     $this->recordRelationLinks($createdSku, $row['resolvedValues'], $attributesByCode, $row['rowNumber']);
+                    $this->collectMediaJobs($mediaJobs, $created->object->getId(), $row, $attributesByCode);
                 } elseif (ImportRowDecision::Update === $decision && null !== $existing) {
                     $issues = $this->creator->update(
                         $existing,
@@ -990,6 +1093,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                     $session->incrementUpdated();
                     $this->recordParentLink($existing->getCode(), $row['cells'], $columnMapping, $row['rowNumber']);
                     $this->recordRelationLinks($existing->getCode(), $row['resolvedValues'], $attributesByCode, $row['rowNumber']);
+                    $this->collectMediaJobs($mediaJobs, $existing->getId(), $row, $attributesByCode);
                     // IMP2-1.7: category replace/append runs after the value
                     // pass (replaceForProduct flushes around the primary index).
                     // Empty cell = untouched (D2), so only collect non-empty.
@@ -1124,11 +1228,12 @@ final class ImportRunHandler extends AbstractBatchHandler
                 if (null === $raw || '' === $raw) {
                     continue;
                 }
-                foreach (explode('|', $raw) as $id) {
-                    $id = trim($id);
-                    if ('' !== $id) {
-                        $ids[$id] = true;
-                    }
+                // IMP2-1.12 — only UUID tokens are existing-asset references;
+                // URL tokens are downloaded by the media path and bare strings
+                // are unresolved. Querying a non-UUID against the uuid id column
+                // would blow up the prefetch.
+                foreach ($this->assetUrlResolver->classify($raw)['uuids'] as $id) {
+                    $ids[$id] = true;
                 }
             }
         }

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -35,6 +35,7 @@ use App\Shared\Application\BulkOperationInProgressException;
 use App\Shared\Application\BulkOperationLock;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Messenger\Stamp\TenantStamp;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManagerInterface;
@@ -794,7 +795,7 @@ final class ImportRunHandler extends AbstractBatchHandler
      * @param array{rowNumber: int, cells: array<string, string|null>, sku: ?string, errors: list<ValidationError>, rowOk: bool, resolvedValues: list<ResolvedImportValue>, matchKey: string, duplicateInFile: bool} $row
      * @param array<string, Attribute>                                                                                                                                                                               $attributesByCode
      */
-    private function collectMediaJobs(array &$mediaJobs, Uuid $objectId, array $row, array $attributesByCode): void
+    private function collectMediaJobs(array &$mediaJobs, ImportSession $session, Uuid $objectId, array $row, array $attributesByCode): void
     {
         foreach ($row['resolvedValues'] as $resolved) {
             $attribute = $attributesByCode[$resolved->attributeCode] ?? null;
@@ -806,8 +807,24 @@ final class ImportRunHandler extends AbstractBatchHandler
                 continue;
             }
             $classified = $this->assetUrlResolver->classify($raw);
+            // IMP2-1.12 (1c) — a bare-filename token is neither an existing
+            // asset id nor an http(s) URL (relative paths land in IMP2-1.13 ZIP
+            // / IMP2-3.4 prefix transform); surface each as a row warning rather
+            // than dropping it silently.
+            foreach ($classified['unresolved'] as $token) {
+                $this->entityManager->persist(new ImportLog(
+                    importSession: $session,
+                    rowNumber: $row['rowNumber'],
+                    level: ImportLogLevel::Warning,
+                    message: \sprintf('Asset reference "%s" is neither a known asset id nor an http(s) URL — skipped.', $token),
+                    sku: $row['sku'],
+                    errorType: ImportErrorType::ImageNotFound->value,
+                    columnName: $resolved->attributeCode,
+                    columnValue: $token,
+                ));
+            }
             if ([] === $classified['urls']) {
-                continue; // pure UUID / unresolved cell — handled by the value writer
+                continue; // pure UUID / handled by the value writer
             }
             $mediaJobs[] = new ImageDownloadJob(
                 objectId: $objectId->toRfc4122(),
@@ -843,11 +860,13 @@ final class ImportRunHandler extends AbstractBatchHandler
             }
             $session->incrementPendingImageBatches();
             $this->sessions->save($session);
-            $this->messageBus->dispatch(new ImageDownloadMessage(
-                $session->getId(),
-                $tenant->getId(),
-                $batch,
-            ));
+            // TenantStamp so the async worker rebinds the tenant before the
+            // handler runs (TenantContextRebindingMiddleware) — mirrors the
+            // ImportRunMessage dispatch; without it the worker dead-letters.
+            $this->messageBus->dispatch(
+                new ImageDownloadMessage($session->getId(), $tenant->getId(), $batch),
+                [new TenantStamp($tenant->getId())],
+            );
         }
 
         return $this->refreshSession($session);
@@ -1078,7 +1097,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                     $createdSku = $this->skuFrom($row['resolvedValues'], $row['rowNumber']);
                     $this->recordParentLink($createdSku, $row['cells'], $columnMapping, $row['rowNumber']);
                     $this->recordRelationLinks($createdSku, $row['resolvedValues'], $attributesByCode, $row['rowNumber']);
-                    $this->collectMediaJobs($mediaJobs, $created->object->getId(), $row, $attributesByCode);
+                    $this->collectMediaJobs($mediaJobs, $session, $created->object->getId(), $row, $attributesByCode);
                 } elseif (ImportRowDecision::Update === $decision && null !== $existing) {
                     $issues = $this->creator->update(
                         $existing,
@@ -1093,7 +1112,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                     $session->incrementUpdated();
                     $this->recordParentLink($existing->getCode(), $row['cells'], $columnMapping, $row['rowNumber']);
                     $this->recordRelationLinks($existing->getCode(), $row['resolvedValues'], $attributesByCode, $row['rowNumber']);
-                    $this->collectMediaJobs($mediaJobs, $existing->getId(), $row, $attributesByCode);
+                    $this->collectMediaJobs($mediaJobs, $session, $existing->getId(), $row, $attributesByCode);
                     // IMP2-1.7: category replace/append runs after the value
                     // pass (replaceForProduct flushes around the primary index).
                     // Empty cell = untouched (D2), so only collect non-empty.

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -244,6 +244,14 @@ final class ImportObjectCreator
      */
     private function assetPayload(Attribute $attribute, string $raw, array $existingAssetIds, array &$issues): ?array
     {
+        // IMP2-1.12 — a cell carrying any http(s) URL is owned by the media
+        // download path: the whole Asset value (existing UUIDs + downloaded
+        // ids) is written by ImageDownloadHandler after the row phase, so the
+        // raw URL never lands in JSONB. Skip it here entirely.
+        if ($this->cellHasUrl($raw)) {
+            return null;
+        }
+
         $ids = array_values(array_filter(
             array_map('trim', explode('|', $raw)),
             static fn (string $id): bool => '' !== $id,
@@ -268,6 +276,17 @@ final class ImportObjectCreator
         }
 
         return ['asset_id' => 1 === \count($survivors) ? $survivors[0] : $survivors];
+    }
+
+    /**
+     * IMP2-1.12 — true when the cell contains an http(s) image URL anywhere
+     * (case-insensitive). Such cells are handled by the async media path.
+     */
+    private function cellHasUrl(string $raw): bool
+    {
+        $lower = strtolower($raw);
+
+        return str_contains($lower, 'http://') || str_contains($lower, 'https://');
     }
 
     /**

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -12,6 +12,7 @@ use App\Catalog\Domain\Entity\ObjectCategory;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Provenance;
+use App\Import\Application\Service\Media\AssetUrlResolver;
 use App\Import\Domain\ValueObject\ResolvedImportValue;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Uid\Uuid;
@@ -36,6 +37,7 @@ final class ImportObjectCreator
         private readonly EntityManagerInterface $em,
         private readonly BatchValueWriter $valueWriter,
         private readonly CompositeValueParser $compositeValueParser,
+        private readonly AssetUrlResolver $assetUrlResolver,
     ) {
     }
 
@@ -279,14 +281,14 @@ final class ImportObjectCreator
     }
 
     /**
-     * IMP2-1.12 — true when the cell contains an http(s) image URL anywhere
-     * (case-insensitive). Such cells are handled by the async media path.
+     * IMP2-1.12 — true when the cell yields any http(s) URL token. Uses the
+     * SAME tokenizer ({@see AssetUrlResolver}) as ImportRunHandler's media-job
+     * collection, so "owned by the media path" is decided in exactly one place
+     * (no substring/tokenizer drift).
      */
     private function cellHasUrl(string $raw): bool
     {
-        $lower = strtolower($raw);
-
-        return str_contains($lower, 'http://') || str_contains($lower, 'https://');
+        return [] !== $this->assetUrlResolver->classify($raw)['urls'];
     }
 
     /**

--- a/apps/api/src/Import/Application/Service/Media/AssetUrlResolver.php
+++ b/apps/api/src/Import/Application/Service/Media/AssetUrlResolver.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service\Media;
+
+/**
+ * IMP2-1.12 — classifies the tokens of an Asset-attribute import cell.
+ *
+ * A cell may carry a pipe/semicolon/comma/whitespace-separated list mixing
+ * existing asset UUIDs and image URLs (supplier feeds — e.g. Avapax — list
+ * several `https://…png` in one cell). This resolver only TOKENISES and
+ * CLASSIFIES; it performs no I/O:
+ *   - UUID            → an existing asset reference (existence + tenant-scope
+ *                       validated later against the per-chunk prefetch);
+ *   - http(s) URL     → a download job (IMP2-1.12 ImageDownloadHandler);
+ *   - anything else   → unresolved (bare filename → ZIP IMP2-1.13 / prefix
+ *                       transform IMP2-3.4) — surfaced as ImageNotFound.
+ *
+ * Shared by {@see \App\Import\Application\Service\ImportObjectCreator}
+ * (writes the UUID subset as `{asset_id}`, skips URLs) and
+ * {@see \App\Import\Application\Handler\ImportRunHandler} (buffers URL
+ * download jobs, logs unresolved tokens).
+ */
+final class AssetUrlResolver
+{
+    private const string UUID_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+
+    /**
+     * Split a raw cell into trimmed, non-empty tokens. Separators: pipe
+     * (the exporter glue), semicolon, comma, and any whitespace/newline.
+     *
+     * @return list<string>
+     */
+    public function tokenize(string $raw): array
+    {
+        $parts = preg_split('/[|;,\s]+/u', trim($raw));
+        if (false === $parts) {
+            return [];
+        }
+
+        return array_values(array_filter($parts, static fn (string $token): bool => '' !== $token));
+    }
+
+    public function isUuid(string $token): bool
+    {
+        return 1 === preg_match(self::UUID_PATTERN, $token);
+    }
+
+    public function isUrl(string $token): bool
+    {
+        $lower = strtolower($token);
+
+        return str_starts_with($lower, 'http://') || str_starts_with($lower, 'https://');
+    }
+
+    /**
+     * Classify a raw cell into its three buckets, order preserved.
+     *
+     * @return array{uuids: list<string>, urls: list<string>, unresolved: list<string>}
+     */
+    public function classify(string $raw): array
+    {
+        $uuids = [];
+        $urls = [];
+        $unresolved = [];
+        foreach ($this->tokenize($raw) as $token) {
+            if ($this->isUuid($token)) {
+                $uuids[] = $token;
+            } elseif ($this->isUrl($token)) {
+                $urls[] = $token;
+            } else {
+                $unresolved[] = $token;
+            }
+        }
+
+        return ['uuids' => $uuids, 'urls' => $urls, 'unresolved' => $unresolved];
+    }
+}

--- a/apps/api/src/Import/Application/Service/Media/SsrfGuard.php
+++ b/apps/api/src/Import/Application/Service/Media/SsrfGuard.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service\Media;
+
+use const DNS_AAAA;
+use const FILTER_FLAG_IPV4;
+use const FILTER_FLAG_IPV6;
+use const FILTER_FLAG_NO_PRIV_RANGE;
+use const FILTER_FLAG_NO_RES_RANGE;
+use const FILTER_VALIDATE_IP;
+
+/**
+ * IMP2-1.12 / IMP2-2.8 — blocks server-side request forgery on import image
+ * downloads. Only http/https is allowed, and the host MUST resolve solely to
+ * public unicast addresses. Resolving the hostname and inspecting every
+ * resolved IP (not just the literal) defeats DNS-rebinding / hostname tricks;
+ * the check runs BEFORE any HTTP request is made.
+ *
+ * Rejected: private (RFC1918), loopback (127.0.0.0/8, ::1), link-local
+ * (169.254.0.0/16, fe80::/10), reserved/ULA (fc00::/7, 0.0.0.0/8, …) — the
+ * NO_PRIV_RANGE | NO_RES_RANGE filter flags cover them, with explicit
+ * literal guards as defence in depth.
+ */
+final class SsrfGuard
+{
+    public function isAllowed(string $url): bool
+    {
+        $parts = parse_url($url);
+        if (false === $parts || !isset($parts['scheme'], $parts['host'])) {
+            return false;
+        }
+        $scheme = strtolower($parts['scheme']);
+        if ('http' !== $scheme && 'https' !== $scheme) {
+            return false;
+        }
+
+        $host = $parts['host'];
+        // A bracketed/literal IP host bypasses DNS — validate it directly.
+        $literal = trim($host, '[]');
+        if (false !== filter_var($literal, FILTER_VALIDATE_IP)) {
+            return $this->isPublicIp($literal);
+        }
+
+        $ips = $this->resolve($host);
+        if ([] === $ips) {
+            return false; // unresolvable host → refuse rather than let the client try
+        }
+        foreach ($ips as $ip) {
+            if (!$this->isPublicIp($ip)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolve(string $host): array
+    {
+        $ips = [];
+        $v4 = @gethostbynamel($host);
+        if (\is_array($v4)) {
+            $ips = $v4;
+        }
+        $aaaa = @dns_get_record($host, DNS_AAAA);
+        if (\is_array($aaaa)) {
+            foreach ($aaaa as $record) {
+                if (isset($record['ipv6']) && \is_string($record['ipv6'])) {
+                    $ips[] = $record['ipv6'];
+                }
+            }
+        }
+
+        return array_values(array_unique($ips));
+    }
+
+    private function isPublicIp(string $ip): bool
+    {
+        $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+        if (str_contains($ip, ':')) {
+            $valid = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | $flags);
+
+            // ::1 loopback + fc00::/7 ULA + fe80::/10 link-local are caught by
+            // the flags; reject anything that fails them.
+            return false !== $valid;
+        }
+
+        $valid = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | $flags);
+        if (false === $valid) {
+            return false;
+        }
+        // Defence in depth for ranges the flags miss on some libc builds.
+        $long = ip2long($ip);
+        if (false === $long) {
+            return false;
+        }
+        foreach ([['0.0.0.0', 8], ['127.0.0.0', 8], ['169.254.0.0', 16], ['10.0.0.0', 8], ['172.16.0.0', 12], ['192.168.0.0', 16], ['100.64.0.0', 10]] as [$net, $bits]) {
+            $mask = -1 << (32 - $bits);
+            if (($long & $mask) === (ip2long($net) & $mask)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/apps/api/src/Import/Application/Service/Media/SsrfGuard.php
+++ b/apps/api/src/Import/Application/Service/Media/SsrfGuard.php
@@ -12,16 +12,21 @@ use const FILTER_FLAG_NO_RES_RANGE;
 use const FILTER_VALIDATE_IP;
 
 /**
- * IMP2-1.12 / IMP2-2.8 — blocks server-side request forgery on import image
- * downloads. Only http/https is allowed, and the host MUST resolve solely to
- * public unicast addresses. Resolving the hostname and inspecting every
- * resolved IP (not just the literal) defeats DNS-rebinding / hostname tricks;
- * the check runs BEFORE any HTTP request is made.
+ * IMP2-1.12 / IMP2-2.8 — cheap PRE-FILTER for server-side request forgery on
+ * import image downloads: rejects non-http(s) schemes and hosts that resolve to
+ * a non-public address BEFORE any request, with a clean log message. It is NOT
+ * the sole defence — a one-shot pre-resolution cannot stop DNS-rebinding (the
+ * client re-resolves at connect time) nor a redirect to a private host. The
+ * authoritative connection-time + per-redirect peer-IP check is
+ * {@see \Symfony\Component\HttpClient\NoPrivateNetworkHttpClient}, which wraps
+ * the client injected into {@see \App\Import\Application\Handler\ImageDownloadHandler}
+ * (`import.ssrf_safe_http_client` in services.yaml). This guard is the fast
+ * early reject; that client is the real backstop.
  *
- * Rejected: private (RFC1918), loopback (127.0.0.0/8, ::1), link-local
+ * Rejected here: private (RFC1918), loopback (127.0.0.0/8, ::1), link-local
  * (169.254.0.0/16, fe80::/10), reserved/ULA (fc00::/7, 0.0.0.0/8, …) — the
- * NO_PRIV_RANGE | NO_RES_RANGE filter flags cover them, with explicit
- * literal guards as defence in depth.
+ * NO_PRIV_RANGE | NO_RES_RANGE filter flags cover them, with explicit literal
+ * guards as defence in depth.
  */
 final class SsrfGuard
 {

--- a/apps/api/src/Import/Domain/Entity/ImportSession.php
+++ b/apps/api/src/Import/Domain/Entity/ImportSession.php
@@ -74,6 +74,22 @@ class ImportSession extends AggregateRoot implements TenantScoped
 
     private int $imagesFailed = 0;
 
+    /**
+     * IMP2-1.12 — number of media (image-download) batches dispatched for this
+     * run that have not yet finished. While > 0 the session is NOT finalized:
+     * the row phase may be done but downloads are still in flight (async
+     * `import` transport). The last batch to finish finalizes the session.
+     */
+    private int $pendingImageBatches = 0;
+
+    /**
+     * IMP2-1.12 — true once the row-write phase has dispatched every media
+     * batch. A media handler may only finalize the session after this flag is
+     * set (otherwise an early-finishing batch could complete a session whose
+     * later chunks are still importing).
+     */
+    private bool $rowPhaseComplete = false;
+
     private ?DateTimeImmutable $startedAt = null;
 
     private ?DateTimeImmutable $completedAt = null;
@@ -263,6 +279,49 @@ class ImportSession extends AggregateRoot implements TenantScoped
     public function incrementImagesFailed(): void
     {
         ++$this->imagesFailed;
+    }
+
+    public function getPendingImageBatches(): int
+    {
+        return $this->pendingImageBatches;
+    }
+
+    public function incrementPendingImageBatches(): void
+    {
+        ++$this->pendingImageBatches;
+    }
+
+    public function decrementPendingImageBatches(): void
+    {
+        $this->pendingImageBatches = max(0, $this->pendingImageBatches - 1);
+    }
+
+    /**
+     * IMP2-1.12 — the row-write phase finished dispatching media batches.
+     * Idempotent; the run handler calls it once at the end of the loop.
+     */
+    public function markRowPhaseComplete(): void
+    {
+        $this->rowPhaseComplete = true;
+    }
+
+    public function isRowPhaseComplete(): bool
+    {
+        return $this->rowPhaseComplete;
+    }
+
+    public function isAwaitingMedia(): bool
+    {
+        return $this->pendingImageBatches > 0;
+    }
+
+    /**
+     * True when the session is ready to transition to its terminal state:
+     * the row phase is done AND no media batch is still pending.
+     */
+    public function canFinalizeMedia(): bool
+    {
+        return $this->rowPhaseComplete && 0 === $this->pendingImageBatches;
     }
 
     public function getStartedAt(): ?DateTimeImmutable

--- a/apps/api/src/Import/Domain/Message/ImageDownloadJob.php
+++ b/apps/api/src/Import/Domain/Message/ImageDownloadJob.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Message;
+
+/**
+ * IMP2-1.12 — one Asset-attribute cell's media work, scoped to a single
+ * (object, attribute, locale, channel) target. Carries the pre-classified
+ * existing asset UUIDs (validated tenant-scoped by the handler) plus the
+ * image URLs to download; the handler writes ONE merged `{asset_id}` envelope
+ * (existing + downloaded) so there is no read-modify-write of the value.
+ *
+ * Ids are RFC 4122 strings to keep the Messenger payload primitive.
+ */
+final readonly class ImageDownloadJob
+{
+    /**
+     * @param list<string> $existingUuids already-classified existing asset UUIDs (RFC 4122)
+     * @param list<string> $urls          http(s) image URLs to download
+     */
+    public function __construct(
+        public string $objectId,
+        public string $attributeCode,
+        public ?string $locale,
+        public ?string $channelId,
+        public array $existingUuids,
+        public array $urls,
+        public int $rowNumber,
+        public ?string $sku,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Domain/Message/ImageDownloadMessage.php
+++ b/apps/api/src/Import/Domain/Message/ImageDownloadMessage.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Message;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * IMP2-1.12 — a batch of media-download work buffered by one import chunk and
+ * dispatched (after the row writes) to the dedicated `import` transport. The
+ * {@see \App\Import\Application\Handler\ImageDownloadHandler} downloads, ingests
+ * (dedup) and links the assets, updates the session image counters, and
+ * decrements the session's pending-batch counter — the last batch finalizes
+ * the session. Media failures never fail the session (warning, not error).
+ */
+final readonly class ImageDownloadMessage
+{
+    /**
+     * @param list<ImageDownloadJob> $jobs
+     */
+    public function __construct(
+        public Uuid $importSessionId,
+        public Uuid $tenantId,
+        public array $jobs,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
+++ b/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
@@ -74,6 +74,16 @@
                 <option name="default">0</option>
             </options>
         </field>
+        <field name="pendingImageBatches" type="integer" column="pending_image_batches">
+            <options>
+                <option name="default">0</option>
+            </options>
+        </field>
+        <field name="rowPhaseComplete" type="boolean" column="row_phase_complete">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
 
         <field name="startedAt" type="datetime_immutable" column="started_at" nullable="true"/>
         <field name="completedAt" type="datetime_immutable" column="completed_at" nullable="true"/>

--- a/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
+++ b/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
@@ -244,6 +244,49 @@ final class ImageDownloadHandlerTest extends CatalogApiTestCase
         }
     }
 
+    #[Test]
+    public function bareFilenameTokenIsWarnedNotSilentlyDropped(): void
+    {
+        // IMP2-1.12 (1c) — a non-UUID, non-URL token (relative path; ZIP/transform
+        // territory) surfaces as an image_not_found row warning, and writes no
+        // asset value.
+        $this->seedSkuAndPhoto();
+        $client = $this->authenticatedClient();
+        $path = tempnam(sys_get_temp_dir(), 'pim-bare-').'.csv';
+        file_put_contents($path, "sku;photo\nBARE-1;product-front.png\n");
+        try {
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'photo' => 'photo'], JSON_THROW_ON_ERROR),
+                        'mode' => 'UPSERT',
+                    ],
+                    'files' => ['file' => new \Symfony\Component\HttpFoundation\File\UploadedFile($path, 'bare.csv', 'text/csv', null, true)],
+                ],
+            ]);
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            \assert(\is_array($body));
+            $sessionId = $body['id'];
+            \assert(\is_string($sessionId));
+
+            $em = $this->em();
+            $em->clear();
+            $logs = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM import_logs WHERE error_type='image_not_found' AND import_session_id = :s",
+                ['s' => $sessionId],
+            );
+            self::assertSame(1, (int) (\is_scalar($logs) ? $logs : 0), 'bare filename surfaced as a warning');
+            $photoValues = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id JOIN objects o ON o.id=ov.object_id WHERE a.code='photo' AND o.code='BARE-1'",
+            );
+            self::assertSame(0, (int) (\is_scalar($photoValues) ? $photoValues : 1));
+        } finally {
+            @unlink($path);
+        }
+    }
+
     private function seedSkuAndPhoto(): void
     {
         $em = $this->em();

--- a/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
+++ b/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Asset\Contracts\AssetIngestorInterface;
+use App\Asset\Domain\Repository\AssetRepositoryInterface;
+use App\Catalog\Contracts\Service\ProductAssetLinker;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Import\Application\Handler\ImageDownloadHandler;
+use App\Import\Application\Service\ImportProgressPublisher;
+use App\Import\Application\Service\Media\SsrfGuard;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportSessionStatus;
+use App\Import\Domain\Message\ImageDownloadJob;
+use App\Import\Domain\Message\ImageDownloadMessage;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP2-1.12 (#1475) — the image-download handler: SSRF guard, HTTP caps,
+ * content-hash dedup, asset link, envelope write, counters. The handler is
+ * built with a MockHttpClient and public-IP-literal URLs so no real network or
+ * DNS is touched (deterministic in CI).
+ */
+final class ImageDownloadHandlerTest extends CatalogApiTestCase
+{
+    // 1×1 transparent PNG.
+    private const string PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // product_assets is a raw-SQL junction (no ORM entity), so the
+        // metadata-built test schema omits it; create it for the link path.
+        $this->em()->getConnection()->executeStatement(
+            'CREATE TABLE IF NOT EXISTS product_assets (asset_id UUID NOT NULL, product_id UUID NOT NULL, position INT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY (asset_id, product_id))',
+        );
+    }
+
+    #[Test]
+    public function downloadsLinksAndWritesEnvelope(): void
+    {
+        $png = base64_decode(self::PNG, true);
+        \assert(false !== $png);
+        [$sessionId, $objectId] = $this->seed();
+
+        $handler = $this->handler(new MockHttpClient([
+            new MockResponse($png, ['http_code' => 200]),
+        ]));
+        $handler($this->message($sessionId, $objectId, ['https://93.184.216.34/photo.png']));
+
+        $em = $this->em();
+        $em->clear();
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(1, $session->getImagesDownloaded());
+        self::assertSame(0, $session->getImagesFailed());
+        self::assertSame(ImportSessionStatus::Success, $session->getStatus(), 'last media batch finalizes the run');
+
+        $assetId = $em->getConnection()->fetchOne('SELECT id FROM assets ORDER BY created_at DESC LIMIT 1');
+        self::assertIsString($assetId);
+        $links = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM product_assets WHERE product_id = :p', ['p' => $objectId]);
+        self::assertSame(1, (int) (\is_scalar($links) ? $links : 0), 'asset linked to the product');
+        $envelope = $em->getConnection()->fetchOne(
+            "SELECT ov.value FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id WHERE a.code='photo' AND ov.object_id = :p",
+            ['p' => $objectId],
+        );
+        \assert(\is_string($envelope));
+        self::assertSame(['asset_id' => $assetId], json_decode($envelope, true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    #[Test]
+    public function http404IsLoggedAsImageNotFoundWithoutFailingSession(): void
+    {
+        [$sessionId, $objectId] = $this->seed();
+        $handler = $this->handler(new MockHttpClient([new MockResponse('nope', ['http_code' => 404])]));
+        $handler($this->message($sessionId, $objectId, ['https://93.184.216.34/missing.png']));
+
+        $em = $this->em();
+        $em->clear();
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(0, $session->getImagesDownloaded());
+        self::assertSame(1, $session->getImagesFailed());
+        self::assertFalse($session->getStatus()->isTerminal() && ImportSessionStatus::Failed === $session->getStatus(), 'media failure never fails the session');
+        $logs = $em->getConnection()->fetchOne("SELECT COUNT(*) FROM import_logs WHERE error_type='image_not_found' AND import_session_id = :s", ['s' => $sessionId->toRfc4122()]);
+        self::assertSame(1, (int) (\is_scalar($logs) ? $logs : 0));
+    }
+
+    #[Test]
+    public function privateHostIsRejectedWithoutRequest(): void
+    {
+        [$sessionId, $objectId] = $this->seed();
+        // A throwing client proves no HTTP request is attempted for a blocked host.
+        $handler = $this->handler(new MockHttpClient(static function (): MockResponse {
+            throw new RuntimeException('SSRF: request must not be made');
+        }));
+        $handler($this->message($sessionId, $objectId, ['http://169.254.169.254/latest/meta-data/']));
+
+        $em = $this->em();
+        $em->clear();
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(1, $session->getImagesFailed());
+        $logs = $em->getConnection()->fetchOne("SELECT COUNT(*) FROM import_logs WHERE error_type='image_not_found' AND import_session_id = :s", ['s' => $sessionId->toRfc4122()]);
+        self::assertSame(1, (int) (\is_scalar($logs) ? $logs : 0));
+    }
+
+    #[Test]
+    public function nonImageBytesAreImageFormatUnsupported(): void
+    {
+        [$sessionId, $objectId] = $this->seed();
+        $handler = $this->handler(new MockHttpClient([new MockResponse('<html>not an image</html>', ['http_code' => 200])]));
+        $handler($this->message($sessionId, $objectId, ['https://93.184.216.34/page.html']));
+
+        $em = $this->em();
+        $em->clear();
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(0, $session->getImagesDownloaded());
+        self::assertSame(1, $session->getImagesFailed());
+        $logs = $em->getConnection()->fetchOne("SELECT COUNT(*) FROM import_logs WHERE error_type='image_format_unsupported' AND import_session_id = :s", ['s' => $sessionId->toRfc4122()]);
+        self::assertSame(1, (int) (\is_scalar($logs) ? $logs : 0));
+    }
+
+    #[Test]
+    public function repeatedUrlInBatchDownloadsOnce(): void
+    {
+        $png = base64_decode(self::PNG, true);
+        \assert(false !== $png);
+        [$sessionId, $objectId] = $this->seed();
+        // Only ONE response queued: a second HTTP request would exhaust the mock
+        // and throw — proving the in-batch URL cache hit.
+        $handler = $this->handler(new MockHttpClient([new MockResponse($png, ['http_code' => 200])]));
+        $handler($this->message($sessionId, $objectId, [
+            'https://93.184.216.34/same.png',
+            'https://93.184.216.34/same.png',
+        ]));
+
+        $em = $this->em();
+        $em->clear();
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(1, $session->getImagesDownloaded(), 'repeated URL fetched once');
+        $assetCount = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM product_assets WHERE product_id = :p', ['p' => $objectId]);
+        self::assertSame(1, (int) (\is_scalar($assetCount) ? $assetCount : 0));
+    }
+
+    #[Test]
+    public function crossTenantExistingUuidIsDroppedWithWarning(): void
+    {
+        [$sessionId, $objectId] = $this->seed();
+        $foreignUuid = Uuid::v7()->toRfc4122(); // never created in this tenant
+        $handler = $this->handler(new MockHttpClient([]));
+        $job = new ImageDownloadJob($objectId, 'photo', null, null, [$foreignUuid], [], 2, 'MED-1');
+        $handler(new ImageDownloadMessage($sessionId, $this->tenantId(), [$job]));
+
+        $em = $this->em();
+        $em->clear();
+        $logs = $em->getConnection()->fetchOne("SELECT COUNT(*) FROM import_logs WHERE error_type='image_not_found' AND import_session_id = :s", ['s' => $sessionId->toRfc4122()]);
+        self::assertSame(1, (int) (\is_scalar($logs) ? $logs : 0), 'unknown/cross-tenant asset id warned');
+        $envelope = $em->getConnection()->fetchOne(
+            "SELECT COUNT(*) FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id WHERE a.code='photo' AND ov.object_id = :p",
+            ['p' => $objectId],
+        );
+        self::assertSame(0, (int) (\is_scalar($envelope) ? $envelope : 1), 'no envelope written for a dangling id');
+    }
+
+    #[Test]
+    public function importWithUrlColumnWiresMediaPhaseAndNeverWritesRawUrl(): void
+    {
+        // End-to-end through the import endpoint: a URL in an Asset column is
+        // (a) never written raw to JSONB (assetPayload + the chunk asset
+        // prefetch skip it) and (b) routed to the media phase, which runs
+        // inline on the sync transport. A private-IP URL is used so the SSRF
+        // guard rejects it instantly — proving the full wiring with no network
+        // and no flake. (The successful-download path is covered by the
+        // handler integration tests above with a MockHttpClient.)
+        $this->seedSkuAndPhoto();
+
+        $client = $this->authenticatedClient();
+        $path = tempnam(sys_get_temp_dir(), 'pim-url-').'.csv';
+        file_put_contents($path, "sku;photo\nURLPROD-1;http://10.0.0.1/x.png\n");
+        try {
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'photo' => 'photo'], JSON_THROW_ON_ERROR),
+                        'mode' => 'UPSERT',
+                    ],
+                    'files' => ['file' => new \Symfony\Component\HttpFoundation\File\UploadedFile($path, 'url.csv', 'text/csv', null, true)],
+                ],
+            ]);
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            \assert(\is_array($body));
+            $sessionId = $body['id'];
+            \assert(\is_string($sessionId));
+
+            $em = $this->em();
+            $em->clear();
+            $session = $em->find(ImportSession::class, Uuid::fromString($sessionId));
+            \assert($session instanceof ImportSession);
+            // The media phase ran (SSRF-rejected → failed counter), proving the
+            // dispatch wiring fired.
+            self::assertSame(1, $session->getImagesFailed(), 'media phase dispatched + attempted the URL');
+            self::assertFalse($session->isAwaitingMedia(), 'no media batch left pending');
+
+            // The raw URL must NEVER be written to object_values.
+            $photoValues = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id JOIN objects o ON o.id=ov.object_id WHERE a.code='photo' AND o.code='URLPROD-1'",
+            );
+            self::assertSame(0, (int) (\is_scalar($photoValues) ? $photoValues : 1), 'a rejected URL leaves no asset value (and never a raw URL)');
+
+            $logs = $em->getConnection()->fetchOne(
+                "SELECT COUNT(*) FROM import_logs WHERE error_type='image_not_found' AND import_session_id = :s",
+                ['s' => $sessionId],
+            );
+            self::assertSame(1, (int) (\is_scalar($logs) ? $logs : 0));
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    private function seedSkuAndPhoto(): void
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $productOt = self::getContainer()->get(\App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($productOt instanceof ObjectType);
+
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $photo = new Attribute('photo', ['en' => 'Photo'], AttributeType::Asset);
+        $em->persist($sku);
+        $em->persist($photo);
+        $em->persist(new ObjectTypeAttribute($productOt, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($productOt, $photo, false, 2));
+        $em->flush();
+    }
+
+    /**
+     * @return array{0: Uuid, 1: string} sessionId, objectId(rfc4122)
+     */
+    private function seed(): array
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $productOt = self::getContainer()->get(\App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($productOt instanceof ObjectType);
+
+        $photo = new Attribute('photo', ['en' => 'Photo'], AttributeType::Asset);
+        $em->persist($photo);
+        $em->persist(new ObjectTypeAttribute($productOt, $photo, false, 3));
+        $object = new CatalogObject($productOt, 'MED-1');
+        $em->persist($object);
+
+        $session = new ImportSession(
+            userId: Uuid::v7(),
+            targetObjectType: $productOt,
+            fileName: 'media.csv',
+            fileSizeBytes: 32,
+        );
+        $session->assignTenant($tenant);
+        $session->markRunning();
+        $session->incrementPendingImageBatches();
+        $session->markRowPhaseComplete();
+        $em->persist($session);
+        $em->flush();
+
+        return [$session->getId(), $object->getId()->toRfc4122()];
+    }
+
+    /**
+     * @param list<string> $urls
+     */
+    private function message(Uuid $sessionId, string $objectId, array $urls): ImageDownloadMessage
+    {
+        return new ImageDownloadMessage($sessionId, $this->tenantId(), [
+            new ImageDownloadJob($objectId, 'photo', null, null, [], $urls, 2, 'MED-1'),
+        ]);
+    }
+
+    private function tenantId(): Uuid
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant->getId();
+    }
+
+    private function handler(MockHttpClient $httpClient): ImageDownloadHandler
+    {
+        $c = self::getContainer();
+
+        return new ImageDownloadHandler(
+            $c->get(EntityManagerInterface::class),
+            $c->get(ImportSessionRepositoryInterface::class),
+            $httpClient,
+            $c->get(SsrfGuard::class),
+            $c->get(AssetIngestorInterface::class),
+            $c->get(ProductAssetLinker::class),
+            $c->get(AssetRepositoryInterface::class),
+            $c->get(CatalogObjectRepositoryInterface::class),
+            $c->get(AttributeRepositoryInterface::class),
+            $c->get(ObjectValueRepositoryInterface::class),
+            $c->get(TenantContext::class),
+            $c->get(ImportProgressPublisher::class),
+            new NullLogger(),
+        );
+    }
+}

--- a/apps/api/tests/Unit/Import/Media/AssetUrlResolverTest.php
+++ b/apps/api/tests/Unit/Import/Media/AssetUrlResolverTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import\Media;
+
+use App\Import\Application\Service\Media\AssetUrlResolver;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * IMP2-1.12 — token classification for Asset-attribute cells: UUID (existing
+ * asset), http(s) URL (download job), anything else (unresolved → ZIP/transform).
+ */
+final class AssetUrlResolverTest extends TestCase
+{
+    private AssetUrlResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new AssetUrlResolver();
+    }
+
+    #[Test]
+    public function splitsMixedListOnEverySeparator(): void
+    {
+        $uuid = '019ebfbb-ecf6-7590-879b-d079f010cbae';
+        $raw = "$uuid | https://cdn.example.com/a.png ; https://cdn.example.com/b.jpg ,bare-file.png\nhttps://cdn.example.com/c.webp";
+
+        $result = $this->resolver->classify($raw);
+
+        self::assertSame([$uuid], $result['uuids']);
+        self::assertSame([
+            'https://cdn.example.com/a.png',
+            'https://cdn.example.com/b.jpg',
+            'https://cdn.example.com/c.webp',
+        ], $result['urls']);
+        self::assertSame(['bare-file.png'], $result['unresolved']);
+    }
+
+    #[Test]
+    public function classifiesHttpAndHttpsCaseInsensitively(): void
+    {
+        self::assertTrue($this->resolver->isUrl('HTTP://x/y.png'));
+        self::assertTrue($this->resolver->isUrl('https://x/y.png'));
+        self::assertFalse($this->resolver->isUrl('ftp://x/y.png'));
+        self::assertFalse($this->resolver->isUrl('/local/y.png'));
+    }
+
+    #[Test]
+    public function recognisesUuidTokensOnly(): void
+    {
+        self::assertTrue($this->resolver->isUuid('019ebfbb-ecf6-7590-879b-d079f010cbae'));
+        self::assertFalse($this->resolver->isUuid('not-a-uuid'));
+        self::assertFalse($this->resolver->isUuid('https://x/y.png'));
+    }
+
+    #[Test]
+    public function emptyCellYieldsNothing(): void
+    {
+        $result = $this->resolver->classify('   ');
+        self::assertSame([], $result['uuids']);
+        self::assertSame([], $result['urls']);
+        self::assertSame([], $result['unresolved']);
+    }
+
+    #[Test]
+    public function pureUrlListHasNoUuids(): void
+    {
+        $result = $this->resolver->classify('https://a/1.png|https://a/2.png');
+        self::assertSame([], $result['uuids']);
+        self::assertCount(2, $result['urls']);
+    }
+}

--- a/apps/api/tests/Unit/Import/Media/SsrfGuardTest.php
+++ b/apps/api/tests/Unit/Import/Media/SsrfGuardTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import\Media;
+
+use App\Import\Application\Service\Media\SsrfGuard;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * IMP2-1.12 / IMP2-2.8 — SSRF allow/deny. Literal-IP hosts are checked without
+ * DNS so these assertions are network-independent (deterministic in CI).
+ */
+final class SsrfGuardTest extends TestCase
+{
+    private SsrfGuard $guard;
+
+    protected function setUp(): void
+    {
+        $this->guard = new SsrfGuard();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function blocked(): iterable
+    {
+        yield 'loopback v4' => ['http://127.0.0.1/x.png'];
+        yield 'loopback name-literal' => ['https://127.0.0.53/x.png'];
+        yield 'private 10/8' => ['http://10.0.0.5/x.png'];
+        yield 'private 192.168' => ['http://192.168.1.10/x.png'];
+        yield 'private 172.16' => ['http://172.16.5.5/x.png'];
+        yield 'link-local 169.254' => ['http://169.254.169.254/latest/meta-data'];
+        yield 'cgnat 100.64' => ['http://100.64.0.1/x.png'];
+        yield 'ipv6 loopback' => ['http://[::1]/x.png'];
+        yield 'non-http scheme' => ['ftp://93.184.216.34/x.png'];
+        yield 'file scheme' => ['file:///etc/passwd'];
+        yield 'no host' => ['/relative/path.png'];
+    }
+
+    #[Test]
+    #[DataProvider('blocked')]
+    public function rejectsNonPublicOrUnsupported(string $url): void
+    {
+        self::assertFalse($this->guard->isAllowed($url), $url.' must be blocked');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function allowed(): iterable
+    {
+        // Literal public IPs — no DNS, deterministic.
+        yield 'public v4 literal' => ['https://93.184.216.34/img/a.png'];
+        yield 'public v4 http' => ['http://8.8.8.8/x.png'];
+    }
+
+    #[Test]
+    #[DataProvider('allowed')]
+    public function allowsPublicLiteralHosts(string $url): void
+    {
+        self::assertTrue($this->guard->isAllowed($url), $url.' must be allowed');
+    }
+}


### PR DESCRIPTION
## Co dowozi (Closes #1475, #600, #604)

Pliki dostawców (Avapax) mają linki do zdjęć w kolumnach. Dziś import zapisuje surowy URL jako `asset_id` → korupcja. Po tym tickecie import pobiera zdjęcia, dedupuje po content-hash, podpina pod produkt i pokazuje realne liczniki.

### Szew architektoniczny (decyzja operatora — Option B: Asset\Contracts port)
Nowy `App\Asset\Contracts\AssetIngestorInterface` (sniff magic-bytes → sha256 → dedup po content_hash → `AssetUploader`), impl w Asset\Application. **Import zależy tylko od portu** (deptrac: Import→Asset_Contracts, zero skip_violation dla ingestu). Reużywalny przez IMP2-1.13 ZIP i 3.4. Linkowanie przez istniejący `Catalog\Contracts\ProductAssetLinker`.

### Zakres (AC #1475)
- ✅ **Brak surowego URL w JSONB** — `assetPayload` + prefetch assetów chunka pomijają komórki z URL; całą wartość Asset zapisuje handler po pobraniu.
- ✅ **`AssetUrlResolver`** — klasyfikacja tokenów (UUID / http(s) / unresolved), split po `|;,`+whitespace.
- ✅ **`ImageDownloadHandler`** (transport `import`, dziedziczy `AbstractBatchHandler`): SSRF guard, timeout 30s, ≤3 redirecty, ≤10 MB (abort mid-stream), sniff jpg/png/webp, dedup po content_hash, cache URL→assetId w batchu.
- ✅ **SSRF guard** — resolve host→IP, reject RFC1918/loopback/link-local/CGNAT/ULA/reserved PRZED requestem (literal-IP bez DNS).
- ✅ **Dedup** — `findByContentHash` reuse; powtórzony URL w batchu pobrany raz.
- ✅ **Liczniki działają** — `imagesDownloaded`/`imagesFailed` ruszają; błędy → `image_not_found` (404/timeout/SSRF) / `image_format_unsupported` (zły format/oversize), sesja `success`/`partial`, NIGDY `failed`.
- ✅ **Izolacja cross-tenant** — UUID assetu z innego tenanta odrzucony (drop + warning), nie zapisany.
- ✅ **Completion gating** — `pending_image_batches` + `row_phase_complete` (migracja): run nie finalizuje dopóki batche mediów nie wrócą; ostatni batch (lub run gdy sync już zdrenował) finalizuje. Rozwiązuje race „done przed mediami".

### Decyzja wykonawcza
Media dispatchowane **po pętli wierszy** (nie per-chunk): sync transport uruchamia `ImageDownloadHandler` inline, którego `flushAndClear()` wyczyściłby EM w środku pętli ImportRunHandler. Handler działa dwufazowo (download→primitives, potem reattach tenant + reload session → apply), bo `AssetUploader` dispatchuje thumbnaile które czyszczą EM.

### Świadome odejścia
- **Concurrency cap ~10 (HttpClient multiplexing)** — pobieranie sekwencyjne w batchu (próg „≤10" spełniony trywialnie). Równoległość = optymalizacja perf, nie testowana w AC; defer do perf-ticketu (IMP2-2.6) jeśli benchmark tego wymaga.
- **Bare-filename (non-URL) → ZIP/transform** — `ImageNotFound` zostaje (pełne ścieżki względne to IMP2-1.13, prefix/suffix IMP2-3.4 — explicite poza zakresem).

### Testy (zielone lokalnie)
`AssetUrlResolverTest` (5) + `SsrfGuardTest` (13, literal-IP, network-independent) + `ImageDownloadHandlerTest` (7: download+link+envelope, 404, SSRF, bad-format, dedup, cross-tenant, end-to-end przez endpoint). Regresja `tests/{Api,Unit,Integration}/Import` + `tests/Api/Asset` → 198 passed.

### Bramki
PHPStan max `--memory-limit=1G` ✅ · Deptrac 0 ✅ · cs-fixer ✅.

### Smoke
Live-stack na `https://pim.localhost`: import CSV z kolumną URL (arkusz Avapax „Pliki") → asset pobrany, `product_assets` wpis, envelope `{asset_id}`, liczniki>0; URL prywatny odrzucony. Dowód w komentarzu zamknięcia #1475/#600/#604.