### PR TITLE
fix(import): kafelkowy krok wyboru danych zamiast Combobox (rework #1675)

### DIFF
--- a/apps/admin/e2e/1429-import-wizard-6-steps.spec.ts
+++ b/apps/admin/e2e/1429-import-wizard-6-steps.spec.ts
@@ -17,6 +17,7 @@ test('NUI-10 — wizard walks six steps and commits an import session', async ({
   // Stepper renders all six steps.
   const stepper = page.getByLabel('Wizard steps');
   for (const label of [
+    /dane|data/i,
     /źródło|source/i,
     /wykrywanie|detect/i,
     /mapowanie|mapping/i,
@@ -27,7 +28,13 @@ test('NUI-10 — wizard walks six steps and commits an import session', async ({
     await expect(stepper.getByText(label).first()).toBeVisible();
   }
 
-  // Step 1 — Źródło: upload a tiny CSV.
+  // Step 1 — Dane: pick the Products tile, then advance to Źródło (#1678).
+  await page.getByRole('radio', { name: /produkty|products/i }).click();
+  const dataNext = page.getByRole('button', { name: /dalej|next/i });
+  await expect(dataNext).toBeEnabled({ timeout: 10_000 });
+  await dataNext.click();
+
+  // Step 2 — Źródło: upload a tiny CSV.
   const sku = `NUI10-${Date.now()}`;
   const csv = `sku;name\n${sku};Wizard smoke product\n`;
   await page
@@ -36,13 +43,13 @@ test('NUI-10 — wizard walks six steps and commits an import session', async ({
     .setInputFiles({ name: 'nui10.csv', mimeType: 'text/csv', buffer: Buffer.from(csv, 'utf-8') });
   await page.getByRole('button', { name: /dalej|next/i }).click();
 
-  // Step 2 — Wykrywanie: detection table + preview from parse-preview.
+  // Step 3 — Wykrywanie: detection table + preview from parse-preview.
   await expect(page.getByText(/kodowanie|encoding/i).first()).toBeVisible({ timeout: 20_000 });
   await expect(page.getByText(/kolumn wykrytych|columns detected/i)).toBeVisible();
   await expect(page.getByText(sku)).toBeVisible();
   await page.getByRole('button', { name: /dalej|next/i }).click();
 
-  // Step 3 — Mapowanie: auto-map produces rows; computed-column modal is a mock.
+  // Step 4 — Mapowanie: auto-map produces rows; computed-column modal is a mock.
   await expect(page.getByRole('button', { name: /kolumna obliczona|computed/i })).toBeVisible({
     timeout: 20_000,
   });
@@ -57,16 +64,16 @@ test('NUI-10 — wizard walks six steps and commits an import session', async ({
   await expect(nextOnMapping).toBeEnabled({ timeout: 20_000 });
   await nextOnMapping.click();
 
-  // Step 4 — Reguły: truth card + disabled mode tiles.
+  // Step 5 — Reguły: truth card + disabled mode tiles.
   await expect(page.getByText(/upsert (po identyfikatorze|by identifier)/i)).toBeVisible();
   await expect(page.getByText('UPSERT', { exact: true })).toBeVisible();
   await page.getByRole('button', { name: /dalej|next/i }).click();
 
-  // Step 5 — Podgląd: dry-run resolves with KPIs.
+  // Step 6 — Podgląd: dry-run resolves with KPIs.
   await expect(page.getByText(/ok/i).first()).toBeVisible({ timeout: 30_000 });
   await page.getByRole('button', { name: /dalej|next/i }).click();
 
-  // Step 6 — Start: summary + run. Capture the POST so a PROD-05 bulk
+  // Step 7 — Start: summary + run. Capture the POST so a PROD-05 bulk
   // lock collision (409 from a concurrent CI worker) skips instead of
   // flaking — the live-stack smoke covers the full commit path.
   await expect(page.getByText(/podsumowanie|summary/i)).toBeVisible();

--- a/apps/admin/e2e/1675-import-object-type-picker.spec.ts
+++ b/apps/admin/e2e/1675-import-object-type-picker.spec.ts
@@ -3,50 +3,45 @@ import { expect, test } from '@playwright/test';
 import { loginAsAdmin } from './helpers/auth';
 
 /**
- * #1675 — the import wizard's first step now lets the operator choose WHICH
- * ObjectType to import into, instead of being hardcoded to `product`. This
- * proves the FE wiring on the live stack:
- *   1. the "Co importujesz?" picker is the first control and defaults to a
- *      product (regression guard for the previously hardcoded type),
- *   2. switching to another built-in type updates the selection,
- *   3. the choice does not block the wizard flow (upload → step 2).
- *
- * The full import INTO a chosen custom ObjectType is covered by the live-stack
- * smoke on the issue — the backend pipeline is already type-generic
- * (StartImportController accepts any ObjectType), so this spec guards the FE
- * picker wiring without the flaky six-step commit into a freshly-created type.
+ * #1678 — the import wizard's first step is a tile screen mirroring the export
+ * wizard's "Krok 1: Wybierz dane do eksportu": Produkty / Moduły własne /
+ * Kategorie are selectable, while Schemat modułów + Atrybuty i grupy are
+ * disabled ("soon") because the import pipeline creates objects per ObjectType,
+ * not metadata. Picking a tile sets the target type and advances to Źródło.
+ * (Replaces the earlier, wrong Combobox-in-StepSource approach.)
  */
-test('#1675 — import wizard exposes an object-type picker, default product', async ({ page }) => {
+test('#1678 — import wizard step 1 is the data-kind tile screen', async ({ page }) => {
   test.setTimeout(120_000);
-
   await loginAsAdmin(page);
   await page.goto('/integrations/imports/new');
 
-  // 1. The object-type picker is the first, most prominent control on step 1.
-  await expect(page.getByText(/co importujesz\?|what are you importing\?/i)).toBeVisible({
+  // Step 1 — tiles, mirroring the export wizard.
+  await expect(
+    page.getByRole('heading', { name: /wybierz dane do importu|choose the data to import/i }),
+  ).toBeVisible({ timeout: 20_000 });
+
+  const productTile = page.getByRole('radio', { name: /produkty|products/i });
+  const categoryTile = page.getByRole('radio', { name: /kategorie|categories/i });
+  await expect(productTile).toBeVisible();
+  await expect(categoryTile).toBeVisible();
+
+  // The metadata tiles are disabled ("soon").
+  await expect(page.getByRole('radio', { name: /schemat modułów|module schema/i })).toHaveAttribute(
+    'aria-disabled',
+    'true',
+  );
+
+  // Pick "Kategorie" → it becomes the selected tile → advance to Źródło.
+  await categoryTile.click();
+  await expect(categoryTile).toHaveAttribute('aria-checked', 'true');
+  const nextButton = page.getByRole('button', { name: /dalej|next/i });
+  await expect(nextButton).toBeEnabled();
+  await nextButton.click();
+
+  // Step 2 — Źródło: the upload control is visible and the old "Co importujesz?"
+  // combobox is gone.
+  await expect(page.getByText(/wgraj plik|upload a file/i).first()).toBeVisible({
     timeout: 20_000,
   });
-
-  // 2. It defaults to a product (the type the wizard used to be locked to).
-  const picker = page.locator('button[aria-haspopup="listbox"]').first();
-  await expect(picker).toContainText(/produkt|product/i);
-
-  // 3. Switching to another built-in type updates the selection. Filter the
-  //    list down to the category type and click its label option.
-  await picker.click();
-  await page.getByPlaceholder(/szukaj typu|search types/i).fill('categ');
-  await page
-    .getByText(/^(Kategoria|Category)$/)
-    .first()
-    .click();
-  await expect(picker).toContainText(/kategoria|category/i);
-
-  // 4. The choice does not block the flow: upload a CSV and advance to step 2.
-  const csv = 'sku;name\nCAT-1675-1;Smoke 1675\n';
-  await page
-    .locator('input[type="file"]')
-    .first()
-    .setInputFiles({ name: 'pick.csv', mimeType: 'text/csv', buffer: Buffer.from(csv, 'utf-8') });
-  await page.getByRole('button', { name: /dalej|next/i }).click();
-  await expect(page.getByText(/kodowanie|encoding/i).first()).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText(/co importujesz|what are you importing/i)).toHaveCount(0);
 });

--- a/apps/admin/e2e/imports-wizard.spec.ts
+++ b/apps/admin/e2e/imports-wizard.spec.ts
@@ -12,19 +12,20 @@ test('imports wizard — header + stepper + step 1 active', async ({ page }) => 
   await loginAsAdmin(page);
   await page.goto('/integrations/imports/new');
 
-  // Header eyebrow + h2 title (NUI-10 — six steps).
-  await expect(page.getByText(/self-service, 6 (kroków|steps)/i)).toBeVisible();
+  // Header eyebrow + h2 title (#1678 — seven steps, data-kind step first).
+  await expect(page.getByText(/self-service, 7 (kroków|steps)/i)).toBeVisible();
   await expect(page.getByRole('heading', { name: /^nowy import$|^new import$/i })).toBeVisible();
 
-  // Stepper: aria-current step pinned to the first pill — it carries
-  // the step number + label + description, so match a substring.
+  // Stepper: aria-current step pinned to the first pill — now the data-kind
+  // step ("Dane"). It carries the step number + label + description.
   const activePill = page.locator('[aria-current="step"]');
   await expect(activePill).toBeVisible();
-  await expect(activePill).toContainText(/źródło|source/i);
+  await expect(activePill).toContainText(/dane|data/i);
 
-  // All 6 step pills visible.
+  // All 7 step pills visible.
   const stepper = page.getByLabel('Wizard steps');
   for (const label of [
+    /dane|data/i,
     /źródło|source/i,
     /wykrywanie|detection/i,
     /mapowanie|mapping/i,

--- a/apps/admin/src/features/imports/hooks/use-import-entity-object-types.ts
+++ b/apps/admin/src/features/imports/hooks/use-import-entity-object-types.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { jsonFetch } from '@/lib/http';
+
+export interface ImportObjectTypeRow {
+  id: string;
+  code: string;
+  kind?: string;
+  builtIn?: boolean;
+  label?: Record<string, string>;
+}
+
+interface ObjectTypesResponse {
+  member?: ImportObjectTypeRow[];
+  'hydra:member'?: ImportObjectTypeRow[];
+}
+
+/**
+ * #1678 — all ObjectTypes for the import entity-tile step (StepEntityType
+ * derives built-in product/category + the custom list). Kept in its own hook
+ * so the transport (`jsonFetch`) lives in the data layer via `useQuery` and the
+ * step component stays clear of the jsonFetch+useEffect guard (ADR-0021): the
+ * cached query is mutation-reactive, and the component's own `useEffect` only
+ * syncs local wizard state, never loads server data.
+ */
+export function useImportEntityObjectTypes() {
+  return useQuery({
+    queryKey: ['object-types', 'import-entity'],
+    staleTime: 60_000,
+    queryFn: async (): Promise<ImportObjectTypeRow[]> => {
+      const response = await jsonFetch<ObjectTypesResponse>('/api/object_types?pagination=false');
+      return response.member ?? response['hydra:member'] ?? [];
+    },
+  });
+}

--- a/apps/admin/src/features/imports/hooks/useImportWizard.ts
+++ b/apps/admin/src/features/imports/hooks/useImportWizard.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-export type WizardStepIndex = 0 | 1 | 2 | 3 | 4 | 5;
+export type WizardStepIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+/** #1678 — data kind chosen on the first wizard step (tiles). */
+export type ImportEntityType = 'product' | 'custom_module' | 'categories';
 
 /** Authoritative parse-preview snapshot captured on the Detect step (NUI-10). */
 export interface ParsedFilePreview {
@@ -33,6 +36,8 @@ export interface ValidationFinding {
 
 export interface WizardState {
   step: WizardStepIndex;
+  /** #1678 — data kind picked on step 1 (tiles); null until a tile is chosen. */
+  entityType: ImportEntityType | null;
   file: File | null;
   zipFile: File | null;
   locale: string | null;
@@ -67,6 +72,7 @@ export interface WizardState {
 
 const INITIAL_STATE: WizardState = {
   step: 0,
+  entityType: null,
   file: null,
   zipFile: null,
   locale: null,
@@ -130,7 +136,7 @@ export function useImportWizard(): WizardController {
   const next = React.useCallback(() => {
     setState((prev) => ({
       ...prev,
-      step: Math.min(prev.step + 1, 5) as WizardStepIndex,
+      step: Math.min(prev.step + 1, 6) as WizardStepIndex,
     }));
   }, []);
 
@@ -154,6 +160,7 @@ export function useImportWizard(): WizardController {
     }
     const persisted = {
       step: state.step,
+      entityType: state.entityType,
       locale: state.locale,
       encoding: state.encoding,
       delimiter: state.delimiter,

--- a/apps/admin/src/features/imports/wizard/ImportWizardPage.tsx
+++ b/apps/admin/src/features/imports/wizard/ImportWizardPage.tsx
@@ -5,6 +5,7 @@ import { useImportWizard } from '@/features/imports/hooks/useImportWizard';
 
 import { StepConfirmPlaceholder } from './StepConfirm';
 import { StepDetect } from './StepDetect';
+import { StepEntityType } from './StepEntityType';
 import { StepMapping } from './StepMapping';
 import { StepRules } from './StepRules';
 import { StepSource } from './StepSource';
@@ -32,6 +33,13 @@ export function ImportWizardPage(): React.ReactElement {
   }, []);
 
   const steps: ReadonlyArray<WizardStep> = [
+    {
+      id: 'entity',
+      label: t('imports.wizard.steps.entity', { defaultValue: 'Dane' }),
+      description: t('imports.wizard.descriptions.entity', {
+        defaultValue: 'co importujesz',
+      }),
+    },
     {
       id: 'source',
       label: t('imports.wizard.steps.source', { defaultValue: 'Źródło' }),
@@ -88,7 +96,7 @@ export function ImportWizardPage(): React.ReactElement {
         <p className="text-[13.5px] text-zinc-500 leading-relaxed max-w-3xl">
           {t('imports.wizard.subtitle', {
             defaultValue:
-              'Każdy plik przechodzi przez 6 kroków: źródło, wykrywanie formatu, mapowanie kolumn, reguły, dry-run i commit do bazy. Po commicie sesja trafia do zakładki „Sesje" gdzie możesz ją wycofać w oknie 24h.',
+              'Każdy plik przechodzi przez 7 kroków: wybór danych, źródło, wykrywanie formatu, mapowanie kolumn, reguły, dry-run i commit do bazy. Po commicie sesja trafia do zakładki „Sesje" gdzie możesz ją wycofać w oknie 24h.',
           })}
         </p>
       </header>
@@ -100,12 +108,13 @@ export function ImportWizardPage(): React.ReactElement {
         id={`wizard-step-${steps[wizard.state.step]?.id ?? 'unknown'}`}
         aria-labelledby={`wizard-step-${steps[wizard.state.step]?.id ?? 'unknown'}-label`}
       >
-        {wizard.state.step === 0 && <StepSource wizard={wizard} />}
-        {wizard.state.step === 1 && <StepDetect wizard={wizard} />}
-        {wizard.state.step === 2 && <StepMapping wizard={wizard} />}
-        {wizard.state.step === 3 && <StepRules wizard={wizard} />}
-        {wizard.state.step === 4 && <StepValidationPlaceholder wizard={wizard} />}
-        {wizard.state.step === 5 && <StepConfirmPlaceholder wizard={wizard} />}
+        {wizard.state.step === 0 && <StepEntityType wizard={wizard} />}
+        {wizard.state.step === 1 && <StepSource wizard={wizard} />}
+        {wizard.state.step === 2 && <StepDetect wizard={wizard} />}
+        {wizard.state.step === 3 && <StepMapping wizard={wizard} />}
+        {wizard.state.step === 4 && <StepRules wizard={wizard} />}
+        {wizard.state.step === 5 && <StepValidationPlaceholder wizard={wizard} />}
+        {wizard.state.step === 6 && <StepConfirmPlaceholder wizard={wizard} />}
       </section>
     </div>
   );

--- a/apps/admin/src/features/imports/wizard/StepEntityType.tsx
+++ b/apps/admin/src/features/imports/wizard/StepEntityType.tsx
@@ -1,0 +1,193 @@
+import { Boxes, FolderTree, Layers, Package, Tags } from 'lucide-react';
+import { type ReactElement, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { SelectableCard, SelectableCardGroup } from '@/components/ui-v2/selectable-card';
+import {
+  type ImportObjectTypeRow,
+  useImportEntityObjectTypes,
+} from '@/features/imports/hooks/use-import-entity-object-types';
+import type { ImportEntityType, useImportWizard } from '@/features/imports/hooks/useImportWizard';
+import { cn } from '@/lib/utils';
+
+/** #1678 — tile ids: the three importable entity kinds + two "soon" tiles
+ * mirroring the export wizard (import does not yet create schema/attribute
+ * definitions from a file). */
+type TileId = ImportEntityType | 'module_schema' | 'attributes_groups';
+
+const ENTITY_DEFS: Array<{ id: TileId; icon: typeof Package; comingSoon?: boolean }> = [
+  { id: 'product', icon: Package },
+  { id: 'custom_module', icon: Boxes },
+  { id: 'module_schema', icon: Layers, comingSoon: true },
+  { id: 'attributes_groups', icon: Tags, comingSoon: true },
+  { id: 'categories', icon: FolderTree },
+];
+
+const DEFAULT_TITLES: Record<TileId, string> = {
+  product: 'Produkty',
+  custom_module: 'Moduły własne',
+  module_schema: 'Schemat modułów',
+  attributes_groups: 'Atrybuty i grupy',
+  categories: 'Kategorie',
+};
+
+const DEFAULT_DESCS: Record<TileId, string> = {
+  product: 'Importuj główny katalog produktów, warianty, ceny i powiązane multimedia.',
+  custom_module:
+    'Importuj dane do zdefiniowanych przez użytkownika modułów niestandardowych (np. Producenci, Kolekcje).',
+  module_schema: 'Wgranie struktury definicji i relacji modułów — wkrótce.',
+  attributes_groups: 'Import słownika atrybutów, ich wartości i podziału na grupy — wkrótce.',
+  categories: 'Importuj strukturę drzewa kategorii oraz tłumaczenia nazw.',
+};
+
+interface StepEntityTypeProps {
+  wizard: ReturnType<typeof useImportWizard>;
+}
+
+/**
+ * #1678 — import wizard step 1: a 3+2 tile grid mirroring the export wizard's
+ * StepEntityType. Product / Moduły własne / Kategorie are importable; Schemat
+ * modułów + Atrybuty i grupy are "soon" (the pipeline creates objects per
+ * ObjectType, not metadata). Picking a tile maps to the concrete
+ * `targetObjectTypeId`; "Moduły własne" reveals a custom-ObjectType select.
+ * Reuses the generic SelectableCard/SelectableCardGroup components.
+ */
+export function StepEntityType({ wizard }: StepEntityTypeProps): ReactElement {
+  const { t, i18n } = useTranslation();
+  const { state, setField, next } = wizard;
+  const lang = i18n.language === 'pl' ? 'pl' : 'en';
+  const objectTypes = useImportEntityObjectTypes();
+
+  const rows = objectTypes.data ?? [];
+  const productType = rows.find((row) => row.kind === 'product');
+  const categoryType = rows.find((row) => row.kind === 'category');
+  const customTypes = rows.filter((row) => row.kind === 'custom');
+  const customAvailable = customTypes.length > 0;
+
+  // #1678 — object_types load async; if a tile was picked before the query
+  // resolved, backfill its targetObjectTypeId once the built-in OT is known
+  // (product/categories). custom_module is set explicitly through the dropdown.
+  useEffect(() => {
+    if (state.targetObjectTypeId !== null) {
+      return;
+    }
+    if (state.entityType === 'product' && productType !== undefined) {
+      setField('targetObjectTypeId', productType.id);
+    } else if (state.entityType === 'categories' && categoryType !== undefined) {
+      setField('targetObjectTypeId', categoryType.id);
+    }
+  }, [state.entityType, state.targetObjectTypeId, productType, categoryType, setField]);
+
+  const selectEntity = (id: TileId): void => {
+    if (id === 'module_schema' || id === 'attributes_groups') {
+      return; // "soon" tiles are inert
+    }
+    if (id !== state.entityType) {
+      // Column mapping + auto-suggestions target the previous type's
+      // attributes, so they are stale once the data kind changes.
+      setField('mapping', {});
+      setField('suggestions', []);
+    }
+    setField('entityType', id);
+    if (id === 'product') {
+      setField('targetObjectTypeId', productType?.id ?? null);
+    } else if (id === 'categories') {
+      setField('targetObjectTypeId', categoryType?.id ?? null);
+    } else {
+      setField('targetObjectTypeId', null); // custom_module → choose below
+    }
+  };
+
+  const labelOf = (row: ImportObjectTypeRow): string => {
+    const labels = row.label ?? {};
+    return labels[lang] ?? labels.pl ?? labels.en ?? row.code;
+  };
+
+  const canProceed = state.entityType !== null && state.targetObjectTypeId !== null;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-zinc-100 bg-white p-7 shadow-sm">
+        <h2 className="text-[16px] font-semibold tracking-tight">
+          {t('imports.wizard.step1_title', { defaultValue: 'Krok 1: Wybierz dane do importu' })}
+        </h2>
+        <p className="mt-1 text-[13px] text-zinc-500">
+          {t('imports.wizard.step1_subtitle', {
+            defaultValue: 'Wybierz główny typ encji, do którego trafią wiersze pliku.',
+          })}
+        </p>
+
+        <SelectableCardGroup
+          ariaLabel={t('imports.wizard.entity_group_aria', {
+            defaultValue: 'Wybór typu danych do importu',
+          })}
+          className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3"
+        >
+          {ENTITY_DEFS.map(({ id, icon: Icon, comingSoon }) => (
+            <SelectableCard
+              key={id}
+              icon={<Icon className="size-5" aria-hidden />}
+              title={t(`imports.entity.${id}`, { defaultValue: DEFAULT_TITLES[id] })}
+              description={t(`imports.wizard.entity_desc.${id}`, {
+                defaultValue: DEFAULT_DESCS[id],
+              })}
+              selected={state.entityType === id}
+              disabled={
+                comingSoon === true ||
+                (id === 'custom_module' && !customAvailable && !objectTypes.isLoading)
+              }
+              onSelect={() => selectEntity(id)}
+            />
+          ))}
+        </SelectableCardGroup>
+
+        {state.entityType === 'custom_module' && (
+          <div className="mt-5 rounded-xl border border-zinc-200 bg-zinc-50/60 p-4">
+            <label
+              htmlFor="import-custom-object-type"
+              className="block text-[11px] font-medium uppercase tracking-wider text-zinc-500"
+            >
+              {t('imports.wizard.custom_object_type_label', {
+                defaultValue: 'Wybierz moduł własny',
+              })}
+            </label>
+            <select
+              id="import-custom-object-type"
+              value={state.targetObjectTypeId ?? ''}
+              onChange={(event) => setField('targetObjectTypeId', event.target.value || null)}
+              className={cn(
+                'mt-2 h-10 w-full max-w-md rounded-xl border bg-white px-3 text-[13px]',
+                state.targetObjectTypeId === null ? 'border-rose-300' : 'border-zinc-200',
+              )}
+            >
+              <option value="">
+                {t('imports.wizard.custom_object_type_placeholder', {
+                  defaultValue: '— wybierz —',
+                })}
+              </option>
+              {customTypes.map((row) => (
+                <option key={row.id} value={row.id}>
+                  {labelOf(row)}
+                </option>
+              ))}
+            </select>
+            {state.targetObjectTypeId === null && (
+              <p className="mt-1.5 text-[12px] text-rose-600">
+                {t('imports.wizard.custom_object_type_required', {
+                  defaultValue: 'Wybierz moduł własny, aby kontynuować',
+                })}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button onClick={() => next()} disabled={!canProceed}>
+          {t('imports.wizard.next', { defaultValue: 'Dalej →' })}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/features/imports/wizard/StepSource.tsx
+++ b/apps/admin/src/features/imports/wizard/StepSource.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
-import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
 import { MockBadge } from '@/components/ui/mock-badge';
 import { toast } from '@/components/ui/toast';
 import { FileDropzone } from '@/features/imports/components/FileDropzone';
@@ -16,13 +15,6 @@ import { cn } from '@/lib/utils';
 
 const MAX_CSV_BYTES = 50 * 1024 * 1024;
 const MAX_ZIP_BYTES = 500 * 1024 * 1024;
-
-interface ObjectTypeOption {
-  id: string;
-  code: string;
-  kind: string;
-  label?: Record<string, string>;
-}
 
 interface ImportProfileOption {
   id: string;
@@ -50,17 +42,10 @@ interface StepSourceProps {
  * over from the 4-step wizard unchanged — payload contract is identical.
  */
 export function StepSource({ wizard }: StepSourceProps): React.ReactElement {
-  const { t, i18n } = useTranslation();
-  const lang = i18n.language === 'pl' ? 'pl' : 'en';
+  const { t } = useTranslation();
   const { state, setField, next } = wizard;
   const [testingId, setTestingId] = React.useState<string | null>(null);
 
-  const { result: typesResult } = useList<ObjectTypeOption>({
-    resource: 'object_types',
-    // #1675 — operators may run dozens of custom ObjectTypes; 50 would clip the
-    // picker. 100 covers current usage without a full pagination sweep.
-    pagination: { pageSize: 100 },
-  });
   const { result: profilesResult } = useList<ImportProfileOption>({
     resource: 'import-profiles',
     pagination: { pageSize: 100 },
@@ -70,38 +55,11 @@ export function StepSource({ wizard }: StepSourceProps): React.ReactElement {
     pagination: { pageSize: 50 },
   });
 
-  const objectTypes = typesResult.data ?? [];
   const profiles = profilesResult.data ?? [];
   const sources = sourcesResult.data ?? [];
 
-  const productType = objectTypes.find((option) => option.kind === 'product') ?? objectTypes[0];
-  if (state.targetObjectTypeId === null && productType !== undefined) {
-    setField('targetObjectTypeId', productType.id);
-  }
-
-  // #1675 — let operators choose WHAT they import (product / category / asset /
-  // custom). The import pipeline is generic per ObjectType; product + custom are
-  // fully covered, while category hierarchy + asset binaries stay out of scope.
-  const objectTypeOptions: ComboboxOption[] = objectTypes.map((option) => ({
-    value: option.id,
-    label: option.label?.[lang] ?? option.label?.en ?? option.code,
-    description: option.code,
-  }));
-  const selectedType = objectTypes.find((option) => option.id === state.targetObjectTypeId);
-  const showHierarchyHint = selectedType?.kind === 'category' || selectedType?.kind === 'asset';
-
-  const handleObjectTypeChange = (nextId: string | null): void => {
-    if (nextId === null || nextId === state.targetObjectTypeId) {
-      return;
-    }
-    setField('targetObjectTypeId', nextId);
-    // Column mapping + auto-suggestions target the previous type's attributes,
-    // so they are stale once the target type changes — reset both. The parsed
-    // file snapshot depends on the FILE, not the type, so it is preserved.
-    setField('mapping', {});
-    setField('suggestions', []);
-  };
-
+  // #1678 — the data kind (and its targetObjectTypeId) is chosen on the new
+  // first wizard step (StepEntityType tiles); this step only handles the file.
   const canProceed = state.file !== null && state.targetObjectTypeId !== null;
 
   const testConnection = async (source: ImportSourceRow): Promise<void> => {
@@ -130,42 +88,6 @@ export function StepSource({ wizard }: StepSourceProps): React.ReactElement {
 
   return (
     <div className="space-y-4">
-      {/* #1675 — choose WHAT to import (was hardcoded to product). First, most
-          prominent control on the step. */}
-      <div className="rounded-2xl border border-zinc-100 bg-white p-6 shadow-sm">
-        <div className="text-[13.5px] font-semibold">
-          {t('imports.source.object_type.title', { defaultValue: 'Co importujesz?' })}
-        </div>
-        <div className="mt-0.5 text-[12px] text-zinc-500">
-          {t('imports.source.object_type.subtitle', {
-            defaultValue: 'Wybierz typ obiektu, do którego trafią wiersze pliku',
-          })}
-        </div>
-        <div className="mt-3 max-w-md">
-          <Combobox
-            options={objectTypeOptions}
-            value={state.targetObjectTypeId}
-            onChange={handleObjectTypeChange}
-            allowClear={false}
-            placeholder={t('imports.source.object_type.placeholder', {
-              defaultValue: 'Wybierz typ…',
-            })}
-            searchPlaceholder={t('imports.source.object_type.search', {
-              defaultValue: 'Szukaj typu…',
-            })}
-            className="rounded-xl text-[13.5px]"
-          />
-        </div>
-        {showHierarchyHint ? (
-          <p className="mt-2 text-[12px] text-amber-600">
-            {t('imports.source.object_type.hierarchy_hint', {
-              defaultValue:
-                'Import utworzy obiekty i wartości atrybutów. Hierarchia kategorii i pliki zasobów są poza zakresem importu.',
-            })}
-          </p>
-        ) : null}
-      </div>
-
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.4fr_1fr]">
         {/* Left — upload + saved sources */}
         <div className="space-y-5 rounded-2xl border border-zinc-100 bg-white p-6 shadow-sm">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2251,11 +2251,25 @@
       },
       "empty": "No imports yet. Start your first import."
     },
+    "entity": {
+      "product": "Products",
+      "custom_module": "Custom modules",
+      "module_schema": "Module schema",
+      "attributes_groups": "Attributes & groups",
+      "categories": "Categories"
+    },
     "wizard": {
-      "eyebrow": "Import wizard — self-service, 6 steps",
+      "eyebrow": "Import wizard — self-service, 7 steps",
       "title": "New import",
-      "subtitle": "Every file goes through 6 steps: source, format detection, column mapping, rules, dry-run and commit. After commit the session shows up under \"Sessions\" — you can roll it back within 24h.",
+      "subtitle": "Every file goes through 7 steps: data, source, format detection, column mapping, rules, dry-run and commit. After commit the session shows up under \"Sessions\" — you can roll it back within 24h.",
+      "step1_title": "Step 1: Choose the data to import",
+      "step1_subtitle": "Pick the main entity type the file rows will land in.",
+      "entity_group_aria": "Import data type selection",
+      "custom_object_type_label": "Choose a custom module",
+      "custom_object_type_placeholder": "— choose —",
+      "custom_object_type_required": "Choose a custom module to continue",
       "descriptions": {
+        "entity": "what you import",
         "upload": "CSV / XLSX + optional ZIP with images",
         "mapping": "columns → attributes + categories",
         "validation": "dry-run, validation errors",
@@ -2265,6 +2279,7 @@
         "rules": "mode · validation"
       },
       "steps": {
+        "entity": "Data",
         "upload": "Upload",
         "mapping": "Mapping",
         "validation": "Preview",
@@ -2272,6 +2287,13 @@
         "source": "Source",
         "detect": "Detection",
         "rules": "Rules"
+      },
+      "entity_desc": {
+        "product": "Import the main product catalog, variants, prices and linked media.",
+        "custom_module": "Import data into user-defined custom modules (e.g. Manufacturers, Collections).",
+        "module_schema": "Upload module definition and relation structure — coming soon.",
+        "attributes_groups": "Import the attribute dictionary, values and group split — coming soon.",
+        "categories": "Import the category tree structure and name translations."
       },
       "next": "Next",
       "back": "Back",
@@ -2405,14 +2427,7 @@
       "profiles_title": "Suggested profiles",
       "profiles_subtitle": "Saved mapping profiles",
       "new_profile": "New profile (configure in the wizard)",
-      "settings_title": "File settings",
-      "object_type": {
-        "title": "What are you importing?",
-        "subtitle": "Pick the object type the file rows will land in",
-        "placeholder": "Pick a type…",
-        "search": "Search types…",
-        "hierarchy_hint": "Import creates objects and attribute values. Category hierarchy and asset binaries are out of scope for import."
-      }
+      "settings_title": "File settings"
     },
     "detect": {
       "title": "Auto-detection results",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2301,11 +2301,25 @@
       },
       "empty": "Brak importów. Utwórz pierwszy import."
     },
+    "entity": {
+      "product": "Produkty",
+      "custom_module": "Moduły własne",
+      "module_schema": "Schemat modułów",
+      "attributes_groups": "Atrybuty i grupy",
+      "categories": "Kategorie"
+    },
     "wizard": {
-      "eyebrow": "Kreator importu — self-service, 6 kroków",
+      "eyebrow": "Kreator importu — self-service, 7 kroków",
       "title": "Nowy import",
-      "subtitle": "Każdy plik przechodzi przez 6 kroków: źródło, wykrywanie formatu, mapowanie kolumn, reguły, dry-run i commit do bazy. Po commicie sesja trafia do zakładki „Sesje\", gdzie możesz ją wycofać w oknie 24h.",
+      "subtitle": "Każdy plik przechodzi przez 7 kroków: wybór danych, źródło, wykrywanie formatu, mapowanie kolumn, reguły, dry-run i commit do bazy. Po commicie sesja trafia do zakładki „Sesje\", gdzie możesz ją wycofać w oknie 24h.",
+      "step1_title": "Krok 1: Wybierz dane do importu",
+      "step1_subtitle": "Wybierz główny typ encji, do którego trafią wiersze pliku.",
+      "entity_group_aria": "Wybór typu danych do importu",
+      "custom_object_type_label": "Wybierz moduł własny",
+      "custom_object_type_placeholder": "— wybierz —",
+      "custom_object_type_required": "Wybierz moduł własny, aby kontynuować",
       "descriptions": {
+        "entity": "co importujesz",
         "upload": "CSV / XLSX + opcjonalny ZIP ze zdjęciami",
         "mapping": "kolumny → atrybuty + kategorie",
         "validation": "dry-run, błędy walidacji",
@@ -2315,6 +2329,7 @@
         "rules": "tryb · walidacja"
       },
       "steps": {
+        "entity": "Dane",
         "upload": "Upload",
         "mapping": "Mapowanie",
         "validation": "Podgląd",
@@ -2322,6 +2337,13 @@
         "source": "Źródło",
         "detect": "Wykrywanie",
         "rules": "Reguły"
+      },
+      "entity_desc": {
+        "product": "Importuj główny katalog produktów, warianty, ceny i powiązane multimedia.",
+        "custom_module": "Importuj dane do zdefiniowanych przez użytkownika modułów niestandardowych (np. Producenci, Kolekcje).",
+        "module_schema": "Wgranie struktury definicji i relacji modułów — wkrótce.",
+        "attributes_groups": "Import słownika atrybutów, ich wartości i podziału na grupy — wkrótce.",
+        "categories": "Importuj strukturę drzewa kategorii oraz tłumaczenia nazw."
       },
       "next": "Dalej",
       "back": "Wstecz",
@@ -2455,14 +2477,7 @@
       "profiles_title": "Sugerowane profile",
       "profiles_subtitle": "Zapisane profile mapowań",
       "new_profile": "Nowy profil (skonfiguruj w kreatorze)",
-      "settings_title": "Ustawienia pliku",
-      "object_type": {
-        "title": "Co importujesz?",
-        "subtitle": "Wybierz typ obiektu, do którego trafią wiersze pliku",
-        "placeholder": "Wybierz typ…",
-        "search": "Szukaj typu…",
-        "hierarchy_hint": "Import utworzy obiekty i wartości atrybutów. Hierarchia kategorii i pliki zasobów są poza zakresem importu."
-      }
+      "settings_title": "Ustawienia pliku"
     },
     "detect": {
       "title": "Wyniki auto-detekcji",


### PR DESCRIPTION
## Summary

Rework błędnej implementacji #1675/#1676. Kreator importu dostaje pełnoekranowy **kafelkowy** pierwszy krok „Wybierz dane do importu" — analogiczny do eksportu (`/integrations/exports/new`) — zamiast prostego Combobox w kroku Źródło.

## Root cause

#1675 dodał `Combobox` „Co importujesz?" w `StepSource`. Operator oczekiwał kafelkowego ekranu jak w eksporcie (`StepEntityType` z `SelectableCard`). To inny wzorzec UI.

## Zmiany (FE-only, zero BE)

- **Usunięto** Combobox z `StepSource.tsx` (+ logikę object_types/auto-default) i klucze i18n `imports.source.object_type.*`.
- **Nowy krok** `StepEntityType.tsx` — **reużywa** generyczne `SelectableCard`/`SelectableCardGroup` (bez duplikacji), wzorem eksportowego `StepEntityType`. Kafelki: Produkty / Moduły własne / Kategorie (aktywne) + Schemat modułów / Atrybuty i grupy („wkrótce", disabled). Wybór mapuje na `targetObjectTypeId` (built-in product/category, custom przez dropdown). `useEffect` dociąga id po async-load `object_types`.
- `useImportWizard`: `entityType` + 7 kroków (`WizardStepIndex 0..6`).
- `ImportWizardPage`: nowy pierwszy krok „Dane"; render przesunięty o +1 (6 → 7 kroków).
- i18n `imports.entity.*` + `imports.wizard.{step1_*,entity_desc,custom_object_type_*,steps.entity,descriptions.entity}` (pl + en); subtitle/eyebrow „6 → 7 kroków".

## Quality gates

- Biome strict + admin typecheck (tsc -b): 0.
- Playwright: `1675` (kafelki: heading, Produkty/Kategorie wybieralne, Schemat „soon" disabled, wybór → Źródło, brak Combobox) — zielony; `1429` (zaktualizowany na 7 kroków, pełny commit) — zielony.
- JSON locale poprawny.

## Smoke test plan (operator, po merge)

1. Login `admin@demo.localhost / changeme`.
2. `/integrations/imports/new` → Krok 1 = kafelki jak w eksporcie. Produkty domyślnie wybieralne, Schemat modułów / Atrybuty i grupy wyszarzone „wkrótce".
3. „Moduły własne" → pojawia się dropdown wyboru custom OT.
4. Wybierz Produkty → Dalej → krok Źródło (upload). Brak resztek „Co importujesz?".
5. Pełny import do wybranego typu (curl proof w issue).
6. Console bez czerwonych errorów.

## Świadome odejścia

- Schemat modułów / Atrybuty i grupy — „wkrótce" (import tworzy obiekty per ObjectType, nie metadane). Aktywacja = osobny ticket. Zero zmian backendu (pipeline już generyczny).

Closes #1678

🤖 Generated with [Claude Code](https://claude.com/claude-code)
