### PR TITLE
AUD-025/060: fix onboarding creds, seed flow, shared-types OpenAPI URL (W1-13)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -11,11 +11,18 @@ git clone https://github.com/malipie/PIM.git
 cd PIM
 pnpm install
 pnpm stack:up                 # docker compose up -d (api + admin + caddy + postgres + redis + meilisearch + minio + mercure)
-docker compose exec -T api bin/console doctrine:migrations:migrate --no-interaction
-docker compose exec -T api bin/console doctrine:fixtures:load --no-interaction
+docker compose exec -T api bin/console pim:db:reset --with-fixtures   # canonical one-shot: drop+create+migrate+audit:schema:update+fixtures
 ```
 
-Open `https://pim.localhost` (Caddy will produce a self-signed cert — accept it once). Login with `admin@demo.local` / `demo`. Navigate to **Products** — the demo dataset seeded by `App\DataFixtures\AppFixtures` should be visible.
+> The manual equivalent is **three** steps, not two — `audit:schema:update` is required: audit tables live outside the Doctrine migration pipeline, so without it any INSERT into an audited entity 500s with `relation "*_audit" does not exist`:
+>
+> ```bash
+> docker compose exec -T api bin/console doctrine:migrations:migrate --no-interaction
+> docker compose exec -T api bin/console audit:schema:update --force
+> docker compose exec -T api bin/console doctrine:fixtures:load --no-interaction
+> ```
+
+Open `https://pim.localhost` (Caddy will produce a self-signed cert — accept it once). Login with `admin@demo.localhost` / `changeme`. Navigate to **Products** — the demo dataset seeded by `App\DataFixtures\AppFixtures` should be visible.
 
 Verify your environment with the same gates CI runs:
 

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -10,7 +10,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "generate": "openapi-typescript http://pim.localhost/api/docs.json -o src/api.d.ts",
+    "generate": "NODE_TLS_REJECT_UNAUTHORIZED=0 openapi-typescript https://pim.localhost/api/docs.jsonopenapi -o src/api.d.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,5 +1,5 @@
 // Re-exports populated after `pnpm --filter @pim/shared-types generate`
-// (uses openapi-typescript on http://pim.localhost/api/docs.jsonld).
+// (uses openapi-typescript on https://pim.localhost/api/docs.jsonopenapi).
 //
 // Until the first generation this file is intentionally empty so that
 // `tsc --noEmit` passes in CI without a generated artifact in the repo.


### PR DESCRIPTION
> Audyt fix-plan **W1-13** (Wave 1). Closes #1592 (AUD-025, AUD-060).

## Naprawa
- **AUD-025 (HIGH) — onboarding kłamie:** `ONBOARDING.md` uczył `admin@demo.local`/`demo` (login failuje — fixtures seedują `admin@demo.localhost`/`changeme`) i 2-krokowego seedu BEZ `audit:schema:update` → INSERT do audytowanej encji w „Day 1" → **500 `relation "*_audit" does not exist`**. Fix: udokumentowany **`pim:db:reset --with-fixtures`** jako kanoniczny one-shot (zawiera `audit:schema:update --force`, `DatabaseResetCommand.php:84`) + 3-krokowy manualny ekwiwalent z jawnym `audit:schema:update`. Creds poprawione.
- **AUD-060 — shared-types generate:** `packages/shared-types/package.json` używał `http://pim.localhost/api/docs.json` (zła schema + ścieżka). AP4 serwuje OpenAPI pod **`https`** `/api/docs.jsonopenapi`. Fix komendy + komentarza w `src/index.ts`.

## Smoke (dowody na żywym stacku)
```
GET https://pim.localhost/api/docs.json        → 404
GET https://pim.localhost/api/docs.jsonopenapi → 200 (openapi 3.1.0)
GET http://pim.localhost/...                    → 000 (tylko https)
login admin@demo.localhost / changeme           → 200 + JWT   (admin@demo.local/demo → fail)
pnpm generate (poprawiona komenda)               → 🚀 .../docs.jsonopenapi → api.d.ts [454ms], 5767 linii valid TS
```
`pim:db:reset` potwierdzony w `bin/console list` (drop+create+migrate+**audit:schema:update**+fixtures).

## Bramki
package.json valid JSON · generate smoke OK (do /tmp, bez nadpisania commitowanego `api.d.ts` — regeneracja typów to osobna sprawa, nie scope tego ticketu) · brak PHP (PHPStan/Deptrac N/A). Docs-only + 1 linia script + komentarz.
