### PR TITLE
ci: run backend gates unless PR is pure-docs; guard benchmark group

### DIFF
--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -4,29 +4,41 @@ name: Quality (PHP)
 # See ticket #11 (0.0.11) for the full quality gates rationale.
 
 on:
+  # AUD-061 — blacklist (paths-ignore), not whitelist (paths). The old `paths:`
+  # whitelist (apps/api + a few scripts) silently skipped every backend gate
+  # (PHPStan / PHPUnit / Deptrac / cs-fixer) on any PR that did not touch
+  # apps/api/** — e.g. a PR touching only packages/shared-types/** (which feeds
+  # the OpenAPI/TS contract), root composer files, or this workflow itself.
+  # That meta-gap let latent PHPStan errors land on main (W1-7 TenantOffboarding-
+  # PurgeTest, fixed in W2-1). A whitelist also re-opens the same hole for every
+  # *future* backend-relevant directory nobody remembers to add. paths-ignore is
+  # fail-safe: the gates run ALWAYS unless a PR touches ONLY pure docs/markdown.
+  #
+  # docs/api-spec/** is NOT ignored (it is re-included via `!`): the openapi-spec
+  # job diffs docs/api-spec/v0.json, so a spec change must still re-trigger.
   pull_request:
-    paths:
-      - "apps/api/**"
-      - "docs/api-spec/**"
-      - "scripts/lint-raw-sql.sh"
-      - "scripts/lint-tracked-secrets.sh"
-      - "scripts/lint-backup-cron.sh"
-      - "docker/postgres/**"
-      - ".gitignore"
-      - ".github/workflows/quality-php.yml"
-      - ".semgrep/**"
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "!docs/api-spec/**"
+      - "Project Plan/**"
+      - "Testy/**"
+      - "Zrodla/**"
+      - "agent/**"
+      - "agent_sample/**"
+      - "backups/**"
   push:
     branches: [main]
-    paths:
-      - "apps/api/**"
-      - "docs/api-spec/**"
-      - "scripts/lint-raw-sql.sh"
-      - "scripts/lint-tracked-secrets.sh"
-      - "scripts/lint-backup-cron.sh"
-      - "docker/postgres/**"
-      - ".gitignore"
-      - ".github/workflows/quality-php.yml"
-      - ".semgrep/**"
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "!docs/api-spec/**"
+      - "Project Plan/**"
+      - "Testy/**"
+      - "Zrodla/**"
+      - "agent/**"
+      - "agent_sample/**"
+      - "backups/**"
 
 concurrency:
   group: quality-php-${{ github.ref }}
@@ -296,6 +308,31 @@ jobs:
           # Foundry's ResetDatabase rebuilds the schema from entity metadata into the
           # dbname_suffix-derived "pim_test" database — Postgres service is enough,
           # no migrations step required for the Sprint-0 entity surface.
+          DATABASE_URL: postgresql://pim:ChangeMeInDev@127.0.0.1:5432/pim?serverVersion=16&charset=utf8
+          MESSENGER_TRANSPORT_DSN: in-memory://
+          MERCURE_URL: http://localhost/.well-known/mercure
+          MERCURE_PUBLIC_URL: http://localhost/.well-known/mercure
+          MERCURE_JWT_SECRET: ci-mercure-key-at-least-256-bits-long
+          JWT_PASSPHRASE: ci
+          APP_DEFAULT_TENANT_CODE: demo
+
+      # AUD-063 — meta-assertion guarding the memory gate below. An empty
+      # `--group import-benchmark` selection runs 0 tests and exits 0, so if
+      # the benchmark tests are ever deleted/renamed out of the group the
+      # 256 MiB ceiling would silently stop being enforced while CI stays
+      # green. This step fails the (required) phpunit job when the group is
+      # empty. `^ - ` matches PHPUnit 12's per-test `--list-tests` prefix.
+      - name: Assert import-benchmark group is non-empty
+        run: |
+          COUNT=$(php bin/phpunit --group import-benchmark --list-tests 2>/dev/null | grep -cE '^ - ' || true)
+          if [ "$COUNT" -lt 1 ]; then
+            echo "::error::import-benchmark group is empty — the 256 MiB memory gate would silently pass. Re-tag the benchmark tests with @group import-benchmark."
+            exit 1
+          fi
+          echo "import-benchmark tests: $COUNT"
+        env:
+          APP_ENV: test
+          APP_DEBUG: "0"
           DATABASE_URL: postgresql://pim:ChangeMeInDev@127.0.0.1:5432/pim?serverVersion=16&charset=utf8
           MESSENGER_TRANSPORT_DSN: in-memory://
           MERCURE_URL: http://localhost/.well-known/mercure


### PR DESCRIPTION
## W2-14 — AUD-061 + AUD-063 (#1606) — domena J (CI/test-infra)

### AUD-061 — `paths:` filter ukrywał backend-gates (META-luka)
`quality-php.yml` używał **whitelisty** `paths: [apps/api/**, docs/api-spec/**]` → PR dotykający tylko `packages/shared-types/**` przechodził BEZ PHPStan/PHPUnit/Deptrac/cs-fixer. To ta sama klasa cichego-skipu która przepuściła latent PHPStan na main (W1-7, naprawione w W2-1).
**Fix (robustniejszy wariant z dopiska ticketu):** `paths:` → **`paths-ignore`** (blacklist). Backend-gates biegną **zawsze**, chyba że PR dotyka WYŁĄCZNIE czystych docs/markdown (`**/*.md`, `docs/**`, `Project Plan/**`, `Testy/**`, `Zrodla/**`, `agent/**`, `backups/**`). `!docs/api-spec/**` re-included przez negację (job `openapi-spec` diffuje `v0.json`). Oba triggery (pull_request+push) identycznie. **Fail-safe:** nowy backend-relevant katalog nie ominie gate'ów po cichu (przyczyna whitelisty: trzeba pamiętać dodać; blacklisty: trzeba pamiętać wykluczyć — bezpieczniej).

### AUD-063 — import-benchmark memory-gate mógł przejść próżno
`import-benchmark` (256 MiB gate) na ręcznym kroku; pusta grupa = 0 testów = pass. **Fix:** krok `Assert import-benchmark group is non-empty` przed benchmarkiem (job `phpunit`, required):
```
COUNT=$(php bin/phpunit --group import-benchmark --list-tests | grep -cE '^ - ')
[ "$COUNT" -lt 1 ] && exit 1
```
Zweryfikowane w kontenerze (PHPUnit 12.5.23): realna grupa **COUNT=7** (6× Export + 1× Import benchmark) → pass; symulacja pustej grupy → COUNT=0 → exit 1 (logika failuje).

### AUD-062 — świadomie deferowany
`playwright.config.ts` retries:2 NIE zmieniany — per treść ticketu „część AUD-022" (root cause = storageState). Zmiana retries bez fixu root-cause odsłoniłaby flaky bez naprawy. Deferred do AUD-022 (oznaczę w findings).

### Dowód (CI-config — brak live smoke)
YAML validity potwierdzone (parser). **Ten PR dotyka workflow → nowy `paths-ignore` go nie ignoruje → pełna suita backend biegnie na tym PR** (self-validating: gates muszą przejść na rebased main). Meta-asercja COUNT≥1 zweryfikowana lokalnie + failuje przy 0.

Closes #1606
