### PR TITLE
AUD-013/014: restore GIN + GiST scale indexes on objects (W1-9)

### DIFF
--- a/apps/api/migrations/Version20260617210000.php
+++ b/apps/api/migrations/Version20260617210000.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * AUD-013 / AUD-014 (W1-9) — restore scale indexes on `objects` dropped by the
+ * auto-generated regression in Version20260430092112.
+ *
+ * That migration's up() DROPped three indexes without recreating them in the
+ * forward path:
+ *   - objects_attributes_indexed_gin (GIN on attributes_indexed)
+ *   - objects_path_gist_idx          (GiST on path, partial kind='category')
+ *   - objects_path_btree_idx         (btree on path, partial)
+ * Doctrine's diff did not understand `USING GIN` / `USING GIST`, treated them
+ * as foreign, and the regenerated down() restored them as plain btree.
+ *
+ * Consequence (confirmed on the live dev DB, 6852 objects):
+ *   - `attributes_indexed @> '{...}'` (AttributeFilter / JsonbContainsFunction,
+ *     the hybrid-attribute filter that backs `?attribute[brand]=…`) runs as a
+ *     Seq Scan + Filter over every tenant row — the product differentiator does
+ *     not scale to 50k SKU.
+ *   - `path <@ :ancestor` (ltree category-tree queries) can only be evaluated as
+ *     a post-scan Filter; no usable index exists even with enable_seqscan=off.
+ *
+ * Fix: recreate the GIN and GiST indexes in a forward migration.
+ *   - GIN uses `jsonb_path_ops`: smaller and faster than the default opclass for
+ *     the `@>` containment operator, which is the only operator the codebase
+ *     issues against attributes_indexed.
+ *   - GiST is partial (kind='category'): only category objects carry a path.
+ *
+ * Standard (transactional) CREATE INDEX is used rather than CONCURRENTLY: the
+ * table is tiny on dev (6852 rows / 5 categories), index builds are instant, and
+ * keeping the migration transactional guarantees a clean up/down/up round-trip.
+ * CONCURRENTLY would require isTransactional(): false and forfeit atomicity for a
+ * benefit that does not apply at this volume.
+ */
+final class Version20260617210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Restore scale indexes on objects: GIN(attributes_indexed jsonb_path_ops) + GiST(path) partial kind=category (AUD-013/AUD-014, W1-9).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // AUD-013: GIN on attributes_indexed for jsonb `@>` containment.
+        // jsonb_path_ops is the smaller/faster opclass for the @> operator.
+        $this->addSql('CREATE INDEX IF NOT EXISTS objects_attributes_indexed_gin_idx ON objects USING GIN (attributes_indexed jsonb_path_ops)');
+
+        // AUD-014: GiST on ltree path, partial to the category subtree (only
+        // category objects have a path), for `path <@ :ancestor` / `path ~ :lquery`.
+        $this->addSql("CREATE INDEX IF NOT EXISTS objects_path_gist_idx ON objects USING GIST (path) WHERE (kind)::text = 'category'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS objects_attributes_indexed_gin_idx');
+        $this->addSql('DROP INDEX IF EXISTS objects_path_gist_idx');
+    }
+}


### PR DESCRIPTION
> Audyt fix-plan **W1-9** (Wave 1). Closes #1588 (AUD-013, AUD-014).

## Problem (HIGH perf, confirmed)
Migracja `Version20260430092112` (regres) DROPnęła indeksy bez odtworzenia w forward-path:
- **AUD-013:** brak GIN na `objects.attributes_indexed` → `?attribute[brand]=…` (`@>`) = Seq Scan po wszystkich wierszach tenanta (do 50k). Rdzeń wyróżnika hybrid-atrybutów nie skaluje.
- **AUD-014:** brak GiST na `objects.path` → ltree `path <@ :ancestor` = Filter/seq scan.

## Naprawa
Nowa forward-migracja `Version20260617210000.php` (NIE edytuje regresowanej):
```sql
CREATE INDEX IF NOT EXISTS objects_attributes_indexed_gin_idx ON objects USING GIN (attributes_indexed jsonb_path_ops)
CREATE INDEX IF NOT EXISTS objects_path_gist_idx ON objects USING GIST (path) WHERE (kind)::text = 'category'
```
`jsonb_path_ops` (mniejszy/szybszy dla jedynego używanego `@>`). Transactional (tabela mała, build natychmiastowy, czysty round-trip up/down/up). `ANALYZE objects` po CREATE.

## Benchmark PRZED/PO (żywy dev DB, demo 6849 wierszy)
**AUD-013** `attributes_indexed @> '{"sku":{"value":"RPT-3"}}'`:
| | PRZED | PO |
|---|---|---|
| Plan | Seq Scan + Filter | **Bitmap Index Scan (GIN)** |
| Exec | 2.138 ms | **0.058 ms (~37x)** |
| Cost | 0..561 | 12.8..16.8 (**~33x**) |
| Buffers | 460 | 4 |

**AUD-014** `path <@ 'apparel'::ltree AND kind='category'`: PRZED `<@` zawsze Filter (żaden indeks nie ewaluuje ltree, nawet z `enable_seqscan=off`) → PO **Index Cond na GiST**. Twardy dowód użycia indeksu niezależny od N.

## Uwaga
Test DB budowany z metadanych ORM (Foundry), nie z migracji — partial/GIN/GiST nie da się wyrazić w ORM XML (komentarz w `CatalogObject.orm.xml`), więc indeksy żyją tylko w migracji; ta migracja nie biegnie w test DB → nie psuje testów (schemat identyczny). Filtr `@>` i ltree są poprawne bez indeksu (to optymalizacja). Regresja: `CatalogFiltersApiTest` 11/30, `CategoriesApiTest` 6/17 OK.

## Bramki
PHPStan **No errors** · cs-fixer 0 · Deptrac **0** · smoke `?attribute[sku]=RPT-3`→200, login 200 · round-trip up/down/up czysty · dane nietknięte (6852 obiekty).
