### PR TITLE
AUD-033: server-side HTML sanitization for wysiwyg (W2-2)

### DIFF
--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -17,6 +17,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.7",
         "doctrine/orm": "^3.6.3",
         "dragonmantank/cron-expression": "^3.6",
+        "ezyang/htmlpurifier": "^4.19",
         "league/csv": "^9.28",
         "league/flysystem-aws-s3-v3": "^3.32",
         "league/flysystem-bundle": "^3.7",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8715ad91d74b817dae2384274eca221d",
+    "content-hash": "4989286ab9b9ff8fdb17ef09ced0c20b",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -2947,6 +2947,67 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.19.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "reference": "b287d2a16aceffbf6e0295559b39662612b77fcf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.6.0 || ~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "cerdic/css-tidy": "^1.7 || ^2.0",
+                "simpletest/simpletest": "dev-master"
+            },
+            "suggest": {
+                "cerdic/css-tidy": "If you want to use the filter 'Filter.ExtractStyleBlocks'.",
+                "ext-bcmath": "Used for unit conversion and imagecrash protection",
+                "ext-iconv": "Converts text to and from non-UTF-8 encodings",
+                "ext-tidy": "Used for pretty-printing HTML"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ],
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "exclude-from-classmap": [
+                    "/library/HTMLPurifier/Language/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "issues": "https://github.com/ezyang/htmlpurifier/issues",
+                "source": "https://github.com/ezyang/htmlpurifier/tree/v4.19.0"
+            },
+            "time": "2025-10-17T16:34:55+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/apps/api/src/Catalog/Application/HtmlSanitizer.php
+++ b/apps/api/src/Catalog/Application/HtmlSanitizer.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use HTMLPurifier;
+use HTMLPurifier_Config;
+
+/**
+ * AUD-033 / W2-2 (C-4) — server-side HTML sanitisation for `wysiwyg`
+ * attribute values, applied on the WRITE path (defense-in-depth).
+ *
+ * Until now stored-XSS was blocked ONLY by the frontend DOMPurify call in
+ * `wysiwyg-editor.tsx` before `dangerouslySetInnerHTML`. Any other consumer
+ * of `object_values.value` that forgets to sanitise — a future admin view, a
+ * storefront, a partner panel, a report, an e-mail, an HTML export to a sales
+ * channel — would fire the payload. This neutralises the HTML at the source,
+ * so a `<script>`, an `onerror=` handler, or a `javascript:` / `data:` href
+ * never reaches the database verbatim, regardless of who reads it later.
+ *
+ * The allow-list is a conservative rich-text set (block/inline formatting,
+ * lists, links, headings, blockquote, code). HTMLPurifier drops every tag and
+ * attribute outside the list — so `<script>`, `<style>`, `<iframe>` and all
+ * `on*` event handlers are stripped, and `URI.AllowedSchemes` constrains
+ * `<a href>` to http/https/mailto, blocking `javascript:`/`data:` URIs.
+ */
+final class HtmlSanitizer
+{
+    /**
+     * Conservative rich-text allow-list. `*[id]` is intentionally absent —
+     * stable ids on user content are not needed and invite DOM-clobbering.
+     */
+    private const string ALLOWED_HTML =
+        'p,br,strong,b,em,i,u,s,sub,sup,'
+        .'ul,ol,li,'
+        .'a[href|title|target|rel],'
+        .'h1,h2,h3,h4,h5,h6,'
+        .'blockquote,pre,code,hr,'
+        .'table,thead,tbody,tr,th,td';
+
+    /**
+     * Schemes permitted in `<a href>`. `javascript` and `data` are absent by
+     * design — they are the wysiwyg stored-XSS vectors flagged by AUD-033.
+     */
+    private const string ALLOWED_URI_SCHEMES = 'http,https,mailto';
+
+    private ?HTMLPurifier $purifier = null;
+
+    /**
+     * Sanitise a wysiwyg HTML string, returning the cleaned markup. A
+     * non-string is returned unchanged — the per-type validator
+     * ({@see Validation\TypeValidator\WysiwygValidator})
+     * is what rejects a non-string wysiwyg value; this method only mutates
+     * the HTML it is given.
+     */
+    public function sanitize(string $html): string
+    {
+        if ('' === $html) {
+            return '';
+        }
+
+        return $this->purifier()->purify($html);
+    }
+
+    private function purifier(): HTMLPurifier
+    {
+        if (null !== $this->purifier) {
+            return $this->purifier;
+        }
+
+        $config = HTMLPurifier_Config::createDefault();
+        $config->set('HTML.Allowed', self::ALLOWED_HTML);
+        $config->set('URI.AllowedSchemes', array_fill_keys(
+            explode(',', self::ALLOWED_URI_SCHEMES),
+            true,
+        ));
+        // Keep external links safe + crawler-neutral without relying on the
+        // reader to add it: rel="noopener noreferrer nofollow" on every <a>.
+        $config->set('HTML.TargetBlank', false);
+        $config->set('Attr.AllowedRel', ['noopener', 'noreferrer', 'nofollow']);
+        $config->set('HTML.Nofollow', true);
+        // FrankenPHP worker mode + read-only-friendly: no serialiser cache on
+        // disk. The definition is cheap to rebuild and the instance is reused
+        // for the lifetime of the worker, so the perf hit is negligible.
+        $config->set('Cache.DefinitionImpl', null);
+
+        return $this->purifier = new HTMLPurifier($config);
+    }
+}

--- a/apps/api/src/Catalog/Application/ValueWriteCore.php
+++ b/apps/api/src/Catalog/Application/ValueWriteCore.php
@@ -58,6 +58,7 @@ final readonly class ValueWriteCore
     public function __construct(
         private AttributeValueValidator $valueValidator,
         private IdentifierUniquenessValidator $identifierUniqueness,
+        private HtmlSanitizer $htmlSanitizer,
     ) {
     }
 
@@ -272,6 +273,13 @@ final readonly class ValueWriteCore
             AttributeType::Multiselect => \is_array($value) ? ['option_codes' => array_values($value)] + $rest : $envelope,
             AttributeType::Price => \is_int($value) || \is_float($value) || (\is_string($value) && is_numeric($value))
                 ? ['amount' => \is_string($value) ? (float) $value : $value] + $rest
+                : $envelope,
+            // AUD-033 / W2-2 (C-4) — neutralise stored-XSS in wysiwyg HTML on
+            // the write path (defense-in-depth, independent of frontend
+            // DOMPurify). A non-string value is left for WysiwygValidator to
+            // reject; only an actual HTML string is sanitised + re-stored.
+            AttributeType::Wysiwyg => \is_string($value)
+                ? ['value' => $this->htmlSanitizer->sanitize($value)] + $rest
                 : $envelope,
             default => $envelope,
         };

--- a/apps/api/tests/Unit/Catalog/Application/HtmlSanitizerTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/HtmlSanitizerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application;
+
+use App\Catalog\Application\HtmlSanitizer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AUD-033 / W2-2 (C-4) — server-side wysiwyg HTML sanitisation.
+ *
+ * Stored-XSS payloads must be neutralised at the source: `<script>`,
+ * `on*` event handlers, `<style>`/`<iframe>`, and `javascript:`/`data:`
+ * hrefs are stripped, while a conservative rich-text set survives intact
+ * so legitimate product copy is not destroyed.
+ */
+final class HtmlSanitizerTest extends TestCase
+{
+    private HtmlSanitizer $sanitizer;
+
+    protected function setUp(): void
+    {
+        $this->sanitizer = new HtmlSanitizer();
+    }
+
+    #[Test]
+    public function stripsScriptTag(): void
+    {
+        $out = $this->sanitizer->sanitize('<p>ok</p><script>alert(1)</script>');
+
+        self::assertStringNotContainsStringIgnoringCase('<script', $out);
+        self::assertStringNotContainsString('alert(1)', $out);
+        self::assertStringContainsString('<p>ok</p>', $out);
+    }
+
+    #[Test]
+    public function stripsEventHandlerAttribute(): void
+    {
+        $out = $this->sanitizer->sanitize('<img src=x onerror=alert(1)>');
+
+        self::assertStringNotContainsStringIgnoringCase('onerror', $out);
+        self::assertStringNotContainsString('alert(1)', $out);
+    }
+
+    #[Test]
+    public function stripsStyleAndIframe(): void
+    {
+        $out = $this->sanitizer->sanitize(
+            '<style>body{display:none}</style><iframe src="https://evil.test"></iframe><p>keep</p>',
+        );
+
+        self::assertStringNotContainsStringIgnoringCase('<style', $out);
+        self::assertStringNotContainsStringIgnoringCase('<iframe', $out);
+        self::assertStringContainsString('<p>keep</p>', $out);
+    }
+
+    #[Test]
+    public function removesJavascriptSchemeHref(): void
+    {
+        $out = $this->sanitizer->sanitize('<a href="javascript:alert(1)">click</a>');
+
+        self::assertStringNotContainsStringIgnoringCase('javascript:', $out);
+        // The link text is preserved even though the dangerous href is dropped.
+        self::assertStringContainsString('click', $out);
+    }
+
+    #[Test]
+    public function removesDataSchemeHref(): void
+    {
+        $out = $this->sanitizer->sanitize(
+            '<a href="data:text/html,<script>alert(1)</script>">x</a>',
+        );
+
+        self::assertStringNotContainsStringIgnoringCase('data:text/html', $out);
+        self::assertStringNotContainsString('alert(1)', $out);
+    }
+
+    #[Test]
+    public function preservesSafeRichText(): void
+    {
+        $out = $this->sanitizer->sanitize('<p><strong>ok</strong></p>');
+
+        self::assertSame('<p><strong>ok</strong></p>', $out);
+    }
+
+    #[Test]
+    public function preservesHttpsLink(): void
+    {
+        $out = $this->sanitizer->sanitize('<a href="https://example.com">link</a>');
+
+        self::assertStringContainsString('href="https://example.com"', $out);
+        self::assertStringContainsString('link', $out);
+    }
+
+    #[Test]
+    public function preservesListsAndHeadings(): void
+    {
+        $html = '<h2>Tytuł</h2><ul><li>jeden</li><li>dwa</li></ul>';
+        $out = $this->sanitizer->sanitize($html);
+
+        self::assertStringContainsString('<h2>Tytuł</h2>', $out);
+        self::assertStringContainsString('<li>jeden</li>', $out);
+        self::assertStringContainsString('<li>dwa</li>', $out);
+    }
+
+    #[Test]
+    public function emptyStringStaysEmpty(): void
+    {
+        self::assertSame('', $this->sanitizer->sanitize(''));
+    }
+}

--- a/apps/api/tests/Unit/Catalog/Application/ValueWriteCoreFormatViolationsTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/ValueWriteCoreFormatViolationsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Catalog\Application;
 
+use App\Catalog\Application\HtmlSanitizer;
 use App\Catalog\Application\Validation\AttributeValueValidator;
 use App\Catalog\Application\ValueWriteCore;
 use App\Catalog\Domain\AttributeType;
@@ -32,11 +33,14 @@ final class ValueWriteCoreFormatViolationsTest extends TestCase
 {
     private function core(): ValueWriteCore
     {
-        $core = new ReflectionClass(ValueWriteCore::class)->newInstanceWithoutConstructor();
-        $property = new ReflectionClass(ValueWriteCore::class)->getProperty('valueValidator');
+        $reflection = new ReflectionClass(ValueWriteCore::class);
+        $core = $reflection->newInstanceWithoutConstructor();
         // Bare default() — no option repository, so select/multiselect check
         // shape only (option membership needs the DB and is covered in Api tests).
-        $property->setValue($core, AttributeValueValidator::default());
+        $reflection->getProperty('valueValidator')->setValue($core, AttributeValueValidator::default());
+        // AUD-033 — normalise() sanitises wysiwyg HTML, so the collaborator
+        // must be present for the wysiwyg cases below.
+        $reflection->getProperty('htmlSanitizer')->setValue($core, new HtmlSanitizer());
 
         return $core;
     }

--- a/apps/api/tests/Unit/Catalog/Application/ValueWriteCoreWysiwygSanitizationTest.php
+++ b/apps/api/tests/Unit/Catalog/Application/ValueWriteCoreWysiwygSanitizationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog\Application;
+
+use App\Catalog\Application\HtmlSanitizer;
+use App\Catalog\Application\ValueWriteCore;
+use App\Catalog\Domain\AttributeType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * AUD-033 / W2-2 (C-4) — the wysiwyg HTML must be sanitised on the WRITE
+ * path, inside the single shared {@see ValueWriteCore::normalise()} both
+ * the admin ({@see \App\Catalog\Application\ObjectAttributesUpserter}) and
+ * the import ({@see \App\Catalog\Application\BatchValueWriter}) flow through.
+ *
+ * Before the fix a `<script>` / `onerror=` / `javascript:` href landed in
+ * `object_values.value` verbatim (proven empirically in the audit's C-3/C-4);
+ * after it the stored envelope carries the cleaned markup, independent of
+ * whatever the frontend DOMPurify does at render time. The sanitizer is the
+ * collaborator added reflectively (same pattern as the valueValidator in the
+ * sibling ValueWriteCore tests), so the DI-heavy readonly constructor stays
+ * out of the unit test.
+ */
+final class ValueWriteCoreWysiwygSanitizationTest extends TestCase
+{
+    private function core(): ValueWriteCore
+    {
+        $core = new ReflectionClass(ValueWriteCore::class)->newInstanceWithoutConstructor();
+        new ReflectionClass(ValueWriteCore::class)
+            ->getProperty('htmlSanitizer')
+            ->setValue($core, new HtmlSanitizer());
+
+        return $core;
+    }
+
+    #[Test]
+    public function normaliseStripsScriptFromWysiwyg(): void
+    {
+        $envelope = $this->core()->normalise(AttributeType::Wysiwyg, [
+            'value' => '<p>ok</p><script>alert(1)</script>',
+        ]);
+
+        self::assertIsString($envelope['value']);
+        self::assertStringNotContainsStringIgnoringCase('<script', $envelope['value']);
+        self::assertStringNotContainsString('alert(1)', $envelope['value']);
+        self::assertStringContainsString('<p>ok</p>', $envelope['value']);
+    }
+
+    #[Test]
+    public function normaliseStripsEventHandlerFromWysiwyg(): void
+    {
+        $envelope = $this->core()->normalise(AttributeType::Wysiwyg, [
+            'value' => '<img src=x onerror=alert(1)>',
+        ]);
+
+        self::assertIsString($envelope['value']);
+        self::assertStringNotContainsStringIgnoringCase('onerror', $envelope['value']);
+        self::assertStringNotContainsString('alert(1)', $envelope['value']);
+    }
+
+    #[Test]
+    public function normaliseRemovesJavascriptHrefFromWysiwyg(): void
+    {
+        $envelope = $this->core()->normalise(AttributeType::Wysiwyg, [
+            'value' => '<a href="javascript:alert(1)">click</a>',
+        ]);
+
+        self::assertIsString($envelope['value']);
+        self::assertStringNotContainsStringIgnoringCase('javascript:', $envelope['value']);
+    }
+
+    #[Test]
+    public function normaliseRemovesDataHrefFromWysiwyg(): void
+    {
+        $envelope = $this->core()->normalise(AttributeType::Wysiwyg, [
+            'value' => '<a href="data:text/html,<script>alert(1)</script>">x</a>',
+        ]);
+
+        self::assertIsString($envelope['value']);
+        self::assertStringNotContainsStringIgnoringCase('data:text/html', $envelope['value']);
+        self::assertStringNotContainsString('alert(1)', $envelope['value']);
+    }
+
+    #[Test]
+    public function normalisePreservesLegitimateRichText(): void
+    {
+        $envelope = $this->core()->normalise(AttributeType::Wysiwyg, [
+            'value' => '<p><strong>ok</strong></p>',
+        ]);
+
+        self::assertSame(['value' => '<p><strong>ok</strong></p>'], $envelope);
+    }
+
+    #[Test]
+    public function normalisePreservesHttpsLinkInWysiwyg(): void
+    {
+        $envelope = $this->core()->normalise(AttributeType::Wysiwyg, [
+            'value' => '<a href="https://example.com">link</a>',
+        ]);
+
+        self::assertIsString($envelope['value']);
+        self::assertStringContainsString('href="https://example.com"', $envelope['value']);
+    }
+
+    #[Test]
+    public function normaliseLeavesNonWysiwygUntouched(): void
+    {
+        // A text attribute must NOT be HTML-sanitised — its `<` is data, and the
+        // additionalProperties/format check (AUD-032) is what guards it.
+        $envelope = $this->core()->normalise(AttributeType::Text, [
+            'value' => 'a < b && c > d',
+        ]);
+
+        self::assertSame(['value' => 'a < b && c > d'], $envelope);
+    }
+}


### PR DESCRIPTION
> Audyt fix-plan **W2-2** (Wave 2). Closes #1594 (AUD-033).

## Problem (confirmed, stored-XSS defense-in-depth)
`WysiwygValidator` walidował tylko `is_string`+`max_length` → surowy HTML (`<img onerror>`, `<script>`, `javascript:`/`data:` href) zapisywany verbatim do `object_values.value`. XSS broniony WYŁĄCZNIE frontendowym DOMPurify — każdy przyszły/niezaudytowany konsument (storefront/raport/email/eksport HTML) renderujący wartość → stored-XSS.

## Naprawa
- **`HtmlSanitizer`** (HTMLPurifier **4.19.0**): allow-list bezpiecznych tagów (p/br/strong/em/ul/ol/li/a[href]/h1-h6/blockquote/code/table…); usuwa `<script>`/`<style>`/`<iframe>`/`<img>`/event-handlery; **`URI.AllowedSchemes={http,https,mailto}`** blokuje `javascript:`/`data:` href; `rel=nofollow`; bez disk-cache (FrankenPHP-safe).
- Wpięty w **`ValueWriteCore::canonicalise`** (gałąź wysiwyg) — JEDEN współdzielony punkt mutacji obu write-paths (admin `ObjectAttributesUpserter` + import `BatchValueWriter`). Mutuje `{value:<html>}`→`{value:<sanitized>}` (defense-in-depth, nie tylko reject).

## Reguła naprawy — failing test FIRST
RED: `ValueWriteCoreWysiwygSanitizationTest` (7) ERROR (sanitizer niewpięty) → GREEN po wiringu + `HtmlSanitizerTest` (9). Malicious sanityzowany (`<script>`/`onerror`/`javascript:`/`data:` usunięte), legalny zachowany (`<p><strong>`, `https://` href, listy/nagłówki).

## Bramki
Catalog unit **440** + Api (Golden round-trip, AttributeValueValidation) zielone · **composer audit** clean (HTMLPurifier bez CVE) · PHPStan **No errors** · cs-fixer 0 · Deptrac **0** (HtmlSanitizer w Catalog_Internals). Smoke: PATCH wysiwyg z `<img onerror>`/`<script>`/`javascript:` → 200, w bazie oczyszczony HTML + https zachowane (po `restart api worker` — worker trzymał stary kod).
