### PR TITLE
AUD-042: unified RFC 7807 errors for custom controllers (W2-7)

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -63,6 +63,15 @@ services:
     App\:
         resource: '../src/'
 
+    # W2-7 / AUD-042 — single RFC 7807 contract for custom controllers.
+    # `$debug` is bound to the kernel flag so the listener can keep the
+    # real exception message in `detail` for 5xx locally while collapsing
+    # it to the generic status text in prod. `class`/`trace` are never
+    # emitted regardless of env (the FQCN is the information leak).
+    App\Shared\Infrastructure\Http\Rfc7807ExceptionListener:
+        arguments:
+            $debug: '%kernel.debug%'
+
     App\Identity\Application\CurrentTenantProvider:
         arguments:
             $defaultTenantCode: '%app.default_tenant_code%'

--- a/apps/api/src/Shared/Infrastructure/Http/Rfc7807ExceptionListener.php
+++ b/apps/api/src/Shared/Infrastructure/Http/Rfc7807ExceptionListener.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Http;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * W2-7 / AUD-042 — single RFC 7807 error contract for the custom
+ * controllers under `/api/*`.
+ *
+ * API Platform native resources already emit clean RFC 7807
+ * (`application/problem+json`, members `type`/`title`/`status`/`detail`,
+ * validation errors carrying `violations`). The ~157 custom `#[Route]`
+ * controllers do NOT flow through an API Platform resource, so their
+ * `HttpExceptionInterface` throws fall through to Symfony's stock error
+ * handling: a FlattenException JSON shape with `type` pointing at RFC 2616,
+ * the exception FQCN in `class` (information leak) and a full `trace` in
+ * debug — and, with no `Accept` header, an HTML error page (routing
+ * structure leak). Integrators were handed two different error contracts
+ * on one API.
+ *
+ * This subscriber normalises that second contract to match API Platform:
+ * for `/api/*` requests that API Platform does NOT own, it maps the
+ * thrown {@see HttpExceptionInterface} onto an `application/problem+json`
+ * RFC 7807 document with no `class`/`trace`, regardless of the `Accept`
+ * header (so a missing `Accept` never yields HTML).
+ *
+ * It deliberately does nothing for:
+ *   - requests API Platform handles (its `ExceptionListener` already
+ *     produces RFC 7807 — see the `_api_resource_class` / `_api_respond` /
+ *     `_graphql` gate, mirroring API Platform's own check);
+ *   - validation exceptions carrying a violation list (left to API
+ *     Platform so the `violations` array survives);
+ *   - non-`/api` paths (the admin SPA and Mercure live on other origins;
+ *     HTML profiler pages stay useful in dev);
+ *   - authentication / access-denied flows, which the security component
+ *     answers with its own response before/around this event.
+ *
+ * Runs at a high priority — below {@see PermissionDeniedProblemListener}
+ * (128) so its richer permission payload still wins, and well above API
+ * Platform's `ExceptionListener` (-96) / Symfony's `ErrorListener` (-128)
+ * so it claims custom-route errors before HTML/FlattenException rendering.
+ */
+final class Rfc7807ExceptionListener implements EventSubscriberInterface
+{
+    public function __construct(private readonly bool $debug = false)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [KernelEvents::EXCEPTION => ['onException', 64]];
+    }
+
+    public function onException(ExceptionEvent $event): void
+    {
+        // A higher-priority listener already produced a response — defer to
+        // it. In particular {@see PermissionDeniedProblemListener} (priority
+        // 128) emits a richer 403 carrying `permission_required`; since
+        // `PermissionDeniedException extends AccessDeniedHttpException` it
+        // would otherwise be caught below and flattened. Setting a response
+        // on an ExceptionEvent does not stop propagation, so this guard is
+        // what keeps the specialised payload intact.
+        if (null !== $event->getResponse()) {
+            return;
+        }
+
+        $throwable = $event->getThrowable();
+
+        // Only HTTP exceptions carry a status + safe public message. Domain
+        // exceptions (500s) keep Symfony's handling so they are logged and
+        // rendered as opaque 500s without a leaked message.
+        if (!$throwable instanceof HttpExceptionInterface) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$this->isCustomApiRequest($request)) {
+            return;
+        }
+
+        $status = $throwable->getStatusCode();
+
+        $payload = [
+            'type' => $this->typeForStatus($status),
+            'title' => Response::$statusTexts[$status] ?? 'An error occurred',
+            'status' => $status,
+            'detail' => $this->detailFor($throwable, $status),
+        ];
+
+        // `class` and `trace` are never emitted — even in debug — because the
+        // exception FQCN is an information leak (AUD-042). Symfony's profiler
+        // and logs remain the place to inspect the stack in dev.
+
+        $response = new JsonResponse(
+            data: $payload,
+            status: $status,
+            headers: ['content-type' => 'application/problem+json'],
+        );
+
+        // Preserve transport headers the HttpException advertises
+        // (e.g. `Retry-After` on 429, `Allow` on 405).
+        $response->headers->add($throwable->getHeaders());
+        $response->headers->set('content-type', 'application/problem+json');
+
+        $event->setResponse($response);
+    }
+
+    /**
+     * True only for `/api/*` requests that API Platform does NOT manage.
+     *
+     * Mirrors API Platform's own `ExceptionListener` gate: a request is
+     * API-Platform-managed when it carries `_api_resource_class` (set by
+     * API Platform routing), `_api_respond`, or `_graphql`. Those keep
+     * their native RFC 7807 pipeline; everything else under `/api/` is a
+     * custom controller this listener normalises.
+     */
+    private function isCustomApiRequest(Request $request): bool
+    {
+        $path = $request->getPathInfo();
+        if (!str_starts_with($path, '/api/') && '/api' !== $path) {
+            return false;
+        }
+
+        if (null !== $request->attributes->get('_api_resource_class')) {
+            return false;
+        }
+
+        if ($request->attributes->getBoolean('_api_respond')) {
+            return false;
+        }
+
+        if ($request->attributes->getBoolean('_graphql')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * RFC 7807 `type` URI. Mirrors the API Platform shape (`/errors/{status}`)
+     * so integrators see one scheme across the whole API instead of the
+     * old RFC 2616 sentinel.
+     */
+    private function typeForStatus(int $status): string
+    {
+        return \sprintf('/errors/%d', $status);
+    }
+
+    /**
+     * Human-readable `detail`. The custom controllers throw
+     * `HttpException` with an operator-authored message (e.g.
+     * "code is required."); that message is safe to surface and is the
+     * actionable part for an integrator. For 5xx we fall back to the
+     * generic status text so internal failure strings never leak; in debug
+     * the real message is kept to aid local debugging.
+     */
+    private function detailFor(HttpExceptionInterface $throwable, int $status): string
+    {
+        // `HttpExceptionInterface extends \Throwable`, so `getMessage()` is
+        // always available.
+        $message = $throwable->getMessage();
+
+        if ($status >= 500 && !$this->debug) {
+            return Response::$statusTexts[$status] ?? 'An error occurred';
+        }
+
+        return '' !== $message
+            ? $message
+            : (Response::$statusTexts[$status] ?? 'An error occurred');
+    }
+}

--- a/apps/api/tests/Api/Shared/Rfc7807ErrorContractApiTest.php
+++ b/apps/api/tests/Api/Shared/Rfc7807ErrorContractApiTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Shared;
+
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * W2-7 / AUD-042 — single RFC 7807 error contract for custom controllers.
+ *
+ * Before this ticket the ~157 custom `#[Route]` controllers (which throw
+ * `BadRequestHttpException`/`ConflictHttpException`/… instead of flowing
+ * through an API Platform resource) returned Symfony's FlattenException
+ * shape: `type` pointing at RFC 2616, plus `class` (the exception FQCN —
+ * an information leak) and, in debug, a full `trace`. Without an `Accept`
+ * header they returned an HTML error page (routing-structure leak).
+ *
+ * API Platform native routes already emit clean RFC 7807
+ * (`application/problem+json`, `type`/`title`/`status`/`detail`,
+ * validation errors carrying `violations`). This suite pins both halves
+ * of the contract:
+ *   - custom routes are normalised to RFC 7807 with NO `class`/`trace`;
+ *   - API Platform routes keep their RFC 7807 shape untouched;
+ *   - API Platform validation keeps `violations`.
+ *
+ * Assertions check status + key presence/absence (not full detail
+ * strings) so they hold in both debug and non-debug environments
+ * (lessons: error `detail` differs debug vs prod).
+ */
+final class Rfc7807ErrorContractApiTest extends CatalogApiTestCase
+{
+    private const string PROBLEM_JSON = 'application/problem+json';
+
+    /**
+     * Custom controller throwing `BadRequestHttpException('code is required.')`.
+     * Must be RFC 7807 `application/problem+json`, NOT the FlattenException
+     * shape with `class`/`trace`.
+     */
+    #[Test]
+    public function customControllerErrorIsRfc7807WithoutClassOrTrace(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/object_types', [
+            'headers' => [
+                'content-type' => 'application/json',
+                'accept' => 'application/json',
+            ],
+            'body' => json_encode([], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $contentType = $response->getHeaders(false)['content-type'][0] ?? '';
+        self::assertStringContainsString(
+            self::PROBLEM_JSON,
+            $contentType,
+            'Custom controller error must be served as application/problem+json.',
+        );
+
+        $payload = $response->toArray(false);
+
+        // RFC 7807 members present and correctly typed.
+        self::assertArrayHasKey('type', $payload);
+        self::assertArrayHasKey('title', $payload);
+        self::assertArrayHasKey('status', $payload);
+        self::assertArrayHasKey('detail', $payload);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $payload['status']);
+
+        // `type` must NOT be the RFC 2616 sentinel the old FlattenException used.
+        self::assertIsString($payload['type']);
+        self::assertStringNotContainsString(
+            'rfc2616',
+            $payload['type'],
+            'RFC 7807 `type` must reference an error document, not RFC 2616.',
+        );
+
+        // Information-leak fields must be gone.
+        self::assertArrayNotHasKey('class', $payload, 'Exception FQCN must not leak.');
+        self::assertArrayNotHasKey('trace', $payload, 'Stack trace must not leak.');
+    }
+
+    /**
+     * A custom controller error WITHOUT an `Accept` header must still return
+     * JSON problem details for `/api/*`, never an HTML error page.
+     */
+    #[Test]
+    public function customControllerErrorWithoutAcceptHeaderStaysJson(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/object_types', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode([], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
+
+        $contentType = $response->getHeaders(false)['content-type'][0] ?? '';
+        self::assertStringContainsString(
+            self::PROBLEM_JSON,
+            $contentType,
+            'A /api/* error must not fall back to an HTML error page.',
+        );
+        self::assertStringNotContainsString('text/html', $contentType);
+
+        $payload = $response->toArray(false);
+        self::assertArrayNotHasKey('class', $payload);
+        self::assertArrayNotHasKey('trace', $payload);
+    }
+
+    /**
+     * API Platform native route (Get item on a missing id) must keep its
+     * own clean RFC 7807 response — the listener must not intercept it.
+     */
+    #[Test]
+    public function apiPlatformRouteErrorStaysRfc7807(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('GET', '/api/object_types/99999999-0000-0000-0000-000000000000', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+
+        $payload = $response->toArray(false);
+        self::assertArrayHasKey('type', $payload);
+        self::assertArrayHasKey('title', $payload);
+        self::assertArrayHasKey('status', $payload);
+        self::assertSame(Response::HTTP_NOT_FOUND, $payload['status']);
+        // API Platform's Hydra error keeps its JSON-LD context.
+        self::assertArrayHasKey('@context', $payload, 'API Platform RFC 7807 (Hydra) must be untouched.');
+        // API Platform never emits `class`; guard against the listener
+        // accidentally re-adding it.
+        self::assertArrayNotHasKey('class', $payload);
+    }
+
+    /**
+     * API Platform validation error (422) must keep its `violations` array —
+     * the listener must not flatten it into a plain problem document.
+     */
+    #[Test]
+    public function apiPlatformValidationErrorKeepsViolations(): void
+    {
+        $client = $this->authenticatedClient();
+
+        $response = $client->request('POST', '/api/objects', [
+            'headers' => [
+                'content-type' => 'application/ld+json',
+                'accept' => 'application/ld+json',
+            ],
+            'body' => json_encode([], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        $payload = $response->toArray(false);
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $payload['status']);
+        self::assertArrayHasKey('violations', $payload, 'Validation 422 must keep the violations array.');
+        self::assertNotEmpty($payload['violations']);
+    }
+}


### PR DESCRIPTION
> Audyt fix-plan **W2-7** (Wave 2). Closes #1599 (AUD-042).

## Problem (confirmed, info-leak + niespójny kontrakt)
~157 custom `#[Route]` controllerów rzucało HttpException → Symfony default → `application/json` z **`class` (FQCN info-leak)** + `trace` + `type:rfc2616`; bez `Accept` → HTML error page. API Platform routes dawały RFC7807 → integrator miał DWA kontrakty błędów.

## Naprawa
**`Rfc7807ExceptionListener`** (`kernel.exception`, prio 64 — między PermissionDenied=128 a AP=-96):
- Mapuje `HttpExceptionInterface` na **`application/problem+json`** `{type:/errors/{status}, title, status, detail}` (spójnie z AP).
- **Strip `class`/`trace` ZAWSZE** (FQCN to leak niezależnie od env; profiler/logi zostają do debug).
- Content-type wymuszony na problem+json niezależnie od `Accept` (koniec HTML); zachowuje headery transportowe (`Allow`/`Retry-After`).
- `isCustomApiRequest` (wg `_api_resource_class`/`_api_respond`/`_graphql`) → **NIE dotyka** AP-routes, GraphQL; guard `getResponse()!==null` → nie psuje controllerów zwracających Response ani bogatego 403 `permission_required`.

## Reguła naprawy — failing test FIRST
`Rfc7807ErrorContractApiTest` (4): custom `POST /api/object_types {}` → problem+json bez class/trace (PRZED: class/trace/rfc2616); bez Accept → json nie HTML; AP 404 → RFC7807 nietknięty; AP 422 → `violations` zachowane. RED→GREEN 4/4.

## Bramki
Regresja Identity 110 / Catalog 254+11+75 (OpenApiSpec) / Import 128 / pozostałe 72 zielone (1 znany Meili-flake w izolacji OK) · PHPStan **No errors** · cs-fixer 0 · Deptrac 0 · **OpenAPI drift: identyczne** (listener nie dodaje zasobów). Smoke: custom 400 problem+json bez leak, AP RFC7807 + `@context`, 422 violations, 405 `allow` header, self-deactivate 409 custom zachowane, login 200.
