### PR TITLE
IMP2-2.6 cz.3 — perf(import): throttle Mercure progress (per-chunk) + FE live-log

### DIFF
--- a/apps/admin/src/features/imports/hooks/useImportProgress.ts
+++ b/apps/admin/src/features/imports/hooks/useImportProgress.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 interface ProgressEvent {
-  type: 'progress' | 'row_processed' | 'error' | 'completed';
+  type: 'progress' | 'error' | 'completed';
   session_id: string;
   data: {
     processed_rows?: number;
@@ -10,6 +10,10 @@ interface ProgressEvent {
     error_count?: number;
     current_sku?: string | null;
     status?: string;
+    // IMP2-2.6 — `error` events carry the offending row's sku + message.
+    sku?: string | null;
+    row_number?: number;
+    message?: string;
   };
 }
 
@@ -24,7 +28,7 @@ const LOG_BUFFER_CAP = 200;
 export interface ImportProgressState {
   /** True until the first SSE event lands or the connection drops. */
   connecting: boolean;
-  /** NUI-11 — capped live-log buffer built from row_processed/error events. */
+  /** NUI-11 / IMP2-2.6 — capped live-log buffer built from `error` + throttled `progress` events. */
   log: ImportLogEntry[];
   processedRows: number;
   totalRows: number;
@@ -87,17 +91,29 @@ export function useImportProgress(sessionId: string | null): ImportProgressState
         const raw = JSON.parse(event.data) as ProgressEvent;
         setState((prev) => {
           let log = prev.log;
-          if (raw.type === 'row_processed' || raw.type === 'error') {
-            const sku = raw.data.current_sku ?? null;
-            const entry: ImportLogEntry = {
-              id: logSeq++,
-              level: raw.type === 'error' ? 'error' : 'info',
-              message:
-                raw.type === 'error'
-                  ? `✗ ${sku ?? 'row'} — error`
-                  : `✓ ${sku ?? 'row'} (${raw.data.processed_rows ?? '?'} / ${raw.data.total_rows ?? '?'})`,
-            };
-            log = [...prev.log.slice(-(LOG_BUFFER_CAP - 1)), entry];
+          // IMP2-2.6 — the per-row `row_processed` event is gone (it was 50k hub
+          // POSTs on a 50k import). The live log is built from blocking `error`
+          // events and the throttled `progress` snapshots (≤ ~100 for 50k rows).
+          if (raw.type === 'error') {
+            const label = raw.data.sku ?? `row ${raw.data.row_number ?? '?'}`;
+            log = [
+              ...prev.log.slice(-(LOG_BUFFER_CAP - 1)),
+              {
+                id: logSeq++,
+                level: 'error',
+                message: `✗ ${label} — ${raw.data.message ?? 'error'}`,
+              },
+            ];
+          } else if (raw.type === 'progress') {
+            const sku = raw.data.current_sku ? ` — ${raw.data.current_sku}` : '';
+            log = [
+              ...prev.log.slice(-(LOG_BUFFER_CAP - 1)),
+              {
+                id: logSeq++,
+                level: 'info',
+                message: `✓ ${raw.data.processed_rows ?? '?'} / ${raw.data.total_rows ?? '?'}${sku}`,
+              },
+            ];
           }
           return {
             ...prev,

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -100,6 +100,18 @@ final class ImportRunHandler extends AbstractBatchHandler
      */
     private ?int $rowPhasePeakBytes = null;
 
+    /**
+     * IMP2-2.6 — Mercure progress throttle. The batch path no longer publishes a
+     * `row_processed` event per row (50k rows = 50k HTTP POSTs to the hub);
+     * instead {@see publishProgress()} emits a `progress` snapshot no more often
+     * than every ~1% of the file. `$lastProgressAt` is the row count at the last
+     * emitted snapshot; `$lastProcessedSku` rides along as the snapshot's
+     * `current_sku`. Both reset per run.
+     */
+    private int $lastProgressAt = 0;
+
+    private ?string $lastProcessedSku = null;
+
     public function __construct(
         EntityManagerInterface $entityManager,
         private readonly ImportSessionRepositoryInterface $sessions,
@@ -222,6 +234,8 @@ final class ImportRunHandler extends AbstractBatchHandler
         $this->bulkContext->setBulk(true, $session->getId());
         $this->bulkTouchedIds = [];
         $this->rowPhasePeakBytes = null;
+        $this->lastProgressAt = 0;
+        $this->lastProcessedSku = null;
 
         // IMP2-2.3 — resume point: a prior (paused/crashed) run left a checkpoint.
         // Rows at/below it are already written, so we skip their writes (still
@@ -292,13 +306,14 @@ final class ImportRunHandler extends AbstractBatchHandler
                 // (the refreshed session carries the just-written status).
                 $lock->refresh();
                 if ($this->haltRequested($session)) {
-                    $this->progressPublisher->progress($session, $processed, null);
+                    $this->publishProgress($session, $processed, true);
 
                     return;
                 }
 
                 $attributesByCode = $this->validator->loadAttributesByCode($tenant, $columnMapping);
-                $this->progressPublisher->progress($session, $processed, null);
+                // Throttled: at most one snapshot per ~1% of the file (force=false).
+                $this->publishProgress($session, $processed);
             }
 
             if ([] !== $buffer) {
@@ -309,7 +324,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                 $session = $this->refreshSession($session);
                 $lock->refresh();
                 if ($this->haltRequested($session)) {
-                    $this->progressPublisher->progress($session, $processed, null);
+                    $this->publishProgress($session, $processed, true);
 
                     return;
                 }
@@ -350,7 +365,7 @@ final class ImportRunHandler extends AbstractBatchHandler
             // the checkpoint (relations) lets a resume re-run the idempotent
             // link pass without touching already-written rows.
             if ($this->haltRequested($session)) {
-                $this->progressPublisher->progress($session, $processed, null);
+                $this->publishProgress($session, $processed, true);
 
                 return;
             }
@@ -370,7 +385,7 @@ final class ImportRunHandler extends AbstractBatchHandler
             // (no media jobs), so read the COMMITTED status straight from the DB
             // and never force a paused/cancelled session into a terminal state.
             if ($this->persistedStatusHalts($session)) {
-                $this->progressPublisher->progress($session, $processed, null);
+                $this->publishProgress($session, $processed, true);
 
                 return;
             }
@@ -385,7 +400,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                 $this->progressPublisher->completed($session);
             } else {
                 $this->sessions->save($session);
-                $this->progressPublisher->progress($session, $processed, null);
+                $this->publishProgress($session, $processed, true);
             }
 
             // IMP2-2.6 — the row phase ran under BulkContext (no per-flush
@@ -426,6 +441,25 @@ final class ImportRunHandler extends AbstractBatchHandler
     public function rowPhasePeakBytes(): ?int
     {
         return $this->rowPhasePeakBytes;
+    }
+
+    /**
+     * IMP2-2.6 — publish a Mercure `progress` snapshot, throttled. The batch path
+     * dropped the per-row `row_processed` event (50k rows = 50k hub POSTs); this
+     * emits a `progress` snapshot at most once per ~1% of the file, so a 50k
+     * import lands ~100 hub messages instead of 50k. `$force` always emits — used
+     * for the terminal / halt snapshots so the UI never misses the final state.
+     * `current_sku` carries the last processed row's SKU for the live view.
+     */
+    private function publishProgress(ImportSession $session, int $processed, bool $force = false): void
+    {
+        $total = $session->getTotalRows() ?? 0;
+        $every = max($this->batchSize, (int) ceil($total / 100));
+        if (!$force && ($processed - $this->lastProgressAt) < $every) {
+            return;
+        }
+        $this->lastProgressAt = $processed;
+        $this->progressPublisher->progress($session, $processed, $this->lastProcessedSku);
     }
 
     /**
@@ -1433,9 +1467,20 @@ final class ImportRunHandler extends AbstractBatchHandler
                     columnName: $error->columnName,
                     columnValue: $error->columnValue,
                 ));
+                // IMP2-2.6 — only ROW-BLOCKING errors go per-row on Mercure for the
+                // live log; blocking errors are rare. Warnings (e.g. per-row
+                // duplicate findings on a self-reimport) stay in the persisted
+                // ImportLog only — emitting them would re-introduce O(N) hub POSTs.
+                // The per-row `row_processed` ticker is gone (replaced by the
+                // throttled `progress` snapshots in run()).
+                if ($error->isRowBlocking()) {
+                    $this->progressPublisher->error($session, $error->rowNumber, $error->sku, $error->errorType->value, $error->message);
+                }
             }
 
-            $this->progressPublisher->rowProcessed($session, $row['rowNumber'], $row['sku'], $row['rowOk']);
+            // IMP2-2.6 — feed the throttled `progress` snapshot's current_sku
+            // instead of emitting a Mercure event per row.
+            $this->lastProcessedSku = $row['sku'];
         }
 
         // IMP2-1.7: category replace/append for UPDATE rows, after the value

--- a/apps/api/src/Import/Application/Service/ImportProgressPublisher.php
+++ b/apps/api/src/Import/Application/Service/ImportProgressPublisher.php
@@ -49,15 +49,6 @@ final class ImportProgressPublisher
         ]);
     }
 
-    public function rowProcessed(ImportSession $session, int $rowNumber, ?string $sku, bool $success): void
-    {
-        $this->publish($session, 'row_processed', [
-            'row_number' => $rowNumber,
-            'sku' => $sku,
-            'success' => $success,
-        ]);
-    }
-
     public function error(ImportSession $session, int $rowNumber, ?string $sku, string $errorType, string $message): void
     {
         $this->publish($session, 'error', [

--- a/apps/api/tests/Api/Import/ImportRunHandlerAsyncTest.php
+++ b/apps/api/tests/Api/Import/ImportRunHandlerAsyncTest.php
@@ -17,7 +17,9 @@ use App\Import\Domain\Message\ImportRunMessage;
 use App\Shared\Application\BulkOperationLock;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
 use App\Tests\Api\Catalog\CatalogApiTestCase;
+use App\Tests\Support\InMemoryMercureHub;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionClass;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -189,6 +191,67 @@ final class ImportRunHandlerAsyncTest extends CatalogApiTestCase
             "SELECT COUNT(*) FROM objects WHERE code LIKE 'IDX-%' AND attributes_indexed = '{}'::jsonb",
         );
         self::assertSame(0, (int) (\is_scalar($emptyCount) ? $emptyCount : 1), 'no imported object left with an empty attributes_indexed cache');
+    }
+
+    #[Test]
+    public function batchImportThrottlesProgressInsteadOfPerRowEvents(): void
+    {
+        // IMP2-2.6 — the batch path must not emit a Mercure event per row (50k
+        // rows would be 50k hub POSTs). Prove a multi-chunk import publishes a
+        // handful of throttled `progress` snapshots and ZERO `row_processed`.
+        // Drive the handler directly: a functional request reboots the kernel and
+        // drops the in-memory hub's captured updates, so the hub assertion must
+        // run in-process.
+        $this->seedSkuName();
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $product = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $session = new ImportSession(
+            userId: Uuid::v7(),
+            targetObjectType: $product,
+            fileName: 'throttle.csv',
+            fileSizeBytes: 1024,
+        );
+        $session->assignTenant($tenant);
+        $session->setColumnMapping(['sku' => 'sku', 'name' => 'name']);
+        $em->persist($session);
+        $em->flush();
+        $sessionId = $session->getId();
+
+        $count = 500; // > one chunk (batchSize 200) → several throttled snapshots
+        $csv = "sku;name\n";
+        for ($i = 1; $i <= $count; ++$i) {
+            $csv .= \sprintf("THR-%d;Product %d\n", $i, $i);
+        }
+        self::getContainer()->get('imports.storage')->write(
+            \sprintf('%s/%s/throttle.csv', $tenant->getId()->toRfc4122(), $sessionId->toRfc4122()),
+            $csv,
+        );
+
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+        $hub = self::getContainer()->get(InMemoryMercureHub::class);
+        \assert($hub instanceof InMemoryMercureHub);
+        $hub->reset();
+
+        self::getContainer()->get(ImportRunHandler::class)->run($session);
+
+        $types = [];
+        foreach ($hub->getCapturedUpdates() as $update) {
+            $decoded = json_decode($update->getData(), true, 512, JSON_THROW_ON_ERROR);
+            if (\is_array($decoded) && \is_string($decoded['type'] ?? null)) {
+                $types[] = $decoded['type'];
+            }
+        }
+
+        self::assertNotContains('row_processed', $types, 'batch path must not emit a Mercure event per row');
+        $progress = array_filter($types, static fn (string $t): bool => 'progress' === $t);
+        self::assertGreaterThanOrEqual(1, \count($progress), 'a throttled progress snapshot is published; all types: ['.implode(',', $types).']');
+        self::assertLessThanOrEqual(20, \count($progress), \sprintf('progress is throttled, not per-row (got %d for %d rows)', \count($progress), $count));
     }
 
     /**


### PR DESCRIPTION
## Zakres (IMP2-2.6 cz.3 — Mercure throttle + FE live-log, #1482)

Trzecia (ostatnia) część rozbicia #1482. Realizuje punkt 4 zakresu: throttle powiadomień Mercure + adaptacja FE.

### Zmiany
- **Backend throttle** (`ImportRunHandler` + `ImportProgressPublisher`):
  - Usunięto per-row event `row_processed` — przy 50k wierszach to było 50k POST-ów HTTP do huba Mercure.
  - `progress()` publikowany **throttlowany**: nie częściej niż co ~1% pliku (`max(batchSize, ceil(totalRows/100))`), więc import 50k → ~100 wiadomości do huba zamiast 50k. Snapshoty terminalne/halt zawsze publikowane (force).
  - `current_sku` w snapshocie progress (ostatni przetworzony SKU chunka).
  - Eventy `error` **per blokujący wiersz** zostają (błędów mało); warningi (np. duplikaty per wiersz przy re-imporcie własnego eksportu) zostają TYLKO w `ImportLog` — publikowanie ich wróciłoby do O(N) POST-ów.
  - Usunięto martwą metodę `rowProcessed()` z publishera.
- **FE** (`useImportProgress.ts`): live-log budowany z eventów `error` + throttlowanych snapshotów `progress` (pokazuje `processed_rows / total_rows` + `current_sku`); usunięto typ `row_processed`.

### Walidacja
- PHPStan max: ✓ No errors.
- `ImportRunHandlerAsyncTest`: 5/5 ✓ (env jak CI: `async=in-memory`, `import=sync`, `APP_DEBUG=0`).
- Biome strict + TypeScript noEmit (admin): ✓.
- Playwright: bez nowego testu dla SSE live-log (timing/worker → flaky); istniejące testy UI importu nietknięte (komponenty dostają ten sam `ImportLogEntry[]`, zmienione tylko źródło). Throttle weryfikowany smoke testem na żywym stacku (DevTools EventStream — wymóg #1482 smoke punkt 4).

### Domknięcie #1482
Po zielonym CI + smoke teście na żywym stacku (login → import → EventStream pokazuje progress co ~1-2%, nie per wiersz → import searchable) zamykam #1482 z proof (CLOSED MEANS CLOSED — bez auto-close przez merge).

Refs #1482
