### PR TITLE
feat(imports): przycisk „Nowy import” w pustym stanie sesji (jak w eksporcie)

### DIFF
--- a/apps/admin/e2e/1428-imports-hub-v2.spec.ts
+++ b/apps/admin/e2e/1428-imports-hub-v2.spec.ts
@@ -18,8 +18,8 @@ test('NUI-09 — imports hub v2: tabs, redirect, deep links', async ({ page }) =
   await expect(tabs.getByRole('tab', { name: /sesje|sessions/i })).toBeVisible();
   await expect(page.getByText(/imports, exports, konektory/i)).toHaveCount(0);
 
-  // CTA lives in the topbar now.
-  await expect(page.getByRole('link', { name: /nowy import|new import/i })).toBeVisible();
+  // CTA lives in the topbar now (and the empty active-sessions state mirrors it).
+  await expect(page.getByRole('link', { name: /nowy import|new import/i }).first()).toBeVisible();
 
   // Tab navigation.
   await tabs.getByRole('tab', { name: /źródła|sources/i }).click();

--- a/apps/admin/e2e/imports-sessions.spec.ts
+++ b/apps/admin/e2e/imports-sessions.spec.ts
@@ -33,7 +33,11 @@ test('imports sessions hub — KPI + filter + new-import CTA', async ({ page }) 
   await allPill.click();
   await expect(allPill).toHaveAttribute('aria-pressed', 'true');
 
-  // "Nowy import" CTA navigates to the wizard.
-  await page.getByRole('link', { name: /nowy import|new import/i }).click();
+  // "Nowy import" CTA navigates to the wizard. Two exist now (header + the
+  // empty active-sessions state), both pointing at the wizard — click the first.
+  await page
+    .getByRole('link', { name: /nowy import|new import/i })
+    .first()
+    .click();
   await expect(page).toHaveURL(/\/integrations\/imports\/new$/);
 });

--- a/apps/admin/e2e/imports.spec.ts
+++ b/apps/admin/e2e/imports.spec.ts
@@ -19,7 +19,10 @@ test.describe('Imports MVP', () => {
     // renders pill tabs + the sessions view heading under the v2 shell.
     await expect(page.getByRole('heading', { name: /importy|import sessions/i })).toBeVisible();
 
-    await page.getByRole('link', { name: /nowy import|new import/i }).click();
+    await page
+      .getByRole('link', { name: /nowy import|new import/i })
+      .first()
+      .click();
     await expect(page).toHaveURL(/\/integrations\/imports\/new$/);
   });
 

--- a/apps/admin/src/features/imports/sessions/ImportSessionsView.tsx
+++ b/apps/admin/src/features/imports/sessions/ImportSessionsView.tsx
@@ -1,7 +1,10 @@
 import { useApiUrl, useCustom, useList } from '@refinedev/core';
-import { Search } from 'lucide-react';
+import { Search, Upload } from 'lucide-react';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { EmptyState } from '@/components/ui-v2/empty-state';
 
 import { HistoryTable } from './HistoryTable';
 import { KpiStrip } from './KpiStrip';
@@ -107,8 +110,20 @@ export function ImportSessionsView() {
         {liveSession ? (
           <LiveSessionCard session={liveSession} throughput={throughput} />
         ) : (
-          <div className="rounded-2xl border border-dashed border-zinc-200 bg-zinc-50/60 px-6 py-10 text-center text-[13px] text-zinc-500">
-            {t('imports.sessions.live.empty')}
+          <div className="rounded-2xl border border-dashed border-zinc-200 bg-surface">
+            <EmptyState
+              icon={<Upload className="size-5" />}
+              title={t('imports.sessions.live.empty_title')}
+              description={t('imports.sessions.live.empty_subtitle')}
+              action={
+                <Link
+                  to="/integrations/imports/new"
+                  className="focus-ring inline-flex h-9 items-center rounded-xl bg-cta px-3.5 text-[13px] font-semibold text-cta-foreground transition hover:bg-accent-hover"
+                >
+                  {t('imports.sessions.new_import')}
+                </Link>
+              }
+            />
           </div>
         )}
       </section>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2179,7 +2179,9 @@
         "warnings": "Warnings",
         "errors": "Errors",
         "open": "Open",
-        "empty": "No active imports. Start with \"New import\" to launch a new session."
+        "empty": "No active imports. Start with \"New import\" to launch a new session.",
+        "empty_title": "No active imports",
+        "empty_subtitle": "Start with \"New import\" — small files process instantly, large ones land here with a progress bar."
       },
       "history": {
         "heading": "History",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2229,7 +2229,9 @@
         "warnings": "Ostrzeżenia",
         "errors": "Błędy",
         "open": "Otwórz",
-        "empty": "Brak aktywnych importów. Zacznij od „Nowy import”, aby uruchomić nową sesję."
+        "empty": "Brak aktywnych importów. Zacznij od „Nowy import”, aby uruchomić nową sesję.",
+        "empty_title": "Brak aktywnych importów",
+        "empty_subtitle": "Zacznij od „Nowy import” — małe pliki wczytasz od razu, duże trafią tutaj z paskiem postępu."
       },
       "history": {
         "heading": "Historia",


### PR DESCRIPTION
## Summary
Widok Eksportów ma w pustym stanie „W toku" wyśrodkowany przycisk „Nowy eksport"; Importy miały tylko tekst. Dodaję analogiczny `EmptyState` z ikoną Upload + tytuł/podtytuł + CTA „Nowy import" → `/integrations/imports/new`.

## Changes
- `ImportSessionsView.tsx`: goły div empty-state → `EmptyState` z `action` (Link CTA, styl `bg-cta` jak eksport).
- i18n pl+en: `imports.sessions.live.empty_title` + `empty_subtitle`.

## Quality gates (lokalnie)
typecheck **0**, Biome lint **0**, vite build **OK**.

## Smoke
`/integrations/imports/sessions` bez aktywnego importu → wyśrodkowany przycisk „Nowy import" prowadzący do kreatora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)