### PR TITLE
feat(import): wybór typu obiektu w kreatorze importu

### DIFF
--- a/apps/admin/e2e/1675-import-object-type-picker.spec.ts
+++ b/apps/admin/e2e/1675-import-object-type-picker.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+import { loginAsAdmin } from './helpers/auth';
+
+/**
+ * #1675 — the import wizard's first step now lets the operator choose WHICH
+ * ObjectType to import into, instead of being hardcoded to `product`. This
+ * proves the FE wiring on the live stack:
+ *   1. the "Co importujesz?" picker is the first control and defaults to a
+ *      product (regression guard for the previously hardcoded type),
+ *   2. switching to another built-in type updates the selection,
+ *   3. the choice does not block the wizard flow (upload → step 2).
+ *
+ * The full import INTO a chosen custom ObjectType is covered by the live-stack
+ * smoke on the issue — the backend pipeline is already type-generic
+ * (StartImportController accepts any ObjectType), so this spec guards the FE
+ * picker wiring without the flaky six-step commit into a freshly-created type.
+ */
+test('#1675 — import wizard exposes an object-type picker, default product', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  await loginAsAdmin(page);
+  await page.goto('/integrations/imports/new');
+
+  // 1. The object-type picker is the first, most prominent control on step 1.
+  await expect(page.getByText(/co importujesz\?|what are you importing\?/i)).toBeVisible({
+    timeout: 20_000,
+  });
+
+  // 2. It defaults to a product (the type the wizard used to be locked to).
+  const picker = page.locator('button[aria-haspopup="listbox"]').first();
+  await expect(picker).toContainText(/produkt|product/i);
+
+  // 3. Switching to another built-in type updates the selection. Filter the
+  //    list down to the category type and click its label option.
+  await picker.click();
+  await page.getByPlaceholder(/szukaj typu|search types/i).fill('categ');
+  await page
+    .getByText(/^(Kategoria|Category)$/)
+    .first()
+    .click();
+  await expect(picker).toContainText(/kategoria|category/i);
+
+  // 4. The choice does not block the flow: upload a CSV and advance to step 2.
+  const csv = 'sku;name\nCAT-1675-1;Smoke 1675\n';
+  await page
+    .locator('input[type="file"]')
+    .first()
+    .setInputFiles({ name: 'pick.csv', mimeType: 'text/csv', buffer: Buffer.from(csv, 'utf-8') });
+  await page.getByRole('button', { name: /dalej|next/i }).click();
+  await expect(page.getByText(/kodowanie|encoding/i).first()).toBeVisible({ timeout: 20_000 });
+});

--- a/apps/admin/src/features/imports/wizard/StepSource.tsx
+++ b/apps/admin/src/features/imports/wizard/StepSource.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
+import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
 import { MockBadge } from '@/components/ui/mock-badge';
 import { toast } from '@/components/ui/toast';
 import { FileDropzone } from '@/features/imports/components/FileDropzone';
@@ -49,13 +50,16 @@ interface StepSourceProps {
  * over from the 4-step wizard unchanged — payload contract is identical.
  */
 export function StepSource({ wizard }: StepSourceProps): React.ReactElement {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language === 'pl' ? 'pl' : 'en';
   const { state, setField, next } = wizard;
   const [testingId, setTestingId] = React.useState<string | null>(null);
 
   const { result: typesResult } = useList<ObjectTypeOption>({
     resource: 'object_types',
-    pagination: { pageSize: 50 },
+    // #1675 — operators may run dozens of custom ObjectTypes; 50 would clip the
+    // picker. 100 covers current usage without a full pagination sweep.
+    pagination: { pageSize: 100 },
   });
   const { result: profilesResult } = useList<ImportProfileOption>({
     resource: 'import-profiles',
@@ -74,6 +78,29 @@ export function StepSource({ wizard }: StepSourceProps): React.ReactElement {
   if (state.targetObjectTypeId === null && productType !== undefined) {
     setField('targetObjectTypeId', productType.id);
   }
+
+  // #1675 — let operators choose WHAT they import (product / category / asset /
+  // custom). The import pipeline is generic per ObjectType; product + custom are
+  // fully covered, while category hierarchy + asset binaries stay out of scope.
+  const objectTypeOptions: ComboboxOption[] = objectTypes.map((option) => ({
+    value: option.id,
+    label: option.label?.[lang] ?? option.label?.en ?? option.code,
+    description: option.code,
+  }));
+  const selectedType = objectTypes.find((option) => option.id === state.targetObjectTypeId);
+  const showHierarchyHint = selectedType?.kind === 'category' || selectedType?.kind === 'asset';
+
+  const handleObjectTypeChange = (nextId: string | null): void => {
+    if (nextId === null || nextId === state.targetObjectTypeId) {
+      return;
+    }
+    setField('targetObjectTypeId', nextId);
+    // Column mapping + auto-suggestions target the previous type's attributes,
+    // so they are stale once the target type changes — reset both. The parsed
+    // file snapshot depends on the FILE, not the type, so it is preserved.
+    setField('mapping', {});
+    setField('suggestions', []);
+  };
 
   const canProceed = state.file !== null && state.targetObjectTypeId !== null;
 
@@ -103,6 +130,42 @@ export function StepSource({ wizard }: StepSourceProps): React.ReactElement {
 
   return (
     <div className="space-y-4">
+      {/* #1675 — choose WHAT to import (was hardcoded to product). First, most
+          prominent control on the step. */}
+      <div className="rounded-2xl border border-zinc-100 bg-white p-6 shadow-sm">
+        <div className="text-[13.5px] font-semibold">
+          {t('imports.source.object_type.title', { defaultValue: 'Co importujesz?' })}
+        </div>
+        <div className="mt-0.5 text-[12px] text-zinc-500">
+          {t('imports.source.object_type.subtitle', {
+            defaultValue: 'Wybierz typ obiektu, do którego trafią wiersze pliku',
+          })}
+        </div>
+        <div className="mt-3 max-w-md">
+          <Combobox
+            options={objectTypeOptions}
+            value={state.targetObjectTypeId}
+            onChange={handleObjectTypeChange}
+            allowClear={false}
+            placeholder={t('imports.source.object_type.placeholder', {
+              defaultValue: 'Wybierz typ…',
+            })}
+            searchPlaceholder={t('imports.source.object_type.search', {
+              defaultValue: 'Szukaj typu…',
+            })}
+            className="rounded-xl text-[13.5px]"
+          />
+        </div>
+        {showHierarchyHint ? (
+          <p className="mt-2 text-[12px] text-amber-600">
+            {t('imports.source.object_type.hierarchy_hint', {
+              defaultValue:
+                'Import utworzy obiekty i wartości atrybutów. Hierarchia kategorii i pliki zasobów są poza zakresem importu.',
+            })}
+          </p>
+        ) : null}
+      </div>
+
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.4fr_1fr]">
         {/* Left — upload + saved sources */}
         <div className="space-y-5 rounded-2xl border border-zinc-100 bg-white p-6 shadow-sm">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2405,7 +2405,14 @@
       "profiles_title": "Suggested profiles",
       "profiles_subtitle": "Saved mapping profiles",
       "new_profile": "New profile (configure in the wizard)",
-      "settings_title": "File settings"
+      "settings_title": "File settings",
+      "object_type": {
+        "title": "What are you importing?",
+        "subtitle": "Pick the object type the file rows will land in",
+        "placeholder": "Pick a type…",
+        "search": "Search types…",
+        "hierarchy_hint": "Import creates objects and attribute values. Category hierarchy and asset binaries are out of scope for import."
+      }
     },
     "detect": {
       "title": "Auto-detection results",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2455,7 +2455,14 @@
       "profiles_title": "Sugerowane profile",
       "profiles_subtitle": "Zapisane profile mapowań",
       "new_profile": "Nowy profil (skonfiguruj w kreatorze)",
-      "settings_title": "Ustawienia pliku"
+      "settings_title": "Ustawienia pliku",
+      "object_type": {
+        "title": "Co importujesz?",
+        "subtitle": "Wybierz typ obiektu, do którego trafią wiersze pliku",
+        "placeholder": "Wybierz typ…",
+        "search": "Szukaj typu…",
+        "hierarchy_hint": "Import utworzy obiekty i wartości atrybutów. Hierarchia kategorii i pliki zasobów są poza zakresem importu."
+      }
     },
     "detect": {
       "title": "Wyniki auto-detekcji",


### PR DESCRIPTION
## Summary

Kreator importu (`/integrations/imports/new`) pozwala teraz wybrać **typ obiektu**, do którego trafią dane — zamiast być na sztywno zablokowanym na produkty. Operator ma 28 custom ObjectType'ów (usługi, requesty…) i mógł importować tylko produkty.

## Root cause

`StepSource.tsx` auto-ustawiał `targetObjectTypeId` na product bez UI wyboru (tak od pierwszej wersji — *„Imports MVP UI is locked to kind=product"*). Backend był jednak gotowy: `StartImportController` przyjmuje dowolny ObjectType, `ImportObjectCreator` tworzy obiekty generycznie.

## Frontend changes

- `StepSource.tsx`: searchable `Combobox` „Co importujesz?" jako pierwsza sekcja kroku; opcje z `object_types` (pageSize 50 → 100); domyślnie produkt.
- Zmiana typu resetuje `mapping` + `suggestions` (celują w atrybuty poprzedniego typu); `parsed`/`stagedFileId` (zależne od pliku) zachowane.
- Hint dla category/asset: import buduje obiekty + atrybuty; hierarchia kategorii i pliki zasobów poza zakresem.
- i18n `imports.source.object_type.*` (pl + en).

## Quality gates

- Biome strict + admin typecheck (tsc -b): 0.
- Playwright E2E `1675-import-object-type-picker.spec.ts`: zielony — picker widoczny, domyślnie produkt, przełączenie typu, przejście kroku.
- Bez zmian zależności / OpenAPI (zero BE).

## Smoke test plan (operator, po merge)

1. Login `admin@demo.localhost / changeme`.
2. `/integrations/imports/new` → na 1. kroku „Co importujesz?" z listą typów (produkt domyślnie).
3. Wybierz custom typ (np. usługa) → wgraj CSV → mapuj → Start.
4. Sprawdź, że utworzone obiekty należą do wybranego typu.
5. Console bez czerwonych errorów.

## Świadome odejścia

- **Import kategorii z hierarchią** (parent/ltree — reserved `__category__` tylko dla product) i **binaria zasobów** — osobne tickety. Category/asset tworzą obiekty + atrybuty bez hierarchii/binariów.
- Pełny import do custom typu zweryfikowany live-stack smoke (E2E pokrywa wiring pickera deterministycznie; pełny 6-krokowy commit do świeżo utworzonego typu jest flaky w CI).

Closes #1675

🤖 Generated with [Claude Code](https://claude.com/claude-code)
