### PR TITLE
AUD-019/020: ordered tenant hard-delete + MinIO cascade (W1-7)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -302,6 +302,16 @@ services:
         arguments:
             $exportsStorage: '@exports.storage'
 
+    # AUD-019/020 (W1-7) — tenant offboarding purger. Bind all three named
+    # storages so the prefix-delete cascade can sweep assets + imports +
+    # exports under `<tenant-uuid>/` (autowire can't pick among the
+    # per-storage FilesystemOperator services).
+    App\Shared\Infrastructure\Maintenance\TenantPurger:
+        arguments:
+            $assetsStorage: '@assets.storage'
+            $importsStorage: '@imports.storage'
+            $exportsStorage: '@exports.storage'
+
     # VIEW-IMP-03 (#500) — health-check drivers for ImportSource. Only the
     # folder driver does a real probe in the MVP; sftp/ftp/http/webhook/
     # api/upload land with the polling daemon follow-up and use the

--- a/apps/api/src/Identity/Presentation/Command/PurgeDeletedTenantsCommand.php
+++ b/apps/api/src/Identity/Presentation/Command/PurgeDeletedTenantsCommand.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace App\Identity\Presentation\Command;
 
 use App\Identity\Application\SuperAdmin\SuperAdminContext;
-use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Infrastructure\Maintenance\TenantPurger;
+use App\Shared\Infrastructure\Maintenance\TenantStoragePurgeException;
 use Doctrine\DBAL\Connection;
 use InvalidArgumentException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -27,11 +28,15 @@ use Symfony\Component\Uid\Uuid;
  *     by the Super Admin operator via the API.
  *   - Recovery window is `--retention-days` (default 30).
  *   - After the window expires, this command hard-deletes the tenant
- *     row. CASCADE on FKs takes care of dependent rows (users,
- *     api_tokens, audit_logs, etc.).
+ *     and EVERY dependent row + object-storage prefix via
+ *     {@see TenantPurger}
+ *     (GDPR art. 17). NB: most FKs to `tenants` are ON DELETE RESTRICT,
+ *     so a bare `DELETE FROM tenants` would fail — the purger deletes
+ *     dependents in child→parent order inside a transaction (AUD-019),
+ *     then `deleteDirectory(<tenant-uuid>)` per bucket (AUD-020).
  *
- * The hard delete runs inside `SuperAdminContext::runCrossTenant()` so
- * the `tenant_filter` doesn't hide deleted rows from the lookup query.
+ * The lookup runs inside `SuperAdminContext::runCrossTenant()` so the
+ * tenant filter doesn't hide soft-deleted rows from the candidate query.
  * `--dry-run` lists the candidate rows without touching them — safer
  * default for the first deployment cycle. Operators flip the flag off
  * once they've validated the candidates are correct.
@@ -51,7 +56,7 @@ final class PurgeDeletedTenantsCommand extends Command
     public function __construct(
         private readonly Connection $connection,
         private readonly SuperAdminContext $superAdminContext,
-        private readonly TenantRepositoryInterface $tenants,
+        private readonly TenantPurger $tenantPurger,
     ) {
         parent::__construct();
     }
@@ -121,6 +126,7 @@ final class PurgeDeletedTenantsCommand extends Command
         }
 
         $deleted = 0;
+        $storageFailures = 0;
         foreach ($rows as $row) {
             try {
                 $uuid = Uuid::fromString($row['id']);
@@ -128,20 +134,39 @@ final class PurgeDeletedTenantsCommand extends Command
                 $io->warning(\sprintf('Skipping malformed tenant id `%s`.', $row['id']));
                 continue;
             }
-            $tenant = $this->superAdminContext->runCrossTenant(
-                $callerId,
-                fn () => $this->tenants->findById($uuid),
-            );
-            if (null === $tenant) {
-                continue;
+
+            // The purger sets the RLS GUC to this exact tenant for its
+            // deletes; running inside cross-tenant mode additionally drops
+            // the Doctrine TenantFilter for any ORM read it may trigger.
+            try {
+                $this->superAdminContext->runCrossTenant(
+                    $callerId,
+                    fn (): int => $this->tenantPurger->purge($uuid),
+                );
+                ++$deleted;
+            } catch (TenantStoragePurgeException $e) {
+                // DB rows are gone (GDPR-compliant for the database), but
+                // object-storage blobs may linger — surface it loudly so the
+                // operator triggers a manual / GC sweep. Counts as deleted
+                // for the DB, separately reported for storage.
+                ++$deleted;
+                ++$storageFailures;
+                $io->warning(\sprintf(
+                    'Tenant %s: DB purged but storage cleanup failed for bucket(s) %s. Blobs may linger.',
+                    $row['code'],
+                    implode(', ', $e->failedBuckets),
+                ));
             }
-            $this->superAdminContext->runCrossTenant(
-                $callerId,
-                function () use ($tenant): void {
-                    $this->tenants->remove($tenant);
-                },
-            );
-            ++$deleted;
+        }
+
+        if ($storageFailures > 0) {
+            $io->warning(\sprintf(
+                'Hard-deleted %d tenant(s); %d had storage-purge failures (see warnings above).',
+                $deleted,
+                $storageFailures,
+            ));
+
+            return Command::FAILURE;
         }
 
         $io->success(\sprintf('Hard-deleted %d tenant(s).', $deleted));

--- a/apps/api/src/Shared/Infrastructure/Maintenance/TenantPurger.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/TenantPurger.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Maintenance;
+
+use Doctrine\DBAL\Connection;
+use League\Flysystem\FilesystemOperator;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * AUD-019 / AUD-020 (W1-7) — irreversibly erases every row and storage
+ * object that belongs to a single tenant, satisfying GDPR art. 17 (right
+ * to erasure) for the hard-delete leg of tenant offboarding.
+ *
+ * Why ordered code-delete instead of FK CASCADE:
+ *   24 of the 38 foreign keys pointing at `tenants` are ON DELETE RESTRICT
+ *   (objects, object_values, users, assets, attributes, channels, the
+ *   import_* / export_* clusters, …). They exist on purpose: a stray
+ *   `DELETE FROM tenants` must NOT silently cascade through the whole
+ *   catalogue. Re-pointing all 24 to CASCADE via migration would be a
+ *   dangerous, hard-to-reverse weakening of that guard for every code path,
+ *   not just offboarding. Instead we delete the dependent rows ourselves in
+ *   strict child→parent order inside one transaction, then the tenant row.
+ *   This is controlled, testable, idempotent and batched.
+ *
+ * RLS interaction (the subtle part):
+ *   The runtime/CLI connects as `pim_app` (NOBYPASSRLS) and every
+ *   tenant-scoped table has FORCE ROW LEVEL SECURITY. A plain `DELETE …
+ *   WHERE tenant_id = :id` would therefore see ZERO rows (and silently
+ *   delete nothing — a worse bug than the FK violation) unless the session
+ *   GUC `app.current_tenant` is set to the tenant being purged. {@see purge}
+ *   sets it for the duration of the delete and resets it in a finally, so
+ *   the operation is scoped to exactly one tenant at the DB layer — the
+ *   `demo` / `acme` tenants are physically invisible to these statements.
+ *   The explicit `WHERE tenant_id = :id` predicate is defence in depth on
+ *   top of RLS. Under the test schema (built from ORM metadata, no RLS
+ *   policies) the GUC is a harmless no-op and the WHERE clause is the only
+ *   guard — which is exactly what the offboarding test asserts.
+ *
+ * Memory (FrankenPHP worker mode, §3.10): deletes go through the DBAL
+ * connection as set-based SQL (no entity hydration, no Identity Map growth),
+ * so no per-row `clear()` is needed; the largest tenant's `object_values`
+ * delete is a single server-side statement.
+ *
+ * Storage cascade: every Asset / export / import-upload object lives under
+ * the `<tenant-uuid>/` path prefix (flysystem.yaml). After the DB rows are
+ * gone we `deleteDirectory(<tenant-uuid>)` on each of the three named
+ * operators. Storage failure is logged at error level and rethrown by
+ * default so the caller never reports a clean purge while PII blobs linger;
+ * see {@see purge} ordering note.
+ */
+final readonly class TenantPurger
+{
+    /**
+     * Child→parent delete order across every tenant-scoped table. Each row
+     * is `[table, tenantColumn]`. The order is a topological sort of the
+     * inter-table foreign keys so a child is always gone before its parent:
+     *
+     *   1. import_* / export_* / channel_* leaf rows (logs, runs, sessions,
+     *      placements, category nodes) before their profiles/schedules.
+     *   2. object_values / object_relations / saved_views / bulk_edit_jobs
+     *      before objects.
+     *   3. objects before object_types and before bulk_sessions
+     *      (objects → bulk_sessions / import_sessions is ON DELETE SET NULL,
+     *      so objects must precede them to avoid dangling set-nulls; but
+     *      semantically the children are purged first anyway).
+     *   4. attribute_options before attributes before attribute_groups.
+     *   5. channels / assets / api_* / backups (their children already gone).
+     *   6. identity: invitations (RESTRICT → users/roles) before the
+     *      user-scoped tokens, before users.
+     *
+     * Tables whose FK to `tenants` is already ON DELETE CASCADE (roles,
+     * sso_providers, tenant_locales, menu_configurations,
+     * tenant_agent_configs, channel_publication_profiles, refresh_tokens via
+     * users, …) are STILL listed and deleted explicitly: relying on the
+     * final `DELETE FROM tenants` cascade would make the row counts the
+     * offboarding test asserts depend on cascade side effects, and leaves
+     * orphan-prone tables (bulk_sessions, bulk_edit_jobs, smart_filter_presets,
+     * refresh_tokens, saved_views) — which carry `tenant_id` but NO FK to
+     * tenants — behind forever. Explicit is safer and idempotent.
+     *
+     * @var list<array{0: string, 1: string}>
+     */
+    private const array DELETE_ORDER = [
+        // ── Import / Export / Channel leaves ───────────────────────────
+        ['import_undo_log', 'tenant_id'],
+        ['import_logs', 'tenant_id'],
+        ['import_source_logs', 'tenant_id'],
+        ['import_schedule_runs', 'tenant_id'],
+        ['import_schedules', 'tenant_id'],
+        ['import_sources', 'tenant_id'],
+        ['import_sessions', 'tenant_id'],
+        ['import_profiles', 'tenant_id'],
+        ['import_staged_files', 'tenant_id'],
+        ['export_sessions', 'tenant_id'],
+        ['export_profiles', 'tenant_id'],
+        ['object_channel_placements', 'tenant_id'],
+        ['channel_category_node_mappings', 'tenant_id'],
+        ['channel_category_nodes', 'tenant_id'],
+        ['channel_publication_profiles', 'tenant_id'],
+
+        // ── Object values / relations / view state ─────────────────────
+        ['object_values', 'tenant_id'],
+        ['object_relations', 'tenant_id'],
+        ['saved_views', 'tenant_id'],
+        ['smart_filter_presets', 'tenant_id'],
+        ['bulk_edit_jobs', 'tenant_id'],
+
+        // ── Objects, then the sessions they SET NULL-referenced, then types
+        ['objects', 'tenant_id'],
+        ['bulk_sessions', 'tenant_id'],
+        ['object_types', 'tenant_id'],
+
+        // ── Attributes ─────────────────────────────────────────────────
+        ['attribute_options', 'tenant_id'],
+        ['attributes', 'tenant_id'],
+        ['attribute_groups', 'tenant_id'],
+
+        // ── Channels / assets / API / backups ──────────────────────────
+        ['channels', 'tenant_id'],
+        ['assets', 'tenant_id'],
+        ['api_keys', 'tenant_id'],
+        ['api_profiles', 'tenant_id'],
+        ['backups', 'tenant_id'],
+
+        // ── Identity (children of users before users) ──────────────────
+        ['invitations', 'tenant_id'],
+        ['api_tokens', 'tenant_id'],
+        ['password_reset_tokens', 'tenant_id'],
+        ['user_tenant_memberships', 'tenant_id'],
+        ['refresh_tokens', 'tenant_id'],
+        ['users', 'tenant_id'],
+
+        // ── Remaining tenant-scoped config (CASCADE → tenants anyway) ───
+        ['roles', 'tenant_id'],
+        ['sso_providers', 'tenant_id'],
+        ['tenant_locales', 'tenant_id'],
+        ['menu_configurations', 'tenant_id'],
+        ['tenant_agent_configs', 'tenant_id'],
+    ];
+
+    public function __construct(
+        private Connection $connection,
+        private FilesystemOperator $assetsStorage,
+        private FilesystemOperator $importsStorage,
+        private FilesystemOperator $exportsStorage,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Hard-deletes one tenant: all dependent rows (in FK order) + the tenant
+     * row in a single transaction, then the tenant's object-storage prefix
+     * across all three buckets.
+     *
+     * Ordering rationale (DB before storage): the database row is the source
+     * of truth for "this tenant exists". We commit the DB erasure first so a
+     * crash mid-storage-delete leaves NO dangling tenant pointing at blobs;
+     * the worst case is orphan blobs under a now-unknown prefix, which the
+     * logged error flags for a manual / GC sweep — never a live tenant whose
+     * data is half-gone. Storage failure is rethrown so the caller does not
+     * count the tenant as cleanly purged.
+     *
+     * Idempotent: re-running on an already-purged tenant deletes 0 rows and
+     * `deleteDirectory` on a missing prefix is a no-op.
+     *
+     * @return int total number of dependent + tenant rows deleted from the DB
+     */
+    public function purge(Uuid $tenantId): int
+    {
+        $idString = $tenantId->toRfc4122();
+
+        $deleted = $this->connection->transactional(static function (Connection $conn) use ($idString): int {
+            // Scope the session to this tenant so FORCE RLS lets the deletes
+            // see the rows. Session scope (is_local=false) survives the
+            // implicit per-statement commits inside the transaction; the
+            // finally below resets it for the pooled worker connection.
+            $conn->executeStatement(
+                "SELECT set_config('app.current_tenant', :t, false)",
+                ['t' => $idString],
+            );
+
+            // tenant-safe: tenant offboarding hard-delete — deletes ONLY the
+            // explicitly-resolved soft-deleted tenant's rows (WHERE <col> =
+            // :tenant) with the RLS GUC pinned to that tenant. TenantFilter
+            // scopes to the *current request* tenant, which is exactly wrong
+            // for purging a different tenant, so it is intentionally bypassed.
+            $total = 0;
+            try {
+                foreach (self::DELETE_ORDER as [$table, $column]) {
+                    // $table / $column are compile-time constants from
+                    // DELETE_ORDER, never external input — safe to inline.
+                    $total += (int) $conn->executeStatement(
+                        \sprintf('DELETE FROM %s WHERE %s = :tenant', $table, $column),
+                        ['tenant' => $idString],
+                    );
+                }
+
+                // `tenants` is NOT RLS-protected (no tenant_id of its own),
+                // so this delete is visible regardless of the GUC.
+                $total += (int) $conn->executeStatement(
+                    'DELETE FROM tenants WHERE id = :id',
+                    ['id' => $idString],
+                );
+            } finally {
+                $conn->executeStatement("SELECT set_config('app.current_tenant', '', false)");
+            }
+
+            return $total;
+        });
+
+        $this->purgeStorage($idString);
+
+        return $deleted;
+    }
+
+    /**
+     * Removes the `<tenant-uuid>/` prefix from each of the three buckets.
+     * Throws if any operator fails so the caller treats the purge as
+     * incomplete — DB rows are already gone (see ordering note), but the
+     * operator MUST know blobs may linger.
+     */
+    private function purgeStorage(string $tenantId): void
+    {
+        $operators = [
+            'assets' => $this->assetsStorage,
+            'imports' => $this->importsStorage,
+            'exports' => $this->exportsStorage,
+        ];
+
+        $failures = [];
+        foreach ($operators as $bucket => $operator) {
+            try {
+                // Tenant isolation rides on the path prefix `<tenant-uuid>/`
+                // (flysystem.yaml). deleteDirectory removes every object
+                // under it; a missing prefix is a no-op (idempotent).
+                $operator->deleteDirectory($tenantId);
+            } catch (Throwable $e) {
+                $this->logger->error(
+                    'Tenant storage purge failed; DB rows already deleted, blobs may linger under prefix.',
+                    ['tenant_id' => $tenantId, 'bucket' => $bucket, 'exception' => $e],
+                );
+                $failures[] = $bucket;
+            }
+        }
+
+        if ([] !== $failures) {
+            throw new TenantStoragePurgeException($tenantId, $failures);
+        }
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Maintenance/TenantStoragePurgeException.php
+++ b/apps/api/src/Shared/Infrastructure/Maintenance/TenantStoragePurgeException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Maintenance;
+
+use RuntimeException;
+
+/**
+ * AUD-020 (W1-7) — raised when a tenant's database rows were deleted but
+ * one or more object-storage prefixes could not be removed. Signals the
+ * offboarding caller that the purge is incomplete: PII blobs may still
+ * exist under `<tenant-uuid>/` and require a manual / GC sweep.
+ */
+final class TenantStoragePurgeException extends RuntimeException
+{
+    /**
+     * @param list<string> $failedBuckets
+     */
+    public function __construct(
+        public readonly string $tenantId,
+        public readonly array $failedBuckets,
+    ) {
+        parent::__construct(\sprintf(
+            'Tenant %s storage purge failed for bucket(s): %s. DB rows are deleted; blobs may linger.',
+            $tenantId,
+            implode(', ', $failedBuckets),
+        ));
+    }
+}

--- a/apps/api/tests/Integration/Maintenance/TenantOffboardingPurgeTest.php
+++ b/apps/api/tests/Integration/Maintenance/TenantOffboardingPurgeTest.php
@@ -1,0 +1,394 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Maintenance;
+
+use Doctrine\DBAL\Connection;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AUD-019 / AUD-020 (W1-7) — proves tenant offboarding actually erases a
+ * tenant end to end (GDPR art. 17).
+ *
+ * FAILING-FIRST: before the fix, `pim:tenants:purge-deleted` ran a bare
+ * `remove($tenant)` → `DELETE FROM tenants`, which hit 24 ON DELETE RESTRICT
+ * foreign keys and threw a foreign-key violation for any tenant carrying
+ * data — so this test (which seeds a full dependency chain) went RED with an
+ * FK error and the dependent rows survived. After the fix the command drives
+ * {@see \App\Shared\Infrastructure\Maintenance\TenantPurger}, which deletes
+ * dependents in child→parent order + sweeps the object-storage prefix.
+ *
+ * OPERATOR-DATA SAFETY: this test never touches the real `demo` / `acme`
+ * tenants. It creates a THROWAWAY tenant (random uuid) plus a KEEPER tenant
+ * (proxy for "another tenant on the platform") and asserts the keeper's rows
+ * + storage are untouched after the throwaway is purged. The schema is reset
+ * per test (Foundry ResetDatabase), so nothing leaks.
+ *
+ * RLS note: the test DB schema is built from ORM metadata, so the FORCE RLS
+ * policies do NOT exist here and the GUC the purger sets is a no-op — the
+ * `WHERE tenant_id = :id` predicate is the active guard. The cross-tenant
+ * isolation under real RLS is covered by ForceRlsTenantIsolationTest.
+ */
+final class TenantOffboardingPurgeTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    /**
+     * Every tenant-scoped table the purger sweeps. Asserted to reach 0 rows
+     * for the throwaway tenant and to stay unchanged for the keeper.
+     *
+     * @var list<string>
+     */
+    private const array TENANT_TABLES = [
+        'import_undo_log', 'import_logs', 'import_source_logs', 'import_schedule_runs',
+        'import_schedules', 'import_sources', 'import_sessions', 'import_profiles',
+        'import_staged_files', 'export_sessions', 'export_profiles',
+        'object_channel_placements', 'channel_category_node_mappings',
+        'channel_category_nodes', 'channel_publication_profiles',
+        'object_values', 'object_relations', 'saved_views', 'smart_filter_presets',
+        'bulk_edit_jobs', 'objects', 'bulk_sessions', 'object_types',
+        'attribute_options', 'attributes', 'attribute_groups',
+        'channels', 'assets', 'api_keys', 'api_profiles', 'backups',
+        'invitations', 'api_tokens', 'password_reset_tokens',
+        'user_tenant_memberships', 'refresh_tokens', 'users',
+        'roles', 'sso_providers', 'tenant_locales', 'menu_configurations',
+        'tenant_agent_configs',
+    ];
+
+    #[Test]
+    public function purgesThrowawayTenantEntirelyAndLeavesOtherTenantIntact(): void
+    {
+        $kernel = self::bootKernel();
+        $connection = $this->connection($kernel);
+        $assets = $this->storage($kernel, 'assets.storage');
+        $imports = $this->storage($kernel, 'imports.storage');
+        $exports = $this->storage($kernel, 'exports.storage');
+
+        $throwaway = Uuid::v7();
+        $keeper = Uuid::v7();
+
+        // Seed a representative dependency chain that exercises the RESTRICT
+        // FKs (objects → object_types, object_values → attributes) for BOTH
+        // tenants, plus storage objects under each tenant's prefix.
+        $this->seedTenant($connection, $throwaway, 'throwaway');
+        $this->seedTenant($connection, $keeper, 'keeper');
+        $throwawayObjectValues = $this->seedDataChain($connection, $throwaway);
+        $keeperObjectValues = $this->seedDataChain($connection, $keeper);
+        $this->seedStorage($assets, $imports, $exports, $throwaway);
+        $this->seedStorage($assets, $imports, $exports, $keeper);
+
+        // Sanity: both tenants have data before the purge.
+        self::assertSame(1, $this->rowCount($connection, 'object_values', $throwaway));
+        self::assertSame(1, $this->rowCount($connection, 'object_values', $keeper));
+        self::assertTrue($assets->directoryExists($throwaway->toRfc4122()));
+
+        // Soft-delete ONLY the throwaway, past the retention window.
+        $this->softDelete($connection, $throwaway, '-40 days');
+
+        // Run the command (no --dry-run): it must hard-delete the throwaway.
+        $tester = $this->commandTester($kernel);
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+
+        // ── Throwaway: tenant row + EVERY dependent row gone ───────────
+        self::assertSame(
+            0,
+            (int) $connection->fetchOne('SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $throwaway->toRfc4122()]),
+            'Throwaway tenant row must be hard-deleted.',
+        );
+        foreach (self::TENANT_TABLES as $table) {
+            self::assertSame(
+                0,
+                $this->rowCount($connection, $table, $throwaway),
+                \sprintf('Throwaway tenant must have 0 rows left in `%s`.', $table),
+            );
+        }
+        // Targeted check on the row whose FK chain (object_values →
+        // attributes RESTRICT) was the original blocker.
+        self::assertSame(
+            0,
+            (int) $connection->fetchOne('SELECT COUNT(*) FROM object_values WHERE id = :id', ['id' => $throwawayObjectValues]),
+        );
+
+        // ── Throwaway storage prefix swept across all three buckets ────
+        self::assertFalse($assets->directoryExists($throwaway->toRfc4122()), 'Throwaway assets prefix must be gone.');
+        self::assertFalse($imports->directoryExists($throwaway->toRfc4122()), 'Throwaway imports prefix must be gone.');
+        self::assertFalse($exports->directoryExists($throwaway->toRfc4122()), 'Throwaway exports prefix must be gone.');
+
+        // ── KEEPER tenant fully intact (proxy for demo/acme) ───────────
+        self::assertSame(
+            1,
+            (int) $connection->fetchOne('SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $keeper->toRfc4122()]),
+            'Keeper tenant must be untouched.',
+        );
+        self::assertSame(1, $this->rowCount($connection, 'object_values', $keeper), 'Keeper object_values intact.');
+        self::assertSame(1, $this->rowCount($connection, 'objects', $keeper), 'Keeper objects intact.');
+        self::assertSame(1, $this->rowCount($connection, 'assets', $keeper), 'Keeper assets intact.');
+        self::assertSame(1, $this->rowCount($connection, 'users', $keeper), 'Keeper users intact.');
+        self::assertSame(
+            1,
+            (int) $connection->fetchOne('SELECT COUNT(*) FROM object_values WHERE id = :id', ['id' => $keeperObjectValues]),
+        );
+        self::assertTrue($assets->directoryExists($keeper->toRfc4122()), 'Keeper assets prefix intact.');
+        self::assertTrue($exports->directoryExists($keeper->toRfc4122()), 'Keeper exports prefix intact.');
+    }
+
+    #[Test]
+    public function dryRunDeletesNothing(): void
+    {
+        $kernel = self::bootKernel();
+        $connection = $this->connection($kernel);
+
+        $throwaway = Uuid::v7();
+        $this->seedTenant($connection, $throwaway, 'dry-run');
+        $this->seedDataChain($connection, $throwaway);
+        $this->softDelete($connection, $throwaway, '-40 days');
+
+        $tester = $this->commandTester($kernel);
+        $exit = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertSame(
+            1,
+            (int) $connection->fetchOne('SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $throwaway->toRfc4122()]),
+            'Dry-run must not delete the tenant row.',
+        );
+        self::assertSame(1, $this->rowCount($connection, 'object_values', $throwaway), 'Dry-run must keep dependents.');
+    }
+
+    #[Test]
+    public function leavesTenantsStillInsideRetentionWindow(): void
+    {
+        $kernel = self::bootKernel();
+        $connection = $this->connection($kernel);
+
+        $recent = Uuid::v7();
+        $this->seedTenant($connection, $recent, 'recent');
+        $this->seedDataChain($connection, $recent);
+        // Soft-deleted only 5 days ago — inside the default 30-day window.
+        $this->softDelete($connection, $recent, '-5 days');
+
+        $tester = $this->commandTester($kernel);
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertSame(
+            1,
+            (int) $connection->fetchOne('SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $recent->toRfc4122()]),
+            'A tenant soft-deleted inside the retention window must survive.',
+        );
+    }
+
+    private function seedTenant(Connection $connection, Uuid $id, string $codePrefix): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $connection->executeStatement(
+            'INSERT INTO tenants (id, code, name, created_at) VALUES (:id, :code, :name, NOW())',
+            ['id' => $id->toRfc4122(), 'code' => $codePrefix.'-'.$suffix, 'name' => $codePrefix],
+        );
+    }
+
+    /**
+     * Seeds object_type → object → object_value(+attribute) + attribute_group
+     * + asset + user + export_profile → export_session for the given tenant.
+     * Returns the object_value id (the row guarded by the RESTRICT FK to
+     * attributes that originally blocked the purge).
+     */
+    private function seedDataChain(Connection $connection, Uuid $tenant): string
+    {
+        $t = $tenant->toRfc4122();
+        $suffix = bin2hex(random_bytes(4));
+
+        $objectTypeId = Uuid::v7()->toRfc4122();
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO object_types
+                    (id, tenant_id, code, kind, is_built_in, code_immutable, deletable, label,
+                     completeness_rules, hierarchical, has_variants, abstract, expose_to_main_menu,
+                     is_categorizable, has_multimedia, allowed_parent_type_ids, schema_version,
+                     created_at, updated_at)
+                VALUES
+                    (:id, :t, :code, 'product', false, false, true, '{}'::jsonb,
+                     '{}'::jsonb, false, false, false, true,
+                     false, false, '[]'::jsonb, 1,
+                     NOW(), NOW())
+                SQL,
+            ['id' => $objectTypeId, 't' => $t, 'code' => 'ot-'.$suffix],
+        );
+
+        $attributeGroupId = Uuid::v7()->toRfc4122();
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO attribute_groups
+                    (id, tenant_id, code, label, is_system_group, auto_attached, is_required_section,
+                     is_shared, has_conditional_visibility, position, created_at)
+                VALUES (:id, :t, :code, '{}'::jsonb, false, false, false, false, false, 0, NOW())
+                SQL,
+            ['id' => $attributeGroupId, 't' => $t, 'code' => 'ag-'.$suffix],
+        );
+
+        $attributeId = Uuid::v7()->toRfc4122();
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO attributes
+                    (id, tenant_id, code, label, type, is_localizable, is_scopable, is_required,
+                     is_filterable, is_system, validation_rules, relation_target_object_type_ids,
+                     relation_advanced, relation_preview_fields, position, created_at, group_id)
+                VALUES
+                    (:id, :t, :code, '{}'::jsonb, 'text', false, false, false,
+                     false, false, '{}'::jsonb, '[]'::jsonb,
+                     false, '[]'::jsonb, 0, NOW(), :gid)
+                SQL,
+            ['id' => $attributeId, 't' => $t, 'code' => 'attr-'.$suffix, 'gid' => $attributeGroupId],
+        );
+
+        $objectId = Uuid::v7()->toRfc4122();
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO objects
+                    (id, tenant_id, object_type_id, kind, code, enabled, status, completeness,
+                     completeness_pct, sync_status_aggregate, attributes_indexed, schema_drift,
+                     created_at, updated_at, version)
+                VALUES
+                    (:id, :t, :ot, 'product', :code, true, 'draft', '{}'::jsonb,
+                     0, 'never', '{}'::jsonb, false,
+                     NOW(), NOW(), 1)
+                SQL,
+            ['id' => $objectId, 't' => $t, 'ot' => $objectTypeId, 'code' => 'obj-'.$suffix],
+        );
+
+        $objectValueId = Uuid::v7()->toRfc4122();
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO object_values
+                    (id, tenant_id, object_id, attribute_id, value, provenance, provenance_meta)
+                VALUES (:id, :t, :obj, :attr, :value, 'manual', '{}'::jsonb)
+                SQL,
+            [
+                'id' => $objectValueId,
+                't' => $t,
+                'obj' => $objectId,
+                'attr' => $attributeId,
+                'value' => '{"value": "hello"}',
+            ],
+        );
+
+        $assetId = Uuid::v7()->toRfc4122();
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO assets
+                    (id, tenant_id, code, original_filename, mime_type, size, metadata, storage_path,
+                     created_at, tags, thumbnails_status)
+                VALUES
+                    (:id, :t, :code, 'photo.jpg', 'image/jpeg', 1234, '{}'::jsonb, :path,
+                     NOW(), '[]'::jsonb, 'pending')
+                SQL,
+            [
+                'id' => $assetId,
+                't' => $t,
+                'code' => 'asset-'.$suffix,
+                'path' => $t.'/'.$assetId.'/original.jpg',
+            ],
+        );
+
+        $userId = Uuid::v7()->toRfc4122();
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO users (id, email, password, roles, status, totp_backup_codes,
+                                   created_at, password_change_required, tenant_id)
+                VALUES (:id, :email, 'x', '[]'::json, 'active', '[]'::jsonb,
+                        NOW(), false, :t)
+                SQL,
+            ['id' => $userId, 'email' => 'user-'.$suffix.'@example.test', 't' => $t],
+        );
+
+        $exportProfileId = Uuid::v7()->toRfc4122();
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO export_profiles
+                    (id, tenant_id, user_id, name, entity_type, config, run_count, created_at, updated_at)
+                VALUES (:id, :t, :uid, :name, 'product', '{}'::jsonb, 0, NOW(), NOW())
+                SQL,
+            ['id' => $exportProfileId, 't' => $t, 'uid' => $userId, 'name' => 'exp-'.$suffix],
+        );
+
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO export_sessions
+                    (id, tenant_id, user_id, source, format, target_scope, entity_type,
+                     selected_columns, include_variants, target_count, success_count,
+                     status, started_at, profile_id)
+                VALUES
+                    (:id, :t, :uid, 'manual', 'xlsx', 'all', 'product',
+                     '[]'::jsonb, false, 0, 0,
+                     'pending', NOW(), :pid)
+                SQL,
+            ['id' => Uuid::v7()->toRfc4122(), 't' => $t, 'uid' => $userId, 'pid' => $exportProfileId],
+        );
+
+        return $objectValueId;
+    }
+
+    private function seedStorage(
+        FilesystemOperator $assets,
+        FilesystemOperator $imports,
+        FilesystemOperator $exports,
+        Uuid $tenant,
+    ): void {
+        $prefix = $tenant->toRfc4122();
+        $assets->write($prefix.'/asset/original.jpg', 'binary-bytes');
+        $imports->write($prefix.'/upload/source.csv', 'a,b,c');
+        $exports->write($prefix.'/session.xlsx', 'xlsx-bytes');
+    }
+
+    private function softDelete(Connection $connection, Uuid $tenant, string $when): void
+    {
+        $connection->executeStatement(
+            "UPDATE tenants SET status = 'deleted', deleted_at = NOW() + (:when)::interval WHERE id = :id",
+            ['when' => $when, 'id' => $tenant->toRfc4122()],
+        );
+    }
+
+    private function rowCount(Connection $connection, string $table, Uuid $tenant): int
+    {
+        // $table comes only from the class constant TENANT_TABLES (no
+        // external input) — safe to inline.
+        return (int) $connection->fetchOne(
+            \sprintf('SELECT COUNT(*) FROM %s WHERE tenant_id = :t', $table),
+            ['t' => $tenant->toRfc4122()],
+        );
+    }
+
+    private function commandTester(object $kernel): CommandTester
+    {
+        \assert($kernel instanceof \Symfony\Component\HttpKernel\KernelInterface);
+        $application = new Application($kernel);
+
+        return new CommandTester($application->find('pim:tenants:purge-deleted'));
+    }
+
+    private function connection(object $kernel): Connection
+    {
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        \assert($connection instanceof Connection);
+
+        return $connection;
+    }
+
+    private function storage(object $kernel, string $serviceId): FilesystemOperator
+    {
+        $storage = self::getContainer()->get($serviceId);
+        \assert($storage instanceof FilesystemOperator);
+
+        return $storage;
+    }
+}


### PR DESCRIPTION
> Audyt fix-plan **W1-7** (Wave 1). Closes #1586 (AUD-019, AUD-020). RODO art. 17.

## Problem (HIGH, confirmed)
- **AUD-019:** `PurgeDeletedTenantsCommand` robił sam `remove($tenant)`, ale 24 FK na `tenants` to `ON DELETE RESTRICT` → `DELETE FROM tenants` rzucał FK-violation dla realnego tenanta. Offboarding niewykonalny, RODO art.17 niespełnione. Zero testów.
- **AUD-020:** brak kaskady MinIO → assety (PII) + eksporty zostawały bezterminowo.

## Naprawa — kod-ordered hard-delete (NIE FK CASCADE)
FK CASCADE na 24 FK osłabiłoby ochronę dla KAŻDEJ ścieżki (RESTRICT jest celowy). Wybrano kontrolowany kod:
- **`TenantPurger`** (`Shared/Infrastructure/Maintenance`, DBAL-only, zero coupling do encji → Deptrac 0): usuwa **42 tabele tenant-scoped w kolejności topologicznej FK** (dzieci→rodzice) w jednej transakcji, na końcu `tenants`. **Wykryto 5 tabel z `tenant_id` BEZ FK** (`bulk_sessions`, `bulk_edit_jobs`, `refresh_tokens`, `smart_filter_presets`, `saved_views`) — CASCADE by je osierocił, czyszczę jawnie. Ustawia GUC `app.current_tenant` (inaczej `pim_app`+FORCE RLS → DELETE widzi 0 wierszy = cichy no-op). Operuje TYLKO na soft-deleted.
- **Kaskada MinIO:** `deleteDirectory(<tenant-uuid>)` na 3 bucketach (`@assets/imports/exports.storage`). **DB przed storage** (tenant = source-of-truth); awaria storage → `TenantStoragePurgeException` + log + FAILURE (nigdy cichy half-delete).

## Test (failing-first) + smoke
`TenantOffboardingPurgeTest` (3/64): throwaway + keeper tenant, pełny łańcuch + obiekty w 3 storage → soft-delete→purge → 42 tabele=0 dla throwaway + storage prefix pusty + **keeper nietknięty**. PRZED: bare DELETE → `SQLSTATE[23503] FK violation`; PO: zielono.
**Live smoke (dev, pim_app+RLS):** throwaway purge → `[OK] Hard-deleted 1`; psql: throwaway=0 wszędzie, **demo=6849/acme=3 (baseline, nietknięte)**, MinIO prefix throwaway pusty w 3 bucketach, **login demo → 200**.

## Bramki
PHPUnit 3/3 + regresja Maintenance/SuperAdmin 15/15 · PHPStan **0** · Deptrac **0** (brak cross-context coupling) · cs-fixer 0.
