### PR TITLE
fix(export): neutralizacja formuł w XlsxStreamWriter — XLSX formula injection (#1552)

### DIFF
--- a/apps/api/src/Export/Infrastructure/Writer/XlsxStreamWriter.php
+++ b/apps/api/src/Export/Infrastructure/Writer/XlsxStreamWriter.php
@@ -70,7 +70,7 @@ final class XlsxStreamWriter implements RowWriter
         }
 
         $style = new Style()->withFontBold(true);
-        $this->writer->addRow(Row::fromValuesWithStyle($headers, $style));
+        $this->writer->addRow(Row::fromValuesWithStyle(array_map([$this, 'neutraliseFormula'], $headers), $style));
         $this->headersWritten = true;
     }
 
@@ -83,7 +83,14 @@ final class XlsxStreamWriter implements RowWriter
     public function writeRow(array $values): void
     {
         $this->guardOpen();
-        $this->writer->addRow(Row::fromValues($values));
+
+        // IMP2-2.8 (#1484) follow-up — CSV/Formula-injection defence for XLSX.
+        // OpenSpout Cell::fromValue() turns a string with a leading '=' into an
+        // active FormulaCell, so a cell like '=HYPERLINK(...)' would execute when
+        // the file is opened in Excel/Numbers (RCE/exfiltration vector). Prefix a
+        // TAB to formula-trigger cells so they render as text. Mirrors
+        // CsvStreamWriter::neutraliseFormula — export only, never mutates import.
+        $this->writer->addRow(Row::fromValues(array_map([$this, 'neutraliseFormula'], $values)));
     }
 
     /**
@@ -103,5 +110,21 @@ final class XlsxStreamWriter implements RowWriter
         if (!$this->opened) {
             throw new LogicException('Open the writer before writing rows.');
         }
+    }
+
+    /**
+     * Prefix a TAB to cells whose first character is a spreadsheet formula
+     * trigger so the value is rendered as text instead of being evaluated.
+     * Identical contract to {@see CsvStreamWriter::neutraliseFormula()}.
+     */
+    private function neutraliseFormula(string $value): string
+    {
+        if ('' === $value) {
+            return '';
+        }
+
+        return \in_array($value[0], ['=', '+', '-', '@', "\t", "\r"], true)
+            ? "\t".$value
+            : $value;
     }
 }

--- a/apps/api/tests/Unit/Export/XlsxStreamWriterTest.php
+++ b/apps/api/tests/Unit/Export/XlsxStreamWriterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Export;
+
+use App\Export\Infrastructure\Writer\XlsxStreamWriter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ZipArchive;
+
+/**
+ * IMP2-2.8 (#1484) follow-up — CSV/Formula-injection neutralisation on the XLSX
+ * export path. OpenSpout's Cell::fromValue() promotes a string with a leading
+ * '=' to an active FormulaCell, so without neutralisation a cell like
+ * '=HYPERLINK(...)' is written as a live formula (<f> element) that executes when
+ * opened in Excel/Numbers. The writer must prefix a TAB to formula-trigger cells
+ * so the worksheet contains only inline string cells, never a <f> element.
+ */
+final class XlsxStreamWriterTest extends TestCase
+{
+    #[Test]
+    public function neutralisesFormulaCellsAndNeverEmitsFormulaElement(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'pim-xlsx-');
+        self::assertIsString($path);
+
+        try {
+            $writer = new XlsxStreamWriter();
+            $writer->openToFile($path);
+            $writer->writeHeaders(['sku', 'name']);
+            $writer->writeRow(['=HYPERLINK("http://evil","x")', 'safe']);
+            $writer->writeRow(['+48123', 'a=b']);
+            $writer->writeRow(['-5', '@cmd']);
+            $writer->close();
+
+            $zip = new ZipArchive();
+            self::assertTrue(true === $zip->open($path));
+            $xml = (string) $zip->getFromName('xl/worksheets/sheet1.xml');
+            $zip->close();
+
+            // 1) The actual injection vector: no active formula element at all.
+            self::assertStringNotContainsString('<f>', $xml);
+
+            // 2) Formula-trigger cells are TAB-prefixed inline strings.
+            self::assertStringContainsString("<t>\t=HYPERLINK(", $xml);
+            self::assertStringContainsString("<t>\t+48123</t>", $xml);
+            self::assertStringContainsString("<t>\t-5</t>", $xml);
+            self::assertStringContainsString("<t>\t@cmd</t>", $xml);
+
+            // 3) Safe values and a non-leading '=' are left untouched.
+            self::assertStringContainsString('<t>safe</t>', $xml);
+            self::assertStringContainsString('<t>a=b</t>', $xml);
+            self::assertStringNotContainsString("\tsafe", $xml);
+            self::assertStringNotContainsString("\ta=b", $xml);
+        } finally {
+            @unlink($path);
+        }
+    }
+}


### PR DESCRIPTION
## Co i dlaczego
Audyt IMP2 (2026-06-16) wykrył, że eksport **XLSX nie neutralizował formuł**. `XlsxStreamWriter::writeRow` przekazywał wartości do OpenSpout `Row::fromValues()`, które zamienia string zaczynający się od `=` w aktywną `FormulaCell`. Eksport komórki `=HYPERLINK(...)` zapisywał **wykonywalną formułę** (`<f>` w `sheet1.xml`) — wektor CSV/Formula injection po otwarciu w Excel/Numbers. Guard `neutraliseFormula` istniał wyłącznie w `CsvStreamWriter`.

## Zmiana
- `XlsxStreamWriter`: dodano prywatne `neutraliseFormula()` (kontrakt identyczny jak `CsvStreamWriter.php:98-107`) i zastosowano w `writeRow()` **oraz** `writeHeaders()`. Komórki zaczynające się od `= + - @ \t \r` dostają prefiks TAB → renderują się jako tekst.

## Dowód empiryczny (na żywym kontenerze)
- **Przed:** `xl/worksheets/sheet1.xml` zawierał `<f>HYPERLINK("http://evil.test","klik")</f>` (aktywna formuła).
- **Po:** 0 elementów `<f>`; wartość zapisana jako `t="inlineStr"` z prefiksem TAB.

## Testy
- Nowy `XlsxStreamWriterTest::neutralisesFormulaCellsAndNeverEmitsFormulaElement` — asercja braku `<f>` + TAB-prefiks dla `= + - @`, brak prefiksu dla `safe`/`a=b`.
- Export unit suite zielony (73 testy, 223 asercje); CSV bez regresji.
- PHPStan max + php-cs-fixer lokalnie zielone.

Closes #1552
