### PR TITLE
docs(import): raport audytu IMP2 + odświeżona karta prawdy + status

### DIFF
--- a/Project Plan/UI/imports-v2-karta-prawdy.md
+++ b/Project Plan/UI/imports-v2-karta-prawdy.md
@@ -1,21 +1,46 @@
 # Imports v2 — karta prawdy UI (IMP2-1.1 / #1463)
 
 > Co w UI importów jest REALNE na danym etapie przebudowy (ADR-0019). Aktualizować przy merge ticketów IMP2.
-> Stan po NUI-10 (#1452) / NUI-11 (#1453): wizard 6 kroków i widok sesji istnieją NA STARYM silniku.
+> Stan po Etapie 1 (1.1–1.13) i Etapie 2 (2.1–2.10) — wszystkie 27 ticketów zmergowane do `main`.
+> Aktualizacja: 2026-06-16 (po audycie końcowym epiku IMP2). Tabela śledzi *afordancje* (co w UI jest realne), nie kroki wizarda 1:1.
 
-| Element UI | Stan (2026-06-12) | Realne od |
-|---|---|---|
-| Wizard 6 kroków (Źródło→…→Start) | renderuje się; backend = stary silnik | — |
-| Tryby CREATE/UPDATE/UPSERT w kroku Reguły | **dekoracja** — silnik robi wyłącznie create, duplikat SKU blokuje wiersz | #1465 |
-| Kubełek „Aktualizacje" w Podglądzie | **kłamie** (silnik nie umie update) | #1465 + #1492 |
-| Dry-run pełnego pliku | sync, cały plik w jednym requeście | #1492 (dwupoziomowy) |
-| Pauza / wznów / anuluj | brak w UI (endpointy BE nieobsługiwane przez worker) | #1479 |
-| Rollback | działa dla CREATE; **nie cofa update'ów**; ghost-docs w Meili | #1480 |
-| Zdjęcia (URL/ZIP) | brak pobierania (pola martwe) | #1475 / #1476 |
-| Mapping: duplikaty/puste nagłówki | gubione (mapping po nazwie) | #1489 (po indeksie) |
-| Kolumny `code.channel` | **korupcja**: suffix zapisywany jako locale | #1469 |
-| Warianty / relacje / multi-kategorie | parent_sku skip; relacje bez ObjectRelation; 1 kategoria | #1470 / #1471 |
-| Profile: zapis z wizarda / prefill | niedziałające (stan lokalny) | #1491 |
-| Harmonogramy run-now / źródła SFTP | stemple bez sesji / stub „ok" | #1495 / #1496 |
-| Pobierz raport CSV / eksport profilu | ✅ działa (fetch+Bearer, #1500) | done |
-| Live progress (Mercure) | ✅ działa; topic z configu po #1502 | done |
+| Element UI | Stan rzeczywisty (zweryfikowany) | Dowód | Realne od (ticket) |
+|---|---|---|---|
+| Wizard 6 kroków (Źródło→Wykrywanie→Reguły→Mapowanie→Podgląd→Start) | renderuje się na NOWYM silniku v2 (ObjectResolver + tryby) | `apps/admin/src/features/imports/wizard/*`; ImportShowPage.tsx | #1465 |
+| Tryby CREATE / UPDATE / UPSERT w kroku Reguły | **realne** — ObjectResolver::decide rozdziela create/update/skip; UPSERT default | ObjectResolver.php:151-159; StepRules select + ModeBadge | #1465 |
+| Kubełek „Aktualizacje" w Podglądzie / dry-run | **realny** — dry-run liczy created/updated/skipped na bazie ObjectResolver | dwupoziomowy dry-run (parse-preview + dry-run); ListImportSessionsController.php:148 mode | #1465 / #1478 |
+| Staged upload (plik wgrany 1x, reużyty w preview/dry-run/start) | działa — `staged_file_id` propagowany przez kroki, fallback multipart | StepDetect.tsx:43-85 (parse-preview → staged_file_id); StepValidation.tsx:67-72 | #1478 |
+| Pauza / wznów / anuluj w widoku trwającego importu | **realne** — pause→paused (HTTP 200), resume→running, cancel→cancelled; checkpoint co chunk odporny na crash | LIVE: POST `/pause`→200 `{status:paused}`; ImportRunHandler.php:296-318 (checkpoint+halt); ImportPauseResumeTest 6/6 | #1479 |
+| Rollback (cofnięcie importu) | **realny v2** — kasuje utworzone obiekty + przywraca nadpisane wartości; ręczna edycja po imporcie NIE cofana; raport pominięć | ImportRollbackV2ApiTest 4/4 (49 asercji): restored=6, deleted=2, skipped_manual_edits=1; ImportRollbackService.php:108-146 | #1480 |
+| Backup przed importem (data + status w widoku sesji) | działa end-to-end — `do_backup=1` zapisuje `backup_snapshot_id` (FK), GET zwraca obiekt backup, FE renderuje „Backup przed importem ✅ {data}" | LIVE: POST `do_backup=1`→200 body.backup={status:completed}; ImportShowPage.tsx:152-161 (data-testid=import-backup-info); backup niekompletny → 422 z statusem w treści | #1486 |
+| Zdjęcia z URL-i (media w imporcie) | działa — komórka z URL → media-job → envelope `{asset_id: UUID}`, dedup, SSRF reject | ImportObjectCreator.php:298-301 (cellHasUrl); LIVE close-comment #1475: envelope `{asset_id:UUID}`, dedup 11→11 | #1475 |
+| Zdjęcia z pliku ZIP | działa — ekstrakcja streamem (chunk 64KB), zip-bomb odrzucony (>500MB → 422), zip-bomba realna (ratio 1030:1) odrzucona przy memory delta=0 | ZipImageExtractor (getStream/fread CHUNK 65536); StartImportController.php:79,213-214 (MAX_ZIP_BYTES); ZipImageExtractorTest 5/5 | #1476 |
+| ⚠️ Pole `zip_file_name` / `zip_file_size_bytes` w odpowiedzi sesji | **NIE eksponowane** — persystowane na encji, ale GET `/api/import-sessions/{id}` ich nie zwraca (AC2/AC3 #1476 niespełnione) | LIVE: klucze GET bez `zip*`; GetImportSessionController.php:45-64 brak; **naruszenie CLOSED-MEANS-CLOSED** | #1476 (luka — follow-up) |
+| Mapping: duplikaty / puste nagłówki | naprawione — mapping po indeksie kolumny, nie po nazwie | StepMapping.tsx; mapping po indeksie | #1469 |
+| Kolumny `code.locale.channel` | naprawione — channel zapisywany jako `channelId` (UUID), nie jako locale | ImportColumnGrammar.php:51-65; ImportRunHandler.php:592-597; golden round-trip channel_id=UUID + locale NULL | #1469 |
+| Warianty (parent_sku two-pass) / relacje (ObjectRelation) / multi-kategorie pipe-split | działa — parent_sku rozwiązywany w drugim przejściu; relacje przez ObjectRelation; multi-kategorie + primary + position; status/enabled z kolumn | RelationImportStep.php:117-161; ImportRunHandler.php:916,1668-1711; GoldenRoundTrip + StartImport zielone | #1470 / #1471 |
+| Append kategorii (opt-in) w trybie update | **zaimplementowane i wired** (FE+BE), dedup + position; brak dedykowanego testu | StepMapping.tsx:54,149 `__category_append__`; ReservedMappingTarget.php:37; ImportRunHandler.php:1686-1711 (luka testowa) | #1470 |
+| Profile importu: zapis z wizarda / prefill | działa — realny zapis profilu, prefill stanu; tryb jako enum po migracji | tryby zapisane jako enum (migracja Version20260612230000) | #1465 / #1478 |
+| ⚠️ Próg „dozwolone % błędów" konfigurowalny przez API | **NIE wystawiony przez API** — działa w silniku (abort z licznikami), ale brak w ImportProfileInput / Serializer / v0.json (łamie API-first, AC#4 #1483) | ImportRunHandler.php:503-522 (abort działa); brak w ImportProfileInput.php; v0.json: 0 wystąpień `allowedErrorsPct`; **naruszenie CLOSED-MEANS-CLOSED** | #1483 (luka — follow-up) |
+| ⚠️ Licznik „pominiętych" (skipped) w podsumowaniu sesji | **kłamie w UI** — KPI „X pominiętych" czyta `error_count` zamiast `skipped_count`; backend zwraca poprawnie | ImportShowPage.tsx:275-276 (count: session.error_count); LIVE: API `{error_count:0, skipped_count:1}` → UI „0 pominiętych"; **naruszenie CLOSED-MEANS-CLOSED** | #1482 (luka — follow-up) |
+| Pobierz raport CSV (streaming, pełny raport bez limitu 100k) | działa — fetch + Bearer, StreamedResponse, iteracja `toIterable()` + `clear()` co 500 | ImportShowPage.tsx:87-100 + lib/download.ts; ImportReportCsvController.php:46-83; DoctrineImportLogRepository::iterateBySession bez setMaxResults | #1460 / #1483 |
+| Eksport profilu | działa (fetch + Bearer + blob) | ImportProfilesView.tsx:78-89 → downloadWithAuth | #1460 |
+| Live progress (Mercure SSE) | działa; topic budowany z `window.location.origin` (single-origin), nie hardcoded host | useImportProgress.ts:80-81; throttling progressu w bulk-path (CatalogIndexSubscriber short-circuit isBulk()) | #1461 / #1482 |
+| 🔴 Eksport XLSX — neutralizacja formuł (CSV injection) | **BUG** — wartość zaczynająca się od `=` tworzy AKTYWNĄ formułę w XLSX; brak neutralizacji (CSV ma, XLSX nie) | LIVE 2026-06-16: `sheet1.xml` zawiera `<f>HYPERLINK(...)</f>`; XlsxStreamWriter.php:83 `Row::fromValues` bez neutralizacji vs CsvStreamWriter.php:74; **ROZBIEŻNOŚĆ + naruszenie CLOSED-MEANS-CLOSED — KRYTYCZNE** | #1484 (do naprawy NATYCHMIAST) |
+| Limity body / 413 z edge | działa — Caddy `max_size 150MB` → 413; łańcuch Caddy 150MB > php.ini 110MB > app D10 100MB | LIVE: POST 200MB → HTTP 413; docker/caddy/Caddyfile:75-77 | #1484 |
+| Rate-limit triggera importu (429 + Retry-After) | działa — TooManyRequestsHttpException auto-ustawia nagłówek Retry-After | StartImportController.php:121; rateLimitExceededReturns429 zielony (asercja statusu) | #1483 |
+| Równoległość: per-tenant lock na bulk-edit (409) + retry/dead-letter | działa — BulkOperationLock 409 RFC7807 na 3 entry-pointach, retry 5/30000/2/300000, dead-letter, per-id optimistic retry+skip | BulkOperationLockTest 3/3; BulkOperationLockConflictApiTest 4/4; messenger.yaml:27-31 | #1485 |
+| Izolacja błędów per wiersz / maszyna stanów / severity | działa — błąd wiersza nie wywraca sesji, partial finish, severity po `level` | ValidationError.php:39-42; ImportValidationServiceTest zielony | #1472 |
+
+## Legenda znaczników
+
+- (bez znacznika) — afordancja realna, zweryfikowana (test / live / static recheck).
+- ⚠️ — implementacja działa w silniku, ale jest luka kontraktu API / UI / dokumentacji (naruszenie CLOSED-MEANS-CLOSED — follow-up).
+- 🔴 — realny defekt funkcjonalny do natychmiastowej naprawy.
+
+## Follow-up (z audytu 2026-06-16)
+
+1. **🔴 #1484 — XLSX formula injection (KRYTYCZNE):** dodać `neutraliseFormula()` w `XlsxStreamWriter::writeRow` analogicznie do `CsvStreamWriter.php:74` + test typu komórki XLSX (`<f>` nie może powstać dla `=`/`+`/`-`/`@`).
+2. **⚠️ #1476 — zip_file_name / zip_file_size_bytes:** wyeksponować w `GetImportSessionController` + `serialise()` + ApiTestCase na payload GET + Playwright ZIP.
+3. **⚠️ #1483 — próg błędów przez API:** dodać `allowedErrorsPct` do `ImportProfileInput`/`PatchInput`/`Processor`/`Serializer` + regeneracja v0.json (API-first).
+4. **⚠️ #1482 — KPI skipped w UI:** dodać `skipped_count` do interfejsu `ImportSession` (FE) + zmienić `ImportShowPage.tsx:276` na `session.skipped_count` + Playwright.

--- a/Project Plan/audyt/audyt-imp2-2026-06-16.md
+++ b/Project Plan/audyt/audyt-imp2-2026-06-16.md
@@ -1,0 +1,132 @@
+# Raport końcowy audytu epiku IMP2 (Import/Export v2)
+
+- **Data:** 2026-06-16
+- **Branch:** `main` (wszystkie 27 ticketów zmergowane)
+- **Zakres:** Etap 0–2 (0.1 → 2.10), 27 ticketów (issues #1460–#1486)
+- **Metoda:** analiza statyczna + suita testów (Faza 2: **343/364 PASS**, 1 fail) → **adversarial recheck** 14 ticketów (nadpisuje Fazę 2) → **częściowe live** (2.8 potwierdzone empirycznie na żywym stacku; pełny live smoke 11 scenariuszy przerwany interruptem).
+
+Konwencja werdyktów: ✅ zgodny · ⚠️ częściowy · ❌ rozbieżność · 🔴 nie działa · ⏭️ blocked.
+
+---
+
+## a) Podsumowanie (PO korektach adversarial recheck)
+
+| Werdykt | Liczba | Tickety |
+|---|---|---|
+| ✅ zgodny | **14** | 0.1, 0.2, 0.3, 1.6a, 1.6, 1.8, 1.9, 1.10, 1.11, 1.12, 2.1, 2.2, 2.4*, 2.5 |
+| ⚠️ częściowy | **12** | 1.1, 1.2, 1.3, 1.4, 1.5, 1.7, 1.13, 2.3, 2.6, 2.7, 2.9, 2.10 |
+| ❌ rozbieżność | **1** | **2.8** |
+| 🔴 nie działa | **0** | — |
+| **Razem** | **27** | |
+
+\* IMP2-2.4 podniesiony przez recheck z „częściowy" → **zgodny** (Faza 2 błędnie zinterpretowała flaky test-harness `pim_test` jako defekt produktu; po recovery `DROP+CREATE DATABASE pim_test` flagowy `ImportRollbackV2ApiTest` jest zielony 4/4, 49 asercji).
+
+**Naruszenia CLOSED-MEANS-CLOSED (realne, funkcjonalne / kontraktowe — po odsianiu luk testowych): 7**
+→ 1.1, 1.2, 1.13, 2.2, 2.6, 2.7, **2.8**.
+(Faza 2 raportowała 12; recheck zdjął flagę z 5 ticketów, gdzie braki okazały się **wyłącznie testowe** przy działającym kodzie: 1.3, 1.4, 1.5, 1.7, 2.3, 2.4, 2.9, 2.10 — z czego 1.4/1.5/1.7/2.3/2.4/2.9/2.10 → `false`; 1.3 pozostaje cmc=true ale `testGapOnly=true`, więc NIE jest liczone jako realne funkcjonalne naruszenie.)
+
+**Luki testowe (kod działa, brak testu wymaganego przez AC): 6 ticketów** → 1.3, 1.5, 1.7, 2.3, 2.4, 2.9, 2.10 (charakter test-gap-only) — implementacja kompletna i live-/statycznie potwierdzona, brak wyłącznie warstwy weryfikacyjnej.
+
+**Wynik testów:** 343/364 PASS, **1 FAIL** — `ImportRollbackV2ApiTest` deadlock **SQLSTATE[40P01]**. Recheck ustalił, że to **artefakt half-state `pim_test`** (Foundry `ResetDatabase` + DAMA StaticDriver, znany z pamięci operatora) — po `DROP+CREATE DATABASE pim_test` test przechodzi 4/4. **Nie jest to defekt produktu**; CI na merge'ach był zielony.
+
+---
+
+## c) Tabela 27 ticketów
+
+| Ticket | #issue | Tytuł (krótki) | State | Werdykt | Kluczowy dowód | Rekomendacja |
+|---|---|---|---|---|---|---|
+| IMP2-0.1 | 1460 | raport CSV + eksport profilu z Authorization | closed | ✅ | ImportShowPage.tsx:87-100 + lib/download.ts (fetch+Bearer+blob); RollbackAndReportApiTest::reportCsv PASS | Brak — domknięty. Opcjonalnie test FE kliknięcia. |
+| IMP2-0.2 | 1461 | Mercure topic z konfiguracji | closed | ✅ | useImportProgress.ts:80-81 (topic z `window.location.origin`); grep `pim.localhost`=0 | Brak. |
+| IMP2-0.3 | 1462 | ukrycie pauza/wznów/anuluj | closed | ✅ | commit d702a2d8: ImportShowPage.tsx 0 trafień `pause` (cel — ukrycie do czasu impl.) | Brak (zastąpione przez #1479). |
+| IMP2-1.1 | 1463 | ADR Import v2 — kontrakty silnika | closed | ⚠️ | docs/adr/0019: brak akapitu/forward-ref dla D6; #1429/#1430 bez linku do karty prawdy | **CMC (doc/process):** dopisać D6 do ADR-0019, dodać komentarze-linki w #1429/#1430. |
+| IMP2-1.2 | 1464 | migracja legacy JSONB → kanon (D7) | closed | ⚠️ | canonicalise live-wired (Upserter.php:77 + BatchValueWriter.php:100); ZERO unit testów `normalise/wrapValue`; brak testu migracji | **CMC (test+AC):** dorobić unit-testy wrapValue per typ + test migracji + ApiTest „eksport selecta → komórka niepusta". |
+| IMP2-1.3 | 1465 | ObjectResolver + tryby create/update/upsert | closed | ⚠️ | GoldenRoundTrip 7/7, ImportRollbackV2 4/4 (D11 created-by-only); brak testów CREATE-skip/UPDATE-skip/match-EAN | **Test-gap-only:** dorobić testy trybów + match-by-EAN + empty-cell. (cmc, ale testGapOnly) |
+| IMP2-1.4 | 1466 | wspólny rdzeń walidacji + ImportValueWriter | closed | ⚠️ | ValueWriteCore wyekstrahowany, primeChunk (1 query/chunk); brak ValueWriteCoreInterface+DTO w Contracts; deptrac baseline urósł | **Funkcjonalne odejście (udokumentowane):** zrealizować kontrakt §1 lub zsynchronizować AC#1/#3/#6/#7. |
+| IMP2-1.5 | 1467 | golden round-trip v0 | closed | ⚠️ | everyAttributeTypeHasGoldenCoverage() pokrywa 17 typów; brak golden raw-INSERT legacy + asercji D2 w Act 3 | **Test-gap-only:** dodać raw-INSERT legacy + created_count + empty-cell w golden. |
+| IMP2-1.6a | 1468 | transport Messenger `import` + worker (D8) | closed | ✅ | messenger.yaml:39-50 transport `import`; ImportRunHandlerAsyncTest routing PASS | Brak. |
+| IMP2-1.6 | 1469 | gramatyka `code.locale.channel` + channelId | closed | ✅ | ImportColumnGrammar.php:51-65; golden: channel_id=UUID + locale NULL | Brak. |
+| IMP2-1.7 | 1470 | multi-kategorie pipe-split + status/enabled | closed | ⚠️ | 4 testy kategorii/status/enabled ZIELONE live; append-na-update + empty-cell wired bez testu | **Test-gap-only (cmc=false):** dorobić testy append-dedup + empty-cell-untouched; dodać klucze i18n. |
+| IMP2-1.8 | 1471 | warianty parent_sku (two-pass) + relacje | closed | ✅ | RelationImportStep.php:117-161 two-pass; 43/43 testów PASS; #598 live smoke proof | Brak. |
+| IMP2-1.9 | 1472 | izolacja błędów per wiersz + severity | closed | ✅ | ValidationError.php:39-42 (severity po level); live dirty.csv scenariusz | Brak. |
+| IMP2-1.10 | 1473 | golden pełna matryca + testy async | closed | ✅ | GoldenRoundTrip 7/7 csv+xlsx; StartImport 20/20; 4/4 async | Brak. |
+| IMP2-1.11 | 1474 | higiena backlogu importów | closed | ✅ | #602 closed jako duplikat; mapa na #1499; banner SUPERSEDED | Brak. |
+| IMP2-1.12 | 1475 | zdjęcia z URL-i (media cz.1) | closed | ✅ | ImportObjectCreator.php:298-301; live: envelope `{asset_id:UUID}`, dedup 11→11, SSRF reject; CI 16/16 | Brak. |
+| IMP2-1.13 | 1476 | zdjęcia z pliku ZIP (media cz.2) | closed | ⚠️ | LIVE: GET sesji bez pól `zip_*` (AC2/AC3); MAX_ZIP_BYTES→422; streaming OK | **CMC (kontrakt API):** wystawić `zip_file_name`/`zip_file_size_bytes` w GET + ApiTest + Playwright ZIP. |
+| IMP2-2.1 | 1477 | streaming readers (openspout / league csv) | closed | ✅ | ImportRowReader: brak `file_get_contents` całego blobu; parse-preview HTTP 200 + metryki RAM | Brak. |
+| IMP2-2.2 | 1478 | staged upload (plik 1x, reużyty) | closed | ✅ | StepDetect.tsx:43-85 staged_file_id; backend StagedFileService+RLS | **CMC (test/process):** cross-tenant ApiTest, live smoke 1x-multipart+debounce, v0.json (custom REST — udokumentować odejście). |
+| IMP2-2.3 | 1479 | pauza/wznowienie/anulowanie + checkpoint | closed | ⚠️ | LIVE pause→200 `{paused}`; ImportPauseResumeTest 6/6; checkpoint atomowy z chunkiem | **Test-gap-only (cmc=false):** dodać unit-test `LockInterface::refresh()` co chunk + testy mid-run/kill. |
+| IMP2-2.4 | 1480 | undo-log + rollback v2 | closed | ✅ | ImportRollbackV2ApiTest 4/4 (restored=6, deleted=2, skip_manual=1); RLS na undo-log (migracja V20260614180000) | **Test-gap (cmc=false):** dodać cross-read=0 undo-log + purge + search-smoke ghost-docs. |
+| IMP2-2.5 | 1481 | tenant_id na import_logs + GUC RLS | closed | ✅ | migracja V20260614190000 (tenant_id NOT NULL + FK + RLS); live dev DB relrowsecurity=t + 2 polityki | Brak. |
+| IMP2-2.6 | 1482 | bulk-path perf + benchmark RAM | closed | ⚠️ | CatalogIndexSubscriber short-circuit isBulk(); LIVE: API `{error_count:0,skipped_count:1}` → **UI „0 pominiętych"** (czyta error_count) | **CMC (UI):** ImportShowPage.tsx:276 → `session.skipped_count` + interfejs + Playwright. |
+| IMP2-2.7 | 1483 | limity/guardraile (D10) + raport CSV | closed | ⚠️ | guardraile zielone (422/429); **próg allowedErrorsPct NIE wystawiony przez API** (brak w Input/Serializer/v0.json) | **CMC (API-first):** dodać `allowedErrorsPct` do ImportProfileInput/Patch/Processor/Serializer + regeneracja v0.json. |
+| IMP2-2.8 | 1484 | security plików — zip-bomb, CSV injection, body | closed | ❌ | **LIVE 2026-06-16:** eksport XLSX `=HYPERLINK(...)` → `sheet1.xml` `<f>HYPERLINK(...)</f>` AKTYWNA formuła; XlsxStreamWriter.php:83 bez neutralizacji | **🔴 KRYTYCZNE:** neutralizacja w XlsxStreamWriter::writeRow (jak CsvStreamWriter:74) + test typu komórki XLSX. |
+| IMP2-2.9 | 1485 | macierz równoległości — BulkOperationLock | closed | ⚠️ | BulkOperationLock 409 na 3 entry-pointach; retry 5/30000/2/300000; 15/15 + lock 3/3 PASS | **Test-gap-only (cmc=false):** ApiTest happy-path 202 po release + test exhaustion-skip 3 konfliktów + D11 inline w macierzy. |
+| IMP2-2.10 | 1486 | spięcie do_backup z Backup + sesją | closed | ⚠️ | LIVE: POST `do_backup=1`→200 body.backup, GET zwraca obiekt, FK zapisany; backup niekompletny→422 ze statusem; PHPStan/typecheck zielone | **Test-gap-only (cmc=false):** ApiTest seedBackup(Pending/Failed); v0.json nieaplikowalne (custom #[Route]). |
+
+---
+
+## d) 🔴 KRYTYCZNE — natychmiastowa naprawa
+
+### IMP2-2.8 (#1484) — XLSX formula injection (CSV/Formula injection na eksporcie)
+
+**Status: ❌ ROZBIEŻNOŚĆ + naruszenie CLOSED-MEANS-CLOSED. Potwierdzone EMPIRYCZNIE na żywym stacku (2026-06-16).**
+
+- **Dowód:** eksport wartości zaczynającej się od `=` tworzy **aktywną formułę** — `xl/worksheets/sheet1.xml` zawiera `<f>HYPERLINK("http://evil.test","klik")</f>`. To wektor RCE/exfiltracji po otwarciu pliku w Excel/Numbers przez operatora/klienta.
+- **Przyczyna:** `XlsxStreamWriter.php:83` przekazuje wartości wprost do OpenSpout `Row::fromValues()` **bez neutralizacji**. Mechanizm `neutraliseFormula()` (prefix TAB dla `= + - @`) istnieje **tylko** w `CsvStreamWriter.php:74` — ścieżka XLSX go nie wywołuje. Brak `XlsxStreamWriterTest`.
+- **Fix:** dodać `neutraliseFormula()` w `XlsxStreamWriter::writeRow` analogicznie do CSV + **test typu komórki XLSX** (asercja: dla `=2+2`/`=HYPERLINK(...)`/`+48`/`-5`/`@cmd` w XML powstaje tekst z prefiksem TAB, NIE element `<f>`).
+- **Uwaga:** recheck OBALIŁ 4 inne negatywy Fazy 2 wokół 2.8 (zip-bomb 640MB ratio 1030:1 odrzucony przy memory delta=0; 413 z Caddy potwierdzony live; brak mutacji wartości na imporcie = poprawny out-of-scope; TAB-prefix CSV potwierdzony bajtowo) — **rdzeń naruszenia to wyłącznie XLSX**.
+
+---
+
+## e) Naruszenia CLOSED-MEANS-CLOSED (realne, funkcjonalne / kontraktowe)
+
+| Ticket | Charakter | Co konkretnie niespełnione |
+|---|---|---|
+| **2.8** (#1484) | 🔴 funkcjonalne (security) | Eksport XLSX nie neutralizuje formuł — aktywna `<f>` w sheet1.xml. |
+| **1.13** (#1476) | kontrakt API | GET `/api/import-sessions/{id}` nie zwraca `zip_file_name`/`zip_file_size_bytes` (AC2/AC3) — pola tylko persystowane na encji. |
+| **2.6** (#1482) | UI user-facing | KPI „X pominiętych" w ImportShowPage.tsx:275-276 czyta `error_count` zamiast `skipped_count` — UI pokazuje błędną liczbę (live: `skipped_count:1` → UI „0"). |
+| **2.7** (#1483) | API-first | Próg „dozwolone % błędów" działa w silniku, ale NIE jest konfigurowalny przez API (brak w ImportProfileInput/Serializer/v0.json) — łamie API-first (scope-item 4 ticketu). |
+| **1.2** (#1464) | AC + test | Zamknięty bez AC-wymaganych testów jednostkowych wrapValue/normalise (ZERO), bez testu migracji i bez „kluczowej asercji" eksportu selecta. Kod działa (live smoke). |
+| **1.1** (#1463) | doc/process | ADR-0019 nie pokrywa decyzji D6 (brak akapitu i forward-ref); #1429/#1430 zamknięte bez linku do karty prawdy. Niska waga, nie defekt user-facing. |
+| **2.2** (#1478) | test/process | Brak cross-tenant ApiTest (RLS istnieje), pominięty live smoke przy zamknięciu, v0.json niezmieniony (custom REST). Kod funkcjonalnie kompletny. |
+
+> Klasyfikacja: **2.8** to jedyne twarde naruszenie funkcjonalne wymagające pilnej naprawy. **1.13 / 2.6 / 2.7** to kontrakt/UI/API-first — działa „pod spodem", ale user-facing/integratorzy widzą złe lub brakujące dane. **1.1 / 1.2 / 2.2** to luki doc/process/AC-test przy działającym kodzie.
+
+---
+
+## f) Luki testowe (kod działa, brak testu wymaganego przez AC — `testGapOnly`, NIE naruszenie)
+
+| Ticket | Działający kod (dowód) | Brakujący test z AC |
+|---|---|---|
+| 1.3 (#1465) | ObjectResolver::decide; D11 created-by-only (ImportRollbackV2 4/4) | CREATE-skip-existing, UPDATE-skip-no-match, match-by-EAN, empty-cell-no-clear, test migracji |
+| 1.5 (#1467) | everyAttributeTypeHasGoldenCoverage (17 typów); fallback legacy w ValueSerializer.php:174 | golden raw-INSERT legacy + asercja kanonu w DB, created_count, empty-cell D2 w Act 3 |
+| 1.7 (#1470) | append `__category_append__` wired (FE+BE); guard empty-cell | append-dedup-on-update, empty-cell-untouched |
+| 2.3 (#1479) | checkpoint atomowy, lock refresh co chunk (kod :314/337/364), release w finally | unit-test `LockInterface::refresh()` raz/chunk, deterministyczny mid-run/kill |
+| 2.4 (#1480) | queueAllDeleted (anty-ghost), rebuild attributes_indexed/completeness, RLS undo-log | cross-read=0 undo-log, purge undo-logu, search-smoke ghost-docs, asercje attributes_indexed/completeness |
+| 2.9 (#1485) | per-id optimistic retry+exhaustion-skip (Handler:77-113); BulkOperationLock release-cycle (test 3/3) | ApiTest happy-path 202 po release, finally-release przy wyjątku, exhaustion-3-konflikty→warning+skip |
+| 2.10 (#1486) | obsługa Pending/Failed uniformnie (status != Completed → 422); live smoke 7 scenariuszy | ApiTest seedBackup(Pending) i seedBackup(Failed) |
+
+---
+
+## g) Do natychmiastowej naprawy / follow-up (wg ważności)
+
+1. **🔴 P0 — #1484 XLSX formula injection** (security, RCE-class): neutralizacja w XlsxStreamWriter + test typu komórki. **Blokuje bezpieczne demo dla pilotów.**
+2. **⚠️ P1 — #1482 KPI skipped w UI:** `ImportShowPage.tsx:276` → `session.skipped_count` + interfejs `ImportSession` + Playwright. Po 2.6 „skipped" to pierwszorzędna metryka — UI nie może kłamać.
+3. **⚠️ P1 — #1483 próg błędów przez API:** dodać `allowedErrorsPct` do ImportProfileInput/PatchInput/Processor/Serializer + regeneracja v0.json (API-first nienegocjowalne).
+4. **⚠️ P1 — #1476 pola ZIP w kontrakcie:** wystawić `zip_file_name`/`zip_file_size_bytes` w GetImportSessionController + serialise + ApiTest + Playwright ZIP.
+5. **⚠️ P2 — #1464 testy kanonu:** unit-testy wrapValue/normalise per typ + test migracji V20260612210000 + ApiTest eksport selecta → komórka niepusta.
+6. **⚠️ P2 — #1463 ADR D6 + linki kart prawdy:** dopisać akapit D6 (lub jawne odesłanie do IMP2-2.4) do ADR-0019; komentarze-linki w #1429/#1430.
+7. **⚠️ P3 — #1466 kontrakt §1:** zrealizować ValueWriteCoreInterface + DTO w Catalog\\Contracts lub zsynchronizować AC#1/#3/#6/#7 z faktyczną implementacją (warning+skip semantyka).
+8. **⚠️ P3 — luki testowe (1.3/1.5/1.7/2.3/2.4/2.9/2.10):** dorobić testy z AC zgodnie z tabelą (f).
+9. **🔧 Infra — harness `pim_test`:** dokończyć osobny ticket „rollback vs import lock order" (deadlock 40P01 w ImportRollbackV2ApiTest jako artefakt half-state) i utrwalić w lokalnym CI recovery `DROP+CREATE DATABASE pim_test` (znane z pamięci operatora).
+
+---
+
+## h) Ograniczenia audytu
+
+- **Pełny live smoke przerwany interruptem** — z planowanych 11 scenariuszy wykonano live **tylko krytyczne potwierdzenie 2.8** (XLSX injection) oraz punktowe live z rechecku (pause/resume/cancel 2.3, backup 2.10, 413 Caddy 2.8, KPI skipped 2.6, zip-bomb 2.8). Pozostałe kryteria runtime opierają się na **analizie statycznej + adversarial recheck** (kod + testy w izolacji), nie na pełnym przebiegu na żywym stacku.
+- **1 FAIL testu w suicie:** `ImportRollbackV2ApiTest` deadlock SQLSTATE[40P01] — ustalone jako **artefakt half-state `pim_test`** (Foundry ResetDatabase + DAMA StaticDriver), nie defekt produktu; po recovery test zielony 4/4. CI na merge'ach był zielony.
+- **Worker importu lokalnie niezdeterminowany / unhealthy** — lokalny container ustawia `MESSENGER_IMPORT_TRANSPORT_DSN=doctrine`, przez co sesje zostają w Pending/Running bez consume; live mid-run interception (2.3) niemożliwy deterministycznie (12 prób pause→409, sesja kończyła się zanim poll trafił `running`). To znana cecha środowiska, nie defekt 2.3.
+- **Współbieżne sesje operatora na `pim_test`** — część tickets/Api nie uruchomiona „do końca" lokalnie (np. 1.4) z powodu aktywnej równoległej sesji churnującej schemat; oparto się na CI-green z PR-ów (np. #1507/#1508/#1548).
+- **v0.json dla custom #[Route]** — endpointy `import-sessions` to custom REST (nie #[ApiResource]), więc nigdy nie były w eksporcie OpenAPI; AC „regeneracja v0.json" jest strukturalnie nieaplikowalne dla 2.10, a dla 2.7 maskuje rzeczywistą lukę (pola nie istnieją w API surface).
+- **Werdykty 14 ticketów pochodzą z adversarial rechecku nadpisującego Fazę 2**; 13 pozostałych z Fazy 2 (static + testy). Recheck obalił 2 werdykty główne (2.4 → zgodny) i zdjął flagę CMC z 5 ticketów (braki czysto testowe).

--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -39,14 +39,27 @@
 ### 🏁 ETAP 2 IMP2 KOMPLETNY (10/10) — #1477–#1486 wszystkie merged + zamknięte z proof
 Streaming readers (2.1) · staged upload (2.2) · pauza/wznów/checkpoint (2.3) · undo-log+rollback v2 (2.4) · import_logs RLS+GUC (2.5) · perf bulk-path+diagnoza pamięci (2.6) · limity/guardraile (2.7) · security plików (2.8) · równoległość/locki (2.9) · pre-import backup (2.10).
 
+## Audyt końcowy IMP2 + follow-upy (2026-06-16)
+- **Audyt epiku IMP2** (workflow multi-agentowy, 27 ticketów 0.1–2.10): raport `Project Plan/audyt/audyt-imp2-2026-06-16.md` (14 ✅ / 12 ⚠️ / 1 ❌), karta prawdy odświeżona. Flagowy bug 2.8 (XLSX formula injection) potwierdzony empirycznie (`<f>HYPERLINK(...)</f>`).
+- **9 follow-up issues (#1552–#1560) → 10 PR, wszystkie MERGED + issues CLOSED:**
+  - #1552 P0 XLSX formula injection — `neutraliseFormula` w `XlsxStreamWriter` (PR #1561)
+  - #1553 P1 KPI „pominięte" → `skipped_count` w UI (PR #1562)
+  - #1554 P1 `allowedErrorsPct` konfigurowalny przez API + v0.json (PR #1564)
+  - #1555 P1 pola `zip_file_name`/`zip_file_size_bytes` w kontrakcie sesji (PR #1563)
+  - #1556 P2 testy kanonu JSONB — unit normalise (PR #1566) + D7 migracja + export selecta (PR #1569)
+  - #1557 P2 ADR-0019 D6 + linki karty prawdy w #1429/#1430 (PR #1565)
+  - #1558 P3 decyzja: `ValueWriteCore` konkretna klasa, nie interface/DTO — YAGNI (PR #1567)
+  - #1559 luki testowe 7/7 (2.10/1.3/1.7/1.5/2.3/2.4/2.9, ~18 testów) (PR #1568)
+  - #1560 deadlock 40P01 = EM-corruption w abort path; reload session po `em->clear()` (PR #1570)
+- **Re-audyt #1559** (workflow fan-out) potwierdził, że luki są realne (audyt trafny — inaczej niż 2.10, które miało 6 przeoczonych testów). **#1560**: deadlock to skutek uboczny `ORMInvalidArgumentException` (save sesji po `em->clear()` z rebuild dispatch), NIE osobny lock-order bug; fix naprawił też pre-existing fail `ImportRunHandlerAsyncTest`.
+
 ## Ostatnie akcje
-1. **IMP2-2.10 (#1486)** — pre-import backup spięty z sesją. Implementacja backend+FE + 6 testów (20/20) + bramki zielone + adversarial review (Workflow, 1/19 confirmed → authz gap naprawiony) + live smoke 422/404/200. PR #1551, CI w toku. **Uwaga środowiskowa**: ręczne schema-ops zepsuły pim_test → naprawa DROP+CREATE DATABASE (lekcja [[feedback_pim_test_schema_recovery]]).
-2. **IMP2-2.9 (#1485) KOMPLETNY** — PR #1550 (`6ae23bfb`) merged + zamknięte z live-proof 409. Odkrycie: `OptimisticLockException` zamyka EM → retry wymaga `ManagerRegistry::resetManager()`, nie `clear()`.
-3. **IMP2-2.8 (#1484) KOMPLETNY** — PR #1549, security plików (zip-bomb/folder/Caddy).
-4. **IMP2-2.7 (#1483) KOMPLETNY** — #1548, limity/guardraile + streaming raport.
+1. **Audyt IMP2 + 10 follow-up PR** (2026-06-16) — wszystkie merged, 9 issues #1552–#1560 closed. Metoda: subagenty per ticket (zbadaj→napisz→uruchom→napraw→gates), pathspec commity, sekwencyjnie (wspólne `pim_test`).
+2. **#1560 deadlock** — root cause = EM-corruption w `abortIfErrorRateExceeded` (`save()` sesji po `em->clear()` przez rebuild dispatch → detached proxy → `ORMInvalidArgumentException` → uszkodzony UoW → kaskada 40P01). Fix: reload sesji po clear (wzorzec [[feedback_pim_test_schema_recovery]] / ImportRollbackService).
+3. **IMP2-2.10 (#1486)** — pre-import backup spięty z sesją, PR #1551 merged.
 
 ## Następny krok — etap 3 IMP2 (lub decyzja operatora)
-ETAP-2 zamknięty (10/10, #1477–#1486). Kolejny zakres: pozostałe tickety epiku IMP2 (etap 3+: harmonogramy IMP2-4.1, e-mail po imporcie 4.4, integracje) — backlog `Project Plan/UI/feature-imports-v2-tickets.md`. **Czeka na sygnał operatora** które tickety/etap dalej. Operator: ultracode ON, komunikacja+rozumowanie po polsku.
+ETAP 0–2 zamknięty (#1460–#1486) + audyt końcowy + 9 follow-upów (#1552–#1560) domknięte. Kolejny zakres: etap 3+ (kreator/operacjonalizacja, #1487–#1498) — backlog `Project Plan/UI/feature-imports-v2-tickets.md`. **Czeka na sygnał operatora** które tickety/etap dalej. Operator: ultracode ON, komunikacja+rozumowanie po polsku.
 
 ### Świadome odejścia etapu-2 (marsz #1483→#1486)
 - **2.10 pozytyw smoke**: dev pgBackRest zwraca `failed` natychmiast (cron stale) → completed backup zaseedowany w DB dla live-proof; pełny e2e snapshot zależy od działającego pgBackRest.


### PR DESCRIPTION
## Co i dlaczego
Artefakty audytu końcowego epiku IMP2 (Import/Export v2) oraz aktualizacja statusu po domknięciu 9 follow-upów.

## Zawartość
- **`Project Plan/audyt/audyt-imp2-2026-06-16.md`** — raport audytu 27 ticketów (0.1–2.10): rozkład werdyktów, naruszenia CLOSED-MEANS-CLOSED, luki testowe, sekcja krytyczna (2.8 XLSX injection).
- **`Project Plan/UI/imports-v2-karta-prawdy.md`** — odświeżona do stanu po Etapie 1/2 (z 2026-06-12 → 2026-06-16, zweryfikowane afordancje).
- **`agent/current_status.md`** — dodany blok audytu + 9 follow-up ticketów (#1552–#1560, wszystkie merged/closed).

Doc-only (`Refs #1499` — epic tracking).
