### PR TITLE
fix(deps): bump jmespath.php to 2.9.1 (CVE-2026-54133)

### DIFF
--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4257,16 +4257,16 @@
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34",
                 "shasum": ""
             },
             "require": {
@@ -4275,7 +4275,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -4283,7 +4283,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -4317,9 +4317,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-06-11T10:43:56+00:00"
         },
         {
             "name": "onelogin/php-saml",


### PR DESCRIPTION
Nowo ujawnione advisory **CVE-2026-54133** (GHSA-pcw8-m77r-2528, CompilerRuntime code injection via unescaped function names) dotyczy `mtdowling/jmespath.php` <2.9.1 — zależność tranzytywna. `composer audit` failuje na tym, blokując wszystkie otwarte PR-y (W1-3 #1627, W1-4 #1628 itd.).

Bump tylko zablokowanej wersji (2.8.0 → 2.9.1), bez zmiany constraintu w composer.json (transitive). Po bumpie: `composer audit` → **No security vulnerability advisories found**. Zero innych pakietów ruszonych w lock (zweryfikowane: 1 zmiana version).