### PR TITLE
fix(admin): connect completeness ring to API and flag demo widgets

### DIFF
--- a/apps/admin/src/features/dashboard/__tests__/use-dashboard-completeness.test.tsx
+++ b/apps/admin/src/features/dashboard/__tests__/use-dashboard-completeness.test.tsx
@@ -1,0 +1,58 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { jsonFetch } from '@/lib/http';
+
+import { useDashboardCompleteness } from '../use-dashboard-completeness';
+
+vi.mock('@/lib/http', () => ({ jsonFetch: vi.fn() }));
+
+const jsonFetchMock = vi.mocked(jsonFetch);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/** Resolve each `?completeness[gte]=N` (and the unfiltered total) to a count. */
+function mockCounts(counts: { total: number; gte: Record<number, number> }) {
+  jsonFetchMock.mockImplementation(async (_path, init) => {
+    const gte = init?.query?.['completeness[gte]'];
+    if (gte === undefined) {
+      return { totalItems: counts.total };
+    }
+    return { totalItems: counts.gte[Number(gte)] ?? 0 };
+  });
+}
+
+afterEach(() => {
+  jsonFetchMock.mockReset();
+});
+
+describe('useDashboardCompleteness', () => {
+  it('computes the publish-ready share from real bucket counts', async () => {
+    mockCounts({ total: 6913, gte: { 25: 6911, 50: 1464, 80: 302, 100: 100 } });
+
+    const { result } = renderHook(() => useDashboardCompleteness(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data;
+    expect(data?.total).toBe(6913);
+    expect(data?.publishReady).toBe(302);
+    // 302 / 6913 = 4.37% → rounds to 4.
+    expect(data?.publishReadyPct).toBe(4);
+    expect(data?.buckets).toHaveLength(4);
+  });
+
+  it('degrades to null when the total count is unavailable', async () => {
+    jsonFetchMock.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useDashboardCompleteness(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/apps/admin/src/features/dashboard/components/CompletenessMetrics.tsx
+++ b/apps/admin/src/features/dashboard/components/CompletenessMetrics.tsx
@@ -3,30 +3,35 @@ import { useTranslation } from 'react-i18next';
 import { MockBadge } from '@/components/ui/mock-badge';
 
 import { COMPLETENESS } from '../mock-data';
+import { PUBLISH_READY_THRESHOLD, useDashboardCompleteness } from '../use-dashboard-completeness';
 
 /**
- * MOCK component — completeness rings (overall + 4 channels).
- * Backend: GET /api/dashboard/completeness (do dorobienia).
- * Patrz Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md.
+ * Completeness rings. The OVERALL ring is LIVE (AUD-058 #1610): a real
+ * publish-readiness share derived from the indexed `completeness[gte]=N`
+ * product filter. The per-channel rings stay mock — channel-aware
+ * completeness is parked until ChannelObjectTypeMapping reads land (epic 0.6)
+ * — and are flagged with their own MockBadge under the dashboard banner.
  */
-function Ring({ percent }: { percent: number }) {
+function Ring({ percent, pending = false }: { percent: number; pending?: boolean }) {
   const r = 28;
   const c = 2 * Math.PI * r;
   const dash = (percent / 100) * c;
   return (
     <svg viewBox="0 0 64 64" className="size-16" aria-hidden="true">
       <circle cx="32" cy="32" r={r} fill="none" stroke="#ececea" strokeWidth="6" />
-      <circle
-        cx="32"
-        cy="32"
-        r={r}
-        fill="none"
-        stroke="#10b981"
-        strokeWidth="6"
-        strokeLinecap="round"
-        strokeDasharray={`${dash} ${c}`}
-        transform="rotate(-90 32 32)"
-      />
+      {!pending && (
+        <circle
+          cx="32"
+          cy="32"
+          r={r}
+          fill="none"
+          stroke="#10b981"
+          strokeWidth="6"
+          strokeLinecap="round"
+          strokeDasharray={`${dash} ${c}`}
+          transform="rotate(-90 32 32)"
+        />
+      )}
       <text
         x="32"
         y="36"
@@ -36,24 +41,61 @@ function Ring({ percent }: { percent: number }) {
         fill="#18181b"
         style={{ fontFamily: 'Inter', fontFeatureSettings: '"tnum"' }}
       >
-        {percent}%
+        {pending ? '…' : `${percent}%`}
       </text>
     </svg>
   );
 }
 
+const numberFormatter = new Intl.NumberFormat('pl-PL');
+
 export function CompletenessMetrics() {
   const { t } = useTranslation();
+  const { data, isPending } = useDashboardCompleteness();
+
+  // Live overall ring when the count query succeeds; otherwise fall back to the
+  // mock overall slice so the widget never renders blank.
+  const overallMock = COMPLETENESS.find((c) => c.key === 'overall');
+  const overallPercent = data ? data.publishReadyPct : (overallMock?.percent ?? 0);
+  const overallIsLive = Boolean(data);
+  const channelSlices = COMPLETENESS.filter((c) => c.key !== 'overall');
+
   return (
     <div className="relative rounded-2xl border border-line bg-surface p-5 soft-shadow">
-      <MockBadge variant="corner" />
       <h3 className="text-[15px] font-semibold text-ink">{t('dashboard.completeness.title')}</h3>
       <p className="mt-1 text-[12px] text-muted-foreground">
         {t('dashboard.completeness.subtitle')}
       </p>
       <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
-        {COMPLETENESS.map((c) => (
-          <div key={c.key} className="flex flex-col items-center gap-2 text-center">
+        {/* Overall — LIVE */}
+        <div className="flex flex-col items-center gap-2 text-center">
+          <Ring percent={overallPercent} pending={isPending && !overallIsLive} />
+          <span className="text-[12px] font-medium text-ink-2">
+            {t('dashboard.completeness.overall', { defaultValue: 'Ogólna' })}
+          </span>
+          {overallIsLive && data ? (
+            <span className="num text-[11px] text-muted-foreground">
+              {t('dashboard.completeness.publish_ready', {
+                defaultValue: '{{count}} z {{total}} ≥ {{threshold}}%',
+                count: numberFormatter.format(data.publishReady),
+                total: numberFormatter.format(data.total),
+                threshold: PUBLISH_READY_THRESHOLD,
+              })}
+            </span>
+          ) : null}
+        </div>
+
+        {/* Per-channel — MOCK (channel-aware completeness lands in epic 0.6) */}
+        {channelSlices.map((c) => (
+          <div key={c.key} className="relative flex flex-col items-center gap-2 text-center">
+            <span className="absolute -right-1 -top-1 z-10">
+              <MockBadge
+                tooltip={t('dashboard.completeness.channel_mock_tooltip', {
+                  defaultValue:
+                    'MOCK — kompletność per kanał wymaga mapowania kanał↔typ (epik 0.6)',
+                })}
+              />
+            </span>
             <Ring percent={c.percent} />
             <span className="text-[12px] font-medium text-ink-2">{c.label}</span>
           </div>

--- a/apps/admin/src/features/dashboard/components/DashboardMockBanner.tsx
+++ b/apps/admin/src/features/dashboard/components/DashboardMockBanner.tsx
@@ -1,0 +1,38 @@
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * AUD-058 (#1610) — page-level honesty banner.
+ *
+ * The dashboard mixes live data (KPI entity totals, overall completeness) with
+ * widgets that still render demo data because their backend does not exist yet
+ * (agent activity — Faza 2; integration syncs — Faza 1; alerts; pgBackRest
+ * status; activity history; channel distribution). The per-widget MockBadge is
+ * easy to miss, so this explicit banner names exactly which blocks are
+ * demonstrative. Remove it once every widget is wired to a real endpoint.
+ */
+export function DashboardMockBanner() {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900 soft-shadow"
+    >
+      <AlertTriangle className="mt-0.5 size-5 shrink-0 text-amber-600" aria-hidden />
+      <div className="min-w-0 text-[13px] leading-relaxed">
+        <p className="font-semibold">
+          {t('dashboard.mock_banner.title', {
+            defaultValue: 'Część widżetów pokazuje dane demonstracyjne',
+          })}
+        </p>
+        <p className="mt-0.5 text-amber-800">
+          {t('dashboard.mock_banner.body', {
+            defaultValue:
+              'Liczby KPI oraz kafelek „Kompletność” (ogólna) są na żywo z API. Pozostałe bloki — aktywność, status synchronizacji, alerty, aktywność agenta, backup, dystrybucja kanałów i ranking edytowanych — to makieta (funkcje w przygotowaniu).',
+          })}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/dashboard/components/__tests__/CompletenessMetrics.test.tsx
+++ b/apps/admin/src/features/dashboard/components/__tests__/CompletenessMetrics.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+import type { DashboardCompleteness } from '../../use-dashboard-completeness';
+import { CompletenessMetrics } from '../CompletenessMetrics';
+
+const mockUseDashboardCompleteness = vi.fn();
+
+vi.mock('../../use-dashboard-completeness', async () => {
+  const actual = await vi.importActual<typeof import('../../use-dashboard-completeness')>(
+    '../../use-dashboard-completeness',
+  );
+  return {
+    ...actual,
+    useDashboardCompleteness: () => mockUseDashboardCompleteness(),
+  };
+});
+
+function renderWidget() {
+  return render(
+    <TooltipProvider>
+      <CompletenessMetrics />
+    </TooltipProvider>,
+  );
+}
+
+afterEach(() => {
+  mockUseDashboardCompleteness.mockReset();
+});
+
+describe('CompletenessMetrics', () => {
+  it('renders the live overall ring from real bucket counts', () => {
+    const data: DashboardCompleteness = {
+      total: 6913,
+      publishReady: 302,
+      publishReadyPct: 4,
+      buckets: [
+        { gte: 25, count: 6911 },
+        { gte: 50, count: 1464 },
+        { gte: 80, count: 302 },
+        { gte: 100, count: 100 },
+      ],
+    };
+    mockUseDashboardCompleteness.mockReturnValue({ data, isPending: false });
+
+    renderWidget();
+
+    // Live percentage rendered in the overall ring.
+    expect(screen.getByText('4%')).toBeInTheDocument();
+    // Real publish-ready stat line with thin-space grouped totals.
+    expect(screen.getByText(/302 z 6\s?913 ≥ 80%/)).toBeInTheDocument();
+  });
+
+  it('falls back to the mock overall slice when the count query fails', () => {
+    mockUseDashboardCompleteness.mockReturnValue({ data: null, isPending: false });
+
+    renderWidget();
+
+    // Mock overall percent (87%) from mock-data, no publish-ready stat line.
+    expect(screen.getByText('87%')).toBeInTheDocument();
+    expect(screen.queryByText(/≥ 80%/)).toBeNull();
+  });
+
+  it('shows a pending placeholder before the first count resolves', () => {
+    mockUseDashboardCompleteness.mockReturnValue({ data: undefined, isPending: true });
+
+    renderWidget();
+
+    expect(screen.getByText('…')).toBeInTheDocument();
+  });
+});

--- a/apps/admin/src/features/dashboard/components/__tests__/DashboardMockBanner.test.tsx
+++ b/apps/admin/src/features/dashboard/components/__tests__/DashboardMockBanner.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DashboardMockBanner } from '../DashboardMockBanner';
+
+describe('DashboardMockBanner', () => {
+  it('renders an explicit page-level demo-data notice', () => {
+    render(<DashboardMockBanner />);
+
+    const banner = screen.getByRole('status');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent('Część widżetów pokazuje dane demonstracyjne');
+    // Names the live blocks so the notice is not mistaken for "everything is fake".
+    expect(banner).toHaveTextContent(/KPI/);
+    expect(banner).toHaveTextContent(/Kompletność/);
+  });
+});

--- a/apps/admin/src/features/dashboard/page.tsx
+++ b/apps/admin/src/features/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { AlertCenter } from './components/AlertCenter';
 import { BackupWidget } from './components/BackupWidget';
 import { ChannelDistribution } from './components/ChannelDistribution';
 import { CompletenessMetrics } from './components/CompletenessMetrics';
+import { DashboardMockBanner } from './components/DashboardMockBanner';
 import { HeroAgentPanel } from './components/HeroAgentPanel';
 import { KpiCards } from './components/KpiCards';
 import { RecentAgentActivity } from './components/RecentAgentActivity';
@@ -15,8 +16,10 @@ import { useDashboardCounts } from './use-dashboard-counts';
  * Hero → KPI → [Activity | Sync] → [Completeness | Channels] →
  * [Alerts | Agent activity] → [Backup | Top edited].
  *
- * KPI entity totals are LIVE (useDashboardCounts); every other block stays a
- * mock with a MockBadge — backend follow-ups in
+ * KPI entity totals (useDashboardCounts) and the overall completeness ring
+ * (useDashboardCompleteness, AUD-058 #1610) are LIVE; the remaining blocks
+ * stay mock and are flagged by both a per-widget MockBadge and the explicit
+ * DashboardMockBanner — backend follow-ups in
  * Project Plan/UI/Wdrozenie_grafiki/dashboard-do-oprogramowania.md.
  */
 export function DashboardPage() {
@@ -24,6 +27,7 @@ export function DashboardPage() {
 
   return (
     <div className="space-y-6 px-4 py-6 sm:px-6 lg:px-10">
+      <DashboardMockBanner />
       <HeroAgentPanel />
       <KpiCards counts={counts} isPending={isPending} />
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/apps/admin/src/features/dashboard/use-dashboard-completeness.ts
+++ b/apps/admin/src/features/dashboard/use-dashboard-completeness.ts
@@ -1,0 +1,89 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+interface LdCollection {
+  totalItems?: number;
+  'hydra:totalItems'?: number;
+}
+
+/** Publish-ready threshold: a product at/above this completeness counts as ready. */
+export const PUBLISH_READY_THRESHOLD = 80;
+
+export interface CompletenessBucket {
+  /** Lower bound (inclusive) of the bucket, in completeness percent. */
+  gte: number;
+  /** Number of products at or above {@link gte}. */
+  count: number;
+}
+
+export interface DashboardCompleteness {
+  /** Total product count (the `>= 0` bucket). */
+  total: number;
+  /** Products at/above {@link PUBLISH_READY_THRESHOLD}. */
+  publishReady: number;
+  /** Share of {@link publishReady} over {@link total}, 0–100 (rounded). */
+  publishReadyPct: number;
+  /** Cumulative "at least N%" counts for the distribution strip. */
+  buckets: CompletenessBucket[];
+}
+
+/**
+ * Cumulative thresholds the ring + distribution strip read. `total` is the
+ * unfiltered count; the rest are `?completeness[gte]=N` cumulative counts.
+ */
+const THRESHOLDS = [25, 50, PUBLISH_READY_THRESHOLD, 100] as const;
+
+async function fetchCount(query: Record<string, string | number>): Promise<number | null> {
+  try {
+    const data = await jsonFetch<LdCollection>('/api/products', {
+      accept: 'application/ld+json',
+      query: { itemsPerPage: 1, ...query },
+    });
+    return data.totalItems ?? data['hydra:totalItems'] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * AUD-058 (#1610) — real overall completeness for the dashboard ring.
+ *
+ * The backend has no completeness aggregate endpoint, but the products
+ * collection exposes the indexed `completeness[gte]=N` numeric-range filter
+ * (`CompletenessFilter`, sargable on `completeness_pct`). A handful of cheap
+ * `itemsPerPage=1 → totalItems` counts give a genuine publish-readiness
+ * figure instead of the hard-coded mock ring.
+ *
+ * Channel-scoped completeness stays mock: channel-aware completeness is
+ * parked until ChannelObjectTypeMapping reads land (epic 0.6), so the
+ * per-channel rings remain demonstrative under the dashboard banner.
+ */
+export function useDashboardCompleteness() {
+  return useQuery({
+    queryKey: ['dashboard-completeness'],
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    queryFn: async (): Promise<DashboardCompleteness | null> => {
+      const [total, ...thresholdCounts] = await Promise.all([
+        fetchCount({}),
+        ...THRESHOLDS.map((gte) => fetchCount({ 'completeness[gte]': gte })),
+      ]);
+
+      if (total === null) {
+        // Without a total we cannot compute a share — degrade to the mock.
+        return null;
+      }
+
+      const buckets: CompletenessBucket[] = THRESHOLDS.map((gte, i) => ({
+        gte,
+        count: thresholdCounts[i] ?? 0,
+      }));
+
+      const publishReady = buckets.find((b) => b.gte === PUBLISH_READY_THRESHOLD)?.count ?? 0;
+      const publishReadyPct = total > 0 ? Math.round((publishReady / total) * 100) : 0;
+
+      return { total, publishReady, publishReadyPct, buckets };
+    },
+  });
+}

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -985,9 +985,16 @@
       "force": "Force",
       "force_disabled": "Mock — needs POST /api/integrations/{id}/sync"
     },
+    "mock_banner": {
+      "title": "Some widgets show demonstration data",
+      "body": "KPI counts and the “Completeness” (overall) tile are live from the API. The other blocks — activity, sync status, alerts, agent activity, backup, channel distribution and the edited ranking — are mock (features in progress)."
+    },
     "completeness": {
       "title": "Completeness",
-      "subtitle": "overall and per channel — publish readiness"
+      "subtitle": "overall and per channel — publish readiness",
+      "overall": "Overall",
+      "publish_ready": "{{count}} of {{total}} ≥ {{threshold}}%",
+      "channel_mock_tooltip": "MOCK — per-channel completeness needs channel↔type mapping (epic 0.6)"
     },
     "agent_activity": {
       "title": "Recent agent activity",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -995,9 +995,16 @@
       "force": "Wymuś",
       "force_disabled": "Mock — wymaga POST /api/integrations/{id}/sync"
     },
+    "mock_banner": {
+      "title": "Część widżetów pokazuje dane demonstracyjne",
+      "body": "Liczby KPI oraz kafelek „Kompletność” (ogólna) są na żywo z API. Pozostałe bloki — aktywność, status synchronizacji, alerty, aktywność agenta, backup, dystrybucja kanałów i ranking edytowanych — to makieta (funkcje w przygotowaniu)."
+    },
     "completeness": {
       "title": "Kompletność",
-      "subtitle": "ogólna i per kanał — wskazuje gotowość do publikacji"
+      "subtitle": "ogólna i per kanał — wskazuje gotowość do publikacji",
+      "overall": "Ogólna",
+      "publish_ready": "{{count}} z {{total}} ≥ {{threshold}}%",
+      "channel_mock_tooltip": "MOCK — kompletność per kanał wymaga mapowania kanał↔typ (epik 0.6)"
     },
     "agent_activity": {
       "title": "Ostatnia aktywność agenta",


### PR DESCRIPTION
## Wave 3 / W3-4 — AUD-058 (#1610)

Cały dashboard (10 widgetów) na `mock-data.ts` → pierwsze wrażenie po loginie = atrapa. **Honest fix (API gdzie wykonalne + wyraźny baner):**

### Podłączone do realnego API (useQuery)
- **KpiCards** — już live (`/api/products|attributes|attribute_groups|categories` totalItems).
- **CompletenessMetrics (ogólny ring)** — nowy hook `use-dashboard-completeness` (useQuery, `?completeness[gte]=N` na zindeksowanej kolumnie). Live smoke: total **6913**, ≥80%=**100** → ring **1%** (realne). Loading + error-fallback do mocka.

### Baner zamiast cichej atrapy
`DashboardMockBanner` (role=status, bursztynowy, pl+en) — JAWNIE wymienia live (KPI + completeness ogólny) vs demo (aktywność/syncs/alerty/agent/backup/kanały/ranking). Per-widget MockBadge zostają.

### Mock-only + uzasadnienie (deferrale)
- **TopEditedProducts** — AP4 cicho ignoruje `order[updatedAt]` (whitelist tylko `id`) → sortowanie kłamałoby etykietę → świadomie mock.
- **ChannelDistribution** — brak endpointu zliczającego członkostwo w kanałach.
- **per-kanał completeness** — parked do epiku 0.6.
- **ActivityChart/Syncs/Alerts/Agent/Backup/Hero** — backend Faza 1/2 nie istnieje.

### Bramki
Biome clean · tsc 0 (NODE 4096) · build OK · vitest 6 (hook publish-ready% + CompletenessMetrics live/fallback + baner). **Live smoke:** KPI 6913 produktów realne, completeness buckets HTTP 200 — wszystko 200, zero 4xx/5xx.

Closes #1610