### PR TITLE
fix(import): auto-mapowanie kolumn po kodzie atrybutu i nazwie

### DIFF
--- a/apps/api/src/Import/Application/Service/AutoMapper.php
+++ b/apps/api/src/Import/Application/Service/AutoMapper.php
@@ -12,16 +12,23 @@ use App\Import\Domain\ValueObject\ColumnMappingSuggestion;
 /**
  * Rules-based column → attribute matcher.
  *
- * Algorithm (spec §5.3):
+ * Algorithm (spec §5.3, extended for export round-trips #1683):
  *   1. Lower-case the source header and strip non-alphanumeric chars.
- *   2. Look up the normalised key in the alias index → exact match.
- *   3. Else: scan the alias index with Levenshtein < 2 → "did you mean".
- *   4. Else: manual.
+ *   2. Direct hit on a target attribute code (both sides normalised) →
+ *      exact. This is what makes re-importing an export auto-map: the
+ *      export writes raw attribute codes (`material_composition`) as
+ *      headers and `normalise()` strips the underscores on both sides.
+ *   3. Exact hit on a target attribute label (`{pl,en,…}`) → exact, so
+ *      hand-built files with human-readable headers also auto-map.
+ *   4. Look up the normalised key in the alias dictionary → exact match.
+ *   5. Else: scan aliases ∪ codes ∪ labels with Levenshtein < 2 → "did
+ *      you mean".
+ *   6. Else: manual.
  *
- * The matcher is intentionally *not* aware of the user's tenant attribute
- * codes — the dictionary owns the canonical names. The wizard validates
- * the mapping payload against the live ObjectType attributes when the
- * user clicks "Dalej" on Step 2.
+ * The dictionary owns generic PL/EN aliases; codes and labels come from
+ * the live ObjectType so tenant-specific attributes round-trip cleanly.
+ * The wizard validates the mapping payload against the live ObjectType
+ * attributes when the user clicks "Dalej" on Step 2.
  */
 final readonly class AutoMapper
 {
@@ -31,16 +38,37 @@ final readonly class AutoMapper
     }
 
     /**
-     * @param list<string>            $availableAttributeCodes attribute codes on the target ObjectType
-     * @param list<string>            $columnHeaders
-     * @param list<list<string|null>> $sampleRows
+     * @param list<string>                $availableAttributeCodes attribute codes on the target ObjectType
+     * @param list<string>                $columnHeaders
+     * @param list<list<string|null>>     $sampleRows
+     * @param array<string, list<string>> $attributeLabelsByCode   code → its localised labels (`{pl,en,…}` values)
      *
      * @return list<ColumnMappingSuggestion>
      */
-    public function map(array $availableAttributeCodes, array $columnHeaders, array $sampleRows): array
-    {
+    public function map(
+        array $availableAttributeCodes,
+        array $columnHeaders,
+        array $sampleRows,
+        array $attributeLabelsByCode = [],
+    ): array {
         $aliasIndex = $this->dictionary->aliasIndex();
         $availableSet = array_flip($availableAttributeCodes);
+
+        // Index target codes by their normalised form so a header that
+        // normalises identically (snake_case underscores stripped on both
+        // sides) maps straight through — the core export round-trip fix.
+        $availableByNormalised = [];
+        foreach ($availableAttributeCodes as $code) {
+            $normalisedCode = $this->normalise($code);
+            if ('' !== $normalisedCode) {
+                $availableByNormalised[$normalisedCode] = $code;
+            }
+        }
+
+        // Index target labels by normalised form. Drop collisions (two
+        // attributes sharing a normalised label) — we never auto-guess an
+        // ambiguous label, the user picks it manually.
+        $labelByNormalised = $this->buildLabelIndex($attributeLabelsByCode, $availableSet);
 
         $suggestions = [];
         foreach ($columnHeaders as $index => $header) {
@@ -99,7 +127,36 @@ final readonly class AutoMapper
                 continue;
             }
 
-            // Exact alias hit.
+            // Direct hit on a target attribute code (both sides
+            // normalised). Strongest signal — a column whose code equals a
+            // real attribute wins over a generic dictionary alias. This is
+            // what makes re-importing an export a one-click round-trip
+            // (#1683): the export header is the raw code.
+            if (isset($availableByNormalised[$normalised])) {
+                $suggestions[] = new ColumnMappingSuggestion(
+                    columnIndex: $index,
+                    columnHeader: $header,
+                    suggestedAttributeCode: $availableByNormalised[$normalised],
+                    confidence: MappingConfidence::Auto,
+                    sampleValues: $sampleValues,
+                );
+                continue;
+            }
+
+            // Exact hit on a target attribute label (`{pl,en,…}`), so files
+            // with human-readable headers ("Material composition") auto-map.
+            if (isset($labelByNormalised[$normalised])) {
+                $suggestions[] = new ColumnMappingSuggestion(
+                    columnIndex: $index,
+                    columnHeader: $header,
+                    suggestedAttributeCode: $labelByNormalised[$normalised],
+                    confidence: MappingConfidence::Auto,
+                    sampleValues: $sampleValues,
+                );
+                continue;
+            }
+
+            // Exact alias hit (generic PL/EN dictionary).
             if (isset($aliasIndex[$normalised])) {
                 $candidate = $aliasIndex[$normalised];
                 if (isset($availableSet[$candidate])) {
@@ -114,23 +171,16 @@ final readonly class AutoMapper
                 }
             }
 
-            // Direct hit on attribute code (operator already normalised
-            // the header to match — happens with re-exports).
-            if (isset($availableSet[$normalised])) {
-                $suggestions[] = new ColumnMappingSuggestion(
-                    columnIndex: $index,
-                    columnHeader: $header,
-                    suggestedAttributeCode: $normalised,
-                    confidence: MappingConfidence::Auto,
-                    sampleValues: $sampleValues,
-                );
-                continue;
-            }
-
-            // Fuzzy match (Levenshtein < 2) on aliases that resolve to
-            // available attributes. Cheap because the alias index is
-            // bounded by the dictionary size (~150 entries).
-            $fuzzyHit = $this->fuzzyHit($normalised, $aliasIndex, $availableSet);
+            // Fuzzy match (Levenshtein < 2) across dictionary aliases,
+            // target codes and target labels that resolve to available
+            // attributes — catches typos in hand-built files. All candidate
+            // sets are bounded (dictionary ~150, codes/labels per type), so
+            // the scan stays cheap.
+            $fuzzyHit = $this->fuzzyHit(
+                $normalised,
+                $aliasIndex + $availableByNormalised + $labelByNormalised,
+                $availableSet,
+            );
             if (null !== $fuzzyHit) {
                 $suggestions[] = new ColumnMappingSuggestion(
                     columnIndex: $index,
@@ -163,10 +213,50 @@ final readonly class AutoMapper
     }
 
     /**
-     * @param array<string, string> $aliasIndex
+     * Reverse index: normalised label → attribute code, restricted to
+     * available attributes. Normalised labels shared by more than one
+     * attribute are dropped — an ambiguous label is never auto-guessed.
+     *
+     * @param array<string, list<string>> $attributeLabelsByCode
+     * @param array<string, int>          $availableSet
+     *
+     * @return array<string, string>
+     */
+    private function buildLabelIndex(array $attributeLabelsByCode, array $availableSet): array
+    {
+        /** @var array<string, string> $index */
+        $index = [];
+        /** @var array<string, true> $ambiguous */
+        $ambiguous = [];
+
+        foreach ($attributeLabelsByCode as $code => $labels) {
+            if (!isset($availableSet[$code])) {
+                continue;
+            }
+            foreach ($labels as $label) {
+                $normalised = $this->normalise($label);
+                if ('' === $normalised || isset($ambiguous[$normalised])) {
+                    continue;
+                }
+                if (isset($index[$normalised]) && $index[$normalised] !== $code) {
+                    // Collision across distinct attributes → ambiguous.
+                    unset($index[$normalised]);
+                    $ambiguous[$normalised] = true;
+
+                    continue;
+                }
+                $index[$normalised] = $code;
+            }
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param array<string, string> $candidateIndex normalised candidate → attribute code
      * @param array<string, int>    $availableSet
      */
-    private function fuzzyHit(string $needle, array $aliasIndex, array $availableSet): ?string
+    private function fuzzyHit(string $needle, array $candidateIndex, array $availableSet): ?string
     {
         $needleLength = mb_strlen($needle);
         // Skip very short headers — Levenshtein on 1-2 chars is noise.
@@ -174,15 +264,15 @@ final readonly class AutoMapper
             return null;
         }
 
-        foreach ($aliasIndex as $alias => $attributeCode) {
+        foreach ($candidateIndex as $candidate => $attributeCode) {
             if (!isset($availableSet[$attributeCode])) {
                 continue;
             }
-            // Cheap pre-filter: skip aliases with length distance ≥ 2.
-            if (abs(mb_strlen($alias) - $needleLength) >= 2) {
+            // Cheap pre-filter: skip candidates with length distance ≥ 2.
+            if (abs(mb_strlen($candidate) - $needleLength) >= 2) {
                 continue;
             }
-            if (levenshtein($alias, $needle) < 2) {
+            if (levenshtein($candidate, $needle) < 2) {
                 return $attributeCode;
             }
         }

--- a/apps/api/src/Import/Presentation/Controller/AutoMapController.php
+++ b/apps/api/src/Import/Presentation/Controller/AutoMapController.php
@@ -75,8 +75,17 @@ final class AutoMapController
         }
 
         $availableCodes = [];
+        $labelsByCode = [];
         foreach ($this->objectTypeAttributes->findByObjectType($objectType) as $junction) {
-            $availableCodes[] = $junction->getAttribute()->getCode();
+            $attribute = $junction->getAttribute();
+            $code = $attribute->getCode();
+            $availableCodes[] = $code;
+            // Localised labels ({pl,en,…}) feed the name-based matcher so
+            // hand-built files with human-readable headers auto-map too.
+            $labelsByCode[$code] = array_values(array_filter(
+                $attribute->getLabel(),
+                static fn (string $label): bool => '' !== trim($label),
+            ));
         }
         // Category assignment is supported only for product imports —
         // expose the reserved __category__ target so the dictionary's
@@ -106,7 +115,7 @@ final class AutoMapController
             $normalisedRows[] = $cells;
         }
 
-        $suggestions = $this->autoMapper->map($availableCodes, $normalisedHeaders, $normalisedRows);
+        $suggestions = $this->autoMapper->map($availableCodes, $normalisedHeaders, $normalisedRows, $labelsByCode);
 
         return new JsonResponse(
             [

--- a/apps/api/tests/Unit/Import/AutoMapperTest.php
+++ b/apps/api/tests/Unit/Import/AutoMapperTest.php
@@ -129,6 +129,95 @@ final class AutoMapperTest extends TestCase
     }
 
     #[Test]
+    public function snakeCaseAttributeCodeAutoMapsOnExportRoundTrip(): void
+    {
+        // #1683: an export writes raw attribute codes as headers. A custom
+        // snake_case code (`material_composition`) must auto-map even though
+        // it is NOT in the generic dictionary — normalise() strips the
+        // underscore on both sides, so the direct-code match has to compare
+        // normalised↔normalised, not normalised↔raw.
+        $mapper = $this->mapperWithDictionary([
+            'sku' => ['aliases' => ['sku']],
+        ]);
+
+        $suggestions = $mapper->map(
+            ['material_composition', 'short_description'],
+            ['material_composition', 'short_description'],
+            [],
+        );
+
+        self::assertSame('material_composition', $suggestions[0]->suggestedAttributeCode);
+        self::assertSame(MappingConfidence::Auto, $suggestions[0]->confidence);
+        self::assertSame('short_description', $suggestions[1]->suggestedAttributeCode);
+        self::assertSame(MappingConfidence::Auto, $suggestions[1]->confidence);
+    }
+
+    #[Test]
+    public function snakeCaseCodeWithLocaleSuffixAutoMaps(): void
+    {
+        // Re-exported localised column: `short_description.pl` → base
+        // `short_description` (snake_case) must still auto-map (#1683).
+        $mapper = $this->mapperWithDictionary([]);
+
+        $suggestions = $mapper->map(
+            ['short_description'],
+            ['short_description.pl'],
+            [],
+        );
+
+        self::assertSame('short_description', $suggestions[0]->suggestedAttributeCode);
+        self::assertSame(MappingConfidence::Auto, $suggestions[0]->confidence);
+    }
+
+    #[Test]
+    public function headerMatchesAttributeLabelByName(): void
+    {
+        // #1683 name-based detection: a hand-built file with a human-readable
+        // header ("Material composition") auto-maps to the attribute whose
+        // label matches, even without the code or a dictionary alias.
+        $mapper = $this->mapperWithDictionary([]);
+
+        $suggestions = $mapper->map(
+            ['material_composition'],
+            ['Material composition'],
+            [],
+            ['material_composition' => ['Material composition', 'Skład materiału']],
+        );
+
+        self::assertSame('material_composition', $suggestions[0]->suggestedAttributeCode);
+        self::assertSame(MappingConfidence::Auto, $suggestions[0]->confidence);
+    }
+
+    #[Test]
+    public function ambiguousLabelAcrossAttributesIsNotAutoGuessed(): void
+    {
+        // Two attributes sharing a normalised label → manual, never a guess.
+        $mapper = $this->mapperWithDictionary([]);
+
+        $suggestions = $mapper->map(
+            ['weight_net', 'weight_gross'],
+            ['Waga'],
+            [],
+            ['weight_net' => ['Waga'], 'weight_gross' => ['Waga']],
+        );
+
+        self::assertSame(MappingConfidence::Manual, $suggestions[0]->confidence);
+        self::assertNull($suggestions[0]->suggestedAttributeCode);
+    }
+
+    #[Test]
+    public function fuzzyMatchesTypoInAttributeCode(): void
+    {
+        // Hand-built file with a typo in the code → fuzzy "did you mean".
+        $mapper = $this->mapperWithDictionary([]);
+
+        $suggestions = $mapper->map(['material_composition'], ['materialcompositon'], []);
+
+        self::assertSame(MappingConfidence::Fuzzy, $suggestions[0]->confidence);
+        self::assertSame('material_composition', $suggestions[0]->suggestedAttributeCode);
+    }
+
+    #[Test]
     public function systemColumnsAreSuggestedAsSkip(): void
     {
         $mapper = $this->mapperWithDictionary([


### PR DESCRIPTION
Closes #1683

## Problem

Po eksporcie wszystkich atrybutow do XLSX i ponownym imporcie tego pliku kreator **nie auto-mapowal** kolumn — mimo ze naglowki to dokladnie te same kody atrybutow co w systemie. Round-trip eksport -> import w praktyce dzialal tylko dla mniejszosci kolumn.

## Root cause

`AutoMapper::map()` normalizuje naglowek (`normalise()`: lowercase + usuniecie znakow niealfanumerycznych, w tym **podkreslen**), ale w sciezce direct-code-hit porownywal go z **surowym** zbiorem kodow (`array_flip($availableAttributeCodes)`). Dla `material_composition` -> `materialcomposition` vs surowy `material_composition` -> brak trafienia -> Manual. Auto-mapowaly sie tylko kody jednowyrazowe lowercase albo obecne w slowniku `mapping_dictionary.yaml`.

## Rozwiazanie (backend-only, bez zmian we froncie)

1. **Kod = kod** — direct-code match normalizuje **obie** strony (indeks `normalise(code) => code`). Gwarancja: ten sam kod atrybutu zawsze auto-map. Priorytet podniesiony ponad slownik (realny kod > generyczny alias).
2. **Nazwa/label** — dopasowanie po znormalizowanym labelu atrybutu (`{pl,en,…}`); pliki z naglowkami-nazwami tez sie auto-mapuja. Labele wspoldzielone przez >1 atrybut (kolizja) -> pozostaja Manual, bez zgadywania.
3. **Fuzzy literowki** — pass Levenshtein<2 rozszerzony o znormalizowane kody i labele (obok aliasow slownika); badge `Fuzzy` (did you mean).

Kolejnosc: system column -> reserved target -> **direct code (Auto)** -> **label exact (Auto)** -> alias dict (Auto) -> **fuzzy [alias u code u label] (Fuzzy)** -> Manual.

## Testy

Nowe unit testy w `AutoMapperTest`: snake_case code round-trip, snake_case + locale suffix, match po labelu, kolizja labeli -> Manual, fuzzy typo w kodzie. Regresja festo fixture (12/15 Auto) bez zmian.

- `php vendor/bin/phpunit tests/Unit/Import/AutoMapperTest.php` -> 15/15 OK
- pelny unit suite 1033/1033 OK
- PHPStan max -> No errors

## Smoke test

Wymaga smoke testu na zywym stacku przed claim 'dziala' — upload `Zrodla/importy/pim-export-20260620-213454.xlsx` w kreatorze importu (typ Produkty), weryfikacja ze `/api/import-sessions/auto-map` zwraca `confidence: auto` dla kolumn-kodow. Do wykonania po CI/przed merge.