### PR TITLE
fix(import): reload session po batch-clear w abort path — eliminuje deadlock 40P01 (#1560)

### DIFF
--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -507,12 +507,21 @@ final class ImportRunHandler extends AbstractBatchHandler
         }
 
         $this->rowPhasePeakBytes = \memory_get_peak_usage(true);
-        $this->dispatchAttributesRebuild($tenant);
+        // Read the counters off the still-managed session BEFORE the rebuild
+        // dispatch: on a sync transport the inline RebuildAttributesIndexedHandler
+        // (an AbstractBatchHandler) flush+clears the EM, detaching $session and
+        // its tenant/profile/targetObjectType proxies.
         $threshold = $session->getProfile()?->getAllowedErrorsPct() ?? 0;
+        $errorCount = $session->getErrorCount();
+        $this->dispatchAttributesRebuild($tenant);
+        // EM was cleared by the inline rebuild: reload the session so the status
+        // mutation + save flush against a MANAGED entity (mirrors
+        // ImportRollbackService finalize), never re-persisting detached proxies.
+        $session = $this->refreshSession($session);
         $session->markFailed(\sprintf(
             'Przerwano import: odsetek błędnych wierszy przekroczył próg %d%% (%d błędów / %d wierszy).',
             $threshold,
-            $session->getErrorCount(),
+            $errorCount,
             $processed,
         ));
         $this->sessions->save($session);


### PR DESCRIPTION
## Co i dlaczego
Audyt IMP2 wskazał deadlock PostgreSQL **40P01** w `ImportRollbackV2ApiTest` jako jedyny realny fail suity. Diagnoza (reprodukcja w izolacji) pokazała, że **to nie osobny bug lock-order**, lecz skutek uboczny realnego buga w ścieżce abort importu.

## Root cause
`ImportRunHandler::abortIfErrorRateExceeded()` wołał `dispatchAttributesRebuild()` (na sync transporcie inline `RebuildAttributesIndexedHandler` robi `flush()` + `em->clear()`), a następnie `sessions->save($session)`. Po `clear()` sesja i jej proxy (`tenant`/`profile`/`targetObjectType`) są **detached** → flush w save traktuje je jako nowe encje → `ORMInvalidArgumentException`. Nieudany flush zostawiał UnitOfWork/transakcję w uszkodzonym stanie → **kaskada 40P01** w kolejnych testach.

## Fix
- Odczyt skalarów (próg, error-count) z zarządzanej sesji **przed** dispatch rebuild.
- **Reload sesji** z repo (`findById` → managed) przed `markFailed()` + `save()` — wzorzec z `ImportRollbackService:126-127`.
- `em->clear()` zachowany (budżet pamięci workera, CLAUDE.md HARD-02).

## Weryfikacja
- `importAbortsWhenErrorRatioExceeds` zielony (był: ORMInvalidArgumentException).
- `ImportRunHandlerAsyncTest` + `ImportRollbackV2ApiTest` w jednym przebiegu — **11/11, brak 40P01**.
- Grupa `tests/Api|Integration|Unit/Import` — **264/264**.
- PHPStan max + Deptrac (0 violations) + cs-fixer czyste.

## Recovery pim_test
Nie był potrzebny — fix eliminuje half-state u źródła. W razie wystąpienia: `DROP DATABASE pim_test` + `CREATE DATABASE pim_test` (rola pim, osobne psql -c).

Closes #1560
