### PR TITLE
AUD-024: role-escalation + token lifecycle tests (+2 HIGH fixes) (W1-12)

### DIFF
--- a/apps/api/src/Identity/Application/InvitationService.php
+++ b/apps/api/src/Identity/Application/InvitationService.php
@@ -149,6 +149,17 @@ final class InvitationService
             throw new RuntimeException('Invitation tenant not found.');
         }
 
+        // AUD-024 / W1-12: validate + consume the invitation state BEFORE any
+        // write. Previously the User was inserted first and `accept()` ran
+        // last, so a second use of an already-accepted token hit the
+        // users_email_uniq constraint (500 instead of 400) and an EXPIRED
+        // invitation still created a usable account before the expiry guard
+        // threw. Marking the invitation consumed up-front makes a stale token
+        // (already-accepted / revoked / expired) surface as a 400 with no
+        // user/role side effect.
+        $invitation->accept();
+        $this->invitations->save($invitation);
+
         // Create User + hash password.
         $user = new User(
             tenant: $tenant,
@@ -175,10 +186,6 @@ final class InvitationService
             roleId: $invitation->getRoleId(),
         );
         $this->userRoles->save($userRole);
-
-        // Mark invitation accepted (throws if already accepted/revoked/expired).
-        $invitation->accept();
-        $this->invitations->save($invitation);
 
         return $user;
     }

--- a/apps/api/src/Identity/Presentation/Controller/InvitationController.php
+++ b/apps/api/src/Identity/Presentation/Controller/InvitationController.php
@@ -41,8 +41,15 @@ final class InvitationController extends AbstractController
     ) {
     }
 
+    // AUD-024 / W1-12: align the gate with the implemented permission
+    // catalogue. `settings.users.manage` is a PRD §3.2 label that is never
+    // seeded (RbacSeeder seeds the RbacMatrix `{resource}.{action}` cross
+    // product), so the original gate denied EVERY principal — including a
+    // full Super Admin / Tenant Owner — making invitation creation dead.
+    // `user.admin` is the code the sibling user-management endpoints use
+    // (UserCreateController, InvitationActionsController::revoke/resend).
     #[Route(path: '/api/invitations', methods: ['POST'], name: 'api_invitations_create')]
-    #[RequiresPermission(module: 'settings', action: 'users.manage')]
+    #[RequiresPermission(module: 'user', action: 'admin')]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
     public function create(Request $request): JsonResponse
     {

--- a/apps/api/tests/Api/Identity/RoleAttributePermissionsControllerTest.php
+++ b/apps/api/tests/Api/Identity/RoleAttributePermissionsControllerTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\RoleAttributePermission;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleAttributePermissionRepositoryInterface;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AUD-024 / W1-12 — per-attribute permission grants must not become an
+ * escalation vector
+ * ({@see \App\Identity\Presentation\Controller\RoleAttributePermissionsController}).
+ *
+ * PRD-PIM-rbac §3.5: a role may carry a 3-state (view / edit / restricted)
+ * override per attribute. The PUT replace endpoint must refuse to widen a
+ * grant beyond what the caller's tenant/role may legitimately set:
+ *
+ *  - non-admin (Catalog Manager, no `user.admin`) → 403;
+ *  - PUT against a role owned by another tenant → 404 (no existence leak);
+ *  - an `attribute_id` belonging to another tenant → 400 (the catalogue
+ *    reader treats cross-tenant + unknown identically — the grant never
+ *    lands, so a role cannot be handed an override on a foreign attribute);
+ *  - an out-of-range `permission_level` (a state the engine cannot
+ *    enforce) → 400;
+ *  - admin + own-tenant attribute → 200, override persisted (proves the
+ *    rejections above are policy, not a dead endpoint).
+ *
+ * Status codes only (RFC 7807 detail differs debug/non-debug).
+ */
+final class RoleAttributePermissionsControllerTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_A_CODE = 'demo';
+    private const string TENANT_B_CODE = 'other';
+
+    private const string ADMIN_A_EMAIL = 'admin@demo.localhost';
+    private const string CATALOG_A_EMAIL = 'catalog@demo.localhost';
+
+    private string $customAId;
+    private string $customBId;
+    private string $attributeAId;
+    private string $attributeBId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+
+        $roles = self::getContainer()->get(RoleRepositoryInterface::class);
+        $superAdmin = $roles->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        $catalogManager = $roles->findGlobalByCode(RbacMatrix::ROLE_CATALOG_MANAGER);
+        \assert(null !== $superAdmin && null !== $catalogManager);
+
+        $tenantA = new Tenant(self::TENANT_A_CODE, 'Demo Tenant');
+        $tenantB = new Tenant(self::TENANT_B_CODE, 'Other Tenant');
+        $em->persist($tenantA);
+        $em->persist($tenantB);
+
+        $customA = new Role('custom_a', 'Custom Role A', $tenantA);
+        $em->persist($customA);
+        $customB = new Role('custom_b', 'Custom Role B', $tenantB);
+        $em->persist($customB);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $adminStub = new User($tenantA, self::ADMIN_A_EMAIL, '');
+        $admin = new User($tenantA, self::ADMIN_A_EMAIL, $hasher->hashPassword($adminStub, 'changeme'));
+        $admin->addRole($superAdmin);
+        $em->persist($admin);
+
+        $catalogStub = new User($tenantA, self::CATALOG_A_EMAIL, '');
+        $catalog = new User($tenantA, self::CATALOG_A_EMAIL, $hasher->hashPassword($catalogStub, 'changeme'));
+        $catalog->addRole($catalogManager);
+        $em->persist($catalog);
+
+        $em->flush();
+
+        $this->customAId = $customA->getId()->toRfc4122();
+        $this->customBId = $customB->getId()->toRfc4122();
+
+        // Real attributes, one per tenant, persisted under the matching
+        // tenant context so TenantAssignmentListener stamps tenant_id.
+        $this->attributeAId = $this->seedAttribute($tenantA, 'price_a', AttributeType::Number)->toRfc4122();
+        $this->attributeBId = $this->seedAttribute($tenantB, 'price_b', AttributeType::Number)->toRfc4122();
+
+        self::getContainer()->get(TenantContext::class)->clear();
+    }
+
+    // --- Escalation: non-admin denied (403) -------------------------------
+
+    #[Test]
+    public function nonAdminCannotReplaceAttributePermissions(): void
+    {
+        $client = $this->clientFor(self::CATALOG_A_EMAIL);
+        $client->request('PUT', '/api/roles/'.$this->customAId.'/attribute-permissions', [
+            'json' => ['attribute_permissions' => [
+                ['attribute_id' => $this->attributeAId, 'permission_level' => 'edit'],
+            ]],
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertResponseHeaderSame('content-type', 'application/problem+json');
+    }
+
+    // --- Cross-tenant role (404) ------------------------------------------
+
+    #[Test]
+    public function adminCannotReplaceForeignTenantRolePermissions(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('PUT', '/api/roles/'.$this->customBId.'/attribute-permissions', [
+            'json' => ['attribute_permissions' => [
+                ['attribute_id' => $this->attributeAId, 'permission_level' => 'edit'],
+            ]],
+        ]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    // --- Escalation: grant cannot reference a foreign attribute (400) -----
+
+    #[Test]
+    public function adminCannotGrantOverrideOnForeignTenantAttribute(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('PUT', '/api/roles/'.$this->customAId.'/attribute-permissions', [
+            'json' => ['attribute_permissions' => [
+                // attribute_b belongs to tenant B — must not be grantable
+                // on a tenant A role.
+                ['attribute_id' => $this->attributeBId, 'permission_level' => 'edit'],
+            ]],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+
+        // The foreign-attribute override must never have been written.
+        $this->em()->clear();
+        $overrides = self::getContainer()->get(RoleAttributePermissionRepositoryInterface::class)
+            ->findByRole(Uuid::fromString($this->customAId));
+        self::assertCount(0, $overrides, 'A rejected cross-tenant grant must leave no override row.');
+    }
+
+    #[Test]
+    public function adminCannotGrantOverrideOnUnknownAttribute(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('PUT', '/api/roles/'.$this->customAId.'/attribute-permissions', [
+            'json' => ['attribute_permissions' => [
+                ['attribute_id' => Uuid::v7()->toRfc4122(), 'permission_level' => 'view'],
+            ]],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    // --- Escalation: only enforceable levels accepted (400) ---------------
+
+    #[Test]
+    public function adminCannotGrantUnknownPermissionLevel(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('PUT', '/api/roles/'.$this->customAId.'/attribute-permissions', [
+            'json' => ['attribute_permissions' => [
+                // 'admin' is not one of view|edit|restricted — a level the
+                // resolver cannot enforce must be refused.
+                ['attribute_id' => $this->attributeAId, 'permission_level' => 'admin'],
+            ]],
+        ]);
+
+        self::assertResponseStatusCodeSame(400);
+
+        $this->em()->clear();
+        $overrides = self::getContainer()->get(RoleAttributePermissionRepositoryInterface::class)
+            ->findByRole(Uuid::fromString($this->customAId));
+        self::assertCount(0, $overrides, 'An invalid permission level must leave no override row.');
+    }
+
+    // --- Happy path: admin + own attribute (200) --------------------------
+
+    #[Test]
+    public function adminCanReplaceOwnTenantAttributePermissions(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('PUT', '/api/roles/'.$this->customAId.'/attribute-permissions', [
+            'json' => ['attribute_permissions' => [
+                ['attribute_id' => $this->attributeAId, 'permission_level' => RoleAttributePermission::LEVEL_VIEW],
+            ]],
+        ]);
+
+        self::assertResponseStatusCodeSame(200);
+
+        $this->em()->clear();
+        $overrides = self::getContainer()->get(RoleAttributePermissionRepositoryInterface::class)
+            ->findByRole(Uuid::fromString($this->customAId));
+        self::assertCount(1, $overrides, 'A valid own-tenant grant must persist exactly one override.');
+    }
+
+    private function seedAttribute(Tenant $tenant, string $code, AttributeType $type): Uuid
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $attribute = new Attribute($code, ['en' => ucfirst($code)], $type);
+        self::getContainer()->get(AttributeRepositoryInterface::class)->save($attribute);
+
+        return $attribute->getId();
+    }
+
+    private function clientFor(string $email): Client
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail($email);
+        \assert(null !== $user);
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Api/Identity/RoleWriteControllerTest.php
+++ b/apps/api/tests/Api/Identity/RoleWriteControllerTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Domain\Entity\Role;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AUD-024 / W1-12 — role-escalation coverage for the write surface
+ * ({@see \App\Identity\Presentation\Controller\RoleWriteController}).
+ *
+ * Before this test the only role coverage was the GET list
+ * ({@see RolesListControllerTest}); nothing asserted that a non-admin is
+ * denied write access or that a role belonging to another tenant cannot
+ * be mutated. These are the privilege-escalation invariants:
+ *
+ *  - non-admin (Catalog Manager, no `user.admin`) → 403 on
+ *    POST / PATCH / DELETE /api/roles;
+ *  - PATCH / DELETE of a custom role owned by another tenant → 404
+ *    (existence is NOT leaked — same shape as a missing role, per the
+ *    TenantFilter / RLS pattern);
+ *  - admin (Super Admin) happy-path → 201 / 200 / 204 so the 403s above
+ *    are proven to be authorization, not a broken endpoint.
+ *
+ * Asserts status codes only (the RFC 7807 detail differs between
+ * debug/non-debug, so CI would diverge on body strings).
+ */
+final class RoleWriteControllerTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_A_CODE = 'demo';
+    private const string TENANT_B_CODE = 'other';
+
+    private const string ADMIN_A_EMAIL = 'admin@demo.localhost';
+    private const string CATALOG_A_EMAIL = 'catalog@demo.localhost';
+
+    private string $customAId;
+    private string $customBId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+
+        $roles = self::getContainer()->get(RoleRepositoryInterface::class);
+        $superAdmin = $roles->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        $catalogManager = $roles->findGlobalByCode(RbacMatrix::ROLE_CATALOG_MANAGER);
+        \assert(null !== $superAdmin && null !== $catalogManager);
+
+        $tenantA = new Tenant(self::TENANT_A_CODE, 'Demo Tenant');
+        $tenantB = new Tenant(self::TENANT_B_CODE, 'Other Tenant');
+        $em->persist($tenantA);
+        $em->persist($tenantB);
+
+        // Custom role on tenant A — mutable by tenant A admin.
+        $customA = new Role('custom_a', 'Custom Role A', $tenantA);
+        $em->persist($customA);
+
+        // Custom role on tenant B — tenant A admin must see this as 404.
+        $customB = new Role('custom_b', 'Custom Role B', $tenantB);
+        $em->persist($customB);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $adminStub = new User($tenantA, self::ADMIN_A_EMAIL, '');
+        $admin = new User($tenantA, self::ADMIN_A_EMAIL, $hasher->hashPassword($adminStub, 'changeme'));
+        $admin->addRole($superAdmin);
+        $em->persist($admin);
+
+        $catalogStub = new User($tenantA, self::CATALOG_A_EMAIL, '');
+        $catalog = new User($tenantA, self::CATALOG_A_EMAIL, $hasher->hashPassword($catalogStub, 'changeme'));
+        $catalog->addRole($catalogManager);
+        $em->persist($catalog);
+
+        $em->flush();
+
+        $this->customAId = $customA->getId()->toRfc4122();
+        $this->customBId = $customB->getId()->toRfc4122();
+    }
+
+    // --- Escalation: non-admin is denied write (403) ----------------------
+
+    #[Test]
+    public function nonAdminCannotCreateRole(): void
+    {
+        $client = $this->clientFor(self::CATALOG_A_EMAIL);
+        $client->request('POST', '/api/roles', [
+            'json' => ['name' => 'Escalated Role', 'permission_codes' => []],
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertResponseHeaderSame('content-type', 'application/problem+json');
+    }
+
+    #[Test]
+    public function nonAdminCannotUpdateRole(): void
+    {
+        $client = $this->clientFor(self::CATALOG_A_EMAIL);
+        $client->request('PATCH', '/api/roles/'.$this->customAId, [
+            'json' => ['permission_codes' => ['user.admin']],
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertResponseHeaderSame('content-type', 'application/problem+json');
+    }
+
+    #[Test]
+    public function nonAdminCannotDeleteRole(): void
+    {
+        $client = $this->clientFor(self::CATALOG_A_EMAIL);
+        $client->request('DELETE', '/api/roles/'.$this->customAId);
+
+        self::assertResponseStatusCodeSame(403);
+        self::assertResponseHeaderSame('content-type', 'application/problem+json');
+    }
+
+    // --- Cross-tenant: another tenant's role is invisible (404) -----------
+
+    #[Test]
+    public function adminCannotUpdateForeignTenantRole(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('PATCH', '/api/roles/'.$this->customBId, [
+            'json' => ['permission_codes' => ['user.admin']],
+        ]);
+
+        // 404, NOT 403 — do not reveal that the role exists on another tenant.
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    #[Test]
+    public function adminCannotDeleteForeignTenantRole(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('DELETE', '/api/roles/'.$this->customBId);
+
+        self::assertResponseStatusCodeSame(404);
+
+        // The foreign role must survive the cross-tenant delete attempt.
+        $this->em()->clear();
+        $survivor = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findById(Uuid::fromString($this->customBId));
+        self::assertNotNull($survivor, 'Cross-tenant DELETE must not remove the foreign role.');
+    }
+
+    #[Test]
+    public function unknownRoleReturns404ForAdmin(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('PATCH', '/api/roles/'.Uuid::v7()->toRfc4122(), [
+            'json' => ['permission_codes' => []],
+        ]);
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    // --- Happy path: admin can write (proves the 403s are authz) ----------
+
+    #[Test]
+    public function adminCanCreateCustomRole(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('POST', '/api/roles', [
+            'json' => [
+                'name' => 'QA Reviewer',
+                'code' => 'qa_reviewer',
+                'permission_codes' => [],
+            ],
+        ]);
+
+        self::assertResponseStatusCodeSame(201);
+
+        $this->em()->clear();
+        $created = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findByCode('qa_reviewer', $this->tenantA());
+        self::assertNotNull($created, 'Admin POST must persist the custom role on the caller tenant.');
+    }
+
+    #[Test]
+    public function adminCanUpdateOwnTenantCustomRole(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('PATCH', '/api/roles/'.$this->customAId, [
+            'json' => ['permission_codes' => ['user.admin']],
+        ]);
+
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    #[Test]
+    public function adminCanDeleteUnassignedOwnTenantCustomRole(): void
+    {
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('DELETE', '/api/roles/'.$this->customAId);
+
+        self::assertResponseStatusCodeSame(204);
+
+        $this->em()->clear();
+        $deleted = self::getContainer()->get(RoleRepositoryInterface::class)
+            ->findById(Uuid::fromString($this->customAId));
+        self::assertNull($deleted, 'Admin DELETE must remove the own-tenant custom role.');
+    }
+
+    #[Test]
+    public function adminCannotDeleteBuiltInRole(): void
+    {
+        $roles = self::getContainer()->get(RoleRepositoryInterface::class);
+        $builtIn = $roles->findGlobalByCode(RbacMatrix::ROLE_VIEWER);
+        \assert(null !== $builtIn);
+
+        $client = $this->clientFor(self::ADMIN_A_EMAIL);
+        $client->request('DELETE', '/api/roles/'.$builtIn->getId()->toRfc4122());
+
+        // Built-in roles are protected even from a full admin.
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    private function tenantA(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_A_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    private function clientFor(string $email): Client
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail($email);
+        \assert(null !== $user);
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/apps/api/tests/Api/Identity/TokenLifecycleApiTest.php
+++ b/apps/api/tests/Api/Identity/TokenLifecycleApiTest.php
@@ -1,0 +1,391 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Identity\Application\MagicLinkTokenHasher;
+use App\Identity\Application\RbacSeeder;
+use App\Identity\Application\SeedTenantPrdRolesService;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Repository\RoleRepositoryInterface;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AUD-024 / W1-12 / J-03 — account-recovery & onboarding token lifecycle.
+ *
+ * Re-runs the lesson from RBAC Phase 2 re-audit (#657 invitation / #658
+ * password-reset were shipped without an end-to-end test). Both flows put
+ * the raw token on a PUBLIC_ACCESS endpoint, so a reusable / non-expiring /
+ * leaked token is an account-takeover surface. This test pins:
+ *
+ *  Password reset ({@see \App\Identity\Presentation\Controller\PasswordResetController}):
+ *   - request → confirm round-trip lets the user log in with the new password;
+ *   - the token is SINGLE-USE — a second confirm with the same token is
+ *     rejected (400);
+ *   - an EXPIRED token is rejected (400);
+ *   - confirm does NOT leak any token back in the response body.
+ *
+ *  Invitation / magic-link ({@see \App\Identity\Presentation\Controller\InvitationController}):
+ *   - create → accept onboards the user (201) and they can then log in;
+ *   - the token is SINGLE-USE — a second accept is rejected (400);
+ *   - an EXPIRED invitation is rejected on accept (400) and reports
+ *     `expired` (410) on verify;
+ *   - accept does NOT leak any token back in the response body.
+ *
+ *  Note: there is no standalone magic-link login endpoint — the invitation
+ *  accept flow IS the magic link (per InvitationController docblock).
+ *
+ *  The prod-omission of `token_dev_only` (AUD-007 / W0-5) is already pinned
+ *  by {@see \App\Tests\Unit\Identity\Presentation\Controller\DevTokenExposureTest};
+ *  here APP_ENV=test, so the dev token is present and used to drive consume.
+ *
+ * Status codes only (RFC 7807 detail differs debug/non-debug).
+ */
+final class TokenLifecycleApiTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string TENANT_CODE = 'demo';
+    private const string ADMIN_EMAIL = 'admin@demo.localhost';
+    private const string ADMIN_PASSWORD = 'changeme';
+    private const string CATALOG_EMAIL = 'catalog@demo.localhost';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $em = $this->em();
+        self::getContainer()->get(RbacSeeder::class)->seed();
+
+        $roles = self::getContainer()->get(RoleRepositoryInterface::class);
+        $superAdmin = $roles->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);
+        $catalogManager = $roles->findGlobalByCode(RbacMatrix::ROLE_CATALOG_MANAGER);
+        \assert(null !== $superAdmin && null !== $catalogManager);
+
+        $tenant = new Tenant(self::TENANT_CODE, 'Demo Tenant');
+        $em->persist($tenant);
+        $em->flush();
+
+        // Per-tenant roles (viewer, tenant_owner, ...) — InvitationService
+        // resolves role_code per tenant, so a global-only seed would 400.
+        self::getContainer()->get(SeedTenantPrdRolesService::class)->seed($tenant);
+        $tenantOwner = $roles->findByCode('tenant_owner', $tenant);
+        \assert(null !== $tenantOwner);
+
+        $hasher = self::getContainer()->get(UserPasswordHasherInterface::class);
+        $stub = new User($tenant, self::ADMIN_EMAIL, '');
+        $admin = new User($tenant, self::ADMIN_EMAIL, $hasher->hashPassword($stub, self::ADMIN_PASSWORD));
+        $admin->addRole($superAdmin);
+        $admin->addRole($tenantOwner);
+        $em->persist($admin);
+
+        // Non-admin (Catalog Manager) for the invitation-create escalation guard.
+        $catalogStub = new User($tenant, self::CATALOG_EMAIL, '');
+        $catalog = new User($tenant, self::CATALOG_EMAIL, $hasher->hashPassword($catalogStub, 'changeme'));
+        $catalog->addRole($catalogManager);
+        $em->persist($catalog);
+
+        $em->flush();
+    }
+
+    // ===================================================================
+    //  Password reset
+    // ===================================================================
+
+    #[Test]
+    public function passwordResetRoundTripLetsUserLoginWithNewPassword(): void
+    {
+        $token = $this->requestPasswordResetToken(self::ADMIN_EMAIL);
+
+        $client = static::createClient();
+        $client->request('POST', '/api/auth/password-reset/confirm', [
+            'json' => ['token' => $token, 'password' => 'new-strong-password'],
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        // Old password no longer works; the new one does.
+        self::assertSame(401, $this->loginStatus(self::ADMIN_EMAIL, self::ADMIN_PASSWORD));
+        self::assertSame(200, $this->loginStatus(self::ADMIN_EMAIL, 'new-strong-password'));
+    }
+
+    #[Test]
+    public function passwordResetTokenIsSingleUse(): void
+    {
+        $token = $this->requestPasswordResetToken(self::ADMIN_EMAIL);
+
+        $first = static::createClient();
+        $first->request('POST', '/api/auth/password-reset/confirm', [
+            'json' => ['token' => $token, 'password' => 'first-password-x'],
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        // Replaying the same token must be refused.
+        $second = static::createClient();
+        $second->request('POST', '/api/auth/password-reset/confirm', [
+            'json' => ['token' => $token, 'password' => 'second-password-x'],
+        ]);
+        self::assertResponseStatusCodeSame(400);
+
+        // The second password must NOT have taken effect.
+        self::assertSame(401, $this->loginStatus(self::ADMIN_EMAIL, 'second-password-x'));
+        self::assertSame(200, $this->loginStatus(self::ADMIN_EMAIL, 'first-password-x'));
+    }
+
+    #[Test]
+    public function expiredPasswordResetTokenIsRejected(): void
+    {
+        $token = $this->requestPasswordResetToken(self::ADMIN_EMAIL);
+        $this->expireRow('password_reset_tokens', $this->hash($token));
+
+        $client = static::createClient();
+        $client->request('POST', '/api/auth/password-reset/confirm', [
+            'json' => ['token' => $token, 'password' => 'late-password-xx'],
+        ]);
+        self::assertResponseStatusCodeSame(400);
+
+        // The expired-token password must NOT have taken effect.
+        self::assertSame(401, $this->loginStatus(self::ADMIN_EMAIL, 'late-password-xx'));
+        self::assertSame(200, $this->loginStatus(self::ADMIN_EMAIL, self::ADMIN_PASSWORD));
+    }
+
+    #[Test]
+    public function passwordResetConfirmDoesNotLeakToken(): void
+    {
+        $token = $this->requestPasswordResetToken(self::ADMIN_EMAIL);
+
+        $client = static::createClient();
+        $client->request('POST', '/api/auth/password-reset/confirm', [
+            'json' => ['token' => $token, 'password' => 'leak-check-pw-1'],
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        $body = $client->getResponse()?->toArray(throw: false) ?? [];
+        self::assertArrayNotHasKey('token', $body);
+        self::assertArrayNotHasKey('token_dev_only', $body);
+    }
+
+    #[Test]
+    public function unknownPasswordResetTokenIsRejected(): void
+    {
+        $client = static::createClient();
+        $client->request('POST', '/api/auth/password-reset/confirm', [
+            'json' => ['token' => bin2hex(random_bytes(32)), 'password' => 'whatever-pw-12'],
+        ]);
+        // Token not found → 404 (PasswordResetController maps RuntimeException).
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    // ===================================================================
+    //  Invitation / magic link
+    // ===================================================================
+
+    #[Test]
+    public function nonAdminCannotCreateInvitation(): void
+    {
+        // Escalation guard: only an admin (user.admin) may mint a magic-link
+        // invitation. A Catalog Manager must be refused.
+        $client = $this->clientFor(self::CATALOG_EMAIL);
+        $client->request('POST', '/api/invitations', [
+            'json' => ['email' => 'forbidden@example.com', 'role_code' => 'viewer'],
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    #[Test]
+    public function invitationRoundTripOnboardsUserAndAllowsLogin(): void
+    {
+        $token = $this->createInvitationToken('invitee@example.com', 'viewer');
+
+        $client = static::createClient();
+        $client->request('POST', '/api/invitations/'.$token.'/accept', [
+            'json' => ['password' => 'invitee-password-1'],
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        self::assertSame(200, $this->loginStatus('invitee@example.com', 'invitee-password-1'));
+    }
+
+    #[Test]
+    public function invitationTokenIsSingleUse(): void
+    {
+        $token = $this->createInvitationToken('once@example.com', 'viewer');
+
+        $first = static::createClient();
+        $first->request('POST', '/api/invitations/'.$token.'/accept', [
+            'json' => ['password' => 'first-accept-pw-1'],
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        // Second acceptance of the same token must be refused.
+        $second = static::createClient();
+        $second->request('POST', '/api/invitations/'.$token.'/accept', [
+            'json' => ['password' => 'second-accept-pw1'],
+        ]);
+        self::assertResponseStatusCodeSame(400);
+    }
+
+    #[Test]
+    public function expiredInvitationIsRejectedOnAccept(): void
+    {
+        $token = $this->createInvitationToken('expired@example.com', 'viewer');
+        $this->expireRow('invitations', $this->hash($token));
+
+        $client = static::createClient();
+        $client->request('POST', '/api/invitations/'.$token.'/accept', [
+            'json' => ['password' => 'too-late-accept-1'],
+        ]);
+        self::assertResponseStatusCodeSame(400);
+
+        // No account must have been created from the expired invitation.
+        $this->em()->clear();
+        $created = self::getContainer()->get(UserRepositoryInterface::class)
+            ->findByEmail('expired@example.com');
+        self::assertNull($created, 'An expired invitation must not create a user.');
+    }
+
+    #[Test]
+    public function expiredInvitationReportsExpiredOnVerify(): void
+    {
+        $token = $this->createInvitationToken('verify-exp@example.com', 'viewer');
+        $this->expireRow('invitations', $this->hash($token));
+
+        $client = static::createClient();
+        $client->request('GET', '/api/invitations/'.$token.'/verify');
+        self::assertResponseStatusCodeSame(410);
+    }
+
+    #[Test]
+    public function validInvitationReportsValidOnVerify(): void
+    {
+        $token = $this->createInvitationToken('verify-ok@example.com', 'viewer');
+
+        $client = static::createClient();
+        $client->request('GET', '/api/invitations/'.$token.'/verify');
+        self::assertResponseStatusCodeSame(200);
+    }
+
+    #[Test]
+    public function invitationAcceptDoesNotLeakToken(): void
+    {
+        $token = $this->createInvitationToken('leak-inv@example.com', 'viewer');
+
+        $client = static::createClient();
+        $client->request('POST', '/api/invitations/'.$token.'/accept', [
+            'json' => ['password' => 'leak-inv-pw-readable'],
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        $body = $client->getResponse()?->toArray(throw: false) ?? [];
+        self::assertArrayNotHasKey('token', $body);
+        self::assertArrayNotHasKey('token_dev_only', $body);
+    }
+
+    // ===================================================================
+    //  Helpers
+    // ===================================================================
+
+    /**
+     * Drives POST /password-reset/request and returns the dev-mode plaintext
+     * token (present because APP_ENV=test).
+     */
+    private function requestPasswordResetToken(string $email): string
+    {
+        $client = static::createClient();
+        $client->request('POST', '/api/auth/password-reset/request', [
+            'json' => ['email' => $email],
+        ]);
+        self::assertResponseStatusCodeSame(200);
+
+        $body = $client->getResponse()?->toArray() ?? [];
+        $token = $body['token_dev_only'] ?? null;
+        \assert(\is_string($token) && '' !== $token);
+
+        return $token;
+    }
+
+    /**
+     * Drives POST /api/invitations (admin) and returns the dev-mode token.
+     */
+    private function createInvitationToken(string $email, string $roleCode): string
+    {
+        $client = $this->clientFor(self::ADMIN_EMAIL);
+        $client->request('POST', '/api/invitations', [
+            'json' => ['email' => $email, 'role_code' => $roleCode],
+        ]);
+        self::assertResponseStatusCodeSame(201);
+
+        $body = $client->getResponse()?->toArray() ?? [];
+        $token = $body['token_dev_only'] ?? null;
+        \assert(\is_string($token) && '' !== $token);
+
+        return $token;
+    }
+
+    private function loginStatus(string $email, string $password): int
+    {
+        // Login is throttled per IP — reset before each attempt so multiple
+        // checks in one test don't trip the limiter.
+        self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+
+        $client = static::createClient();
+        $client->request('POST', '/api/auth/login', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['email' => $email, 'password' => $password], JSON_THROW_ON_ERROR),
+        ]);
+
+        return $client->getResponse()?->getStatusCode() ?? 0;
+    }
+
+    private function expireRow(string $table, string $tokenHash): void
+    {
+        $em = $this->em();
+        $em->getConnection()->executeStatement(
+            \sprintf('UPDATE %s SET expires_at = :past WHERE token_hash = :hash', $table),
+            ['past' => '1999-01-01 00:00:00', 'hash' => $tokenHash],
+        );
+        $em->clear();
+    }
+
+    private function hash(string $plaintext): string
+    {
+        return self::getContainer()->get(MagicLinkTokenHasher::class)->hash($plaintext);
+    }
+
+    private function clientFor(string $email): Client
+    {
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail($email);
+        \assert(null !== $user);
+        $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+        $client = static::createClient();
+        $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+
+        return $client;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}


### PR DESCRIPTION
> Audyt fix-plan **W1-12** (Wave 1). Closes #1591 (AUD-024).

## Deliverable — 28 testów / 62 asercje (eskalacja ról + token lifecycle)
Powierzchnia bez pokrycia (jedyny test ról = GET listy; lekcja #657/#658):
- **`RoleWriteControllerTest`**: non-admin `POST/PATCH/DELETE /api/roles` → **403**; cross-tenant rola → **404** (bez ujawniania istnienia, obca rola przeżywa); built-in delete → 403; happy-path admin 201/200/204.
- **`RoleAttributePermissionsControllerTest`**: non-admin → 403; cross-tenant → 404; atrybut innego tenanta → 400 (0 override'ów); zły `permission_level` → 400 (0 override'ów); happy-path → 200.
- **`TokenLifecycleApiTest`**: reset + invitation/magic-link — request→consume round-trip, **single-use** (2× → 400), **expiry** (→ 400/410, brak side-effectu), **no-leak** (brak `token`/`token_dev_only` w confirm).

Asercje na status code (nie body-detail). 

## 2 realne bugi HIGH odsłonięte przez testy — oba naprawione tutaj
1. **`POST /api/invitations` martwy dla wszystkich** — gate `#[RequiresPermission(settings, users.manage)]` → kod `settings.users.manage`, którego ŻADNA rola nie ma (`RbacSeeder` seeduje tylko 2-segmentowy `{resource}.{action}` z `RbacMatrix`; 3-segment nigdy nie trafia do katalogu, `SeedTenantPrdRolesService` go pomija nawet dla ownera). Jedyne użycie `module:'settings'`; rodzeństwo używa `user.admin`. **Fix:** wyrównanie do `module:'user', action:'admin'`.
2. **`InvitationService::accept()` check-after-write (security)** — tworzył+zapisywał Usera/UserRole PRZED `$invitation->accept()` (jedyny guard single-use/expiry). Skutki: (a) przeterminowane zaproszenie tworzyło UŻYWALNE konto przed rzuceniem guardu; (b) 2. accept → 500 (unique violation) zamiast 400. **Fix:** `accept()`+save na początku, przed jakimkolwiek zapisem Usera.

## Bramki
PHPUnit **28/28** (env=test + JWT override) + `DevTokenExposureTest` 6/6 (bez regresji) · PHPStan **No errors** · cs-fixer 0 · Deptrac **0**. Bez baseline/skip — oba bugi naprawione, testy realnie zielone.
