### PR TITLE
fix(search): indeks Meili bez primary key → 0 docs, search nie znajduje

### DIFF
--- a/apps/api/src/Search/Application/BulkCatalogObjectIndexer.php
+++ b/apps/api/src/Search/Application/BulkCatalogObjectIndexer.php
@@ -116,7 +116,7 @@ final readonly class BulkCatalogObjectIndexer
         }
 
         try {
-            $client->index(IndexSettingsTemplate::indexName())->addDocuments($documents);
+            $client->index(IndexSettingsTemplate::indexName())->addDocuments($documents, IndexSettingsTemplate::PRIMARY_KEY);
         } catch (Throwable $e) {
             $this->logger->warning('Reindex batch push failed: {message}', [
                 'message' => $e->getMessage(),

--- a/apps/api/src/Search/Application/CatalogObjectIndexer.php
+++ b/apps/api/src/Search/Application/CatalogObjectIndexer.php
@@ -112,7 +112,7 @@ final readonly class CatalogObjectIndexer
 
         foreach (array_chunk($documents, self::BATCH_SIZE) as $chunk) {
             try {
-                $client->index(IndexSettingsTemplate::indexName())->addDocuments($chunk);
+                $client->index(IndexSettingsTemplate::indexName())->addDocuments($chunk, IndexSettingsTemplate::PRIMARY_KEY);
             } catch (Throwable $e) {
                 // Fail-soft per chunk — same rationale as above.
                 $this->logger->warning('Index batch push failed: {message}', [
@@ -181,7 +181,7 @@ final readonly class CatalogObjectIndexer
         try {
             $client = $this->clientFactory->create();
             $client->index(IndexSettingsTemplate::indexName())
-                ->addDocuments([$this->toDocument($object)]);
+                ->addDocuments([$this->toDocument($object)], IndexSettingsTemplate::PRIMARY_KEY);
         } catch (Throwable $e) {
             $this->logger->warning('Index push failed: {message}', [
                 'message' => $e->getMessage(),

--- a/apps/api/src/Search/Application/IndexSettingsTemplate.php
+++ b/apps/api/src/Search/Application/IndexSettingsTemplate.php
@@ -31,6 +31,17 @@ final class IndexSettingsTemplate
     public const string INDEX_NAME = 'objects';
 
     /**
+     * The document field Meilisearch uses as the primary key. MUST be passed to
+     * every addDocuments() call: a Meili index auto-created by a document push
+     * (rather than the provisioner) infers its key from the payload, and our
+     * documents carry several `*Id` fields, so inference fails ("multiple fields
+     * ending with id") and EVERY add silently lands in the failed-task queue —
+     * the index stays at 0 docs and search returns nothing. Passing it pins the
+     * key whether the index was provisioned first or not.
+     */
+    public const string PRIMARY_KEY = 'id';
+
+    /**
      * Reserved filterable fields the universal index always carries
      * regardless of operator-defined attributes. `tenantId` enforces the
      * multi-tenant isolation filter; `objectTypeId` scopes the universal

--- a/apps/api/src/Search/Application/MeilisearchIndexProvisioner.php
+++ b/apps/api/src/Search/Application/MeilisearchIndexProvisioner.php
@@ -42,7 +42,7 @@ final readonly class MeilisearchIndexProvisioner
         $client = $this->clientFactory->create();
         $name = IndexSettingsTemplate::indexName();
 
-        $client->createIndex($name, ['primaryKey' => 'id']);
+        $client->createIndex($name, ['primaryKey' => IndexSettingsTemplate::PRIMARY_KEY]);
         $task = $client->index($name)->updateSettings($this->template->settingsFor());
         $taskUid = $task['taskUid'] ?? $task['uid'] ?? '';
 


### PR DESCRIPTION
## Summary
Po imporcie search nic nie znajdował — Meili indeks `objects` miał **0 docs** mimo 13k+ produktów. Root: `addDocuments()` bez primary key → przy auto-tworzonym indeksie Meili nie umie wywnioskować PK (kilka pól `*Id`) → wszystkie dodania w failed-task queue → 0 docs.

## Fix
`IndexSettingsTemplate::PRIMARY_KEY = 'id'` przekazywana do każdego `addDocuments()` (3 call-site) + provisioner. Meili przypina PK niezależnie od provisioningu.

## Quality gates (lokalnie)
PHPStan max **0**, composer audit czysty, Search unit **17/17**.

## Live proof (na żywym stacku)
Zepsuty indeks (PK=null, 0 docs) usunięty → provision (PK=id) → reindex → **13923 docs**; `GET /api/products?search=5100` → **31 wyników, HTTP 200**.

## Świadome odejścia
- Reindex CLI (`pim:search:reindex`) ma osobny gap: bez tenant context pod FORCE RLS indeksuje 0 (CLI nie ustawia TenantContext). Operacyjnie obszedłem per-tenant; pełny multi-tenant reindex CLI = follow-up.
- Pusty indeks na tym stacku to po części artefakt restore bazy (Postgres podmieniony, Meili nie). Po merge `pim:search:reindex` + provision re-syncuje.

**Wymaga live-stack smoke** — wykonany powyżej (search 31 wyników).

Closes #1712

🤖 Generated with [Claude Code](https://claude.com/claude-code)