### PR TITLE
fix(import): bulk import OOM-uje na per-obiekt Mercure/webhook HTTP

### DIFF
--- a/apps/api/src/ApiConfigurator/Application/Subscriber/WebhookDeliverySubscriber.php
+++ b/apps/api/src/ApiConfigurator/Application/Subscriber/WebhookDeliverySubscriber.php
@@ -6,6 +6,7 @@ namespace App\ApiConfigurator\Application\Subscriber;
 
 use App\ApiConfigurator\Application\WebhookDeliveryClient;
 use App\ApiConfigurator\Domain\Repository\ApiProfileRepositoryInterface;
+use App\Catalog\Application\BulkContext;
 use App\Catalog\Contracts\Event\ObjectArchived;
 use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
@@ -33,6 +34,7 @@ final readonly class WebhookDeliverySubscriber
     public function __construct(
         private ApiProfileRepositoryInterface $profiles,
         private WebhookDeliveryClient $client,
+        private BulkContext $bulkContext,
     ) {
     }
 
@@ -85,6 +87,16 @@ final readonly class WebhookDeliverySubscriber
      */
     private function fanOut(string $eventType, DomainEvent $event, array $data): void
     {
+        // Bulk flows (import, bulk-edit/-delete) emit one event per object on the
+        // SYNC bus; one webhook POST each would pile up HTTP responses and starve
+        // the 256 MiB worker. Per-object webhooks during a bulk run are both
+        // impractical (thousands of inline POSTs) and rarely what an integrator
+        // wants — a batch/summary delivery is the right shape (follow-up). Skip
+        // here, mirroring MercurePublisher's BulkContext opt-out.
+        if ($this->bulkContext->isBulk()) {
+            return;
+        }
+
         $subscribers = $this->profiles->findWebhookSubscribersFor($eventType);
         if ([] === $subscribers) {
             return;

--- a/apps/api/src/ApiConfigurator/Application/Subscriber/WebhookDeliverySubscriber.php
+++ b/apps/api/src/ApiConfigurator/Application/Subscriber/WebhookDeliverySubscriber.php
@@ -6,7 +6,7 @@ namespace App\ApiConfigurator\Application\Subscriber;
 
 use App\ApiConfigurator\Application\WebhookDeliveryClient;
 use App\ApiConfigurator\Domain\Repository\ApiProfileRepositoryInterface;
-use App\Catalog\Application\BulkContext;
+use App\Catalog\Contracts\BulkGuard;
 use App\Catalog\Contracts\Event\ObjectArchived;
 use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
@@ -34,7 +34,7 @@ final readonly class WebhookDeliverySubscriber
     public function __construct(
         private ApiProfileRepositoryInterface $profiles,
         private WebhookDeliveryClient $client,
-        private BulkContext $bulkContext,
+        private BulkGuard $bulkContext,
     ) {
     }
 

--- a/apps/api/src/Catalog/Application/BulkContext.php
+++ b/apps/api/src/Catalog/Application/BulkContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application;
 
+use App\Catalog\Contracts\BulkGuard;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -29,7 +30,7 @@ use Symfony\Contracts\Service\ResetInterface;
  * downstream listeners on `ObjectValue` can stamp
  * `provenance = Bulk` + `meta.bulk_session_id` for audit (PRD §5.4).
  */
-final class BulkContext implements ResetInterface
+final class BulkContext implements ResetInterface, BulkGuard
 {
     private bool $bulk = false;
     private ?Uuid $sessionId = null;

--- a/apps/api/src/Catalog/Application/Subscriber/MercurePublisher.php
+++ b/apps/api/src/Catalog/Application/Subscriber/MercurePublisher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application\Subscriber;
 
+use App\Catalog\Application\BulkContext;
 use App\Catalog\Contracts\Event\ObjectArchived;
 use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
@@ -58,6 +59,7 @@ final readonly class MercurePublisher
 
     public function __construct(
         private HubInterface $hub,
+        private BulkContext $bulkContext,
         private string $topicBase = 'https://pim.localhost',
         ?LoggerInterface $logger = null,
     ) {
@@ -129,6 +131,18 @@ final readonly class MercurePublisher
      */
     private function publish(string $type, DomainEvent&TenantAwareMessage $event, array $payload): void
     {
+        // Bulk flows (import, bulk-edit/-delete) touch thousands of objects in
+        // one process and route these events through the SYNC bus — one Mercure
+        // HTTP push per object would pile up Symfony HttpClient CurlResponse
+        // objects and OOM the 256 MiB worker. Per-row live updates are a
+        // single-edit UX concern; a bulk run is not driving any open editor, so
+        // skip the push (the deferred bulk rebuild reindexes the touched set
+        // once). Mirrors {@see \App\Catalog\Infrastructure\Doctrine\EventListener\AttributesIndexedSyncListener}'s
+        // BulkContext opt-out.
+        if ($this->bulkContext->isBulk()) {
+            return;
+        }
+
         $tenantId = $event->tenantId();
         $rowTopic = MercureSubscribeTopics::objectRow($tenantId, $this->topicBase, $event->aggregateId());
         $broadcastTopic = MercureSubscribeTopics::objectsBroadcast($tenantId, $this->topicBase);

--- a/apps/api/src/Catalog/Contracts/BulkGuard.php
+++ b/apps/api/src/Catalog/Contracts/BulkGuard.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Contracts;
+
+/**
+ * Contracts-level read view of {@see \App\Catalog\Application\BulkContext} so
+ * cross-context subscribers (e.g. ApiConfigurator webhooks) can opt out of
+ * per-object work during a bulk run without depending on Catalog\Application
+ * internals (Deptrac layering).
+ */
+interface BulkGuard
+{
+    public function isBulk(): bool;
+}

--- a/apps/api/tests/Unit/Catalog/MercurePublisherTest.php
+++ b/apps/api/tests/Unit/Catalog/MercurePublisherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Catalog;
 
+use App\Catalog\Application\BulkContext;
 use App\Catalog\Application\Subscriber\MercurePublisher;
 use App\Catalog\Contracts\Event\ObjectAttributesChanged;
 use App\Catalog\Contracts\Event\ObjectCreated;
@@ -78,6 +79,35 @@ final class MercurePublisherTest extends TestCase
     }
 
     #[Test]
+    public function skipsPublishUnderBulkContext(): void
+    {
+        // #import-oom — one Mercure HTTP push per object during a bulk import of
+        // thousands of rows piled up Symfony HttpClient responses and OOM'd the
+        // worker. Under BulkContext the per-row push is suppressed.
+        $bulk = new BulkContext();
+        $bulk->setBulk(true);
+        $hub = new MockHub(
+            'https://example.test/.well-known/mercure',
+            new StaticTokenProvider('jwt'),
+            function (Update $update): string {
+                $this->captured[] = $update;
+
+                return 'urn:uuid:'.bin2hex(random_bytes(8));
+            },
+        );
+        $publisher = new MercurePublisher($hub, $bulk);
+
+        $publisher->onObjectCreated(new ObjectCreated(
+            objectId: Uuid::fromString('019ddb19-a0f7-750a-a9cb-a6a6447ccb26'),
+            kind: ObjectKind::Product,
+            code: 'SKU-1',
+            tenantId: Uuid::fromString(self::TENANT_ID),
+        ));
+
+        self::assertSame([], $this->captured, 'no Mercure push may fire while a bulk run owns the process');
+    }
+
+    #[Test]
     public function objectAttributesChangedCarriesChangedAttributeCodes(): void
     {
         $publisher = $this->makePublisher();
@@ -148,6 +178,6 @@ final class MercurePublisherTest extends TestCase
             },
         );
 
-        return new MercurePublisher($hub);
+        return new MercurePublisher($hub, new BulkContext());
     }
 }


### PR DESCRIPTION
## Summary
Po #1686 (akumulatory undo-set + ImportLog) import na ścieżce **sukcesu/CREATE** (świeży eksport z nowymi kodami) dalej OOM-ował worker — w `CurlResponse` (klient HTTP), nie w hydratacji encji. Trzeci, pre-existing akumulator odsłonięty po naprawie dwóch poprzednich.

## Root cause
`CatalogObject` recorduje domain eventy per update; `DomainEventDispatcher` dispatchuje je sync inline per flush. `MercurePublisher` (Catalog) i `WebhookDeliverySubscriber` (ApiConfigurator) robiły **HTTP per obiekt** — bez guardu `BulkContext` (sync-indexer go ma). 6921 obiektów → 6921× HTTP → akumulacja `CurlResponse` → OOM.

## Fix
- `MercurePublisher::publish()` + `WebhookDeliverySubscriber::fanOut()`: early-return gdy `BulkContext::isBulk()`. Mirror `AttributesIndexedSyncListener`. Reindex robi deferred bulk rebuild; batch webhooks dla bulk = follow-up.

## Tests
- `MercurePublisherTest::skipsPublishUnderBulkContext` — 0 push pod bulk; happy path (non-bulk) nadal publikuje.

## Quality gates (lokalnie)
- PHPStan max: **0**. composer audit: czysty. MercurePublisherTest **5/5**.

## Uwaga (dlaczego benchmark tego nie łapał)
`ImportMemoryBenchmarkTest` używa `MockHub` (nie real HTTP) — mierzył entity-memory, nie akumulację `CurlResponse`. Dlatego przechodził mimo tego buga. Live worker z realnym hubem OOM-ował.

## Smoke test plan (live, po merge)
1. Świeży eksport z NOWYMI kodami → import (UPSERT/CREATE).
2. Worker: brak „Allowed memory size exhausted" w `CurlResponse`. Sesja running→done.
3. Liczba produktów **rośnie** (nowe kody utworzone).

**Wymaga live-stack smoke przed claim „działa"** — wykonam CREATE import na żywym workerze przed `gh issue close`.

Closes #1687

🤖 Generated with [Claude Code](https://claude.com/claude-code)
