### PR TITLE
fix(catalog): enforce attribute-level permissions on read/PATCH/export — AUD-008 (#1578)

### DIFF
--- a/apps/api/src/Catalog/Application/AttributeReadRestrictionOverlay.php
+++ b/apps/api/src/Catalog/Application/AttributeReadRestrictionOverlay.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Identity\Contracts\Policy\AttributePermissionReader;
+use App\Shared\Domain\Tenant;
+
+/**
+ * AUD-008 (#1578) — read-side enforcement of the 3-state per-attribute
+ * permissions (PRD §3.5) on the catalog item/collection GET providers.
+ *
+ * `attributesIndexed` is keyed by attribute code, but the policy contract
+ * ({@see AttributePermissionReader}) answers per attribute UUID. We resolve
+ * the tenant's attribute catalogue once (one query via
+ * {@see AttributeRepositoryInterface::findAllByTenant()}), map code → id,
+ * and drop every key whose resolved permission is `Restricted`
+ * (`canViewAttribute` === false) for the current user.
+ *
+ * Codes with no matching Attribute row — the system attributes injected by
+ * {@see SystemAttributeReadOverlay} (`created_at`, `updated_at`, `created_by`,
+ * `updated_by`) and any stale/removed code — are NOT attribute-permission
+ * subjects, so they pass through untouched. Run this overlay AFTER the
+ * system overlay so those keys are present and preserved.
+ *
+ * Mutation happens on a clone through the side-effect-free
+ * {@see CatalogObject::overlayAttributesIndexedForRead()} — same
+ * non-persisting contract the locale/channel and system overlays rely on,
+ * so it is safe inside a GET provider.
+ *
+ * Perf (#1620): the collection providers call {@see applyBatch()} so the
+ * tenant attribute catalogue ({@see AttributeRepositoryInterface::findAllByTenant()})
+ * is resolved ONCE for the whole page and each attribute's view decision is
+ * memoised across items — instead of one `findAllByTenant` + one
+ * `canViewAttribute` per attribute *per item* (N+1 → 10s timeout on
+ * `?itemsPerPage=200`). The memo is a local variable scoped to a single
+ * call, so nothing leaks between requests under FrankenPHP worker mode —
+ * the service stays `readonly` and stateless.
+ */
+final readonly class AttributeReadRestrictionOverlay
+{
+    public function __construct(
+        private AttributeRepositoryInterface $attributes,
+        private AttributePermissionReader $permissions,
+    ) {
+    }
+
+    public function apply(CatalogObject $object): CatalogObject
+    {
+        $idByCodeByTenant = [];
+        $canView = [];
+
+        return $this->applyOne($object, $idByCodeByTenant, $canView);
+    }
+
+    /**
+     * Batch variant for the collection providers. Resolves the per-tenant
+     * `code => id` catalogue once per distinct tenant in the page and reuses
+     * one `canViewAttribute` decision per attribute id across every item.
+     *
+     * @param list<CatalogObject> $objects
+     *
+     * @return list<CatalogObject>
+     */
+    public function applyBatch(array $objects): array
+    {
+        // Shared within this call only — keyed by tenant id for the (rare)
+        // mixed-tenant page, never persisted on the (shared) service.
+        $idByCodeByTenant = [];
+        // attribute id (RFC4122) => can the current principal view it.
+        $canView = [];
+
+        $out = [];
+        foreach ($objects as $object) {
+            $out[] = $this->applyOne($object, $idByCodeByTenant, $canView);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, array<string, \Symfony\Component\Uid\Uuid>> $idByCodeByTenant tenant id => (code => id)
+     * @param array<string, bool>                                       $canView          attribute id => view decision
+     */
+    private function applyOne(CatalogObject $object, array &$idByCodeByTenant, array &$canView): CatalogObject
+    {
+        $tenant = $object->getTenant();
+        if (!$tenant instanceof Tenant) {
+            return $object;
+        }
+
+        $indexed = $object->getAttributesIndexed();
+        if ([] === $indexed) {
+            return $object;
+        }
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        $idByCode = $idByCodeByTenant[$tenantId] ??= $this->idByCode($tenant);
+
+        $filtered = [];
+        foreach ($indexed as $code => $value) {
+            $attributeId = $idByCode[$code] ?? null;
+            // Unknown code = not an attribute-permission subject (system
+            // attribute / stale profile) → keep it.
+            if (null === $attributeId) {
+                $filtered[$code] = $value;
+
+                continue;
+            }
+
+            $key = $attributeId->toRfc4122();
+            $visible = $canView[$key] ??= $this->permissions->canViewAttribute($attributeId);
+            if ($visible) {
+                $filtered[$code] = $value;
+            }
+        }
+
+        if (\count($filtered) === \count($indexed)) {
+            // Nothing dropped — avoid the clone + index overlay entirely.
+            return $object;
+        }
+
+        $copy = clone $object;
+        $copy->overlayAttributesIndexedForRead($filtered);
+
+        return $copy;
+    }
+
+    /**
+     * @return array<string, \Symfony\Component\Uid\Uuid> attribute code => id
+     */
+    private function idByCode(Tenant $tenant): array
+    {
+        $map = [];
+        foreach ($this->attributes->findAllByTenant($tenant) as $attribute) {
+            $map[$attribute->getCode()] = $attribute->getId();
+        }
+
+        return $map;
+    }
+}

--- a/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
+++ b/apps/api/src/Catalog/Application/ObjectAttributesUpserter.php
@@ -10,7 +10,9 @@ use App\Catalog\Domain\Entity\ObjectValue;
 use App\Catalog\Domain\Provenance;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
+use App\Identity\Contracts\Policy\AttributePermissionReader;
 use App\Shared\Domain\Tenant;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Uid\Uuid;
@@ -36,6 +38,7 @@ final readonly class ObjectAttributesUpserter
         private AttributeRepositoryInterface $attributes,
         private ObjectValueRepositoryInterface $values,
         private ValueWriteCore $core,
+        private AttributePermissionReader $attributePermissions,
     ) {
     }
 
@@ -70,6 +73,19 @@ final readonly class ObjectAttributesUpserter
             $attribute = $this->attributes->findByCode($code, $tenant);
             if (!$attribute instanceof Attribute) {
                 continue;
+            }
+
+            // AUD-008 (#1578) — enforce the 3-state per-attribute permission
+            // on the write path (PRD §3.5). A caller with `view`/`restricted`
+            // on this attribute must not be able to mutate it. Only enforced
+            // when a domain user is present — CLI backfills / system jobs
+            // carry no token and write under their own authority.
+            if ($this->attributePermissions->isAttributePermissionEnforced()
+                && !$this->attributePermissions->canEditAttribute($attribute->getId())) {
+                throw new AccessDeniedHttpException(\sprintf(
+                    'You do not have permission to edit attribute "%s".',
+                    $code,
+                ));
             }
 
             [$targetLocale, $targetChannel] = $this->core->routeScope($attribute, $tenant, $locale, $channelId);

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Pagination\PaginatorInterface;
 use ApiPlatform\State\Pagination\TraversablePaginator;
 use ApiPlatform\State\ProviderInterface;
+use App\Catalog\Application\AttributeReadRestrictionOverlay;
 use App\Catalog\Application\ObjectValueLocaleOverlay;
 use App\Catalog\Application\SystemAttributeReadOverlay;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -46,6 +47,7 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         private ObjectValueRepositoryInterface $objectValues,
         private RequestStack $requestStack,
         private ChannelPublicationResolverInterface $publicationResolver,
+        private AttributeReadRestrictionOverlay $restrictionOverlay,
     ) {
     }
 
@@ -86,13 +88,19 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         }
 
         // Always apply system overlay so created_at/updated_at render.
-        // When no locale/channel scope and no publication filter, skip overlay.
+        // When no locale/channel scope and no publication filter, skip the
+        // value/publication overlays but still run system + restriction on
+        // clones (AUD-008 #1578: restricted attributes must not leak through
+        // the list path either).
         if (null === $locale && null === $channel && null === $publication) {
-            foreach ($objects as $object) {
-                $this->systemOverlay->apply($object);
-            }
+            $overlaid = $this->restrictionOverlay->applyBatch(
+                array_map(
+                    fn (CatalogObject $o): CatalogObject => $this->systemOverlay->apply($o),
+                    $objects,
+                ),
+            );
 
-            return $result; // @phpstan-ignore-line (inner provider return type is wider)
+            return $this->rebuildResult($result, $overlaid);
         }
 
         // Batch-load all ObjectValue rows for the current page in one query.
@@ -113,20 +121,31 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
             $overlaid = $this->applyPublicationFilter($overlaid, $publication);
         }
 
-        // Apply system overlay on the (already cloned) overlaid objects.
-        $overlaid = array_map(
-            fn (CatalogObject $o): CatalogObject => $this->systemOverlay->apply($o),
-            $overlaid,
+        // Apply system overlay then strip restricted attributes (AUD-008
+        // #1578) on the (already cloned) overlaid objects. Restriction runs
+        // as one batch so the tenant attribute catalogue + per-attribute
+        // view decisions are resolved once for the page, not per item (#1620).
+        $overlaid = $this->restrictionOverlay->applyBatch(
+            array_map(
+                fn (CatalogObject $o): CatalogObject => $this->systemOverlay->apply($o),
+                $overlaid,
+            ),
         );
 
-        // Re-build the result preserving the paginator wrapper when present.
-        if (\is_array($result)) {
-            return $overlaid;
-        }
+        return $this->rebuildResult($result, $overlaid);
+    }
 
-        // For AP4 paginator results, wrap the overlaid items in a
-        // TraversablePaginator so the serializer still gets correct
-        // total-count / current-page metadata from the original paginator.
+    /**
+     * Re-build the collection result preserving the paginator wrapper when
+     * present, so the serializer still gets the correct total-count /
+     * current-page metadata from the original paginator.
+     *
+     * @param list<CatalogObject> $overlaid
+     *
+     * @return iterable<CatalogObject>
+     */
+    private function rebuildResult(mixed $result, array $overlaid): iterable
+    {
         if ($result instanceof PaginatorInterface) {
             return new TraversablePaginator(
                 new ArrayIterator($overlaid),

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
@@ -6,6 +6,7 @@ namespace App\Catalog\Infrastructure\ApiPlatform\State;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use App\Catalog\Application\AttributeReadRestrictionOverlay;
 use App\Catalog\Application\ObjectValueLocaleOverlay;
 use App\Catalog\Application\SystemAttributeReadOverlay;
 use App\Catalog\Domain\Entity\CatalogObject;
@@ -40,6 +41,7 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
         private SystemAttributeReadOverlay $systemOverlay,
         private RequestStack $requestStack,
         private ChannelPublicationResolverInterface $publicationResolver,
+        private AttributeReadRestrictionOverlay $restrictionOverlay,
     ) {
     }
 
@@ -72,7 +74,13 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
 
         // #1207 — always surface the system attributes (created_at/updated_at +
         // created_by/updated_by) so they render real values instead of "—".
-        return $this->systemOverlay->apply($object);
+        $object = $this->systemOverlay->apply($object);
+
+        // AUD-008 (#1578) — strip attributes the caller may not view
+        // (3-state per-attribute permission, PRD §3.5). Runs last so the
+        // system attributes injected above are present (and preserved —
+        // they are not attribute-permission subjects).
+        return $this->restrictionOverlay->apply($object);
     }
 
     private function applyPublicationFilter(CatalogObject $object, string $channelCode): CatalogObject

--- a/apps/api/src/Export/Application/Builder/ExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/ExportBuilder.php
@@ -52,6 +52,7 @@ final class ExportBuilder
         private readonly ChannelResolverInterface $channels,
         private readonly \App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface $relations,
         private readonly \App\Catalog\Domain\Repository\AttributeRepositoryInterface $attributes,
+        private readonly \App\Identity\Contracts\Policy\AttributePermissionReader $attributePermissions,
     ) {
     }
 
@@ -197,10 +198,32 @@ final class ExportBuilder
             return $this->builtIn($object, $column->code);
         }
 
+        $attribute = $attributeMap[$column->code] ?? null;
+
+        // AUD-008 (#1578): never export an attribute the caller may not view
+        // (3-state per-attribute permission, PRD §3.5). Emit a blank cell —
+        // same shape as a stale/missing column — so the row stays well-formed
+        // without leaking the value. Built-in columns above are not
+        // attribute-permission subjects. Unknown codes (no resolved
+        // Attribute) fall through to the existing blank-cell handling.
+        //
+        // Only enforced when a domain user is present. The sync runner
+        // (EXP-05) and async handler (EXP-06) reach this from system contexts
+        // that carry no security token — the same way the write path
+        // ({@see \App\Catalog\Application\ObjectAttributesUpserter}) gates on
+        // isAttributePermissionEnforced(). Without that guard the
+        // anonymous-→-restricted default of canViewAttribute() would blank
+        // every attribute cell of a legitimate export (CustomModuleExport,
+        // GoldenRoundTrip).
+        if ($attribute instanceof Attribute
+            && $this->attributePermissions->isAttributePermissionEnforced()
+            && !$this->attributePermissions->canViewAttribute($attribute->getId())) {
+            return '';
+        }
+
         // IMP2-1.8 (D5): Relation/Reference columns emit pipe-joined target
         // CODES read from object_relations (symmetry with the import, which
         // writes relations there — not as ObjectValue).
-        $attribute = $attributeMap[$column->code] ?? null;
         if ($attribute instanceof Attribute
             && (AttributeType::Relation === $attribute->getType() || AttributeType::Reference === $attribute->getType())) {
             $codes = [];

--- a/apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php
+++ b/apps/api/src/Identity/Application/Policy/AttributePermissionPolicy.php
@@ -8,9 +8,6 @@ use App\Identity\Application\PermissionResolverInterface;
 use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Rbac\AttributePermission;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception\DatabaseObjectNotFoundException;
-use Doctrine\DBAL\Exception\InvalidFieldNameException;
-use Doctrine\DBAL\Exception\TableNotFoundException;
 use Symfony\Component\Uid\Uuid;
 
 /**
@@ -61,11 +58,25 @@ use Symfony\Component\Uid\Uuid;
  * 3-state values — the serializer composes them with the integration
  * flag for the final response shape.
  */
-readonly class AttributePermissionPolicy
+class AttributePermissionPolicy
 {
+    /**
+     * Memoised schema-existence probes (#1620). The `information_schema`
+     * introspection in {@see tableExists()} / {@see columnExists()} is the
+     * same for every attribute and role in a request — and the schema is
+     * stable for a worker's whole lifetime — yet it ran once per role per
+     * attribute, which on a 200-item collection page (resolved one attribute
+     * id at a time by the read overlay) dominated the GET latency. Caching
+     * the boolean result removes that cost without changing any permission
+     * decision; the SELECTs that read actual grant rows are NOT cached.
+     *
+     * @var array<string, bool>
+     */
+    private array $schemaProbeCache = [];
+
     public function __construct(
-        private Connection $connection,
-        private PermissionResolverInterface $resolver,
+        private readonly Connection $connection,
+        private readonly PermissionResolverInterface $resolver,
     ) {
     }
 
@@ -155,7 +166,15 @@ readonly class AttributePermissionPolicy
         //    via `doctrine:schema:create` from entities never get the
         //    table (no entity exists for it). Treat a missing table as
         //    "no per-group override" — same outcome as an empty row set.
-        try {
+        //
+        //    AUD-008 (#1578): probe the schema with the SchemaManager
+        //    (reads information_schema) BEFORE issuing the SELECT. A failing
+        //    SELECT inside an open transaction aborts the whole transaction
+        //    in PostgreSQL (SQLSTATE 25P02) even when the PHP exception is
+        //    caught — and this resolver now runs inside the write path's
+        //    transaction (ObjectAttributesUpserter). Probing first never
+        //    dirties the transaction.
+        if ($this->tableExists('role_attribute_group_permissions')) {
             $perGroup = $this->connection->fetchOne(
                 <<<'SQL'
                     SELECT rgp.permission_level
@@ -175,8 +194,6 @@ readonly class AttributePermissionPolicy
             if (false !== $perGroup && \is_string($perGroup)) {
                 return AttributePermission::from($perGroup);
             }
-        } catch (TableNotFoundException|InvalidFieldNameException|DatabaseObjectNotFoundException) {
-            // schema not migrated yet — drop through to role default
         }
 
         // 3. Role default — column defaults to 'edit' for tenant-level
@@ -184,8 +201,9 @@ readonly class AttributePermissionPolicy
         //    Same compatibility note: `roles.default_attribute_permission`
         //    only exists when the original migration ran; otherwise we
         //    infer from `roles.code` to preserve the migration's intent
-        //    (viewer → View, everyone else → Edit).
-        try {
+        //    (viewer → View, everyone else → Edit). Probe the column the
+        //    same transaction-safe way as the group table above.
+        if ($this->columnExists('roles', 'default_attribute_permission')) {
             $default = $this->connection->fetchOne(
                 'SELECT default_attribute_permission FROM roles WHERE id = :role_id',
                 ['role_id' => $roleId],
@@ -193,8 +211,6 @@ readonly class AttributePermissionPolicy
             if (false !== $default && \is_string($default)) {
                 return AttributePermission::from($default);
             }
-        } catch (InvalidFieldNameException|DatabaseObjectNotFoundException) {
-            return $this->inferDefaultFromRoleCode($roleId);
         }
 
         return $this->inferDefaultFromRoleCode($roleId);
@@ -217,5 +233,41 @@ readonly class AttributePermissionPolicy
         }
 
         return 'viewer' === $code ? AttributePermission::View : AttributePermission::Edit;
+    }
+
+    /**
+     * Transaction-safe existence probe. Reads `information_schema` via the
+     * SchemaManager instead of issuing a SELECT that would abort an open
+     * transaction (SQLSTATE 25P02) when the table is absent on a DB built
+     * from ORM metadata rather than migrations.
+     *
+     * @param non-empty-string $table
+     */
+    private function tableExists(string $table): bool
+    {
+        return $this->schemaProbeCache['table:'.$table] ??= $this->connection
+            ->createSchemaManager()
+            ->tablesExist([$table]);
+    }
+
+    /**
+     * @param non-empty-string $table
+     */
+    private function columnExists(string $table, string $column): bool
+    {
+        return $this->schemaProbeCache['column:'.$table.'.'.$column] ??= $this->probeColumn($table, $column);
+    }
+
+    /**
+     * @param non-empty-string $table
+     */
+    private function probeColumn(string $table, string $column): bool
+    {
+        $schemaManager = $this->connection->createSchemaManager();
+        if (!$schemaManager->tablesExist([$table])) {
+            return false;
+        }
+
+        return $schemaManager->introspectTableByUnquotedName($table)->hasColumn($column);
     }
 }

--- a/apps/api/src/Identity/Application/Policy/SecurityAttributePermissionReader.php
+++ b/apps/api/src/Identity/Application/Policy/SecurityAttributePermissionReader.php
@@ -46,6 +46,11 @@ final readonly class SecurityAttributePermissionReader implements AttributePermi
         return $this->policy->canEditAttribute($user, $attributeId);
     }
 
+    public function isAttributePermissionEnforced(): bool
+    {
+        return null !== $this->currentUser();
+    }
+
     private function currentUser(): ?User
     {
         $user = $this->security->getUser();

--- a/apps/api/src/Identity/Contracts/Policy/AttributePermissionReader.php
+++ b/apps/api/src/Identity/Contracts/Policy/AttributePermissionReader.php
@@ -30,4 +30,18 @@ interface AttributePermissionReader
     public function canViewAttribute(Uuid $attributeId): bool;
 
     public function canEditAttribute(Uuid $attributeId): bool;
+
+    /**
+     * AUD-008 (#1578) — whether per-attribute permissions apply to the
+     * current principal at all.
+     *
+     * Write paths ({@see \App\Catalog\Application\ObjectAttributesUpserter})
+     * are also reachable from system contexts with no security token — CLI
+     * backfills, fixtures, async system jobs. Those carry no domain user, so
+     * there is no per-attribute grant to enforce and they must NOT be blocked
+     * by the anonymous-→-restricted default that {@see canEditAttribute()}
+     * returns. This predicate is `true` only when the current principal is a
+     * domain {@see \App\Identity\Domain\Entity\User} the policy can resolve.
+     */
+    public function isAttributePermissionEnforced(): bool;
 }

--- a/apps/api/tests/Api/Catalog/CatalogObjectAttributePermissionApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogObjectAttributePermissionApiTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Identity\Domain\Entity\RoleAttributePermission;
+use App\Identity\Domain\Repository\RoleAttributePermissionRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Uuid;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AUD-008 (#1578) — 3-state attribute permissions MUST be enforced on the
+ * DATA path, not only in the form/list schema (PRD §3.5).
+ *
+ * Scenario: the caller clears the broad gate (`products.view`/`.edit`) but
+ * carries a per-attribute `restricted` (or `view`) grant on a sensitive
+ * attribute (e.g. purchase price). It must NOT be able to
+ *   (a) read the value through `GET /api/products/{id}`,
+ *   (b) modify it through PATCH (→ 403),
+ * while attributes it CAN see/edit keep working unchanged.
+ *
+ * The grant is attached to EVERY role the test admin carries. The policy
+ * resolves a user's attribute permission as the most-permissive across all
+ * roles (PRD §3.5), so a single-role override would be masked by another
+ * role's default (`super_admin` defaults every attribute to `edit`).
+ * Restricting on all roles makes the override the effective permission while
+ * leaving the broad PRD §3.2 gate intact — so any 403/omission is the
+ * per-attribute policy doing its job, not the endpoint guard.
+ */
+final class CatalogObjectAttributePermissionApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function getOmitsAttributeWhenCallerHasRestrictedGrant(): void
+    {
+        $this->seedAttribute('purchase_price', AttributeType::Number);
+        $this->seedAttribute('color', AttributeType::Text);
+
+        $client = $this->authenticatedClient();
+        $id = $this->createProduct($client, 'AUD008-GET', [
+            'purchase_price' => 19.99,
+            'color' => 'red',
+        ]);
+
+        $this->grantAttributePermission('purchase_price', RoleAttributePermission::LEVEL_RESTRICTED);
+
+        $body = $client->request('GET', '/api/products/'.$id)->toArray();
+        $cache = $body['attributesIndexed'] ?? [];
+        \assert(\is_array($cache));
+
+        self::assertArrayNotHasKey(
+            'purchase_price',
+            $cache,
+            'restricted attribute must be removed from the GET response (PRD §3.5)',
+        );
+        // The visible attribute is untouched.
+        self::assertSame(['value' => 'red'], $cache['color'] ?? null);
+    }
+
+    #[Test]
+    public function getKeepsAttributeWhenCallerHasViewGrant(): void
+    {
+        $this->seedAttribute('purchase_price', AttributeType::Number);
+
+        $client = $this->authenticatedClient();
+        $id = $this->createProduct($client, 'AUD008-VIEW', ['purchase_price' => 42.5]);
+
+        // `view` grant: still readable, just not editable.
+        $this->grantAttributePermission('purchase_price', RoleAttributePermission::LEVEL_VIEW);
+
+        $body = $client->request('GET', '/api/products/'.$id)->toArray();
+        $cache = $body['attributesIndexed'] ?? [];
+        \assert(\is_array($cache));
+
+        self::assertSame(['value' => 42.5], $cache['purchase_price'] ?? null);
+    }
+
+    #[Test]
+    public function patchRejectsEditOfAttributeWhenCallerHasViewGrant(): void
+    {
+        $this->seedAttribute('purchase_price', AttributeType::Number);
+        $this->seedAttribute('color', AttributeType::Text);
+
+        $client = $this->authenticatedClient();
+        $id = $this->createProduct($client, 'AUD008-PATCH', [
+            'purchase_price' => 10.5,
+            'color' => 'red',
+        ]);
+
+        // `view`: read-only — editing must be rejected with 403.
+        $this->grantAttributePermission('purchase_price', RoleAttributePermission::LEVEL_VIEW);
+
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode([
+                'attributes' => ['purchase_price' => 999.0],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(
+            Response::HTTP_FORBIDDEN,
+            'editing a view-only attribute must be forbidden (PRD §3.5)',
+        );
+
+        // The write never landed. Read the canonical value back via a fresh
+        // request with the grant lifted so the read itself is not masked.
+        $this->liftAttributePermission('purchase_price');
+        $body = $this->authenticatedClient()->request('GET', '/api/products/'.$id)->toArray();
+        $cache = $body['attributesIndexed'] ?? [];
+        \assert(\is_array($cache));
+        self::assertSame(['value' => 10.5], $cache['purchase_price'] ?? null);
+    }
+
+    #[Test]
+    public function patchAllowsEditOfAttributeStillEditable(): void
+    {
+        $this->seedAttribute('purchase_price', AttributeType::Number);
+        $this->seedAttribute('color', AttributeType::Text);
+
+        $client = $this->authenticatedClient();
+        $id = $this->createProduct($client, 'AUD008-OK', [
+            'purchase_price' => 10.5,
+            'color' => 'red',
+        ]);
+
+        // purchase_price restricted to view, but `color` keeps the role
+        // default (edit) — editing it must still succeed.
+        $this->grantAttributePermission('purchase_price', RoleAttributePermission::LEVEL_VIEW);
+
+        $client->request('PATCH', '/api/products/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'body' => json_encode([
+                'attributes' => ['color' => 'blue'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    private function createProduct(\ApiPlatform\Symfony\Bundle\Test\Client $client, string $code, array $attributes): string
+    {
+        $created = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => $code,
+                'objectTypeId' => $this->objectTypeIdFor(ObjectKind::Product),
+                'attributes' => $attributes,
+            ], JSON_THROW_ON_ERROR),
+        ])->toArray();
+
+        $id = $created['id'] ?? null;
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    private function seedAttribute(string $code, AttributeType $type): Uuid
+    {
+        $em = $this->em();
+        $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $attribute = new Attribute($code, ['en' => ucfirst($code)], $type);
+        self::getContainer()->get(AttributeRepositoryInterface::class)->save($attribute);
+
+        return $attribute->getId();
+    }
+
+    /**
+     * Grant the given level on the attribute for EVERY role the admin holds,
+     * so the most-permissive merge across roles resolves to that level.
+     */
+    private function grantAttributePermission(string $attributeCode, string $level): void
+    {
+        $attributeId = $this->attributeId($attributeCode);
+        $repo = self::getContainer()->get(RoleAttributePermissionRepositoryInterface::class);
+
+        foreach ($this->adminRoleIds() as $roleId) {
+            $existing = $repo->findByRoleAndAttribute($roleId, $attributeId);
+            if (null !== $existing) {
+                $existing->setPermissionLevel($level);
+                $repo->save($existing);
+
+                continue;
+            }
+            $repo->save(new RoleAttributePermission($roleId, $attributeId, $level));
+        }
+        $this->em()->flush();
+    }
+
+    private function liftAttributePermission(string $attributeCode): void
+    {
+        $attributeId = $this->attributeId($attributeCode);
+        $repo = self::getContainer()->get(RoleAttributePermissionRepositoryInterface::class);
+
+        foreach ($this->adminRoleIds() as $roleId) {
+            $existing = $repo->findByRoleAndAttribute($roleId, $attributeId);
+            if (null !== $existing) {
+                $repo->remove($existing);
+            }
+        }
+        $this->em()->flush();
+    }
+
+    private function attributeId(string $attributeCode): Uuid
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $attribute = self::getContainer()->get(AttributeRepositoryInterface::class)
+            ->findByCode($attributeCode, $tenant);
+        \assert(null !== $attribute);
+
+        return $attribute->getId();
+    }
+
+    /**
+     * @return list<Uuid>
+     */
+    private function adminRoleIds(): array
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail(self::ADMIN_EMAIL);
+        \assert(null !== $user);
+
+        $ids = [];
+        foreach ($user->getAssignedRoles() as $role) {
+            $ids[] = $role->getId();
+        }
+        \assert([] !== $ids);
+
+        return $ids;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/AttributeReadRestrictionOverlayTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/AttributeReadRestrictionOverlayTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application;
+
+use App\Catalog\Application\AttributeReadRestrictionOverlay;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Identity\Contracts\Policy\AttributePermissionReader;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-008 (#1578) correctness + #1620 perf-regression guard.
+ *
+ * The overlay strips per-attribute `restricted` columns from the read
+ * response. On the collection path it MUST resolve the tenant attribute
+ * catalogue once and reuse each attribute's view decision across items —
+ * the per-item resolution introduced by #1578 turned a 200-item page into
+ * N×(findAllByTenant + canViewAttribute) and timed out the Playwright
+ * multi-tenant-isolation spec at 10s.
+ */
+final class AttributeReadRestrictionOverlayTest extends TestCase
+{
+    #[Test]
+    public function dropsRestrictedAttributeAndKeepsVisibleOnes(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Text);
+        $price = new Attribute('purchase_price', ['en' => 'Price'], AttributeType::Number);
+
+        $attributes = new CountingAttributeRepository([$color, $price]);
+        // `purchase_price` restricted, everything else viewable.
+        $permissions = new CountingPermissionReader([$price->getId()]);
+
+        $overlay = new AttributeReadRestrictionOverlay($attributes, $permissions);
+
+        $object = $this->object($tenant, [
+            'color' => ['value' => 'red'],
+            'purchase_price' => ['value' => 19.99],
+            'created_at' => ['value' => '2026-01-01'], // unknown code → system attr → kept
+        ]);
+
+        $result = $overlay->apply($object);
+        $indexed = $result->getAttributesIndexed();
+
+        self::assertArrayNotHasKey('purchase_price', $indexed, 'restricted attribute must be dropped');
+        self::assertSame(['value' => 'red'], $indexed['color'] ?? null);
+        self::assertArrayHasKey('created_at', $indexed, 'system attribute must pass through');
+    }
+
+    #[Test]
+    public function batchResolvesCatalogueOnceAndMemoisesViewDecisionPerAttribute(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Text);
+        $price = new Attribute('purchase_price', ['en' => 'Price'], AttributeType::Number);
+
+        $attributes = new CountingAttributeRepository([$color, $price]);
+        $permissions = new CountingPermissionReader([$price->getId()]);
+
+        $overlay = new AttributeReadRestrictionOverlay($attributes, $permissions);
+
+        // 200 items, each carrying the same two attribute codes — the exact
+        // shape `GET /api/products?itemsPerPage=200` produced.
+        $objects = [];
+        for ($i = 0; $i < 200; ++$i) {
+            $objects[] = $this->object($tenant, [
+                'color' => ['value' => 'red'],
+                'purchase_price' => ['value' => 19.99],
+            ]);
+        }
+
+        $result = $overlay->applyBatch($objects);
+
+        self::assertCount(200, $result);
+        // The N+1 the regression introduced: one catalogue load + one view
+        // decision per attribute id — NOT per item.
+        self::assertSame(1, $attributes->findAllByTenantCalls, 'findAllByTenant must run once for the whole page');
+        self::assertSame(
+            2,
+            $permissions->canViewCalls,
+            'canViewAttribute must be resolved once per unique attribute id, not per item',
+        );
+
+        foreach ($result as $object) {
+            $indexed = $object->getAttributesIndexed();
+            self::assertArrayNotHasKey('purchase_price', $indexed);
+            self::assertArrayHasKey('color', $indexed);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $indexed
+     */
+    private function object(Tenant $tenant, array $indexed): CatalogObject
+    {
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $object = new CatalogObject($type, 'SKU-'.bin2hex(random_bytes(4)));
+        $object->assignTenant($tenant);
+        $object->updateAttributeIndex($indexed);
+
+        return $object;
+    }
+}
+
+/**
+ * @internal counts findAllByTenant calls so the batch path can assert the
+ *           per-page catalogue load happens exactly once (#1620)
+ */
+final class CountingAttributeRepository implements AttributeRepositoryInterface
+{
+    public int $findAllByTenantCalls = 0;
+
+    /**
+     * @param list<Attribute> $attributes
+     */
+    public function __construct(private readonly array $attributes)
+    {
+    }
+
+    public function findAllByTenant(Tenant $tenant): array
+    {
+        ++$this->findAllByTenantCalls;
+
+        return $this->attributes;
+    }
+
+    public function findById(Uuid $id): ?Attribute
+    {
+        foreach ($this->attributes as $attribute) {
+            if ($attribute->getId()->equals($id)) {
+                return $attribute;
+            }
+        }
+
+        return null;
+    }
+
+    public function findByCode(string $code, Tenant $tenant): ?Attribute
+    {
+        foreach ($this->attributes as $attribute) {
+            if ($attribute->getCode() === $code) {
+                return $attribute;
+            }
+        }
+
+        return null;
+    }
+
+    public function save(Attribute $attribute): void
+    {
+    }
+
+    public function remove(Attribute $attribute): void
+    {
+    }
+
+    public function filterableCodes(): array
+    {
+        return [];
+    }
+}
+
+/**
+ * @internal counts canViewAttribute calls so the batch path can assert each
+ *           attribute id is resolved once, not once per item (#1620)
+ */
+final class CountingPermissionReader implements AttributePermissionReader
+{
+    public int $canViewCalls = 0;
+
+    /** @var list<string> attribute ids (RFC4122) the principal may NOT view */
+    private readonly array $denied;
+
+    /**
+     * @param list<Uuid> $deniedIds
+     */
+    public function __construct(array $deniedIds)
+    {
+        $this->denied = array_map(static fn (Uuid $id): string => $id->toRfc4122(), $deniedIds);
+    }
+
+    public function canViewAttribute(Uuid $attributeId): bool
+    {
+        ++$this->canViewCalls;
+
+        return !\in_array($attributeId->toRfc4122(), $this->denied, true);
+    }
+
+    public function canEditAttribute(Uuid $attributeId): bool
+    {
+        return $this->canViewAttribute($attributeId);
+    }
+
+    public function isAttributePermissionEnforced(): bool
+    {
+        return true;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectTypeListSchemaHandlerTest.php
@@ -191,6 +191,11 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
             {
                 return true;
             }
+
+            public function isAttributePermissionEnforced(): bool
+            {
+                return true;
+            }
         };
     }
 
@@ -211,6 +216,11 @@ final class GetObjectTypeListSchemaHandlerTest extends TestCase
             public function canEditAttribute(Uuid $attributeId): bool
             {
                 return $this->code !== $attributeId->toRfc4122();
+            }
+
+            public function isAttributePermissionEnforced(): bool
+            {
+                return true;
             }
         };
     }

--- a/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
@@ -292,14 +292,83 @@ final class ExportBuilderTest extends TestCase
         self::assertSame(['sku' => 'SKU-R', 'related' => 'REL-A|REL-B'], $rows[0]);
     }
 
+    #[Test]
+    public function exportsRestrictedAttributeUnderSystemContextWithoutEnforcement(): void
+    {
+        // AUD-008 (#1578) regression: the sync runner (EXP-05) / async handler
+        // (EXP-06) reach the builder from a system context with no security
+        // token — isAttributePermissionEnforced() is false. The
+        // anonymous-→-restricted default of canViewAttribute() must NOT blank
+        // cells there, or a legitimate export comes out empty (CI #1620).
+        $product = $this->newProduct('SKU-SYS');
+        $restrictedId = Uuid::v7();
+        $priceAttr = $this->newAttribute('purchase_price', AttributeType::Number, $restrictedId);
+
+        $valuesByObject = [
+            spl_object_id($product) => [
+                new ObjectValue($product, $priceAttr, ['value' => 19.99]),
+            ],
+        ];
+
+        $builder = $this->newBuilder(
+            valuesByObject: $valuesByObject,
+            categoriesByObject: [],
+            attributesByCode: ['purchase_price' => $priceAttr],
+            // canViewAttribute() would return false for this id, but
+            // enforcement is off → the value still exports.
+            restrictedAttrIds: [$restrictedId->toRfc4122()],
+            permissionsEnforced: false,
+        );
+        $session = $this->newSessionWithTenant(['sku', 'purchase_price']);
+        $rows = iterator_to_array($builder->build([$product], $session));
+
+        self::assertSame(['sku' => 'SKU-SYS', 'purchase_price' => '19.99'], $rows[0]);
+    }
+
+    #[Test]
+    public function blanksAttributeColumnTheCallerMayNotView(): void
+    {
+        // AUD-008 (#1578) — a column whose attribute the caller cannot view
+        // (3-state per-attribute permission, PRD §3.5) must export as a blank
+        // cell, never the real value. A visible attribute on the same row is
+        // untouched.
+        $product = $this->newProduct('SKU-SEC');
+        $restrictedId = Uuid::v7();
+        $priceAttr = $this->newAttribute('purchase_price', AttributeType::Number, $restrictedId);
+        $descAttr = $this->newAttribute('description', AttributeType::Text);
+
+        $valuesByObject = [
+            spl_object_id($product) => [
+                new ObjectValue($product, $priceAttr, ['value' => 19.99]),
+                new ObjectValue($product, $descAttr, ['value' => 'Visible copy']),
+            ],
+        ];
+
+        $builder = $this->newBuilder(
+            valuesByObject: $valuesByObject,
+            categoriesByObject: [],
+            attributesByCode: ['purchase_price' => $priceAttr, 'description' => $descAttr],
+            restrictedAttrIds: [$restrictedId->toRfc4122()],
+        );
+        $session = $this->newSessionWithTenant(['sku', 'purchase_price', 'description']);
+        $rows = iterator_to_array($builder->build([$product], $session));
+
+        self::assertSame(
+            ['sku' => 'SKU-SEC', 'purchase_price' => '', 'description' => 'Visible copy'],
+            $rows[0],
+        );
+    }
+
     // ----- helpers -----
 
     /**
-     * @param array<int, list<ObjectValue>>    $valuesByObject     keyed by spl_object_id($product)
-     * @param array<int, list<ObjectCategory>> $categoriesByObject same
-     * @param array<string, Uuid>              $channelIds         channel code => id (#1229)
-     * @param array<int, list<ObjectRelation>> $relationsBySource  keyed by spl_object_id($source) (#1471)
-     * @param array<string, Attribute>         $attributesByCode   attribute column code => Attribute (#1471)
+     * @param array<int, list<ObjectValue>>    $valuesByObject      keyed by spl_object_id($product)
+     * @param array<int, list<ObjectCategory>> $categoriesByObject  same
+     * @param array<string, Uuid>              $channelIds          channel code => id (#1229)
+     * @param array<int, list<ObjectRelation>> $relationsBySource   keyed by spl_object_id($source) (#1471)
+     * @param array<string, Attribute>         $attributesByCode    attribute column code => Attribute (#1471)
+     * @param list<string>                     $restrictedAttrIds   attribute UUIDs the caller may NOT view (AUD-008 #1578)
+     * @param bool                             $permissionsEnforced whether a domain user is present so per-attribute grants apply (AUD-008 #1578)
      */
     private function newBuilder(
         array $valuesByObject,
@@ -307,6 +376,8 @@ final class ExportBuilderTest extends TestCase
         array $channelIds = [],
         array $relationsBySource = [],
         array $attributesByCode = [],
+        array $restrictedAttrIds = [],
+        bool $permissionsEnforced = true,
     ): ExportBuilder {
         $values = $this->createStub(ObjectValueRepositoryInterface::class);
         $values->method('findByObject')->willReturnCallback(
@@ -333,6 +404,13 @@ final class ExportBuilderTest extends TestCase
             static fn (string $code): ?Attribute => $attributesByCode[$code] ?? null
         );
 
+        $permissions = $this->createStub(\App\Identity\Contracts\Policy\AttributePermissionReader::class);
+        $permissions->method('canViewAttribute')->willReturnCallback(
+            static fn (Uuid $id): bool => !\in_array($id->toRfc4122(), $restrictedAttrIds, true)
+        );
+        $permissions->method('canEditAttribute')->willReturn(true);
+        $permissions->method('isAttributePermissionEnforced')->willReturn($permissionsEnforced);
+
         return new ExportBuilder(
             values: $values,
             categories: $categories,
@@ -341,6 +419,7 @@ final class ExportBuilderTest extends TestCase
             channels: $channels,
             relations: $relations,
             attributes: $attributes,
+            attributePermissions: $permissions,
         );
     }
 
@@ -360,11 +439,12 @@ final class ExportBuilderTest extends TestCase
         return $object;
     }
 
-    private function newAttribute(string $code, AttributeType $type): Attribute
+    private function newAttribute(string $code, AttributeType $type, ?Uuid $id = null): Attribute
     {
         $attribute = $this->createStub(Attribute::class);
         $attribute->method('getCode')->willReturn($code);
         $attribute->method('getType')->willReturn($type);
+        $attribute->method('getId')->willReturn($id ?? Uuid::v7());
 
         return $attribute;
     }

--- a/apps/api/tests/Unit/Identity/Application/Policy/AttributePermissionPolicyTest.php
+++ b/apps/api/tests/Unit/Identity/Application/Policy/AttributePermissionPolicyTest.php
@@ -11,7 +11,10 @@ use App\Identity\Domain\Rbac\AttributePermission;
 use App\Identity\Domain\Rbac\PermissionSet;
 use App\Shared\Domain\Tenant;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Table;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
 
@@ -126,6 +129,7 @@ final class AttributePermissionPolicyTest extends TestCase
 
                 return false;
             });
+        $this->withSchema($connection);
 
         $policy = new AttributePermissionPolicy($connection, $resolver);
 
@@ -251,7 +255,27 @@ final class AttributePermissionPolicyTest extends TestCase
 
                 return false;
             });
+        $this->withSchema($connection);
 
         return $connection;
+    }
+
+    /**
+     * Stub the SchemaManager existence probes added in AUD-008 (#1578) so
+     * the policy reaches its per-group / role-default SELECTs. Mirrors a
+     * migrated DB where both the group table and the default column exist.
+     *
+     * @param Connection&MockObject $connection
+     */
+    private function withSchema(Connection $connection): void
+    {
+        $table = $this->createStub(Table::class);
+        $table->method('hasColumn')->willReturn(true);
+
+        $schemaManager = $this->createMock(AbstractSchemaManager::class);
+        $schemaManager->method('tablesExist')->willReturn(true);
+        $schemaManager->method('introspectTableByUnquotedName')->willReturn($table);
+
+        $connection->method('createSchemaManager')->willReturn($schemaManager);
     }
 }


### PR DESCRIPTION
## AUD-008 (HIGH) — attribute-level permissions nieegzekwowane na ścieżce danych
3-state attribute permissions (PRD §3.5) egzekwowane tylko w schemacie formularza, nie na danych: GET zwracał wartości restricted atrybutu, PATCH je zmieniał bez `edit`, export wypisywał.

## Fix (3 ścieżki)
- **READ:** `AttributeReadRestrictionOverlay` filtruje `attributes_indexed` po `canViewAttribute` (GET item + collection).
- **PATCH:** `ObjectAttributesUpserter` → 403 gdy `!canEditAttribute`.
- **EXPORT:** `ExportBuilder` → pusta komórka bez `canViewAttribute`.
- Bonus: `AttributePermissionPolicy` schema-introspect przed opcjonalnymi query (brakująca tabela abortowała write-tx — realny bug).

## Test (failing → green) + Smoke (CLOSED MEANS CLOSED)
ApiTest (GET-omitted/PATCH-403/editable-200) + Unit ExportBuilder. Smoke (atrybut `brand`, `DEMO-001`): bez restricted → widoczny/PATCH 200/export wartość; **z restricted → GET usuwa, PATCH 403, export pusto**.

Gates: PHPStan max + deptrac 0 + cs-fixer; regresja unit 630 + Api zielone.

Closes #1578
