### PR TITLE
feat(import): allowedErrorsPct konfigurowalny przez API ImportProfile (#1554)

### DIFF
--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfileInput.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfileInput.php
@@ -55,4 +55,11 @@ final class ImportProfileInput
     public ?string $imageSource = null;
 
     public ?string $imageZipNamingConvention = null;
+
+    /**
+     * IMP2-2.7 (#1483) — abort the run once blocking errors exceed this
+     * percentage of processed rows. null = no threshold (partial behaviour).
+     */
+    #[Assert\Range(min: 0, max: 100)]
+    public ?int $allowedErrorsPct = null;
 }

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfilePatchInput.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfilePatchInput.php
@@ -36,4 +36,11 @@ final class ImportProfilePatchInput
     public ?string $imageSource = null;
 
     public ?string $imageZipNamingConvention = null;
+
+    /**
+     * IMP2-2.7 (#1483) — error-rate abort threshold (percent of processed
+     * rows). null in a merge-patch means "leave unchanged".
+     */
+    #[Assert\Range(min: 0, max: 100)]
+    public ?int $allowedErrorsPct = null;
 }

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/State/ImportProfileProcessor.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/State/ImportProfileProcessor.php
@@ -104,6 +104,7 @@ final readonly class ImportProfileProcessor implements ProcessorInterface
         $profile->setEncoding($data->encoding);
         $profile->setDelimiter($data->delimiter);
         $profile->setImageZipNamingConvention($data->imageZipNamingConvention);
+        $profile->setAllowedErrorsPct($data->allowedErrorsPct);
         if (null !== $data->imageSource) {
             $source = ImportImageSource::tryFrom($data->imageSource);
             if (null !== $source) {
@@ -162,6 +163,9 @@ final readonly class ImportProfileProcessor implements ProcessorInterface
             if (null !== $source) {
                 $profile->setImageSource($source);
             }
+        }
+        if (null !== $data->allowedErrorsPct) {
+            $profile->setAllowedErrorsPct($data->allowedErrorsPct);
         }
 
         $this->profiles->save($profile);

--- a/apps/api/src/Import/Infrastructure/Serializer/ImportProfile.xml
+++ b/apps/api/src/Import/Infrastructure/Serializer/ImportProfile.xml
@@ -50,6 +50,10 @@
             <group>import_profile:read</group>
             <group>import_profile:write</group>
         </attribute>
+        <attribute name="allowedErrorsPct">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
         <attribute name="lastUsedAt">
             <group>import_profile:read</group>
         </attribute>

--- a/apps/api/tests/Api/Import/ImportProfileApiTest.php
+++ b/apps/api/tests/Api/Import/ImportProfileApiTest.php
@@ -113,4 +113,55 @@ final class ImportProfileApiTest extends CatalogApiTestCase
         $client->request('GET', \sprintf('/api/import-profiles/%s', $profileId));
         self::assertResponseStatusCodeSame(404);
     }
+
+    /**
+     * IMP2-2.7 (#1483) follow-up — the error-rate abort threshold is
+     * configurable through the API (API-first), round-trips on read, and
+     * rejects out-of-range values.
+     */
+    #[Test]
+    public function allowedErrorsPctIsConfigurableThroughTheApi(): void
+    {
+        $client = $this->authenticatedClient();
+        $targetId = $this->objectTypeIdFor(ObjectKind::Product);
+
+        // POST with a threshold → echoed back on read.
+        $client->request('POST', '/api/import-profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'name' => 'Threshold Profile',
+                'targetObjectTypeId' => $targetId,
+                'columnMapping' => [],
+                'allowedErrorsPct' => 10,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $created = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($created);
+        self::assertSame(10, $created['allowedErrorsPct']);
+        $profileId = $created['id'] ?? null;
+        self::assertIsString($profileId);
+
+        // PATCH updates the threshold.
+        $client->request('PATCH', \sprintf('/api/import-profiles/%s', $profileId), [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode(['allowedErrorsPct' => 25], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseIsSuccessful();
+        $patched = json_decode((string) $client->getResponse()?->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($patched);
+        self::assertSame(25, $patched['allowedErrorsPct']);
+
+        // Out-of-range value is rejected.
+        $client->request('POST', '/api/import-profiles', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'name' => 'Bad Threshold',
+                'targetObjectTypeId' => $targetId,
+                'columnMapping' => [],
+                'allowedErrorsPct' => 150,
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(422);
+    }
 }

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -8943,6 +8943,13 @@
                             "null"
                         ]
                     },
+                    "allowedErrorsPct": {
+                        "description": "IMP2-2.7 (#1483) \u2014 Allowed-Errors guardrail (D10). Percentage of failed\nrows (0-100) above which the run aborts to `partial` instead of letting a\nmostly-broken file dump garbage into the catalog. `null` = OFF (D10\ndefault), i.e. the run never self-aborts on the error ratio.",
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
+                    },
                     "lastUsedAt": {
                         "readOnly": true,
                         "type": [
@@ -9040,6 +9047,15 @@
                             "string",
                             "null"
                         ]
+                    },
+                    "allowedErrorsPct": {
+                        "minimum": 0,
+                        "maximum": 100,
+                        "description": "IMP2-2.7 (#1483) \u2014 abort the run once blocking errors exceed this\npercentage of processed rows. null = no threshold (partial behaviour).",
+                        "type": [
+                            "integer",
+                            "null"
+                        ]
                     }
                 }
             },
@@ -9109,6 +9125,15 @@
                     "imageZipNamingConvention": {
                         "type": [
                             "string",
+                            "null"
+                        ]
+                    },
+                    "allowedErrorsPct": {
+                        "minimum": 0,
+                        "maximum": 100,
+                        "description": "IMP2-2.7 (#1483) \u2014 error-rate abort threshold (percent of processed\nrows). null in a merge-patch means \"leave unchanged\".",
+                        "type": [
+                            "integer",
                             "null"
                         ]
                     }
@@ -9192,6 +9217,13 @@
                             "imageZipNamingConvention": {
                                 "type": [
                                     "string",
+                                    "null"
+                                ]
+                            },
+                            "allowedErrorsPct": {
+                                "description": "IMP2-2.7 (#1483) \u2014 Allowed-Errors guardrail (D10). Percentage of failed\nrows (0-100) above which the run aborts to `partial` instead of letting a\nmostly-broken file dump garbage into the catalog. `null` = OFF (D10\ndefault), i.e. the run never self-aborts on the error ratio.",
+                                "type": [
+                                    "integer",
                                     "null"
                                 ]
                             },


### PR DESCRIPTION
## Co i dlaczego
Audyt IMP2 (2026-06-16) wykrył, że próg „dozwolone % błędów" (`allowedErrorsPct`) działa w silniku (`ImportRunHandler:489,511`), ale **nie był konfigurowalny przez API** — łamało to API-first (scope-item 4 ticketu IMP2-2.7).

## Zmiana
- `ImportProfileInput` + `ImportProfilePatchInput`: `allowedErrorsPct` z `Range(0..100)`.
- `ImportProfileProcessor`: mapowanie w POST (bezwarunkowo) i PATCH (merge-patch — tylko gdy podane).
- `Serializer/ImportProfile.xml`: `allowedErrorsPct` w grupach read+write.
- Regeneracja `docs/api-spec/v0.json` (+32 linie, wyłącznie `allowedErrorsPct`).

## Testy
- `ImportProfileApiTest::allowedErrorsPctIsConfigurableThroughTheApi`: POST→201 z polem, PATCH→update, 150 → 422.
- PHPStan max + cs-fixer zielone; OpenAPI-drift zsynchronizowany.

Closes #1554
