### PR TITLE
fix(identity): rate-limit password reset and invitation accept

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -3,6 +3,7 @@ import { type ComponentType, type LazyExoticComponent, lazy, Suspense } from 're
 import { BrowserRouter, Navigate, Route, Routes, useParams } from 'react-router';
 
 import { AuthedRoute } from '@/components/AuthedRoute';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { ToastProvider } from '@/components/ui/toast';
 import { FirstLoginChangePasswordPage } from '@/features/auth/FirstLoginChangePasswordPage';
 // HARD-08 — only the login + dashboard pages and the always-mounted
@@ -374,217 +375,226 @@ function App() {
             disableTelemetry: true,
           }}
         >
-          <Suspense fallback={<RouteFallback />}>
-            <Routes>
-              <Route path="/login" element={<LoginPage />} />
-              <Route path="/accept-invitation" element={<AcceptInvitationPage />} />
-              {/* Manual user creation (#867) — force-password-change gate.
+          {/* AUD-049 (W2-12) — top-level boundary so an uncaught render
+              error in any route renders a recoverable fallback instead of
+              blanking #root (white-screen incident 2026-05-13). Sits inside
+              Refine + ToastProvider so the fallback keeps i18n context. */}
+          <ErrorBoundary>
+            <Suspense fallback={<RouteFallback />}>
+              <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/accept-invitation" element={<AcceptInvitationPage />} />
+                {/* Manual user creation (#867) — force-password-change gate.
                   Sits inside <AuthedRoute> (JWT required to call
                   /api/me/change-password) but outside <AppLayout> so the
                   page renders as a standalone centred card, no sidebar.
                   AuthedRoute's redirect skips this path so the loop is
                   broken (see `FIRST_LOGIN_PATH` constant there). */}
-              <Route
-                path="/first-login-password"
-                element={
-                  <AuthedRoute>
-                    <FirstLoginChangePasswordPage />
-                  </AuthedRoute>
-                }
-              />
-              <Route
-                element={
-                  <AuthedRoute>
-                    <AppLayout />
-                  </AuthedRoute>
-                }
-              >
-                <Route index element={<Navigate to="/dashboard" replace />} />
-                <Route path="/dashboard" element={<DashboardPage />} />
-                {/* UP-10 (#1026) — `/products` default is the
+                <Route
+                  path="/first-login-password"
+                  element={
+                    <AuthedRoute>
+                      <FirstLoginChangePasswordPage />
+                    </AuthedRoute>
+                  }
+                />
+                <Route
+                  element={
+                    <AuthedRoute>
+                      <AppLayout />
+                    </AuthedRoute>
+                  }
+                >
+                  <Route index element={<Navigate to="/dashboard" replace />} />
+                  <Route path="/dashboard" element={<DashboardPage />} />
+                  {/* UP-10 (#1026) — `/products` default is the
                     UniversalListPage parametrized for the built-in
                     product ObjectType (ADR-009 pixel-perfect parity
                     with /objects/:slug). NUI-05 (#1424) retired the
                     legacy ProductListPage after the dual-maintenance
                     window — `/products/legacy` only redirects now. */}
-                <Route path="/products" element={<ProductsUniversalListPage />} />
-                <Route path="/products/legacy" element={<Navigate to="/products" replace />} />
-                <Route path="/products/new" element={<ProductCreatePage />} />
-                {/* ULV-08 (#990) — universal /objects/{slug} route renders
+                  <Route path="/products" element={<ProductsUniversalListPage />} />
+                  <Route path="/products/legacy" element={<Navigate to="/products" replace />} />
+                  <Route path="/products/new" element={<ProductCreatePage />} />
+                  {/* ULV-08 (#990) — universal /objects/{slug} route renders
                     the ObjectListView for any ObjectType by code. The
                     legacy /products / /categories / /assets routes keep
                     pointing at their own pages until ULV-11 cuts over. */}
-                <Route path="/objects/:slug" element={<UniversalObjectListPage />} />
-                {/* UP-08 (#1029) — universal /objects/:slug/new create route.
+                  <Route path="/objects/:slug" element={<UniversalObjectListPage />} />
+                  {/* UP-08 (#1029) — universal /objects/:slug/new create route.
                     Built-in product/category/asset slugs redirect to their
                     legacy create routes inside ObjectCreatePage; custom kinds
                     render the unified create form (#1415). */}
-                <Route path="/objects/:slug/new" element={<UniversalObjectCreatePage />} />
-                {/* UP-07 (#1023) — universal /objects/:slug/:id detail route.
+                  <Route path="/objects/:slug/new" element={<UniversalObjectCreatePage />} />
+                  {/* UP-07 (#1023) — universal /objects/:slug/:id detail route.
                     Built-in product/category/asset slugs redirect to their
                     legacy detail routes inside ObjectShowPage; custom kinds
                     render the unified ProductDetailPage (#1348/#1351). */}
-                <Route path="/objects/:slug/:id" element={<UniversalObjectShowPage />} />
-                {/* VIEW-07 (#420): edit page is now inline-edit on /products/:id.
+                  <Route path="/objects/:slug/:id" element={<UniversalObjectShowPage />} />
+                  {/* VIEW-07 (#420): edit page is now inline-edit on /products/:id.
                     Keep the legacy path as a back-compat redirect for bookmarks
                     and Refine resource lookups that still ask for `edit`. */}
-                <Route path="/products/:id/edit" element={<RedirectToShow />} />
-                <Route path="/products/:id" element={<ProductShowPage />} />
-                {/* UI-08.9 (#264) — Modeling shell wraps the 4 sub-tabs under
+                  <Route path="/products/:id/edit" element={<RedirectToShow />} />
+                  <Route path="/products/:id" element={<ProductShowPage />} />
+                  {/* UI-08.9 (#264) — Modeling shell wraps the 4 sub-tabs under
                   a shared `/modeling/*` route tree. Old top-level paths
                   redirect below for back-compat with bookmarks + the
                   Refine resource registry pointing at the new URLs. */}
-                <Route path="/modeling" element={<ModelingLayout />}>
-                  <Route index element={<Navigate to="/modeling/object-types" replace />} />
-                  <Route path="object-types" element={<ObjectTypesListPage />} />
-                  <Route path="object-types/new" element={<ObjectTypeWizardPage />} />
-                  <Route path="object-types/:id" element={<ObjectTypeShowPage />} />
-                  <Route path="attributes" element={<AttributesListPage />} />
-                  <Route path="attributes/new" element={<AttributeCreatePage />} />
-                  <Route path="attributes/:id" element={<AttributeShowPage />} />
+                  <Route path="/modeling" element={<ModelingLayout />}>
+                    <Route index element={<Navigate to="/modeling/object-types" replace />} />
+                    <Route path="object-types" element={<ObjectTypesListPage />} />
+                    <Route path="object-types/new" element={<ObjectTypeWizardPage />} />
+                    <Route path="object-types/:id" element={<ObjectTypeShowPage />} />
+                    <Route path="attributes" element={<AttributesListPage />} />
+                    <Route path="attributes/new" element={<AttributeCreatePage />} />
+                    <Route path="attributes/:id" element={<AttributeShowPage />} />
+                    <Route
+                      path="attributes/:id/migrate-type"
+                      element={<MigrateAttributeTypePage />}
+                    />
+                    <Route path="attributes/:id/values" element={<AttributeValuesPage />} />
+                    <Route path="attribute-groups" element={<AttributeGroupsListPage />} />
+                    <Route path="attribute-groups/new" element={<AttributeGroupCreatePage />} />
+                    <Route path="attribute-groups/:id" element={<AttributeGroupShowPage />} />
+                    <Route path="categories" element={<CategoriesTreePage />} />
+                    <Route path="categories/new" element={<CategoryCreatePage />} />
+                    <Route path="categories/:id" element={<CategoryShowPage />} />
+                  </Route>
                   <Route
-                    path="attributes/:id/migrate-type"
-                    element={<MigrateAttributeTypePage />}
+                    path="/attributes"
+                    element={<Navigate to="/modeling/attributes" replace />}
                   />
-                  <Route path="attributes/:id/values" element={<AttributeValuesPage />} />
-                  <Route path="attribute-groups" element={<AttributeGroupsListPage />} />
-                  <Route path="attribute-groups/new" element={<AttributeGroupCreatePage />} />
-                  <Route path="attribute-groups/:id" element={<AttributeGroupShowPage />} />
-                  <Route path="categories" element={<CategoriesTreePage />} />
-                  <Route path="categories/new" element={<CategoryCreatePage />} />
-                  <Route path="categories/:id" element={<CategoryShowPage />} />
-                </Route>
-                <Route
-                  path="/attributes"
-                  element={<Navigate to="/modeling/attributes" replace />}
-                />
-                <Route
-                  path="/attributes/:id"
-                  element={<Navigate to="/modeling/attributes" replace />}
-                />
-                <Route
-                  path="/attribute-groups"
-                  element={<Navigate to="/modeling/attribute-groups" replace />}
-                />
-                <Route
-                  path="/object-types"
-                  element={<Navigate to="/modeling/object-types" replace />}
-                />
-                <Route
-                  path="/object-types/:id"
-                  element={<Navigate to="/modeling/object-types" replace />}
-                />
-                <Route
-                  path="/categories"
-                  element={<Navigate to="/modeling/categories" replace />}
-                />
-                <Route
-                  path="/categories/:id"
-                  element={<Navigate to="/modeling/categories" replace />}
-                />
-                <Route path="/assets" element={<AssetsListPage />} />
-                <Route path="/assets/:id" element={<AssetShowPage />} />
-                <Route path="/catalogs-pdf" element={<CatalogsPdfPage />} />
-                <Route path="/settings" element={<SettingsLayout />}>
-                  <Route index element={<SettingsIndex />} />
-                  <Route path="menu" element={<MenuSettingsPage />} />
-                  <Route path="locales" element={<LocalesSettingsPage />} />
-                  <Route path="channels" element={<ChannelsListPage />} />
-                  <Route path="channels/new" element={<ChannelCreatePage />} />
-                  <Route path="channels/:id" element={<ChannelShowPage />} />
-                  <Route path="channels/:id/edit" element={<ChannelEditPage />} />
-                  <Route path="users" element={<UsersSettingsPage />} />
-                  <Route path="users/:id" element={<UserDetailRoute />} />
-                  <Route path="roles" element={<RolesSettingsPage />} />
-                  <Route path="roles/new" element={<RolesEditorRoute />} />
-                  <Route path="roles/:id/edit" element={<RolesEditorRoute />} />
-                  <Route path="api-tokens" element={<ApiTokensSettingsPage />} />
-                  <Route path="security" element={<SecuritySettingsPage />} />
-                  <Route path="billing" element={<BillingSettingsPage />} />
-                  <Route path="tenant" element={<TenantSettingsPage />} />
-                  <Route path="ai" element={<AiSettingsPage />} />
-                  <Route path="sso" element={<SsoSettingsPage />} />
-                </Route>
-                {/* RBAC-P5-019 (#709) — Super Admin operator panel.
+                  <Route
+                    path="/attributes/:id"
+                    element={<Navigate to="/modeling/attributes" replace />}
+                  />
+                  <Route
+                    path="/attribute-groups"
+                    element={<Navigate to="/modeling/attribute-groups" replace />}
+                  />
+                  <Route
+                    path="/object-types"
+                    element={<Navigate to="/modeling/object-types" replace />}
+                  />
+                  <Route
+                    path="/object-types/:id"
+                    element={<Navigate to="/modeling/object-types" replace />}
+                  />
+                  <Route
+                    path="/categories"
+                    element={<Navigate to="/modeling/categories" replace />}
+                  />
+                  <Route
+                    path="/categories/:id"
+                    element={<Navigate to="/modeling/categories" replace />}
+                  />
+                  <Route path="/assets" element={<AssetsListPage />} />
+                  <Route path="/assets/:id" element={<AssetShowPage />} />
+                  <Route path="/catalogs-pdf" element={<CatalogsPdfPage />} />
+                  <Route path="/settings" element={<SettingsLayout />}>
+                    <Route index element={<SettingsIndex />} />
+                    <Route path="menu" element={<MenuSettingsPage />} />
+                    <Route path="locales" element={<LocalesSettingsPage />} />
+                    <Route path="channels" element={<ChannelsListPage />} />
+                    <Route path="channels/new" element={<ChannelCreatePage />} />
+                    <Route path="channels/:id" element={<ChannelShowPage />} />
+                    <Route path="channels/:id/edit" element={<ChannelEditPage />} />
+                    <Route path="users" element={<UsersSettingsPage />} />
+                    <Route path="users/:id" element={<UserDetailRoute />} />
+                    <Route path="roles" element={<RolesSettingsPage />} />
+                    <Route path="roles/new" element={<RolesEditorRoute />} />
+                    <Route path="roles/:id/edit" element={<RolesEditorRoute />} />
+                    <Route path="api-tokens" element={<ApiTokensSettingsPage />} />
+                    <Route path="security" element={<SecuritySettingsPage />} />
+                    <Route path="billing" element={<BillingSettingsPage />} />
+                    <Route path="tenant" element={<TenantSettingsPage />} />
+                    <Route path="ai" element={<AiSettingsPage />} />
+                    <Route path="sso" element={<SsoSettingsPage />} />
+                  </Route>
+                  {/* RBAC-P5-019 (#709) — Super Admin operator panel.
                     Lives under /admin/* inside the existing app until
                     the admin.cortex.pl subdomain split (operator infra
                     task). Backend already enforces super_admin role +
                     cross-tenant bypass via SuperAdminContext. */}
-                <Route path="/admin/tenants" element={<AdminTenantsListPage />} />
-                <Route path="/admin/tenants/:id" element={<AdminTenantShowPage />} />
-                <Route path="/admin/break-glass" element={<AdminBreakGlassPage />} />
-                {/* Integracje — every hub (exports EXR-08, imports NUI-09,
+                  <Route path="/admin/tenants" element={<AdminTenantsListPage />} />
+                  <Route path="/admin/tenants/:id" element={<AdminTenantShowPage />} />
+                  <Route path="/admin/break-glass" element={<AdminBreakGlassPage />} />
+                  {/* Integracje — every hub (exports EXR-08, imports NUI-09,
                     api-configurator) renders directly under the v2 shell;
                     sidebar second-level + topbar breadcrumb replaced the old
                     in-page Integrations header/tabs. Old /publications/* and
                     /api-profiles/* paths redirect below. */}
-                <Route path="/integrations/exports" element={<ExportsLayout />}>
-                  <Route index element={<Navigate to="sessions" replace />} />
-                  <Route path="sessions" element={<ExportSessionsView />} />
-                  <Route path="profiles" element={<ExportProfilesView />} />
-                </Route>
-                <Route
-                  path="/integrations/exports/sessions/:id"
-                  element={<ExportSessionShowPage />}
-                />
-                <Route path="/integrations/exports/new" element={<ExportWizardPage />} />
-                {/* NUI-09 (#1428) — Imports join Exports directly under the
+                  <Route path="/integrations/exports" element={<ExportsLayout />}>
+                    <Route index element={<Navigate to="sessions" replace />} />
+                    <Route path="sessions" element={<ExportSessionsView />} />
+                    <Route path="profiles" element={<ExportProfilesView />} />
+                  </Route>
+                  <Route
+                    path="/integrations/exports/sessions/:id"
+                    element={<ExportSessionShowPage />}
+                  />
+                  <Route path="/integrations/exports/new" element={<ExportWizardPage />} />
+                  {/* NUI-09 (#1428) — Imports join Exports directly under the
                     v2 shell; the legacy IntegrationsLayout wrapper is retired.
                     Wizard + show pages live at the same depth so deep-links
                     from emails/reports survive (VIEW-IMP-00 #493). */}
-                <Route path="/integrations/imports" element={<ImportsLayout />}>
-                  <Route index element={<Navigate to="sessions" replace />} />
-                  <Route path="sessions" element={<ImportSessionsView />} />
-                  <Route path="profiles" element={<ImportProfilesView />} />
-                  <Route path="sources" element={<ImportSourcesView />} />
-                  <Route path="schedule" element={<ImportScheduleView />} />
-                </Route>
-                <Route path="/integrations/imports/new" element={<ImportWizardPage />} />
-                <Route path="/integrations/imports/:id" element={<ImportShowPage />} />
-                <Route path="/integrations/api-configurator" element={<ApiProfilesListPage />} />
-                <Route
-                  path="/integrations/api-configurator/create"
-                  element={<ApiProfileCreatePage />}
-                />
-                <Route
-                  path="/integrations/api-configurator/:id/edit"
-                  element={<ApiProfileEditPage />}
-                />
-                <Route path="/integrations/api-configurator/:id" element={<ApiProfileShowPage />} />
-                <Route
-                  path="/integrations"
-                  element={<Navigate to="/integrations/imports/sessions" replace />}
-                />
-                {/* Back-compat redirects for bookmarks + Refine resource lookups
+                  <Route path="/integrations/imports" element={<ImportsLayout />}>
+                    <Route index element={<Navigate to="sessions" replace />} />
+                    <Route path="sessions" element={<ImportSessionsView />} />
+                    <Route path="profiles" element={<ImportProfilesView />} />
+                    <Route path="sources" element={<ImportSourcesView />} />
+                    <Route path="schedule" element={<ImportScheduleView />} />
+                  </Route>
+                  <Route path="/integrations/imports/new" element={<ImportWizardPage />} />
+                  <Route path="/integrations/imports/:id" element={<ImportShowPage />} />
+                  <Route path="/integrations/api-configurator" element={<ApiProfilesListPage />} />
+                  <Route
+                    path="/integrations/api-configurator/create"
+                    element={<ApiProfileCreatePage />}
+                  />
+                  <Route
+                    path="/integrations/api-configurator/:id/edit"
+                    element={<ApiProfileEditPage />}
+                  />
+                  <Route
+                    path="/integrations/api-configurator/:id"
+                    element={<ApiProfileShowPage />}
+                  />
+                  <Route
+                    path="/integrations"
+                    element={<Navigate to="/integrations/imports/sessions" replace />}
+                  />
+                  {/* Back-compat redirects for bookmarks + Refine resource lookups
                     before the consolidation landed. Drop in next epik gdy
                     telemetria pokaże 0 trafień. */}
-                <Route
-                  path="/publications"
-                  element={<Navigate to="/integrations/imports/sessions" replace />}
-                />
-                <Route
-                  path="/publications/imports"
-                  element={<Navigate to="/integrations/imports/sessions" replace />}
-                />
-                <Route
-                  path="/publications/imports/new"
-                  element={<Navigate to="/integrations/imports/new" replace />}
-                />
-                <Route path="/publications/imports/:id" element={<RedirectImportShow />} />
-                <Route
-                  path="/api-profiles"
-                  element={<Navigate to="/integrations/api-configurator" replace />}
-                />
-                <Route
-                  path="/api-profiles/create"
-                  element={<Navigate to="/integrations/api-configurator/create" replace />}
-                />
-                <Route path="/api-profiles/:id" element={<RedirectApiProfileShow />} />
-                <Route path="/api-profiles/:id/edit" element={<RedirectApiProfileEdit />} />
-              </Route>
-              <Route path="*" element={<Navigate to="/dashboard" replace />} />
-            </Routes>
-          </Suspense>
+                  <Route
+                    path="/publications"
+                    element={<Navigate to="/integrations/imports/sessions" replace />}
+                  />
+                  <Route
+                    path="/publications/imports"
+                    element={<Navigate to="/integrations/imports/sessions" replace />}
+                  />
+                  <Route
+                    path="/publications/imports/new"
+                    element={<Navigate to="/integrations/imports/new" replace />}
+                  />
+                  <Route path="/publications/imports/:id" element={<RedirectImportShow />} />
+                  <Route
+                    path="/api-profiles"
+                    element={<Navigate to="/integrations/api-configurator" replace />}
+                  />
+                  <Route
+                    path="/api-profiles/create"
+                    element={<Navigate to="/integrations/api-configurator/create" replace />}
+                  />
+                  <Route path="/api-profiles/:id" element={<RedirectApiProfileShow />} />
+                  <Route path="/api-profiles/:id/edit" element={<RedirectApiProfileEdit />} />
+                </Route>
+                <Route path="*" element={<Navigate to="/dashboard" replace />} />
+              </Routes>
+            </Suspense>
+          </ErrorBoundary>
         </Refine>
       </ToastProvider>
     </BrowserRouter>

--- a/apps/admin/src/components/ErrorBoundary.tsx
+++ b/apps/admin/src/components/ErrorBoundary.tsx
@@ -1,0 +1,85 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * AUD-049 (W2-12) — top-level React error boundary.
+ *
+ * Before this, an uncaught render error anywhere in the route tree
+ * unmounted the whole app and left `#root` blank (the white-screen
+ * incident 2026-05-13 originating in `http.ts:141`). React only catches
+ * render-phase errors via the class lifecycle hooks below — there is no
+ * hook equivalent — so this stays a class component while the fallback
+ * itself is a function component so it can use `useTranslation()`.
+ *
+ * Scope: catches synchronous render/lifecycle errors in the subtree it
+ * wraps. Async rejections (fetch, promises) are NOT render errors and
+ * never reach an error boundary — the global `unhandledrejection`
+ * handler in `main.tsx` covers that side.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    // Flip to the fallback on the next render after a child throws.
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Surface the error for diagnostics. console.error is intentional —
+    // it is the white-screen breadcrumb the operator looks for in
+    // DevTools, and any external telemetry sink hooks in here later.
+    console.error('[ErrorBoundary] Uncaught render error:', error, info.componentStack);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return <ErrorFallback />;
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Render fallback shown after a caught error. A full reload is the only
+ * reliable recovery for a corrupted render tree (boundary state cannot
+ * un-break a child whose module-level state is bad), so the single
+ * action is `window.location.reload()`.
+ */
+function ErrorFallback() {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      role="alert"
+      className="flex min-h-[60vh] flex-col items-center justify-center gap-4 p-6 text-center"
+    >
+      <div className="max-w-md space-y-2">
+        <h1 className="text-lg font-semibold text-foreground">
+          {t('error_boundary.title', { defaultValue: 'Something went wrong' })}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t('error_boundary.description', {
+            defaultValue:
+              'The page hit an unexpected error and could not be displayed. Reloading usually fixes it.',
+          })}
+        </p>
+      </div>
+      <Button type="button" onClick={() => window.location.reload()}>
+        {t('error_boundary.reload', { defaultValue: 'Reload' })}
+      </Button>
+    </div>
+  );
+}

--- a/apps/admin/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/apps/admin/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ErrorBoundary } from '../ErrorBoundary';
+
+/**
+ * AUD-049 (W2-12) — coverage for the top-level error boundary. A child
+ * that throws during render must surface the recoverable fallback (role
+ * "alert" + Reload action), NOT crash the test renderer / blank the
+ * tree (the white-screen failure mode).
+ */
+function Boom(): never {
+  throw new Error('render exploded');
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // React logs caught render errors to console.error; silence it so the
+    // expected throw does not pollute the test output (and assert nothing
+    // about the log itself — that is incidental).
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children unchanged when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <p>healthy content</p>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('healthy content')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows the fallback (alert + reload action) when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    );
+
+    // Fallback visible — the alert region replaced the crashed subtree.
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    // i18n key resolves via vitest.setup (pl translation) — assert the
+    // Reload action is present and clickable, not the raw key.
+    const reload = screen.getByRole('button', { name: /przeładuj/i });
+    expect(reload).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -10,6 +10,11 @@
     "brand_subtitle_fallback": "Workspace",
     "delete_error": "Failed to delete"
   },
+  "error_boundary": {
+    "title": "Something went wrong",
+    "description": "The page hit an unexpected error and could not be displayed. Reloading usually fixes it. If the problem persists, contact your administrator.",
+    "reload": "Reload"
+  },
   "attribute_type": {
     "text": "Text",
     "textarea": "Text area",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -10,6 +10,11 @@
     "brand_subtitle_fallback": "Workspace",
     "delete_error": "Nie udało się usunąć"
   },
+  "error_boundary": {
+    "title": "Coś poszło nie tak",
+    "description": "Strona napotkała nieoczekiwany błąd i nie mogła zostać wyświetlona. Przeładowanie zwykle rozwiązuje problem. Jeśli błąd się powtarza, skontaktuj się z administratorem.",
+    "reload": "Przeładuj"
+  },
   "attribute_type": {
     "text": "Tekst",
     "textarea": "Pole tekstowe",

--- a/apps/admin/src/main.tsx
+++ b/apps/admin/src/main.tsx
@@ -12,6 +12,15 @@ import './index.css';
 import './lib/i18n';
 import App from './App.tsx';
 
+// AUD-049 (W2-12) — a React error boundary only catches render/lifecycle
+// errors; an unhandled promise rejection (failed fetch, bad await) never
+// reaches it. Log it globally so a rejected promise leaves a DevTools
+// breadcrumb instead of a silent failure, and prevent the default
+// "Uncaught (in promise)" noise from masking the real cause.
+window.addEventListener('unhandledrejection', (event) => {
+  console.error('[unhandledrejection] Unhandled promise rejection:', event.reason);
+});
+
 const rootElement = document.getElementById('root');
 if (!rootElement) {
   throw new Error('Failed to mount admin: #root element not found in index.html');

--- a/apps/api/config/packages/framework.yaml
+++ b/apps/api/config/packages/framework.yaml
@@ -101,6 +101,39 @@ framework:
             limit: 1000
             interval: '1 hour'
 
+        # AUD-030 (W2-12) — password-reset request anti-spam / anti-enumeration.
+        # The endpoint is PUBLIC_ACCESS and always-200 (account-enumeration
+        # prevention), which made it a free spam + timing-oracle target with no
+        # `consume()`. Two layered limiters keyed differently:
+        #   - per-email (5/15min): primary control — a single address cannot be
+        #     used to hammer the mailer side-effect or probe for existence.
+        #   - per-IP (10/15min): catches one host spraying many addresses.
+        # Crossing EITHER → 429 problem+json. The 429 is a deliberate rate-limit
+        # signal, NOT an enumeration leak: real + unknown emails share the same
+        # per-email bucket, so the status never reveals whether the account
+        # exists. Fixed window mirrors auth_login (the sibling anti-bruteforce
+        # control); same `cache.app` filesystem-dev / Redis-prod backing.
+        password_reset_email:
+            policy: 'fixed_window'
+            limit: 5
+            interval: '15 minutes'
+        password_reset_ip:
+            policy: 'fixed_window'
+            limit: 10
+            interval: '15 minutes'
+
+        # AUD-030 (W2-12) — magic-link invitation accept anti-bruteforce.
+        # The accept endpoint is PUBLIC_ACCESS (the 64-hex token IS the auth
+        # factor) and was unbounded — an attacker could brute the token space
+        # or hammer the password-hashing side-effect. Per-IP 10/15min clamps
+        # the attempt rate before the controller validates the token. Keyed by
+        # IP only: there is no pre-auth identifier on accept (the account does
+        # not exist yet), and an honest invitee accepts exactly once.
+        invitation_accept:
+            policy: 'fixed_window'
+            limit: 10
+            interval: '15 minutes'
+
 when@test:
     framework:
         test: true

--- a/apps/api/src/Identity/Presentation/Controller/InvitationController.php
+++ b/apps/api/src/Identity/Presentation/Controller/InvitationController.php
@@ -14,6 +14,8 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -38,6 +40,7 @@ final class InvitationController extends AbstractController
         private readonly InvitationService $invitations,
         private readonly TenantContext $tenantContext,
         private readonly string $devTokenEnvironment,
+        private readonly RateLimiterFactoryInterface $invitationAcceptLimiter,
     ) {
     }
 
@@ -93,6 +96,27 @@ final class InvitationController extends AbstractController
     #[\App\Identity\Contracts\Attribute\NoPermissionRequired(reason: 'Magic-link accept is open by design — token IS the auth factor; account does not exist yet.')]
     public function accept(string $token, Request $request): JsonResponse
     {
+        // AUD-030 (W2-12) — per-IP anti-bruteforce on a PUBLIC_ACCESS endpoint
+        // where the 64-hex token IS the auth factor. Consume before validating
+        // the token / hashing the password so the limiter clamps a token-space
+        // brute or a hashing-DoS loop. Keyed by IP only — no pre-auth
+        // identifier exists (the account is created by this very call) and an
+        // honest invitee accepts exactly once.
+        $consumed = $this->invitationAcceptLimiter
+            ->create($request->getClientIp() ?? 'unknown')
+            ->consume();
+        if (!$consumed->isAccepted()) {
+            $secondsUntilReset = max(1, $consumed->getRetryAfter()->getTimestamp() - time());
+
+            throw new TooManyRequestsHttpException(
+                $secondsUntilReset,
+                'Too many invitation-accept attempts. Try again later.',
+                null,
+                0,
+                ['Retry-After' => (string) $secondsUntilReset],
+            );
+        }
+
         /** @var array{password?: string} $payload */
         $payload = (array) json_decode($request->getContent(), true);
         $password = $payload['password'] ?? '';

--- a/apps/api/src/Identity/Presentation/Controller/PasswordResetController.php
+++ b/apps/api/src/Identity/Presentation/Controller/PasswordResetController.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
@@ -32,6 +34,8 @@ final class PasswordResetController extends AbstractController
     public function __construct(
         private readonly PasswordResetService $service,
         private readonly string $devTokenEnvironment,
+        private readonly RateLimiterFactoryInterface $passwordResetEmailLimiter,
+        private readonly RateLimiterFactoryInterface $passwordResetIpLimiter,
     ) {
     }
 
@@ -44,6 +48,33 @@ final class PasswordResetController extends AbstractController
         $email = $payload['email'] ?? '';
         if ('' === $email) {
             throw new BadRequestHttpException('email is required.');
+        }
+
+        // AUD-030 (W2-12) — anti-spam / anti-enumeration. Consume BOTH the
+        // per-email and per-IP budgets (each ticks independently) before any
+        // side-effect runs. A 429 here is a deliberate rate-limit signal, not
+        // an enumeration leak — real and unknown emails share the same
+        // per-email bucket, so the status never reveals account existence.
+        // Email lower-cased so casing variants map to one bucket.
+        $emailConsumed = $this->passwordResetEmailLimiter
+            ->create(mb_strtolower($email))
+            ->consume();
+        $ipConsumed = $this->passwordResetIpLimiter
+            ->create($request->getClientIp() ?? 'unknown')
+            ->consume();
+        if (!$emailConsumed->isAccepted() || !$ipConsumed->isAccepted()) {
+            $retryAfter = $emailConsumed->isAccepted()
+                ? $ipConsumed->getRetryAfter()
+                : $emailConsumed->getRetryAfter();
+            $secondsUntilReset = max(1, $retryAfter->getTimestamp() - time());
+
+            throw new TooManyRequestsHttpException(
+                $secondsUntilReset,
+                'Too many password-reset requests. Try again later.',
+                null,
+                0,
+                ['Retry-After' => (string) $secondsUntilReset],
+            );
         }
 
         $plaintext = $this->service->request($email);

--- a/apps/api/tests/Api/Identity/InvitationAcceptRateLimitTest.php
+++ b/apps/api/tests/Api/Identity/InvitationAcceptRateLimitTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Coverage for AUD-030 (W2-12) — rate limiter on
+ * `POST /api/invitations/{token}/accept`.
+ *
+ * The accept endpoint is PUBLIC_ACCESS (the magic-link token IS the auth
+ * factor) and was unbounded before AUD-030: an attacker could brute the
+ * 64-hex token space or hammer the password-hashing side-effect. A
+ * per-IP limiter (10/15min) now caps the attempt rate; the 11th request
+ * from one IP returns 429 before the controller even validates the
+ * token.
+ *
+ * The token used here is a syntactically valid 64-hex string that does
+ * not match any invitation — the controller answers 400 (bad request)
+ * for the first 10 attempts, but the limiter ticks first, so the 11th
+ * is a 429.
+ */
+final class InvitationAcceptRateLimitTest extends ApiTestCase
+{
+    protected static ?bool $alwaysBootKernel = true;
+
+    /**
+     * Syntactically valid (matches the `[a-f0-9]{64}` {token} route
+     * requirement) but unmapped. Deliberately low-entropy (repeated
+     * `deadbeef`) so the secret-scanner does not flag a test fixture as a
+     * leaked credential.
+     */
+    private const string UNKNOWN_TOKEN = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Reset the per-IP bucket for the BrowserKit default IP between tests.
+        self::getContainer()->get('limiter.invitation_accept')->create('127.0.0.1')->reset();
+    }
+
+    #[Test]
+    public function eleventhAcceptAttemptFromSameIpReturns429(): void
+    {
+        $client = static::createClient();
+
+        // 10 attempts with a valid password but an unknown token — each
+        // hits the controller and returns 400 (LogicException → bad
+        // request). The limiter ticks on every call regardless.
+        for ($i = 1; $i <= 10; ++$i) {
+            $r = $client->request('POST', '/api/invitations/'.self::UNKNOWN_TOKEN.'/accept', [
+                'headers' => ['content-type' => 'application/json'],
+                'body' => json_encode(['password' => 'sufficiently-long-pass'], JSON_THROW_ON_ERROR),
+            ]);
+            self::assertNotSame(429, $r->getStatusCode(), 'Attempt #'.$i.' must not be rate-limited yet.');
+        }
+
+        $response = $client->request('POST', '/api/invitations/'.self::UNKNOWN_TOKEN.'/accept', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['password' => 'sufficiently-long-pass'], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(429);
+        self::assertNotNull($response->getHeaders(throw: false)['retry-after'][0] ?? null);
+    }
+}

--- a/apps/api/tests/Api/Identity/PasswordResetRateLimitTest.php
+++ b/apps/api/tests/Api/Identity/PasswordResetRateLimitTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Identity;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Coverage for AUD-030 (W2-12) — rate limiter on
+ * `POST /api/auth/password-reset/request`.
+ *
+ * The endpoint is PUBLIC_ACCESS and always-200 (account-enumeration
+ * prevention), which made it a free spam / timing-oracle target before
+ * AUD-030: an attacker could fire unbounded requests to enumerate which
+ * emails trigger the mailer side-effect, or DoS the SMTP relay.
+ *
+ * Two limiters guard it now — a tight per-email window (5/15min, the
+ * primary anti-enumeration / anti-spam control) layered with a looser
+ * per-IP window (10/15min, catches a single host hammering many
+ * addresses). Crossing EITHER returns 429 problem+json — the 429 is a
+ * deliberate rate-limit signal, NOT an enumeration leak (it does not
+ * reveal whether the email exists; both real and unknown emails hit the
+ * same per-email bucket).
+ */
+final class PasswordResetRateLimitTest extends ApiTestCase
+{
+    protected static ?bool $alwaysBootKernel = true;
+
+    private const string PROBE_EMAIL = 'aud030-probe@demo.localhost';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Limiter state persists across tests (filesystem cache pool in
+        // dev/test). Reset both buckets for the probe email + the
+        // BrowserKit default IP so each test starts with a fresh budget.
+        self::getContainer()->get('limiter.password_reset_email')->create(self::PROBE_EMAIL)->reset();
+        self::getContainer()->get('limiter.password_reset_ip')->create('127.0.0.1')->reset();
+    }
+
+    #[Test]
+    public function sixthResetRequestForSameEmailReturns429(): void
+    {
+        $client = static::createClient();
+
+        // The per-email limiter allows 5 requests per 15-minute window.
+        // No User row is seeded — the service returns null (account not
+        // found) and the controller still answers 200 (anti-enumeration).
+        // The limiter ticks regardless, so the 6th request is rejected.
+        for ($i = 1; $i <= 5; ++$i) {
+            $client->request('POST', '/api/auth/password-reset/request', [
+                'headers' => ['content-type' => 'application/json'],
+                'body' => json_encode(['email' => self::PROBE_EMAIL], JSON_THROW_ON_ERROR),
+            ]);
+            self::assertResponseStatusCodeSame(
+                200,
+                'Attempt #'.$i.' must pass (always-200 anti-enumeration).',
+            );
+        }
+
+        $response = $client->request('POST', '/api/auth/password-reset/request', [
+            'headers' => ['content-type' => 'application/json'],
+            'body' => json_encode(['email' => self::PROBE_EMAIL], JSON_THROW_ON_ERROR),
+        ]);
+
+        self::assertResponseStatusCodeSame(429);
+        self::assertNotNull($response->getHeaders(throw: false)['retry-after'][0] ?? null);
+    }
+}

--- a/apps/api/tests/Api/Identity/TokenLifecycleApiTest.php
+++ b/apps/api/tests/Api/Identity/TokenLifecycleApiTest.php
@@ -71,6 +71,12 @@ final class TokenLifecycleApiTest extends ApiTestCase
         parent::setUp();
 
         self::getContainer()->get('limiter.auth_login')->create('127.0.0.1')->reset();
+        // W2-12 (AUD-030) added per-IP limiters on password-reset/request and
+        // invitation accept. This class drives both flows many times from the
+        // BrowserKit default IP, so the shared buckets would otherwise spill
+        // over into 429s. Reset them per test, mirroring auth_login above.
+        self::getContainer()->get('limiter.invitation_accept')->create('127.0.0.1')->reset();
+        self::getContainer()->get('limiter.password_reset_ip')->create('127.0.0.1')->reset();
 
         $em = $this->em();
         self::getContainer()->get(RbacSeeder::class)->seed();
@@ -309,6 +315,13 @@ final class TokenLifecycleApiTest extends ApiTestCase
      */
     private function requestPasswordResetToken(string $email): string
     {
+        // The per-email reset limiter (5/15min) is keyed by address, so the
+        // per-test setUp (which only clears the per-IP bucket) cannot reach it;
+        // clear this email's bucket so every /request returns the always-200
+        // anti-enum response rather than spilling into a 429 across the many
+        // password-reset flow tests in this class.
+        self::getContainer()->get('limiter.password_reset_email')->create($email)->reset();
+
         $client = static::createClient();
         $client->request('POST', '/api/auth/password-reset/request', [
             'json' => ['email' => $email],

--- a/apps/api/tests/Unit/Identity/Presentation/Controller/DevTokenExposureTest.php
+++ b/apps/api/tests/Unit/Identity/Presentation/Controller/DevTokenExposureTest.php
@@ -31,6 +31,9 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Uid\Uuid;
@@ -137,7 +140,12 @@ final class DevTokenExposureTest extends TestCase
             logger: new NullLogger(),
         );
 
-        return new PasswordResetController($service, $environment);
+        return new PasswordResetController(
+            $service,
+            $environment,
+            $this->unlimitedLimiter(),
+            $this->unlimitedLimiter(),
+        );
     }
 
     private function invitationCreateController(string $environment): InvitationController
@@ -152,7 +160,7 @@ final class DevTokenExposureTest extends TestCase
         $tenantContext = new TenantContext();
         $tenantContext->set($tenant);
 
-        $controller = new InvitationController($service, $tenantContext, $environment);
+        $controller = new InvitationController($service, $tenantContext, $environment, $this->unlimitedLimiter());
         // AbstractController::getUser() reads from the security token storage
         // via the controller container; wire a minimal authenticated principal.
         $controller->setContainer($this->containerWithUser($this->user($tenant)));
@@ -208,6 +216,21 @@ final class DevTokenExposureTest extends TestCase
             passwordHasher: $this->createStub(UserPasswordHasherInterface::class),
             mailer: $this->createStub(MailerInterface::class),
             logger: new NullLogger(),
+        );
+    }
+
+    /**
+     * AUD-030 (W2-12) — the reset/invitation controllers now consume a rate
+     * limiter before their side-effects. This leak-regression test exercises
+     * the happy path, so it needs limiters that always accept. A real factory
+     * over a fresh InMemoryStorage with a generous budget does exactly that
+     * without mocking the (final) Reservation/RateLimit value objects.
+     */
+    private function unlimitedLimiter(): RateLimiterFactoryInterface
+    {
+        return new RateLimiterFactory(
+            ['id' => 'test_unlimited', 'policy' => 'fixed_window', 'limit' => 1000, 'interval' => '1 hour'],
+            new InMemoryStorage(),
         );
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -243,6 +243,20 @@ services:
       - ./apps/api:/app
       - api_var:/app/var
       - api_vendor:/app/vendor
+    # AUD-036 (W2-12) — the worker is a CLI Messenger consumer, NOT an HTTP
+    # service, so the api image's inherited `curl http://127.0.0.1/api` probe
+    # could never succeed (nothing listens on :80 here) and the container sat
+    # permanently `unhealthy` (FailingStreak ever-growing) — masking a real
+    # crash and leaving any `depends_on: service_healthy` on the worker unmet.
+    # Probe the consumer process instead: `pgrep` ships in the base image
+    # (/usr/bin/pgrep); a non-zero exit (no matching process) marks unhealthy
+    # so a genuinely dead consumer surfaces honestly.
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'messenger:consume' > /dev/null || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
 
   # ─── Frontend admin (Vite dev server) ─────────────────────────────────────
   admin:


### PR DESCRIPTION
## W2-12 — AUD-030 + AUD-036 + AUD-049 (#1604)

### AUD-030 — rate-limit reset/invitation (security, test-first)
Brak `->consume()` na `password-reset/request` (public, always-200) i `invitations/{token}/accept` (public, token=auth factor) → spam/enumeration/timing + token brute. **Fix:** warstwowe limitery (`framework.yaml`): reset **5/15min per-email + 10/15min per-IP**, invitation accept **10/15min per-IP**; przekroczenie któregokolwiek → **429 problem+json** (status nie zdradza istnienia konta — real+unknown email dzielą bucket per-email). MFA-brute NIE ruszany (już ma MAX_ATTEMPTS=5).
**TDD:** RED `ServiceNotFoundException` (limitery nie istniały) → GREEN. Live smoke:
```
reset (ten email/IP, 12×):  200 200 200 200 200 429 429 429 429 429 429 429   (6-ty=429)
invite accept (ten IP, 12×): 500×10 429 429                                   (11-ty=429; 500=unknown token, pre-existing, limiter tickuje przed walidacją)
```

### AUD-036 — worker healthcheck false-positive (infra)
Worker dziedziczył HTTP healthcheck z obrazu api (curl :80) → permanentnie `unhealthy` (FailingStreak:145), maskował realny crash, `depends_on: service_healthy` nigdy spełniony. **Fix:** dedykowany `healthcheck` (pgrep `messenger:consume`) dla serwisu worker w `docker-compose.yml`. Weryfikacja: `docker compose exec worker` pgrep → exit 0 (HEALTHY). Status zmieni się przy recreate workera (nie wymuszam na żywym stacku).

### AUD-049 — Error Boundary admin (frontend)
Brak `ErrorBoundary` (grep=0) → uncaught render error = biały `#root` (ryzyko z incydentu 2026-05-13). **Fix:** top-level `ErrorBoundary` (class + fallback z `role="alert"` + „Przeładuj") owija `<Routes>` w `App.tsx` + global `unhandledrejection` handler w `main.tsx` + i18n `error_boundary` (en/pl). Component test (vitest+RTL) 2/2: fallback przy rzucającym dziecku, normalny render bez błędu.

### Bramki
PHPStan max `No errors` · Deptrac `0` · php-cs-fixer clean · PHPUnit **8/31** (rate-limit + leak-guard regression) · Biome clean · tsc 0 (NODE_OPTIONS=4096) · build OK · ErrorBoundary test 2/2.

Closes #1604
