### PR TITLE
docs(catalog): decyzja ValueWriteCore — konkretna klasa zamiast interface/DTO (#1558)

### DIFF
--- a/docs/adr/0019-import-v2-engine-contracts.md
+++ b/docs/adr/0019-import-v2-engine-contracts.md
@@ -152,6 +152,16 @@ Extending this list requires bumping the rule version here and in the test.
   enter the baseline (`skip_violations`) and are burned down by #1466.
 - The wizard "karta prawdy" (`Project Plan/UI/imports-v2-karta-prawdy.md`)
   tracks which UI affordances are real at any point of the rebuild.
+- The IMP2-1.4 (#1466) shared writer core ships as the **concrete**
+  `App\Catalog\Application\ValueWriteCore`, not the `ValueWriteCoreInterface` +
+  `ValueWriteResult` / `ValueWriteIssue` DTOs sketched in that ticket's
+  acceptance criteria. Deliberate (YAGNI, #1558): one implementation is shared
+  by all three write paths (`ObjectAttributesUpserter`, `BatchValueWriter`,
+  `ImportUndoLogger`) and per-rule violations travel as plain message
+  strings / arrays that each consumer maps to its own context (HTTP exceptions
+  vs import result issues). An interface + result DTO would add indirection
+  with no second implementation to justify it. Revisit if a second validator
+  core (e.g. a remote/agent one) appears.
 
 ## Links
 


### PR DESCRIPTION
## Co i dlaczego
Audyt IMP2 (2026-06-16) wykrył rozjazd kontrakt↔kod w IMP2-1.4 (#1466): AC zakładał `ValueWriteCoreInterface` + DTO `ValueWriteResult`/`ValueWriteIssue` w `Catalog\Contracts`, a dostarczono **konkretną** klasę `ValueWriteCore` zwracającą stringi/tablice.

## Decyzja (opcja B z #1558 — sync AC z implementacją)
Świadome odejście udokumentowane w ADR-0019 (Consequences): jedna implementacja współdzielona przez 3 ścieżki zapisu (`ObjectAttributesUpserter`, `BatchValueWriter`, `ImportUndoLogger`) **nie uzasadnia** interfejsu + result-DTO (YAGNI). Naruszenia jako message-stringi są prostsze i każdy konsument mapuje je do własnego kontekstu (HTTP exceptions vs import result issues). Do rewizji, gdy pojawi się druga implementacja (np. walidator agenta).

## DoD
Doc-only; decyzja utrwalona w ADR + komentarz w #1466.

Closes #1558
