### PR TITLE
fix: strip X-Powered-By header and cap relation import buffers

### DIFF
--- a/apps/api/frankenphp/php.ini
+++ b/apps/api/frankenphp/php.ini
@@ -3,6 +3,14 @@
 
 date.timezone = UTC
 
+; AUD-067 — never advertise the PHP version. Without this PHP appends an
+; `X-Powered-By: PHP/8.4.x` header to every response, leaking the exact
+; runtime version to any client (a reconnaissance hint for version-specific
+; CVEs). The edge Caddy also strips it (`-X-Powered-By` in docker/caddy/
+; Caddyfile) as the primary, always-applied control — this is the in-process
+; backstop so a direct hit on the FrankenPHP container is covered too.
+expose_php = Off
+
 memory_limit = 256M
 max_execution_time = 30
 

--- a/apps/api/src/Import/Application/Service/RelationImportStep.php
+++ b/apps/api/src/Import/Application/Service/RelationImportStep.php
@@ -16,6 +16,7 @@ use App\Import\Domain\ValueObject\ValidationError;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
 
 /**
  * IMP2-1.8 (#1471) — the "dedicated step" (Akeneo pattern) that wires
@@ -43,6 +44,33 @@ final class RelationImportStep
 {
     private const int CHUNK = 200;
 
+    /**
+     * AUD-069 (W3-5.3) — hard cap on the count of pass-1 link tuples buffered
+     * before pass 2 runs.
+     *
+     * Unlike the pass-2 dedupe set (cleared per flush above), these two buffers
+     * CANNOT be flushed incrementally: the two-pass design (Akeneo pattern,
+     * class docblock) exists precisely because a variant master or relation
+     * target may appear AFTER its source in the file, so a link is resolvable
+     * only once EVERY object is written. Flushing mid-pass-1 would resolve
+     * against a half-written catalog and drop legitimate forward references —
+     * a correctness regression. The buffers therefore stay O(links) by design.
+     *
+     * The risk this cap addresses is a pathological/misconfigured import — e.g.
+     * a Relation column whose cells fan out to thousands of targets each, or a
+     * near-cartesian self-reference — where the link count explodes far beyond
+     * the row count and the buffers alone exhaust the 256 MiB import worker.
+     * Rather than let the worker OOM (SIGKILL → session stuck `running`, no
+     * diagnostic), we fail loud: a normal 50k-SKU import with a handful of
+     * relations per row sits at ~hundreds of thousands of tuples, well under
+     * the cap; crossing 1,000,000 buffered links (~150 MiB of small string
+     * arrays, still inside budget with headroom) signals runaway fan-out and
+     * aborts with a readable message. The handler's row-phase try/catch turns
+     * this into a `partial`/`failed` session with the reason logged, not a
+     * crash.
+     */
+    public const int DEFAULT_MAX_BUFFERED_LINKS = 1_000_000;
+
     /** @var list<array{childSku: string, parentSku: string, rowNumber: int}> */
     private array $parentLinks = [];
 
@@ -57,6 +85,9 @@ final class RelationImportStep
         private readonly AttributeRepositoryInterface $attributes,
         private readonly TenantContext $tenantContext,
         private readonly EntityManagerInterface $em,
+        // AUD-069 — overridable only so a regression test can drive the
+        // fail-loud cap with a small threshold; prod autowires the default.
+        private readonly int $maxBufferedLinks = self::DEFAULT_MAX_BUFFERED_LINKS,
     ) {
     }
 
@@ -70,6 +101,7 @@ final class RelationImportStep
     public function recordParent(string $childSku, string $parentSku, int $rowNumber): void
     {
         $this->parentLinks[] = ['childSku' => $childSku, 'parentSku' => $parentSku, 'rowNumber' => $rowNumber];
+        $this->guardBufferSize();
     }
 
     /**
@@ -83,6 +115,22 @@ final class RelationImportStep
             'targetCodes' => $targetCodes,
             'rowNumber' => $rowNumber,
         ];
+        $this->guardBufferSize();
+    }
+
+    /**
+     * AUD-069 — abort before the buffered link tuples exhaust the worker's
+     * memory budget. See {@see self::MAX_BUFFERED_LINKS} for why these buffers
+     * can't be flushed incrementally and why fail-loud beats a silent OOM.
+     */
+    private function guardBufferSize(): void
+    {
+        if (\count($this->parentLinks) + \count($this->relationLinks) > $this->maxBufferedLinks) {
+            throw new RuntimeException(\sprintf(
+                'Import relation buffer exceeded %d links — the file declares far more parent/relation links than rows (runaway fan-out). Aborting before the worker runs out of memory; split the import or reduce per-cell relation targets.',
+                $this->maxBufferedLinks,
+            ));
+        }
     }
 
     public function hasWork(): bool
@@ -170,6 +218,17 @@ final class RelationImportStep
         // Cross-link dedupe of the unique (source, target, attribute) triple —
         // catches the same relation declared in two rows before a flush makes
         // it visible to findBySourceAndAttribute.
+        //
+        // AUD-069 (W3-5.3) — this set is bounded to ONE flush window, not the
+        // whole pass. It only needs to catch a duplicate triple that is still
+        // pending (not yet INSERTed): once a chunk is flushed, the rows are in
+        // the DB and findBySourceAndAttribute (a DQL read, $existingTargets
+        // below) sees them, so the in-memory entry is redundant. Carrying it
+        // for the entire pass would grow O(total relations) — a dense 50k
+        // import (every product referencing many others) would accumulate
+        // millions of triple strings and OOM the 256 MiB import worker. We
+        // therefore clear it on every flush ({@see flushClearReattachRelations}),
+        // capping it at O(one chunk) while keeping dedup correct.
         $seenTriples = [];
         $linkCount = 0;
 
@@ -229,7 +288,12 @@ final class RelationImportStep
             }
 
             if (0 === ++$linkCount % self::CHUNK) {
+                // AUD-069 — flush+clear the chunk AND drop the per-window dedupe
+                // set: the just-flushed triples are now visible to the DQL
+                // findBySourceAndAttribute read above, so keeping them in memory
+                // is redundant and would grow unbounded over a dense import.
                 $this->flushClearReattach();
+                $seenTriples = [];
             }
         }
 

--- a/apps/api/tests/Integration/Import/RelationImportStepMemoryTest.php
+++ b/apps/api/tests/Integration/Import/RelationImportStepMemoryTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\RelationCardinality;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface;
+use App\Import\Application\Service\RelationImportStep;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * AUD-069 (W3-5.3) — regression guard for {@see RelationImportStep}'s memory
+ * posture in pass 2 (relation wiring).
+ *
+ * Two unbounded structures were the OOM risk on a dense 50k import:
+ *   1. the per-window `$seenTriples` dedupe set — now CLEARED on every flush
+ *      ({@see RelationImportStep::resolveRelations}), so it stays O(one chunk)
+ *      instead of O(total relations);
+ *   2. the pass-1 link buffers, which can't be flushed incrementally (two-pass
+ *      design) — now guarded by a fail-loud cap so a runaway fan-out aborts
+ *      readably instead of SIGKILL-ing the worker.
+ *
+ * The first test is the correctness half: it declares the SAME triple across
+ * more rows than one flush chunk (CHUNK = 200), forcing several flush+clear
+ * cycles, and asserts the catalog ends with exactly ONE relation row. That
+ * proves clearing the in-memory set does NOT regress dedup — once a chunk is
+ * flushed, the DQL `findBySourceAndAttribute` read re-detects the persisted
+ * triple, so the cleared set is genuinely redundant.
+ */
+final class RelationImportStepMemoryTest extends KernelTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    #[Test]
+    public function duplicateTripleAcrossFlushChunksStillDedupesToOneRelation(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+        $em = $this->em();
+
+        $type = $this->productObjectType($em);
+        $typeId = $type->getId()->toRfc4122();
+
+        $source = new CatalogObject($type, 'SRC');
+        $target = new CatalogObject($type, 'TGT');
+        $em->persist($source);
+        $em->persist($target);
+
+        $attr = new Attribute('related', ['en' => 'Related'], AttributeType::Relation);
+        $attr->setRelationTargetObjectTypeIds([$typeId]);
+        $attr->setRelationCardinality(RelationCardinality::Many);
+        $em->persist($attr);
+        $em->flush();
+        $em->clear();
+
+        $step = $this->step();
+        $step->reset();
+
+        // Declare the identical (SRC, related, TGT) triple on 450 rows — more
+        // than 2× CHUNK (200), so resolveRelations flushes+clears the dedupe
+        // set at least twice while still walking the same triple. Pre-fix this
+        // relied on the set never being cleared; post-fix the DQL existing-
+        // targets read must carry dedup across the flush boundary.
+        for ($row = 1; $row <= 450; ++$row) {
+            $step->recordRelation('SRC', 'related', ['TGT'], $row);
+        }
+
+        $errors = $step->resolve(ObjectKind::Product, $tenant);
+        self::assertSame([], $errors, 'a valid self-consistent relation must not error');
+
+        // tenant-safe: single-tenant integration test; the only tenant in the
+        // schema is `alpha`, so an unfiltered COUNT cannot read another tenant.
+        $count = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM object_relations');
+        self::assertSame(
+            1,
+            (int) (\is_scalar($count) ? $count : -1),
+            'the same triple declared across many flush chunks must collapse to exactly one relation row',
+        );
+    }
+
+    #[Test]
+    public function duplicateTargetsWithinOneCellDedupeBeforeFlush(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+        $em = $this->em();
+
+        $type = $this->productObjectType($em);
+        $typeId = $type->getId()->toRfc4122();
+
+        $source = new CatalogObject($type, 'SRC');
+        $target = new CatalogObject($type, 'TGT');
+        $em->persist($source);
+        $em->persist($target);
+
+        $attr = new Attribute('related', ['en' => 'Related'], AttributeType::Relation);
+        $attr->setRelationTargetObjectTypeIds([$typeId]);
+        $attr->setRelationCardinality(RelationCardinality::Many);
+        $em->persist($attr);
+        $em->flush();
+        $em->clear();
+
+        $step = $this->step();
+        $step->reset();
+        // Same triple twice in ONE flush window (well under CHUNK) — the
+        // in-memory $seenTriples set is what catches this before any flush.
+        $step->recordRelation('SRC', 'related', ['TGT'], 1);
+        $step->recordRelation('SRC', 'related', ['TGT'], 2);
+
+        $errors = $step->resolve(ObjectKind::Product, $tenant);
+        self::assertSame([], $errors);
+
+        // tenant-safe: single-tenant schema (only `alpha`).
+        $count = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM object_relations');
+        self::assertSame(1, (int) (\is_scalar($count) ? $count : -1), 'in-window duplicate triple must dedupe to one row');
+    }
+
+    #[Test]
+    public function bufferCapAbortsRunawayFanOutBeforeOom(): void
+    {
+        $tenant = $this->createTenant('alpha');
+        $this->activateTenantFilter($tenant);
+
+        // A RelationImportStep wired with a tiny cap (3) — the prod default is
+        // 1,000,000; the small value lets us prove the fail-loud guard without
+        // buffering a million tuples in the test.
+        $step = new RelationImportStep(
+            self::getContainer()->get(CatalogObjectRepositoryInterface::class),
+            self::getContainer()->get(ObjectRelationRepositoryInterface::class),
+            self::getContainer()->get(AttributeRepositoryInterface::class),
+            self::getContainer()->get(TenantContext::class),
+            self::getContainer()->get(EntityManagerInterface::class),
+            maxBufferedLinks: 3,
+        );
+        $step->reset();
+
+        $step->recordRelation('SRC', 'related', ['T1'], 1);
+        $step->recordParent('SRC', 'M1', 2);
+        $step->recordRelation('SRC', 'related', ['T2'], 3);
+
+        // The 4th buffered link crosses the cap (3) → fail loud, no silent OOM.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/relation buffer exceeded 3 links/');
+        $step->recordRelation('SRC', 'related', ['T3'], 4);
+    }
+
+    private function step(): RelationImportStep
+    {
+        return self::getContainer()->get(RelationImportStep::class);
+    }
+
+    private function productObjectType(EntityManagerInterface $em): ObjectType
+    {
+        $type = $em->getRepository(ObjectType::class)->findOneBy(['kind' => ObjectKind::Product]);
+        if ($type instanceof ObjectType) {
+            return $type;
+        }
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        $em->flush();
+
+        return $type;
+    }
+
+    private function activateTenantFilter(Tenant $tenant): void
+    {
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+    }
+
+    private function createTenant(string $code): Tenant
+    {
+        $tenant = new Tenant($code, ucfirst($code).' Tenant');
+        $em = $this->em();
+        $em->persist($tenant);
+        $em->flush();
+
+        return $tenant;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        \assert($em instanceof EntityManagerInterface);
+
+        return $em;
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -91,6 +91,15 @@ services:
       DATABASE_URL_OWNER: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required in prod (no default).}@pgbouncer:6432/${POSTGRES_DB:-app}?serverVersion=16&charset=utf8&application_name=pim_migrations
       MERCURE_JWT_SECRET: ${MERCURE_JWT_SECRET:?MERCURE_JWT_SECRET is required in prod — min 256 bits, e.g. `openssl rand -hex 32` (no default).}
       MEILI_KEY: ${MEILI_MASTER_KEY:?MEILI_MASTER_KEY is required in prod — `openssl rand -base64 32` (no default).}
+      # AUD-068 (W3-5.3) — fail-loud TRUSTED_HOSTS in prod. The base compose
+      # pins `^pim\.localhost$|^localhost$|^api$` so the dev stack boots out-of-
+      # the-box; without this override the prod api INHERITS that dev regex and
+      # Symfony's HostRegexConfigurator rejects every request to the real domain
+      # with a 400 (host not in trusted list). Same W1-4 prod-secrets pattern as
+      # APP_SECRET above: `${VAR:?message}` aborts `docker compose config|up`
+      # non-zero when unset, forcing the operator to set the deploy host regex
+      # (e.g. TRUSTED_HOSTS='^pim\.example\.com$') at deploy time.
+      TRUSTED_HOSTS: ${TRUSTED_HOSTS:?TRUSTED_HOSTS is required in prod — anchored regex of the public host(s), e.g. `^pim\.example\.com$` (no default; the dev fallback only trusts pim.localhost).}
 
   # ─── Symfony Messenger worker pool ────────────────────────────────────────
   #

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -52,8 +52,15 @@
         # need cross-origin window handles.
         Cross-Origin-Opener-Policy "same-origin"
         Cross-Origin-Resource-Policy "same-origin"
-        # Remove fingerprinting hint.
+        # Remove fingerprinting hints. -Server drops Caddy's banner;
+        # -X-Powered-By strips the `PHP/8.4.x` version leak FrankenPHP adds
+        # to every /api response (AUD-067). This global header block is
+        # imported into both site blocks, so it applies to the reverse-proxied
+        # /api responses too — defence-in-depth alongside `expose_php = Off`
+        # in frankenphp/php.ini (the edge strip is the primary control because
+        # php.ini is not always re-read by a running worker).
         -Server
+        -X-Powered-By
     }
 }
 


### PR DESCRIPTION
## Wave 3 / W3-5.3 — AUD-067 + AUD-068 + AUD-069 (#1613) — hardening hygiene

### AUD-067 — `x-powered-by: PHP/8.4.21` wyciek na `/api` (security)
Caddy nie zdejmował nagłówka. **Fix (defense-in-depth):** `docker/caddy/Caddyfile` współdzielony blok `header { -X-Powered-By }` (pokrywa reverse-proxy `/api`) + `expose_php = Off` w `frankenphp/php.ini` (in-image backstop). **Live smoke:**
```
BEFORE: HTTP/2 200 · x-powered-by: PHP/8.4.21
AFTER  (caddy reload): HTTP/2 200 · x-powered-by ABSENT
```
(php.ini backstop = build-time COPY → aktywny po `docker compose build api`; Caddy strip pokrywa runtime już teraz, primary.)

### AUD-068 — prod overlay nie nadpisuje TRUSTED_HOSTS (config)
`docker-compose.prod.yml` dziedziczył dev `^pim\.localhost$` → Symfony odrzuciłby realny host. **Fix:** fail-loud `TRUSTED_HOSTS: ${TRUSTED_HOSTS:?...}` (wzorzec W1-4). Config-check: bez zmiennej `docker compose config` → **exit 1** z komunikatem; z `^pim\.example\.com$` renderuje się poprawnie.

### AUD-069 — RelationImportStep bufory bez capu (memory)
`$seenTriples` rósł monotonicznie O(relacje); bufory linków nieograniczone. **Fix:** (a) `$seenTriples` czyszczony per flush-chunk (200) — poprawność dedup zachowana (flushnięte triple czytane z DB w `$existingTargets`); (b) two-pass input buffers NIE mogą flushować mid-pass (forward references — Akeneo two-pass), więc **hard-cap 1M linków (~150 MiB) z fail-loud RuntimeException** (row-phase try/catch → sesja partial/failed + log, zamiast SIGKILL workera). **Test RED/GREEN:** guard wyłączony → `bufferCapAbortsRunawayFanOut` failuje; przywrócony → 3/6 green. **Dedup poprawny:** ten sam triple na 450 wierszach (>2×CHUNK, wielokrotny flush+clear) → dokładnie 1 relacja w DB.

### Bramki
PHPStan max `No errors` · Deptrac `0` (baseline 288 nienaruszony) · php-cs-fixer clean · testy `Integration/Unit Import` **163/163** + `Api/Import` **23/23** · live smoke AUD-067 + config-check AUD-068.

Closes #1613
