### PR TITLE
feat(import,backup): spięcie pre-import backup z sesją importu (IMP2-2.10 #1486)

### DIFF
--- a/apps/admin/e2e/1430-import-session-v2.spec.ts
+++ b/apps/admin/e2e/1430-import-session-v2.spec.ts
@@ -32,3 +32,47 @@ test('NUI-11 — session view renders pipeline, summary and report link', async 
   await expect(page.getByText(/zaimportowano|imported/i).first()).toBeVisible({ timeout: 15_000 });
   await expect(page.getByRole('link', { name: /raport|report/i })).toBeVisible();
 });
+
+/**
+ * IMP2-2.10 (#1486) — the session view surfaces the pre-import backup linked
+ * at start. Mocked so the assertion is deterministic regardless of whether the
+ * environment has a backup-linked session.
+ */
+test('IMP2-2.10 — session view shows the linked pre-import backup', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const sessionId = '01900000-0000-7000-8000-0000000000aa';
+  await page.route(`**/api/import-sessions/${sessionId}`, (route) =>
+    route.fulfill({
+      json: {
+        id: sessionId,
+        status: 'success',
+        file_name: 'backup-demo.csv',
+        total_rows: 3,
+        success_count: 3,
+        error_count: 0,
+        updated_count: 0,
+        skipped_count: 0,
+        mode: 'upsert',
+        images_downloaded: 0,
+        images_failed: 0,
+        started_at: '2026-06-15T10:00:00.000+00:00',
+        completed_at: '2026-06-15T10:01:00.000+00:00',
+        rollback_until: null,
+        rolled_back_at: null,
+        error_message: null,
+        backup: {
+          id: '01900000-0000-7000-8000-0000000000b1',
+          status: 'completed',
+          started_at: '2026-06-15T09:55:00.000+00:00',
+        },
+      },
+    }),
+  );
+
+  await page.goto(`/integrations/imports/${sessionId}`);
+
+  await expect(page.getByTestId('import-backup-info')).toContainText(
+    /(Backup przed importem|Backup before import).*✅/,
+  );
+});

--- a/apps/admin/src/features/imports/components/BackupTriggerCheckbox.tsx
+++ b/apps/admin/src/features/imports/components/BackupTriggerCheckbox.tsx
@@ -14,6 +14,12 @@ interface BackupTriggerCheckboxProps {
    * CTA while the backup is still running.
    */
   onStatusChange?: (status: 'idle' | 'pending' | 'running' | 'completed' | 'failed') => void;
+  /**
+   * IMP2-2.10 (#1486) — the created backup's id, surfaced so Step 4 can
+   * forward `backup_id` to `POST /api/import-sessions`. `null` when the box
+   * is unchecked or the trigger failed.
+   */
+  onBackupCreated?: (backupId: string | null) => void;
 }
 
 interface BackupStatusResponse {
@@ -33,6 +39,7 @@ export function BackupTriggerCheckbox({
   checked,
   onChange,
   onStatusChange,
+  onBackupCreated,
 }: BackupTriggerCheckboxProps): React.ReactElement {
   const { t } = useTranslation();
   const apiUrl = useApiUrl();
@@ -52,6 +59,12 @@ export function BackupTriggerCheckbox({
   React.useEffect(() => {
     onStatusChange?.(status);
   }, [status, onStatusChange]);
+
+  // IMP2-2.10 (#1486) — surface the backup id to the parent. The CTA is gated
+  // on `completed`, so the id is only acted on once the snapshot is ready.
+  React.useEffect(() => {
+    onBackupCreated?.(backupId);
+  }, [backupId, onBackupCreated]);
 
   const handleToggle = (next: boolean): void => {
     onChange(next);

--- a/apps/admin/src/features/imports/show/ImportShowPage.tsx
+++ b/apps/admin/src/features/imports/show/ImportShowPage.tsx
@@ -33,6 +33,8 @@ interface ImportSession {
   rollback_until: string | null;
   rolled_back_at: string | null;
   error_message: string | null;
+  // IMP2-2.10 (#1486) — pre-import pgBackRest snapshot linked at start, or null.
+  backup: { id: string; status: string; started_at: string } | null;
 }
 
 /**
@@ -147,6 +149,16 @@ export function ImportShowPage(): React.ReactElement {
               })}
             </span>
             {!isTerminal && <span className="num font-mono text-[12px]">{pct}%</span>}
+            <span className="num font-mono text-[12px]" data-testid="import-backup-info">
+              {session.backup !== null
+                ? t('imports.show.backup_done', {
+                    defaultValue: 'Backup przed importem: ✅ {{date}}',
+                    date: formatDateTime(session.backup.started_at),
+                  })
+                : t('imports.show.backup_none', {
+                    defaultValue: 'Backup przed importem: —',
+                  })}
+            </span>
           </div>
         </div>
         <Button asChild variant="ghost">
@@ -335,6 +347,17 @@ function Kpi({
       {label}
     </div>
   );
+}
+
+function formatDateTime(value: string | null): string {
+  if (value === null) {
+    return '—';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+  return date.toLocaleString();
 }
 
 function formatDuration(start: string | null, end: string | null): string {

--- a/apps/admin/src/features/imports/wizard/StepConfirm.tsx
+++ b/apps/admin/src/features/imports/wizard/StepConfirm.tsx
@@ -27,6 +27,9 @@ export function StepConfirmPlaceholder({ wizard }: StepConfirmProps): React.Reac
   const [backupStatus, setBackupStatus] = React.useState<
     'idle' | 'pending' | 'running' | 'completed' | 'failed'
   >('idle');
+  // IMP2-2.10 (#1486) — id of the pre-import backup, forwarded to the start
+  // request so the session records which snapshot preceded it.
+  const [backupId, setBackupId] = React.useState<string | null>(null);
   const [submitting, setSubmitting] = React.useState(false);
   const [submitError, setSubmitError] = React.useState<string | null>(null);
 
@@ -56,6 +59,12 @@ export function StepConfirmPlaceholder({ wizard }: StepConfirmProps): React.Reac
     formData.set('encoding', state.encoding);
     formData.set('delimiter', state.delimiter);
     formData.set('do_backup', state.doBackup ? '1' : '0');
+    // IMP2-2.10 (#1486) — when a backup was requested, the CTA only enables
+    // once it is `completed`, so backupId is set here; forward it so the
+    // backend links the snapshot to the session.
+    if (state.doBackup && backupId !== null) {
+      formData.set('backup_id', backupId);
+    }
     formData.set('mode', state.mode);
     // IMP2-1.13 — image source + optional ZIP of images (was never sent before).
     formData.set('image_source', state.imageSource);
@@ -108,6 +117,7 @@ export function StepConfirmPlaceholder({ wizard }: StepConfirmProps): React.Reac
         checked={state.doBackup}
         onChange={(next) => setField('doBackup', next)}
         onStatusChange={setBackupStatus}
+        onBackupCreated={setBackupId}
       />
 
       <label className="flex items-center gap-2 text-sm">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2455,6 +2455,10 @@
       "resume": "Resume",
       "cancel": "Cancel",
       "action_failed": "Action failed"
+    },
+    "show": {
+      "backup_done": "Backup before import: ✅ {{date}}",
+      "backup_none": "Backup before import: —"
     }
   },
   "rbac": {

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2505,6 +2505,10 @@
       "resume": "Wznów",
       "cancel": "Anuluj",
       "action_failed": "Akcja nie powiodła się"
+    },
+    "show": {
+      "backup_done": "Backup przed importem: ✅ {{date}}",
+      "backup_none": "Backup przed importem: —"
     }
   },
   "rbac": {

--- a/apps/api/config/packages/framework.yaml
+++ b/apps/api/config/packages/framework.yaml
@@ -60,6 +60,13 @@ framework:
         # cannot saturate the disk. Sliding window so back-to-back
         # legitimate retries (network blip, second attempt the next
         # minute) wait the full hour, not just the next tick.
+        # IMP2-2.10 (#1486) — the pre-import backup checkbox reuses THIS limiter
+        # (the wizard POSTs /api/backups with triggered_by_action=pre_import).
+        # 1/h/tenant is fine for manual wizard imports, but it collides with
+        # scheduled imports (IMP2-4.1): a cron that also snapshots would exhaust
+        # the budget. DECISION: pre-import backup stays a MANUAL-wizard-only
+        # feature; IMP2-4.1 must NOT auto-trigger backups through this limiter.
+        # See docs/architecture/concurrency-matrix.md (§ backup_trigger).
         backup_trigger:
             policy: 'sliding_window'
             limit: 1

--- a/apps/api/src/Import/Presentation/Controller/GetImportSessionController.php
+++ b/apps/api/src/Import/Presentation/Controller/GetImportSessionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Import\Presentation\Controller;
 
+use App\Backup\Domain\Entity\Backup;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Identity\Domain\Entity\User;
 use App\Import\Domain\Entity\ImportSession;
@@ -58,7 +59,25 @@ final class GetImportSessionController
             'rollback_until' => $session->getRollbackUntil()?->format(DateTimeInterface::RFC3339_EXTENDED),
             'rolled_back_at' => $session->getRolledBackAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
             'error_message' => $session->getErrorMessage(),
+            // IMP2-2.10 (#1486) — the pre-import backup linked at start, or null.
+            'backup' => self::serializeBackup($session->getBackupSnapshot()),
         ], Response::HTTP_OK);
+    }
+
+    /**
+     * @return array{id: string, status: string, started_at: string}|null
+     */
+    private static function serializeBackup(?Backup $backup): ?array
+    {
+        if (!$backup instanceof Backup) {
+            return null;
+        }
+
+        return [
+            'id' => $backup->getId()->toRfc4122(),
+            'status' => $backup->getStatus()->value,
+            'started_at' => $backup->getStartedAt()->format(DateTimeInterface::RFC3339_EXTENDED),
+        ];
     }
 
     private function loadSession(string $rawId): ImportSession

--- a/apps/api/src/Import/Presentation/Controller/ListImportSessionsController.php
+++ b/apps/api/src/Import/Presentation/Controller/ListImportSessionsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Import\Presentation\Controller;
 
+use App\Backup\Domain\Entity\Backup;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Identity\Domain\Entity\User;
 use App\Import\Domain\Entity\ImportSession;
@@ -69,9 +70,12 @@ final class ListImportSessionsController
         $query = trim($request->query->get('q', ''));
 
         $qb = $this->entityManager->createQueryBuilder()
-            ->select('s', 'p')
+            ->select('s', 'p', 'b')
             ->from(ImportSession::class, 's')
             ->leftJoin('s.profile', 'p')
+            // IMP2-2.10 (#1486) — eager-join the pre-import backup so the hub
+            // badge does not trigger an N+1 across the page of sessions.
+            ->leftJoin('s.backupSnapshot', 'b')
             ->where('s.tenant = :tenant')
             ->andWhere('s.userId = :userId')
             ->orderBy('s.createdAt', 'DESC')
@@ -142,6 +146,23 @@ final class ListImportSessionsController
             'profile_id' => $profile?->getId()->toRfc4122(),
             'target_object_type_code' => $session->getTargetObjectType()->getCode(),
             'mode' => $session->getMode()->value,
+            'backup' => self::serializeBackup($session->getBackupSnapshot()),
+        ];
+    }
+
+    /**
+     * @return array{id: string, status: string, started_at: string}|null
+     */
+    private static function serializeBackup(?Backup $backup): ?array
+    {
+        if (!$backup instanceof Backup) {
+            return null;
+        }
+
+        return [
+            'id' => $backup->getId()->toRfc4122(),
+            'status' => $backup->getStatus()->value,
+            'started_at' => $backup->getStartedAt()->format(DateTimeInterface::RFC3339_EXTENDED),
         ];
     }
 }

--- a/apps/api/src/Import/Presentation/Controller/StartImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/StartImportController.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Import\Presentation\Controller;
 
+use App\Backup\Domain\Entity\Backup;
+use App\Backup\Domain\Enum\BackupStatus;
+use App\Backup\Domain\Repository\BackupRepositoryInterface;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\ObjectType;
@@ -60,7 +63,13 @@ use Symfony\Component\Uid\Uuid;
  *   - `mapping` — JSON `{column_header: attribute_code | "skip"}`
  *   - `profile_id` — UUID, optional
  *   - `locale`, `encoding`, `delimiter` — optional overrides
- *   - `do_backup` — boolean, optional (forwarded to IMP-06 in a follow-up)
+ *   - `do_backup` — boolean, optional. When `1`/`true` a `backup_id` of an
+ *     already-`completed` {@see Backup} is required (IMP2-2.10 #1486): the FE
+ *     wizard triggers the pre-import snapshot via the Backup module and gates
+ *     its CTA on `completed`, then passes the id here so the session records
+ *     which snapshot preceded it.
+ *   - `backup_id` — UUID, required when `do_backup=1`; must be a completed
+ *     backup owned by the caller's tenant.
  */
 final class StartImportController
 {
@@ -86,6 +95,7 @@ final class StartImportController
         private readonly StagedFileService $stagedFiles,
         private readonly RateLimiterFactoryInterface $importTriggerLimiter,
         private readonly XlsxArchiveGuard $xlsxArchiveGuard,
+        private readonly BackupRepositoryInterface $backups,
     ) {
     }
 
@@ -161,6 +171,12 @@ final class StartImportController
         $mapping = $this->parseMapping($request->request->get('mapping', '{}'));
         $profile = $this->resolveProfile($request->request->get('profile_id'), $tenant, $user->getId(), $mapping, $objectType);
 
+        // IMP2-2.10 (#1486) — when the wizard's "create a full backup" box is
+        // ticked it triggers the snapshot via the Backup module and gates its
+        // CTA on `completed`, then forwards the backup_id here. Validate it
+        // up-front (fail fast before persistence) and link it to the session.
+        $backup = $this->resolveBackup($request, $tenant);
+
         // IMP2-1.6a (#1468, ADR-0019 D8): the sync/async split counts DATA
         // ROWS, not bytes — a wide 20-row CSV stays inline, a narrow 500-row
         // one goes to the worker. Counting stops at the threshold; the +1
@@ -225,6 +241,9 @@ final class StartImportController
                 ? ImportImageSource::Zip
                 : (ImportImageSource::tryFrom((string) $request->request->get('image_source', 'none')) ?? ImportImageSource::None),
         );
+        if ($backup instanceof Backup) {
+            $session->setBackupSnapshot($backup);
+        }
 
         // Persist before upload so a later upload failure has a session id
         // to attach to (status stays `pending`, error_message captures
@@ -343,6 +362,63 @@ final class StartImportController
         return $staged;
     }
 
+    /**
+     * IMP2-2.10 (#1486) — resolve the optional pre-import backup. Returns null
+     * when `do_backup` is off; otherwise the referenced backup MUST exist, be
+     * owned by the caller's tenant, and be `completed`.
+     *
+     * Surfaces: missing `backup_id` while requested → 422; unknown / foreign
+     * tenant → 404 (no existence leak); not yet `completed` → 422 with the
+     * current status. The FE already gates its CTA on `completed`, so a 422
+     * here only fires on a tampered / out-of-band request.
+     */
+    private function resolveBackup(Request $request, Tenant $tenant): ?Backup
+    {
+        $rawFlag = strtolower((string) $request->request->get('do_backup', '0'));
+        if (!\in_array($rawFlag, ['1', 'true', 'on', 'yes'], true)) {
+            return null;
+        }
+
+        $rawId = (string) $request->request->get('backup_id', '');
+        if ('' === $rawId) {
+            throw new UnprocessableEntityHttpException(
+                'Zaznaczono utworzenie backupu, ale nie przekazano backup_id ukończonego backupu.',
+            );
+        }
+        try {
+            $id = Uuid::fromString($rawId);
+        } catch (InvalidArgumentException) {
+            throw new UnprocessableEntityHttpException(\sprintf('Nieprawidłowy backup_id "%s".', $rawId));
+        }
+
+        $backup = $this->backups->findById($id);
+        // 404 (not 403) for a foreign-tenant / unknown id — do not reveal that
+        // a backup with this id exists for another tenant.
+        if (!$backup instanceof Backup
+            || $backup->getTenant()?->getId()->toRfc4122() !== $tenant->getId()->toRfc4122()) {
+            throw new NotFoundHttpException(\sprintf('Backup "%s" nie został znaleziony.', $rawId));
+        }
+        // Every other path to a Backup gates on `backup:read` (GetBackupController
+        // + BackupVoter). This endpoint is only guarded by `imports:run`, so a
+        // same-tenant role with imports:run but no backup:read could otherwise
+        // probe backup existence/status through the 422 below. Run the same voter
+        // and 404 on denial to keep the no-leak contract. Catalog Manager — the
+        // import persona — holds backup:read for exactly this (RbacMatrix), and
+        // Owner/Admin bypass, so the wizard happy path is unaffected.
+        if (!$this->security->isGranted('READ', $backup)) {
+            throw new NotFoundHttpException(\sprintf('Backup "%s" nie został znaleziony.', $rawId));
+        }
+        if (BackupStatus::Completed !== $backup->getStatus()) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Backup "%s" nie jest ukończony (status: %s) — poczekaj na zakończenie snapshotu przed startem importu.',
+                $rawId,
+                $backup->getStatus()->value,
+            ));
+        }
+
+        return $backup;
+    }
+
     private function parseUuid(mixed $raw, string $field): Uuid
     {
         if (!\is_string($raw) || '' === $raw) {
@@ -420,6 +496,23 @@ final class StartImportController
             'started_at' => $session->getStartedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
             'completed_at' => $session->getCompletedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
             'rollback_until' => $session->getRollbackUntil()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'backup' => self::serializeBackup($session->getBackupSnapshot()),
+        ];
+    }
+
+    /**
+     * @return array{id: string, status: string, started_at: string}|null
+     */
+    private static function serializeBackup(?Backup $backup): ?array
+    {
+        if (!$backup instanceof Backup) {
+            return null;
+        }
+
+        return [
+            'id' => $backup->getId()->toRfc4122(),
+            'status' => $backup->getStatus()->value,
+            'started_at' => $backup->getStartedAt()->format(DateTimeInterface::RFC3339_EXTENDED),
         ];
     }
 

--- a/apps/api/tests/Api/Import/StartImportApiTest.php
+++ b/apps/api/tests/Api/Import/StartImportApiTest.php
@@ -838,6 +838,7 @@ final class StartImportApiTest extends CatalogApiTestCase
             self::assertSame('completed', $body['backup']['status']);
 
             // The GET endpoint exposes the same backup.
+            self::assertIsString($body['id']);
             $client->request('GET', '/api/import-sessions/'.$body['id']);
             self::assertResponseIsSuccessful();
             $show = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);

--- a/apps/api/tests/Api/Import/StartImportApiTest.php
+++ b/apps/api/tests/Api/Import/StartImportApiTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Api\Import;
 
+use App\Backup\Domain\Entity\Backup;
+use App\Backup\Domain\Enum\BackupStatus;
+use App\Backup\Domain\Enum\BackupTriggerAction;
+use App\Backup\Domain\Repository\BackupRepositoryInterface;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -21,6 +25,7 @@ use App\Shared\Domain\Tenant;
 use App\Tests\Api\Catalog\CatalogApiTestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Uid\Uuid;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
@@ -800,6 +805,218 @@ final class StartImportApiTest extends CatalogApiTestCase
         } finally {
             @unlink($xlsxPath);
         }
+    }
+
+    #[Test]
+    public function backupRequestedWithCompletedBackupLinksItToSession(): void
+    {
+        // IMP2-2.10 (#1486) — do_backup=1 + a completed backup_id → the session
+        // records the snapshot, the start response and the GET both expose it.
+        $this->seedAttributes();
+        $backupId = $this->seedBackup(BackupStatus::Completed);
+        $csvPath = $this->writeSmallCsv();
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                        'do_backup' => '1',
+                        'backup_id' => $backupId,
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'small.csv', 'text/csv', null, true)],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertIsArray($body['backup'] ?? null, 'start response carries the linked backup');
+            self::assertSame($backupId, $body['backup']['id']);
+            self::assertSame('completed', $body['backup']['status']);
+
+            // The GET endpoint exposes the same backup.
+            $client->request('GET', '/api/import-sessions/'.$body['id']);
+            self::assertResponseIsSuccessful();
+            $show = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($show);
+            self::assertIsArray($show['backup'] ?? null);
+            self::assertSame($backupId, $show['backup']['id']);
+
+            // And the FK column is actually persisted.
+            $linked = $this->em()->getConnection()->fetchOne(
+                'SELECT backup_snapshot_id FROM import_sessions WHERE id = :id',
+                ['id' => $body['id']],
+            );
+            self::assertSame($backupId, \is_scalar($linked) ? (string) $linked : null);
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function backupRequestedWithoutBackupIdIs422(): void
+    {
+        $this->seedAttributes();
+        $csvPath = $this->writeSmallCsv();
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                        'do_backup' => '1',
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'small.csv', 'text/csv', null, true)],
+                ],
+            ]);
+            self::assertResponseStatusCodeSame(422);
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function backupRequestedWithIncompleteBackupIs422(): void
+    {
+        // A still-running snapshot must not be accepted as the pre-import backup.
+        $this->seedAttributes();
+        $backupId = $this->seedBackup(BackupStatus::Running);
+        $csvPath = $this->writeSmallCsv();
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                        'do_backup' => '1',
+                        'backup_id' => $backupId,
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'small.csv', 'text/csv', null, true)],
+                ],
+            ]);
+            self::assertResponseStatusCodeSame(422);
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function unknownBackupIdIs404(): void
+    {
+        $this->seedAttributes();
+        $csvPath = $this->writeSmallCsv();
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                        'do_backup' => '1',
+                        'backup_id' => Uuid::v7()->toRfc4122(),
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'small.csv', 'text/csv', null, true)],
+                ],
+            ]);
+            self::assertResponseStatusCodeSame(404);
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function backupFromAnotherTenantIs404(): void
+    {
+        // Tenant isolation — a completed backup owned by a different tenant must
+        // not be linkable; 404 (no existence leak), never 200.
+        $this->seedAttributes();
+        $backupId = $this->seedForeignTenantBackup();
+        $csvPath = $this->writeSmallCsv();
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                        'do_backup' => '1',
+                        'backup_id' => $backupId,
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'small.csv', 'text/csv', null, true)],
+                ],
+            ]);
+            self::assertResponseStatusCodeSame(404);
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
+    public function noBackupRequestedLeavesBackupNull(): void
+    {
+        // Regression — do_backup absent → session starts as before, backup null.
+        $this->seedAttributes();
+        $csvPath = $this->writeSmallCsv();
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'name' => 'name'], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => ['file' => new UploadedFile($csvPath, 'small.csv', 'text/csv', null, true)],
+                ],
+            ]);
+            self::assertResponseIsSuccessful();
+            $body = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+            self::assertNull($body['backup'], 'no backup requested → backup is null');
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    private function seedBackup(BackupStatus $status): string
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $backup = new Backup(Uuid::v7(), BackupTriggerAction::PreImport);
+        $backup->assignTenant($tenant);
+        if (BackupStatus::Running === $status || BackupStatus::Completed === $status) {
+            $backup->markRunning();
+        }
+        if (BackupStatus::Completed === $status) {
+            $backup->markCompleted(1024, 'test-label');
+        }
+        self::getContainer()->get(BackupRepositoryInterface::class)->save($backup);
+
+        return $backup->getId()->toRfc4122();
+    }
+
+    private function seedForeignTenantBackup(): string
+    {
+        $em = $this->em();
+        $other = new Tenant('other-'.bin2hex(random_bytes(4)), 'Other Tenant');
+        $em->persist($other);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($other);
+
+        $backup = new Backup(Uuid::v7(), BackupTriggerAction::PreImport);
+        $backup->assignTenant($other);
+        $backup->markRunning();
+        $backup->markCompleted(1024, 'foreign');
+        self::getContainer()->get(BackupRepositoryInterface::class)->save($backup);
+
+        return $backup->getId()->toRfc4122();
     }
 
     private function writeCsv(string $contents, string $prefix): string

--- a/docs/architecture/concurrency-matrix.md
+++ b/docs/architecture/concurrency-matrix.md
@@ -64,6 +64,27 @@ per-batch): on conflict it clears the unit of work, re-reads, and retries up to
 `ObjectValuesChanged` event re-queues it) — so one conflicting object never
 dead-letters the whole batch (including the objects already rebuilt).
 
+## `backup_trigger` rate limit (IMP2-2.10, #1486)
+
+The pre-import backup checkbox (wizard Step "Confirm") reuses the existing
+`backup_trigger` rate limiter (`config/packages/framework.yaml`): **1 backup
+per hour per tenant**, sliding window. The FE triggers the snapshot via
+`POST /api/backups` (`triggered_by_action=pre_import`), gates the "Run import"
+CTA on the backup reaching `completed`, then forwards `backup_id` to
+`POST /api/import-sessions`, which links it to the session
+(`backup_snapshot_id`). There is **no** backend "backup-then-auto-start" state
+machine — the FE gate is the orchestration (decision recorded in #1486).
+
+**Collision with scheduled imports (IMP2-4.1):** a cron-driven import that also
+wanted a pre-import snapshot would exhaust the 1/h budget (or starve a manual
+import that ran in the same hour). **Decision: the pre-import backup is a
+manual-wizard-only feature.** IMP2-4.1 (scheduled imports) MUST NOT
+auto-trigger backups through `backup_trigger`; if scheduled-import snapshots
+are ever wanted they need their own policy/budget. A second manual import in
+the same hour with the box ticked gets a 429 from `/api/backups` — the wizard
+surfaces a readable "1 backup/h" message and lets the operator continue without
+a backup.
+
 ## Links
 
 - ADR-0019 §4.4 D11 — `docs/adr/0019-import-v2-engine-contracts.md`


### PR DESCRIPTION
## IMP2-2.10 (#1486) — backup przed importem powiązany z sesją

Checkbox „Utwórz pełen backup" w kreatorze tworzył snapshot, ale `backup_id` nigdy nie trafiał do startu importu — sesja nie zapamiętywała, który backup ją poprzedził (martwe pole schematu + „fałszywa affordancja" z planu §2.7). Teraz FE przekazuje `backup_id`, backend waliduje i linkuje, a widok sesji to pokazuje.

### Backend
- **`StartImportController`** czyta `do_backup` + `backup_id`: brak id przy `do_backup=1` → **422**; nieznany / obcy-tenant id → **404** (bez ujawniania istnienia); status ≠ `completed` → **422** ze statusem; poprawny → `setBackupSnapshot()` przed `save`. Docblock „forwarded in a follow-up" usunięty.
- **Authz (z adversarial review)**: odczyt backupu uruchamia ten sam `BackupVoter` (`READ`→`backup:read`) co `GetBackupController` — rola z `imports:run` bez `backup:read` nie może probować stanu backupu; denial → 404 (zachowuje no-leak). Catalog Manager ma `backup:read` (RbacMatrix, „keeps wizard polling working"), Owner/Admin bypass → happy path nietknięty.
- **`GetImportSessionController` + `ListImportSessionsController`** serializują `backup: {id, status, started_at} | null` (lista przez `leftJoin`+`addSelect`, bez N+1). `ImportSession.backupSnapshot` był już zmapowany (many-to-one, `backup_snapshot_id`, SET NULL) — **bez migracji**.
- **`framework.yaml`**: komentarz o kolizji `backup_trigger` 1/h z harmonogramami (IMP2-4.1); decyzja „backup tylko dla importów manualnych" w `docs/architecture/concurrency-matrix.md`.

### Frontend
- `BackupTriggerCheckbox` → `onBackupCreated(id)`; `StepConfirm` trzyma `backupId`, dodaje `backup_id` do `formData` gdy `do_backup=1` (CTA już gate'owane na `completed`); `ImportShowPage` pokazuje „Backup przed importem: ✅ data / —" (i18n `pl`/`en`).

### Decyzje (per ticket, poza zakresem)
Brak backendowej orkiestracji „backup→auto-start" (FE-gate wystarcza); restore/rollback UI i backup w harmonogramach poza zakresem.

### Bramki
PHPUnit **20/20** (110 asercji — 6 nowych: completed-links, 422 bez-id, 422 incomplete, 404 unknown, 404 foreign-tenant, null-when-absent) · PHPStan max (composer parity) ✅ · Deptrac 0 · php-cs-fixer ✅ · Biome ✅ · FE `tsc --noEmit` ✅ · OpenAPI v0.json bez driftu (endpointy custom). Adversarial review (4 wymiary × verify, 19 findings → 1 confirmed) — naprawiony authz gap powyżej.

### Live smoke (https://pim.localhost)
- `do_backup=1` bez `backup_id` → **422** „Zaznaczono utworzenie backupu, ale nie przekazano backup_id…".
- `backup_id` nieistniejący → **404**.
- import z `backup_id` ukończonego backupu → **200**, response + `GET /api/import-sessions/{id}` zwracają `backup:{id,status:completed,started_at}`.
  *(dev pgBackRest zwraca `failed` natychmiast — cron stale; status `completed` zaseedowany w DB by zwerywikować pełny pozytyw, walidacja pokryta też ApiTestCase.)*

Refs #1486