### PR TITLE
fix(identity): split platform operator from per-tenant super_admin — AUD-003 (#1575)

### DIFF
--- a/apps/api/src/DataFixtures/AppFixtures.php
+++ b/apps/api/src/DataFixtures/AppFixtures.php
@@ -115,14 +115,15 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
 
         $superAdmin = $this->roleRepository->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
         \assert(null !== $superAdmin, 'RbacSeeder must create the super_admin role.');
+        $platformOperator = $this->roleRepository->findGlobalByCode(RbacMatrix::ROLE_PLATFORM_OPERATOR);
+        \assert(null !== $platformOperator, 'RbacSeeder must create the platform_operator role.');
 
-        // Grant super_admin every PRD §3.2 permission so platform-level
-        // admins can drive the Settings UI without a Phase 6 retrofit
-        // gap (the retrofit consolidates Voters onto PRD codes but the
-        // grant matrix should be permissive on the platform tier from
-        // day one — Super Admin is by definition the most privileged
-        // role).
+        // Grant super_admin every tenant-scoped PRD §3.2 permission so a
+        // tenant Owner can drive the Settings UI without a Phase 6 retrofit
+        // gap. AUD-003 (#1575): the cross-tenant `platform.*` block is
+        // deliberately withheld here and granted only to platform_operator.
         $this->grantAllPermissionsToSuperAdmin($superAdmin);
+        $this->grantPlatformPermissionsToOperator($platformOperator);
 
         // Per-tenant: built-in ObjectTypes (#33) → admin user → demo
         // catalog rows. The seeder is idempotent — `pim:db:reset` re-runs
@@ -196,6 +197,25 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
             $admin->addRole($tenantOwner);
             $manager->persist($admin);
         }
+
+        // AUD-003 (#1575): the platform operator (operator panel + break-glass)
+        // is a SEPARATE principal from any tenant Owner. It holds ONLY the
+        // global `platform_operator` role (the `platform.*` grants) and no
+        // tenant-scoped role, so the cross-tenant `/api/admin/tenants/*` panel
+        // is reachable for break-glass / onboarding but NOT by an Owner.
+        // Every User needs tenant_id NOT NULL; it is parked in the demo tenant
+        // but carries no tenant-scoped authority there.
+        $operatorEmail = 'platform-operator@cortex.localhost';
+        $operatorStub = new User($tenants[0], $operatorEmail, '', []);
+        $operator = new User(
+            $tenants[0],
+            $operatorEmail,
+            $this->passwordHasher->hashPassword($operatorStub, self::DEFAULT_ADMIN_PASSWORD),
+            [],
+        );
+        $operator->addRole($platformOperator);
+        $manager->persist($operator);
+
         $manager->flush();
 
         // #1259 — seed one real demo channel (Allegro) for the demo tenant so
@@ -245,7 +265,14 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
     /**
      * Attach every permission row (legacy RbacMatrix + PRD §3.2 codes
      * loaded by PrdPermissionFixtures) to the global super_admin role so
-     * the demo admin user holds the union of both permission graphs.
+     * the demo admin user holds the union of both permission graphs —
+     * EXCEPT the cross-tenant `platform.*` block.
+     *
+     * AUD-003 (#1575): `super_admin` is the role every tenant Owner holds.
+     * Granting it `platform.tenants.manage` / `platform.break_glass_recovery`
+     * lets an Owner recon + suspend + delete competitor tenants. Those
+     * grants belong exclusively to the dedicated `platform_operator` role
+     * ({@see grantPlatformPermissionsToOperator}), never to a tenant Owner.
      *
      * Idempotent: only the permissions not yet on the role are added,
      * so re-running fixtures (or extending PRD codes later) keeps the
@@ -259,10 +286,38 @@ class AppFixtures extends Fixture implements DependentFixtureInterface
         }
 
         foreach ($this->permissionRepository->findAllOrdered() as $permission) {
+            if (str_starts_with($permission->getCode(), 'platform.')) {
+                continue; // platform-scope grants are operator-only (AUD-003)
+            }
             if (\in_array($permission->getCode(), $existingCodes, true)) {
                 continue;
             }
             $superAdmin->getPermissions()->add($permission);
+        }
+    }
+
+    /**
+     * AUD-003 (#1575): grant the four cross-tenant `platform.*` permissions
+     * to the global `platform_operator` role. RbacSeeder already wires this
+     * via RbacMatrix, but PrdPermissionFixtures may have created the
+     * `platform.*` rows with their own UUIDs first; re-attach idempotently
+     * so the role holds the canonical rows regardless of seed order.
+     */
+    private function grantPlatformPermissionsToOperator(\App\Identity\Domain\Entity\Role $operator): void
+    {
+        $existingCodes = [];
+        foreach ($operator->getPermissions() as $existing) {
+            $existingCodes[] = $existing->getCode();
+        }
+
+        foreach ($this->permissionRepository->findAllOrdered() as $permission) {
+            if (!str_starts_with($permission->getCode(), 'platform.')) {
+                continue;
+            }
+            if (\in_array($permission->getCode(), $existingCodes, true)) {
+                continue;
+            }
+            $operator->getPermissions()->add($permission);
         }
     }
 

--- a/apps/api/src/Identity/Application/SuperAdmin/PlatformOperatorGuard.php
+++ b/apps/api/src/Identity/Application/SuperAdmin/PlatformOperatorGuard.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\SuperAdmin;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Exception\PermissionDeniedException;
+use Symfony\Bundle\SecurityBundle\Security;
+
+/**
+ * AUD-003 (#1575) — single gate for the platform operator panel.
+ *
+ * Before this guard existed, the `/api/admin/tenants/*` and
+ * `/api/admin/break-glass/*` controllers gated on the `super_admin`
+ * ROLE CODE. Fixtures grant that global role to every tenant Owner, so an
+ * Owner could list / read / suspend / delete competitor tenants and invoke
+ * break-glass. The role code is the wrong signal — authority must be
+ * carried by a platform-scope PERMISSION (`platform.*`) that only the
+ * dedicated `platform_operator` role holds (PRD-PIM-rbac §3.2 cross-tenant
+ * block).
+ *
+ * The guard resolves the authenticated user's permission set through the
+ * shared {@see PermissionResolverInterface} (same path the
+ * EndpointGuardListener uses) and throws {@see PermissionDeniedException}
+ * — rendered as RFC 7807 problem+json by PermissionDeniedProblemListener —
+ * when the platform permission is absent. On success it returns the
+ * {@see User} so callers keep the principal for the cross-tenant audit
+ * stamp.
+ */
+final readonly class PlatformOperatorGuard
+{
+    public function __construct(
+        private Security $security,
+        private PermissionResolverInterface $resolver,
+    ) {
+    }
+
+    /**
+     * @throws PermissionDeniedException when no domain user is authenticated
+     *                                   or the user lacks $permissionCode
+     */
+    public function require(string $permissionCode): User
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            // Anonymous / non-domain principal. Mirror the EndpointGuard
+            // contract: surface 403 with the missing code rather than a
+            // bare 401 so SPA logic stays uniform.
+            throw new PermissionDeniedException($permissionCode);
+        }
+
+        if (!$this->resolver->resolve($user)->has($permissionCode)) {
+            throw new PermissionDeniedException($permissionCode);
+        }
+
+        return $user;
+    }
+}

--- a/apps/api/src/Identity/Domain/Rbac/RbacMatrix.php
+++ b/apps/api/src/Identity/Domain/Rbac/RbacMatrix.php
@@ -25,6 +25,27 @@ final class RbacMatrix
     public const string ROLE_INTEGRATION_MANAGER = 'integration_manager';
     public const string ROLE_VIEWER = 'viewer';
 
+    /**
+     * AUD-003 (#1575) — platform-level operator role. Global (tenant_id
+     * NULL) but, unlike `super_admin`, it is NEVER assigned to a tenant
+     * Owner. It is the only role holding the cross-tenant `platform.*`
+     * permissions, so the `/api/admin/tenants/*` operator panel and the
+     * break-glass endpoints gate on a grant a regular Owner cannot reach.
+     */
+    public const string ROLE_PLATFORM_OPERATOR = 'platform_operator';
+
+    /**
+     * Cross-tenant platform permission codes (PRD-PIM-rbac §3.2 "Super
+     * Admin only" block). These are intentionally NOT part of the legacy
+     * resource×action grid — they are held exclusively by
+     * `platform_operator`, never by `super_admin`, so a tenant Owner who
+     * carries `super_admin` cannot manage / recon other tenants.
+     */
+    public const string PERMISSION_PLATFORM_TENANTS_LIST = 'platform.tenants.list';
+    public const string PERMISSION_PLATFORM_TENANTS_MANAGE = 'platform.tenants.manage';
+    public const string PERMISSION_PLATFORM_AUDIT_VIEW_ALL = 'platform.audit.view_all';
+    public const string PERMISSION_PLATFORM_BREAK_GLASS = 'platform.break_glass_recovery';
+
     public const string ACTION_READ = 'read';
     public const string ACTION_WRITE = 'write';
     public const string ACTION_DELETE = 'delete';
@@ -68,6 +89,20 @@ final class RbacMatrix
     ];
 
     /**
+     * Cross-tenant permission codes split as (resource, action) on the
+     * last segment so they slot into the same `permissions` table as the
+     * legacy grid. `platform.tenants.manage` → (platform.tenants, manage).
+     *
+     * @var list<array{0: string, 1: string}>
+     */
+    private const array PLATFORM_PERMISSIONS = [
+        ['platform.tenants', 'list'],
+        ['platform.tenants', 'manage'],
+        ['platform.audit', 'view_all'],
+        ['platform', 'break_glass_recovery'],
+    ];
+
+    /**
      * @return list<PermissionDefinition>
      */
     public static function permissions(): array
@@ -77,6 +112,14 @@ final class RbacMatrix
             foreach (self::ACTIONS as $action) {
                 $permissions[] = new PermissionDefinition($resource, $action);
             }
+        }
+
+        // AUD-003 (#1575): platform-scope permissions live in the same
+        // pool so `pim:rbac:seed` provisions them in production (not only
+        // dev fixtures), but they are granted exclusively to
+        // `platform_operator` — see roles() below.
+        foreach (self::PLATFORM_PERMISSIONS as [$resource, $action]) {
+            $permissions[] = new PermissionDefinition($resource, $action);
         }
 
         return $permissions;
@@ -140,15 +183,47 @@ final class RbacMatrix
                     actions: [self::ACTION_READ],
                 ),
             ),
+            // AUD-003 (#1575) — platform operator: the ONLY role with the
+            // cross-tenant `platform.*` grants. Never assigned to a tenant
+            // Owner, so the operator panel + break-glass stay platform-only.
+            new RoleDefinition(
+                code: self::ROLE_PLATFORM_OPERATOR,
+                name: 'Platform Operator',
+                permissionCodes: self::platformPermissionCodes(),
+            ),
         ];
+    }
+
+    /**
+     * Every legacy resource×action code. Excludes the `platform.*` block
+     * by construction (it is not part of the grid) so `super_admin` —
+     * which a tenant Owner holds — never gains cross-tenant authority.
+     *
+     * @return list<string>
+     */
+    private static function allPermissionCodes(): array
+    {
+        $codes = [];
+        foreach (self::RESOURCES as $resource) {
+            foreach (self::ACTIONS as $action) {
+                $codes[] = \sprintf('%s.%s', $resource, $action);
+            }
+        }
+
+        return $codes;
     }
 
     /**
      * @return list<string>
      */
-    private static function allPermissionCodes(): array
+    private static function platformPermissionCodes(): array
     {
-        return array_map(static fn (PermissionDefinition $p): string => $p->code(), self::permissions());
+        return [
+            self::PERMISSION_PLATFORM_TENANTS_LIST,
+            self::PERMISSION_PLATFORM_TENANTS_MANAGE,
+            self::PERMISSION_PLATFORM_AUDIT_VIEW_ALL,
+            self::PERMISSION_PLATFORM_BREAK_GLASS,
+        ];
     }
 
     /**

--- a/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineRoleRepository.php
+++ b/apps/api/src/Identity/Infrastructure/Doctrine/Repository/DoctrineRoleRepository.php
@@ -6,6 +6,7 @@ namespace App\Identity\Infrastructure\Doctrine\Repository;
 
 use App\Identity\Domain\Entity\Role;
 use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
 use App\Identity\Domain\Repository\RoleRepositoryInterface;
 use App\Shared\Domain\Tenant;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -57,10 +58,17 @@ class DoctrineRoleRepository extends ServiceEntityRepository implements RoleRepo
         // custom roles. The Settings → Roles list orders them with system
         // (global) roles first (PRD §3.2 macierz prescribes that on-screen
         // grouping), then name ASC.
+        //
+        // AUD-003 (#1575): the platform-level `platform_operator` role is
+        // excluded — it is never assignable inside a tenant (assignment is
+        // already rejected by the tenant-scoped findByCode lookup) and must
+        // not be surfaced as an option in Settings → Roles.
         /** @var list<Role> $roles */
         $roles = $this->createQueryBuilder('r')
             ->where('r.tenant IS NULL OR r.tenant = :tenant')
+            ->andWhere('r.code != :platformOperator')
             ->setParameter('tenant', $tenant->getId())
+            ->setParameter('platformOperator', RbacMatrix::ROLE_PLATFORM_OPERATOR)
             ->orderBy('CASE WHEN r.tenant IS NULL THEN 0 ELSE 1 END', 'ASC')
             ->addOrderBy('r.name', 'ASC')
             ->getQuery()

--- a/apps/api/src/Identity/Presentation/Controller/BreakGlassController.php
+++ b/apps/api/src/Identity/Presentation/Controller/BreakGlassController.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Identity\Presentation\Controller;
 
+use App\Identity\Application\SuperAdmin\PlatformOperatorGuard;
 use App\Identity\Application\SuperAdmin\SuperAdminContext;
 use App\Identity\Application\TotpEnrolmentService;
 use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Identity\Domain\Entity\AuditLog;
-use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Rbac\RbacMatrix;
 use App\Identity\Domain\Repository\AuditLogRepositoryInterface;
 use App\Identity\Domain\Repository\RoleRepositoryInterface;
@@ -17,7 +17,6 @@ use App\Shared\Domain\Repository\TenantRepositoryInterface;
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -66,7 +65,7 @@ final readonly class BreakGlassController
     private const string OWNER_ROLE_CODE = 'tenant_owner';
 
     public function __construct(
-        private Security $security,
+        private PlatformOperatorGuard $guard,
         private TotpEnrolmentService $totp,
         private SuperAdminContext $superAdminContext,
         private UserRepositoryInterface $users,
@@ -79,13 +78,10 @@ final readonly class BreakGlassController
     }
 
     #[Route(path: '/api/admin/break-glass/usage', methods: ['GET'], name: 'api_admin_break_glass_usage')]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform', action: 'break_glass_recovery')]
     public function usage(): JsonResponse
     {
-        $caller = $this->requireSuperAdmin();
-        if ($caller instanceof JsonResponse) {
-            return $caller;
-        }
+        $caller = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_BREAK_GLASS);
 
         $used = $this->countRecentInvocations($caller->getId());
         $recent = $this->listRecentInvocations($caller->getId());
@@ -100,13 +96,10 @@ final readonly class BreakGlassController
     }
 
     #[Route(path: '/api/admin/break-glass', methods: ['POST'], name: 'api_admin_break_glass_invoke')]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform', action: 'break_glass_recovery')]
     public function invoke(Request $request): JsonResponse
     {
-        $caller = $this->requireSuperAdmin();
-        if ($caller instanceof JsonResponse) {
-            return $caller;
-        }
+        $caller = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_BREAK_GLASS);
 
         $payload = $this->decode($request);
         if ($payload instanceof JsonResponse) {
@@ -249,31 +242,6 @@ final readonly class BreakGlassController
         );
 
         return $result;
-    }
-
-    /**
-     * Returns the caller's User aggregate on success, or a 403 problem
-     * response when they do not hold the `super_admin` role.
-     */
-    private function requireSuperAdmin(): User|JsonResponse
-    {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
-        }
-
-        foreach ($user->getAssignedRoles() as $role) {
-            if (RbacMatrix::ROLE_SUPER_ADMIN === $role->getCode()) {
-                return $user;
-            }
-        }
-
-        return $this->problem(
-            Response::HTTP_FORBIDDEN,
-            'Forbidden',
-            'Super Admin role required.',
-            ['code' => 'super_admin_required'],
-        );
     }
 
     private function countRecentInvocations(Uuid $superAdminId): int

--- a/apps/api/src/Identity/Presentation/Controller/SuperAdminTenantWriteController.php
+++ b/apps/api/src/Identity/Presentation/Controller/SuperAdminTenantWriteController.php
@@ -6,6 +6,7 @@ namespace App\Identity\Presentation\Controller;
 
 use App\Identity\Application\InvitationService;
 use App\Identity\Application\SeedTenantPrdRolesService;
+use App\Identity\Application\SuperAdmin\PlatformOperatorGuard;
 use App\Identity\Application\SuperAdmin\SuperAdminContext;
 use App\Identity\Application\SuperAdmin\SuperAdminTenantResponseBuilder;
 use App\Identity\Contracts\Attribute\RequiresPermission;
@@ -14,7 +15,6 @@ use App\Identity\Domain\Rbac\RbacMatrix;
 use App\Shared\Domain\Repository\TenantRepositoryInterface;
 use App\Shared\Domain\Tenant;
 use InvalidArgumentException;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -67,7 +67,7 @@ final readonly class SuperAdminTenantWriteController
     private const string DEFAULT_PLAN = Tenant::PLAN_STARTER;
 
     public function __construct(
-        private Security $security,
+        private PlatformOperatorGuard $guard,
         private SuperAdminContext $superAdminContext,
         private TenantRepositoryInterface $tenants,
         private SuperAdminTenantResponseBuilder $builder,
@@ -77,13 +77,10 @@ final readonly class SuperAdminTenantWriteController
     }
 
     #[Route(path: '/api/admin/tenants', methods: ['POST'], name: 'api_admin_tenants_create')]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform.tenants', action: 'manage')]
     public function create(Request $request): JsonResponse
     {
-        $caller = $this->requireSuperAdmin();
-        if ($caller instanceof JsonResponse) {
-            return $caller;
-        }
+        $caller = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_TENANTS_MANAGE);
 
         $payload = $this->decode($request);
         if ($payload instanceof JsonResponse) {
@@ -167,13 +164,10 @@ final readonly class SuperAdminTenantWriteController
         name: 'api_admin_tenants_update',
         requirements: ['id' => '[0-9a-f-]{36}'],
     )]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform.tenants', action: 'manage')]
     public function update(string $id, Request $request): JsonResponse
     {
-        $caller = $this->requireSuperAdmin();
-        if ($caller instanceof JsonResponse) {
-            return $caller;
-        }
+        $caller = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_TENANTS_MANAGE);
 
         $payload = $this->decode($request);
         if ($payload instanceof JsonResponse) {
@@ -221,13 +215,10 @@ final readonly class SuperAdminTenantWriteController
         name: 'api_admin_tenants_suspend',
         requirements: ['id' => '[0-9a-f-]{36}'],
     )]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform.tenants', action: 'manage')]
     public function suspend(string $id): JsonResponse
     {
-        $caller = $this->requireSuperAdmin();
-        if ($caller instanceof JsonResponse) {
-            return $caller;
-        }
+        $caller = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_TENANTS_MANAGE);
 
         return $this->mutate(
             $caller,
@@ -246,13 +237,10 @@ final readonly class SuperAdminTenantWriteController
         name: 'api_admin_tenants_reactivate',
         requirements: ['id' => '[0-9a-f-]{36}'],
     )]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform.tenants', action: 'manage')]
     public function reactivate(string $id): JsonResponse
     {
-        $caller = $this->requireSuperAdmin();
-        if ($caller instanceof JsonResponse) {
-            return $caller;
-        }
+        $caller = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_TENANTS_MANAGE);
 
         return $this->mutate(
             $caller,
@@ -271,13 +259,10 @@ final readonly class SuperAdminTenantWriteController
         name: 'api_admin_tenants_delete',
         requirements: ['id' => '[0-9a-f-]{36}'],
     )]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform.tenants', action: 'manage')]
     public function delete(string $id): JsonResponse
     {
-        $caller = $this->requireSuperAdmin();
-        if ($caller instanceof JsonResponse) {
-            return $caller;
-        }
+        $caller = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_TENANTS_MANAGE);
 
         return $this->mutate(
             $caller,
@@ -327,26 +312,6 @@ final readonly class SuperAdminTenantWriteController
         }
 
         return new JsonResponse($this->builder->buildOne($result));
-    }
-
-    private function requireSuperAdmin(): User|JsonResponse
-    {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
-        }
-        foreach ($user->getAssignedRoles() as $role) {
-            if (RbacMatrix::ROLE_SUPER_ADMIN === $role->getCode()) {
-                return $user;
-            }
-        }
-
-        return $this->problem(
-            Response::HTTP_FORBIDDEN,
-            'Forbidden',
-            'Super Admin role required.',
-            ['code' => 'super_admin_required'],
-        );
     }
 
     /**

--- a/apps/api/src/Identity/Presentation/Controller/SuperAdminTenantsController.php
+++ b/apps/api/src/Identity/Presentation/Controller/SuperAdminTenantsController.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace App\Identity\Presentation\Controller;
 
+use App\Identity\Application\SuperAdmin\PlatformOperatorGuard;
 use App\Identity\Application\SuperAdmin\SuperAdminContext;
 use App\Identity\Application\SuperAdmin\SuperAdminTenantResponseBuilder;
 use App\Identity\Contracts\Attribute\RequiresPermission;
-use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Rbac\RbacMatrix;
 use App\Shared\Domain\Repository\TenantRepositoryInterface;
 use InvalidArgumentException;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -34,11 +33,13 @@ use Symfony\Component\Uid\Uuid;
  * audit subsystem stamps `cross_tenant_access=true` on every entry
  * produced by this controller via {@see SuperAdminContext}.
  *
- * Auth gate: the route requires the global `super_admin` role.
- * `RequiresPermission(module: 'user', action: 'admin')` keeps the same
- * legacy attribute the rest of Phase 5 uses + we add an explicit
- * super-admin role check on top (Phase 6 retrofit migrates onto PRD
- * `platform.tenants.list` / `platform.tenants.manage`).
+ * Auth gate (AUD-003 #1575): the routes require the cross-tenant
+ * `platform.tenants.manage` permission, held ONLY by the dedicated
+ * `platform_operator` role — never by a tenant Owner's `super_admin`.
+ * Both the `#[RequiresPermission]` attribute (enforced by the
+ * EndpointGuardListener) and the in-controller {@see PlatformOperatorGuard}
+ * check that permission, so neither a forgotten attribute nor a future
+ * listener change can re-open the panel to ordinary Owners.
  *
  * **Deployment topology note:** per #709 the long-term home for these
  * endpoints is the dedicated `admin.cortex.pl` subdomain with a
@@ -51,7 +52,7 @@ use Symfony\Component\Uid\Uuid;
 final readonly class SuperAdminTenantsController
 {
     public function __construct(
-        private Security $security,
+        private PlatformOperatorGuard $guard,
         private SuperAdminContext $superAdminContext,
         private TenantRepositoryInterface $tenants,
         private SuperAdminTenantResponseBuilder $builder,
@@ -59,13 +60,10 @@ final readonly class SuperAdminTenantsController
     }
 
     #[Route(path: '/api/admin/tenants', methods: ['GET'], name: 'api_admin_tenants_list')]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform.tenants', action: 'manage')]
     public function list(): JsonResponse
     {
-        $superAdminId = $this->requireSuperAdmin();
-        if ($superAdminId instanceof JsonResponse) {
-            return $superAdminId;
-        }
+        $superAdminId = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_TENANTS_MANAGE)->getId();
 
         $rows = $this->superAdminContext->runCrossTenant(
             $superAdminId,
@@ -90,13 +88,10 @@ final readonly class SuperAdminTenantsController
         name: 'api_admin_tenants_detail',
         requirements: ['id' => '[0-9a-f-]{36}'],
     )]
-    #[RequiresPermission(module: 'user', action: 'admin')]
+    #[RequiresPermission(module: 'platform.tenants', action: 'manage')]
     public function detail(string $id): JsonResponse
     {
-        $superAdminId = $this->requireSuperAdmin();
-        if ($superAdminId instanceof JsonResponse) {
-            return $superAdminId;
-        }
+        $superAdminId = $this->guard->require(RbacMatrix::PERMISSION_PLATFORM_TENANTS_MANAGE)->getId();
 
         try {
             $uuid = Uuid::fromString($id);
@@ -113,37 +108,6 @@ final readonly class SuperAdminTenantsController
         }
 
         return new JsonResponse($this->builder->buildOne($tenant));
-    }
-
-    /**
-     * Returns the active Super Admin's Uuid on success, or a 403 problem
-     * response if the caller does not hold the `super_admin` role.
-     */
-    private function requireSuperAdmin(): Uuid|JsonResponse
-    {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
-            return $this->problem(Response::HTTP_UNAUTHORIZED, 'Unauthorized', 'No authenticated user.');
-        }
-
-        $hasSuperAdmin = false;
-        foreach ($user->getAssignedRoles() as $role) {
-            if (RbacMatrix::ROLE_SUPER_ADMIN === $role->getCode()) {
-                $hasSuperAdmin = true;
-                break;
-            }
-        }
-
-        if (!$hasSuperAdmin) {
-            return $this->problem(
-                Response::HTTP_FORBIDDEN,
-                'Forbidden',
-                'Super Admin role required to access the operator panel.',
-                ['code' => 'super_admin_required'],
-            );
-        }
-
-        return $user->getId();
     }
 
     /**

--- a/apps/api/tests/Api/Identity/RbacSeederTest.php
+++ b/apps/api/tests/Api/Identity/RbacSeederTest.php
@@ -40,15 +40,33 @@ final class RbacSeederTest extends ApiTestCase
         $catalogManager = $roles->findGlobalByCode(RbacMatrix::ROLE_CATALOG_MANAGER);
         $integrationManager = $roles->findGlobalByCode(RbacMatrix::ROLE_INTEGRATION_MANAGER);
         $viewer = $roles->findGlobalByCode(RbacMatrix::ROLE_VIEWER);
+        $platformOperator = $roles->findGlobalByCode(RbacMatrix::ROLE_PLATFORM_OPERATOR);
 
         self::assertNotNull($superAdmin, 'super_admin must exist after seeding.');
         self::assertNotNull($catalogManager);
         self::assertNotNull($integrationManager);
         self::assertNotNull($viewer);
+        self::assertNotNull($platformOperator, 'platform_operator must exist after seeding.');
 
-        // Super admin gets every (resource, action) — the matrix lists 13
-        // resources times 4 actions = 52 permissions today.
-        self::assertCount(\count(RbacMatrix::permissions()), $superAdmin->getPermissions());
+        // AUD-003 (#1575): super_admin gets every legacy (resource, action)
+        // pair but NONE of the cross-tenant `platform.*` codes — those are
+        // exclusive to platform_operator so a tenant Owner (who holds
+        // super_admin) cannot manage other tenants.
+        $superAdminCodes = array_map(static fn (Permission $p): string => $p->getCode(), $superAdmin->getPermissions()->toArray());
+        foreach ($superAdminCodes as $code) {
+            self::assertStringStartsNotWith('platform.', $code, 'super_admin must not hold any platform.* permission.');
+        }
+        self::assertContains('tenant.admin', $superAdminCodes);
+
+        // platform_operator holds exactly the four cross-tenant grants.
+        $platformCodes = array_map(static fn (Permission $p): string => $p->getCode(), $platformOperator->getPermissions()->toArray());
+        sort($platformCodes);
+        self::assertSame([
+            'platform.audit.view_all',
+            'platform.break_glass_recovery',
+            'platform.tenants.list',
+            'platform.tenants.manage',
+        ], $platformCodes);
 
         // Viewer is read-only: no write/delete/admin pairs in its set.
         foreach ($viewer->getPermissions() as $permission) {

--- a/apps/api/tests/Api/Identity/RolesListControllerTest.php
+++ b/apps/api/tests/Api/Identity/RolesListControllerTest.php
@@ -108,6 +108,9 @@ final class RolesListControllerTest extends ApiTestCase
         self::assertContains(RbacMatrix::ROLE_VIEWER, $codes);
         self::assertContains('custom_a', $codes);
         self::assertNotContains('custom_b', $codes);
+        // AUD-003 (#1575): the platform-level operator role is never offered
+        // as an assignable tenant role.
+        self::assertNotContains(RbacMatrix::ROLE_PLATFORM_OPERATOR, $codes);
     }
 
     #[Test]

--- a/apps/api/tests/Api/Identity/SuperAdminTenantsGateTest.php
+++ b/apps/api/tests/Api/Identity/SuperAdminTenantsGateTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AUD-003 (#1575) — the `/api/admin/tenants/*` operator panel exposes
+ * cross-tenant platform metadata + tenant lifecycle controls. It must be
+ * gated on the platform-level `platform.tenants.manage` permission, NOT
+ * on the per-tenant `super_admin` role a regular Tenant Owner holds.
+ *
+ * Threat model: before the fix, fixtures granted the GLOBAL `super_admin`
+ * role to every tenant Owner. The controller gated on that role code, so
+ * Owner A could list every tenant (recon competitor metadata) and could
+ * suspend/delete a competitor tenant.
+ *
+ * Invariants asserted here:
+ *  - a Tenant Owner (global `super_admin` + per-tenant `tenant_owner`,
+ *    exactly the fixtures shape) is FORBIDDEN from list / detail / write
+ *    on the operator panel,
+ *  - a dedicated platform operator (`platform_operator` global role with
+ *    `platform.tenants.manage`) is ALLOWED.
+ */
+final class SuperAdminTenantsGateTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_A_CODE = 'acme';
+    private const string TENANT_B_CODE = 'demo';
+
+    private const string OWNER_A_EMAIL = 'owner@acme.localhost';
+    private const string PLATFORM_OPERATOR_EMAIL = 'ops@platform.localhost';
+
+    private string $tenantBId = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+
+        $roles = self::getContainer()->get(RoleRepositoryInterface::class);
+        // The per-tenant Owner holds the GLOBAL super_admin role exactly as
+        // AppFixtures + RbacSeeder grant it today (the vulnerable shape).
+        $superAdmin = $roles->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        $platformOperator = $roles->findGlobalByCode(RbacMatrix::ROLE_PLATFORM_OPERATOR);
+        \assert(null !== $superAdmin, 'super_admin must exist after seeding.');
+        \assert(null !== $platformOperator, 'platform_operator must exist after seeding.');
+
+        $tenantA = new Tenant(self::TENANT_A_CODE, 'Acme Industries');
+        $tenantB = new Tenant(self::TENANT_B_CODE, 'Demo Tenant');
+        $em->persist($tenantA);
+        $em->persist($tenantB);
+        $em->flush();
+        $this->tenantBId = $tenantB->getId()->toRfc4122();
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+
+        // Tenant Owner: global super_admin exactly as AppFixtures grants it
+        // to every tenant's admin. That role code is what the panel gated on
+        // before the fix — it must no longer grant platform access.
+        $ownerA = $this->makeUser($tenantA, self::OWNER_A_EMAIL, $hasher);
+        $ownerA->addRole($superAdmin);
+        $em->persist($ownerA);
+
+        // Platform operator lives in a tenant row too (every User needs a
+        // tenant_id NOT NULL) but is the only principal holding the global
+        // platform_operator role with platform.tenants.manage.
+        $operator = $this->makeUser($tenantA, self::PLATFORM_OPERATOR_EMAIL, $hasher);
+        $operator->addRole($platformOperator);
+        $em->persist($operator);
+
+        $em->flush();
+    }
+
+    #[Test]
+    public function tenantOwnerIsForbiddenFromCrossTenantList(): void
+    {
+        $client = $this->clientFor(self::OWNER_A_EMAIL);
+        $client->request('GET', '/api/admin/tenants');
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertResponseHeaderSame('content-type', 'application/problem+json');
+    }
+
+    #[Test]
+    public function tenantOwnerIsForbiddenFromCompetitorTenantDetail(): void
+    {
+        $client = $this->clientFor(self::OWNER_A_EMAIL);
+        $client->request('GET', '/api/admin/tenants/'.$this->tenantBId);
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertResponseHeaderSame('content-type', 'application/problem+json');
+    }
+
+    #[Test]
+    public function tenantOwnerIsForbiddenFromSuspendingCompetitorTenant(): void
+    {
+        $client = $this->clientFor(self::OWNER_A_EMAIL);
+        $client->request('POST', '/api/admin/tenants/'.$this->tenantBId.'/suspend');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function tenantOwnerIsForbiddenFromDeletingCompetitorTenant(): void
+    {
+        $client = $this->clientFor(self::OWNER_A_EMAIL);
+        $client->request('DELETE', '/api/admin/tenants/'.$this->tenantBId);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function platformOperatorCanListEveryTenant(): void
+    {
+        $client = $this->clientFor(self::PLATFORM_OPERATOR_EMAIL);
+        $client->request('GET', '/api/admin/tenants');
+
+        self::assertResponseStatusCodeSame(200);
+        $response = $client->getResponse();
+        \assert(null !== $response);
+        /** @var array<string, mixed> $body */
+        $body = $response->toArray();
+        self::assertArrayHasKey('member', $body);
+        self::assertSame(2, $body['totalItems'] ?? null);
+    }
+
+    #[Test]
+    public function platformOperatorCanReadTenantDetail(): void
+    {
+        $client = $this->clientFor(self::PLATFORM_OPERATOR_EMAIL);
+        $client->request('GET', '/api/admin/tenants/'.$this->tenantBId);
+
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    private function makeUser(Tenant $tenant, string $email, UserPasswordHasherInterface $hasher): User
+    {
+        $stub = new User($tenant, $email, '');
+
+        return new User($tenant, $email, $hasher->hashPassword($stub, 'changeme'));
+    }
+
+    private function clientFor(string $email): Client
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail($email);
+        \assert(null !== $user);
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
## AUD-003 (HIGH) — globalny super_admin Ownerom (recon metadanych platformy)
Fixtures nadawały **globalny** `super_admin` (tenant_id NULL, z `platform.*`) Ownerowi każdego tenanta → Owner widział/mógł suspend/delete konkurencyjne tenanty przez `/api/admin/tenants` i break-glass.

## Fix
- Nowa rola `platform_operator` (global) trzyma `platform.*`; `super_admin` (per-tenant Owner) **bez** `platform.*`.
- `/api/admin/tenants/*` + `BreakGlassController` (ten sam, niezgłoszony leak) gate na `platform.tenants.manage` / `platform.break_glass_recovery` przez `PlatformOperatorGuard`.
- Fixtures: Owner = super_admin (bez platform) + tenant_owner; osobny `platform-operator@cortex.localhost`.

## Test (failing → green) + Smoke (CLOSED MEANS CLOSED)
`SuperAdminTenantsGateTest` (6): Owner→403 (read+write), operator→200. Smoke (`admin@acme.localhost`): **PRZED** GET `/api/admin/tenants/{demo}` = 200 (recon); **PO** = 403 (list/detail/suspend/delete + break-glass), operator → 200.

Gates: PHPStan max + deptrac 0 + cs-fixer; Identity 80.

Closes #1575
