### PR TITLE
fix(search): signal degraded mode instead of empty results

### DIFF
--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -1,6 +1,6 @@
 import { Copy, CornerDownRight, Link2, Lock } from 'lucide-react';
+import { lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { WysiwygEditor } from '@/components/catalog/wysiwyg-editor';
 import { RelationCreateField } from '@/components/objects/relation-create-field';
 import { type Provenance, ProvenanceBadge } from '@/components/provenance-badge';
 import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
@@ -12,6 +12,26 @@ import { cn } from '@/lib/utils';
 import { AssetField } from './asset-field';
 import { RelationInlineEditor } from './relation-inline-editor';
 import type { AttributeMeta, AttributeOptionMeta, ProductLocale } from './types';
+
+// AUD-071 (#1614) — the WYSIWYG editor drags in the entire @udecode/plate
+// (Slate) stack + dompurify, which dominated the product-detail-page chunk
+// even though it only renders for `wysiwyg`-typed attributes. Code-split it
+// so the editor stack downloads on demand the first time a rich-text field
+// appears, instead of on every product detail load.
+const WysiwygEditor = lazy(() =>
+  import('@/components/catalog/wysiwyg-editor').then((m) => ({ default: m.WysiwygEditor })),
+);
+
+// Minimal placeholder while the editor chunk loads — sized to the editor's
+// idle height so the form doesn't jump.
+function WysiwygFallback() {
+  return (
+    <div
+      className="min-h-[7.5rem] w-full animate-pulse rounded-xl border border-zinc-200 bg-zinc-50"
+      aria-hidden
+    />
+  );
+}
 
 export interface AttrRowProps {
   attribute: AttributeMeta;
@@ -236,11 +256,13 @@ export function AttrRow({
           <RelationCreateField attribute={attribute} value={value} onChange={onChange} />
         ) : editable ? (
           attribute.type === 'wysiwyg' ? (
-            <WysiwygEditor
-              value={stringValue}
-              onChange={(next) => onChange(next)}
-              ariaLabel={label}
-            />
+            <Suspense fallback={<WysiwygFallback />}>
+              <WysiwygEditor
+                value={stringValue}
+                onChange={(next) => onChange(next)}
+                ariaLabel={label}
+              />
+            </Suspense>
           ) : attribute.type === 'richtext' || attribute.type === 'textarea' ? (
             <Textarea
               id={`attr-${attribute.code}`}
@@ -366,7 +388,9 @@ export function AttrRow({
             />
           )
         ) : attribute.type === 'wysiwyg' ? (
-          <WysiwygEditor value={stringValue} onChange={() => undefined} readOnly />
+          <Suspense fallback={<WysiwygFallback />}>
+            <WysiwygEditor value={stringValue} onChange={() => undefined} readOnly />
+          </Suspense>
         ) : attribute.type === 'color' && isHexColor(stringValue) ? (
           <div className="flex items-center gap-2 px-3 py-2 text-[13.5px]">
             <span

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Clock, Link2, MoreHorizontal, Save, Sparkles, Trash2 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 
@@ -28,7 +28,6 @@ import { useDefaultObjectType } from '../use-default-object-type';
 import { AgentSuggestionsCard } from './agent-suggestions-card';
 import { AttrGroupCard } from './attr-group-card';
 import { AttrRow } from './attr-row';
-import { CategoriesTab } from './categories-tab';
 import { CategorySelectorCard } from './category-selector-card';
 import { CompletenessRing } from './completeness-ring';
 import { DuplicateButton } from './duplicate-button';
@@ -36,8 +35,6 @@ import { EffectiveModelCard } from './effective-model-card';
 
 import { LocaleChannelToolbar } from './locale-channel-toolbar';
 import { PreviewButton } from './preview-button';
-import { ProductMultimediaTab } from './product-multimedia-tab';
-import { RelationsTab } from './relations-tab';
 import { scopedCompleteness, scopeQuery } from './scope';
 import { SyncStatusCard } from './sync-status-card';
 import type {
@@ -52,7 +49,27 @@ import type {
   ScopeStatus,
 } from './types';
 import { VariantsListCard } from './variants-list-card';
-import { VariantsTabHost } from './variants-tab-host';
+
+// AUD-071 (#1614) — the four bespoke tab views below are rendered ONLY
+// after the operator clicks their tab (multimedia / categories / variants /
+// relations). Statically importing them pinned ~1.7k lines of grids +
+// editors (incl. the heavy VariantsTab) into the main detail chunk, pushing
+// product-detail-page over the 700 KB warning threshold. Code-split each
+// behind React.lazy so the initial detail render only ships the attributes
+// view; the tab chunk loads on demand behind the <Suspense> boundary in the
+// content dispatcher.
+const CategoriesTab = lazy(() =>
+  import('./categories-tab').then((m) => ({ default: m.CategoriesTab })),
+);
+const ProductMultimediaTab = lazy(() =>
+  import('./product-multimedia-tab').then((m) => ({ default: m.ProductMultimediaTab })),
+);
+const RelationsTab = lazy(() =>
+  import('./relations-tab').then((m) => ({ default: m.RelationsTab })),
+);
+const VariantsTabHost = lazy(() =>
+  import('./variants-tab-host').then((m) => ({ default: m.VariantsTabHost })),
+);
 
 /**
  * MODR-03 (#925) — special-purpose tabs that are NOT driven by
@@ -1045,98 +1062,103 @@ export function ProductDetailPage({
       {/* Body */}
       <div className="grid grid-cols-1 gap-5 px-7 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="min-w-0 space-y-3">
-          {(() => {
-            // MODR-03 (#925) — content area dispatch based on active tab.
-            // 'attributes' hosts every stacked group as inline AttrGroupCard
-            // sections; a tab-mode group code renders that single group;
-            // 'categories'/'history'/'variants' delegate to bespoke components.
-            const renderStackedGroup = (group: GroupMeta) => (
-              <AttrGroupCard
-                key={group.id}
-                id={group.id}
-                title={group.label[lang] ?? group.code}
-                icon={GROUP_ICONS[group.code]}
-                filledCount={countFilled(group, fieldValue)}
-                totalCount={group.attributes.length}
-                expanded={expandedGroups.has(group.id)}
-                onToggle={() => toggleGroup(group.id)}
-                isSystem={isLegacyOptionalSystemGroupCode(group.code)}
-              >
-                {group.attributes.map((attr) => (
-                  <AttrRow
-                    key={attr.id}
-                    attribute={attr}
-                    value={fieldValue(attr.code)}
-                    provenance={resolveProvenance(attr, product)}
+          {/* AUD-071 (#1614) — lazy tab chunks (multimedia/categories/variants/
+              relations) resolve behind this boundary; the attributes view and
+              tab-mode groups render synchronously and never suspend. */}
+          <Suspense fallback={<TabLoadingFallback />}>
+            {(() => {
+              // MODR-03 (#925) — content area dispatch based on active tab.
+              // 'attributes' hosts every stacked group as inline AttrGroupCard
+              // sections; a tab-mode group code renders that single group;
+              // 'categories'/'history'/'variants' delegate to bespoke components.
+              const renderStackedGroup = (group: GroupMeta) => (
+                <AttrGroupCard
+                  key={group.id}
+                  id={group.id}
+                  title={group.label[lang] ?? group.code}
+                  icon={GROUP_ICONS[group.code]}
+                  filledCount={countFilled(group, fieldValue)}
+                  totalCount={group.attributes.length}
+                  expanded={expandedGroups.has(group.id)}
+                  onToggle={() => toggleGroup(group.id)}
+                  isSystem={isLegacyOptionalSystemGroupCode(group.code)}
+                >
+                  {group.attributes.map((attr) => (
+                    <AttrRow
+                      key={attr.id}
+                      attribute={attr}
+                      value={fieldValue(attr.code)}
+                      provenance={resolveProvenance(attr, product)}
+                      locale={locale}
+                      channel={channel}
+                      isEditing={isEditing}
+                      isLocked={attr.is_system}
+                      onChange={(next) => setFieldValue(attr.code, next)}
+                      createMode={mode === 'create'}
+                      relationContextProductId={isEditMode ? id : undefined}
+                      isInherited={
+                        scopeStatus[attr.code]?.has_override === false &&
+                        scopeStatus[attr.code]?.inherited_from != null
+                      }
+                      inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
+                      requiredError={requiredErrors.has(attr.code)}
+                    />
+                  ))}
+                </AttrGroupCard>
+              );
+
+              if (activeTab === 'attributes') {
+                // #1357 — the non-functional "Dodaj grupę atrybutów ad-hoc"
+                // stub was removed from this view per operator request.
+                return <>{stackedGroups.map(renderStackedGroup)}</>;
+              }
+
+              // Tab-mode AttributeGroup → render only that group, with
+              // a bespoke component for relations that retains its legacy
+              // data flow (relation links endpoint). Multimedia is no
+              // longer dispatched here — UX-02 removes it from the
+              // AttributeGroup model entirely; the conditional Multimedia
+              // tab lives as a hardcoded special tab driven by
+              // `ObjectType.hasMultimedia` (UX-06+).
+              const tabGroup = tabModeGroups.find((g) => g.code === activeTab);
+              if (tabGroup) {
+                if (tabGroup.code === 'relations') {
+                  // Reverse-links UI needs a persisted object — edit only;
+                  // forward relation attrs render via RelationCreateField.
+                  return mode === 'edit' ? (
+                    <RelationsTab productId={id} />
+                  ) : (
+                    renderStackedGroup(tabGroup)
+                  );
+                }
+                return renderStackedGroup(tabGroup);
+              }
+
+              // MODR-06 (#928) — synthetic `relations` tab for the
+              // reverse-only case (object has no forward AttributeGroup
+              // but is pointed at from elsewhere). RelationsTab already
+              // gracefully renders just the reverse panel when forward
+              // groups are empty.
+              if (activeTab === 'relations' && mode === 'edit') {
+                return <RelationsTab productId={id} />;
+              }
+
+              if (mode === 'edit' && isSpecialTab(activeTab)) {
+                return (
+                  <OtherTabs
+                    activeTab={activeTab}
+                    productId={id}
+                    objectTypeId={objectTypeId}
+                    kind={kind ?? 'product'}
                     locale={locale}
                     channel={channel}
-                    isEditing={isEditing}
-                    isLocked={attr.is_system}
-                    onChange={(next) => setFieldValue(attr.code, next)}
-                    createMode={mode === 'create'}
-                    relationContextProductId={isEditMode ? id : undefined}
-                    isInherited={
-                      scopeStatus[attr.code]?.has_override === false &&
-                      scopeStatus[attr.code]?.inherited_from != null
-                    }
-                    inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
-                    requiredError={requiredErrors.has(attr.code)}
                   />
-                ))}
-              </AttrGroupCard>
-            );
-
-            if (activeTab === 'attributes') {
-              // #1357 — the non-functional "Dodaj grupę atrybutów ad-hoc"
-              // stub was removed from this view per operator request.
-              return <>{stackedGroups.map(renderStackedGroup)}</>;
-            }
-
-            // Tab-mode AttributeGroup → render only that group, with
-            // a bespoke component for relations that retains its legacy
-            // data flow (relation links endpoint). Multimedia is no
-            // longer dispatched here — UX-02 removes it from the
-            // AttributeGroup model entirely; the conditional Multimedia
-            // tab lives as a hardcoded special tab driven by
-            // `ObjectType.hasMultimedia` (UX-06+).
-            const tabGroup = tabModeGroups.find((g) => g.code === activeTab);
-            if (tabGroup) {
-              if (tabGroup.code === 'relations') {
-                // Reverse-links UI needs a persisted object — edit only;
-                // forward relation attrs render via RelationCreateField.
-                return mode === 'edit' ? (
-                  <RelationsTab productId={id} />
-                ) : (
-                  renderStackedGroup(tabGroup)
                 );
               }
-              return renderStackedGroup(tabGroup);
-            }
 
-            // MODR-06 (#928) — synthetic `relations` tab for the
-            // reverse-only case (object has no forward AttributeGroup
-            // but is pointed at from elsewhere). RelationsTab already
-            // gracefully renders just the reverse panel when forward
-            // groups are empty.
-            if (activeTab === 'relations' && mode === 'edit') {
-              return <RelationsTab productId={id} />;
-            }
-
-            if (mode === 'edit' && isSpecialTab(activeTab)) {
-              return (
-                <OtherTabs
-                  activeTab={activeTab}
-                  productId={id}
-                  objectTypeId={objectTypeId}
-                  kind={kind ?? 'product'}
-                  locale={locale}
-                  channel={channel}
-                />
-              );
-            }
-
-            return null;
-          })()}
+              return null;
+            })()}
+          </Suspense>
 
           {mode === 'create' && isCategorizable && createCategoryIds.length === 0 ? (
             <p className="px-1 text-[12px] text-muted-foreground">
@@ -1401,6 +1423,25 @@ function OtherTabs({
       />
     );
   return null;
+}
+
+/**
+ * AUD-071 (#1614) — discreet fallback while a lazy tab chunk loads. The
+ * tab chunks are small (a few tens of KB gzip) so this flashes only on a
+ * cold cache; it intentionally mirrors the muted card surface of the real
+ * tabs to avoid a jarring layout shift.
+ */
+function TabLoadingFallback() {
+  const { t } = useTranslation();
+  return (
+    <div
+      className="rounded-2xl border border-line bg-surface p-5 text-[12.5px] text-muted-foreground soft-shadow"
+      role="status"
+      aria-live="polite"
+    >
+      {t('products.detail.tabs.loading', { defaultValue: 'Ładowanie…' })}
+    </div>
+  );
 }
 
 function HistoryStub() {

--- a/apps/api/src/Catalog/Application/ObjectTypeService.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeService.php
@@ -14,6 +14,7 @@ use App\Catalog\Domain\Exception\ObjectTypeHasInstancesException;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
@@ -235,8 +236,20 @@ final readonly class ObjectTypeService
             throw new ObjectTypeHasInstancesException($objectType, $instanceCount);
         }
 
-        $this->em->remove($objectType);
-        $this->em->flush();
+        // AUD-072 (#1614) — safety-net mirroring DeleteAttributeHandler: the
+        // pre-check above can race with a concurrent insert (an object of this
+        // type, or any other FK referencing it) between the COUNT and the
+        // DELETE. Postgres then raises a FK violation that otherwise escapes as
+        // a 500. Translate it into the same 409-mapped domain exception the
+        // pre-check uses, so the API answers a consistent ConflictHttpException
+        // instead of a raw server error. Re-count for an accurate message;
+        // fall back to the FK signal (count 1) if the re-count also fails.
+        try {
+            $this->em->remove($objectType);
+            $this->em->flush();
+        } catch (ForeignKeyConstraintViolationException $e) {
+            throw new ObjectTypeHasInstancesException($objectType, max(1, $this->countInstances($objectType)), $e);
+        }
     }
 
     /**

--- a/apps/api/src/Catalog/Domain/Exception/ObjectTypeHasInstancesException.php
+++ b/apps/api/src/Catalog/Domain/Exception/ObjectTypeHasInstancesException.php
@@ -6,12 +6,18 @@ namespace App\Catalog\Domain\Exception;
 
 use App\Catalog\Domain\Entity\ObjectType;
 use RuntimeException;
+use Throwable;
 
 /**
  * VIEW-01 (#372) — raised when DELETE on a custom ObjectType is attempted
  * while it still has live `objects` rows. The Danger zone in the modeling
  * UI guards against this on the FE, but the API enforces the same
  * invariant authoritatively (FE could be bypassed by a direct call).
+ *
+ * AUD-072 (#1614) — also raised as the safety-net translation of a Postgres
+ * `ForeignKeyConstraintViolationException` when a concurrent insert wins the
+ * race against the pre-delete count; the original DBAL exception is chained
+ * via `$previous` for diagnostics.
  *
  * Mapped to 409 RFC 7807 with type
  * `urn:pim:errors:object-type-has-instances`.
@@ -21,11 +27,12 @@ final class ObjectTypeHasInstancesException extends RuntimeException
     public function __construct(
         public readonly ObjectType $objectType,
         public readonly int $instanceCount,
+        ?Throwable $previous = null,
     ) {
         parent::__construct(\sprintf(
             'ObjectType "%s" has %d instance(s); migrate or delete them before removing the type.',
             $objectType->getCode(),
             $instanceCount,
-        ));
+        ), 0, $previous);
     }
 }

--- a/apps/api/src/Search/Application/CatalogSearchService.php
+++ b/apps/api/src/Search/Application/CatalogSearchService.php
@@ -48,7 +48,15 @@ final readonly class CatalogSearchService
      * @param array<string, array{gte?: float, lte?: float}> $rangeFilters           numeric range filters (UI-02.24); mapped to Meili `key >= N AND key <= N`
      * @param ?string                                        $customFilterExpression VIEW-10 — pre-built Meilisearch filter expression from FilterDslResolver::toMeilisearchFilter() AND-merged with tenant + flat filters
      *
-     * @return array{hits: list<array<string, mixed>>, totalHits: int, facetDistribution: array<string, mixed>, processingTimeMs: int}
+     * AUD-070 (#1614) — the result carries a `degraded` flag. It is `false`
+     * for every normal answer (including a legitimately empty hit list) and
+     * `true` only when the Meilisearch backend itself failed (connection /
+     * timeout / protocol error). Callers MUST distinguish the two: a degraded
+     * search is a backend outage, NOT "zero results", and surfacing it as an
+     * empty list silently misleads the operator. The presentation layer maps
+     * `degraded:true` to a 503 problem+json instead of an empty `200`.
+     *
+     * @return array{hits: list<array<string, mixed>>, totalHits: int, facetDistribution: array<string, mixed>, processingTimeMs: int, degraded: bool}
      */
     public function search(
         ObjectKind $kind,
@@ -148,13 +156,21 @@ final readonly class CatalogSearchService
             $result = $client->index(IndexSettingsTemplate::indexName())->search($query, $options);
             $raw = $result->toArray();
         } catch (Throwable $e) {
+            // AUD-070 (#1614) — the Meili backend is unreachable / errored.
+            // Do NOT collapse this to an empty result: an empty list is
+            // indistinguishable from "no matches" and silently misleads the
+            // operator into thinking the catalog is empty. Flag the result as
+            // `degraded` so the controller can answer 503 problem+json. The
+            // products *list* path keeps its Postgres fallback; search has no
+            // equivalent fallback in MVP, so signalling the outage is the
+            // correct behaviour here.
             $this->logger->warning('Meilisearch query failed: {message}', [
                 'message' => $e->getMessage(),
                 'kind' => $kind->value,
                 'query' => $query,
             ]);
 
-            return $this->emptyResult();
+            return $this->degradedResult();
         }
 
         $rawHits = $raw['hits'] ?? [];
@@ -186,11 +202,15 @@ final readonly class CatalogSearchService
             'totalHits' => \is_numeric($rawTotal) ? (int) $rawTotal : 0,
             'facetDistribution' => $facets,
             'processingTimeMs' => \is_numeric($rawProcessing) ? (int) $rawProcessing : 0,
+            'degraded' => false,
         ];
     }
 
     /**
-     * @return array{hits: list<array<string, mixed>>, totalHits: int, facetDistribution: array<string, mixed>, processingTimeMs: int}
+     * A legitimately empty answer (e.g. no tenant context). `degraded` stays
+     * `false` — there is no backend outage, the query simply has no results.
+     *
+     * @return array{hits: list<array<string, mixed>>, totalHits: int, facetDistribution: array<string, mixed>, processingTimeMs: int, degraded: bool}
      */
     private function emptyResult(): array
     {
@@ -199,6 +219,25 @@ final readonly class CatalogSearchService
             'totalHits' => 0,
             'facetDistribution' => [],
             'processingTimeMs' => 0,
+            'degraded' => false,
+        ];
+    }
+
+    /**
+     * AUD-070 (#1614) — the search backend failed. Shaped identically to an
+     * empty result but flagged `degraded:true` so the controller answers 503
+     * instead of a misleading empty `200`.
+     *
+     * @return array{hits: list<array<string, mixed>>, totalHits: int, facetDistribution: array<string, mixed>, processingTimeMs: int, degraded: bool}
+     */
+    private function degradedResult(): array
+    {
+        return [
+            'hits' => [],
+            'totalHits' => 0,
+            'facetDistribution' => [],
+            'processingTimeMs' => 0,
+            'degraded' => true,
         ];
     }
 

--- a/apps/api/src/Search/Presentation/Controller/BulkSelectionController.php
+++ b/apps/api/src/Search/Presentation/Controller/BulkSelectionController.php
@@ -14,6 +14,7 @@ use App\Shared\Application\TenantContext;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -88,6 +89,21 @@ final class BulkSelectionController
                 perPage: self::PAGE_SIZE,
                 customFilterExpression: $customFilterExpression,
             );
+            // AUD-070 (#1614) — the search backend is down. Returning an empty
+            // selection here would silently run "select all matching" against
+            // zero rows; surface the outage as 503 problem+json instead.
+            if ($result['degraded']) {
+                return new JsonResponse(
+                    [
+                        'type' => 'urn:pim:errors:search-degraded',
+                        'title' => 'Search Temporarily Unavailable',
+                        'status' => Response::HTTP_SERVICE_UNAVAILABLE,
+                        'detail' => 'The search backend is currently unavailable. This is not an empty result — please retry shortly.',
+                    ],
+                    Response::HTTP_SERVICE_UNAVAILABLE,
+                    ['Content-Type' => 'application/problem+json; charset=utf-8'],
+                );
+            }
             $totalMatched = $result['totalHits'];
             foreach ($result['hits'] as $hit) {
                 if (isset($hit['id']) && \is_string($hit['id'])) {

--- a/apps/api/src/Search/Presentation/Controller/ProductQuickSearchController.php
+++ b/apps/api/src/Search/Presentation/Controller/ProductQuickSearchController.php
@@ -9,6 +9,7 @@ use App\Identity\Contracts\Attribute\RequiresPermission;
 use App\Search\Application\CatalogSearchService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -20,9 +21,10 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
  * caps to 50 hits, and exposes a flat `{hits, total, processingTimeMs}`
  * shape that `<ProductSearchBar>` (UI-02.9) consumes verbatim.
  *
- * The underlying service already short-circuits to an empty result when
- * Meilisearch is unreachable (try/catch + warning log) — the products
- * list `<EmptyState>` swallows that as a no-match render. A Postgres
+ * AUD-070 (#1614) — when Meilisearch is unreachable the service flags the
+ * result `degraded` instead of pretending it found zero hits. This wrapper
+ * relays that as a 503 problem+json so the quick-search dropdown can show
+ * "search unavailable" rather than a misleading "no matches". A Postgres
  * `LIKE 'q%'` fallback path is deferred until we observe a real outage
  * pattern (Faza 1+ candidate, see UI-02.2 ticket out-of-scope notes).
  *
@@ -76,6 +78,21 @@ final class ProductQuickSearchController
                 'attributesToSearchOn' => ['sku', 'name', 'code'],
             ],
         );
+
+        // AUD-070 (#1614) — relay a backend outage as 503 problem+json rather
+        // than an empty `{hits: []}` the dropdown would render as "no matches".
+        if ($result['degraded']) {
+            return new JsonResponse(
+                [
+                    'type' => 'urn:pim:errors:search-degraded',
+                    'title' => 'Search Temporarily Unavailable',
+                    'status' => Response::HTTP_SERVICE_UNAVAILABLE,
+                    'detail' => 'The search backend is currently unavailable. This is not an empty result — please retry shortly.',
+                ],
+                Response::HTTP_SERVICE_UNAVAILABLE,
+                ['Content-Type' => 'application/problem+json; charset=utf-8'],
+            );
+        }
 
         return new JsonResponse([
             'hits' => $result['hits'],

--- a/apps/api/src/Search/Presentation/Controller/SearchController.php
+++ b/apps/api/src/Search/Presentation/Controller/SearchController.php
@@ -15,6 +15,7 @@ use App\Shared\Application\TenantContext;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
@@ -193,6 +194,15 @@ final class SearchController
             customFilterExpression: $customFilterExpression,
         );
 
+        // AUD-070 (#1614) — the search backend is down. Answering an empty
+        // `200` here would read as "no products match", silently misleading
+        // the operator. Signal the outage with a 503 problem+json so the FE
+        // can render a "search temporarily unavailable" state distinct from
+        // an empty result set.
+        if ($result['degraded']) {
+            return $this->searchDegradedResponse();
+        }
+
         if ($countOnly) {
             return new JsonResponse([
                 'totalHits' => $result['totalHits'],
@@ -208,6 +218,26 @@ final class SearchController
             'page' => $page,
             'perPage' => $perPage,
         ]);
+    }
+
+    /**
+     * AUD-070 (#1614) — RFC 7807 problem+json for a search-backend outage.
+     * 503 (not 500) because the condition is transient and retryable; the
+     * dedicated `type` URN lets the FE branch on "search down" vs. a generic
+     * server error and render the right empty/error state.
+     */
+    private function searchDegradedResponse(): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'type' => 'urn:pim:errors:search-degraded',
+                'title' => 'Search Temporarily Unavailable',
+                'status' => Response::HTTP_SERVICE_UNAVAILABLE,
+                'detail' => 'The search backend is currently unavailable. This is not an empty result — please retry shortly.',
+            ],
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            ['Content-Type' => 'application/problem+json; charset=utf-8'],
+        );
     }
 
     /**

--- a/apps/api/tests/Api/Search/SearchEndpointsApiTest.php
+++ b/apps/api/tests/Api/Search/SearchEndpointsApiTest.php
@@ -99,6 +99,37 @@ final class SearchEndpointsApiTest extends CatalogApiTestCase
     }
 
     /**
+     * AUD-070 (#1614) — a healthy search must answer a normal `200` JSON
+     * payload, NOT a 503 problem+json. This pins the other side of the
+     * degraded/empty distinction: only a backend outage yields 503; a healthy
+     * search — whatever it matches — is an ordinary `200` carrying the regular
+     * `{hits, totalHits}` shape. (The outage→503 branch is covered
+     * deterministically at the service unit level, where Meili can be forced
+     * unreachable without taking the container down. Asserting an exact empty
+     * count here would be brittle against Meili's match-all on an empty query,
+     * so we assert the response *shape* instead, which is what distinguishes
+     * "healthy" from "degraded".)
+     */
+    #[Test]
+    public function healthyEmptySearchIsOkNotDegraded(): void
+    {
+        $this->seedProduct('PRESENT-1', ['brand' => 'Nike']);
+        $this->forceReindex(ObjectKind::Product);
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('GET', '/api/search/products?query=zzz-no-such-token-zzz');
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertResponseHeaderSame('content-type', 'application/json');
+        $body = $response->toArray();
+        // Normal search shape — degraded would have returned a problem+json
+        // body with a `type`/`status` instead of these keys.
+        self::assertArrayHasKey('hits', $body);
+        self::assertArrayHasKey('totalHits', $body);
+        self::assertArrayNotHasKey('type', $body);
+    }
+
+    /**
      * AUD-004 (#1574) — Meilisearch filter-key injection → cross-tenant read.
      *
      * The flat `?filter[<KEY>]=<value>` map fed `<KEY>` straight into the

--- a/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
+++ b/apps/api/tests/Integration/Catalog/ObjectTypeServiceTest.php
@@ -7,17 +7,21 @@ namespace App\Tests\Integration\Catalog;
 use App\Catalog\Application\ObjectTypeService;
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Exception\BuiltInObjectTypeException;
 use App\Catalog\Domain\Exception\DisabledFeatureException;
+use App\Catalog\Domain\Exception\ObjectTypeHasInstancesException;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Import\Domain\Entity\ImportProfile;
 use App\Shared\Application\TenantContext;
 use App\Shared\Domain\Tenant;
 use Doctrine\ORM\EntityManagerInterface;
 use LogicException;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Uid\Uuid;
 use Zenstruck\Foundry\Test\Factories;
 use Zenstruck\Foundry\Test\ResetDatabase;
 
@@ -112,6 +116,46 @@ final class ObjectTypeServiceTest extends KernelTestCase
         $this->em()->clear();
 
         self::assertNull($this->em()->find(ObjectType::class, $id));
+    }
+
+    #[Test]
+    public function deleteWithLiveInstancesIsBlocked(): void
+    {
+        // Pre-check path: a custom ObjectType with a live `objects` row is
+        // refused via the DBAL count guard, before any flush is attempted.
+        $service = $this->serviceWithCustomEnabled(true);
+        $type = $service->create('shoes', ObjectKind::Custom, ['pl' => 'Buty']);
+
+        $object = new CatalogObject($type, 'SHOE-1');
+        $this->em()->persist($object);
+        $this->em()->flush();
+
+        $this->expectException(ObjectTypeHasInstancesException::class);
+        $service->delete($type);
+    }
+
+    #[Test]
+    public function deleteCaughtForeignKeyViolationSurfacesAsHasInstances(): void
+    {
+        // AUD-072 (#1614) — the pre-delete count only looks at the `objects`
+        // table. Another RESTRICT FK (here `import_profiles.target_object_type_id`)
+        // is NOT counted, so the count guard passes (0 instances) but the
+        // DELETE itself raises a Postgres FK violation — the exact race the
+        // safety-net guards. The service must translate that DBAL exception
+        // into ObjectTypeHasInstancesException (→ 409), not let it escape as a
+        // raw 500. RED before the try/catch lands, GREEN after.
+        $service = $this->serviceWithCustomEnabled(true);
+        $type = $service->create('shoes', ObjectKind::Custom, ['pl' => 'Buty']);
+
+        // ImportProfile references the type via target_object_type_id (RESTRICT)
+        // but lives in a different table than `objects`, so countInstances()
+        // returns 0 and the pre-check waves the delete through to the flush.
+        $profile = new ImportProfile(Uuid::v7(), 'Cennik', $type);
+        $this->em()->persist($profile);
+        $this->em()->flush();
+
+        $this->expectException(ObjectTypeHasInstancesException::class);
+        $service->delete($type);
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Search/Application/CatalogSearchServiceFilterKeyTest.php
+++ b/apps/api/tests/Unit/Search/Application/CatalogSearchServiceFilterKeyTest.php
@@ -102,8 +102,8 @@ final class CatalogSearchServiceFilterKeyTest extends TestCase
         $service = $this->serviceWithTenant();
 
         // `enabled` is a RESERVED_FILTERABLE — must pass the key whitelist.
-        // Meili is unreachable (url=null) so the service returns emptyResult
-        // rather than 400; the absence of a thrown 400 is the assertion.
+        // Meili is unreachable (url=null) so the service returns a degraded
+        // result rather than 400; the absence of a thrown 400 is the assertion.
         $result = $service->search(
             kind: ObjectKind::Product,
             query: '',
@@ -112,6 +112,53 @@ final class CatalogSearchServiceFilterKeyTest extends TestCase
 
         self::assertArrayHasKey('hits', $result);
         self::assertArrayHasKey('totalHits', $result);
+    }
+
+    /**
+     * AUD-070 (#1614) — when the Meilisearch backend is unreachable the
+     * service must NOT collapse to a silent empty result (indistinguishable
+     * from "no matches"); it flags the result `degraded:true` so the
+     * controller can answer 503 instead of a misleading empty `200`.
+     *
+     * The factory is wired with `url=null`, so `create()` throws inside the
+     * service's try/catch — the same path a real connection/timeout failure
+     * takes. RED before the fix (returned `emptyResult()` → no `degraded`
+     * flag / `false`), GREEN after.
+     */
+    #[Test]
+    public function flagsResultDegradedWhenBackendUnavailable(): void
+    {
+        $service = $this->serviceWithTenant();
+
+        $result = $service->search(kind: ObjectKind::Product, query: 'anything');
+
+        self::assertTrue($result['degraded'], 'backend outage must be flagged degraded, not a silent empty');
+        self::assertSame([], $result['hits']);
+        self::assertSame(0, $result['totalHits']);
+    }
+
+    /**
+     * AUD-070 (#1614) — the degraded flag is reserved for backend outages.
+     * A request with no active tenant context is a legitimate empty result
+     * (defence-in-depth refusal to hit the hub), so it must report
+     * `degraded:false` — otherwise every unauthenticated edge would falsely
+     * read as "search down".
+     */
+    #[Test]
+    public function emptyResultWithoutTenantIsNotDegraded(): void
+    {
+        // No token set → CurrentTenantProvider yields null → emptyResult().
+        $factory = new MeilisearchClientFactory(null, null);
+        $tenantProvider = new CurrentTenantProvider(
+            new TokenStorage(),
+            $this->createStub(\App\Shared\Infrastructure\Doctrine\Repository\DoctrineTenantRepository::class),
+        );
+        $service = new CatalogSearchService($factory, $tenantProvider);
+
+        $result = $service->search(kind: ObjectKind::Product, query: 'anything');
+
+        self::assertFalse($result['degraded'], 'a no-tenant empty result is not a backend outage');
+        self::assertSame([], $result['hits']);
     }
 
     private function serviceWithTenant(): CatalogSearchService


### PR DESCRIPTION
## Wave 3 / W3-5.4 — AUD-070 + AUD-071 + AUD-072 (#1614)

### AUD-070 — Meili degraded zwracał „0 trafień" zamiast sygnału (reliability)
`CatalogSearchService` cicho zwracał `[]` gdy Meili pada → nieodróżnialne od braku wyników. **Fix:** flaga `degraded:true` w wyniku → 503 `application/problem+json` (`type:urn:pim:errors:search-degraded`) we wszystkich 3 konsumentach (search/quick-search/bulk-select); healthy-empty zostaje 200. **RED/GREEN** + **live smoke:** healthy → 200; `docker compose stop meilisearch` → **503** degraded; `start` → 200 recovery (meili przywrócony).

### AUD-071 — chunk product-detail-page 797KB > 700KB (perf FE)
**Fix:** lazy-load ciężkich tabów (categories/multimedia/relations/variants) + stack WYSIWYG (`@udecode/plate`+dompurify) za `Suspense`. **Before/after: 797.08 KB → 67.02 KB** (wysiwyg-editor wydzielony do 676KB chunk, ładuje się tylko dla pól rich-text). Warning zniknął. Funkcjonalność nienaruszona (taby renderują po kliknięciu).

### AUD-072 — ObjectTypeService::delete FK → 500 zamiast 409 (data-integrity)
Race delete → `ForeignKeyConstraintViolationException` uciekał jako 500. **Fix:** catch → `ObjectTypeHasInstancesException` (409), wzorzec z `DeleteAttributeHandler`. **RED/GREEN** + **live:** `DELETE /api/object_types/{id}` z żywą instancją → **409** (nie 500).

### Bramki
PHPStan max `No errors` · Deptrac `0` (baseline intact) · php-cs-fixer clean · backend `Api/Search` 12/12 + `ObjectTypeServiceTest` 13/13 + `Unit/Search`+`Unit/Catalog` 460/460 + regresja green · frontend Biome/tsc(0)/build · v0.json bez zmian (search = plain Symfony routes).

Closes #1614
