### PR TITLE
AUD-039: detect + reconcile attributes_indexed drift (W2-4)

### DIFF
--- a/apps/api/src/Catalog/Application/Handler/AttributesIndexedRebuildFailedException.php
+++ b/apps/api/src/Catalog/Application/Handler/AttributesIndexedRebuildFailedException.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Handler;
+
+use RuntimeException;
+
+/**
+ * AUD-039 / G-01 — raised by {@see RebuildAttributesIndexedHandler} when one
+ * or more objects could not have their `attributes_indexed` cache rebuilt
+ * after exhausting the per-id version-conflict retries.
+ *
+ * Before this, the handler logged a Warning and returned normally, so the
+ * Messenger envelope completed "successfully" and the drift was invisible:
+ * no `failed` transport entry, no retry. Throwing instead lets the async
+ * transport's retry policy re-deliver the batch (the rebuild is idempotent,
+ * so already-rebuilt ids are cheap no-ops) and, once those are exhausted,
+ * dead-letters the envelope to the `failed` transport where
+ * {@see \App\Catalog\Infrastructure\Messenger\AttributesIndexedRebuildDeadLetterListener}
+ * logs it at error level. Drift becomes loud, never silent.
+ */
+final class AttributesIndexedRebuildFailedException extends RuntimeException
+{
+    /**
+     * @param list<string> $objectIds the ids that could not be rebuilt
+     */
+    public function __construct(public readonly array $objectIds)
+    {
+        parent::__construct(\sprintf(
+            'attributes_indexed rebuild failed for %d object(s) after exhausting version-conflict retries: %s',
+            \count($objectIds),
+            implode(', ', $objectIds),
+        ));
+    }
+}

--- a/apps/api/src/Catalog/Application/Handler/RebuildAttributesIndexedHandler.php
+++ b/apps/api/src/Catalog/Application/Handler/RebuildAttributesIndexedHandler.php
@@ -59,20 +59,46 @@ final class RebuildAttributesIndexedHandler extends AbstractBatchHandler
     {
         // IMP2-2.9 (#1485) — rebuild + flush PER ID so a concurrent edit (UI bump
         // of objects.version between find and flush) only affects the conflicting
-        // object: it is retried with a fresh read, and after exhausting retries it
-        // is logged + skipped — instead of an OptimisticLockException dead-lettering
-        // the whole batch (including the objects already rebuilt). The skipped
-        // object's next ObjectValuesChanged event re-queues it.
+        // object: it is retried with a fresh read, instead of an
+        // OptimisticLockException dead-lettering the whole batch (including the
+        // objects already rebuilt).
+        //
+        // AUD-039 / G-01 — an object that exhausts its retries is NO LONGER
+        // silently skipped: it is collected, the rest of the batch is finished
+        // (the rebuild is idempotent, so a re-delivery re-runs the survivors as
+        // cheap no-ops), and the handler throws at the end. The async retry
+        // policy re-delivers the batch and, once exhausted, dead-letters it to
+        // the `failed` transport — making drift loud instead of hiding it behind
+        // a "successful" message.
+        $reindexable = [];
+        $failedIds = [];
         foreach ($message->objectIds as $idString) {
-            $this->rebuildOneWithRetry(Uuid::fromString($idString), $idString);
+            if ($this->rebuildOneWithRetry(Uuid::fromString($idString), $idString)) {
+                $reindexable[] = $idString;
+            } else {
+                $failedIds[] = $idString;
+            }
         }
 
-        // IMP2-2.6 — attributes_indexed is rebuilt + committed; reindex the batch
-        // in Meilisearch (reads the fresh attributes_indexed).
-        $this->reindexQueue->queueAll($message->objectIds);
+        // IMP2-2.6 — attributes_indexed is rebuilt + committed for the survivors;
+        // reindex them in Meilisearch (reads the fresh attributes_indexed). Skip
+        // the failed ids — their cache is stale and the re-delivery will reindex
+        // them once rebuilt.
+        if ([] !== $reindexable) {
+            $this->reindexQueue->queueAll($reindexable);
+        }
+
+        if ([] !== $failedIds) {
+            $this->logger->error(
+                'attributes_indexed rebuild failed for {count} object(s) after exhausting version conflicts',
+                ['object_ids' => $failedIds, 'count' => \count($failedIds)],
+            );
+
+            throw new AttributesIndexedRebuildFailedException($failedIds);
+        }
     }
 
-    private function rebuildOneWithRetry(Uuid $id, string $idString): void
+    private function rebuildOneWithRetry(Uuid $id, string $idString): bool
     {
         for ($attempt = 1; $attempt <= self::MAX_REBUILD_RETRIES; ++$attempt) {
             // Pull the manager fresh each attempt: a prior conflict reset it
@@ -82,7 +108,9 @@ final class RebuildAttributesIndexedHandler extends AbstractBatchHandler
 
             $object = $em->find(CatalogObject::class, $id);
             if (!$object instanceof CatalogObject) {
-                return;
+                // Object was deleted between the change event and this rebuild —
+                // nothing to rebuild, nothing drifted; treat as a clean success.
+                return true;
             }
 
             try {
@@ -90,7 +118,7 @@ final class RebuildAttributesIndexedHandler extends AbstractBatchHandler
                 $em->flush();
                 $em->clear();
 
-                return;
+                return true;
             } catch (OptimisticLockException) {
                 // A concurrent edit bumped objects.version between find and
                 // flush. Doctrine's UnitOfWork::commit closes the EM on a failed
@@ -102,14 +130,13 @@ final class RebuildAttributesIndexedHandler extends AbstractBatchHandler
                 $this->managerRegistry->resetManager();
 
                 if ($attempt >= self::MAX_REBUILD_RETRIES) {
-                    $this->logger->warning(
-                        'attributes_indexed rebuild skipped after {attempts} version conflicts',
-                        ['object_id' => $idString, 'attempts' => $attempt],
-                    );
-
-                    return;
+                    // AUD-039 — exhausted: report failure to the caller so the
+                    // batch can be dead-lettered. No more silent return.
+                    return false;
                 }
             }
         }
+
+        return false;
     }
 }

--- a/apps/api/src/Catalog/Infrastructure/Messenger/AttributesIndexedRebuildDeadLetterListener.php
+++ b/apps/api/src/Catalog/Infrastructure/Messenger/AttributesIndexedRebuildDeadLetterListener.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Infrastructure\Messenger;
+
+use App\Catalog\Application\Message\ObjectValuesChangedMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+
+/**
+ * AUD-039 / G-01 — dead-letter guard for the async attributes_indexed rebuild.
+ *
+ * When a {@see ObjectValuesChangedMessage} exhausts the async transport's
+ * retries (the per-id rebuild kept hitting version conflicts, see
+ * {@see \App\Catalog\Application\Handler\RebuildAttributesIndexedHandler}), the
+ * envelope lands in the `failed` transport. Previously the handler swallowed
+ * that case with a Warning + a "successful" return, so the cache drifted from
+ * `object_values` with no trace. This listener logs the final failure at error
+ * level with the affected object ids, so the drift is visible in logs /
+ * alerting and `pim:catalog:detect-attributes-drift --reconcile` can repair it.
+ *
+ * Mirrors {@see \App\Import\Infrastructure\Messenger\ImportRunDeadLetterListener}:
+ * fires only on the FINAL failure (`willRetry() === false`) so retriable
+ * failures are left to the long-backoff retry policy.
+ */
+#[AsEventListener(event: WorkerMessageFailedEvent::class)]
+final readonly class AttributesIndexedRebuildDeadLetterListener
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    public function __invoke(WorkerMessageFailedEvent $event): void
+    {
+        if ($event->willRetry()) {
+            return;
+        }
+
+        $message = $event->getEnvelope()->getMessage();
+        if (!$message instanceof ObjectValuesChangedMessage) {
+            return;
+        }
+
+        $this->logger->error(
+            'attributes_indexed rebuild dead-lettered after exhausting retries — '
+            .'cache may drift from object_values; run pim:catalog:detect-attributes-drift --reconcile',
+            [
+                'object_ids' => $message->objectIds,
+                'count' => \count($message->objectIds),
+                'exception' => $event->getThrowable()->getMessage(),
+            ],
+        );
+    }
+}

--- a/apps/api/src/Catalog/Presentation/Command/DetectAttributesDriftCommand.php
+++ b/apps/api/src/Catalog/Presentation/Command/DetectAttributesDriftCommand.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Presentation\Command;
+
+use App\Catalog\Application\AttributesIndexedRebuilder;
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * AUD-039 / G-01 — detect (and optionally reconcile) drift between the
+ * denormalised `objects.attributes_indexed` cache and the canonical
+ * `object_values` rows.
+ *
+ * The cache holds only the GLOBAL reading (locale=null, channel=null) keyed
+ * by `Attribute.code`, copied verbatim from `ObjectValue.value`
+ * ({@see AttributesIndexedRebuilder}). Drift is therefore measured against
+ * the same global slice the rebuilder writes:
+ *   - ORPHANED   — a code in the cache with no global ObjectValue row.
+ *   - MISSING    — a global ObjectValue row whose code is absent from the cache.
+ *   - MISMATCHED — a code in both whose JSONB value differs.
+ *
+ * `RebuildAttributesIndexedHandler` used to silently skip an object after
+ * exhausting its version-conflict retries, and the only reconciliation was the
+ * completeness backfill (which never reports drift). This command closes that
+ * gap: it is exit-code aware (non-zero on drift, in detect mode) so CI / cron
+ * fails loudly, and `--reconcile` reuses {@see AttributesIndexedRebuilder} to
+ * rewrite the cache from the canon — never touching `object_values`.
+ *
+ * Tenant scoping: FORCE RLS hides every `objects` / `object_values` row from
+ * the application role until the `app.current_tenant` GUC is set, so the scan
+ * runs per tenant — it binds {@see TenantContext} (TenantFilter) AND the
+ * Postgres GUC (RLS), exactly like {@see \App\Shared\Infrastructure\Messenger\TenantRlsGucMiddleware}
+ * does for workers. Omit `--tenant` to sweep every tenant (cron-friendly).
+ *
+ * Memory shape mirrors {@see RecalculateCompletenessCommand}: Doctrine
+ * `toIterable()` + `EntityManager::clear()` every {@see self::FLUSH_EVERY}
+ * rows so a 50k-SKU scan keeps the FrankenPHP worker peak bounded.
+ */
+#[AsCommand(
+    name: 'pim:catalog:detect-attributes-drift',
+    description: 'Detect (and with --reconcile fix) drift between attributes_indexed cache and canonical object_values.',
+)]
+final class DetectAttributesDriftCommand extends Command
+{
+    private const int FLUSH_EVERY = 200;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly Connection $connection,
+        private readonly AttributesIndexedRebuilder $rebuilder,
+        private readonly BulkContext $bulkContext,
+        private readonly TenantContext $tenantContext,
+        private readonly TenantRepositoryInterface $tenants,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'tenant',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Tenant code to scope the scan. Omit to scan every tenant.',
+            )
+            ->addOption(
+                'kind',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'ObjectKind code (`product`, `category`, `asset`, `brand`) or `all`.',
+                'all',
+            )
+            ->addOption(
+                'reconcile',
+                null,
+                InputOption::VALUE_NONE,
+                'Rewrite attributes_indexed from object_values for every drifted object. Only the cache is touched.',
+            )
+            ->addOption(
+                'limit',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Max number of drifted objects to list per kind in the report (the count is always exact).',
+                '50',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var string|null $tenantCode */
+        $tenantCode = $input->getOption('tenant');
+        if (null !== $tenantCode && '' === $tenantCode) {
+            $io->error('--tenant must be a non-empty string when provided.');
+
+            return Command::INVALID;
+        }
+
+        /** @var string $kindOption */
+        $kindOption = $input->getOption('kind');
+        $kinds = 'all' === $kindOption
+            ? [ObjectKind::Product, ObjectKind::Category, ObjectKind::Asset]
+            : [ObjectKind::from($kindOption)];
+
+        /** @var bool $reconcile */
+        $reconcile = $input->getOption('reconcile');
+        /** @var string $limitOption */
+        $limitOption = $input->getOption('limit');
+        $listLimit = max(0, (int) $limitOption);
+
+        $tenants = $this->resolveTenants($tenantCode);
+        if (null === $tenants) {
+            $io->error(\sprintf('Tenant "%s" not found.', (string) $tenantCode));
+
+            return Command::FAILURE;
+        }
+
+        // Bulk path: silence the synchronous AttributesIndexedSyncListener so a
+        // --reconcile flush does not recurse into a per-object rebuild.
+        $this->bulkContext->setBulk(true);
+
+        $totalScanned = 0;
+        $totalDrifted = 0;
+        $totalReconciled = 0;
+
+        try {
+            foreach ($tenants as $tenant) {
+                $this->bindTenant($tenant);
+                try {
+                    foreach ($kinds as $kind) {
+                        $io->section(\sprintf('tenant=%s, kind=%s', $tenant->getCode(), $kind->value));
+
+                        $report = $this->scanKind($kind, $reconcile, $listLimit);
+
+                        $totalScanned += $report['scanned'];
+                        $totalDrifted += $report['drifted'];
+                        $totalReconciled += $report['reconciled'];
+
+                        $io->writeln(\sprintf(
+                            '  scanned=%d, drifted=%d%s',
+                            $report['scanned'],
+                            $report['drifted'],
+                            $reconcile ? \sprintf(', reconciled=%d', $report['reconciled']) : '',
+                        ));
+
+                        foreach ($report['samples'] as $line) {
+                            $io->writeln('    '.$line);
+                        }
+                        if ($report['drifted'] > \count($report['samples'])) {
+                            $io->writeln(\sprintf(
+                                '    … and %d more (raise --limit to list).',
+                                $report['drifted'] - \count($report['samples']),
+                            ));
+                        }
+                    }
+                } finally {
+                    $this->unbindTenant();
+                }
+            }
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+
+        if (0 === $totalDrifted) {
+            $io->success(\sprintf('No drift. %d object(s) scanned.', $totalScanned));
+
+            return Command::SUCCESS;
+        }
+
+        if ($reconcile) {
+            // After a reconcile the cache is back in sync; report success so a
+            // cron `--reconcile` run does not page on self-healed drift.
+            $io->success(\sprintf(
+                '%d drifted object(s) of %d scanned reconciled — cache rewritten from object_values.',
+                $totalReconciled,
+                $totalScanned,
+            ));
+
+            return Command::SUCCESS;
+        }
+
+        $io->warning(\sprintf(
+            '%d drifted object(s) of %d scanned. Re-run with --reconcile to rewrite the cache.',
+            $totalDrifted,
+            $totalScanned,
+        ));
+
+        return Command::FAILURE;
+    }
+
+    /**
+     * @return list<Tenant>|null null when an explicit --tenant code does not resolve
+     */
+    private function resolveTenants(?string $tenantCode): ?array
+    {
+        if (null !== $tenantCode) {
+            $tenant = $this->tenants->findByCode($tenantCode);
+
+            return $tenant instanceof Tenant ? [$tenant] : null;
+        }
+
+        return $this->tenants->findAllOrderedByCode();
+    }
+
+    /**
+     * Bind the tenant on BOTH isolation layers so the scan sees the tenant's
+     * rows: the PHP-side {@see TenantContext} (TenantFilter) and the Postgres
+     * `app.current_tenant` GUC (FORCE RLS). Mirrors TenantRlsGucMiddleware.
+     */
+    private function bindTenant(Tenant $tenant): void
+    {
+        $this->tenantContext->set($tenant);
+        // tenant-safe: infrastructure (establishes the tenant_id RLS policies read in this CLI session; this IS the tenant boundary, not a bypass)
+        $this->connection->executeStatement(
+            "SELECT set_config('app.current_tenant', :tenant_id, false)",
+            ['tenant_id' => $tenant->getId()->toRfc4122()],
+        );
+        // tenant-safe: infrastructure (the maintenance CLI never runs as super-admin)
+        $this->connection->executeStatement("SELECT set_config('app.is_super_admin', 'false', false)");
+    }
+
+    private function unbindTenant(): void
+    {
+        $this->tenantContext->clear();
+        // tenant-safe: infrastructure (resets the RLS tenant marker so the next tenant in the sweep starts clean)
+        $this->connection->executeStatement("SELECT set_config('app.current_tenant', '', false)");
+    }
+
+    /**
+     * @return array{scanned: int, drifted: int, reconciled: int, samples: list<string>}
+     */
+    private function scanKind(ObjectKind $kind, bool $reconcile, int $listLimit): array
+    {
+        $query = $this->em->createQuery(
+            'SELECT o FROM '.CatalogObject::class.' o WHERE o.kind = :kind',
+        );
+        $query->setParameter('kind', $kind->value);
+
+        $scanned = 0;
+        $drifted = 0;
+        $reconciled = 0;
+        $samples = [];
+
+        /** @var iterable<int, CatalogObject> $iterable */
+        $iterable = $query->toIterable();
+        foreach ($iterable as $object) {
+            ++$scanned;
+
+            $diff = $this->diffObject($object);
+            if ([] !== $diff['orphaned'] || [] !== $diff['missing'] || [] !== $diff['mismatched']) {
+                ++$drifted;
+                if (\count($samples) < $listLimit) {
+                    $samples[] = $this->formatDiff($object, $diff);
+                }
+                if ($reconcile) {
+                    // Reuse the canonical rebuilder — the SINGLE writer of the
+                    // cache (jsonb-schemas contract). Reads object_values, never
+                    // mutates them; only attributes_indexed + completeness change.
+                    $this->rebuilder->rebuild($object);
+                    ++$reconciled;
+                }
+            }
+
+            if (0 === $scanned % self::FLUSH_EVERY) {
+                if ($reconcile) {
+                    $this->em->flush();
+                }
+                $this->em->clear();
+            }
+        }
+
+        if ($reconcile) {
+            $this->em->flush();
+        }
+        $this->em->clear();
+
+        return [
+            'scanned' => $scanned,
+            'drifted' => $drifted,
+            'reconciled' => $reconciled,
+            'samples' => $samples,
+        ];
+    }
+
+    /**
+     * Compare the cache against the canonical GLOBAL reading the rebuilder
+     * would produce (locale=null + channel=null rows), keyed by attribute code.
+     *
+     * @return array{orphaned: list<string>, missing: list<string>, mismatched: list<string>}
+     */
+    private function diffObject(CatalogObject $object): array
+    {
+        $canon = $this->canonicalGlobalReading($object);
+        $cache = $object->getAttributesIndexed();
+
+        // Both maps are keyed by Attribute.code (a non-numeric identifier such
+        // as `sku` / `brand`), so keys stay string on both sides and direct
+        // array_key_exists comparisons are symmetric.
+        $orphaned = [];
+        $mismatched = [];
+        foreach ($cache as $code => $cachedValue) {
+            if (!\array_key_exists($code, $canon)) {
+                $orphaned[] = $code;
+                continue;
+            }
+            if ($canon[$code] !== $cachedValue) {
+                $mismatched[] = $code;
+            }
+        }
+
+        $missing = [];
+        foreach ($canon as $code => $canonValue) {
+            if (!\array_key_exists($code, $cache)) {
+                $missing[] = $code;
+            }
+        }
+
+        sort($orphaned);
+        sort($missing);
+        sort($mismatched);
+
+        return ['orphaned' => $orphaned, 'missing' => $missing, 'mismatched' => $mismatched];
+    }
+
+    /**
+     * The GLOBAL slice of object_values, keyed by attribute code — the exact
+     * shape {@see AttributesIndexedRebuilder::rebuild()} writes into the cache.
+     *
+     * @return array<string, mixed>
+     */
+    private function canonicalGlobalReading(CatalogObject $object): array
+    {
+        /** @var list<ObjectValue> $values */
+        $values = $this->em->getRepository(ObjectValue::class)->findBy(['object' => $object]);
+
+        $canon = [];
+        foreach ($values as $value) {
+            if (null !== $value->getLocale() || null !== $value->getChannelId()) {
+                continue;
+            }
+            $canon[$value->getAttribute()->getCode()] = $value->getValue();
+        }
+
+        return $canon;
+    }
+
+    /**
+     * @param array{orphaned: list<string>, missing: list<string>, mismatched: list<string>} $diff
+     */
+    private function formatDiff(CatalogObject $object, array $diff): string
+    {
+        $parts = [];
+        if ([] !== $diff['orphaned']) {
+            $parts[] = 'orphaned='.implode(',', $diff['orphaned']);
+        }
+        if ([] !== $diff['missing']) {
+            $parts[] = 'missing='.implode(',', $diff['missing']);
+        }
+        if ([] !== $diff['mismatched']) {
+            $parts[] = 'mismatched='.implode(',', $diff['mismatched']);
+        }
+
+        return \sprintf('%s [%s]', $object->getCode(), implode(' ', $parts));
+    }
+}

--- a/apps/api/tests/Api/Catalog/DetectAttributesDriftCommandTest.php
+++ b/apps/api/tests/Api/Catalog/DetectAttributesDriftCommandTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\ObjectKind;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AUD-039 / G-01 — `pim:catalog:detect-attributes-drift` finds an
+ * `attributes_indexed` key with no canonical `object_values` row (the exact
+ * ACME-001/002/003 shape the audit probe found in dev: cache populated, zero
+ * global values), fails with a non-zero exit so CI / cron catches it, and
+ * `--reconcile` rewrites the cache from the canon so the next scan is clean.
+ *
+ * The orphaned key is planted with a raw `UPDATE` on `attributes_indexed`
+ * (bypassing the rebuilder) to reproduce drift without an actual ObjectValue —
+ * the same on-disk state the drift produces in production.
+ */
+final class DetectAttributesDriftCommandTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function detectsOrphanedCacheKeyThenReconcileClearsIt(): void
+    {
+        $client = $this->authenticatedClient();
+        $productOt = $this->objectTypeIdFor(ObjectKind::Product);
+
+        // A custom (non-system) attribute so its value lands in the GLOBAL cache
+        // — `name`/`sku` are read-overlay system attributes that never enter
+        // attributes_indexed, so they would not exercise the legit-key path.
+        $legitAttrId = $this->createTextAttribute($client, 'legit_attr');
+        $client->request('POST', '/api/object_types/'.$productOt.'/attributes/'.$legitAttrId);
+        self::assertResponseStatusCodeSame(204);
+
+        // A legitimate object: one real value → one canonical object_values row
+        // + one matching cache entry. This entry must SURVIVE the reconcile.
+        $response = $client->request('POST', '/api/products', [
+            'headers' => ['content-type' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => 'DRIFT-1',
+                'objectTypeId' => $productOt,
+                'attributes' => ['legit_attr' => 'Legit Value'],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $objectId = $response->toArray()['id'];
+        \assert(\is_string($objectId));
+
+        // Plant an orphaned cache key ("ghost") with no object_values backing —
+        // the canon ({name}) knows nothing about it. Take the real cache (keeps
+        // the genuine `name` envelope), add the ghost, write it back verbatim as
+        // a JSON object. Raw UPDATE so the sync listener does not rebuild it away;
+        // a full-object write also sidesteps `jsonb_set` choking on the empty
+        // `[]` Doctrine serialises for a value-less map.
+        $conn = $this->connection();
+        $current = $conn->fetchOne('SELECT attributes_indexed FROM objects WHERE id = :id', ['id' => $objectId]);
+        \assert(\is_string($current));
+        /** @var array<string, mixed> $cache */
+        $cache = json_decode($current, true, 512, JSON_THROW_ON_ERROR);
+        $cache['ghost'] = ['value' => 'orphan'];
+        $conn->executeStatement(
+            'UPDATE objects SET attributes_indexed = CAST(:cache AS jsonb) WHERE id = :id',
+            ['cache' => json_encode($cache, JSON_THROW_ON_ERROR), 'id' => $objectId],
+        );
+
+        // Sanity: the orphan really is on disk now.
+        $cacheBefore = $this->cacheKeys($conn, $objectId);
+        self::assertContains('ghost', $cacheBefore, 'orphan must be planted before detect');
+        self::assertContains('legit_attr', $cacheBefore, 'the legit key must coexist');
+
+        // detect (no reconcile): non-zero exit, the object + orphaned key listed.
+        $tester = $this->commandTester();
+        $exitCode = $tester->execute(['--tenant' => self::TENANT_CODE, '--kind' => 'product']);
+        self::assertSame(Command::FAILURE, $exitCode, $tester->getDisplay());
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('drifted=1', $display);
+        self::assertStringContainsString('DRIFT-1', $display);
+        self::assertStringContainsString('orphaned=ghost', $display);
+
+        // detect did not mutate anything.
+        self::assertContains('ghost', $this->cacheKeys($conn, $objectId), 'detect must be read-only');
+
+        // detect --reconcile: success, orphan removed, legit key kept.
+        $tester = $this->commandTester();
+        $exitCode = $tester->execute([
+            '--tenant' => self::TENANT_CODE,
+            '--kind' => 'product',
+            '--reconcile' => true,
+        ]);
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('reconciled=1', $tester->getDisplay());
+
+        $cacheAfter = $this->cacheKeys($conn, $objectId);
+        self::assertNotContains('ghost', $cacheAfter, 'reconcile must drop the orphaned key');
+        self::assertContains('legit_attr', $cacheAfter, 'reconcile must keep the canonical value');
+
+        // The canon was never touched: still exactly one object_values row.
+        $valueCount = $conn->fetchOne(
+            'SELECT COUNT(*) FROM object_values WHERE object_id = :id',
+            ['id' => $objectId],
+        );
+        self::assertSame(
+            1,
+            (int) (\is_scalar($valueCount) ? $valueCount : 0),
+            'reconcile must not delete or add object_values rows',
+        );
+
+        // Re-scan: drift is gone, clean exit.
+        $tester = $this->commandTester();
+        $exitCode = $tester->execute(['--tenant' => self::TENANT_CODE, '--kind' => 'product']);
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('No drift', $tester->getDisplay());
+    }
+
+    private function createTextAttribute(
+        \ApiPlatform\Symfony\Bundle\Test\Client $client,
+        string $code,
+    ): string {
+        $response = $client->request('POST', '/api/attributes', [
+            'headers' => ['content-type' => 'application/ld+json', 'accept' => 'application/ld+json'],
+            'body' => json_encode([
+                'code' => $code,
+                'type' => 'text',
+                'label' => ['pl' => $code, 'en' => $code],
+            ], JSON_THROW_ON_ERROR),
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $id = $response->toArray()['id'];
+        \assert(\is_string($id));
+
+        return $id;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function cacheKeys(Connection $conn, string $objectId): array
+    {
+        $raw = $conn->fetchOne(
+            'SELECT attributes_indexed FROM objects WHERE id = :id',
+            ['id' => $objectId],
+        );
+        \assert(\is_string($raw));
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+
+        return array_keys($decoded);
+    }
+
+    private function connection(): Connection
+    {
+        return $this->em()->getConnection();
+    }
+
+    private function commandTester(): CommandTester
+    {
+        $application = new Application(self::$kernel ?? self::bootKernel());
+
+        return new CommandTester($application->find('pim:catalog:detect-attributes-drift'));
+    }
+}

--- a/apps/api/tests/Api/Catalog/RebuildAttributesIndexedOptimisticRetryTest.php
+++ b/apps/api/tests/Api/Catalog/RebuildAttributesIndexedOptimisticRetryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Api\Catalog;
 
 use App\Catalog\Application\AttributesIndexedRebuilder;
+use App\Catalog\Application\Handler\AttributesIndexedRebuildFailedException;
 use App\Catalog\Application\Handler\RebuildAttributesIndexedHandler;
 use App\Catalog\Application\Message\ObjectValuesChangedMessage;
 use App\Catalog\Application\Reindex\BulkReindexQueueInterface;
@@ -92,11 +93,14 @@ final class RebuildAttributesIndexedOptimisticRetryTest extends CatalogApiTestCa
     }
 
     /**
-     * IMP2-2.9 (#1485) — when the conflict NEVER clears (a hot object edited on
-     * every retry), the handler must not retry forever or dead-letter the batch:
+     * AUD-039 / G-01 — when the conflict NEVER clears (a hot object edited on
+     * every retry), the handler must NOT swallow it with a "successful" return:
      * after {@see RebuildAttributesIndexedHandler::MAX_REBUILD_RETRIES} attempts
-     * it logs a Warning and skips that id, returning normally. The skipped
-     * object's next ObjectValuesChanged event re-queues it.
+     * on that id it logs an ERROR and throws
+     * {@see AttributesIndexedRebuildFailedException}. The async retry policy then
+     * re-delivers the batch and, once exhausted, dead-letters it to `failed`
+     * (handled by {@see AttributesIndexedRebuildDeadLetterListener}) — drift
+     * becomes loud instead of being hidden behind a Warning + success.
      *
      * Deterministic perpetual conflict: a `preFlush` listener bumps
      * `objects.version` on the EM's own connection right before EVERY flush, so
@@ -106,7 +110,7 @@ final class RebuildAttributesIndexedOptimisticRetryTest extends CatalogApiTestCa
      * the guard fails once more.
      */
     #[Test]
-    public function versionConflictExhaustedRetriesIsSkippedWithWarning(): void
+    public function versionConflictExhaustedRetriesThrowsAndLogsError(): void
     {
         $em = $this->em();
         $tenant = $em->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
@@ -146,12 +150,12 @@ final class RebuildAttributesIndexedOptimisticRetryTest extends CatalogApiTestCa
 
         $logger = new class extends AbstractLogger {
             /** @var list<array{level: mixed, message: string, context: array<mixed>}> */
-            public array $warnings = [];
+            public array $errors = [];
 
             public function log(mixed $level, string|Stringable $message, array $context = []): void
             {
-                if ('warning' === $level) {
-                    $this->warnings[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+                if ('error' === $level) {
+                    $this->errors[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
                 }
             }
         };
@@ -166,21 +170,30 @@ final class RebuildAttributesIndexedOptimisticRetryTest extends CatalogApiTestCa
             $logger,
         );
 
+        $caught = null;
         try {
-            // Must NOT throw — exhausting retries logs + skips, it never propagates.
+            // AUD-039 — exhausting retries must NOT return "successfully": it
+            // throws so the async transport re-delivers + eventually dead-letters.
             $handler(new ObjectValuesChangedMessage([$idString]));
+        } catch (AttributesIndexedRebuildFailedException $e) {
+            $caught = $e;
         } finally {
             // Detach the listener via a fresh manager so it cannot leak into the
             // teardown flush or sibling tests sharing this kernel boot.
             $registry->resetManager();
         }
 
-        self::assertCount(1, $logger->warnings, 'exactly one skip-warning after exhausting retries');
-        $warning = $logger->warnings[0];
-        self::assertStringContainsString('rebuild skipped', $warning['message']);
-        self::assertSame($idString, $warning['context']['object_id'] ?? null);
-        // RebuildAttributesIndexedHandler::MAX_REBUILD_RETRIES (private const) — the
-        // handler gives up after the 3rd failed attempt.
-        self::assertSame(3, $warning['context']['attempts'] ?? null, 'the warning reports it gave up after the max attempts');
+        self::assertInstanceOf(
+            AttributesIndexedRebuildFailedException::class,
+            $caught,
+            'exhausting retries must throw, not silently skip',
+        );
+        self::assertSame([$idString], $caught->objectIds, 'the exception carries the failed id');
+
+        self::assertCount(1, $logger->errors, 'exactly one error log after exhausting retries');
+        $error = $logger->errors[0];
+        self::assertStringContainsString('rebuild failed', $error['message']);
+        self::assertSame([$idString], $error['context']['object_ids'] ?? null);
+        self::assertSame(1, $error['context']['count'] ?? null);
     }
 }

--- a/apps/api/tests/Unit/Catalog/AttributesIndexedRebuildDeadLetterListenerTest.php
+++ b/apps/api/tests/Unit/Catalog/AttributesIndexedRebuildDeadLetterListenerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use App\Catalog\Application\Message\ObjectValuesChangedMessage;
+use App\Catalog\Infrastructure\Messenger\AttributesIndexedRebuildDeadLetterListener;
+use App\Import\Domain\Message\ImportRunMessage;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use RuntimeException;
+use Stringable;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-039 / G-01 — the dead-letter listener makes a drifted rebuild LOUD: it
+ * logs an error (with the affected ids) only on the FINAL failure of an
+ * {@see ObjectValuesChangedMessage}, leaving retriable failures and unrelated
+ * messages untouched.
+ */
+final class AttributesIndexedRebuildDeadLetterListenerTest extends TestCase
+{
+    #[Test]
+    public function logsErrorOnFinalFailureOfRebuildMessage(): void
+    {
+        $logger = $this->errorCollectingLogger();
+        $listener = new AttributesIndexedRebuildDeadLetterListener($logger);
+
+        $ids = [Uuid::v7()->toRfc4122(), Uuid::v7()->toRfc4122()];
+        $event = new WorkerMessageFailedEvent(
+            new Envelope(new ObjectValuesChangedMessage($ids)),
+            'async',
+            new RuntimeException('version conflict exhausted'),
+        );
+        // willRetry() defaults to false → this is the final failure.
+
+        $listener($event);
+
+        self::assertCount(1, $logger->errors);
+        self::assertSame($ids, $logger->errors[0]['context']['object_ids'] ?? null);
+        self::assertSame(2, $logger->errors[0]['context']['count'] ?? null);
+        self::assertStringContainsString('detect-attributes-drift', $logger->errors[0]['message']);
+    }
+
+    #[Test]
+    public function silentWhenMessageWillRetry(): void
+    {
+        $logger = $this->errorCollectingLogger();
+        $listener = new AttributesIndexedRebuildDeadLetterListener($logger);
+
+        $event = new WorkerMessageFailedEvent(
+            new Envelope(new ObjectValuesChangedMessage([Uuid::v7()->toRfc4122()])),
+            'async',
+            new RuntimeException('transient'),
+        );
+        $event->setForRetry();
+
+        $listener($event);
+
+        self::assertCount(0, $logger->errors, 'retriable failures must not be logged as dead-lettered');
+    }
+
+    #[Test]
+    public function ignoresUnrelatedMessages(): void
+    {
+        $logger = $this->errorCollectingLogger();
+        $listener = new AttributesIndexedRebuildDeadLetterListener($logger);
+
+        $event = new WorkerMessageFailedEvent(
+            new Envelope(new ImportRunMessage(Uuid::v7(), Uuid::v7())),
+            'import',
+            new RuntimeException('unrelated'),
+        );
+
+        $listener($event);
+
+        self::assertCount(0, $logger->errors, 'only ObjectValuesChangedMessage failures are handled here');
+    }
+
+    /**
+     * @return AbstractLogger&object{errors: list<array{message: string, context: array<mixed>}>}
+     */
+    private function errorCollectingLogger(): AbstractLogger
+    {
+        return new class extends AbstractLogger {
+            /** @var list<array{message: string, context: array<mixed>}> */
+            public array $errors = [];
+
+            public function log(mixed $level, string|Stringable $message, array $context = []): void
+            {
+                if ('error' === $level) {
+                    $this->errors[] = ['message' => (string) $message, 'context' => $context];
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
> Audyt fix-plan **W2-4** (Wave 2). Closes #1596 (AUD-039).

## Problem (confirmed empirycznie — drift JUŻ w danych)
`objects.attributes_indexed` (denormalizowany cache) dryfował od `object_values` bez detektora: 13 osieroconych kluczy w 4 obiektach (ACME-001/002/003, DEMO-100). `RebuildAttributesIndexedHandler` po 3 retry **cicho skipował** (warning+success) → drift rósł niewidoczny.

## Naprawa
- **`pim:catalog:detect-attributes-drift`**: skan per-tenant (`--tenant`) lub sweep wszystkich (cron-ready), iterate+clear/200, raport per-obiekt (orphaned/missing/mismatched), **exit≠0 gdy drift**; `--reconcile` odbudowuje cache z `object_values` (reuse `AttributesIndexedRebuilder`, jedyny writer; **nigdy nie tyka object_values**). RLS-aware (`app.current_tenant` GUC per tenant — inaczej FORCE RLS ukrywa wiersze przed `pim_app`).
- **Koniec cichego skipu** (`RebuildAttributesIndexedHandler`): po wyczerpaniu retry NIE „success" — loguje error + rzuca `AttributesIndexedRebuildFailedException` → async retry 5×→`failed` transport; **dead-letter listener** (wzorzec `ImportRunDeadLetterListener`) loguje na final failure z podpowiedzią `--reconcile`.

## Reguła naprawy — failing test FIRST
`DetectAttributesDriftCommandTest`: orphan `ghost` w cache → detect=FAILURE+listuje → `--reconcile` → SUCCESS, ghost usunięty, legit+object_values zachowane → re-detect „No drift". `RebuildAttributesIndexedOptimisticRetryTest`: perpetual conflict → **rzuca**+error-log (było warning+success). RED potwierdzony (rewert→exception missing).

## Bramki + smoke
6 nowych + 26 regresji zielone · PHPStan **No errors** · cs-fixer 0 · Deptrac 0. **Smoke realny drift:** PRZED `in_index_not_in_values=13` → detect exit 1 → reconcile (103 fixed: 13 orphaned + 90 legacy bare-string mismatches) → PO **0**, detect exit 0. `object_values` 10635 **niezmienione**, login 200.

## Nota
Cron reconcyliacji nie dodany (wymaga decyzji ops o harmonogramie — grupuje W2-11 scheduled cleanup); komenda cron-ready (udokumentowane w docblocku).
