### PR TITLE
IMP2-1.13 — feat(import,asset): zdjęcia z pliku ZIP (media część 2)

### DIFF
--- a/apps/admin/src/features/imports/wizard/StepConfirm.tsx
+++ b/apps/admin/src/features/imports/wizard/StepConfirm.tsx
@@ -51,6 +51,11 @@ export function StepConfirmPlaceholder({ wizard }: StepConfirmProps): React.Reac
     formData.set('delimiter', state.delimiter);
     formData.set('do_backup', state.doBackup ? '1' : '0');
     formData.set('mode', state.mode);
+    // IMP2-1.13 — image source + optional ZIP of images (was never sent before).
+    formData.set('image_source', state.imageSource);
+    if (state.imageSource === 'zip' && state.zipFile) {
+      formData.append('zip_file', state.zipFile);
+    }
 
     jsonFetch<{ id: string }>('/api/import-sessions', {
       method: 'POST',

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -242,6 +242,7 @@ services:
     App\Import\Application\Handler\ImageDownloadHandler:
         arguments:
             $httpClient: '@import.ssrf_safe_http_client'
+            $importsStorage: '@imports.storage'
 
     # EXP-06 (#585) — async export worker. Same named-storage binding so
     # the handler can write the generated XLSX/CSV to MinIO under

--- a/apps/api/migrations/Version20260614150000.php
+++ b/apps/api/migrations/Version20260614150000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * IMP2-1.13 (#1476) — media-from-ZIP source flag on the import session.
+ *
+ * `image_source` records how Asset-attribute cells resolve for the run:
+ * `http` (download URLs — IMP2-1.12), `zip` (extract from the uploaded
+ * archive), or `none`. Defaults to `none` so pre-existing sessions are
+ * unaffected.
+ */
+final class Version20260614150000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'IMP2-1.13: import_sessions.image_source (http|zip|none)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE import_sessions ADD image_source VARCHAR(8) NOT NULL DEFAULT 'none'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import_sessions DROP COLUMN image_source');
+    }
+}

--- a/apps/api/src/Import/Application/Handler/ImageDownloadHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImageDownloadHandler.php
@@ -17,6 +17,7 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Import\Application\Service\ImportProgressPublisher;
 use App\Import\Application\Service\Media\SsrfGuard;
+use App\Import\Application\Service\Media\ZipImageExtractor;
 use App\Import\Domain\Entity\ImportLog;
 use App\Import\Domain\Entity\ImportSession;
 use App\Import\Domain\Enum\ImportErrorType;
@@ -28,6 +29,7 @@ use App\Shared\Application\AbstractBatchHandler;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemOperator;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -82,6 +84,7 @@ final class ImageDownloadHandler extends AbstractBatchHandler
         private readonly TenantContext $tenantContext,
         private readonly ImportProgressPublisher $progressPublisher,
         private readonly LoggerInterface $logger,
+        private readonly FilesystemOperator $importsStorage,
     ) {
         parent::__construct($entityManager);
     }
@@ -107,25 +110,68 @@ final class ImageDownloadHandler extends AbstractBatchHandler
         $pendingWrites = [];
         $urlCache = [];
 
-        foreach ($message->jobs as $job) {
-            $ids = [];
-            foreach ($job->urls as $url) {
-                if (isset($urlCache[$url])) {
-                    $ids[] = $urlCache[$url];
-
-                    continue;
+        // IMP2-1.13 — stage the run's ZIP once (streamed from MinIO) and open
+        // the extractor. A zip-bomb / unreadable archive is a SYSTEMIC failure:
+        // fail the session with a clear message rather than per-row.
+        $stagedZip = null;
+        $extractor = null;
+        if (null !== $message->zipStoragePath) {
+            try {
+                $stagedZip = $this->stageZip($message->zipStoragePath);
+                $extractor = new ZipImageExtractor($stagedZip);
+            } catch (Throwable $exception) {
+                if (null !== $stagedZip && is_file($stagedZip)) {
+                    @unlink($stagedZip);
                 }
-                $assetId = $this->fetchAndIngest($job, $url, $pendingLogs);
-                if (null === $assetId) {
-                    ++$failed;
+                $this->failSessionSystemic($message->importSessionId, 'Import ZIP could not be read: '.$exception->getMessage());
 
-                    continue;
-                }
-                $urlCache[$url] = $assetId;
-                $ids[] = $assetId;
-                ++$downloaded;
+                return;
             }
-            $pendingWrites[] = ['job' => $job, 'downloaded' => $ids];
+        }
+
+        try {
+            foreach ($message->jobs as $job) {
+                $ids = [];
+                foreach ($job->urls as $url) {
+                    if (isset($urlCache[$url])) {
+                        $ids[] = $urlCache[$url];
+
+                        continue;
+                    }
+                    $assetId = $this->fetchAndIngest($job, $url, $pendingLogs);
+                    if (null === $assetId) {
+                        ++$failed;
+
+                        continue;
+                    }
+                    $urlCache[$url] = $assetId;
+                    $ids[] = $assetId;
+                    ++$downloaded;
+                }
+                foreach ($job->zipNames as $name) {
+                    $cacheKey = 'zip:'.$name;
+                    if (isset($urlCache[$cacheKey])) {
+                        $ids[] = $urlCache[$cacheKey];
+
+                        continue;
+                    }
+                    $assetId = null !== $extractor ? $this->extractAndIngest($extractor, $job, $name, $pendingLogs) : null;
+                    if (null === $assetId) {
+                        ++$failed;
+
+                        continue;
+                    }
+                    $urlCache[$cacheKey] = $assetId;
+                    $ids[] = $assetId;
+                    ++$downloaded;
+                }
+                $pendingWrites[] = ['job' => $job, 'downloaded' => $ids];
+            }
+        } finally {
+            $extractor?->close();
+            if (null !== $stagedZip && is_file($stagedZip)) {
+                @unlink($stagedZip);
+            }
         }
 
         // ── Phase 2: APPLY (EM may have been cleared by ingest) ──
@@ -164,13 +210,21 @@ final class ImageDownloadHandler extends AbstractBatchHandler
         $rowPhaseDone = \is_array($row) && (bool) $row['row_phase_complete'];
 
         // The batch that drives the counter to zero AFTER the row phase is done
-        // finalizes the session (success / partial).
+        // finalizes the session (success / partial) and removes the now-spent
+        // ZIP from MinIO (IMP2-1.13 item 7 — full TTL sweep is IMP2-2.2).
         if (0 === $pending && $rowPhaseDone) {
             $session = $this->sessions->findById($message->importSessionId);
             if ($session instanceof ImportSession && !$session->getStatus()->isTerminal()) {
                 $session->markCompleted();
                 $this->sessions->save($session);
                 $this->progressPublisher->completed($session);
+            }
+            if (null !== $message->zipStoragePath) {
+                try {
+                    $this->importsStorage->delete($message->zipStoragePath);
+                } catch (Throwable $exception) {
+                    $this->logger->warning('Failed to delete spent import ZIP from storage.', ['path' => $message->zipStoragePath, 'exception' => $exception]);
+                }
             }
         }
     }
@@ -312,6 +366,78 @@ final class ImageDownloadHandler extends AbstractBatchHandler
         $this->tenantContext->set($tenant);
 
         return $tenant;
+    }
+
+    /**
+     * Stream the run's ZIP from MinIO to a local temp path (constant memory).
+     * Caller unlinks. Throws on a missing/unreadable archive (systemic).
+     */
+    private function stageZip(string $storagePath): string
+    {
+        $stream = $this->importsStorage->readStream($storagePath);
+        $local = tempnam(sys_get_temp_dir(), 'pim-zip-src-');
+        if (false === $local) {
+            throw new RuntimeException('Failed to allocate a temp file for the import ZIP.');
+        }
+        $out = fopen($local, 'w');
+        if (false === $out) {
+            throw new RuntimeException('Failed to open the import ZIP temp file.');
+        }
+        try {
+            stream_copy_to_stream($stream, $out);
+        } finally {
+            fclose($out);
+            if (\is_resource($stream)) {
+                fclose($stream);
+            }
+        }
+
+        return $local;
+    }
+
+    /**
+     * @param list<array{job: ImageDownloadJob, type: ImportErrorType, message: string, value: string}> $pendingLogs by ref
+     */
+    private function extractAndIngest(ZipImageExtractor $extractor, ImageDownloadJob $job, string $name, array &$pendingLogs): ?string
+    {
+        $tmp = null;
+        try {
+            $tmp = $extractor->extractToTemp($name);
+            if (null === $tmp) {
+                $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageNotFound, 'message' => \sprintf('File "%s" was not found in the uploaded ZIP.', $name), 'value' => $name];
+
+                return null;
+            }
+
+            return $this->assetIngestor->ingest($tmp, $name)->assetId->toRfc4122();
+        } catch (UnsupportedMediaFormatException $exception) {
+            $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageFormatUnsupported, 'message' => \sprintf('ZIP entry "%s": %s', $name, $exception->getMessage()), 'value' => $name];
+
+            return null;
+        } catch (Throwable $exception) {
+            $this->logger->warning('Import ZIP entry ingest failed.', ['name' => $name, 'exception' => $exception]);
+            $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageNotFound, 'message' => \sprintf('ZIP entry "%s" could not be extracted: %s', $name, $exception->getMessage()), 'value' => $name];
+
+            return null;
+        } finally {
+            if (null !== $tmp && is_file($tmp)) {
+                @unlink($tmp);
+            }
+        }
+    }
+
+    /**
+     * Mark the session failed for a systemic media fault (e.g. zip bomb /
+     * unreadable archive) instead of letting the batch dead-letter.
+     */
+    private function failSessionSystemic(Uuid $sessionId, string $message): void
+    {
+        $session = $this->sessions->findById($sessionId);
+        if ($session instanceof ImportSession && !$session->getStatus()->isTerminal()) {
+            $session->markFailed($message);
+            $this->sessions->save($session);
+            $this->progressPublisher->completed($session);
+        }
     }
 
     private function filenameFor(string $url): string

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -21,6 +21,7 @@ use App\Import\Application\Service\RelationImportStep;
 use App\Import\Domain\Entity\ImportLog;
 use App\Import\Domain\Entity\ImportSession;
 use App\Import\Domain\Enum\ImportErrorType;
+use App\Import\Domain\Enum\ImportImageSource;
 use App\Import\Domain\Enum\ImportLogLevel;
 use App\Import\Domain\Message\ImageDownloadJob;
 use App\Import\Domain\Message\ImageDownloadMessage;
@@ -807,23 +808,26 @@ final class ImportRunHandler extends AbstractBatchHandler
                 continue;
             }
             $classified = $this->assetUrlResolver->classify($raw);
-            // IMP2-1.12 (1c) — a bare-filename token is neither an existing
-            // asset id nor an http(s) URL (relative paths land in IMP2-1.13 ZIP
-            // / IMP2-3.4 prefix transform); surface each as a row warning rather
-            // than dropping it silently.
-            foreach ($classified['unresolved'] as $token) {
-                $this->entityManager->persist(new ImportLog(
-                    importSession: $session,
-                    rowNumber: $row['rowNumber'],
-                    level: ImportLogLevel::Warning,
-                    message: \sprintf('Asset reference "%s" is neither a known asset id nor an http(s) URL — skipped.', $token),
-                    sku: $row['sku'],
-                    errorType: ImportErrorType::ImageNotFound->value,
-                    columnName: $resolved->attributeCode,
-                    columnValue: $token,
-                ));
+            // IMP2-1.13 — in ZIP mode a bare-filename token is a ZIP entry to
+            // extract (not unresolved); in HTTP/none mode it stays unresolved
+            // and is warned (1c) — relative paths arrive in IMP2-3.4.
+            $zipMode = ImportImageSource::Zip === $session->getImageSource();
+            $zipNames = $zipMode ? $classified['unresolved'] : [];
+            if (!$zipMode) {
+                foreach ($classified['unresolved'] as $token) {
+                    $this->entityManager->persist(new ImportLog(
+                        importSession: $session,
+                        rowNumber: $row['rowNumber'],
+                        level: ImportLogLevel::Warning,
+                        message: \sprintf('Asset reference "%s" is neither a known asset id nor an http(s) URL — skipped.', $token),
+                        sku: $row['sku'],
+                        errorType: ImportErrorType::ImageNotFound->value,
+                        columnName: $resolved->attributeCode,
+                        columnValue: $token,
+                    ));
+                }
             }
-            if ([] === $classified['urls']) {
+            if ([] === $classified['urls'] && [] === $zipNames) {
                 continue; // pure UUID / handled by the value writer
             }
             $mediaJobs[] = new ImageDownloadJob(
@@ -835,6 +839,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                 urls: $classified['urls'],
                 rowNumber: $row['rowNumber'],
                 sku: $row['sku'],
+                zipNames: $zipNames,
             );
         }
     }
@@ -858,13 +863,19 @@ final class ImportRunHandler extends AbstractBatchHandler
             if (!$tenant instanceof Tenant) {
                 break;
             }
+            // IMP2-1.13 — pass the run's ZIP location so the handler stages +
+            // extracts entries (only in zip mode with an uploaded archive).
+            $zipStoragePath = null;
+            if (ImportImageSource::Zip === $session->getImageSource() && null !== $session->getZipFileName()) {
+                $zipStoragePath = \sprintf('%s/%s/%s', $tenant->getId()->toRfc4122(), $session->getId()->toRfc4122(), $session->getZipFileName());
+            }
             $session->incrementPendingImageBatches();
             $this->sessions->save($session);
             // TenantStamp so the async worker rebinds the tenant before the
             // handler runs (TenantContextRebindingMiddleware) — mirrors the
             // ImportRunMessage dispatch; without it the worker dead-letters.
             $this->messageBus->dispatch(
-                new ImageDownloadMessage($session->getId(), $tenant->getId(), $batch),
+                new ImageDownloadMessage($session->getId(), $tenant->getId(), $batch, $zipStoragePath),
                 [new TenantStamp($tenant->getId())],
             );
         }

--- a/apps/api/src/Import/Application/Service/Media/ZipImageExtractor.php
+++ b/apps/api/src/Import/Application/Service/Media/ZipImageExtractor.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service\Media;
+
+use Normalizer;
+use RuntimeException;
+use ZipArchive;
+
+use const PATHINFO_BASENAME;
+
+/**
+ * IMP2-1.13 — extracts single image entries from an import ZIP by filename,
+ * streamed (never extractTo() the whole archive, never load it into RAM).
+ *
+ * Opens the archive once and builds a case-insensitive name index keyed by BOTH
+ * the full relative path and the basename, each registered in Unicode NFC and
+ * NFD form (a cell may carry `żółć.png` while the archive — zipped on macOS —
+ * stored the NFD bytes, or vice-versa).
+ *
+ * Hardened against malicious archives (coordination point with IMP2-2.8):
+ *   - path traversal / absolute / symlink entries are skipped at index time;
+ *   - zip-bomb caps — max entries, max total uncompressed size, max per-entry
+ *     compression ratio — throw {@see RuntimeException} (the run treats it as a
+ *     systemic failure, not a per-row error).
+ */
+final class ZipImageExtractor
+{
+    private const int MAX_ENTRIES = 50_000;
+    private const int MAX_TOTAL_UNCOMPRESSED = 2 * 1024 * 1024 * 1024; // 2 GiB
+    private const int MAX_RATIO = 200; // uncompressed/compressed per entry
+    private const int CHUNK = 65536;
+
+    private ZipArchive $zip;
+
+    /** @var array<string, string> normalised lookup key → real archive entry name */
+    private array $index = [];
+
+    public function __construct(string $zipPath)
+    {
+        $zip = new ZipArchive();
+        $opened = $zip->open($zipPath, ZipArchive::RDONLY);
+        if (true !== $opened) {
+            throw new RuntimeException(\sprintf('Failed to open ZIP "%s" (code %s).', $zipPath, (string) $opened));
+        }
+        $this->zip = $zip;
+        $this->buildIndex();
+    }
+
+    public function close(): void
+    {
+        $this->zip->close();
+    }
+
+    /**
+     * Resolve a cell value (filename or relative path) to a real archive entry,
+     * case-insensitively and Unicode-normalisation-insensitively.
+     */
+    public function resolve(string $name): ?string
+    {
+        $trimmed = trim($name);
+        foreach ($this->lookupKeys($trimmed) as $key) {
+            if (isset($this->index[$key])) {
+                return $this->index[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Stream a resolved entry to a local temp file. Returns the temp path, or
+     * null when the entry is absent. Caller unlinks.
+     */
+    public function extractToTemp(string $name): ?string
+    {
+        $entry = $this->resolve($name);
+        if (null === $entry) {
+            return null;
+        }
+
+        $stream = $this->zip->getStream($entry);
+        if (false === $stream) {
+            return null;
+        }
+
+        $tmp = tempnam(sys_get_temp_dir(), 'pim-zip-');
+        if (false === $tmp) {
+            fclose($stream);
+
+            throw new RuntimeException('Failed to allocate a temp file for ZIP extraction.');
+        }
+        $out = fopen($tmp, 'w');
+        if (false === $out) {
+            fclose($stream);
+
+            throw new RuntimeException('Failed to open the ZIP extraction temp file.');
+        }
+        try {
+            while (!feof($stream)) {
+                $chunk = fread($stream, self::CHUNK);
+                if (false === $chunk) {
+                    break;
+                }
+                fwrite($out, $chunk);
+            }
+        } finally {
+            fclose($stream);
+            fclose($out);
+        }
+
+        return $tmp;
+    }
+
+    private function buildIndex(): void
+    {
+        $count = $this->zip->count();
+        if ($count > self::MAX_ENTRIES) {
+            throw new RuntimeException(\sprintf('ZIP has %d entries, exceeding the %d limit (possible zip bomb).', $count, self::MAX_ENTRIES));
+        }
+
+        $totalUncompressed = 0;
+        for ($i = 0; $i < $count; ++$i) {
+            $stat = $this->zip->statIndex($i);
+            if (false === $stat) {
+                continue;
+            }
+            $entryName = $stat['name'];
+
+            // Directories + unsafe paths never enter the index.
+            if (str_ends_with($entryName, '/')) {
+                continue;
+            }
+            if ($this->isUnsafePath($entryName)) {
+                continue;
+            }
+
+            $uncompressed = $stat['size'];
+            $compressed = $stat['comp_size'];
+            $totalUncompressed += $uncompressed;
+            if ($totalUncompressed > self::MAX_TOTAL_UNCOMPRESSED) {
+                throw new RuntimeException('ZIP uncompressed size exceeds the limit (possible zip bomb).');
+            }
+            if ($compressed > 0 && $uncompressed / $compressed > self::MAX_RATIO) {
+                throw new RuntimeException(\sprintf('ZIP entry "%s" has a suspicious compression ratio (possible zip bomb).', $entryName));
+            }
+
+            $basename = pathinfo($entryName, PATHINFO_BASENAME);
+            foreach ([$entryName, $basename] as $candidate) {
+                foreach ($this->lookupKeys($candidate) as $key) {
+                    // First writer wins for the full path; basename collisions
+                    // keep the first occurrence (deterministic).
+                    $this->index[$key] ??= $entryName;
+                }
+            }
+        }
+    }
+
+    /**
+     * Lookup keys for a name: lower-cased, in NFC and NFD normalisation.
+     *
+     * @return list<string>
+     */
+    private function lookupKeys(string $name): array
+    {
+        $lower = mb_strtolower($name);
+        $keys = [$lower];
+        if (class_exists(Normalizer::class)) {
+            $nfc = Normalizer::normalize($lower, Normalizer::FORM_C);
+            $nfd = Normalizer::normalize($lower, Normalizer::FORM_D);
+            if (\is_string($nfc)) {
+                $keys[] = $nfc;
+            }
+            if (\is_string($nfd)) {
+                $keys[] = $nfd;
+            }
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    private function isUnsafePath(string $entryName): bool
+    {
+        if (str_starts_with($entryName, '/') || str_starts_with($entryName, '\\')) {
+            return true;
+        }
+        if (1 === preg_match('#^[a-zA-Z]:[\\\\/]#', $entryName)) {
+            return true; // Windows absolute (C:\…)
+        }
+        $parts = preg_split('#[\\\\/]#', $entryName);
+        if (false === $parts) {
+            return false;
+        }
+
+        return \in_array('..', $parts, true);
+    }
+}

--- a/apps/api/src/Import/Domain/Entity/ImportSession.php
+++ b/apps/api/src/Import/Domain/Entity/ImportSession.php
@@ -6,6 +6,7 @@ namespace App\Import\Domain\Entity;
 
 use App\Backup\Domain\Entity\Backup;
 use App\Catalog\Domain\Entity\ObjectType;
+use App\Import\Domain\Enum\ImportImageSource;
 use App\Import\Domain\Enum\ImportMode;
 use App\Import\Domain\Enum\ImportSessionStatus;
 use App\Shared\Application\TenantScoped;
@@ -49,6 +50,9 @@ class ImportSession extends AggregateRoot implements TenantScoped
     private ?string $zipFileName = null;
 
     private ?int $zipFileSizeBytes = null;
+
+    /** IMP2-1.13 — media source for Asset cells: http | zip | none. */
+    private string $imageSource = ImportImageSource::None->value;
 
     private ObjectType $targetObjectType;
 
@@ -183,6 +187,16 @@ class ImportSession extends AggregateRoot implements TenantScoped
     public function getZipFileSizeBytes(): ?int
     {
         return $this->zipFileSizeBytes;
+    }
+
+    public function getImageSource(): ImportImageSource
+    {
+        return ImportImageSource::from($this->imageSource);
+    }
+
+    public function setImageSource(ImportImageSource $imageSource): void
+    {
+        $this->imageSource = $imageSource->value;
     }
 
     public function getTargetObjectType(): ObjectType

--- a/apps/api/src/Import/Domain/Message/ImageDownloadJob.php
+++ b/apps/api/src/Import/Domain/Message/ImageDownloadJob.php
@@ -17,7 +17,8 @@ final readonly class ImageDownloadJob
 {
     /**
      * @param list<string> $existingUuids already-classified existing asset UUIDs (RFC 4122)
-     * @param list<string> $urls          http(s) image URLs to download
+     * @param list<string> $urls          http(s) image URLs to download (http mode)
+     * @param list<string> $zipNames      filenames to extract from the run's ZIP (zip mode, IMP2-1.13)
      */
     public function __construct(
         public string $objectId,
@@ -28,6 +29,7 @@ final readonly class ImageDownloadJob
         public array $urls,
         public int $rowNumber,
         public ?string $sku,
+        public array $zipNames = [],
     ) {
     }
 }

--- a/apps/api/src/Import/Domain/Message/ImageDownloadMessage.php
+++ b/apps/api/src/Import/Domain/Message/ImageDownloadMessage.php
@@ -18,11 +18,13 @@ final readonly class ImageDownloadMessage
 {
     /**
      * @param list<ImageDownloadJob> $jobs
+     * @param ?string                $zipStoragePath MinIO path of the run's ZIP (zip mode, IMP2-1.13); null in http mode
      */
     public function __construct(
         public Uuid $importSessionId,
         public Uuid $tenantId,
         public array $jobs,
+        public ?string $zipStoragePath = null,
     ) {
     }
 }

--- a/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
+++ b/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
@@ -32,6 +32,11 @@
         <field name="fileSizeBytes" type="bigint" column="file_size_bytes"/>
         <field name="zipFileName" type="string" length="255" column="zip_file_name" nullable="true"/>
         <field name="zipFileSizeBytes" type="bigint" column="zip_file_size_bytes" nullable="true"/>
+        <field name="imageSource" type="string" length="8" column="image_source">
+            <options>
+                <option name="default">none</option>
+            </options>
+        </field>
 
         <many-to-one field="targetObjectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
             <join-column name="target_object_type_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>

--- a/apps/api/src/Import/Presentation/Controller/StartImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/StartImportController.php
@@ -14,6 +14,7 @@ use App\Identity\Domain\Entity\User;
 use App\Import\Application\Handler\ImportRunHandler;
 use App\Import\Domain\Entity\ImportProfile;
 use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportImageSource;
 use App\Import\Domain\Enum\ImportMode;
 use App\Import\Domain\Message\ImportRunMessage;
 use App\Import\Domain\Repository\ImportProfileRepositoryInterface;
@@ -36,6 +37,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Uid\Uuid;
@@ -57,6 +59,9 @@ use Symfony\Component\Uid\Uuid;
 final class StartImportController
 {
     private const int SYNC_THRESHOLD_ROWS = 50;
+
+    /** IMP2-1.13 — server-side ZIP upload cap (D13). */
+    private const int MAX_ZIP_BYTES = 500 * 1024 * 1024;
 
     public function __construct(
         private readonly ImportSessionRepositoryInterface $sessions,
@@ -114,12 +119,31 @@ final class StartImportController
             // XLSX is a zip — line counting is meaningless; spreadsheets
             // always take the worker path (cheap now that dev runs one).
             : self::SYNC_THRESHOLD_ROWS + 1;
+        // IMP2-1.13 — optional ZIP of images. Validate extension + 500 MB cap
+        // server-side (FE pre-validates too); the bytes are streamed to MinIO
+        // after the session is persisted.
+        $zipFile = $request->files->get('zip_file');
+        $zipName = null;
+        $zipSize = null;
+        if ($zipFile instanceof UploadedFile) {
+            $zipName = $zipFile->getClientOriginalName();
+            if ('' === $zipName || !str_ends_with(strtolower($zipName), '.zip')) {
+                throw new BadRequestHttpException('"zip_file" must be a .zip archive.');
+            }
+            $zipSize = (int) $zipFile->getSize();
+            if ($zipSize > self::MAX_ZIP_BYTES) {
+                throw new UnprocessableEntityHttpException(\sprintf('ZIP exceeds the %d MB limit.', self::MAX_ZIP_BYTES >> 20));
+            }
+        }
+
         $session = new ImportSession(
             userId: $user->getId(),
             targetObjectType: $objectType,
             fileName: $originalName,
             fileSizeBytes: (int) $file->getSize(),
             profile: $profile,
+            zipFileName: $zipName,
+            zipFileSizeBytes: $zipSize,
         );
 
         $mode = $this->resolveMode($request->request->get('mode'), $profile);
@@ -130,6 +154,14 @@ final class StartImportController
         );
         $session->configureRun($mode, $matchAttributeCode);
         $session->setColumnMapping($mapping);
+        // IMP2-1.13 — a ZIP forces zip mode; otherwise honour the wizard's
+        // image_source (http|none). http behaves like none for the engine
+        // (URL cells are auto-detected), so only `zip` changes routing.
+        $session->setImageSource(
+            null !== $zipName
+                ? ImportImageSource::Zip
+                : (ImportImageSource::tryFrom((string) $request->request->get('image_source', 'none')) ?? ImportImageSource::None),
+        );
 
         // Persist before upload so a later upload failure has a session id
         // to attach to (status stays `pending`, error_message captures
@@ -156,6 +188,26 @@ final class StartImportController
             $session->markFailed(\sprintf('Failed to stage uploaded file: %s', $exception->getMessage()));
             $this->sessions->save($session);
             throw new BadRequestHttpException('Failed to stage the uploaded file.', $exception);
+        }
+
+        // IMP2-1.13 — stage the ZIP next to the data file (same tenant/session
+        // prefix); the media handler downloads + extracts it after the row phase.
+        if ($zipFile instanceof UploadedFile) {
+            $zipRemotePath = \sprintf('%s/%s/%s', $tenant->getId()->toRfc4122(), $session->getId()->toRfc4122(), $zipName);
+            try {
+                $zipStream = fopen($zipFile->getPathname(), 'r');
+                if (false === $zipStream) {
+                    throw new RuntimeException('Failed to open uploaded ZIP for reading.');
+                }
+                $this->importsStorage->writeStream($zipRemotePath, $zipStream);
+                if (\is_resource($zipStream)) {
+                    fclose($zipStream);
+                }
+            } catch (FilesystemException|RuntimeException $exception) {
+                $session->markFailed(\sprintf('Failed to stage uploaded ZIP: %s', $exception->getMessage()));
+                $this->sessions->save($session);
+                throw new BadRequestHttpException('Failed to stage the uploaded ZIP.', $exception);
+            }
         }
 
         // Spec decision §3: <50 rows runs inline so the operator does not

--- a/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
+++ b/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
@@ -34,6 +34,7 @@ use RuntimeException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Uid\Uuid;
+use ZipArchive;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -287,6 +288,68 @@ final class ImageDownloadHandlerTest extends CatalogApiTestCase
         }
     }
 
+    #[Test]
+    public function multipartZipImportExtractsLinksAndSetsZipName(): void
+    {
+        // End-to-end through the endpoint: multipart `file` + `zip_file` +
+        // image_source=zip → ZIP staged, filename cell extracted + linked
+        // (sync transport runs the media handler inline).
+        $png = base64_decode(self::PNG, true);
+        \assert(false !== $png);
+        $this->seedSkuAndPhoto();
+
+        $client = $this->authenticatedClient();
+        $csvPath = tempnam(sys_get_temp_dir(), 'pim-zcsv-').'.csv';
+        file_put_contents($csvPath, "sku;photo\nZIPPROD-1;front.jpg\n");
+        $zipPath = tempnam(sys_get_temp_dir(), 'pim-zfix-').'.zip';
+        $zip = new ZipArchive();
+        \assert(true === $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        $zip->addFromString('catalog/Front.JPG', $png);
+        $zip->close();
+
+        try {
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'photo' => 'photo'], JSON_THROW_ON_ERROR),
+                        'mode' => 'UPSERT',
+                        'image_source' => 'zip',
+                    ],
+                    'files' => [
+                        'file' => new \Symfony\Component\HttpFoundation\File\UploadedFile($csvPath, 'data.csv', 'text/csv', null, true),
+                        'zip_file' => new \Symfony\Component\HttpFoundation\File\UploadedFile($zipPath, 'images.zip', 'application/zip', null, true),
+                    ],
+                ],
+            ]);
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            \assert(\is_array($body));
+            $sessionId = $body['id'];
+            \assert(\is_string($sessionId));
+
+            $em = $this->em();
+            $em->clear();
+            $session = $em->find(ImportSession::class, Uuid::fromString($sessionId));
+            \assert($session instanceof ImportSession);
+            self::assertSame('images.zip', $session->getZipFileName(), 'zip metadata recorded on the session');
+            self::assertNotNull($session->getZipFileSizeBytes());
+            self::assertSame(1, $session->getImagesDownloaded(), 'ZIP entry extracted + ingested inline');
+
+            $envelope = $em->getConnection()->fetchOne(
+                "SELECT ov.value FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id JOIN objects o ON o.id=ov.object_id WHERE a.code='photo' AND o.code='ZIPPROD-1'",
+            );
+            self::assertIsString($envelope);
+            self::assertStringContainsString('asset_id', $envelope);
+            self::assertStringNotContainsString('front.jpg', $envelope, 'filename never lands raw in JSONB');
+            $links = $em->getConnection()->fetchOne("SELECT COUNT(*) FROM product_assets pa JOIN objects o ON o.id=pa.product_id WHERE o.code='ZIPPROD-1'");
+            self::assertSame(1, (int) (\is_scalar($links) ? $links : 0));
+        } finally {
+            @unlink($csvPath);
+            @unlink($zipPath);
+        }
+    }
+
     private function seedSkuAndPhoto(): void
     {
         $em = $this->em();
@@ -377,6 +440,88 @@ final class ImageDownloadHandlerTest extends CatalogApiTestCase
             $c->get(TenantContext::class),
             $c->get(ImportProgressPublisher::class),
             new NullLogger(),
+            $c->get('imports.storage'),
         );
+    }
+
+    #[Test]
+    public function extractsFromZipLinksAndWritesEnvelope(): void
+    {
+        $png = base64_decode(self::PNG, true);
+        \assert(false !== $png);
+        [$sessionId, $objectId] = $this->seed();
+
+        // Stage a ZIP (with one image) in the imports storage + point the
+        // message at it; the handler streams it down and extracts by filename.
+        $zipBytes = $this->makeZipBytes(['catalog/Front.JPG' => $png]);
+        $tenantId = $this->tenantId()->toRfc4122();
+        $zipPath = $tenantId.'/'.$sessionId->toRfc4122().'/images.zip';
+        self::getContainer()->get('imports.storage')->write($zipPath, $zipBytes);
+
+        $job = new ImageDownloadJob($objectId, 'photo', null, null, [], [], 2, 'MED-1', ['front.jpg']);
+        $handler = $this->handler(new MockHttpClient([]));
+        $handler(new ImageDownloadMessage($sessionId, $this->tenantId(), [$job], $zipPath));
+
+        $em = $this->em();
+        $em->clear();
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(1, $session->getImagesDownloaded(), 'ZIP entry counts as a downloaded image');
+        self::assertSame(ImportSessionStatus::Success, $session->getStatus());
+
+        $envelope = $em->getConnection()->fetchOne(
+            "SELECT ov.value FROM object_values ov JOIN attributes a ON a.id=ov.attribute_id WHERE a.code='photo' AND ov.object_id = :p",
+            ['p' => $objectId],
+        );
+        self::assertIsString($envelope);
+        $decoded = json_decode($envelope, true, 512, JSON_THROW_ON_ERROR);
+        \assert(\is_array($decoded));
+        self::assertArrayHasKey('asset_id', $decoded);
+        $links = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM product_assets WHERE product_id = :p', ['p' => $objectId]);
+        self::assertSame(1, (int) (\is_scalar($links) ? $links : 0));
+
+        // The spent ZIP is removed from storage on finalize.
+        self::assertFalse(self::getContainer()->get('imports.storage')->fileExists($zipPath), 'spent ZIP deleted');
+    }
+
+    #[Test]
+    public function missingZipEntryIsImageNotFound(): void
+    {
+        $png = base64_decode(self::PNG, true);
+        \assert(false !== $png);
+        [$sessionId, $objectId] = $this->seed();
+        $zipBytes = $this->makeZipBytes(['other.jpg' => $png]);
+        $zipPath = $this->tenantId()->toRfc4122().'/'.$sessionId->toRfc4122().'/images.zip';
+        self::getContainer()->get('imports.storage')->write($zipPath, $zipBytes);
+
+        $job = new ImageDownloadJob($objectId, 'photo', null, null, [], [], 2, 'MED-1', ['absent.jpg']);
+        $handler = $this->handler(new MockHttpClient([]));
+        $handler(new ImageDownloadMessage($sessionId, $this->tenantId(), [$job], $zipPath));
+
+        $em = $this->em();
+        $em->clear();
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(1, $session->getImagesFailed());
+        $logs = $em->getConnection()->fetchOne("SELECT COUNT(*) FROM import_logs WHERE error_type='image_not_found' AND import_session_id = :s", ['s' => $sessionId->toRfc4122()]);
+        self::assertSame(1, (int) (\is_scalar($logs) ? $logs : 0));
+    }
+
+    /**
+     * @param array<string, string> $entries
+     */
+    private function makeZipBytes(array $entries): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pim-ztest-').'.zip';
+        $zip = new ZipArchive();
+        \assert(true === $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        foreach ($entries as $name => $contents) {
+            $zip->addFromString($name, $contents);
+        }
+        $zip->close();
+        $bytes = (string) file_get_contents($path);
+        @unlink($path);
+
+        return $bytes;
     }
 }

--- a/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
+++ b/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
@@ -301,9 +301,11 @@ final class ImageDownloadHandlerTest extends CatalogApiTestCase
         $client = $this->authenticatedClient();
         $csvPath = tempnam(sys_get_temp_dir(), 'pim-zcsv-').'.csv';
         file_put_contents($csvPath, "sku;photo\nZIPPROD-1;front.jpg\n");
-        $zipPath = tempnam(sys_get_temp_dir(), 'pim-zfix-').'.zip';
+        $zipPath = tempnam(sys_get_temp_dir(), 'pim-zfix-');
         $zip = new ZipArchive();
-        \assert(true === $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        if (true !== $zip->open($zipPath, ZipArchive::OVERWRITE)) {
+            throw new RuntimeException('Failed to create test ZIP fixture.');
+        }
         $zip->addFromString('catalog/Front.JPG', $png);
         $zip->close();
 
@@ -512,9 +514,11 @@ final class ImageDownloadHandlerTest extends CatalogApiTestCase
      */
     private function makeZipBytes(array $entries): string
     {
-        $path = tempnam(sys_get_temp_dir(), 'pim-ztest-').'.zip';
+        $path = tempnam(sys_get_temp_dir(), 'pim-ztest-');
         $zip = new ZipArchive();
-        \assert(true === $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        if (true !== $zip->open($path, ZipArchive::OVERWRITE)) {
+            throw new RuntimeException('Failed to create test ZIP fixture.');
+        }
         foreach ($entries as $name => $contents) {
             $zip->addFromString($name, $contents);
         }

--- a/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
+++ b/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
@@ -302,6 +302,7 @@ final class ImageDownloadHandlerTest extends CatalogApiTestCase
         $csvPath = tempnam(sys_get_temp_dir(), 'pim-zcsv-').'.csv';
         file_put_contents($csvPath, "sku;photo\nZIPPROD-1;front.jpg\n");
         $zipPath = tempnam(sys_get_temp_dir(), 'pim-zfix-');
+        \assert(false !== $zipPath);
         $zip = new ZipArchive();
         if (true !== $zip->open($zipPath, ZipArchive::OVERWRITE)) {
             throw new RuntimeException('Failed to create test ZIP fixture.');
@@ -515,6 +516,7 @@ final class ImageDownloadHandlerTest extends CatalogApiTestCase
     private function makeZipBytes(array $entries): string
     {
         $path = tempnam(sys_get_temp_dir(), 'pim-ztest-');
+        \assert(false !== $path);
         $zip = new ZipArchive();
         if (true !== $zip->open($path, ZipArchive::OVERWRITE)) {
             throw new RuntimeException('Failed to create test ZIP fixture.');

--- a/apps/api/tests/Unit/Import/Media/ZipImageExtractorTest.php
+++ b/apps/api/tests/Unit/Import/Media/ZipImageExtractorTest.php
@@ -131,10 +131,18 @@ final class ZipImageExtractorTest extends TestCase
      */
     private function makeZip(array $entries): string
     {
-        $path = tempnam(sys_get_temp_dir(), 'pim-ziptest-').'.zip';
+        // tempnam() creates the file, so OVERWRITE (overwrite-existing) is the
+        // portable open mode — CREATE|OVERWRITE on a non-existent `.zip` path
+        // errors on some libzip builds (CI). Throw explicitly because assert is
+        // a no-op when zend.assertions is off (CI), which would otherwise
+        // surface only as a later "Invalid or uninitialized Zip object".
+        $path = tempnam(sys_get_temp_dir(), 'pim-ziptest-');
         $this->tmpFiles[] = $path;
         $zip = new ZipArchive();
-        \assert(true === $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        $opened = $zip->open($path, ZipArchive::OVERWRITE);
+        if (true !== $opened) {
+            throw new RuntimeException('Failed to create test ZIP: '.var_export($opened, true));
+        }
         foreach ($entries as $name => $contents) {
             $zip->addFromString($name, $contents);
         }

--- a/apps/api/tests/Unit/Import/Media/ZipImageExtractorTest.php
+++ b/apps/api/tests/Unit/Import/Media/ZipImageExtractorTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import\Media;
+
+use App\Import\Application\Service\Media\ZipImageExtractor;
+use Normalizer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use ZipArchive;
+
+/**
+ * IMP2-1.13 — ZIP entry extraction: case-insensitive + Unicode-normalisation
+ * matching, subdirectories, traversal rejection, zip-bomb guard.
+ */
+final class ZipImageExtractorTest extends TestCase
+{
+    private const string PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    /** @var list<string> */
+    private array $tmpFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpFiles as $f) {
+            if (is_file($f)) {
+                @unlink($f);
+            }
+        }
+    }
+
+    #[Test]
+    public function resolvesCaseInsensitivelyAcrossSubdirAndBasename(): void
+    {
+        $zip = $this->makeZip([
+            'images/Zdjecie1.JPG' => $this->png(),
+            'flat.png' => $this->png(),
+        ]);
+        $extractor = new ZipImageExtractor($zip);
+        try {
+            // basename, different case
+            self::assertSame('images/Zdjecie1.JPG', $extractor->resolve('zdjecie1.jpg'));
+            // full relative path, different case
+            self::assertSame('images/Zdjecie1.JPG', $extractor->resolve('IMAGES/zdjecie1.JPG'));
+            self::assertSame('flat.png', $extractor->resolve('FLAT.PNG'));
+            self::assertNull($extractor->resolve('missing.png'));
+        } finally {
+            $extractor->close();
+        }
+    }
+
+    #[Test]
+    public function extractsEntryToTempPreservingBytes(): void
+    {
+        $zip = $this->makeZip(['a.png' => $this->png()]);
+        $extractor = new ZipImageExtractor($zip);
+        try {
+            $tmp = $extractor->extractToTemp('a.png');
+            self::assertIsString($tmp);
+            $this->tmpFiles[] = $tmp;
+            self::assertSame($this->png(), file_get_contents($tmp));
+            self::assertNull($extractor->extractToTemp('nope.png'));
+        } finally {
+            $extractor->close();
+        }
+    }
+
+    #[Test]
+    public function matchesPolishFilenameAcrossUnicodeNormalisation(): void
+    {
+        if (!class_exists(Normalizer::class)) {
+            self::markTestSkipped('intl Normalizer not available');
+        }
+        $nfc = Normalizer::normalize('żółć.png', Normalizer::FORM_C);
+        $nfd = Normalizer::normalize('żółć.png', Normalizer::FORM_D);
+        self::assertIsString($nfc);
+        self::assertIsString($nfd);
+
+        // Store under NFC, look up with NFD (and vice-versa).
+        $zip = $this->makeZip([$nfc => $this->png()]);
+        $extractor = new ZipImageExtractor($zip);
+        try {
+            self::assertNotNull($extractor->resolve($nfd), 'NFD query must match an NFC-stored entry');
+            self::assertNotNull($extractor->resolve($nfc));
+        } finally {
+            $extractor->close();
+        }
+    }
+
+    #[Test]
+    public function traversalAndAbsoluteEntriesAreNotIndexed(): void
+    {
+        $zip = $this->makeZip([
+            '../evil.png' => $this->png(),
+            'safe.png' => $this->png(),
+        ]);
+        $extractor = new ZipImageExtractor($zip);
+        try {
+            self::assertNull($extractor->resolve('../evil.png'));
+            self::assertNull($extractor->resolve('evil.png'));
+            self::assertNotNull($extractor->resolve('safe.png'));
+        } finally {
+            $extractor->close();
+        }
+    }
+
+    #[Test]
+    public function zipBombRatioIsRejected(): void
+    {
+        // 1 MiB of a single repeated byte compresses to ~KB → ratio >> 200.
+        $bomb = str_repeat('A', 1024 * 1024);
+        $zip = $this->makeZip(['bomb.bin' => $bomb]);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/zip bomb/i');
+        new ZipImageExtractor($zip);
+    }
+
+    private function png(): string
+    {
+        $bytes = base64_decode(self::PNG, true);
+        \assert(false !== $bytes);
+
+        return $bytes;
+    }
+
+    /**
+     * @param array<string, string> $entries name => contents
+     */
+    private function makeZip(array $entries): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pim-ziptest-').'.zip';
+        $this->tmpFiles[] = $path;
+        $zip = new ZipArchive();
+        \assert(true === $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        foreach ($entries as $name => $contents) {
+            $zip->addFromString($name, $contents);
+        }
+        $zip->close();
+
+        return $path;
+    }
+}

--- a/apps/api/tests/Unit/Import/Media/ZipImageExtractorTest.php
+++ b/apps/api/tests/Unit/Import/Media/ZipImageExtractorTest.php
@@ -137,6 +137,9 @@ final class ZipImageExtractorTest extends TestCase
         // a no-op when zend.assertions is off (CI), which would otherwise
         // surface only as a later "Invalid or uninitialized Zip object".
         $path = tempnam(sys_get_temp_dir(), 'pim-ziptest-');
+        if (false === $path) {
+            throw new RuntimeException('tempnam() failed for the test ZIP.');
+        }
         $this->tmpFiles[] = $path;
         $zip = new ZipArchive();
         $opened = $zip->open($path, ZipArchive::OVERWRITE);


### PR DESCRIPTION
## Co dowozi (Closes #1476)

Dostawca przysyła ZIP ze zdjęciami + Excel z nazwami plików (Tubądzin). Dziś picker ZIP to atrapa (plik nie opuszcza przeglądarki). Po tym tickecie ZIP realnie wjeżdża, zdjęcia są wyciągane i podpinane po nazwie — streamem, bez OOM przy 500 MB.

### Reużycie substratu 1.12
ZIP funneluje przez TEN SAM pipeline co URL: `AssetIngestorInterface` (sniff→sha256→dedup→AssetUploader), `ProductAssetLinker`, liczniki `imagesDownloaded/Failed`, błędy `image_not_found`/`image_format_unsupported`, completion gating (`pending_image_batches`+`row_phase_complete`), dwufazowy handler (download/extract→primitives, potem reattach+apply).

### Zakres (AC #1476)
- ✅ **Upload ZIP** — `StartImportController` przyjmuje opcjonalny `zip_file` (≤500 MB serwerowo, 422 RFC7807) + `image_source`, streamuje do MinIO obok pliku danych, ustawia `zipFileName`/`zipFileSizeBytes`/`imageSource` na sesji. `StepConfirm` wysyła `zip_file`+`image_source` (picker był wpięty, FormData je gubił).
- ✅ **`ZipImageExtractor`** — `ZipArchive` RDONLY, `getStream()` per wpis kopiowany chunkami (nigdy `extractTo()` ani RAM). Indeks: pełna ścieżka + basename, **case-insensitive + Unicode NFC/NFD** (polskie znaki macOS/Windows).
- ✅ **Hardening** — wpisy `../`/absolutne/symlink pomijane przy indeksowaniu; **zip-bomb cap** (liczba wpisów, łączny rozmiar, ratio per wpis) → systemic failure sesji (nie OOM).
- ✅ **Matching** — w trybie zip komórka Asset = nazwa pliku → lookup w ZIP → ekstrakcja → ingest/dedup/link/envelope; brak pliku → `image_not_found` (warning, nie failuje sesji).
- ✅ **Cleanup** — ZIP usuwany z MinIO po finalizacji sesji (TTL sweep → IMP2-2.2).
- ✅ **Stream RAM** — ekstrakcja chunkami 64 KB; brak ładowania archiwum do pamięci.

### Świadome odejścia
- **Prefix/suffix transform** (Tubądzin ma nazwę bez rozszerzenia) → **IMP2-3.4** (tu wymagamy dokładnej nazwy pliku, per scope).
- **Playwright** — picker ZIP + radio image_source już istniały w UI (StepSource); ten ticket zmienia tylko wysyłkę FormData (zero nowego widocznego elementu). Zmiana behawioralna pokryta testem Api multipart e2e; brak nowej powierzchni UI do nowego E2E.
- **OpenAPI regen** — endpoint `POST /api/import-sessions` to plain `#[Route]` controller, nieobecny w `docs/api-spec/v0.json` → regen zbędny.

### Testy (zielone lokalnie)
`ZipImageExtractorTest` (5: case-insensitive+subdir, byte-preserve, NFC/NFD polski, traversal-reject, zip-bomb) + `ImageDownloadHandlerTest` ZIP (3: extract+link+envelope+delete-spent, missing→ImageNotFound, multipart e2e przez endpoint). Regresja `tests/{Api,Unit,Integration}/Import` → 206+ passed.

### Bramki
PHPStan max ✅ · Deptrac 0 ✅ · cs-fixer ✅ · Biome (StepConfirm) ✅.

### Smoke
Live-stack ZIP import na `https://pim.localhost` (CSV z nazwami + test.zip) → asset wyciągnięty + podpięty, `zipFileName` set, ZIP usunięty po finalizacji. Dowód w komentarzu zamknięcia #1476.