### PR TITLE
fix(identity): deny unauthenticated tenant fallback in prod

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -87,6 +87,12 @@ services:
     App\Identity\Application\CurrentTenantProvider:
         arguments:
             $defaultTenantCode: '%app.default_tenant_code%'
+            # AUD-064 (W3-5.2): the unauthenticated env-default fallback is a
+            # dev/test convenience only. The provider gates it to non-prod so
+            # an anonymous request in prod denies (null) instead of silently
+            # inheriting the `demo` tenant. The prod overlay also clears
+            # APP_DEFAULT_TENANT_CODE as defence in depth.
+            $environment: '%kernel.environment%'
 
     App\Identity\Application\RefreshTokenService:
         arguments:

--- a/apps/api/src/Identity/Application/CurrentTenantProvider.php
+++ b/apps/api/src/Identity/Application/CurrentTenantProvider.php
@@ -15,13 +15,24 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  *
  * Resolution order:
  *  1. Authenticated user implementing TenantAware  → user's tenant
- *  2. Environment override APP_DEFAULT_TENANT_CODE → tenant looked up by code
- *  3. null → caller decides (usually means: throw before persisting)
+ *  2. API-key principal                            → tenant looked up by id
+ *  3. Environment override APP_DEFAULT_TENANT_CODE → tenant looked up by code
+ *     (NON-PROD ONLY — see AUD-064 below)
+ *  4. null → caller decides (usually means: throw before persisting)
  *
  * Auth wiring lands in ticket #4 (0.0.4) and the User↔Tenant relation in #24
  * (0.2.1); for Sprint 0 the env-override path is the operative one and the
  * smoke test (#12) verifies isolation by switching APP_DEFAULT_TENANT_CODE
  * between two seeded tenants.
+ *
+ * AUD-064 (W3-5.2): the unauthenticated env-default fallback is a dev/test
+ * convenience (a single seeded `demo` tenant + fixtures rely on it). In a
+ * production posture it is an anti-pattern — an anonymous caller would
+ * silently inherit the `demo` tenant context. The fallback is therefore
+ * gated to non-prod environments. In prod an unauthenticated request gets
+ * null (deny); tenant scope comes exclusively from the authenticated
+ * principal. A prod overlay additionally clears APP_DEFAULT_TENANT_CODE as
+ * defence in depth, but the env gate holds even if that value leaks.
  */
 final class CurrentTenantProvider
 {
@@ -29,6 +40,7 @@ final class CurrentTenantProvider
         private readonly TokenStorageInterface $tokenStorage,
         private readonly DoctrineTenantRepository $tenantRepository,
         private readonly ?string $defaultTenantCode = null,
+        private readonly string $environment = 'prod',
     ) {
     }
 
@@ -48,7 +60,11 @@ final class CurrentTenantProvider
             return $this->tenantRepository->findById($user->tenantId());
         }
 
-        if (null !== $this->defaultTenantCode && '' !== $this->defaultTenantCode) {
+        // AUD-064: the env-default fallback is a dev/test convenience only.
+        // In prod an unauthenticated caller must NOT silently resolve a
+        // tenant — deny by returning null so tenant scope can only come from
+        // an authenticated principal.
+        if ('prod' !== $this->environment && null !== $this->defaultTenantCode && '' !== $this->defaultTenantCode) {
             return $this->tenantRepository->findByCode($this->defaultTenantCode);
         }
 

--- a/apps/api/src/Import/Application/Service/FileParserService.php
+++ b/apps/api/src/Import/Application/Service/FileParserService.php
@@ -32,6 +32,15 @@ final class FileParserService
     private const array XLSX_EXTENSIONS = ['xlsx'];
     private const array CSV_EXTENSIONS = ['csv'];
 
+    /**
+     * AUD-066 (W3-5.2) — ZIP local-file-header magic bytes. An XLSX is a ZIP
+     * archive and always opens with this signature. The two alternative ZIP
+     * end-of-central-directory ("PK\x05\x06", empty archive) and spanned
+     * ("PK\x07\x08") markers also start with "PK", but a freshly written
+     * single-file XLSX always leads with the local-file-header below.
+     */
+    private const string ZIP_SIGNATURE = "PK\x03\x04";
+
     public function __construct(
         private readonly EncodingDetector $encodingDetector,
         private readonly DelimiterDetector $delimiterDetector,
@@ -46,6 +55,15 @@ final class FileParserService
 
         $extension = strtolower(pathinfo($absolutePath, PATHINFO_EXTENSION));
 
+        // AUD-066: extension-based dispatch is spoofable. Before picking a
+        // parser, verify the file's leading bytes are consistent with its
+        // extension — an XLSX must carry the ZIP signature, a CSV must not.
+        // The XlsxArchiveGuard (zip-bomb) and OpenSpout's own "not a zip"
+        // failure already backstop the XLSX path; this is a cheap, explicit
+        // first line of defence that also protects the CSV path (a binary
+        // stream renamed to .csv would otherwise be silently mis-parsed).
+        $this->assertSignatureMatchesExtension($absolutePath, $extension);
+
         if (\in_array($extension, self::XLSX_EXTENSIONS, true)) {
             return $this->parseXlsx($absolutePath);
         }
@@ -54,6 +72,42 @@ final class FileParserService
         }
 
         throw InvalidImportFileException::unsupportedExtension($extension);
+    }
+
+    /**
+     * AUD-066 — lightweight magic-byte check. Only known extensions are
+     * inspected; the `unsupportedExtension` guard above handles the rest.
+     *
+     *   - .xlsx → MUST start with the ZIP local-file-header "PK\x03\x04".
+     *   - .csv  → MUST NOT start with that ZIP signature (a renamed archive).
+     */
+    private function assertSignatureMatchesExtension(string $absolutePath, string $extension): void
+    {
+        if (!\in_array($extension, self::XLSX_EXTENSIONS, true)
+            && !\in_array($extension, self::CSV_EXTENSIONS, true)
+        ) {
+            return;
+        }
+
+        $handle = fopen($absolutePath, 'r');
+        if (false === $handle) {
+            throw InvalidImportFileException::unreadable($absolutePath);
+        }
+        try {
+            $signature = fread($handle, \strlen(self::ZIP_SIGNATURE));
+        } finally {
+            fclose($handle);
+        }
+        $signature = false === $signature ? '' : $signature;
+
+        $looksLikeZip = str_starts_with($signature, self::ZIP_SIGNATURE);
+
+        if (\in_array($extension, self::XLSX_EXTENSIONS, true) && !$looksLikeZip) {
+            throw InvalidImportFileException::signatureMismatch($extension);
+        }
+        if (\in_array($extension, self::CSV_EXTENSIONS, true) && $looksLikeZip) {
+            throw InvalidImportFileException::signatureMismatch($extension);
+        }
     }
 
     private function parseXlsx(string $absolutePath): ParsedFile

--- a/apps/api/src/Import/Domain/Exception/InvalidImportFileException.php
+++ b/apps/api/src/Import/Domain/Exception/InvalidImportFileException.php
@@ -41,4 +41,17 @@ final class InvalidImportFileException extends RuntimeException
     {
         return new self('Import file is missing the header row.');
     }
+
+    /**
+     * AUD-066 (W3-5.2) — the file's binary signature does not match its
+     * extension (e.g. a CSV body renamed to .xlsx, or a ZIP/XLSX renamed to
+     * .csv). Reject before any parser touches the bytes.
+     */
+    public static function signatureMismatch(string $extension): self
+    {
+        return new self(\sprintf(
+            'Import file content does not match its ".%s" extension (binary signature mismatch).',
+            $extension,
+        ));
+    }
 }

--- a/apps/api/tests/Unit/Identity/Application/CurrentTenantProviderTest.php
+++ b/apps/api/tests/Unit/Identity/Application/CurrentTenantProviderTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Application;
+
+use App\Identity\Application\CurrentTenantProvider;
+use App\Shared\Application\Auth\ApiKeyPrincipal;
+use App\Shared\Application\TenantAware;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Repository\DoctrineTenantRepository;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-064 (W3-5.2) — the unauthenticated `APP_DEFAULT_TENANT_CODE=demo`
+ * fallback must never apply in a production posture.
+ *
+ * Resolution order (see {@see CurrentTenantProvider}):
+ *   1. authenticated TenantAware user  → user's tenant (any env)
+ *   2. API-key principal               → tenant by id (any env)
+ *   3. env-default fallback            → ONLY outside prod (dev/test single
+ *      tenant + fixtures rely on `demo`); in prod an unauthenticated request
+ *      gets null (deny) — no silent tenant `demo` access.
+ */
+final class CurrentTenantProviderTest extends TestCase
+{
+    #[Test]
+    public function prodPostureUnauthenticatedRequestGetsNoSilentDemoFallback(): void
+    {
+        $repository = $this->createMock(DoctrineTenantRepository::class);
+        // The vulnerability: a default code resolving the `demo` tenant for an
+        // anonymous caller. In prod the provider must never reach the lookup.
+        $repository->expects(self::never())->method('findByCode');
+
+        $provider = new CurrentTenantProvider(
+            tokenStorage: new TokenStorage(),
+            tenantRepository: $repository,
+            defaultTenantCode: 'demo',
+            environment: 'prod',
+        );
+
+        self::assertNull(
+            $provider->getCurrent(),
+            'An unauthenticated request in prod must not silently resolve the demo tenant.',
+        );
+    }
+
+    #[Test]
+    public function devPostureStillHonoursTheEnvDefaultFallback(): void
+    {
+        $tenant = new Tenant('demo', 'Demo');
+
+        $repository = $this->createMock(DoctrineTenantRepository::class);
+        $repository->method('findByCode')->with('demo')->willReturn($tenant);
+
+        $provider = new CurrentTenantProvider(
+            tokenStorage: new TokenStorage(),
+            tenantRepository: $repository,
+            defaultTenantCode: 'demo',
+            environment: 'dev',
+        );
+
+        self::assertSame(
+            $tenant,
+            $provider->getCurrent(),
+            'Dev/test keep the env-default fallback so single-tenant fixtures resolve.',
+        );
+    }
+
+    #[Test]
+    public function emptyDefaultCodeNeverFallsBackRegardlessOfEnvironment(): void
+    {
+        $repository = $this->createMock(DoctrineTenantRepository::class);
+        $repository->expects(self::never())->method('findByCode');
+
+        $provider = new CurrentTenantProvider(
+            tokenStorage: new TokenStorage(),
+            tenantRepository: $repository,
+            defaultTenantCode: '',
+            environment: 'dev',
+        );
+
+        self::assertNull($provider->getCurrent());
+    }
+
+    #[Test]
+    public function authenticatedUserTenantWinsEvenInProd(): void
+    {
+        $tenant = new Tenant('alpha', 'Alpha');
+        $user = new class($tenant) implements TenantAware, UserInterface {
+            public function __construct(private readonly Tenant $tenant)
+            {
+            }
+
+            public function getTenant(): Tenant
+            {
+                return $this->tenant;
+            }
+
+            public function getRoles(): array
+            {
+                return ['ROLE_USER'];
+            }
+
+            public function eraseCredentials(): void
+            {
+            }
+
+            public function getUserIdentifier(): string
+            {
+                return 'kasia@alpha.test';
+            }
+        };
+
+        $repository = $this->createMock(DoctrineTenantRepository::class);
+        $repository->expects(self::never())->method('findByCode');
+
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken($user, 'main'));
+
+        $provider = new CurrentTenantProvider(
+            tokenStorage: $tokenStorage,
+            tenantRepository: $repository,
+            defaultTenantCode: 'demo',
+            environment: 'prod',
+        );
+
+        self::assertSame(
+            $tenant,
+            $provider->getCurrent(),
+            'An authenticated user always resolves to their own tenant — unchanged by AUD-064.',
+        );
+    }
+
+    #[Test]
+    public function apiKeyPrincipalTenantResolvesEvenInProd(): void
+    {
+        $tenantId = Uuid::v4();
+        $tenant = new Tenant('beta', 'Beta');
+
+        $principal = $this->createStub(ApiKeyPrincipal::class);
+        $principal->method('tenantId')->willReturn($tenantId);
+
+        $repository = $this->createMock(DoctrineTenantRepository::class);
+        $repository->expects(self::once())->method('findById')->with($tenantId)->willReturn($tenant);
+        $repository->expects(self::never())->method('findByCode');
+
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken($principal, 'main'));
+
+        $provider = new CurrentTenantProvider(
+            tokenStorage: $tokenStorage,
+            tenantRepository: $repository,
+            defaultTenantCode: 'demo',
+            environment: 'prod',
+        );
+
+        self::assertSame($tenant, $provider->getCurrent());
+    }
+}

--- a/apps/api/tests/Unit/Identity/Rbac/RbacRoleSourceReconciliationTest.php
+++ b/apps/api/tests/Unit/Identity/Rbac/RbacRoleSourceReconciliationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Identity\Rbac;
+
+use App\Identity\Domain\Rbac\PrdRoleTemplates;
+use App\Identity\Domain\Rbac\RbacMatrix;
+use App\Identity\Domain\Rbac\RoleDefinition;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AUD-065 (W3-5.2) — make the RBAC role drift AUDITABLE from one place.
+ *
+ * Two seeders write roles into the DB:
+ *   - {@see \App\Identity\Application\RbacSeeder} reads {@see RbacMatrix::roles()}
+ *     (global built-in roles, tenant_id NULL).
+ *   - {@see \App\Identity\Application\SeedTenantPrdRolesService} reads
+ *     {@see PrdRoleTemplates::tenantRolePermissions()} (per-tenant PRD §3.2
+ *     roles) plus the global `super_admin` from {@see PrdRoleTemplates}.
+ *
+ * Before AUD-065 the two sources drifted silently: RbacMatrix declares ~5
+ * roles, the PRD templates 10, and nothing failed when a role existed in one
+ * source but not the canonical PRD §3.2 set. This meta-test asserts that
+ * EVERY role code reachable by either seeder is represented in the canonical
+ * source of truth (PRD-PIM-rbac §3.2), so adding a role to a seeder without a
+ * matching canonical entry fails the build.
+ *
+ * It deliberately verifies role *coverage* only — it does NOT assert grant
+ * contents (those belong to RbacSeederTest / RbacVotersTest), so it changes
+ * zero permissions.
+ */
+final class RbacRoleSourceReconciliationTest extends TestCase
+{
+    /**
+     * Canonical role codes from PRD-PIM-rbac §3.2 (the macierz uprawnień):
+     * 1 platform-level (`super_admin`) + 9 tenant-level (Owner, Admin,
+     * Catalog Mgr, Marketing, Modeler, Integ. Mgr, Channel Mgr, Approver,
+     * Viewer) + the AUD-003 `platform_operator` (the only holder of the
+     * cross-tenant `platform.*` grants; PRD §3.2 "Super Admin only" block).
+     *
+     * This list is the single audit surface: every seeded role must appear
+     * here, and every entry here is justified by PRD §3.2.
+     *
+     * @var list<string>
+     */
+    private const array CANONICAL_ROLE_CODES = [
+        // Platform-level
+        'super_admin',
+        'platform_operator',
+        // Tenant-level (PRD §3.2 matrix columns, left-to-right after Super Admin)
+        'tenant_owner',
+        'admin',
+        'catalog_manager',
+        'marketing',
+        'modeler',
+        'integration_manager',
+        'channel_manager',
+        'approver',
+        'viewer',
+    ];
+
+    #[Test]
+    public function everyGlobalSeededRoleIsRepresentedInTheCanonicalSource(): void
+    {
+        $globalRoleCodes = array_map(
+            static fn (RoleDefinition $definition): string => $definition->code,
+            RbacMatrix::roles(),
+        );
+
+        foreach ($globalRoleCodes as $code) {
+            self::assertContains(
+                $code,
+                self::CANONICAL_ROLE_CODES,
+                \sprintf(
+                    'RbacMatrix seeds global role "%s" but it is absent from the canonical '
+                    .'PRD §3.2 role set. Add it to CANONICAL_ROLE_CODES (and PRD §3.2) or remove it from RbacMatrix.',
+                    $code,
+                ),
+            );
+        }
+    }
+
+    #[Test]
+    public function everyPerTenantSeededRoleIsRepresentedInTheCanonicalSource(): void
+    {
+        $tenantRoleCodes = array_keys(PrdRoleTemplates::tenantRolePermissions());
+
+        foreach ($tenantRoleCodes as $code) {
+            self::assertContains(
+                $code,
+                self::CANONICAL_ROLE_CODES,
+                \sprintf(
+                    'SeedTenantPrdRolesService seeds per-tenant role "%s" but it is absent from '
+                    .'the canonical PRD §3.2 role set. Add it to CANONICAL_ROLE_CODES (and PRD §3.2).',
+                    $code,
+                ),
+            );
+        }
+    }
+
+    #[Test]
+    public function tenantRoleNamesAndPermissionsCoverTheSameRoleCodes(): void
+    {
+        // A name without a permission set (or vice versa) is the exact kind of
+        // half-defined role that produces a drift; assert the two PrdRoleTemplates
+        // maps stay in lockstep.
+        $nameCodes = array_keys(PrdRoleTemplates::tenantRoleNames());
+        $permissionCodes = array_keys(PrdRoleTemplates::tenantRolePermissions());
+
+        sort($nameCodes);
+        sort($permissionCodes);
+
+        self::assertSame(
+            $nameCodes,
+            $permissionCodes,
+            'PrdRoleTemplates::tenantRoleNames() and tenantRolePermissions() must define the same role codes.',
+        );
+    }
+
+    #[Test]
+    public function canonicalSourceHasNoUnusedRoleCodes(): void
+    {
+        // Guard the reverse direction: a canonical entry that no seeder emits
+        // is dead documentation. `tenant_owner`/`admin`/`marketing`/`modeler`/
+        // `channel_manager`/`approver` come from PrdRoleTemplates; the rest
+        // (super_admin / platform_operator / catalog_manager / integration_manager
+        // / viewer) come from RbacMatrix and/or PrdRoleTemplates.
+        $seededCodes = array_unique([
+            ...array_map(static fn (RoleDefinition $d): string => $d->code, RbacMatrix::roles()),
+            ...array_keys(PrdRoleTemplates::tenantRolePermissions()),
+            'super_admin', // PrdRoleTemplates::superAdminPermissions() seeds this globally
+        ]);
+
+        foreach (self::CANONICAL_ROLE_CODES as $code) {
+            self::assertContains(
+                $code,
+                $seededCodes,
+                \sprintf(
+                    'Canonical role "%s" is declared in PRD §3.2 but no seeder emits it. '
+                    .'Remove it from CANONICAL_ROLE_CODES or wire a seeder.',
+                    $code,
+                ),
+            );
+        }
+    }
+}

--- a/apps/api/tests/Unit/Import/FileParserServiceTest.php
+++ b/apps/api/tests/Unit/Import/FileParserServiceTest.php
@@ -9,6 +9,8 @@ use App\Import\Application\Service\EncodingDetector;
 use App\Import\Application\Service\FileParserService;
 use App\Import\Domain\Enum\FileEncoding;
 use App\Import\Domain\Exception\InvalidImportFileException;
+use OpenSpout\Common\Entity\Row;
+use OpenSpout\Writer\XLSX\Writer as XlsxWriter;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -92,9 +94,95 @@ final class FileParserServiceTest extends TestCase
         }
     }
 
+    #[Test]
+    public function rejectsXlsxExtensionCarryingCsvContent(): void
+    {
+        // AUD-066 (W3-5.2) — extension-only dispatch is spoofable: a CSV body
+        // renamed to .xlsx must be rejected by the magic-byte guard before the
+        // XLSX reader sees it (a real XLSX always opens with the ZIP signature
+        // "PK\x03\x04"; CSV text does not).
+        $service = $this->parser();
+        $path = $this->writeTempFile("sku;name\nABC-1;Sensor\n", '.xlsx');
+
+        try {
+            $this->expectException(InvalidImportFileException::class);
+            $this->expectExceptionMessageMatches('/signature|sygnatur|magic|does not match|nie odpowiada/i');
+            $service->parse($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function acceptsGenuineXlsxWithZipSignature(): void
+    {
+        // AUD-066 — the positive control: a real XLSX (PK\x03\x04 header)
+        // written by openspout passes the magic-byte guard and parses.
+        $service = $this->parser();
+        $path = $this->writeGenuineXlsx();
+
+        try {
+            $parsed = $service->parse($path);
+            self::assertSame(['sku', 'name'], $parsed->headers);
+            self::assertSame(1, $parsed->totalRows);
+            self::assertSame('ABC-1', $parsed->sampleRows[0][0]);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function acceptsGenuineCsvWithoutZipSignature(): void
+    {
+        // AUD-066 — the symmetric positive control: a plain CSV (no binary
+        // signature) keeps parsing unchanged.
+        $service = $this->parser();
+        $path = $this->writeTempFile("sku;name\nABC-1;Sensor\n", '.csv');
+
+        try {
+            $parsed = $service->parse($path);
+            self::assertSame(['sku', 'name'], $parsed->headers);
+            self::assertSame(1, $parsed->totalRows);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    #[Test]
+    public function rejectsCsvExtensionCarryingZipContent(): void
+    {
+        // AUD-066 — the inverse spoof: a ZIP/XLSX body renamed to .csv. A CSV
+        // is text and must never start with the ZIP local-file-header
+        // signature; reject before the CSV reader mangles the binary stream.
+        $service = $this->parser();
+        $xlsxPath = $this->writeGenuineXlsx();
+        $csvNamed = $this->writeTempFile((string) file_get_contents($xlsxPath), '.csv');
+        @unlink($xlsxPath);
+
+        try {
+            $this->expectException(InvalidImportFileException::class);
+            $this->expectExceptionMessageMatches('/signature|sygnatur|magic|does not match|nie odpowiada/i');
+            $service->parse($csvNamed);
+        } finally {
+            @unlink($csvNamed);
+        }
+    }
+
     private function parser(): FileParserService
     {
         return new FileParserService(new EncodingDetector(), new DelimiterDetector());
+    }
+
+    private function writeGenuineXlsx(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'imp-test-').'.xlsx';
+        $writer = new XlsxWriter();
+        $writer->openToFile($path);
+        $writer->addRow(Row::fromValues(['sku', 'name']));
+        $writer->addRow(Row::fromValues(['ABC-1', 'Sensor']));
+        $writer->close();
+
+        return $path;
     }
 
     private function writeTempFile(string $contents, string $suffix): string

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -100,6 +100,13 @@ services:
       # non-zero when unset, forcing the operator to set the deploy host regex
       # (e.g. TRUSTED_HOSTS='^pim\.example\.com$') at deploy time.
       TRUSTED_HOSTS: ${TRUSTED_HOSTS:?TRUSTED_HOSTS is required in prod — anchored regex of the public host(s), e.g. `^pim\.example\.com$` (no default; the dev fallback only trusts pim.localhost).}
+      # AUD-064 (W3-5.2) — defence in depth. The base `.env` ships
+      # APP_DEFAULT_TENANT_CODE=demo so the single-tenant dev stack resolves a
+      # tenant for anonymous requests. In prod that fallback is an anti-pattern
+      # (anonymous → silent `demo` tenant). CurrentTenantProvider already gates
+      # the fallback to non-prod, but clearing the value here removes it at the
+      # source too, so even a misconfigured APP_ENV cannot resurrect it.
+      APP_DEFAULT_TENANT_CODE: ""
 
   # ─── Symfony Messenger worker pool ────────────────────────────────────────
   #


### PR DESCRIPTION
## Wave 3 / W3-5.2 — AUD-064 + AUD-065 + AUD-066 (#1612)

### AUD-064 — unauthenticated tenant fallback do `demo` (security, test-first)
`CurrentTenantProvider` cicho rozwiązywał nieuwierzytelniony request do commitowanego `APP_DEFAULT_TENANT_CODE=demo` (anti-wzorzec SaaS). **Fix:** fallback tylko poza prod (`$environment` wstrzyknięty, default `'prod'` fail-safe) + prod overlay czyści `APP_DEFAULT_TENANT_CODE`; `.env` zostaje `demo` (dev/test nietknięte). Uwierzytelniona ścieżka bez zmian. **RED/GREEN:** prod+anon+default=demo → `null` (deny); dev+anon → demo; auth → tenant z usera. **Live smoke:** prod-posture anon → NULL; HTTP unauth `/api/products` → 401, `/api/assets/{id}/preview` (PUBLIC_ACCESS) → 403 — żaden nie dostaje cichego demo.

### AUD-065 — drift macierzy RBAC (meta-test, ZERO zmian grantów)
RbacMatrix (4 role) vs DB (10+). **Fix (low-risk):** meta-test `RbacRoleSourceReconciliationTest` — każda seedowana rola (global RbacMatrix + per-tenant PrdRoleTemplates) reprezentowana w PRD §3.2 canon (dwukierunkowo) → drift audytowalny z jednego miejsca, test failuje przy nowej nieudokumentowanej roli. **ZERO zmian grantów** (RbacMatrix/RbacSeeder/PrdRoleTemplates UNMODIFIED — RbacSeeder czyta RbacMatrix, więc edycja zmieniłaby live granty). RBAC testy 112/112.

### AUD-066 — detekcja formatu po rozszerzeniu (import)
`FileParserService` wybierał parser po rozszerzeniu. **Fix:** magic-byte guard — `.xlsx` musi mieć ZIP `PK\x03\x04`, `.csv` nie może (renamed archive → `InvalidImportFileException::signatureMismatch()`). **RED/GREEN:** `.xlsx`+CSV → odrzucony; genuine XLSX/CSV → akceptowane; `.csv`+ZIP → odrzucony (9/9).

### Bramki
PHPStan max `No errors` · Deptrac `0` (baseline 288 intact) · php-cs-fixer clean · testy **349/349** Unit + **112/112** Api/Identity + **15/15** Integration/Import.

Closes #1612
