### PR TITLE
feat(export): enforce free-tier export retention and schedule cleanup

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -134,6 +134,13 @@ AWS_IMPORTS_BUCKET=pim-imports
 AWS_EXPORTS_BUCKET=pim-exports
 ###< app/asset-storage ###
 
+###> app/export-retention ###
+# AUD-050 (W2-11) — free-tier export retention window in days (GDPR / RODO).
+# `pim:exports:cleanup` erases free-tier (`starter`) exports older than this;
+# paid tiers (`pro` / `enterprise`) keep exports forever (PRD §11.7).
+EXPORT_FREE_RETENTION_DAYS=7
+###< app/export-retention ###
+
 ###> symfony/mercure-bundle ###
 # See https://symfony.com/doc/current/mercure.html#configuration
 # The URL of the Mercure hub, used by the app to publish updates (can be a local URL)

--- a/apps/api/composer.json
+++ b/apps/api/composer.json
@@ -47,6 +47,7 @@
         "symfony/property-info": "7.4.*",
         "symfony/rate-limiter": "7.4.*",
         "symfony/runtime": "7.4.*",
+        "symfony/scheduler": "7.4.*",
         "symfony/security-bundle": "7.4.*",
         "symfony/serializer": "7.4.*",
         "symfony/twig-bundle": "7.4.*",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4989286ab9b9ff8fdb17ef09ced0c20b",
+    "content-hash": "606587519b42e2512874a1a32ff54b58",
     "packages": [
         {
             "name": "api-platform/doctrine-common",
@@ -9627,6 +9627,91 @@
                 }
             ],
             "time": "2026-05-23T18:04:28+00:00"
+        },
+        {
+            "name": "symfony/scheduler",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/scheduler.git",
+                "reference": "d8fff93e5d29af0262e5693b76376117259b4532"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/scheduler/zipball/d8fff93e5d29af0262e5693b76376117259b4532",
+                "reference": "d8fff93e5d29af0262e5693b76376117259b4532",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/clock": "^6.4|^7.0|^8.0"
+            },
+            "require-dev": {
+                "dragonmantank/cron-expression": "^3.1",
+                "symfony/cache": "^6.4.36|^7.4.8|^8.0.8",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.1|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Scheduler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sergey Rabochiy",
+                    "email": "upyx.00@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides scheduling through Symfony Messenger",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cron",
+                "schedule",
+                "scheduler"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/scheduler/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T06:06:12+00:00"
         },
         {
             "name": "symfony/security-bundle",

--- a/apps/api/config/reference.php
+++ b/apps/api/config/reference.php
@@ -468,7 +468,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         }>,
  *     },
  *     scheduler?: bool|array{ // Scheduler configuration
- *         enabled?: bool|Param, // Default: false
+ *         enabled?: bool|Param, // Default: true
  *     },
  *     disallow_search_engine_index?: bool|Param, // Enabled by default when debug is enabled. // Default: true
  *     http_client?: bool|array{ // HTTP Client configuration

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -33,6 +33,11 @@ parameters:
     # ADR-013.
     pim.catalog.enable_custom_object_types: '%env(bool:CATALOG_ENABLE_CUSTOM_OBJECT_TYPES)%'
 
+    # AUD-050 (W2-11) — free-tier export retention window in days (GDPR / RODO).
+    # `pim:exports:cleanup` erases free-tier exports older than this; paid tiers
+    # keep exports forever (PRD §11.7). Default 7 lives in .env; tune per deploy.
+    pim.export.free_retention_days: '%env(int:EXPORT_FREE_RETENTION_DAYS)%'
+
     # Asset upload limits (#438 — DAM MVP). Per-MIME caps decoupled
     # because PDFs are realistically larger than product imagery yet
     # still bounded; raster images stop at 25 MB so a power-user dump
@@ -331,6 +336,18 @@ services:
     App\Import\Application\Service\HealthCheck\FolderPathGuard:
         arguments:
             $basePath: '%env(IMPORT_SOURCE_BASE_PATH)%'
+
+    # AUD-050 (W2-11) — retention window injected from the bound parameter; the
+    # `$exportsStorage` operator is the flysystem named alias (exports.storage).
+    App\Export\Presentation\Command\CleanupExportsCommand:
+        arguments:
+            $freeRetentionDays: '%pim.export.free_retention_days%'
+
+    # AUD-052 (W2-11) — `data_export` audit port. The Export controller writes
+    # the audit entry through this Identity_Contracts interface (deptrac:
+    # Export → Identity_Contracts); autowiring needs the explicit alias.
+    App\Identity\Contracts\Audit\DataExportAuditor:
+        alias: App\Identity\Infrastructure\Audit\DataExportAuditor
 
     App\Import\Application\Service\HealthCheck\FolderHealthCheckDriver:
         tags: ['app.import.health_check_driver']

--- a/apps/api/src/Export/Domain/Repository/ExportSessionRepositoryInterface.php
+++ b/apps/api/src/Export/Domain/Repository/ExportSessionRepositoryInterface.php
@@ -6,6 +6,7 @@ namespace App\Export\Domain\Repository;
 
 use App\Export\Domain\Entity\ExportSession;
 use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
 
 interface ExportSessionRepositoryInterface
@@ -34,4 +35,15 @@ interface ExportSessionRepositoryInterface
      * responsibility (EXP-08 download path).
      */
     public function remove(ExportSession $session): void;
+
+    /**
+     * AUD-050 (W2-11) — retention sweep: sessions for $tenant whose
+     * `started_at` is older than $olderThan, oldest first, capped at $limit so
+     * a tenant with a huge export backlog is drained across several command
+     * runs (FrankenPHP worker-mode memory: bounded batch + the caller clears
+     * the EntityManager between tenants).
+     *
+     * @return list<ExportSession>
+     */
+    public function findOlderThan(Tenant $tenant, DateTimeImmutable $olderThan, int $limit = 500): array;
 }

--- a/apps/api/src/Export/Infrastructure/Doctrine/Repository/DoctrineExportSessionRepository.php
+++ b/apps/api/src/Export/Infrastructure/Doctrine/Repository/DoctrineExportSessionRepository.php
@@ -8,6 +8,7 @@ use App\Export\Domain\Entity\ExportSession;
 use App\Export\Domain\Enum\ExportStatus;
 use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
 use App\Shared\Domain\Tenant;
+use DateTimeImmutable;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Uid\Uuid;
@@ -53,6 +54,25 @@ class DoctrineExportSessionRepository extends ServiceEntityRepository implements
             ->setMaxResults($limit)
             ->setParameter('tenant', $tenant)
             ->setParameter('userId', $userId);
+
+        /** @var list<ExportSession> $result */
+        $result = $qb->getQuery()->getResult();
+
+        return $result;
+    }
+
+    /**
+     * @return list<ExportSession>
+     */
+    public function findOlderThan(Tenant $tenant, DateTimeImmutable $olderThan, int $limit = 500): array
+    {
+        $qb = $this->createQueryBuilder('s')
+            ->where('s.tenant = :tenant')
+            ->andWhere('s.startedAt < :cutoff')
+            ->orderBy('s.startedAt', 'ASC')
+            ->setMaxResults($limit)
+            ->setParameter('tenant', $tenant)
+            ->setParameter('cutoff', $olderThan);
 
         /** @var list<ExportSession> $result */
         $result = $qb->getQuery()->getResult();

--- a/apps/api/src/Export/Presentation/Command/CleanupExportsCommand.php
+++ b/apps/api/src/Export/Presentation/Command/CleanupExportsCommand.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Presentation\Command;
+
+use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Repository\TenantRepositoryInterface;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * AUD-050 (W2-11) — enforces export retention for compliance (GDPR / RODO).
+ *
+ * Generated exports carry full product data and PII. Paid tiers keep them
+ * forever (PRD §11.7); the free tier (`starter`) must NOT accumulate PII
+ * indefinitely, so this command deletes free-tier `export_sessions` (DB row +
+ * the MinIO file under `<tenant_id>/<session_id>.<format>`) whose `started_at`
+ * is older than the retention window (env `EXPORT_FREE_RETENTION_DAYS`,
+ * default 7). Until this landed, the only cleanup note in flysystem.yaml was a
+ * TODO ("lands with scheduled command") and exports grew without bound.
+ *
+ * Tenant-scoped by design — it iterates every tenant and sets the tenant
+ * context per tenant so the (RLS-protected, once FORCE RLS lands) query +
+ * cleanup never reach across tenant boundaries, mirroring
+ * {@see \App\Import\Presentation\Command\PurgeStagedFilesCommand}. Paid tenants
+ * are skipped entirely. Intended for a daily scheduler entry (AUD-051).
+ *
+ * Memory (FrankenPHP worker mode, §3.10): `findOlderThan` caps the per-tenant
+ * batch and the EntityManager is cleared after each tenant's flush, so the
+ * Identity Map stays bounded even across many tenants.
+ */
+#[AsCommand(
+    name: 'pim:exports:cleanup',
+    description: 'Delete free-tier exports (DB row + file) past the retention window. Paid tiers keep exports forever.',
+)]
+final class CleanupExportsCommand extends Command
+{
+    public function __construct(
+        private readonly TenantRepositoryInterface $tenants,
+        private readonly ExportSessionRepositoryInterface $sessions,
+        private readonly TenantContext $tenantContext,
+        private readonly FilesystemOperator $exportsStorage,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly int $freeRetentionDays,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'retention-days',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Override the free-tier retention window in days (default: env EXPORT_FREE_RETENTION_DAYS).',
+            )
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'List what would be deleted without touching anything.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $dryRun = true === $input->getOption('dry-run');
+
+        $override = $input->getOption('retention-days');
+        $days = null === $override ? $this->freeRetentionDays : (int) $override;
+        if ($days < 1) {
+            $io->error('Retention window must be a positive integer (days).');
+
+            return Command::INVALID;
+        }
+
+        $cutoff = new DateTimeImmutable(\sprintf('-%d days', $days));
+        $io->title(\sprintf(
+            'Cleanup free-tier exports older than %dd (cutoff %s)%s',
+            $days,
+            $cutoff->format('c'),
+            $dryRun ? ' — DRY RUN' : '',
+        ));
+
+        $deleted = 0;
+        $fileFailures = 0;
+        $skippedPaid = 0;
+        foreach ($this->tenants->findAllOrderedByCode() as $tenant) {
+            if (!$tenant->isFreeTier()) {
+                ++$skippedPaid;
+                continue;
+            }
+
+            $this->tenantContext->set($tenant);
+            $stale = $this->sessions->findOlderThan($tenant, $cutoff);
+            $removedThisTenant = false;
+            foreach ($stale as $session) {
+                $io->writeln(\sprintf(
+                    '  [%s] session %s (started %s, file %s)',
+                    $tenant->getCode(),
+                    $session->getId()->toRfc4122(),
+                    $session->getStartedAt()->format('c'),
+                    $session->getFilePath() ?? '—',
+                ));
+                if ($dryRun) {
+                    ++$deleted;
+                    continue;
+                }
+
+                $filePath = $session->getFilePath();
+                if (null !== $filePath && '' !== $filePath) {
+                    try {
+                        $this->exportsStorage->delete($filePath);
+                    } catch (FilesystemException $exception) {
+                        // File already gone (manual cleanup / failed write): still
+                        // drop the row so the table does not keep a dangling ref.
+                        $io->warning(\sprintf('Storage delete failed for %s: %s', $filePath, $exception->getMessage()));
+                        ++$fileFailures;
+                    }
+                }
+                // Batch the row deletes: one flush per tenant instead of one per
+                // session (findOlderThan caps the batch, so memory stays bounded).
+                $this->entityManager->remove($session);
+                $removedThisTenant = true;
+                ++$deleted;
+            }
+            if ($removedThisTenant) {
+                $this->entityManager->flush();
+                $this->entityManager->clear();
+            }
+        }
+
+        $io->success(\sprintf(
+            '%s %d free-tier export(s)%s; skipped %d paid tenant(s) (forever retention).',
+            $dryRun ? 'Would delete' : 'Deleted',
+            $deleted,
+            $fileFailures > 0 ? \sprintf(' (%d with storage warnings)', $fileFailures) : '',
+            $skippedPaid,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/apps/api/src/Export/Presentation/Controller/ExportSessionController.php
+++ b/apps/api/src/Export/Presentation/Controller/ExportSessionController.php
@@ -15,6 +15,7 @@ use App\Export\Domain\Repository\ExportLogRepositoryInterface;
 use App\Export\Domain\Repository\ExportProfileRepositoryInterface;
 use App\Export\Domain\Repository\ExportSessionRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Contracts\Audit\DataExportAuditor;
 use App\Shared\Application\TenantContext;
 use App\Shared\Application\UserIdentityAware;
 use DateTimeInterface;
@@ -65,6 +66,7 @@ final class ExportSessionController
         private readonly MessageBusInterface $bus,
         private readonly FilesystemOperator $exportsStorage,
         private readonly ExportProgressPublisher $progress,
+        private readonly DataExportAuditor $dataExportAuditor,
     ) {
     }
 
@@ -153,6 +155,21 @@ final class ExportSessionController
         } catch (FilesystemException $error) {
             throw new NotFoundHttpException(sprintf('Export file for %s is missing from storage.', $id), $error);
         }
+
+        // AUD-052 — dedicated `data_export` audit event: full product data + PII
+        // is leaving the system. Recorded once the file stream is open (the
+        // download will proceed) so the compliance trail captures who exported
+        // what, when. Written before the streamed body so it persists even if
+        // the client aborts mid-stream.
+        $this->dataExportAuditor->recordExport($session->getId()->toRfc4122(), [
+            'entity_type' => $session->getEntityType()->value,
+            'object_type_id' => $session->getObjectTypeId()?->toRfc4122(),
+            'format' => $session->getFormat()->value,
+            'target_scope' => $session->getTargetScope()->value,
+            'row_count' => $session->getSuccessCount(),
+            'locales' => $session->getLocales(),
+            'channels' => $session->getChannels(),
+        ]);
 
         $filename = sprintf('pim-export-%s.%s', $session->getStartedAt()->format('Ymd-His'), $session->getFormat()->value);
 

--- a/apps/api/src/Identity/Contracts/Audit/DataExportAuditor.php
+++ b/apps/api/src/Identity/Contracts/Audit/DataExportAuditor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Audit;
+
+/**
+ * AUD-052 (W2-11) — cross-context contract for the dedicated `data_export`
+ * audit event (compliance / RODO).
+ *
+ * The generic {@see \App\Identity\Infrastructure\Audit\AuditLogListener} only
+ * captures HTTP metadata (method + permission outcome, old/new null) — it never
+ * records that a data export, i.e. full product data + PII, actually left the
+ * system. This contract lets the Export bounded context (Deptrac: Export may
+ * only reach `*_Contracts` + `Shared`) write a first-class audit entry without
+ * importing the Identity `AuditLog` entity or its repository.
+ *
+ * The actor + tenant come from the Symfony security token via the adapter, so
+ * callers only describe WHAT was exported, never WHO — keeping the surface
+ * narrow and the question "who exported what, when?" answerable from
+ * `audit_logs` with `action = 'data_export'`.
+ */
+interface DataExportAuditor
+{
+    /**
+     * Records a `data_export` audit entry for the current principal.
+     *
+     * @param string               $sessionId export session id (RFC 4122) — the audit `resource_id`
+     * @param array<string, mixed> $scope     what was exported (entity type, format, row count, scope, …) → audit `new_value`
+     */
+    public function recordExport(string $sessionId, array $scope): void;
+}

--- a/apps/api/src/Identity/Infrastructure/Audit/DataExportAuditor.php
+++ b/apps/api/src/Identity/Infrastructure/Audit/DataExportAuditor.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Infrastructure\Audit;
+
+use App\Identity\Application\CurrentTenantProvider;
+use App\Identity\Contracts\Audit\DataExportAuditor as DataExportAuditorContract;
+use App\Identity\Domain\Entity\AuditLog;
+use App\Identity\Domain\Entity\User;
+use App\Identity\Domain\Repository\AuditLogRepositoryInterface;
+use DateTimeImmutable;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-052 (W2-11) — writes the dedicated `data_export` audit entry.
+ *
+ * Unlike the generic {@see AuditLogListener} (which records the GET request's
+ * method + permission outcome with old/new null), this entry carries
+ * `action = 'data_export'`, the session id as `resource_id`, and the export
+ * scope (entity type / format / row count) in `new_value` so the compliance
+ * trail answers "who exported what, when?".
+ *
+ * Actor + tenant are resolved from the security token, mirroring the listener;
+ * the IP / user-agent are pulled from the current request when available.
+ */
+final readonly class DataExportAuditor implements DataExportAuditorContract
+{
+    public function __construct(
+        private AuditLogRepositoryInterface $repository,
+        private Security $security,
+        private CurrentTenantProvider $tenantProvider,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    public function recordExport(string $sessionId, array $scope): void
+    {
+        $user = $this->security->getUser();
+        $userId = $user instanceof User ? $user->getId() : null;
+        $request = $this->requestStack->getCurrentRequest();
+
+        $entry = new AuditLog(
+            id: Uuid::v7(),
+            tenantId: $this->tenantProvider->getCurrent()?->getId(),
+            userId: $userId,
+            superAdminId: null,
+            action: 'data_export',
+            resourceType: 'export_session',
+            resourceId: $sessionId,
+            oldValue: null,
+            newValue: $scope,
+            permissionCheckResult: 'granted',
+            crossTenantAccess: false,
+            specialFlags: [],
+            ipAddress: $request?->getClientIp(),
+            userAgent: $request?->headers->get('User-Agent'),
+            createdAt: new DateTimeImmutable(),
+        );
+
+        $this->repository->save($entry);
+    }
+}

--- a/apps/api/src/Shared/Domain/Tenant.php
+++ b/apps/api/src/Shared/Domain/Tenant.php
@@ -146,6 +146,18 @@ class Tenant
         $this->plan = $plan;
     }
 
+    /**
+     * AUD-050 (W2-11) — "free tier" for retention purposes is the lowest plan
+     * (`starter`). Free-tier exports carry full data / PII and are erased past
+     * the retention window (GDPR / RODO); paid tiers (`pro` / `enterprise`)
+     * keep exports forever (PRD §11.7). New paid plans are retained-forever by
+     * default — only `starter` opts into the cleanup sweep.
+     */
+    public function isFreeTier(): bool
+    {
+        return self::PLAN_STARTER === $this->plan;
+    }
+
     public function getStatus(): string
     {
         return $this->status;

--- a/apps/api/src/Shared/Infrastructure/Scheduler/MaintenanceSchedule.php
+++ b/apps/api/src/Shared/Infrastructure/Scheduler/MaintenanceSchedule.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Scheduler;
+
+use Symfony\Component\Scheduler\Attribute\AsSchedule;
+use Symfony\Component\Scheduler\RecurringMessage;
+use Symfony\Component\Scheduler\Schedule;
+use Symfony\Component\Scheduler\ScheduleProviderInterface;
+
+/**
+ * AUD-051 (W2-11) — the platform's retention / offboarding maintenance schedule.
+ *
+ * Before this, none of the retention commands were scheduled — Symfony Scheduler
+ * was unused and there was no cron, so `audit_logs` grew without bound, the
+ * tenant soft-delete window never closed, abandoned staged uploads lingered, and
+ * (with AUD-050) free-tier exports were never swept. This provider registers
+ * each command as a daily recurring message, drained off the dedicated
+ * `scheduler_maintenance` transport.
+ *
+ * Cadence: daily is enough for every sweep here — the smallest retention window
+ * (staged uploads, 24h) is still an order of magnitude longer than a daily run,
+ * and the tenant grace period (30d) / audit horizon (365d) are far longer. Runs
+ * are spread across off-peak early-morning UTC slots so they don't contend.
+ *
+ * Worker: the transport is consumed by `messenger:consume scheduler_maintenance`
+ * (see messenger.yaml + docker-compose `worker`). Each message runs its console
+ * command through {@see RunMaintenanceCommandHandler}.
+ *
+ * No --dry-run here: this is the real sweep. Operators validate candidates with
+ * `--dry-run` manually (each command supports it) before relying on the schedule.
+ */
+#[AsSchedule('maintenance')]
+final class MaintenanceSchedule implements ScheduleProviderInterface
+{
+    private ?Schedule $schedule = null;
+
+    public function getSchedule(): Schedule
+    {
+        return $this->schedule ??= new Schedule()->add(
+            // Free-tier export retention (AUD-050) — 02:00 UTC daily.
+            RecurringMessage::cron('0 2 * * *', new RunMaintenanceCommand('pim:exports:cleanup')),
+            // Audit-log retention horizon (#99) — 02:30 UTC daily.
+            RecurringMessage::cron('30 2 * * *', new RunMaintenanceCommand('pim:audit:cleanup')),
+            // Tenant soft-delete hard-delete sweep (RBAC-P5-021) — 03:00 UTC daily.
+            RecurringMessage::cron('0 3 * * *', new RunMaintenanceCommand('pim:tenants:purge-deleted')),
+            // Abandoned staged-upload TTL sweep (IMP2-2.2) — 03:30 UTC daily.
+            RecurringMessage::cron('30 3 * * *', new RunMaintenanceCommand('pim:import:purge-staged')),
+        );
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Scheduler/RunMaintenanceCommand.php
+++ b/apps/api/src/Shared/Infrastructure/Scheduler/RunMaintenanceCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Scheduler;
+
+/**
+ * AUD-051 (W2-11) — message that asks the worker to run one maintenance console
+ * command on its scheduled cadence.
+ *
+ * Symfony Scheduler has no built-in "run a console command" recurring message,
+ * so {@see MaintenanceSchedule} emits this and {@see RunMaintenanceCommandHandler}
+ * dispatches it to the Symfony console application. Keeping the command name +
+ * args in the payload (rather than one message class per command) keeps the
+ * schedule declarative and the handler trivially testable.
+ */
+final readonly class RunMaintenanceCommand
+{
+    /**
+     * @param array<string, scalar|bool> $arguments console input (options/args), e.g. `['--dry-run' => true]`
+     */
+    public function __construct(
+        public string $command,
+        public array $arguments = [],
+    ) {
+    }
+}

--- a/apps/api/src/Shared/Infrastructure/Scheduler/RunMaintenanceCommandHandler.php
+++ b/apps/api/src/Shared/Infrastructure/Scheduler/RunMaintenanceCommandHandler.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\Scheduler;
+
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * AUD-051 (W2-11) — runs the scheduled maintenance console command on the
+ * worker.
+ *
+ * The `scheduler_maintenance` transport is auto-registered by the scheduler from
+ * {@see MaintenanceSchedule}'s `#[AsSchedule('maintenance')]` (no messenger.yaml
+ * entry needed) and must be drained by `messenger:consume scheduler_maintenance`
+ * (docker-compose `worker`), so this handler executes in the worker process. It
+ * boots a console {@see Application} over the SAME kernel
+ * (no sub-process), runs the requested command, and throws on a non-zero exit so
+ * Messenger's retry / failure transport handles a failed sweep instead of
+ * silently swallowing it.
+ *
+ * Memory (FrankenPHP worker mode, §3.10): each maintenance command does its own
+ * `EntityManager::clear()` batching; the console Application adds no persistent
+ * state beyond the request.
+ */
+#[AsMessageHandler]
+final readonly class RunMaintenanceCommandHandler
+{
+    public function __construct(
+        private KernelInterface $kernel,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(RunMaintenanceCommand $message): void
+    {
+        $application = new Application($this->kernel);
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $input = new ArrayInput(['command' => $message->command] + $message->arguments);
+        $input->setInteractive(false);
+        $output = new BufferedOutput();
+
+        $exitCode = $application->doRun($input, $output);
+
+        $this->logger->info('Scheduled maintenance command finished.', [
+            'command' => $message->command,
+            'exit_code' => $exitCode,
+            'output' => $output->fetch(),
+        ]);
+
+        if (0 !== $exitCode) {
+            throw new RuntimeException(\sprintf(
+                'Scheduled maintenance command "%s" exited with code %d.',
+                $message->command,
+                $exitCode,
+            ));
+        }
+    }
+}

--- a/apps/api/symfony.lock
+++ b/apps/api/symfony.lock
@@ -279,6 +279,18 @@
             "config/routes.yaml"
         ]
     },
+    "symfony/scheduler": {
+        "version": "7.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.2",
+            "ref": "caea3c928ee9e1b21288fd76aef36f16ea355515"
+        },
+        "files": [
+            "src/Schedule.php"
+        ]
+    },
     "symfony/security-bundle": {
         "version": "7.4",
         "recipe": {

--- a/apps/api/tests/Api/Export/ExportDownloadAuditApiTest.php
+++ b/apps/api/tests/Api/Export/ExportDownloadAuditApiTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Export;
+
+use App\Export\Domain\Entity\ExportSession;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Export\Domain\Enum\ExportFormat;
+use App\Export\Domain\Enum\ExportSource;
+use App\Export\Domain\Enum\ExportTargetScope;
+use App\Identity\Domain\Repository\UserRepositoryInterface;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * AUD-052 (W2-11) — a data export leaves a dedicated `data_export` audit trail.
+ *
+ * The generic AuditLogListener only records HTTP metadata (method + permission
+ * outcome, old/new null) — it never tells you that PII left the building. This
+ * test pins a dedicated audit entry written at download time with
+ * action=`data_export`, the session id as resource id, and the export scope in
+ * `new_value` (entity type / format / row count) — the compliance question
+ * "who exported what, when?" must be answerable from the audit log.
+ *
+ * FAILING-FIRST: before the fix, downloading an export writes no `data_export`
+ * row, so the COUNT below is 0 and the test is RED.
+ */
+final class ExportDownloadAuditApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function downloadingExportWritesDataExportAuditEntry(): void
+    {
+        $session = $this->doneSession();
+        $this->em()->persist($session);
+        $this->em()->flush();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request(
+            'GET',
+            sprintf('/api/exports/sessions/%s/download', $session->getId()->toRfc4122()),
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $count = $this->em()->getConnection()->fetchOne(
+            "SELECT COUNT(*) FROM audit_logs WHERE action = 'data_export' AND resource_id = :rid",
+            ['rid' => $session->getId()->toRfc4122()],
+        );
+        self::assertSame(1, \is_numeric($count) ? (int) $count : 0, 'A data_export audit entry must be written on download.');
+
+        /** @var array<string, mixed>|false $row */
+        $row = $this->em()->getConnection()->fetchAssociative(
+            "SELECT new_value, resource_type FROM audit_logs WHERE action = 'data_export' AND resource_id = :rid",
+            ['rid' => $session->getId()->toRfc4122()],
+        );
+        self::assertIsArray($row);
+        self::assertIsString($row['new_value']);
+        /** @var array<string, mixed> $newValue */
+        $newValue = json_decode($row['new_value'], true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('product', $newValue['entity_type'] ?? null);
+        self::assertSame('csv', $newValue['format'] ?? null);
+    }
+
+    private function doneSession(): ExportSession
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        $user = self::getContainer()->get(UserRepositoryInterface::class)->findByEmail(self::ADMIN_EMAIL);
+        \assert(null !== $user);
+
+        $session = new ExportSession(
+            userId: $user->getId(),
+            source: ExportSource::CentralTab,
+            format: ExportFormat::Csv,
+            targetScope: ExportTargetScope::All,
+            selectedColumns: ['sku'],
+            entityType: ExportEntityType::Product,
+        );
+        $session->assignTenant($tenant);
+
+        $path = sprintf('%s/%s.csv', $tenant->getId()->toRfc4122(), $session->getId()->toRfc4122());
+        $session->markRunning();
+        $session->markDone(1, $path, 9);
+
+        // The container resolves `exports.storage` to a concrete Filesystem
+        // (a FilesystemOperator) — write the export bytes the download streams.
+        self::getContainer()->get('exports.storage')->write($path, 'sku\nABC1');
+
+        return $session;
+    }
+}

--- a/apps/api/tests/Integration/Maintenance/ExportRetentionCleanupTest.php
+++ b/apps/api/tests/Integration/Maintenance/ExportRetentionCleanupTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Maintenance;
+
+use App\Shared\Domain\Tenant;
+use Doctrine\DBAL\Connection;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Uid\Uuid;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AUD-050 (W2-11) — proves export retention enforcement (GDPR / RODO): free-tier
+ * exports (full data / PII) past the retention window get erased — file + DB row —
+ * while fresh free-tier exports and ALL paid-tier exports survive forever.
+ *
+ * FAILING-FIRST: before the fix `pim:exports:cleanup` does not exist, so the
+ * CommandTester construction throws CommandNotFoundException and the test is RED.
+ * After the fix the command iterates tenants under TenantContext, deletes the
+ * stale free-tier session rows + their MinIO objects, and leaves the rest.
+ *
+ * OPERATOR-DATA SAFETY: throwaway tenants with random uuids; schema reset per
+ * test (Foundry ResetDatabase). Never touches the real demo / acme tenants.
+ */
+final class ExportRetentionCleanupTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    #[Test]
+    public function deletesStaleFreeTierExportsAndKeepsFreshAndPaid(): void
+    {
+        $kernel = self::bootKernel();
+        $connection = $this->connection();
+        $exports = $this->exportsStorage();
+
+        $free = Uuid::v7();
+        $paid = Uuid::v7();
+        $this->seedTenant($connection, $free, 'free', Tenant::PLAN_STARTER);
+        $this->seedTenant($connection, $paid, 'paid', Tenant::PLAN_PRO);
+
+        $freeUser = $this->seedUser($connection, $free);
+        $paidUser = $this->seedUser($connection, $paid);
+
+        // Free tenant: one stale export (8 days old, default window 7) + one fresh.
+        $staleFree = $this->seedSession($connection, $exports, $free, $freeUser, '-8 days');
+        $freshFree = $this->seedSession($connection, $exports, $free, $freeUser, '-1 days');
+        // Paid tenant: one equally-stale export — must be kept (forever retention).
+        $stalePaid = $this->seedSession($connection, $exports, $paid, $paidUser, '-8 days');
+
+        // Sanity: every session + file is present before the cleanup.
+        self::assertTrue($exports->fileExists($this->path($free, $staleFree)));
+        self::assertTrue($exports->fileExists($this->path($free, $freshFree)));
+        self::assertTrue($exports->fileExists($this->path($paid, $stalePaid)));
+
+        $tester = $this->commandTester($kernel);
+        $exit = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+
+        // Stale free-tier export: row + file gone.
+        self::assertSame(0, $this->rowExists($connection, $staleFree), 'Stale free-tier session row must be deleted.');
+        self::assertFalse($exports->fileExists($this->path($free, $staleFree)), 'Stale free-tier file must be deleted.');
+
+        // Fresh free-tier export: untouched.
+        self::assertSame(1, $this->rowExists($connection, $freshFree), 'Fresh free-tier session must survive.');
+        self::assertTrue($exports->fileExists($this->path($free, $freshFree)), 'Fresh free-tier file must survive.');
+
+        // Stale paid-tier export: untouched (forever retention).
+        self::assertSame(1, $this->rowExists($connection, $stalePaid), 'Paid-tier session must survive forever.');
+        self::assertTrue($exports->fileExists($this->path($paid, $stalePaid)), 'Paid-tier file must survive forever.');
+    }
+
+    #[Test]
+    public function dryRunDeletesNothing(): void
+    {
+        $kernel = self::bootKernel();
+        $connection = $this->connection();
+        $exports = $this->exportsStorage();
+
+        $free = Uuid::v7();
+        $this->seedTenant($connection, $free, 'free-dry', Tenant::PLAN_STARTER);
+        $freeUser = $this->seedUser($connection, $free);
+        $staleFree = $this->seedSession($connection, $exports, $free, $freeUser, '-30 days');
+
+        $tester = $this->commandTester($kernel);
+        $exit = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertSame(1, $this->rowExists($connection, $staleFree), 'Dry-run must keep the row.');
+        self::assertTrue($exports->fileExists($this->path($free, $staleFree)), 'Dry-run must keep the file.');
+    }
+
+    private function seedTenant(Connection $connection, Uuid $id, string $codePrefix, string $plan): void
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $connection->executeStatement(
+            'INSERT INTO tenants (id, code, name, plan, created_at) VALUES (:id, :code, :name, :plan, NOW())',
+            ['id' => $id->toRfc4122(), 'code' => $codePrefix.'-'.$suffix, 'name' => $codePrefix, 'plan' => $plan],
+        );
+    }
+
+    private function seedUser(Connection $connection, Uuid $tenant): Uuid
+    {
+        $userId = Uuid::v7();
+        $suffix = bin2hex(random_bytes(4));
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO users (id, email, password, roles, status, totp_backup_codes,
+                                   created_at, password_change_required, tenant_id)
+                VALUES (:id, :email, 'x', '[]'::json, 'active', '[]'::jsonb, NOW(), false, :t)
+                SQL,
+            ['id' => $userId->toRfc4122(), 'email' => 'user-'.$suffix.'@example.test', 't' => $tenant->toRfc4122()],
+        );
+
+        return $userId;
+    }
+
+    /**
+     * Seeds a done export_session with a file at `<tenant>/<session>.xlsx` and
+     * `started_at` shifted by $when. Returns the session id.
+     */
+    private function seedSession(
+        Connection $connection,
+        FilesystemOperator $exports,
+        Uuid $tenant,
+        Uuid $user,
+        string $when,
+    ): Uuid {
+        $sessionId = Uuid::v7();
+        $path = $this->path($tenant, $sessionId);
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO export_sessions
+                    (id, tenant_id, user_id, source, format, target_scope, entity_type,
+                     selected_columns, include_variants, target_count, success_count,
+                     status, started_at, file_path)
+                VALUES
+                    (:id, :t, :uid, 'manual', 'xlsx', 'all', 'product',
+                     '[]'::jsonb, false, 1, 1,
+                     'done', NOW() + (:when)::interval, :path)
+                SQL,
+            [
+                'id' => $sessionId->toRfc4122(),
+                't' => $tenant->toRfc4122(),
+                'uid' => $user->toRfc4122(),
+                'when' => $when,
+                'path' => $path,
+            ],
+        );
+        $exports->write($path, 'xlsx-bytes');
+
+        return $sessionId;
+    }
+
+    private function path(Uuid $tenant, Uuid $session): string
+    {
+        return $tenant->toRfc4122().'/'.$session->toRfc4122().'.xlsx';
+    }
+
+    private function rowExists(Connection $connection, Uuid $session): int
+    {
+        $value = $connection->fetchOne(
+            'SELECT COUNT(*) FROM export_sessions WHERE id = :id',
+            ['id' => $session->toRfc4122()],
+        );
+
+        return \is_numeric($value) ? (int) $value : 0;
+    }
+
+    private function commandTester(object $kernel): CommandTester
+    {
+        \assert($kernel instanceof \Symfony\Component\HttpKernel\KernelInterface);
+        $application = new Application($kernel);
+
+        return new CommandTester($application->find('pim:exports:cleanup'));
+    }
+
+    private function connection(): Connection
+    {
+        /** @var Connection $connection */
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+
+        return $connection;
+    }
+
+    private function exportsStorage(): FilesystemOperator
+    {
+        // The container resolves `exports.storage` to a concrete Filesystem
+        // (a FilesystemOperator) — return it directly, no narrowing needed.
+        return self::getContainer()->get('exports.storage');
+    }
+}

--- a/apps/api/tests/Integration/Scheduler/MaintenanceScheduleTest.php
+++ b/apps/api/tests/Integration/Scheduler/MaintenanceScheduleTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Scheduler;
+
+use App\Shared\Infrastructure\Scheduler\MaintenanceSchedule;
+use App\Shared\Infrastructure\Scheduler\RunMaintenanceCommand;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Scheduler\Generator\MessageContext;
+use Symfony\Component\Scheduler\RecurringMessage;
+
+/**
+ * AUD-051 (W2-11) — proves the maintenance retention/offboarding schedule
+ * registers every retention command as a recurring message.
+ *
+ * Before the fix the schedule provider did not exist (Symfony Scheduler unused),
+ * so the retention commands never ran on a cadence and `audit_logs` / exports /
+ * staged files / soft-deleted tenants grew without bound. This asserts the
+ * declarative schedule contains exactly the expected commands — without booting
+ * a worker (which the live-stack smoke covers via `debug:scheduler`).
+ */
+final class MaintenanceScheduleTest extends KernelTestCase
+{
+    #[Test]
+    public function registersEveryRetentionCommandAsRecurringMessage(): void
+    {
+        self::bootKernel();
+
+        $provider = self::getContainer()->get(MaintenanceSchedule::class);
+        self::assertInstanceOf(MaintenanceSchedule::class, $provider);
+
+        $messages = $provider->getSchedule()->getRecurringMessages();
+        $commands = [];
+        foreach ($messages as $recurring) {
+            self::assertInstanceOf(RecurringMessage::class, $recurring);
+            $trigger = $recurring->getTrigger();
+            $context = new MessageContext('maintenance', $recurring->getId(), $trigger, new DateTimeImmutable());
+            foreach ($recurring->getMessages($context) as $message) {
+                self::assertInstanceOf(
+                    RunMaintenanceCommand::class,
+                    $message,
+                    'Every scheduled message must be a RunMaintenanceCommand.',
+                );
+                $commands[] = $message->command;
+            }
+        }
+
+        sort($commands);
+        self::assertSame(
+            [
+                'pim:audit:cleanup',
+                'pim:exports:cleanup',
+                'pim:import:purge-staged',
+                'pim:tenants:purge-deleted',
+            ],
+            $commands,
+            'The maintenance schedule must drive all four retention/offboarding commands.',
+        );
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,7 +212,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: php bin/console messenger:consume import --time-limit=3600 --memory-limit=256M
+    # AUD-051 (W2-11) — also consume `scheduler_maintenance` so the
+    # MaintenanceSchedule (export/audit/tenant/staged-file retention) actually
+    # fires its daily cron; without a consumer the schedule is inert.
+    command: php bin/console messenger:consume import scheduler_maintenance --time-limit=3600 --memory-limit=256M
     environment:
       APP_ENV: ${APP_ENV:-dev}
       APP_SECRET: ${APP_SECRET:-ChangeMeBeforeDeploy}


### PR DESCRIPTION
## W2-11 — AUD-050 + AUD-051 + AUD-052 (#1603) — compliance/RODO (domena K)

### AUD-050 — enforcement retencji eksportów (PII forever → RODO)
Eksporty (pełne dane/PII) były trzymane bezterminowo bez enforcement (`flysystem.yaml` flagował free 7d jako TODO). **Fix:** `pim:exports:cleanup` — usuwa free-tier (`starter`) eksporty starsze niż `EXPORT_FREE_RETENTION_DAYS` (default 7) z `exports.storage` + rekord DB; paid (`pro`/`enterprise`) = forever (PRD §11.7). Tenant-scoped, flush+clear per tenant (worker-mode memory), `--dry-run` / `--retention-days`.
**TDD:** RED `CommandNotFoundException` → GREEN (stale free usunięty plik+rekord; fresh free + stale paid zostają; dry-run nic nie usuwa).

### AUD-051 — scheduling retencji/offboardingu
Symfony Scheduler nieużywany; `audit_logs` rósł bez granic. **Fix:** `symfony/scheduler` v7.4.13 + `MaintenanceSchedule` (`#[AsSchedule('maintenance')]`) — 4 daily cron (export cleanup 02:00, audit cleanup 02:30, purge-deleted-tenants 03:00, purge-staged-files 03:30 UTC) przez `RunMaintenanceCommand`→handler. **Worker konsumuje teraz `scheduler_maintenance`** (docker-compose.yml — wejdzie przy recreate; running worker nietknięty).
**TDD:** RED provider nie istniał → GREEN (schedule = dokładnie 4 commandy). `debug:scheduler`: `maintenance` z 4 zadaniami + poprawne Next Run.

### AUD-052 — `data_export` audit event
Generyczny listener łapał tylko metadane HTTP. **Fix:** emisja `data_export` w `ExportSessionController::download()` (po otwarciu streamu — moment gdy PII opuszcza system) przez port `DataExportAuditor` (Identity\Contracts, Deptrac-safe): action=`data_export`, resource=export_session, new_value=scope (entity_type/format/scope/row_count/locales/channels), actor+tenant z tokenu.
**TDD:** RED download 200 ale 0 wpisów → GREEN (wpis `data_export` istnieje).
**Świadomie DEFEROWANE:** włączenie `dh_auditor` dla `CatalogObject`/`ObjectValue` (pełny diff danych produktowych) — decyzja perf/architektura (audyt każdego write'u ObjectValue przy bulk-import 50k SKU może rozsadzić `audit_logs`); wymaga write-throughput benchmarku → dedykowany tracking issue.

### Bramki
PHPStan max `No errors` (CI-parity) · Deptrac `0` (nowy port Export→Identity\Contracts bez baseline) · php-cs-fixer clean · testy **47/47 regresja (200 asercji) + 3 nowe (4 cases/29 asercji)** · `composer audit` czysty dla symfony/scheduler v7.4.13 · lint-raw-sql/lint:container OK.

### Live smoke
`pim:exports:cleanup --dry-run`: `[OK] Would delete 0 free-tier export(s); skipped 0 paid tenant(s)` (dev: 2× starter, 0 eksportów — spójne; usuwanie udowodnione testem na pim_test). `debug:scheduler`: 4 zadania z Next Run. data_export: test API potwierdza wpis. Dev DB `pim` nietknięta.

> Uwaga: scheduling jest zaimplementowany + wpięty (worker consume `scheduler_maintenance`) + zarejestrowany (`debug:scheduler` 4 zadania); faktyczne odpalenie crona wchodzi przy recreate workera (nie wymuszam na żywym stacku). Command + audit event przetestowane end-to-end.

Closes #1603
