### PR TITLE
fix(deps): patch qs, dompurify and guzzle CVEs; ignore dev undici

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -39,7 +39,7 @@
     "@udecode/plate-serializer-html": "^21.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "dompurify": "^3.4.8",
+    "dompurify": "^3.4.9",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.17.0",

--- a/apps/api/composer.lock
+++ b/apps/api/composer.lock
@@ -3011,25 +3011,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.4",
+            "version": "7.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "aec528da477062d3af11f51e6b33402be233b21f"
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aec528da477062d3af11f51e6b33402be233b21f",
-                "reference": "aec528da477062d3af11f51e6b33402be233b21f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d34627490fbc03bf5c5d7cfed81f2faa19519425",
+                "reference": "d34627490fbc03bf5c5d7cfed81f2faa19519425",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -3038,7 +3039,7 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
-                "guzzlehttp/test-server": "^0.3.2",
+                "guzzlehttp/test-server": "^0.5.1",
                 "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
@@ -3118,7 +3119,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.4"
+                "source": "https://github.com/guzzle/guzzle/tree/7.12.1"
             },
             "funding": [
                 {
@@ -3134,24 +3135,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-22T19:00:53+00:00"
+            "time": "2026-06-18T14:12:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.4.1",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/09e8a212562fb1fb6a512c4156ed71525969d6c2",
-                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -3201,7 +3203,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.4.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -3217,20 +3219,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-20T22:57:30+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
                 "shasum": ""
             },
             "require": {
@@ -3320,7 +3322,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
             },
             "funding": [
                 {
@@ -3336,7 +3338,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-06-18T09:49:37+00:00"
         },
         {
             "name": "lcobucci/jwt",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,15 @@
   },
   "pnpm": {
     "overrides": {
-      "fast-uri": ">=3.1.2"
+      "fast-uri": ">=3.1.2",
+      "qs": ">=6.15.2",
+      "dompurify": ">=3.4.9"
     },
     "auditConfig": {
       "ignoreGhsas": [
-        "GHSA-vmh5-mc38-953g"
+        "GHSA-vmh5-mc38-953g",
+        "GHSA-vxpw-j846-p89q",
+        "GHSA-hm92-r4w5-c3mj"
       ]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   fast-uri: '>=3.1.2'
+  qs: '>=6.15.2'
+  dompurify: '>=3.4.9'
 
 importers:
 
@@ -103,8 +105,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       dompurify:
-        specifier: ^3.4.8
-        version: 3.4.8
+        specifier: '>=3.4.9'
+        version: 3.4.11
       i18next:
         specifier: ^26.3.1
         version: 26.3.1(typescript@6.0.3)
@@ -1877,8 +1879,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -2522,8 +2524,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   react-dom@19.2.7:
@@ -3961,7 +3963,7 @@ snapshots:
       lodash-es: 4.18.1
       papaparse: 5.5.3
       pluralize: 8.0.0
-      qs: 6.15.1
+      qs: 6.15.2
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
@@ -4194,7 +4196,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.4.8
+      dompurify: 3.4.11
 
   '@types/estree@1.0.9': {}
 
@@ -4777,7 +4779,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.8:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5326,7 +5328,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
## W2-13 — AUD-048 + AUD-073 (#1605) + unblock repo-wide audit gate

> CI ma osobne joby `composer audit` i `pnpm audit --audit-level=high`. 2026-06-19 oba poszły na czerwono (świeże advisories) — blokując WSZYSTKIE PR-y. Ten PR domyka findingi #1605 ORAZ odblokowuje bramkę (jeden PR musi naprawić oba joby, bo każdy failuje osobno).

### Findingi ticketu (#1605)
- **AUD-048** — `qs` 6.15.1→**6.15.2** (pnpm override): DoS w `qs.stringify` (GHSA-q8mj-m7cp-5q26), transitive via `@refinedev/core`.
- **AUD-073** — `dompurify` 3.4.8→**3.4.11**: Trusted Types policy survives `clearConfig` (GHSA-vxr8-fq34-vvx9) + ALLOWED_ATTR pollution.

### Środowiskowy unblock (świeże 2026-06-19, nie z planu Wave 2)
- **composer**: `guzzlehttp/guzzle` 7.10.4→**7.12.1** + `guzzlehttp/psr7` 2.11.0→**2.12.1** (CVE-2026-55767 dot-only cookie domains, CVE-2026-55568 HTTPS proxy downgrade, CVE-2026-55766 CRLF injection). `composer audit` → **No advisories**.
- **undici**: 2 nowe high (GHSA-vxpw-j846-p89q WebSocket DoS, GHSA-hm92-r4w5-c3mj cross-origin routing) — wyłącznie przez `jsdom` (dev test tooling, nigdy nie shipowane); dodane do `ignoreGhsas`, ref #1644 (gdzie śledzimy undici-jsdom). Brak kompatybilnego upgrade jsdom (precedens jak GHSA-vmh5).

### Dowód (before/after)
```
composer audit:  3 advisories (guzzle×2, psr7×1)  →  No security vulnerability advisories found
pnpm audit qs:   moderate GHSA-q8mj present       →  qs@6.15.2, advisory gone
pnpm audit domp: moderate ALLOWED_ATTR present    →  dompurify@3.4.11, advisory gone
pnpm audit --audit-level=high:  exit 0  (3 high wszystkie ignored: undici×3 dev-only)
```
Bramki: tsc **0 errors** (NODE_OPTIONS=4096) · vite build OK (2861 modułów) · composer.json nietknięty (tylko lock).

Closes #1605
