### PR TITLE
fix(catalog): odblokuj edycję nazwy produktu w nagłówku detalu

### DIFF
--- a/apps/admin/e2e/1351-product-detail-edit-mode.spec.ts
+++ b/apps/admin/e2e/1351-product-detail-edit-mode.spec.ts
@@ -108,3 +108,69 @@ test('product detail opens in edit mode with save + save-and-return actions', as
 
   await page.request.delete(`/api/products/${product.id}`, { headers: bearer });
 });
+
+/**
+ * Regression: the header name <Input> is controlled by `nameValue`. In edit
+ * mode `nameValue` previously read only the loaded `attrs.name` and ignored
+ * `dirtyFields.name`, so keystrokes were immediately overwritten on re-render
+ * and the field appeared locked. It must now reflect typed input and persist.
+ */
+test('product name is editable in the header and persists', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  const loginResponse = await page.request.post('/api/auth/login', {
+    data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    headers: { accept: 'application/json' },
+  });
+  expect(loginResponse.status()).toBe(200);
+  const { token } = (await loginResponse.json()) as { token: string };
+  const bearer = { authorization: `Bearer ${token}` };
+
+  await apiLogin(page);
+
+  const objectTypesResponse = await page.request.get('/api/object_types?itemsPerPage=200', {
+    headers: { ...bearer, accept: 'application/ld+json' },
+  });
+  const types =
+    (
+      (await objectTypesResponse.json()) as {
+        member?: Array<{ id: string; kind: string; codeImmutable: boolean }>;
+      }
+    ).member ?? [];
+  const productType = types.find((t) => t.kind === 'product' && t.codeImmutable);
+  if (productType === undefined) throw new Error('Built-in product ObjectType not seeded.');
+
+  const sku = `NM1351-${Date.now().toString(36).toUpperCase()}`;
+  const created = await page.request.post('/api/products', {
+    headers: { ...bearer, 'content-type': 'application/ld+json' },
+    data: { code: sku, objectTypeId: productType.id, attributes: { name: `Before ${sku}`, sku } },
+  });
+  expect(created.status()).toBe(201);
+  const product = (await created.json()) as { id: string };
+
+  await page.goto(`/products/${product.id}`);
+
+  const nameInput = page.getByRole('textbox', { name: /nazwa produktu|product name/i });
+  await expect(nameInput).toBeVisible({ timeout: 15_000 });
+  await expect(nameInput).toHaveValue(`Before ${sku}`);
+
+  // Core regression: typed value must stick in the controlled input.
+  const newName = `After ${sku}`;
+  await nameInput.fill(newName);
+  await expect(nameInput).toHaveValue(newName);
+
+  // Persist via the merge-patch path and confirm it round-trips.
+  const patch = await page.request.patch(`/api/objects/${product.id}`, {
+    headers: { ...bearer, 'content-type': 'application/merge-patch+json' },
+    data: { attributes: { name: newName } },
+  });
+  expect(patch.status(), await patch.text()).toBe(200);
+
+  await page.reload();
+  await expect(page.getByRole('textbox', { name: /nazwa produktu|product name/i })).toHaveValue(
+    newName,
+    { timeout: 15_000 },
+  );
+
+  await page.request.delete(`/api/products/${product.id}`, { headers: bearer });
+});

--- a/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
+++ b/apps/admin/src/features/catalog/products/components/product-detail-page.tsx
@@ -319,14 +319,19 @@ export function ProductDetailPage({
         ? dirtyFields.sku
         : ''
       : (product?.code ?? '');
+  // The header name <Input> is controlled by `nameValue`, so it must reflect
+  // unsaved edits — read `dirtyFields.name` first (the user's keystrokes),
+  // then fall back to the loaded value. Without the dirty branch in edit mode
+  // the controlled input always re-rendered the original value and the field
+  // appeared locked.
   const nameValue =
-    mode === 'create'
-      ? typeof dirtyFields.name === 'string'
-        ? dirtyFields.name
-        : ''
-      : typeof attrs.name === 'string'
-        ? attrs.name
-        : (product?.code ?? '');
+    typeof dirtyFields.name === 'string'
+      ? dirtyFields.name
+      : mode === 'create'
+        ? ''
+        : typeof attrs.name === 'string'
+          ? attrs.name
+          : (product?.code ?? '');
   const brandValue =
     mode === 'create'
       ? typeof dirtyFields.brand === 'string'


### PR DESCRIPTION
## Problem

Na detalu produktu (`/products/{id}`) nie dało się wpisać nic w pole nazwy — pole zachowywało się jak zablokowane (żaden request nie leciał, bo znaki nie wchodziły).

## Root cause (FE)

Strona detalu jest zawsze w trybie edycji (`isEditing = true`), więc nagłówek renderuje kontrolowany `<Input value={nameValue}>`. W [product-detail-page.tsx](apps/admin/src/features/catalog/products/components/product-detail-page.tsx) `nameValue` w trybie **edit** było liczone wyłącznie z `attrs.name` (załadowany produkt) i **ignorowało `dirtyFields.name`** — w odróżnieniu od trybu create. Input kontrolowany: wpisanie znaku → `onFieldChange('name', …)` → `setFieldValue` aktualizuje `dirtyFields.name`, ale re-render bierze niezmienione `attrs.name` → znak „znika" → pole wygląda na zablokowane.

To bug niezależny od modelu danych i **nie** wynika z PR #1715 (asset/category).

## Fix

`nameValue` czyta najpierw `dirtyFields.name` (niezapisana zmiana), z fallbackiem na `attrs.name` → kod produktu — spójnie z istniejącym `fieldValue()`, które już nakłada dirty na `attrs`. Tryb create bez zmian. 1 plik, ~6 linii.

## Weryfikacja (live stack)

Playwright regression w `e2e/1351-product-detail-edit-mode.spec.ts` (tworzy i kasuje własny produkt testowy):
- wpisanie nazwy w input nagłówka **utrzymuje się** (`toHaveValue`), PATCH 200, po reloadzie nazwa utrwalona.
- **Kontrfaktyczny dowód:** bez fixu test pada — `Expected "After…"` / `Received "Before…"` (znaki odrzucane); z fixem przechodzi (4.3s).
- Biome + tsc czysto.

## Powiązane (osobne, do decyzji — NIE w tym PR)

- Usuwanie atrybutu `kolor` blokuje istniejąca wartość na produkcie (`object_values`), nie przypięcie do typu — poprawne zachowanie `DeleteAttributeHandler`. Workaround: wyczyść pole → zapisz → usuń. Ewentualny „force delete" osobno.
- Typ `product` (demo) ma zero przypiętych atrybutów; integracja zapisuje wartości dla kodów spoza modelu typu. Osobny ticket na uporządkowanie modelu typu (bez kasowania danych).

🤖 Generated with [Claude Code](https://claude.com/claude-code)