### PR TITLE
docs(agent): zapis fixów #1673 (walidacja) + #1678 (kafelki importu)

### DIFF
--- a/agent/current_status.md
+++ b/agent/current_status.md
@@ -7,6 +7,10 @@
 - **Epik:** IMP2 — Import/Export v2 engine ([#1499](https://github.com/malipie/PIM/issues/1499), ADR-0019). Kontrakty silnika + warstwy Deptrac Import/Export.
 - **Backlog ticketów (source of truth speców):** `Project Plan/UI/feature-imports-v2-tickets.md` (Issues #1460–#1499).
 
+## Najnowsze bug-fixy (2026-06-20, post-Wave 3)
+- **#1673** `fix(catalog)` — walidacja zapisu egzekwuje atrybuty wymagane-w-grupie (PR #1674, merged `d0260c34`). Gwiazdka „wymagane" pokazywała `is_required||is_required_in_group`, save-guard sprawdzał tylko `is_required` → pole z gwiazdką zapisywało się puste. Wspólny helper `isAttributeRequired`; blokada **w edit** (create global-only, by nie blokować szkicu). Live proof: spec `1673` + unit 6/6 + produkt `019ee1a6` `description.is_required_in_group=true`.
+- **#1678** `fix(import)` — kafelkowy krok „Wybierz dane do importu" w kreatorze (PR #1679, merged `37b8f902`). Analogiczny do eksportu, reużywa generyczne `SelectableCard`/`SelectableCardGroup`: Produkty / Moduły własne (dropdown custom OT) / Kategorie aktywne; Schemat modułów + Atrybuty i grupy „wkrótce". Kreator 6→7 kroków; wybór mapuje na `targetObjectTypeId`. **Rework błędnego #1675/#1676** (operator chciał kafelków jak eksport, nie Combobox „Co importujesz?"). Live proof: spec `1675`+`1429`+a11y zielone, import do custom typu success 2/2. Schemat/Atrybuty = osobne tickety (import per ObjectType, nie metadane).
+
 ## Postęp epiku IMP2
 - **Fala A — KOMPLETNA (8/8):** #1460–62 quick-winy, #1463 ADR-0019, #1464 kanon JSONB, #1465 tryby CREATE/UPDATE/UPSERT, #1466 ValueWriteCore+BatchValueWriter, #1467 golden round-trip v0, #1468/#1509 transport Messenger `import`+worker.
 - **Fala B — w toku:**

--- a/agent/lessons.md
+++ b/agent/lessons.md
@@ -2,6 +2,19 @@
 
 > Plik startowy zasiany twardymi wytycznymi z `Project Plan/01-architektura-pim.md`. Po każdej korekcie operatora lub odkrytym wzorcu (sukces ALBO porażka) — dopisz wpis. Czytaj przed każdą sesją.
 
+## Lessons z #1673 + #1678 (2026-06-20, bug-fixy: walidacja group-required + kafelki importu)
+
+### Patterns to Follow
+- **Gwiazdka „wymagane" i save-guard MUSZĄ dzielić jeden predykat.** #1673: `attr-row` rysował gwiazdkę dla `is_required || is_required_in_group`, ale guard sprawdzał tylko `is_required` → pole z gwiazdką zapisywało się puste. Fix: wspólny helper `isAttributeRequired` w obu miejscach. Completeness-required egzekwuj w EDIT (zaimportowany niekompletny wpis), nie CREATE (świeży szkic) — inaczej blokujesz tworzenie produktu na każdym completeness-polu naraz (padły `view-07` + `1351` w CI).
+- **„Analogiczny widok jak X" = reużyj komponent X, nie buduj wariantu.** #1678: operator chciał kafelkowego wyboru danych jak eksport; pierwsza próba (#1675) dała Combobox — źle. Eksport `StepEntityType` używa generycznych `SelectableCard`/`SelectableCardGroup` — import reużywa je 1:1 (tablica `ENTITY_DEFS` + mapowanie kafelka na `targetObjectTypeId`). Zero duplikacji. Gdy operator mówi „jak przy X" — najpierw znajdź i przeczytaj komponent X, potwierdź wzorzec ([[feedback_closed_means_closed]]-style AskUserQuestion: kafelki vs select + struktura kroków) PRZED implementacją.
+
+### Patterns to Avoid
+- **Zmiana liczby kroków wizarda łamie WSZYSTKIE jego specy — uruchom je wszystkie lokalnie przed push.** 6→7 kroków importu zepsuło `imports-wizard.spec` (eyebrow „6 kroków", active pill „źródło", 6 pilli), mimo że `1675` przechodził. Trzeba było `grep -rln "imports/new\|Wizard steps\|6 kroków" e2e` → uruchomić CAŁĄ listę (1675, 1429, imports-wizard, nui-13-a11y, imports). Pojedyncze-spec runy = wiele rund CI zmarnowanych.
+- **`scripts/lint-jsonfetch-useeffect.sh` liczy pliki z `jsonFetch` + `useEffect(` (baseline 61) — guard niezależny od intencji.** Nowy komponent z `useQuery({queryFn: jsonFetch})` + `useEffect` (nawet gdy useEffect tylko synchronizuje lokalny state, nie ładuje danych) = +1 nad baseline → czerwony „Frontend lint guards". Fix: wynieś transport (`jsonFetch`+`useQuery`) do osobnego hooka; komponent zostaje z `useEffect` bez `jsonFetch`.
+
+### Package Quirks / Toolchain
+- **Force-push w trakcie trwającego CI runu bywa nie-triggerujący nowego runu.** Po `git push --force-with-lease` GitHub czasem nie startuje workflow dla nowego sha (stary run wciąż `in_progress`). Re-trigger: pusty commit (`git commit --allow-empty`) + push, albo amend realnego pliku + force-push. Sprawdź `gh run list --json headSha` czy run istnieje dla HEAD.
+
 ## Lessons z #1314 + #1316 (2026-06-07, channel placement reconcile + label→name refactor)
 
 ### Patterns to Follow


### PR DESCRIPTION
Aktualizacja `current_status.md` + `lessons.md` po dwóch zmergowanych fixach: walidacja group-required (edit-only, #1674) i kafelkowy krok wyboru danych w imporcie (rework #1675 → #1678/#1679). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)