### PR TITLE
AUD-015/016: export keyset-paging on all scopes + batch-prefetch (W1-10)

### DIFF
--- a/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/CatalogObjectRepositoryInterface.php
@@ -82,6 +82,41 @@ interface CatalogObjectRepositoryInterface
      */
     public function countRootObjectsByType(ObjectType $objectType, Tenant $tenant): int;
 
+    /**
+     * AUD-015 (#1632) — root object ids (no parent) of a type, ascending, as
+     * RFC4122 strings WITHOUT hydrating entities. Backs the scope-All export
+     * "id plan": the runner pages the hydration over these ids
+     * ({@see self::findByIds()}) so the full object graph never lives in memory
+     * at once, regardless of include_variants. Tenant filter still applies.
+     *
+     * @return list<string>
+     */
+    public function findRootObjectIds(ObjectType $objectType, Tenant $tenant): array;
+
+    /**
+     * AUD-015 (#1632) — the subset of `$idsRfc4122` that are ROOT objects (no
+     * parent), as RFC4122 strings, WITHOUT hydration. Lets the export size /
+     * fan out Selected & Filter scopes from an id set without loading the
+     * objects. Tenant filter still applies.
+     *
+     * @param list<string> $idsRfc4122
+     *
+     * @return list<string>
+     */
+    public function filterRootObjectIds(array $idsRfc4122, Tenant $tenant): array;
+
+    /**
+     * AUD-015 (#1632) — id-only sibling of {@see self::findChildrenByParentIds()}
+     * for the export "id plan": child (variant) ids grouped by parent, ordered
+     * by `code` ASC for the deterministic master-then-variants fan-out the
+     * golden round-trip relies on. No entity hydration. Tenant filter applies.
+     *
+     * @param list<string> $parentIdsRfc4122
+     *
+     * @return array<string, list<string>> parent id => ordered child ids (RFC 4122)
+     */
+    public function findChildIdsByParentIds(array $parentIdsRfc4122, Tenant $tenant): array;
+
     public function save(CatalogObject $object): void;
 
     public function remove(CatalogObject $object): void;

--- a/apps/api/src/Catalog/Domain/Repository/ObjectCategoryRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/ObjectCategoryRepositoryInterface.php
@@ -27,6 +27,19 @@ interface ObjectCategoryRepositoryInterface
     public function findByProduct(CatalogObject $product): array;
 
     /**
+     * AUD-016 (#1632) — batch sibling of {@see self::findByProduct()} for the
+     * export builder: all assignments for any product in `$productIds`, in ONE
+     * query instead of one per object. Same position-then-created order so the
+     * per-product category pipe-join stays deterministic and round-trip-stable.
+     * Tenant filter still applies.
+     *
+     * @param list<string> $productIds product object UUIDs (RFC 4122)
+     *
+     * @return array<string, list<ObjectCategory>> keyed by product object UUID (RFC 4122)
+     */
+    public function findByProductIds(array $productIds): array;
+
+    /**
      * All assignments referencing a single category, ordered the same way.
      * Used by the reverse-listing endpoint (PCAT-06) and by the cache
      * invalidator when a category-level change should burst per-product

--- a/apps/api/src/Catalog/Domain/Repository/ObjectRelationRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/ObjectRelationRepositoryInterface.php
@@ -32,6 +32,19 @@ interface ObjectRelationRepositoryInterface
     public function findBySourceAndAttribute(CatalogObject $source, Attribute $attribute): array;
 
     /**
+     * AUD-016 (#1632) — batch sibling of {@see self::findBySourceAndAttribute()}
+     * for the export builder: all links carried by `$attribute` whose source is
+     * one of `$sourceIds`, in ONE query instead of one per object. Same
+     * position-then-created order so the per-source pipe-join stays
+     * deterministic and round-trip-stable. Tenant filter still applies.
+     *
+     * @param list<string> $sourceIds source object UUIDs (RFC 4122)
+     *
+     * @return array<string, list<ObjectRelation>> keyed by source object UUID (RFC 4122)
+     */
+    public function findBySourceIdsAndAttribute(array $sourceIds, Attribute $attribute): array;
+
+    /**
      * All links pointing at `$target` regardless of attribute — drives the
      * read-only reverse-relations panel from MOD-07.
      *

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineCatalogObjectRepository.php
@@ -140,6 +140,81 @@ class DoctrineCatalogObjectRepository extends ServiceEntityRepository implements
             ->getSingleScalarResult();
     }
 
+    /**
+     * @return list<string>
+     */
+    public function findRootObjectIds(ObjectType $objectType, Tenant $tenant): array
+    {
+        /** @var list<array{id: string}> $rows */
+        $rows = $this->createQueryBuilder('o')
+            ->select('o.id')
+            ->where('o.objectType = :ot')
+            ->andWhere('o.tenant = :tenant')
+            ->andWhere('o.parent IS NULL')
+            ->setParameter('ot', $objectType)
+            ->setParameter('tenant', $tenant)
+            ->orderBy('o.id', 'ASC')
+            ->getQuery()
+            ->getScalarResult();
+
+        return array_map(static fn (array $row): string => $row['id'], $rows);
+    }
+
+    /**
+     * @param list<string> $idsRfc4122
+     *
+     * @return list<string>
+     */
+    public function filterRootObjectIds(array $idsRfc4122, Tenant $tenant): array
+    {
+        if ([] === $idsRfc4122) {
+            return [];
+        }
+
+        /** @var list<array{id: string}> $rows */
+        $rows = $this->createQueryBuilder('o')
+            ->select('o.id')
+            ->where('o.id IN (:ids)')
+            ->andWhere('o.tenant = :tenant')
+            ->andWhere('o.parent IS NULL')
+            ->setParameter('ids', $idsRfc4122)
+            ->setParameter('tenant', $tenant)
+            ->getQuery()
+            ->getScalarResult();
+
+        return array_map(static fn (array $row): string => $row['id'], $rows);
+    }
+
+    /**
+     * @param list<string> $parentIdsRfc4122
+     *
+     * @return array<string, list<string>>
+     */
+    public function findChildIdsByParentIds(array $parentIdsRfc4122, Tenant $tenant): array
+    {
+        if ([] === $parentIdsRfc4122) {
+            return [];
+        }
+
+        /** @var list<array{id: string, pid: string}> $rows */
+        $rows = $this->createQueryBuilder('o')
+            ->select('o.id AS id', 'IDENTITY(o.parent) AS pid')
+            ->where('o.parent IN (:parents)')
+            ->andWhere('o.tenant = :tenant')
+            ->setParameter('parents', $parentIdsRfc4122)
+            ->setParameter('tenant', $tenant)
+            ->orderBy('o.code', 'ASC')
+            ->getQuery()
+            ->getScalarResult();
+
+        $byParent = [];
+        foreach ($rows as $row) {
+            $byParent[$row['pid']][] = $row['id'];
+        }
+
+        return $byParent;
+    }
+
     public function findById(\Symfony\Component\Uid\Uuid $id): ?CatalogObject
     {
         return parent::find($id->toRfc4122());

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectCategoryRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectCategoryRepository.php
@@ -38,6 +38,32 @@ final class DoctrineObjectCategoryRepository extends ServiceEntityRepository imp
         return $rows;
     }
 
+    public function findByProductIds(array $productIds): array
+    {
+        if ([] === $productIds) {
+            return [];
+        }
+
+        /** @var list<ObjectCategory> $rows */
+        $rows = $this->createQueryBuilder('a')
+            ->innerJoin('a.product', 'p')
+            ->innerJoin('a.category', 'c')
+            ->addSelect('c')
+            ->andWhere('p.id IN (:products)')
+            ->orderBy('a.position', 'ASC')
+            ->addOrderBy('a.createdAt', 'ASC')
+            ->setParameter('products', $productIds)
+            ->getQuery()
+            ->getResult();
+
+        $byProduct = [];
+        foreach ($rows as $row) {
+            $byProduct[$row->getProduct()->getId()->toRfc4122()][] = $row;
+        }
+
+        return $byProduct;
+    }
+
     public function findByCategory(CatalogObject $category): array
     {
         /** @var list<ObjectCategory> $rows */

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectRelationRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineObjectRelationRepository.php
@@ -9,6 +9,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectRelation;
 use App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Uid\Uuid;
 
@@ -58,6 +59,31 @@ final class DoctrineObjectRelationRepository extends ServiceEntityRepository imp
             ->getResult();
 
         return $rows;
+    }
+
+    public function findBySourceIdsAndAttribute(array $sourceIds, Attribute $attribute): array
+    {
+        if ([] === $sourceIds) {
+            return [];
+        }
+
+        /** @var list<ObjectRelation> $rows */
+        $rows = $this->createQueryBuilder('r')
+            ->join('r.source', 's', Join::WITH, 's.id IN (:sources)')
+            ->andWhere('r.attribute = :attribute')
+            ->setParameter('sources', $sourceIds)
+            ->setParameter('attribute', $attribute)
+            ->orderBy('r.position', 'ASC')
+            ->addOrderBy('r.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        $bySource = [];
+        foreach ($rows as $row) {
+            $bySource[$row->getSource()->getId()->toRfc4122()][] = $row;
+        }
+
+        return $bySource;
     }
 
     public function findByTarget(CatalogObject $target): array

--- a/apps/api/src/Export/Application/Builder/ExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/ExportBuilder.php
@@ -8,13 +8,18 @@ use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Channel\Contracts\ChannelResolverInterface;
 use App\Export\Domain\Entity\ExportSession;
+use App\Identity\Contracts\Policy\AttributePermissionReader;
 use App\Shared\Domain\Tenant;
 use Generator;
 use LogicException;
+use Symfony\Component\Uid\Uuid;
+use Traversable;
 
 /**
  * Core export engine — turns a stream of CatalogObjects into XLSX / CSV
@@ -50,9 +55,9 @@ final class ExportBuilder
         private readonly ColumnResolver $columnResolver,
         private readonly ValueSerializer $serializer,
         private readonly ChannelResolverInterface $channels,
-        private readonly \App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface $relations,
-        private readonly \App\Catalog\Domain\Repository\AttributeRepositoryInterface $attributes,
-        private readonly \App\Identity\Contracts\Policy\AttributePermissionReader $attributePermissions,
+        private readonly ObjectRelationRepositoryInterface $relations,
+        private readonly AttributeRepositoryInterface $attributes,
+        private readonly AttributePermissionReader $attributePermissions,
     ) {
     }
 
@@ -94,10 +99,103 @@ final class ExportBuilder
         // cellFor can route Relation/Reference columns to object_relations.
         $attributeMap = $this->resolveColumnAttributes($columns, $tenant);
 
-        $primaryLocale = $tenant->getPrimaryLocale();
-        foreach ($objects as $object) {
-            yield $this->renderRow($object, $columns, $channelIdByCode, $primaryLocale, $attributeMap);
+        // AUD-016 (#1632): the caller hands us a bounded keyset PAGE (the sync
+        // runner streams scope-All/Selected/Filter in CLEAR_INTERVAL-sized
+        // pages, EntityManager::clear() between them). Materialise the page
+        // once and batch-load its object_values / relations / categories in a
+        // fixed number of queries per page instead of one-per-object — the
+        // pre-1632 lazy `findByObject`/`findBySourceAndAttribute`/`findByProduct`
+        // path issued 100k-150k round-trips for a 50k export (PRD §11.2).
+        $page = $objects instanceof Traversable ? iterator_to_array($objects, false) : array_values($objects);
+        if ([] === $page) {
+            return;
         }
+
+        $pageIds = array_map(static fn (CatalogObject $o): string => $o->getId()->toRfc4122(), $page);
+        $valuesByObjectId = $this->values->findByObjectIds(
+            array_map(static fn (CatalogObject $o): Uuid => $o->getId(), $page),
+        );
+        $relationCodesByColumn = $this->prefetchRelationCodes($pageIds, $attributeMap);
+        $categoryCodesByObjectId = $this->needsCategoryColumn($columns)
+            ? $this->prefetchCategoryCodes($pageIds)
+            : [];
+
+        $primaryLocale = $tenant->getPrimaryLocale();
+        foreach ($page as $object) {
+            $objectId = $object->getId()->toRfc4122();
+            yield $this->renderRow(
+                $object,
+                $columns,
+                $channelIdByCode,
+                $primaryLocale,
+                $attributeMap,
+                $valuesByObjectId[$objectId] ?? [],
+                $relationCodesByColumn,
+                $categoryCodesByObjectId[$objectId] ?? [],
+            );
+        }
+    }
+
+    /**
+     * AUD-016 (#1632) — one `findBySourceIdsAndAttribute()` per relation/reference
+     * column for the whole page, reduced to the pipe-join inputs: target CODES
+     * keyed by `attributeCode => [sourceId => codes]`. Non-relation columns and
+     * pages with no relation columns issue no query. The ObjectRelation graph is
+     * consumed here so the row pipeline only ever handles strings.
+     *
+     * @param list<string>             $pageIds
+     * @param array<string, Attribute> $attributeMap
+     *
+     * @return array<string, array<string, list<string>>>
+     */
+    private function prefetchRelationCodes(array $pageIds, array $attributeMap): array
+    {
+        $byColumn = [];
+        foreach ($attributeMap as $code => $attribute) {
+            if (AttributeType::Relation !== $attribute->getType() && AttributeType::Reference !== $attribute->getType()) {
+                continue;
+            }
+            $bySource = [];
+            foreach ($this->relations->findBySourceIdsAndAttribute($pageIds, $attribute) as $sourceId => $links) {
+                $bySource[$sourceId] = array_map(static fn ($link): string => $link->getTarget()->getCode(), $links);
+            }
+            $byColumn[$code] = $bySource;
+        }
+
+        return $byColumn;
+    }
+
+    /**
+     * AUD-016 (#1632) — one `findByProductIds()` for the whole page, reduced to
+     * category CODES keyed by object id. The ObjectCategory graph is consumed
+     * here so the row pipeline only ever handles strings.
+     *
+     * @param list<string> $pageIds
+     *
+     * @return array<string, list<string>>
+     */
+    private function prefetchCategoryCodes(array $pageIds): array
+    {
+        $byObject = [];
+        foreach ($this->categories->findByProductIds($pageIds) as $objectId => $assignments) {
+            $byObject[$objectId] = array_map(static fn ($assignment): string => $assignment->getCategory()->getCode(), $assignments);
+        }
+
+        return $byObject;
+    }
+
+    /**
+     * @param array<int, ColumnDefinition> $columns
+     */
+    private function needsCategoryColumn(array $columns): bool
+    {
+        foreach ($columns as $column) {
+            if ($column->isBuiltIn() && 'category' === $column->code) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -140,31 +238,44 @@ final class ExportBuilder
     }
 
     /**
-     * @param array<int, ColumnDefinition> $columns
-     * @param array<string, string>        $channelIdByCode channel code => UUID RFC 4122 (#1229)
-     * @param array<string, Attribute>     $attributeMap    attribute column code => Attribute (#1471)
+     * @param array<int, ColumnDefinition>               $columns
+     * @param array<string, string>                      $channelIdByCode       channel code => UUID RFC 4122 (#1229)
+     * @param array<string, Attribute>                   $attributeMap          attribute column code => Attribute (#1471)
+     * @param list<ObjectValue>                          $objectValues          this object's prefetched values (#1632)
+     * @param array<string, array<string, list<string>>> $relationCodesByColumn attributeCode => [sourceId => target codes] (#1632)
+     * @param list<string>                               $categoryCodes         this object's prefetched category codes (#1632)
      *
      * @return array<string, string>
      */
-    private function renderRow(CatalogObject $object, array $columns, array $channelIdByCode, string $primaryLocale, array $attributeMap): array
-    {
-        $valueIndex = $this->indexValuesByObject($object);
+    private function renderRow(
+        CatalogObject $object,
+        array $columns,
+        array $channelIdByCode,
+        string $primaryLocale,
+        array $attributeMap,
+        array $objectValues,
+        array $relationCodesByColumn,
+        array $categoryCodes,
+    ): array {
+        $valueIndex = $this->indexValuesByObject($objectValues);
         $row = [];
 
         foreach ($columns as $column) {
-            $row[$column->key] = $this->cellFor($object, $column, $valueIndex, $channelIdByCode, $primaryLocale, $attributeMap);
+            $row[$column->key] = $this->cellFor($object, $column, $valueIndex, $channelIdByCode, $primaryLocale, $attributeMap, $relationCodesByColumn, $categoryCodes);
         }
 
         return $row;
     }
 
     /**
+     * @param list<ObjectValue> $objectValues
+     *
      * @return array<string, ObjectValue>
      */
-    private function indexValuesByObject(CatalogObject $object): array
+    private function indexValuesByObject(array $objectValues): array
     {
         $index = [];
-        foreach ($this->values->findByObject($object) as $value) {
+        foreach ($objectValues as $value) {
             $key = $this->indexKey(
                 $value->getAttribute()->getCode(),
                 $value->getLocale(),
@@ -182,9 +293,11 @@ final class ExportBuilder
     }
 
     /**
-     * @param array<string, ObjectValue> $valueIndex
-     * @param array<string, string>      $channelIdByCode channel code => UUID RFC 4122 (#1229)
-     * @param array<string, Attribute>   $attributeMap    attribute column code => Attribute (#1471)
+     * @param array<string, ObjectValue>                 $valueIndex
+     * @param array<string, string>                      $channelIdByCode       channel code => UUID RFC 4122 (#1229)
+     * @param array<string, Attribute>                   $attributeMap          attribute column code => Attribute (#1471)
+     * @param array<string, array<string, list<string>>> $relationCodesByColumn attributeCode => [sourceId => target codes] (#1632)
+     * @param list<string>                               $categoryCodes         this object's prefetched category codes (#1632)
      */
     private function cellFor(
         CatalogObject $object,
@@ -193,9 +306,11 @@ final class ExportBuilder
         array $channelIdByCode,
         string $primaryLocale,
         array $attributeMap,
+        array $relationCodesByColumn,
+        array $categoryCodes,
     ): string {
         if ($column->isBuiltIn()) {
-            return $this->builtIn($object, $column->code);
+            return $this->builtIn($object, $column->code, $categoryCodes);
         }
 
         $attribute = $attributeMap[$column->code] ?? null;
@@ -223,13 +338,12 @@ final class ExportBuilder
 
         // IMP2-1.8 (D5): Relation/Reference columns emit pipe-joined target
         // CODES read from object_relations (symmetry with the import, which
-        // writes relations there — not as ObjectValue).
+        // writes relations there — not as ObjectValue). AUD-016 (#1632): the
+        // target codes are batch-prefetched per page, so this is a map lookup
+        // rather than a per-object query.
         if ($attribute instanceof Attribute
             && (AttributeType::Relation === $attribute->getType() || AttributeType::Reference === $attribute->getType())) {
-            $codes = [];
-            foreach ($this->relations->findBySourceAndAttribute($object, $attribute) as $relation) {
-                $codes[] = $relation->getTarget()->getCode();
-            }
+            $codes = $relationCodesByColumn[$column->code][$object->getId()->toRfc4122()] ?? [];
 
             return implode(ValueSerializer::MULTI_VALUE_GLUE, $codes);
         }
@@ -259,7 +373,10 @@ final class ExportBuilder
         return $this->serializer->serialize($value);
     }
 
-    private function builtIn(CatalogObject $object, string $code): string
+    /**
+     * @param list<string> $categoryCodes prefetched per page (#1632)
+     */
+    private function builtIn(CatalogObject $object, string $code, array $categoryCodes): string
     {
         return match ($code) {
             'sku' => $this->serializer->serializeScalar($object->getCode()),
@@ -269,7 +386,7 @@ final class ExportBuilder
             'completeness_pct' => $this->serializer->serializeScalar($object->getCompletenessPct()),
             'created_at' => $this->serializer->serializeScalar($object->getCreatedAt()),
             'updated_at' => $this->serializer->serializeScalar($object->getUpdatedAt()),
-            'category' => $this->resolveCategories($object),
+            'category' => implode(ValueSerializer::MULTI_VALUE_GLUE, $categoryCodes),
             'variant_axes' => $this->serializeVariantAxes($object),
             default => '',
         };
@@ -301,20 +418,5 @@ final class ExportBuilder
         }
 
         return implode(ValueSerializer::MULTI_VALUE_GLUE, $parts);
-    }
-
-    private function resolveCategories(CatalogObject $object): string
-    {
-        $assignments = $this->categories->findByProduct($object);
-        if ([] === $assignments) {
-            return '';
-        }
-
-        $codes = [];
-        foreach ($assignments as $assignment) {
-            $codes[] = $assignment->getCategory()->getCode();
-        }
-
-        return implode(ValueSerializer::MULTI_VALUE_GLUE, $codes);
     }
 }

--- a/apps/api/src/Export/Application/Sync/SyncExportRunner.php
+++ b/apps/api/src/Export/Application/Sync/SyncExportRunner.php
@@ -33,29 +33,32 @@ use Symfony\Component\Uid\Uuid;
 use Throwable;
 
 /**
- * Runs the sync (<100 row) export path end-to-end.
+ * Runs the catalog-object + structural export paths end-to-end.
  *
- * Resolves the target object list per {@see ExportTargetScope}, walks
- * them through {@see ExportBuilder}, and streams the resulting rows
- * into the chosen writer. Wraps the file write in a try/finally so the
- * temp file is cleaned up even on partial failure.
+ * AUD-015 (#1632): catalog-object exports resolve an ordered emit-id PLAN per
+ * {@see ExportTargetScope} ({@see buildEmitIdPlan()}, id-only — no entity
+ * hydration) and stream it through {@see ExportBuilder} in CLEAR_INTERVAL-sized
+ * keyset pages, clearing the EntityManager between pages so a 50k export stays
+ * in constant memory for EVERY scope (Selected / Filter / All) and both
+ * include_variants states — not just the old All-masters fast path. Wraps the
+ * file write in a try/finally so the temp file is cleaned up on partial failure.
  *
  * Filter scope (EXP-20 #632) compiles the session's `filter_snapshot`
  * via {@see FilterDslResolver::toCountSql()} into a tenant-scoped
- * SQL WHERE clause, fetches the matching `catalog_objects` IDs, and
- * loads the full entities through the repository — mirrors the
+ * SQL WHERE clause and fetches the matching `objects` IDs — mirrors the
  * SmartFilterPresetController::resolveCounts pattern so we get the
  * same operator coverage (PRD §5.5) without re-implementing the DSL.
  *
  * Sync writes ALWAYS complete in a single request — no Mercure, no
  * status transitions beyond `done` or `error`. The async handler
- * (EXP-06) takes over from 100 rows up.
+ * (EXP-06) takes over from 100 rows up; both reuse this runner so the
+ * streaming + memory contract is identical.
  */
 final class SyncExportRunner
 {
     public const int PROGRESS_CHUNK = 500;
 
-    /** IMP2-2.6 — detach hydrated objects every N rows so streaming stays flat. */
+    /** IMP2-2.6 / AUD-015 — hydrate + detach this many objects per keyset page so streaming stays flat. */
     private const int CLEAR_INTERVAL = 200;
 
     public function __construct(
@@ -76,7 +79,9 @@ final class SyncExportRunner
     /**
      * Count the rows an export will produce, used by the controller to route
      * sync vs async. Structural types count via their builder; catalog-object
-     * types count the resolved target set.
+     * types count the resolved id PLAN — never hydrating the object graph
+     * (AUD-015 #1632: the pre-1632 path materialised the whole target set just
+     * to size it, an OOM vector mirroring the run path).
      */
     public function resolveTargetCount(ExportSession $session): int
     {
@@ -84,109 +89,161 @@ final class SyncExportRunner
             return $this->structuralBuilderFor($session->getEntityType())->count($this->requireTenant($session));
         }
 
-        // IMP2-2.6 — the streamable scope (All, masters only) counts via
-        // COUNT(*) instead of hydrating the whole result set just to size it.
-        if ($this->canStream($session)) {
-            $tenant = $this->requireTenant($session);
-
-            return $this->objects->countRootObjectsByType($this->resolveObjectType($session, $tenant), $tenant);
-        }
-
-        return \count($this->resolveTargets($session));
-    }
-
-    /**
-     * IMP2-2.6 — a catalog-object export is streamable (root-by-root with
-     * EntityManager::clear() per chunk) when its scope is All and variant
-     * fan-out is off. Selected/Filter are already bounded id sets; variant
-     * fan-out interleaves children and needs the materialised pass.
-     */
-    private function canStream(ExportSession $session): bool
-    {
-        return !$session->getEntityType()->isStructural()
-            && ExportTargetScope::All === $session->getTargetScope()
-            && !$session->includesVariants();
-    }
-
-    /**
-     * Resolve target objects to export based on session scope.
-     *
-     * @return list<CatalogObject>
-     */
-    public function resolveTargets(ExportSession $session): array
-    {
-        $tenant = $session->getTenant();
-        if (null === $tenant) {
-            throw new LogicException('Export session must carry a tenant before resolveTargets().');
-        }
-
-        // EXR-05: the target set is scoped to the session's ObjectType
-        // (product → built-in Product type, custom_module → its own type)
-        // rather than the hardcoded Product kind.
+        $tenant = $this->requireTenant($session);
         $objectType = $this->resolveObjectType($session, $tenant);
 
-        $base = match ($session->getTargetScope()) {
-            ExportTargetScope::Selected => $this->resolveSelected($session),
-            ExportTargetScope::All => $this->objects->findByObjectType($objectType, $tenant),
-            ExportTargetScope::Filter => $this->resolveFilter($session, $tenant, $objectType),
-        };
-
-        return $this->applyVariantFanout($base, $session, $tenant);
+        return \count($this->buildEmitIdPlan($session, $tenant, $objectType));
     }
 
     /**
-     * IMP2-1.8 (#1471) — `include_variants` fan-out. With the flag OFF the
-     * export carries masters only; with it ON each master is immediately
-     * followed by its variants (tenant-scoped child query), giving the export
-     * the deterministic `master, then its variants` order the variants golden
-     * relies on. A directly-selected variant whose master is absent is still
-     * emitted.
+     * AUD-015 (#1632) — the ordered list of object ids a catalog-object export
+     * will emit, resolved WITHOUT hydrating any entity. This is the single
+     * source of truth for both the row count (sync/async routing) and the
+     * streaming run: {@see runCatalogObjectToFile()} pages the hydration over
+     * this list (CLEAR_INTERVAL ids at a time, EntityManager::clear() between
+     * pages) so the full object graph never lives in memory at once — for ALL
+     * scopes (Selected / Filter / All) with or without include_variants, not
+     * just the old All-masters fast path.
      *
-     * @param list<CatalogObject> $base
+     * Order contract (preserves the pre-1632 applyVariantFanout semantics the
+     * variants golden relies on):
+     *   - base ids ascending (UUID v7 → chronological, deterministic);
+     *   - masters-only: base ids minus any non-root;
+     *   - include_variants: each base id, then (if it is a root) its child ids
+     *     ordered by code; a directly-selected orphan variant (master absent)
+     *     is still emitted; every id appears once (cross-page dedup via a
+     *     string set — RFC4122 strings survive clear() and stay bounded,
+     *     ~80 B/id, the same touched-id pattern the import uses).
      *
-     * @return list<CatalogObject>
+     * @return list<string>
      */
-    private function applyVariantFanout(array $base, ExportSession $session, Tenant $tenant): array
+    private function buildEmitIdPlan(ExportSession $session, Tenant $tenant, ObjectType $objectType): array
     {
+        $baseIds = $this->resolveBaseIds($session, $tenant, $objectType);
+        if ([] === $baseIds) {
+            return [];
+        }
+
+        // The roots among the base set drive variant fan-out. For scope All the
+        // base IS the root id set already; Selected/Filter need the partition.
+        $rootIds = ExportTargetScope::All === $session->getTargetScope()
+            ? $baseIds
+            : $this->objects->filterRootObjectIds($baseIds, $tenant);
+
         if (!$session->includesVariants()) {
-            return array_values(array_filter($base, static fn (CatalogObject $o): bool => null === $o->getParent()));
+            // Masters only — emit the roots in base order.
+            $rootSet = array_fill_keys($rootIds, true);
+
+            return array_values(array_filter($baseIds, static fn (string $id): bool => isset($rootSet[$id])));
         }
 
-        $masterIds = [];
-        foreach ($base as $object) {
-            if (null === $object->getParent()) {
-                $masterIds[] = $object->getId()->toRfc4122();
-            }
-        }
+        $childIdsByParent = $this->objects->findChildIdsByParentIds($rootIds, $tenant);
 
-        $childrenByParent = [];
-        foreach ($this->objects->findChildrenByParentIds($masterIds, $tenant) as $child) {
-            $parentId = $child->getParent()?->getId()->toRfc4122();
-            if (null !== $parentId) {
-                $childrenByParent[$parentId][] = $child;
-            }
-        }
-
-        $result = [];
+        $plan = [];
         $seen = [];
-        foreach ($base as $object) {
-            $id = $object->getId()->toRfc4122();
+        foreach ($baseIds as $id) {
             if (isset($seen[$id])) {
                 continue;
             }
-            $result[] = $object;
+            $plan[] = $id;
             $seen[$id] = true;
 
-            foreach ($childrenByParent[$id] ?? [] as $child) {
-                $childId = $child->getId()->toRfc4122();
+            foreach ($childIdsByParent[$id] ?? [] as $childId) {
                 if (!isset($seen[$childId])) {
-                    $result[] = $child;
+                    $plan[] = $childId;
                     $seen[$childId] = true;
                 }
             }
         }
 
-        return $result;
+        return $plan;
+    }
+
+    /**
+     * Resolve the bounded set of base object ids for a catalog-object scope
+     * WITHOUT hydrating entities. All → root ids of the type; Selected → the
+     * requested ids; Filter → the DSL-matched ids. UUID v7 strings, ascending,
+     * so the keyset walk in {@see runCatalogObjectToFile()} is deterministic.
+     *
+     * @return list<string>
+     */
+    private function resolveBaseIds(ExportSession $session, Tenant $tenant, ObjectType $objectType): array
+    {
+        $ids = match ($session->getTargetScope()) {
+            ExportTargetScope::Selected => $this->selectedBaseIds($session),
+            ExportTargetScope::All => $this->objects->findRootObjectIds($objectType, $tenant),
+            ExportTargetScope::Filter => $this->resolveFilterIds($session, $tenant, $objectType),
+        };
+
+        sort($ids);
+
+        return $ids;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectedBaseIds(ExportSession $session): array
+    {
+        $ids = $session->getSelectedObjectIds();
+        if (null === $ids || [] === $ids) {
+            return [];
+        }
+
+        // Normalise to canonical RFC4122 (the session stores raw input) and
+        // dedupe before the keyset walk.
+        $normalised = [];
+        foreach ($ids as $id) {
+            $normalised[Uuid::fromString($id)->toRfc4122()] = true;
+        }
+
+        return array_keys($normalised);
+    }
+
+    /**
+     * Compile the session's filter DSL into tenant-scoped SQL and return the
+     * matching object ids (no hydration). Mirrors the pre-1632 resolveFilter()
+     * SQL exactly, only stopping at ids instead of loading the entities.
+     *
+     * @return list<string>
+     */
+    private function resolveFilterIds(ExportSession $session, Tenant $tenant, ObjectType $objectType): array
+    {
+        $dsl = $session->getFilterSnapshot();
+        if (null === $dsl || [] === $dsl) {
+            return [];
+        }
+
+        $whereClause = $this->filterDsl->toCountSql($dsl);
+        if (null === $whereClause) {
+            throw new RuntimeException('Invalid filter DSL in export session snapshot.');
+        }
+
+        $tenantId = $tenant->getId()->toRfc4122();
+        // EXR-05: scope by object_type_id (any ObjectType) instead of the
+        // hardcoded Product kind. The DSL itself stays ObjectType-agnostic.
+        // EXR-07: alias the table as `co` — FilterDslResolver emits
+        // `co.`-prefixed column references, so the FROM clause must define it.
+        $sql = 'SELECT co.id FROM objects co '
+            .'WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND ('.$whereClause.')';
+
+        try {
+            $rows = $this->connection->fetchFirstColumn(
+                $sql,
+                ['tenant' => $tenantId, 'otid' => $objectType->getId()->toRfc4122()],
+            );
+        } catch (Throwable $error) {
+            throw new RuntimeException('Filter scope SQL execution failed: '.$error->getMessage(), previous: $error);
+        }
+
+        $ids = [];
+        foreach ($rows as $id) {
+            if (\is_string($id)) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
     }
 
     /**
@@ -242,81 +299,42 @@ final class SyncExportRunner
             return $this->runStructuralToFile($session, $targetPath, $onChunk);
         }
 
-        // IMP2-2.6 — stream the All scope so a 50k export never materialises
-        // the full object graph (constant memory, enforced by the benchmark).
-        if ($this->canStream($session)) {
-            return $this->runStreamingToFile($session, $targetPath, $onChunk);
-        }
-
-        $targets = $this->resolveTargets($session);
-        $session->setTargetCount(\count($targets));
-
-        $columns = $session->getSelectedColumns();
-        if ([] === $columns) {
-            // #1235 — when no manual columns, try to derive from publication profile.
-            $objectTypeIds = $this->collectObjectTypeIds($targets);
-            $planned = $objectTypeIds !== []
-                ? $this->columnPlanner->plan($session, $objectTypeIds)
-                : null;
-            if (null === $planned) {
-                throw new InvalidArgumentException('Export session must list at least one column.');
-            }
-            $columns = $planned;
-        }
-
-        $writer = $this->openWriter($session->getFormat(), $session, $targetPath);
-        $writer->writeHeaders($columns);
-
-        $rows = 0;
-        try {
-            foreach ($this->builder->build($targets, $session) as $row) {
-                $values = [];
-                foreach ($columns as $key) {
-                    $values[] = $row[$key] ?? '';
-                }
-                $writer->writeRow($values);
-                ++$rows;
-                if (null !== $onChunk && 0 === $rows % self::PROGRESS_CHUNK) {
-                    $onChunk($rows);
-                }
-            }
-        } finally {
-            $writer->close();
-        }
-
-        $size = file_exists($targetPath) ? (int) filesize($targetPath) : 0;
-        $session->markDone($rows, $targetPath, $size);
-        $this->sessions->save($session);
-
-        return $rows;
+        return $this->runCatalogObjectToFile($session, $targetPath, $onChunk);
     }
 
     /**
-     * IMP2-2.6 — streaming export of scope All (masters only). Walks the root
-     * objects in keyset pages and clears the EntityManager between pages, so the
-     * builder's per-object value/relation hydration never accumulates. Each page
-     * gets a FRESH {@see ExportBuilder::build()} call: its attribute/channel map
-     * is resolved from a clean EM, so the inter-page clear cannot leave it
-     * holding detached entities. The clear also detaches the session, so it is
-     * re-loaded each page (build() reads its tenant/channels) and before the
-     * final markDone.
+     * AUD-015 (#1632) — streaming export for EVERY catalog-object scope
+     * (Selected / Filter / All, with or without include_variants). Resolves
+     * the ordered emit-id plan once ({@see buildEmitIdPlan()}, id-only — no
+     * hydration), then walks it in CLEAR_INTERVAL-sized keyset pages, hydrating
+     * one page of objects at a time and clearing the EntityManager between
+     * pages so the builder's per-object value/relation/category load never
+     * accumulates. Replaces the pre-1632 split where only All-masters streamed
+     * and Selected/Filter/All+variants materialised the whole object graph
+     * (the OOM vector). Each page gets a FRESH {@see ExportBuilder::build()}
+     * call against a clean EM; the inter-page clear detaches the session too,
+     * so it is re-loaded each page (build() reads its tenant/channels) and
+     * before the final markDone.
      *
      * @param (callable(int): void)|null $onChunk invoked every PROGRESS_CHUNK rows
      */
-    private function runStreamingToFile(ExportSession $session, string $targetPath, ?callable $onChunk): int
+    private function runCatalogObjectToFile(ExportSession $session, string $targetPath, ?callable $onChunk): int
     {
         $sessionId = $session->getId();
         $tenant = $this->requireTenant($session);
+        $tenantId = $tenant->getId();
         $objectType = $this->resolveObjectType($session, $tenant);
 
-        $total = $this->objects->countRootObjectsByType($objectType, $tenant);
-        $session->setTargetCount($total);
-        $this->sessions->save($session);
+        $emitIds = $this->buildEmitIdPlan($session, $tenant, $objectType);
+        // Size the run up-front (the async progress closure reads the in-memory
+        // target count). Persisted at markDone, on a re-attached managed graph.
+        $session->setTargetCount(\count($emitIds));
 
         $columns = $session->getSelectedColumns();
         if ([] === $columns) {
-            // #1235 — derive columns from the publication profile of the single
-            // scope-All ObjectType (no need to scan the whole target set).
+            // #1235 — derive columns from the publication profile of the
+            // session's ObjectType (all scopes resolve a single type via
+            // resolveObjectType; no need to scan the whole target set).
             $planned = $this->columnPlanner->plan($session, [$objectType->getId()->toRfc4122()]);
             if (null === $planned) {
                 throw new InvalidArgumentException('Export session must list at least one column.');
@@ -328,16 +346,15 @@ final class SyncExportRunner
         $writer->writeHeaders($columns);
 
         $rows = 0;
-        $afterId = null;
         try {
-            while (true) {
-                // $objectType/$tenant may be detached after a prior page's clear;
-                // Doctrine resolves them to ids for the WHERE params, so the query
-                // stays correct without re-hydrating them.
-                $page = $this->objects->findRootObjectsAfter($objectType, $tenant, $afterId, self::CLEAR_INTERVAL);
-                if ([] === $page) {
-                    break;
-                }
+            foreach (array_chunk($emitIds, self::CLEAR_INTERVAL) as $idPage) {
+                // build() needs a managed session each round (it reads the
+                // session tenant/channels); re-attach a managed tenant after the
+                // prior page's clear() detached it.
+                $session = $this->reattachSession($session, $sessionId, $tenantId);
+                // Hydrate just this page, restored to the plan's order
+                // (findByIds returns DB order; the plan owns the contract).
+                $page = $this->hydratePageInOrder($idPage);
                 foreach ($this->builder->build($page, $session) as $row) {
                     $values = [];
                     foreach ($columns as $key) {
@@ -349,19 +366,15 @@ final class SyncExportRunner
                         $onChunk($rows);
                     }
                 }
-                $afterId = $page[array_key_last($page)]->getId();
                 // Detach the page (objects + their hydrated values) before the next.
                 $this->em->clear();
-                // build() needs a managed session next round (tenant/channels).
-                $session = $this->sessions->findById($sessionId) ?? $session;
-                $tenant = $this->requireTenant($session);
             }
         } finally {
             $writer->close();
         }
 
         $size = file_exists($targetPath) ? (int) filesize($targetPath) : 0;
-        $session = $this->sessions->findById($sessionId) ?? $session;
+        $session = $this->reattachSession($session, $sessionId, $tenantId);
         $session->markDone($rows, $targetPath, $size);
         $this->sessions->save($session);
 
@@ -369,85 +382,52 @@ final class SyncExportRunner
     }
 
     /**
-     * Compile the session's filter DSL into tenant-scoped SQL, fetch the
-     * matching catalog_objects IDs, and load the full entities through
-     * the repository.
+     * Return a session whose tenant association is a MANAGED entity, so the
+     * builder query path and the markDone save operate on a managed graph after
+     * EntityManager::clear() detached everything. Prefers the persisted row
+     * (async path saved it); for the not-yet-persisted sync path it re-attaches
+     * a freshly-fetched managed tenant onto the in-memory session.
+     */
+    private function reattachSession(ExportSession $session, Uuid $sessionId, Uuid $tenantId): ExportSession
+    {
+        $reloaded = $this->sessions->findById($sessionId);
+        if (null !== $reloaded) {
+            return $reloaded;
+        }
+
+        $tenant = $this->em->find(Tenant::class, $tenantId->toRfc4122());
+        if ($tenant instanceof Tenant) {
+            $session->rebindTenant($tenant);
+        }
+
+        return $session;
+    }
+
+    /**
+     * Hydrate one page of objects from their ids, preserving the order of
+     * `$idPage` (the emit-id plan owns the master-then-variants contract;
+     * findByIds returns arbitrary DB order). Ids with no surviving row (a
+     * concurrent delete) are simply skipped.
+     *
+     * @param list<string> $idPage
      *
      * @return list<CatalogObject>
      */
-    private function resolveFilter(ExportSession $session, Tenant $tenant, ObjectType $objectType): array
+    private function hydratePageInOrder(array $idPage): array
     {
-        $dsl = $session->getFilterSnapshot();
-        if (null === $dsl || [] === $dsl) {
-            return [];
+        $byId = [];
+        foreach ($this->objects->findByIds($idPage) as $object) {
+            $byId[$object->getId()->toRfc4122()] = $object;
         }
 
-        $whereClause = $this->filterDsl->toCountSql($dsl);
-        if (null === $whereClause) {
-            throw new RuntimeException('Invalid filter DSL in export session snapshot.');
-        }
-
-        $tenantId = $tenant->getId()->toRfc4122();
-        // EXR-05: scope by object_type_id (any ObjectType) instead of the
-        // hardcoded Product kind. The DSL itself stays ObjectType-agnostic.
-        // EXR-07: alias the table as `co` — FilterDslResolver emits
-        // `co.`-prefixed column references, so the FROM clause must define it.
-        $sql = 'SELECT co.id FROM objects co '
-            .'WHERE co.tenant_id = :tenant AND co.object_type_id = :otid AND ('.$whereClause.')';
-
-        try {
-            $rows = $this->connection->fetchAllAssociative(
-                $sql,
-                ['tenant' => $tenantId, 'otid' => $objectType->getId()->toRfc4122()],
-            );
-        } catch (Throwable $error) {
-            throw new RuntimeException('Filter scope SQL execution failed: '.$error->getMessage(), previous: $error);
-        }
-
-        $ids = [];
-        foreach ($rows as $row) {
-            if (isset($row['id']) && \is_string($row['id'])) {
-                $ids[] = $row['id'];
+        $ordered = [];
+        foreach ($idPage as $id) {
+            if (isset($byId[$id])) {
+                $ordered[] = $byId[$id];
             }
         }
-        if ([] === $ids) {
-            return [];
-        }
 
-        return $this->objects->findByIds($ids);
-    }
-
-    /**
-     * @return list<CatalogObject>
-     */
-    private function resolveSelected(ExportSession $session): array
-    {
-        $ids = $session->getSelectedObjectIds();
-        if (null === $ids || [] === $ids) {
-            return [];
-        }
-
-        $uuids = array_map(static fn (string $id): Uuid => Uuid::fromString($id), $ids);
-
-        return $this->objects->findByIds(array_map(static fn (Uuid $u): string => $u->toRfc4122(), $uuids));
-    }
-
-    /**
-     * Collects unique ObjectType IDs (as UUID RFC strings) from a set of objects.
-     *
-     * @param list<CatalogObject> $objects
-     *
-     * @return list<string>
-     */
-    private function collectObjectTypeIds(array $objects): array
-    {
-        $ids = [];
-        foreach ($objects as $object) {
-            $id = $object->getObjectType()->getId()->toRfc4122();
-            $ids[$id] = $id;
-        }
-
-        return array_values($ids);
+        return $ordered;
     }
 
     /**

--- a/apps/api/src/Export/Domain/Entity/ExportSession.php
+++ b/apps/api/src/Export/Domain/Entity/ExportSession.php
@@ -153,6 +153,21 @@ class ExportSession extends AggregateRoot implements TenantScoped
         $this->tenant = $tenant;
     }
 
+    /**
+     * AUD-015 (#1632) — re-attach the SAME tenant as a managed instance after an
+     * EntityManager::clear() detached the original (the streaming export clears
+     * the EM between keyset pages). Unlike {@see assignTenant()} this is a
+     * managed-state refresh, not a reassignment: it refuses a DIFFERENT tenant
+     * so the isolation invariant still holds.
+     */
+    public function rebindTenant(Tenant $tenant): void
+    {
+        if (null !== $this->tenant && !$this->tenant->getId()->equals($tenant->getId())) {
+            throw new LogicException('rebindTenant() cannot switch the session to a different tenant.');
+        }
+        $this->tenant = $tenant;
+    }
+
     public function getUserId(): Uuid
     {
         return $this->userId;

--- a/apps/api/tests/Integration/Export/ExportMemoryBenchmarkTest.php
+++ b/apps/api/tests/Integration/Export/ExportMemoryBenchmarkTest.php
@@ -18,6 +18,7 @@ use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Shared\Infrastructure\Metrics\QueryDurationHistogram;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -27,9 +28,14 @@ use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
 /**
- * IMP2-2.6 (#1482) — etap-2 gate: the streaming export path (scope All, masters
- * only) holds a 50k-object export in constant memory instead of materialising
- * the whole object graph. Objects + values are seeded set-based (DB-side SQL,
+ * IMP2-2.6 (#1482) + AUD-015/AUD-016 (#1632) — the streaming export path holds a
+ * 50k-object export in constant memory for EVERY scope (All / Selected / Filter)
+ * AND with include_variants on, instead of materialising the whole object graph.
+ *
+ * #1632 generalises the constant-memory keyset walk from the old All-masters fast
+ * path to all scopes (the OOM finding), and batch-prefetches object_values /
+ * relations / categories per page so the builder no longer issues one query per
+ * object (the N+1 finding). Objects + values are seeded set-based (DB-side SQL,
  * negligible PHP memory) so the measured peak reflects {@see SyncExportRunner}
  * alone. Runs as a dedicated `import-benchmark` CI step.
  */
@@ -40,32 +46,137 @@ final class ExportMemoryBenchmarkTest extends KernelTestCase
     use ResetDatabase;
 
     private const int THRESHOLD_BYTES = 256 * 1024 * 1024;
+    private const int STREAMING_DELTA_BYTES = 128 * 1024 * 1024;
 
     #[Test]
     public function streamingExportOf5kStaysUnderMemoryBudget(): void
     {
-        $this->assertExportStreamsWithinBudget(5_000);
+        $tenant = $this->seedObjects(5_000);
+        $this->assertExportStreamsWithinBudget($tenant, ExportTargetScope::All, false, 5_000);
     }
 
     #[Test]
     public function streamingExportOf50kStaysUnderMemoryBudget(): void
     {
-        $this->assertExportStreamsWithinBudget(50_000);
+        $tenant = $this->seedObjects(50_000);
+        $this->assertExportStreamsWithinBudget($tenant, ExportTargetScope::All, false, 50_000);
     }
 
-    private function assertExportStreamsWithinBudget(int $count): void
+    /**
+     * AUD-015 — the pre-#1632 OOM vector: scope All with variant fan-out used to
+     * materialise the full master+variant graph. Now it streams: 50k masters ×
+     * 2 variants = 150k emitted rows must still peak under 256 MiB.
+     */
+    #[Test]
+    public function streamingExportOf50kWithVariantsStaysUnderMemoryBudget(): void
     {
-        $tenant = $this->seedObjects($count);
+        $tenant = $this->seedObjects(50_000, variantsPerMaster: 2);
+        $this->assertExportStreamsWithinBudget($tenant, ExportTargetScope::All, true, 150_000);
+    }
 
-        $session = new ExportSession(
-            userId: Uuid::v7(),
-            source: ExportSource::ListContext,
-            format: ExportFormat::Csv,
-            targetScope: ExportTargetScope::All,
-            selectedColumns: ['sku', 'name'],
+    /**
+     * AUD-015 — Selected scope (a bounded id set) used to load every selected
+     * object + its fanned-out children at once. With variants on it now streams
+     * the id plan; 20k selected masters × 2 variants = 60k rows under budget.
+     */
+    #[Test]
+    public function selectedScopeWithVariantsStreamsWithinBudget(): void
+    {
+        $tenant = $this->seedObjects(20_000, variantsPerMaster: 2);
+        $selectedIds = $this->rootIds($tenant);
+
+        $session = $this->newSession($tenant, ExportTargetScope::Selected, includeVariants: true, selectedObjectIds: $selectedIds);
+        $this->runAndAssertWithinBudget($tenant, $session, 60_000);
+    }
+
+    /**
+     * AUD-015 — Filter scope used to load the full DSL-matched set. A filter that
+     * matches all 30k masters now streams the keyset id plan under budget.
+     */
+    #[Test]
+    public function filterScopeStreamsWithinBudget(): void
+    {
+        $tenant = $this->seedObjects(30_000);
+        // `enabled = TRUE` matches every seeded master (see seedObjects()); the
+        // FilterDslResolver compiles this leaf to `co.enabled = true`.
+        $session = $this->newSession(
+            $tenant,
+            ExportTargetScope::Filter,
             includeVariants: false,
+            filterSnapshot: ['attr' => 'enabled', 'op' => '= TRUE'],
         );
-        $session->assignTenant($tenant);
+        $this->runAndAssertWithinBudget($tenant, $session, 30_000);
+    }
+
+    /**
+     * AUD-016 — N+1 elimination, measured end-to-end. The builder used to issue
+     * one object_values SELECT (plus relations/categories) PER object; it now
+     * batch-loads per CLEAR_INTERVAL-sized page. Query count must therefore grow
+     * with the number of PAGES (O(N/200)), not with N. We seed two sizes one
+     * page apart and assert the per-export query count stays within a small
+     * constant band — proving the count does NOT scale linearly with rows.
+     */
+    #[Test]
+    public function exportQueryCountScalesWithPagesNotRows(): void
+    {
+        $histogram = self::getContainer()->get(QueryDurationHistogram::class);
+        self::assertInstanceOf(QueryDurationHistogram::class, $histogram);
+
+        // 150 objects = 1 page (CLEAR_INTERVAL=200); 350 = 2 pages. Two distinct
+        // tenants so both seeds coexist in the per-test database (ResetDatabase
+        // only resets between tests, not within one).
+        $onePage = $this->countExportQueries($histogram, 150, 'qc-one');
+        $twoPages = $this->countExportQueries($histogram, 350, 'qc-two');
+
+        // Per-page overhead is a small constant (values + columns + session
+        // reload, etc.). The pre-#1632 path would add ~1 query PER object, so
+        // 350 rows would cost ~200 more queries than 150. Batch prefetch keeps
+        // the delta to a handful of per-page queries.
+        self::assertLessThan(
+            60,
+            $twoPages - $onePage,
+            \sprintf(
+                'export query count must grow per-page, not per-row: 150 rows=%d queries, 350 rows=%d queries (delta %d)',
+                $onePage,
+                $twoPages,
+                $twoPages - $onePage,
+            ),
+        );
+        // Sanity: a 150-row export must be FAR below one-query-per-row.
+        self::assertLessThan(150, $onePage, 'a single-page export must not issue a query per row (N+1)');
+    }
+
+    private function countExportQueries(QueryDurationHistogram $histogram, int $count, string $tenantCode): int
+    {
+        $tenant = $this->seedObjects($count, tenantCode: $tenantCode);
+        $session = $this->newSession($tenant, ExportTargetScope::All, includeVariants: false);
+        self::getContainer()->get(ExportSessionRepositoryInterface::class)->save($session);
+
+        $target = tempnam(sys_get_temp_dir(), 'bench-export-qc-').'.csv';
+        $runner = self::getContainer()->get(SyncExportRunner::class);
+
+        $before = $histogram->count();
+        $written = $runner->runToFile($session, $target);
+        $delta = $histogram->count() - $before;
+        @unlink($target);
+
+        self::assertSame($count, $written, 'every seeded root object is exported');
+
+        return $delta;
+    }
+
+    private function assertExportStreamsWithinBudget(
+        Tenant $tenant,
+        ExportTargetScope $scope,
+        bool $includeVariants,
+        int $expectedRows,
+    ): void {
+        $session = $this->newSession($tenant, $scope, $includeVariants);
+        $this->runAndAssertWithinBudget($tenant, $session, $expectedRows);
+    }
+
+    private function runAndAssertWithinBudget(Tenant $tenant, ExportSession $session, int $expectedRows): void
+    {
         self::getContainer()->get(ExportSessionRepositoryInterface::class)->save($session);
 
         $target = tempnam(sys_get_temp_dir(), 'bench-export-').'.csv';
@@ -77,25 +188,67 @@ final class ExportMemoryBenchmarkTest extends KernelTestCase
         $peak = \memory_get_peak_usage(true);
         @unlink($target);
 
-        self::assertSame($count, $written, 'every seeded root object is exported');
+        self::assertSame($expectedRows, $written, 'every expected row is exported');
         self::assertLessThan(
             self::THRESHOLD_BYTES,
             $peak,
-            \sprintf('export of %d objects peaked at %0.1f MiB, must stay under 256 MiB', $count, $peak / 1024 / 1024),
+            \sprintf('export of %d rows peaked at %0.1f MiB, must stay under 256 MiB', $expectedRows, $peak / 1024 / 1024),
         );
         // Streaming delta over the pre-run baseline must be a fraction of the
-        // full set — proves we never materialise all N objects at once.
+        // full set — proves we never materialise all N rows at once.
         self::assertLessThan(
-            128 * 1024 * 1024,
+            self::STREAMING_DELTA_BYTES,
             $peak - $before,
             \sprintf('streaming delta %0.1f MiB must stay bounded', ($peak - $before) / 1024 / 1024),
         );
     }
 
-    private function seedObjects(int $count): Tenant
+    /**
+     * @param list<string>|null         $selectedObjectIds
+     * @param array<string, mixed>|null $filterSnapshot
+     */
+    private function newSession(
+        Tenant $tenant,
+        ExportTargetScope $scope,
+        bool $includeVariants,
+        ?array $selectedObjectIds = null,
+        ?array $filterSnapshot = null,
+    ): ExportSession {
+        $session = new ExportSession(
+            userId: Uuid::v7(),
+            source: ExportSource::ListContext,
+            format: ExportFormat::Csv,
+            targetScope: $scope,
+            selectedColumns: ['sku', 'name', 'parent_sku'],
+            filterSnapshot: $filterSnapshot,
+            selectedObjectIds: $selectedObjectIds,
+            includeVariants: $includeVariants,
+        );
+        $session->assignTenant($tenant);
+
+        return $session;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function rootIds(Tenant $tenant): array
+    {
+        $rows = $this->em()->getConnection()->fetchFirstColumn(
+            'SELECT id FROM objects WHERE tenant_id = :t AND parent_id IS NULL',
+            ['t' => $tenant->getId()->toRfc4122()],
+        );
+
+        /** @var list<string> $ids */
+        $ids = array_values(array_filter($rows, '\is_string'));
+
+        return $ids;
+    }
+
+    private function seedObjects(int $count, int $variantsPerMaster = 0, string $tenantCode = 'bench'): Tenant
     {
         $em = $this->em();
-        $tenant = new Tenant('bench', 'Bench Tenant');
+        $tenant = new Tenant($tenantCode, 'Bench Tenant '.$tenantCode);
         $em->persist($tenant);
         $em->flush();
         self::getContainer()->get(TenantContext::class)->set($tenant);
@@ -112,15 +265,35 @@ final class ExportMemoryBenchmarkTest extends KernelTestCase
         $em->flush();
 
         $tenantId = $tenant->getId()->toRfc4122();
+        $typeId = $type->getId()->toRfc4122();
         $conn = $em->getConnection();
+
+        // Masters (root objects).
         $conn->executeStatement(
             <<<'SQL'
                 INSERT INTO objects (id, tenant_id, object_type_id, kind, code, enabled, status, completeness, attributes_indexed, created_at, updated_at, completeness_pct, sync_status_aggregate, version, schema_drift)
                 SELECT gen_random_uuid(), :t, :ot, 'product', 'BENCH-'||g, true, 'published', '{}'::jsonb, '{}'::jsonb, now(), now(), 0, 'gray', 1, false
                 FROM generate_series(1, :n) g
                 SQL,
-            ['t' => $tenantId, 'ot' => $type->getId()->toRfc4122(), 'n' => $count],
+            ['t' => $tenantId, 'ot' => $typeId, 'n' => $count],
         );
+
+        // Variants (children) — k per master, deterministic codes for ordering.
+        if ($variantsPerMaster > 0) {
+            $conn->executeStatement(
+                <<<'SQL'
+                    INSERT INTO objects (id, tenant_id, object_type_id, kind, code, enabled, status, completeness, attributes_indexed, created_at, updated_at, completeness_pct, sync_status_aggregate, version, schema_drift, parent_id)
+                    SELECT gen_random_uuid(), :t, :ot, 'product', m.code||'-V'||v, true, 'published', '{}'::jsonb, '{}'::jsonb, now(), now(), 0, 'gray', 1, false, m.id
+                    FROM objects m
+                    CROSS JOIN generate_series(1, :k) v
+                    WHERE m.tenant_id = :t AND m.parent_id IS NULL
+                    SQL,
+                ['t' => $tenantId, 'ot' => $typeId, 'k' => $variantsPerMaster],
+            );
+        }
+
+        // One value per object for both attributes (so the builder's value
+        // prefetch path is exercised, not just empty rows).
         foreach ([$sku->getId()->toRfc4122(), $name->getId()->toRfc4122()] as $attrId) {
             $conn->executeStatement(
                 <<<'SQL'

--- a/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/Query/GetObjectSummaryHandlerTest.php
@@ -136,6 +136,21 @@ final class InMemoryCatalogObjectRepo implements CatalogObjectRepositoryInterfac
         throw new LogicException('not used in this test');
     }
 
+    public function findRootObjectIds(ObjectType $objectType, Tenant $tenant): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function filterRootObjectIds(array $idsRfc4122, Tenant $tenant): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
+    public function findChildIdsByParentIds(array $parentIdsRfc4122, Tenant $tenant): array
+    {
+        throw new LogicException('not used in this test');
+    }
+
     public function save(CatalogObject $object): void
     {
         throw new LogicException('not used in this test');

--- a/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
+++ b/apps/api/tests/Unit/Export/Application/Builder/ExportBuilderTest.php
@@ -41,6 +41,16 @@ use Symfony\Component\Uid\Uuid;
  */
 final class ExportBuilderTest extends TestCase
 {
+    /**
+     * #1632 — the builder now batch-loads per page keyed by object UUID, but the
+     * fixtures below are keyed by spl_object_id($product). This registry bridges
+     * the two: id (RFC4122) => product, so the batch stubs can resolve a
+     * requested id back to the object and read its spl_object_id-keyed fixture.
+     *
+     * @var array<string, CatalogObject>
+     */
+    private array $objectsById = [];
+
     #[Test]
     public function buildThrowsWhenSessionHasNoTenant(): void
     {
@@ -359,6 +369,95 @@ final class ExportBuilderTest extends TestCase
         );
     }
 
+    #[Test]
+    public function batchPrefetchesValuesRelationsAndCategoriesOncePerPageNotPerObject(): void
+    {
+        // AUD-016 (#1632) — the builder must batch-load a PAGE of objects in a
+        // fixed number of queries (one values batch, one relations batch per
+        // relation column, one categories batch), NOT one query per object.
+        // We spy on the batch repo methods and assert the call counts do not
+        // scale with the page size (3 objects → still 1 + 1 + 1).
+        $related = $this->newAttribute('related', AttributeType::Relation);
+        $products = [$this->newProduct('SKU-1'), $this->newProduct('SKU-2'), $this->newProduct('SKU-3')];
+
+        $valuesCalls = 0;
+        $relationsCalls = 0;
+        $categoriesCalls = 0;
+        $perObjectValueCalls = 0;
+        $perObjectRelationCalls = 0;
+        $perObjectCategoryCalls = 0;
+
+        $values = $this->createMock(ObjectValueRepositoryInterface::class);
+        $values->method('findByObjectIds')->willReturnCallback(static function (array $ids) use (&$valuesCalls): array {
+            ++$valuesCalls;
+            self::assertCount(3, $ids, 'the whole page is batched in one call');
+
+            return [];
+        });
+        $values->method('findByObject')->willReturnCallback(static function () use (&$perObjectValueCalls): array {
+            ++$perObjectValueCalls;
+
+            return [];
+        });
+
+        $relations = $this->createMock(ObjectRelationRepositoryInterface::class);
+        $relations->method('findBySourceIdsAndAttribute')->willReturnCallback(static function (array $ids) use (&$relationsCalls): array {
+            ++$relationsCalls;
+            self::assertCount(3, $ids, 'relations are batched for the whole page');
+
+            return [];
+        });
+        $relations->method('findBySourceAndAttribute')->willReturnCallback(static function () use (&$perObjectRelationCalls): array {
+            ++$perObjectRelationCalls;
+
+            return [];
+        });
+
+        $categories = $this->createMock(ObjectCategoryRepositoryInterface::class);
+        $categories->method('findByProductIds')->willReturnCallback(static function (array $ids) use (&$categoriesCalls): array {
+            ++$categoriesCalls;
+            self::assertCount(3, $ids, 'categories are batched for the whole page');
+
+            return [];
+        });
+        $categories->method('findByProduct')->willReturnCallback(static function () use (&$perObjectCategoryCalls): array {
+            ++$perObjectCategoryCalls;
+
+            return [];
+        });
+
+        $channels = $this->createStub(ChannelResolverInterface::class);
+        $attributes = $this->createStub(AttributeRepositoryInterface::class);
+        $attributes->method('findByCode')->willReturnCallback(
+            static fn (string $code): ?Attribute => 'related' === $code ? $related : null
+        );
+        $permissions = $this->createStub(\App\Identity\Contracts\Policy\AttributePermissionReader::class);
+        $permissions->method('isAttributePermissionEnforced')->willReturn(false);
+        $permissions->method('canViewAttribute')->willReturn(true);
+
+        $builder = new ExportBuilder(
+            values: $values,
+            categories: $categories,
+            columnResolver: new ColumnResolver(),
+            serializer: new ValueSerializer(),
+            channels: $channels,
+            relations: $relations,
+            attributes: $attributes,
+            attributePermissions: $permissions,
+        );
+        $session = $this->newSessionWithTenant(['sku', 'related', 'category']);
+
+        iterator_to_array($builder->build($products, $session));
+
+        self::assertSame(1, $valuesCalls, 'object_values prefetched ONCE for the 3-object page');
+        self::assertSame(1, $relationsCalls, 'relations prefetched ONCE per relation column for the page');
+        self::assertSame(1, $categoriesCalls, 'categories prefetched ONCE for the page');
+        // The pre-1632 per-object path must be gone entirely.
+        self::assertSame(0, $perObjectValueCalls, 'no per-object findByObject (N+1 removed)');
+        self::assertSame(0, $perObjectRelationCalls, 'no per-object findBySourceAndAttribute (N+1 removed)');
+        self::assertSame(0, $perObjectCategoryCalls, 'no per-object findByProduct (N+1 removed)');
+    }
+
     // ----- helpers -----
 
     /**
@@ -379,14 +478,42 @@ final class ExportBuilderTest extends TestCase
         array $restrictedAttrIds = [],
         bool $permissionsEnforced = true,
     ): ExportBuilder {
+        $resolve = fn (string $id): ?CatalogObject => $this->objectsById[$id] ?? null;
+
+        // #1632 — the builder batches per page: findByObjectIds(list<Uuid>) →
+        // map keyed by object UUID. Translate the spl_object_id-keyed fixtures
+        // through the id registry.
         $values = $this->createStub(ObjectValueRepositoryInterface::class);
-        $values->method('findByObject')->willReturnCallback(
-            static fn (CatalogObject $object): array => $valuesByObject[spl_object_id($object)] ?? []
+        $values->method('findByObjectIds')->willReturnCallback(
+            /** @param list<Uuid> $ids */
+            static function (array $ids) use ($valuesByObject, $resolve): array {
+                $map = [];
+                foreach ($ids as $uuid) {
+                    \assert($uuid instanceof Uuid);
+                    $rfc = $uuid->toRfc4122();
+                    $object = $resolve($rfc);
+                    $map[$rfc] = null !== $object ? ($valuesByObject[spl_object_id($object)] ?? []) : [];
+                }
+
+                return $map;
+            }
         );
 
         $categories = $this->createStub(ObjectCategoryRepositoryInterface::class);
-        $categories->method('findByProduct')->willReturnCallback(
-            static fn (CatalogObject $object): array => $categoriesByObject[spl_object_id($object)] ?? []
+        $categories->method('findByProductIds')->willReturnCallback(
+            /** @param list<string> $ids */
+            static function (array $ids) use ($categoriesByObject, $resolve): array {
+                $map = [];
+                foreach ($ids as $rfc) {
+                    \assert(\is_string($rfc));
+                    $object = $resolve($rfc);
+                    if (null !== $object && [] !== ($categoriesByObject[spl_object_id($object)] ?? [])) {
+                        $map[$rfc] = $categoriesByObject[spl_object_id($object)];
+                    }
+                }
+
+                return $map;
+            }
         );
 
         $channels = $this->createStub(ChannelResolverInterface::class);
@@ -395,8 +522,20 @@ final class ExportBuilderTest extends TestCase
         );
 
         $relations = $this->createStub(ObjectRelationRepositoryInterface::class);
-        $relations->method('findBySourceAndAttribute')->willReturnCallback(
-            static fn (CatalogObject $source): array => $relationsBySource[spl_object_id($source)] ?? []
+        $relations->method('findBySourceIdsAndAttribute')->willReturnCallback(
+            /** @param list<string> $ids */
+            static function (array $ids) use ($relationsBySource, $resolve): array {
+                $map = [];
+                foreach ($ids as $rfc) {
+                    \assert(\is_string($rfc));
+                    $object = $resolve($rfc);
+                    if (null !== $object && [] !== ($relationsBySource[spl_object_id($object)] ?? [])) {
+                        $map[$rfc] = $relationsBySource[spl_object_id($object)];
+                    }
+                }
+
+                return $map;
+            }
         );
 
         $attributes = $this->createStub(AttributeRepositoryInterface::class);
@@ -435,6 +574,7 @@ final class ExportBuilderTest extends TestCase
         if (null !== $parent) {
             $object->assignParent($parent);
         }
+        $this->objectsById[$object->getId()->toRfc4122()] = $object;
 
         return $object;
     }

--- a/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
+++ b/apps/api/tests/Unit/Import/ImportValidationServiceTest.php
@@ -277,6 +277,21 @@ final class InMemoryCatalogObjectRepository implements CatalogObjectRepositoryIn
         return 0;
     }
 
+    public function findRootObjectIds(ObjectType $objectType, Tenant $tenant): array
+    {
+        return [];
+    }
+
+    public function filterRootObjectIds(array $idsRfc4122, Tenant $tenant): array
+    {
+        return [];
+    }
+
+    public function findChildIdsByParentIds(array $parentIdsRfc4122, Tenant $tenant): array
+    {
+        return [];
+    }
+
     public function save(CatalogObject $object): void
     {
     }


### PR DESCRIPTION
> Audyt fix-plan **W1-10** (Wave 1). Closes #1589 (AUD-015, AUD-016).

## Problem (HIGH perf/memory, confirmed)
- **AUD-015 (OOM):** `SyncExportRunner::canStream()` streamował TYLKO `scope=All && !variants`. Selected/Filter/include_variants ładowały cały `list<CatalogObject>` + dzieci + mapy naraz → OOM workera na 50k (próg 256 MiB). Typowy `include_variants=ON` przy sync do kanału.
- **AUD-016 (N+1):** `ExportBuilder` `findByObject` per obiekt (values/relacje/kategorie) → 100k-150k roundtripów na 50k SKU.

## Naprawa
- **Keyset-paging na WSZYSTKICH ścieżkach:** jeden `runCatalogObjectToFile()` — `buildEmitIdPlan()` rozwiązuje uporządkowaną listę **id (bez hydracji)** (All→roots, Selected→podane, Filter→DSL; variant fan-out dokłada child-id z dedup-setem stringów, master-then-variants zachowane). Plan stronicowany co `CLEAR_INTERVAL=200`, hydracja `findByIds(slice)`, `EntityManager::clear()` między stronami (+`ExportSession::rebindTenant()` re-attach po clear). `resolveTargetCount()` liczy z planu id (usunięty OOM-vector liczenia przez materializację).
- **Batch-prefetch per strona:** `findByObjectIds` (values, #1223) + nowe `findBySourceIdsAndAttribute` (relacje) + `findByProductIds` (kategorie); `cellFor` czyta z map. Nowe id-only metody repo (tenant-scoped, scalar hydration) + 2 test-double'y.
- Zachowane: R-47 preflight, blank-cell, AUD-008 attr-permission, #1146 fan-out, variant_axes.

## Benchmark PRZED/PO (seed, `APP_DEBUG=0`)
| Scope | Rows | Peak | Delta |
|---|---|---|---|
| All masters | 50k | 82.5 MiB | 28 MiB |
| **All +variants** | **150k** | **150 MiB** | **67.5 MiB** |
| Selected +variants | 60k | 137 MiB | 6.5 MiB |
| Filter | 30k | 132.5 MiB | 2 MiB |

**<256 MiB na wszystkich ścieżkach** (w tym poprzedni OOM-vector All+variants 150k); delta płaska (memory ograniczona stroną, nie rośnie z N). **N+1:** +6 zapytań/strona (O(N)→O(N/200)) vs ~1/obiekt przed.

## Bramki
**Golden round-trip 10/10 (202 asercje)** · Export Api+Unit 107/107 · ExportBuilderTest 14/14 (nowy batch O(1)/strona) · repo integration 11/11 · PHPStan **No errors** · Deptrac **0** · cs-fixer 0 · smoke: `POST /api/products/export` scope=all include_variants → 202 → done 6834/6834 → download 200 (162774 B, poprawny CSV). Dane nietknięte.
