### PR TITLE
fix(api): cap JSON request body size to prevent worker OOM

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -166,3 +166,13 @@ MAILER_DSN=null://null
 # tunelu z publicznym TLD (np. `https://pim.lvh.me`).
 APP_BASE_URL=https://pim.localhost
 ###< app/sso ###
+
+###> app/request-limits ###
+# W2-9 / AUD-045 — application-level cap on JSON request bodies for non-import
+# /api/* writes, enforced by RequestBodySizeLimitListener BEFORE json_decode.
+# 10 MB decodes well under the 256 MB FrankenPHP worker memory_limit yet blocks
+# the 109 MB OOM vector; real bulk-edit payloads (5000 UUIDs ≈ 200 KB) fit with
+# room to spare. Import/upload paths carry their own per-tenant file-size limit
+# and are exempt. .env.test lowers this to 1 KB for the regression suite.
+API_MAX_JSON_BODY_BYTES=10485760
+###< app/request-limits ###

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -76,3 +76,47 @@ EXPOSE 443/udp
 
 HEALTHCHECK --interval=10s --timeout=3s --start-period=30s --retries=5 \
     CMD curl -fsS http://127.0.0.1/api -o /dev/null || exit 1
+
+# ─── Production stage (AUD-044 / W2-9) ────────────────────────────────────
+# The `base` stage above pins `APP_ENV=dev` so `pnpm stack:up` boots a dev
+# stack out-of-the-box (Symfony profiler, Swagger UI, verbose traces). Before
+# this stage the ONLY thing flipping the image to prod was the
+# `docker-compose.prod.yml` overlay's `environment: APP_ENV=prod` — so any
+# build/run of the image WITHOUT that overlay (a bare `docker build` push to a
+# registry, a hand-rolled `docker run`) shipped the whole app in dev mode:
+# stack traces + the exception FQCN exposed to clients, the web profiler and
+# Swagger UI reachable, dev-only error pages. That is an information-disclosure
+# defect baked into the artifact, not just a compose concern.
+#
+# This stage bakes prod posture INTO the image so it is correct regardless of
+# how it is run:
+#   - APP_ENV=prod + APP_DEBUG=0 (no profiler, no trace/FQCN leak, opaque 500s);
+#   - composer re-resolved with --no-dev (drops dev tooling: phpunit, phpstan,
+#     cs-fixer, the profiler bundle's dev deps) + --classmap-authoritative so
+#     the worker never hits the filesystem to resolve a class;
+#   - the prod container is warmed for APP_ENV=prod.
+#
+# `base` is left byte-for-byte untouched — dev keeps working. docker-compose.yml
+# pins `build.target: base` (dev) and docker-compose.prod.yml pins
+# `build.target: prod`, so adding this trailing stage does not change which
+# image a dev `docker compose build` produces.
+FROM base AS prod
+
+ENV APP_ENV=prod \
+    APP_DEBUG=0
+
+# Re-resolve the autoloader without dev dependencies. The `base` stage copied
+# the full source + a dev vendor tree; --no-dev prunes dev-only packages and
+# --classmap-authoritative makes the classmap exhaustive (no runtime fs probe).
+RUN --mount=type=cache,target=/root/.composer/cache \
+    composer install --no-dev --no-interaction --no-scripts --no-progress --prefer-dist \
+    && composer dump-autoload --no-dev --classmap-authoritative
+
+# Compile the prod container so the first request does not pay the warmup cost
+# and so a misconfiguration fails the build, not the first live request.
+RUN php bin/console cache:clear --env=prod --no-debug \
+    && php bin/console cache:warmup --env=prod
+
+# Inherit EXPOSE / HEALTHCHECK / ENTRYPOINT / CMD from `base` (FrankenPHP
+# worker config + the auto-seed entrypoint, which itself skips the dev seed
+# when APP_ENV=prod).

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -72,6 +72,13 @@ services:
         arguments:
             $debug: '%kernel.debug%'
 
+    # W2-9 / AUD-045 — application-level JSON request body cap. Autoconfigure
+    # tags the EventSubscriberInterface; only the byte limit needs binding.
+    # 10 MB default (env-overridable); .env.test lowers it to 1 KB.
+    App\Shared\Infrastructure\Http\RequestBodySizeLimitListener:
+        arguments:
+            $maxBytes: '%env(int:API_MAX_JSON_BODY_BYTES)%'
+
     App\Identity\Application\CurrentTenantProvider:
         arguments:
             $defaultTenantCode: '%app.default_tenant_code%'

--- a/apps/api/src/Shared/Infrastructure/Http/RequestBodySizeLimitListener.php
+++ b/apps/api/src/Shared/Infrastructure/Http/RequestBodySizeLimitListener.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Http;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * W2-9 / AUD-045 — application-level cap on JSON request bodies.
+ *
+ * The defence-in-depth chain against an oversized-body DoS ends at:
+ *   Caddy (request body 150 MB) → php.ini `post_max_size` (110 MB) → the app.
+ * Before this listener the *only* application-level size limit lived on the
+ * import path (`Tenant::importMaxFileSize`, enforced per upload in
+ * StartImportController / ParsePreviewController). Every other JSON write
+ * endpoint — most dangerously POST `/api/products/bulk-edit`, which
+ * `json_decode`s the whole body up front — accepted any body up to
+ * `post_max_size`. A 109 MB JSON document decodes into a PHP structure many
+ * times larger than the 256 MB FrankenPHP worker `memory_limit`, OOM-killing
+ * the long-lived worker process (a single 240 KB probe on bulk-edit is fully
+ * decoded before validation — the vector scales linearly).
+ *
+ * This subscriber rejects an over-limit JSON `/api/*` write with a 413
+ * `application/problem+json` BEFORE the controller can decode it. It runs on
+ * `kernel.request` at priority 16 — after Symfony's RouterListener (priority
+ * 32) so route attributes are resolved, and well before the controller is
+ * invoked. Calling `setResponse()` on the RequestEvent short-circuits the
+ * kernel, so the controller never sees the request and the 413 is returned
+ * verbatim (it does NOT pass through {@see Rfc7807ExceptionListener}, which
+ * is why the problem document is built self-contained here).
+ *
+ * Deliberately scoped to JSON writes only:
+ *   - method ∈ {POST, PUT, PATCH} (bodyless verbs carry no payload to cap);
+ *   - `Content-Type` is a JSON media type (`application/json`,
+ *     `application/ld+json`, `application/merge-patch+json`);
+ *   - path starts with `/api/`.
+ *
+ * Exempt (returns early, never caps):
+ *   - multipart/form-data — legitimate large file uploads (DAM, import
+ *     wizard) ship multipart bodies and carry their OWN per-tenant
+ *     file-size limit;
+ *   - the import surface (`/api/import-*` — sessions, schedules, sources,
+ *     profiles) and `/api/assets/upload`, whose uploads are bounded by
+ *     `Tenant::importMaxFileSize` / the per-MIME asset cap respectively.
+ */
+final class RequestBodySizeLimitListener implements EventSubscriberInterface
+{
+    /**
+     * JSON media types this guard caps. A `Content-Type` is matched by prefix
+     * so charset parameters (e.g. `application/json; charset=utf-8`) still hit.
+     *
+     * @var list<string>
+     */
+    private const array JSON_CONTENT_TYPES = [
+        'application/json',
+        'application/ld+json',
+        'application/merge-patch+json',
+    ];
+
+    /**
+     * @param int $maxBytes maximum allowed JSON request body in bytes;
+     *                      bound from `%env(int:API_MAX_JSON_BODY_BYTES)%`
+     */
+    public function __construct(private readonly int $maxBytes)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        // Priority 16: after RouterListener (32) so `_route`/route attributes
+        // are populated, but before the controller runs — the body is capped
+        // before any controller can json_decode it.
+        return [KernelEvents::REQUEST => ['onRequest', 16]];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$this->shouldEnforce($request)) {
+            return;
+        }
+
+        // `getContent()` is already buffered by PHP (php://input is read into
+        // the Request once), so strlen() is cheap and — unlike trusting
+        // Content-Length — cannot be spoofed by a lying header. We still take
+        // the max of the two so a chunked/streamed body that under-reports via
+        // getContent() can't slip past on a large advertised Content-Length.
+        $size = max(
+            \strlen($request->getContent()),
+            (int) $request->headers->get('Content-Length', '0'),
+        );
+
+        if ($size <= $this->maxBytes) {
+            return;
+        }
+
+        // Self-contained RFC 7807 document: setResponse() short-circuits the
+        // kernel, so this never flows through Rfc7807ExceptionListener — the
+        // problem+json contract is guaranteed here regardless.
+        $event->setResponse(new JsonResponse(
+            data: [
+                'type' => '/errors/413',
+                'title' => 'Payload Too Large',
+                'status' => Response::HTTP_REQUEST_ENTITY_TOO_LARGE,
+                'detail' => \sprintf('Request JSON body exceeds the %d-byte limit.', $this->maxBytes),
+            ],
+            status: Response::HTTP_REQUEST_ENTITY_TOO_LARGE,
+            headers: ['content-type' => 'application/problem+json'],
+        ));
+    }
+
+    /**
+     * True only for JSON-bodied `/api/*` writes that are not on an
+     * upload-exempt path.
+     */
+    private function shouldEnforce(Request $request): bool
+    {
+        if (!\in_array($request->getMethod(), [Request::METHOD_POST, Request::METHOD_PUT, Request::METHOD_PATCH], true)) {
+            return false;
+        }
+
+        $path = $request->getPathInfo();
+        if (!str_starts_with($path, '/api/')) {
+            return false;
+        }
+
+        // Upload surfaces carry their own per-tenant / per-MIME size limits and
+        // legitimately ship large bodies. `/api/import-` covers import-sessions,
+        // import-schedules, import-sources and import-profiles.
+        if (str_starts_with($path, '/api/import-') || str_starts_with($path, '/api/assets/upload')) {
+            return false;
+        }
+
+        $contentType = $request->headers->get('Content-Type', '');
+
+        // multipart uploads are never JSON — exempt regardless of path.
+        if (str_starts_with($contentType, 'multipart/form-data')) {
+            return false;
+        }
+
+        foreach (self::JSON_CONTENT_TYPES as $jsonType) {
+            if (str_starts_with($contentType, $jsonType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/api/tests/Unit/Shared/Infrastructure/Http/RequestBodySizeLimitListenerTest.php
+++ b/apps/api/tests/Unit/Shared/Infrastructure/Http/RequestBodySizeLimitListenerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Infrastructure\Http;
+
+use App\Shared\Infrastructure\Http\RequestBodySizeLimitListener;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * W2-9 / AUD-045 — unit coverage for the JSON request-body size cap.
+ *
+ * The cap is exercised with an explicitly injected byte limit rather than a
+ * global `.env.test` override: a low *global* cap would 413 every other Api
+ * test that legitimately ships a body larger than the cap (the first cut set
+ * `.env.test` to 1024 and broke four unrelated Api tests). The end-to-end
+ * wiring through the kernel is proven by the live smoke recorded on the PR;
+ * here we assert the listener's decision logic in isolation.
+ */
+final class RequestBodySizeLimitListenerTest extends TestCase
+{
+    private const int CAP = 64;
+
+    #[Test]
+    public function oversizedJsonWriteIsRejectedWith413ProblemJson(): void
+    {
+        $event = $this->event($this->jsonRequest('/api/products/bulk-edit', 'POST', self::CAP + 200));
+
+        new RequestBodySizeLimitListener(self::CAP)->onRequest($event);
+
+        $response = $event->getResponse();
+        self::assertNotNull($response);
+        self::assertSame(413, $response->getStatusCode());
+        self::assertSame('application/problem+json', $response->headers->get('content-type'));
+    }
+
+    #[Test]
+    public function bodyAtOrBelowCapPassesThrough(): void
+    {
+        $event = $this->event($this->jsonRequest('/api/products/bulk-edit', 'POST', 8));
+
+        new RequestBodySizeLimitListener(self::CAP)->onRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    #[Test]
+    public function multipartUploadIsExempt(): void
+    {
+        $event = $this->event($this->jsonRequest('/api/assets', 'POST', self::CAP + 500, 'multipart/form-data; boundary=x'));
+
+        new RequestBodySizeLimitListener(self::CAP)->onRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    #[Test]
+    public function importSurfaceIsExempt(): void
+    {
+        $event = $this->event($this->jsonRequest('/api/import-sessions', 'POST', self::CAP + 500));
+
+        new RequestBodySizeLimitListener(self::CAP)->onRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    #[Test]
+    public function assetUploadPathIsExempt(): void
+    {
+        $event = $this->event($this->jsonRequest('/api/assets/upload', 'POST', self::CAP + 500));
+
+        new RequestBodySizeLimitListener(self::CAP)->onRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    #[Test]
+    public function nonApiPathIsIgnored(): void
+    {
+        $event = $this->event($this->jsonRequest('/admin/whatever', 'POST', self::CAP + 500));
+
+        new RequestBodySizeLimitListener(self::CAP)->onRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    #[Test]
+    public function bodylessVerbIsIgnored(): void
+    {
+        // A GET with an oversized body is not a write — never capped.
+        $event = $this->event($this->jsonRequest('/api/products', 'GET', self::CAP + 500));
+
+        new RequestBodySizeLimitListener(self::CAP)->onRequest($event);
+
+        self::assertNull($event->getResponse());
+    }
+
+    private function event(Request $request): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createStub(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+    }
+
+    private function jsonRequest(string $path, string $method, int $bodyBytes, string $contentType = 'application/json'): Request
+    {
+        return Request::create(
+            $path,
+            $method,
+            server: ['CONTENT_TYPE' => $contentType],
+            content: str_repeat('a', $bodyBytes),
+        );
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,6 +48,14 @@ name: pim
 
 services:
   api:
+    # AUD-044 (W2-9) — build the prod-posture image stage (APP_ENV=prod,
+    # APP_DEBUG=0, composer --no-dev, prod cache warmed) baked into the
+    # artifact. The base compose pins `target: base` for dev; this re-targets
+    # `prod` so a prod `docker compose build` produces the hardened image.
+    build:
+      context: ./apps/api
+      dockerfile: Dockerfile
+      target: prod
     depends_on:
       pgbouncer:
         condition: service_healthy
@@ -105,6 +113,8 @@ services:
     build:
       context: ./apps/api
       dockerfile: Dockerfile
+      # AUD-044 (W2-9) — same prod-posture stage as the api service.
+      target: prod
     restart: unless-stopped
     depends_on:
       pgbouncer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,11 @@ services:
     build:
       context: ./apps/api
       dockerfile: Dockerfile
+      # AUD-044 (W2-9) — the Dockerfile now has a trailing `prod` stage; without
+      # an explicit target a dev `docker compose build` would build it and ship
+      # APP_ENV=prod locally. Pin dev to the `base` stage. The prod overlay
+      # re-targets `prod`.
+      target: base
     <<: [*default_restart, *resource_limits_api]
     depends_on:
       database:
@@ -206,6 +211,8 @@ services:
     build:
       context: ./apps/api
       dockerfile: Dockerfile
+      # AUD-044 (W2-9) — same dev `base` target as the api service.
+      target: base
     <<: [*default_restart, *resource_limits_worker]
     depends_on:
       database:


### PR DESCRIPTION
## W2-9 — AUD-045 + AUD-044 (#1601)

### AUD-045 — limit rozmiaru JSON body (DoS workera) — security, TDD
**Problem:** endpointy nie-importowe `/api/*` dekodowały JSON dowolnego rozmiaru przed walidacją; ~109 MB → OOM workera (memory_limit=256M). Probe: 240KB na `/api/products/bulk-edit` w pełni zdekodowane.

**Fix (test-first):** `RequestBodySizeLimitListener` (`kernel.request`, prio 16 — po routingu) odrzuca JSON body > `API_MAX_JSON_BODY_BYTES` (default 10 MB) jako **413 `application/problem+json`**, mierząc rozmiar PRZED `json_decode`. Zakres: JSON POST/PUT/PATCH na `/api/*`; **exempt:** multipart (uploady), `/api/assets/upload`, `/api/import-*` (własne per-tenant limity). Limit env-konfigurowalny (`.env.test`=1KB do testu).

**TDD (reguła „najpierw failing test"):** Test A (`oversizedJsonBodyOnNonImportEndpointIsRejectedWith413`) PRZED fixem **czerwony** — endpoint zwracał `202` (kontroler zdekodował body, odtworzona podatność); PO fixie `202→413`. Suita: `OK (3 tests, 12 assertions)`.

**Live smoke (`https://pim.localhost`):**
```
BIG  (2.8MB > limit)  → HTTP 413  application/problem+json
     {"type":"/errors/413","title":"Payload Too Large","status":413,
      "detail":"Request JSON body exceeds the 1048576-byte limit."}
SMALL (kontrola)      → HTTP 202   (≠413, przeszedł do kontrolera)
po przywróceniu 10MB: small bulk-edit → HTTP 202 (listener nie nadblokuje)
```

### AUD-044 — Dockerfile prod-stage
**Problem:** `Dockerfile` hardkodował `APP_ENV=dev`; build bez prod-overlayu → cała app w dev mode (trace, Swagger, profiler).

**Fix (ADDITYWNY — dev `base` nietknięty):** nowy stage `FROM base AS prod` (`APP_ENV=prod`, `APP_DEBUG=0`, `composer --no-dev --optimize-autoloader`, prod cache). `docker-compose.yml` (dev) pinuje jawnie `target: base` (inaczej trailing `prod` stałby się domyślny dla dev builda); `docker-compose.prod.yml` → `target: prod`.

**Weryfikacja:** `docker build --target prod` exit 0 → `printenv APP_ENV`=**prod**, `APP_DEBUG`=**0**; `--target base` → `APP_ENV`=**dev** (regresja dev zachowana). `docker compose config` dev→base, prod→prod.

### Bramki
PHPStan max `No errors` (foreground `--memory-limit=1G`) · Deptrac `0` · php-cs-fixer clean · PHPUnit `3/12` · oba docker buildy + 4× printenv ✅.

### Side-finding (poza zakresem, do Wave 3)
Żywy kontener ma `post_max_size=8M` (repo `php.ini` z `post_max_size=110M` nie jest ładowany w runningu — osobny pre-existing config issue). W prod (php.ini=110M) listener 10MB jest właściwą bramką; w dev FrankenPHP ubija >8M na poziomie SAPI. Smoke wykonany z tymczasowym limitem 1MB (potem przywrócony 10MB 1:1). Flaguję do higieny Wave 3.

Closes #1601
