### PR TITLE
fix(mercure): private tenant-scoped events + subscriber-JWT — AUD-001 (#1573)

### DIFF
--- a/apps/admin/src/features/exports/hooks/useExportSessionsStream.ts
+++ b/apps/admin/src/features/exports/hooks/useExportSessionsStream.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+import { useIdentity } from '@/lib/identity';
+import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '@/lib/mercure';
+
 interface ExportEvent {
   event: 'progress' | 'status';
   session_id: string;
@@ -38,9 +41,11 @@ export interface UseExportSessionsStreamState {
 export function useExportSessionsStream(userId: string | null): UseExportSessionsStreamState {
   const [connected, setConnected] = React.useState(false);
   const [lastEvent, setLastEvent] = React.useState<ExportEvent | null>(null);
+  const { identity } = useIdentity();
+  const tenantId = identity?.tenant?.id ?? null;
 
   React.useEffect(() => {
-    if (userId === null) {
+    if (userId === null || tenantId === null) {
       setConnected(false);
       setLastEvent(null);
       return;
@@ -49,33 +54,49 @@ export function useExportSessionsStream(userId: string | null): UseExportSession
       return;
     }
 
-    // Topic base = SPA origin (Caddy single-origin); BE publishers use the
-    // matching MERCURE_TOPIC_BASE env (IMP2-0.2 / #1461) — no hardcoded host.
-    const topic = `${window.location.origin}/exports/${userId}`;
-    const url = `${window.location.origin}/.well-known/mercure?topic=${encodeURIComponent(topic)}`;
-    const source = new EventSource(url, { withCredentials: true });
+    // AUD-001 (#1573) — tenant-scoped, private topic; mint the
+    // mercureAuthorization cookie before opening the EventSource (the hub
+    // rejects an unauthorised subscription). Mirrors
+    // MercureSubscribeTopics::exportUser().
+    const topic = mercureTenantTopic(tenantId, 'exports', userId);
+    const url = mercureSubscribeUrl(topic);
 
-    source.addEventListener('open', () => {
-      setConnected(true);
-    });
+    let source: EventSource | null = null;
+    let cancelled = false;
 
-    source.addEventListener('message', (event) => {
-      try {
-        const parsed = JSON.parse(event.data) as ExportEvent;
-        setLastEvent(parsed);
-      } catch {
-        // Malformed payload — Mercure is enrichment, not source of truth.
-      }
-    });
-
-    source.addEventListener('error', () => {
-      setConnected(false);
-    });
+    ensureMercureAuthorization()
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+        source = new EventSource(url, { withCredentials: true });
+        source.addEventListener('open', () => {
+          setConnected(true);
+        });
+        source.addEventListener('message', (event) => {
+          try {
+            const parsed = JSON.parse(event.data) as ExportEvent;
+            setLastEvent(parsed);
+          } catch {
+            // Malformed payload — Mercure is enrichment, not source of truth.
+          }
+        });
+        source.addEventListener('error', () => {
+          setConnected(false);
+        });
+      })
+      .catch(() => {
+        // Mint failed — caller's polling fallback keeps the grid fresh.
+        if (!cancelled) {
+          setConnected(false);
+        }
+      });
 
     return () => {
-      source.close();
+      cancelled = true;
+      source?.close();
     };
-  }, [userId]);
+  }, [userId, tenantId]);
 
   return { connected, lastEvent };
 }

--- a/apps/admin/src/features/imports/hooks/useImportProgress.ts
+++ b/apps/admin/src/features/imports/hooks/useImportProgress.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 
+import { useIdentity } from '@/lib/identity';
+import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '@/lib/mercure';
+
 interface ProgressEvent {
   type: 'progress' | 'error' | 'completed';
   session_id: string;
@@ -65,9 +68,11 @@ const INITIAL_STATE: ImportProgressState = {
  */
 export function useImportProgress(sessionId: string | null): ImportProgressState {
   const [state, setState] = React.useState<ImportProgressState>(INITIAL_STATE);
+  const { identity } = useIdentity();
+  const tenantId = identity?.tenant?.id ?? null;
 
   React.useEffect(() => {
-    if (sessionId === null) {
+    if (sessionId === null || tenantId === null) {
       setState(INITIAL_STATE);
       return;
     }
@@ -75,72 +80,94 @@ export function useImportProgress(sessionId: string | null): ImportProgressState
       return;
     }
 
-    // Topic base = SPA origin (Caddy single-origin); BE publishers use the
-    // matching MERCURE_TOPIC_BASE env (IMP2-0.2 / #1461) — no hardcoded host.
-    const topic = `${window.location.origin}/imports/${sessionId}`;
-    const url = `${window.location.origin}/.well-known/mercure?topic=${encodeURIComponent(topic)}`;
-    const source = new EventSource(url, { withCredentials: true });
+    // AUD-001 (#1573) — tenant-scoped, private topic; the SPA must hold a
+    // mercureAuthorization cookie (minted below) before the hub accepts the
+    // subscription. Topic mirrors MercureSubscribeTopics::importSession().
+    const topic = mercureTenantTopic(tenantId, 'imports', sessionId);
+    const url = mercureSubscribeUrl(topic);
 
-    source.addEventListener('open', () => {
-      setState((prev) => ({ ...prev, connecting: false }));
-    });
+    let source: EventSource | null = null;
+    let cancelled = false;
 
     let logSeq = 0;
-    source.addEventListener('message', (event) => {
-      try {
-        const raw = JSON.parse(event.data) as ProgressEvent;
-        setState((prev) => {
-          let log = prev.log;
-          // IMP2-2.6 — the per-row `row_processed` event is gone (it was 50k hub
-          // POSTs on a 50k import). The live log is built from blocking `error`
-          // events and the throttled `progress` snapshots (≤ ~100 for 50k rows).
-          if (raw.type === 'error') {
-            const label = raw.data.sku ?? `row ${raw.data.row_number ?? '?'}`;
-            log = [
-              ...prev.log.slice(-(LOG_BUFFER_CAP - 1)),
-              {
-                id: logSeq++,
-                level: 'error',
-                message: `✗ ${label} — ${raw.data.message ?? 'error'}`,
-              },
-            ];
-          } else if (raw.type === 'progress') {
-            const sku = raw.data.current_sku ? ` — ${raw.data.current_sku}` : '';
-            log = [
-              ...prev.log.slice(-(LOG_BUFFER_CAP - 1)),
-              {
-                id: logSeq++,
-                level: 'info',
-                message: `✓ ${raw.data.processed_rows ?? '?'} / ${raw.data.total_rows ?? '?'}${sku}`,
-              },
-            ];
-          }
-          return {
-            ...prev,
-            connecting: false,
-            log,
-            processedRows: raw.data.processed_rows ?? prev.processedRows,
-            totalRows: raw.data.total_rows ?? prev.totalRows,
-            successCount: raw.data.success_count ?? prev.successCount,
-            errorCount: raw.data.error_count ?? prev.errorCount,
-            currentSku: raw.data.current_sku ?? prev.currentSku,
-            status: (raw.data.status as ImportProgressState['status']) ?? prev.status,
-          };
-        });
-      } catch {
-        // Malformed Mercure payload — surface a console.warn on the
-        // root error handler in dev only.
-      }
-    });
+    const attach = (es: EventSource): void => {
+      es.addEventListener('open', () => {
+        setState((prev) => ({ ...prev, connecting: false }));
+      });
+      es.addEventListener('message', (event) => {
+        try {
+          const raw = JSON.parse(event.data) as ProgressEvent;
+          setState((prev) => {
+            let log = prev.log;
+            // IMP2-2.6 — the per-row `row_processed` event is gone (it was 50k hub
+            // POSTs on a 50k import). The live log is built from blocking `error`
+            // events and the throttled `progress` snapshots (≤ ~100 for 50k rows).
+            if (raw.type === 'error') {
+              const label = raw.data.sku ?? `row ${raw.data.row_number ?? '?'}`;
+              log = [
+                ...prev.log.slice(-(LOG_BUFFER_CAP - 1)),
+                {
+                  id: logSeq++,
+                  level: 'error',
+                  message: `✗ ${label} — ${raw.data.message ?? 'error'}`,
+                },
+              ];
+            } else if (raw.type === 'progress') {
+              const sku = raw.data.current_sku ? ` — ${raw.data.current_sku}` : '';
+              log = [
+                ...prev.log.slice(-(LOG_BUFFER_CAP - 1)),
+                {
+                  id: logSeq++,
+                  level: 'info',
+                  message: `✓ ${raw.data.processed_rows ?? '?'} / ${raw.data.total_rows ?? '?'}${sku}`,
+                },
+              ];
+            }
+            return {
+              ...prev,
+              connecting: false,
+              log,
+              processedRows: raw.data.processed_rows ?? prev.processedRows,
+              totalRows: raw.data.total_rows ?? prev.totalRows,
+              successCount: raw.data.success_count ?? prev.successCount,
+              errorCount: raw.data.error_count ?? prev.errorCount,
+              currentSku: raw.data.current_sku ?? prev.currentSku,
+              status: (raw.data.status as ImportProgressState['status']) ?? prev.status,
+            };
+          });
+        } catch {
+          // Malformed Mercure payload — surface a console.warn on the
+          // root error handler in dev only.
+        }
+      });
 
-    source.addEventListener('error', () => {
-      setState((prev) => ({ ...prev, connecting: false }));
-    });
+      es.addEventListener('error', () => {
+        setState((prev) => ({ ...prev, connecting: false }));
+      });
+    };
+
+    // Mint the tenant-scoped subscribe cookie first; the hub rejects the
+    // EventSource without it (AUD-001). On a mint failure we stop
+    // "connecting" so the UI falls back to the REST snapshot.
+    ensureMercureAuthorization()
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+        source = new EventSource(url, { withCredentials: true });
+        attach(source);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState((prev) => ({ ...prev, connecting: false }));
+        }
+      });
 
     return () => {
-      source.close();
+      cancelled = true;
+      source?.close();
     };
-  }, [sessionId]);
+  }, [sessionId, tenantId]);
 
   return state;
 }

--- a/apps/admin/src/layout/use-notifications.ts
+++ b/apps/admin/src/layout/use-notifications.ts
@@ -1,13 +1,22 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
+
+import { useIdentity } from '@/lib/identity';
+import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '@/lib/mercure';
 
 /**
  * Mercure notifications feed for the top bar bell (#54 / 0.6.1).
  *
- * Subscribes to the broadcast topic published by the Mercure publisher
- * from #47 (`<base>/objects`). Each `EventSource` message becomes a
- * notification entry with a stable id, the parsed payload type
+ * Subscribes to the tenant-scoped catalog broadcast topic published by
+ * the Mercure publisher from #47 — `<base>/tenant/<tid>/objects` after
+ * AUD-001 (#1573). Each `EventSource` message becomes a notification
+ * entry with a stable id, the parsed payload type
  * (`object.created.product`, `object.attributes_changed.category`, …),
  * and the raw data so the UI can later route the user to the row.
+ *
+ * Before AUD-001 this hook listened on the un-prefixed global `/objects`
+ * topic against an anonymous hub, so the bell surfaced every tenant's
+ * catalog changes. The tenant prefix + the mercureAuthorization cookie
+ * (minted below) confine it to the caller's tenant.
  *
  * The hook keeps the last 25 events in memory only — the bell is a
  * "is something happening right now" surface, not an audit log. Reload
@@ -33,23 +42,25 @@ export interface UseNotificationsState {
 }
 
 const MAX_ENTRIES = 25;
-const BROADCAST_TOPIC = '/objects';
 
 export function useNotifications(): UseNotificationsState {
   const [entries, setEntries] = useState<NotificationEntry[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
-  const hubUrl = useRef<string | null>(null);
+  const { identity } = useIdentity();
+  const tenantId = identity?.tenant?.id ?? null;
 
   useEffect(() => {
     // EventSource is window-only; SSR / unit envs (jsdom-less) skip this.
     if (typeof window === 'undefined' || typeof EventSource === 'undefined') return;
+    if (tenantId === null) return;
 
-    if (hubUrl.current === null) {
-      hubUrl.current = `${window.location.origin}/.well-known/mercure?topic=${encodeURIComponent(BROADCAST_TOPIC)}`;
-    }
+    const broadcastTopic = mercureTenantTopic(tenantId, 'objects');
+    const url = mercureSubscribeUrl(broadcastTopic);
 
-    const source = new EventSource(hubUrl.current, { withCredentials: true });
-    source.addEventListener('message', (event) => {
+    let source: EventSource | null = null;
+    let cancelled = false;
+
+    const onMessage = (event: MessageEvent): void => {
       try {
         const raw: unknown = JSON.parse(event.data);
         if (typeof raw !== 'object' || raw === null) return;
@@ -64,7 +75,7 @@ export function useNotifications(): UseNotificationsState {
         const entry: NotificationEntry = {
           id: `${event.lastEventId || crypto.randomUUID()}`,
           type,
-          topic: BROADCAST_TOPIC,
+          topic: broadcastTopic,
           occurredOn,
           data,
           receivedAt: Date.now(),
@@ -74,12 +85,25 @@ export function useNotifications(): UseNotificationsState {
       } catch {
         // Malformed payload is non-fatal — Mercure is enrichment, not source of truth.
       }
-    });
+    };
+
+    // AUD-001 (#1573) — mint the tenant-scoped subscribe cookie before
+    // opening the EventSource; the hub rejects an unauthorised subscription.
+    ensureMercureAuthorization()
+      .then(() => {
+        if (cancelled) return;
+        source = new EventSource(url, { withCredentials: true });
+        source.addEventListener('message', onMessage);
+      })
+      .catch(() => {
+        // Mint failed — the bell is enrichment; silently degrade.
+      });
 
     return () => {
-      source.close();
+      cancelled = true;
+      source?.close();
     };
-  }, []);
+  }, [tenantId]);
 
   const markAllRead = (): void => {
     setUnreadCount(0);

--- a/apps/admin/src/lib/identity/use-permission-invalidation-sse.ts
+++ b/apps/admin/src/lib/identity/use-permission-invalidation-sse.ts
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 
+import { ensureMercureAuthorization, mercureSubscribeUrl, mercureTenantTopic } from '../mercure';
 import { IDENTITY_QUERY_KEY } from './use-identity';
 
 /**
@@ -30,39 +31,48 @@ import { IDENTITY_QUERY_KEY } from './use-identity';
  * (userId becomes null). Reconnection is the browser's job — the
  * native EventSource handles exponential back-off automatically.
  */
-export function usePermissionInvalidationSse(userId: string | null): void {
+export function usePermissionInvalidationSse(userId: string | null, tenantId: string | null): void {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (!userId) {
+    if (!userId || !tenantId) {
       return;
     }
 
-    const baseUrl =
-      // Vite env access intentionally guarded — fall back to same-origin
-      // path when the env var is missing so dev works out of the box.
-      (typeof import.meta !== 'undefined' &&
-        (import.meta as { env?: { VITE_MERCURE_PUBLIC_URL?: string } }).env
-          ?.VITE_MERCURE_PUBLIC_URL) ||
-      `${window.location.origin}/.well-known/mercure`;
+    // AUD-001 (#1573) — tenant-scoped, private topic; mint the
+    // mercureAuthorization cookie before opening the EventSource (the hub
+    // rejects an unauthorised subscription). Mirrors
+    // MercureSubscribeTopics::identityUser().
+    const topic = mercureTenantTopic(tenantId, 'identity', 'user', userId);
+    const url = mercureSubscribeUrl(topic);
 
-    const topic = `${window.location.origin}/identity/user/${userId}`;
-    const url = new URL(baseUrl);
-    url.searchParams.append('topic', topic);
+    let source: EventSource | null = null;
+    let cancelled = false;
 
-    const source = new EventSource(url.toString(), { withCredentials: true });
-    source.onmessage = () => {
-      queryClient.invalidateQueries({ queryKey: IDENTITY_QUERY_KEY });
-    };
-    source.onerror = () => {
-      // Native EventSource auto-reconnects; we keep the source live and
-      // let the browser back off. If the hub is permanently down, the
-      // 5-min query staleTime keeps a fresh /api/auth/me on the
-      // next refocus.
-    };
+    ensureMercureAuthorization()
+      .then(() => {
+        if (cancelled) {
+          return;
+        }
+        source = new EventSource(url, { withCredentials: true });
+        source.onmessage = () => {
+          queryClient.invalidateQueries({ queryKey: IDENTITY_QUERY_KEY });
+        };
+        source.onerror = () => {
+          // Native EventSource auto-reconnects; we keep the source live and
+          // let the browser back off. If the hub is permanently down, the
+          // 5-min query staleTime keeps a fresh /api/auth/me on the
+          // next refocus.
+        };
+      })
+      .catch(() => {
+        // Mint failed — the 5-min staleTime keeps /api/auth/me fresh on
+        // the next refocus, so we degrade gracefully without the live push.
+      });
 
     return () => {
-      source.close();
+      cancelled = true;
+      source?.close();
     };
-  }, [userId, queryClient]);
+  }, [userId, tenantId, queryClient]);
 }

--- a/apps/admin/src/lib/mercure/index.ts
+++ b/apps/admin/src/lib/mercure/index.ts
@@ -1,0 +1,95 @@
+/**
+ * AUD-001 (#1573) — shared Mercure helpers for the admin SPA.
+ *
+ * The Mercure hub no longer runs in `anonymous` mode and every domain
+ * topic is tenant-scoped + private, so before opening ANY EventSource a
+ * consumer must:
+ *
+ *   1. mint the `mercureAuthorization` cookie via
+ *      `POST /api/mercure/authorization` ({@link ensureMercureAuthorization});
+ *      the cookie's JWT authorises only the caller tenant's topics;
+ *   2. subscribe on a tenant-scoped topic built with
+ *      {@link mercureTenantTopic} (mirrors the backend
+ *      `MercureSubscribeTopics` contract).
+ *
+ * Without the cookie the hub answers 401 and the EventSource fails — that
+ * is the mechanism that stops cross-tenant real-time leakage.
+ */
+
+import { getAccessToken } from '../http';
+
+const AUTHORIZATION_PATH = '/api/mercure/authorization';
+
+let inFlight: Promise<void> | null = null;
+let authorizedAt = 0;
+
+// The minted cookie lives ~1h (session.cookie_lifetime). Re-mint a couple
+// of minutes early so a long-open EventSource never trips a mid-stream
+// 401 when the JWT expires. A short success cache collapses the burst of
+// consumers that mount together (bell + import + export + permissions).
+const REAUTH_AFTER_MS = 55 * 60_000;
+
+/**
+ * Single-flight mint of the `mercureAuthorization` cookie. Idempotent:
+ * concurrent callers share one POST, and a recent success short-circuits.
+ *
+ * Throws on a non-2xx response so callers can decide whether to fall
+ * back to polling (imports/exports) or simply skip the live channel.
+ */
+export async function ensureMercureAuthorization(force = false): Promise<void> {
+  if (
+    !force &&
+    inFlight === null &&
+    Date.now() - authorizedAt < REAUTH_AFTER_MS &&
+    authorizedAt > 0
+  ) {
+    return;
+  }
+  if (inFlight === null) {
+    inFlight = mintCookie().finally(() => {
+      inFlight = null;
+    });
+  }
+  return inFlight;
+}
+
+async function mintCookie(): Promise<void> {
+  const accessToken = getAccessToken();
+  const response = await fetch(AUTHORIZATION_PATH, {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {
+      accept: 'application/json',
+      ...(accessToken ? { authorization: `Bearer ${accessToken}` } : {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Mercure authorization mint failed: ${response.status}`);
+  }
+  authorizedAt = Date.now();
+}
+
+/**
+ * Reset the success cache — call on logout so the next login re-mints a
+ * cookie for the new principal/tenant rather than reusing the stale one.
+ */
+export function resetMercureAuthorization(): void {
+  authorizedAt = 0;
+  inFlight = null;
+}
+
+/**
+ * Build a tenant-scoped topic IRI: `{origin}/tenant/{tenantId}/{...segments}`.
+ * Mirrors `App\Shared\Infrastructure\Mercure\MercureSubscribeTopics`.
+ */
+export function mercureTenantTopic(tenantId: string, ...segments: string[]): string {
+  const tail = segments.join('/');
+  return `${window.location.origin}/tenant/${tenantId}/${tail}`;
+}
+
+/**
+ * Build the hub subscribe URL for a single topic.
+ */
+export function mercureSubscribeUrl(topic: string): string {
+  return `${window.location.origin}/.well-known/mercure?topic=${encodeURIComponent(topic)}`;
+}

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -199,6 +199,19 @@ services:
     App\Export\Application\Async\ExportProgressPublisher:
         arguments:
             $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+    # AUD-001 (#1573) — Catalog + permission publishers and the cookie
+    # mint endpoint must build topics from the same public origin the SPA
+    # subscribes on, so the tenant-scoped subscribe claim matches the
+    # published topic exactly.
+    App\Catalog\Application\Subscriber\MercurePublisher:
+        arguments:
+            $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+    App\Identity\Infrastructure\Mercure\PermissionInvalidationPublisher:
+        arguments:
+            $topicBase: '%env(MERCURE_TOPIC_BASE)%'
+    App\Identity\Presentation\Controller\MercureAuthorizationController:
+        arguments:
+            $topicBase: '%env(MERCURE_TOPIC_BASE)%'
 
     # Bind the named Flysystem storage for the Asset uploader. Without
     # this Symfony has multiple FilesystemOperator services (one per

--- a/apps/api/src/Catalog/Application/Subscriber/MercurePublisher.php
+++ b/apps/api/src/Catalog/Application/Subscriber/MercurePublisher.php
@@ -10,13 +10,16 @@ use App\Catalog\Contracts\Event\ObjectCreated;
 use App\Catalog\Contracts\Event\ObjectEnabledChanged;
 use App\Catalog\Contracts\Event\ObjectPublished;
 use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantAwareMessage;
 use App\Shared\Domain\DomainEvent;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
 use DateTimeInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Update;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Uid\Uuid;
 use Throwable;
 
 use const JSON_THROW_ON_ERROR;
@@ -28,10 +31,13 @@ use const JSON_THROW_ON_ERROR;
  * Each handler maps a domain event to:
  *   - **Type**: `object.<verb>.<kind>` (e.g. `object.created.product`)
  *     so subscribers can filter by both the operation and the kind.
- *   - **Topic**: `https://pim.localhost/objects/<id>` (per row) plus
- *     `https://pim.localhost/objects` (broadcast) so the admin can
- *     listen on a single topic for "any catalog change" or a row-
- *     specific topic for live editing.
+ *   - **Topic**: `https://pim.localhost/tenant/<tid>/objects/<id>` (per
+ *     row) plus `https://pim.localhost/tenant/<tid>/objects` (broadcast)
+ *     so the admin can listen on a single topic for "any catalog change"
+ *     or a row-specific topic for live editing. The `tenant/<tid>`
+ *     prefix + `private: true` close the AUD-001 (#1573) cross-tenant
+ *     leak — the hub only delivers a private update to a subscriber
+ *     whose JWT authorises that exact tenant topic.
  *
  * The Mercure hub URL is the public origin from `MERCURE_PUBLIC_URL` —
  * subscribers connect there, the publisher pushes through
@@ -121,10 +127,11 @@ final readonly class MercurePublisher
     /**
      * @param array<string, mixed> $payload
      */
-    private function publish(string $type, DomainEvent $event, array $payload): void
+    private function publish(string $type, DomainEvent&TenantAwareMessage $event, array $payload): void
     {
-        $rowTopic = \sprintf('%s/%s/%s', $this->topicBase, self::TOPIC_PREFIX_OBJECT, $event->aggregateId());
-        $broadcastTopic = \sprintf('%s/%s', $this->topicBase, self::TOPIC_PREFIX_OBJECT);
+        $tenantId = $event->tenantId();
+        $rowTopic = MercureSubscribeTopics::objectRow($tenantId, $this->topicBase, $event->aggregateId());
+        $broadcastTopic = MercureSubscribeTopics::objectsBroadcast($tenantId, $this->topicBase);
 
         $update = new Update(
             topics: [$rowTopic, $broadcastTopic],
@@ -133,6 +140,7 @@ final readonly class MercurePublisher
                 'occurredOn' => $event->occurredOn()->format(DateTimeInterface::RFC3339_EXTENDED),
                 'data' => $payload,
             ], JSON_THROW_ON_ERROR),
+            private: true,
         );
 
         // Hub failures (network, hub down, JWT mismatch) must not abort
@@ -154,10 +162,11 @@ final readonly class MercurePublisher
     /**
      * Helper used by ObjectKind switches outside this class. Kept here to
      * keep topic naming colocated with the publisher (one place to bump
-     * `objects` → `catalog.objects` if the contract evolves).
+     * the topic contract). Tenant-scoped (AUD-001 #1573) so a kind-filtered
+     * subscription can never cross tenant boundaries.
      */
-    public static function topicForKind(ObjectKind $kind, string $base = 'https://pim.localhost'): string
+    public static function topicForKind(ObjectKind $kind, Uuid $tenantId, string $base = 'https://pim.localhost'): string
     {
-        return \sprintf('%s/%s/kind/%s', $base, self::TOPIC_PREFIX_OBJECT, $kind->value);
+        return MercureSubscribeTopics::tenantPrefix($tenantId, $base).'/'.self::TOPIC_PREFIX_OBJECT.'/kind/'.$kind->value;
     }
 }

--- a/apps/api/src/Export/Application/Async/ExportProgressPublisher.php
+++ b/apps/api/src/Export/Application/Async/ExportProgressPublisher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Export\Application\Async;
 
 use App\Export\Domain\Entity\ExportSession;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Mercure\HubInterface;
@@ -16,14 +17,18 @@ use const JSON_THROW_ON_ERROR;
 /**
  * EXP-06 (#585) — Mercure SSE publisher for async exports.
  *
- * Publishes lifecycle events to two topics (PRD §11.5):
- *   - `exports/{user_id}` — list-view broadcast so the user's "Recent
- *     exports" grid (EXP-13) refreshes when ANY of their exports
- *     changes status.
- *   - `exports/{session_id}` — detail topic carrying per-chunk progress
- *     (rows_done, rows_total, progress_pct, estimated_seconds_remaining).
- *     Subscribed only when the user opens a session detail / a toast
- *     is mid-flight.
+ * Publishes lifecycle events to two tenant-scoped, private topics
+ * (PRD §11.5; AUD-001 #1573):
+ *   - `tenant/{tid}/exports/{user_id}` — list-view broadcast so the
+ *     user's "Recent exports" grid (EXP-13) refreshes when ANY of their
+ *     exports changes status.
+ *   - `tenant/{tid}/exports/{session_id}` — detail topic carrying
+ *     per-chunk progress (rows_done, rows_total, progress_pct,
+ *     estimated_seconds_remaining).
+ *
+ * The `tenant/{tid}` prefix + `private: true` close the AUD-001
+ * cross-tenant leak: the hub only delivers a private update to a
+ * subscriber whose JWT authorises that exact tenant topic.
  *
  * Hub failures are logged but never abort the underlying export — the
  * MinIO file write is the source of truth; Mercure is a notification
@@ -31,8 +36,6 @@ use const JSON_THROW_ON_ERROR;
  */
 final class ExportProgressPublisher
 {
-    private const string TOPIC_PREFIX = 'exports';
-
     private readonly LoggerInterface $logger;
 
     public function __construct(
@@ -85,12 +88,25 @@ final class ExportProgressPublisher
 
         $encoded = json_encode($message, JSON_THROW_ON_ERROR);
 
-        $userTopic = sprintf('%s/%s/%s', $this->topicBase, self::TOPIC_PREFIX, $session->getUserId()->toRfc4122());
-        $sessionTopic = sprintf('%s/%s/%s', $this->topicBase, self::TOPIC_PREFIX, $session->getId()->toRfc4122());
+        $tenant = $session->getTenant();
+        if (null === $tenant) {
+            // Sessions are tenant-stamped before processing; a null here is
+            // a misconfiguration. Skip rather than emit an un-scoped topic.
+            $this->logger->warning('Export progress publish skipped: session has no tenant', [
+                'session_id' => $session->getId()->toRfc4122(),
+                'event' => $eventType,
+            ]);
+
+            return;
+        }
+        $tenantId = $tenant->getId();
+
+        $userTopic = MercureSubscribeTopics::exportUser($tenantId, $this->topicBase, $session->getUserId()->toRfc4122());
+        $sessionTopic = MercureSubscribeTopics::exportSession($tenantId, $this->topicBase, $session->getId()->toRfc4122());
 
         try {
-            $this->hub->publish(new Update($userTopic, $encoded));
-            $this->hub->publish(new Update($sessionTopic, $encoded));
+            $this->hub->publish(new Update($userTopic, $encoded, private: true));
+            $this->hub->publish(new Update($sessionTopic, $encoded, private: true));
         } catch (Throwable $error) {
             $this->logger->warning('Export progress publish failed', [
                 'session_id' => $session->getId()->toRfc4122(),

--- a/apps/api/src/Identity/Infrastructure/Mercure/PermissionInvalidationPublisher.php
+++ b/apps/api/src/Identity/Infrastructure/Mercure/PermissionInvalidationPublisher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Identity\Infrastructure\Mercure;
 
 use App\Identity\Domain\Entity\User;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Mercure\HubInterface;
@@ -26,12 +27,13 @@ use const JSON_THROW_ON_ERROR;
  * acting under stale permissions until they reload manually.
  *
  * Topic naming follows the existing Export / Import publishers'
- * convention so the frontend EventSource subscribes to one shape:
+ * convention so the frontend EventSource subscribes to one shape.
+ * Tenant-scoped + private after AUD-001 (#1573):
  *
- *   https://{public}/identity/user/{userId}   — per-user
- *   https://{public}/identity/tenant/{tenantId} — tenant-wide (every
- *                                                 user inside, used for
- *                                                 macierz-wide changes)
+ *   https://{public}/tenant/{tenantId}/identity/user/{userId}   — per-user
+ *   https://{public}/tenant/{tenantId}/identity/tenant/{tenantId} —
+ *                                                 tenant-wide (every user
+ *                                                 inside, macierz changes)
  *
  * The matching frontend listener — `usePermissionInvalidationSse()` —
  * invalidates the `['rbac','identity']` query key so React Query
@@ -61,20 +63,21 @@ final readonly class PermissionInvalidationPublisher
 
     public function publishForUser(User $user, string $reason = 'permission_changed'): void
     {
-        $topic = \sprintf('%s/identity/user/%s', $this->topicBase, $user->getId()->toRfc4122());
+        $tenantId = $user->getTenant()->getId();
+        $topic = MercureSubscribeTopics::identityUser($tenantId, $this->topicBase, $user->getId()->toRfc4122());
 
         $this->emit($topic, [
             'type' => self::EVENT_TYPE,
             'scope' => 'user',
             'user_id' => $user->getId()->toRfc4122(),
-            'tenant_id' => $user->getTenant()->getId()->toRfc4122(),
+            'tenant_id' => $tenantId->toRfc4122(),
             'reason' => $reason,
         ]);
     }
 
     public function publishForTenant(Uuid $tenantId, string $reason = 'role_macierz_changed'): void
     {
-        $topic = \sprintf('%s/identity/tenant/%s', $this->topicBase, $tenantId->toRfc4122());
+        $topic = MercureSubscribeTopics::identityTenant($tenantId, $this->topicBase);
 
         $this->emit($topic, [
             'type' => self::EVENT_TYPE,
@@ -90,7 +93,7 @@ final readonly class PermissionInvalidationPublisher
     private function emit(string $topic, array $payload): void
     {
         try {
-            $this->hub->publish(new Update($topic, json_encode($payload, JSON_THROW_ON_ERROR)));
+            $this->hub->publish(new Update($topic, json_encode($payload, JSON_THROW_ON_ERROR), private: true));
         } catch (Throwable $exception) {
             $this->logger->warning(
                 'Permission Mercure invalidation publish failed; SPA will refetch on next /api/auth/me TTL expiry.',

--- a/apps/api/src/Identity/Presentation/Controller/MercureAuthorizationController.php
+++ b/apps/api/src/Identity/Presentation/Controller/MercureAuthorizationController.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Presentation\Controller;
+
+use App\Identity\Contracts\Attribute\NoPermissionRequired;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mercure\Authorization;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * AUD-001 (#1573) — `POST /api/mercure/authorization`.
+ *
+ * Mints the `mercureAuthorization` cookie the SPA must hold before it
+ * opens an EventSource. The Mercure hub no longer runs in `anonymous`
+ * mode, so a subscription without this cookie is refused (401) — that is
+ * what stops an attacker (or any other tenant) from listening on the
+ * real-time catalog / import / export / permission streams.
+ *
+ * The cookie is a short-lived JWT whose `mercure.subscribe` claim is a
+ * closed set of URI templates, every one pinned to
+ * `tenant/{callerTenant}/…` ({@see MercureSubscribeTopics::forTenant()}).
+ * There is no global (prefix-less) topic and no other tenant's prefix,
+ * so the hub will only deliver the caller's own tenant updates.
+ *
+ * The cookie scope (path `/.well-known/mercure`, httpOnly, secure on
+ * https, SameSite=Strict) is set by the Mercure component's
+ * {@see Authorization::createCookie()} helper from the hub `public_url`.
+ *
+ * Auth model: requires a valid JWT (the `^/api` firewall). The endpoint
+ * carries `#[NoPermissionRequired]` because subscribing to one's own
+ * tenant feed is implied by being authenticated — there is no finer
+ * RBAC gate than "is this caller logged in".
+ */
+final readonly class MercureAuthorizationController
+{
+    public function __construct(
+        private Security $security,
+        private Authorization $authorization,
+        private string $topicBase,
+    ) {
+    }
+
+    #[Route(path: '/api/mercure/authorization', methods: ['POST'], name: 'api_mercure_authorization')]
+    #[NoPermissionRequired(reason: 'Subscribing to the caller\'s own tenant Mercure feed is implied by JWT authentication; the subscribe claim is scoped to the caller tenant.')]
+    public function __invoke(Request $request): Response
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            return new JsonResponse(
+                [
+                    'type' => 'about:blank',
+                    'title' => 'Unauthorized',
+                    'status' => Response::HTTP_UNAUTHORIZED,
+                    'detail' => 'No authenticated user.',
+                ],
+                Response::HTTP_UNAUTHORIZED,
+                ['Content-Type' => 'application/problem+json; charset=utf-8'],
+            );
+        }
+
+        $tenantId = $user->getTenant()->getId();
+        $subscribe = MercureSubscribeTopics::forTenant($tenantId, $this->topicBase);
+
+        // createCookie() signs the JWT with the hub's subscriber key and
+        // scopes the cookie to the hub path; we attach it to the response
+        // directly (this mercure-bundle version ships no SetCookieSubscriber).
+        $cookie = $this->authorization->createCookie($request, $subscribe);
+
+        $response = new JsonResponse(['status' => 'ok'], Response::HTTP_OK);
+        $response->headers->setCookie($cookie);
+
+        return $response;
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportProgressPublisher.php
+++ b/apps/api/src/Import/Application/Service/ImportProgressPublisher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Import\Application\Service;
 
 use App\Import\Domain\Entity\ImportSession;
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Mercure\HubInterface;
@@ -14,10 +15,14 @@ use Throwable;
 use const JSON_THROW_ON_ERROR;
 
 /**
- * Publishes import lifecycle / progress updates to two Mercure topics
- * (spec §8.5):
- *   - `imports/{user_id}` — broadcast list view (status changes)
- *   - `imports/{session_id}` — detail (progress %, current SKU, errors)
+ * Publishes import lifecycle / progress updates to two tenant-scoped,
+ * private Mercure topics (spec §8.5; AUD-001 #1573):
+ *   - `tenant/{tid}/imports/user/{user_id}` — broadcast list view
+ *   - `tenant/{tid}/imports/{session_id}` — detail (progress %, SKU, errors)
+ *
+ * The `tenant/{tid}` prefix + `private: true` close the AUD-001
+ * cross-tenant leak: the hub only delivers a private update to a
+ * subscriber whose JWT authorises that exact tenant topic.
  *
  * Hub failures are logged but never abort the underlying write — Mercure
  * is a notification channel, not the source of truth (mirrors the
@@ -25,8 +30,6 @@ use const JSON_THROW_ON_ERROR;
  */
 final class ImportProgressPublisher
 {
-    private const string TOPIC_PREFIX = 'imports';
-
     private readonly LoggerInterface $logger;
 
     public function __construct(
@@ -74,8 +77,22 @@ final class ImportProgressPublisher
      */
     private function publish(ImportSession $session, string $type, array $payload): void
     {
-        $sessionTopic = \sprintf('%s/%s/%s', $this->topicBase, self::TOPIC_PREFIX, $session->getId()->toRfc4122());
-        $userTopic = \sprintf('%s/%s/user/%s', $this->topicBase, self::TOPIC_PREFIX, $session->getUserId()->toRfc4122());
+        $tenant = $session->getTenant();
+        if (null === $tenant) {
+            // A session is always tenant-stamped before processing; a null
+            // here means a misconfigured caller. Skipping the publish is
+            // safer than emitting an un-scoped (cross-tenant) topic.
+            $this->logger->warning('Mercure import progress publish skipped: session has no tenant', [
+                'session_id' => $session->getId()->toRfc4122(),
+                'type' => $type,
+            ]);
+
+            return;
+        }
+        $tenantId = $tenant->getId();
+
+        $sessionTopic = MercureSubscribeTopics::importSession($tenantId, $this->topicBase, $session->getId()->toRfc4122());
+        $userTopic = MercureSubscribeTopics::importUser($tenantId, $this->topicBase, $session->getUserId()->toRfc4122());
 
         $update = new Update(
             topics: [$sessionTopic, $userTopic],
@@ -84,6 +101,7 @@ final class ImportProgressPublisher
                 'session_id' => $session->getId()->toRfc4122(),
                 'data' => $payload,
             ], JSON_THROW_ON_ERROR),
+            private: true,
         );
 
         try {

--- a/apps/api/src/Shared/Infrastructure/Mercure/MercureSubscribeTopics.php
+++ b/apps/api/src/Shared/Infrastructure/Mercure/MercureSubscribeTopics.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Mercure;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-001 (#1573) — single source of truth for Mercure topic naming and
+ * for the per-tenant `mercure.subscribe` claim.
+ *
+ * Every domain topic is prefixed with `tenant/{tenantId}/` so the hub can
+ * isolate tenants: a private update on `…/tenant/A/objects` is only
+ * delivered to a subscriber whose JWT authorises that exact topic, and
+ * the authorization endpoint mints a cookie scoped to the caller's
+ * tenant alone ({@see forTenant()}).
+ *
+ * Before this class the publishers used un-prefixed topics
+ * (`{base}/objects`, `{base}/imports/{id}`, …) and the hub ran in
+ * `anonymous` mode, so any client — even one with no account — received
+ * every tenant's real-time catalog / import / export / permission
+ * events. The tenant prefix + `private: true` on every Update + a
+ * subscriber-JWT requirement on the hub together close that leak.
+ *
+ * The subscribe claim uses RFC 6570 URI templates (`{id}`) which the
+ * dunglas/mercure hub matches per path segment — `…/tenant/A/objects/{id}`
+ * authorises any single object row under tenant A but nothing outside the
+ * `tenant/A/` prefix.
+ */
+final class MercureSubscribeTopics
+{
+    public const string SEGMENT_TENANT = 'tenant';
+
+    /**
+     * Tenant-scoped prefix every topic family hangs off, e.g.
+     * `https://pim.localhost/tenant/<uuid>`.
+     */
+    public static function tenantPrefix(Uuid $tenantId, string $base): string
+    {
+        return \sprintf('%s/%s/%s', rtrim($base, '/'), self::SEGMENT_TENANT, $tenantId->toRfc4122());
+    }
+
+    public static function objectRow(Uuid $tenantId, string $base, string $objectId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/objects/'.$objectId;
+    }
+
+    public static function objectsBroadcast(Uuid $tenantId, string $base): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/objects';
+    }
+
+    public static function importSession(Uuid $tenantId, string $base, string $sessionId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/imports/'.$sessionId;
+    }
+
+    public static function importUser(Uuid $tenantId, string $base, string $userId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/imports/user/'.$userId;
+    }
+
+    public static function exportSession(Uuid $tenantId, string $base, string $sessionId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/exports/'.$sessionId;
+    }
+
+    public static function exportUser(Uuid $tenantId, string $base, string $userId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/exports/'.$userId;
+    }
+
+    public static function identityUser(Uuid $tenantId, string $base, string $userId): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/identity/user/'.$userId;
+    }
+
+    public static function identityTenant(Uuid $tenantId, string $base): string
+    {
+        return self::tenantPrefix($tenantId, $base).'/identity/tenant/'.$tenantId->toRfc4122();
+    }
+
+    /**
+     * URI-template subscribe claim for the caller's tenant — a closed set,
+     * every entry pinned to the `tenant/{tenantId}/` prefix. Used to mint
+     * the `mercureAuthorization` cookie. There is deliberately NO global
+     * (prefix-less) topic and NO other tenant's prefix in the list.
+     *
+     * @return list<string>
+     */
+    public static function forTenant(Uuid $tenantId, string $base): array
+    {
+        $prefix = self::tenantPrefix($tenantId, $base);
+
+        return [
+            // Catalog live updates (bell + row editing).
+            $prefix.'/objects',
+            $prefix.'/objects/{id}',
+            // Import progress (list + detail).
+            $prefix.'/imports/{id}',
+            $prefix.'/imports/user/{id}',
+            // Export progress (list + detail).
+            $prefix.'/exports/{id}',
+            // Permission invalidation (per-user + tenant-wide).
+            $prefix.'/identity/user/{id}',
+            $prefix.'/identity/tenant/{id}',
+        ];
+    }
+}

--- a/apps/api/tests/Api/Catalog/MercureBroadcastApiTest.php
+++ b/apps/api/tests/Api/Catalog/MercureBroadcastApiTest.php
@@ -43,11 +43,26 @@ final class MercureBroadcastApiTest extends CatalogApiTestCase
         self::assertNotEmpty($updates, 'POST /api/products must publish at least one Mercure update.');
 
         // First update is the ObjectCreated event — topic shape should
-        // include the per-row IRI + the broadcast IRI.
+        // include the per-row IRI + the broadcast IRI, both tenant-scoped
+        // and private after AUD-001 (#1573).
         $first = $updates[0];
         $topics = $first->getTopics();
-        self::assertContains('https://pim.localhost/objects/'.$newId, $topics);
-        self::assertContains('https://pim.localhost/objects', $topics);
+        self::assertTrue($first->isPrivate(), 'Catalog Mercure updates must be private (AUD-001).');
+        self::assertCount(2, $topics);
+        // Row topic: …/tenant/<uuid>/objects/<newId>; broadcast: …/objects.
+        [$rowTopic, $broadcastTopic] = $topics;
+        self::assertIsString($rowTopic);
+        self::assertIsString($broadcastTopic);
+        self::assertMatchesRegularExpression(
+            '#^https://pim\.localhost/tenant/[0-9a-f-]{36}/objects/'.preg_quote($newId, '#').'$#',
+            $rowTopic,
+        );
+        self::assertMatchesRegularExpression(
+            '#^https://pim\.localhost/tenant/[0-9a-f-]{36}/objects$#',
+            $broadcastTopic,
+        );
+        // The pre-fix global topic must be gone.
+        self::assertNotContains('https://pim.localhost/objects', $topics);
 
         $payload = json_decode($first->getData(), true);
         \assert(\is_array($payload));

--- a/apps/api/tests/Api/Identity/MercureAuthorizationControllerTest.php
+++ b/apps/api/tests/Api/Identity/MercureAuthorizationControllerTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AUD-001 (#1573) — the Mercure subscriber-authorization endpoint mints
+ * the `mercureAuthorization` cookie that the SPA presents before opening
+ * an EventSource. This is the gate that closes the cross-tenant SSE leak:
+ *
+ *   1. anonymous callers get 401 — no cookie, so the (now non-anonymous)
+ *      hub refuses every subscription;
+ *   2. an authenticated caller's cookie carries a `mercure.subscribe`
+ *      claim scoped to `tenant/{ownTenant}/…` ONLY — never the global
+ *      `objects` topic that leaked every tenant's catalog events.
+ */
+final class MercureAuthorizationControllerTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_CODE = 'demo';
+    private const string ADMIN_EMAIL = 'admin@demo.localhost';
+    private const string ADMIN_PASSWORD = 'changeme';
+
+    private string $tenantId = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+        $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        \assert(null !== $superAdmin);
+
+        $tenant = new Tenant(self::TENANT_CODE, 'Demo Tenant');
+        $em->persist($tenant);
+
+        $hasher = $this->passwordHasher();
+        $stub = new User($tenant, self::ADMIN_EMAIL, '');
+        $admin = new User($tenant, self::ADMIN_EMAIL, $hasher->hashPassword($stub, self::ADMIN_PASSWORD));
+        $admin->addRole($superAdmin);
+        $em->persist($admin);
+        $em->flush();
+
+        $this->tenantId = $tenant->getId()->toRfc4122();
+    }
+
+    #[Test]
+    public function anonymousCallReturns401(): void
+    {
+        static::createClient()->request('POST', '/api/mercure/authorization');
+        self::assertResponseStatusCodeSame(401);
+    }
+
+    #[Test]
+    public function authenticatedCallMintsTenantScopedSubscribeCookie(): void
+    {
+        $client = static::createClient();
+        $token = $this->loginAndExtractToken();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$token]]);
+
+        $response = $client->request('POST', '/api/mercure/authorization');
+        self::assertResponseIsSuccessful();
+
+        $setCookie = $response->getHeaders()['set-cookie'] ?? [];
+        $authCookie = null;
+        foreach ($setCookie as $line) {
+            if (str_starts_with($line, 'mercureAuthorization=')) {
+                $authCookie = $line;
+                break;
+            }
+        }
+        self::assertNotNull($authCookie, 'Endpoint must emit a mercureAuthorization cookie.');
+
+        $subscribe = $this->decodeSubscribeClaim($authCookie);
+        self::assertNotEmpty($subscribe, 'JWT must carry a non-empty mercure.subscribe claim.');
+
+        $prefix = 'https://pim.localhost/tenant/'.$this->tenantId.'/';
+        foreach ($subscribe as $topic) {
+            self::assertStringStartsWith(
+                $prefix,
+                $topic,
+                \sprintf('Subscribe topic "%s" escapes the caller tenant scope.', $topic),
+            );
+        }
+
+        // The exact globals that leaked before the fix must be absent.
+        self::assertNotContains('https://pim.localhost/objects', $subscribe);
+        self::assertNotContains('/objects', $subscribe);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function decodeSubscribeClaim(string $setCookieLine): array
+    {
+        // mercureAuthorization=<jwt>; path=...; ...
+        $value = substr($setCookieLine, \strlen('mercureAuthorization='));
+        $jwt = explode(';', $value, 2)[0];
+        $parts = explode('.', $jwt);
+        self::assertCount(3, $parts, 'Cookie value must be a JWT.');
+
+        $payload = json_decode($this->base64UrlDecode($parts[1]), true);
+        \assert(\is_array($payload));
+        $mercure = $payload['mercure'] ?? [];
+        \assert(\is_array($mercure));
+        $subscribe = $mercure['subscribe'] ?? [];
+        \assert(\is_array($subscribe));
+
+        $list = [];
+        foreach ($subscribe as $topic) {
+            \assert(\is_string($topic));
+            $list[] = $topic;
+        }
+
+        return $list;
+    }
+
+    private function base64UrlDecode(string $data): string
+    {
+        $decoded = base64_decode(strtr($data, '-_', '+/'), true);
+        \assert(false !== $decoded);
+
+        return $decoded;
+    }
+
+    private function loginAndExtractToken(): string
+    {
+        $response = static::createClient()->request('POST', '/api/auth/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(
+                ['email' => self::ADMIN_EMAIL, 'password' => self::ADMIN_PASSWORD],
+                JSON_THROW_ON_ERROR,
+            ),
+        ]);
+
+        $token = $response->toArray()['token'] ?? null;
+        \assert(\is_string($token));
+
+        return $token;
+    }
+
+    private function passwordHasher(): UserPasswordHasherInterface
+    {
+        return self::getContainer()->get(UserPasswordHasherInterface::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/MercurePublisherTest.php
+++ b/apps/api/tests/Unit/Catalog/MercurePublisherTest.php
@@ -17,13 +17,21 @@ use Symfony\Component\Mercure\Update;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * Unit coverage for MercurePublisher topic + payload contract (#47 / 0.4.7).
+ * Unit coverage for MercurePublisher topic + payload contract (#47 / 0.4.7;
+ * tenant-scoped + private after AUD-001 / #1573).
  *
- * Publisher emits domain events on two topics:
- *   - row-specific `<base>/objects/<id>` so an admin editing a single
- *     row subscribes once and gets every change to that row;
- *   - broadcast `<base>/objects` so a list view picks up creations /
- *     deletions across the whole catalog with one connection.
+ * Publisher emits domain events on two **tenant-scoped, private** topics:
+ *   - row-specific `<base>/tenant/<tid>/objects/<id>` so an admin editing
+ *     a single row subscribes once and gets every change to that row;
+ *   - broadcast `<base>/tenant/<tid>/objects` so a list view picks up
+ *     creations / deletions across the tenant's catalog with one
+ *     connection.
+ *
+ * The `tenant/<tid>` prefix + `private: true` together close the
+ * cross-tenant SSE leak (AUD-001): the hub only delivers a private
+ * update to subscribers whose JWT `mercure.subscribe` claim authorises
+ * the exact topic, and the mint endpoint scopes that claim to the
+ * caller's tenant alone.
  *
  * Payload shape: `{type, occurredOn, data}` — `type` is the per-event
  * dot-cased name (kind-aware for create), `data` is a small dict the
@@ -31,6 +39,8 @@ use Symfony\Component\Uid\Uuid;
  */
 final class MercurePublisherTest extends TestCase
 {
+    private const string TENANT_ID = '019ddb19-1111-7000-8000-aaaaaaaaaaaa';
+
     /**
      * @var list<Update>
      */
@@ -44,7 +54,7 @@ final class MercurePublisherTest extends TestCase
             objectId: Uuid::fromString('019ddb19-a0f7-750a-a9cb-a6a6447ccb26'),
             kind: ObjectKind::Product,
             code: 'SKU-1',
-            tenantId: Uuid::v7(),
+            tenantId: Uuid::fromString(self::TENANT_ID),
         );
 
         $publisher->onObjectCreated($event);
@@ -52,9 +62,10 @@ final class MercurePublisherTest extends TestCase
         self::assertCount(1, $this->captured);
         $update = $this->captured[0];
         self::assertSame([
-            'https://pim.localhost/objects/019ddb19-a0f7-750a-a9cb-a6a6447ccb26',
-            'https://pim.localhost/objects',
+            'https://pim.localhost/tenant/'.self::TENANT_ID.'/objects/019ddb19-a0f7-750a-a9cb-a6a6447ccb26',
+            'https://pim.localhost/tenant/'.self::TENANT_ID.'/objects',
         ], $update->getTopics());
+        self::assertTrue($update->isPrivate(), 'Catalog updates must be private so the hub enforces the subscribe claim.');
 
         $payload = json_decode($update->getData(), true);
         \assert(\is_array($payload));
@@ -79,6 +90,7 @@ final class MercurePublisherTest extends TestCase
         $publisher->onObjectAttributesChanged($event);
 
         self::assertCount(1, $this->captured);
+        self::assertTrue($this->captured[0]->isPrivate());
         $payload = json_decode($this->captured[0]->getData(), true);
         \assert(\is_array($payload));
         self::assertSame('object.attributes_changed', $payload['type'] ?? null);
@@ -109,15 +121,16 @@ final class MercurePublisherTest extends TestCase
     }
 
     #[Test]
-    public function topicForKindHelperBuildsKindFilteredTopic(): void
+    public function topicForKindHelperBuildsTenantScopedKindFilteredTopic(): void
     {
+        $tenant = Uuid::fromString(self::TENANT_ID);
         self::assertSame(
-            'https://pim.localhost/objects/kind/product',
-            MercurePublisher::topicForKind(ObjectKind::Product),
+            'https://pim.localhost/tenant/'.self::TENANT_ID.'/objects/kind/product',
+            MercurePublisher::topicForKind(ObjectKind::Product, $tenant),
         );
         self::assertSame(
-            'https://pim.example.com/objects/kind/category',
-            MercurePublisher::topicForKind(ObjectKind::Category, 'https://pim.example.com'),
+            'https://pim.example.com/tenant/'.self::TENANT_ID.'/objects/kind/category',
+            MercurePublisher::topicForKind(ObjectKind::Category, $tenant, 'https://pim.example.com'),
         );
     }
 

--- a/apps/api/tests/Unit/Shared/Mercure/MercureSubscribeTopicsTest.php
+++ b/apps/api/tests/Unit/Shared/Mercure/MercureSubscribeTopicsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Mercure;
+
+use App\Shared\Infrastructure\Mercure\MercureSubscribeTopics;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-001 (#1573) — the subscribe-claim builder is the single chokepoint
+ * that decides which Mercure topics a logged-in caller may listen on.
+ *
+ * The regression this pins: before the fix every caller (even anonymous)
+ * could subscribe to the GLOBAL `objects` / `imports` / `exports` /
+ * `identity` topics, so tenant A received tenant B's real-time events.
+ *
+ * The contract now: the claim is a closed set of URI templates, every
+ * one prefixed with `tenant/{thisTenant}/…`. There must be NO global
+ * (prefix-less) topic and NO other tenant's prefix in the list — that is
+ * what stops the hub from delivering a private cross-tenant update.
+ */
+final class MercureSubscribeTopicsTest extends TestCase
+{
+    private const string BASE = 'https://pim.localhost';
+    private const string TENANT_A = '019ddb19-1111-7000-8000-aaaaaaaaaaaa';
+    private const string TENANT_B = '019ddb19-2222-7000-8000-bbbbbbbbbbbb';
+
+    #[Test]
+    public function everyTopicIsScopedToTheGivenTenantPrefix(): void
+    {
+        $topics = MercureSubscribeTopics::forTenant(Uuid::fromString(self::TENANT_A), self::BASE);
+
+        self::assertNotEmpty($topics);
+        $prefix = self::BASE.'/tenant/'.self::TENANT_A.'/';
+        foreach ($topics as $topic) {
+            self::assertStringStartsWith(
+                $prefix,
+                $topic,
+                \sprintf('Subscribe topic "%s" escapes the tenant scope %s', $topic, $prefix),
+            );
+        }
+    }
+
+    #[Test]
+    public function claimContainsNoGlobalPrefixlessTopic(): void
+    {
+        $topics = MercureSubscribeTopics::forTenant(Uuid::fromString(self::TENANT_A), self::BASE);
+
+        // The exact strings that leaked before the fix.
+        $leakedGlobals = [
+            self::BASE.'/objects',
+            '/objects',
+            self::BASE.'/imports/{id}',
+            self::BASE.'/exports/{id}',
+            self::BASE.'/identity/user/{id}',
+        ];
+        foreach ($leakedGlobals as $global) {
+            self::assertNotContains(
+                $global,
+                $topics,
+                \sprintf('Global topic "%s" must never be in a tenant subscribe claim.', $global),
+            );
+        }
+    }
+
+    #[Test]
+    public function tenantAClaimDoesNotAuthoriseTenantBTopics(): void
+    {
+        $topics = MercureSubscribeTopics::forTenant(Uuid::fromString(self::TENANT_A), self::BASE);
+
+        $otherPrefix = self::BASE.'/tenant/'.self::TENANT_B.'/';
+        foreach ($topics as $topic) {
+            self::assertFalse(
+                str_starts_with($topic, $otherPrefix),
+                'Tenant A must not be granted any tenant B topic.',
+            );
+        }
+    }
+
+    #[Test]
+    public function claimCoversObjectsImportsExportsAndIdentityFamilies(): void
+    {
+        $topics = MercureSubscribeTopics::forTenant(Uuid::fromString(self::TENANT_A), self::BASE);
+        $joined = implode("\n", $topics);
+
+        // Each live SSE consumer family must be reachable for the tenant.
+        self::assertStringContainsString('/objects', $joined);
+        self::assertStringContainsString('/imports', $joined);
+        self::assertStringContainsString('/exports', $joined);
+        self::assertStringContainsString('/identity', $joined);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -369,9 +369,13 @@ services:
       SERVER_NAME: ":80"
       MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET:-!ChangeMercureKeyAtLeast256BitsLong!}
       MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET:-!ChangeMercureKeyAtLeast256BitsLong!}
+      # AUD-001 (#1573) — NO `anonymous` directive: every subscription must
+      # present a `mercureAuthorization` cookie (minted by
+      # POST /api/mercure/authorization, scoped to the caller's tenant
+      # topics). Without it the hub answers 401. Re-adding `anonymous`
+      # re-opens the cross-tenant SSE leak.
       MERCURE_EXTRA_DIRECTIVES: |
         cors_origins https://pim.localhost https://localhost
-        anonymous
     expose:
       - "80"
     volumes:


### PR DESCRIPTION
## AUD-001 (CRITICAL, confirmed) — Mercure cross-tenant SSE leak
Hub `anonymous`, eventy bez `private`, topiki bez prefiksu tenanta → anonimowy klient odbierał real-time eventy WSZYSTKICH tenantów (potwierdzone: anonim curl → `object.enabled_changed` demo). Bell (`use-notifications`) słuchał gołego `/objects` — najszerszy wektor.

## Fix (pełny zakres)
- `docker-compose.yml`: usunięty `anonymous` (wymóg subscriber-JWT).
- 4 publishery (Catalog/Import/Export/PermissionInvalidation): `private:true` + topiki `tenant/{tenantId}/...` (jedno źródło `MercureSubscribeTopics`).
- `POST /api/mercure/authorization` (JWT): mintuje cookie `mercureAuthorization` z claim subscribe ograniczonym do topików tenanta usera.
- FE: 4 EventSource consumery mintują cookie przed połączeniem + tenant-scope topic.

## Test (failing → green) — 12/63
anon→401, cookie zawiera wyłącznie topiki własnego tenanta, cross-tenant non-delivery, publisher tenant-scope+private.

## Smoke (CLOSED MEANS CLOSED)
- **PRZED:** anonim `curl /.well-known/mercure?topic=.../objects` → HTTP/2 200 event-stream (leak).
- **PO** (`docker compose up -d mercure` + restart api): anonim → **401**; cookie tenanta A + event A → dostarczony; cookie A + event B → **NIE dostarczony**; FE import progress dochodzi.

Gates: PHPStan max + Biome + tsc + cs-fixer. (Preexisting 5 `ImportPauseResume`/`Async` failures = lokalny `pim_test` half-state, zweryfikowane origin/main identyczne — nie z tego PR.)

Closes #1573
