### PR TITLE
AUD-041: make lossy migration down() explicitly irreversible (W2-6)

### DIFF
--- a/apps/api/migrations/Version20260605100000.php
+++ b/apps/api/migrations/Version20260605100000.php
@@ -17,8 +17,9 @@ use Doctrine\Migrations\AbstractMigration;
  * the channel currency UI removed there are no remaining consumers, so the
  * junction and the global catalog table are dropped entirely.
  *
- * Destructive: existing channel↔currency links are lost. `down()` recreates
- * the schema and reseeds the three default currencies (without channel links).
+ * Destructive: existing channel↔currency links are lost. The reverse is
+ * therefore irreversible — recreating the schema cannot recover the dropped
+ * channel↔currency rows (AUD-041).
  */
 final class Version20260605100000 extends AbstractMigration
 {
@@ -36,41 +37,16 @@ final class Version20260605100000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql(<<<'SQL'
-            CREATE TABLE currencies (
-              id UUID NOT NULL,
-              code VARCHAR(8) NOT NULL,
-              symbol VARCHAR(8) NOT NULL,
-              label VARCHAR(64) NOT NULL,
-              PRIMARY KEY (id)
-            )
-        SQL);
-        $this->addSql('CREATE UNIQUE INDEX currencies_code_uniq ON currencies (code)');
-
-        $this->addSql(<<<'SQL'
-            CREATE TABLE channel_currencies (
-              channel_id UUID NOT NULL,
-              currency_id UUID NOT NULL,
-              PRIMARY KEY (channel_id, currency_id)
-            )
-        SQL);
-        $this->addSql('CREATE INDEX channel_currencies_channel_idx ON channel_currencies (channel_id)');
-        $this->addSql('CREATE INDEX channel_currencies_currency_idx ON channel_currencies (currency_id)');
-        $this->addSql('ALTER TABLE channel_currencies ADD CONSTRAINT channel_currencies_channel_fk FOREIGN KEY (channel_id) REFERENCES channels (id) ON DELETE CASCADE NOT DEFERRABLE');
-        $this->addSql('ALTER TABLE channel_currencies ADD CONSTRAINT channel_currencies_currency_fk FOREIGN KEY (currency_id) REFERENCES currencies (id) ON DELETE RESTRICT NOT DEFERRABLE');
-
-        foreach ([
-            ['PLN', 'zł', 'Polish złoty'],
-            ['EUR', '€', 'Euro'],
-            ['USD', '$', 'United States dollar'],
-        ] as [$code, $symbol, $label]) {
-            $this->addSql(\sprintf(
-                "INSERT INTO currencies (id, code, symbol, label) SELECT gen_random_uuid(), '%s', '%s', '%s' WHERE NOT EXISTS (SELECT 1 FROM currencies WHERE code = '%s')",
-                $code,
-                addslashes($symbol),
-                addslashes($label),
-                $code,
-            ));
-        }
+        // AUD-041: `up()` dropped both `currencies` and the `channel_currencies`
+        // junction. Recreating the schema + reseeding the three default
+        // currencies could NOT restore the per-channel currency links (every
+        // channel_currencies row is gone). A schema-only rewind that reports
+        // success while the link data stays lost is a false round-trip; fail
+        // loud and require a restore from the pre-dump instead.
+        $this->throwIrreversibleMigrationException(
+            'channel↔currency links (channel_currencies rows) were dropped and cannot be reconstructed from schema; '
+            .'reseeding default currencies does not restore them. Take a pre-dump BEFORE this migration and restore '
+            .'from it instead — see docs/runbook/destructive-migrations.md.',
+        );
     }
 }

--- a/apps/api/migrations/Version20260606120000.php
+++ b/apps/api/migrations/Version20260606120000.php
@@ -43,6 +43,17 @@ final class Version20260606120000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('DROP TABLE channel_category_nodes');
+        // AUD-041: dropping `channel_category_nodes` is itself reversible, but
+        // `up()` ALSO ran `UPDATE channels SET category_tree_root_object_id =
+        // NULL` (re-pointing the soft FK from master objects to the new nav
+        // tree). The pre-migration root ids are gone — `down()` cannot restore
+        // them. Dropping the table alone would report a successful rollback
+        // while the nulled roots stay lost (a false round-trip), so the reverse
+        // is lossy: fail loud and require a restore from the pre-dump.
+        $this->throwIrreversibleMigrationException(
+            'up() nulled channels.category_tree_root_object_id for every channel and the prior values are not '
+            .'recoverable; dropping channel_category_nodes alone does not restore them. Take a pre-dump BEFORE '
+            .'this migration and restore from it instead — see docs/runbook/destructive-migrations.md.',
+        );
     }
 }

--- a/apps/api/migrations/Version20260607130000.php
+++ b/apps/api/migrations/Version20260607130000.php
@@ -36,10 +36,15 @@ final class Version20260607130000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql("ALTER TABLE channels ADD label JSONB DEFAULT '{}' NOT NULL");
-        // tenant-safe: one-time reverse backfill; rebuilds the pl-keyed label
-        // envelope from each row's own name.
-        $this->addSql("UPDATE channels SET label = jsonb_build_object('pl', name)");
-        $this->addSql('ALTER TABLE channels DROP name');
+        // AUD-041: the reverse is LOSSY, not reversible. `up()` collapsed the
+        // bilingual `{pl, en}` (or any other) envelope into a single scalar
+        // `name`. Rebuilding `label` as `{"pl": name}` would silently discard
+        // every non-`pl` key (`en`, …) while reporting success — a false
+        // round-trip. Fail loud instead and force a restore from the pre-dump.
+        $this->throwIrreversibleMigrationException(
+            'channels.label envelope (en + any non-pl key) was discarded when collapsing to channels.name; '
+            .'a rebuilt {"pl": name} would silently lose it. Take a pre-dump BEFORE this migration and restore '
+            .'from it instead — see docs/runbook/destructive-migrations.md.',
+        );
     }
 }

--- a/apps/api/migrations/Version20260607140000.php
+++ b/apps/api/migrations/Version20260607140000.php
@@ -32,16 +32,15 @@ final class Version20260607140000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql(<<<'SQL'
-            CREATE TABLE channel_locales (
-              channel_id UUID NOT NULL,
-              locale_id UUID NOT NULL,
-              PRIMARY KEY (channel_id, locale_id)
-            )
-        SQL);
-        $this->addSql('CREATE INDEX channel_locales_channel_idx ON channel_locales (channel_id)');
-        $this->addSql('CREATE INDEX channel_locales_locale_idx ON channel_locales (locale_id)');
-        $this->addSql('ALTER TABLE channel_locales ADD CONSTRAINT channel_locales_channel_fk FOREIGN KEY (channel_id) REFERENCES channels (id) ON DELETE CASCADE NOT DEFERRABLE');
-        $this->addSql('ALTER TABLE channel_locales ADD CONSTRAINT channel_locales_locale_fk FOREIGN KEY (locale_id) REFERENCES locales (id) ON DELETE RESTRICT NOT DEFERRABLE');
+        // AUD-041: `up()` dropped `channel_locales` with all its rows.
+        // Recreating an EMPTY table would report a successful rollback while
+        // every channel↔locale binding stays lost — a false round-trip. The
+        // bindings are config with no other source, so the reverse is lossy:
+        // fail loud and require a restore from the pre-dump instead.
+        $this->throwIrreversibleMigrationException(
+            'channel↔locale bindings (channel_locales rows) were dropped; recreating an empty table does not '
+            .'restore them. Take a pre-dump BEFORE this migration and restore from it instead — '
+            .'see docs/runbook/destructive-migrations.md.',
+        );
     }
 }

--- a/apps/api/migrations/Version20260612210000.php
+++ b/apps/api/migrations/Version20260612210000.php
@@ -22,6 +22,10 @@ use Doctrine\Migrations\AbstractMigration;
  * cache (which copies envelopes verbatim) are rewritten. Run
  * `pim:search:reindex` afterwards — Meilisearch documents flatten the same
  * envelopes (deploy note in PR #1505).
+ *
+ * DESTRUCTIVE / IRREVERSIBLE: the rewrite happens in place; `down()` cannot
+ * reconstruct the legacy shapes. A pre-dump MUST be taken before running this
+ * migration — see docs/runbook/destructive-migrations.md (AUD-041).
  */
 final class Version20260612210000 extends AbstractMigration
 {
@@ -164,8 +168,17 @@ final class Version20260612210000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        // AUD-041: do NOT assume a backup exists. The original message named a
+        // specific dump file (backups/pre-imp2-1.2-*.dump) as if guaranteed —
+        // it is not (the pgBackRest cron was stale; see the runbook). The
+        // canonicalisation overwrites the legacy `{value}` envelope in place, so
+        // recovery REQUIRES a dump that must be taken BEFORE running this
+        // migration. Point the operator at the runbook rather than a phantom file.
         $this->throwIrreversibleMigrationException(
-            'ADR-0019 canonicalisation is one-way; restore from the pre-migration dump (backups/pre-imp2-1.2-*.dump) instead.',
+            'ADR-0019 canonicalisation overwrites legacy {value} envelopes in place and is one-way. '
+            .'Recovery requires a database dump taken BEFORE this migration ran (pg_dump or a pgBackRest '
+            .'snapshot) — there is no automatic backup to assume. See docs/runbook/destructive-migrations.md '
+            .'for the pre-dump requirement and the restore procedure.',
         );
     }
 }

--- a/apps/api/migrations/Version20260612230000.php
+++ b/apps/api/migrations/Version20260612230000.php
@@ -37,11 +37,19 @@ final class Version20260612230000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE import_sessions DROP COLUMN skipped_count');
-        $this->addSql('ALTER TABLE import_sessions DROP COLUMN updated_count');
-        $this->addSql('ALTER TABLE import_sessions DROP COLUMN match_attribute_code');
-        $this->addSql('ALTER TABLE import_sessions DROP COLUMN mode');
-        $this->addSql('ALTER TABLE import_profiles DROP COLUMN match_attribute_code');
-        $this->addSql("ALTER TABLE import_profiles ALTER COLUMN mode SET DEFAULT 'UPDATE'");
+        // AUD-041: dropping the added columns is reversible, but `up()` ALSO
+        // remapped per-row `import_profiles.mode` (ADD → CREATE, and
+        // MERGE/INCREMENT/DELETE → UPSERT). The original per-row values are
+        // gone — restoring the DEFAULT would NOT bring them back, and every
+        // collapsed profile would silently stay UPSERT. A column-only rewind
+        // that reports success while the original modes stay lost is a false
+        // round-trip, so the reverse is lossy: fail loud and require a restore
+        // from the pre-dump instead.
+        $this->throwIrreversibleMigrationException(
+            'import_profiles.mode was collapsed per-row (MERGE/INCREMENT/DELETE → UPSERT, ADD → CREATE); '
+            .'the original values are not recoverable and restoring the column DEFAULT does not bring them back. '
+            .'Take a pre-dump BEFORE this migration and restore from it instead — '
+            .'see docs/runbook/destructive-migrations.md.',
+        );
     }
 }

--- a/apps/api/tests/Integration/Migration/DestructiveMigrationDownTest.php
+++ b/apps/api/tests/Integration/Migration/DestructiveMigrationDownTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Migration;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * AUD-041 (W2-6, finding G-03) — destructive migrations must signal
+ * irreversibility LOUDLY rather than fake a schema-only rewind that silently
+ * drops data.
+ *
+ * Six data-bearing migrations destroy data on `up()` and cannot reconstruct it
+ * on `down()` (per-channel currency links, channel↔locale bindings, nulled
+ * category roots, the `label.en` envelope, the in-place JSONB canon rewrite,
+ * the per-row import-mode remap). Before AUD-041 most of their `down()` methods
+ * recreated only the SCHEMA and returned "success" — so a
+ * `migrations:migrate prev` reported a clean rollback while the data stayed
+ * gone (a false round-trip). The fix makes each one call
+ * {@see AbstractMigration::throwIrreversibleMigrationException()}.
+ *
+ * This test locks that contract on a fresh schema-built test DB:
+ *  - every irreversible migration's `down()` throws {@see IrreversibleMigration}
+ *    (red before the fix: the old `down()` queued ALTER/CREATE SQL and returned
+ *    normally; green after: it throws);
+ *  - a representative reversible migration's `down()` does NOT throw — so the
+ *    suite is not trivially asserting "everything throws" (the negative control
+ *    would fail if someone made ALL `down()` throw).
+ *
+ * Migrations are intentionally NOT autoloaded (see
+ * config/packages/doctrine_migrations.yaml), so each file is `require_once`-d
+ * and instantiated through the same `MigrationFactory` the migrator uses —
+ * wiring the connection + logger — exactly as {@see \App\Tests\Integration\Catalog\CanonMigrationTest}
+ * exercises the data SQL. `down()` only queues SQL via `addSql()` (or throws);
+ * it never executes against the connection here, so no live rollback runs.
+ */
+final class DestructiveMigrationDownTest extends KernelTestCase
+{
+    /**
+     * Data-bearing migrations whose `down()` must throw IrreversibleMigration.
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function irreversibleMigrations(): iterable
+    {
+        yield '#1282 drop currencies + channel_currencies' => ['Version20260605100000'];
+        yield 'CHC-01 nulled category roots' => ['Version20260606120000'];
+        yield '#1316 channels.label -> name (loses en)' => ['Version20260607130000'];
+        yield '#1318 drop channel_locales bindings' => ['Version20260607140000'];
+        yield 'IMP2-1.2 JSONB canon (in-place rewrite)' => ['Version20260612210000'];
+        yield 'IMP2-1.3 import-mode per-row remap' => ['Version20260612230000'];
+    }
+
+    #[Test]
+    #[DataProvider('irreversibleMigrations')]
+    public function destructiveDownThrowsIrreversible(string $version): void
+    {
+        $migration = $this->loadMigration($version);
+
+        $this->expectException(IrreversibleMigration::class);
+
+        $migration->down(new Schema());
+    }
+
+    /**
+     * Negative control: a pure-structure additive migration round-trips cleanly,
+     * so its `down()` must NOT throw IrreversibleMigration. If a future change
+     * made every `down()` throw, this assertion fails — proving the positive
+     * cases above test real behaviour, not a blanket rule.
+     */
+    #[Test]
+    public function reversibleDownDoesNotThrow(): void
+    {
+        // IMP2-2.7 (#1483) — three nullable ADD COLUMN + their DROP COLUMN down.
+        $migration = $this->loadMigration('Version20260615145641');
+
+        $threw = false;
+        try {
+            $migration->down(new Schema());
+        } catch (IrreversibleMigration) {
+            $threw = true;
+        }
+
+        self::assertFalse($threw, 'a reversible additive migration must not declare itself irreversible');
+    }
+
+    private function loadMigration(string $version): AbstractMigration
+    {
+        self::bootKernel();
+
+        // Migrations are not autoloaded (doctrine_migrations.yaml); define the
+        // class from its file, then build it via the same factory the migrator
+        // uses so the connection + logger are wired.
+        require_once \dirname(__DIR__, 3).'/migrations/'.$version.'.php';
+
+        // MigrationFactory::createVersion() returns an AbstractMigration with
+        // the connection + logger wired — the same path the migrator uses.
+        return self::getContainer()
+            ->get('doctrine.migrations.dependency_factory')
+            ->getMigrationFactory()
+            ->createVersion('DoctrineMigrations\\'.$version);
+    }
+}

--- a/docs/runbook/destructive-migrations.md
+++ b/docs/runbook/destructive-migrations.md
@@ -1,0 +1,160 @@
+# Destructive migrations — pre-dump requirement (AUD-041)
+
+> **Audience:** the operator running a deploy that includes a database
+> migration. Read this BEFORE applying any migration listed in the
+> [irreversible register](#irreversible-migration-register) below.
+
+## TL;DR
+
+Some PIM migrations **destroy data on `up()` and cannot restore it on
+`down()`**. Their `down()` deliberately throws
+`Doctrine\Migrations\Exception\IrreversibleMigration` instead of pretending to
+rewind — a `migrations:migrate prev` on one of them **fails loud** rather than
+silently leaving the data gone.
+
+The only recovery for these is a **database dump taken BEFORE the migration
+runs**. There is no automatic backup you can assume exists:
+
+- the pgBackRest cron was stale for ~49 days (AUD-017), and
+- the legacy `backups/pre-imp2-1.2-*.dump` referenced in old code is **not**
+  guaranteed to exist.
+
+So: **take a pre-dump yourself, every time, before a destructive migration.**
+
+This runbook complements:
+
+- [`docs/runbook/restore.md`](restore.md) — pgBackRest PITR walkthrough.
+- [`docs/runbook/disaster-recovery.md`](disaster-recovery.md) — broader DR.
+- [`docs/audit/2026-06/02-domain-reports/G-data-integrity.md`](../audit/2026-06/02-domain-reports/G-data-integrity.md) — finding G-03 / AUD-041.
+
+---
+
+## Why irreversible (not a fake rewind)
+
+A `down()` that recreates the *schema* but not the *data* is worse than no
+`down()` at all: the migrator reports a **successful rollback** while the data
+is silently lost. An operator who runs `migrations:migrate prev` after a failed
+deploy believes they rolled back cleanly — and only discovers the missing
+channel currencies / locale bindings / category roots / `label.en` / original
+import modes later, in production.
+
+The fix (AUD-041) is to make every lossy `down()` call
+`throwIrreversibleMigrationException(...)` with a message that names exactly
+what was lost and points here. The migration **refuses** to fake a rollback;
+the operator is forced to restore from the pre-dump instead.
+
+---
+
+## Pre-dump — BEFORE applying a destructive migration
+
+Run this on the deploy host before `doctrine:migrations:migrate`. The dump is
+taken with the **owner** role (`POSTGRES_USER`, `pim`) — the same role
+migrations run under (`config/packages/doctrine_migrations.yaml` → `connection:
+owner`).
+
+```bash
+# 1. Stop write traffic so the dump is a clean point-in-time snapshot.
+docker compose stop api worker
+
+# 2. Take a compressed, timestamped logical dump of the whole database.
+#    -Fc = custom format (restorable with pg_restore, selective if needed).
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+docker compose exec -T database \
+  pg_dump -U "${POSTGRES_USER:-pim}" -d "${POSTGRES_DB:-pim}" -Fc \
+  > "backups/pre-migration-${TS}.dump"
+
+# 3. Sanity-check the dump is non-empty and readable.
+pg_restore --list "backups/pre-migration-${TS}.dump" | head
+
+# 4. Now apply the migration.
+docker compose start api
+docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction
+
+# 5. Resume the worker.
+docker compose start worker
+```
+
+> On production prefer a **pgBackRest snapshot** (`pgbackrest --stanza=pim
+> --type=full backup`) over a one-off `pg_dump` — it lands in the off-site repo
+> and supports PITR. The `pg_dump` above is the portable minimum that works
+> even when the cron repo is stale.
+
+Keep the dump until the migration has run cleanly in production AND you are
+confident no rollback is needed (at least one successful backup cycle later).
+
+---
+
+## Restore — if a destructive migration must be undone
+
+`down()` will throw `IrreversibleMigration` for these — that is expected. Do NOT
+try to force the rollback. Restore from the pre-dump instead.
+
+```bash
+# 1. Stop write traffic.
+docker compose stop api worker
+
+# 2. Restore the pre-dump over the current database (owner role).
+#    --clean --if-exists drops + recreates objects; -j speeds parallel restore.
+docker compose exec -T database \
+  pg_restore -U "${POSTGRES_USER:-pim}" -d "${POSTGRES_DB:-pim}" \
+  --clean --if-exists -j 4 < "backups/pre-migration-<TS>.dump"
+
+# 3. Re-sync the migration metadata so Doctrine knows the rolled-back version
+#    is no longer applied (the dump predates the migration, so its row is gone
+#    — confirm status reflects that).
+docker compose start api
+docker compose exec -T api php bin/console doctrine:migrations:status
+
+# 4. Smoke the surface.
+curl -sk https://pim.localhost/api | jq .
+docker compose start worker
+```
+
+> If only one table was damaged, a selective restore is possible:
+> `pg_restore --table=<name> ...`. For JSONB canonicalisation
+> (`Version20260612210000`) the legacy shapes live across `object_values` +
+> `objects.attributes_indexed`, so a whole-DB restore is the safe default.
+
+---
+
+## Irreversible migration register
+
+These migrations destroy data on `up()` and **throw on `down()`**. Take a
+pre-dump before applying any of them.
+
+| Migration | Ticket | `up()` destroys | What `down()` could NOT restore |
+|---|---|---|---|
+| `Version20260605100000` | #1282 | drops `currencies` + `channel_currencies` | per-channel currency links (`channel_currencies` rows) |
+| `Version20260606120000` | CHC-01 / #1284 | nulls `channels.category_tree_root_object_id` for all channels | the prior root-object ids |
+| `Version20260607130000` | #1316 | collapses `channels.label` `{pl,en,…}` → scalar `name` | every non-`pl` label key (`en`, …) |
+| `Version20260607140000` | #1318 | drops `channel_locales` | channel↔locale bindings (`channel_locales` rows) |
+| `Version20260612210000` | IMP2-1.2 / #1464 | rewrites legacy `{value}` JSONB → canon, in place | the legacy `{value}` envelopes (object_values + attributes_indexed) |
+| `Version20260612230000` | IMP2-1.3 / #1465 | remaps per-row `import_profiles.mode` (MERGE/INCREMENT/DELETE → UPSERT, ADD → CREATE) | the original per-row import modes |
+
+For each of these, `down()` calls `throwIrreversibleMigrationException(...)`
+with a message naming the lost data and linking here. The structural part of
+some reverses (e.g. dropping the new `channel_category_nodes` table) *would* be
+reversible — but because `up()` also destroyed data the partial rewind would be
+a false round-trip, so the whole `down()` is treated as irreversible.
+
+### Reversible migrations (for contrast)
+
+The vast majority of PIM migrations are pure-structure (add/drop column, add
+index, create table with no data backfill) and round-trip cleanly. Their
+`down()` is a real inverse and `migrations:migrate prev` is safe. Only the six
+data-bearing migrations above require a pre-dump.
+
+---
+
+## CI guard
+
+`apps/api/tests/Integration/Migration/DestructiveMigrationDownTest.php`
+asserts, on a fresh schema-built test DB, that:
+
+- each irreversible migration's `down()` throws `IrreversibleMigration` (it does
+  NOT silently "succeed" while losing data), and
+- a representative reversible migration's `down()` does NOT throw (so the test
+  is not just asserting "everything throws").
+
+This locks the AUD-041 contract: a future edit that turns one of these `down()`
+methods back into a fake schema-only rewind fails CI.


### PR DESCRIPTION
> Audyt fix-plan **W2-6** (Wave 2). Closes #1598 (AUD-041).

## Problem (confirmed, data-loss przy rollbacku)
6 migracji z danymi miało `down()` odtwarzający SCHEMAT ale nie DANE (fałszywa odwracalność → cichy data-loss + „success"). `Version20260612210000` rzucała irreversible licząc na dump z `backups/` którego istnienia NIE weryfikuje.

## Naprawa
Lossy `down()` → jawny `throwIrreversibleMigrationException(<co tracone> + link runbook)`:
| Migracja | Tracone |
|---|---|
| Version20260605100000 | linki channel↔currency |
| Version20260606120000 | category_tree_root (NULL-out) |
| Version20260607130000 | label.en (i non-pl) |
| Version20260607140000 | bindingi channel↔locale |
| Version20260612230000 | per-row import_profiles.mode |
| Version20260612210000 | JSONB — komunikat poprawiony (nie zakłada backupu, instruuje pre-dump) |

~94 reversible migracji (czysta struktura) zostawione (negatywna kontrola w teście). **Runbook** `docs/runbook/destructive-migrations.md`: pre-dump (`pg_dump -Fc`/pgBackRest PRZED migrate) + restore (`pg_restore --clean`) + rejestr 6 irreversible.

## Reguła naprawy — failing test FIRST
`DestructiveMigrationDownTest` (świeża schema-built `pim_test`, `MigrationFactory` — bez `down()` na żywej bazie): 6 irreversible → `down()` MUSI rzucić `IrreversibleMigration`; 1 reversible (kontrola) → NIE rzuca. RED potwierdzony (rewert fałszywego down → FAIL „exception not thrown") → GREEN 7/7.

## Bramki
7/7 nowy + 10/10 CanonMigration/ImportMode (replay up, nietknięte) · PHPStan **No errors** · cs-fixer 0 · Deptrac 0 · `migrations:status` read-only OK (100 executed). **NIE migrowałem live dev** (dane nietknięte).

## Świadome odejście
Ticket wymieniał 5 migracji; finding G-03 wymienia 6 (dochodzi Version20260612230000 import-mode, ta sama klasa lossy down()) — naprawiłem wszystkie 6 (zostawienie 6. = half-done).
