### PR TITLE
refactor(deptrac): cover vendor edges, gate Backup, drop audit orphans

### DIFF
--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -362,6 +362,14 @@ services:
     App\Identity\Contracts\Audit\DataExportAuditor:
         alias: App\Identity\Infrastructure\Audit\DataExportAuditor
 
+    # AUD-053 (W3-1) — "current user" port. Lets controllers outside Identity
+    # (Backup; later the Import controllers) read the authenticated principal's
+    # id/tenant without importing Identity\Domain\Entity\User (deptrac:
+    # Backup/Import → Identity_Contracts). Impl name differs from the
+    # interface, so autowiring needs the explicit alias.
+    App\Identity\Contracts\Auth\CurrentUserProvider:
+        alias: App\Identity\Application\Auth\SecurityCurrentUserProvider
+
     App\Import\Application\Service\HealthCheck\FolderHealthCheckDriver:
         tags: ['app.import.health_check_driver']
 

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -67,12 +67,39 @@ parameters:
           collectors:
               - type: directory
                 value: 'src/Identity/Domain/.*'
-              - type: directory
-                value: 'src/Identity/Application/.*'
+              # AUD-053 (W3-1): all of Identity\Application EXCEPT the
+              # carved-out CurrentTenantProvider, which lives in its own
+              # single-class layer so Search can reach it without the whole
+              # Internals surface. A token may only live in one layer.
+              - type: bool
+                must:
+                    - type: directory
+                      value: 'src/Identity/Application/.*'
+                must_not:
+                    - type: classNameRegex
+                      value: '#^App\\Identity\\Application\\CurrentTenantProvider$#'
               - type: directory
                 value: 'src/Identity/Infrastructure/.*'
               - type: directory
                 value: 'src/Identity/Presentation/.*'
+              # AUD-053 (W3-1): the OpenApi factory was unassigned to any
+              # layer (deptrac debug:unassigned). It is an Identity-internal
+              # API Platform decorator; fold it into the Internals layer so
+              # every first-party Identity class is governed.
+              - type: directory
+                value: 'src/Identity/OpenApi/.*'
+        # AUD-053 (W3-1): a single-class sub-layer carved out of Identity so
+        # other BCs (Search) can reach the tenant resolver WITHOUT being
+        # granted the whole Identity_Internals surface. CurrentTenantProvider
+        # reads the security token (authenticated user / API-key principal /
+        # non-prod env default) — the security-backed source the cross-tenant
+        # search guard needs. The pending cleanup is moving it into
+        # Shared\Application (see the RequestTenantSubscriber baseline note);
+        # until then this is the minimum honest grant, not a broad allow.
+        - name: Identity_TenantProvider
+          collectors:
+              - type: classNameRegex
+                value: '#^App\\Identity\\Application\\CurrentTenantProvider$#'
         - name: Identity_Contracts
           collectors:
               - type: directory
@@ -90,6 +117,27 @@ parameters:
               - type: directory
                 value: 'src/Search/.*'
 
+        # ─── Backup (pgBackRest snapshots — IMP-06) ────────────────────
+        # AUD-079 (W3-1): the Backup BC shipped without any deptrac rules,
+        # so all 12 of its classes were unassigned (debug:unassigned) and
+        # every reach INTO it (ImportSession.backupSnapshot, BackupVoter)
+        # was an unreported uncovered edge. Split it like every other BC —
+        # Internals + a forward-compatible Contracts layer.
+        - name: Backup_Internals
+          collectors:
+              - type: directory
+                value: 'src/Backup/Domain/.*'
+              - type: directory
+                value: 'src/Backup/Application/.*'
+              - type: directory
+                value: 'src/Backup/Infrastructure/.*'
+              - type: directory
+                value: 'src/Backup/Presentation/.*'
+        - name: Backup_Contracts
+          collectors:
+              - type: directory
+                value: 'src/Backup/Contracts/.*'
+
         # ─── Forward-compatible BCs (empty today) ──────────────────────
         - name: Integration
           collectors:
@@ -103,6 +151,21 @@ parameters:
           collectors:
               - type: directory
                 value: 'src/ApiConfigurator/.*'
+
+        # ─── Vendor (third-party + PHP-internal classes) ───────────────
+        # AUD-053 (W3-1): every dependency from a first-party class onto a
+        # framework/library/PHP-internal class (Symfony, Doctrine, API
+        # Platform, PSR, …) was previously counted as "Uncovered" — ~5.3k
+        # silent edges that hid the handful of REAL first-party gaps among
+        # them. This catch-all assigns "anything not under App\" to a named
+        # Vendor layer that every BC is explicitly allowed to use, so the
+        # uncovered count collapses to genuine first-party blind spots only.
+        - name: Vendor
+          collectors:
+              - type: bool
+                must_not:
+                    - type: classNameRegex
+                      value: '#^App\\#'
 
         # ─── Import / Export (ADR-0019, IMP2-1.1 #1463) ────────────────
         # Target ruleset: only *_Contracts + Shared. Existing reaches into
@@ -132,14 +195,19 @@ parameters:
                 value: 'src/PHPStan/.*'
 
     ruleset:
+        # AUD-053 (W3-1): `Vendor` appears in every ruleset below so that
+        # framework / library / PHP-internal edges resolve to an allowed
+        # layer instead of inflating the Uncovered count.
         Catalog_Internals:
             - Catalog_Contracts
             - Asset_Contracts
             - Channel_Contracts
             - Identity_Contracts
             - Shared
+            - Vendor
         Catalog_Contracts:
             - Shared
+            - Vendor
 
         Channel_Internals:
             - Channel_Contracts
@@ -147,36 +215,62 @@ parameters:
             - Asset_Contracts
             - Identity_Contracts
             - Shared
+            - Vendor
         Channel_Contracts:
             - Shared
+            - Vendor
 
         Asset_Internals:
             - Asset_Contracts
             - Catalog_Contracts
             - Identity_Contracts
             - Shared
+            - Vendor
         Asset_Contracts:
             - Shared
+            - Vendor
 
         Import:
             - Catalog_Contracts
             - Channel_Contracts
             - Asset_Contracts
             - Identity_Contracts
+            # AUD-079 (W3-1): ImportSession carries a `backupSnapshot`
+            # many-to-one onto the Backup entity (IMP2-2.10 pre-import
+            # snapshot badge). A Doctrine association needs the concrete
+            # target-entity class, so this is a structural coupling that
+            # cannot be hidden behind a Contracts interface; allow it
+            # explicitly rather than baseline it as a violation.
+            - Backup_Internals
             - Shared
+            - Vendor
         Export:
             - Catalog_Contracts
             - Channel_Contracts
             - Asset_Contracts
             - Identity_Contracts
             - Shared
+            - Vendor
 
         Identity_Internals:
             - Identity_Contracts
             - Catalog_Contracts
+            # AUD-079 (W3-1): BackupVoter references the Backup entity it
+            # protects — the same "voter references its resource" pattern
+            # already accepted for ProductVoter / CategoryVoter / AssetVoter.
+            - Backup_Internals
+            # AUD-053 (W3-1): CurrentTenantProvider was carved out of this
+            # layer; the audit listeners that still consume it reach back in
+            # through its dedicated single-class layer.
+            - Identity_TenantProvider
             - Shared
+            - Vendor
+        Identity_TenantProvider:
+            - Shared
+            - Vendor
         Identity_Contracts:
             - Shared
+            - Vendor
 
         Shared:
             # Shared is normally a leaf. The exception is the RBAC attribute
@@ -186,6 +280,7 @@ parameters:
             # attribute classes (RequiresPermission + NoPermissionRequired),
             # which are pure metadata with zero runtime coupling.
             - Identity_Contracts
+            - Vendor
 
         Search:
             - Shared
@@ -193,7 +288,24 @@ parameters:
             - Catalog_Internals
             - Channel_Contracts
             - Identity_Contracts
-            - Identity_Internals
+            # AUD-079 (W3-1): narrowed from the whole Identity_Internals to
+            # the single CurrentTenantProvider class the search tenant guard
+            # actually uses (debug: it touches nothing else in Identity
+            # Internals).
+            - Identity_TenantProvider
+            - Vendor
+
+        Backup_Internals:
+            - Backup_Contracts
+            # AUD-079 (W3-1): Backup's only cross-BC reach is the current-user
+            # port (CurrentUserProvider in Identity_Contracts) plus Shared —
+            # the User-entity leak was removed via that seam in W3-1.
+            - Identity_Contracts
+            - Shared
+            - Vendor
+        Backup_Contracts:
+            - Shared
+            - Vendor
 
         Integration:
             - Shared
@@ -201,11 +313,13 @@ parameters:
             - Channel_Contracts
             - Asset_Contracts
             - Identity_Contracts
+            - Vendor
 
         Agent:
             - Shared
             - Catalog_Contracts
             - Identity_Contracts
+            - Vendor
 
         ApiConfigurator:
             - Shared
@@ -213,6 +327,7 @@ parameters:
             - Channel_Contracts
             - Asset_Contracts
             - Identity_Contracts
+            - Vendor
 
         Tooling:
             - Catalog_Internals
@@ -226,6 +341,7 @@ parameters:
             - Shared
             - Import
             - Export
+            - Vendor
 
     # Inline baseline of pre-existing cross-BC violations that the cleanup
     # tickets handle in follow-ups (see ADR-0013). Three clusters:
@@ -237,6 +353,18 @@ parameters:
     #      CurrentTenantProvider into Shared\Application.
     # Every entry below is a TODO; new violations not in this list fail the
     # build through CI.
+    #
+    # AUD-053 (W3-1) burndown — the dominant cluster here is the repeated
+    # `Identity\Domain\Entity\User` leak: ~17 controllers reached for the
+    # concrete User entity just to read the authenticated principal's id /
+    # tenant off the security token. W3-1 introduced the seam
+    # `Identity\Contracts\Auth\CurrentUserProvider` and migrated the first
+    # batch off it (Backup TriggerBackupController + 4 Import controllers:
+    # ImportReportCsv, ImportThroughput, ListScheduleRuns, UpcomingSchedules),
+    # deleting their baseline entries below. The remaining User-leak
+    # controllers + the Export/Import → Catalog\Domain reaches stay baselined
+    # and are tracked as the #1466 burndown follow-up — each migrates to the
+    # same seam (User) or a Catalog Contracts seam, one controller at a time.
     skip_violations:
         App\Catalog\Application\DemoCatalogSeeder:
             - App\Asset\Domain\Entity\Asset
@@ -394,15 +522,9 @@ parameters:
             - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
             - App\Identity\Domain\Entity\User
-        App\Import\Presentation\Controller\ImportReportCsvController:
-            - App\Identity\Domain\Entity\User
         App\Import\Presentation\Controller\ImportSessionStateController:
             - App\Identity\Domain\Entity\User
-        App\Import\Presentation\Controller\ImportThroughputController:
-            - App\Identity\Domain\Entity\User
         App\Import\Presentation\Controller\ListImportSessionsController:
-            - App\Identity\Domain\Entity\User
-        App\Import\Presentation\Controller\ListScheduleRunsController:
             - App\Identity\Domain\Entity\User
         App\Import\Presentation\Controller\ParsePreviewController:
             - App\Identity\Domain\Entity\User
@@ -418,8 +540,6 @@ parameters:
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Repository\AttributeRepositoryInterface
         App\Import\Presentation\Controller\TestImportSourceConnectionController:
-            - App\Identity\Domain\Entity\User
-        App\Import\Presentation\Controller\UpcomingSchedulesController:
             - App\Identity\Domain\Entity\User
         App\Import\Presentation\Controller\ValidateDryRunController:
             - App\Catalog\Domain\Entity\ObjectType

--- a/apps/api/migrations/Version20260620120000.php
+++ b/apps/api/migrations/Version20260620120000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * AUD-078 (W3-1) — drop the orphaned `object_associations_audit` /
+ * `association_types_audit` EntityAuditBundle shadow tables.
+ *
+ * ADR-014 (Version20260524110000) dropped the dormant `object_associations`
+ * and `association_types` base tables when `object_relations` replaced them.
+ * The matching DamianBadura/EntityAuditBundle audit tables (created in
+ * Version20260430092112) were left behind: their owning entities no longer
+ * exist, no audit trigger or revision flow writes into them, and they hold
+ * zero rows. They are pure schema sludge — a confusing leftover for anyone
+ * reading `\dt`.
+ *
+ * This migration drops both. Verified before writing: both tables exist,
+ * each has 0 rows, and no trigger / trigger-function references them.
+ *
+ * Down: irreversible. The tables shadow entities that no longer exist, so
+ * recreating empty audit shells would only resurrect the same orphan state
+ * ADR-014 set out to remove — there is nothing to restore.
+ */
+final class Version20260620120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'AUD-078: drop orphaned object_associations_audit / association_types_audit shadow tables (ADR-014 leftovers).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS object_associations_audit');
+        $this->addSql('DROP TABLE IF EXISTS association_types_audit');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException(
+            'Audit shadow tables for entities removed in ADR-014 are not restored — recreating empty shells would only reintroduce the orphan state.',
+        );
+    }
+}

--- a/apps/api/src/Backup/Presentation/Controller/TriggerBackupController.php
+++ b/apps/api/src/Backup/Presentation/Controller/TriggerBackupController.php
@@ -9,7 +9,7 @@ use App\Backup\Domain\Enum\BackupTriggerAction;
 use App\Backup\Domain\Message\BackupSnapshotMessage;
 use App\Backup\Domain\Repository\BackupRepositoryInterface;
 use App\Identity\Contracts\Attribute\RequiresPermission;
-use App\Identity\Domain\Entity\User;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Shared\Application\TenantContext;
 use DateTimeInterface;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -41,6 +41,7 @@ final class TriggerBackupController
         private readonly MessageBusInterface $bus,
         private readonly RateLimiterFactoryInterface $backupTriggerLimiter,
         private readonly Security $security,
+        private readonly CurrentUserProvider $currentUser,
         private readonly TenantContext $tenantContext,
     ) {
     }
@@ -53,14 +54,14 @@ final class TriggerBackupController
     #[RequiresPermission(module: 'backup', action: 'write')]
     public function __invoke(Request $request): JsonResponse
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
+        $userId = $this->currentUser->userId();
+        $tenant = $this->currentUser->tenant();
+        if (null === $userId || null === $tenant) {
             throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
         }
         if (!$this->security->isGranted('WRITE', Backup::class)) {
             throw new AccessDeniedHttpException();
         }
-        $tenant = $user->getTenant();
         $this->tenantContext->set($tenant);
 
         $limiter = $this->backupTriggerLimiter->create($tenant->getId()->toRfc4122());
@@ -86,7 +87,7 @@ final class TriggerBackupController
         }
 
         $backup = new Backup(
-            triggeredByUserId: $user->getId(),
+            triggeredByUserId: $userId,
             triggeredByAction: $action,
         );
         $this->backups->save($backup);

--- a/apps/api/src/Identity/Application/Auth/SecurityCurrentUserProvider.php
+++ b/apps/api/src/Identity/Application/Auth/SecurityCurrentUserProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Application\Auth;
+
+use App\Identity\Contracts\Auth\CurrentUserProvider;
+use App\Identity\Domain\Entity\User;
+use App\Shared\Domain\Tenant;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-053 (W3-1) — adapter wiring the {@see CurrentUserProvider} contract to
+ * the Symfony security token. Mirrors {@see \App\Identity\Application\Policy\SecurityAttributePermissionReader}.
+ *
+ * Anonymous principals (no token / non-{@see User} principal such as an
+ * API-key) resolve to `null`, so callers keep their explicit auth guard.
+ */
+final readonly class SecurityCurrentUserProvider implements CurrentUserProvider
+{
+    public function __construct(
+        private Security $security,
+    ) {
+    }
+
+    public function userId(): ?Uuid
+    {
+        return $this->currentUser()?->getId();
+    }
+
+    public function tenant(): ?Tenant
+    {
+        return $this->currentUser()?->getTenant();
+    }
+
+    private function currentUser(): ?User
+    {
+        $user = $this->security->getUser();
+
+        return $user instanceof User ? $user : null;
+    }
+}

--- a/apps/api/src/Identity/Contracts/Auth/CurrentUserProvider.php
+++ b/apps/api/src/Identity/Contracts/Auth/CurrentUserProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Identity\Contracts\Auth;
+
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * AUD-053 (W3-1) — cross-context seam for "who is the current user".
+ *
+ * Controllers and services outside the Identity bundle repeatedly reach for
+ * {@see \App\Identity\Domain\Entity\User} just to pull the authenticated
+ * principal's id (and, less often, its tenant) off the Symfony security
+ * token — an `Identity_Internals` leak that Deptrac baselines today (see the
+ * `App\Identity\Domain\Entity\User` cluster in `deptrac.yaml`).
+ *
+ * This contract exposes the minimum surface those callers need so they can
+ * stop importing the concrete entity. The current principal comes from the
+ * security token via the adapter; callers do not pass the user explicitly —
+ * same shape as {@see \App\Identity\Contracts\Policy\AttributePermissionReader}.
+ *
+ * Both accessors return `null` for anonymous principals (no authenticated
+ * domain user). Callers that require authentication assert on the `null` and
+ * raise their own 401, exactly as the pre-seam `instanceof User` guard did.
+ *
+ * {@see Tenant} lives in `Shared` so returning it keeps the contract within
+ * the `Identity_Contracts → Shared` allowance.
+ */
+interface CurrentUserProvider
+{
+    /**
+     * The authenticated domain user's id, or `null` when the principal is
+     * anonymous / not a domain {@see \App\Identity\Domain\Entity\User}
+     * (e.g. an API-key principal or an unauthenticated request).
+     */
+    public function userId(): ?Uuid;
+
+    /**
+     * The authenticated domain user's tenant, or `null` when there is no
+     * domain user on the token.
+     */
+    public function tenant(): ?Tenant;
+}

--- a/apps/api/src/Import/Presentation/Controller/ImportReportCsvController.php
+++ b/apps/api/src/Import/Presentation/Controller/ImportReportCsvController.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\Import\Presentation\Controller;
 
 use App\Identity\Contracts\Attribute\RequiresPermission;
-use App\Identity\Domain\Entity\User;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Import\Domain\Entity\ImportSession;
 use App\Import\Domain\Enum\ImportLogLevel;
 use App\Import\Domain\Repository\ImportLogRepositoryInterface;
 use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
 use InvalidArgumentException;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -32,7 +31,7 @@ final class ImportReportCsvController
     public function __construct(
         private readonly ImportSessionRepositoryInterface $sessions,
         private readonly ImportLogRepositoryInterface $logs,
-        private readonly Security $security,
+        private readonly CurrentUserProvider $currentUser,
     ) {
     }
 
@@ -84,8 +83,8 @@ final class ImportReportCsvController
 
     private function loadOwned(string $rawId): ImportSession
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
+        $userId = $this->currentUser->userId();
+        if (null === $userId) {
             throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
         }
 
@@ -96,7 +95,7 @@ final class ImportReportCsvController
         }
 
         $session = $this->sessions->findById($id);
-        if (!$session instanceof ImportSession || $session->getUserId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+        if (!$session instanceof ImportSession || $session->getUserId()->toRfc4122() !== $userId->toRfc4122()) {
             throw new NotFoundHttpException(\sprintf('Import session "%s" was not found.', $rawId));
         }
 

--- a/apps/api/src/Import/Presentation/Controller/ImportThroughputController.php
+++ b/apps/api/src/Import/Presentation/Controller/ImportThroughputController.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace App\Import\Presentation\Controller;
 
 use App\Identity\Contracts\Attribute\RequiresPermission;
-use App\Identity\Domain\Entity\User;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Import\Application\Service\ImportThroughputCalculator;
 use DateTimeInterface;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,7 +27,7 @@ final class ImportThroughputController
 {
     public function __construct(
         private readonly ImportThroughputCalculator $calculator,
-        private readonly Security $security,
+        private readonly CurrentUserProvider $currentUser,
     ) {
     }
 
@@ -40,8 +39,9 @@ final class ImportThroughputController
     #[RequiresPermission(module: 'import_session', action: 'read')]
     public function __invoke(Request $request): JsonResponse
     {
-        $user = $this->security->getUser();
-        if (!$user instanceof User) {
+        $userId = $this->currentUser->userId();
+        $tenant = $this->currentUser->tenant();
+        if (null === $userId || null === $tenant) {
             throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
         }
 
@@ -51,8 +51,8 @@ final class ImportThroughputController
         }
 
         $snapshot = $this->calculator->calculate(
-            tenant: $user->getTenant(),
-            userId: $user->getId(),
+            tenant: $tenant,
+            userId: $userId,
             windowMin: $windowMin,
         );
 

--- a/apps/api/src/Import/Presentation/Controller/ListScheduleRunsController.php
+++ b/apps/api/src/Import/Presentation/Controller/ListScheduleRunsController.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace App\Import\Presentation\Controller;
 
 use App\Identity\Contracts\Attribute\RequiresPermission;
-use App\Identity\Domain\Entity\User;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Import\Domain\Entity\ImportSchedule;
 use App\Import\Domain\Entity\ImportScheduleRun;
 use App\Import\Domain\Repository\ImportScheduleRepositoryInterface;
 use App\Import\Domain\Repository\ImportScheduleRunRepositoryInterface;
 use DateTimeInterface;
 use InvalidArgumentException;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -36,10 +35,10 @@ final class ListScheduleRunsController
         string $id,
         ImportScheduleRepositoryInterface $schedules,
         ImportScheduleRunRepositoryInterface $runs,
-        Security $security,
+        CurrentUserProvider $currentUser,
     ): JsonResponse {
-        $user = $security->getUser();
-        if (!$user instanceof User) {
+        $userId = $currentUser->userId();
+        if (null === $userId) {
             throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
         }
         try {
@@ -51,7 +50,7 @@ final class ListScheduleRunsController
         if (!$schedule instanceof ImportSchedule) {
             throw new NotFoundHttpException(\sprintf('Import schedule "%s" was not found.', $id));
         }
-        if ($schedule->getUserId()->toRfc4122() !== $user->getId()->toRfc4122()) {
+        if ($schedule->getUserId()->toRfc4122() !== $userId->toRfc4122()) {
             throw new NotFoundHttpException(\sprintf('Import schedule "%s" was not found.', $id));
         }
 

--- a/apps/api/src/Import/Presentation/Controller/UpcomingSchedulesController.php
+++ b/apps/api/src/Import/Presentation/Controller/UpcomingSchedulesController.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\Import\Presentation\Controller;
 
 use App\Identity\Contracts\Attribute\RequiresPermission;
-use App\Identity\Domain\Entity\User;
+use App\Identity\Contracts\Auth\CurrentUserProvider;
 use App\Import\Domain\Entity\ImportSchedule;
 use App\Import\Domain\Repository\ImportScheduleRepositoryInterface;
 use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -36,10 +35,10 @@ final class UpcomingSchedulesController
     public function __invoke(
         Request $request,
         ImportScheduleRepositoryInterface $schedules,
-        Security $security,
+        CurrentUserProvider $currentUser,
     ): JsonResponse {
-        $user = $security->getUser();
-        if (!$user instanceof User) {
+        $tenant = $currentUser->tenant();
+        if (null === $tenant) {
             throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
         }
         $hours = (int) $request->query->get('hours', '24');
@@ -55,7 +54,7 @@ final class UpcomingSchedulesController
                 'priority' => $s->getPriority()->value,
                 'next_run' => $s->getNextRun()?->format(DateTimeInterface::RFC3339_EXTENDED),
             ],
-            $schedules->findUpcoming($user->getTenant(), $until),
+            $schedules->findUpcoming($tenant, $until),
         );
 
         return new JsonResponse([


### PR DESCRIPTION
## Wave 3 / W3-1 — AUD-053 + AUD-079 + AUD-078 (#1607)

### AUD-053 — Deptrac „0 violations" maskuje 286 skip + 5283 Uncovered
**Kluczowy insight:** 5283 Uncovered to first-party→**vendor** edges (4491 Symfony, 473 Doctrine, 122 ApiPlatform…), NIE leaki. **Fix:** warstwa `Vendor` (catch-all) → **Uncovered 5283→0**, unassigned 13→0. Seam `Identity\Contracts\Auth\CurrentUserProvider` (token-backed) — **5 kontrolerów** zmigrowanych z `Identity\Domain\Entity\User` (−4 baseline). Pozostały bulk Import/Export→Catalog/User (~30 + 13, część zamkniętego #1466) → **#1668** (kierunek udowodniony, wielokontrolerowy refaktor poza scope).

### AUD-079 — Backup poza gate + Search za szeroki
**Backup BC** (12 plików, 0 reguł) → `Backup_Internals`+`Backup_Contracts`; jedyny outbound User-leak naprawiony seam; inbound (ORM `ImportSession.backupSnapshot` + BackupVoter) udokumentowany, nie blanket. **Search** zawężony z całego `Identity_Internals` do jednoklasowej `Identity_TenantProvider` (tylko `CurrentTenantProvider` realnie używany), udokumentowane DLACZEGO.

### AUD-078 — sieroty schematu DB
`object_associations_audit`/`association_types_audit` (encje usunięte ADR-014, tabele audit zostały — 0 wierszy, brak triggerów) → migracja DROP, `down()` irreversible (W2-6). **Live:** drop potwierdzony na dev, `object_relations` (replacement) nienaruszony.

### Deptrac before/after
| | Before | After |
|---|---|---|
| Violations | 0 | 0 |
| Skipped | 288 | **284** (−4) |
| Uncovered | 5283 | **0** |
| Unassigned | 13 | **0** |

Baseline tylko mniejszy, zero nowych skipów/wyciszeń.

### Bramki
PHPStan max `No errors` (2G — 1G OOM quirk) · Deptrac 0 violations · php-cs-fixer clean · 25 testów (Backup/Import/Schedule) zielone · live smoke (drop + login HTTP 200).

Closes #1607
