### PR TITLE
fix(asset): signed preview URLs + drop public MinIO — AUD-006/028 (#1576)

### DIFF
--- a/apps/api/config/packages/security.yaml
+++ b/apps/api/config/packages/security.yaml
@@ -97,11 +97,16 @@ security:
         - { path: ^/api$, roles: PUBLIC_ACCESS }
         # /api/assets/{uuid}/preview streams thumbnail/medium/original
         # bytes for `<img>` tags in the admin grid. `<img>` cannot send
-        # the Bearer header, so the endpoint must be reachable without a
-        # JWT. Path-knowledge gates access — UUID v7 ids are 128-bit and
-        # not enumerable. Tenant isolation is enforced by Doctrine
-        # finder logic inside the controller. Signed-URL hardening
-        # ships with Faza 1 (#438 follow-up).
+        # the Bearer header, so the firewall must let the request through
+        # without a JWT — but authority is NOT path-knowledge. AUD-006
+        # (#1576): the request must carry a short-lived HMAC signature
+        # minted by AssetPreviewUrlSigner (the catalog read API hands out
+        # signed `previewUrl`s only to authenticated callers). The
+        # controller verifies the signature before loading any row and
+        # 403s an unsigned/expired/tampered request — same "the token IS
+        # the auth factor" model as the magic-link / SSO-callback routes
+        # above. PUBLIC_ACCESS here means "no session required", not
+        # "no credential required".
         - { path: '^/api/assets/[0-9a-f-]+/preview$', roles: PUBLIC_ACCESS }
         # `IS_AUTHENTICATED_FULLY` covers BOTH a logged-in user (ROLE_USER
         # + tenant context) and an API key principal (ROLE_API_KEY). The

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -119,6 +119,14 @@ services:
     App\Asset\Application\Thumbnail\ImageProcessorInterface:
         alias: App\Asset\Infrastructure\Thumbnail\ImagickImageProcessor
 
+    # AUD-006 (#1576) — public port for the preview-URL signer. The Catalog
+    # read overlay signs `previewUrl` per request through this interface
+    # (deptrac: Catalog → Asset_Contracts), so the implementation must be
+    # aliased to the contract explicitly (autowiring does not map an
+    # interface to its single implementation on its own).
+    App\Asset\Contracts\Service\AssetPreviewSigner:
+        alias: App\Asset\Application\AssetPreviewUrlSigner
+
     # Per-AttributeType validator dispatcher (#39). The factory wires up
     # one validator per AttributeType so the rest of the app can ask
     # "is this {value: ...} payload valid against this Attribute?" without

--- a/apps/api/src/Asset/Application/AssetPreviewUrlSigner.php
+++ b/apps/api/src/Asset/Application/AssetPreviewUrlSigner.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Application;
+
+use App\Asset\Contracts\Service\AssetPreviewSigner;
+use DateInterval;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\UriSigner;
+
+/**
+ * AUD-006 / #1576 — mints and verifies short-lived HMAC-signed preview
+ * URLs for `GET /api/assets/{id}/preview`.
+ *
+ * Why signed URLs instead of a Bearer-gated endpoint: the admin renders
+ * thumbnails with `<img src="/api/assets/{id}/preview?…">`, and an
+ * `<img>` tag cannot attach an `Authorization` header. Before the fix the
+ * route was simply `PUBLIC_ACCESS` and the controller disabled the tenant
+ * filter, so anyone holding the (timestamped, partly predictable) UUID
+ * could stream any tenant's bytes anonymously.
+ *
+ * The signature IS the auth factor — exactly the model the magic-link and
+ * SSO-callback routes in `security.yaml` already use. Only an
+ * authenticated caller who can read the asset ever receives a signed URL
+ * (the catalog read providers sign `previewUrl` per-request), and the
+ * signature expires after {@see self::TTL}, so a leaked URL stops working
+ * shortly after issuance instead of forever.
+ *
+ * Signing/verification deliberately operate on the path + query string
+ * only (never scheme/host) so a relative `previewUrl` persisted in
+ * `attributes_indexed` verifies identically regardless of the public
+ * host (`pim.localhost` dev vs `pim.example.com` prod vs the BrowserKit
+ * test host). {@see UriSigner::check()} hashes the string as-is, unlike
+ * {@see UriSigner::checkRequest()} which prepends the request scheme+host.
+ */
+final readonly class AssetPreviewUrlSigner implements AssetPreviewSigner
+{
+    /**
+     * URL lifetime. Long enough that a thumbnail survives a slow page +
+     * browser cache (`Cache-Control: private, max-age=300`), short enough
+     * that a leaked URL (logs, referrer, export) is useless within the
+     * hour rather than indefinitely.
+     */
+    private const string TTL = 'PT1H';
+
+    public function __construct(
+        private UriSigner $uriSigner,
+    ) {
+    }
+
+    /**
+     * Returns a signed, relative preview URL for the asset id (RFC-4122).
+     *
+     * @param DateTimeImmutable|null $now test seam — when provided, the
+     *                                    expiration is computed as $now + TTL
+     *                                    so an expired URL can be produced
+     *                                    deterministically in tests
+     */
+    public function sign(string $assetId, ?string $variant = null, ?DateTimeImmutable $now = null): string
+    {
+        $uri = $this->buildUri($assetId, $variant);
+        $expiration = ($now ?? new DateTimeImmutable())->add(new DateInterval(self::TTL));
+
+        return $this->uriSigner->sign($uri, $expiration);
+    }
+
+    /**
+     * Verifies the signature + expiration carried by the request's path +
+     * query string. Returns false for a missing, tampered, or expired
+     * signature.
+     */
+    public function verify(Request $request): bool
+    {
+        $qs = $request->server->get('QUERY_STRING');
+        $uri = $request->getPathInfo().(\is_string($qs) && '' !== $qs ? '?'.$qs : '');
+
+        return $this->uriSigner->check($uri);
+    }
+
+    private function buildUri(string $assetId, ?string $variant): string
+    {
+        $uri = \sprintf('/api/assets/%s/preview', $assetId);
+        if (null !== $variant && '' !== $variant) {
+            $uri .= '?variant='.rawurlencode($variant);
+        }
+
+        return $uri;
+    }
+}

--- a/apps/api/src/Asset/Contracts/Service/AssetPreviewSigner.php
+++ b/apps/api/src/Asset/Contracts/Service/AssetPreviewSigner.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Asset\Contracts\Service;
+
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * AUD-006 / #1576 — public port for minting and verifying the short-lived
+ * HMAC-signed preview URLs that authorise `GET /api/assets/{id}/preview`.
+ *
+ * Lives in Asset\Contracts so the Catalog read surface (which signs the
+ * denormalised `previewUrl` per request) depends only on this port, never
+ * on Asset\Application internals (deptrac: Catalog → Asset_Contracts, see
+ * ADR-0013). The implementation — {@see \App\Asset\Application\AssetPreviewUrlSigner}
+ * — owns the TTL and the {@see \Symfony\Component\HttpFoundation\UriSigner}
+ * wiring.
+ *
+ * The signature IS the auth factor (an `<img>` tag cannot attach a Bearer
+ * header), so only an authenticated caller who can already read the asset
+ * ever receives a signed URL, and the signature expires shortly after
+ * issuance.
+ */
+interface AssetPreviewSigner
+{
+    /**
+     * Returns a signed, relative preview URL for the asset id (RFC-4122).
+     *
+     * @param DateTimeImmutable|null $now test seam — when provided, the
+     *                                    expiration is computed as $now + TTL
+     *                                    so an expired URL can be produced
+     *                                    deterministically in tests
+     */
+    public function sign(string $assetId, ?string $variant = null, ?DateTimeImmutable $now = null): string;
+
+    /**
+     * Verifies the signature + expiration carried by the request's path +
+     * query string. Returns false for a missing, tampered, or expired
+     * signature.
+     */
+    public function verify(Request $request): bool;
+}

--- a/apps/api/src/Asset/Presentation/Controller/PreviewAssetController.php
+++ b/apps/api/src/Asset/Presentation/Controller/PreviewAssetController.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 
 namespace App\Asset\Presentation\Controller;
 
+use App\Asset\Contracts\Service\AssetPreviewSigner;
 use App\Asset\Domain\Entity\AssetVariant;
 use App\Asset\Domain\Repository\AssetRepositoryInterface;
 use App\Asset\Domain\ThumbnailsStatus;
 use App\Identity\Contracts\Attribute\NoPermissionRequired;
-use Doctrine\ORM\EntityManagerInterface;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\FilesystemOperator;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * `GET /api/assets/{id}/preview[?variant=thumb|medium|original]` (#438).
+ * `GET /api/assets/{id}/preview[?variant=thumb|medium|original]` (#438,
+ * hardened in AUD-006 / #1576).
  *
- * Single-origin preview surface — `<img src="/api/assets/{id}/preview"
+ * Single-origin preview surface — `<img src="/api/assets/{id}/preview?…"
  * />` works from the admin without exposing MinIO directly to the
  * browser (CSP allows only `'self'` and `data:` for img-src). Defaults
  * to the `thumb` variant when ready, falls back to `medium` →
@@ -30,43 +33,43 @@ use Symfony\Component\Uid\Uuid;
  * max-age=...` lets the browser cache previews across navigations
  * inside the same session.
  *
- * Auth model: the endpoint is registered under `PUBLIC_ACCESS` in
- * `security.yaml` because `<img>` tags cannot send the Bearer token
- * in their request. Path-knowledge gates access — UUID v7 ids are
- * 128-bit and not enumerable, so cross-tenant leakage requires
- * guessing the exact id (effectively impossible without DB access).
- * Doctrine `tenant_filter` is disabled for the lookup so the
- * un-authenticated request reaches the row at all; tenant isolation
- * is therefore by-id rather than by-context here. Faza 1 swaps this
- * for short-lived signed URLs minted by the catalog read API.
+ * Auth model (AUD-006): the request must carry a valid, unexpired
+ * HMAC signature minted by {@see AssetPreviewSigner}. An `<img>` tag
+ * cannot send a Bearer header, so the signature — embedded in the query
+ * string of the `previewUrl` the catalog read API hands out to an
+ * authenticated caller — IS the auth factor (same model as the
+ * magic-link / SSO-callback routes). Without a valid signature the
+ * request is rejected with 403 before any row is loaded, closing the
+ * pre-fix hole where id-knowledge alone streamed any tenant's bytes.
+ *
+ * The Doctrine `tenant` filter is left ENABLED: for an anonymous signed
+ * request it contributes no constraint (no tenant context is set, so the
+ * filter is a no-op), while an authenticated caller's tenant scopes the
+ * lookup as defence in depth.
  */
 final readonly class PreviewAssetController
 {
     public function __construct(
         private AssetRepositoryInterface $assets,
         private FilesystemOperator $assetsStorage,
-        private EntityManagerInterface $em,
+        private AssetPreviewSigner $urlSigner,
+        private RequestStack $requestStack,
     ) {
     }
 
     #[Route(path: '/api/assets/{id}/preview', name: 'pim_assets_preview', methods: ['GET'])]
-    #[NoPermissionRequired(reason: 'Registered under PUBLIC_ACCESS in security.yaml — <img> tags cannot send the Bearer token. Path-knowledge (UUID v7, 128-bit, non-enumerable) gates access; tenant isolation is by-id inside the handler. A RequiresPermission gate here would 403 every <img> request (anonymous principal) and break all thumbnails.')]
+    #[NoPermissionRequired(reason: 'Authorised by a short-lived HMAC signature (AssetPreviewUrlSigner), not by RBAC: <img> tags cannot send a Bearer token, so the signed query string IS the auth factor. The signature is verified in the handler before any row loads; an unsigned/expired/tampered request gets 403. A RequiresPermission gate here would 403 every legitimate <img> request (anonymous principal) and break all thumbnails.')]
     public function __invoke(string $id, ?string $variant = null): StreamedResponse
     {
-        $assetId = Uuid::fromString($id);
+        $request = $this->requestStack->getCurrentRequest();
+        if (null === $request || !$this->urlSigner->verify($request)) {
+            // No valid signature → reject before touching the database, so
+            // id-knowledge alone never reaches (let alone streams) a row.
+            throw new AccessDeniedHttpException('A valid, unexpired preview signature is required.');
+        }
 
-        $filters = $this->em->getFilters();
-        $tenantFilterWasEnabled = $filters->isEnabled('tenant');
-        if ($tenantFilterWasEnabled) {
-            $filters->disable('tenant');
-        }
-        try {
-            $asset = $this->assets->findById($assetId) ?? $this->assets->findByObjectId($assetId);
-        } finally {
-            if ($tenantFilterWasEnabled) {
-                $filters->enable('tenant');
-            }
-        }
+        $assetId = Uuid::fromString($id);
+        $asset = $this->assets->findById($assetId) ?? $this->assets->findByObjectId($assetId);
 
         if (null === $asset) {
             throw new NotFoundHttpException(\sprintf('Asset "%s" was not found.', $id));

--- a/apps/api/src/Asset/Presentation/Controller/ProductAssetsController.php
+++ b/apps/api/src/Asset/Presentation/Controller/ProductAssetsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Asset\Presentation\Controller;
 
+use App\Asset\Contracts\Service\AssetPreviewSigner;
 use App\Asset\Domain\Entity\Asset;
 use App\Asset\Domain\Repository\AssetRepositoryInterface;
 use App\Catalog\Contracts\Service\ProductAssetLinker;
@@ -38,6 +39,7 @@ final readonly class ProductAssetsController
     public function __construct(
         private AssetRepositoryInterface $assets,
         private ProductAssetLinker $linker,
+        private AssetPreviewSigner $previewUrlSigner,
     ) {
     }
 
@@ -153,7 +155,9 @@ final readonly class ProductAssetsController
             'tags' => $asset->getTags(),
             'thumbnailsStatus' => $asset->getThumbnailsStatus()->value,
             'folderCode' => $asset->getFolderCode(),
-            'previewUrl' => \sprintf('/api/assets/%s/preview', $asset->getId()->toRfc4122()),
+            // AUD-006 / #1576 — hand out a short-lived signed URL, never the
+            // bare path, so the preview endpoint stays signature-gated.
+            'previewUrl' => $this->previewUrlSigner->sign($asset->getId()->toRfc4122()),
         ];
     }
 }

--- a/apps/api/src/Catalog/Application/AssetPreviewUrlReadOverlay.php
+++ b/apps/api/src/Catalog/Application/AssetPreviewUrlReadOverlay.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Asset\Contracts\Service\AssetPreviewSigner;
+use App\Catalog\Domain\Entity\CatalogObject;
+
+use const PHP_URL_QUERY;
+
+/**
+ * AUD-006 / #1576 — read-only overlay that replaces the bare,
+ * persisted `previewUrl` in `attributes_indexed` with a freshly minted,
+ * short-lived HMAC-signed URL on every GET.
+ *
+ * `previewUrl` is denormalised into `attributes_indexed` at upload time
+ * (see {@see \App\Asset\Application\AssetUploader::buildIndexedAttributes()})
+ * as the bare path `/api/assets/{id}/preview`. Persisting a signed URL
+ * instead is impossible — the signature expires. So, mirroring
+ * {@see SystemAttributeReadOverlay}, we sign per-request on a clone using
+ * the side-effect-free {@see CatalogObject::overlayAttributesIndexedForRead()}
+ * so a GET never touches `updatedAt` or risks persistence.
+ *
+ * The signed URL keeps the `<img src>` flow working: the browser sends
+ * no Bearer header, but the query-string signature authorises the
+ * preview endpoint. The signature is only ever handed to a caller who
+ * has already passed RBAC on the catalog read surface.
+ *
+ * Idempotent + defensive: only values shaped like an asset preview path
+ * are signed, and an already-signed value (carrying `_hash`) is left
+ * untouched, so applying the overlay twice or over an unrelated URL is a
+ * no-op.
+ */
+final readonly class AssetPreviewUrlReadOverlay
+{
+    private const string PREVIEW_KEY = 'previewUrl';
+
+    public function __construct(
+        private AssetPreviewSigner $signer,
+    ) {
+    }
+
+    public function apply(CatalogObject $object): CatalogObject
+    {
+        $indexed = $object->getAttributesIndexed();
+        if (!\array_key_exists(self::PREVIEW_KEY, $indexed)) {
+            return $object;
+        }
+
+        $value = $indexed[self::PREVIEW_KEY];
+
+        // `previewUrl` is stored as a bare string, but tolerate the
+        // envelope `{value: …}` shape some writers use.
+        if (\is_string($value)) {
+            $signed = $this->signPath($value, $object->getId()->toRfc4122());
+            if (null === $signed) {
+                return $object;
+            }
+            $indexed[self::PREVIEW_KEY] = $signed;
+        } elseif (\is_array($value) && isset($value['value']) && \is_string($value['value'])) {
+            $signed = $this->signPath($value['value'], $object->getId()->toRfc4122());
+            if (null === $signed) {
+                return $object;
+            }
+            $value['value'] = $signed;
+            $indexed[self::PREVIEW_KEY] = $value;
+        } else {
+            return $object;
+        }
+
+        $copy = clone $object;
+        $copy->overlayAttributesIndexedForRead($indexed);
+
+        return $copy;
+    }
+
+    /**
+     * Signs a bare `/api/assets/{id}/preview[?variant=…]` path. Returns
+     * null (caller keeps the original) when the value is not a preview
+     * path or already carries a signature.
+     */
+    private function signPath(string $path, string $assetId): ?string
+    {
+        if (!str_contains($path, '/api/assets/') || !str_contains($path, '/preview')) {
+            return null;
+        }
+        if (str_contains($path, '_hash=')) {
+            // Already signed (e.g. overlay applied twice) — leave as-is.
+            return null;
+        }
+
+        $variant = null;
+        $query = parse_url($path, PHP_URL_QUERY);
+        if (\is_string($query) && '' !== $query) {
+            parse_str($query, $params);
+            $candidate = $params['variant'] ?? null;
+            $variant = \is_string($candidate) && '' !== $candidate ? $candidate : null;
+        }
+
+        return $this->signer->sign($assetId, $variant);
+    }
+}

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectCollectionLocaleOverlayProvider.php
@@ -8,6 +8,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Pagination\PaginatorInterface;
 use ApiPlatform\State\Pagination\TraversablePaginator;
 use ApiPlatform\State\ProviderInterface;
+use App\Catalog\Application\AssetPreviewUrlReadOverlay;
 use App\Catalog\Application\AttributeReadRestrictionOverlay;
 use App\Catalog\Application\ObjectValueLocaleOverlay;
 use App\Catalog\Application\SystemAttributeReadOverlay;
@@ -44,6 +45,7 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
         private ProviderInterface $collectionProvider,
         private ObjectValueLocaleOverlay $overlay,
         private SystemAttributeReadOverlay $systemOverlay,
+        private AssetPreviewUrlReadOverlay $previewUrlOverlay,
         private ObjectValueRepositoryInterface $objectValues,
         private RequestStack $requestStack,
         private ChannelPublicationResolverInterface $publicationResolver,
@@ -87,33 +89,21 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
             return $result; // @phpstan-ignore-line (inner provider return type is wider)
         }
 
-        // Always apply system overlay so created_at/updated_at render.
-        // When no locale/channel scope and no publication filter, skip the
-        // value/publication overlays but still run system + restriction on
-        // clones (AUD-008 #1578: restricted attributes must not leak through
-        // the list path either).
-        if (null === $locale && null === $channel && null === $publication) {
-            $overlaid = $this->restrictionOverlay->applyBatch(
-                array_map(
-                    fn (CatalogObject $o): CatalogObject => $this->systemOverlay->apply($o),
-                    $objects,
-                ),
-            );
-
-            return $this->rebuildResult($result, $overlaid);
-        }
-
-        // Batch-load all ObjectValue rows for the current page in one query.
-        $objectIds = array_map(
-            static fn (CatalogObject $o): Uuid => $o->getId(),
-            $objects,
-        );
-        $valuesByObjectId = $this->objectValues->findByObjectIds($objectIds);
-
         // Apply locale/channel overlay on clones (no identity map mutation).
-        $overlaid = (null !== $locale || null !== $channel)
-            ? $this->overlay->applyBatch($objects, $valuesByObjectId, $locale, $channel)
-            : array_map(static fn (CatalogObject $o): CatalogObject => clone $o, $objects);
+        // With no locale/channel scope this is a plain clone — the system +
+        // preview overlays below still run so created_at/updated_at render and
+        // `previewUrl` is signed per-request (AUD-006 / #1576).
+        if (null !== $locale || null !== $channel) {
+            // Batch-load all ObjectValue rows for the current page in one query.
+            $objectIds = array_map(
+                static fn (CatalogObject $o): Uuid => $o->getId(),
+                $objects,
+            );
+            $valuesByObjectId = $this->objectValues->findByObjectIds($objectIds);
+            $overlaid = $this->overlay->applyBatch($objects, $valuesByObjectId, $locale, $channel);
+        } else {
+            $overlaid = array_map(static fn (CatalogObject $o): CatalogObject => clone $o, $objects);
+        }
 
         // #1234 — ?publication=<channelCode> filters attributes_indexed per
         // publication profile. Applied after value overlay.
@@ -121,13 +111,14 @@ final readonly class CatalogObjectCollectionLocaleOverlayProvider implements Pro
             $overlaid = $this->applyPublicationFilter($overlaid, $publication);
         }
 
-        // Apply system overlay then strip restricted attributes (AUD-008
-        // #1578) on the (already cloned) overlaid objects. Restriction runs
-        // as one batch so the tenant attribute catalogue + per-attribute
-        // view decisions are resolved once for the page, not per item (#1620).
+        // Apply system overlay + sign previewUrl per item (AUD-006 #1576),
+        // then strip restricted attributes as one batch (AUD-008 #1578/#1620)
+        // on the (already cloned) overlaid objects. Restriction runs as one
+        // batch so the tenant attribute catalogue + per-attribute view
+        // decisions are resolved once for the page, not per item.
         $overlaid = $this->restrictionOverlay->applyBatch(
             array_map(
-                fn (CatalogObject $o): CatalogObject => $this->systemOverlay->apply($o),
+                fn (CatalogObject $o): CatalogObject => $this->previewUrlOverlay->apply($this->systemOverlay->apply($o)),
                 $overlaid,
             ),
         );

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php
@@ -6,6 +6,7 @@ namespace App\Catalog\Infrastructure\ApiPlatform\State;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use App\Catalog\Application\AssetPreviewUrlReadOverlay;
 use App\Catalog\Application\AttributeReadRestrictionOverlay;
 use App\Catalog\Application\ObjectValueLocaleOverlay;
 use App\Catalog\Application\SystemAttributeReadOverlay;
@@ -39,6 +40,7 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
         private ProviderInterface $itemProvider,
         private ObjectValueLocaleOverlay $overlay,
         private SystemAttributeReadOverlay $systemOverlay,
+        private AssetPreviewUrlReadOverlay $previewUrlOverlay,
         private RequestStack $requestStack,
         private ChannelPublicationResolverInterface $publicationResolver,
         private AttributeReadRestrictionOverlay $restrictionOverlay,
@@ -76,11 +78,12 @@ final readonly class CatalogObjectLocaleOverlayProvider implements ProviderInter
         // created_by/updated_by) so they render real values instead of "—".
         $object = $this->systemOverlay->apply($object);
 
-        // AUD-008 (#1578) — strip attributes the caller may not view
-        // (3-state per-attribute permission, PRD §3.5). Runs last so the
-        // system attributes injected above are present (and preserved —
-        // they are not attribute-permission subjects).
-        return $this->restrictionOverlay->apply($object);
+        // AUD-006 (#1576) sign the `previewUrl` per-request, then AUD-008
+        // (#1578) strip attributes the caller may not view (3-state
+        // per-attribute permission, PRD §3.5). Restriction runs last so the
+        // system attributes injected above are preserved (not permission
+        // subjects) and only the short-lived signed previewUrl is handed out.
+        return $this->restrictionOverlay->apply($this->previewUrlOverlay->apply($object));
     }
 
     private function applyPublicationFilter(CatalogObject $object, string $channelCode): CatalogObject

--- a/apps/api/tests/Api/Asset/AssetPreviewPublicAccessApiTest.php
+++ b/apps/api/tests/Api/Asset/AssetPreviewPublicAccessApiTest.php
@@ -8,26 +8,41 @@ use App\Tests\Api\Catalog\CatalogApiTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
- * Regression for #1143 — asset thumbnails (`<img src="/api/assets/{id}/preview">`)
+ * Regression for #1143 + AUD-006 (#1576).
+ *
+ * #1143: asset thumbnails (`<img src="/api/assets/{id}/preview">`) once
  * returned 403 for every request because the controller carried
  * `#[RequiresPermission]` while the route is `PUBLIC_ACCESS`: an `<img>`
  * tag cannot send the Bearer token, so the request is anonymous and the
- * EndpointGuardListener rejected it before the controller ran.
+ * EndpointGuardListener rejected it before the controller ran. The
+ * endpoint therefore must NOT be RBAC-gated.
  *
- * The endpoint must be reachable anonymously — an unknown asset yields a
- * 404 (handler reached), never a 401/403 (guard short-circuit).
+ * AUD-006: before the hardening, "not RBAC-gated" had degraded into "open
+ * to anyone with the id" — an anonymous request reached the row
+ * cross-tenant and (with a blob present) streamed the bytes. The fix
+ * gates the endpoint on a short-lived HMAC signature instead: the
+ * controller is still reachable without a Bearer token, but an
+ * unsigned request is rejected with 403, never served.
+ *
+ * This suite pins the negative half of that contract — an anonymous,
+ * UNSIGNED request must be 403 (not 200, not 404). The positive half
+ * (a valid signature streams the bytes) lives in
+ * {@see AssetPreviewSignedUrlApiTest}.
  */
 final class AssetPreviewPublicAccessApiTest extends CatalogApiTestCase
 {
     #[Test]
-    public function previewIsReachableAnonymouslyAndReturns404ForUnknownAsset(): void
+    public function unsignedAnonymousRequestIsForbiddenNotFound(): void
     {
-        // No Authorization header — mirrors a browser `<img>` request.
+        // No Authorization header AND no signature — mirrors a raw `<img>`
+        // request that never went through the signing read API.
         $client = static::createClient();
         $client->request('GET', '/api/assets/00000000-0000-0000-0000-000000000000/preview');
 
-        // 404 = controller ran and found no asset. 401/403 would mean the
-        // RBAC guard blocked the anonymous request (the #1143 regression).
-        self::assertResponseStatusCodeSame(404);
+        // 403 = the signature guard blocked the request before any row
+        // loaded. 404 would mean the handler ran and authorised by
+        // id-knowledge alone (the AUD-006 hole); 200 would mean it
+        // streamed bytes.
+        self::assertResponseStatusCodeSame(403);
     }
 }

--- a/apps/api/tests/Api/Asset/AssetPreviewSignedUrlApiTest.php
+++ b/apps/api/tests/Api/Asset/AssetPreviewSignedUrlApiTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Asset;
+
+use App\Asset\Application\AssetPreviewUrlSigner;
+use App\Asset\Application\AssetUploader;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\File\File;
+
+/**
+ * AUD-006 / #1576 regression — `GET /api/assets/{id}/preview` must not
+ * serve any tenant's bytes by id-knowledge alone.
+ *
+ * Before the fix the route was `PUBLIC_ACCESS` and the controller
+ * explicitly `disable('tenant')`-ed the lookup, so an anonymous request
+ * carrying only the (timestamped, partly predictable) UUID reached the
+ * row cross-tenant. The empirical probe returned 404 (handler reached,
+ * blob missing) instead of 401/403 — proof the request was authorised
+ * by path knowledge, not by a credential.
+ *
+ * The hardened model mints a short-lived HMAC-signed URL via the
+ * authenticated catalog read surface ({@see AssetPreviewUrlSigner}). The
+ * `<img src>` then carries the signature in the query string, so the
+ * browser needs no Bearer header, yet a request without a valid
+ * signature (and without a tenant-scoped principal) is rejected.
+ */
+final class AssetPreviewSignedUrlApiTest extends CatalogApiTestCase
+{
+    /**
+     * Anonymous request WITHOUT a valid signature must be denied (403),
+     * not merely "not found" (404). 404 means the handler ran and the
+     * caller was implicitly authorised by id knowledge — the AUD-006
+     * vulnerability.
+     */
+    #[Test]
+    public function anonymousRequestWithoutSignatureIsForbidden(): void
+    {
+        $asset = $this->uploadAssetForTenant(self::TENANT_CODE, 'aud006 owner bytes');
+
+        $client = static::createClient();
+        // No Authorization header, no _hash/_expiration query — mirrors a
+        // raw `<img src="/api/assets/{id}/preview">` with a tampered/absent
+        // signature.
+        $client->request('GET', \sprintf('/api/assets/%s/preview', $asset));
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * A tampered signature (right shape, wrong hash) must also be denied.
+     */
+    #[Test]
+    public function tamperedSignatureIsForbidden(): void
+    {
+        $asset = $this->uploadAssetForTenant(self::TENANT_CODE, 'aud006 tamper bytes');
+
+        $client = static::createClient();
+        $client->request('GET', \sprintf(
+            '/api/assets/%s/preview?_hash=not-a-real-hash&_expiration=%d',
+            $asset,
+            time() + 3600,
+        ));
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * An expired but otherwise valid signature must be denied.
+     */
+    #[Test]
+    public function expiredSignatureIsForbidden(): void
+    {
+        $asset = $this->uploadAssetForTenant(self::TENANT_CODE, 'aud006 expired bytes');
+
+        $signer = self::getContainer()->get(AssetPreviewUrlSigner::class);
+        // Sign with an already-past expiration.
+        $signed = $signer->sign($asset, null, new DateTimeImmutable('-1 hour'));
+
+        $client = static::createClient();
+        $client->request('GET', $signed);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    /**
+     * A request carrying a freshly minted, valid signature streams the
+     * bytes back (200) without any Authorization header — the `<img>`
+     * flow the admin grid relies on.
+     */
+    #[Test]
+    public function validSignatureStreamsBytesAnonymously(): void
+    {
+        $asset = $this->uploadAssetForTenant(self::TENANT_CODE, 'aud006 valid bytes');
+
+        $signer = self::getContainer()->get(AssetPreviewUrlSigner::class);
+        $signed = $signer->sign($asset);
+
+        $client = static::createClient();
+        $client->request('GET', $signed);
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * Cross-tenant: a URL signed for tenant B's asset still streams the
+     * bytes IF the signature is valid (the signature is the auth factor,
+     * minted only by an authenticated caller who can already read the
+     * asset). What must NEVER work is reaching tenant B's bytes WITHOUT a
+     * valid signature — covered by the anonymous/tampered cases. Here we
+     * assert the negative directly: tenant B's asset, no signature → 403,
+     * never the bytes.
+     */
+    #[Test]
+    public function crossTenantAssetWithoutSignatureLeaksNoBytes(): void
+    {
+        // Asset belongs to a *second* tenant; attacker knows only its id.
+        $foreignAsset = $this->uploadAssetForTenant('acme', 'aud006 foreign secret bytes');
+
+        $client = static::createClient();
+        $response = $client->request('GET', \sprintf('/api/assets/%s/preview', $foreignAsset));
+
+        $status = $response->getStatusCode();
+        self::assertContains(
+            $status,
+            [401, 403, 404],
+            'Cross-tenant preview without a signature must never return 200 with bytes.',
+        );
+        self::assertNotSame(200, $status);
+    }
+
+    /**
+     * Uploads a real asset (with a stored blob) for the given tenant and
+     * returns its RFC-4122 id. Mirrors {@see AssetUploaderTest}: the test
+     * `assets.storage` is a local filesystem, so the bytes are reachable.
+     */
+    private function uploadAssetForTenant(string $tenantCode, string $contents): string
+    {
+        $tenant = $this->resolveOrCreateTenant($tenantCode);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $path = tempnam(sys_get_temp_dir(), 'pim-aud006-');
+        \assert(false !== $path);
+        file_put_contents($path.'.txt', $contents);
+        rename($path, $path.'.txt');
+
+        $uploader = self::getContainer()->get(AssetUploader::class);
+        $asset = $uploader->upload(new File($path.'.txt'), null);
+
+        @unlink($path.'.txt');
+
+        return $asset->getId()->toRfc4122();
+    }
+
+    private function resolveOrCreateTenant(string $code): Tenant
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        $existing = $em->getRepository(Tenant::class)->findOneBy(['code' => $code]);
+        if ($existing instanceof Tenant) {
+            return $existing;
+        }
+
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -344,6 +344,11 @@ services:
       - "443"
 
   # Initialise required buckets the first time the stack comes up.
+  # AUD-028 (#1576): pim-assets is explicitly set to `none` — never a public
+  # `download` policy. Asset bytes are served only through the signature-gated
+  # `/api/assets/{id}/preview` endpoint (AUD-006); the bucket must not be
+  # anonymously readable even if MinIO is ever published. `set none` also
+  # remediates a stack initialised before this change.
   minio-init:
     image: minio/mc:latest
     depends_on:
@@ -356,7 +361,7 @@ services:
       mc mb -p local/pim-backups || true;
       mc mb -p local/pim-imports || true;
       mc mb -p local/pim-exports || true;
-      mc anonymous set download local/pim-assets || true;
+      mc anonymous set none local/pim-assets || true;
       mc ilm rule add --expire-days 7 local/pim-imports || true;
       "
     restart: "no"


### PR DESCRIPTION
## AUD-006 (HIGH) + AUD-028 — asset preview cross-tenant bytes
`GET /api/assets/{id}/preview` = PUBLIC_ACCESS + `$filters->disable('tenant')` → bajty dowolnego tenanta po UUID, bez auth. MinIO `pim-assets` = anonymous-download.

## Fix (signed URL — rekomendacja audytu)
- `AssetPreviewUrlSigner` (HMAC+TTL, UriSigner/APP_SECRET) + `AssetPreviewUrlReadOverlay` (podpis per-request na odczyt; ścieżka persystowana goła, podpis w query → `<img src>` działa bez Bearera).
- `PreviewAssetController`: weryfikuje podpis → 403 PRZED lookupem; **usunięto `disable('tenant')`** (tenant-scope gdy principal).
- `docker-compose.yml`: MinIO `pim-assets` → private (AUD-028).

## Test (failing → green) + Smoke (CLOSED MEANS CLOSED)
ApiTest 6/6: anon-no-sig/tampered/expired → 403, valid → 200, cross-tenant bez bajtów. **Failing baseline odtworzył leak** (anon → 200 ze strumieniem bajtów). Smoke: **PRZED** anon `/preview` → 404 (reachable bez auth); **PO** → 403 (bez podpisu), MinIO `mc anonymous get` → **private**.

Gates: PHPStan max (clear-result-cache) + cs-fixer; preview 6/6 + overlay 20/20.

Closes #1576
