### PR TITLE
perf(export): stream scope-All export in constant memory (#1482 cz.1)

### DIFF
--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -259,6 +259,22 @@ jobs:
           JWT_PASSPHRASE: ci
           APP_DEFAULT_TENANT_CODE: demo
 
+      # IMP2-2.6 (#1482) — etap-2 memory gate. Excluded from the default run
+      # (phpunit.dist.xml <groups>); the explicit --group overrides that and
+      # runs the heavy 5k/50k import + export benchmarks with a 256 MiB ceiling.
+      - name: Run memory benchmarks (import-benchmark group)
+        run: php bin/phpunit --group import-benchmark
+        env:
+          APP_ENV: test
+          APP_DEBUG: "0"
+          DATABASE_URL: postgresql://pim:ChangeMeInDev@127.0.0.1:5432/pim?serverVersion=16&charset=utf8
+          MESSENGER_TRANSPORT_DSN: in-memory://
+          MERCURE_URL: http://localhost/.well-known/mercure
+          MERCURE_PUBLIC_URL: http://localhost/.well-known/mercure
+          MERCURE_JWT_SECRET: ci-mercure-key-at-least-256-bits-long
+          JWT_PASSPHRASE: ci
+          APP_DEFAULT_TENANT_CODE: demo
+
   openapi-spec:
     name: OpenAPI spec drift
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -13,3 +13,10 @@ paths = [
     # for documentation. It is not a live secret.
     '''docs/security/tooling\.md''',
 ]
+regexes = [
+    # IMP2-2.6: the CI workflow seeds a hard-coded dummy MERCURE_JWT_SECRET so
+    # the kernel boots in the PHPUnit/benchmark jobs. It is a fixed test
+    # placeholder (never a live key); allowlist the literal so adding it to a
+    # new CI step does not trip the generic-api-key rule.
+    '''ci-mercure-key-at-least-256-bits-long''',
+]

--- a/apps/api/phpunit.dist.xml
+++ b/apps/api/phpunit.dist.xml
@@ -44,6 +44,15 @@
         </testsuite>
     </testsuites>
 
+    <!-- IMP2-2.6: the memory benchmark is heavy (50k rows); it is excluded
+         from the default run and executed as a dedicated CI step by passing
+         the group on the CLI, which overrides this exclusion. -->
+    <groups>
+        <exclude>
+            <group>import-benchmark</group>
+        </exclude>
+    </groups>
+
     <source ignoreSuppressionOfDeprecations="true"
             ignoreIndirectDeprecations="true"
             restrictNotices="true"

--- a/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
@@ -66,6 +66,22 @@ interface CatalogObjectRepositoryInterface
      */
     public function findByObjectType(ObjectType $objectType, Tenant $tenant): array;
 
+    /**
+     * IMP2-2.6 — one keyset page of ROOT objects (no parent) of a type, ordered
+     * by id, for the bulk export path; mirrors `include_variants=off` (masters
+     * only). The caller walks pages with `id > :afterId` and `EntityManager::clear()`s
+     * between them so a 50k export stays in constant memory.
+     *
+     * @return list<CatalogObject>
+     */
+    public function findRootObjectsAfter(ObjectType $objectType, Tenant $tenant, ?Uuid $afterId, int $limit): array;
+
+    /**
+     * IMP2-2.6 — count the root objects of a type without hydrating them
+     * (COUNT(*)), so the export progress total never loads the whole set.
+     */
+    public function countRootObjectsByType(ObjectType $objectType, Tenant $tenant): int;
+
     public function save(CatalogObject $object): void;
 
     public function remove(CatalogObject $object): void;

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
@@ -92,6 +92,54 @@ class DoctrineCatalogObjectRepository extends ServiceEntityRepository implements
         return $rows;
     }
 
+    /**
+     * IMP2-2.6 — one keyset page of ROOT objects (no parent) of a type, ordered
+     * by id, for the bulk export path. Roots-only mirrors `include_variants=off`
+     * (masters only). The caller walks pages and `EntityManager::clear()`s
+     * between them so a 50k export stays in constant memory; keyset (`id >
+     * :afterId`) avoids the O(n²) cost of OFFSET on a large table.
+     *
+     * @return list<CatalogObject>
+     */
+    public function findRootObjectsAfter(ObjectType $objectType, Tenant $tenant, ?\Symfony\Component\Uid\Uuid $afterId, int $limit): array
+    {
+        $qb = $this->createQueryBuilder('o')
+            ->where('o.objectType = :ot')
+            ->andWhere('o.tenant = :tenant')
+            ->andWhere('o.parent IS NULL')
+            ->setParameter('ot', $objectType)
+            ->setParameter('tenant', $tenant)
+            ->orderBy('o.id', 'ASC')
+            ->setMaxResults(max(1, $limit));
+
+        if (null !== $afterId) {
+            $qb->andWhere('o.id > :afterId')->setParameter('afterId', $afterId->toRfc4122());
+        }
+
+        /** @var list<CatalogObject> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $rows;
+    }
+
+    /**
+     * IMP2-2.6 — count root objects of a type via COUNT(*) without hydrating
+     * entities (the export progress total needs the count, not the object
+     * graph). Roots-only matches {@see self::iterateRootObjectsByType()}.
+     */
+    public function countRootObjectsByType(ObjectType $objectType, Tenant $tenant): int
+    {
+        return (int) $this->createQueryBuilder('o')
+            ->select('COUNT(o.id)')
+            ->where('o.objectType = :ot')
+            ->andWhere('o.tenant = :tenant')
+            ->andWhere('o.parent IS NULL')
+            ->setParameter('ot', $objectType)
+            ->setParameter('tenant', $tenant)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
     public function findById(\Symfony\Component\Uid\Uuid $id): ?CatalogObject
     {
         return parent::find($id->toRfc4122());

--- a/apps/api/src/Export/Application/Async/ExportJobHandler.php
+++ b/apps/api/src/Export/Application/Async/ExportJobHandler.php
@@ -133,19 +133,27 @@ final class ExportJobHandler extends AbstractBatchHandler
             };
 
             $this->runner->runToFile($session, $tempPath, $onChunk);
+            // IMP2-2.6 — the streaming runner clears the EM mid-run to stay in
+            // flat memory, which detaches our $session/$tenant. Re-load them so
+            // the post-flight upload + status flush operate on managed entities.
+            $session = $this->sessions->findById($message->exportSessionId) ?? $session;
+            $tenant = $session->getTenant() ?? $tenant;
             $this->uploadToMinio($session, $tenant, $tempPath);
             $this->progress->progress($session, $session->getSuccessCount(), estimatedSecondsRemaining: 0);
             $this->progress->status($session);
         } catch (ExportCancelledException) {
             // EXR-15 — the cancel endpoint already persisted the terminal
-            // status; refresh the stale entity and notify subscribers so
-            // the card drops out of "W toku" instantly.
-            $this->entityManager->refresh($session);
+            // status; reload the (possibly EM-cleared, IMP2-2.6) entity and
+            // notify subscribers so the card drops out of "W toku" instantly.
+            $session = $this->sessions->findById($message->exportSessionId) ?? $session;
             $this->progress->status($session);
             $this->logger->info('Export job cancelled by user', [
                 'session_id' => $session->getId()->toRfc4122(),
             ]);
         } catch (Throwable $error) {
+            // The streaming runner may have cleared the EM (IMP2-2.6); reload so
+            // the terminal markError flush operates on a managed entity.
+            $session = $this->sessions->findById($message->exportSessionId) ?? $session;
             // markError throws if the session has already transitioned to
             // 'done' (e.g. runToFile completed but MinIO upload failed
             // afterwards). In that case the rows are already in the temp

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -24,6 +24,7 @@ use App\Export\Infrastructure\Writer\RowWriter;
 use App\Export\Infrastructure\Writer\XlsxStreamWriter;
 use App\Shared\Domain\Tenant;
 use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use LogicException;
 use RuntimeException;
@@ -54,6 +55,9 @@ final class SyncExportRunner
 {
     public const int PROGRESS_CHUNK = 500;
 
+    /** IMP2-2.6 — detach hydrated objects every N rows so streaming stays flat. */
+    private const int CLEAR_INTERVAL = 200;
+
     public function __construct(
         private readonly ExportBuilder $builder,
         private readonly CatalogObjectRepositoryInterface $objects,
@@ -62,6 +66,7 @@ final class SyncExportRunner
         private readonly Connection $connection,
         private readonly PublicationColumnPlanner $columnPlanner,
         private readonly ObjectTypeRepositoryInterface $objectTypes,
+        private readonly EntityManagerInterface $em,
         /** @var iterable<StructuralExportBuilderInterface> */
         #[AutowireIterator('app.export.structural_builder')]
         private readonly iterable $structuralBuilders = [],
@@ -79,7 +84,28 @@ final class SyncExportRunner
             return $this->structuralBuilderFor($session->getEntityType())->count($this->requireTenant($session));
         }
 
+        // IMP2-2.6 — the streamable scope (All, masters only) counts via
+        // COUNT(*) instead of hydrating the whole result set just to size it.
+        if ($this->canStream($session)) {
+            $tenant = $this->requireTenant($session);
+
+            return $this->objects->countRootObjectsByType($this->resolveObjectType($session, $tenant), $tenant);
+        }
+
         return \count($this->resolveTargets($session));
+    }
+
+    /**
+     * IMP2-2.6 — a catalog-object export is streamable (root-by-root with
+     * EntityManager::clear() per chunk) when its scope is All and variant
+     * fan-out is off. Selected/Filter are already bounded id sets; variant
+     * fan-out interleaves children and needs the materialised pass.
+     */
+    private function canStream(ExportSession $session): bool
+    {
+        return !$session->getEntityType()->isStructural()
+            && ExportTargetScope::All === $session->getTargetScope()
+            && !$session->includesVariants();
     }
 
     /**
@@ -216,6 +242,12 @@ final class SyncExportRunner
             return $this->runStructuralToFile($session, $targetPath, $onChunk);
         }
 
+        // IMP2-2.6 — stream the All scope so a 50k export never materialises
+        // the full object graph (constant memory, enforced by the benchmark).
+        if ($this->canStream($session)) {
+            return $this->runStreamingToFile($session, $targetPath, $onChunk);
+        }
+
         $targets = $this->resolveTargets($session);
         $session->setTargetCount(\count($targets));
 
@@ -253,6 +285,83 @@ final class SyncExportRunner
         }
 
         $size = file_exists($targetPath) ? (int) filesize($targetPath) : 0;
+        $session->markDone($rows, $targetPath, $size);
+        $this->sessions->save($session);
+
+        return $rows;
+    }
+
+    /**
+     * IMP2-2.6 — streaming export of scope All (masters only). Walks the root
+     * objects in keyset pages and clears the EntityManager between pages, so the
+     * builder's per-object value/relation hydration never accumulates. Each page
+     * gets a FRESH {@see ExportBuilder::build()} call: its attribute/channel map
+     * is resolved from a clean EM, so the inter-page clear cannot leave it
+     * holding detached entities. The clear also detaches the session, so it is
+     * re-loaded each page (build() reads its tenant/channels) and before the
+     * final markDone.
+     *
+     * @param (callable(int): void)|null $onChunk invoked every PROGRESS_CHUNK rows
+     */
+    private function runStreamingToFile(ExportSession $session, string $targetPath, ?callable $onChunk): int
+    {
+        $sessionId = $session->getId();
+        $tenant = $this->requireTenant($session);
+        $objectType = $this->resolveObjectType($session, $tenant);
+
+        $total = $this->objects->countRootObjectsByType($objectType, $tenant);
+        $session->setTargetCount($total);
+        $this->sessions->save($session);
+
+        $columns = $session->getSelectedColumns();
+        if ([] === $columns) {
+            // #1235 — derive columns from the publication profile of the single
+            // scope-All ObjectType (no need to scan the whole target set).
+            $planned = $this->columnPlanner->plan($session, [$objectType->getId()->toRfc4122()]);
+            if (null === $planned) {
+                throw new InvalidArgumentException('Export session must list at least one column.');
+            }
+            $columns = $planned;
+        }
+
+        $writer = $this->openWriter($session->getFormat(), $session, $targetPath);
+        $writer->writeHeaders($columns);
+
+        $rows = 0;
+        $afterId = null;
+        try {
+            while (true) {
+                // $objectType/$tenant may be detached after a prior page's clear;
+                // Doctrine resolves them to ids for the WHERE params, so the query
+                // stays correct without re-hydrating them.
+                $page = $this->objects->findRootObjectsAfter($objectType, $tenant, $afterId, self::CLEAR_INTERVAL);
+                if ([] === $page) {
+                    break;
+                }
+                foreach ($this->builder->build($page, $session) as $row) {
+                    $values = [];
+                    foreach ($columns as $key) {
+                        $values[] = $row[$key] ?? '';
+                    }
+                    $writer->writeRow($values);
+                    ++$rows;
+                    if (null !== $onChunk && 0 === $rows % self::PROGRESS_CHUNK) {
+                        $onChunk($rows);
+                    }
+                }
+                $afterId = $page[array_key_last($page)]->getId();
+                // Detach the page (objects + their hydrated values) before the next.
+                $this->em->clear();
+                // build() needs a managed session next round (tenant/channels).
+                $session = $this->sessions->findById($sessionId) ?? $session;
+                $tenant = $this->requireTenant($session);
+            }
+        } finally {
+            $writer->close();
+        }
+
+        $size = file_exists($targetPath) ? (int) filesize($targetPath) : 0;
+        $session = $this->sessions->findById($sessionId) ?? $session;
         $session->markDone($rows, $targetPath, $size);
         $this->sessions->save($session);
 

--- a/apps/api/src/Export/Presentation/Controller/SyncExportController.php
+++ b/apps/api/src/Export/Presentation/Controller/SyncExportController.php
@@ -160,12 +160,17 @@ final class SyncExportController
         }
 
         $tempPath = $this->prepareTempFile($format);
+        $sessionId = $session->getId();
         try {
             $this->runner->runToFile($session, $tempPath);
         } catch (Throwable $error) {
             @unlink($tempPath);
             throw new HttpException(Response::HTTP_INTERNAL_SERVER_ERROR, $error->getMessage(), $error);
         }
+
+        // IMP2-2.6 — the streaming runner clears the EM mid-run (flat memory),
+        // detaching $session; reload it before the post-flight path flush.
+        $session = $this->sessions->findById($sessionId) ?? $session;
 
         // EXR-12 — the sync session lands in history (screen 1 shows the
         // 1-second exports too), but its file is a temp deleted after send:

--- a/apps/api/tests/Integration/Export/ExportMemoryBenchmarkTest.php
+++ b/apps/api/tests/Integration/Export/ExportMemoryBenchmarkTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Export;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Export\Application\Sync\SyncExportRunner;
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * IMP2-2.6 (#1482) — etap-2 gate: the streaming export path (scope All, masters
+ * only) holds a 50k-object export in constant memory instead of materialising
+ * the whole object graph. Objects + values are seeded set-based (DB-side SQL,
+ * negligible PHP memory) so the measured peak reflects {@see SyncExportRunner}
+ * alone. Runs as a dedicated `import-benchmark` CI step.
+ */
+#[Group('import-benchmark')]
+final class ExportMemoryBenchmarkTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    private const int THRESHOLD_BYTES = 256 * 1024 * 1024;
+
+    #[Test]
+    public function streamingExportOf5kStaysUnderMemoryBudget(): void
+    {
+        $this->assertExportStreamsWithinBudget(5_000);
+    }
+
+    #[Test]
+    public function streamingExportOf50kStaysUnderMemoryBudget(): void
+    {
+        $this->assertExportStreamsWithinBudget(50_000);
+    }
+
+    private function assertExportStreamsWithinBudget(int $count): void
+    {
+        $tenant = $this->seedObjects($count);
+
+        $session = new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::ListContext,
+            format: ExportFormat::Csv,
+            targetScope: ExportTargetScope::All,
+            selectedColumns: ['sku', 'name'],
+            includeVariants: false,
+        );
+        $session->assignTenant($tenant);
+        self::getContainer()->get(ExportSessionRepositoryInterface::class)->save($session);
+
+        $target = tempnam(sys_get_temp_dir(), 'bench-export-').'.csv';
+        $runner = self::getContainer()->get(SyncExportRunner::class);
+
+        \memory_reset_peak_usage();
+        $before = \memory_get_usage(true);
+        $written = $runner->runToFile($session, $target);
+        $peak = \memory_get_peak_usage(true);
+        @unlink($target);
+
+        self::assertSame($count, $written, 'every seeded root object is exported');
+        self::assertLessThan(
+            self::THRESHOLD_BYTES,
+            $peak,
+            \sprintf('export of %d objects peaked at %0.1f MiB, must stay under 256 MiB', $count, $peak / 1024 / 1024),
+        );
+        // Streaming delta over the pre-run baseline must be a fraction of the
+        // full set — proves we never materialise all N objects at once.
+        self::assertLessThan(
+            128 * 1024 * 1024,
+            $peak - $before,
+            \sprintf('streaming delta %0.1f MiB must stay bounded', ($peak - $before) / 1024 / 1024),
+        );
+    }
+
+    private function seedObjects(int $count): Tenant
+    {
+        $em = $this->em();
+        $tenant = new Tenant('bench', 'Bench Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $type->markBuiltIn();
+        $em->persist($type);
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist(new ObjectTypeAttribute($type, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($type, $name, false, 2));
+        $em->flush();
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        $conn = $em->getConnection();
+        $conn->executeStatement(
+            <<<'SQL'
+                INSERT INTO objects (id, tenant_id, object_type_id, kind, code, enabled, status, completeness, attributes_indexed, created_at, updated_at, completeness_pct, sync_status_aggregate, version, schema_drift)
+                SELECT gen_random_uuid(), :t, :ot, 'product', 'BENCH-'||g, true, 'published', '{}'::jsonb, '{}'::jsonb, now(), now(), 0, 'gray', 1, false
+                FROM generate_series(1, :n) g
+                SQL,
+            ['t' => $tenantId, 'ot' => $type->getId()->toRfc4122(), 'n' => $count],
+        );
+        foreach ([$sku->getId()->toRfc4122(), $name->getId()->toRfc4122()] as $attrId) {
+            $conn->executeStatement(
+                <<<'SQL'
+                    INSERT INTO object_values (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                    SELECT gen_random_uuid(), :t, o.id, :a, jsonb_build_object('value', o.code), 'import', '{}'::jsonb
+                    FROM objects o WHERE o.tenant_id = :t
+                    SQL,
+                ['t' => $tenantId, 'a' => $attrId],
+            );
+        }
+        $em->clear();
+
+        $reloaded = $em->getRepository(Tenant::class)->find($tenantId);
+        \assert($reloaded instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($reloaded);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+
+        return $reloaded;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
@@ -126,6 +126,16 @@ final class InMemoryCatalogObjectRepo implements CatalogObjectRepositoryInterfac
         throw new LogicException('not used in this test');
     }
 
+    public function findRootObjectsAfter(ObjectType $objectType, Tenant $tenant, ?Uuid $afterId, int $limit): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function countRootObjectsByType(ObjectType $objectType, Tenant $tenant): int
+    {
+        throw new LogicException('not used in this test');
+    }
+
     public function save(CatalogObject $object): void
     {
         throw new LogicException('not used in this test');

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -267,6 +267,16 @@ final class InMemoryCatalogObjectRepository implements CatalogObjectRepositoryIn
         return [];
     }
 
+    public function findRootObjectsAfter(ObjectType $objectType, Tenant $tenant, ?Uuid $afterId, int $limit): array
+    {
+        return [];
+    }
+
+    public function countRootObjectsByType(ObjectType $objectType, Tenant $tenant): int
+    {
+        return 0;
+    }
+
     public function save(CatalogObject $object): void
     {
     }


### PR DESCRIPTION
## IMP2-2.6 — sub-PR 1/3: strona EKSPORTU

Pierwszy z trzech sub-PR-ów pod #1482 (operator: dostarczyć ten 7-punktowy, 4-kontekstowy ticket jako 2-3 smoke-testowane kawałki; #1482 zostaje OPEN/partial aż wszystkie wejdą).

### Problem
`SyncExportRunner` materializował CAŁY zbiór (`findByObjectType`) i nawet **liczył** go ładując każdą encję (`count(resolveTargets())`), więc eksport 50k obiektów skalował pamięć z rozmiarem katalogu.

### Zmiany
- **`resolveTargetCount()`** dla scope All liczy przez `COUNT(*)` (`countRootObjectsByType`) zamiast hydratacji całego zbioru.
- **`runToFile()`** streamuje scope All (mastery, bez variant fan-out) w stronach keyset (`findRootObjectsAfter`, `id > :afterId`), czyszcząc EntityManager między stronami. Każda strona dostaje **świeże `ExportBuilder::build()`** — jego mapa atrybutów/kanałów jest rozwiązywana z czystego managera, więc clear między stronami nie zostawia odłączonych encji (kolumny relacyjne bezpieczne). Selected/Filter + variant fan-out zachowują ścieżkę zmaterializowaną (ograniczone zbiory / przeplatane dzieci).
- **Benchmark `import-benchmark`**: 5k i 50k eksportu < 256 MiB (lokalnie peak ~184 MiB). Wykluczony z domyślnego runu (`phpunit.dist.xml <groups>`), uruchamiany osobnym krokiem CI (`bin/phpunit --group import-benchmark`).

### Testy + bramki
- Benchmark **2/2** (5k+50k), peak 184.5 MB < 256 MiB.
- Regresja `tests/Api/Export` + `tests/Unit/Export` **102/102**.
- PHPStan `--memory-limit=1G` No errors; Deptrac 0; php-cs-fixer; raw-SQL lint clean.

### Poza tym sub-PR-em (kolejne części #1482)
- **cz.2 (import)**: BulkContext ON + async rebuild + batch Meili + Mercure throttle + compare-values diff + benchmark importu.
- **cz.3 (FE)**: `useImportProgress` (progress zamiast row_processed) + Playwright. Po niej zamknięcie #1482 z pełnym live smoke.

Refs #1482