### PR TITLE
fix(identity): guard token_dev_only behind non-prod env — AUD-007 (#1577)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -81,6 +81,25 @@ services:
         arguments:
             $inner: '@lexik_jwt_authentication.handler.authentication_success'
 
+    # AUD-007 (#1577) — bind the kernel environment into the controllers
+    # that ship the dev-only magic-link / password-reset plaintext token.
+    # The DevTokenExposure trait omits `token_dev_only` from the JSON body
+    # when env === 'prod' (PUBLIC_ACCESS endpoints → leaking it = account
+    # takeover). Bound explicitly because a scalar string argument is not
+    # autowired. Drop these once the mailer fully replaces the in-response
+    # token and the field is removed outright.
+    App\Identity\Presentation\Controller\PasswordResetController:
+        arguments:
+            $devTokenEnvironment: '%kernel.environment%'
+
+    App\Identity\Presentation\Controller\InvitationController:
+        arguments:
+            $devTokenEnvironment: '%kernel.environment%'
+
+    App\Identity\Presentation\Controller\InvitationActionsController:
+        arguments:
+            $devTokenEnvironment: '%kernel.environment%'
+
     App\Catalog\Application\ObjectTypeService:
         arguments:
             $enableCustomObjectTypes: '%pim.catalog.enable_custom_object_types%'

--- a/apps/api/src/Identity/Presentation/Controller/DevTokenExposure.php
+++ b/apps/api/src/Identity/Presentation/Controller/DevTokenExposure.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+/**
+ * AUD-007 (#1577) — environment guard for the dev-only magic-link /
+ * password-reset plaintext token.
+ *
+ * Until the production email send fully replaces the in-response token,
+ * the password-reset + invitation endpoints expose the freshly minted
+ * 256-bit plaintext token in their JSON body so the operator can drive
+ * the confirm/accept flow without a mailbox. That convenience is a
+ * CRITICAL account-takeover vector on any prod deploy: the endpoints are
+ * PUBLIC_ACCESS, so knowing a victim's email is enough to mint + read a
+ * working reset token.
+ *
+ * This trait gates the field on the kernel environment. Consuming
+ * controllers take the environment as a constructor argument (bound to
+ * `%kernel.environment%` in services.yaml) so the guard is unit-testable
+ * without booting a prod kernel: in `prod` the field is omitted entirely
+ * (not nulled — the key must be absent so no contract reader treats it as
+ * present-but-empty); in dev/test it is returned verbatim, preserving the
+ * existing operator workflow.
+ */
+trait DevTokenExposure
+{
+    /**
+     * Returns the `token_dev_only` payload fragment to merge into a JSON
+     * response. Empty (key absent) on prod; `['token_dev_only' => $token]`
+     * everywhere else.
+     *
+     * @return array{token_dev_only?: string|null}
+     */
+    private function devTokenPayload(?string $token): array
+    {
+        if ('prod' === $this->devTokenEnvironment) {
+            return [];
+        }
+
+        return ['token_dev_only' => $token];
+    }
+}

--- a/apps/api/src/Identity/Presentation/Controller/InvitationActionsController.php
+++ b/apps/api/src/Identity/Presentation/Controller/InvitationActionsController.php
@@ -33,11 +33,14 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class InvitationActionsController
 {
+    use DevTokenExposure;
+
     public function __construct(
         private Security $security,
         private InvitationRepositoryInterface $invitations,
         private RoleRepositoryInterface $roles,
         private InvitationService $service,
+        private string $devTokenEnvironment,
     ) {
     }
 
@@ -145,7 +148,9 @@ final readonly class InvitationActionsController
             'invitation_id' => $newInvitation->getId()->toRfc4122(),
             'email' => $newInvitation->getEmail(),
             'expires_at' => $newInvitation->getExpiresAt()->format(DateTimeInterface::ATOM),
-            'token_dev_only' => $result['token'],
+            // Dev/test only — production omits the plaintext token entirely
+            // (AUD-007 / #1577); the resend re-triggers the mailer instead.
+            ...$this->devTokenPayload($result['token']),
         ], Response::HTTP_CREATED);
     }
 

--- a/apps/api/src/Identity/Presentation/Controller/InvitationController.php
+++ b/apps/api/src/Identity/Presentation/Controller/InvitationController.php
@@ -32,9 +32,12 @@ use const DATE_ATOM;
  */
 final class InvitationController extends AbstractController
 {
+    use DevTokenExposure;
+
     public function __construct(
         private readonly InvitationService $invitations,
         private readonly TenantContext $tenantContext,
+        private readonly string $devTokenEnvironment,
     ) {
     }
 
@@ -72,10 +75,10 @@ final class InvitationController extends AbstractController
             'invitation_id' => $result['invitation']->getId()->toRfc4122(),
             'email' => $result['invitation']->getEmail(),
             'expires_at' => $result['invitation']->getExpiresAt()->format(DATE_ATOM),
-            // Dev-mode: token shipped in response so operator can test
-            // accept flow before mailer infra ships. Production removes
-            // this field and emails it via the Mailer follow-up.
-            'token_dev_only' => $result['token'],
+            // Dev/test: token shipped in response so operator can test the
+            // accept flow before mailer infra ships. Production omits this
+            // field entirely (AUD-007 / #1577) and relies on the Mailer.
+            ...$this->devTokenPayload($result['token']),
         ], 201);
     }
 

--- a/apps/api/src/Identity/Presentation/Controller/PasswordResetController.php
+++ b/apps/api/src/Identity/Presentation/Controller/PasswordResetController.php
@@ -27,8 +27,11 @@ use Symfony\Component\Routing\Attribute\Route;
  */
 final class PasswordResetController extends AbstractController
 {
+    use DevTokenExposure;
+
     public function __construct(
         private readonly PasswordResetService $service,
+        private readonly string $devTokenEnvironment,
     ) {
     }
 
@@ -46,11 +49,13 @@ final class PasswordResetController extends AbstractController
         $plaintext = $this->service->request($email);
 
         // ALWAYS return success — account-enumeration prevention. The
-        // plaintext is exposed in dev-mode response only because the
-        // mailer infra is not yet shipped; production drops this field.
+        // plaintext is exposed in dev/test response only because the
+        // mailer infra is not yet shipped; production omits the field
+        // entirely (AUD-007 / #1577 — the token IS the auth factor on a
+        // PUBLIC_ACCESS endpoint, so leaking it = account takeover).
         return new JsonResponse([
             'status' => 'sent',
-            'token_dev_only' => $plaintext, // null when email not found
+            ...$this->devTokenPayload($plaintext), // null when email not found
         ]);
     }
 

--- a/apps/api/tests/Unit/Identity/Presentation/Controller/DevTokenExposureTest.php
+++ b/apps/api/tests/Unit/Identity/Presentation/Controller/DevTokenExposureTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Presentation\Controller;
+
+use App\Identity\Application\InvitationService;
+use App\Identity\Application\MagicLinkTokenHasher;
+use App\Identity\Application\PasswordResetService;
+use App\Identity\Domain\Entity\Invitation;
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\InvitationRepositoryInterface;
+use App\Identity\Domain\Repository\PasswordResetTokenRepositoryInterface;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Identity\Domain\Repository\UserRoleRepositoryInterface;
+use App\Identity\Presentation\Controller\InvitationActionsController;
+use App\Identity\Presentation\Controller\InvitationController;
+use App\Identity\Presentation\Controller\PasswordResetController;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AUD-007 (#1577) — regression guard for the dev-only plaintext token leak.
+ *
+ * The password-reset + invitation endpoints are PUBLIC_ACCESS and used to
+ * return the freshly minted 256-bit reset/invitation token in their JSON
+ * body UNCONDITIONALLY. On any prod deploy that is a CRITICAL account
+ * takeover: an attacker who knows a victim's email mints + reads a working
+ * reset token, then confirms it (lesson #657/#658).
+ *
+ * The fix gates `token_dev_only` on the injected kernel environment via the
+ * DevTokenExposure trait. These tests drive the real controller actions with
+ * real services (their collaborators are mocked at the interface boundary) and
+ * an explicit environment, so the prod-mode behaviour is proven WITHOUT
+ * booting a prod kernel:
+ *
+ *   - env === 'prod'  → the `token_dev_only` key MUST be absent (the leak).
+ *   - env === 'test'  → the key MUST be present (dev/test operator workflow
+ *                       preserved until the mailer fully replaces it).
+ *
+ * Covers all three leak sites from the finding:
+ *   PasswordResetController::request        (POST /api/auth/password-reset/request)
+ *   InvitationController::create            (POST /api/invitations)
+ *   InvitationActionsController::resend     (POST /api/invitations/{id}/resend)
+ */
+final class DevTokenExposureTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('leakSites')]
+    public function prodEnvironmentOmitsTokenDevOnly(string $controllerKey): void
+    {
+        $body = $this->invoke($controllerKey, 'prod');
+
+        self::assertArrayNotHasKey(
+            'token_dev_only',
+            $body,
+            \sprintf('%s leaked token_dev_only in prod (account-takeover vector)', $controllerKey),
+        );
+    }
+
+    #[Test]
+    #[DataProvider('leakSites')]
+    public function nonProdEnvironmentKeepsTokenDevOnly(string $controllerKey): void
+    {
+        $body = $this->invoke($controllerKey, 'test');
+
+        self::assertArrayHasKey(
+            'token_dev_only',
+            $body,
+            \sprintf('%s dropped token_dev_only in test (broke dev workflow)', $controllerKey),
+        );
+        $token = $body['token_dev_only'];
+        self::assertIsString($token);
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $token);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function leakSites(): iterable
+    {
+        yield 'password-reset/request' => ['password_reset'];
+        yield 'invitations/create' => ['invitation_create'];
+        yield 'invitations/resend' => ['invitation_resend'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function invoke(string $controllerKey, string $environment): array
+    {
+        $response = match ($controllerKey) {
+            'password_reset' => $this->passwordResetController($environment)
+                ->request(self::jsonRequest(['email' => 'victim@demo.localhost'])),
+            'invitation_create' => $this->invitationCreateController($environment)
+                ->create(self::jsonRequest(['email' => 'invitee@demo.localhost', 'role_code' => 'viewer'])),
+            'invitation_resend' => $this->invitationActionsController($environment)
+                ->resend('11111111-1111-1111-1111-111111111111'),
+            default => self::fail('unknown controller key'),
+        };
+
+        return $this->decode($response);
+    }
+
+    private function passwordResetController(string $environment): PasswordResetController
+    {
+        $tenant = $this->tenant();
+
+        $users = $this->createStub(UserRepositoryInterface::class);
+        $users->method('findByEmail')->willReturn($this->user($tenant));
+
+        $service = new PasswordResetService(
+            em: $this->createStub(EntityManagerInterface::class),
+            tokens: $this->createStub(PasswordResetTokenRepositoryInterface::class),
+            users: $users,
+            tokenHasher: new MagicLinkTokenHasher(),
+            passwordHasher: $this->createStub(UserPasswordHasherInterface::class),
+            mailer: $this->createStub(MailerInterface::class),
+            logger: new NullLogger(),
+        );
+
+        return new PasswordResetController($service, $environment);
+    }
+
+    private function invitationCreateController(string $environment): InvitationController
+    {
+        $tenant = $this->tenant();
+
+        $roles = $this->createStub(RoleRepositoryInterface::class);
+        $roles->method('findByCode')->willReturn($this->role($tenant));
+
+        $service = $this->invitationService($roles, $this->createStub(InvitationRepositoryInterface::class));
+
+        $tenantContext = new TenantContext();
+        $tenantContext->set($tenant);
+
+        $controller = new InvitationController($service, $tenantContext, $environment);
+        // AbstractController::getUser() reads from the security token storage
+        // via the controller container; wire a minimal authenticated principal.
+        $controller->setContainer($this->containerWithUser($this->user($tenant)));
+
+        return $controller;
+    }
+
+    private function invitationActionsController(string $environment): InvitationActionsController
+    {
+        $tenant = $this->tenant();
+        $caller = $this->user($tenant);
+
+        $existing = $this->createStub(Invitation::class);
+        $existing->method('getTenantId')->willReturn($tenant->getId());
+        $existing->method('getEmail')->willReturn('invitee@demo.localhost');
+        $existing->method('getAcceptedAt')->willReturn(null);
+        $existing->method('getRevokedAt')->willReturn(null);
+        $existing->method('getRoleId')->willReturn(Uuid::v7());
+
+        $role = $this->role($tenant);
+
+        $invitations = $this->createStub(InvitationRepositoryInterface::class);
+        $invitations->method('findById')->willReturn($existing);
+
+        $roles = $this->createStub(RoleRepositoryInterface::class);
+        $roles->method('findById')->willReturn($role);
+        $roles->method('findByCode')->willReturn($role);
+
+        $security = $this->createStub(Security::class);
+        $security->method('getUser')->willReturn($caller);
+
+        // The controller's revoke()+create() path delegates back into the
+        // service, which re-reads the invitation via findById — share the
+        // same repo mock so the service sees the existing invitation too.
+        return new InvitationActionsController(
+            $security,
+            $invitations,
+            $roles,
+            $this->invitationService($roles, $invitations),
+            $environment,
+        );
+    }
+
+    private function invitationService(RoleRepositoryInterface $roles, InvitationRepositoryInterface $invitations): InvitationService
+    {
+        return new InvitationService(
+            em: $this->createStub(EntityManagerInterface::class),
+            invitations: $invitations,
+            users: $this->createStub(UserRepositoryInterface::class),
+            userRoles: $this->createStub(UserRoleRepositoryInterface::class),
+            roles: $roles,
+            tokenHasher: new MagicLinkTokenHasher(),
+            passwordHasher: $this->createStub(UserPasswordHasherInterface::class),
+            mailer: $this->createStub(MailerInterface::class),
+            logger: new NullLogger(),
+        );
+    }
+
+    private function tenant(): Tenant
+    {
+        return new Tenant('demo', 'Demo');
+    }
+
+    private function user(Tenant $tenant): User
+    {
+        return new User($tenant, 'admin@demo.localhost', 'placeholder-hash');
+    }
+
+    private function role(Tenant $tenant): Role
+    {
+        return new Role('viewer', 'Viewer', $tenant);
+    }
+
+    private function containerWithUser(User $user): ContainerInterface
+    {
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken($user, 'main', $user->getRoles()));
+
+        return new class($tokenStorage) implements ContainerInterface {
+            public function __construct(private readonly TokenStorage $tokenStorage)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                return 'security.token_storage' === $id ? $this->tokenStorage : null;
+            }
+
+            public function has(string $id): bool
+            {
+                return 'security.token_storage' === $id;
+            }
+        };
+    }
+
+    /**
+     * @param array<string, string> $payload
+     */
+    private static function jsonRequest(array $payload): Request
+    {
+        return new Request(content: json_encode($payload, JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(JsonResponse $response): array
+    {
+        /** @var array<string, mixed> $body */
+        $body = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        return $body;
+    }
+}


### PR DESCRIPTION
## AUD-007 (CRITICAL) — token_dev_only account-takeover
Audyt: `token_dev_only` (64-znakowy plaintext token resetu/zaproszenia) zwracany w odpowiedzi HTTP **bezwarunkowo** (PasswordReset/Invitation/InvitationActions) — znając email ofiary → reset → confirm → przejęcie konta.

## Fix
- Nowy trait `DevTokenExposure::devTokenPayload()` — w `prod` zwraca `[]` (klucz **całkowicie nieobecny**), w dev/test `['token_dev_only'=>$token]`. Wstrzyknięty `%kernel.environment%` (testowalne bez bootowania prod).
- 3 kontrolery używają traitu (eliminacja 3× copy-paste); wiring w `services.yaml`.

## Test (reguła: failing → fix → green)
`DevTokenExposureTest` (6/6): prod → `assertArrayNotHasKey('token_dev_only')` ×3; dev/test → klucz obecny + 64-hex ×3. RED przed fixem (3 failures = leak), GREEN po.

## Smoke (CLOSED MEANS CLOSED)
`POST /api/auth/password-reset/request {email}`:
- **PRZED** (dev): `{"status":"sent","token_dev_only":"57ee0533…fd74"}` — leak.
- **PO** (prod-mode, żywy kernel): `HTTP 200 {"status":"sent"}` — `token_dev_only` NIEOBECNE.

Gates: PHPStan max + cs-fixer + PHPUnit (Identity 265/265) zielone.

Closes #1577
