### PR TITLE
fix(search): whitelist Meili filter keys — AUD-004 (#1574)

### DIFF
--- a/apps/api/src/Search/Application/CatalogSearchService.php
+++ b/apps/api/src/Search/Application/CatalogSearchService.php
@@ -10,6 +10,7 @@ use App\Search\Infrastructure\MeilisearchClientFactory;
 use App\Shared\Domain\Tenant;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Throwable;
 
 /**
@@ -71,6 +72,17 @@ final readonly class CatalogSearchService
             // multi-tenant isolation contract.
             return $this->emptyResult();
         }
+
+        // AUD-004 (#1574) — every user-supplied filter/range key is
+        // interpolated into the Meili filter expression below. Without a
+        // whitelist a key carrying a Meili operator (e.g.
+        // `parentId IS NULL OR tenantId`) injects a low-precedence `OR` that
+        // closes the AND-scoped tenant clause → cross-tenant read. Validate
+        // every key against the index's `filterableAttributes` (the same
+        // source already trusted for facets) and 400 on anything else.
+        $allowedKeys = $this->filterableAttributesFor($kind);
+        $this->assertFilterKeys(array_keys($filters), $allowedKeys);
+        $this->assertFilterKeys(array_keys($rangeFilters), $allowedKeys);
 
         $tenantFilter = \sprintf('tenantId = "%s"', $tenant->getId()->toRfc4122());
         $extraFilters = [];
@@ -188,6 +200,35 @@ final readonly class CatalogSearchService
             'facetDistribution' => [],
             'processingTimeMs' => 0,
         ];
+    }
+
+    /**
+     * AUD-004 (#1574) — validate user-supplied filter keys against the
+     * index's filterable attributes before any value is interpolated into
+     * the Meili expression.
+     *
+     * Two rules:
+     *   1. `tenantId` is a reserved, non-mixable scope — it is always
+     *      AND-merged separately ({@see $tenantFilter}) and must never be
+     *      driven by a user filter, otherwise the scope can be widened.
+     *   2. Every other key must be a known filterable attribute. Anything
+     *      else (unknown field, or a string smuggling a Meili operator such
+     *      as `parentId IS NULL OR tenantId`) is rejected with a 400.
+     *
+     * @param list<int|string> $keys
+     * @param list<string>     $allowed
+     */
+    private function assertFilterKeys(array $keys, array $allowed): void
+    {
+        foreach ($keys as $key) {
+            $key = (string) $key;
+            if ('tenantId' === $key) {
+                throw new BadRequestHttpException('Filter key "tenantId" is reserved and cannot be set explicitly.');
+            }
+            if (!\in_array($key, $allowed, true)) {
+                throw new BadRequestHttpException(\sprintf('Unknown filter attribute "%s".', $key));
+            }
+        }
     }
 
     /**

--- a/apps/api/tests/Api/Search/SearchEndpointsApiTest.php
+++ b/apps/api/tests/Api/Search/SearchEndpointsApiTest.php
@@ -98,6 +98,69 @@ final class SearchEndpointsApiTest extends CatalogApiTestCase
         self::assertResponseStatusCodeSame(401);
     }
 
+    /**
+     * AUD-004 (#1574) — Meilisearch filter-key injection → cross-tenant read.
+     *
+     * The flat `?filter[<KEY>]=<value>` map fed `<KEY>` straight into the
+     * Meili filter expression via `sprintf('%s = "%s"', $key, ...)` with no
+     * whitelist on the key (only facets were checked). A key carrying a
+     * Meili operator — `parentId IS NULL OR tenantId` — closes the AND-scoped
+     * tenant clause with a low-precedence `OR`, so the hub answers across
+     * tenants. The key must be validated against `filterableAttributes`;
+     * anything else is a 400, never a silent injection.
+     */
+    #[Test]
+    public function searchRejectsFilterKeyWithMeiliOperatorInjection(): void
+    {
+        $this->seedProduct('INJ-1', enabled: true);
+        $this->forceReindex(ObjectKind::Product);
+
+        $client = $this->authenticatedClient();
+        // Key = "parentId IS NULL OR tenantId" — not a filterable attribute.
+        // urlencode the bracketed key so the operator/spaces survive routing.
+        $key = rawurlencode('parentId IS NULL OR tenantId');
+        $client->request('GET', \sprintf('/api/search/products?filter%%5B%s%%5D=%s', $key, '00000000-0000-7000-8000-000000000000'));
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    /**
+     * AUD-004 (#1574) — a plain key that is not a known filterable attribute
+     * (no operator, just an unknown field) is also rejected. Guards against a
+     * whitelist that only blocks keys containing spaces/operators while still
+     * letting arbitrary field names leak through the filter expression.
+     */
+    #[Test]
+    public function searchRejectsUnknownFilterKey(): void
+    {
+        $this->seedProduct('INJ-2', enabled: true);
+        $this->forceReindex(ObjectKind::Product);
+
+        $client = $this->authenticatedClient();
+        $client->request('GET', '/api/search/products?filter%5Btotally_unknown_field%5D=x');
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    /**
+     * AUD-004 (#1574) — regression guard: legitimate filters on whitelisted
+     * attributes (`enabled` is a RESERVED_FILTERABLE) must keep working after
+     * the key whitelist lands. The fix must reject injected keys without
+     * breaking the documented flat-filter surface.
+     */
+    #[Test]
+    public function searchKeepsWhitelistedFilterWorking(): void
+    {
+        $this->seedProduct('OK-1', enabled: true);
+        $this->seedProduct('OK-2', enabled: true);
+        $this->forceReindex(ObjectKind::Product);
+
+        $client = $this->authenticatedClient();
+        $body = $client->request('GET', '/api/search/products?filter%5Benabled%5D=true')->toArray();
+
+        self::assertGreaterThanOrEqual(2, $body['totalHits'] ?? 0);
+    }
+
     #[Test]
     public function searchObjectsScopedToObjectTypeId(): void
     {

--- a/apps/api/tests/Unit/Search/Application/CatalogSearchServiceFilterKeyTest.php
+++ b/apps/api/tests/Unit/Search/Application/CatalogSearchServiceFilterKeyTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Search\Application;
+
+use App\Catalog\Domain\ObjectKind;
+use App\Identity\Application\CurrentTenantProvider;
+use App\Identity\Domain\Entity\User;
+use App\Search\Application\CatalogSearchService;
+use App\Search\Infrastructure\MeilisearchClientFactory;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+/**
+ * AUD-004 (#1574) — unit-level guard for Meilisearch filter-key injection.
+ *
+ * Deterministic counterpart to the live-Meili ApiTest: a filter key that is
+ * not a known filterable attribute (e.g. `parentId IS NULL OR tenantId`,
+ * which smuggles a low-precedence `OR` that closes the tenant AND-scope)
+ * must be rejected with a 400 *before* the service touches Meilisearch.
+ *
+ * We wire the service with a {@see MeilisearchClientFactory} that has no URL
+ * configured, so `create()` throws {@see LogicException}. If the key
+ * whitelist is missing (pre-fix), the service builds the filter expression
+ * and reaches `create()` → `LogicException` surfaces. With the fix, the key
+ * is rejected up front → `BadRequestHttpException` and `create()` is never
+ * called. The exception *type* is therefore the assertion.
+ */
+final class CatalogSearchServiceFilterKeyTest extends TestCase
+{
+    #[Test]
+    public function rejectsFilterKeyCarryingMeiliOperator(): void
+    {
+        $service = $this->serviceWithTenant();
+
+        $this->expectException(BadRequestHttpException::class);
+
+        $service->search(
+            kind: ObjectKind::Product,
+            query: '',
+            filters: ['parentId IS NULL OR tenantId' => '00000000-0000-7000-8000-000000000000'],
+        );
+    }
+
+    #[Test]
+    public function rejectsUnknownPlainFilterKey(): void
+    {
+        $service = $this->serviceWithTenant();
+
+        $this->expectException(BadRequestHttpException::class);
+
+        $service->search(
+            kind: ObjectKind::Product,
+            query: '',
+            filters: ['totally_unknown_field' => 'x'],
+        );
+    }
+
+    #[Test]
+    public function rejectsUnknownKeyInArrayValuedFilter(): void
+    {
+        $service = $this->serviceWithTenant();
+
+        $this->expectException(BadRequestHttpException::class);
+
+        $service->search(
+            kind: ObjectKind::Product,
+            query: '',
+            filters: ['brand" OR tenantId' => ['a', 'b']],
+        );
+    }
+
+    #[Test]
+    public function rejectsUnknownRangeFilterKey(): void
+    {
+        $service = $this->serviceWithTenant();
+
+        $this->expectException(BadRequestHttpException::class);
+
+        $service->search(
+            kind: ObjectKind::Product,
+            query: '',
+            rangeFilters: ['price >= 0 OR tenantId' => ['gte' => 1.0]],
+        );
+    }
+
+    /**
+     * Whitelisted attribute keys must NOT be rejected by the validator. The
+     * service swallows the downstream Meili failure (unconfigured factory)
+     * inside its try/catch and degrades to an empty result — the point here
+     * is that NO {@see BadRequestHttpException} escapes for a legitimate key,
+     * proving the whitelist accepts known fields instead of blanket-rejecting.
+     */
+    #[Test]
+    public function acceptsWhitelistedFilterKey(): void
+    {
+        $service = $this->serviceWithTenant();
+
+        // `enabled` is a RESERVED_FILTERABLE — must pass the key whitelist.
+        // Meili is unreachable (url=null) so the service returns emptyResult
+        // rather than 400; the absence of a thrown 400 is the assertion.
+        $result = $service->search(
+            kind: ObjectKind::Product,
+            query: '',
+            filters: ['enabled' => 'true'],
+        );
+
+        self::assertArrayHasKey('hits', $result);
+        self::assertArrayHasKey('totalHits', $result);
+    }
+
+    private function serviceWithTenant(): CatalogSearchService
+    {
+        $tenant = new Tenant('demo', 'Demo Tenant');
+        $user = new User($tenant, 'admin@demo.localhost', '', ['ROLE_USER']);
+
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken($user, 'main', ['ROLE_USER']));
+
+        // No DoctrineTenantRepository needed: the User implements TenantAware,
+        // so CurrentTenantProvider short-circuits to $user->getTenant().
+        $tenantProvider = new CurrentTenantProvider(
+            $tokenStorage,
+            $this->createStub(\App\Shared\Infrastructure\Doctrine\Repository\DoctrineTenantRepository::class),
+        );
+
+        // url=null → create() throws LogicException, marking "reached Meili".
+        $factory = new MeilisearchClientFactory(null, null);
+
+        return new CatalogSearchService($factory, $tenantProvider);
+    }
+}


### PR DESCRIPTION
## AUD-004 (CRITICAL) — Meili filter-key injection → cross-tenant read
Klucz z `?filter[<KEY>]` wstawiany do wyrażenia Meili bez whitelistu klucza (tylko wartości/facets chronione). `filter[parentId IS NULL OR tenantId]=<B>` wstrzykiwał `OR` znoszący tenant AND-scope → odczyt cudzego tenanta.

## Fix
`CatalogSearchService`: walidacja każdego klucza filtra wobec `filterableAttributes` (400 spoza); `tenantId` odrzucany jako reserved/niemieszalny scope (doklejany zawsze osobno).

## Test (failing → green)
Unit `CatalogSearchServiceFilterKeyTest` 5/5 (operator-injection, nieznane pole, range, akceptacja whitelisted) + ApiTest 3 (injection→400, regresja-pozytyw). RED przed, GREEN po.

## Smoke (CLOSED MEANS CLOSED)
`GET /api/search/products?query=ACME-001&filter[parentId IS NULL OR tenantId]=<ACME>` (token demo):
- **PRZED:** HTTP 200, totalHits=17 — 3 produkty acme wyciekły (ACME-001/002/003).
- **PO** (cache:clear + restart api + reindex): **HTTP 400** "Unknown filter attribute"; czysty scope: acme leaked = **False**.

`BulkSelectionController` niepodatny (DSL `safeIdent` whitelist). Gates: PHPStan full OK + cs-fixer.

Closes #1574
