### PR TITLE
fix(deps): accept test-only undici CVE via auditConfig ignore (pnpm-audit blocker)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
   "pnpm": {
     "overrides": {
       "fast-uri": ">=3.1.2"
+    },
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-vmh5-mc38-953g"
+      ]
     }
   },
   "dependencies": {


### PR DESCRIPTION
> Unblocker `pnpm audit --audit-level=high` dla Wave 2 (blokuje #1641, #1642). Decyzja operatora: ignoreGhsas (#1644 tracking).

## Problem
Nowe HIGH advisory **GHSA-vmh5-mc38-953g** (undici TLS cert-validation bypass, >=7.23.0 <7.28.0) failuje CI gate `pnpm audit --audit-level=high`. undici jest **test-only** (`apps/admin>jsdom>undici`, devDependency — NIE w produkcyjnym buildzie). Fix (undici 7.28.0) **łamie jsdom 29.1.1** (reachuje wewnętrzny `undici/lib/handler/wrap-handler.js` usunięty w 7.28 → vitest `MODULE_NOT_FOUND`); jsdom nie ma kompatybilnej wersji.

## Decyzja (operator)
`pnpm.auditConfig.ignoreGhsas=['GHSA-vmh5-mc38-953g']` — risk-acceptance: nie-exploitowalne (test-env jsdom nie robi prod-TLS), nie shippowane, brak upstream fixu. undici pozostaje jsdom-kompatybilny **7.27.2** (override cofnięty). pnpm-lock vs main bez zmian.

## Weryfikacja
`pnpm audit --audit-level=high` → **exit 0** (ignoreGhsas filtruje GHSA). Vitest naprawiony (wrap-handler.js obecny, 2/2 sanity). Moderate (qs AUD-048/#1605, js-yaml, dompurify #1594) poniżej gate — osobno.

## Tracking rewizji: #1644
Zdjąć ignore gdy jsdom kompatybilny z undici ≥7.28 (lub migracja na happy-dom).
