### PR TITLE
AUD-017/021: register postgres crontab so backups actually run (W1-5)

### DIFF
--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -10,6 +10,8 @@ on:
       - "docs/api-spec/**"
       - "scripts/lint-raw-sql.sh"
       - "scripts/lint-tracked-secrets.sh"
+      - "scripts/lint-backup-cron.sh"
+      - "docker/postgres/**"
       - ".gitignore"
       - ".github/workflows/quality-php.yml"
       - ".semgrep/**"
@@ -20,6 +22,8 @@ on:
       - "docs/api-spec/**"
       - "scripts/lint-raw-sql.sh"
       - "scripts/lint-tracked-secrets.sh"
+      - "scripts/lint-backup-cron.sh"
+      - "docker/postgres/**"
       - ".gitignore"
       - ".github/workflows/quality-php.yml"
       - ".semgrep/**"
@@ -126,6 +130,23 @@ jobs:
 
       - name: Lint raw SQL escape hatches
         run: bash scripts/lint-raw-sql.sh
+
+  backup-cron-lint:
+    # AUD-017 / AUD-021 — guard-rail keeping the pgBackRest backup cron alive.
+    # Fails if start-pim.sh stops registering the postgres crontab via
+    # `crontab -u` (dcron silently ignores an unregistered per-user file —
+    # the bug that killed the cron for ~49 days) or if the Dockerfile schedule
+    # drops the full / diff / weekly restore-test entries. Cheap shell job.
+    name: Backup cron wiring lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Lint backup cron wiring
+        run: bash scripts/lint-backup-cron.sh
 
   tracked-secrets-lint:
     # AUD-005 / AUD-010 — guard-rail against real secrets committed to VCS.

--- a/docker/postgres/start-pim.sh
+++ b/docker/postgres/start-pim.sh
@@ -2,8 +2,9 @@
 # Custom entrypoint wrapper for the PIM database image.
 #
 # Responsibilities (in order):
-#   1. Launch busybox dcron in the background so the hourly /etc/crontabs/postgres
-#      schedule can run pgBackRest backups under the postgres user.
+#   1. Register the postgres crontab via `crontab -u` and launch dcron in the
+#      background so the production schedule (full/diff + weekly restore-test)
+#      runs pgBackRest under the postgres user.
 #   2. Launch pim-init-backup.sh in the background. It waits until postgres is
 #      accepting connections, then idempotently creates the stanza and triggers
 #      an initial full backup. Backgrounded so it never blocks postgres start-up.
@@ -11,6 +12,18 @@
 #      which performs initdb on first run and then exec's postgres.
 
 set -euo pipefail
+
+# AUD-017: dcron (dillon's cron 4.5) only loads a per-user crontab once it has
+# been (re)registered through `crontab -u` — a file dropped straight into
+# /etc/crontabs by the Dockerfile is synchronised for `root` but silently
+# ignored for every other user, so the postgres schedule never fired and the
+# backup cron was dead for ~49 days (the repo kept only the 2026-04-28 full).
+# Re-install it from the baked-in source on every boot so dcron picks it up on
+# a fresh volume AND a pre-existing one. Idempotent: same content each time.
+CRONTAB_SRC=/etc/crontabs/postgres
+if [ -f "${CRONTAB_SRC}" ]; then
+    crontab -u postgres "${CRONTAB_SRC}"
+fi
 
 # dcron logs to stderr; -L /dev/stderr keeps everything visible in `docker logs`.
 crond -b -L /dev/stderr

--- a/scripts/lint-backup-cron.sh
+++ b/scripts/lint-backup-cron.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# AUD-017 / AUD-021 — guard-rail keeping the pgBackRest backup cron alive.
+#
+# The PIM database image (docker/postgres) schedules backups with dcron
+# (dillon's cron 4.5). Two regressions silently killed the backup cron for
+# ~49 days and would do so again, neither caught by hadolint/yamllint:
+#
+#   (1) dcron only loads a PER-USER crontab once it has been registered
+#       through `crontab -u <user>`. A file dropped straight into
+#       /etc/crontabs by the Dockerfile is synchronised for `root` but
+#       SILENTLY IGNORED for `postgres` — so the schedule never fired
+#       (cronstamps/postgres never created, no cron.log, repo stuck on the
+#       2026-04-28 full). The fix lives in start-pim.sh: it MUST run
+#       `crontab -u postgres …` before launching crond.
+#
+#   (2) The crontab baked into the Dockerfile drifted from the production
+#       schedule (a single arg-less `pim-cron.sh` line → TYPE=incr, and the
+#       weekly restore-test was missing entirely). The schedule MUST carry a
+#       full backup, a differential backup, AND the weekly restore-test.
+#
+# This script fails the build when EITHER hole reopens. It is purely static
+# (greps the repo tree, no Docker needed) so it runs in seconds in CI.
+# Run from the repo root.
+
+set -eu
+
+ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "$ROOT"
+
+DOCKERFILE="docker/postgres/Dockerfile"
+ENTRYPOINT="docker/postgres/start-pim.sh"
+CRON_SCRIPT="docker/postgres/pim-cron.sh"
+RESTORE_SCRIPT="docker/postgres/pim-restore-test.sh"
+
+status=0
+fail() { echo "lint-backup-cron: $*" >&2; status=1; }
+
+# ── Pre-flight: the files this guard reasons about must exist. ────────────
+for f in "$DOCKERFILE" "$ENTRYPOINT" "$CRON_SCRIPT" "$RESTORE_SCRIPT"; do
+    [ -f "$f" ] || fail "expected file missing: $f"
+done
+[ "$status" -eq 0 ] || exit 1
+
+# ── Rule 1: the entrypoint must register the postgres crontab via
+#    `crontab -u postgres` (dcron ignores an unregistered per-user file). ──
+if ! grep -Eq 'crontab[[:space:]]+-u[[:space:]]+postgres' "$ENTRYPOINT"; then
+    fail "root cause guard — $ENTRYPOINT does not register the postgres crontab.
+  dcron silently ignores /etc/crontabs/postgres unless start-pim.sh runs
+  'crontab -u postgres <file>' BEFORE launching crond. Without it the backup
+  cron is dead (AUD-017). Re-add the registration step."
+fi
+
+# The registration must precede `crond` — installing after the daemon starts
+# leaves a window (and historically was simply absent).
+if grep -Eq 'crontab[[:space:]]+-u[[:space:]]+postgres' "$ENTRYPOINT" \
+   && grep -nq '^[[:space:]]*crond\b' "$ENTRYPOINT"; then
+    reg_line=$(grep -nE 'crontab[[:space:]]+-u[[:space:]]+postgres' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+    crond_line=$(grep -nE '^[[:space:]]*crond\b' "$ENTRYPOINT" | head -1 | cut -d: -f1)
+    if [ "$reg_line" -ge "$crond_line" ]; then
+        fail "ordering — $ENTRYPOINT registers the crontab (line $reg_line) at or
+  after starting crond (line $crond_line). Register the postgres crontab
+  BEFORE 'crond' so the daemon loads it on the first synchronisation pass."
+    fi
+fi
+
+# ── Rule 2: the Dockerfile crontab must carry full + diff + weekly
+#    restore-test, written for the postgres user. ──────────────────────────
+if ! grep -Eq 'pim-cron\.sh[[:space:]]+full' "$DOCKERFILE"; then
+    fail "schedule — $DOCKERFILE crontab missing a full backup ('pim-cron.sh full')."
+fi
+if ! grep -Eq 'pim-cron\.sh[[:space:]]+diff' "$DOCKERFILE"; then
+    fail "schedule — $DOCKERFILE crontab missing a differential backup ('pim-cron.sh diff')."
+fi
+if ! grep -Eq 'pim-restore-test\.sh' "$DOCKERFILE"; then
+    fail "schedule — $DOCKERFILE crontab missing the weekly restore-test
+  ('pim-restore-test.sh'). This is the early-warning probe for silent backup
+  corruption (AUD-021); it must stay scheduled."
+fi
+# The crontab must be installed for the postgres user (the role pgBackRest and
+# the schedule run as), not left only for root.
+if ! grep -Eq '/etc/crontabs/postgres' "$DOCKERFILE"; then
+    fail "schedule — $DOCKERFILE does not write the schedule to /etc/crontabs/postgres."
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "lint-backup-cron: backup cron wiring intact (crontab registered for postgres, full/diff/restore-test scheduled). Clean."
+fi
+
+exit "$status"


### PR DESCRIPTION
> Audyt fix-plan **W1-5** (Wave 1). Closes #1584 (AUD-017, AUD-021).

## Root cause (dlaczego cron backupu był martwy ~49 dni)
Obraz `pim-database` używa **dcron** (dillon's cron). `start-pim.sh` uruchamiał goły `crond -b` zakładając, że `/etc/crontabs/postgres` (wgrany przez Dockerfile) zostanie załadowany. **Dcron tego nie robi** — per-user crontab jest synchronizowany dopiero po rejestracji `crontab -u postgres <plik>`. Eksperyment runtime (`crond -f -d -l 9`): `Synchronizing /etc/crontabs` ładuje wyłącznie `User root`, plik `postgres` cicho ignorowany. To wyjaśnia obraz audytu (cronstamps pusty od dnia 1, repo zatrzymane na 2026-04-28). **Drift starego obrazu (AUD-021) był wtórny** — nawet poprawny 3-liniowy crontab nie działał bez rejestracji.

## Naprawa
- **`docker/postgres/start-pim.sh`**: przed `crond` rejestruje `crontab -u postgres /etc/crontabs/postgres` (idempotentnie, każdy start — świeży i istniejący wolumen). Treść crontaba (full Sun 02:00 / diff Mon-Sat / restore-test Sat 03:30) była już poprawna.
- **`scripts/lint-backup-cron.sh`** + job `backup-cron-lint` (quality-php.yml): drift-guard — faili gdy `start-pim.sh` przestanie rejestrować crontab lub Dockerfile zgubi wpis full/diff/restore-test.

## CLOSED MEANS CLOSED — przed/po (rebuild NON-destructive, volume `pim_postgres_data` nietknięty)
| | PRZED | PO |
|---|---|---|
| `pgbackrest --stanza=pim info` | tylko full `20260428-070020F` | **+ diff `…20260617-202151D`** (dziś, 77.9MB, completed) |
| dcron ładuje crontab postgres | NIE (`Synchronizing` → tylko User root) | TAK (`User postgres Entry` ×3) |
| ręczny `pim-cron.sh diff` (postgres) | — | EXIT 0, nowy backup label |
| `pim-restore-test.sh` | wyłączony w runtime | `PASS: restore-test OK` (side-cluster: 2 tenanty, 3 userów) |
| smoke login po `--force-recreate database` | — | HTTP **200** (dane demo całe) |

Volume PRZED=PO = `pim_postgres_data`; zero `down -v`/`volume rm`.

## Drobny follow-up (poza AUD-017/021)
`pim-restore-test.sh` porównanie live↔side jest iluzoryczne (live query przez peer-auth zwraca 0); werdykt opiera się na hard-failu `side==0` (działa). Skrypt istniał wcześniej — wart osobnego ticketu jakości testu.
