### PR TITLE
AUD-026: fix break-glass tenant filter name + reset (W1-3)

### DIFF
--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4257,16 +4257,16 @@
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34",
                 "shasum": ""
             },
             "require": {
@@ -4275,7 +4275,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -4283,7 +4283,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -4317,9 +4317,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-06-11T10:43:56+00:00"
         },
         {
             "name": "onelogin/php-saml",

--- a/apps/api/src/Identity/Application/SuperAdmin/SuperAdminContext.php
+++ b/apps/api/src/Identity/Application/SuperAdmin/SuperAdminContext.php
@@ -7,6 +7,7 @@ namespace App\Identity\Application\SuperAdmin;
 use Closure;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Uid\Uuid;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * RBAC-P3-014 (#677) — switches the request into the platform-level
@@ -24,12 +25,23 @@ use Symfony\Component\Uid\Uuid;
  * requests within the same FrankenPHP worker. The class returns the
  * previous filter state so nested activations compose correctly.
  *
- * Postgres RLS context is handled separately by the existing
- * `RlsContextListener` (RBAC-P2-005 #654) — when activated here, the
- * caller is also responsible for setting `app.bypass_rls = true` via
- * `SET LOCAL` if the caller intends to read tenant-scoped tables. The
- * helper {@see runCrossTenant()} wraps both concerns into one closure
- * for the typical break-glass path.
+ * Disabling the Doctrine filter is an application-layer concern only.
+ * After AUD-002/W1-1 the runtime connects as `pim_app` (NOBYPASSRLS)
+ * with FORCE ROW LEVEL SECURITY on every tenant-scoped table, so a
+ * disabled `TenantFilter` does NOT by itself grant cross-tenant reads of
+ * domain data — Postgres RLS still filters by the `app.current_tenant`
+ * GUC. Crossing the RLS wall additionally requires the
+ * `super_admin_bypass_<table>` policy, which is keyed on
+ * `app.is_super_admin = 'true'` (set via {@see \App\Identity\Infrastructure\Doctrine\RlsContextListener}).
+ * Setting that GUC is intentionally out of scope here (AUD-026 only
+ * realigns the filter-name invariant); the RLS layer staying active for
+ * `pim_app` is defence-in-depth, not a bug.
+ *
+ * Note that the break-glass entry points in MVP operate on `users` /
+ * `roles` (auth tables) — `User` is {@see \App\Shared\Application\TenantAware},
+ * not {@see \App\Shared\Application\TenantScoped}, so the Doctrine filter
+ * never constrained those lookups; the filter toggle matters for any
+ * `TenantScoped` read performed inside the cross-tenant closure.
  *
  * `superAdminId` is tracked on every cross-tenant write through the
  * audit log (`audit_logs.super_admin_id`, `cross_tenant_access=true`)
@@ -39,9 +51,17 @@ use Symfony\Component\Uid\Uuid;
  * a request attribute so the listener does not need to reach into
  * this service.
  */
-final class SuperAdminContext
+final class SuperAdminContext implements ResetInterface
 {
-    public const string FILTER_NAME = 'tenant_filter';
+    /**
+     * Must match the filter name registered in
+     * `config/packages/doctrine.yaml` (`doctrine.orm.filters.tenant`) and
+     * toggled by {@see \App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator}.
+     * AUD-026: this was `tenant_filter`, which silently no-op'd every
+     * `enable()`/`disable()` here because that name is not registered —
+     * the cross-tenant invariant was a lie.
+     */
+    public const string FILTER_NAME = 'tenant';
 
     private ?Uuid $activeSuperAdminId = null;
 
@@ -112,5 +132,20 @@ final class SuperAdminContext
                 $filters->enable(self::FILTER_NAME);
             }
         }
+    }
+
+    /**
+     * Symfony `kernel.reset` hook — fires at the end of every request in
+     * FrankenPHP worker mode. Clears any cross-tenant mode that survived
+     * the request (e.g. an exception that bypassed the `finally`, or a
+     * long-running command that died mid-flight) so the privileged
+     * super-admin context can never leak into the next request served by
+     * the reused worker. The Doctrine filter itself is re-armed per request
+     * by {@see \App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator},
+     * so here we only have to drop the in-memory super-admin marker.
+     */
+    public function reset(): void
+    {
+        $this->activeSuperAdminId = null;
     }
 }

--- a/apps/api/tests/Integration/Identity/SuperAdminContextFilterNameTest.php
+++ b/apps/api/tests/Integration/Identity/SuperAdminContextFilterNameTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Identity;
+
+use App\Identity\Application\SuperAdmin\SuperAdminContext;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-026 / W1-3 — black-box guard that {@see SuperAdminContext} toggles
+ * the SAME Doctrine filter that `doctrine.yaml` actually registers.
+ *
+ * Why an integration test rather than the existing mocked unit suite
+ * ({@see \App\Tests\Unit\Identity\Application\SuperAdmin\SuperAdminContextTest}):
+ * those mock `FilterCollection` and assert the call happens *with*
+ * `SuperAdminContext::FILTER_NAME` — so they pass for ANY value of the
+ * constant, including the wrong one. They could not catch the bug where
+ * the constant (`tenant_filter`) drifted from the registered filter name
+ * (`tenant`).
+ *
+ * Here the EntityManager comes from the real container, so its filter
+ * registry is the one built from `doctrine.yaml`. Enabling the registered
+ * filter and asserting `useCrossTenantMode()` disables it proves the names
+ * agree end to end.
+ *
+ * RED (pre-fix, FILTER_NAME='tenant_filter'): `useCrossTenantMode()` calls
+ * `isEnabled('tenant_filter')` → false → never disables the real `tenant`
+ * filter, so it stays enabled inside the cross-tenant scope. The break-glass
+ * "isolation off" invariant is a lie.
+ * GREEN (post-fix, FILTER_NAME='tenant'): the registered filter is disabled
+ * inside the scope and restored afterwards.
+ */
+final class SuperAdminContextFilterNameTest extends KernelTestCase
+{
+    /**
+     * The literal name `doctrine.yaml` registers the TenantFilter under.
+     * Hard-coded on purpose: the test must fail if EITHER the YAML name OR
+     * the SuperAdminContext constant moves without the other following.
+     */
+    private const string REGISTERED_FILTER_NAME = 'tenant';
+
+    #[Test]
+    public function crossTenantModeDisablesTheRegisteredTenantFilter(): void
+    {
+        self::bootKernel();
+        $em = $this->em();
+        $context = self::getContainer()->get(SuperAdminContext::class);
+        self::assertInstanceOf(SuperAdminContext::class, $context);
+
+        $filters = $em->getFilters();
+        // Establish the realistic request-time precondition: the tenant
+        // filter is enabled. (TenantFilterConfigurator does this once a
+        // tenant is known.) A parameter is not required to assert
+        // enabled/disabled state.
+        if (!$filters->isEnabled(self::REGISTERED_FILTER_NAME)) {
+            $filters->enable(self::REGISTERED_FILTER_NAME);
+        }
+        self::assertTrue(
+            $filters->isEnabled(self::REGISTERED_FILTER_NAME),
+            'Precondition: the registered tenant filter must be enabled before entering cross-tenant mode.',
+        );
+
+        $insideEnabled = null;
+        $context->runCrossTenant(Uuid::v7(), static function () use ($filters, &$insideEnabled): void {
+            $insideEnabled = $filters->isEnabled(self::REGISTERED_FILTER_NAME);
+        });
+
+        // The core invariant: inside the break-glass closure the app-layer
+        // tenant filter is actually OFF. Pre-fix this is true (bug) because
+        // the constant pointed at a non-existent filter name.
+        self::assertFalse(
+            $insideEnabled,
+            'Inside cross-tenant mode the registered "tenant" filter must be disabled; '
+            .'a true here means SuperAdminContext::FILTER_NAME drifted from doctrine.yaml.',
+        );
+
+        // And it is restored afterwards so the cross-tenant view does not
+        // leak past the closure (worker reuse).
+        self::assertTrue(
+            $filters->isEnabled(self::REGISTERED_FILTER_NAME),
+            'After cross-tenant mode the tenant filter must be re-enabled.',
+        );
+
+        // Clean state for any sibling test reusing the kernel's EM — the
+        // filter is enabled here (asserted above), so disable it directly.
+        $filters->disable(self::REGISTERED_FILTER_NAME);
+    }
+
+    /**
+     * AUD-026 — `reset()` (Symfony `kernel.reset`) must clear an active
+     * cross-tenant mode so a thrown exception that skipped the finally, or
+     * a half-finished CLI run, cannot leak the super-admin context into the
+     * next request served by the same FrankenPHP worker.
+     */
+    #[Test]
+    public function resetClearsActiveCrossTenantState(): void
+    {
+        self::bootKernel();
+        $context = self::getContainer()->get(SuperAdminContext::class);
+        self::assertInstanceOf(SuperAdminContext::class, $context);
+
+        $context->useCrossTenantMode(Uuid::v7());
+        self::assertTrue($context->isActive(), 'Context is active after entering cross-tenant mode.');
+
+        $context->reset();
+
+        self::assertFalse($context->isActive(), 'reset() must clear the active super-admin context.');
+        self::assertNull($context->activeSuperAdminId(), 'reset() must clear the active super-admin id.');
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        self::assertInstanceOf(EntityManagerInterface::class, $em);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
> Audyt fix-plan **W1-3** (Wave 1). Closes #1582 (AUD-026).

## Problem (confirmed)
`SuperAdminContext::FILTER_NAME='tenant_filter'`, ale `doctrine.yaml:160` rejestruje filtr jako **`tenant`** → `getFilters()->isEnabled('tenant_filter')` zawsze false → `disable()` w break-glass `useCrossTenantMode()` pomijane → filtr `tenant` POZOSTAWAŁ aktywny. Fałszywy invariant „break-glass wyłącza izolację". Bug przeszedł niezauważony, bo istniejący `SuperAdminContextTest` mockował `FilterCollection` i asercje robił symbolicznie z `FILTER_NAME` (przechodził dla dowolnej wartości).

## Naprawa
- `FILTER_NAME = 'tenant'` (zgodne z `doctrine.yaml`; jedyne miejsce z driftem — `TenantFilterConfigurator` już używał `'tenant'`).
- `implements ResetInterface` + `reset()` czyści `activeSuperAdminId` między requestami (FrankenPHP worker reuse — autoconfigured `kernel.reset`, zweryfikowane `debug:container`).
- Poprawiony stale docblock (`app.bypass_rls` → faktyczne `app.is_super_admin` z W1-1).

## Failing test FIRST
`tests/Integration/Identity/SuperAdminContextFilterNameTest.php` (KernelTestCase, REALNY rejestr filtrów): PRE-FIX → `Failed asserting that true is false` (filtr `tenant` aktywny w cross-tenant scope); POST-FIX → OK (2 tests, 9 assertions). Drugi test: `reset()` czyści stan.

## Interakcja z W1-1 (FORCE RLS)
**Naprawia:** app-layer — `useCrossTenantMode()` faktycznie wyłącza Doctrine `TenantFilter` dla encji `TenantScoped` w closure. **NIE zmienia (poprawnie — defence-in-depth):** po W1-1 app łączy się jako `pim_app` (NOBYPASSRLS)+FORCE RLS; samo wyłączenie filtra NIE daje cross-tenant odczytu danych domenowych — RLS dalej filtruje po `app.current_tenant`. Przejście RLS wymaga policy `super_admin_bypass` na GUC `app.is_super_admin`, czego SuperAdminContext celowo nie robi.
**Znane ograniczenie (osobny ticket, poza AUD-026):** break-glass cross-tenant na danych domenowych nie ustawia `app.is_super_admin` → RLS blokuje mimo wyłączonego filtra. Break-glass MVP operuje na `users`/`roles` (nie-`TenantScoped`), więc lookupy działają.

## Bramki
PHPStan **No errors** · cs-fixer clean · Deptrac **0** · test red→green + regresja SuperAdmin/Identity 20 passed · smoke: login 200, `GET /api/admin/break-glass/usage` → 403 RFC7807 (nie 500 → serwis z ResetInterface instancjonuje się OK).
