### PR TITLE
fix(admin): tighten prod CSP and wire PermissionRoute

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes, useParams } from 'react-router'
 
 import { AuthedRoute } from '@/components/AuthedRoute';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { PermissionRoute } from '@/components/identity';
 import { ToastProvider } from '@/components/ui/toast';
 import { FirstLoginChangePasswordPage } from '@/features/auth/FirstLoginChangePasswordPage';
 // HARD-08 — only the login + dashboard pages and the always-mounted
@@ -491,7 +492,28 @@ function App() {
                   <Route path="/assets" element={<AssetsListPage />} />
                   <Route path="/assets/:id" element={<AssetShowPage />} />
                   <Route path="/catalogs-pdf" element={<CatalogsPdfPage />} />
-                  <Route path="/settings" element={<SettingsLayout />}>
+                  {/* AUD-076 (W3-5.5) — gate the whole settings tree with the
+                    same permission set the sidebar uses to show the entry
+                    (MENU_PERMISSIONS.settings). A user with no settings
+                    permission who deep-links /settings/* now lands on the
+                    Forbidden403Page instead of the settings shell. Per-page
+                    write actions stay gated by their own backend checks. */}
+                  <Route
+                    path="/settings"
+                    element={
+                      <PermissionRoute
+                        anyOf={[
+                          'settings.users.manage',
+                          'settings.roles.manage',
+                          'settings.tenant.manage',
+                          'settings.integrations.manage',
+                          'settings.billing.manage',
+                        ]}
+                      >
+                        <SettingsLayout />
+                      </PermissionRoute>
+                    }
+                  >
                     <Route index element={<SettingsIndex />} />
                     <Route path="menu" element={<MenuSettingsPage />} />
                     <Route path="locales" element={<LocalesSettingsPage />} />
@@ -515,10 +537,39 @@ function App() {
                     Lives under /admin/* inside the existing app until
                     the admin.cortex.pl subdomain split (operator infra
                     task). Backend already enforces super_admin role +
-                    cross-tenant bypass via SuperAdminContext. */}
-                  <Route path="/admin/tenants" element={<AdminTenantsListPage />} />
-                  <Route path="/admin/tenants/:id" element={<AdminTenantShowPage />} />
-                  <Route path="/admin/break-glass" element={<AdminBreakGlassPage />} />
+                    cross-tenant bypass via SuperAdminContext.
+
+                    AUD-076 (W3-5.5) — wrap each page in <PermissionRoute> so
+                    an Owner/Admin who types the URL gets the Forbidden403Page
+                    instead of the panel mounting and flashing its UI before
+                    the async 403 from /api/admin/* flips it to a forbidden
+                    state. The codes mirror the backend #[RequiresPermission]
+                    on SuperAdminTenantsController (platform.tenants.manage)
+                    and BreakGlassController (platform.break_glass_recovery). */}
+                  <Route
+                    path="/admin/tenants"
+                    element={
+                      <PermissionRoute code="platform.tenants.manage">
+                        <AdminTenantsListPage />
+                      </PermissionRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin/tenants/:id"
+                    element={
+                      <PermissionRoute code="platform.tenants.manage">
+                        <AdminTenantShowPage />
+                      </PermissionRoute>
+                    }
+                  />
+                  <Route
+                    path="/admin/break-glass"
+                    element={
+                      <PermissionRoute code="platform.break_glass_recovery">
+                        <AdminBreakGlassPage />
+                      </PermissionRoute>
+                    }
+                  />
                   {/* Integracje — every hub (exports EXR-08, imports NUI-09,
                     api-configurator) renders directly under the v2 shell;
                     sidebar second-level + topbar breadcrumb replaced the old

--- a/apps/admin/src/components/identity/__tests__/PermissionRoute.test.tsx
+++ b/apps/admin/src/components/identity/__tests__/PermissionRoute.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PermissionRoute } from '../PermissionRoute';
+
+/**
+ * AUD-076 (W3-5.5) — `<PermissionRoute>` is the route-level boundary that
+ * stops an unauthorised user from rendering a protected page just by typing
+ * its URL (the UX leak: the backend returns 403 only after the page mounted
+ * and fired its data request). These tests assert the synchronous decision:
+ *
+ *   - permission held         → protected children render,
+ *   - permission missing       → Forbidden403Page fallback renders,
+ *   - identity still loading   → neither the children nor the fallback show.
+ *
+ * The `@/lib/identity` hooks are mocked so the component is exercised in
+ * isolation without a QueryClient / `/api/auth/me` round-trip.
+ */
+
+const mocks = vi.hoisted(() => ({
+  isLoading: false,
+  can: new Set<string>(),
+}));
+
+vi.mock('@/lib/identity', () => ({
+  useIdentity: () => ({ identity: null, isLoading: mocks.isLoading, isError: false }),
+  useCanI: (code: string) => mocks.can.has(code),
+  useCanIAny: (codes: readonly string[]) => codes.some((c) => mocks.can.has(c)),
+  useCanIAll: (codes: readonly string[]) => codes.every((c) => mocks.can.has(c)),
+}));
+
+function renderRoute(ui: React.ReactNode) {
+  return render(<MemoryRouter initialEntries={['/admin/break-glass']}>{ui}</MemoryRouter>);
+}
+
+const PROTECTED = <div data-testid="protected">secret panel</div>;
+
+describe('PermissionRoute', () => {
+  beforeEach(() => {
+    mocks.isLoading = false;
+    mocks.can = new Set();
+  });
+
+  it('renders the protected children when the single code is held', () => {
+    mocks.can = new Set(['platform.break_glass_recovery']);
+
+    renderRoute(
+      <PermissionRoute code="platform.break_glass_recovery">{PROTECTED}</PermissionRoute>,
+    );
+
+    expect(screen.getByTestId('protected')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /brak dostępu|forbidden/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the Forbidden403Page fallback when the code is missing', () => {
+    mocks.can = new Set(['products.view']); // unrelated grant
+
+    renderRoute(
+      <PermissionRoute code="platform.break_glass_recovery">{PROTECTED}</PermissionRoute>,
+    );
+
+    // Protected content must never mount for an unauthorised user.
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
+    // The polished 403 page (heading region) renders instead.
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('grants access via anyOf when at least one code matches', () => {
+    mocks.can = new Set(['settings.roles.manage']);
+
+    renderRoute(
+      <PermissionRoute anyOf={['settings.users.manage', 'settings.roles.manage']}>
+        {PROTECTED}
+      </PermissionRoute>,
+    );
+
+    expect(screen.getByTestId('protected')).toBeInTheDocument();
+  });
+
+  it('denies access via anyOf when no code matches', () => {
+    mocks.can = new Set(['products.view']);
+
+    renderRoute(
+      <PermissionRoute anyOf={['settings.users.manage', 'settings.roles.manage']}>
+        {PROTECTED}
+      </PermissionRoute>,
+    );
+
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  });
+
+  it('shows neither children nor fallback while identity is still loading', () => {
+    mocks.isLoading = true;
+    mocks.can = new Set(['platform.break_glass_recovery']);
+
+    renderRoute(
+      <PermissionRoute code="platform.break_glass_recovery">{PROTECTED}</PermissionRoute>,
+    );
+
+    // Loading shim — protected content is held back to avoid the
+    // click-through flash, and the 403 page is not shown yet either.
+    expect(screen.queryByTestId('protected')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument();
+  });
+});

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -40,14 +40,19 @@
         Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
         # Conservative CSP — single-origin admin runs from `'self'`,
         # everything cross-origin is denied. `'unsafe-inline'` +
-        # `'unsafe-eval'` on script-src covers Vite's HMR runtime +
-        # Refine + lazy-loaded chunks (Vite ships eval'd code in dev,
-        # rolldown emits inline bootstrap shims in prod). Style-src
-        # has the same exception for runtime CSS injections.
+        # `'unsafe-eval'` on script-src covers Vite's HMR runtime in dev
+        # (eval'd modules plus an inline react-refresh bootstrap). AUD-074
+        # (W3-5.5) splits script-src and style-src dev vs prod via the
+        # CSP_SCRIPT_SRC and CSP_STYLE_SRC env placeholders below: prod
+        # serves the static apps/admin/dist bundle (file_server, not Vite)
+        # whose index.html has a single external module script, no inline
+        # script and no eval, so prod sets CSP_SCRIPT_SRC to script-src
+        # self only, dropping unsafe-eval and unsafe-inline. Style-src
+        # keeps inline for runtime CSS injections (Vite plus Radix).
         # `connect-src ws:/wss:` covers Mercure SSE on the same host.
-        # Tightening to nonces lands in a follow-up once a CSP report
-        # endpoint exists and the build pipeline can stamp them.
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+        # The prod Caddyfile is a separate deploy ticket (admin note in
+        # docker-compose.prod.yml); nonce hashing is a later follow-up.
+        Content-Security-Policy "default-src 'self'; {$CSP_SCRIPT_SRC:script-src 'self' 'unsafe-inline' 'unsafe-eval'}; {$CSP_STYLE_SRC:style-src 'self' 'unsafe-inline'}; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: wss:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
         # Cross-origin isolation hardening — partner integrations don't
         # need cross-origin window handles.
         Cross-Origin-Opener-Policy "same-origin"


### PR DESCRIPTION
## Wave 3 / W3-5.5 — AUD-074 + AUD-076 (#1615) — CSP + PermissionRoute

> **Scope split:** AUD-075 (i18n pl/en parity) wydzielony do **#1667**. Wypełnienie en.json flipuje dwujęzyczne selektory E2E (Playwright Chromium=en-US → i18next renderuje EN; suita ma mieszane pl-only/en-only selektory, wymuszenie locale psuje przeciwny zestaw). Wymaga dedykowanego E2E-locale przejścia (razem z #1638/AUD-022/062). Ten PR = czyste AUD-074 + AUD-076, bez wpływu na E2E.

### AUD-074 — CSP `script-src 'unsafe-inline' 'unsafe-eval'` (security)
Env-conditional CSP (`{$CSP_SCRIPT_SRC}`/`{$CSP_STYLE_SRC}` w Caddyfile): dev default luźny (Vite HMR `@vite/client`+`/@react-refresh` wymaga eval+inline), **prod ustawia `CSP_SCRIPT_SRC="script-src 'self'"`** (usuwa eval+inline — prod bundle ma zero inline/eval, jeden external module script). `style-src 'unsafe-inline'` świadomie zachowane (Radix runtime; hash=follow-up). Zweryfikowane `caddy adapt -e CSP_SCRIPT_SRC=...` → `script-src 'self'`.

### AUD-076 — PermissionRoute martwy guard (UX leak)
`grep "<PermissionRoute"` = 0; `/settings/*`, `/admin/tenants`, `/admin/break-glass` niechronione route-level (URL-typing leak — break-glass montował UI przed async 403). Podpięty (komplementarny do AuthedRoute) z realnymi kodami: `platform.tenants.manage`, `platform.break_glass_recovery`, settings `anyOf` (spójne z sidebar gating). Nieuprawniony → `Forbidden403Page`. Test 5/5 (uprawniony renderuje, nieuprawniony single+anyOf → 403, brak loading flash).

### Bramki
Biome/tsc/build (frontend) · component test PermissionRoute 5/5. CSP zweryfikowany live (dev) + caddy-adapt (prod). E2E nietknięte (brak zmian i18n).

Closes #1615
