### PR TITLE
feat(import): pola zip_file_name/zip_file_size_bytes w kontrakcie sesji (#1555)

### DIFF
--- a/apps/api/src/Import/Presentation/Controller/GetImportSessionController.php
+++ b/apps/api/src/Import/Presentation/Controller/GetImportSessionController.php
@@ -54,6 +54,10 @@ final class GetImportSessionController
             'mode' => $session->getMode()->value,
             'images_downloaded' => $session->getImagesDownloaded(),
             'images_failed' => $session->getImagesFailed(),
+            // IMP2-1.13 (#1476) follow-up — ZIP source metadata in the contract,
+            // null for non-ZIP imports.
+            'zip_file_name' => $session->getZipFileName(),
+            'zip_file_size_bytes' => $session->getZipFileSizeBytes(),
             'started_at' => $session->getStartedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
             'completed_at' => $session->getCompletedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
             'rollback_until' => $session->getRollbackUntil()?->format(DateTimeInterface::RFC3339_EXTENDED),

--- a/apps/api/tests/Api/Import/GetImportSessionApiTest.php
+++ b/apps/api/tests/Api/Import/GetImportSessionApiTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Import\Domain\Entity\ImportSession;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * IMP2-1.13 (#1476) follow-up — GET /api/import-sessions/{id} must expose the
+ * ZIP source metadata (zip_file_name / zip_file_size_bytes). The fields were
+ * persisted on the entity but missing from the contract, so consumers had no
+ * way to read them. null for non-ZIP imports.
+ */
+final class GetImportSessionApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function getReturnsZipMetadataForZipImport(): void
+    {
+        $session = $this->persistSession('photos.zip', 204_800);
+
+        $client = $this->authenticatedClient();
+        $client->request('GET', \sprintf('/api/import-sessions/%s', $session->getId()->toRfc4122()));
+
+        self::assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertSame('photos.zip', $body['zip_file_name']);
+        self::assertSame(204_800, $body['zip_file_size_bytes']);
+    }
+
+    #[Test]
+    public function getReturnsNullZipMetadataForPlainImport(): void
+    {
+        $session = $this->persistSession(null, null);
+
+        $client = $this->authenticatedClient();
+        $client->request('GET', \sprintf('/api/import-sessions/%s', $session->getId()->toRfc4122()));
+
+        self::assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        self::assertNotNull($response);
+        $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('zip_file_name', $body);
+        self::assertArrayHasKey('zip_file_size_bytes', $body);
+        self::assertNull($body['zip_file_name']);
+        self::assertNull($body['zip_file_size_bytes']);
+    }
+
+    private function persistSession(?string $zipFileName, ?int $zipFileSizeBytes): ImportSession
+    {
+        $em = $this->em();
+        $tenant = $this->demoTenant();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $product = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $session = new ImportSession(
+            userId: $this->adminUserId(),
+            targetObjectType: $product,
+            fileName: $zipFileName ?? 'plain.csv',
+            fileSizeBytes: 1_024,
+            zipFileName: $zipFileName,
+            zipFileSizeBytes: $zipFileSizeBytes,
+        );
+        $session->assignTenant($tenant);
+        $em->persist($session);
+        $em->flush();
+
+        return $session;
+    }
+
+    private function demoTenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    private function adminUserId(): Uuid
+    {
+        $user = self::getContainer()->get(\App\Identity\Domain\Repository\UserRepositoryInterface::class)
+            ->findByEmail(self::ADMIN_EMAIL);
+        \assert(null !== $user);
+
+        return $user->getId();
+    }
+}


### PR DESCRIPTION
## Co i dlaczego
Audyt IMP2 (2026-06-16) wykrył, że `GET /api/import-sessions/{id}` **nie zwracał** `zip_file_name` ani `zip_file_size_bytes`, mimo że encja je persystuje (AC2/AC3 ticketu IMP2-1.13). UI i integratorzy nie mieli dostępu do metadanych ZIP.

## Zmiana
- `GetImportSessionController`: dodano `zip_file_name` i `zip_file_size_bytes` do odpowiedzi (null dla importów nie-ZIP).

## Testy
- Nowy `GetImportSessionApiTest`: sesja z ZIP → pola wypełnione; sesja zwykła → oba null. (2 testy, 8 asercji, zielone lokalnie.)
- PHPStan max + cs-fixer zielone.

Closes #1555
