### PR TITLE
fix(import): import OOM-uje na dużych plikach (capturedScopes + ImportLog volume)

### DIFF
--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -87,6 +87,23 @@ final class ImportRunHandler extends AbstractBatchHandler
     private const int ALLOWED_ERRORS_MIN_ROWS = 20;
 
     /**
+     * Hard cap on per-run ImportLog rows. A pathological file (e.g. a stale
+     * export whose channel/locale-suffixed columns no longer match the catalog)
+     * raises dozens of row-level errors per row; persisting one ImportLog entity
+     * each made the row phase grow O(total errors) and OOM the 256 MiB worker
+     * (each persisted entity retains its message + raw-row snippet past the
+     * per-chunk EntityManager::clear()). Beyond the cap we count suppressed
+     * messages and emit a single summary row (Akeneo's "first N + tail count"
+     * pattern) — 5 000 logged messages already exceeds any human-actionable
+     * report, so nothing diagnostic is lost.
+     */
+    public const int MAX_PERSISTED_IMPORT_LOGS = 5_000;
+
+    /** Per-run ImportLog accounting for {@see MAX_PERSISTED_IMPORT_LOGS}. */
+    private int $importLogsPersisted = 0;
+    private int $importLogsSuppressed = 0;
+
+    /**
      * IMP2-2.6 — RFC4122 ids of objects this run created or actually changed,
      * collected for the end-of-run async rebuild + reindex. Strings (not
      * entities) so they survive the per-chunk EntityManager::clear().
@@ -240,6 +257,8 @@ final class ImportRunHandler extends AbstractBatchHandler
         // Reset in finally — a long-lived worker must not leak the flag.
         $this->bulkContext->setBulk(true, $session->getId());
         $this->bulkTouchedIds = [];
+        $this->importLogsPersisted = 0;
+        $this->importLogsSuppressed = 0;
         $this->rowPhasePeakBytes = null;
         $this->lastProgressAt = 0;
         $this->lastProcessedSku = null;
@@ -364,6 +383,9 @@ final class ImportRunHandler extends AbstractBatchHandler
                     $lock->refresh();
                     foreach ($linkErrors as $error) {
                         $session->incrementError();
+                        if (!$this->importLogBudgetAvailable()) {
+                            continue;
+                        }
                         $this->entityManager->persist(new ImportLog(
                             importSession: $session,
                             rowNumber: $error->rowNumber,
@@ -388,6 +410,7 @@ final class ImportRunHandler extends AbstractBatchHandler
             }
 
             $session->setTotalRows($totalRows);
+            $this->persistSuppressedImportLogSummary($session);
             $this->sessions->save($session);
 
             // IMP2-1.12 — dispatch the buffered media batches now (after the
@@ -458,6 +481,60 @@ final class ImportRunHandler extends AbstractBatchHandler
     public function rowPhasePeakBytes(): ?int
     {
         return $this->rowPhasePeakBytes;
+    }
+
+    /**
+     * True while the run is still under {@see MAX_PERSISTED_IMPORT_LOGS}. Each
+     * call that returns true reserves one slot; once the cap is hit every later
+     * call counts a suppressed message and returns false, so the row phase stays
+     * O(cap) instead of O(total errors). {@see persistSuppressedImportLogSummary}
+     * surfaces the suppressed tail to the operator.
+     */
+    private function importLogBudgetAvailable(): bool
+    {
+        if ($this->importLogsPersisted >= self::MAX_PERSISTED_IMPORT_LOGS) {
+            ++$this->importLogsSuppressed;
+
+            return false;
+        }
+        ++$this->importLogsPersisted;
+
+        return true;
+    }
+
+    /**
+     * Emit one summary ImportLog when the per-run cap suppressed messages, so a
+     * truncated report never silently hides that more rows had issues.
+     */
+    private function persistSuppressedImportLogSummary(ImportSession $session): void
+    {
+        if (0 === $this->importLogsSuppressed) {
+            return;
+        }
+        // The row/relation phases clear the EM, leaving TenantContext holding a
+        // detached Tenant; re-attach a managed one so the TenantAssignmentListener
+        // can stamp this summary row (mirrors the per-chunk reattach).
+        $tenant = $session->getTenant();
+        if ($tenant instanceof Tenant) {
+            $managed = $this->entityManager->find(Tenant::class, $tenant->getId()->toRfc4122());
+            if ($managed instanceof Tenant) {
+                $this->tenantContext->set($managed);
+            }
+        }
+        $this->entityManager->persist(new ImportLog(
+            importSession: $session,
+            rowNumber: 0,
+            level: ImportLogLevel::Warning,
+            message: \sprintf(
+                '%d further messages were suppressed — this import logged the first %d issues (per-run cap). Fix the reported problems and re-run to see the rest.',
+                $this->importLogsSuppressed,
+                self::MAX_PERSISTED_IMPORT_LOGS,
+            ),
+            sku: null,
+            errorType: ImportErrorType::InvalidValue->value,
+            columnName: null,
+            columnValue: null,
+        ));
     }
 
     /**
@@ -1073,6 +1150,9 @@ final class ImportRunHandler extends AbstractBatchHandler
             $zipNames = $zipMode ? $classified['unresolved'] : [];
             if (!$zipMode) {
                 foreach ($classified['unresolved'] as $token) {
+                    if (!$this->importLogBudgetAvailable()) {
+                        continue;
+                    }
                     $this->entityManager->persist(new ImportLog(
                         importSession: $session,
                         rowNumber: $row['rowNumber'],
@@ -1525,6 +1605,9 @@ final class ImportRunHandler extends AbstractBatchHandler
             }
 
             foreach ($errors as $error) {
+                if (!$this->importLogBudgetAvailable()) {
+                    continue;
+                }
                 $this->entityManager->persist(new ImportLog(
                     importSession: $session,
                     rowNumber: $error->rowNumber,

--- a/apps/api/src/Import/Application/Service/ImportUndoLogger.php
+++ b/apps/api/src/Import/Application/Service/ImportUndoLogger.php
@@ -33,7 +33,19 @@ final class ImportUndoLogger
     /** @var array<string, \App\Catalog\Domain\Entity\ObjectValue> "objId|attrId|locale|channel" => existing row (primed per chunk) */
     private array $existingIndex = [];
 
-    /** @var array<string, true> scope keys already captured this run (first-write-wins) */
+    /**
+     * @var array<string, true> scope keys already captured in THIS chunk
+     *                          (first-write-wins within the chunk)
+     *
+     * Reset per chunk in {@see primeChunk()} — NOT once per run. The dedup only
+     * needs chunk lifetime: a given object is written in exactly one chunk (a
+     * second row matching the same object — duplicate SKU or shared identifier —
+     * is skipped by the handler's file-wide seen-sets BEFORE it reaches capture),
+     * so the same scope key is never touched across two chunks. Keeping it for
+     * the whole run made it grow O(total value-writes) and OOM the 256 MiB
+     * worker on a large UPSERT re-import (one string per written value, never
+     * freed by EntityManager::clear()).
+     */
     private array $capturedScopes = [];
 
     public function __construct(
@@ -59,6 +71,10 @@ final class ImportUndoLogger
     public function primeChunk(array $existingObjects): void
     {
         $this->existingIndex = [];
+        // Per-chunk first-write-wins window (see $capturedScopes docblock): an
+        // object is written in a single chunk, so chunk-scoped dedup is exact and
+        // keeps memory flat across an arbitrarily large run.
+        $this->capturedScopes = [];
         if ([] === $existingObjects) {
             return;
         }

--- a/apps/api/tests/Integration/Import/ImportMemoryBenchmarkTest.php
+++ b/apps/api/tests/Integration/Import/ImportMemoryBenchmarkTest.php
@@ -158,6 +158,96 @@ final class ImportMemoryBenchmarkTest extends KernelTestCase
         );
     }
 
+    /**
+     * #import-oom — an error-dense import (a stale export whose channel-suffixed
+     * columns no longer resolve raises a row-level error on EVERY row) must not
+     * persist one ImportLog entity per error unbounded: that retained
+     * O(total errors) past the per-chunk clear and OOM'd the 256 MiB worker.
+     * The per-run cap ({@see ImportRunHandler::MAX_PERSISTED_IMPORT_LOGS}) bounds
+     * the row count and appends a single summary row.
+     */
+    #[Test]
+    public function errorDenseImportCapsImportLogVolume(): void
+    {
+        $originalLimit = \ini_get('memory_limit');
+        \ini_set('memory_limit', '-1');
+
+        // One row-blocking error per row (a channel suffix that is not a real
+        // channel), just over the 5 000 cap so the tail is suppressed.
+        $rows = ImportRunHandler::MAX_PERSISTED_IMPORT_LOGS + 100;
+        $em = $this->em();
+
+        $tenant = new Tenant('bench-err', 'Bench Err Tenant');
+        $em->persist($tenant);
+        $em->flush();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        $type = new ObjectType('product', ObjectKind::Product, ['en' => 'Product']);
+        $em->persist($type);
+        $sku = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $name = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($sku);
+        $em->persist($name);
+        $em->persist(new ObjectTypeAttribute($type, $sku, false, 1));
+        $em->persist(new ObjectTypeAttribute($type, $name, false, 2));
+
+        $session = new ImportSession(
+            userId: Uuid::v7(),
+            targetObjectType: $type,
+            fileName: 'errors.csv',
+            fileSizeBytes: 1024,
+        );
+        $session->assignTenant($tenant);
+        // `name.nochannel` — the suffix is neither an active locale nor a channel,
+        // so the value resolution blocks every row with one error.
+        $session->setColumnMapping(['sku' => 'sku', 'name.nochannel' => 'name']);
+        $em->persist($session);
+        $em->flush();
+        $sessionId = $session->getId();
+
+        $csv = "sku;name.nochannel\n";
+        for ($i = 1; $i <= $rows; ++$i) {
+            $csv .= \sprintf("ERR-%d;Value %d\n", $i, $i);
+        }
+        $storage = self::getContainer()->get('imports.storage');
+        $storage->write(
+            \sprintf('%s/%s/errors.csv', $tenant->getId()->toRfc4122(), $sessionId->toRfc4122()),
+            $csv,
+        );
+
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+        $hub = self::getContainer()->get(InMemoryMercureHub::class);
+        \assert($hub instanceof InMemoryMercureHub);
+        $hub->stopRetaining();
+        $handler = self::getContainer()->get(ImportRunHandler::class);
+
+        \memory_reset_peak_usage();
+        $handler->run($session);
+        $peak = $handler->rowPhasePeakBytes();
+        \ini_set('memory_limit', $originalLimit);
+
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $rawCount = $this->em()->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM import_logs WHERE import_session_id = :id',
+            ['id' => $sessionId->toRfc4122()],
+        );
+        \assert(is_numeric($rawCount));
+        $persistedLogs = (int) $rawCount;
+
+        // 5 000 capped error rows + exactly one suppressed-tail summary row.
+        self::assertSame(
+            ImportRunHandler::MAX_PERSISTED_IMPORT_LOGS + 1,
+            $persistedLogs,
+            'ImportLog rows must be capped at the per-run budget plus one summary',
+        );
+        self::assertNotNull($peak);
+        self::assertLessThan(
+            self::THRESHOLD_BYTES,
+            $peak,
+            \sprintf('error-dense import peaked at %0.1f MiB, must stay under 256 MiB', $peak / 1024 / 1024),
+        );
+    }
+
     private function em(): EntityManagerInterface
     {
         $em = self::getContainer()->get('doctrine')->getManager();


### PR DESCRIPTION
## Summary
Import workera OOM-ował na dużych plikach (re-import pełnego eksportu 13.8k wierszy). Dwa niezależne akumulatory pamięci O(run) przekraczały budżet 256 MiB → SIGKILL → kolejka `import` redeliveruje 4h → import „wisi".

## Root cause (potwierdzone profilingiem na żywym handlerze)
- **A — UPDATE path**: `ImportUndoLogger::$capturedScopes` (dedup undo-loga) resetowany raz/run zamiast per-chunk → rośnie per zapis wartości, przeżywa `clear()`.
- **B — ERROR path**: jeden `ImportLog` per błąd, retencja ~1.7 KiB każdy past `clear()`. Plik ze stale channel-suffix kolumnami (dryf kodów kanałów po restore) erroruje masowo → O(total errors) → OOM.

## Backend changes
- `ImportUndoLogger`: reset `capturedScopes` w `primeChunk()` (O(chunk)). Dedup potrzebny tylko per-chunk (obiekt pisany w jednym chunku; dup pomijane przez seen-sets przed capture).
- `ImportRunHandler`: cap `MAX_PERSISTED_IMPORT_LOGS = 5000` per run + summary row „N more suppressed" (wzorzec Akeneo).

## Tests
- `ImportMemoryBenchmarkTest::errorDenseImportCapsImportLogVolume` (grupa import-benchmark): error-dense import → import_logs = 5001 (cap+summary), row-phase peak < 256 MiB.
- Undo correctness niezmieniona: `ImportRollbackV2ApiTest` 5/5.

## Quality gates (lokalnie)
- PHPStan max: **0**.
- composer audit: czysty.
- PHPUnit import suite: **bez nowych failures** (8 pre-existing async/MinIO env-failures identyczne na base — nie z tej zmiany).
- Profiling (handler na żywo): UPDATE path **120 MiB**, ERROR path **108 MiB** @ 13.8k wierszy (oba wcześniej OOM).

## Smoke test plan (live, po merge)
1. `/integrations/importy` → upload świeżego eksportu OBECNEGO katalogu (zgodne kody kanałów) → start.
2. Sesja parsing→running→done/partial, worker bez „Allowed memory size exhausted".
3. Plik ze stale kolumnami → masowe błędy ALE worker nie pada (cap), import_logs zbounduje + summary.

**Wymaga live-stack smoke przed claim „działa".** Profiling potwierdza memory-safety; pełen UI smoke wykonam przed `gh issue close`.

## Świadome odejścia
- Plik `pim-export-20260621-184013.xlsx` operatora ma **stale channel codes** (dryf po restore→export→import) — erroruje masowo niezależnie od fixu (data issue). Fix zapewnia że worker NIE pada na takim pliku; czysty import wymaga świeżego eksportu obecnego katalogu.

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)
