### PR TITLE
docs(dev): add vertical-slice guide and fix onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ PHP 8.4 + Symfony 7.4 LTS + API Platform 4 + FrankenPHP 2.x worker mode · Postg
 
 - **`CLAUDE.md`** — konstytucja projektu (system prompt dla Claude Code)
 - **`CONTRIBUTING.md`** + **`ONBOARDING.md`** — onboarding nowego developera
+- **`docs/development/adding-a-field-or-endpoint.md`** — jak dodać pole/endpoint (vertical slice backend↔front)
+- **`apps/admin/README.md`** — panel admina (Refine + shadcn): komendy, shared-types
 - **`CHANGELOG.md`** — release history per epic
 - **`Project Plan/01-architektura-pim.md`** — pełna architektura, ADR, model danych
 - **`Project Plan/02-plan-projektu-pim.md`** — fazy, milestones, backlog, ryzyka
@@ -30,7 +32,7 @@ PHP 8.4 + Symfony 7.4 LTS + API Platform 4 + FrankenPHP 2.x worker mode · Postg
 │   ├── api/        Symfony 7.4 + API Platform 4 + FrankenPHP (PHP 8.4)
 │   └── admin/      Vite + React 19 + TypeScript (Refine + shadcn dochodzą w 0.1.4)
 ├── packages/
-│   └── shared-types/   TypeScript types generowane z OpenAPI spec (build step)
+│   └── shared-types/   TypeScript types generowane z OpenAPI spec (codegen, nie build)
 ├── docker/
 │   └── caddy/      Edge Caddyfile — single-origin proxy
 ├── docker-compose.yml  Cały stack dev: Caddy + FrankenPHP + Postgres + Redis +
@@ -50,7 +52,9 @@ PHP 8.4 + Symfony 7.4 LTS + API Platform 4 + FrankenPHP 2.x worker mode · Postg
 # 1. Sklonuj i zainstaluj zależności node (root + apps/admin + packages/*)
 pnpm install
 
-# 2. Skopiuj .env.example → .env (override hasła Postgres / Mercure / Meilisearch / MinIO)
+# 2. Skopiuj .env.example → .env i podmień hasła (Postgres / Mercure / Meilisearch / MinIO).
+#    Tylko .env.example jest w gitcie. .env (oraz .env.dev / .env.local) są
+#    ignorowane i trzymają REALNE sekrety — patrz "Pliki .env" niżej.
 cp .env.example .env
 
 # 3. Wystartuj cały stack (build kontenerów przy pierwszym uruchomieniu trwa kilka minut)
@@ -59,19 +63,86 @@ pnpm dev          # foreground, Ctrl+C zatrzymuje
 pnpm stack:up     # detached, działa w tle
 pnpm stack:logs   # tail logów
 
-# 4. Sprawdź single-origin
+# 4. Zainicjalizuj bazę: drop + create + migrate + audit:schema:update + fixtures.
+#    Jeden skrót (zalecane — patrz "pim:db:reset" niżej):
+docker compose exec -T api php bin/console pim:db:reset --with-fixtures --force
+#    Manualny odpowiednik to TRZY kroki (audit:schema:update jest wymagany —
+#    tabele *_audit są poza pipeline'em migracji; bez tego INSERT do audytowanej
+#    encji wywala 500 "relation '*_audit' does not exist"):
+#      docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction
+#      docker compose exec -T api php bin/console audit:schema:update --force
+#      docker compose exec -T api php bin/console doctrine:fixtures:load --no-interaction
+
+# 5. Sprawdź single-origin i zaloguj się (admin@demo.localhost / changeme)
 curl -sk https://pim.localhost/api/docs.jsonld | head  # Hydra/JSON-LD API documentation
-open https://pim.localhost/                            # Vite admin (HMR przez Caddy)
+open https://pim.localhost/                            # admin (login: admin@demo.localhost / changeme)
 open https://pim.localhost/api/docs                    # Swagger UI (HTML)
 open https://pim.localhost/api                         # API Platform entrypoint
 
-# 5. Restart / reset
+# 6. Restart / reset
 pnpm stack:down               # stop, zachowaj dane
-pnpm stack:reset              # stop + wipe volumes
+pnpm stack:reset              # stop + wipe volumes (USUWA dane bazy — patrz ostrzeżenie niżej)
 pnpm stack:rebuild            # rebuild obrazów (po zmianie Dockerfile / composer.json)
 ```
 
 Caddy ma własny lokalny CA — przy pierwszym `pnpm dev` przeglądarka wymaga zaakceptowania certyfikatu. Można też zaufać CA na hoście: skopiuj `caddy_data` volume → `~/.local/share/caddy/pki/authorities/local/root.crt` i dodaj do System Keychain (macOS).
+
+### Pliki `.env`
+
+- **`.env.example`** (w gitcie) — szablon z placeholderami. Skopiuj do `.env`.
+- **`.env`** (ignorowany) — Twoje lokalne sekrety; nadpisuje `.env.example`.
+- **`.env.dev` / `.env.local`** (ignorowane) — realne sekrety per środowisko.
+  `.gitignore` celowo łapie `.env` oraz każde `.env.*` (poza allowlistą
+  `.env.example`, `apps/api/.env`, `apps/api/.env.test`). Nigdy nie commituj
+  pliku z realnym hasłem.
+
+> **Uwaga (operator):** `.env.dev` jest *trackowany* na starszych branchach
+> (sprzed W0-7), a *nietrackowany* na `main`. Przełączenie/`pull` może skasować
+> Twój realny `.env.dev` — zrób backup do `/tmp` przed checkoutem, potem przywróć
+> i zrestartuj stack.
+
+### `pim:db:reset` — reset bazy w jednym kroku
+
+```bash
+docker compose exec -T api php bin/console pim:db:reset --with-fixtures --force
+```
+
+Robi po kolei: `doctrine:database:drop` → `create` → `migrations:migrate` →
+`audit:schema:update --force` → (z `--with-fixtures`) `fixtures:load` +
+`pim:search:reindex --purge`. Flagi: `--with-fixtures` (załaduj fixtures),
+`--force` (pomiń pytanie potwierdzające), `--force-prod` (dopuść `APP_ENV=prod` —
+domyślnie odmawia). Używaj **tylko na bazie deweloperskiej**.
+
+> **OSTRZEŻENIE — wipe stanu manualnego.** `pim:db:reset` (i `pnpm stack:reset`)
+> kasują bazę i ładują od nowa tylko fixtures. **Nie odtwarzają** custom
+> ObjectType / grup atrybutów / danych utworzonych ręcznie przez UI — ten stan
+> przepada. Zrób smoke-test/eksport zanim zresetujesz, albo uprzedź operatora.
+> (Jeśli worker api działa, najpierw `docker compose stop api`, żeby FrankenPHP
+> zwolnił połączenie.)
+
+### `exec` vs `exec -T`
+
+Komendy w kontenerze odpalasz przez `docker compose exec api …`. Flaga **`-T`
+wyłącza alokację pseudo-TTY** — używaj jej w **skryptach, CI i potokach** (gdy
+nie ma interaktywnego terminala), inaczej `docker compose exec` może się wywalić
+na braku TTY. Interaktywnie (ręcznie w terminalu) `-T` jest opcjonalne. W tym
+README komendy dokumentowane są z `-T` dla powtarzalności (kopiuj-wklej działa
+też w skrypcie); ręcznie możesz pominąć `-T`.
+
+## shared-types (kontrakt TS z OpenAPI)
+
+`packages/shared-types` to **codegen**, nie klasyczny build: typy TypeScript są
+generowane z żywego dokumentu OpenAPI API Platform do
+`packages/shared-types/src/api.d.ts`. Stack musi działać:
+
+```bash
+pnpm --filter @pim/shared-types generate
+# = openapi-typescript https://pim.localhost/api/docs.jsonopenapi -o src/api.d.ts
+```
+
+Regeneruj po każdej zmianie kształtu API (nowy zasób, nowe pole, zmiana grup
+serializacji). Pełny przepływ „jak dodać pole/endpoint" (z regeneracją włącznie):
+[`docs/development/adding-a-field-or-endpoint.md`](docs/development/adding-a-field-or-endpoint.md).
 
 ## Quality gates
 

--- a/apps/admin/README.md
+++ b/apps/admin/README.md
@@ -1,73 +1,139 @@
-# React + TypeScript + Vite
+# @pim/admin — panel administracyjny PIM
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Admin do PIM-a: **React 19 + TypeScript 5 + Vite + [Refine.dev](https://refine.dev) +
+[shadcn/ui](https://ui.shadcn.com) (Radix + Tailwind)**. To frontendowy workspace
+monorepo Turborepo (`apps/admin`). Konsumuje wyłącznie publiczne API z
+`apps/api` (API Platform 4) — żadnych prywatnych endpointów, ten sam kontrakt co
+integratorzy.
 
-Currently, two official plugins are available:
+> To **nie jest** standalone aplikacja. Admin działa **za reverse-proxy Caddy w
+> obrębie całego stacka** (single-origin, bez CORS) — uruchamiasz go przez
+> `pnpm stack:up` z roota repo, nie samym `vite` w tym katalogu. Patrz niżej.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## Jak uruchomić (w kontekście całego stacka)
 
-## React Compiler
+Z **roota repo** (nie z `apps/admin`):
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+pnpm install          # raz, z roota — instaluje cały workspace (root + apps/admin + packages/*)
+pnpm stack:up         # docker compose up -d: caddy + api + admin (Vite) + postgres + redis + meili + minio + mercure + mailpit
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Admin Vite startuje jako usługa `admin` w `docker-compose.yml` i jest serwowany
+przez Caddy pod jednym originem:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+- `https://pim.localhost/` → admin (HMR Vite przez WebSocket upgrade w Caddy)
+- `https://pim.localhost/api/*` → API Platform (Symfony)
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+Login: `admin@demo.localhost` / `changeme` (po `pim:db:reset --with-fixtures` —
+patrz [ONBOARDING](../../ONBOARDING.md)).
+
+Pełna sekwencja Day-1 (migracje, fixtures, reset bazy, akceptacja certyfikatu
+Caddy) jest w [`../../ONBOARDING.md`](../../ONBOARDING.md) i
+[`../../README.md`](../../README.md) — nie powielamy jej tutaj.
+
+### Standalone `vite dev` (rzadko, do izolowanego debugowania UI)
+
+Skrypt `dev` z `package.json` (`vite --host 0.0.0.0 --port 5173`) odpala sam dev
+server, ale **bez backendu** (`/api/*` zwróci 404/502, bo nie ma proxy Caddy).
+Domyślnym trybem pracy jest stack przez `pnpm stack:up`.
+
+## Komendy (skrypty `package.json`)
+
+Uruchamiaj per-workspace z roota przez `pnpm --filter @pim/admin <skrypt>`
+(nazwa pakietu to `@pim/admin`):
+
+| Skrypt | Komenda | Do czego |
+|--------|---------|----------|
+| `dev` | `vite --host 0.0.0.0 --port 5173` | dev server (zwykle odpalany w kontenerze przez stack) |
+| `build` | `tsc -b && vite build` | build produkcyjny (typecheck + bundle) |
+| `typecheck` | `tsc -b --noEmit` | sam typecheck, bez emisji |
+| `lint` | `biome check src e2e` | Biome (lint + format check) |
+| `lint:fix` | `biome check --write src e2e` | Biome z autofixem |
+| `format` | `biome format --write src e2e` | tylko formatowanie |
+| `test` | `vitest run` | testy jednostkowe (Vitest + Testing Library) |
+| `e2e` | `playwright test` | E2E Playwright przeciw `https://pim.localhost` |
+| `e2e:ui` | `playwright test --ui` | Playwright w trybie UI |
+| `e2e:install` | `playwright install --with-deps chromium` | instalacja Chromium dla E2E |
+
+```bash
+pnpm --filter @pim/admin typecheck
+pnpm --filter @pim/admin lint
+pnpm --filter @pim/admin build
+pnpm --filter @pim/admin test
 ```
+
+> **OOM przy typecheck / build.** `tsc` na tym projekcie potrafi przekroczyć
+> domyślny limit pamięci Node i wywalić się na OOM. Ustaw
+> `NODE_OPTIONS="--max-old-space-size=4096"`:
+>
+> ```bash
+> NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @pim/admin typecheck
+> NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @pim/admin build
+> ```
+
+### Turborepo (z roota, wszystkie workspace'y naraz)
+
+```bash
+pnpm typecheck     # turbo run typecheck (apps/admin + packages/*)
+pnpm build         # turbo run build
+pnpm lint          # turbo run lint
+pnpm test          # turbo run test
+```
+
+### E2E — pierwsze uruchomienie
+
+Alpine w kontenerze nie hostuje zależności Playwright, więc Chromium instalujesz
+po stronie hosta:
+
+```bash
+pnpm stack:up
+docker compose exec -T api php bin/console doctrine:fixtures:load --no-interaction --env=dev
+pnpm --filter @pim/admin exec playwright install chromium   # raz, host-side
+pnpm --filter @pim/admin e2e
+```
+
+> Po edycji plików tłumaczeń (`src/.../locales/pl.json` / `en.json`) zrestartuj
+> kontener admina (`docker compose restart admin`) — HMR nie re-inicjalizuje
+> i18next, nowe klucze renderują się jako surowe klucze.
+
+## shared-types — kontrakt TypeScript z OpenAPI
+
+Typy współdzielone z backendem **nie są pisane ręcznie** — są generowane z
+dokumentu OpenAPI API Platform do `packages/shared-types/src/api.d.ts`:
+
+```bash
+# stack musi działać (https://pim.localhost dostępny)
+pnpm --filter @pim/shared-types generate
+# = openapi-typescript https://pim.localhost/api/docs.jsonopenapi -o src/api.d.ts
+```
+
+**Kiedy regenerować:** po każdej zmianie kształtu API (nowy zasób, nowe pole,
+zmiana grup serializacji). To NIE jest klasyczny „build step" kompilujący kod —
+to **codegen kontraktu** odpytujący żywy endpoint. Admin importuje te typy przez
+nazwę pakietu `@pim/shared-types` (workspace pnpm). Jak dodać pole/endpoint
+end-to-end (łącznie z regeneracją): [dev-guide](../../docs/development/adding-a-field-or-endpoint.md).
+
+> Wewnątrz `apps/admin` ścieżki własne mapuje alias `@/*` → `src/*`
+> (`tsconfig.app.json`). Wywołania API idą przez warstwę `src/lib/http.ts`
+> (`jsonFetch`, doklejanie `Authorization: Bearer <jwt>`) i Refine data provider
+> `src/lib/data-provider.ts`.
+
+## Stos i konwencje
+
+- **Refine.dev** — data/auth provider + hooki (`useList`, `useOne`, `useCreate`,
+  `useUpdate`, `useDelete`). Zasoby rejestrowane w `src/App.tsx`.
+- **shadcn/ui na Radix** — a11y za darmo; customowe komponenty walidowane
+  axe-core (jest-axe / `@axe-core/playwright`).
+- **i18n** — wszystkie stringi user-facing przez `t()` (react-i18next), klucze
+  angielskie, tłumaczenia w plikach `pl`/`en`. Bez literałów w JSX.
+- **Single-origin, bez CORS** — wszystko przez Caddy; base URL API to `/api`
+  (względny). Jeśli widzisz błąd CORS, sprawdź Caddyfile, nie dodawaj nagłówków.
+
+## Powiązane dokumenty
+
+- [`../../README.md`](../../README.md) — przegląd monorepo + lokalny development.
+- [`../../ONBOARDING.md`](../../ONBOARDING.md) — pełna sekwencja Day-1.
+- [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md) — branże, commity, bramki, hooki.
+- [`../../docs/development/adding-a-field-or-endpoint.md`](../../docs/development/adding-a-field-or-endpoint.md) —
+  jak dodać pole/endpoint (vertical slice backend↔front).

--- a/docs/development/adding-a-field-or-endpoint.md
+++ b/docs/development/adding-a-field-or-endpoint.md
@@ -1,0 +1,614 @@
+# Jak dodać pole lub endpoint — pełen vertical slice
+
+> Przewodnik referencyjny dla AUD-059. Pokazuje **wszystkie warstwy**, które
+> trzeba dotknąć, żeby dodać pole do istniejącego zasobu albo wystawić nowy
+> endpoint przez API Platform 4 — z odnośnikami do realnego, działającego kodu
+> w repo (kontekst `Channel`, dla wariantów Provider/JSONB także `Catalog`).
+>
+> Wzorzec architektoniczny: **encja Domain jest czystym PHP** (konstruktor-only
+> agregat, zero adnotacji frameworka). Metadane Doctrine ORM i API Platform są
+> dostarczane **z boku przez XML** w warstwie `Infrastructure` (ADR-0011). Zapis
+> idzie przez **Input DTO → Processor → komenda CQRS → handler**, bo domyślny
+> procesor Doctrine z AP4 nie potrafi zhydratować agregatu, który ma tylko
+> konstruktor. To jest ten brakujący, nieoczywisty kawałek, który ten dokument
+> dokumentuje.
+
+## Spis treści
+
+- [Mapa warstw](#mapa-warstw)
+- [Skąd API Platform i Doctrine czytają XML](#skąd-api-platform-i-doctrine-czytają-xml)
+- [Scenariusz A — dodanie POLA do istniejącego zasobu](#scenariusz-a--dodanie-pola-do-istniejącego-zasobu)
+- [Scenariusz B — dodanie NOWEGO endpointu / zasobu](#scenariusz-b--dodanie-nowego-endpointu--zasobu)
+- [Provider zamiast Processor (odczyt)](#provider-zamiast-processor-odczyt)
+- [Gdzie wpina się TenantFilter / provenance / RBAC](#gdzie-wpina-się-tenantfilter--provenance--rbac)
+- [Czego NIE robić](#czego-nie-robić)
+- [Checklist „Done"](#checklist-done)
+
+---
+
+## Mapa warstw
+
+Pełny przepływ dla zapisu (POST/PATCH), na przykładzie `Channel`
+(`/api/channels`). Każda warstwa to realny plik w repo:
+
+```
+HTTP POST /api/channels
+        │
+        ▼
+┌─ Resource XML ───────────────────────────────────────────────────────────────┐
+│ src/Channel/Infrastructure/ApiPlatform/Resource/Channel.xml                   │
+│   <resource class="App\Channel\Domain\Entity\Channel">                        │
+│     operacja Post: input=ChannelInput, processor=ChannelProcessor             │
+└───────────────────────────────────────────────────────────────────────────────┘
+        │ AP4 deserializuje body do Input DTO (grupy denormalizacji)
+        ▼
+┌─ Input DTO ──────────────────────────────────────────────────────────────────┐
+│ src/Channel/Infrastructure/ApiPlatform/Resource/ChannelInput.php              │
+│   public string $code; public string $name;  (+ #[Assert\*], #[Groups])       │
+└───────────────────────────────────────────────────────────────────────────────┘
+        │ AP4 woła process() z DTO jako $data
+        ▼
+┌─ Processor (State) ──────────────────────────────────────────────────────────┐
+│ src/Channel/Infrastructure/ApiPlatform/State/ChannelProcessor.php             │
+│   mapuje DTO → CreateChannelCommand → MessageBus->dispatch()                  │
+│   rozpakowuje HandlerFailedException → 404/409/422 (zamiast gołego 500)       │
+└───────────────────────────────────────────────────────────────────────────────┘
+        │ Messenger
+        ▼
+┌─ Command + Handler (Application, CQRS) ──────────────────────────────────────┐
+│ src/Channel/Application/Command/CreateChannel/CreateChannelCommand.php        │
+│ src/Channel/Application/Command/CreateChannel/CreateChannelHandler.php        │
+│   walidacja biznesowa (duplikat kodu → 409), new Channel(...), repo->save()   │
+└───────────────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─ Encja Domain (czysty PHP) ──────────────────────────────────────────────────┐
+│ src/Channel/Domain/Entity/Channel.php                                         │
+│   konstruktor-only agregat, extends AggregateRoot implements TenantScoped     │
+└───────────────────────────────────────────────────────────────────────────────┘
+        │ persist → prePersist listener stampuje tenant
+        ▼
+┌─ ORM XML (mapowanie tabeli) ─────────────────────────────────────────────────┐
+│ src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml               │
+│   table="channels", kolumny, indeksy, FK tenant_id                            │
+└───────────────────────────────────────────────────────────────────────────────┘
+
+Odczyt odpowiedzi (serializacja encji z powrotem do JSON-LD):
+┌─ Serializer XML (grupy per atrybut) ─────────────────────────────────────────┐
+│ src/Channel/Infrastructure/Serializer/Channel.xml                             │
+│   <attribute name="code"><group>admin:read</group>...                         │
+└───────────────────────────────────────────────────────────────────────────────┘
+
+Kontrakt do frontu:
+┌─ shared-types (OpenAPI → TS) ────────────────────────────────────────────────┐
+│ packages/shared-types/src/api.d.ts  (generowany, NIE ręczny)                  │
+│   pnpm --filter @pim/shared-types generate                                    │
+└───────────────────────────────────────────────────────────────────────────────┘
+
+Konsumpcja w adminie:
+┌─ Admin UI (Refine + jsonFetch) ──────────────────────────────────────────────┐
+│ apps/admin/src/lib/data-provider.ts  → jsonFetch (apps/admin/src/lib/http.ts) │
+│ apps/admin/src/features/channel/channels/{list,create,edit,show}.tsx          │
+└───────────────────────────────────────────────────────────────────────────────┘
+
+Test:
+┌─ ApiTestCase ────────────────────────────────────────────────────────────────┐
+│ apps/api/tests/Api/Channel/ChannelsCrudApiTest.php                            │
+│   (baza scaffoldingu: tests/Api/Channel/ChannelApiTestCase.php)               │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+Lista plików do dotknięcia przy **nowym zasobie** (wariant B) — typowo 9–11:
+
+| # | Warstwa | Ścieżka (wzorzec `Channel`) |
+|---|---------|------------------------------|
+| 1 | Encja Domain | `apps/api/src/Channel/Domain/Entity/Channel.php` |
+| 2 | ORM XML | `apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml` |
+| 3 | Migracja | `apps/api/migrations/VersionYYYYMMDDHHMMSS.php` (generowana) |
+| 4 | Resource XML (API Platform) | `apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/Channel.xml` |
+| 5 | Input DTO (POST) | `apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelInput.php` |
+| 6 | Patch Input DTO (PATCH) | `apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelPatchInput.php` |
+| 7 | Processor (State) | `apps/api/src/Channel/Infrastructure/ApiPlatform/State/ChannelProcessor.php` |
+| 8 | Command + Handler | `apps/api/src/Channel/Application/Command/CreateChannel/*.php` |
+| 9 | Serializer XML (grupy read) | `apps/api/src/Channel/Infrastructure/Serializer/Channel.xml` |
+| 10 | shared-types (regen) | `packages/shared-types/src/api.d.ts` (`generate`) |
+| 11 | ApiTestCase | `apps/api/tests/Api/Channel/ChannelsCrudApiTest.php` |
+
+Przy **dodaniu pola** (wariant A) dotykasz zwykle 1–2, 4–5 (lub 5–7 jeśli pole
+jest zapisywalne), 9–11 — nie tworzysz nowego Processora ani komendy.
+
+---
+
+## Skąd API Platform i Doctrine czytają XML
+
+To jest klucz do zrozumienia, dlaczego encja nie ma adnotacji. Trzy osobne
+rejestry skanują katalogi per bounded context — **nowy kontekst trzeba dopisać
+do każdego z nich**:
+
+**1. Doctrine ORM** — [`apps/api/config/packages/doctrine.yaml`](../../apps/api/config/packages/doctrine.yaml)
+(`doctrine.orm.mappings`). `auto_mapping: false` jest celowe — każdy kontekst
+mapuje się jawnie:
+
+```yaml
+mappings:
+    Channel:
+        type: xml
+        is_bundle: false
+        dir: '%kernel.project_dir%/src/Channel/Infrastructure/Doctrine/Orm/Mapping'
+        prefix: 'App\Channel\Domain\Entity'
+        alias: Channel
+```
+
+**2. API Platform** — [`apps/api/config/packages/api_platform.yaml`](../../apps/api/config/packages/api_platform.yaml)
+(`api_platform.mapping.paths`):
+
+```yaml
+mapping:
+    paths:
+        - '%kernel.project_dir%/src/Catalog/Infrastructure/ApiPlatform/Resource'
+        - '%kernel.project_dir%/src/Channel/Infrastructure/ApiPlatform/Resource'
+        # ... Asset, ApiConfigurator, Import
+```
+
+**3. Symfony Serializer** — [`apps/api/config/packages/framework.yaml`](../../apps/api/config/packages/framework.yaml)
+(`framework.serializer.mapping.paths`):
+
+```yaml
+serializer:
+    mapping:
+        paths:
+            - '%kernel.project_dir%/src/Channel/Infrastructure/Serializer'
+            # ... per kontekst
+```
+
+> **Pułapka:** jeśli zakładasz **nowy bounded context**, dopisz jego trzy
+> ścieżki do tych trzech plików. Encja w nowym kontekście, której katalogu nie
+> ma w `doctrine.yaml`, nie zmapuje się (Doctrine jej „nie widzi"); Resource bez
+> wpisu w `api_platform.yaml` nie wystawi endpointu; brak wpisu w
+> `framework.yaml` → grupy serializacji z XML nie zadziałają. Dla **istniejącego**
+> kontekstu (Channel, Catalog, Asset…) katalog już jest zarejestrowany — sam
+> dodajesz plik XML w środku, bez zmian w config.
+
+Processor / Handler / Listener **nie wymagają ręcznej rejestracji jako serwis** —
+PSR-4 autowiring łapie cały `src/` ([`apps/api/config/services.yaml`](../../apps/api/config/services.yaml),
+`App\: resource: '../src/'`). Handler jest oznaczony `#[AsMessageHandler]`,
+listener `#[AsDoctrineListener(...)]` — to wystarcza.
+
+---
+
+## Scenariusz A — dodanie POLA do istniejącego zasobu
+
+Przykład w repo: pole `categoryTreeRootId` na `Channel` (mapuje się na kolumnę
+`category_tree_root_object_id`, tylko do odczytu w API, zapisywane osobnym
+endpointem nawigacji). Prześledź je jako wzorzec „field-only".
+
+### A.1 — Encja Domain: właściwość + akcesory
+
+[`apps/api/src/Channel/Domain/Entity/Channel.php`](../../apps/api/src/Channel/Domain/Entity/Channel.php):
+
+```php
+private ?Uuid $categoryTreeRootId = null;
+
+public function getCategoryTreeRootId(): ?Uuid
+{
+    return $this->categoryTreeRootId;
+}
+
+public function attachCategoryTreeRoot(?Uuid $rootId): void { /* ... */ }
+```
+
+Reguły:
+
+- Pola dodajesz jako `private`, mutację wystawiasz **metodą domenową**
+  (`rename()`, `attachCategoryTreeRoot()`), nie publicznym setterem — encja to
+  agregat, nie anemiczny worek na dane.
+- Walidację składniową daj adnotacją `#[Assert\*]` na właściwości (np.
+  `#[Assert\Length(max: 255)]` przy `name`). Walidacja **biznesowa** (np.
+  „kod unikalny w obrębie tenanta") idzie do handlera, nie do encji.
+
+### A.2 — ORM XML: kolumna
+
+[`apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml`](../../apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml):
+
+```xml
+<field name="categoryTreeRootId" type="uuid" column="category_tree_root_object_id" nullable="true"/>
+```
+
+> **Kolumna `NOT NULL` na istniejącej tabeli** musi mieć w XML
+> `<option name="default">...</option>` — baza testowa jest budowana z metadanych
+> ORM (Foundry `ResetDatabase`), nie z migracji, więc istniejące surowe `INSERT`-y
+> w fixtures/testach wywalą się na not-null bez defaultu. (Zob. lekcja
+> „New NOT NULL column needs ORM default".)
+
+### A.3 — Migracja bazy
+
+Wygeneruj diff i przejrzyj go ręcznie przed commitem:
+
+```bash
+docker compose exec -T api php bin/console doctrine:migrations:diff
+# przejrzyj wygenerowany plik w apps/api/migrations/, potem:
+docker compose exec -T api php bin/console doctrine:migrations:migrate --no-interaction
+```
+
+### A.4 — Wystawienie pola w API
+
+- **Read (zawsze):** dodaj atrybut z grupą `admin:read` w Serializer XML —
+  [`apps/api/src/Channel/Infrastructure/Serializer/Channel.xml`](../../apps/api/src/Channel/Infrastructure/Serializer/Channel.xml):
+
+  ```xml
+  <attribute name="categoryTreeRootId">
+      <group>admin:read</group>
+  </attribute>
+  ```
+
+  Grupa musi zgadzać się z `normalizationContext` w Resource XML (`Channel.xml`
+  deklaruje `<value>admin:read</value>`).
+
+- **Write (jeśli pole edytowalne):** dodaj właściwość do Input DTO z odpowiednią
+  grupą denormalizacji i `#[Assert\*]` — [`ChannelInput.php`](../../apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelInput.php) /
+  [`ChannelPatchInput.php`](../../apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelPatchInput.php),
+  a potem przenieś ją w Processorze do komendy. `code` i `name` w `ChannelInput`
+  to gotowy wzorzec:
+
+  ```php
+  #[Assert\NotBlank]
+  #[Assert\Length(max: 255)]
+  #[Groups(['channel:create'])]
+  public string $name = '';
+  ```
+
+### A.5 — Regeneracja shared-types
+
+Po zmianie kształtu odpowiedzi **zawsze** zregeneruj kontrakt TS (stack musi
+działać — patrz [onboarding](#regeneracja-shared-types-osobny-krok)):
+
+```bash
+pnpm --filter @pim/shared-types generate
+```
+
+### A.6 — Admin UI
+
+Front czyta pole z odpowiedzi przez Refine data provider. Dla `Channel`:
+[`apps/admin/src/features/channel/channels/show.tsx`](../../apps/admin/src/features/channel/channels/show.tsx)
+(`useOne`), [`list.tsx`](../../apps/admin/src/features/channel/channels/list.tsx)
+(`useList`), [`edit.tsx`](../../apps/admin/src/features/channel/channels/edit.tsx)
+(`useOne` + `useUpdate`). Wszystkie idą przez
+[`apps/admin/src/lib/data-provider.ts`](../../apps/admin/src/lib/data-provider.ts)
+→ `jsonFetch` ([`apps/admin/src/lib/http.ts`](../../apps/admin/src/lib/http.ts),
+nagłówek `Authorization: Bearer <jwt>` doklejany centralnie).
+
+### A.7 — Test
+
+Dorzuć asercję do istniejącego `ChannelsCrudApiTest`
+([`apps/api/tests/Api/Channel/ChannelsCrudApiTest.php`](../../apps/api/tests/Api/Channel/ChannelsCrudApiTest.php)) —
+np. że POST zwraca nowe pole, albo że PATCH je zmienia.
+
+---
+
+## Scenariusz B — dodanie NOWEGO endpointu / zasobu
+
+Pełny wzorzec to **cały kontekst `Channel`**. Idź po kolei:
+
+### B.1 — Encja Domain (konstruktor-only agregat)
+
+[`apps/api/src/Channel/Domain/Entity/Channel.php`](../../apps/api/src/Channel/Domain/Entity/Channel.php):
+
+```php
+class Channel extends AggregateRoot implements TenantScoped
+{
+    private Uuid $id;
+    private ?Tenant $tenant = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 64)]
+    private string $code;
+
+    public function __construct(string $code, string $name, ?Uuid $id = null)
+    {
+        $this->id = $id ?? Uuid::v7();
+        $this->code = $code;
+        $this->name = $name;
+    }
+    // gettery + metody domenowe (rename, attachCategoryTreeRoot, assignTenant)
+}
+```
+
+- `extends AggregateRoot` — daje `recordThat()` do emisji eventów domenowych.
+- `implements TenantScoped` — wystarcza, żeby `TenantAssignmentListener`
+  ostemplował `tenant_id` na `prePersist` (patrz niżej, sekcja RBAC/tenant).
+- **Brak adnotacji `#[ApiResource]` na encji** — metadane AP4 są w XML. To różni
+  PIM od „domyślnego" tutoriala API Platform.
+- ID generujesz w konstruktorze (`Uuid::v7()`), strategia w ORM XML to
+  `<generator strategy="NONE"/>` — aplikacja, nie baza, nadaje identyfikator.
+
+### B.2 — ORM XML
+
+[`apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml`](../../apps/api/src/Channel/Infrastructure/Doctrine/Orm/Mapping/Channel.orm.xml):
+
+```xml
+<entity name="App\Channel\Domain\Entity\Channel" table="channels"
+        repository-class="App\Channel\Infrastructure\Doctrine\Repository\DoctrineChannelRepository">
+    <unique-constraints>
+        <unique-constraint name="channels_tenant_code_uniq" columns="tenant_id,code"/>
+    </unique-constraints>
+    <id name="id" type="uuid" column="id"><generator strategy="NONE"/></id>
+    <many-to-one field="tenant" target-entity="App\Shared\Domain\Tenant">
+        <join-column name="tenant_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+    </many-to-one>
+    <field name="code" type="string" length="64"/>
+    <field name="name" type="string" length="255"/>
+</entity>
+```
+
+Każda tabela domenowa ma `tenant_id` od dnia 1 i unikalność scope'owaną po
+tenancie (`tenant_id,code`), nie globalną.
+
+### B.3 — Resource XML (API Platform)
+
+[`apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/Channel.xml`](../../apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/Channel.xml).
+To tu deklarujesz operacje, ścieżki, `input`, `processor`, `security` i grupy:
+
+```xml
+<resource class="App\Channel\Domain\Entity\Channel" shortName="Channel">
+    <normalizationContext>
+        <values><value name="groups"><values><value>admin:read</value></values></value></values>
+    </normalizationContext>
+    <operations>
+        <operation class="ApiPlatform\Metadata\GetCollection" uriTemplate="/channels{._format}"
+                   security="is_granted('READ', 'App\\Channel\\Domain\\Entity\\Channel')"/>
+        <operation class="ApiPlatform\Metadata\Get" uriTemplate="/channels/{id}{._format}"
+                   security="is_granted('READ', object)"/>
+        <operation class="ApiPlatform\Metadata\Post" uriTemplate="/channels{._format}"
+                   input="App\Channel\Infrastructure\ApiPlatform\Resource\ChannelInput"
+                   processor="App\Channel\Infrastructure\ApiPlatform\State\ChannelProcessor"
+                   security="is_granted('CREATE', 'App\\Channel\\Domain\\Entity\\Channel')">
+            <denormalizationContext>
+                <values><value name="groups"><values><value>channel:create</value></values></value></values>
+            </denormalizationContext>
+        </operation>
+        <!-- Patch + Delete analogicznie, każde z processor= i security= -->
+    </operations>
+</resource>
+```
+
+Uwagi:
+
+- `input="...ChannelInput"` — POST deserializuje się do DTO, nie do encji.
+- `processor="...ChannelProcessor"` — wskazuje State Processor (B.5).
+- `security="is_granted(...)"` — ekspresja Symfony Security; tu odpalają się
+  Votery RBAC (akcje `READ`/`CREATE`/`UPDATE`/`DELETE`).
+- Backslash w FQCN w atrybucie XML **podwajasz** (`App\\Channel\\...`).
+
+### B.4 — Input DTO (POST i PATCH osobno)
+
+[`ChannelInput.php`](../../apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelInput.php)
+(POST — pełne pola wymagane) i
+[`ChannelPatchInput.php`](../../apps/api/src/Channel/Infrastructure/ApiPlatform/Resource/ChannelPatchInput.php)
+(PATCH — wszystkie pola opcjonalne, `code` pominięty bo niezmienny po utworzeniu).
+DTO niesie `#[Assert\*]` (walidacja wejścia) + `#[Groups([...])]` (zgodne z
+grupami denormalizacji z Resource XML).
+
+> **Dlaczego osobny DTO, a nie hydratacja encji?** Komentarz w `ChannelInput`
+> mówi wprost: „AP4 default Doctrine processor cannot hydrate the constructor-only
+> Channel aggregate — this DTO is the deserialisation target for the
+> ChannelProcessor." Agregat ma tylko konstruktor z wymaganymi argumentami,
+> więc domyślny procesor (który robi `new` + settery) nie zadziała.
+
+### B.5 — Processor (State)
+
+[`apps/api/src/Channel/Infrastructure/ApiPlatform/State/ChannelProcessor.php`](../../apps/api/src/Channel/Infrastructure/ApiPlatform/State/ChannelProcessor.php).
+Most DTO → komenda CQRS:
+
+```php
+final readonly class ChannelProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private MessageBusInterface $bus,
+        private ChannelRepositoryInterface $channels,
+    ) {}
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): ?Channel
+    {
+        if ($operation instanceof DeleteOperationInterface) { return $this->handleDelete($uriVariables); }
+        if ($operation instanceof Post)  { return $this->handlePost($data); }
+        if ($operation instanceof Patch) { return $this->handlePatch($data, $uriVariables); }
+        throw new LogicException(/* ... */);
+    }
+
+    private function handlePost(mixed $data): Channel
+    {
+        // $data to ChannelInput; zbuduj komendę, dispatch, przeładuj encję z repo
+        $command = new CreateChannelCommand(code: $data->code, name: $data->name, categoryTreeRootId: null);
+        $envelope = $this->dispatch($command);
+        $newId = $this->extractResult($envelope); // HandledStamp->getResult()
+        return $this->channels->findById($newId) ?? throw new LogicException(/* ... */);
+    }
+    // dispatch() rozpakowuje HandlerFailedException → oryginalny HttpException (404/409/422)
+}
+```
+
+Krytyczny detal: prywatne `dispatch()` łapie `HandlerFailedException` z Messengera
+i rzuca dalej oryginalny `HttpException` (`ConflictHttpException` →409,
+`UnprocessableEntityHttpException` →422, `NotFoundHttpException` →404). Bez tego
+AP4 pokazałby gołe 500 zamiast właściwego kodu.
+
+### B.6 — Command + Handler (Application, CQRS)
+
+[`CreateChannelCommand.php`](../../apps/api/src/Channel/Application/Command/CreateChannel/CreateChannelCommand.php)
+(niezmienny DTO komendy) +
+[`CreateChannelHandler.php`](../../apps/api/src/Channel/Application/Command/CreateChannel/CreateChannelHandler.php)
+(`#[AsMessageHandler]`). Tu mieszka **walidacja biznesowa** i właściwa mutacja:
+
+```php
+#[AsMessageHandler]
+final readonly class CreateChannelHandler
+{
+    public function __invoke(CreateChannelCommand $command): Uuid
+    {
+        $tenant = $this->tenantContext->get() ?? throw new LogicException(/* ... */);
+
+        if (null !== $this->channels->findByCode($command->code, $tenant)) {
+            throw new ConflictHttpException(/* duplikat → 409 */);
+        }
+        $channel = new Channel(code: $command->code, name: $command->name);
+        $this->channels->save($channel);
+        return $channel->getId();
+    }
+}
+```
+
+### B.7 — Serializer XML (grupy odczytu)
+
+[`apps/api/src/Channel/Infrastructure/Serializer/Channel.xml`](../../apps/api/src/Channel/Infrastructure/Serializer/Channel.xml) —
+per atrybut deklaruje, w których grupach jest widoczny (`admin:read`,
+`integration:read`, `public:read`). Pola bez grupy nie wychodzą w odpowiedzi.
+
+### B.8 — Repozytorium (port + adapter)
+
+Interfejs w Domain
+([`ChannelRepositoryInterface`](../../apps/api/src/Channel/Domain/Repository/ChannelRepositoryInterface.php)),
+implementacja Doctrine w Infrastructure
+([`DoctrineChannelRepository`](../../apps/api/src/Channel/Infrastructure/Doctrine/Repository/DoctrineChannelRepository.php),
+wskazana w `repository-class` w ORM XML). Handler i Processor zależą od
+interfejsu, nie od klasy Doctrine.
+
+### B.9 — Migracja + shared-types + test
+
+- Migracja: `doctrine:migrations:diff` → przegląd → `migrate` (jak A.3).
+- shared-types: `pnpm --filter @pim/shared-types generate` (jak A.5).
+- Test: cały plik
+  [`ChannelsCrudApiTest.php`](../../apps/api/tests/Api/Channel/ChannelsCrudApiTest.php)
+  to wzorzec — POST 201, duplikat 409, zły format 422, blank 422, PATCH 200,
+  DELETE 204→404, brak auth 401. Baza scaffoldingu (seed tenant + super_admin +
+  JWT) jest w
+  [`ChannelApiTestCase.php`](../../apps/api/tests/Api/Channel/ChannelApiTestCase.php):
+
+  ```php
+  abstract class ChannelApiTestCase extends ApiTestCase
+  {
+      use Factories; use ResetDatabase;
+      protected function authenticatedClient(string $email = self::ADMIN_EMAIL): Client
+      {
+          $jwt = self::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+          $client = static::createClient();
+          $client->setDefaultOptions(['headers' => ['authorization' => 'Bearer '.$jwt]]);
+          return $client;
+      }
+  }
+  ```
+
+  > Asercje rób na **kodzie HTTP**, nie na treści błędu RFC 7807 — `detail` jest
+  > pełny tylko w debug (lokalnie), a w CI (non-debug) kolapsuje do generycznego
+  > tekstu statusu. (Lekcja „Assert status not RFC7807 detail".)
+
+---
+
+## Provider zamiast Processor (odczyt)
+
+Processor obsługuje **zapis** (POST/PATCH/DELETE). Jeśli potrzebujesz nietrywialnego
+**odczytu** (np. nakładka per-locale na wartości, agregacja, custom źródło danych),
+napisz **State Provider** (`ProviderInterface`) i wskaż go atrybutem
+`provider="..."` w operacji `Get`/`GetCollection` w Resource XML.
+
+Realny wzorzec: [`CatalogObjectLocaleOverlayProvider`](../../apps/api/src/Catalog/Infrastructure/ApiPlatform/State/CatalogObjectLocaleOverlayProvider.php)
+(deleguje do domyślnego item providera Doctrine, a potem nakłada wartości
+rozwiązane per `?locale=`). Pliki State Catalogu:
+`apps/api/src/Catalog/Infrastructure/ApiPlatform/State/`.
+
+---
+
+## Gdzie wpina się TenantFilter / provenance / RBAC
+
+### Tenant isolation (multi-tenancy)
+
+- **Zapis:** encja implementuje `TenantScoped`; `tenant_id` stempluje
+  [`TenantAssignmentListener`](../../apps/api/src/Shared/Infrastructure/Doctrine/EventListener/TenantAssignmentListener.php)
+  na `prePersist` (woła `assignTenant()` z aktualnym `TenantContext`). **Nigdy
+  nie ustawiaj `tenant_id` ręcznie w handlerze.** Brak aktywnego tenanta → wyjątek,
+  nie ciche `NULL`.
+- **Odczyt:** Doctrine filter `tenant`
+  ([`TenantFilter`](../../apps/api/src/Shared/Infrastructure/Doctrine/Filter/TenantFilter.php),
+  rejestrowany ale `enabled: false` w `doctrine.yaml`) jest włączany per-request,
+  gdy znany jest tenant. Postgres RLS to defence-in-depth (osobny mechanizm).
+  Szczegóły: [`docs/multi-tenancy.md`](../multi-tenancy.md).
+
+Dla nowej encji wystarczy `implements TenantScoped` + kolumna `tenant_id` w ORM
+XML — reszta dzieje się automatycznie.
+
+### Provenance (skąd wzięła się wartość)
+
+Dotyczy zapisu **wartości atrybutów produktu** (`ObjectValue`), nie metadanych
+zasobu jak Channel. Każdy `ObjectValue` niesie
+[`Provenance`](../../apps/api/src/Catalog/Domain/Provenance.php)
+(`manual | import | integration`; `agent` zarezerwowany na Fazę 2) +
+`provenance_meta JSONB`. Jeśli piszesz nowy writer wartości — ustaw provenance
+zgodnie z kanałem zapisu. Kontrakt kształtu JSONB:
+[`docs/api/jsonb-schemas.md`](../api/jsonb-schemas.md).
+
+### RBAC — `#[RequiresPermission]` i `security=`
+
+Dwie warstwy, zależnie od typu endpointu:
+
+- **Operacje API Platform** (jak Channel) — autoryzacja przez `security="is_granted(...)"`
+  w Resource XML (B.3). Votery dostają akcję (`READ`/`CREATE`/...) i obiekt/klasę.
+- **Custom kontrolery** (poza AP4) — adnotacja
+  [`#[RequiresPermission(module, action, subject?)]`](../../apps/api/src/Identity/Contracts/Attribute/RequiresPermission.php)
+  na metodzie, egzekwowana runtime przez
+  [`EndpointGuardListener`](../../apps/api/src/Identity/Infrastructure/Http/EndpointGuardListener.php)
+  (subskrybuje `kernel.controller_arguments`). Kod uprawnienia to
+  `{module}.{action}` (np. `products.edit`), zgodnie z macierzą w
+  [`docs/rbac.md`](../rbac.md) / PRD-PIM-rbac §3.2.
+
+> Reguła PHPStan `RequiresPermissionAnnotationRule` **blokuje PR**, jeśli custom
+> kontroler pod `/api/*` nie ma ani `#[RequiresPermission]`, ani
+> `#[NoPermissionRequired]`. To nie jest opcjonalne.
+
+---
+
+## Czego NIE robić
+
+- **Nie dodawaj `#[ApiResource]` na encji Domain.** Metadane AP4 idą do Resource
+  XML w `Infrastructure/ApiPlatform/Resource/`. Encja zostaje czystym PHP (ADR-0011).
+- **Nie hydratuj agregatu domyślnym procesorem Doctrine.** Zrób Input DTO +
+  Processor + komendę. Domyślny `new + setter` nie zadziała na konstruktor-only.
+- **Nie ustawiaj `tenant_id` ręcznie.** `implements TenantScoped` +
+  `TenantAssignmentListener`. Ręczne ustawienie = naruszenie reguły i ryzyko cross-tenant.
+- **Nie pomijaj regeneracji shared-types** po zmianie kształtu odpowiedzi.
+  `pnpm --filter @pim/shared-types generate` — inaczej kontrakt TS rozjedzie się
+  z API.
+- **Nie zapominaj o `default` dla kolumny `NOT NULL`** na istniejącej tabeli w
+  ORM XML — baza testowa budowana z metadanych ORM wywali istniejące `INSERT`-y.
+- **Nie hardkoduj URL-i, kluczy, sekretów** w kodzie (CLAUDE.md, reguła 7).
+  W froncie data provider używa bazy `/api` + `jsonFetch` (single-origin przez
+  Caddy, **bez CORS**).
+- **Nie asertuj treści błędu RFC 7807** w teście — asertuj kod HTTP (debug vs
+  non-debug rozjazd między lokalnie a CI).
+- **Nie zapominaj dopisać nowego bounded context** do trzech rejestrów
+  (`doctrine.yaml`, `api_platform.yaml`, `framework.yaml`). Dla istniejącego
+  kontekstu katalog już jest — sam dodajesz plik.
+- **Nie pomijaj testu E2E** dla zmiany widocznej w UI (CLAUDE.md, Definicja Done).
+
+---
+
+## Checklist „Done"
+
+- [ ] Encja Domain: właściwość + metody domenowe, walidacja `#[Assert\*]` na wejściu.
+- [ ] ORM XML: kolumna (+ `default` jeśli `NOT NULL` na istniejącej tabeli).
+- [ ] Migracja: `doctrine:migrations:diff` → przegląd → `migrate`.
+- [ ] Resource XML: operacja(e) + `input`/`processor` + `security` + grupy (jeśli nowy zasób).
+- [ ] Input DTO(s): POST i PATCH, `#[Assert\*]` + `#[Groups]`.
+- [ ] Processor: DTO → komenda, rozpakowanie `HandlerFailedException`.
+- [ ] Command + Handler `#[AsMessageHandler]`: walidacja biznesowa + mutacja.
+- [ ] Serializer XML: pole w grupie `admin:read` (i innych wg potrzeby).
+- [ ] Nowy kontekst? trzy ścieżki w `doctrine.yaml` + `api_platform.yaml` + `framework.yaml`.
+- [ ] shared-types: `pnpm --filter @pim/shared-types generate` (stack musi działać).
+- [ ] Admin UI: konsumpcja przez data provider + `jsonFetch`.
+- [ ] ApiTestCase: 201/409/422/200/204/401 wg wzorca `ChannelsCrudApiTest`.
+- [ ] Bramki: `composer phpstan` + `cs-check` + `deptrac` + PHPUnit; `pnpm typecheck` + `build` + Biome.
+- [ ] E2E Playwright dla zmiany widocznej w UI.
+
+---
+
+**Powiązane dokumenty:** [ONBOARDING](../../ONBOARDING.md) ·
+[CONTRIBUTING](../../CONTRIBUTING.md) · [kontrakt JSONB](../api/jsonb-schemas.md) ·
+[multi-tenancy](../multi-tenancy.md) · [RBAC](../rbac.md).


### PR DESCRIPTION
## Wave 3 / W3-3 — AUD-059 + AUD-081 (#1609)

### AUD-059 — brak udokumentowanego vertical-slice
Dodanie pola/endpointu = ~11 plików w 2 apps bez wzorca. **Fix:** `docs/development/adding-a-field-or-endpoint.md` (32KB, PL) — prześledzony REALNY slice `Channel`: encja konstruktor-only → ORM+Resource XML → Input DTO → Processor → shared-types → admin UI → ApiTestCase (11 plików, cytaty z kodu). Scenariusz A (dodanie pola) + B (nowy zasób), wpięcie TenantFilter/RBAC/provenance, „czego NIE robić", checklist Done. Udokumentowany nieoczywisty kawałek: dlaczego Input-DTO+Processor (Doctrine nie zhydratuje konstruktor-only agregatu).

### AUD-081 — onboarding spójność
- `apps/admin/README.md` — przepisany z literalnego template Vite na realny (Refine/shadcn admin, uruchomienie przez `pnpm stack:up`, `NODE_OPTIONS=4096`, sekcja shared-types codegen).
- root `README.md` — naprawione: brakujący db-init (`pim:db:reset --with-fixtures --force` + manualny odpowiednik), `pim:db:reset` z OSTRZEŻENIEM o wipe stanu manualnego, `exec` vs `exec -T`, sekcja plików .env (tracked `.env.example` vs untracked `.env`/`.env.dev`/`.env.local`), shared-types „codegen, nie build", login `admin@demo.localhost`.

**Wszystkie komendy zweryfikowane na żywym stacku** (pim:db:reset --help, migrations, OpenAPI export 200, package.json scripts). Markdown: 55/55 linków OK, bloki zbalansowane. Uczciwie oflagowane realia (shared-types jeszcze nieimportowane w adminie — wzorzec docelowy).

> Docs-only → quality-php CI skipuje (paths-ignore z W2-14); gitleaks/audit biegną.

Closes #1609
