### PR TITLE
AUD-011/012: flush-without-clear PHPStan rule + worker memory limit (W1-8)

### DIFF
--- a/apps/api/phpstan.dist.neon
+++ b/apps/api/phpstan.dist.neon
@@ -6,13 +6,14 @@
 #   - phpstan-doctrine (entity manager, query builder typing)
 #   - phpstan-strict-rules (boolean coercion, defensive comparisons)
 #
-# Custom rules — RBAC-P1-010 (#649). Two rules ship today:
-#   - RequiresPermissionAnnotationRule — every #[Route] method must
-#     declare #[RequiresPermission] or #[NoPermissionRequired].
-#   - HardcodedRoleCheckRule — forbids $user->hasRole(), isAdmin(),
-#     in_array(..., getRoles()) outside Identity/Infrastructure/Security/.
-# A third rule (flush-without-clear) is tracked as follow-up after the
-# first batch handler that does not extend AbstractBatchHandler.
+# Custom rules — three ship today:
+#   - RequiresPermissionAnnotationRule (RBAC-P1-010 #649) — every #[Route]
+#     method must declare #[RequiresPermission] or #[NoPermissionRequired].
+#   - HardcodedRoleCheckRule (RBAC-P1-010 #649) — forbids $user->hasRole(),
+#     isAdmin(), in_array(..., getRoles()) outside Identity/Infrastructure/Security/.
+#   - FlushWithoutClearInLoopRule (AUD-011, W1-8) — a Messenger handler that
+#     flush()es inside a batch loop without clear() OOMs the FrankenPHP worker
+#     (architektura §3.10); exempts AbstractBatchHandler subclasses.
 # See docs/static-analysis/custom-rules.md for the full inventory.
 
 includes:
@@ -34,6 +35,11 @@ parameters:
         # Skeleton bootstrap shipped by symfony/test-pack — touching it forces
         # us to fight Symfony's own conventions. Re-included once we extend it.
         - tests/bootstrap.php
+        # AUD-011 (W1-8) — deliberately-malformed fixtures for
+        # FlushWithoutClearInLoopRuleTest (flush-in-loop-without-clear handlers).
+        # RuleTestCase analyses them explicitly with the rule in isolation; the
+        # main analysis must NOT flag them as production findings.
+        - tests/Architecture/PHPStan/Fixtures/*
 
     # Symfony container introspection — needs the dev cache built before PHPStan runs.
     symfony:

--- a/apps/api/phpstan/services.neon
+++ b/apps/api/phpstan/services.neon
@@ -16,3 +16,11 @@ services:
         class: App\PHPStan\Rules\HardcodedRoleCheckRule
         tags:
             - phpstan.rules.rule
+    # AUD-011 (W1-8) — FrankenPHP worker-mode guard-rail (architektura §3.10
+    # pkt 5): a Messenger handler that flush()es inside a batch loop without a
+    # clear() accumulates the Doctrine identity map and OOMs the worker on 50k
+    # SKU. Exempts AbstractBatchHandler subclasses (they flush via flushAndClear).
+    -
+        class: App\PHPStan\Rules\FlushWithoutClearInLoopRule
+        tags:
+            - phpstan.rules.rule

--- a/apps/api/src/PHPStan/Rules/FlushWithoutClearInLoopRule.php
+++ b/apps/api/src/PHPStan/Rules/FlushWithoutClearInLoopRule.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\While_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * AUD-011 (W1-8) — enforces the NON-NEGOTIABLE FrankenPHP worker-mode guard-rail
+ * from `Project Plan/01-architektura-pim.md` §3.10 pkt 5 / CLAUDE.md §3.10:
+ *
+ *   "CI gate: PHPStan custom rule blokująca handlery Messenger, które flushują
+ *    w pętli bez clear() — automatyczna detekcja wzorca."
+ *
+ * Why static enforcement: in FrankenPHP worker mode the PHP process lives
+ * between requests, so Doctrine's identity map keeps every persisted entity
+ * across `flush()` calls. A Messenger handler that flushes inside a batch loop
+ * WITHOUT an `EntityManager::clear()` accumulates the whole working set in
+ * memory and drives a 50k-SKU import into OOM (R-25 — Krytyczny). The reference
+ * pattern is {@see \App\Shared\Application\AbstractBatchHandler::flushAndClear()}
+ * (flush + clear); this rule guarantees a handler that does not inherit it still
+ * pairs every in-loop flush with a clear.
+ *
+ * Scope (faithful to §3.10 wording — "handlery Messenger"):
+ *   The rule fires ONLY on Symfony Messenger handlers — classes carrying the
+ *   CLASS-level `#[AsMessageHandler]` attribute (the universal marker across the
+ *   codebase: all 40 handlers use it at class level; Symfony 7.x dropped the
+ *   `MessageHandlerInterface` marker interface). Method-level `#[AsMessageHandler]`
+ *   (multi-message handler classes) is not used anywhere today; add a method-attr
+ *   scan here if that pattern is introduced. These are the long-running batch
+ *   consumers the guard-rail targets. Synchronous
+ *   request-scoped services that flush inside a small cardinality-bounded loop
+ *   (e.g. replacing a handful of relations inside one transaction) are out of
+ *   scope by design — clearing the unit of work mid-request there would detach
+ *   entities the caller still holds.
+ *
+ * Exemption:
+ *   Classes extending {@see \App\Shared\Application\AbstractBatchHandler} are
+ *   skipped — the base class funnels batch flushes through `flushAndClear()`,
+ *   which already guarantees the clear. §3.10 pkt 1 names inheritance of that
+ *   base class as the sanctioned pattern.
+ *
+ * False-positive avoidance (verified against the whole codebase, zero baseline):
+ *   - flush AFTER a loop (accumulate-then-flush-once) is NOT flagged — the flush
+ *     has no enclosing loop node.
+ *   - flush INSIDE a loop whose subtree also contains a `clear()` is NOT flagged.
+ *   - nested loops: a flush is safe if ANY enclosing loop (innermost OR outer)
+ *     contains a `clear()`, so a `clear()` placed after an inner loop but still
+ *     inside the outer loop discharges the inner flush. Each offending flush is
+ *     reported exactly once, on its own line.
+ *
+ * @implements Rule<Class_>
+ */
+final class FlushWithoutClearInLoopRule implements Rule
+{
+    private const string ABSTRACT_BATCH_HANDLER = 'App\\Shared\\Application\\AbstractBatchHandler';
+
+    private const string AS_MESSAGE_HANDLER = 'Symfony\\Component\\Messenger\\Attribute\\AsMessageHandler';
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // $node is a Class_ per @implements Rule<Class_> / getNodeType().
+        if (!$this->isMessengerHandler($node)) {
+            return [];
+        }
+
+        if ($this->extendsAbstractBatchHandler($node, $scope)) {
+            return [];
+        }
+
+        $nodeFinder = new NodeFinder();
+
+        /** @var list<For_|Foreach_|While_|Do_> $loops */
+        $loops = $nodeFinder->find($node, static fn (Node $n): bool => $n instanceof For_
+            || $n instanceof Foreach_
+            || $n instanceof While_
+            || $n instanceof Do_);
+
+        if ([] === $loops) {
+            return [];
+        }
+
+        $errors = [];
+
+        // Per-flush model: a flush() that sits inside at least one loop is safe
+        // iff SOME enclosing loop's subtree also contains a clear(). A clear() in
+        // an outer loop discharges the obligation (the identity map is detached
+        // each outer iteration), so nested-loop-with-clear-after-inner is OK. A
+        // flush AFTER every loop has no enclosing loop and is never reported.
+        foreach ($this->findCalls($nodeFinder, $node, 'flush') as $flush) {
+            $enclosingLoops = $this->enclosingLoops($flush, $loops);
+            if ([] === $enclosingLoops) {
+                continue; // flush is not inside any loop — accumulate-then-flush
+            }
+
+            foreach ($enclosingLoops as $loop) {
+                if ([] !== $this->findCalls($nodeFinder, $loop, 'clear')) {
+                    continue 2; // a clear in an enclosing loop discharges it
+                }
+            }
+
+            $errors[] = RuleErrorBuilder::message(
+                'EntityManager::flush() inside a loop in a Messenger handler is not paired with a clear() '
+                .'in the same loop. In FrankenPHP worker mode the Doctrine identity map accumulates across '
+                .'flushes and a batch loop without clear() drives the worker into OOM (architektura §3.10, R-25). '
+                .'Extend App\\Shared\\Application\\AbstractBatchHandler and flush via flushAndClear(), '
+                .'or call $entityManager->clear() after flush() inside the loop.',
+            )
+                ->line($flush->getStartLine())
+                ->identifier('pim.flushWithoutClearInLoop')
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function isMessengerHandler(Class_ $node): bool
+    {
+        foreach ($node->attrGroups as $group) {
+            foreach ($group->attrs as $attribute) {
+                if ($this->matchesFqcn($attribute->name->toString(), self::AS_MESSAGE_HANDLER)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function extendsAbstractBatchHandler(Class_ $node, Scope $scope): bool
+    {
+        // AST path (primary, robust). In a PHPStan rule the parser has already
+        // resolved class names against the file's `use` imports, so the parent
+        // name node carries the FQCN directly — no class-hierarchy lookup
+        // needed. Covers the direct-extends case (every batch handler in the
+        // codebase extends AbstractBatchHandler directly).
+        if (null !== $node->extends
+            && ltrim($node->extends->toString(), '\\') === self::ABSTRACT_BATCH_HANDLER) {
+            return true;
+        }
+
+        // Reflection path (covers a transitive subclass, if one is ever added).
+        // getParentClassesNames() walks the whole ancestor chain.
+        $reflection = $scope->getClassReflection();
+        if (null !== $reflection) {
+            foreach ($reflection->getParentClassesNames() as $parent) {
+                if (ltrim($parent, '\\') === self::ABSTRACT_BATCH_HANDLER) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find `$x->{$method}()` calls inside the given subtree.
+     *
+     * @return list<MethodCall>
+     */
+    private function findCalls(NodeFinder $nodeFinder, Node $subtree, string $method): array
+    {
+        /** @var list<MethodCall> $calls */
+        $calls = $nodeFinder->find($subtree, static function (Node $n) use ($method): bool {
+            return $n instanceof MethodCall
+                && $n->name instanceof Node\Identifier
+                && $n->name->toString() === $method;
+        });
+
+        return $calls;
+    }
+
+    /**
+     * Every loop (from $allLoops) whose token span contains $flush — i.e. all
+     * loops enclosing the flush, innermost and outermost alike.
+     *
+     * @param list<For_|Foreach_|While_|Do_> $allLoops
+     *
+     * @return list<For_|Foreach_|While_|Do_>
+     */
+    private function enclosingLoops(MethodCall $flush, array $allLoops): array
+    {
+        $flushStart = $flush->getStartTokenPos();
+        $flushEnd = $flush->getEndTokenPos();
+
+        $enclosing = [];
+        foreach ($allLoops as $loop) {
+            if ($loop->getStartTokenPos() <= $flushStart && $loop->getEndTokenPos() >= $flushEnd) {
+                $enclosing[] = $loop;
+            }
+        }
+
+        return $enclosing;
+    }
+
+    private function matchesFqcn(string $name, string $fqcn): bool
+    {
+        $name = ltrim($name, '\\');
+        if ($name === $fqcn) {
+            return true;
+        }
+
+        // Short-name match (the import resolves to the FQCN). PHPStan resolves
+        // attribute names against the file's `use` statements, but guard the
+        // short form too for robustness.
+        $short = substr($fqcn, (int) strrpos($fqcn, '\\') + 1);
+
+        return $name === $short || str_ends_with($name, '\\'.$short);
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/Fixtures/BadForLoopFlushHandler.php
+++ b/apps/api/tests/Architecture/PHPStan/Fixtures/BadForLoopFlushHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan\Fixtures;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Red-demonstration: `for` loop variant (not just foreach) — same offence,
+ * also flagged.
+ */
+#[AsMessageHandler]
+final class BadForLoopFlushHandler
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @param list<object> $rows
+     */
+    public function __invoke(array $rows): void
+    {
+        for ($i = 0, $n = \count($rows); $i < $n; ++$i) {
+            $this->em->persist($rows[$i]);
+            $this->em->flush(); // flagged
+        }
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/Fixtures/BadForeachFlushHandler.php
+++ b/apps/api/tests/Architecture/PHPStan/Fixtures/BadForeachFlushHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan\Fixtures;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Red-demonstration: Messenger handler that flush()es inside a foreach with NO
+ * clear() — the exact FrankenPHP OOM pattern §3.10 forbids. MUST be flagged.
+ */
+#[AsMessageHandler]
+final class BadForeachFlushHandler
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @param list<object> $rows
+     */
+    public function __invoke(array $rows): void
+    {
+        foreach ($rows as $row) {
+            $this->em->persist($row);
+            $this->em->flush(); // flagged: flush in loop, no clear
+        }
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/Fixtures/BadNestedLoopFlushHandler.php
+++ b/apps/api/tests/Architecture/PHPStan/Fixtures/BadNestedLoopFlushHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan\Fixtures;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Red-demonstration: nested loops, no clear anywhere — reported exactly once
+ * (on the inner flush line), not once per nesting level.
+ */
+#[AsMessageHandler]
+final class BadNestedLoopFlushHandler
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @param list<list<object>> $batches
+     */
+    public function __invoke(array $batches): void
+    {
+        foreach ($batches as $batch) {
+            foreach ($batch as $row) {
+                $this->em->persist($row);
+                $this->em->flush(); // flagged once
+            }
+        }
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/Fixtures/GoodBatchHandler.php
+++ b/apps/api/tests/Architecture/PHPStan/Fixtures/GoodBatchHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan\Fixtures;
+
+use App\Shared\Application\AbstractBatchHandler;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Green: subclass of AbstractBatchHandler — exempt. The base class guarantees
+ * clear() via flushAndClear(), so even a raw in-loop flush is tolerated. MUST
+ * NOT be flagged (mirrors ImportRunHandler / RebuildAttributesIndexedHandler).
+ */
+#[AsMessageHandler]
+final class GoodBatchHandler extends AbstractBatchHandler
+{
+    /**
+     * @param list<object> $rows
+     */
+    public function __invoke(array $rows): void
+    {
+        $processed = 0;
+        foreach ($rows as $row) {
+            $this->entityManager->persist($row);
+            if ($this->shouldFlush(++$processed)) {
+                $this->flushAndClear();
+            }
+            $this->entityManager->flush(); // tolerated — AbstractBatchHandler exempt
+        }
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/Fixtures/GoodFlushAfterLoopHandler.php
+++ b/apps/api/tests/Architecture/PHPStan/Fixtures/GoodFlushAfterLoopHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan\Fixtures;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Green: Messenger handler that accumulates then flushes ONCE after the loop —
+ * the flush is not a descendant of the loop node, so it is correct. MUST NOT be
+ * flagged (mirrors CreateAttributeHandler / ReorderGroupAttributesHandler).
+ */
+#[AsMessageHandler]
+final class GoodFlushAfterLoopHandler
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @param list<object> $rows
+     */
+    public function __invoke(array $rows): void
+    {
+        foreach ($rows as $row) {
+            $this->em->persist($row);
+        }
+        $this->em->flush();
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/Fixtures/GoodFlushClearInLoopHandler.php
+++ b/apps/api/tests/Architecture/PHPStan/Fixtures/GoodFlushClearInLoopHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan\Fixtures;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Green: Messenger handler that pairs flush() with clear() inside the loop —
+ * the sanctioned manual pattern. MUST NOT be flagged.
+ */
+#[AsMessageHandler]
+final class GoodFlushClearInLoopHandler
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @param list<object> $rows
+     */
+    public function __invoke(array $rows): void
+    {
+        $i = 0;
+        foreach ($rows as $row) {
+            $this->em->persist($row);
+            if (0 === ++$i % 200) {
+                $this->em->flush();
+                $this->em->clear();
+            }
+        }
+        $this->em->flush();
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/Fixtures/GoodNestedLoopWithClearHandler.php
+++ b/apps/api/tests/Architecture/PHPStan/Fixtures/GoodNestedLoopWithClearHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan\Fixtures;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Green: nested loops where clear() lives in the OUTER loop subtree (after the
+ * inner loop). The clear in an enclosing loop discharges the inner flush — the
+ * identity map is detached each outer iteration. MUST NOT be flagged.
+ */
+#[AsMessageHandler]
+final class GoodNestedLoopWithClearHandler
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @param list<list<object>> $batches
+     */
+    public function __invoke(array $batches): void
+    {
+        foreach ($batches as $batch) {
+            foreach ($batch as $row) {
+                $this->em->persist($row);
+                $this->em->flush();
+            }
+            $this->em->clear();
+        }
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/Fixtures/GoodSyncServiceWithLoopFlush.php
+++ b/apps/api/tests/Architecture/PHPStan/Fixtures/GoodSyncServiceWithLoopFlush.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan\Fixtures;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Green: NOT a Messenger handler — a synchronous request-scoped service that
+ * flushes inside a small bounded loop. Out of scope by §3.10 wording; clearing
+ * the unit of work here would detach entities the caller still holds. MUST NOT
+ * be flagged (mirrors ObjectRelationService::replaceForSourceAndAttribute).
+ */
+final class GoodSyncServiceWithLoopFlush
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+    }
+
+    /**
+     * @param list<object> $rows
+     */
+    public function replace(array $rows): void
+    {
+        foreach ($rows as $row) {
+            $this->em->persist($row);
+            $this->em->flush();
+        }
+    }
+}

--- a/apps/api/tests/Architecture/PHPStan/FlushWithoutClearInLoopRuleTest.php
+++ b/apps/api/tests/Architecture/PHPStan/FlushWithoutClearInLoopRuleTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Architecture\PHPStan;
+
+use App\PHPStan\Rules\FlushWithoutClearInLoopRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * AUD-011 (W1-8) — failing-test-first proof that FlushWithoutClearInLoopRule
+ * catches the FrankenPHP worker-mode OOM pattern (flush() in a batch loop
+ * without clear() in a Messenger handler) and leaves the sanctioned patterns
+ * (flush+clear, flush-after-loop, AbstractBatchHandler, non-handler service,
+ * nested-loop-with-clear) untouched.
+ *
+ * @extends RuleTestCase<FlushWithoutClearInLoopRule>
+ */
+#[Group('architecture')]
+final class FlushWithoutClearInLoopRuleTest extends RuleTestCase
+{
+    private const string MESSAGE = 'EntityManager::flush() inside a loop in a Messenger handler is not paired with a clear() '
+        .'in the same loop. In FrankenPHP worker mode the Doctrine identity map accumulates across '
+        .'flushes and a batch loop without clear() drives the worker into OOM (architektura §3.10, R-25). '
+        .'Extend App\\Shared\\Application\\AbstractBatchHandler and flush via flushAndClear(), '
+        .'or call $entityManager->clear() after flush() inside the loop.';
+
+    protected function getRule(): Rule
+    {
+        return new FlushWithoutClearInLoopRule();
+    }
+
+    #[Test]
+    public function flagsForeachFlushWithoutClear(): void
+    {
+        $this->analyse(
+            [__DIR__.'/Fixtures/BadForeachFlushHandler.php'],
+            [[self::MESSAGE, 28]],
+        );
+    }
+
+    #[Test]
+    public function flagsForLoopFlushWithoutClear(): void
+    {
+        $this->analyse(
+            [__DIR__.'/Fixtures/BadForLoopFlushHandler.php'],
+            [[self::MESSAGE, 28]],
+        );
+    }
+
+    #[Test]
+    public function flagsNestedLoopFlushOnceOnInnerLine(): void
+    {
+        // Reported exactly once, on the inner flush line — not once per level.
+        $this->analyse(
+            [__DIR__.'/Fixtures/BadNestedLoopFlushHandler.php'],
+            [[self::MESSAGE, 29]],
+        );
+    }
+
+    #[Test]
+    public function passesFlushClearInLoop(): void
+    {
+        $this->analyse([__DIR__.'/Fixtures/GoodFlushClearInLoopHandler.php'], []);
+    }
+
+    #[Test]
+    public function passesFlushAfterLoop(): void
+    {
+        $this->analyse([__DIR__.'/Fixtures/GoodFlushAfterLoopHandler.php'], []);
+    }
+
+    #[Test]
+    public function passesAbstractBatchHandlerSubclass(): void
+    {
+        $this->analyse([__DIR__.'/Fixtures/GoodBatchHandler.php'], []);
+    }
+
+    #[Test]
+    public function passesNonHandlerSyncService(): void
+    {
+        $this->analyse([__DIR__.'/Fixtures/GoodSyncServiceWithLoopFlush.php'], []);
+    }
+
+    #[Test]
+    public function passesNestedLoopWithClearInOuterLoop(): void
+    {
+        $this->analyse([__DIR__.'/Fixtures/GoodNestedLoopWithClearHandler.php'], []);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,19 +14,24 @@ name: pim
 x-default-restart: &default_restart
   restart: unless-stopped
 
-# HARD-02 — dev-machine resource limits.
+# HARD-02 / AUD-012 (W1-8) — dev-machine resource limits.
 #
 # CLAUDE.md §3.10 calls out FrankenPHP worker mode as the highest memory-leak
 # risk in the stack: Doctrine Identity Map accumulates between requests and a
 # missing EntityManager::clear() inside a long-running handler can OOM the
 # whole worker pool. Without `deploy.resources.limits` the worker can swallow
-# the entire host memory before the leak surfaces in metrics.
+# the entire host memory before the leak surfaces in metrics. The flush-without-
+# clear pattern is now also blocked statically by App\PHPStan\Rules\
+# FlushWithoutClearInLoopRule (CI gate); these container limits are the runtime
+# backstop for leaks the static rule cannot see (e.g. raw DBAL/SQL bulk loads).
 #
-# Limits below are tuned for a 16 GB dev workstation (sum ≈ 6 GB across all
-# services; leaves headroom for editor + browser). Production overrides land
-# in docker-compose.prod.yml (separate ticket — Faza 1 deploy hardening) and
-# should pair with a Prometheus alert on `frankenphp_worker_memory_bytes >
-# 256MB` per CLAUDE.md §3.10.
+# Limits below are tuned for a 16 GB dev workstation (sum ≈ 6.5 GB across all
+# services; leaves headroom for editor + browser). The `worker` service gets its
+# own 512M ceiling (x-resource-limits-worker) since it is the real long-lived
+# consumer. Production overrides live in docker-compose.prod.yml (worker pool at
+# 512M each) and pair with the Prometheus alert on
+# `frankenphp_worker_memory_bytes > 256MB` in docker/prometheus/alerts.yml,
+# per CLAUDE.md §3.10.
 #
 # Compose Spec (v3+) supports `deploy.resources.limits` outside Swarm since
 # 2022 — Docker Desktop 4.x and `docker compose` v2 both honour it.
@@ -64,6 +69,21 @@ x-resource-limits-cache: &resource_limits_cache
       limits:
         memory: 256M
         cpus: "0.5"
+
+# AUD-012 (W1-8) — the Messenger worker is the actual long-lived Doctrine
+# consumer (the `api` container serves HTTP and recycles per worker pick). Its
+# `--memory-limit=256M` flag is a SOFT recycle checked BETWEEN messages: a
+# single message that leaks mid-handle (e.g. a flush without clear in a 50k-row
+# import) grows past 256M and OOM-kills the host before Messenger recycles. The
+# 512M container limit is the HARD ceiling that bounds one in-flight message to
+# ~2× the soft limit and protects the dev workstation. Mirrors the prod worker
+# limit in docker-compose.prod.yml.
+x-resource-limits-worker: &resource_limits_worker
+  deploy:
+    resources:
+      limits:
+        memory: 512M
+        cpus: "1.0"
 
 x-resource-limits-storage: &resource_limits_storage
   deploy:
@@ -186,7 +206,7 @@ services:
     build:
       context: ./apps/api
       dockerfile: Dockerfile
-    <<: *default_restart
+    <<: [*default_restart, *resource_limits_worker]
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
> Audyt fix-plan **W1-8** (Wave 1). Closes #1587 (AUD-011, AUD-012).

## AUD-011 (HIGH) — reguła PHPStan `flush-bez-clear`
CLAUDE.md §3.10 deklaruje NIENEGOCJOWALNY CI-gate blokujący `flush()` w pętli bez `clear()` (FrankenPHP worker OOM pod bulk-load), ale reguła nigdy nie powstała. Dodane:
- **`src/PHPStan/Rules/FlushWithoutClearInLoopRule.php`** — strzela na klasy z class-level `#[AsMessageHandler]` (uniwersalny marker 40 handlerów), exempt `extends AbstractBatchHandler`; model per-flush: flush w pętli bezpieczny ⟺ obejmująca pętla ma `clear()`. Zarejestrowana w `phpstan/services.neon`.
- **`tests/Architecture/PHPStan/FlushWithoutClearInLoopRuleTest.php`** (`RuleTestCase`) + 8 fixtures — red na złych (foreach/for/nested flush-bez-clear), green na dobrych (flush+clear / AbstractBatchHandler / sync-service / clear-w-pętli-zewn.). **8/8.**
- **Pełny PHPStan `--memory-limit=1G` = No errors** na całym codebase → 0 false-positives na 40 handlerach / 239 flush-sites.

## AUD-012 (HIGH) — worker memory limit
- `docker-compose.yml`: anchor `x-resource-limits-worker` (512M/1.0 CPU) na `worker` (był tylko soft `--memory-limit=256M` recycle MIĘDZY wiadomościami — jedna leakująca wiadomość ubijała host). Render: `memory: 536870912`.
- Prometheus alert `FrankenphpWorkerMemoryHigh` (>256MiB) JUŻ ISTNIEJE (`docker/prometheus/alerts.yml`, infra z 2026-05-12 po dacie audytu) — udokumentowane w komentarzu compose.

## Bramki
RuleTestCase 8/8 · pełny PHPStan **No errors** · Architecture suite 9/9 · cs-fixer 0 · Deptrac **0** (`src/PHPStan` w warstwie Tooling) · `docker compose config -q` base+prod OK.

## Świadome odejścia
Reguła scope'owana do `#[AsMessageHandler]` (wierne §3.10 „handlery Messenger"), nie do każdej synchronicznej pętli z flush (gdzie `clear()` zerwałby unit-of-work) — eliminuje FP; udokumentowane w docblocku.
