### PR TITLE
fix(import): finalize stuck sessions on image dead-letter

### DIFF
--- a/apps/api/src/Import/Infrastructure/Messenger/ImageDownloadDeadLetterListener.php
+++ b/apps/api/src/Import/Infrastructure/Messenger/ImageDownloadDeadLetterListener.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Infrastructure\Messenger;
+
+use App\Import\Domain\Entity\ImportLog;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Import\Domain\Enum\ImportSessionStatus;
+use App\Import\Domain\Message\ImageDownloadMessage;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+
+/**
+ * AUD-034 (W2-10) — dead-letter guard for media (image-download) batches.
+ *
+ * Import finalisation gates on {@see ImportSession::$pendingImageBatches}
+ * reaching zero: {@see \App\Import\Application\Handler\ImageDownloadHandler}
+ * decrements the counter (atomically) at the END of each batch and the last
+ * batch finalises the session. When a batch throws BEFORE that decrement, the
+ * retry policy exhausts (5×) and the message dead-letters — the counter is
+ * never decremented, so the session sits `running` forever even though every
+ * other batch finished and the row phase is done.
+ *
+ * This listener replays the SAME atomic decrement on the FINAL failure
+ * (`willRetry() === false`) and, when it drives the counter to zero after the
+ * row phase, finalises the session exactly as the handler does on success. The
+ * lost images are surfaced: every image reference the batch carried bumps
+ * `images_failed`, an error row is logged, and `error_count` is incremented so
+ * the run lands as `partial` (not a silent `success`) — the operator sees that
+ * media was dropped and can re-run.
+ *
+ * Retriable failures are ignored (the long-backoff retry policy still owns the
+ * message); a terminal session is never clobbered.
+ */
+#[AsEventListener(event: WorkerMessageFailedEvent::class)]
+final readonly class ImageDownloadDeadLetterListener
+{
+    public function __construct(
+        private ImportSessionRepositoryInterface $sessions,
+        private TenantRepositoryInterface $tenants,
+        private TenantContext $tenantContext,
+        private EntityManagerInterface $entityManager,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(WorkerMessageFailedEvent $event): void
+    {
+        if ($event->willRetry()) {
+            return;
+        }
+
+        $message = $event->getEnvelope()->getMessage();
+        if (!$message instanceof ImageDownloadMessage) {
+            return;
+        }
+
+        // Rebind the tenant (the failure unwound the messenger middleware that
+        // normally sets it) so the session lookup + writes are scoped correctly.
+        $tenant = $this->tenants->findById($message->tenantId);
+        if (null === $tenant) {
+            return;
+        }
+        $this->tenantContext->set($tenant);
+
+        $lostImages = $this->countImageRefs($message);
+
+        // Mirror the handler's success path: ONE atomic statement bumps the lost
+        // counters and closes this batch's slot in the gate. The status guard
+        // makes it a no-op against a session a concurrent handler / the run
+        // dead-letter listener already finalised, so a terminal outcome is never
+        // clobbered. RETURNING reports the post-decrement gate state.
+        //
+        // tenant-safe: per-row UPDATE keyed by primary key (id from the
+        // tenant-scoped ImageDownloadMessage); tenant already rebound above.
+        $row = $this->entityManager->getConnection()->fetchAssociative(
+            'UPDATE import_sessions'
+            .' SET images_failed = images_failed + :lost,'
+            .'     error_count = error_count + 1,'
+            .'     pending_image_batches = GREATEST(0, pending_image_batches - 1)'
+            .' WHERE id = :id'
+            ."   AND status IN ('pending', 'running', 'paused')"
+            .' RETURNING pending_image_batches, row_phase_complete, status',
+            [
+                'lost' => $lostImages,
+                'id' => $message->importSessionId->toRfc4122(),
+            ],
+        );
+        if (!\is_array($row)) {
+            return;
+        }
+
+        $pending = \is_scalar($row['pending_image_batches']) ? (int) $row['pending_image_batches'] : 1;
+        $rowPhaseDone = (bool) $row['row_phase_complete'];
+
+        $this->logger->warning('Import media batch dead-lettered; images were lost.', [
+            'import_session_id' => $message->importSessionId->toRfc4122(),
+            'lost_images' => $lostImages,
+            'pending_image_batches' => $pending,
+        ]);
+
+        // The batch that drives the gate to zero AFTER the row phase finalises
+        // the run — same condition as the handler's success path.
+        if (0 !== $pending || !$rowPhaseDone) {
+            return;
+        }
+
+        // Re-fetch a MANAGED tenant on the cleared EM so the assignment listener
+        // stamps the new ImportLog with a managed entity (mirrors the handler's
+        // reattachTenant on its post-ingest EM clear).
+        $this->entityManager->clear();
+        $managedTenant = $this->tenants->findById($message->tenantId);
+        if (null === $managedTenant) {
+            return;
+        }
+        $this->tenantContext->set($managedTenant);
+        $session = $this->sessions->findById($message->importSessionId);
+        // markCompleted() only transitions from Running; a Paused session keeps
+        // its (now drained) gate and finalises when the operator resumes.
+        if (!$session instanceof ImportSession || ImportSessionStatus::Running !== $session->getStatus()) {
+            return;
+        }
+
+        $this->entityManager->persist(new ImportLog(
+            importSession: $session,
+            rowNumber: 0,
+            level: ImportLogLevel::Error,
+            message: \sprintf(
+                'Pobieranie %d obrazów nie powiodło się po wyczerpaniu prób (partia trafiła do kolejki błędów). Import zakończono częściowo.',
+                $lostImages,
+            ),
+        ));
+        $session->markCompleted();
+        $this->sessions->save($session);
+    }
+
+    private function countImageRefs(ImageDownloadMessage $message): int
+    {
+        $count = 0;
+        foreach ($message->jobs as $job) {
+            $count += \count($job->urls) + \count($job->zipNames);
+        }
+
+        return $count;
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Messenger/IdempotencyMiddleware.php
+++ b/apps/api/src/Shared/Infrastructure/Messenger/IdempotencyMiddleware.php
@@ -6,6 +6,7 @@ namespace App\Shared\Infrastructure\Messenger;
 
 use DateTimeImmutable;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
@@ -30,11 +31,28 @@ use Symfony\Component\Uid\Uuid;
  * Synchronous dispatches (no ConsumedByWorkerStamp) skip the middleware
  * entirely — sync handlers run inside the originating transaction and
  * are idempotent by construction (a single commit cannot replay).
+ *
+ * AUD-035 (W2-10) — `processed_messages` is provisioned by a raw-SQL
+ * migration, but a worker with `auto_setup=1` only creates
+ * `messenger_messages`. On a fresh deploy where the worker boots before
+ * `doctrine:migrations:migrate`, the INSERT below would raise Postgres
+ * `42P01` (undefined table) and dead-letter the whole queue. The middleware
+ * self-heals: on the first `TableNotFoundException` it creates the table on
+ * demand (idempotent `CREATE TABLE IF NOT EXISTS`, matching the migration
+ * DDL) and retries — so delivery never depends on migrate-before-worker
+ * ordering. The create is attempted once per worker process (a static flag
+ * keeps the steady-state path a single INSERT).
  */
-final readonly class IdempotencyMiddleware implements MiddlewareInterface
+final class IdempotencyMiddleware implements MiddlewareInterface
 {
+    /**
+     * Set once the table has been ensured in this PHP process (worker boot),
+     * so the steady-state path stays a single INSERT with no extra round-trip.
+     */
+    private static bool $tableEnsured = false;
+
     public function __construct(
-        private Connection $connection,
+        private readonly Connection $connection,
     ) {
     }
 
@@ -67,16 +85,60 @@ final readonly class IdempotencyMiddleware implements MiddlewareInterface
         }
 
         try {
-            $this->connection->insert('processed_messages', [
-                'message_id' => $messageId,
-                'handler_class' => $envelope->getMessage()::class,
-                'processed_at' => new DateTimeImmutable()->format('Y-m-d H:i:s'),
-            ]);
+            $this->recordProcessed($messageId, $envelope->getMessage()::class);
         } catch (UniqueConstraintViolationException) {
             // Already processed — short-circuit, return envelope as-is.
             return $envelope;
         }
 
         return $stack->next()->handle($envelope, $stack);
+    }
+
+    /**
+     * INSERT the envelope id, self-healing a missing `processed_messages` on a
+     * worker-booted-before-migrate deploy (AUD-035). A {@see TableNotFoundException}
+     * is recovered exactly once: create the table (idempotent) and retry; a
+     * second miss is a real fault and propagates.
+     */
+    private function recordProcessed(string $messageId, string $handlerClass): void
+    {
+        $row = [
+            'message_id' => $messageId,
+            'handler_class' => $handlerClass,
+            'processed_at' => new DateTimeImmutable()->format('Y-m-d H:i:s'),
+        ];
+
+        try {
+            $this->connection->insert('processed_messages', $row);
+        } catch (TableNotFoundException) {
+            $this->ensureProcessedMessagesTable();
+            $this->connection->insert('processed_messages', $row);
+        }
+    }
+
+    /**
+     * Create `processed_messages` on demand. DDL is kept 1:1 with migration
+     * Version20260429170000 (the authoritative schema); `IF NOT EXISTS` keeps
+     * it safe under concurrent workers racing the same self-heal.
+     */
+    private function ensureProcessedMessagesTable(): void
+    {
+        if (self::$tableEnsured) {
+            return;
+        }
+
+        // tenant-safe: infrastructure DDL — processed_messages is a global
+        // messenger bookkeeping table with no tenant_id (cross-tenant by design).
+        $this->connection->executeStatement(<<<'SQL'
+                CREATE TABLE IF NOT EXISTS processed_messages (
+                    message_id UUID PRIMARY KEY,
+                    handler_class VARCHAR(255) NOT NULL,
+                    processed_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL
+                )
+            SQL);
+        $this->connection->executeStatement('CREATE INDEX IF NOT EXISTS processed_messages_handler_idx ON processed_messages (handler_class)');
+        $this->connection->executeStatement('CREATE INDEX IF NOT EXISTS processed_messages_processed_at_idx ON processed_messages (processed_at)');
+
+        self::$tableEnsured = true;
     }
 }

--- a/apps/api/tests/Integration/Import/IdempotencyMiddlewareSelfHealTest.php
+++ b/apps/api/tests/Integration/Import/IdempotencyMiddlewareSelfHealTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Import;
+
+use App\Shared\Infrastructure\Messenger\IdempotencyMiddleware;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use stdClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-035 (W2-10) — {@see IdempotencyMiddleware} writes to `processed_messages`,
+ * a table created by a raw-SQL migration. A worker with `auto_setup=1` only
+ * provisions `messenger_messages`; on a fresh deploy where the worker boots
+ * before `doctrine:migrations:migrate`, the INSERT used to raise Postgres
+ * `42P01` (undefined table) and dead-letter the entire import queue.
+ *
+ * The middleware now self-heals: it creates the table on demand (idempotent
+ * `CREATE TABLE IF NOT EXISTS`) and retries the INSERT, so the message is
+ * processed regardless of deploy ordering.
+ *
+ * The test DB is built from ORM metadata (Foundry schema:update) and
+ * `processed_messages` is NOT an ORM entity, so it is absent there — `DROP
+ * TABLE IF EXISTS` makes the precondition explicit and the test reproducible
+ * even if a future fixture provisions it.
+ */
+final class IdempotencyMiddlewareSelfHealTest extends KernelTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // The "table ensured" guard is a per-process static; reset it so each
+        // test reproduces the cold worker-boot race regardless of order.
+        $flag = new ReflectionProperty(IdempotencyMiddleware::class, 'tableEnsured');
+        $flag->setValue(null, false);
+    }
+
+    #[Test]
+    public function missingProcessedMessagesTableIsSelfHealedAndMessageProcessed(): void
+    {
+        $connection = $this->connection();
+        $connection->executeStatement('DROP TABLE IF EXISTS processed_messages');
+        self::assertNull(
+            $connection->fetchOne("SELECT to_regclass('public.processed_messages')"),
+            'precondition: the table must be absent so the worker-boot-before-migrate race is reproduced',
+        );
+
+        $middleware = new IdempotencyMiddleware($connection);
+
+        $reached = new stdClass();
+        $reached->value = false;
+
+        // A doctrine-transport delivery id is a bigint, not a UUID — exactly the
+        // shape that hits the processed_messages INSERT on the worker path.
+        $envelope = new Envelope(new stdClass())
+            ->with(new ConsumedByWorkerStamp())
+            ->with(new TransportMessageIdStamp('42'));
+
+        $result = $middleware->handle($envelope, $this->terminalStack($reached));
+
+        self::assertTrue($reached->value, 'the handler must run — a self-heal must not swallow the message');
+        self::assertSame($envelope, $result);
+        self::assertNotNull(
+            $connection->fetchOne("SELECT to_regclass('public.processed_messages')"),
+            'the middleware must have created processed_messages on demand',
+        );
+        self::assertSame(
+            1,
+            $this->countProcessedMessages($connection),
+            'the envelope id must be recorded after the self-heal',
+        );
+    }
+
+    #[Test]
+    public function duplicateDeliveryStillShortCircuitsAfterSelfHeal(): void
+    {
+        $connection = $this->connection();
+        $connection->executeStatement('DROP TABLE IF EXISTS processed_messages');
+
+        $middleware = new IdempotencyMiddleware($connection);
+
+        $messageId = Uuid::v7()->toRfc4122();
+        $first = new stdClass();
+        $first->value = false;
+        $second = new stdClass();
+        $second->value = false;
+
+        $envelope = new Envelope(new stdClass())
+            ->with(new ConsumedByWorkerStamp())
+            ->with(new TransportMessageIdStamp($messageId));
+
+        $middleware->handle($envelope, $this->terminalStack($first));
+        $middleware->handle($envelope, $this->terminalStack($second));
+
+        self::assertTrue($first->value, 'first delivery must reach the handler');
+        self::assertFalse($second->value, 'duplicate delivery must be short-circuited by the UNIQUE PK');
+        self::assertSame(
+            1,
+            $this->countProcessedMessages($connection),
+            'idempotency PK must still hold one row after the self-heal',
+        );
+    }
+
+    private function connection(): Connection
+    {
+        // The container PHPStan extension already types this service id as
+        // Connection (an assert here is flagged always-true), so return as-is.
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+
+        return $connection;
+    }
+
+    private function countProcessedMessages(Connection $connection): int
+    {
+        $count = $connection->fetchOne('SELECT COUNT(*) FROM processed_messages');
+
+        return (int) (\is_scalar($count) ? $count : 0);
+    }
+
+    /**
+     * A one-middleware stack whose terminal handler flags that it ran.
+     */
+    private function terminalStack(stdClass $reached): StackInterface
+    {
+        $terminal = new class($reached) implements MiddlewareInterface {
+            public function __construct(private readonly stdClass $reached)
+            {
+            }
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                $this->reached->value = true;
+
+                return $envelope;
+            }
+        };
+
+        return new class($terminal) implements StackInterface {
+            public function __construct(private readonly MiddlewareInterface $next)
+            {
+            }
+
+            public function next(): MiddlewareInterface
+            {
+                return $this->next;
+            }
+        };
+    }
+}

--- a/apps/api/tests/Integration/Import/ImageDownloadDeadLetterTest.php
+++ b/apps/api/tests/Integration/Import/ImageDownloadDeadLetterTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Import;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Import\Domain\Entity\ImportLog;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportSessionStatus;
+use App\Import\Domain\Message\ImageDownloadJob;
+use App\Import\Domain\Message\ImageDownloadMessage;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Import\Infrastructure\Messenger\ImageDownloadDeadLetterListener;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AUD-034 (W2-10) — when an {@see ImageDownloadMessage} exhausts its retries and
+ * dead-letters, the session's {@see ImportSession::$pendingImageBatches} counter
+ * never reaches zero on the success path, so the run would sit `running` forever
+ * (the row phase finished but the gate never closes). The
+ * {@see ImageDownloadDeadLetterListener} replays the SAME atomic decrement the
+ * handler runs on success — and, when it drives the counter to zero after the
+ * row phase, finalizes the session (as `partial`, because the lost images bump
+ * `images_failed` + leave an error log so the operator knows media was dropped).
+ *
+ * Mirrors {@see ImportRunDeadLetterListenerTest}: fires only on the FINAL failure
+ * and only for a still-active session.
+ */
+final class ImageDownloadDeadLetterTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function lastDeadLetteredBatchFinalisesTheRunningSession(): void
+    {
+        // One pending batch + row phase already done: the dead-lettered batch is
+        // the LAST one, so the listener must close the gate and finalise.
+        [$session, $message] = $this->seedAwaitingMediaSession(pendingBatches: 1, rowPhaseComplete: true, imageRefs: 2);
+
+        $this->dispatchFailure($message, willRetry: false);
+
+        $reloaded = $this->reload($session->getId());
+        self::assertSame(
+            ImportSessionStatus::Partial,
+            $reloaded->getStatus(),
+            'the last dead-lettered media batch must finalise the session (partial — images were lost)',
+        );
+        self::assertSame(0, $reloaded->getPendingImageBatches(), 'the pending-batch gate must reach zero');
+        self::assertSame(2, $reloaded->getImagesFailed(), 'every lost image of the batch must bump images_failed');
+
+        $logs = $this->em()->getRepository(ImportLog::class)->findBy(['importSession' => $reloaded->getId()]);
+        self::assertNotEmpty($logs, 'a dead-lettered media batch must leave an error log for the operator');
+    }
+
+    #[Test]
+    public function earlierDeadLetteredBatchOnlyDecrementsAndLeavesSessionRunning(): void
+    {
+        // Two pending batches: the dead-lettered one decrements to 1 but must
+        // NOT finalise — a sibling batch is still in flight.
+        [$session, $message] = $this->seedAwaitingMediaSession(pendingBatches: 2, rowPhaseComplete: true, imageRefs: 1);
+
+        $this->dispatchFailure($message, willRetry: false);
+
+        $reloaded = $this->reload($session->getId());
+        self::assertSame(
+            ImportSessionStatus::Running,
+            $reloaded->getStatus(),
+            'a non-final dead-lettered batch must leave the session running',
+        );
+        self::assertSame(1, $reloaded->getPendingImageBatches(), 'the gate must decrement by exactly one');
+        self::assertSame(1, $reloaded->getImagesFailed());
+    }
+
+    #[Test]
+    public function retriableFailureLeavesSessionUntouched(): void
+    {
+        [$session, $message] = $this->seedAwaitingMediaSession(pendingBatches: 1, rowPhaseComplete: true, imageRefs: 1);
+
+        // willRetry === true → the backoff policy still has attempts left; the
+        // listener must NOT decrement or finalise.
+        $this->dispatchFailure($message, willRetry: true);
+
+        $reloaded = $this->reload($session->getId());
+        self::assertSame(ImportSessionStatus::Running, $reloaded->getStatus());
+        self::assertSame(1, $reloaded->getPendingImageBatches(), 'a retriable failure must not touch the gate');
+        self::assertSame(0, $reloaded->getImagesFailed());
+    }
+
+    #[Test]
+    public function terminalSessionIsNotClobbered(): void
+    {
+        [$session, $message] = $this->seedAwaitingMediaSession(pendingBatches: 1, rowPhaseComplete: true, imageRefs: 1);
+        // The handler already finalised before the failure event unwinds. Reload
+        // through the repo first — the seeder cleared the EM, so the original
+        // instance is detached and saving it would re-cascade its associations.
+        $managed = $this->reload($session->getId());
+        $managed->markCompleted();
+        $this->sessions()->save($managed);
+
+        $this->dispatchFailure($message, willRetry: false);
+
+        $reloaded = $this->reload($session->getId());
+        self::assertSame(
+            ImportSessionStatus::Success,
+            $reloaded->getStatus(),
+            'a session that already reached a terminal status must not be clobbered',
+        );
+    }
+
+    /**
+     * @return array{ImportSession, ImageDownloadMessage}
+     */
+    private function seedAwaitingMediaSession(int $pendingBatches, bool $rowPhaseComplete, int $imageRefs): array
+    {
+        $tenant = $this->createTenant('demo');
+        $em = $this->em();
+        $this->tenantContext()->set($tenant);
+        $type = $this->productObjectType($em);
+
+        $session = new ImportSession(
+            userId: Uuid::v7(),
+            targetObjectType: $type,
+            fileName: 'media.csv',
+            fileSizeBytes: 128,
+        );
+        $session->assignTenant($tenant);
+        $session->markRunning();
+        for ($i = 0; $i < $pendingBatches; ++$i) {
+            $session->incrementPendingImageBatches();
+        }
+        if ($rowPhaseComplete) {
+            $session->markRowPhaseComplete();
+        }
+        $em->persist($session);
+        $em->flush();
+        $em->clear();
+
+        $urls = [];
+        for ($i = 0; $i < $imageRefs; ++$i) {
+            $urls[] = \sprintf('https://example.com/img-%d.jpg', $i);
+        }
+        $job = new ImageDownloadJob(
+            objectId: Uuid::v7()->toRfc4122(),
+            attributeCode: 'images',
+            locale: null,
+            channelId: null,
+            existingUuids: [],
+            urls: $urls,
+            rowNumber: 1,
+            sku: 'SKU-1',
+        );
+
+        return [$session, new ImageDownloadMessage($session->getId(), $tenant->getId(), [$job])];
+    }
+
+    private function dispatchFailure(ImageDownloadMessage $message, bool $willRetry): void
+    {
+        $event = new WorkerMessageFailedEvent(
+            new Envelope($message),
+            'import',
+            new RuntimeException('image download failed after retries'),
+        );
+        if ($willRetry) {
+            $event->setForRetry();
+        }
+
+        $listener = self::getContainer()->get(ImageDownloadDeadLetterListener::class);
+        $listener($event);
+    }
+
+    private function reload(Uuid $id): ImportSession
+    {
+        $this->em()->clear();
+        $session = $this->sessions()->findById($id);
+        \assert($session instanceof ImportSession);
+
+        return $session;
+    }
+
+    private function sessions(): ImportSessionRepositoryInterface
+    {
+        return self::getContainer()->get(ImportSessionRepositoryInterface::class);
+    }
+
+    private function productObjectType(EntityManagerInterface $em): ObjectType
+    {
+        $type = $em->getRepository(ObjectType::class)->findOneBy(['kind' => ObjectKind::Product]);
+        if ($type instanceof ObjectType) {
+            return $type;
+        }
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        $em->flush();
+
+        return $type;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+}


### PR DESCRIPTION
## W2-10 — AUD-034 + AUD-035 (#1602) — reliability, oba RED→GREEN

### AUD-034 — `ImageDownloadMessage` bez dead-letter → sesja stuck `running` na zawsze
**Bug:** finalizacja importu wymaga `pending_image_batches===0`. Gdy `ImageDownloadHandler::__invoke` rzuci PRZED atomic decrement → 5 retry → dead-letter → licznik nigdy nie zdekrementowany → sesja `running` na zawsze. `ImportRunDeadLetterListener` obsługiwał tylko `ImportRunMessage`.

**Fix:** `ImageDownloadDeadLetterListener` (`WorkerMessageFailedEvent`, tylko `willRetry()===false`). Atomic SQL pod status-guardem:
```sql
UPDATE import_sessions SET images_failed = images_failed + :lost, error_count = error_count + 1,
  pending_image_batches = GREATEST(0, pending_image_batches - 1)
WHERE id = :id AND status IN ('pending','running','paused')
RETURNING pending_image_batches, row_phase_complete, status
```
Gdy `pending===0 && rowPhaseDone && Running` → `ImportLog` poziomu Error (ile obrazów przepadło) + `markCompleted()` → status **`partial`** (error_count++ wymusza Partial, nie cichy Success). Sesja `Paused` → tylko decrement (operator dokończy przy resume). Status w WHERE = atomowy guard przeciw clobberowi terminalnego stanu.

### AUD-035 — `processed_messages` race przy świeżym deployu
**Bug:** `IdempotencyMiddleware` zależy od tabeli z migracji; worker `auto_setup=1` tworzy tylko `messenger_messages`. Świeży deploy (worker przed `migrate`) → `42P01` → cała kolejka import dead-letter. Realny dowód: dead-letterowana wiadomość Id 5 z `42P01` na żywym stacku.

**Fix:** self-heal — INSERT opakowany w try/catch `TableNotFoundException` → `ensureProcessedMessagesTable()` (statyczny flag per proces, steady-state single INSERT) → retry. DDL skopiowany **1:1 z migracji `Version20260429170000`** (`IF NOT EXISTS`, bezpieczne współbieżnie). Bez zmiany kolejności deployu.

### TDD (reguła „najpierw failing test")
- AUD-034 RED: bez listenera → `ServiceNotFoundException` + sesja `running`/`pending>0`. GREEN: 4/4.
- AUD-035 RED: `SQLSTATE[42P01] relation "processed_messages" does not exist` z `IdempotencyMiddleware:70`. GREEN: 2/2.

### Live smoke (żywy stack, realny worker + dev Postgres)
`messenger:failed:show` ujawnił realny dead-letter Id 5 (oba bugi spotkały się w naturze). Kontrolowany live dispatch `WorkerMessageFailedEvent` z `RedeliveryStamp(5)`: log `Removing from transport after 5 retries` + `Import media batch dead-lettered; images were lost`, sesja → **`status=partial pending=0 images_failed=2 error_count=1`** = PASS. `willRetry=true` (przed wyczerpaniem prób) → listener NIE tknął sesji (poprawnie). `debug:event-dispatcher` potwierdził oba listenery wpięte. Dev DB `pim` nietknięta (smoke poszedł na `pim_test`, posprzątane).

### Bramki
PHPStan max `No errors` · Deptrac `0` · php-cs-fixer clean · `tests/Integration/Import` **15/15** (50 asercji) · lint-raw-sql Clean (`tenant-safe:`).

Closes #1602
