### PR TITLE
refactor(admin): consolidate FE fetching, split detail page, dedup bulk

### DIFF
--- a/.github/workflows/quality-frontend.yml
+++ b/.github/workflows/quality-frontend.yml
@@ -37,6 +37,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  guards:
+    name: Frontend lint guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # AUD-055 — block new jsonFetch+useEffect reads (stale-data anti-pattern,
+      # ADR-0021). AUD-057 — block new admin source files growing past the
+      # max-lines threshold (ADR-0021 sibling: readability). Both are pure
+      # bash guards over apps/admin/src — no Node/pnpm needed.
+      - name: jsonFetch + useEffect guard (ADR-0021)
+        run: bash scripts/lint-jsonfetch-useeffect.sh
+
+      - name: Admin max-lines guard
+        run: bash scripts/lint-admin-max-lines.sh
+
   biome:
     name: Biome strict
     runs-on: ubuntu-latest

--- a/apps/admin/src/features/catalog/products/components/product-detail-content.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-content.tsx
@@ -1,0 +1,163 @@
+import { lazy } from 'react';
+
+import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
+import { AttrGroupCard } from './attr-group-card';
+import { AttrRow } from './attr-row';
+import {
+  countFilled,
+  GROUP_ICONS,
+  isSpecialTab,
+  resolveProvenance,
+  type TabKey,
+} from './product-detail-helpers';
+import { OtherTabs } from './product-detail-other-tabs';
+import type {
+  CatalogObjectDto,
+  GroupMeta,
+  ProductChannel,
+  ProductDetailMode,
+  ProductLocale,
+  ScopeStatus,
+} from './types';
+
+// AUD-071 (#1614) — RelationsTab renders ONLY when the operator opens it
+// (forward-relation tab-group or the reverse-only synthetic tab), so it is
+// code-split behind React.lazy + the <Suspense> boundary the page wraps
+// around <ProductDetailContent> (AUD-057).
+const RelationsTab = lazy(() =>
+  import('./relations-tab').then((m) => ({ default: m.RelationsTab })),
+);
+
+export interface ProductDetailContentProps {
+  mode: ProductDetailMode;
+  isEditMode: boolean;
+  id: string;
+  kind: string | null;
+  objectTypeId: string | null;
+  activeTab: TabKey;
+  lang: 'pl' | 'en';
+  locale: ProductLocale;
+  channel: ProductChannel | null;
+  isEditing: boolean;
+  product: CatalogObjectDto | null | undefined;
+  stackedGroups: GroupMeta[];
+  tabModeGroups: GroupMeta[];
+  scopeStatus: ScopeStatus;
+  expandedGroups: Set<string>;
+  requiredErrors: Set<string>;
+  fieldValue: (code: string) => unknown;
+  onFieldChange: (code: string, value: unknown) => void;
+  onToggleGroup: (groupId: string) => void;
+}
+
+/**
+ * AUD-057 (#1608) — the product-detail content-area tab dispatcher, lifted
+ * out of product-detail-page.tsx (which inlined it as an IIFE inside the
+ * Suspense boundary) to bring that monolith under the 500-line guard.
+ *
+ * MODR-03 (#925) — dispatch by active tab: `attributes` hosts every stacked
+ * group as inline AttrGroupCard sections; a tab-mode group code renders that
+ * single group; relations / multimedia / categories / history / variants
+ * delegate to bespoke components.
+ */
+export function ProductDetailContent({
+  mode,
+  isEditMode,
+  id,
+  kind,
+  objectTypeId,
+  activeTab,
+  lang,
+  locale,
+  channel,
+  isEditing,
+  product,
+  stackedGroups,
+  tabModeGroups,
+  scopeStatus,
+  expandedGroups,
+  requiredErrors,
+  fieldValue,
+  onFieldChange,
+  onToggleGroup,
+}: ProductDetailContentProps) {
+  const renderStackedGroup = (group: GroupMeta) => (
+    <AttrGroupCard
+      key={group.id}
+      id={group.id}
+      title={group.label[lang] ?? group.code}
+      icon={GROUP_ICONS[group.code]}
+      filledCount={countFilled(group, fieldValue)}
+      totalCount={group.attributes.length}
+      expanded={expandedGroups.has(group.id)}
+      onToggle={() => onToggleGroup(group.id)}
+      isSystem={isLegacyOptionalSystemGroupCode(group.code)}
+    >
+      {group.attributes.map((attr) => (
+        <AttrRow
+          key={attr.id}
+          attribute={attr}
+          value={fieldValue(attr.code)}
+          provenance={resolveProvenance(attr, product)}
+          locale={locale}
+          channel={channel}
+          isEditing={isEditing}
+          isLocked={attr.is_system}
+          onChange={(next) => onFieldChange(attr.code, next)}
+          createMode={mode === 'create'}
+          relationContextProductId={isEditMode ? id : undefined}
+          isInherited={
+            scopeStatus[attr.code]?.has_override === false &&
+            scopeStatus[attr.code]?.inherited_from != null
+          }
+          inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
+          requiredError={requiredErrors.has(attr.code)}
+        />
+      ))}
+    </AttrGroupCard>
+  );
+
+  if (activeTab === 'attributes') {
+    // #1357 — the non-functional "Dodaj grupę atrybutów ad-hoc" stub was
+    // removed from this view per operator request.
+    return <>{stackedGroups.map(renderStackedGroup)}</>;
+  }
+
+  // Tab-mode AttributeGroup → render only that group, with a bespoke
+  // component for relations that retains its legacy data flow (relation
+  // links endpoint). Multimedia is no longer dispatched here — UX-02 removes
+  // it from the AttributeGroup model; the conditional Multimedia tab lives as
+  // a hardcoded special tab driven by `ObjectType.hasMultimedia` (UX-06+).
+  const tabGroup = tabModeGroups.find((g) => g.code === activeTab);
+  if (tabGroup) {
+    if (tabGroup.code === 'relations') {
+      // Reverse-links UI needs a persisted object — edit only; forward
+      // relation attrs render via RelationCreateField.
+      return mode === 'edit' ? <RelationsTab productId={id} /> : renderStackedGroup(tabGroup);
+    }
+    return renderStackedGroup(tabGroup);
+  }
+
+  // MODR-06 (#928) — synthetic `relations` tab for the reverse-only case
+  // (object has no forward AttributeGroup but is pointed at from elsewhere).
+  // RelationsTab gracefully renders just the reverse panel when forward
+  // groups are empty.
+  if (activeTab === 'relations' && mode === 'edit') {
+    return <RelationsTab productId={id} />;
+  }
+
+  if (mode === 'edit' && isSpecialTab(activeTab)) {
+    return (
+      <OtherTabs
+        activeTab={activeTab}
+        productId={id}
+        objectTypeId={objectTypeId}
+        kind={kind ?? 'product'}
+        locale={locale}
+        channel={channel}
+      />
+    );
+  }
+
+  return null;
+}

--- a/apps/admin/src/features/catalog/products/components/product-detail-header.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-header.tsx
@@ -1,0 +1,380 @@
+import { ArrowLeft, MoreHorizontal, Save, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { CompletenessRing } from './completeness-ring';
+import { DuplicateButton } from './duplicate-button';
+import { LocaleChannelToolbar } from './locale-channel-toolbar';
+import { PreviewButton } from './preview-button';
+import { type TabKey, tabBadge, tabLabel } from './product-detail-helpers';
+import type {
+  CatalogObjectDto,
+  ChannelOption,
+  GroupMeta,
+  LocaleOption,
+  ProductChannel,
+  ProductDetailMode,
+  ProductLocale,
+} from './types';
+
+/**
+ * AUD-057 (#1608) — the product-detail sticky header (breadcrumb + action
+ * bar + title/identity block + completeness ring + tab strip + locale/
+ * channel toolbar), lifted out of product-detail-page.tsx to bring that
+ * monolith under the 500-line guard. Purely presentational: every value +
+ * handler is passed in, so the page keeps ownership of state and the
+ * save/delete logic.
+ */
+export interface ProductDetailHeaderProps {
+  mode: ProductDetailMode;
+  kind: string | null;
+  id: string;
+  backHref: string;
+  objectTypeLabel: string | undefined;
+  breadcrumbCategory: string;
+  skuValue: string;
+  nameValue: string;
+  brandValue: string;
+  objectTypeName: string | null;
+  product: CatalogObjectDto | null | undefined;
+  isEditing: boolean;
+  isSaving: boolean;
+  objectTypeId: string | null;
+  scopedCompletenessPct: number;
+  completenessScope: string | null;
+  lang: 'pl' | 'en';
+  visibleTabs: readonly TabKey[];
+  activeTab: TabKey;
+  groups: GroupMeta[];
+  stackedGroups: GroupMeta[];
+  locale: ProductLocale;
+  channel: ProductChannel | null;
+  locales: LocaleOption[];
+  channels: ChannelOption[];
+  onSave: (returnToList?: boolean) => void;
+  onCancel: () => void;
+  onRequestDelete: () => void;
+  onFieldChange: (code: string, value: unknown) => void;
+  onSelectTab: (tab: TabKey) => void;
+  onLocaleChange: (locale: ProductLocale) => void;
+  onChannelChange: (channel: ProductChannel | null) => void;
+}
+
+export function ProductDetailHeader({
+  mode,
+  kind,
+  id,
+  backHref,
+  objectTypeLabel,
+  breadcrumbCategory,
+  skuValue,
+  nameValue,
+  brandValue,
+  objectTypeName,
+  product,
+  isEditing,
+  isSaving,
+  objectTypeId,
+  scopedCompletenessPct,
+  completenessScope,
+  lang,
+  visibleTabs,
+  activeTab,
+  groups,
+  stackedGroups,
+  locale,
+  channel,
+  locales,
+  channels,
+  onSave,
+  onCancel,
+  onRequestDelete,
+  onFieldChange,
+  onSelectTab,
+  onLocaleChange,
+  onChannelChange,
+}: ProductDetailHeaderProps) {
+  const { t } = useTranslation();
+
+  return (
+    <header className="sticky top-0 z-20 glass-strong border-b border-zinc-100">
+      <div className="px-7 pb-3 pt-5">
+        <div className="flex items-center gap-3">
+          <Button
+            asChild
+            variant="ghost"
+            size="icon"
+            className="size-9 rounded-xl bg-white soft-shadow"
+          >
+            <Link
+              to={backHref}
+              aria-label={t('products.back', { defaultValue: 'Powrót do listy' })}
+            >
+              <ArrowLeft className="size-4" />
+            </Link>
+          </Button>
+          <div className="text-[12px] text-zinc-500">
+            <span>{objectTypeLabel ?? t('products.title', { defaultValue: 'Produkty' })}</span>
+            <span className="mx-1.5 text-zinc-300">/</span>
+            <span>{breadcrumbCategory}</span>
+            {skuValue !== '' ? (
+              <>
+                <span className="mx-1.5 text-zinc-300">/</span>
+                <span className="font-medium text-zinc-900">{skuValue}</span>
+              </>
+            ) : null}
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            {/* Preview / duplicate hit product-only endpoints. */}
+            {kind === 'product' ? <PreviewButton disabled={mode === 'create'} /> : null}
+            {kind === 'product' && mode === 'edit' && id !== '' ? (
+              <DuplicateButton productId={id} />
+            ) : null}
+            {mode === 'edit' && id !== '' ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-9 rounded-xl bg-white soft-shadow"
+                    aria-label={t('products.detail.actions.more', { defaultValue: 'Więcej' })}
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuItem
+                    onSelect={onRequestDelete}
+                    className="text-rose-600 focus:bg-rose-50 focus:text-rose-700"
+                  >
+                    <Trash2 className="mr-2 size-4" />
+                    {t('products.detail.actions.delete', { defaultValue: 'Usuń produkt' })}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-9 rounded-xl bg-white soft-shadow"
+                aria-label={t('products.detail.actions.more', { defaultValue: 'Więcej' })}
+                disabled
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+            )}
+            <span className="mx-1 h-6 w-px bg-zinc-200" />
+            {mode === 'edit' ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={onCancel}
+                disabled={isSaving}
+                className="h-9 rounded-xl px-3 text-[12.5px] text-zinc-600"
+              >
+                {t('products.detail.actions.cancel', { defaultValue: 'Anuluj' })}
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              onClick={() => onSave()}
+              disabled={isSaving || (mode === 'create' && objectTypeId === null)}
+              className="h-9 rounded-xl bg-zinc-900 px-4 text-[12.5px] font-medium text-white hover:bg-zinc-800"
+            >
+              <Save className="size-4" />
+              {mode === 'create'
+                ? kind === 'product'
+                  ? t('products.detail.actions.create', { defaultValue: 'Utwórz produkt' })
+                  : t('object_create.submit', { defaultValue: 'Utwórz' })
+                : t('products.detail.actions.save', { defaultValue: 'Zapisz zmiany' })}
+            </Button>
+            {/* #1351 — save and return to the list (edit mode only). */}
+            {mode === 'edit' ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onSave(true)}
+                disabled={isSaving}
+                className="h-9 rounded-xl px-4 text-[12.5px] font-medium"
+              >
+                <Save className="size-4" />
+                {t('products.detail.actions.save_and_return', {
+                  defaultValue: 'Zapisz i wróć do listy',
+                })}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-4 flex items-start gap-5">
+          <div
+            className="grid size-[72px] shrink-0 place-items-center rounded-2xl bg-white text-[34px] soft-shadow"
+            aria-hidden
+          >
+            ▣
+          </div>
+          <div className="min-w-0 flex-1">
+            {mode === 'create' ? (
+              <div className="space-y-2">
+                <div className="flex items-center gap-2.5 text-[12px] text-zinc-500">
+                  <Input
+                    autoFocus
+                    placeholder={t('object_create.id_placeholder', { defaultValue: 'ID' })}
+                    value={skuValue}
+                    onChange={(event) => onFieldChange('sku', event.target.value)}
+                    className="h-7 w-32 rounded-lg border-zinc-200 bg-white px-2 font-mono text-[12px]"
+                  />
+                </div>
+                <Input
+                  placeholder={
+                    kind === 'product'
+                      ? t('products.detail.create.placeholder.name', {
+                          defaultValue: 'Nazwa produktu',
+                        })
+                      : t('object_create.name_placeholder', { defaultValue: 'Nazwa' })
+                  }
+                  value={nameValue}
+                  onChange={(event) => onFieldChange('name', event.target.value)}
+                  className="font-display h-10 rounded-lg border-zinc-200 bg-white text-[20px] font-semibold tracking-tight"
+                />
+                {/* #1357 — "Marka" removed from the new-entry form. */}
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center gap-2.5 text-[12px] text-zinc-500">
+                  <span className="font-mono">{product?.code}</span>
+                  {brandValue !== '' ? (
+                    <>
+                      <span className="text-zinc-300">·</span>
+                      <span>{brandValue}</span>
+                    </>
+                  ) : null}
+                  <span className="text-zinc-300">·</span>
+                  <span className="inline-flex items-center gap-1.5">
+                    <span
+                      className={cn(
+                        'size-1.5 rounded-full',
+                        product?.enabled ? 'bg-emerald-500' : 'bg-zinc-300',
+                      )}
+                      aria-hidden
+                    />
+                    {product?.enabled
+                      ? t('products.detail.status.active', { defaultValue: 'Aktywny' })
+                      : t('products.detail.status.inactive', { defaultValue: 'Nieaktywny' })}
+                  </span>
+                </div>
+                {isEditing ? (
+                  <Input
+                    aria-label={t('products.detail.create.placeholder.name', {
+                      defaultValue: 'Nazwa produktu',
+                    })}
+                    placeholder={t('products.detail.create.placeholder.name', {
+                      defaultValue: 'Nazwa produktu',
+                    })}
+                    value={nameValue}
+                    onChange={(event) => onFieldChange('name', event.target.value)}
+                    className="font-display mt-1 h-11 rounded-lg border-zinc-200 bg-white text-[26px] font-semibold tracking-tight"
+                  />
+                ) : (
+                  <h1 className="font-display mt-1 text-[26px] font-semibold leading-tight tracking-tight">
+                    {nameValue}
+                  </h1>
+                )}
+                {objectTypeName !== null ? (
+                  <div className="mt-2.5 flex flex-wrap items-center gap-2">
+                    <span className="rounded-full bg-white px-2 py-1 text-[11px] font-medium text-zinc-700 soft-shadow">
+                      {objectTypeName}
+                    </span>
+                  </div>
+                ) : null}
+              </>
+            )}
+          </div>
+          {mode === 'edit' ? (
+            <div className="flex flex-col items-center gap-1">
+              <CompletenessRing pct={scopedCompletenessPct} size={72} stroke={6} />
+              {completenessScope !== null ? (
+                <span
+                  className="num rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-zinc-500"
+                  title={t('products.completeness.scope_tooltip', {
+                    scope: completenessScope.toUpperCase(),
+                    defaultValue: 'Kompletność dla zakresu {{scope}}',
+                  })}
+                >
+                  {completenessScope}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Tabs + locale/channel toolbar */}
+      <div className="flex items-center gap-1 border-t border-zinc-100 px-7">
+        <div
+          className="flex flex-1 items-center gap-1"
+          role="tablist"
+          aria-label={t('products.detail.tabs.aria', { defaultValue: 'Zakładki produktu' })}
+        >
+          {visibleTabs.map((tab) => {
+            const isActive = activeTab === tab;
+            const badge = tabBadge(tab, groups, stackedGroups, product);
+            return (
+              <button
+                key={tab}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => onSelectTab(tab)}
+                className={cn(
+                  'relative inline-flex h-[44px] items-center gap-2 px-3.5 text-[13px] font-medium tracking-tight',
+                  isActive ? 'text-zinc-900' : 'text-zinc-500 hover:text-zinc-800',
+                )}
+              >
+                {tabLabel(tab, groups, lang, t)}
+                {badge !== null ? (
+                  <span
+                    className={cn(
+                      'num rounded px-1.5 py-0.5 text-[10.5px]',
+                      isActive ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-500',
+                    )}
+                  >
+                    {badge}
+                  </span>
+                ) : null}
+                {isActive ? (
+                  <span
+                    className="absolute -bottom-px left-0 right-0 h-[2px] rounded-t bg-zinc-900"
+                    aria-hidden
+                  />
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        {mode === 'edit' ? (
+          <LocaleChannelToolbar
+            locale={locale}
+            channel={channel}
+            onLocaleChange={onLocaleChange}
+            onChannelChange={onChannelChange}
+            locales={locales}
+            channels={channels}
+          />
+        ) : null}
+      </div>
+    </header>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/product-detail-helpers.ts
+++ b/apps/admin/src/features/catalog/products/components/product-detail-helpers.ts
@@ -1,0 +1,174 @@
+import type { Provenance } from '@/components/provenance-badge';
+import type { AttributeMeta, CatalogObjectDto, GroupMeta } from './types';
+
+/**
+ * AUD-057 (#1608) — pure helpers + tab constants extracted out of
+ * product-detail-page.tsx to bring that monolith under the 500-line
+ * guard. Nothing here touches React or component state, so the page is a
+ * thin consumer; the heavy interplay stays in the page + the data hook.
+ */
+
+export const SPECIAL_TABS = [
+  'attributes',
+  'multimedia',
+  'categories',
+  'history',
+  'variants',
+] as const;
+export type SpecialTabKey = (typeof SPECIAL_TABS)[number];
+export type TabKey = SpecialTabKey | string;
+
+export const GROUP_ICONS: Record<string, string> = {
+  identification: '🔑',
+  identyfikacja: '🔑',
+  marketing: '✨',
+  technical: '⚙',
+  technicals: '⚙',
+  specyfikacje: '⚙',
+  logistics: '📦',
+  logistyka: '📦',
+  pricing: '💰',
+  cennik: '💰',
+  audit: '🛡',
+  audyt: '🛡',
+};
+
+const SPECIAL_TAB_DEFAULT_LABELS: Record<SpecialTabKey, string> = {
+  attributes: 'Atrybuty',
+  multimedia: 'Multimedia',
+  categories: 'Kategorie',
+  history: 'Historia',
+  variants: 'Warianty',
+};
+
+export function isSpecialTab(tab: TabKey): tab is SpecialTabKey {
+  return (SPECIAL_TABS as readonly string[]).includes(tab);
+}
+
+export function tabLabel(
+  tab: TabKey,
+  groups: GroupMeta[],
+  lang: 'pl' | 'en',
+  t: (key: string, options?: { defaultValue?: string }) => string,
+): string {
+  if (isSpecialTab(tab)) {
+    return t(`products.detail.tabs.${tab}`, {
+      defaultValue: SPECIAL_TAB_DEFAULT_LABELS[tab],
+    });
+  }
+  const group = groups.find((g) => g.code === tab);
+  if (!group) return tab;
+  const i18nKey = `products.detail.tabs.group_${group.code}`;
+  const fallback = group.label[lang] ?? group.code;
+  return t(i18nKey, { defaultValue: fallback });
+}
+
+export function tabBadge(
+  tab: TabKey,
+  groups: GroupMeta[],
+  stackedGroups: GroupMeta[],
+  product: CatalogObjectDto | null | undefined,
+): number | null {
+  if (tab === 'attributes') {
+    return stackedGroups.length === 0 ? null : stackedGroups.length;
+  }
+  if (tab === 'categories') return null;
+  if (tab === 'history') return null;
+  if (tab === 'variants') {
+    const count = (product?.attributesIndexed as { variantsCount?: number } | undefined)
+      ?.variantsCount;
+    return typeof count === 'number' ? count : null;
+  }
+  // Tab-mode AttributeGroup → badge shows the attribute count when > 0.
+  const group = groups.find((g) => g.code === tab);
+  if (!group) return null;
+  return group.attributes.length === 0 ? null : group.attributes.length;
+}
+
+/**
+ * #1350 — mirrors the upserter's isEmptyEnvelope: null / '' (after trim) /
+ * empty arrays-objects count as empty; booleans and zeros are values.
+ */
+export function isEmptyAttributeValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string') return value.trim() === '';
+  if (Array.isArray(value)) return value.every(isEmptyAttributeValue);
+  if (typeof value === 'object') {
+    const leaves = Object.values(value as Record<string, unknown>);
+    return leaves.length === 0 || leaves.every(isEmptyAttributeValue);
+  }
+  return false;
+}
+
+/**
+ * #1102/#1415 — relation attribute codes across the effective groups;
+ * their create-mode values go through PUT /relations, not the POST body.
+ */
+export function collectRelationCodes(groups: GroupMeta[]): Set<string> {
+  const codes = new Set<string>();
+  for (const group of groups) {
+    for (const attr of group.attributes) {
+      if (attr.type === 'relation') codes.add(attr.code);
+    }
+  }
+  return codes;
+}
+
+export function splitDirtyAttributes(
+  dirty: Record<string, unknown>,
+  relationCodes: Set<string>,
+): { normal: Record<string, unknown>; relations: Record<string, string[]> } {
+  const normal: Record<string, unknown> = {};
+  const relations: Record<string, string[]> = {};
+  for (const [key, value] of Object.entries(dirty)) {
+    if (relationCodes.has(key)) {
+      relations[key] = toRelationIdList(value);
+      continue;
+    }
+    normal[key] = value;
+  }
+  return { normal, relations };
+}
+
+export function toRelationIdList(value: unknown): string[] {
+  if (typeof value === 'string' && value !== '') return [value];
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is string => typeof entry === 'string' && entry !== '');
+  }
+  return [];
+}
+
+export function stripAttributes(dirty: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(dirty)) {
+    if (k === 'sku' || k === 'code') continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+export function countFilled(group: GroupMeta, fieldValue: (code: string) => unknown): number {
+  let filled = 0;
+  for (const attr of group.attributes) {
+    const value = fieldValue(attr.code);
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'string' && value.trim() === '') continue;
+    filled += 1;
+  }
+  return filled;
+}
+
+export function resolveProvenance(
+  attr: AttributeMeta,
+  product: CatalogObjectDto | null | undefined,
+): Provenance {
+  if (attr.is_system) return 'integration';
+  const indexed = product?.attributesIndexed as
+    | Record<string, { provenance?: Provenance }>
+    | undefined;
+  const meta = indexed?.[attr.code];
+  if (meta && typeof meta === 'object' && typeof meta.provenance === 'string') {
+    return meta.provenance;
+  }
+  return 'manual';
+}

--- a/apps/admin/src/features/catalog/products/components/product-detail-other-tabs.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-other-tabs.tsx
@@ -1,0 +1,135 @@
+import { Clock, Link2, Sparkles } from 'lucide-react';
+import { lazy } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { MockBadge } from '@/components/ui/mock-badge';
+import type { ProductChannel, ProductLocale } from './types';
+
+/**
+ * AUD-057 (#1608) — the bespoke special-tab views (multimedia / categories
+ * / variants) + the loading fallback + the history stub, extracted from
+ * product-detail-page.tsx to shrink that monolith under the 500-line guard.
+ *
+ * AUD-071 (#1614) — these tabs render ONLY after the operator clicks them,
+ * so each is code-split behind React.lazy; the chunk loads on demand behind
+ * the <Suspense> boundary the page wraps around <OtherTabs>. RelationsTab
+ * stays in the page itself — it is also reached from the main tab dispatcher
+ * (forward-relation + reverse-only paths), not just here.
+ */
+const CategoriesTab = lazy(() =>
+  import('./categories-tab').then((m) => ({ default: m.CategoriesTab })),
+);
+const ProductMultimediaTab = lazy(() =>
+  import('./product-multimedia-tab').then((m) => ({ default: m.ProductMultimediaTab })),
+);
+const VariantsTabHost = lazy(() =>
+  import('./variants-tab-host').then((m) => ({ default: m.VariantsTabHost })),
+);
+
+export function OtherTabs({
+  activeTab,
+  productId,
+  objectTypeId,
+  kind,
+  locale,
+  channel,
+}: {
+  activeTab: 'multimedia' | 'categories' | 'history' | 'variants' | 'attributes';
+  productId: string;
+  objectTypeId: string | null;
+  kind: string;
+  locale: ProductLocale;
+  channel: ProductChannel | null;
+}) {
+  // UX bug fix #2 — Multimedia is back as a special tab gated by
+  // `ObjectType.hasMultimedia` (UX-02 removed it from the AttributeGroup
+  // dispatcher); the assets link table is poly-kind so the tab works
+  // for every ObjectType.
+  if (activeTab === 'multimedia') return <ProductMultimediaTab productId={productId} />;
+  if (activeTab === 'categories')
+    return <CategoriesTab productId={productId} objectTypeId={objectTypeId} kind={kind} />;
+  if (activeTab === 'history') return <HistoryStub />;
+  if (activeTab === 'variants')
+    return (
+      <VariantsTabHost
+        productId={productId}
+        basePath="/api/objects"
+        locale={locale}
+        channel={channel}
+      />
+    );
+  return null;
+}
+
+/**
+ * AUD-071 (#1614) — discreet fallback while a lazy tab chunk loads. The
+ * tab chunks are small (a few tens of KB gzip) so this flashes only on a
+ * cold cache; it intentionally mirrors the muted card surface of the real
+ * tabs to avoid a jarring layout shift.
+ */
+export function TabLoadingFallback() {
+  const { t } = useTranslation();
+  return (
+    <div
+      className="rounded-2xl border border-line bg-surface p-5 text-[12.5px] text-muted-foreground soft-shadow"
+      role="status"
+      aria-live="polite"
+    >
+      {t('products.detail.tabs.loading', { defaultValue: 'Ładowanie…' })}
+    </div>
+  );
+}
+
+function HistoryStub() {
+  const events = [
+    {
+      who: 'Marcin Lipiec',
+      when: '5 min temu',
+      what: 'Zmieniono description.pl',
+      tone: 'bg-orange-500/10 text-orange-700',
+    },
+    {
+      who: 'agent.sonnet',
+      when: '2 godz. temu',
+      what: 'Wzbogacono kod HS (taryfa UE 2026)',
+      tone: 'bg-accent-emerald/10 text-accent-emerald',
+    },
+    {
+      who: 'Anna Wiśniewska',
+      when: 'wczoraj',
+      what: 'Dodano 3 zdjęcia produktu',
+      tone: 'bg-accent-blue/10 text-accent-blue',
+    },
+  ];
+
+  return (
+    <MockBadge variant="overlay" tooltip="MOCK · Pełna timeline wymaga endpointu audit-log">
+      <div className="rounded-2xl border border-line bg-surface p-5 soft-shadow">
+        <header className="mb-4 flex items-center gap-2">
+          <Sparkles className="size-4 text-muted-foreground" />
+          <h3 className="text-[14px] font-semibold text-ink">Historia zmian</h3>
+        </header>
+        <ol className="relative space-y-4 border-l border-line pl-6">
+          {events.map((event) => (
+            <li key={`${event.who}-${event.when}`} className="relative">
+              <span
+                className={`absolute -left-[31px] flex size-5 items-center justify-center rounded-full ring-2 ring-background ${event.tone}`}
+              >
+                <Clock className="size-2.5" />
+              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-[13px] font-medium text-ink">{event.who}</span>
+                <span className="text-[11px] text-muted-foreground">{event.when}</span>
+              </div>
+              <p className="mt-0.5 text-[12.5px] text-ink-2">{event.what}</p>
+            </li>
+          ))}
+        </ol>
+        <div className="mt-3 flex items-center gap-2 text-[11px] text-muted-foreground">
+          <Link2 className="size-3" />
+          Sidebar pokazuje 5 ostatnich; pełna paginowana historia czeka na endpoint.
+        </div>
+      </div>
+    </MockBadge>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -1,101 +1,20 @@
-import { useQuery } from '@tanstack/react-query';
-import { ArrowLeft, Clock, Link2, MoreHorizontal, Save, Sparkles, Trash2 } from 'lucide-react';
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate, useSearchParams } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 
 import { DetailLoadingState } from '@/components/catalog/detail-loading-state';
 import { DetailNotFoundState } from '@/components/catalog/detail-not-found-state';
-import type { Provenance } from '@/components/provenance-badge';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
-import { MockBadge } from '@/components/ui/mock-badge';
-import { toast } from '@/components/ui/toast';
-import { useListSchema } from '@/hooks/use-list-schema';
-import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
-import { HttpError, httpErrorDetail, jsonFetch } from '@/lib/http';
-import { isLegacyOptionalSystemGroupCode } from '@/lib/legacy-attribute-groups';
-import { objectKeys } from '@/lib/object-query-keys';
-import { cn } from '@/lib/utils';
-import { useDefaultObjectType } from '../use-default-object-type';
-import { AgentSuggestionsCard } from './agent-suggestions-card';
-import { AttrGroupCard } from './attr-group-card';
-import { AttrRow } from './attr-row';
-import { CategorySelectorCard } from './category-selector-card';
-import { CompletenessRing } from './completeness-ring';
-import { DuplicateButton } from './duplicate-button';
-import { EffectiveModelCard } from './effective-model-card';
-
-import { LocaleChannelToolbar } from './locale-channel-toolbar';
-import { PreviewButton } from './preview-button';
-import { scopedCompleteness, scopeQuery } from './scope';
-import { SyncStatusCard } from './sync-status-card';
-import type {
-  AttributeMeta,
-  CatalogObjectDto,
-  ChannelOption,
-  GroupMeta,
-  LocaleOption,
-  ProductChannel,
-  ProductDetailMode,
-  ProductLocale,
-  ScopeStatus,
-} from './types';
-import { VariantsListCard } from './variants-list-card';
-
-// AUD-071 (#1614) — the four bespoke tab views below are rendered ONLY
-// after the operator clicks their tab (multimedia / categories / variants /
-// relations). Statically importing them pinned ~1.7k lines of grids +
-// editors (incl. the heavy VariantsTab) into the main detail chunk, pushing
-// product-detail-page over the 700 KB warning threshold. Code-split each
-// behind React.lazy so the initial detail render only ships the attributes
-// view; the tab chunk loads on demand behind the <Suspense> boundary in the
-// content dispatcher.
-const CategoriesTab = lazy(() =>
-  import('./categories-tab').then((m) => ({ default: m.CategoriesTab })),
-);
-const ProductMultimediaTab = lazy(() =>
-  import('./product-multimedia-tab').then((m) => ({ default: m.ProductMultimediaTab })),
-);
-const RelationsTab = lazy(() =>
-  import('./relations-tab').then((m) => ({ default: m.RelationsTab })),
-);
-const VariantsTabHost = lazy(() =>
-  import('./variants-tab-host').then((m) => ({ default: m.VariantsTabHost })),
-);
-
-/**
- * MODR-03 (#925) — special-purpose tabs that are NOT driven by
- * `effectiveGroups`. `attributes` hosts every `display_mode='stacked'`
- * group as inline sections; the rest are bespoke views (categories
- * picker, audit log, variants tree). Tab-mode groups become tabs
- * dynamically — see `useDynamicTabs`.
- */
-const SPECIAL_TABS = ['attributes', 'multimedia', 'categories', 'history', 'variants'] as const;
-type SpecialTabKey = (typeof SPECIAL_TABS)[number];
-type TabKey = SpecialTabKey | string;
-
-const GROUP_ICONS: Record<string, string> = {
-  identification: '🔑',
-  identyfikacja: '🔑',
-  marketing: '✨',
-  technical: '⚙',
-  technicals: '⚙',
-  specyfikacje: '⚙',
-  logistics: '📦',
-  logistyka: '📦',
-  pricing: '💰',
-  cennik: '💰',
-  audit: '🛡',
-  audyt: '🛡',
-};
+import { ProductDetailContent } from './product-detail-content';
+import { ProductDetailHeader } from './product-detail-header';
+import type { TabKey } from './product-detail-helpers';
+import { TabLoadingFallback } from './product-detail-other-tabs';
+import { ProductDetailSidebar } from './product-detail-sidebar';
+import { scopedCompleteness } from './scope';
+import type { ProductChannel, ProductDetailMode, ProductLocale } from './types';
+import { useProductDetailData } from './use-product-detail-data';
+import { useProductDetailForm } from './use-product-detail-form';
 
 export interface ProductDetailPageProps {
   mode: ProductDetailMode;
@@ -176,57 +95,12 @@ export function ProductDetailPage({
   const [locale, setLocale] = useState<ProductLocale>('pl');
   const [channel, setChannel] = useState<ProductChannel | null>(null);
 
-  // #1150 / #1155 — load the product in the active locale + channel so
-  // localizable / channel-scoped values reflect the picker. Replaces
-  // Refine's useOne (its getOne drops the query string); locale + channel
-  // are part of the query key, so switching either refetches the
-  // scope-resolved reading.
-  const productQuery = useQuery<CatalogObjectDto>({
-    queryKey: objectKeys.scoped(id, locale, channel),
-    queryFn: () =>
-      jsonFetch<CatalogObjectDto>(`/api/objects/${id}${scopeQuery(locale, channel)}`, {
-        accept: 'application/ld+json',
-      }),
-    enabled: isEditMode && id !== '',
-    // A 404 is conclusive — retrying it three times keeps the operator on
-    // "Ładowanie…" for ~8s before the not-found state appears (#1043).
-    retry: (failureCount, error) =>
-      !(error instanceof HttpError && error.status === 404) && failureCount < 3,
-  });
-
-  const { objectTypeId: defaultProductTypeId } = useDefaultObjectType('product');
-  const loadedProduct = isEditMode ? (productQuery.data ?? null) : null;
-  // Edit mode reads capabilities from the object's OWN ObjectType (any
-  // kind); create mode takes the route-resolved ObjectType (#1415) and
-  // falls back to the built-in product for /products/new.
-  const objectTypeId = isEditMode
-    ? (loadedProduct?.objectType?.id ?? null)
-    : (createObjectTypeId ?? defaultProductTypeId);
-  // UX bug fix #2 — UX-02 removed the legacy 'media' AttributeGroup
-  // (operator decision: Multimedia is a capability, not an attribute
-  // group). Capability flags follow list-schema so the tab set matches
-  // what modeling advertises — for every kind, not just products.
-  const schemaQuery = useListSchema(objectTypeId ?? undefined);
-  const schemaObjectType = schemaQuery.data?.objectType;
-  const kind = isEditMode
-    ? (loadedProduct?.kind ?? null)
-    : (schemaObjectType?.kind ?? (createObjectTypeId === undefined ? 'product' : null));
-  const hasMultimediaCapability = schemaObjectType?.has_multimedia ?? false;
-  const hasVariantsCapability = schemaObjectType?.has_variants ?? kind === 'product';
-  const isCategorizable = schemaObjectType?.is_categorizable ?? kind === 'product';
-
   const [activeTab, setActiveTab] = useState<TabKey>('attributes');
   // #1351 — the detail page opens directly in edit mode; there is no
   // read-only state anymore. "Zapisz zmiany" is always visible and a
   // "Zapisz i wróć do listy" action saves + returns to the list.
   const isEditing = true;
-  const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
-  // #1350 — codes of required attributes that blocked the last save.
-  const [requiredErrors, setRequiredErrors] = useState<Set<string>>(new Set());
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-  const [isSaving, setIsSaving] = useState<boolean>(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
-  const [isDeleting, setIsDeleting] = useState<boolean>(false);
 
   // #891 create-mode category selection. POST `/api/products` carries
   // this so the product + assignments land atomically — the previous
@@ -238,107 +112,76 @@ export function ProductDetailPage({
     () => prePopulatedPrimaryId,
   );
 
-  // Resolve the category codes for chip rendering in create mode. Same
-  // query key as `CategoryPickerDialog` so opening the picker hits the
-  // shared cache — and so the sidebar updates the moment the picker
-  // commits a new selection.
-  const categoriesListQuery = useQuery({
-    queryKey: ['categories', 'picker'],
-    queryFn: () =>
-      jsonFetch<{
-        'hydra:member'?: Array<{ id: string; code: string }>;
-        member?: Array<{ id: string; code: string }>;
-      }>('/api/categories?itemsPerPage=200'),
-    enabled: mode === 'create' && createCategoryIds.length > 0,
-    staleTime: 60_000,
+  // AUD-057 (#1608) — every server read + the values derived purely from
+  // it live in this hook (see use-product-detail-data.ts). The page keeps
+  // the UI state (locale/channel/tabs/dirty fields) and the write path.
+  const {
+    productQuery,
+    product,
+    objectTypeId,
+    kind,
+    hasMultimediaCapability,
+    hasVariantsCapability,
+    isCategorizable,
+    attrs,
+    groupsQuery,
+    groups,
+    locales,
+    channels,
+    scopeStatus,
+    tabModeGroups,
+    stackedGroups,
+    hasReverseRelations,
+    createCategoriesSummaries,
+  } = useProductDetailData({
+    mode,
+    id,
+    isEditMode,
+    createObjectTypeId,
+    locale,
+    channel,
+    createCategoryIds,
+    createPrimaryId,
   });
 
-  const createCategoriesSummaries = useMemo(() => {
-    if (mode !== 'create') return [] as { categoryId: string; code: string; isPrimary: boolean }[];
-    const rows =
-      categoriesListQuery.data?.['hydra:member'] ?? categoriesListQuery.data?.member ?? [];
-    const codeById = new Map<string, string>();
-    for (const row of rows) codeById.set(row.id, row.code);
-    return createCategoryIds.map((cid) => ({
-      categoryId: cid,
-      code: codeById.get(cid) ?? cid.slice(0, 8),
-      isPrimary: cid === createPrimaryId,
-    }));
-  }, [mode, createCategoryIds, createPrimaryId, categoriesListQuery.data]);
-
-  const product = loadedProduct;
-  const attrs = useMemo(
-    () =>
-      unwrapAttributesIndexed(product?.attributesIndexed as Record<string, unknown> | undefined),
-    [product?.attributesIndexed],
-  );
-
-  // #891 — fetch effective groups via useQuery so CategoriesTab cache
-  // invalidation actually triggers refetch (the previous useEffect was
-  // immune to invalidation). In create mode the query keys flip between
-  // the preview endpoint (when categories are selected) and the bare
-  // ObjectType endpoint (when none are selected yet).
-  const groupsQuery = useQuery<{ groups: GroupMeta[]; locales?: LocaleOption[] }>({
-    queryKey:
-      isEditMode && id !== ''
-        ? objectKeys.effectiveGroups(id)
-        : [
-            'object-types',
-            objectTypeId,
-            'effective-attribute-groups',
-            createCategoryIds.length > 0 ? [...createCategoryIds].sort() : 'base',
-          ],
-    queryFn: async () => {
-      if (isEditMode && id !== '') {
-        return jsonFetch<{ groups: GroupMeta[]; locales?: LocaleOption[] }>(
-          `/api/objects/${id}/effective-attribute-groups`,
-        );
-      }
-      if (objectTypeId === null) {
-        return { groups: [] };
-      }
-      // #1415 — there is no GET for OT-level effective groups; the
-      // preview POST serves both the bare schema (empty categoryIds)
-      // and the category-driven overlay.
-      return jsonFetch<{ groups: GroupMeta[]; locales?: LocaleOption[] }>(
-        `/api/object_types/${objectTypeId}/effective-attribute-groups/preview`,
-        {
-          method: 'POST',
-          contentType: 'application/json',
-          accept: 'application/json',
-          body: { categoryIds: createCategoryIds },
-        },
-      );
-    },
-    enabled: isEditMode ? id !== '' : objectTypeId !== null,
-    staleTime: 5_000,
-    placeholderData: (prev) => prev,
+  // AUD-057 (#1608) — dirty buffer + required-field validation + the
+  // create/edit save, cancel and delete mutations live in this hook.
+  const {
+    dirtyFields,
+    requiredErrors,
+    expandedGroups,
+    isSaving,
+    isDeleting,
+    setFieldValue,
+    fieldValue,
+    toggleGroup,
+    setExpandedAll,
+    resetDirty,
+    handleSave,
+    cancelEdit,
+    handleDelete,
+  } = useProductDetailForm({
+    mode,
+    id,
+    isEditMode,
+    kind,
+    objectTypeId,
+    isCategorizable,
+    locale,
+    channel,
+    groups,
+    attrs,
+    product,
+    productQuery,
+    createCategoryIds,
+    createPrimaryId,
+    backHref,
+    detailPathFor,
   });
 
-  // Empty groups (no attributes after field-level filtering) render as
-  // bare headers with zero rows — drop them, consistent with #1348's
-  // "no empty Atrybuty tab" rule.
-  // #1415 — the header already carries a dedicated input for the `name`
-  // attribute; the duplicated group row confused operators (two inputs,
-  // one storage), so it is hidden from every group.
-  const groups = useMemo(
-    () =>
-      (groupsQuery.data?.groups ?? [])
-        .map((g) => ({
-          ...g,
-          attributes: g.attributes.filter((attr) => attr.code !== 'name'),
-        }))
-        .filter((g) => g.attributes.length > 0),
-    [groupsQuery.data],
-  );
-
-  // #1149 — the locale picker is fed from the tenant's real enabled locales
-  // (shipped by effective-attribute-groups). Default the selection to the
-  // tenant default once, then respect manual switches.
-  const locales = useMemo<LocaleOption[]>(
-    () => groupsQuery.data?.locales ?? [],
-    [groupsQuery.data],
-  );
+  // #1149 — default the locale selection to the tenant default once the
+  // enabled-locale list arrives (shipped by effective-attribute-groups),
+  // then respect manual switches.
   const [didInitLocale, setDidInitLocale] = useState(false);
   useEffect(() => {
     if (didInitLocale || locales.length === 0) return;
@@ -348,76 +191,19 @@ export function ProductDetailPage({
     setDidInitLocale(true);
   }, [locales, didInitLocale]);
 
-  // #1155 — channel picker fed from /api/channels (tenant's real channels).
-  const channelsQuery = useQuery<ChannelOption[]>({
-    queryKey: ['channels', 'picker'],
-    queryFn: async () => {
-      const response = await jsonFetch<{ member?: ChannelOption[] } | ChannelOption[]>(
-        '/api/channels',
-        { accept: 'application/ld+json' },
-      );
-      return Array.isArray(response) ? response : (response.member ?? []);
-    },
-    enabled: isEditMode,
-    staleTime: 60_000,
-  });
-  const channels = channelsQuery.data ?? [];
-
-  // #1222 — scope-status: per-attribute inherited indicator.
-  // Only fetched in edit mode (detail page), not in create mode.
-  // Enabled only when a non-primary locale is active (primary locale
-  // values are global — nothing can be "inherited from another locale").
-  const scopeStatusQuery = useQuery<ScopeStatus>({
-    queryKey: objectKeys.scopeStatus(id, locale, channel),
-    queryFn: () =>
-      jsonFetch<ScopeStatus>(`/api/objects/${id}/scope-status${scopeQuery(locale, channel)}`),
-    enabled: isEditMode && id !== '' && locale !== null,
-    staleTime: 30_000,
-  });
-  const scopeStatus = scopeStatusQuery.data ?? {};
-
   // #1150 / #1155 — switching locale or channel discards unsaved edits so an
   // edit is never written to the wrong scope; the operator saves first.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — reset on scope change
   useEffect(() => {
-    setDirtyFields({});
+    resetDirty();
   }, [locale, channel]);
 
-  // MODR-03 (#925) — tab list derived dynamically from `groups`:
-  // every group with `display_mode='tab'` becomes its own tab; groups
-  // with `display_mode='stacked'` (and the synthetic "default" bucket)
-  // collect into the single `attributes` tab. Hooks must live above
-  // the loading early-return below to obey rules-of-hooks.
-  const tabModeGroups = useMemo(
-    () => groups.filter((g) => (g.display_mode ?? 'tab') === 'tab'),
-    [groups],
-  );
-  const stackedGroups = useMemo(
-    () => groups.filter((g) => (g.display_mode ?? 'tab') === 'stacked'),
-    [groups],
-  );
-
-  // MODR-06 (#928) — lightweight probe for incoming links so the
-  // "Powiązania" tab can surface even when the object has no forward
-  // relation attributes (e.g. a Category referenced from products).
-  const reverseRelationsQuery = useQuery<{ hasReverse: boolean; count: number }>({
-    queryKey: ['objects', id, 'relations', 'reverse', 'count'],
-    queryFn: () =>
-      jsonFetch<{ hasReverse: boolean; count: number }>(
-        `/api/objects/${id}/relations/reverse/count`,
-      ),
-    enabled: isEditMode && id !== '',
-    staleTime: 30_000,
-  });
-  const hasReverseRelations = reverseRelationsQuery.data?.hasReverse ?? false;
-  // Issue #1092 — forward relation attributes are normal attributes
-  // now: they render inline through their natural group placement
-  // (stacked-mode group → inline in the `attributes` tab; tab-mode
-  // group → its own dedicated tab via `tabModeGroups`). The synthetic
-  // `relations` tab only survives for the reverse-only case (object is
-  // pointed at from elsewhere but has no forward relation attribute of
-  // its own) — that path still needs the bespoke `RelationsTab` because
-  // `effective-attribute-groups` has no concept of "incoming links".
+  // Issue #1092 — forward relation attributes render inline via their
+  // natural group placement; the synthetic `relations` tab survives only
+  // for the reverse-only case (object pointed at from elsewhere but with
+  // no forward relation attribute of its own), which still needs the
+  // bespoke `RelationsTab` (effective-attribute-groups has no concept of
+  // "incoming links").
   const shouldSurfaceRelationsTab = hasReverseRelations;
 
   const visibleTabs: readonly TabKey[] = useMemo(() => {
@@ -488,230 +274,9 @@ export function ProductDetailPage({
   useEffect(() => {
     if (didExpandInitial) return;
     if (groups.length === 0) return;
-    setExpandedGroups(new Set(groups.map((g) => g.id)));
+    setExpandedAll(groups.map((g) => g.id));
     setDidExpandInitial(true);
-  }, [didExpandInitial, groups]);
-
-  const toggleGroup = (groupId: string): void => {
-    setExpandedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(groupId)) next.delete(groupId);
-      else next.add(groupId);
-      return next;
-    });
-  };
-
-  const setFieldValue = (code: string, value: unknown): void => {
-    setDirtyFields((prev) => ({ ...prev, [code]: value }));
-    setRequiredErrors((prev) => {
-      if (!prev.has(code)) return prev;
-      const next = new Set(prev);
-      next.delete(code);
-      return next;
-    });
-  };
-
-  const fieldValue = (code: string): unknown => {
-    if (Object.hasOwn(dirtyFields, code)) {
-      return dirtyFields[code];
-    }
-    return attrs[code];
-  };
-
-  // #1350 — full-state required check at save time: every `is_required`
-  // attribute across the effective groups must carry a non-empty CURRENT
-  // value (dirty edits included). Legacy dirty records are therefore
-  // enforced on their next save, exactly as the ticket specifies.
-  const collectRequiredViolations = (): string[] => {
-    const violations: string[] = [];
-    for (const group of groups) {
-      for (const attr of group.attributes) {
-        if (attr.is_required !== true) continue;
-        // #1350 (reopen #2) — requiredness is meaningless for booleans:
-        // an unchecked box IS the value `false`, not a missing value.
-        // Operator decision: a required boolean always passes.
-        if (attr.type === 'boolean') continue;
-        const current = fieldValue(attr.code);
-        if (isEmptyAttributeValue(current)) violations.push(attr.code);
-      }
-    }
-    return violations;
-  };
-
-  const handleSave = async (returnToList = false): Promise<void> => {
-    if (isSaving) return;
-    const violations = collectRequiredViolations();
-    if (violations.length > 0) {
-      setRequiredErrors(new Set(violations));
-      toast.error(
-        t('products.detail.validation.required_fields', {
-          defaultValue: 'Uzupełnij wymagane pola: {{fields}}',
-          fields: violations.join(', '),
-        }),
-      );
-      return;
-    }
-    setRequiredErrors(new Set());
-    setIsSaving(true);
-    try {
-      if (mode === 'create') {
-        const skuRaw = dirtyFields.sku ?? dirtyFields.code ?? '';
-        const sku = typeof skuRaw === 'string' ? skuRaw.trim() : '';
-        if (sku === '') {
-          // #1415 — the system identifier is labelled "ID" for every
-          // ObjectType (operator decision); custom identifiers live as
-          // ordinary attributes.
-          toast.error(t('object_create.id_required', { defaultValue: 'ID jest wymagane' }));
-          setIsSaving(false);
-          return;
-        }
-        if (objectTypeId === null) {
-          toast.error(
-            t('products.detail.validation.object_type_missing', {
-              defaultValue: 'Brak built-in ObjectType — uruchom seeder katalogu',
-            }),
-          );
-          setIsSaving(false);
-          return;
-        }
-        // #891 / #1359 — categorizable kinds require a category at create.
-        if (isCategorizable && createCategoryIds.length === 0) {
-          toast.error(
-            t('products.detail.validation.categories_required', {
-              defaultValue: 'Przypisz przynajmniej jedną kategorię',
-            }),
-          );
-          setIsSaving(false);
-          return;
-        }
-        // #1102 — relation values cannot ride the create POST (they live
-        // in the relations link table, not object_values); split them out
-        // and PUT after the object exists, like UniversalCreatePage did.
-        const relationCodes = collectRelationCodes(groups);
-        const { normal: attributes, relations } = splitDirtyAttributes(
-          stripAttributes(dirtyFields),
-          relationCodes,
-        );
-        const body: Record<string, unknown> = {
-          code: sku,
-          objectTypeId,
-        };
-        if (createCategoryIds.length > 0) {
-          const primary =
-            createPrimaryId !== null && createCategoryIds.includes(createPrimaryId)
-              ? createPrimaryId
-              : createCategoryIds[0];
-          body.categoryIds = createCategoryIds;
-          body.primaryCategoryId = primary;
-        }
-        if (Object.keys(attributes).length > 0) body.attributes = attributes;
-        // #1415 — poly-kind create: same processor as the /api/products
-        // sugar path, kind comes from objectTypeId.
-        const created = await jsonFetch<{ id: string }>('/api/objects', {
-          method: 'POST',
-          contentType: 'application/ld+json',
-          body,
-        });
-
-        const relationFailures: string[] = [];
-        for (const [attrCode, targets] of Object.entries(relations)) {
-          if (targets.length === 0) continue;
-          try {
-            await jsonFetch(`/api/objects/${created.id}/relations/${attrCode}`, {
-              method: 'PUT',
-              contentType: 'application/json',
-              body: { targets: targets.map((targetId) => ({ id: targetId })) },
-            });
-          } catch {
-            relationFailures.push(attrCode);
-          }
-        }
-        if (relationFailures.length > 0) {
-          toast.error(
-            t('object_create.relations_partial_error', {
-              defaultValue: 'Obiekt utworzony, ale relacje nie zapisane: {{codes}}',
-              codes: relationFailures.join(', '),
-            }),
-          );
-        } else {
-          toast.success(
-            kind === 'product'
-              ? t('products.detail.create.success', {
-                  defaultValue: 'Utworzono produkt {{code}}',
-                  code: sku,
-                })
-              : t('object_create.success', { defaultValue: 'Utworzono {{code}}', code: sku }),
-          );
-        }
-        navigate(detailPathFor(created.id));
-      } else {
-        if (Object.keys(dirtyFields).length === 0) {
-          // Nothing to persist — "Zapisz i wróć do listy" still returns.
-          if (returnToList) navigate(backHref);
-          setIsSaving(false);
-          return;
-        }
-        // #1350 (reopen #2) — in edit mode every dirty key IS an attribute
-        // code; stripping 'sku'/'code' here silently dropped edits to a
-        // real `sku` attribute (field emptied after save). The strip only
-        // belongs to create mode, where the header SKU input doubles as
-        // the object code.
-        const attributes = { ...dirtyFields };
-        // #1150 / #1155 — write in the active locale + channel: localizable
-        // / scopable attributes land on that scope's row, others stay
-        // global (BE decides per flag).
-        await jsonFetch(`/api/objects/${id}${scopeQuery(locale, channel)}`, {
-          method: 'PATCH',
-          contentType: 'application/merge-patch+json',
-          body: { attributes },
-        });
-        await productQuery.refetch();
-        setDirtyFields({});
-        toast.success(t('products.detail.save.success', { defaultValue: 'Zapisano zmiany' }));
-        // #1351 — "Zapisz zmiany" keeps the row in edit mode; only
-        // "Zapisz i wróć do listy" navigates back to the list.
-        if (returnToList) navigate(backHref);
-      }
-    } catch (error) {
-      // #1179 — surface the server's Problem Details `detail` (e.g. duplicate
-      // identifier 409) instead of the generic copy, so the operator knows
-      // what to fix.
-      toast.error(
-        httpErrorDetail(error) ??
-          t('products.detail.save.failed', { defaultValue: 'Nie udało się zapisać' }),
-      );
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const cancelEdit = (): void => {
-    // #1351 — no read-only mode anymore; "Anuluj" just discards unsaved
-    // edits and restores the persisted values.
-    setDirtyFields({});
-    void productQuery.refetch();
-  };
-
-  const handleDelete = async (): Promise<void> => {
-    if (mode !== 'edit' || id === '' || isDeleting) return;
-    setIsDeleting(true);
-    try {
-      await jsonFetch(`/api/objects/${id}`, { method: 'DELETE' });
-      toast.success(
-        t('products.detail.delete.success', {
-          defaultValue: 'Usunięto produkt {{code}}',
-          code: product?.code ?? id,
-        }),
-      );
-      navigate(backHref);
-    } catch {
-      toast.error(
-        t('products.detail.delete.failed', { defaultValue: 'Nie udało się usunąć produktu' }),
-      );
-      setIsDeleting(false);
-      setShowDeleteConfirm(false);
-    }
-  };
+  }, [didExpandInitial, groups, setExpandedAll]);
 
   // Issue #1043 — split the original mixed guard into loading + not-found.
   // The previous condition treated `product === undefined` (post-404) as
@@ -787,277 +352,40 @@ export function ProductDetailPage({
 
   return (
     <div className="bg-zinc-50 -mx-6 -mt-6 min-h-[calc(100vh-3rem)]">
-      {/* Header */}
-      <header className="sticky top-0 z-20 glass-strong border-b border-zinc-100">
-        <div className="px-7 pb-3 pt-5">
-          <div className="flex items-center gap-3">
-            <Button
-              asChild
-              variant="ghost"
-              size="icon"
-              className="size-9 rounded-xl bg-white soft-shadow"
-            >
-              <Link
-                to={backHref}
-                aria-label={t('products.back', { defaultValue: 'Powrót do listy' })}
-              >
-                <ArrowLeft className="size-4" />
-              </Link>
-            </Button>
-            <div className="text-[12px] text-zinc-500">
-              <span>{objectTypeLabel ?? t('products.title', { defaultValue: 'Produkty' })}</span>
-              <span className="mx-1.5 text-zinc-300">/</span>
-              <span>{breadcrumbCategory}</span>
-              {skuValue !== '' ? (
-                <>
-                  <span className="mx-1.5 text-zinc-300">/</span>
-                  <span className="font-medium text-zinc-900">{skuValue}</span>
-                </>
-              ) : null}
-            </div>
-            <div className="ml-auto flex items-center gap-2">
-              {/* Preview / duplicate hit product-only endpoints. */}
-              {kind === 'product' ? <PreviewButton disabled={mode === 'create'} /> : null}
-              {kind === 'product' && mode === 'edit' && id !== '' ? (
-                <DuplicateButton productId={id} />
-              ) : null}
-              {mode === 'edit' && id !== '' ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="size-9 rounded-xl bg-white soft-shadow"
-                      aria-label={t('products.detail.actions.more', { defaultValue: 'Więcej' })}
-                    >
-                      <MoreHorizontal className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-56">
-                    <DropdownMenuItem
-                      onSelect={() => setShowDeleteConfirm(true)}
-                      className="text-rose-600 focus:bg-rose-50 focus:text-rose-700"
-                    >
-                      <Trash2 className="mr-2 size-4" />
-                      {t('products.detail.actions.delete', { defaultValue: 'Usuń produkt' })}
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="size-9 rounded-xl bg-white soft-shadow"
-                  aria-label={t('products.detail.actions.more', { defaultValue: 'Więcej' })}
-                  disabled
-                >
-                  <MoreHorizontal className="size-4" />
-                </Button>
-              )}
-              <span className="mx-1 h-6 w-px bg-zinc-200" />
-              {mode === 'edit' ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={cancelEdit}
-                  disabled={isSaving}
-                  className="h-9 rounded-xl px-3 text-[12.5px] text-zinc-600"
-                >
-                  {t('products.detail.actions.cancel', { defaultValue: 'Anuluj' })}
-                </Button>
-              ) : null}
-              <Button
-                type="button"
-                onClick={() => void handleSave()}
-                disabled={isSaving || (mode === 'create' && objectTypeId === null)}
-                className="h-9 rounded-xl bg-zinc-900 px-4 text-[12.5px] font-medium text-white hover:bg-zinc-800"
-              >
-                <Save className="size-4" />
-                {mode === 'create'
-                  ? kind === 'product'
-                    ? t('products.detail.actions.create', { defaultValue: 'Utwórz produkt' })
-                    : t('object_create.submit', { defaultValue: 'Utwórz' })
-                  : t('products.detail.actions.save', { defaultValue: 'Zapisz zmiany' })}
-              </Button>
-              {/* #1351 — save and return to the list (edit mode only). */}
-              {mode === 'edit' ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => void handleSave(true)}
-                  disabled={isSaving}
-                  className="h-9 rounded-xl px-4 text-[12.5px] font-medium"
-                >
-                  <Save className="size-4" />
-                  {t('products.detail.actions.save_and_return', {
-                    defaultValue: 'Zapisz i wróć do listy',
-                  })}
-                </Button>
-              ) : null}
-            </div>
-          </div>
-
-          <div className="mt-4 flex items-start gap-5">
-            <div
-              className="grid size-[72px] shrink-0 place-items-center rounded-2xl bg-white text-[34px] soft-shadow"
-              aria-hidden
-            >
-              ▣
-            </div>
-            <div className="min-w-0 flex-1">
-              {mode === 'create' ? (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2.5 text-[12px] text-zinc-500">
-                    <Input
-                      autoFocus
-                      placeholder={t('object_create.id_placeholder', { defaultValue: 'ID' })}
-                      value={skuValue}
-                      onChange={(event) => setFieldValue('sku', event.target.value)}
-                      className="h-7 w-32 rounded-lg border-zinc-200 bg-white px-2 font-mono text-[12px]"
-                    />
-                  </div>
-                  <Input
-                    placeholder={
-                      kind === 'product'
-                        ? t('products.detail.create.placeholder.name', {
-                            defaultValue: 'Nazwa produktu',
-                          })
-                        : t('object_create.name_placeholder', { defaultValue: 'Nazwa' })
-                    }
-                    value={nameValue}
-                    onChange={(event) => setFieldValue('name', event.target.value)}
-                    className="font-display h-10 rounded-lg border-zinc-200 bg-white text-[20px] font-semibold tracking-tight"
-                  />
-                  {/* #1357 — "Marka" removed from the new-entry form. */}
-                </div>
-              ) : (
-                <>
-                  <div className="flex items-center gap-2.5 text-[12px] text-zinc-500">
-                    <span className="font-mono">{product?.code}</span>
-                    {brandValue !== '' ? (
-                      <>
-                        <span className="text-zinc-300">·</span>
-                        <span>{brandValue}</span>
-                      </>
-                    ) : null}
-                    <span className="text-zinc-300">·</span>
-                    <span className="inline-flex items-center gap-1.5">
-                      <span
-                        className={cn(
-                          'size-1.5 rounded-full',
-                          product?.enabled ? 'bg-emerald-500' : 'bg-zinc-300',
-                        )}
-                        aria-hidden
-                      />
-                      {product?.enabled
-                        ? t('products.detail.status.active', { defaultValue: 'Aktywny' })
-                        : t('products.detail.status.inactive', { defaultValue: 'Nieaktywny' })}
-                    </span>
-                  </div>
-                  {isEditing ? (
-                    <Input
-                      aria-label={t('products.detail.create.placeholder.name', {
-                        defaultValue: 'Nazwa produktu',
-                      })}
-                      placeholder={t('products.detail.create.placeholder.name', {
-                        defaultValue: 'Nazwa produktu',
-                      })}
-                      value={nameValue}
-                      onChange={(event) => setFieldValue('name', event.target.value)}
-                      className="font-display mt-1 h-11 rounded-lg border-zinc-200 bg-white text-[26px] font-semibold tracking-tight"
-                    />
-                  ) : (
-                    <h1 className="font-display mt-1 text-[26px] font-semibold leading-tight tracking-tight">
-                      {nameValue}
-                    </h1>
-                  )}
-                  {objectTypeName !== null ? (
-                    <div className="mt-2.5 flex flex-wrap items-center gap-2">
-                      <span className="rounded-full bg-white px-2 py-1 text-[11px] font-medium text-zinc-700 soft-shadow">
-                        {objectTypeName}
-                      </span>
-                    </div>
-                  ) : null}
-                </>
-              )}
-            </div>
-            {mode === 'edit' ? (
-              <div className="flex flex-col items-center gap-1">
-                <CompletenessRing pct={scopedCompletenessPct} size={72} stroke={6} />
-                {completenessScope !== null ? (
-                  <span
-                    className="num rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-zinc-500"
-                    title={t('products.completeness.scope_tooltip', {
-                      scope: completenessScope.toUpperCase(),
-                      defaultValue: 'Kompletność dla zakresu {{scope}}',
-                    })}
-                  >
-                    {completenessScope}
-                  </span>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
-        </div>
-
-        {/* Tabs + locale/channel toolbar */}
-        <div className="flex items-center gap-1 border-t border-zinc-100 px-7">
-          <div
-            className="flex flex-1 items-center gap-1"
-            role="tablist"
-            aria-label={t('products.detail.tabs.aria', { defaultValue: 'Zakładki produktu' })}
-          >
-            {visibleTabs.map((tab) => {
-              const isActive = activeTab === tab;
-              const badge = tabBadge(tab, groups, stackedGroups, product);
-              return (
-                <button
-                  key={tab}
-                  type="button"
-                  role="tab"
-                  aria-selected={isActive}
-                  onClick={() => setActiveTab(tab)}
-                  className={cn(
-                    'relative inline-flex h-[44px] items-center gap-2 px-3.5 text-[13px] font-medium tracking-tight',
-                    isActive ? 'text-zinc-900' : 'text-zinc-500 hover:text-zinc-800',
-                  )}
-                >
-                  {tabLabel(tab, groups, lang, t)}
-                  {badge !== null ? (
-                    <span
-                      className={cn(
-                        'num rounded px-1.5 py-0.5 text-[10.5px]',
-                        isActive ? 'bg-zinc-900 text-white' : 'bg-zinc-100 text-zinc-500',
-                      )}
-                    >
-                      {badge}
-                    </span>
-                  ) : null}
-                  {isActive ? (
-                    <span
-                      className="absolute -bottom-px left-0 right-0 h-[2px] rounded-t bg-zinc-900"
-                      aria-hidden
-                    />
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
-          {mode === 'edit' ? (
-            <LocaleChannelToolbar
-              locale={locale}
-              channel={channel}
-              onLocaleChange={setLocale}
-              onChannelChange={setChannel}
-              locales={locales}
-              channels={channels}
-            />
-          ) : null}
-        </div>
-      </header>
+      <ProductDetailHeader
+        mode={mode}
+        kind={kind}
+        id={id}
+        backHref={backHref}
+        objectTypeLabel={objectTypeLabel}
+        breadcrumbCategory={breadcrumbCategory}
+        skuValue={skuValue}
+        nameValue={nameValue}
+        brandValue={brandValue}
+        objectTypeName={objectTypeName}
+        product={product}
+        isEditing={isEditing}
+        isSaving={isSaving}
+        objectTypeId={objectTypeId}
+        scopedCompletenessPct={scopedCompletenessPct}
+        completenessScope={completenessScope}
+        lang={lang}
+        visibleTabs={visibleTabs}
+        activeTab={activeTab}
+        groups={groups}
+        stackedGroups={stackedGroups}
+        locale={locale}
+        channel={channel}
+        locales={locales}
+        channels={channels}
+        onSave={(returnToList) => void handleSave(returnToList)}
+        onCancel={cancelEdit}
+        onRequestDelete={() => setShowDeleteConfirm(true)}
+        onFieldChange={setFieldValue}
+        onSelectTab={setActiveTab}
+        onLocaleChange={setLocale}
+        onChannelChange={setChannel}
+      />
 
       {/* Body */}
       <div className="grid grid-cols-1 gap-5 px-7 py-6 lg:grid-cols-[minmax(0,1fr)_320px]">
@@ -1066,98 +394,27 @@ export function ProductDetailPage({
               relations) resolve behind this boundary; the attributes view and
               tab-mode groups render synchronously and never suspend. */}
           <Suspense fallback={<TabLoadingFallback />}>
-            {(() => {
-              // MODR-03 (#925) — content area dispatch based on active tab.
-              // 'attributes' hosts every stacked group as inline AttrGroupCard
-              // sections; a tab-mode group code renders that single group;
-              // 'categories'/'history'/'variants' delegate to bespoke components.
-              const renderStackedGroup = (group: GroupMeta) => (
-                <AttrGroupCard
-                  key={group.id}
-                  id={group.id}
-                  title={group.label[lang] ?? group.code}
-                  icon={GROUP_ICONS[group.code]}
-                  filledCount={countFilled(group, fieldValue)}
-                  totalCount={group.attributes.length}
-                  expanded={expandedGroups.has(group.id)}
-                  onToggle={() => toggleGroup(group.id)}
-                  isSystem={isLegacyOptionalSystemGroupCode(group.code)}
-                >
-                  {group.attributes.map((attr) => (
-                    <AttrRow
-                      key={attr.id}
-                      attribute={attr}
-                      value={fieldValue(attr.code)}
-                      provenance={resolveProvenance(attr, product)}
-                      locale={locale}
-                      channel={channel}
-                      isEditing={isEditing}
-                      isLocked={attr.is_system}
-                      onChange={(next) => setFieldValue(attr.code, next)}
-                      createMode={mode === 'create'}
-                      relationContextProductId={isEditMode ? id : undefined}
-                      isInherited={
-                        scopeStatus[attr.code]?.has_override === false &&
-                        scopeStatus[attr.code]?.inherited_from != null
-                      }
-                      inheritedFrom={scopeStatus[attr.code]?.inherited_from ?? null}
-                      requiredError={requiredErrors.has(attr.code)}
-                    />
-                  ))}
-                </AttrGroupCard>
-              );
-
-              if (activeTab === 'attributes') {
-                // #1357 — the non-functional "Dodaj grupę atrybutów ad-hoc"
-                // stub was removed from this view per operator request.
-                return <>{stackedGroups.map(renderStackedGroup)}</>;
-              }
-
-              // Tab-mode AttributeGroup → render only that group, with
-              // a bespoke component for relations that retains its legacy
-              // data flow (relation links endpoint). Multimedia is no
-              // longer dispatched here — UX-02 removes it from the
-              // AttributeGroup model entirely; the conditional Multimedia
-              // tab lives as a hardcoded special tab driven by
-              // `ObjectType.hasMultimedia` (UX-06+).
-              const tabGroup = tabModeGroups.find((g) => g.code === activeTab);
-              if (tabGroup) {
-                if (tabGroup.code === 'relations') {
-                  // Reverse-links UI needs a persisted object — edit only;
-                  // forward relation attrs render via RelationCreateField.
-                  return mode === 'edit' ? (
-                    <RelationsTab productId={id} />
-                  ) : (
-                    renderStackedGroup(tabGroup)
-                  );
-                }
-                return renderStackedGroup(tabGroup);
-              }
-
-              // MODR-06 (#928) — synthetic `relations` tab for the
-              // reverse-only case (object has no forward AttributeGroup
-              // but is pointed at from elsewhere). RelationsTab already
-              // gracefully renders just the reverse panel when forward
-              // groups are empty.
-              if (activeTab === 'relations' && mode === 'edit') {
-                return <RelationsTab productId={id} />;
-              }
-
-              if (mode === 'edit' && isSpecialTab(activeTab)) {
-                return (
-                  <OtherTabs
-                    activeTab={activeTab}
-                    productId={id}
-                    objectTypeId={objectTypeId}
-                    kind={kind ?? 'product'}
-                    locale={locale}
-                    channel={channel}
-                  />
-                );
-              }
-
-              return null;
-            })()}
+            <ProductDetailContent
+              mode={mode}
+              isEditMode={isEditMode}
+              id={id}
+              kind={kind}
+              objectTypeId={objectTypeId}
+              activeTab={activeTab}
+              lang={lang}
+              locale={locale}
+              channel={channel}
+              isEditing={isEditing}
+              product={product}
+              stackedGroups={stackedGroups}
+              tabModeGroups={tabModeGroups}
+              scopeStatus={scopeStatus}
+              expandedGroups={expandedGroups}
+              requiredErrors={requiredErrors}
+              fieldValue={fieldValue}
+              onFieldChange={setFieldValue}
+              onToggleGroup={toggleGroup}
+            />
           </Suspense>
 
           {mode === 'create' && isCategorizable && createCategoryIds.length === 0 ? (
@@ -1170,45 +427,25 @@ export function ProductDetailPage({
           ) : null}
         </div>
 
-        <aside
-          className="space-y-3"
-          aria-label={t('products.detail.sidebar.aria', {
-            defaultValue: 'Panel boczny produktu',
-          })}
-        >
-          {isCategorizable ? (
-            <CategorySelectorCard
-              {...(mode === 'edit' && id !== ''
-                ? { mode: 'edit', productId: id, objectTypeId }
-                : {
-                    mode: 'create',
-                    selectedCategoryIds: createCategoryIds,
-                    primaryCategoryId: createPrimaryId,
-                    selectedCategories: createCategoriesSummaries,
-                    onChange: (ids, primary) => {
-                      setCreateCategoryIds(ids);
-                      setCreatePrimaryId(primary);
-                    },
-                    objectTypeId,
-                  })}
-            />
-          ) : null}
-          {mode === 'edit' && id !== '' ? (
-            <>
-              {kind === 'product' ? <SyncStatusCard productId={id} /> : null}
-              {hasVariantsCapability ? (
-                <VariantsListCard
-                  masterProductId={id}
-                  basePath="/api/objects"
-                  onSelectVariant={(variantId) => navigate(detailPathFor(variantId))}
-                  onCreateVariant={() => setActiveTab('variants')}
-                />
-              ) : null}
-              <EffectiveModelCard groups={groups} objectTypeName={objectTypeName ?? 'Product'} />
-              {kind === 'product' ? <AgentSuggestionsCard /> : null}
-            </>
-          ) : null}
-        </aside>
+        <ProductDetailSidebar
+          mode={mode}
+          id={id}
+          kind={kind}
+          objectTypeId={objectTypeId}
+          objectTypeName={objectTypeName}
+          isCategorizable={isCategorizable}
+          hasVariantsCapability={hasVariantsCapability}
+          groups={groups}
+          createCategoryIds={createCategoryIds}
+          createPrimaryId={createPrimaryId}
+          createCategoriesSummaries={createCategoriesSummaries}
+          onCreateCategoriesChange={(ids, primary) => {
+            setCreateCategoryIds(ids);
+            setCreatePrimaryId(primary);
+          }}
+          onSelectVariant={(variantId) => navigate(detailPathFor(variantId))}
+          onCreateVariant={() => setActiveTab('variants')}
+        />
       </div>
 
       <Dialog
@@ -1238,7 +475,11 @@ export function ProductDetailPage({
             >
               {t('app.cancel', { defaultValue: 'Anuluj' })}
             </Button>
-            <Button variant="destructive" onClick={() => void handleDelete()} disabled={isDeleting}>
+            <Button
+              variant="destructive"
+              onClick={() => void handleDelete(() => setShowDeleteConfirm(false))}
+              disabled={isDeleting}
+            >
               {isDeleting
                 ? t('products.detail.delete.deleting', { defaultValue: 'Usuwanie…' })
                 : t('products.detail.delete.confirm_submit', { defaultValue: 'Usuń produkt' })}
@@ -1247,253 +488,5 @@ export function ProductDetailPage({
         </DialogContent>
       </Dialog>
     </div>
-  );
-}
-
-const SPECIAL_TAB_DEFAULT_LABELS: Record<SpecialTabKey, string> = {
-  attributes: 'Atrybuty',
-  multimedia: 'Multimedia',
-  categories: 'Kategorie',
-  history: 'Historia',
-  variants: 'Warianty',
-};
-
-function tabLabel(
-  tab: TabKey,
-  groups: GroupMeta[],
-  lang: 'pl' | 'en',
-  t: (key: string, options?: { defaultValue?: string }) => string,
-): string {
-  if (isSpecialTab(tab)) {
-    return t(`products.detail.tabs.${tab}`, {
-      defaultValue: SPECIAL_TAB_DEFAULT_LABELS[tab],
-    });
-  }
-  const group = groups.find((g) => g.code === tab);
-  if (!group) return tab;
-  const i18nKey = `products.detail.tabs.group_${group.code}`;
-  const fallback = group.label[lang] ?? group.code;
-  return t(i18nKey, { defaultValue: fallback });
-}
-
-function isSpecialTab(tab: TabKey): tab is SpecialTabKey {
-  return (SPECIAL_TABS as readonly string[]).includes(tab);
-}
-
-function tabBadge(
-  tab: TabKey,
-  groups: GroupMeta[],
-  stackedGroups: GroupMeta[],
-  product: CatalogObjectDto | null | undefined,
-): number | null {
-  if (tab === 'attributes') {
-    return stackedGroups.length === 0 ? null : stackedGroups.length;
-  }
-  if (tab === 'categories') return null;
-  if (tab === 'history') return null;
-  if (tab === 'variants') {
-    const count = (product?.attributesIndexed as { variantsCount?: number } | undefined)
-      ?.variantsCount;
-    return typeof count === 'number' ? count : null;
-  }
-  // Tab-mode AttributeGroup → badge shows the attribute count when > 0.
-  const group = groups.find((g) => g.code === tab);
-  if (!group) return null;
-  return group.attributes.length === 0 ? null : group.attributes.length;
-}
-
-/**
- * #1350 — mirrors the upserter's isEmptyEnvelope: null / '' (after trim) /
- * empty arrays-objects count as empty; booleans and zeros are values.
- */
-function isEmptyAttributeValue(value: unknown): boolean {
-  if (value === null || value === undefined) return true;
-  if (typeof value === 'string') return value.trim() === '';
-  if (Array.isArray(value)) return value.every(isEmptyAttributeValue);
-  if (typeof value === 'object') {
-    const leaves = Object.values(value as Record<string, unknown>);
-    return leaves.length === 0 || leaves.every(isEmptyAttributeValue);
-  }
-  return false;
-}
-
-/**
- * #1102/#1415 — relation attribute codes across the effective groups;
- * their create-mode values go through PUT /relations, not the POST body.
- */
-function collectRelationCodes(groups: GroupMeta[]): Set<string> {
-  const codes = new Set<string>();
-  for (const group of groups) {
-    for (const attr of group.attributes) {
-      if (attr.type === 'relation') codes.add(attr.code);
-    }
-  }
-  return codes;
-}
-
-function splitDirtyAttributes(
-  dirty: Record<string, unknown>,
-  relationCodes: Set<string>,
-): { normal: Record<string, unknown>; relations: Record<string, string[]> } {
-  const normal: Record<string, unknown> = {};
-  const relations: Record<string, string[]> = {};
-  for (const [key, value] of Object.entries(dirty)) {
-    if (relationCodes.has(key)) {
-      relations[key] = toRelationIdList(value);
-      continue;
-    }
-    normal[key] = value;
-  }
-  return { normal, relations };
-}
-
-function toRelationIdList(value: unknown): string[] {
-  if (typeof value === 'string' && value !== '') return [value];
-  if (Array.isArray(value)) {
-    return value.filter((entry): entry is string => typeof entry === 'string' && entry !== '');
-  }
-  return [];
-}
-
-function stripAttributes(dirty: Record<string, unknown>): Record<string, unknown> {
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(dirty)) {
-    if (k === 'sku' || k === 'code') continue;
-    out[k] = v;
-  }
-  return out;
-}
-
-function countFilled(group: GroupMeta, fieldValue: (code: string) => unknown): number {
-  let filled = 0;
-  for (const attr of group.attributes) {
-    const value = fieldValue(attr.code);
-    if (value === undefined || value === null) continue;
-    if (typeof value === 'string' && value.trim() === '') continue;
-    filled += 1;
-  }
-  return filled;
-}
-
-function resolveProvenance(
-  attr: AttributeMeta,
-  product: CatalogObjectDto | null | undefined,
-): Provenance {
-  if (attr.is_system) return 'integration';
-  const indexed = product?.attributesIndexed as
-    | Record<string, { provenance?: Provenance }>
-    | undefined;
-  const meta = indexed?.[attr.code];
-  if (meta && typeof meta === 'object' && typeof meta.provenance === 'string') {
-    return meta.provenance;
-  }
-  return 'manual';
-}
-
-function OtherTabs({
-  activeTab,
-  productId,
-  objectTypeId,
-  kind,
-  locale,
-  channel,
-}: {
-  activeTab: SpecialTabKey;
-  productId: string;
-  objectTypeId: string | null;
-  kind: string;
-  locale: ProductLocale;
-  channel: ProductChannel | null;
-}) {
-  // UX bug fix #2 — Multimedia is back as a special tab gated by
-  // `ObjectType.hasMultimedia` (UX-02 removed it from the AttributeGroup
-  // dispatcher); the assets link table is poly-kind so the tab works
-  // for every ObjectType.
-  if (activeTab === 'multimedia') return <ProductMultimediaTab productId={productId} />;
-  if (activeTab === 'categories')
-    return <CategoriesTab productId={productId} objectTypeId={objectTypeId} kind={kind} />;
-  if (activeTab === 'history') return <HistoryStub />;
-  if (activeTab === 'variants')
-    return (
-      <VariantsTabHost
-        productId={productId}
-        basePath="/api/objects"
-        locale={locale}
-        channel={channel}
-      />
-    );
-  return null;
-}
-
-/**
- * AUD-071 (#1614) — discreet fallback while a lazy tab chunk loads. The
- * tab chunks are small (a few tens of KB gzip) so this flashes only on a
- * cold cache; it intentionally mirrors the muted card surface of the real
- * tabs to avoid a jarring layout shift.
- */
-function TabLoadingFallback() {
-  const { t } = useTranslation();
-  return (
-    <div
-      className="rounded-2xl border border-line bg-surface p-5 text-[12.5px] text-muted-foreground soft-shadow"
-      role="status"
-      aria-live="polite"
-    >
-      {t('products.detail.tabs.loading', { defaultValue: 'Ładowanie…' })}
-    </div>
-  );
-}
-
-function HistoryStub() {
-  const events = [
-    {
-      who: 'Marcin Lipiec',
-      when: '5 min temu',
-      what: 'Zmieniono description.pl',
-      tone: 'bg-orange-500/10 text-orange-700',
-    },
-    {
-      who: 'agent.sonnet',
-      when: '2 godz. temu',
-      what: 'Wzbogacono kod HS (taryfa UE 2026)',
-      tone: 'bg-accent-emerald/10 text-accent-emerald',
-    },
-    {
-      who: 'Anna Wiśniewska',
-      when: 'wczoraj',
-      what: 'Dodano 3 zdjęcia produktu',
-      tone: 'bg-accent-blue/10 text-accent-blue',
-    },
-  ];
-
-  return (
-    <MockBadge variant="overlay" tooltip="MOCK · Pełna timeline wymaga endpointu audit-log">
-      <div className="rounded-2xl border border-line bg-surface p-5 soft-shadow">
-        <header className="mb-4 flex items-center gap-2">
-          <Sparkles className="size-4 text-muted-foreground" />
-          <h3 className="text-[14px] font-semibold text-ink">Historia zmian</h3>
-        </header>
-        <ol className="relative space-y-4 border-l border-line pl-6">
-          {events.map((event) => (
-            <li key={`${event.who}-${event.when}`} className="relative">
-              <span
-                className={`absolute -left-[31px] flex size-5 items-center justify-center rounded-full ring-2 ring-background ${event.tone}`}
-              >
-                <Clock className="size-2.5" />
-              </span>
-              <div className="flex items-center gap-2">
-                <span className="text-[13px] font-medium text-ink">{event.who}</span>
-                <span className="text-[11px] text-muted-foreground">{event.when}</span>
-              </div>
-              <p className="mt-0.5 text-[12.5px] text-ink-2">{event.what}</p>
-            </li>
-          ))}
-        </ol>
-        <div className="mt-3 flex items-center gap-2 text-[11px] text-muted-foreground">
-          <Link2 className="size-3" />
-          Sidebar pokazuje 5 ostatnich; pełna paginowana historia czeka na endpoint.
-        </div>
-      </div>
-    </MockBadge>
   );
 }

--- a/apps/admin/src/features/catalog/products/components/product-detail-sidebar.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-sidebar.tsx
@@ -1,0 +1,87 @@
+import { useTranslation } from 'react-i18next';
+
+import { AgentSuggestionsCard } from './agent-suggestions-card';
+import { CategorySelectorCard } from './category-selector-card';
+import { EffectiveModelCard } from './effective-model-card';
+import { SyncStatusCard } from './sync-status-card';
+import type { GroupMeta, ProductDetailMode } from './types';
+import { VariantsListCard } from './variants-list-card';
+
+export interface ProductDetailSidebarProps {
+  mode: ProductDetailMode;
+  id: string;
+  kind: string | null;
+  objectTypeId: string | null;
+  objectTypeName: string | null;
+  isCategorizable: boolean;
+  hasVariantsCapability: boolean;
+  groups: GroupMeta[];
+  createCategoryIds: string[];
+  createPrimaryId: string | null;
+  createCategoriesSummaries: { categoryId: string; code: string; isPrimary: boolean }[];
+  onCreateCategoriesChange: (ids: string[], primary: string | null) => void;
+  onSelectVariant: (variantId: string) => void;
+  onCreateVariant: () => void;
+}
+
+/**
+ * AUD-057 (#1608) — the product-detail right rail (category selector + sync
+ * status + variants list + effective-model card + agent suggestions),
+ * lifted out of product-detail-page.tsx to bring that monolith under the
+ * 500-line guard. Purely presentational.
+ */
+export function ProductDetailSidebar({
+  mode,
+  id,
+  kind,
+  objectTypeId,
+  objectTypeName,
+  isCategorizable,
+  hasVariantsCapability,
+  groups,
+  createCategoryIds,
+  createPrimaryId,
+  createCategoriesSummaries,
+  onCreateCategoriesChange,
+  onSelectVariant,
+  onCreateVariant,
+}: ProductDetailSidebarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <aside
+      className="space-y-3"
+      aria-label={t('products.detail.sidebar.aria', { defaultValue: 'Panel boczny produktu' })}
+    >
+      {isCategorizable ? (
+        <CategorySelectorCard
+          {...(mode === 'edit' && id !== ''
+            ? { mode: 'edit', productId: id, objectTypeId }
+            : {
+                mode: 'create',
+                selectedCategoryIds: createCategoryIds,
+                primaryCategoryId: createPrimaryId,
+                selectedCategories: createCategoriesSummaries,
+                onChange: onCreateCategoriesChange,
+                objectTypeId,
+              })}
+        />
+      ) : null}
+      {mode === 'edit' && id !== '' ? (
+        <>
+          {kind === 'product' ? <SyncStatusCard productId={id} /> : null}
+          {hasVariantsCapability ? (
+            <VariantsListCard
+              masterProductId={id}
+              basePath="/api/objects"
+              onSelectVariant={onSelectVariant}
+              onCreateVariant={onCreateVariant}
+            />
+          ) : null}
+          <EffectiveModelCard groups={groups} objectTypeName={objectTypeName ?? 'Product'} />
+          {kind === 'product' ? <AgentSuggestionsCard /> : null}
+        </>
+      ) : null}
+    </aside>
+  );
+}

--- a/apps/admin/src/features/catalog/products/components/use-product-detail-data.ts
+++ b/apps/admin/src/features/catalog/products/components/use-product-detail-data.ts
@@ -1,0 +1,257 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { useListSchema } from '@/hooks/use-list-schema';
+import { unwrapAttributesIndexed } from '@/lib/attributes-indexed';
+import { HttpError, jsonFetch } from '@/lib/http';
+import { objectKeys } from '@/lib/object-query-keys';
+import { useDefaultObjectType } from '../use-default-object-type';
+import { scopeQuery } from './scope';
+import type {
+  CatalogObjectDto,
+  ChannelOption,
+  GroupMeta,
+  LocaleOption,
+  ProductChannel,
+  ProductDetailMode,
+  ProductLocale,
+  ScopeStatus,
+} from './types';
+
+interface UseProductDetailDataArgs {
+  mode: ProductDetailMode;
+  id: string;
+  isEditMode: boolean;
+  createObjectTypeId: string | undefined;
+  locale: ProductLocale;
+  channel: ProductChannel | null;
+  createCategoryIds: string[];
+  createPrimaryId: string | null;
+}
+
+/**
+ * AUD-057 (#1608) — every server read the product detail screen performs,
+ * lifted out of product-detail-page.tsx so the page composes data + UI
+ * instead of inlining ~250 lines of useQuery + derived memos. The page
+ * still owns the locale/channel UI state and the dirty-field write path;
+ * this hook owns the read side and the values derived purely from it.
+ *
+ * All reads go through useQuery (not jsonFetch+useEffect) so cache
+ * invalidation from sibling tabs (categories, relations) actually refetches
+ * — the same stale-data discipline as ADR-0021.
+ */
+export function useProductDetailData({
+  mode,
+  id,
+  isEditMode,
+  createObjectTypeId,
+  locale,
+  channel,
+  createCategoryIds,
+  createPrimaryId,
+}: UseProductDetailDataArgs) {
+  // #1150 / #1155 — load the product in the active locale + channel so
+  // localizable / channel-scoped values reflect the picker. locale +
+  // channel are part of the query key, so switching either refetches the
+  // scope-resolved reading.
+  const productQuery = useQuery<CatalogObjectDto>({
+    queryKey: objectKeys.scoped(id, locale, channel),
+    queryFn: () =>
+      jsonFetch<CatalogObjectDto>(`/api/objects/${id}${scopeQuery(locale, channel)}`, {
+        accept: 'application/ld+json',
+      }),
+    enabled: isEditMode && id !== '',
+    // A 404 is conclusive — retrying it three times keeps the operator on
+    // "Ładowanie…" for ~8s before the not-found state appears (#1043).
+    retry: (failureCount, error) =>
+      !(error instanceof HttpError && error.status === 404) && failureCount < 3,
+  });
+
+  const { objectTypeId: defaultProductTypeId } = useDefaultObjectType('product');
+  const loadedProduct = isEditMode ? (productQuery.data ?? null) : null;
+  // Edit mode reads capabilities from the object's OWN ObjectType (any
+  // kind); create mode takes the route-resolved ObjectType (#1415) and
+  // falls back to the built-in product for /products/new.
+  const objectTypeId = isEditMode
+    ? (loadedProduct?.objectType?.id ?? null)
+    : (createObjectTypeId ?? defaultProductTypeId);
+
+  const schemaQuery = useListSchema(objectTypeId ?? undefined);
+  const schemaObjectType = schemaQuery.data?.objectType;
+  const kind = isEditMode
+    ? (loadedProduct?.kind ?? null)
+    : (schemaObjectType?.kind ?? (createObjectTypeId === undefined ? 'product' : null));
+  const hasMultimediaCapability = schemaObjectType?.has_multimedia ?? false;
+  const hasVariantsCapability = schemaObjectType?.has_variants ?? kind === 'product';
+  const isCategorizable = schemaObjectType?.is_categorizable ?? kind === 'product';
+
+  // Resolve the category codes for chip rendering in create mode. Same
+  // query key as `CategoryPickerDialog` so opening the picker hits the
+  // shared cache — and so the sidebar updates the moment the picker
+  // commits a new selection.
+  const categoriesListQuery = useQuery({
+    queryKey: ['categories', 'picker'],
+    queryFn: () =>
+      jsonFetch<{
+        'hydra:member'?: Array<{ id: string; code: string }>;
+        member?: Array<{ id: string; code: string }>;
+      }>('/api/categories?itemsPerPage=200'),
+    enabled: mode === 'create' && createCategoryIds.length > 0,
+    staleTime: 60_000,
+  });
+
+  const createCategoriesSummaries = useMemo(() => {
+    if (mode !== 'create') return [] as { categoryId: string; code: string; isPrimary: boolean }[];
+    const rows =
+      categoriesListQuery.data?.['hydra:member'] ?? categoriesListQuery.data?.member ?? [];
+    const codeById = new Map<string, string>();
+    for (const row of rows) codeById.set(row.id, row.code);
+    return createCategoryIds.map((cid) => ({
+      categoryId: cid,
+      code: codeById.get(cid) ?? cid.slice(0, 8),
+      isPrimary: cid === createPrimaryId,
+    }));
+  }, [mode, createCategoryIds, createPrimaryId, categoriesListQuery.data]);
+
+  const product = loadedProduct;
+  const attrs = useMemo(
+    () =>
+      unwrapAttributesIndexed(product?.attributesIndexed as Record<string, unknown> | undefined),
+    [product?.attributesIndexed],
+  );
+
+  // #891 — fetch effective groups via useQuery so CategoriesTab cache
+  // invalidation actually triggers refetch. In create mode the query keys
+  // flip between the preview endpoint (when categories are selected) and
+  // the bare ObjectType endpoint (when none are selected yet).
+  const groupsQuery = useQuery<{ groups: GroupMeta[]; locales?: LocaleOption[] }>({
+    queryKey:
+      isEditMode && id !== ''
+        ? objectKeys.effectiveGroups(id)
+        : [
+            'object-types',
+            objectTypeId,
+            'effective-attribute-groups',
+            createCategoryIds.length > 0 ? [...createCategoryIds].sort() : 'base',
+          ],
+    queryFn: async () => {
+      if (isEditMode && id !== '') {
+        return jsonFetch<{ groups: GroupMeta[]; locales?: LocaleOption[] }>(
+          `/api/objects/${id}/effective-attribute-groups`,
+        );
+      }
+      if (objectTypeId === null) {
+        return { groups: [] };
+      }
+      // #1415 — there is no GET for OT-level effective groups; the preview
+      // POST serves both the bare schema (empty categoryIds) and the
+      // category-driven overlay.
+      return jsonFetch<{ groups: GroupMeta[]; locales?: LocaleOption[] }>(
+        `/api/object_types/${objectTypeId}/effective-attribute-groups/preview`,
+        {
+          method: 'POST',
+          contentType: 'application/json',
+          accept: 'application/json',
+          body: { categoryIds: createCategoryIds },
+        },
+      );
+    },
+    enabled: isEditMode ? id !== '' : objectTypeId !== null,
+    staleTime: 5_000,
+    placeholderData: (prev) => prev,
+  });
+
+  // Empty groups (no attributes after field-level filtering) render as bare
+  // headers with zero rows — drop them, consistent with #1348's "no empty
+  // Atrybuty tab" rule. #1415 — the header already carries a dedicated input
+  // for the `name` attribute; the duplicated group row confused operators.
+  const groups = useMemo(
+    () =>
+      (groupsQuery.data?.groups ?? [])
+        .map((g) => ({
+          ...g,
+          attributes: g.attributes.filter((attr) => attr.code !== 'name'),
+        }))
+        .filter((g) => g.attributes.length > 0),
+    [groupsQuery.data],
+  );
+
+  const locales = useMemo<LocaleOption[]>(
+    () => groupsQuery.data?.locales ?? [],
+    [groupsQuery.data],
+  );
+
+  // #1155 — channel picker fed from /api/channels (tenant's real channels).
+  const channelsQuery = useQuery<ChannelOption[]>({
+    queryKey: ['channels', 'picker'],
+    queryFn: async () => {
+      const response = await jsonFetch<{ member?: ChannelOption[] } | ChannelOption[]>(
+        '/api/channels',
+        { accept: 'application/ld+json' },
+      );
+      return Array.isArray(response) ? response : (response.member ?? []);
+    },
+    enabled: isEditMode,
+    staleTime: 60_000,
+  });
+  const channels = channelsQuery.data ?? [];
+
+  // #1222 — scope-status: per-attribute inherited indicator. Only in edit
+  // mode, and only when a non-primary locale is active (primary locale
+  // values are global — nothing can be "inherited from another locale").
+  const scopeStatusQuery = useQuery<ScopeStatus>({
+    queryKey: objectKeys.scopeStatus(id, locale, channel),
+    queryFn: () =>
+      jsonFetch<ScopeStatus>(`/api/objects/${id}/scope-status${scopeQuery(locale, channel)}`),
+    enabled: isEditMode && id !== '' && locale !== null,
+    staleTime: 30_000,
+  });
+  const scopeStatus = scopeStatusQuery.data ?? {};
+
+  // MODR-03 (#925) — tab list derived dynamically from `groups`: every group
+  // with `display_mode='tab'` becomes its own tab; `display_mode='stacked'`
+  // (and the synthetic "default" bucket) collect into the `attributes` tab.
+  const tabModeGroups = useMemo(
+    () => groups.filter((g) => (g.display_mode ?? 'tab') === 'tab'),
+    [groups],
+  );
+  const stackedGroups = useMemo(
+    () => groups.filter((g) => (g.display_mode ?? 'tab') === 'stacked'),
+    [groups],
+  );
+
+  // MODR-06 (#928) — lightweight probe for incoming links so the
+  // "Powiązania" tab can surface even when the object has no forward
+  // relation attributes (e.g. a Category referenced from products).
+  const reverseRelationsQuery = useQuery<{ hasReverse: boolean; count: number }>({
+    queryKey: ['objects', id, 'relations', 'reverse', 'count'],
+    queryFn: () =>
+      jsonFetch<{ hasReverse: boolean; count: number }>(
+        `/api/objects/${id}/relations/reverse/count`,
+      ),
+    enabled: isEditMode && id !== '',
+    staleTime: 30_000,
+  });
+  const hasReverseRelations = reverseRelationsQuery.data?.hasReverse ?? false;
+
+  return {
+    productQuery,
+    product,
+    objectTypeId,
+    kind,
+    hasMultimediaCapability,
+    hasVariantsCapability,
+    isCategorizable,
+    attrs,
+    groupsQuery,
+    groups,
+    locales,
+    channels,
+    scopeStatus,
+    tabModeGroups,
+    stackedGroups,
+    hasReverseRelations,
+    categoriesListQuery,
+    createCategoriesSummaries,
+  };
+}

--- a/apps/admin/src/features/catalog/products/components/use-product-detail-form.ts
+++ b/apps/admin/src/features/catalog/products/components/use-product-detail-form.ts
@@ -1,0 +1,317 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+
+import { toast } from '@/components/ui/toast';
+import { httpErrorDetail, jsonFetch } from '@/lib/http';
+import {
+  collectRelationCodes,
+  isEmptyAttributeValue,
+  splitDirtyAttributes,
+  stripAttributes,
+} from './product-detail-helpers';
+import { scopeQuery } from './scope';
+import type {
+  CatalogObjectDto,
+  GroupMeta,
+  ProductChannel,
+  ProductDetailMode,
+  ProductLocale,
+} from './types';
+
+interface UseProductDetailFormArgs {
+  mode: ProductDetailMode;
+  id: string;
+  isEditMode: boolean;
+  kind: string | null;
+  objectTypeId: string | null;
+  isCategorizable: boolean;
+  locale: ProductLocale;
+  channel: ProductChannel | null;
+  groups: GroupMeta[];
+  attrs: Record<string, unknown>;
+  product: CatalogObjectDto | null | undefined;
+  productQuery: Pick<UseQueryResult<CatalogObjectDto>, 'refetch'>;
+  createCategoryIds: string[];
+  createPrimaryId: string | null;
+  backHref: string;
+  detailPathFor: (id: string) => string;
+}
+
+/**
+ * AUD-057 (#1608) — the product-detail write path + form state (dirty
+ * fields, required-field validation, expand/collapse, create/edit save,
+ * cancel, delete), lifted out of product-detail-page.tsx to bring that
+ * monolith under the 500-line guard. The page keeps locale/channel + tab
+ * UI state and reads everything else from {@see useProductDetailData}; this
+ * hook owns mutations + the dirty buffer they operate on.
+ */
+export function useProductDetailForm({
+  mode,
+  id,
+  isEditMode,
+  kind,
+  objectTypeId,
+  isCategorizable,
+  locale,
+  channel,
+  groups,
+  attrs,
+  product,
+  productQuery,
+  createCategoryIds,
+  createPrimaryId,
+  backHref,
+  detailPathFor,
+}: UseProductDetailFormArgs) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const [dirtyFields, setDirtyFields] = useState<Record<string, unknown>>({});
+  // #1350 — codes of required attributes that blocked the last save.
+  const [requiredErrors, setRequiredErrors] = useState<Set<string>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const setExpandedAll = (ids: string[]): void => setExpandedGroups(new Set(ids));
+
+  const toggleGroup = (groupId: string): void => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  };
+
+  const setFieldValue = (code: string, value: unknown): void => {
+    setDirtyFields((prev) => ({ ...prev, [code]: value }));
+    setRequiredErrors((prev) => {
+      if (!prev.has(code)) return prev;
+      const next = new Set(prev);
+      next.delete(code);
+      return next;
+    });
+  };
+
+  const fieldValue = (code: string): unknown => {
+    if (Object.hasOwn(dirtyFields, code)) {
+      return dirtyFields[code];
+    }
+    return attrs[code];
+  };
+
+  const resetDirty = (): void => setDirtyFields({});
+
+  // #1350 — full-state required check at save time: every `is_required`
+  // attribute across the effective groups must carry a non-empty CURRENT
+  // value (dirty edits included). Legacy dirty records are therefore
+  // enforced on their next save, exactly as the ticket specifies.
+  const collectRequiredViolations = (): string[] => {
+    const violations: string[] = [];
+    for (const group of groups) {
+      for (const attr of group.attributes) {
+        if (attr.is_required !== true) continue;
+        // #1350 (reopen #2) — requiredness is meaningless for booleans:
+        // an unchecked box IS the value `false`, not a missing value.
+        if (attr.type === 'boolean') continue;
+        const current = fieldValue(attr.code);
+        if (isEmptyAttributeValue(current)) violations.push(attr.code);
+      }
+    }
+    return violations;
+  };
+
+  const handleSave = async (returnToList = false): Promise<void> => {
+    if (isSaving) return;
+    const violations = collectRequiredViolations();
+    if (violations.length > 0) {
+      setRequiredErrors(new Set(violations));
+      toast.error(
+        t('products.detail.validation.required_fields', {
+          defaultValue: 'Uzupełnij wymagane pola: {{fields}}',
+          fields: violations.join(', '),
+        }),
+      );
+      return;
+    }
+    setRequiredErrors(new Set());
+    setIsSaving(true);
+    try {
+      if (mode === 'create') {
+        const skuRaw = dirtyFields.sku ?? dirtyFields.code ?? '';
+        const sku = typeof skuRaw === 'string' ? skuRaw.trim() : '';
+        if (sku === '') {
+          // #1415 — the system identifier is labelled "ID" for every
+          // ObjectType (operator decision); custom identifiers live as
+          // ordinary attributes.
+          toast.error(t('object_create.id_required', { defaultValue: 'ID jest wymagane' }));
+          setIsSaving(false);
+          return;
+        }
+        if (objectTypeId === null) {
+          toast.error(
+            t('products.detail.validation.object_type_missing', {
+              defaultValue: 'Brak built-in ObjectType — uruchom seeder katalogu',
+            }),
+          );
+          setIsSaving(false);
+          return;
+        }
+        // #891 / #1359 — categorizable kinds require a category at create.
+        if (isCategorizable && createCategoryIds.length === 0) {
+          toast.error(
+            t('products.detail.validation.categories_required', {
+              defaultValue: 'Przypisz przynajmniej jedną kategorię',
+            }),
+          );
+          setIsSaving(false);
+          return;
+        }
+        // #1102 — relation values cannot ride the create POST (they live
+        // in the relations link table, not object_values); split them out
+        // and PUT after the object exists, like UniversalCreatePage did.
+        const relationCodes = collectRelationCodes(groups);
+        const { normal: attributes, relations } = splitDirtyAttributes(
+          stripAttributes(dirtyFields),
+          relationCodes,
+        );
+        const body: Record<string, unknown> = {
+          code: sku,
+          objectTypeId,
+        };
+        if (createCategoryIds.length > 0) {
+          const primary =
+            createPrimaryId !== null && createCategoryIds.includes(createPrimaryId)
+              ? createPrimaryId
+              : createCategoryIds[0];
+          body.categoryIds = createCategoryIds;
+          body.primaryCategoryId = primary;
+        }
+        if (Object.keys(attributes).length > 0) body.attributes = attributes;
+        // #1415 — poly-kind create: same processor as the /api/products
+        // sugar path, kind comes from objectTypeId.
+        const created = await jsonFetch<{ id: string }>('/api/objects', {
+          method: 'POST',
+          contentType: 'application/ld+json',
+          body,
+        });
+
+        const relationFailures: string[] = [];
+        for (const [attrCode, targets] of Object.entries(relations)) {
+          if (targets.length === 0) continue;
+          try {
+            await jsonFetch(`/api/objects/${created.id}/relations/${attrCode}`, {
+              method: 'PUT',
+              contentType: 'application/json',
+              body: { targets: targets.map((targetId) => ({ id: targetId })) },
+            });
+          } catch {
+            relationFailures.push(attrCode);
+          }
+        }
+        if (relationFailures.length > 0) {
+          toast.error(
+            t('object_create.relations_partial_error', {
+              defaultValue: 'Obiekt utworzony, ale relacje nie zapisane: {{codes}}',
+              codes: relationFailures.join(', '),
+            }),
+          );
+        } else {
+          toast.success(
+            kind === 'product'
+              ? t('products.detail.create.success', {
+                  defaultValue: 'Utworzono produkt {{code}}',
+                  code: sku,
+                })
+              : t('object_create.success', { defaultValue: 'Utworzono {{code}}', code: sku }),
+          );
+        }
+        navigate(detailPathFor(created.id));
+      } else {
+        if (Object.keys(dirtyFields).length === 0) {
+          // Nothing to persist — "Zapisz i wróć do listy" still returns.
+          if (returnToList) navigate(backHref);
+          setIsSaving(false);
+          return;
+        }
+        // #1350 (reopen #2) — in edit mode every dirty key IS an attribute
+        // code; stripping 'sku'/'code' here silently dropped edits to a
+        // real `sku` attribute. The strip only belongs to create mode.
+        const attributes = { ...dirtyFields };
+        // #1150 / #1155 — write in the active locale + channel: localizable
+        // / scopable attributes land on that scope's row, others stay
+        // global (BE decides per flag).
+        await jsonFetch(`/api/objects/${id}${scopeQuery(locale, channel)}`, {
+          method: 'PATCH',
+          contentType: 'application/merge-patch+json',
+          body: { attributes },
+        });
+        await productQuery.refetch();
+        setDirtyFields({});
+        toast.success(t('products.detail.save.success', { defaultValue: 'Zapisano zmiany' }));
+        // #1351 — "Zapisz zmiany" keeps the row in edit mode; only
+        // "Zapisz i wróć do listy" navigates back to the list.
+        if (returnToList) navigate(backHref);
+      }
+    } catch (error) {
+      // #1179 — surface the server's Problem Details `detail` (e.g. duplicate
+      // identifier 409) instead of the generic copy.
+      toast.error(
+        httpErrorDetail(error) ??
+          t('products.detail.save.failed', { defaultValue: 'Nie udało się zapisać' }),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const cancelEdit = (): void => {
+    // #1351 — no read-only mode anymore; "Anuluj" just discards unsaved
+    // edits and restores the persisted values.
+    setDirtyFields({});
+    void productQuery.refetch();
+  };
+
+  const handleDelete = async (onDone: () => void): Promise<void> => {
+    if (mode !== 'edit' || id === '' || isDeleting) return;
+    setIsDeleting(true);
+    try {
+      await jsonFetch(`/api/objects/${id}`, { method: 'DELETE' });
+      toast.success(
+        t('products.detail.delete.success', {
+          defaultValue: 'Usunięto produkt {{code}}',
+          code: product?.code ?? id,
+        }),
+      );
+      navigate(backHref);
+    } catch {
+      toast.error(
+        t('products.detail.delete.failed', { defaultValue: 'Nie udało się usunąć produktu' }),
+      );
+      setIsDeleting(false);
+      onDone();
+    }
+  };
+
+  return {
+    dirtyFields,
+    requiredErrors,
+    expandedGroups,
+    isSaving,
+    isDeleting,
+    setFieldValue,
+    fieldValue,
+    toggleGroup,
+    setExpandedAll,
+    resetDirty,
+    handleSave,
+    cancelEdit,
+    handleDelete,
+    // Exposed so the page's "reset dirty on scope change" + isEditMode
+    // guards stay in the component where the effects live.
+    isEditMode,
+  };
+}

--- a/apps/admin/src/features/settings/locales/__tests__/locales-invalidation.test.tsx
+++ b/apps/admin/src/features/settings/locales/__tests__/locales-invalidation.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { jsonFetch } from '@/lib/http';
+
+import { LocalesSettingsPage, tenantLocaleKeys } from '../index';
+import type { TenantLocaleListItem } from '../types';
+
+// AUD-055 (ADR-0021) — proof that migrating LocalesSettingsPage from
+// jsonFetch+useEffect to useQuery fixes the stale-data class: invalidating
+// the list key (what every mutation handler now does, and what an external
+// screen could do) re-renders the table with fresh server data. The old
+// useEffect-with-[] read was immune to that.
+
+vi.mock('@/lib/http', () => ({ jsonFetch: vi.fn() }));
+// The "Add locale" modal does its own fetching; not under test here.
+vi.mock('../AddLocaleModal', () => ({ AddLocaleModal: () => null }));
+vi.mock('@/components/ui/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const jsonFetchMock = vi.mocked(jsonFetch);
+
+function makeLocale(
+  code: string,
+  overrides: Partial<TenantLocaleListItem> = {},
+): TenantLocaleListItem {
+  return {
+    id: `id-${code}`,
+    code,
+    label: code.toUpperCase(),
+    language: code,
+    region: null,
+    // Distinct from `code` so getByText(code) targets the mono code cell,
+    // not the localized display name.
+    displayName: { pl: `Język ${code}`, en: `Lang ${code}` },
+    isDefault: false,
+    isMandatory: false,
+    fallbackCode: null,
+    sortOrder: 0,
+    isActive: true,
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  const result = render(<LocalesSettingsPage />, { wrapper });
+  return { client, ...result };
+}
+
+afterEach(() => {
+  jsonFetchMock.mockReset();
+});
+
+describe('LocalesSettingsPage data fetching (ADR-0021)', () => {
+  it('refreshes the list when the query key is invalidated', async () => {
+    // First read: one locale.
+    jsonFetchMock.mockResolvedValue({ items: [makeLocale('pl', { isDefault: true })] });
+
+    const { client } = renderPage();
+
+    // The mono code cell carries the locale code; assert on it specifically
+    // (the code also leaks into other rows' fallback <option>s once active).
+    const codeCell = (code: string) =>
+      screen.queryAllByText(code).find((el) => el.classList.contains('font-mono'));
+
+    await waitFor(() => expect(codeCell('pl')).toBeDefined());
+    expect(codeCell('de')).toBeUndefined();
+
+    // Simulate a mutation landing a new locale server-side, then the exact
+    // invalidation every handler performs.
+    jsonFetchMock.mockResolvedValue({
+      items: [makeLocale('pl', { isDefault: true }), makeLocale('de')],
+    });
+    await client.invalidateQueries({ queryKey: tenantLocaleKeys.list() });
+
+    // The table re-renders with the new row — no manual refetch wiring.
+    await waitFor(() => expect(codeCell('de')).toBeDefined());
+    expect(codeCell('pl')).toBeDefined();
+  });
+});

--- a/apps/admin/src/features/settings/locales/index.tsx
+++ b/apps/admin/src/features/settings/locales/index.tsx
@@ -1,5 +1,6 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Languages, MoreHorizontal, Plus, Star } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -26,6 +27,17 @@ import { AddLocaleModal } from './AddLocaleModal';
 import type { TenantLocaleListItem, TenantLocaleListResponse } from './types';
 
 /**
+ * AUD-055 (ADR-0021) — single query-key family for the tenant-locale
+ * list. Every reader + every invalidation goes through it so the list
+ * refreshes whenever any mutation (here or a future external screen)
+ * busts the key — the stale-data class the migration off jsonFetch +
+ * useEffect was meant to kill.
+ */
+export const tenantLocaleKeys = {
+  list: () => ['tenant-locales'] as const,
+};
+
+/**
  * LOC-07 (#875) — Settings → Languages / `/settings/locales`.
  *
  * Lists the tenant's active + inactive locales backed by
@@ -40,28 +52,29 @@ import type { TenantLocaleListItem, TenantLocaleListResponse } from './types';
  */
 export function LocalesSettingsPage() {
   const { t } = useTranslation();
-  const [rows, setRows] = useState<TenantLocaleListItem[] | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
-  const refetch = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const response = await jsonFetch<TenantLocaleListResponse>('/api/tenant-locales', {
+  // AUD-055 / ADR-0021 — was useState + useEffect + manual refetch (a
+  // read invisible to TanStack Query's cache). Now useQuery so the list
+  // re-renders whenever any mutation invalidates the key, instead of
+  // relying on every call site remembering to refetch.
+  const localesQuery = useQuery({
+    queryKey: tenantLocaleKeys.list(),
+    queryFn: () =>
+      jsonFetch<TenantLocaleListResponse>('/api/tenant-locales', {
         accept: 'application/json',
-      });
-      setRows(response.items);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load locales.');
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+      }),
+  });
+  const rows = localesQuery.data?.items ?? null;
+  const isLoading = localesQuery.isLoading;
+  const error = localesQuery.isError
+    ? localesQuery.error instanceof Error
+      ? localesQuery.error.message
+      : 'Failed to load locales.'
+    : null;
 
-  useEffect(() => {
-    void refetch();
-  }, [refetch]);
+  const invalidate = (): Promise<void> =>
+    queryClient.invalidateQueries({ queryKey: tenantLocaleKeys.list() });
 
   const activeCodes = useMemo(
     () => rows?.filter((r) => r.isActive).map((r) => r.code) ?? [],
@@ -83,7 +96,7 @@ export function LocalesSettingsPage() {
         contentType: 'application/json',
       });
       toast.success(t('settings.locales.toast.default_changed', { code }));
-      void refetch();
+      void invalidate();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Default switch failed.');
     }
@@ -97,7 +110,7 @@ export function LocalesSettingsPage() {
         body: { isMandatory: !row.isMandatory },
         contentType: 'application/json',
       });
-      void refetch();
+      void invalidate();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Update failed.');
     }
@@ -110,7 +123,7 @@ export function LocalesSettingsPage() {
         body: { fallbackCode },
         contentType: 'application/json',
       });
-      void refetch();
+      void invalidate();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Fallback update failed.');
     }
@@ -122,7 +135,7 @@ export function LocalesSettingsPage() {
         method: 'DELETE',
       });
       toast.success(t('settings.locales.toast.deactivated', { code: row.code }));
-      void refetch();
+      void invalidate();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Deactivation failed.');
     }
@@ -135,7 +148,7 @@ export function LocalesSettingsPage() {
         body: {},
         contentType: 'application/json',
       });
-      void refetch();
+      void invalidate();
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Reactivation failed.');
     }
@@ -209,7 +222,7 @@ export function LocalesSettingsPage() {
         activatedCodes={activatedCodes}
         nextSortOrder={nextSortOrder}
         onSuccess={() => {
-          void refetch();
+          void invalidate();
         }}
       />
     </div>

--- a/apps/api/src/Catalog/Application/Bulk/AbstractBulkHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/AbstractBulkHandler.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+use App\Catalog\Application\BulkContext;
+use App\Catalog\Application\Reindex\BulkReindexQueueInterface;
+use App\Catalog\Domain\Entity\BulkLog;
+use App\Catalog\Domain\Entity\BulkSession;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * Shared lifecycle for every per-object Bulk*Handler (AUD-056).
+ *
+ * The audit flagged 13.27 % copy-paste duplication across the Bulk
+ * handlers — each one repeated the same ~45-line skeleton:
+ *
+ *   1. `set_time_limit(0)` so a 2k+ SKU run is not killed at PHP's 30s
+ *      HTTP timeout mid-loop (which left the session incomplete);
+ *   2. flip {@see BulkContext} ON in a try/finally that always flips it
+ *      OFF so the synchronous indexed-attribute listeners stay opted-out
+ *      for the whole run (CLAUDE.md FrankenPHP worker rule);
+ *   3. iterate `BulkSession::getTargetObjectIds()`, resolve each id,
+ *      run the per-object body inside a try/catch that converts an
+ *      unexpected throwable into an error BulkLog row;
+ *   4. flush + {@see EntityManagerInterface::clear()} every CHUNK_SIZE
+ *      rows to cap Doctrine's identity map (worker memory rule);
+ *   5. after the loop reload the BulkSession (the per-chunk clear()
+ *      detached it + its Tenant proxy), `complete()` it with the tally,
+ *      flush, and schedule the Meilisearch reindex.
+ *
+ * Only the per-object body and the reindex call ever differed. This base
+ * owns 1–5; subclasses implement {@see processObject()} for the body and
+ * override {@see reindex()} when they need the delete companion. The
+ * mutable {@see BulkCounters} replaces the three local ints so a handler
+ * can still tally a row however it likes (e.g. multi-attribute edit bumps
+ * `skipped` per locked edit and `success` once for the row).
+ *
+ * Rollback (`BulkRollbackHandler`) deliberately does NOT extend this: it
+ * walks `bulk_logs` rather than target ids and `markRolledBack()`s instead
+ * of `complete()`, so it has its own loop.
+ */
+abstract class AbstractBulkHandler
+{
+    /**
+     * Rows to mutate between flush + clear cycles. Override in a subclass
+     * (e.g. BulkDuplicateHandler clones rows and uses a smaller chunk).
+     */
+    protected const int CHUNK_SIZE = 200;
+
+    public function __construct(
+        protected readonly CatalogObjectRepositoryInterface $catalogObjects,
+        protected readonly EntityManagerInterface $em,
+        protected readonly BulkContext $bulkContext,
+        protected readonly BulkReindexQueueInterface $reindexQueue,
+    ) {
+    }
+
+    /**
+     * Apply the handler-specific mutation to a single resolved object,
+     * persisting whatever BulkLog rows the rollback path needs and
+     * updating the shared {@see BulkCounters}. Throwing here is caught by
+     * {@see runBatch()} and recorded as an error row — but handlers
+     * should prefer to record an explicit warning/error BulkLog and tally
+     * the counter themselves for actionable per-row reporting.
+     */
+    abstract protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void;
+
+    /**
+     * Schedule the post-run search reindex for the touched ids. Defaults
+     * to {@see BulkReindexQueueInterface::queueAll()}; BulkDeleteHandler
+     * overrides to {@see BulkReindexQueueInterface::queueAllDeleted()}.
+     */
+    protected function reindex(BulkSession $session): void
+    {
+        $this->reindexQueue->queueAll($session->getTargetObjectIds());
+    }
+
+    /**
+     * Run the shared bulk lifecycle over the session's target ids.
+     *
+     * @return array{success: int, skipped: int, error: int}
+     */
+    final protected function runBatch(BulkSession $session): array
+    {
+        // Long bulk runs (2k+ products) routinely exceed PHP's 30s HTTP
+        // timeout — without disabling it the handler is killed mid-loop,
+        // the session stays incomplete, and the operator sees 200 + zero
+        // rows touched.
+        set_time_limit(0);
+
+        $this->bulkContext->setBulk(true, $session->getId());
+        try {
+            $counters = new BulkCounters();
+            $chunkCounter = 0;
+
+            foreach ($session->getTargetObjectIds() as $targetId) {
+                try {
+                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
+                    if (!$object instanceof CatalogObject) {
+                        ++$counters->error;
+                        ++$chunkCounter;
+                        continue;
+                    }
+
+                    $this->processObject($object, $session, $counters);
+                } catch (Throwable $e) {
+                    ++$counters->error;
+                    $this->em->persist(new BulkLog(
+                        $session->getId(),
+                        Uuid::fromString($targetId),
+                        null,
+                        null,
+                        null,
+                        BulkLog::LEVEL_ERROR,
+                        $e->getMessage(),
+                    ));
+                }
+
+                ++$chunkCounter;
+                if ($chunkCounter >= static::CHUNK_SIZE) {
+                    $this->em->flush();
+                    $this->em->clear();
+                    $chunkCounter = 0;
+                }
+            }
+
+            if ($chunkCounter > 0) {
+                $this->em->flush();
+            }
+
+            // Reload BulkSession: per-chunk em->clear() detached the
+            // local instance and its Tenant proxy. The final persist
+            // below would otherwise raise EntityNotFoundException on
+            // flush trying to resolve the stale proxy.
+            $reloaded = $this->em->find(BulkSession::class, $session->getId());
+            if ($reloaded instanceof BulkSession) {
+                $session = $reloaded;
+            }
+
+            $session->complete($counters->success, $counters->skipped, $counters->error);
+            $this->em->persist($session);
+            $this->em->flush();
+
+            $this->reindex($session);
+
+            return $counters->toResult();
+        } finally {
+            $this->bulkContext->setBulk(false);
+        }
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAddCategoryHandler.php
@@ -14,7 +14,6 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-14 (#546) — `add_category` bulk action.
@@ -22,19 +21,22 @@ use Throwable;
  * Adds the supplied category ids to each target product. Skips a
  * (product, category) pair when the assignment already exists (warning
  * log). BulkLog `old_value` snapshots the prior assignment id list to
- * support the 24h rollback path via `replaceForProduct`.
+ * support the 24h rollback path via `replaceForProduct`. Shared
+ * lifecycle: {@see AbstractBulkHandler}.
  */
-final class BulkAddCategoryHandler
+final class BulkAddCategoryHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    /** @var list<string> */
+    private array $categoryIds = [];
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        CatalogObjectRepositoryInterface $catalogObjects,
         private readonly ObjectCategoryRepositoryInterface $objectCategories,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -44,119 +46,57 @@ final class BulkAddCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        $this->categoryIds = $categoryIds;
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        return $this->runBatch($session);
+    }
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$product instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        $existing = $this->objectCategories->findByProduct($object);
+        $existingIds = array_map(
+            static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
+            $existing,
+        );
 
-                    $existing = $this->objectCategories->findByProduct($product);
-                    $existingIds = array_map(
-                        static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
-                        $existing,
-                    );
-
-                    $added = 0;
-                    foreach ($categoryIds as $catId) {
-                        if (\in_array($catId, $existingIds, true)) {
-                            continue;
-                        }
-                        $category = $this->catalogObjects->findById(Uuid::fromString($catId));
-                        if (!$category instanceof CatalogObject) {
-                            continue;
-                        }
-                        $this->objectCategories->save(new ObjectCategory($product, $category));
-                        ++$added;
-                    }
-
-                    if (0 === $added) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $product->getId(),
-                            null,
-                            $existingIds,
-                            $existingIds,
-                            BulkLog::LEVEL_WARNING,
-                            'All categories already assigned',
-                        ));
-                    } else {
-                        $product->markTouchedByBulkSession($session->getId());
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $product->getId(),
-                            null,
-                            $existingIds,
-                            array_values(array_unique([...$existingIds, ...$categoryIds])),
-                            BulkLog::LEVEL_INFO,
-                            null,
-                        ));
-                        ++$success;
-                    }
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
+        $added = 0;
+        foreach ($this->categoryIds as $catId) {
+            if (\in_array($catId, $existingIds, true)) {
+                continue;
             }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
+            $category = $this->catalogObjects->findById(Uuid::fromString($catId));
+            if (!$category instanceof CatalogObject) {
+                continue;
             }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+            $this->objectCategories->save(new ObjectCategory($object, $category));
+            ++$added;
         }
+
+        if (0 === $added) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $existingIds,
+                $existingIds,
+                BulkLog::LEVEL_WARNING,
+                'All categories already assigned',
+            ));
+
+            return;
+        }
+
+        $object->markTouchedByBulkSession($session->getId());
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $existingIds,
+            array_values(array_unique([...$existingIds, ...$this->categoryIds])),
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkAppendValueHandler.php
@@ -12,8 +12,6 @@ use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-13 (#545) — `append_value` bulk action (multiselect-safe).
@@ -21,19 +19,22 @@ use Throwable;
  * Appends a value to a list attribute. If the attribute slot is null or
  * scalar, it is promoted to `[old, new]` (dedup). If the value is
  * already present, the row is skipped (no-op, info log). Locked
- * attributes (VIEW-33 / PRD §8.3) skip with a warning entry.
+ * attributes (VIEW-33 / PRD §8.3) skip with a warning entry. Shared
+ * lifecycle: {@see AbstractBulkHandler}.
  */
-final class BulkAppendValueHandler
+final class BulkAppendValueHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    private string $attrCode = '';
+    private mixed $value = null;
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
+        CatalogObjectRepositoryInterface $catalogObjects,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -41,131 +42,65 @@ final class BulkAppendValueHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $value): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        $this->attrCode = $attrCode;
+        $this->value = $value;
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        return $this->runBatch($session);
+    }
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$object instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        if ($this->lockReader->isLocked($object, $this->attrCode)) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                BulkLog::LEVEL_WARNING,
+                'Attribute locked',
+            ));
 
-                    if ($this->lockReader->isLocked($object, $attrCode)) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            BulkLog::LEVEL_WARNING,
-                            'Attribute locked',
-                        ));
-                        ++$chunkCounter;
-                        if ($chunkCounter >= self::CHUNK_SIZE) {
-                            $this->em->flush();
-                            $this->em->clear();
-                            $chunkCounter = 0;
-                        }
-                        continue;
-                    }
-
-                    $indexed = $object->getAttributesIndexed();
-                    $oldValue = $indexed[$attrCode] ?? null;
-                    $list = match (true) {
-                        \is_array($oldValue) => $oldValue,
-                        null === $oldValue => [],
-                        default => [$oldValue],
-                    };
-
-                    if (\in_array($value, $list, true)) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $oldValue,
-                            $oldValue,
-                            BulkLog::LEVEL_WARNING,
-                            'Value already present',
-                        ));
-                    } else {
-                        $list[] = $value;
-                        $indexed[$attrCode] = $list;
-                        $object->updateAttributeIndex($indexed);
-                        $object->markTouchedByBulkSession($session->getId());
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $oldValue,
-                            $list,
-                            BulkLog::LEVEL_INFO,
-                            null,
-                        ));
-                        ++$success;
-                    }
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
-            }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+            return;
         }
+
+        $indexed = $object->getAttributesIndexed();
+        $oldValue = $indexed[$this->attrCode] ?? null;
+        $list = match (true) {
+            \is_array($oldValue) => $oldValue,
+            null === $oldValue => [],
+            default => [$oldValue],
+        };
+
+        if (\in_array($this->value, $list, true)) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $oldValue,
+                $oldValue,
+                BulkLog::LEVEL_WARNING,
+                'Value already present',
+            ));
+
+            return;
+        }
+
+        $list[] = $this->value;
+        $indexed[$this->attrCode] = $list;
+        $object->updateAttributeIndex($indexed);
+        $object->markTouchedByBulkSession($session->getId());
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $oldValue,
+            $list,
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkClearAttributeHandler.php
@@ -12,8 +12,6 @@ use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-13 (#545) — `clear_attribute` bulk action.
@@ -21,19 +19,20 @@ use Throwable;
  * Removes the attribute slot from `attributes_indexed` (unset). Used
  * for resetting a field across N products. BulkLog records `old_value`
  * for the 24h rollback path. Locked attributes (VIEW-33 / PRD §8.3)
- * skip with a warning entry.
+ * skip with a warning entry. Shared lifecycle: {@see AbstractBulkHandler}.
  */
-final class BulkClearAttributeHandler
+final class BulkClearAttributeHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    private string $attrCode = '';
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
+        CatalogObjectRepositoryInterface $catalogObjects,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -41,112 +40,43 @@ final class BulkClearAttributeHandler
      */
     public function handle(BulkSession $session, string $attrCode): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        $this->attrCode = $attrCode;
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        return $this->runBatch($session);
+    }
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$object instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        if ($this->lockReader->isLocked($object, $this->attrCode)) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                BulkLog::LEVEL_WARNING,
+                'Attribute locked',
+            ));
 
-                    if ($this->lockReader->isLocked($object, $attrCode)) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            BulkLog::LEVEL_WARNING,
-                            'Attribute locked',
-                        ));
-                        ++$chunkCounter;
-                        if ($chunkCounter >= self::CHUNK_SIZE) {
-                            $this->em->flush();
-                            $this->em->clear();
-                            $chunkCounter = 0;
-                        }
-                        continue;
-                    }
-
-                    $indexed = $object->getAttributesIndexed();
-                    $oldValue = $indexed[$attrCode] ?? null;
-                    unset($indexed[$attrCode]);
-                    $object->updateAttributeIndex($indexed);
-                    $object->markTouchedByBulkSession($session->getId());
-
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        $object->getId(),
-                        null,
-                        $oldValue,
-                        null,
-                        BulkLog::LEVEL_INFO,
-                        null,
-                    ));
-                    ++$success;
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
-            }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+            return;
         }
+
+        $indexed = $object->getAttributesIndexed();
+        $oldValue = $indexed[$this->attrCode] ?? null;
+        unset($indexed[$this->attrCode]);
+        $object->updateAttributeIndex($indexed);
+        $object->markTouchedByBulkSession($session->getId());
+
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $oldValue,
+            null,
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkCounters.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkCounters.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application\Bulk;
+
+/**
+ * Mutable success/skipped/error accumulator threaded through a bulk run.
+ *
+ * Replaces the three `$success`/`$skipped`/`$errors` locals that every
+ * Bulk*Handler previously declared and incremented inline. Passing a
+ * shared object into {@see AbstractBulkHandler::runBatch()} lets the
+ * base class own the loop + session finalisation while each handler's
+ * per-object body keeps full control over how it tallies a row (some
+ * bump `skipped` per-edit and `success` once-per-row — see
+ * BulkMultiAttributeEditHandler).
+ */
+final class BulkCounters
+{
+    public function __construct(
+        public int $success = 0,
+        public int $skipped = 0,
+        public int $error = 0,
+    ) {
+    }
+
+    /**
+     * @return array{success: int, skipped: int, error: int}
+     */
+    public function toResult(): array
+    {
+        return ['success' => $this->success, 'skipped' => $this->skipped, 'error' => $this->error];
+    }
+}

--- a/apps/api/src/Catalog/Application/Bulk/BulkDeleteHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDeleteHandler.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application\Bulk;
 
-use App\Catalog\Application\BulkContext;
-use App\Catalog\Application\Reindex\BulkReindexQueueInterface;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
-use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
-use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-16 (#548) — `delete` bulk action.
@@ -25,111 +19,43 @@ use Throwable;
  * BulkLog `old_value` snapshots the product code + a flag indicating
  * deletion so rollback can recreate the row in a follow-up handler;
  * present executor only flags the session as containing destructive
- * ops, the recreate path is tracked separately.
+ * ops, the recreate path is tracked separately. Shared lifecycle lives
+ * in {@see AbstractBulkHandler}; this handler overrides {@see reindex()}
+ * to remove the touched documents from Meilisearch.
  */
-final class BulkDeleteHandler
+final class BulkDeleteHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
-
-    public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
-        private readonly BulkReindexQueueInterface $reindexQueue,
-    ) {
-    }
-
     /**
      * @return array{success: int, skipped: int, error: int}
      */
     public function handle(BulkSession $session): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        return $this->runBatch($session);
+    }
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        $snapshot = [
+            'code' => $object->getCode(),
+            'kind' => $object->getKind()->value,
+            'attributes_indexed' => $object->getAttributesIndexed(),
+        ];
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$product instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $snapshot,
+            null,
+            BulkLog::LEVEL_INFO,
+            'deleted',
+        ));
+        $this->catalogObjects->remove($object);
+        ++$counters->success;
+    }
 
-                    $snapshot = [
-                        'code' => $product->getCode(),
-                        'kind' => $product->getKind()->value,
-                        'attributes_indexed' => $product->getAttributesIndexed(),
-                    ];
-
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        $product->getId(),
-                        null,
-                        $snapshot,
-                        null,
-                        BulkLog::LEVEL_INFO,
-                        'deleted',
-                    ));
-                    $this->catalogObjects->remove($product);
-                    ++$success;
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
-            }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, 0, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAllDeleted($session->getTargetObjectIds(), ObjectKind::Product);
-
-            return ['success' => $success, 'skipped' => 0, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
-        }
+    protected function reindex(BulkSession $session): void
+    {
+        $this->reindexQueue->queueAllDeleted($session->getTargetObjectIds(), ObjectKind::Product);
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkDuplicateHandler.php
@@ -16,8 +16,6 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-16 (#548) — `duplicate` bulk action.
@@ -25,20 +23,23 @@ use Throwable;
  * Clones each source product into `{code}-COPY-N` (mirrors
  * DuplicateProductController). Skips collisions (conflict warning) and
  * caps the suffix counter to 9999 per source. The 24h rollback path
- * removes the cloned rows by id (recorded in BulkLog new_value).
+ * removes the cloned rows by id (recorded in BulkLog new_value). Shared
+ * lifecycle: {@see AbstractBulkHandler}; cloning N values per source is
+ * heavier, so the chunk size is halved.
  */
-final class BulkDuplicateHandler
+final class BulkDuplicateHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 100;
+    protected const int CHUNK_SIZE = 100;
     public const int MAX_SUFFIX = 9999;
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        CatalogObjectRepositoryInterface $catalogObjects,
         private readonly ObjectValueRepositoryInterface $values,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -46,124 +47,63 @@ final class BulkDuplicateHandler
      */
     public function handle(BulkSession $session): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        return $this->runBatch($session);
+    }
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        if (ObjectKind::Product !== $object->getKind()) {
+            ++$counters->error;
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $source = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$source instanceof CatalogObject || ObjectKind::Product !== $source->getKind()) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
-
-                    $tenant = $source->getTenant();
-                    if (null === $tenant) {
-                        throw new BadRequestHttpException('Source product is missing tenant context.');
-                    }
-
-                    $newCode = $this->allocateCopySku($source);
-                    if (null === $newCode) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $source->getId(),
-                            null,
-                            ['code' => $source->getCode()],
-                            ['code' => $source->getCode()],
-                            BulkLog::LEVEL_WARNING,
-                            'Suffix exhausted',
-                        ));
-                        ++$chunkCounter;
-                        continue;
-                    }
-
-                    $copy = new CatalogObject($source->getObjectType(), $newCode);
-                    $this->catalogObjects->save($copy);
-                    $copy->markTouchedByBulkSession($session->getId());
-
-                    foreach ($this->values->findByObject($source) as $sourceValue) {
-                        $cloned = new ObjectValue(
-                            object: $copy,
-                            attribute: $sourceValue->getAttribute(),
-                            value: $sourceValue->getValue(),
-                            provenance: Provenance::Manual,
-                        );
-                        $cloned->changeChannelId($sourceValue->getChannelId());
-                        $cloned->changeLocale($sourceValue->getLocale());
-                        $this->values->save($cloned);
-                    }
-
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        $source->getId(),
-                        null,
-                        ['code' => $source->getCode()],
-                        ['copy_id' => $copy->getId()->toRfc4122(), 'copy_code' => $newCode],
-                        BulkLog::LEVEL_INFO,
-                        null,
-                    ));
-                    ++$success;
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
-            }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+            return;
         }
+
+        if (null === $object->getTenant()) {
+            throw new BadRequestHttpException('Source product is missing tenant context.');
+        }
+
+        $newCode = $this->allocateCopySku($object);
+        if (null === $newCode) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                ['code' => $object->getCode()],
+                ['code' => $object->getCode()],
+                BulkLog::LEVEL_WARNING,
+                'Suffix exhausted',
+            ));
+
+            return;
+        }
+
+        $copy = new CatalogObject($object->getObjectType(), $newCode);
+        $this->catalogObjects->save($copy);
+        $copy->markTouchedByBulkSession($session->getId());
+
+        foreach ($this->values->findByObject($object) as $sourceValue) {
+            $cloned = new ObjectValue(
+                object: $copy,
+                attribute: $sourceValue->getAttribute(),
+                value: $sourceValue->getValue(),
+                provenance: Provenance::Manual,
+            );
+            $cloned->changeChannelId($sourceValue->getChannelId());
+            $cloned->changeLocale($sourceValue->getLocale());
+            $this->values->save($cloned);
+        }
+
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            ['code' => $object->getCode()],
+            ['copy_id' => $copy->getId()->toRfc4122(), 'copy_code' => $newCode],
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
     }
 
     private function allocateCopySku(CatalogObject $source): ?string

--- a/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkIncrementNumericHandler.php
@@ -13,8 +13,6 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-13 (#545) — `increment_numeric` bulk action.
@@ -25,19 +23,22 @@ use Throwable;
  * Locked attributes (VIEW-33 / PRD §8.3) skip with a warning entry.
  *
  * Division-by-zero raises a per-row error log (no-op) rather than
- * aborting the batch.
+ * aborting the batch. Shared lifecycle: {@see AbstractBulkHandler}.
  */
-final class BulkIncrementNumericHandler
+final class BulkIncrementNumericHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    private string $attrCode = '';
+    private string $operator = '+';
+    private float $operand = 0.0;
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
+        CatalogObjectRepositoryInterface $catalogObjects,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -45,154 +46,90 @@ final class BulkIncrementNumericHandler
      */
     public function handle(BulkSession $session, string $attrCode, string $operator, float $operand): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's 30s HTTP
-        // timeout — without disabling it the handler is killed mid-loop,
-        // the session stays incomplete, and the operator sees 200 + zero
-        // rows touched.
-        set_time_limit(0);
-
         if (!\in_array($operator, ['+', '-', '*', '/', '%'], true)) {
             throw new BadRequestHttpException(\sprintf('Unsupported operator "%s".', $operator));
         }
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        $this->attrCode = $attrCode;
+        $this->operator = $operator;
+        $this->operand = $operand;
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$object instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+        return $this->runBatch($session);
+    }
 
-                    if ($this->lockReader->isLocked($object, $attrCode)) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            BulkLog::LEVEL_WARNING,
-                            'Attribute locked',
-                        ));
-                        ++$chunkCounter;
-                        if ($chunkCounter >= self::CHUNK_SIZE) {
-                            $this->em->flush();
-                            $this->em->clear();
-                            $chunkCounter = 0;
-                        }
-                        continue;
-                    }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        if ($this->lockReader->isLocked($object, $this->attrCode)) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                BulkLog::LEVEL_WARNING,
+                'Attribute locked',
+            ));
 
-                    $indexed = $object->getAttributesIndexed();
-                    $oldValue = $indexed[$attrCode] ?? null;
-
-                    if (!is_numeric($oldValue)) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $oldValue,
-                            $oldValue,
-                            BulkLog::LEVEL_WARNING,
-                            'Value is not numeric',
-                        ));
-                        ++$chunkCounter;
-                        continue;
-                    }
-
-                    $current = (float) $oldValue;
-                    $newValue = match ($operator) {
-                        '+' => $current + $operand,
-                        '-' => $current - $operand,
-                        '*' => $current * $operand,
-                        '/' => $this->safeDivide($current, $operand),
-                        '%' => $this->safeModulo($current, $operand),
-                    };
-
-                    if (null === $newValue) {
-                        ++$errors;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $oldValue,
-                            null,
-                            BulkLog::LEVEL_ERROR,
-                            'Division by zero',
-                        ));
-                    } else {
-                        $indexed[$attrCode] = $newValue;
-                        $object->updateAttributeIndex($indexed);
-                        $object->markTouchedByBulkSession($session->getId());
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $oldValue,
-                            $newValue,
-                            BulkLog::LEVEL_INFO,
-                            null,
-                        ));
-                        ++$success;
-                    }
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
-            }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+            return;
         }
+
+        $indexed = $object->getAttributesIndexed();
+        $oldValue = $indexed[$this->attrCode] ?? null;
+
+        if (!is_numeric($oldValue)) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $oldValue,
+                $oldValue,
+                BulkLog::LEVEL_WARNING,
+                'Value is not numeric',
+            ));
+
+            return;
+        }
+
+        $current = (float) $oldValue;
+        $newValue = match ($this->operator) {
+            '+' => $current + $this->operand,
+            '-' => $current - $this->operand,
+            '*' => $current * $this->operand,
+            '/' => $this->safeDivide($current, $this->operand),
+            '%' => $this->safeModulo($current, $this->operand),
+            default => null,
+        };
+
+        if (null === $newValue) {
+            ++$counters->error;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $oldValue,
+                null,
+                BulkLog::LEVEL_ERROR,
+                'Division by zero',
+            ));
+
+            return;
+        }
+
+        $indexed[$this->attrCode] = $newValue;
+        $object->updateAttributeIndex($indexed);
+        $object->markTouchedByBulkSession($session->getId());
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $oldValue,
+            $newValue,
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
     }
 
     private function safeDivide(float $a, float $b): ?float

--- a/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMoveCategoryHandler.php
@@ -14,7 +14,6 @@ use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-14 (#546) — `move_category` bulk action.
@@ -22,19 +21,25 @@ use Throwable;
  * Full-replace assignment list. Wipes existing rows and re-inserts the
  * supplied target ids in a single transaction per product via the
  * repository's `replaceForProduct`. Used by the *„Przenieś kategorię"*
- * mockup flow when the operator picks a fresh taxonomy slot.
+ * mockup flow when the operator picks a fresh taxonomy slot. Shared
+ * lifecycle: {@see AbstractBulkHandler}.
  */
-final class BulkMoveCategoryHandler
+final class BulkMoveCategoryHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    /** @var list<string> */
+    private array $categoryIds = [];
+    private ?Uuid $primaryId = null;
+    /** @var list<Uuid> */
+    private array $targetUuids = [];
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        CatalogObjectRepositoryInterface $catalogObjects,
         private readonly ObjectCategoryRepositoryInterface $objectCategories,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -44,96 +49,33 @@ final class BulkMoveCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        $this->categoryIds = $categoryIds;
+        $this->primaryId = [] === $categoryIds ? null : Uuid::fromString($categoryIds[0]);
+        $this->targetUuids = array_map(static fn (string $id) => Uuid::fromString($id), $categoryIds);
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $errors = 0;
-            $chunkCounter = 0;
-            $primaryId = [] === $categoryIds ? null : Uuid::fromString($categoryIds[0]);
-            $targetUuids = array_map(static fn (string $id) => Uuid::fromString($id), $categoryIds);
+        return $this->runBatch($session);
+    }
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$product instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        $existing = $this->objectCategories->findByProduct($object);
+        $existingIds = array_map(
+            static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
+            $existing,
+        );
 
-                    $existing = $this->objectCategories->findByProduct($product);
-                    $existingIds = array_map(
-                        static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
-                        $existing,
-                    );
+        $this->objectCategories->replaceForProduct($object, $this->targetUuids, $this->primaryId);
+        $object->markTouchedByBulkSession($session->getId());
 
-                    $this->objectCategories->replaceForProduct($product, $targetUuids, $primaryId);
-                    $product->markTouchedByBulkSession($session->getId());
-
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        $product->getId(),
-                        null,
-                        $existingIds,
-                        $categoryIds,
-                        BulkLog::LEVEL_INFO,
-                        null,
-                    ));
-                    ++$success;
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
-            }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, 0, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => 0, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
-        }
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $existingIds,
+            $this->categoryIds,
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkMultiAttributeEditHandler.php
@@ -13,8 +13,6 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-13 (#545) — `multi_attribute_edit` bulk action.
@@ -23,22 +21,25 @@ use Throwable;
  * transaction per object. Each attribute change emits its own BulkLog
  * (so rollback can replay individually). Supported ops: `set`, `clear`.
  * Locked attributes (VIEW-33 / PRD §8.3) skip per-edit with a warning
- * entry; other edits in the same row still apply.
+ * entry; other edits in the same row still apply. Shared lifecycle:
+ * {@see AbstractBulkHandler}.
  *
  * Cmd+K killer use case (PRD §3.5): „skopiuj manufacturer do brand i
  * ustaw enabled=true dla wszystkich z manufacturer IS NOT EMPTY".
  */
-final class BulkMultiAttributeEditHandler
+final class BulkMultiAttributeEditHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    /** @var list<array{attr: string, op: string, value?: mixed}> */
+    private array $edits = [];
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
+        CatalogObjectRepositoryInterface $catalogObjects,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -48,137 +49,73 @@ final class BulkMultiAttributeEditHandler
      */
     public function handle(BulkSession $session, array $edits): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's 30s HTTP
-        // timeout — without disabling it the handler is killed mid-loop,
-        // the session stays incomplete, and the operator sees 200 + zero
-        // rows touched.
-        set_time_limit(0);
-
         if ([] === $edits) {
             throw new BadRequestHttpException('edits must be a non-empty list.');
         }
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        $this->edits = $edits;
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$object instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+        return $this->runBatch($session);
+    }
 
-                    $indexed = $object->getAttributesIndexed();
-                    $rowChanged = false;
-                    foreach ($edits as $edit) {
-                        $code = $edit['attr'];
-                        $op = $edit['op'];
-                        $oldValue = $indexed[$code] ?? null;
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        $indexed = $object->getAttributesIndexed();
+        $rowChanged = false;
+        foreach ($this->edits as $edit) {
+            $code = $edit['attr'];
+            $op = $edit['op'];
+            $oldValue = $indexed[$code] ?? null;
 
-                        if ($this->lockReader->isLocked($object, $code)) {
-                            ++$skipped;
-                            $this->em->persist(new BulkLog(
-                                $session->getId(),
-                                $object->getId(),
-                                null,
-                                $oldValue,
-                                $oldValue,
-                                BulkLog::LEVEL_WARNING,
-                                \sprintf('Attribute locked: %s', $code),
-                            ));
-                            continue;
-                        }
-
-                        if ('set' === $op) {
-                            $newValue = $edit['value'] ?? null;
-                            $indexed[$code] = $newValue;
-                        } elseif ('clear' === $op) {
-                            $newValue = null;
-                            unset($indexed[$code]);
-                        } else {
-                            $this->em->persist(new BulkLog(
-                                $session->getId(),
-                                $object->getId(),
-                                null,
-                                $oldValue,
-                                $oldValue,
-                                BulkLog::LEVEL_ERROR,
-                                \sprintf('Unsupported edit op "%s" on attr "%s"', $op, $code),
-                            ));
-                            continue;
-                        }
-
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $oldValue,
-                            $newValue,
-                            BulkLog::LEVEL_INFO,
-                            $code,
-                        ));
-                        $rowChanged = true;
-                    }
-
-                    if ($rowChanged) {
-                        $object->updateAttributeIndex($indexed);
-                        $object->markTouchedByBulkSession($session->getId());
-                        ++$success;
-                    }
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
+            if ($this->lockReader->isLocked($object, $code)) {
+                ++$counters->skipped;
+                $this->em->persist(new BulkLog(
+                    $session->getId(),
+                    $object->getId(),
+                    null,
+                    $oldValue,
+                    $oldValue,
+                    BulkLog::LEVEL_WARNING,
+                    \sprintf('Attribute locked: %s', $code),
+                ));
+                continue;
             }
 
-            if ($chunkCounter > 0) {
-                $this->em->flush();
+            if ('set' === $op) {
+                $newValue = $edit['value'] ?? null;
+                $indexed[$code] = $newValue;
+            } elseif ('clear' === $op) {
+                $newValue = null;
+                unset($indexed[$code]);
+            } else {
+                $this->em->persist(new BulkLog(
+                    $session->getId(),
+                    $object->getId(),
+                    null,
+                    $oldValue,
+                    $oldValue,
+                    BulkLog::LEVEL_ERROR,
+                    \sprintf('Unsupported edit op "%s" on attr "%s"', $op, $code),
+                ));
+                continue;
             }
 
-            // Reload BulkSession: per-chunk em->clear() detached the
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $oldValue,
+                $newValue,
+                BulkLog::LEVEL_INFO,
+                $code,
+            ));
+            $rowChanged = true;
+        }
 
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+        if ($rowChanged) {
+            $object->updateAttributeIndex($indexed);
+            $object->markTouchedByBulkSession($session->getId());
+            ++$counters->success;
         }
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkPublishChannelsHandler.php
@@ -4,15 +4,9 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application\Bulk;
 
-use App\Catalog\Application\BulkContext;
-use App\Catalog\Application\Reindex\BulkReindexQueueInterface;
 use App\Catalog\Domain\Entity\BulkLog;
 use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
-use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
-use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-15 (#547) — `publish_channels` bulk action.
@@ -21,19 +15,13 @@ use Throwable;
  * Real channel_publications + integration adapter calls (Shopify,
  * BaseLinker) land in epik 0.6/0.9 — this handler only writes the
  * intention, not the side effect. The 24h rollback path replays the
- * previous map per row.
+ * previous map per row. Shared lifecycle: {@see AbstractBulkHandler}.
  */
-final class BulkPublishChannelsHandler
+final class BulkPublishChannelsHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
-
-    public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
-        private readonly BulkReindexQueueInterface $reindexQueue,
-    ) {
-    }
+    /** @var list<string> */
+    private array $channelCodes = [];
+    private bool $publish = true;
 
     /**
      * @param list<string> $channelCodes
@@ -42,116 +30,55 @@ final class BulkPublishChannelsHandler
      */
     public function handle(BulkSession $session, array $channelCodes, bool $publish): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        $this->channelCodes = $channelCodes;
+        $this->publish = $publish;
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        return $this->runBatch($session);
+    }
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$product instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
-
-                    $indexed = $product->getAttributesIndexed();
-                    /** @var array<string, mixed> $publishedRaw */
-                    $publishedRaw = \is_array($indexed['published'] ?? null) ? $indexed['published'] : [];
-                    $before = $publishedRaw;
-                    $touched = false;
-                    foreach ($channelCodes as $code) {
-                        $current = (bool) ($publishedRaw[$code] ?? false);
-                        if ($current === $publish) {
-                            continue;
-                        }
-                        $publishedRaw[$code] = $publish;
-                        $touched = true;
-                    }
-
-                    if (!$touched) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $product->getId(),
-                            null,
-                            $before,
-                            $before,
-                            BulkLog::LEVEL_WARNING,
-                            'All channels already in the target state',
-                        ));
-                    } else {
-                        $indexed['published'] = $publishedRaw;
-                        $product->updateAttributeIndex($indexed);
-                        $product->markTouchedByBulkSession($session->getId());
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $product->getId(),
-                            null,
-                            $before,
-                            $publishedRaw,
-                            BulkLog::LEVEL_INFO,
-                            null,
-                        ));
-                        ++$success;
-                    }
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        $indexed = $object->getAttributesIndexed();
+        /** @var array<string, mixed> $publishedRaw */
+        $publishedRaw = \is_array($indexed['published'] ?? null) ? $indexed['published'] : [];
+        $before = $publishedRaw;
+        $touched = false;
+        foreach ($this->channelCodes as $code) {
+            $current = (bool) ($publishedRaw[$code] ?? false);
+            if ($current === $this->publish) {
+                continue;
             }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+            $publishedRaw[$code] = $this->publish;
+            $touched = true;
         }
+
+        if (!$touched) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $before,
+                $before,
+                BulkLog::LEVEL_WARNING,
+                'All channels already in the target state',
+            ));
+
+            return;
+        }
+
+        $indexed['published'] = $publishedRaw;
+        $object->updateAttributeIndex($indexed);
+        $object->markTouchedByBulkSession($session->getId());
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $before,
+            $publishedRaw,
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveCategoryHandler.php
@@ -13,26 +13,27 @@ use App\Catalog\Domain\Entity\ObjectCategory;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-14 (#546) — `remove_category` bulk action.
  *
  * Removes the supplied category ids from each target product. Skips
- * pairs that are not currently assigned (warning log).
+ * pairs that are not currently assigned (warning log). Shared lifecycle:
+ * {@see AbstractBulkHandler}.
  */
-final class BulkRemoveCategoryHandler
+final class BulkRemoveCategoryHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    /** @var list<string> */
+    private array $categoryIds = [];
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
+        CatalogObjectRepositoryInterface $catalogObjects,
         private readonly ObjectCategoryRepositoryInterface $objectCategories,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -42,115 +43,53 @@ final class BulkRemoveCategoryHandler
      */
     public function handle(BulkSession $session, array $categoryIds): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        $this->categoryIds = $categoryIds;
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        return $this->runBatch($session);
+    }
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $product = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$product instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        $existing = $this->objectCategories->findByProduct($object);
+        $existingIds = array_map(
+            static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
+            $existing,
+        );
 
-                    $existing = $this->objectCategories->findByProduct($product);
-                    $existingIds = array_map(
-                        static fn (ObjectCategory $oc): string => $oc->getCategory()->getId()->toRfc4122(),
-                        $existing,
-                    );
-
-                    $removed = 0;
-                    foreach ($existing as $assignment) {
-                        if (\in_array($assignment->getCategory()->getId()->toRfc4122(), $categoryIds, true)) {
-                            $this->objectCategories->remove($assignment);
-                            ++$removed;
-                        }
-                    }
-
-                    if (0 === $removed) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $product->getId(),
-                            null,
-                            $existingIds,
-                            $existingIds,
-                            BulkLog::LEVEL_WARNING,
-                            'No matching category assignments',
-                        ));
-                    } else {
-                        $product->markTouchedByBulkSession($session->getId());
-                        $afterIds = array_values(array_diff($existingIds, $categoryIds));
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $product->getId(),
-                            null,
-                            $existingIds,
-                            $afterIds,
-                            BulkLog::LEVEL_INFO,
-                            null,
-                        ));
-                        ++$success;
-                    }
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
+        $removed = 0;
+        foreach ($existing as $assignment) {
+            if (\in_array($assignment->getCategory()->getId()->toRfc4122(), $this->categoryIds, true)) {
+                $this->objectCategories->remove($assignment);
+                ++$removed;
             }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
         }
+
+        if (0 === $removed) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $existingIds,
+                $existingIds,
+                BulkLog::LEVEL_WARNING,
+                'No matching category assignments',
+            ));
+
+            return;
+        }
+
+        $object->markTouchedByBulkSession($session->getId());
+        $afterIds = array_values(array_diff($existingIds, $this->categoryIds));
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $existingIds,
+            $afterIds,
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+        ++$counters->success;
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkRemoveValueHandler.php
@@ -12,8 +12,6 @@ use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-13 (#545) — `remove_value` bulk action (multiselect-safe).
@@ -21,19 +19,22 @@ use Throwable;
  * Removes a value from a list attribute. If the slot is scalar matching
  * the value, it becomes null (unset). If the value is not present, the
  * row is skipped (no-op, warning log). Locked attributes (VIEW-33 /
- * PRD §8.3) skip with a warning entry.
+ * PRD §8.3) skip with a warning entry. Shared lifecycle:
+ * {@see AbstractBulkHandler}.
  */
-final class BulkRemoveValueHandler
+final class BulkRemoveValueHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    private string $attrCode = '';
+    private mixed $value = null;
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
+        CatalogObjectRepositoryInterface $catalogObjects,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -41,157 +42,97 @@ final class BulkRemoveValueHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $value): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        $this->attrCode = $attrCode;
+        $this->value = $value;
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        return $this->runBatch($session);
+    }
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$object instanceof CatalogObject) {
-                        ++$errors;
-                        ++$chunkCounter;
-                        continue;
-                    }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        if ($this->lockReader->isLocked($object, $this->attrCode)) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                BulkLog::LEVEL_WARNING,
+                'Attribute locked',
+            ));
 
-                    if ($this->lockReader->isLocked($object, $attrCode)) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            BulkLog::LEVEL_WARNING,
-                            'Attribute locked',
-                        ));
-                        ++$chunkCounter;
-                        if ($chunkCounter >= self::CHUNK_SIZE) {
-                            $this->em->flush();
-                            $this->em->clear();
-                            $chunkCounter = 0;
-                        }
-                        continue;
-                    }
-
-                    $indexed = $object->getAttributesIndexed();
-                    $oldValue = $indexed[$attrCode] ?? null;
-
-                    if (\is_array($oldValue)) {
-                        $idx = array_search($value, $oldValue, true);
-                        if (false === $idx) {
-                            ++$skipped;
-                            $this->em->persist(new BulkLog(
-                                $session->getId(),
-                                $object->getId(),
-                                null,
-                                $oldValue,
-                                $oldValue,
-                                BulkLog::LEVEL_WARNING,
-                                'Value not present',
-                            ));
-                        } else {
-                            $newList = array_values(array_filter(
-                                $oldValue,
-                                static fn ($v) => $v !== $value,
-                            ));
-                            $indexed[$attrCode] = $newList;
-                            $object->updateAttributeIndex($indexed);
-                            $object->markTouchedByBulkSession($session->getId());
-                            $this->em->persist(new BulkLog(
-                                $session->getId(),
-                                $object->getId(),
-                                null,
-                                $oldValue,
-                                $newList,
-                                BulkLog::LEVEL_INFO,
-                                null,
-                            ));
-                            ++$success;
-                        }
-                    } elseif ($oldValue === $value) {
-                        unset($indexed[$attrCode]);
-                        $object->updateAttributeIndex($indexed);
-                        $object->markTouchedByBulkSession($session->getId());
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $oldValue,
-                            null,
-                            BulkLog::LEVEL_INFO,
-                            null,
-                        ));
-                        ++$success;
-                    } else {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $oldValue,
-                            $oldValue,
-                            BulkLog::LEVEL_WARNING,
-                            'Value not present',
-                        ));
-                    }
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
-            }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+            return;
         }
+
+        $indexed = $object->getAttributesIndexed();
+        $oldValue = $indexed[$this->attrCode] ?? null;
+
+        if (\is_array($oldValue)) {
+            $idx = array_search($this->value, $oldValue, true);
+            if (false === $idx) {
+                ++$counters->skipped;
+                $this->em->persist(new BulkLog(
+                    $session->getId(),
+                    $object->getId(),
+                    null,
+                    $oldValue,
+                    $oldValue,
+                    BulkLog::LEVEL_WARNING,
+                    'Value not present',
+                ));
+
+                return;
+            }
+
+            $newList = array_values(array_filter(
+                $oldValue,
+                fn ($v) => $v !== $this->value,
+            ));
+            $indexed[$this->attrCode] = $newList;
+            $object->updateAttributeIndex($indexed);
+            $object->markTouchedByBulkSession($session->getId());
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $oldValue,
+                $newList,
+                BulkLog::LEVEL_INFO,
+                null,
+            ));
+            ++$counters->success;
+
+            return;
+        }
+
+        if ($oldValue === $this->value) {
+            unset($indexed[$this->attrCode]);
+            $object->updateAttributeIndex($indexed);
+            $object->markTouchedByBulkSession($session->getId());
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $oldValue,
+                null,
+                BulkLog::LEVEL_INFO,
+                null,
+            ));
+            ++$counters->success;
+
+            return;
+        }
+
+        ++$counters->skipped;
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $oldValue,
+            $oldValue,
+            BulkLog::LEVEL_WARNING,
+            'Value not present',
+        ));
     }
 }

--- a/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Bulk/BulkSetAttributeHandler.php
@@ -12,32 +12,32 @@ use App\Catalog\Domain\Entity\BulkSession;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Uid\Uuid;
-use Throwable;
 
 /**
  * VIEW-12 (#543) — handler for `set_attribute` bulk action.
  *
  * Synchronous in MVP (<100 SKU per click). Async via Symfony Messenger
- * follows in VIEW-12.1. Chunk size N=200 + `EntityManager::clear()`
- * per chunk to honour the FrankenPHP worker memory rule (CLAUDE.md
- * §3.10).
+ * follows in VIEW-12.1. The shared chunked-loop + session lifecycle lives
+ * in {@see AbstractBulkHandler} (AUD-056); this class only carries the
+ * per-object `set_attribute` body.
  *
  * Returns a result summary the controller serialises to the wizard's
  * Step 3 stat grid. `BulkSession` carries the rollback recipe via the
  * accompanying `bulk_logs` rows.
  */
-final class BulkSetAttributeHandler
+final class BulkSetAttributeHandler extends AbstractBulkHandler
 {
-    public const int CHUNK_SIZE = 200;
+    private string $attrCode = '';
+    private mixed $newValue = null;
 
     public function __construct(
-        private readonly CatalogObjectRepositoryInterface $catalogObjects,
-        private readonly EntityManagerInterface $em,
-        private readonly BulkContext $bulkContext,
+        CatalogObjectRepositoryInterface $catalogObjects,
+        EntityManagerInterface $em,
+        BulkContext $bulkContext,
         private readonly AttributeLockReader $lockReader,
-        private readonly BulkReindexQueueInterface $reindexQueue,
+        BulkReindexQueueInterface $reindexQueue,
     ) {
+        parent::__construct($catalogObjects, $em, $bulkContext, $reindexQueue);
     }
 
     /**
@@ -49,127 +49,50 @@ final class BulkSetAttributeHandler
      */
     public function handle(BulkSession $session, string $attrCode, mixed $newValue): array
     {
-        // Long bulk runs (2k+ products) routinely exceed PHP's
-        // 30s HTTP timeout — without disabling it the handler
-        // is killed mid-loop, the session stays incomplete, and
-        // the operator sees 200 + zero rows touched.
-        set_time_limit(0);
+        $this->attrCode = $attrCode;
+        $this->newValue = $newValue;
 
-        $this->bulkContext->setBulk(true, $session->getId());
-        try {
-            $success = 0;
-            $skipped = 0;
-            $errors = 0;
-            $chunkCounter = 0;
+        return $this->runBatch($session);
+    }
 
-            foreach ($session->getTargetObjectIds() as $targetId) {
-                try {
-                    $object = $this->catalogObjects->findById(Uuid::fromString($targetId));
-                    if (!$object instanceof CatalogObject) {
-                        ++$errors;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            Uuid::fromString($targetId),
-                            null,
-                            null,
-                            null,
-                            BulkLog::LEVEL_ERROR,
-                            'Object not found',
-                        ));
-                        ++$chunkCounter;
-                        continue;
-                    }
+    protected function processObject(CatalogObject $object, BulkSession $session, BulkCounters $counters): void
+    {
+        if ($this->lockReader->isLocked($object, $this->attrCode)) {
+            ++$counters->skipped;
+            $this->em->persist(new BulkLog(
+                $session->getId(),
+                $object->getId(),
+                null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                $object->getAttributesIndexed()[$this->attrCode] ?? null,
+                BulkLog::LEVEL_WARNING,
+                'Attribute locked',
+            ));
 
-                    if ($this->lockReader->isLocked($object, $attrCode)) {
-                        ++$skipped;
-                        $this->em->persist(new BulkLog(
-                            $session->getId(),
-                            $object->getId(),
-                            null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            $object->getAttributesIndexed()[$attrCode] ?? null,
-                            BulkLog::LEVEL_WARNING,
-                            'Attribute locked',
-                        ));
-                        ++$chunkCounter;
-                        if ($chunkCounter >= self::CHUNK_SIZE) {
-                            $this->em->flush();
-                            $this->em->clear();
-                            $chunkCounter = 0;
-                        }
-                        continue;
-                    }
-
-                    $oldValue = $object->getAttributesIndexed()[$attrCode] ?? null;
-
-                    // Set in attributesIndexed (denormalised JSONB) — the
-                    // canonical write path lives in object_values; for the
-                    // MVP slice this is a thin wrapper, full write through
-                    // ObjectAttributesUpserter lands in VIEW-13.
-                    $indexed = $object->getAttributesIndexed();
-                    $indexed[$attrCode] = $newValue;
-                    $object->updateAttributeIndex($indexed);
-                    $object->markTouchedByBulkSession($session->getId());
-
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        $object->getId(),
-                        null,
-                        $oldValue,
-                        $newValue,
-                        BulkLog::LEVEL_INFO,
-                        null,
-                    ));
-
-                    ++$success;
-                } catch (Throwable $e) {
-                    ++$errors;
-                    $this->em->persist(new BulkLog(
-                        $session->getId(),
-                        Uuid::fromString($targetId),
-                        null,
-                        null,
-                        null,
-                        BulkLog::LEVEL_ERROR,
-                        $e->getMessage(),
-                    ));
-                }
-
-                ++$chunkCounter;
-                if ($chunkCounter >= self::CHUNK_SIZE) {
-                    $this->em->flush();
-                    $this->em->clear();
-                    $chunkCounter = 0;
-                }
-            }
-
-            if ($chunkCounter > 0) {
-                $this->em->flush();
-            }
-
-            // Reload BulkSession: per-chunk em->clear() detached the
-
-            // local instance and its Tenant proxy. The final persist
-
-            // below would otherwise raise EntityNotFoundException on
-
-            // flush trying to resolve the stale proxy.
-
-            $reloaded = $this->em->find(BulkSession::class, $session->getId());
-
-            if ($reloaded instanceof BulkSession) {
-                $session = $reloaded;
-            }
-
-            $session->complete($success, $skipped, $errors);
-            $this->em->persist($session);
-            $this->em->flush();
-
-            $this->reindexQueue->queueAll($session->getTargetObjectIds());
-
-            return ['success' => $success, 'skipped' => $skipped, 'error' => $errors];
-        } finally {
-            $this->bulkContext->setBulk(false);
+            return;
         }
+
+        $oldValue = $object->getAttributesIndexed()[$this->attrCode] ?? null;
+
+        // Set in attributesIndexed (denormalised JSONB) — the canonical
+        // write path lives in object_values; for the MVP slice this is a
+        // thin wrapper, full write through ObjectAttributesUpserter lands
+        // in VIEW-13.
+        $indexed = $object->getAttributesIndexed();
+        $indexed[$this->attrCode] = $this->newValue;
+        $object->updateAttributeIndex($indexed);
+        $object->markTouchedByBulkSession($session->getId());
+
+        $this->em->persist(new BulkLog(
+            $session->getId(),
+            $object->getId(),
+            null,
+            $oldValue,
+            $this->newValue,
+            BulkLog::LEVEL_INFO,
+            null,
+        ));
+
+        ++$counters->success;
     }
 }

--- a/docs/adr/0021-frontend-data-fetching.md
+++ b/docs/adr/0021-frontend-data-fetching.md
@@ -1,0 +1,49 @@
+# ADR-0021 — Strategia pobierania danych w adminie (useQuery jako domyślny mechanizm)
+
+- Status: Accepted
+- Data: 2026-06-20
+- Kontekst audytu: audyt połówkowy 2026-06, finding AUD-055 (Wave 3 / W3-2, #1608)
+- Powiązane: lekcja `feedback_useeffect_to_usequery_pattern`, CLAUDE.md („Polish matters" / API-first), ADR-0020 (kształt powierzchni API)
+
+## Kontekst
+
+Admin (`apps/admin`) pobiera dane na **trzy** współistniejące sposoby:
+
+- **`jsonFetch` + `useState`/`useEffect`** — ~138 plików. Surowy wrapper `fetch` (`src/lib/http.ts`) z ręcznym zarządzaniem `isLoading`/`error`/`refetch`.
+- **`useQuery` (TanStack Query)** — ~55 plików. Cache z kluczami, dedup, automatyczna inwalidacja przez `queryClient.invalidateQueries`.
+- **Refine data-provider** (`useList`/`useOne`/`useTable`) — ~50 plików. Warstwa CRUD frameworka Refine.
+
+Problem nie jest kosmetyczny. **Mutacje w wielu ekranach inwalidują cache przez `queryClient`** (`invalidateQueries` używane w kilkudziesięciu komponentach katalogu — `attributes/show`, `object-types/show`, `attribute-groups/show`, taby produktu itd.). Ekran, który ładuje te same dane przez `jsonFetch` + `useEffect`, **nie reaguje na inwalidację** — `useEffect` z zależnością `[]` (albo `[refetch]`) odpala się raz przy mount i nie wie nic o `queryClient`. Efekt: lista nie odświeża się po `create`/`delete`/`update` wykonanym gdzie indziej, operator widzi nieaktualny stan do ręcznego F5.
+
+To dokładnie wzorzec z lekcji `feedback_useeffect_to_usequery_pattern`: *„gdy dane są inwalidowane przez `queryClient` w innym miejscu, a `useEffect`+`jsonFetch` je ładuje, to bug stale-data — refaktor do `useQuery`"*.
+
+`jsonFetch` sam w sobie zostaje — jest poprawnym, jednoźródłowym (single-origin Caddy) transportem HTTP z obsługą silent-refresh JWT (#29). Jest **warstwą transportu**, nie warstwą cache. `useQuery` ma go wołać w `queryFn`.
+
+## Decyzja
+
+1. **Nowy kod reagujący na dane = `useQuery` (TanStack Query).** Każdy nowy ekran/komponent, który czyta dane serwerowe mogące się zmienić wskutek mutacji (listy, detale, liczniki, statusy), używa `useQuery` z jawnym `queryKey`. `queryFn` woła `jsonFetch` (transport zostaje jednolity).
+2. **`jsonFetch` + `useEffect` jest deprecated dla danych reagujących na mutacje.** Dozwolone pozostaje wyłącznie dla:
+   - **akcji komendowych** (POST/PATCH/DELETE wywoływane z handlerów — mutacje, nie odczyt),
+   - **odczytów jednorazowych, niereaktywnych** (np. pobranie pliku, eksport blob, parse-preview uploadu), które nie są współdzielone z żadnym `queryKey`.
+3. **Refine zostaje tam, gdzie już jest.** Nie migrujemy istniejących ekranów Refine → useQuery i nie wprowadzamy Refine w nowych miejscach, gdzie go nie ma. Trzy mechanizmy redukujemy do dwóch w długim horyzoncie (`useQuery` + Refine), eliminując `jsonFetch`+`useEffect` jako wzorzec odczytu.
+4. **Egzekwowanie przyrostowe (stop-the-bleeding), nie big-bang.** Pełna migracja ~138 plików to robota klasy L i NIE jest treścią tego ticketu. Zamiast tego:
+   - skrypt CI `scripts/lint-jsonfetch-useeffect.sh` **zlicza** pliki z współwystępującym `jsonFetch` + `useEffect` i pilnuje **nierosnącego progu** (baseline zamrożony w skrypcie). Nowy plik z tym wzorcem = czerwone CI, dopóki autor nie użyje `useQuery` albo świadomie nie podniesie baseline z uzasadnieniem.
+   - migracja istniejących plików idzie priorytetowo: **najpierw ekrany mutation-reactive** (listy odświeżane po create/delete, detale inwalidowane z innych ekranów), reszta oportunistycznie przy okazji dotykania pliku.
+
+## Konsekwencje
+
+**Pozytywne**
+
+- Znika cała klasa bugów stale-data: ekran na `useQuery` z właściwym `queryKey` odświeża się automatycznie, gdy mutacja gdziekolwiek zawoła `invalidateQueries` na tym kluczu.
+- Mniej kodu boilerplate (`isLoading`/`error`/`refetch` znika z komponentu), dedup zapytań i cache za darmo.
+- Bramka CI hamuje przyrost długu — liczba ekranów z anty-wzorcem może tylko maleć.
+
+**Negatywne / dług**
+
+- ~136 plików nadal na `jsonFetch`+`useEffect` po tym ticketcie. To **świadomie odłożony** dług (migracja L), wytropiony i zamrożony progiem, nie ukryty. Tracking w osobnym tickecie utrzymaniowym.
+- Baseline w skrypcie wymaga aktualizacji przy każdej migracji w dół (intencjonalnie — wymusza ruch wyłącznie w dobrą stronę).
+
+## Roadmap / remediacja
+
+- **Ten ticket (proof-slice):** migracja `settings/locales/index.tsx` (lista lokali z modalem „Dodaj" + inline lifecycle — kanoniczny przypadek listy reagującej na mutacje) z `jsonFetch`+`useEffect` na `useQuery` + `invalidateQueries`, z testem jednostkowym dowodzącym, że inwalidacja odświeża listę.
+- **Follow-up (utrzymaniowy, L):** migracja pozostałych ekranów mutation-reactive (priorytet: listy w `settings/*`, `admin/*`, `exports/sessions/*`), schodzenie progiem w `lint-jsonfetch-useeffect.sh` w dół przy każdej migracji.

--- a/scripts/lint-admin-max-lines.sh
+++ b/scripts/lint-admin-max-lines.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# AUD-057 — guard-rail against new admin source monoliths.
+#
+# The audit flagged 17+ admin files over 500 lines (product-detail-page
+# 1499, universal-list-page 1141, attributes/show 1137, …). Long files
+# hurt readability + review and tend to grow unbounded. Biome 2.x has no
+# per-file max-lines rule (its complexity rules are per-function), so this
+# script fills the gap.
+#
+# Like lint-jsonfetch-useeffect.sh it does the affordable thing rather than
+# a big-bang split of every monolith (out of scope — ADR-0021 sibling):
+# it counts admin .ts/.tsx files whose length exceeds THRESHOLD lines and
+# fails the build if that count *exceeds* a frozen baseline. A new file
+# over the line, or an existing borderline file crossing it, pushes the
+# count up → red CI. Splitting a monolith below the line → lower the
+# baseline. The number may only shrink.
+#
+# This is a WARN-style policy for the existing offenders (they stay, the
+# baseline tolerates them) and a hard stop for regressions.
+
+set -eu
+
+ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="${ROOT}/apps/admin/src"
+
+THRESHOLD="${ADMIN_MAX_LINES_THRESHOLD:-500}"
+# Frozen baseline = number of files currently over THRESHOLD. Lower it
+# (never raise without justification) whenever a monolith is split below
+# the line. product-detail-page.tsx was split under AUD-057, dropping the
+# count from 22 to 21.
+BASELINE="${ADMIN_MAX_LINES_BASELINE:-21}"
+
+if [ ! -d "$SRC" ]; then
+    echo "lint-admin-max-lines: source dir $SRC not found" >&2
+    exit 1
+fi
+
+count=0
+offenders=""
+while IFS= read -r f; do
+    lines=$(wc -l < "$f")
+    if [ "$lines" -gt "$THRESHOLD" ]; then
+        count=$((count + 1))
+        offenders="$offenders\n  $lines  ${f#"$ROOT"/}"
+    fi
+done <<EOF
+$(find "$SRC" \( -name '*.ts' -o -name '*.tsx' \) -type f)
+EOF
+
+if [ "$count" -gt "$BASELINE" ]; then
+    echo "lint-admin-max-lines: FAIL — $count files exceed ${THRESHOLD} lines (baseline $BASELINE)." >&2
+    cat >&2 <<TXT
+
+A file grew past ${THRESHOLD} lines (or a new one shipped over it). Split it
+into focused sibling modules — extract pure helpers, sub-components, or a
+data hook — so the page only composes them. See product-detail-page.tsx /
+product-detail-helpers.ts / product-detail-other-tabs.tsx for the pattern.
+TXT
+    printf 'Files over %s lines:%b\n' "$THRESHOLD" "$offenders" | sort -rn >&2
+    exit 1
+fi
+
+if [ "$count" -lt "$BASELINE" ]; then
+    echo "lint-admin-max-lines: $count files exceed ${THRESHOLD} lines — below baseline $BASELINE."
+    echo "  Nice — lower BASELINE in this script to $count to lock in the win."
+    exit 0
+fi
+
+echo "lint-admin-max-lines: $count files exceed ${THRESHOLD} lines — at baseline $BASELINE. No regression."
+exit 0

--- a/scripts/lint-jsonfetch-useeffect.sh
+++ b/scripts/lint-jsonfetch-useeffect.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# AUD-055 — guard-rail against the stale-data anti-pattern in the admin.
+#
+# Background (ADR-0021 + lesson feedback_useeffect_to_usequery_pattern):
+# `jsonFetch` is the single-origin HTTP transport, NOT a cache layer. When
+# a component loads server data with `jsonFetch` inside a `useEffect`, that
+# read is invisible to TanStack Query's cache — so a mutation elsewhere
+# that calls `queryClient.invalidateQueries(...)` does NOT refresh the
+# screen. The fix is `useQuery` (queryFn may still call jsonFetch).
+#
+# Migrating all ~138 jsonFetch sites is an L-sized job and is explicitly
+# out of scope (ADR-0021 §4). This script does the affordable thing:
+# stop the bleeding. It counts admin source files where `jsonFetch` and
+# `useEffect` co-occur (the anti-pattern signature) and fails the build if
+# that count *exceeds* a frozen baseline. New offenders push the count up
+# → red CI. Migrating an existing file down → lower the baseline below
+# (intentionally one-directional: the number may only shrink).
+#
+# Why a count and not a per-file marker: the offenders pre-date the rule;
+# a marker scheme would require touching all 64 today. The threshold lets
+# the debt drain over time without a big-bang refactor while making any
+# *new* regression a hard CI failure.
+
+set -eu
+
+ROOT="${ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+SRC="${ROOT}/apps/admin/src"
+
+# Frozen baseline. Lower this (never raise it without an ADR-0021 §4
+# justification in the PR) every time a mutation-reactive screen is
+# migrated jsonFetch+useEffect -> useQuery.
+BASELINE="${JSONFETCH_USEEFFECT_BASELINE:-61}"
+
+if [ ! -d "$SRC" ]; then
+    echo "lint-jsonfetch-useeffect: source dir $SRC not found" >&2
+    exit 1
+fi
+
+# grep -rln returns 0 (matches) / 1 (none) / 2 (error); treat "none" green.
+jsonfetch_files=$(grep -rln "jsonFetch" "$SRC" --include='*.ts' --include='*.tsx' || true)
+
+# Match the call `useEffect(` rather than the bare word so prose in
+# comments / ADR references does not count as an offender.
+count=0
+offenders=""
+for f in $jsonfetch_files; do
+    if grep -q 'useEffect(' "$f"; then
+        count=$((count + 1))
+        offenders="$offenders\n  ${f#"$ROOT"/}"
+    fi
+done
+
+if [ "$count" -gt "$BASELINE" ]; then
+    echo "lint-jsonfetch-useeffect: FAIL — $count files mix jsonFetch + useEffect (baseline $BASELINE)." >&2
+    cat >&2 <<'TXT'
+
+A new file pairs jsonFetch with useEffect to read server data. That read
+is invisible to TanStack Query's cache, so a mutation elsewhere that calls
+queryClient.invalidateQueries(...) will NOT refresh it (stale-data bug —
+see ADR-0021 + lesson feedback_useeffect_to_usequery_pattern).
+
+Fix: load the data with useQuery (queryFn may call jsonFetch), give it an
+explicit queryKey, and invalidate that key after mutations. jsonFetch is
+fine for command actions (POST/PATCH/DELETE) and one-shot non-reactive
+reads (file/blob/parse-preview) — those do not count here.
+TXT
+    printf 'Current offenders:%b\n' "$offenders" >&2
+    exit 1
+fi
+
+if [ "$count" -lt "$BASELINE" ]; then
+    echo "lint-jsonfetch-useeffect: $count files mix jsonFetch + useEffect — below baseline $BASELINE."
+    echo "  Nice — lower BASELINE in this script to $count to lock in the win."
+    exit 0
+fi
+
+echo "lint-jsonfetch-useeffect: $count files mix jsonFetch + useEffect — at baseline $BASELINE. No regression."
+exit 0


### PR DESCRIPTION
## Wave 3 / W3-2 — AUD-055 + AUD-056 + AUD-057 (#1608) — FE/architecture tech-debt

> Cross-cutting L/M → mandat minimum-viable: **enforcement + proof-slice + defer bulk** (#1670). Zero big-bang.

### AUD-055 — 3 wzorce fetch (jsonFetch 138 / useQuery 55 / Refine 50), stale-data
- **ADR-0021** `docs/adr/0021-frontend-data-fetching.md`: nowy kod = useQuery; jsonFetch+useEffect deprecated dla mutation-reactive.
- **CI guard** `lint-jsonfetch-useeffect.sh` (baseline **61**, fail przy wzroście) wpięty do `quality-frontend.yml`.
- **Proof:** `settings/locales` zmigrowane → `useQuery` + `invalidateQueries`; test dowodzi odświeżenia po mutacji. Pozostałe ~136 → #1670.

### AUD-056 — 13 Bulk handlerów kopiuj-wklej (13.27% dup)
12/13 dzieliło ~45-liniowy szkielet (set_time_limit → chunked flush/clear → reload → complete → reindex). **AbstractBulkHandler** (template-method `runBatch`+`processObject`) + **BulkCounters**; każdy handler BYTE-identyczna logika per-item. **−627 linii (~30% klastra).** Rollback wykluczony (iteruje bulk_logs, inny kształt). Testy bulk **16/16**.

### AUD-057 — monolity bez max-lines (product-detail 1499, +16 plików >500)
- **CI guard** `lint-admin-max-lines.sh` (baseline **21**, >500 linii, hard-stop regresji).
- **product-detail-page: 1499 → 492 linii** (−67%), rozbity na header/content/sidebar/other-tabs + data/form hooks. Funkcjonalność zachowana (E2E 1351 PASSED). Pozostałe 16 → #1670.

### Bramki
PHPStan max No errors · Deptrac 0 · cs-fixer · Bulk 16/16 · Biome/tsc/build · vitest **59/59** · lint negative-controls (oba guardy fail przy wzroście) · live smoke (login 200, locales mutation 200, **E2E product-detail 1351 PASSED**).

Closes #1608
