### PR TITLE
AUD-018: version MinIO buckets + separate pgBackRest repo (W1-6)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -202,9 +202,23 @@ services:
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required in prod (no default).}
       APP_DB_PASSWORD: ${APP_DB_PASSWORD:?APP_DB_PASSWORD is required in prod — runtime role password (no default).}
-      # pgBackRest pushes WAL to MinIO using the MinIO root credentials.
-      PGBACKREST_REPO1_S3_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required in prod (no default).}
-      PGBACKREST_REPO1_S3_KEY_SECRET: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required in prod (no default).}
+      # AUD-018 (W1-6) — anti-SPOF: in prod the pgBackRest repo MUST live on a
+      # MinIO/S3 endpoint SEPARATE from the one serving DAM assets, so an
+      # assets-storage failure can never take the database backups with it.
+      # pgBackRest reads these PGBACKREST_* env vars at runtime and they win over
+      # the baked-in pgbackrest.conf, so the repo can be redirected to a separate
+      # instance / region / S3 account WITHOUT rebuilding the database image:
+      #   PGBACKREST_REPO1_S3_ENDPOINT — host of the dedicated backup MinIO/S3
+      #   PGBACKREST_REPO1_S3_BUCKET   — dedicated repo bucket on that endpoint
+      #   PGBACKREST_REPO1_S3_KEY / _KEY_SECRET — credentials for THAT account
+      # Defaults below keep the dev topology (bucket-level separation on the same
+      # MinIO) working if the operator has not yet provisioned a second store;
+      # production deploys SHOULD set the dedicated endpoint. The fail-loud
+      # secrets stay required.
+      PGBACKREST_REPO1_S3_ENDPOINT: ${PGBACKREST_REPO1_S3_ENDPOINT:-minio-tls}
+      PGBACKREST_REPO1_S3_BUCKET: ${PGBACKREST_REPO1_S3_BUCKET:-pim-pgbackrest}
+      PGBACKREST_REPO1_S3_KEY: ${PGBACKREST_REPO1_S3_KEY:?PGBACKREST_REPO1_S3_KEY is required in prod — credentials for the dedicated backup store (no default).}
+      PGBACKREST_REPO1_S3_KEY_SECRET: ${PGBACKREST_REPO1_S3_KEY_SECRET:?PGBACKREST_REPO1_S3_KEY_SECRET is required in prod — credentials for the dedicated backup store (no default).}
 
   meilisearch:
     environment:
@@ -225,10 +239,56 @@ services:
   # minio-init re-runs `mc alias set` with the root credentials; same fail-loud.
   # The entrypoint references ${MINIO_ROOT_USER}/${MINIO_ROOT_PASSWORD} inline,
   # so the override is on the *service environment* the entrypoint reads.
+  #
+  # AUD-018 (W1-6) — the base minio-init enables bucket versioning on the durable
+  # buckets (pim-assets, pim-pgbackrest, pim-exports). That survives an
+  # accidental object delete/overwrite but NOT loss of the whole MinIO instance.
+  # Two production-only follow-ups give true off-site durability; both are
+  # documented in docs/runbook/disaster-recovery.md → "MinIO disaster recovery":
+  #   1. Dedicated backup store — point the database service's
+  #      PGBACKREST_REPO1_S3_ENDPOINT/_BUCKET at a SEPARATE MinIO/S3 region so the
+  #      pgBackRest repo and the DAM assets cannot fail together.
+  #   2. Asset replication — run scripts/minio-mirror-assets.sh on a cron / a
+  #      MinIO bucket-replication rule to copy pim-assets to that second region.
+  #      A `mirror-assets` sidecar (commented below) is the wiring template.
   minio-init:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required in prod (no default).}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required in prod (no default).}
+
+  # ─── Asset off-site replication (AUD-018 / W1-6) ──────────────────────────
+  # Periodically mirrors the DAM assets bucket to a SEPARATE MinIO/S3 region so
+  # assets survive loss of the primary `minio_data` volume (versioning alone
+  # only protects against object-level delete/overwrite, not volume loss).
+  #
+  # Disabled by default (profile `dr`) because it needs a real second store:
+  #   docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  #     --profile dr up -d mirror-assets
+  # Provide the replica endpoint + credentials in the deployment env. Prefer a
+  # bucket-scoped service account on the replica, NOT its root credentials.
+  # For a fully managed alternative, configure a native MinIO bucket-replication
+  # rule (`mc replicate add`) instead of this poll-based sidecar.
+  mirror-assets:
+    image: minio/mc:latest
+    profiles: ["dr"]
+    restart: unless-stopped
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MIRROR_SOURCE_URL: http://minio:9000
+      MIRROR_SOURCE_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required in prod (no default).}
+      MIRROR_SOURCE_SECRET: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required in prod (no default).}
+      MIRROR_SOURCE_BUCKET: pim-assets
+      MIRROR_TARGET_URL: ${MIRROR_TARGET_URL:?MIRROR_TARGET_URL is required for asset replication — endpoint of the SECOND MinIO/S3 region (no default).}
+      MIRROR_TARGET_KEY: ${MIRROR_TARGET_KEY:?MIRROR_TARGET_KEY is required for asset replication (no default).}
+      MIRROR_TARGET_SECRET: ${MIRROR_TARGET_SECRET:?MIRROR_TARGET_SECRET is required for asset replication (no default).}
+      MIRROR_TARGET_BUCKET: ${MIRROR_TARGET_BUCKET:-pim-assets-replica}
+      # --watch keeps the mirror live (event-driven) instead of one-shot.
+      MIRROR_WATCH: "1"
+    volumes:
+      - ./scripts:/scripts:ro
+    entrypoint: ["/bin/sh", "/scripts/minio-mirror-assets.sh"]
 
   mercure:
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -385,6 +385,23 @@ services:
   # `/api/assets/{id}/preview` endpoint (AUD-006); the bucket must not be
   # anonymously readable even if MinIO is ever published. `set none` also
   # remediates a stack initialised before this change.
+  #
+  # AUD-018 (W1-6): bucket versioning + repo separation against the backup SPOF.
+  #   - `mc version enable` on the durable buckets (assets, the pgBackRest repo
+  #     bucket, exports) so an accidental/malicious `mc rm` or overwrite leaves
+  #     the previous object version recoverable (`mc cp --version-id`). This is
+  #     the only line of defence for assets, which — unlike Postgres — have no
+  #     other backup. Idempotent: `version enable` on an already-versioned
+  #     bucket is a no-op, so it also upgrades a stack created before this change.
+  #   - `pim-pgbackrest` is a DEDICATED bucket for the database backup repo,
+  #     separate from `pim-assets`. In dev this is bucket-level separation on the
+  #     same MinIO; true anti-SPOF (separate instance / region) is configured in
+  #     the prod overlay — see docker-compose.prod.yml minio-init + the MinIO DR
+  #     section of docs/runbook/disaster-recovery.md. The legacy `pim-backups`
+  #     bucket is left in place (existing 2026-04-28 repo objects are NOT
+  #     destroyed); the stanza re-creates in the new isolated bucket.
+  #   - pim-imports stays un-versioned on purpose: transient ingest payloads with
+  #     a 7-day expiry — versioning would only pile up delete-markers.
   minio-init:
     image: minio/mc:latest
     depends_on:
@@ -395,9 +412,13 @@ services:
       mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-minioadmin} ${MINIO_ROOT_PASSWORD:-minioadmin};
       mc mb -p local/pim-assets || true;
       mc mb -p local/pim-backups || true;
+      mc mb -p local/pim-pgbackrest || true;
       mc mb -p local/pim-imports || true;
       mc mb -p local/pim-exports || true;
       mc anonymous set none local/pim-assets || true;
+      mc version enable local/pim-assets || true;
+      mc version enable local/pim-pgbackrest || true;
+      mc version enable local/pim-exports || true;
       mc ilm rule add --expire-days 7 local/pim-imports || true;
       "
     restart: "no"

--- a/docker/postgres/pgbackrest.conf
+++ b/docker/postgres/pgbackrest.conf
@@ -12,6 +12,15 @@
 #   - Retention: 4 full + 28 differential — covers a 4-week PITR window with
 #     headroom for one botched run before older backups age out.
 #
+# AUD-018 (W1-6) — the repo lives in its OWN bucket `pim-pgbackrest`, separate
+# from the DAM assets bucket `pim-assets`. Co-locating the database backup repo
+# with the assets was a single point of failure: losing the asset bucket also
+# lost every database backup. In dev this is bucket-level separation on the same
+# MinIO; in production the repo belongs on a SEPARATE MinIO instance / region /
+# S3 account (point `repo1-s3-endpoint`/`repo1-s3-bucket` at it via the prod
+# overlay) so an assets-storage failure can never take the backups with it.
+# See docs/runbook/disaster-recovery.md (MinIO DR) + restore.md.
+#
 # Note for dev: weekly schedule and async archive land here for parity with
 # production. Local devs hit the boxes through `pnpm backup:run` (one-off),
 # not the cron timer; nothing in this config blocks that path.
@@ -21,7 +30,9 @@ repo1-type=s3
 # Goes through the minio-tls Caddy sidecar (HTTPS:443) which reverse-proxies
 # to plain-HTTP MinIO on minio:9000. pgBackRest 2.57 has no HTTP-S3 mode.
 repo1-s3-endpoint=minio-tls
-repo1-s3-bucket=pim-backups
+# AUD-018 (W1-6) — dedicated repo bucket, separate from `pim-assets` (DAM).
+# In prod, override repo1-s3-endpoint to a separate MinIO/S3 (anti-SPOF).
+repo1-s3-bucket=pim-pgbackrest
 repo1-s3-region=us-east-1
 repo1-s3-uri-style=path
 repo1-storage-verify-tls=n

--- a/docs/runbook/disaster-recovery.md
+++ b/docs/runbook/disaster-recovery.md
@@ -23,6 +23,7 @@ This runbook complements:
 7. [Audit log — retention + manual prune](#7-audit-log--retention--manual-prune)
 8. [Async worker stuck — tenant context drift](#8-async-worker-stuck--tenant-context-drift)
 9. [Rate limiter — operator unblock](#9-rate-limiter--operator-unblock)
+10. [MinIO — object storage disaster recovery](#10-minio--object-storage-disaster-recovery)
 
 ---
 
@@ -189,7 +190,9 @@ flag on egress traffic.
 **Triage** (in this order)
 1. **Contain** — disable suspect API keys + JWT signing key (sections 2 + 5).
 2. **Snapshot** — `pgbackrest backup --type=full` (out-of-cycle full
-   for forensic analysis) + freeze MinIO bucket `pim-backups`.
+   for forensic analysis) + freeze the MinIO buckets `pim-pgbackrest`
+   (backup repo) and `pim-assets` (DAM). Versioning is enabled on both, so
+   prior object versions are preserved for forensics even if data is altered.
 3. **Inventory** — what tenants are affected? Audit logs answer:
 
 ```bash
@@ -281,6 +284,114 @@ The command resets BOTH `auth_login` and `auth_refresh` buckets for
 the supplied IP. API-key budgets aren't covered by this command —
 those are per-key, not per-IP; use the rotate-secret endpoint
 instead.
+
+---
+
+## 10. MinIO — object storage disaster recovery
+
+> **AUD-018 / W1-6.** MinIO holds two distinct classes of data with very
+> different recovery stories:
+>
+> - **DAM assets** (`pim-assets`) — the ONLY copy of product imagery/files.
+>   Unlike Postgres there is no WAL/PITR; durability comes from bucket
+>   versioning + off-site replication.
+> - **pgBackRest repo** (`pim-pgbackrest`) — the database backup. It now lives
+>   in its OWN bucket, separate from the assets, so an assets-storage failure
+>   cannot take the database backups with it.
+
+### Defence layers (what protects what)
+
+| Layer | Protects against | Where configured |
+|---|---|---|
+| **Bucket versioning** (`pim-assets`, `pim-pgbackrest`, `pim-exports`) | Accidental / malicious object delete or overwrite | `minio-init` (`mc version enable`) — base `docker-compose.yml` |
+| **Repo bucket separation** (`pim-pgbackrest` ≠ `pim-assets`) | Losing both assets and DB backups in one failure | `docker/postgres/pgbackrest.conf` (`repo1-s3-bucket`) |
+| **Separate backup store** (prod: dedicated MinIO/S3 region) | Loss of the whole primary MinIO instance taking the DB repo too | prod overlay `database.PGBACKREST_REPO1_S3_ENDPOINT/_BUCKET` |
+| **Asset replication** (prod: `mc mirror` / bucket-replication rule) | Loss of the primary `minio_data` volume losing all assets | `scripts/minio-mirror-assets.sh` + prod overlay `mirror-assets` (profile `dr`) |
+
+### Symptom A — accidental object delete / overwrite (versioning recovery)
+
+A user or a buggy job deleted or clobbered an asset/export object. The bucket is
+versioned, so the previous version is still there behind a delete-marker.
+
+**Action**
+
+```bash
+# Helper: run mc against the live MinIO (replace creds in prod).
+MC() { docker compose run --rm --no-deps --entrypoint /bin/sh minio/mc:latest -c \
+  "mc alias set local http://minio:9000 \"$MINIO_ROOT_USER\" \"$MINIO_ROOT_PASSWORD\" >/dev/null; $*"; }
+
+# 1. List every version of the object (delete-markers + prior PUTs).
+MC 'mc ls --versions local/pim-assets/<tenant-uuid>/<asset-uuid>/original.bin'
+
+# 2. Read the prior (non-delete-marker) version by its version-id to confirm.
+MC 'mc cat --version-id <VERSION_ID> local/pim-assets/<...>/original.bin'
+
+# 3. Restore it as the current version (copy the old version onto the key).
+MC 'mc cp --version-id <VERSION_ID> local/pim-assets/<...>/original.bin \
+                                    local/pim-assets/<...>/original.bin'
+```
+
+> Validated 2026-06-18 on the live dev stack: put → `mc rm` (delete-marker) →
+> the prior `PUT` version survives → `mc cp --version-id` restores the bytes.
+
+### Symptom B — total loss of the primary MinIO volume / instance
+
+`minio_data` is gone (volume corruption, host loss, ransomware). Assets and — on
+dev, where the repo shares the instance — the DB backup repo are unreachable.
+
+**Triage**
+1. Stand up a fresh MinIO (new `minio_data` volume). `minio-init` recreates the
+   buckets and re-enables versioning idempotently on first boot.
+2. Decide the source of truth for assets: the off-site replica (prod) or, on dev
+   where no replica exists, accept asset loss (assets are non-authoritative dev
+   fixtures; product DATA is authoritative and restored from Postgres).
+
+**Action — restore assets from the replica (prod)**
+
+```bash
+# Pull the replica back into the rebuilt primary (reverse of the normal mirror).
+MIRROR_SOURCE_URL=<replica-endpoint> MIRROR_SOURCE_KEY=… MIRROR_SOURCE_SECRET=… \
+MIRROR_SOURCE_BUCKET=pim-assets-replica \
+MIRROR_TARGET_URL=http://minio:9000 MIRROR_TARGET_KEY="$MINIO_ROOT_USER" \
+MIRROR_TARGET_SECRET="$MINIO_ROOT_PASSWORD" MIRROR_TARGET_BUCKET=pim-assets \
+  docker compose run --rm --no-deps -v "$PWD/scripts:/scripts:ro" \
+  --entrypoint /bin/sh minio/mc:latest /scripts/minio-mirror-assets.sh
+```
+
+**Action — restore the database (repo on a separate store survives)**
+
+Because `pim-pgbackrest` is a separate bucket (prod: separate instance), the
+pgBackRest repo is unaffected by an assets-only failure. Follow
+[§1 PITR](#1-postgresql--point-in-time-recovery-pitr) / `restore.md` as usual.
+On dev (shared instance) the repo is lost with the volume; rebuild from the
+newest `backups/*.dump` + migrations per the dev DB recovery policy.
+
+### Restore-from-zero drill (assets + database)
+
+The end-to-end "rebuild from nothing" target for W1-6. Do NOT run by wiping
+`minio_data` on a machine you care about — exercise it on a throwaway stack:
+
+1. Fresh stack, empty volumes → `minio-init` recreates + versions buckets.
+2. `mc mirror` the off-site asset replica back into `pim-assets` (Symptom B).
+3. pgBackRest `stanza-create` + restore the latest backup from `pim-pgbackrest`
+   (separate store) → PITR to target time.
+4. Smoke: login `200`, a product read returns a signed `previewUrl`, the signed
+   URL serves bytes (`200`, correct `content-type`).
+
+### Enabling replication in production
+
+```bash
+# Provision a SECOND MinIO/S3 region with a bucket-scoped service account
+# (NOT root). Then run the mirror sidecar (profile `dr`):
+MIRROR_TARGET_URL=https://minio-dr.example.com \
+MIRROR_TARGET_KEY=<replica-key> MIRROR_TARGET_SECRET=<replica-secret> \
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  --profile dr up -d mirror-assets
+```
+
+Prefer a native MinIO bucket-replication rule (`mc replicate add`) for managed,
+event-driven replication where available; the `mc mirror` sidecar is the
+portable fallback.
 
 ---
 

--- a/docs/runbook/restore.md
+++ b/docs/runbook/restore.md
@@ -10,9 +10,12 @@
   (`docker/postgres/Dockerfile`).
 - WAL archiving: `archive_mode=on`, `archive_command='pgbackrest --stanza=pim
   archive-push %p'`. Continuous, async via `archive-async=y`.
-- Repository: MinIO bucket `pim-backups`, path `/pim`. Credentials reuse
+- Repository: MinIO bucket `pim-pgbackrest` (dedicated repo bucket, separate
+  from the DAM assets bucket — AUD-018/W1-6), path `/pim`. Dev credentials reuse
   `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` via `PGBACKREST_REPO1_S3_KEY*` env
-  vars in `docker-compose.yml`.
+  vars in `docker-compose.yml`; prod takes a dedicated, fail-loud
+  `PGBACKREST_REPO1_S3_KEY`/`_KEY_SECRET` and can target a separate MinIO/S3
+  region (see "Backup storage layout" below).
 - **Schedule** (cron inside the database container, see Dockerfile):
   - Sundays 02:00 UTC — `pgbackrest --type=full backup`.
   - Mon-Sat 02:00 UTC — `pgbackrest --type=diff backup`.
@@ -144,20 +147,45 @@ produkty po restore = produkty przed dropem").
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `stanza-create` fails with `unable to load info file` | MinIO bucket missing | `docker compose up -d minio-init` (check `pim-backups` exists in MinIO) |
+| `stanza-create` fails with `unable to load info file` | MinIO bucket missing | `docker compose up -d minio-init` (check `pim-pgbackrest` exists in MinIO) |
 | `archive-push` warnings in postgres log | Stanza not initialised yet | Wait for `pim-init-backup.sh` to finish, or run `pgbackrest --stanza=pim stanza-create` manually |
 | `pgbackrest backup` complains about WAL not archived | `archive-async` queue full | Check `/var/spool/pgbackrest`, ensure MinIO is reachable from the database container |
 | Restore fails with `unable to remove path` | API still holds connections | The orchestrator stops `api` first; if running pgbackrest manually, `docker compose stop api` before wiping `$PGDATA` |
 | Healthcheck never goes green after restore | WAL replay still in progress | `docker compose logs -f database` and wait — large WAL ranges take longer |
 
+## Backup storage layout (AUD-018 / W1-6)
+
+The pgBackRest repo lives in its OWN MinIO bucket, **`pim-pgbackrest`**, separate
+from the DAM assets bucket `pim-assets`. Co-locating them was a single point of
+failure: losing the asset bucket also lost every database backup. The durable
+buckets (`pim-assets`, `pim-pgbackrest`, `pim-exports`) have **versioning
+enabled** so an accidental delete/overwrite is recoverable
+(`mc cp --version-id`). The legacy `pim-backups` bucket is retained (its
+2026-04-28 objects are untouched) but no longer the active repo target; the
+stanza re-creates in `pim-pgbackrest`. See the MinIO DR section of
+[`disaster-recovery.md`](disaster-recovery.md) for recovery procedures.
+
+In **production**, the repo should point at a SEPARATE MinIO/S3 instance/region
+(true anti-SPOF) via the prod overlay's
+`database.PGBACKREST_REPO1_S3_ENDPOINT`/`_BUCKET` env (no rebuild needed —
+pgBackRest reads `PGBACKREST_*` env over the baked-in config).
+
 ## Production gaps (post-0.11.11 follow-ups)
 
-- **Off-site repo replication** — second MinIO region or AWS S3 cross-region.
+- **Off-site asset replication** — wired as `scripts/minio-mirror-assets.sh` +
+  the `mirror-assets` sidecar (prod overlay, profile `dr`). Needs a real second
+  MinIO region/account provisioned; consider a native `mc replicate` rule for
+  managed replication.
+- **Off-site repo replication** — point `PGBACKREST_REPO1_S3_ENDPOINT` at a
+  dedicated backup region (prod overlay). Provisioning of that region is the
+  remaining deploy-time step.
 - **Encryption at rest** for the repo (`repo1-cipher-type=aes-256-cbc` +
   `repo1-cipher-pass` from Vault). Today the repo lives on TLS-terminated
   MinIO; at-rest encryption is opt-in.
-- **Hardened credentials** — dedicated S3 user with bucket-scoped IAM,
-  not the MinIO root.
+- **Hardened credentials** — the prod overlay now takes a dedicated
+  `PGBACKREST_REPO1_S3_KEY`/`_KEY_SECRET` (fail-loud, no default) so the repo
+  can authenticate with a bucket-scoped service account instead of MinIO root.
+  Creating that scoped account on the backup store is the deploy-time step.
 - **Slack/Sentry alert** when `pim-restore-test.sh` fails or when no
   successful backup landed in the last 24h. The 0.11.10 dashboard
   widget surfaces it; alerting needs a dedicated webhook in 0.11.10

--- a/scripts/minio-mirror-assets.sh
+++ b/scripts/minio-mirror-assets.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# AUD-018 (W1-6) — off-site replication of the DAM assets bucket.
+#
+# Bucket versioning (minio-init: `mc version enable pim-assets`) protects assets
+# against an accidental/malicious overwrite or delete WITHIN one MinIO instance.
+# It does NOT protect against losing the whole `minio_data` volume / instance —
+# for that the bytes must live in a SECOND location. This script mirrors the
+# assets bucket to a second MinIO/S3 target with `mc mirror`, the same way the
+# pgBackRest repo now lives in its own bucket (separate failure domain).
+#
+# Design:
+#   - Idempotent + incremental: `mc mirror` copies only new/changed objects and
+#     (with --remove) prunes objects deleted at the source, so re-running it is
+#     cheap. Safe to put on a cron / Symfony Scheduler / Kubernetes CronJob.
+#   - Source and target are configured via env so the same script works for the
+#     local stack (second bucket on the same MinIO — a smoke target) and for
+#     production (a genuinely separate instance / region / S3 account).
+#   - No destructive default: --remove (prune at target) is opt-in via
+#     MIRROR_PRUNE=1 so a misconfigured target can't wipe the replica.
+#
+# Required env:
+#   MIRROR_SOURCE_ALIAS   mc alias for the primary MinIO          (default: local)
+#   MIRROR_SOURCE_BUCKET  source bucket                            (default: pim-assets)
+#   MIRROR_TARGET_URL     S3/MinIO endpoint of the replica        (REQUIRED)
+#   MIRROR_TARGET_KEY     access key for the replica              (REQUIRED)
+#   MIRROR_TARGET_SECRET  secret key for the replica              (REQUIRED)
+#   MIRROR_TARGET_BUCKET  target bucket                            (default: pim-assets-replica)
+# Optional:
+#   MIRROR_SOURCE_URL/KEY/SECRET  configure the source alias inline instead of
+#                                 relying on a pre-existing `mc alias`.
+#   MIRROR_PRUNE=1        delete target objects removed at source (default: off)
+#   MIRROR_WATCH=1        run `mc mirror --watch` (long-lived) instead of one-shot
+#
+# Usage (one-shot, local smoke against a second bucket on the same MinIO):
+#   MIRROR_TARGET_URL=http://minio:9000 \
+#   MIRROR_TARGET_KEY=minioadmin MIRROR_TARGET_SECRET=minioadmin \
+#   MIRROR_TARGET_BUCKET=pim-assets-replica \
+#   docker run --rm --network pim_default \
+#     -e MIRROR_TARGET_URL -e MIRROR_TARGET_KEY -e MIRROR_TARGET_SECRET \
+#     -e MIRROR_TARGET_BUCKET -e MIRROR_SOURCE_URL=http://minio:9000 \
+#     -e MIRROR_SOURCE_KEY=minioadmin -e MIRROR_SOURCE_SECRET=minioadmin \
+#     --entrypoint /bin/sh -v "$PWD/scripts:/scripts:ro" minio/mc:latest \
+#     /scripts/minio-mirror-assets.sh
+#
+# In production: run this from a CronJob / cron entry against a SEPARATE MinIO
+# region (see docs/runbook/disaster-recovery.md → "MinIO disaster recovery").
+
+set -euo pipefail
+
+SOURCE_ALIAS="${MIRROR_SOURCE_ALIAS:-local}"
+SOURCE_BUCKET="${MIRROR_SOURCE_BUCKET:-pim-assets}"
+TARGET_ALIAS="mirror-target"
+TARGET_BUCKET="${MIRROR_TARGET_BUCKET:-pim-assets-replica}"
+
+log() { printf '[%s] minio-mirror-assets: %s\n' "$(date -u +%FT%TZ)" "$*"; }
+fail() { printf '[%s] minio-mirror-assets: ERROR: %s\n' "$(date -u +%FT%TZ)" "$*" >&2; exit 1; }
+
+[ -n "${MIRROR_TARGET_URL:-}" ]    || fail "MIRROR_TARGET_URL is required (replica MinIO/S3 endpoint)."
+[ -n "${MIRROR_TARGET_KEY:-}" ]    || fail "MIRROR_TARGET_KEY is required (replica access key)."
+[ -n "${MIRROR_TARGET_SECRET:-}" ] || fail "MIRROR_TARGET_SECRET is required (replica secret key)."
+
+# Optionally (re)configure the source alias inline — handy for a fresh mc
+# container that has no persisted aliases. Otherwise we trust a pre-existing one.
+if [ -n "${MIRROR_SOURCE_URL:-}" ]; then
+    log "configuring source alias '${SOURCE_ALIAS}' → ${MIRROR_SOURCE_URL}"
+    mc alias set "${SOURCE_ALIAS}" "${MIRROR_SOURCE_URL}" \
+        "${MIRROR_SOURCE_KEY:?MIRROR_SOURCE_KEY required when MIRROR_SOURCE_URL is set}" \
+        "${MIRROR_SOURCE_SECRET:?MIRROR_SOURCE_SECRET required when MIRROR_SOURCE_URL is set}" >/dev/null
+fi
+
+log "configuring target alias '${TARGET_ALIAS}' → ${MIRROR_TARGET_URL}"
+mc alias set "${TARGET_ALIAS}" "${MIRROR_TARGET_URL}" "${MIRROR_TARGET_KEY}" "${MIRROR_TARGET_SECRET}" >/dev/null
+
+# Ensure the replica bucket exists and is versioned (same protection as primary).
+mc mb -p "${TARGET_ALIAS}/${TARGET_BUCKET}" 2>/dev/null || true
+mc version enable "${TARGET_ALIAS}/${TARGET_BUCKET}" >/dev/null 2>&1 || true
+
+MIRROR_ARGS="--overwrite"
+[ "${MIRROR_PRUNE:-0}" = "1" ] && MIRROR_ARGS="${MIRROR_ARGS} --remove"
+[ "${MIRROR_WATCH:-0}" = "1" ] && MIRROR_ARGS="${MIRROR_ARGS} --watch"
+
+log "mirroring ${SOURCE_ALIAS}/${SOURCE_BUCKET} → ${TARGET_ALIAS}/${TARGET_BUCKET} (args: ${MIRROR_ARGS})"
+# shellcheck disable=SC2086
+mc mirror ${MIRROR_ARGS} "${SOURCE_ALIAS}/${SOURCE_BUCKET}" "${TARGET_ALIAS}/${TARGET_BUCKET}"
+
+log "mirror pass complete"


### PR DESCRIPTION
> Audyt fix-plan **W1-6** (Wave 1). Closes #1585 (AUD-018).

## Problem (HIGH, confirmed)
Buckety MinIO bez wersjonowania; repo pgBackRest (backup BAZY) w TYM SAMYM MinIO co assety → utrata `minio_data` = jednoczesna utrata assetów + backupów (SPOF).

## Naprawa (dev-testowalna + prod-oriented overlay)
1. **Wersjonowanie** (`minio-init`, idempotentne): `pim-assets`, nowy `pim-pgbackrest`, `pim-exports`. `pim-imports` celowo bez (transient + 7d ILM).
2. **Separacja repo (anti-SPOF):** nowy dedykowany bucket `pim-pgbackrest` ≠ `pim-assets`; `pgbackrest.conf` `repo1-s3-bucket` → `pim-pgbackrest`. Niedestrukcyjnie (stary `pim-backups` z 2026-04-28 nietknięty). **Prod overlay:** osobny endpoint/region + fail-loud dedykowane creds (nie MinIO root).
3. **`mc mirror`:** `scripts/minio-mirror-assets.sh` (idempotentny, inkrementalny) + prod sidecar `mirror-assets` w profilu `dr`.
4. **Docs:** sekcja MinIO DR + restore-from-zero drill w runbookach.

## Smoke (CLOSED MEANS CLOSED)
| | PRZED | PO |
|---|---|---|
| `mc version info pim-assets` | un-versioned | **enabled** |
| `pim-pgbackrest` | brak | **enabled** |
| repo pgBackRest | `pim-backups` = bucket assetów (SPOF) | dedykowany `pim-pgbackrest` ≠ assets |

- **Versioning-recovery (dowód):** put v1 → `mc rm` (delete-marker) → `mc ls --versions` pokazuje v1 → `mc cp --version-id` przywrócił → cleanup.
- **mc mirror (dowód):** skrypt zreplikował test-obiekt + realne assety do targetu, content match.
- login 200, `GET /api/assets` 200, MinIO żyje (129 assetów nietknięte). ZERO `down -v`/volume rm.

## Świadome odejścia
NIE rebuildowałem live `database` (repo redirect = `docker compose build database`, ryzyko mid-session dla DB operatora; live stanza czyta `pim-backups` do rebuildu, status ok — udokumentowane). Prawdziwy prod anti-SPOF (osobna instancja/region + provisioning) = deploy-time, w overlay + runbooku.
