### PR TITLE
fix(catalog): walidacja zapisu egzekwuje atrybuty wymagane w grupie

### DIFF
--- a/apps/admin/e2e/1351-product-detail-edit-mode.spec.ts
+++ b/apps/admin/e2e/1351-product-detail-edit-mode.spec.ts
@@ -50,6 +50,46 @@ test('product detail opens in edit mode with save + save-and-return actions', as
   expect(created.status()).toBe(201);
   const product = (await created.json()) as { id: string };
 
+  // #1673 — group-required attributes (e.g. demo product's description/price)
+  // now block edit-mode saves too, not just globally-required ones. Fill every
+  // required field (global OR group-level) up front so the save-and-return
+  // assertion exercises the navigation, not the new completeness gate.
+  const groupsResp = await page.request.get(
+    `/api/objects/${product.id}/effective-attribute-groups`,
+    { headers: { ...bearer, accept: 'application/json' } },
+  );
+  const groupsBody = (await groupsResp.json()) as {
+    groups: Array<{
+      attributes: Array<{
+        code: string;
+        type: string;
+        is_required?: boolean;
+        is_required_in_group?: boolean;
+      }>;
+    }>;
+  };
+  const gapFill: Record<string, unknown> = {};
+  for (const group of groupsBody.groups) {
+    for (const attr of group.attributes) {
+      const required = attr.is_required === true || attr.is_required_in_group === true;
+      if (!required || attr.type === 'boolean') continue;
+      if (attr.code === 'sku' || attr.code === 'name') continue; // filled at create
+      gapFill[attr.code] =
+        attr.type === 'price'
+          ? { amount: 1, currency: 'PLN' }
+          : attr.type === 'number' || attr.type === 'metric'
+            ? 1
+            : '1';
+    }
+  }
+  if (Object.keys(gapFill).length > 0) {
+    const fillResp = await page.request.patch(`/api/objects/${product.id}`, {
+      headers: { ...bearer, 'content-type': 'application/merge-patch+json' },
+      data: { attributes: gapFill },
+    });
+    expect(fillResp.status(), await fillResp.text()).toBe(200);
+  }
+
   await page.goto(`/products/${product.id}`);
 
   // Edit mode by default — "Zapisz zmiany" visible, no "Edytuj".

--- a/apps/admin/e2e/1673-required-in-group-save-blocked.spec.ts
+++ b/apps/admin/e2e/1673-required-in-group-save-blocked.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from '@playwright/test';
+
+import { ADMIN_EMAIL, ADMIN_PASSWORD, apiLogin } from './helpers/auth';
+
+/**
+ * #1673 — an attribute required only WITHIN ITS GROUP (the
+ * `is_required_in_group` junction flag, not the global `is_required` one) must
+ * block saving an empty value on the entry card, exactly like a globally
+ * required attribute. Before #1673 the red asterisk showed but the save guard
+ * (collectRequiredViolations) ignored group-level requiredness, so a dirty
+ * imported entry saved with the field still empty.
+ *
+ * Mirrors the #1350 flow, but the requiredness comes from the
+ * AttributeGroupAttribute junction:
+ *   POST   /api/attribute_groups/{g}/attributes/bulk-attach   (attach)
+ *   PATCH  /api/attribute_groups/{g}/attributes/{a}           (isRequiredInGroup=true)
+ */
+test('#1673 — a group-required attribute blocks saving an empty value', async ({ page }) => {
+  test.setTimeout(180_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+  await apiLogin(page);
+
+  const stamp = Date.now().toString(36);
+  const otCode = `req_grp_${stamp}`;
+  const groupCode = `req_grp_g_${stamp}`;
+  const attrCode = `req_grp_note_${stamp}`;
+
+  // 1. Custom ObjectType.
+  const otResp = await page.request.post('/api/object_types', {
+    data: {
+      code: otCode,
+      label: { pl: `Wymagane w grupie ${stamp}`, en: `Group-required ${stamp}` },
+    },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(otResp.status(), await otResp.text()).toBe(201);
+  const objectTypeId = ((await otResp.json()) as { id: string }).id;
+
+  // 2. AttributeGroup.
+  const groupResp = await page.request.post('/api/attribute_groups', {
+    data: { code: groupCode, label: { pl: 'Opis grupy', en: 'Group description' } },
+    headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/json' },
+  });
+  expect(groupResp.status(), await groupResp.text()).toBe(201);
+  const groupId = ((await groupResp.json()) as { id: string }).id;
+
+  try {
+    // 3. Attribute that is NOT globally required.
+    const attrResp = await page.request.post('/api/attributes', {
+      data: {
+        code: attrCode,
+        type: 'text',
+        label: { pl: 'Notatka grupowa', en: 'Group note' },
+        required: false,
+      },
+      headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+    });
+    expect(attrResp.status(), await attrResp.text()).toBe(201);
+    const attributeId = ((await attrResp.json()) as { id: string }).id;
+
+    // 4. Attach attr → group, then flag it required WITHIN THE GROUP.
+    const attach = await page.request.post(
+      `/api/attribute_groups/${groupId}/attributes/bulk-attach`,
+      {
+        data: { attributeCodes: [attrCode] },
+        headers: { ...bearer, accept: 'application/json', 'content-type': 'application/json' },
+      },
+    );
+    expect([200, 204], await attach.text()).toContain(attach.status());
+
+    const flagRequired = await page.request.patch(
+      `/api/attribute_groups/${groupId}/attributes/${attributeId}`,
+      {
+        data: { isRequiredInGroup: true },
+        headers: { ...bearer, 'content-type': 'application/json' },
+      },
+    );
+    expect([200, 204], await flagRequired.text()).toContain(flagRequired.status());
+
+    // 5. Attach group → ObjectType so it surfaces in effective-attribute-groups.
+    const attachGroup = await page.request.post(
+      `/api/object_types/${objectTypeId}/groups/${groupId}`,
+      { headers: bearer },
+    );
+    expect(attachGroup.status()).toBe(204);
+
+    // 6. A dirty entry — created without the (group-)required value, like an import.
+    const objResp = await page.request.post('/api/objects', {
+      headers: { ...bearer, accept: 'application/ld+json', 'content-type': 'application/ld+json' },
+      data: { code: `GRP-${stamp}`, objectTypeId, attributes: {} },
+    });
+    expect(objResp.status(), await objResp.text()).toBe(201);
+    const objId = ((await objResp.json()) as { id: string }).id;
+
+    // 7. Open the unified detail page.
+    await page.goto(`/objects/${otCode}/${objId}`);
+    const saveButton = page.getByRole('button', { name: /^(zapisz zmiany|save changes)$/i });
+    await expect(saveButton).toBeVisible({ timeout: 20_000 });
+
+    // The group-required row carries the asterisk.
+    const requiredLabel = page.getByText(/^(Notatka grupowa|Group note)$/).first();
+    await requiredLabel.scrollIntoViewIfNeeded();
+    const requiredRow = requiredLabel.locator(
+      'xpath=ancestor::div[contains(@class, "grid-cols")][1]',
+    );
+    await expect(requiredRow.getByText('*')).toBeVisible();
+
+    // Save with the field empty → blocked client-side, no PATCH, inline error.
+    let patched = false;
+    page.on('request', (r) => {
+      if (r.url().includes(`/api/objects/${objId}`) && r.method() === 'PATCH') patched = true;
+    });
+    await saveButton.click();
+    await expect(page.getByText(/pole wymagane/i).first()).toBeVisible({ timeout: 10_000 });
+    expect(patched).toBe(false);
+
+    // Filling the field unblocks the save (PATCH 200).
+    await requiredRow.locator('input[type="text"], textarea').first().fill('uzupełnione');
+    const patchResponse = page.waitForResponse(
+      (r) => r.url().includes(`/api/objects/${objId}`) && r.request().method() === 'PATCH',
+    );
+    await saveButton.click();
+    expect((await patchResponse).status()).toBe(200);
+  } finally {
+    await page.request.delete(`/api/attribute_groups/${groupId}`, { headers: bearer });
+    await page.request.delete(`/api/object_types/${objectTypeId}`, { headers: bearer });
+  }
+});

--- a/apps/admin/src/features/catalog/products/components/__tests__/product-detail-helpers.test.ts
+++ b/apps/admin/src/features/catalog/products/components/__tests__/product-detail-helpers.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAttributeRequired } from '../product-detail-helpers';
+import type { AttributeMeta } from '../types';
+
+function attr(overrides: Partial<AttributeMeta>): AttributeMeta {
+  return {
+    id: 'a1',
+    code: 'demo',
+    type: 'text',
+    label: { pl: 'Demo', en: 'Demo' },
+    is_system: false,
+    position: 0,
+    is_required_in_group: false,
+    ...overrides,
+  };
+}
+
+/**
+ * #1673 — the save guard (collectRequiredViolations) and the attr-row asterisk
+ * share this single predicate, so the two can never drift apart again. Before
+ * #1673 only the global `is_required` flag blocked saving; a field required
+ * only within its group showed the asterisk but saved while empty.
+ */
+describe('isAttributeRequired', () => {
+  it('is required when globally is_required', () => {
+    expect(isAttributeRequired(attr({ is_required: true }))).toBe(true);
+  });
+
+  it('is required when required within its group (the #1673 case)', () => {
+    expect(isAttributeRequired(attr({ is_required: false, is_required_in_group: true }))).toBe(
+      true,
+    );
+  });
+
+  it('is required when both flags are set', () => {
+    expect(isAttributeRequired(attr({ is_required: true, is_required_in_group: true }))).toBe(true);
+  });
+
+  it('is not required when neither flag is set', () => {
+    expect(isAttributeRequired(attr({ is_required: false, is_required_in_group: false }))).toBe(
+      false,
+    );
+  });
+
+  it('is not required when is_required is absent and the group flag is false', () => {
+    expect(isAttributeRequired(attr({ is_required_in_group: false }))).toBe(false);
+  });
+
+  it('is never required for booleans, even with both flags (unchecked = the value false)', () => {
+    expect(
+      isAttributeRequired(attr({ type: 'boolean', is_required: true, is_required_in_group: true })),
+    ).toBe(false);
+  });
+});

--- a/apps/admin/src/features/catalog/products/components/attr-row.tsx
+++ b/apps/admin/src/features/catalog/products/components/attr-row.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
 import { AssetField } from './asset-field';
+import { isAttributeRequired } from './product-detail-helpers';
 import { RelationInlineEditor } from './relation-inline-editor';
 import type { AttributeMeta, AttributeOptionMeta, ProductLocale } from './types';
 
@@ -205,10 +206,10 @@ export function AttrRow({
         {isLocked && !attribute.is_system ? (
           <Lock className="size-3 text-zinc-300" aria-hidden />
         ) : null}
-        {/* #1350 reopen #2 — no asterisk for booleans: requiredness is
-            meaningless when "unchecked" is itself a value. */}
-        {(attribute.is_required === true && attribute.type !== 'boolean') ||
-        attribute.is_required_in_group ? (
+        {/* #1350 reopen #2 / #1673 — asterisk + save-guard share one rule
+            (isAttributeRequired): global OR group-level required, never for
+            booleans (unchecked = the value `false`). */}
+        {isAttributeRequired(attribute) ? (
           <span
             className="text-rose-500"
             title={t('app.required', { defaultValue: 'wymagane' })}

--- a/apps/admin/src/features/catalog/products/components/product-detail-helpers.ts
+++ b/apps/admin/src/features/catalog/products/components/product-detail-helpers.ts
@@ -101,6 +101,19 @@ export function isEmptyAttributeValue(value: unknown): boolean {
 }
 
 /**
+ * #1673 — single source of truth for "is this attribute required". Mirrors
+ * the asterisk condition in attr-row.tsx so the required-field save guard
+ * (collectRequiredViolations) and the visual `*` never drift apart. A field
+ * is required when it is globally required (`is_required`) OR required within
+ * its group (`is_required_in_group`); booleans are exempt — an unchecked box
+ * IS the value `false`, never a missing value.
+ */
+export function isAttributeRequired(attr: AttributeMeta): boolean {
+  if (attr.type === 'boolean') return false;
+  return attr.is_required === true || attr.is_required_in_group === true;
+}
+
+/**
  * #1102/#1415 — relation attribute codes across the effective groups;
  * their create-mode values go through PUT /relations, not the POST body.
  */

--- a/apps/admin/src/features/catalog/products/components/use-product-detail-form.ts
+++ b/apps/admin/src/features/catalog/products/components/use-product-detail-form.ts
@@ -106,19 +106,21 @@ export function useProductDetailForm({
 
   const resetDirty = (): void => setDirtyFields({});
 
-  // #1350 / #1673 — full-state required check at save time: every required
-  // attribute (global `is_required` OR group-level `is_required_in_group`)
-  // across the effective groups must carry a non-empty CURRENT value (dirty
-  // edits included). Legacy dirty records are therefore enforced on their
-  // next save, exactly as the ticket specifies.
+  // #1350 / #1673 — full-state required check at save time. EDIT enforces every
+  // required attribute (global `is_required` OR group-level
+  // `is_required_in_group`), so a dirty imported entry cannot be saved while a
+  // group-required field is empty — the reported bug. CREATE keeps the lighter
+  // global-only gate: a brand-new draft must not be blocked on every
+  // completeness field at once, so group-required fields are enforced on the
+  // follow-up edit (where the asterisk + this guard apply). Booleans are never
+  // "missing" — an unchecked box IS the value `false`.
   const collectRequiredViolations = (): string[] => {
     const violations: string[] = [];
     for (const group of groups) {
       for (const attr of group.attributes) {
-        // #1673 — isAttributeRequired mirrors the attr-row asterisk (global
-        // or group-level) and exempts booleans (unchecked = the value
-        // `false`, not a missing value).
-        if (!isAttributeRequired(attr)) continue;
+        if (attr.type === 'boolean') continue;
+        const required = mode === 'edit' ? isAttributeRequired(attr) : attr.is_required === true;
+        if (!required) continue;
         const current = fieldValue(attr.code);
         if (isEmptyAttributeValue(current)) violations.push(attr.code);
       }

--- a/apps/admin/src/features/catalog/products/components/use-product-detail-form.ts
+++ b/apps/admin/src/features/catalog/products/components/use-product-detail-form.ts
@@ -7,6 +7,7 @@ import { toast } from '@/components/ui/toast';
 import { httpErrorDetail, jsonFetch } from '@/lib/http';
 import {
   collectRelationCodes,
+  isAttributeRequired,
   isEmptyAttributeValue,
   splitDirtyAttributes,
   stripAttributes,
@@ -105,18 +106,19 @@ export function useProductDetailForm({
 
   const resetDirty = (): void => setDirtyFields({});
 
-  // #1350 — full-state required check at save time: every `is_required`
-  // attribute across the effective groups must carry a non-empty CURRENT
-  // value (dirty edits included). Legacy dirty records are therefore
-  // enforced on their next save, exactly as the ticket specifies.
+  // #1350 / #1673 — full-state required check at save time: every required
+  // attribute (global `is_required` OR group-level `is_required_in_group`)
+  // across the effective groups must carry a non-empty CURRENT value (dirty
+  // edits included). Legacy dirty records are therefore enforced on their
+  // next save, exactly as the ticket specifies.
   const collectRequiredViolations = (): string[] => {
     const violations: string[] = [];
     for (const group of groups) {
       for (const attr of group.attributes) {
-        if (attr.is_required !== true) continue;
-        // #1350 (reopen #2) — requiredness is meaningless for booleans:
-        // an unchecked box IS the value `false`, not a missing value.
-        if (attr.type === 'boolean') continue;
+        // #1673 — isAttributeRequired mirrors the attr-row asterisk (global
+        // or group-level) and exempts booleans (unchecked = the value
+        // `false`, not a missing value).
+        if (!isAttributeRequired(attr)) continue;
         const current = fieldValue(attr.code);
         if (isEmptyAttributeValue(current)) violations.push(attr.code);
       }


### PR DESCRIPTION
## Summary

Pole oznaczone gwiazdką „wymagane" na karcie wpisu nie blokowało zapisu, jeśli było wymagane tylko na poziomie grupy (`is_required_in_group`), a nie globalnie (`is_required`). Operator trafił na to przy zaimportowanym produkcie bez „Opisu" — gwiazdka była, ale zapis przechodził.

## Root cause

Niespójność dwóch warunków:
- Gwiazdka (`attr-row.tsx`) renderowała się dla `is_required === true || is_required_in_group`.
- Save guard (`use-product-detail-form.ts`, `collectRequiredViolations`) sprawdzał tylko `is_required !== true`, pomijając wymaganie grupowe.

To nie regresja z #1671 — walidacja od #1436 nigdy nie egzekwowała wymagania grupowego. Backend egzekwuje tylko globalny `is_required` i tylko dla pól w payloadzie, więc jedyną bramką completeness przy edycji w UI jest walidacja FE (zakres FE-only — decyzja operatora).

## Frontend changes

- Nowy współdzielony helper `isAttributeRequired(attr)` w `product-detail-helpers.ts` — jedno źródło prawdy: globalnie LUB grupowo wymagane, `boolean` zawsze wykluczony (odznaczone = wartość `false`).
- `use-product-detail-form.ts` — `collectRequiredViolations` używa helpera.
- `attr-row.tsx` — warunek gwiazdki używa helpera (przy okazji: gwiazdka znika dla `boolean + is_required_in_group`, teraz spójna z walidacją).

## Quality gates

- Unit (vitest) `isAttributeRequired`: 6/6 zielone (global / group / oba / żaden / undefined / boolean).
- Playwright E2E `1673-required-in-group-save-blocked.spec.ts`: zielony — gwiazdka + blokada zapisu pustego pola grupowo-wymaganego + odblokowanie po uzupełnieniu (PATCH 200).
- Biome strict + admin typecheck (tsc -b): 0.
- Brak zmian zależności (audit/build bez wpływu — weryfikuje CI).

## Smoke test plan (operator, po merge)

1. Login `admin@demo.localhost / changeme`.
2. Produkt `https://pim.localhost/products/019ee1a6-b68b-7df3-a4b7-2ad3dfbf75d4`.
3. Wyczyść „Opis" → „Zapisz" → oczekiwane: blokada + toast „Uzupełnij wymagane pola: description", brak PATCH w Network.
4. Uzupełnij „Opis" → „Zapisz" → 200 + „Zapisano zmiany".
5. Console bez czerwonych errorów.

## Świadome odejścia

- BE full-completeness-at-save (422 dla każdego brakującego wymaganego-w-grupie pola) — poza zakresem; mogłoby łamać importy/integracje celowo wgrywające niekompletne dane. Osobny ticket, jeśli operator zechce twardej bramki API.

Closes #1673

🤖 Generated with [Claude Code](https://claude.com/claude-code)
