### PR TITLE
fix(identity): stop legacy roles from widening per-locale/channel scope

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-tooltip": "^1.2.9",
     "@refinedev/core": "^5.0.12",
     "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-virtual": "^3.14.3",
     "@udecode/plate": "^49.0.0",
     "@udecode/plate-basic-elements": "^49.0.0",
     "@udecode/plate-basic-marks": "^49.0.0",

--- a/apps/admin/src/components/catalog/__tests__/excel-like-grid.test.tsx
+++ b/apps/admin/src/components/catalog/__tests__/excel-like-grid.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ExcelColumn, ExcelLikeGrid } from '../excel-like-grid';
+
+/**
+ * AUD-038 (#1611) — column virtualization for ExcelLikeGrid.
+ *
+ * jsdom has no layout engine (every element reports size 0), so
+ * `@tanstack/react-virtual` is fed a deterministic viewport: a 500px-wide
+ * scroll container over many 160px columns. With overscan that mounts a
+ * single-digit subset of the 60 columns — proving windowing — while the
+ * editing / keyboard behaviours the grid had regressions on (UI-02) are
+ * re-asserted to stay intact.
+ */
+
+interface Row extends Record<string, unknown> {
+  [key: `c${number}`]: string;
+}
+
+const COLUMN_COUNT = 60;
+const COLUMN_WIDTH = 160;
+const VIEWPORT_WIDTH = 500;
+
+const columns: ExcelColumn<Row>[] = Array.from({ length: COLUMN_COUNT }, (_, i) => ({
+  key: `c${i}` as keyof Row & string,
+  label: `Col ${i}`,
+  type: 'text' as const,
+  width: COLUMN_WIDTH,
+}));
+
+const rows: Row[] = Array.from({ length: 5 }, (_, r) => {
+  const row = {} as Row;
+  for (let c = 0; c < COLUMN_COUNT; c += 1) {
+    row[`c${c}` as keyof Row & string] = `r${r}-c${c}`;
+  }
+  return row;
+});
+
+/**
+ * Give the virtualizer a finite viewport. `@tanstack/virtual-core` reads the
+ * scroll element's `offsetWidth` (horizontal mode) and re-measures via
+ * ResizeObserver; jsdom reports 0 for both and never fires the observer, so
+ * the column window would otherwise be empty. We stub `offsetWidth` on the
+ * scroll container and fire a one-shot ResizeObserver callback with its
+ * borderBoxSize so the virtualizer materialises a real window on mount.
+ */
+function mockLayout(): void {
+  // Parameter properties are disallowed under `erasableSyntaxOnly`, so the
+  // callback is held in a plain field.
+  class StubResizeObserver {
+    private readonly cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+    observe(target: Element): void {
+      // Report the viewport size for the scroll container immediately.
+      if (target instanceof HTMLElement && target.classList.contains('overflow-x-auto')) {
+        this.cb(
+          [
+            {
+              target,
+              borderBoxSize: [{ inlineSize: VIEWPORT_WIDTH, blockSize: 0 }],
+              contentBoxSize: [{ inlineSize: VIEWPORT_WIDTH, blockSize: 0 }],
+              contentRect: { width: VIEWPORT_WIDTH, height: 0 } as DOMRectReadOnly,
+              devicePixelContentBoxSize: [{ inlineSize: VIEWPORT_WIDTH, blockSize: 0 }],
+            } as unknown as ResizeObserverEntry,
+          ],
+          this as unknown as ResizeObserver,
+        );
+      }
+    }
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  vi.stubGlobal('ResizeObserver', StubResizeObserver);
+
+  // offsetWidth/offsetHeight are non-configurable accessors in jsdom; redefine
+  // them so the scroll container reports a finite width.
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.classList.contains('overflow-x-auto') ? VIEWPORT_WIDTH : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      return 0;
+    },
+  });
+}
+
+describe('ExcelLikeGrid column virtualization', () => {
+  beforeEach(() => {
+    mockLayout();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    // The offsetWidth/offsetHeight accessors are defined straight on the
+    // prototype, so restoreAllMocks does not clear them.
+    Reflect.deleteProperty(HTMLElement.prototype, 'offsetWidth');
+    Reflect.deleteProperty(HTMLElement.prototype, 'offsetHeight');
+  });
+
+  it('windows columns — renders only a subset of a wide ObjectType', () => {
+    render(<ExcelLikeGrid<Row> rows={rows} columns={columns} onCommit={() => {}} />);
+
+    const headers = screen
+      .getAllByRole('columnheader')
+      .filter((h) => /^Col \d+$/.test(h.textContent ?? ''));
+    // 500px / 160px ≈ 4 visible + overscan → far fewer than the 60 total.
+    expect(headers.length).toBeGreaterThan(0);
+    expect(headers.length).toBeLessThan(COLUMN_COUNT);
+
+    // The very last column is well outside the initial viewport: not mounted.
+    expect(screen.queryByText(`Col ${COLUMN_COUNT - 1}`)).not.toBeInTheDocument();
+    // The first columns are in view.
+    expect(screen.getByText('Col 0')).toBeInTheDocument();
+  });
+
+  it('renders body cells only for the windowed columns', () => {
+    render(<ExcelLikeGrid<Row> rows={rows} columns={columns} onCommit={() => {}} />);
+
+    // First row's first cell is visible; a far-right cell is windowed out.
+    expect(screen.getByText('r0-c0')).toBeInTheDocument();
+    expect(screen.queryByText(`r0-c${COLUMN_COUNT - 1}`)).not.toBeInTheDocument();
+  });
+
+  it('still edits a visible cell on single click and commits on Enter', async () => {
+    const user = userEvent.setup();
+    const onCommit = vi.fn();
+    render(<ExcelLikeGrid<Row> rows={rows} columns={columns} onCommit={onCommit} />);
+
+    const cell = screen.getByText('r0-c0');
+    await user.click(cell);
+
+    const editor = screen.getByDisplayValue('r0-c0');
+    expect(editor).toBeInTheDocument();
+
+    await user.clear(editor);
+    await user.type(editor, 'edited{Enter}');
+    expect(onCommit).toHaveBeenCalledWith(0, 'c0', 'edited');
+  });
+
+  it('keeps keyboard navigation: Enter re-opens the editor on the active cell', async () => {
+    const user = userEvent.setup();
+    render(<ExcelLikeGrid<Row> rows={rows} columns={columns} onCommit={() => {}} />);
+
+    // Click establishes the active cell AND opens its editor (single-click UX).
+    await user.click(screen.getByText('r1-c1'));
+    expect(screen.getByDisplayValue('r1-c1')).toBeInTheDocument();
+
+    // Escape closes the editor but the cell stays active.
+    await user.keyboard('{Escape}');
+    expect(screen.queryByDisplayValue('r1-c1')).not.toBeInTheDocument();
+
+    // Enter on the table (handleKeyDown) must re-open the editor on the
+    // active cell — the keyboard-nav path the grid had regressed on.
+    const table = screen.getByRole('table');
+    fireEvent.keyDown(table, { key: 'Enter' });
+    expect(within(table).getByDisplayValue('r1-c1')).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/components/catalog/excel-like-grid.tsx
+++ b/apps/admin/src/components/catalog/excel-like-grid.tsx
@@ -1,3 +1,4 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface ExcelColumn<T extends Record<string, unknown>> {
@@ -13,6 +14,9 @@ interface CellAddress {
   rowIdx: number;
   colKey: string;
 }
+
+/** Fallback column width (px) used by the virtualizer when a column omits one. */
+const DEFAULT_COLUMN_WIDTH = 160;
 
 /**
  * UI-02.12 (#302) — Excel-like data grid for the products list.
@@ -39,6 +43,17 @@ interface CellAddress {
  * Validation, async-save UX, undo/redo, formula cells, frozen rows
  * are deliberately out of MVP — the contract surface is callback-based
  * so the parent can layer those without re-touching grid internals.
+ *
+ * AUD-038 (#1611) — **column virtualization**. A wide ObjectType (200+
+ * attributes) × 200 rows produced ~20k+ live DOM cells, the dominant cost.
+ * Columns are now windowed with `@tanstack/react-virtual` (horizontal):
+ * only the columns intersecting the horizontal viewport (+ overscan) mount,
+ * with leading / trailing spacer cells (`colSpan`) consuming the
+ * off-screen width so the native `<table>` layout, sticky-ish header,
+ * rectangular selection, inline edit and keyboard navigation are all
+ * preserved. Every handler keys off the FULL `columns` array index, so
+ * windowing is transparent to selection / nav math — an off-screen
+ * selection anchor stays valid and re-renders when scrolled back into view.
  */
 export function ExcelLikeGrid<T extends Record<string, unknown>>({
   rows,
@@ -54,11 +69,35 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
   const [editing, setEditing] = useState<CellAddress | null>(null);
   const editorRef = useRef<HTMLInputElement | null>(null);
   const gridRef = useRef<HTMLTableElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const colIndex = useCallback(
     (colKey: string) => columns.findIndex((c) => c.key === colKey),
     [columns],
   );
+
+  // Horizontal column virtualizer. Estimates from each column's declared
+  // width (falling back to DEFAULT_COLUMN_WIDTH) so spacer math matches the
+  // real header/body widths. Overscan keeps a couple of columns mounted on
+  // each side so keyboard arrow-scroll and shift-select feel seamless.
+  const columnVirtualizer = useVirtualizer({
+    horizontal: true,
+    count: columns.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (index) => columns[index]?.width ?? DEFAULT_COLUMN_WIDTH,
+    overscan: 4,
+  });
+
+  const virtualColumns = columnVirtualizer.getVirtualItems();
+  const totalWidth = columnVirtualizer.getTotalSize();
+  // Width consumed by the off-screen columns before / after the window —
+  // rendered as spacer cells so column alignment and horizontal scroll
+  // extent stay identical to the non-virtualized table.
+  const leadWidth = virtualColumns.length > 0 ? (virtualColumns[0]?.start ?? 0) : 0;
+  const tailWidth =
+    virtualColumns.length > 0
+      ? Math.max(0, totalWidth - (virtualColumns[virtualColumns.length - 1]?.end ?? 0))
+      : 0;
 
   const selectionRect = (() => {
     if (active === null) return null;
@@ -165,77 +204,95 @@ export function ExcelLikeGrid<T extends Record<string, unknown>>({
     [active, editing, selectionRect, columns, rows, colIndex, onCommit],
   );
 
-  return (
-    <table
-      ref={gridRef}
-      // biome-ignore lint/a11y/noNoninteractiveTabindex: grid keyboard nav requires the table itself to receive focus.
-      tabIndex={0}
-      onKeyDown={handleKeyDown}
-      className="w-full table-fixed border-collapse text-sm focus:outline-none"
-    >
-      <thead>
-        <tr className="bg-muted">
-          {columns.map((col) => (
-            <th
-              key={col.key}
-              style={{ width: col.width }}
-              className="border px-2 py-1 text-left font-medium"
-            >
-              {col.label}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, rowIdx) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: row identity is positional in this grid view.
-          <tr key={rowIdx}>
-            {columns.map((col, colIdx) => {
-              const isActive =
-                selectionRect !== null &&
-                rowIdx >= selectionRect.r1 &&
-                rowIdx <= selectionRect.r2 &&
-                colIdx >= selectionRect.c1 &&
-                colIdx <= selectionRect.c2;
-              const isPrimary =
-                active !== null && active.rowIdx === rowIdx && active.colKey === col.key;
-              const isEditing =
-                editing !== null && editing.rowIdx === rowIdx && editing.colKey === col.key;
-              const value = row[col.key];
+  const renderCell = (row: T, rowIdx: number, colIdx: number) => {
+    const col = columns[colIdx];
+    if (col === undefined) return null;
+    const isActive =
+      selectionRect !== null &&
+      rowIdx >= selectionRect.r1 &&
+      rowIdx <= selectionRect.r2 &&
+      colIdx >= selectionRect.c1 &&
+      colIdx <= selectionRect.c2;
+    const isPrimary = active !== null && active.rowIdx === rowIdx && active.colKey === col.key;
+    const isEditing = editing !== null && editing.rowIdx === rowIdx && editing.colKey === col.key;
+    const value = row[col.key];
 
+    return (
+      // biome-ignore lint/a11y/useKeyWithClickEvents: the parent <table> owns keyboard nav (handleKeyDown).
+      <td
+        key={col.key}
+        style={{ width: col.width }}
+        onClick={(e) => handleCellClick(rowIdx, col.key, e.shiftKey)}
+        onDoubleClick={() => handleCellDoubleClick(rowIdx, col.key)}
+        className={`relative border px-2 py-1 ${
+          isPrimary ? 'ring-2 ring-primary' : isActive ? 'bg-primary/10' : ''
+        } ${col.readOnly === true ? 'bg-muted/40 text-muted-foreground' : 'cursor-cell'}`}
+      >
+        {isEditing ? (
+          <input
+            ref={editorRef}
+            defaultValue={String(value ?? '')}
+            onBlur={(e) => commitEdit(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                commitEdit((e.target as HTMLInputElement).value);
+              } else if (e.key === 'Escape') {
+                setEditing(null);
+              }
+            }}
+            className="w-full bg-background outline-none"
+          />
+        ) : (
+          <span>{String(value ?? '')}</span>
+        )}
+      </td>
+    );
+  };
+
+  return (
+    <div ref={scrollRef} className="w-full overflow-x-auto">
+      <table
+        ref={gridRef}
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: grid keyboard nav requires the table itself to receive focus.
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+        style={{ width: totalWidth > 0 ? totalWidth : undefined }}
+        className="border-collapse text-sm focus:outline-none"
+      >
+        <thead>
+          <tr className="bg-muted">
+            {leadWidth > 0 ? <th aria-hidden style={{ width: leadWidth }} className="p-0" /> : null}
+            {virtualColumns.map((vc) => {
+              const col = columns[vc.index];
+              if (col === undefined) return null;
               return (
-                // biome-ignore lint/a11y/useKeyWithClickEvents: the parent <table> owns keyboard nav (handleKeyDown).
-                <td
+                <th
                   key={col.key}
-                  onClick={(e) => handleCellClick(rowIdx, col.key, e.shiftKey)}
-                  onDoubleClick={() => handleCellDoubleClick(rowIdx, col.key)}
-                  className={`relative border px-2 py-1 ${
-                    isPrimary ? 'ring-2 ring-primary' : isActive ? 'bg-primary/10' : ''
-                  } ${col.readOnly === true ? 'bg-muted/40 text-muted-foreground' : 'cursor-cell'}`}
+                  style={{ width: col.width }}
+                  className="border px-2 py-1 text-left font-medium"
                 >
-                  {isEditing ? (
-                    <input
-                      ref={editorRef}
-                      defaultValue={String(value ?? '')}
-                      onBlur={(e) => commitEdit(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          commitEdit((e.target as HTMLInputElement).value);
-                        } else if (e.key === 'Escape') {
-                          setEditing(null);
-                        }
-                      }}
-                      className="w-full bg-background outline-none"
-                    />
-                  ) : (
-                    <span>{String(value ?? '')}</span>
-                  )}
-                </td>
+                  {col.label}
+                </th>
               );
             })}
+            {tailWidth > 0 ? <th aria-hidden style={{ width: tailWidth }} className="p-0" /> : null}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIdx) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: row identity is positional in this grid view.
+            <tr key={rowIdx}>
+              {leadWidth > 0 ? (
+                <td aria-hidden style={{ width: leadWidth }} className="p-0" />
+              ) : null}
+              {virtualColumns.map((vc) => renderCell(row, rowIdx, vc.index))}
+              {tailWidth > 0 ? (
+                <td aria-hidden style={{ width: tailWidth }} className="p-0" />
+              ) : null}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/CompletenessFilter.php
+++ b/apps/api/src/Catalog/Infrastructure/ApiPlatform/Filter/CompletenessFilter.php
@@ -11,9 +11,19 @@ use Doctrine\ORM\QueryBuilder;
 
 /**
  * `?completeness[gt]=80` / `?completeness[gte]=50&completeness[lt]=100`
- * — numeric range query against the per-row `completeness.pct` JSONB
- * key (admin-side completeness percentage stamped by
- * `CompletenessRecalculator` from #38).
+ * — numeric range query against the per-row completeness percentage
+ * stamped by `AttributesIndexedRebuilder` (#38).
+ *
+ * AUD-037 (#1611): filters on the denormalised `completenessPct` smallint
+ * column (`completeness_pct`), NOT the `completeness` JSONB blob. The
+ * column is the flat mirror of `completeness['global']` maintained by
+ * `CatalogObject::recordCompleteness()` and is covered by
+ * `objects_tenant_kind_compl_idx`, so the predicate is sargable. The
+ * previous `JSONB_GET_NUMERIC(o.completeness, 'pct')` form could not use
+ * that index (function over a JSONB column) and also read the wrong key —
+ * the payload writes `global`, never `pct`, so it silently matched
+ * nothing. The same column is what `FilterDslResolver` (Smart Filters /
+ * Meilisearch) already targets, so both paths now agree.
  *
  * Channel-aware completeness (`?completeness[gt]=80&channel=ecommerce_pl`)
  * is parked until ChannelObjectTypeMapping reads land in epic 0.6 — the
@@ -70,12 +80,12 @@ final class CompletenessFilter implements FilterInterface
             $parameter = $queryNameGenerator->generateParameterName('completeness_'.$op);
             $queryBuilder
                 ->andWhere(\sprintf(
-                    "JSONB_GET_NUMERIC(%s.completeness, 'pct') %s :%s",
+                    '%s.completenessPct %s :%s',
                     $alias,
                     $sqlOperator,
                     $parameter,
                 ))
-                ->setParameter($parameter, (float) $threshold);
+                ->setParameter($parameter, (int) $threshold);
         }
     }
 
@@ -91,7 +101,7 @@ final class CompletenessFilter implements FilterInterface
                 'property' => 'completeness',
                 'type' => 'number',
                 'required' => false,
-                'description' => 'Filter by per-row completeness percentage (`completeness.pct` JSONB key).',
+                'description' => 'Filter by per-row completeness percentage (indexed `completeness_pct` column).',
                 'strategy' => 'numeric_range',
                 'is_collection' => true,
             ],

--- a/apps/api/src/Identity/Application/PermissionResolver.php
+++ b/apps/api/src/Identity/Application/PermissionResolver.php
@@ -110,6 +110,24 @@ final class PermissionResolver implements PermissionResolverInterface
         // equality operator for type json`). Cast to text — dedup happens
         // on string form, which is fine because mergeScope() re-decodes
         // the JSON below before producing the final list.
+        //
+        // AUD-029 (#1611): the legacy `user_roles` branch projects a literal
+        // `'[]'` scope. That `'[]'` is NOT an intentional "no restriction"
+        // grant — `user_roles` has no scope columns at all — yet mergeScope()
+        // reads any empty array as most-permissive and short-circuits the
+        // union to `[]`. UserCreateService writes EVERY (user, role) pair to
+        // BOTH tables (addRole + UserRole entity), so a user given a
+        // locale-scoped role saw that restriction silently widened to "all
+        // locales" by its own legacy duplicate row. Fix (INTERIM — full
+        // consolidation is #644): exclude a legacy `user_roles` row from the
+        // union whenever a `user_role_assignments` row already covers the same
+        // (user, role); the scoped assignment then owns the scope projection.
+        // A legacy-ONLY role (no matching assignment — e.g. the fixture
+        // super_admin / tenant_owner attached via addRole only) still
+        // contributes its broad `'[]'`, so genuinely unrestricted roles keep
+        // full access. Permission CODES still come from both tables, so a
+        // legacy-only role's grants are never dropped — only its redundant
+        // scope row is.
         $sql = <<<'SQL'
                 SELECT DISTINCT p.code, ura.locale_scope::text AS locale_scope, ura.channel_scope::text AS channel_scope, ura.attribute_group_scope::text AS attribute_group_scope
                 FROM user_role_assignments ura
@@ -122,6 +140,11 @@ final class PermissionResolver implements PermissionResolverInterface
                 INNER JOIN role_permissions rp ON rp.role_id = ur.role_id
                 INNER JOIN permissions p ON p.id = rp.permission_id
                 WHERE ur.user_id = :user_id
+                  AND NOT EXISTS (
+                      SELECT 1 FROM user_role_assignments ura2
+                      WHERE ura2.user_id = ur.user_id
+                        AND ura2.role_id = ur.role_id
+                  )
             SQL;
 
         /** @var list<array{code: string, locale_scope: string, channel_scope: string, attribute_group_scope: string}> $rows */

--- a/apps/api/tests/Api/Catalog/CatalogFiltersApiTest.php
+++ b/apps/api/tests/Api/Catalog/CatalogFiltersApiTest.php
@@ -223,9 +223,11 @@ final class CatalogFiltersApiTest extends CatalogApiTestCase
     #[Test]
     public function completenessFilterRangeQuery(): void
     {
-        $this->seedProducts(['LOW'], completeness: ['pct' => 30]);
-        $this->seedProducts(['MID'], completeness: ['pct' => 70]);
-        $this->seedProducts(['HIGH'], completeness: ['pct' => 95]);
+        // AUD-037: the filter now reads the `completeness_pct` column, which
+        // `recordCompleteness()` mirrors from the `global` key (not `pct`).
+        $this->seedProducts(['LOW'], completeness: ['global' => 30]);
+        $this->seedProducts(['MID'], completeness: ['global' => 70]);
+        $this->seedProducts(['HIGH'], completeness: ['global' => 95]);
 
         $client = $this->authenticatedClient();
         $body = $client->request('GET', '/api/products?completeness[gte]=80')->toArray();

--- a/apps/api/tests/Integration/Identity/PermissionResolverLegacyScopeTest.php
+++ b/apps/api/tests/Integration/Identity/PermissionResolverLegacyScopeTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Identity;
+
+use App\Identity\Application\PermissionResolverInterface;
+use App\Identity\Domain\Entity\User;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-029 / W3-5.1 (#1611) — the legacy `user_roles` M2M must not neutralise
+ * the per-locale/channel scope carried by `user_role_assignments`.
+ *
+ * Brownfield reality: {@see \App\Identity\Application\UserCreateService} writes
+ * every (user, role) pair to BOTH tables — `user_roles` (Symfony Security graph)
+ * and `user_role_assignments` (scope columns). The legacy row projects a literal
+ * `'[]'` scope which {@see \App\Identity\Application\PermissionResolver::mergeScope}
+ * reads as "no restriction" and short-circuits the union to `[]`, silently
+ * widening a locale-scoped role to all locales.
+ *
+ * RED  (pre-fix): a user with role R via `user_role_assignments` (locale=['pl'])
+ *      AND a legacy `user_roles` row for the SAME R resolves to localeScope=[]
+ *      (most-permissive) — the `'[]'` from the legacy branch wins the union.
+ * GREEN (post-fix): the legacy branch is excluded when an assignment covers the
+ *      same (user, role); localeScope stays ['pl'].
+ *
+ * Regression guard: a legacy-ONLY role (no matching assignment — the fixture
+ * super_admin / tenant_owner attached via addRole only) keeps localeScope=[]
+ * so genuinely unrestricted roles retain full access.
+ *
+ * Uses the real container Connection + PermissionResolver against the test DB
+ * (schema built from ORM metadata), seeds raw rows, and cleans up in a finally.
+ */
+final class PermissionResolverLegacyScopeTest extends KernelTestCase
+{
+    #[Test]
+    public function legacyUserRolesDoesNotWidenScopedAssignment(): void
+    {
+        self::bootKernel();
+        $connection = $this->connection();
+
+        $suffix = bin2hex(random_bytes(4));
+        $tenantId = Uuid::v7()->toRfc4122();
+        $roleId = Uuid::v7()->toRfc4122();
+        $permissionId = Uuid::v7()->toRfc4122();
+        $userId = Uuid::v7()->toRfc4122();
+        $assignmentId = Uuid::v7()->toRfc4122();
+        $code = 'products.view.scoped.'.$suffix;
+
+        try {
+            $this->seedTenant($connection, $tenantId, 'aud029-a-'.$suffix);
+            $this->seedRole($connection, $roleId, $tenantId, 'scoped-role-'.$suffix);
+            $this->seedPermission($connection, $permissionId, $code);
+            $this->linkRolePermission($connection, $roleId, $permissionId);
+            $this->seedUser($connection, $userId, $tenantId, 'aud029-'.$suffix.'@demo.localhost');
+
+            // Scoped assignment: role restricted to the `pl` locale.
+            $this->seedAssignment($connection, $assignmentId, $userId, $roleId, '["pl"]');
+            // Legacy duplicate of the SAME role (UserCreateService writes both).
+            $this->seedLegacyUserRole($connection, $userId, $roleId);
+
+            $resolved = $this->resolver()->resolve($this->loadUser($userId));
+
+            self::assertContains($code, $resolved->getCodes());
+            // The crux: the legacy `'[]'` row must NOT have widened the scope.
+            self::assertSame(
+                ['pl'],
+                $resolved->getLocaleScope(),
+                'A scoped (locale=pl) assignment must stay restricted; the legacy '
+                .'user_roles `[]` row must not widen it to most-permissive (all locales).',
+            );
+            self::assertTrue(
+                $resolved->appliesToLocale('pl'),
+                'The pl locale is in scope.',
+            );
+            self::assertFalse(
+                $resolved->appliesToLocale('en'),
+                'A non-pl locale must be out of scope; a true here means the legacy '
+                .'row re-opened the full locale set.',
+            );
+        } finally {
+            $this->cleanup($connection, $userId, $roleId, $permissionId, $tenantId);
+        }
+    }
+
+    #[Test]
+    public function legacyOnlyRoleKeepsMostPermissiveScope(): void
+    {
+        self::bootKernel();
+        $connection = $this->connection();
+
+        $suffix = bin2hex(random_bytes(4));
+        $tenantId = Uuid::v7()->toRfc4122();
+        $roleId = Uuid::v7()->toRfc4122();
+        $permissionId = Uuid::v7()->toRfc4122();
+        $userId = Uuid::v7()->toRfc4122();
+        $code = 'platform.tenants.manage.legacy.'.$suffix;
+
+        try {
+            $this->seedTenant($connection, $tenantId, 'aud029-b-'.$suffix);
+            $this->seedRole($connection, $roleId, $tenantId, 'legacy-only-role-'.$suffix);
+            $this->seedPermission($connection, $permissionId, $code);
+            $this->linkRolePermission($connection, $roleId, $permissionId);
+            $this->seedUser($connection, $userId, $tenantId, 'aud029b-'.$suffix.'@demo.localhost');
+
+            // No user_role_assignments row — this models the fixture super_admin /
+            // tenant_owner attached via addRole() only.
+            $this->seedLegacyUserRole($connection, $userId, $roleId);
+
+            $resolved = $this->resolver()->resolve($this->loadUser($userId));
+
+            self::assertContains($code, $resolved->getCodes());
+            self::assertSame(
+                [],
+                $resolved->getLocaleScope(),
+                'A legacy-only role (no scoped assignment) must keep the most-permissive '
+                .'empty scope so super_admin / tenant_owner retain full access.',
+            );
+            self::assertTrue($resolved->appliesToLocale('en'), 'An unrestricted role applies to any locale.');
+            self::assertTrue($resolved->appliesToChannel('shopify'), 'An unrestricted role applies to any channel.');
+        } finally {
+            $this->cleanup($connection, $userId, $roleId, $permissionId, $tenantId);
+        }
+    }
+
+    private function seedTenant(Connection $connection, string $id, string $code): void
+    {
+        $connection->executeStatement(
+            'INSERT INTO tenants (id, code, name, created_at) VALUES (:id, :code, :name, NOW())',
+            ['id' => $id, 'code' => $code, 'name' => $code],
+        );
+    }
+
+    private function seedRole(Connection $connection, string $id, string $tenantId, string $code): void
+    {
+        $connection->executeStatement(
+            'INSERT INTO roles (id, tenant_id, code, name, created_at) VALUES (:id, :tenant, :code, :name, NOW())',
+            ['id' => $id, 'tenant' => $tenantId, 'code' => $code, 'name' => $code],
+        );
+    }
+
+    private function seedPermission(Connection $connection, string $id, string $code): void
+    {
+        // resource/action have their own UNIQUE constraint; derive unique values
+        // from the (already unique) code so parallel runs never collide.
+        $connection->executeStatement(
+            'INSERT INTO permissions (id, code, resource, action, created_at) VALUES (:id, :code, :resource, :action, NOW())',
+            ['id' => $id, 'code' => $code, 'resource' => $code, 'action' => 'view'],
+        );
+    }
+
+    private function linkRolePermission(Connection $connection, string $roleId, string $permissionId): void
+    {
+        $connection->executeStatement(
+            'INSERT INTO role_permissions (role_id, permission_id) VALUES (:role, :permission)',
+            ['role' => $roleId, 'permission' => $permissionId],
+        );
+    }
+
+    private function seedUser(Connection $connection, string $id, string $tenantId, string $email): void
+    {
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO users (id, tenant_id, email, password, roles, status, totp_backup_codes, created_at, password_change_required)
+                VALUES (:id, :tenant, :email, '', '["ROLE_USER"]', 'active', '[]', NOW(), false)
+                SQL,
+            ['id' => $id, 'tenant' => $tenantId, 'email' => $email],
+        );
+    }
+
+    private function seedAssignment(Connection $connection, string $id, string $userId, string $roleId, string $localeScope): void
+    {
+        $connection->executeStatement(
+            <<<'SQL'
+                INSERT INTO user_role_assignments (id, user_id, role_id, locale_scope, channel_scope, attribute_group_scope, assigned_at)
+                VALUES (:id, :user, :role, CAST(:locale AS json), CAST('[]' AS json), CAST('[]' AS json), NOW())
+                SQL,
+            ['id' => $id, 'user' => $userId, 'role' => $roleId, 'locale' => $localeScope],
+        );
+    }
+
+    private function seedLegacyUserRole(Connection $connection, string $userId, string $roleId): void
+    {
+        $connection->executeStatement(
+            'INSERT INTO user_roles (user_id, role_id) VALUES (:user, :role)',
+            ['user' => $userId, 'role' => $roleId],
+        );
+    }
+
+    private function cleanup(
+        Connection $connection,
+        string $userId,
+        string $roleId,
+        string $permissionId,
+        string $tenantId,
+    ): void {
+        // FK order: junctions first, then owned rows, then the tenant.
+        $connection->executeStatement('DELETE FROM user_role_assignments WHERE user_id = :id', ['id' => $userId]);
+        $connection->executeStatement('DELETE FROM user_roles WHERE user_id = :id', ['id' => $userId]);
+        $connection->executeStatement('DELETE FROM role_permissions WHERE role_id = :id', ['id' => $roleId]);
+        $connection->executeStatement('DELETE FROM users WHERE id = :id', ['id' => $userId]);
+        $connection->executeStatement('DELETE FROM permissions WHERE id = :id', ['id' => $permissionId]);
+        $connection->executeStatement('DELETE FROM roles WHERE id = :id', ['id' => $roleId]);
+        $connection->executeStatement('DELETE FROM tenants WHERE id = :id', ['id' => $tenantId]);
+    }
+
+    private function loadUser(string $userId): User
+    {
+        $user = $this->em()->getRepository(User::class)->find(Uuid::fromString($userId));
+        self::assertInstanceOf(User::class, $user);
+
+        return $user;
+    }
+
+    private function resolver(): PermissionResolverInterface
+    {
+        $resolver = self::getContainer()->get(PermissionResolverInterface::class);
+        self::assertInstanceOf(PermissionResolverInterface::class, $resolver);
+
+        return $resolver;
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        $em = self::getContainer()->get('doctrine')->getManager();
+        self::assertInstanceOf(EntityManagerInterface::class, $em);
+
+        return $em;
+    }
+
+    private function connection(): Connection
+    {
+        $connection = self::getContainer()->get('doctrine.dbal.default_connection');
+        self::assertInstanceOf(Connection::class, $connection);
+
+        return $connection;
+    }
+}

--- a/apps/api/tests/Unit/Catalog/CompletenessFilterTest.php
+++ b/apps/api/tests/Unit/Catalog/CompletenessFilterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Catalog;
+
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Infrastructure\ApiPlatform\Filter\CompletenessFilter;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * AUD-037 / W3-5.1 (#1611) — the completeness range filter must generate a
+ * predicate on the indexed `completenessPct` column, NOT a non-sargable
+ * `JSONB_GET_NUMERIC(o.completeness, 'pct')` function call.
+ *
+ * EXPLAIN on 50k rows is not reproducible against the empty dev/test DB, so
+ * the regression is pinned at the query-shape level: the generated DQL
+ * condition references the column (which `objects_tenant_kind_compl_idx`
+ * covers) and never the JSONB function (which the index cannot serve, and
+ * which read the wrong `pct` key the payload never writes).
+ */
+final class CompletenessFilterTest extends TestCase
+{
+    #[Test]
+    public function generatesColumnPredicateNotJsonbFunction(): void
+    {
+        $capture = new CompletenessFilterTestCapture();
+        $nameGenerator = $this->createStub(QueryNameGeneratorInterface::class);
+        $nameGenerator->method('generateParameterName')->willReturnCallback(
+            static fn (string $field): string => $field.'_p1',
+        );
+
+        new CompletenessFilter()->apply(
+            $this->queryBuilderCapturing($capture),
+            $nameGenerator,
+            CatalogObject::class,
+            null,
+            ['filters' => ['completeness' => ['gte' => 80]]],
+        );
+
+        self::assertCount(1, $capture->where, 'Exactly one range predicate is added for a single operator.');
+        $condition = $capture->where[0];
+
+        self::assertStringContainsString(
+            'o.completenessPct >= :completeness_gte_p1',
+            $condition,
+            'The filter must compare the sargable completenessPct column.',
+        );
+        self::assertStringNotContainsString(
+            'JSONB_GET_NUMERIC',
+            $condition,
+            'The filter must NOT fall back to the non-indexable JSONB function.',
+        );
+        self::assertStringNotContainsString(
+            'completeness,',
+            $condition,
+            'The filter must NOT read the completeness JSONB blob.',
+        );
+
+        self::assertArrayHasKey('completeness_gte_p1', $capture->params);
+        self::assertSame(80, $capture->params['completeness_gte_p1'], 'Threshold binds as an int matching the smallint column.');
+    }
+
+    #[Test]
+    public function multipleOperatorsEachUseTheColumn(): void
+    {
+        $capture = new CompletenessFilterTestCapture();
+        $nameGenerator = $this->createStub(QueryNameGeneratorInterface::class);
+        $nameGenerator->method('generateParameterName')->willReturnCallback(
+            static fn (string $field): string => $field.'_p',
+        );
+
+        new CompletenessFilter()->apply(
+            $this->queryBuilderCapturing($capture),
+            $nameGenerator,
+            CatalogObject::class,
+            null,
+            ['filters' => ['completeness' => ['gt' => 30, 'lt' => 90]]],
+        );
+
+        self::assertCount(2, $capture->where);
+        foreach ($capture->where as $condition) {
+            self::assertStringContainsString('o.completenessPct', $condition);
+            self::assertStringNotContainsString('JSONB_GET_NUMERIC', $condition);
+        }
+    }
+
+    /**
+     * A QueryBuilder double that records every andWhere() condition + bound
+     * parameter so the generated DQL can be asserted without a DB. The real
+     * Expr is used so string casting matches Doctrine's output.
+     */
+    private function queryBuilderCapturing(CompletenessFilterTestCapture $capture): QueryBuilder
+    {
+        $queryBuilder = $this->createStub(QueryBuilder::class);
+        $queryBuilder->method('getRootAliases')->willReturn(['o']);
+        $queryBuilder->method('expr')->willReturn(new Expr());
+        $queryBuilder->method('andWhere')->willReturnCallback(
+            static function (string $condition) use ($capture, $queryBuilder): QueryBuilder {
+                $capture->where[] = $condition;
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('setParameter')->willReturnCallback(
+            static function (string $key, mixed $value) use ($capture, $queryBuilder): QueryBuilder {
+                $capture->params[$key] = $value;
+
+                return $queryBuilder;
+            },
+        );
+
+        return $queryBuilder;
+    }
+}
+
+/**
+ * Mutable sink for the conditions / parameters the filter pushes onto the
+ * QueryBuilder double — a typed holder so PHPStan max sees concrete property
+ * shapes instead of an optional-key array.
+ */
+final class CompletenessFilterTestCapture
+{
+    /** @var list<string> */
+    public array $where = [];
+
+    /** @var array<string, mixed> */
+    public array $params = [];
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -1946,7 +1946,7 @@
                     {
                         "name": "completeness[eq|gt|gte|lt|lte]",
                         "in": "query",
-                        "description": "Filter by per-row completeness percentage (`completeness.pct` JSONB key).",
+                        "description": "Filter by per-row completeness percentage (indexed `completeness_pct` column).",
                         "required": false,
                         "deprecated": false,
                         "schema": {
@@ -2299,7 +2299,7 @@
                     {
                         "name": "completeness[eq|gt|gte|lt|lte]",
                         "in": "query",
-                        "description": "Filter by per-row completeness percentage (`completeness.pct` JSONB key).",
+                        "description": "Filter by per-row completeness percentage (indexed `completeness_pct` column).",
                         "required": false,
                         "deprecated": false,
                         "schema": {
@@ -2989,7 +2989,7 @@
                     {
                         "name": "completeness[eq|gt|gte|lt|lte]",
                         "in": "query",
-                        "description": "Filter by per-row completeness percentage (`completeness.pct` JSONB key).",
+                        "description": "Filter by per-row completeness percentage (indexed `completeness_pct` column).",
                         "required": false,
                         "deprecated": false,
                         "schema": {
@@ -3679,7 +3679,7 @@
                     {
                         "name": "completeness[eq|gt|gte|lt|lte]",
                         "in": "query",
-                        "description": "Filter by per-row completeness percentage (`completeness.pct` JSONB key).",
+                        "description": "Filter by per-row completeness percentage (indexed `completeness_pct` column).",
                         "required": false,
                         "deprecated": false,
                         "schema": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.0
         version: 5.101.0(react@19.2.7)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.3
+        version: 3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@udecode/plate':
         specifier: ^49.0.0
         version: 49.0.0(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.124.1(slate@0.124.1))(slate@0.124.1)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -1320,6 +1323,15 @@ packages:
     resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.14.3':
+    resolution: {integrity: sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.1':
+    resolution: {integrity: sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4127,6 +4139,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.101.0
       react: 19.2.7
+
+  '@tanstack/react-virtual@3.14.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/virtual-core@3.17.1': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Wave 3 / W3-5.1 — AUD-029 + AUD-037 + AUD-038 (#1611)

### AUD-029 — legacy `user_roles` neutralizował per-locale/channel scope (security, test-first)
`PermissionResolver` UNIONował `user_role_assignments` (scoped) z legacy `user_roles` (literalny `[]`); `mergeScope` traktuje `[]` jako most-permissive → user z tą samą rolą w obu tabelach tracił WSZYSTKIE restrykcje locale/channel (demo fixtures to trafiały). **Fix (wariant b):** wyklucz legacy `user_roles` gdy istnieje scoped-assignment dla tej samej (user, role); role legacy-only (np. global super_admin) zachowują szeroki scope. Pełna konsolidacja → #644. **RED/GREEN:** scoped locale=`["pl"]` + legacy duplikat → przed: `[]` (all); po: pozostaje `["pl"]`. **super_admin nietknięty** (test legacy-only + live `/api/auth/me` admin@demo: locale_scope `[]`, 117 perms — pełny dostęp).

### AUD-037 — CompletenessFilter na JSONB zamiast indexed column (perf + bonus correctness)
Generował non-sargable `JSONB_GET_NUMERIC(o.completeness,'pct')`. **Fix:** `o.completenessPct` (kolumna pokryta `objects_tenant_kind_compl_idx`). **Bonus:** payload klucz to `global`, nigdy `pct` → stary filtr matchował 0 wyników (latent bug). Live: `completeness[gte]=1` → 6911 items.

### AUD-038 — wirtualizacja gridu (perf FE)
`ExcelLikeGrid` renderował każdy wiersz×kolumna (200×200+ = 20k+ DOM). **Fix:** wirtualizacja kolumn (`@tanstack/react-virtual`) ze spacer-cells; handlery keyują po indeksie pełnej tablicy → inline-edit/selection/keyboard-nav bez zmian. **Component test 4/4** (realny guard: Col 59 niezamontowana, edit-commit, nav).

### Bramki
PHPStan max `No errors` · Deptrac `0` (baseline intact) · php-cs-fixer clean · backend **15 nowe + 205 Identity + 77 filter** green · frontend Biome/tsc(0)/build + grid test **4/4**.

Closes #1611
