### PR TITLE
AUD-031: harden FilterDSL escaping + validate ExportPreflight DSL (W2-3)

### DIFF
--- a/apps/api/src/Catalog/Application/Validation/TypeValidator/AssetValidator.php
+++ b/apps/api/src/Catalog/Application/Validation/TypeValidator/AssetValidator.php
@@ -10,17 +10,36 @@ use App\Catalog\Domain\Entity\Attribute;
 use Symfony\Component\Uid\Uuid;
 
 /**
- * `asset` AttributeType validator — value points at an Asset row.
+ * `asset` AttributeType validator — value points at one Asset row or, for a
+ * gallery, a list of them.
  *
- * Schema-shape only here: `value.asset_id` must be a valid UUID. Cross-
- * checking that the row actually exists + belongs to the same tenant is
- * the API layer's job (#41) where the database is reachable.
+ * Schema-shape only here: `value.asset_id` is either a single UUID string
+ * ({@see \App\Import\Application\Service\ImportObjectCreator} keeps the scalar
+ * shape for a lone asset) or a non-empty list of UUID strings (the gallery
+ * shape written by the media-download path). Cross-checking that each row
+ * actually exists + belongs to the same tenant is the API/import layer's job
+ * where the database is reachable.
  */
 final class AssetValidator implements AttributeValueValidatorInterface
 {
     public function validate(Attribute $attribute, array $value): array
     {
         $raw = $value['asset_id'] ?? null;
+
+        if (\is_array($raw)) {
+            if ([] === $raw) {
+                return [new ValidationError('value.asset_id', 'asset.empty_list', 'Asset gallery must contain at least one asset_id UUID.')];
+            }
+            $errors = [];
+            foreach (array_values($raw) as $i => $id) {
+                if (!\is_string($id) || !Uuid::isValid($id)) {
+                    $errors[] = new ValidationError(\sprintf('value.asset_id.%d', $i), 'asset.expected_uuid', 'Each gallery asset_id must be a valid UUID.');
+                }
+            }
+
+            return $errors;
+        }
+
         if (!\is_string($raw) || !Uuid::isValid($raw)) {
             return [new ValidationError('value.asset_id', 'asset.expected_uuid', 'Asset value must include a valid asset_id UUID.')];
         }

--- a/apps/api/src/Catalog/Application/ValueWriteCore.php
+++ b/apps/api/src/Catalog/Application/ValueWriteCore.php
@@ -25,18 +25,34 @@ use Symfony\Component\Uid\Uuid;
 final readonly class ValueWriteCore
 {
     /**
-     * #1216 — types whose value validator reads the canonical envelope and
-     * carries a real format rule. See the original Upserter docblock for why
-     * lenient scalar types stay out until backfilled.
+     * AUD-032 / W2-1 — the `additionalProperties: false` contract from
+     * `docs/api/jsonb-schemas.md` §6: the exact set of keys the canonical
+     * envelope of each AttributeType may carry inside `object_values.value`.
+     * locale / channel / provenance / provenance_meta are NOT envelope keys —
+     * they are dedicated columns on the row — so they never appear here. Any
+     * key outside an entry's set is rejected (proto-pollution, stored-XSS via
+     * smuggled fields, integration garbage).
      *
-     * @var list<AttributeType>
+     * @var array<string, list<string>>
      */
-    private const array VALUE_VALIDATED_TYPES = [
-        AttributeType::Email,
-        AttributeType::Color,
-        AttributeType::Identifier,
-        AttributeType::Select,
-        AttributeType::Multiselect,
+    private const array ALLOWED_KEYS = [
+        AttributeType::Text->value => ['value'],
+        AttributeType::Textarea->value => ['value'],
+        AttributeType::Wysiwyg->value => ['value'],
+        AttributeType::Number->value => ['value'],
+        AttributeType::Date->value => ['value'],
+        AttributeType::Datetime->value => ['value'],
+        AttributeType::Boolean->value => ['value'],
+        AttributeType::Color->value => ['value'],
+        AttributeType::Email->value => ['value'],
+        AttributeType::Identifier->value => ['value'],
+        AttributeType::Select->value => ['option_code'],
+        AttributeType::Multiselect->value => ['option_codes'],
+        AttributeType::Price->value => ['amount', 'currency'],
+        AttributeType::Metric->value => ['value', 'unit'],
+        AttributeType::Asset->value => ['asset_id'],
+        AttributeType::Relation->value => ['object_id'],
+        AttributeType::Reference->value => ['object_id'],
     ];
 
     public function __construct(
@@ -81,8 +97,18 @@ final readonly class ValueWriteCore
     }
 
     /**
-     * #1216 / #1261 — per-type format + option-membership validation.
-     * Empty values are skipped (clearing is always allowed).
+     * #1216 / #1261 / AUD-032 — per-type format + option-membership validation,
+     * enforced for EVERY AttributeType (the contract in jsonb-schemas.md §6,
+     * not just the five legacy `VALUE_VALIDATED_TYPES`). Two layers:
+     *
+     *   1. `additionalProperties: false` — reject any envelope key the type's
+     *      canon does not allow. Runs even for a non-content payload like
+     *      `{__proto__: ...}` so smuggled fields never reach JSONB.
+     *   2. The per-type value validator (numeric for number, ISO currency for
+     *      price, strict bool for boolean, …). Skipped only when the envelope
+     *      is an empty clear (clearing a value is always allowed) or the type
+     *      has no validator registered (`reference`, a system/listener-written
+     *      type whose shape is covered by layer 1).
      *
      * @param array<string, mixed> $envelope
      *
@@ -90,8 +116,14 @@ final readonly class ValueWriteCore
      */
     public function formatViolations(Attribute $attribute, array $envelope): array
     {
-        if (!\in_array($attribute->getType(), self::VALUE_VALIDATED_TYPES, true)
-            || !self::hasValidatableContent($attribute->getType(), $envelope)) {
+        $type = $attribute->getType();
+
+        $unknownKey = $this->unknownKeyViolation($type, $envelope);
+        if (null !== $unknownKey) {
+            return [$unknownKey];
+        }
+
+        if (!self::hasValidatableContent($type, $envelope) || !$this->hasValidator($type)) {
             return [];
         }
 
@@ -101,6 +133,42 @@ final readonly class ValueWriteCore
         }
 
         return $messages;
+    }
+
+    /**
+     * AUD-032 — `additionalProperties: false`: the first envelope key outside
+     * the type's canonical set, as a violation message, or null when the
+     * envelope only carries allowed keys. ALLOWED_KEYS covers every
+     * AttributeType, so a new enum case added without a canon entry trips a
+     * PHPStan error here rather than silently skipping the check.
+     *
+     * @param array<string, mixed> $envelope
+     */
+    private function unknownKeyViolation(AttributeType $type, array $envelope): ?string
+    {
+        $allowed = self::ALLOWED_KEYS[$type->value];
+
+        foreach (array_keys($envelope) as $key) {
+            if (!\in_array($key, $allowed, true)) {
+                return \sprintf(
+                    'Unexpected key "%s" for attribute type "%s"; allowed: %s.',
+                    $key,
+                    $type->value,
+                    implode(', ', $allowed),
+                );
+            }
+        }
+
+        return null;
+    }
+
+    private function hasValidator(AttributeType $type): bool
+    {
+        // `reference` is system-only (created_by / updated_by, stamped by
+        // Doctrine listeners) and carries no AttributeValueValidator — running
+        // the dispatcher would yield a spurious "unsupported_type". Its shape
+        // ({object_id}) is already guarded by the additionalProperties check.
+        return AttributeType::Reference !== $type;
     }
 
     /**
@@ -140,25 +208,18 @@ final readonly class ValueWriteCore
     }
 
     /**
+     * True when the envelope carries something to validate — i.e. it is not an
+     * empty clear. Clearing a value (`{}`, `{value: ''}`, `{value: null}`) is
+     * always allowed, so the per-type validator is skipped for those; every
+     * other shape (including object-shaped asset / relation / price / metric
+     * payloads, not just `{value}`) is validated. AUD-032 widened this from the
+     * old select/multiselect/`value`-only special-casing.
+     *
      * @param array<string, mixed> $envelope
      */
     public static function hasValidatableContent(AttributeType $type, array $envelope): bool
     {
-        if (AttributeType::Select === $type) {
-            $optionCode = $envelope['option_code'] ?? null;
-
-            return \is_string($optionCode) && '' !== $optionCode;
-        }
-
-        if (AttributeType::Multiselect === $type) {
-            $optionCodes = $envelope['option_codes'] ?? null;
-
-            return \is_array($optionCodes) && [] !== $optionCodes;
-        }
-
-        $scalar = $envelope['value'] ?? null;
-
-        return null !== $scalar && '' !== $scalar;
+        return !self::isEmptyEnvelope($envelope);
     }
 
     /**

--- a/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportPreflightController.php
@@ -210,6 +210,14 @@ final class ExportPreflightController
         if (null === $dsl || [] === $dsl) {
             return 0;
         }
+        // AUD-031 / W2-3 (C-2): validate the DSL BEFORE compiling it to SQL,
+        // exactly like every other filter entry point (SmartFilterPresetController).
+        // FilterDslResolver builds parameter-free SQL by inlining escaped
+        // literals; until VIEW-10 moves it to PDO-bound parameters, validate()
+        // is the gate that rejects structurally-malicious or out-of-contract
+        // DSL (unknown operators, unsafe identifiers, oversized groups) up
+        // front (400) instead of letting it reach the COUNT query.
+        $this->filterDsl->validate($dsl);
         $whereClause = $this->filterDsl->toCountSql($dsl);
         if (null === $whereClause) {
             throw new BadRequestHttpException('Invalid filter DSL.');

--- a/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/StandardConformingStringsDriver.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/StandardConformingStringsDriver.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;
+use RuntimeException;
+use SensitiveParameter;
+
+/**
+ * AUD-031 / W2-3 (C-2) — forces and verifies `standard_conforming_strings = on`
+ * on each physical connection the moment it is opened.
+ *
+ * Runs once per connect (the only place a raw driver connection is created),
+ * so the value is established before any query — including under FrankenPHP
+ * worker mode, where a fresh physical connection is established lazily and
+ * then reused across requests. See {@see StandardConformingStringsMiddleware}
+ * for why the setting is load-bearing for FilterDSL escaping.
+ */
+final class StandardConformingStringsDriver extends AbstractDriverMiddleware
+{
+    public function connect(
+        #[SensitiveParameter]
+        array $params,
+    ): Connection {
+        $connection = parent::connect($params);
+
+        // Force the safe mode regardless of the server default, then read it
+        // back and fail loud if the server did not honour it — a silent `off`
+        // would re-open the FilterDSL injection vector.
+        $connection->exec('SET standard_conforming_strings = on');
+
+        $value = $connection->query('SHOW standard_conforming_strings')->fetchOne();
+        if ('on' !== $value) {
+            throw new RuntimeException(sprintf(
+                'Refusing to use a Postgres connection with standard_conforming_strings=%s. '
+                .'FilterDSL literal escaping (single-quote doubling) is only injection-safe when it is "on" (AUD-031 / W2-3).',
+                \is_scalar($value) ? (string) $value : get_debug_type($value),
+            ));
+        }
+
+        return $connection;
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/StandardConformingStringsMiddleware.php
+++ b/apps/api/src/Shared/Infrastructure/Doctrine/Middleware/StandardConformingStringsMiddleware.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Doctrine\Middleware;
+
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Middleware;
+
+/**
+ * AUD-031 / W2-3 (C-2) — guarantees `standard_conforming_strings = on` on
+ * every physical Postgres connection.
+ *
+ * {@see \App\Catalog\Application\Filter\FilterDslResolver} compiles the
+ * product/export filter DSL to *parameter-free* SQL, escaping string literals
+ * by doubling single quotes (`'` → `''`). That escaping is only injection-safe
+ * while `standard_conforming_strings` is on: with the setting off, Postgres
+ * treats a backslash inside a literal as an escape character, so `\'` closes
+ * the literal and the doubled-quote escaping leaks — re-opening the SQLi
+ * vector the audit otherwise confirmed contained (`backslash_quote=safe_encoding`
+ * + `standard_conforming_strings=on`).
+ *
+ * Postgres defaults the setting on since 9.1, but the audit demands a
+ * *guarantee*, not an assumption about server configuration. This driver
+ * middleware forces it on at connect time and fails loud if the server refuses
+ * (so a hostile / mis-set GUC surfaces as a connection error rather than a
+ * silent escaping bypass). Full PDO parameterisation of the DSL stays deferred
+ * to VIEW-10; this is the defence-in-depth floor under it.
+ *
+ * Tagged with `doctrine.middleware` via autoconfiguration (it implements
+ * {@see Middleware}), so Symfony's Doctrine bundle slots it into the driver
+ * chain without touching `doctrine.yaml` — the same wiring as
+ * {@see QueryTimingMiddleware}. It applies to every connection (`default` and
+ * `owner`) and re-runs on each physical connect, including FrankenPHP worker
+ * reuse.
+ */
+final readonly class StandardConformingStringsMiddleware implements Middleware
+{
+    public function wrap(Driver $driver): Driver
+    {
+        return new StandardConformingStringsDriver($driver);
+    }
+}

--- a/apps/api/tests/Api/Export/ExportPreflightApiTest.php
+++ b/apps/api/tests/Api/Export/ExportPreflightApiTest.php
@@ -92,6 +92,104 @@ final class ExportPreflightApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function rejectsFilterWithInvalidOperatorBeforeRunningSql(): void
+    {
+        // AUD-031 / W2-3 (C-2) — countFilter previously compiled the DSL
+        // straight to SQL without validate(). An operator that is not in the
+        // known set must be rejected at validation (400) before the literal
+        // ever reaches the COUNT query.
+        $tenant = $this->tenant();
+        $services = $this->customObjectType($tenant, 'invalid-op-services');
+        $this->object($tenant, $services, 'IO-1', ['brand' => 'Festo']);
+        $this->em()->flush();
+
+        $response = $this->preflightRaw([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $services->getId()->toRfc4122(),
+            'target_scope' => 'filter',
+            'filter' => ['attr' => 'brand', 'op' => 'REGEX MATCH', 'value' => '^F.*$'],
+        ]);
+
+        self::assertSame(400, $response);
+    }
+
+    #[Test]
+    public function rejectsOversizedFilterGroupBeforeRunningSql(): void
+    {
+        // AUD-031 / W2-3 (C-2) — the genuine behavioural gap closed by calling
+        // validate() in countFilter. A group with >20 conditions COMPILES to
+        // valid SQL (the compiler caps only nesting depth, not condition
+        // count), so before the fix this reached the DB and returned HTTP 200
+        // with a real count. validate() rejects it up front (400), matching
+        // every other DSL entry point (SmartFilterPresetController).
+        $tenant = $this->tenant();
+        $services = $this->customObjectType($tenant, 'oversized-group-services');
+        $this->object($tenant, $services, 'OG-1', ['brand' => 'Festo']);
+        $this->em()->flush();
+
+        $conditions = [];
+        for ($i = 0; $i < 21; ++$i) {
+            $conditions[] = ['attr' => 'brand', 'op' => '=', 'value' => 'Festo'];
+        }
+
+        $response = $this->preflightRaw([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $services->getId()->toRfc4122(),
+            'target_scope' => 'filter',
+            'filter' => ['operator' => 'AND', 'conditions' => $conditions],
+        ]);
+
+        self::assertSame(400, $response);
+    }
+
+    #[Test]
+    public function rejectsFilterWithUnsafeAttributeIdentifierBeforeRunningSql(): void
+    {
+        // An attribute identifier carrying SQL metacharacters must be
+        // rejected by validate() (safeIdent regex) with a 400, not silently
+        // dropped (toCountSql -> null path) after bypassing validation.
+        $tenant = $this->tenant();
+        $services = $this->customObjectType($tenant, 'unsafe-ident-services');
+        $this->object($tenant, $services, 'UI-1', ['brand' => 'Festo']);
+        $this->em()->flush();
+
+        $response = $this->preflightRaw([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $services->getId()->toRfc4122(),
+            'target_scope' => 'filter',
+            'filter' => ['attr' => "brand'; DROP TABLE objects; --", 'op' => '=', 'value' => 'x'],
+        ]);
+
+        self::assertSame(400, $response);
+    }
+
+    #[Test]
+    public function adversarialOrInjectionValueDoesNotMatchEveryRow(): void
+    {
+        // AUD-031 (C-2) adversarial: a classic `x' OR '1'='1` payload as the
+        // filter VALUE must be treated as a single escaped string literal,
+        // matching only rows whose brand literally equals that string (none),
+        // never every row in the ObjectType.
+        $tenant = $this->tenant();
+        $services = $this->customObjectType($tenant, 'adversarial-services');
+        $this->object($tenant, $services, 'A-1', ['brand' => 'Festo']);
+        $this->object($tenant, $services, 'A-2', ['brand' => 'Bosch']);
+        $this->object($tenant, $services, 'A-3', ['brand' => 'Siemens']);
+        $this->em()->flush();
+
+        $body = $this->preflight([
+            'entity_type' => 'custom_module',
+            'object_type_id' => $services->getId()->toRfc4122(),
+            'target_scope' => 'filter',
+            'filter' => ['attr' => 'brand', 'op' => '=', 'value' => "x' OR '1'='1"],
+        ]);
+
+        // Escaping holds: no brand equals the literal payload, so 0 rows —
+        // categorically NOT the 3 rows an `OR '1'='1' would have leaked.
+        self::assertSame(0, $body['count']);
+    }
+
+    #[Test]
     public function countsUniqueSelectedIds(): void
     {
         $id = '019eae00-0000-7000-8000-000000000001';

--- a/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
+++ b/apps/api/tests/Api/Import/GoldenRoundTripApiTest.php
@@ -638,14 +638,21 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
             ]);
         };
         $insertLegacy($select->getId()->toRfc4122(), '{"value": "red"}');
-        $insertLegacy($price->getId()->toRfc4122(), '{"value": 99.99}');
+        // AUD-032: the legacy price wrap carries its currency sibling. The
+        // write side rewrites the `value` KEY to `amount` (the normalisation
+        // under test); the price validator — now enforced for every type —
+        // requires the currency, so a currency-less legacy wrap would be
+        // (correctly) rejected on re-import and never reach the canon. The
+        // canon migration (Version20260612210000) documents the same: a
+        // currency-less migrated price stays incomplete until the next edit.
+        $insertLegacy($price->getId()->toRfc4122(), '{"value": 99.99, "currency": "PLN"}');
 
         // Sanity: the seeded rows really are legacy, not canon. Read straight
         // off the connection so the managed Tenant the exporter needs stays
         // attached (no $em->clear() before runToFile, which re-persists it).
         $before = $this->legacyEnvelopesOf($productId);
         self::assertSame(['value' => 'red'], $before['lg_select'], 'select seeded as legacy {value}');
-        self::assertSame(['value' => 99.99], $before['lg_price'], 'price seeded as legacy {value}');
+        self::assertSame(['value' => 99.99, 'currency' => 'PLN'], $before['lg_price'], 'price seeded as legacy {value} + currency');
 
         // ── Round-trip through the REAL export → import engine ──
         $columns = ['sku', 'lg_select', 'lg_price'];
@@ -655,9 +662,10 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         // The Select serialiser reads `option_code` ONLY — a legacy select cell
         // exports empty (it never had the canonical key). Inject the option code
         // so the re-import has a cell to canonicalise; price exports fine because
-        // its serialiser falls back to `value` (#1271), so it rides as-is.
+        // its serialiser falls back to `value` (#1271) and appends the currency
+        // sibling, so it rides as "99.99 PLN".
         // The exporter writes `;`-delimited cells behind a UTF-8 BOM (#1484).
-        self::assertStringContainsString('99.99', $csv, 'legacy price exports via the value fallback');
+        self::assertStringContainsString('99.99 PLN', $csv, 'legacy price exports amount + currency via the value fallback');
         $clean = ltrim($csv, "\xEF\xBB\xBF");
         $lines = explode("\n", trim($clean));
         self::assertCount(2, $lines, 'header + one data row');
@@ -680,7 +688,7 @@ final class GoldenRoundTripApiTest extends CatalogApiTestCase
         $em->clear();
         $after = $this->legacyEnvelopesOf($productId);
         self::assertSame(['option_code' => 'red'], $after['lg_select'], 'select normalised {value}→{option_code}');
-        self::assertSame(['amount' => 99.99], $after['lg_price'], 'price normalised {value}→{amount}');
+        self::assertSame(['amount' => 99.99, 'currency' => 'PLN'], $after['lg_price'], 'price normalised {value}→{amount}, currency preserved');
         self::assertArrayNotHasKey('value', $after['lg_select'], 'no legacy key survives on select');
         self::assertArrayNotHasKey('value', $after['lg_price'], 'no legacy key survives on price');
     }

--- a/apps/api/tests/Integration/Configuration/StandardConformingStringsTest.php
+++ b/apps/api/tests/Integration/Configuration/StandardConformingStringsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Configuration;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * AUD-031 / W2-3 (C-2) — regression guard for the FilterDSL escaping
+ * security premise.
+ *
+ * {@see \App\Catalog\Application\Filter\FilterDslResolver} compiles the
+ * product/export filter DSL to parameter-free SQL, escaping string literals
+ * by doubling single quotes (`'` → `''`). That escaping is ONLY safe while
+ * Postgres runs with `standard_conforming_strings = on`: with the setting
+ * `off`, a backslash inside a literal escapes the closing quote (`\'`) and
+ * the doubled-quote escaping leaks, re-opening the SQL-injection vector the
+ * audit confirmed is otherwise contained.
+ *
+ * The setting defaults `on` since Postgres 9.1, but the audit demands a
+ * *guarantee*, not an assumption. {@see \App\Shared\Infrastructure\Doctrine\Middleware\StandardConformingStringsMiddleware}
+ * forces `SET standard_conforming_strings = on` on every physical connection
+ * and fails loud if the server somehow refuses. This test pins that the live
+ * runtime connection reports `on`, so flipping the server default (or
+ * regressing the middleware) turns the suite red.
+ */
+final class StandardConformingStringsTest extends KernelTestCase
+{
+    #[Test]
+    public function runtimeConnectionEnforcesStandardConformingStrings(): void
+    {
+        self::bootKernel();
+        $connection = $this->connection();
+
+        $value = $connection->fetchOne('SHOW standard_conforming_strings');
+
+        self::assertSame(
+            'on',
+            $value,
+            'FilterDSL literal escaping (single-quote doubling) is only injection-safe while '
+            .'standard_conforming_strings is on; the connection-init middleware must guarantee it.',
+        );
+    }
+
+    #[Test]
+    public function escapedLiteralIsInterpretedAsASingleStringNotInjection(): void
+    {
+        self::bootKernel();
+        $connection = $this->connection();
+
+        // The exact escaping FilterDslResolver::literal() emits for the
+        // adversarial value `x' OR '1'='1`: doubled single quotes. Under
+        // standard_conforming_strings=on Postgres MUST read this as one
+        // string literal equal to the original input, never as a closed
+        // string followed by an OR predicate.
+        $roundTripped = $connection->fetchOne("SELECT 'x'' OR ''1''=''1'");
+
+        self::assertSame("x' OR '1'='1", $roundTripped);
+    }
+
+    private function connection(): Connection
+    {
+        // The container PHPStan extension types this service id as Connection.
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+
+        return $connection;
+    }
+}

--- a/apps/api/tests/Integration/Maintenance/TenantOffboardingPurgeTest.php
+++ b/apps/api/tests/Integration/Maintenance/TenantOffboardingPurgeTest.php
@@ -102,7 +102,7 @@ final class TenantOffboardingPurgeTest extends KernelTestCase
         // ── Throwaway: tenant row + EVERY dependent row gone ───────────
         self::assertSame(
             0,
-            (int) $connection->fetchOne('SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $throwaway->toRfc4122()]),
+            $this->countOne($connection, 'SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $throwaway->toRfc4122()]),
             'Throwaway tenant row must be hard-deleted.',
         );
         foreach (self::TENANT_TABLES as $table) {
@@ -116,7 +116,7 @@ final class TenantOffboardingPurgeTest extends KernelTestCase
         // attributes RESTRICT) was the original blocker.
         self::assertSame(
             0,
-            (int) $connection->fetchOne('SELECT COUNT(*) FROM object_values WHERE id = :id', ['id' => $throwawayObjectValues]),
+            $this->countOne($connection, 'SELECT COUNT(*) FROM object_values WHERE id = :id', ['id' => $throwawayObjectValues]),
         );
 
         // ── Throwaway storage prefix swept across all three buckets ────
@@ -127,7 +127,7 @@ final class TenantOffboardingPurgeTest extends KernelTestCase
         // ── KEEPER tenant fully intact (proxy for demo/acme) ───────────
         self::assertSame(
             1,
-            (int) $connection->fetchOne('SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $keeper->toRfc4122()]),
+            $this->countOne($connection, 'SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $keeper->toRfc4122()]),
             'Keeper tenant must be untouched.',
         );
         self::assertSame(1, $this->rowCount($connection, 'object_values', $keeper), 'Keeper object_values intact.');
@@ -136,7 +136,7 @@ final class TenantOffboardingPurgeTest extends KernelTestCase
         self::assertSame(1, $this->rowCount($connection, 'users', $keeper), 'Keeper users intact.');
         self::assertSame(
             1,
-            (int) $connection->fetchOne('SELECT COUNT(*) FROM object_values WHERE id = :id', ['id' => $keeperObjectValues]),
+            $this->countOne($connection, 'SELECT COUNT(*) FROM object_values WHERE id = :id', ['id' => $keeperObjectValues]),
         );
         self::assertTrue($assets->directoryExists($keeper->toRfc4122()), 'Keeper assets prefix intact.');
         self::assertTrue($exports->directoryExists($keeper->toRfc4122()), 'Keeper exports prefix intact.');
@@ -159,7 +159,7 @@ final class TenantOffboardingPurgeTest extends KernelTestCase
         self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
         self::assertSame(
             1,
-            (int) $connection->fetchOne('SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $throwaway->toRfc4122()]),
+            $this->countOne($connection, 'SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $throwaway->toRfc4122()]),
             'Dry-run must not delete the tenant row.',
         );
         self::assertSame(1, $this->rowCount($connection, 'object_values', $throwaway), 'Dry-run must keep dependents.');
@@ -183,7 +183,7 @@ final class TenantOffboardingPurgeTest extends KernelTestCase
         self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
         self::assertSame(
             1,
-            (int) $connection->fetchOne('SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $recent->toRfc4122()]),
+            $this->countOne($connection, 'SELECT COUNT(*) FROM tenants WHERE id = :id', ['id' => $recent->toRfc4122()]),
             'A tenant soft-deleted inside the retention window must survive.',
         );
     }
@@ -362,10 +362,23 @@ final class TenantOffboardingPurgeTest extends KernelTestCase
     {
         // $table comes only from the class constant TENANT_TABLES (no
         // external input) — safe to inline.
-        return (int) $connection->fetchOne(
+        return $this->countOne(
+            $connection,
             \sprintf('SELECT COUNT(*) FROM %s WHERE tenant_id = :t', $table),
             ['t' => $tenant->toRfc4122()],
         );
+    }
+
+    /**
+     * COUNT(*) helper — DBAL fetchOne() returns mixed; narrow to int safely.
+     *
+     * @param array<string, scalar> $params
+     */
+    private function countOne(Connection $connection, string $sql, array $params): int
+    {
+        $value = $connection->fetchOne($sql, $params);
+
+        return \is_numeric($value) ? (int) $value : 0;
     }
 
     private function commandTester(object $kernel): CommandTester
@@ -379,7 +392,6 @@ final class TenantOffboardingPurgeTest extends KernelTestCase
     private function connection(object $kernel): Connection
     {
         $connection = self::getContainer()->get('doctrine.dbal.default_connection');
-        \assert($connection instanceof Connection);
 
         return $connection;
     }

--- a/apps/api/tests/Unit/Catalog/Application/ValueWriteCoreFormatViolationsTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/ValueWriteCoreFormatViolationsTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application;
+
+use App\Catalog\Application\Validation\AttributeValueValidator;
+use App\Catalog\Application\ValueWriteCore;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * AUD-032 / W2-1 (C-3) — the JSONB envelope contract from
+ * `docs/api/jsonb-schemas.md` §6 must be enforced on the WRITE path for
+ * EVERY AttributeType, not just the five that used to sit in
+ * `VALUE_VALIDATED_TYPES`. The audit proved 12/17 types accepted arbitrary
+ * garbage (`number = "abc OR 1=1"`, `price.amount = "lol"`, extra keys
+ * `__proto__` / `evil`, raw `<script>`) verbatim into `object_values.value`.
+ *
+ * This test pins the adversarial contract directly on
+ * {@see ValueWriteCore::formatViolations()}: garbage is rejected (non-empty
+ * violation list) and the canonical per-type envelope is accepted (empty
+ * list). formatViolations() reads only the injected AttributeValueValidator,
+ * so the (final, DI-heavy) constructor is skipped and the collaborator is set
+ * reflectively — same pattern as {@see ValueWriteCoreTest}.
+ */
+final class ValueWriteCoreFormatViolationsTest extends TestCase
+{
+    private function core(): ValueWriteCore
+    {
+        $core = new ReflectionClass(ValueWriteCore::class)->newInstanceWithoutConstructor();
+        $property = new ReflectionClass(ValueWriteCore::class)->getProperty('valueValidator');
+        // Bare default() — no option repository, so select/multiselect check
+        // shape only (option membership needs the DB and is covered in Api tests).
+        $property->setValue($core, AttributeValueValidator::default());
+
+        return $core;
+    }
+
+    /**
+     * @param array<string, mixed> $rules
+     */
+    private function attribute(AttributeType $type, array $rules = []): Attribute
+    {
+        $attribute = new Attribute('attr_'.$type->value, ['en' => $type->value], $type);
+        if ([] !== $rules) {
+            $attribute->updateValidationRules($rules);
+        }
+
+        return $attribute;
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    #[Test]
+    #[DataProvider('garbageProvider')]
+    public function formatViolationsRejectsGarbage(AttributeType $type, array $envelope): void
+    {
+        $core = $this->core();
+        $violations = $core->formatViolations($this->attribute($type), $core->normalise($type, $envelope));
+
+        self::assertNotSame(
+            [],
+            $violations,
+            \sprintf('garbage for "%s" must be rejected, got: %s', $type->value, json_encode($envelope)),
+        );
+    }
+
+    /**
+     * Each entry is a shape the canon (jsonb-schemas.md §6) does NOT allow:
+     * a wrong value type or an extra envelope key (additionalProperties:false).
+     *
+     * @return iterable<string, array{AttributeType, array<string, mixed>}>
+     */
+    public static function garbageProvider(): iterable
+    {
+        // ── Wrong value type per AttributeType ──────────────────────────────
+        yield 'number string injection' => [AttributeType::Number, ['value' => 'abc OR 1=1']];
+        yield 'number nested object' => [AttributeType::Number, ['value' => ['x' => 1]]];
+        yield 'metric non-numeric value' => [AttributeType::Metric, ['value' => 'lol', 'unit' => 'kg']];
+        yield 'metric missing unit' => [AttributeType::Metric, ['value' => 5]];
+        yield 'price non-numeric amount' => [AttributeType::Price, ['amount' => 'lol', 'currency' => 'PLN']];
+        yield 'price bad currency' => [AttributeType::Price, ['amount' => 9.99, 'currency' => ['x']]];
+        yield 'boolean object' => [AttributeType::Boolean, ['value' => ['a' => 'b']]];
+        yield 'boolean string truthy' => [AttributeType::Boolean, ['value' => 'true']];
+        yield 'text nested object' => [AttributeType::Text, ['value' => ['deep' => ['x' => 1]]]];
+        yield 'textarea non-string' => [AttributeType::Textarea, ['value' => 123]];
+        yield 'wysiwyg non-string' => [AttributeType::Wysiwyg, ['value' => ['html' => 'x']]];
+        yield 'date unparseable' => [AttributeType::Date, ['value' => 'not-a-date']];
+        yield 'datetime unparseable' => [AttributeType::Datetime, ['value' => 'garbage']];
+        yield 'color non-string' => [AttributeType::Color, ['value' => 123]];
+        yield 'email malformed' => [AttributeType::Email, ['value' => 'not-an-email']];
+        yield 'asset non-uuid' => [AttributeType::Asset, ['asset_id' => 'not-a-uuid']];
+        yield 'asset list with garbage' => [AttributeType::Asset, ['asset_id' => ['not-a-uuid']]];
+        yield 'relation non-uuid' => [AttributeType::Relation, ['object_id' => 'lol']];
+
+        // ── additionalProperties:false — extra envelope keys are garbage ─────
+        yield 'text extra evil key' => [AttributeType::Text, ['value' => 'ok', 'evil' => '<script>alert(1)</script>']];
+        yield 'text proto pollution key' => [AttributeType::Text, ['value' => 'ok', '__proto__' => 'x']];
+        yield 'number extra key' => [AttributeType::Number, ['value' => 42, 'rogue' => 1]];
+        yield 'price extra key' => [AttributeType::Price, ['amount' => 9.99, 'currency' => 'PLN', 'evil' => 1]];
+        yield 'metric extra key' => [AttributeType::Metric, ['value' => 5, 'unit' => 'kg', 'x' => 1]];
+        yield 'asset extra key' => [AttributeType::Asset, ['asset_id' => '019edb88-9ed8-7638-94dc-be4a2a721a91', 'evil' => 1]];
+        yield 'relation extra key' => [AttributeType::Relation, ['object_id' => '019edb88-9ed8-7638-94dc-be4a2a721a91', 'evil' => 1]];
+        yield 'select extra key' => [AttributeType::Select, ['option_code' => 'red', 'evil' => 1]];
+        yield 'multiselect extra key' => [AttributeType::Multiselect, ['option_codes' => ['a'], 'evil' => 1]];
+        yield 'reference extra key' => [AttributeType::Reference, ['object_id' => '019edb88-9ed8-7638-94dc-be4a2a721a91', 'evil' => 1]];
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    #[Test]
+    #[DataProvider('validProvider')]
+    public function formatViolationsAcceptsCanonicalEnvelopes(AttributeType $type, array $envelope): void
+    {
+        $core = $this->core();
+        $violations = $core->formatViolations($this->attribute($type), $core->normalise($type, $envelope));
+
+        self::assertSame(
+            [],
+            $violations,
+            \sprintf('canonical "%s" must pass, got: %s', $type->value, implode('; ', $violations)),
+        );
+    }
+
+    /**
+     * One canonical, valid envelope per AttributeType (jsonb-schemas.md §6).
+     * `reference` carries no validator (system, listener-written) — its shape
+     * is still checked, so a clean `{object_id}` must pass.
+     *
+     * @return iterable<string, array{AttributeType, array<string, mixed>}>
+     */
+    public static function validProvider(): iterable
+    {
+        $uuid = '019edb88-9ed8-7638-94dc-be4a2a721a91';
+        $uuid2 = '019edb88-9ed8-7638-94dc-be4a2a721a92';
+
+        yield 'text' => [AttributeType::Text, ['value' => 'Stalowy uchwyt M8']];
+        yield 'textarea' => [AttributeType::Textarea, ['value' => "Linia 1\nLinia 2"]];
+        yield 'wysiwyg' => [AttributeType::Wysiwyg, ['value' => '<p>Opis <b>HTML</b></p>']];
+        yield 'number int' => [AttributeType::Number, ['value' => 42]];
+        yield 'number float' => [AttributeType::Number, ['value' => 12.5]];
+        yield 'date' => [AttributeType::Date, ['value' => '2026-03-15']];
+        yield 'datetime' => [AttributeType::Datetime, ['value' => '2026-03-15T10:30:00+00:00']];
+        yield 'boolean true' => [AttributeType::Boolean, ['value' => true]];
+        yield 'boolean false' => [AttributeType::Boolean, ['value' => false]];
+        yield 'color hex' => [AttributeType::Color, ['value' => '#ff8800']];
+        yield 'email' => [AttributeType::Email, ['value' => 'kontakt@example.com']];
+        yield 'identifier' => [AttributeType::Identifier, ['value' => '5901234123457']];
+        yield 'select' => [AttributeType::Select, ['option_code' => 'red']];
+        yield 'multiselect' => [AttributeType::Multiselect, ['option_codes' => ['new', 'sale']]];
+        yield 'price' => [AttributeType::Price, ['amount' => 249.99, 'currency' => 'PLN']];
+        yield 'metric' => [AttributeType::Metric, ['value' => 0.75, 'unit' => 'kg']];
+        yield 'asset single' => [AttributeType::Asset, ['asset_id' => $uuid]];
+        yield 'asset gallery list' => [AttributeType::Asset, ['asset_id' => [$uuid, $uuid2]]];
+        yield 'relation' => [AttributeType::Relation, ['object_id' => $uuid]];
+        yield 'reference' => [AttributeType::Reference, ['object_id' => $uuid]];
+
+        // Clearing a value (empty envelope) is always allowed for every type.
+        yield 'empty clear' => [AttributeType::Text, []];
+        yield 'empty string clear' => [AttributeType::Number, ['value' => '']];
+    }
+}

--- a/apps/api/tests/Unit/Catalog/FilterDslResolverTest.php
+++ b/apps/api/tests/Unit/Catalog/FilterDslResolverTest.php
@@ -164,6 +164,20 @@ final class FilterDslResolverTest extends TestCase
         self::assertStringNotContainsString("'O'Reilly'", $sql); // not bare single-quote
     }
 
+    public function testToCountSqlNeutralisesOrInjectionPayloadAsSingleLiteral(): void
+    {
+        // AUD-031 / W2-3 (C-2) — the canonical SQLi probe must compile to ONE
+        // escaped string literal (every inner quote doubled), so Postgres
+        // (standard_conforming_strings=on, enforced by the connection-init
+        // middleware) reads it as a single value, never a closed string + OR.
+        $sql = $this->resolver->toCountSql(['attr' => 'brand', 'op' => '=', 'value' => "x' OR '1'='1"]);
+
+        self::assertNotNull($sql);
+        self::assertStringContainsString("= 'x'' OR ''1''=''1'", $sql);
+        // No un-doubled quote that could terminate the literal early.
+        self::assertStringNotContainsString("'x' OR", $sql);
+    }
+
     public function testToCountSqlReturnsNullForCompilationFailure(): void
     {
         // Suppress validation: pass directly to compile via toCountSql.

--- a/apps/api/tests/Unit/Shared/Infrastructure/Doctrine/StandardConformingStringsMiddlewareTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Doctrine/StandardConformingStringsMiddlewareTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Doctrine;
+
+use App\Shared\Infrastructure\Doctrine\Middleware\StandardConformingStringsMiddleware;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Driver\Result;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * AUD-031 / W2-3 (C-2) — the middleware that guarantees
+ * `standard_conforming_strings = on` on every physical connection (the
+ * premise FilterDslResolver's single-quote escaping depends on).
+ */
+final class StandardConformingStringsMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function connectForcesTheSettingOnAndVerifiesIt(): void
+    {
+        $result = $this->createStub(Result::class);
+        $result->method('fetchOne')->willReturn('on');
+
+        // Mock (not stub) the connection — the SET + verification calls are
+        // the behaviour under test, so they carry explicit expectations.
+        $inner = $this->createMock(DriverConnection::class);
+        $inner->expects(self::once())
+            ->method('exec')
+            ->with('SET standard_conforming_strings = on');
+        $inner->expects(self::once())
+            ->method('query')
+            ->with('SHOW standard_conforming_strings')
+            ->willReturn($result);
+
+        $driver = $this->createStub(Driver::class);
+        $driver->method('connect')->willReturn($inner);
+
+        $middleware = new StandardConformingStringsMiddleware();
+        $connection = $middleware->wrap($driver)->connect([]);
+
+        // The wrapper transparently exposes the underlying connection.
+        self::assertInstanceOf(DriverConnection::class, $connection);
+    }
+
+    #[Test]
+    public function connectFailsLoudWhenTheServerRefusesTheSetting(): void
+    {
+        // If the server somehow reports the setting as `off` after the SET
+        // (mis-set GUC, hostile config), the connection MUST fail loud rather
+        // than silently allow FilterDSL escaping to leak.
+        $result = $this->createStub(Result::class);
+        $result->method('fetchOne')->willReturn('off');
+
+        $inner = $this->createStub(DriverConnection::class);
+        $inner->method('exec')->willReturn(0);
+        $inner->method('query')->willReturn($result);
+
+        $driver = $this->createStub(Driver::class);
+        $driver->method('connect')->willReturn($inner);
+
+        $middleware = new StandardConformingStringsMiddleware();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/standard_conforming_strings/');
+
+        $middleware->wrap($driver)->connect([]);
+    }
+}


### PR DESCRIPTION
> Audyt fix-plan **W2-3** (Wave 2). Closes #1595 (AUD-031). Hardening (S), nie pełna PDO (L/VIEW-10).

## Problem (confirmed, defence-in-depth/dług — NIE dziś-exploitowalne)
`FilterDslResolver` buduje SQL przez konkatenację literałów — injection-safe TYLKO przy Postgres `standard_conforming_strings=on`; `ExportPreflightController::countFilter` kompilował DSL z payloadu **bez `validate()`**.

## Naprawa (hardening)
1. **Gwarancja `standard_conforming_strings=on`:** nowy DBAL driver-middleware (`StandardConformingStringsMiddleware`+`Driver`, autoconfigured `doctrine.middleware`, wzorzec `QueryTimingMiddleware`) — w `connect()` (raz/połączenie, też reuse FrankenPHP) `SET standard_conforming_strings=on` + `SHOW` weryfikacja → **`RuntimeException` fail-loud** gdy serwer zwraca cokolwiek innego. Założenie → gwarancja; pokrywa `default`+`owner`.
2. **`validate()` w ExportPreflight:** `$this->filterDsl->validate($dsl)` PRZED `toCountSql()` (wzorzec `SmartFilterPresetController`).

## Reguła naprawy — failing test FIRST
- ExportPreflight: grupa 21-warunkowa kompilowała się → szła do DB (**200** przed) → PO `validate()` → **400** (RED→GREEN potwierdzony empirycznie). + unknown-operator/unsafe-identifier → 400; adwersarski `x' OR '1'='1` → count 0.
- Middleware unit: SET + weryfikacja + **fail-loud gdy `off`**. Config integration: `standard_conforming_strings=on` na żywym połączeniu + round-trip escapowanego literału.

## Bramki
Nowe + regresja: 36/36 + 115/115 (FilterDsl/CatalogFilters/Export/SmartFilterPresets/config) + 5/5 RLS-GUC (middleware współistnieje). PHPStan **No errors** (moje 7 plików) · cs-fixer 0 · Deptrac 0. Smoke: products filter 200, ExportPreflight oversized/unknown→400, `x' OR '1'='1`→count 0, login 200.

## Decyzje
`validate()`→**400** (`BadRequestHttpException`, spójnie z `SmartFilterPresetController` + istniejącym `countFilter`; brak mapowania 400→422 w repo) — load-bearing wymóg (walidacja PRZED SQL) spełniony. Pełna PDO-parametryzacja → VIEW-10 (udokumentowane w docblocku).
