### PR TITLE
fix(admin): KPI 'pominiętych' czyta skipped_count zamiast error_count (#1553)

### DIFF
--- a/apps/admin/e2e/1430-import-session-v2.spec.ts
+++ b/apps/admin/e2e/1430-import-session-v2.spec.ts
@@ -76,3 +76,44 @@ test('IMP2-2.10 — session view shows the linked pre-import backup', async ({ p
     /(Backup przed importem|Backup before import).*✅/,
   );
 });
+
+/**
+ * #1553 follow-up (IMP2-2.6) — the "pominiętych" KPI must read skipped_count,
+ * not error_count. Mocked with distinct values (skipped=2, error=1) so a
+ * regression that reads error_count would render "1 pominiętych" instead of "2".
+ */
+test('#1553 — KPI "pominiętych" reads skipped_count, not error_count', async ({ page }) => {
+  await loginAsAdmin(page);
+
+  const sessionId = '01900000-0000-7000-8000-0000000000cc';
+  await page.route(`**/api/import-sessions/${sessionId}`, (route) =>
+    route.fulfill({
+      json: {
+        id: sessionId,
+        status: 'success',
+        file_name: 'skipped-demo.csv',
+        total_rows: 6,
+        success_count: 3,
+        error_count: 1,
+        updated_count: 0,
+        skipped_count: 2,
+        mode: 'upsert',
+        images_downloaded: 0,
+        images_failed: 0,
+        started_at: '2026-06-15T10:00:00.000+00:00',
+        completed_at: '2026-06-15T10:01:00.000+00:00',
+        rollback_until: null,
+        rolled_back_at: null,
+        error_message: null,
+        backup: null,
+      },
+    }),
+  );
+
+  await page.goto(`/integrations/imports/${sessionId}`);
+
+  // The "skipped" KPI reflects skipped_count (2), never error_count (1).
+  // Locale-agnostic: the suite runs in EN ("2 skipped") or PL ("2 pominiętych").
+  await expect(page.getByText(/2 (skipped|pominiętych)/)).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(/1 (skipped|pominiętych)/)).toHaveCount(0);
+});

--- a/apps/admin/src/features/imports/show/ImportShowPage.tsx
+++ b/apps/admin/src/features/imports/show/ImportShowPage.tsx
@@ -26,6 +26,7 @@ interface ImportSession {
   total_rows: number | null;
   success_count: number;
   error_count: number;
+  skipped_count: number;
   images_downloaded: number;
   images_failed: number;
   started_at: string | null;
@@ -273,7 +274,7 @@ export function ImportShowPage(): React.ReactElement {
             />
             <Kpi
               label={t('imports.results.skipped', {
-                count: session.error_count,
+                count: session.skipped_count,
                 defaultValue: '{{count}} pominiętych',
               })}
               tone="warn"
@@ -290,7 +291,7 @@ export function ImportShowPage(): React.ReactElement {
           {session.total_rows !== null && session.total_rows > 0 && (
             <ResultBar
               ok={session.success_count}
-              warn={0}
+              warn={session.skipped_count}
               err={session.error_count}
               total={session.total_rows}
             />


### PR DESCRIPTION
## Co i dlaczego
Audyt IMP2 (2026-06-16) wykrył, że widok sesji importu **kłamał na liczniku „pominiętych"**. `ImportShowPage.tsx:276` przekazywał `session.error_count` do etykiety `imports.results.skipped`, a `ResultBar` miał `warn={0}` — pominięte wiersze nie były nigdzie pokazywane, a liczba błędów była błędnie etykietowana jako „pominięte". API **już zwracało** `skipped_count` (`GetImportSessionController:53`, `ListImportSessionsController:140`, `StartImportController:494`) — problem był czysto frontendowy.

## Zmiana
- `ImportSession` (interfejs FE): dodano `skipped_count: number`.
- KPI „pominiętych" → `session.skipped_count`.
- `ResultBar` → `warn={session.skipped_count}` (pominięte reprezentowane w pasku).

## Testy
- `1430-import-session-v2.spec.ts`: nowy test mockuje sesję `skipped=2, error=1` i asercją sprawdza, że KPI pokazuje „2 pominiętych" (nie „1") — regresja czytająca `error_count` by oblała.
- tsc + Biome zielone.

Closes #1553
