### PR TITLE
fix(catalog): kaskadowe usuwanie osieroconych wartości przy kasowaniu odpiętego atrybutu

### DIFF
--- a/apps/admin/src/features/catalog/attributes/show.tsx
+++ b/apps/admin/src/features/catalog/attributes/show.tsx
@@ -388,7 +388,7 @@ function Editor({
             <DialogDescription>
               {t('attributes.delete.confirm_body', {
                 defaultValue:
-                  'Atrybut "{{code}}" zostanie trwale usunięty wraz z jego wartościami słownikowymi. Tej operacji nie można cofnąć.',
+                  'Atrybut "{{code}}" zostanie trwale usunięty wraz z jego wartościami słownikowymi. Jeśli atrybut nie jest już przypisany do żadnego typu, grupy ani kategorii, jego osierocone wartości na obiektach również zostaną usunięte. Tej operacji nie można cofnąć.',
                 code: attribute.code,
               })}
             </DialogDescription>

--- a/apps/api/src/Catalog/Application/Command/DeleteAttribute/DeleteAttributeHandler.php
+++ b/apps/api/src/Catalog/Application/Command/DeleteAttribute/DeleteAttributeHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Catalog\Application\Command\DeleteAttribute;
 
+use App\Catalog\Application\OrphanedAttributeValuePurger;
 use App\Catalog\Application\Query\Usage\UsageQueryService;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
@@ -17,14 +18,19 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
  * attribute detail page (`show.tsx`); the trash button is only rendered for
  * non-system rows but the BE guards below are the source of truth.
  *
- * Two guards, both backed by Postgres FK semantics:
+ * Guards:
  *   - System attributes (`is_system=true`) are immutable per UI-08.3 (#258) → 422.
- *   - Attributes still in use are non-deletable → 409: `object_type_attributes`
- *     and `object_values` both have ON DELETE RESTRICT, so the DB would reject
- *     the delete anyway. We pre-check via UsageQueryService to return a helpful
- *     message instead of a raw 500, and catch the FK violation as a safety-net
- *     for the race window left by the 60s usage cache. The supported path for
- *     removing an in-use attribute is detach + the `/migrate-type` flow.
+ *   - An attribute still REACHABLE in the model — attached to an ObjectType,
+ *     an AttributeGroup, or distributed via a Category overlay — is non-deletable
+ *     → 409. The supported path is to detach / remove it from the group first
+ *     (both reachable in the modeling UI).
+ *
+ * Orphaned values: an attribute detached from EVERYTHING but still carrying
+ * `object_values` is a dead-end — detaching removes it from the editor, so its
+ * values can never be cleared through the UI, yet `object_values.attribute_id`
+ * is ON DELETE RESTRICT and blocks the delete forever. When the attribute is
+ * unreachable we therefore cascade-delete those orphaned values (rebuilding the
+ * denormalised cache + queuing a reindex) via {@see OrphanedAttributeValuePurger}.
  *
  * Cascade behavior: `attribute_options.attribute_id` and
  * `attribute_group_attributes.attribute_id` are ON DELETE CASCADE, so options
@@ -36,6 +42,7 @@ final readonly class DeleteAttributeHandler
     public function __construct(
         private AttributeRepositoryInterface $repository,
         private UsageQueryService $usageQueryService,
+        private OrphanedAttributeValuePurger $orphanedValuePurger,
     ) {
     }
 
@@ -58,9 +65,21 @@ final readonly class DeleteAttributeHandler
 
         $usage = $this->usageQueryService->forAttribute($attribute);
         $objectTypeCount = \count($usage['objectTypes']);
-        $instanceCount = $usage['instanceCount'];
-        if ($objectTypeCount > 0 || $instanceCount > 0) {
-            throw $this->inUseConflict($attribute->getCode(), $objectTypeCount, $instanceCount);
+        $groupCount = \count($usage['groups']);
+        $categoryCount = \count($usage['categories']);
+
+        // Reachable anywhere in the model → must be detached / removed from the
+        // group first (both doable in the UI). Values, if any, stay reachable.
+        if ($objectTypeCount > 0 || $groupCount > 0 || $categoryCount > 0) {
+            throw $this->inUseConflict($attribute->getCode(), $objectTypeCount, $groupCount, $categoryCount);
+        }
+
+        // Detached from everything but still has values → orphaned, unreachable
+        // in any form. Cascade-delete them with the attribute.
+        if ($usage['instanceCount'] > 0) {
+            $this->orphanedValuePurger->purgeAndDelete($attribute);
+
+            return;
         }
 
         try {
@@ -68,17 +87,18 @@ final readonly class DeleteAttributeHandler
         } catch (ForeignKeyConstraintViolationException) {
             // Safety-net: usage cache (60s TTL) may have been stale and a new
             // attachment/value slipped in between the pre-check and remove.
-            throw $this->inUseConflict($attribute->getCode(), $objectTypeCount, $instanceCount);
+            throw $this->inUseConflict($attribute->getCode(), $objectTypeCount, $groupCount, $categoryCount);
         }
     }
 
-    private function inUseConflict(string $code, int $objectTypeCount, int $instanceCount): ConflictHttpException
+    private function inUseConflict(string $code, int $objectTypeCount, int $groupCount, int $categoryCount): ConflictHttpException
     {
         return new ConflictHttpException(\sprintf(
-            'Attribute "%s" is attached to %d object type(s) and used by %d object(s); detach or migrate it before deleting.',
+            'Attribute "%s" is attached to %d object type(s), %d group(s) and %d categor(y/ies); detach or remove it from the group before deleting.',
             $code,
             $objectTypeCount,
-            $instanceCount,
+            $groupCount,
+            $categoryCount,
         ));
     }
 }

--- a/apps/api/src/Catalog/Application/OrphanedAttributeValuePurger.php
+++ b/apps/api/src/Catalog/Application/OrphanedAttributeValuePurger.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Application\Reindex\BulkReindexQueueInterface;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Deletes an Attribute together with its ORPHANED `object_values` and then
+ * the attribute row itself, keeping the denormalised cache and the search
+ * index consistent.
+ *
+ * "Orphaned" means the attribute is attached to no ObjectType, no
+ * AttributeGroup and no Category overlay — the caller
+ * ({@see Command\DeleteAttribute\DeleteAttributeHandler})
+ * guarantees that precondition. Such values are unreachable from any form:
+ * once an attribute is detached it disappears from the editor, so its values
+ * can never be cleared through the UI and would otherwise block deletion
+ * forever (the `object_values.attribute_id` FK is ON DELETE RESTRICT).
+ *
+ * Mirrors the proven {@see \App\Import\Application\Service\ImportRollbackService}
+ * shape: set-based DELETE inside a transaction, per-object cache rebuild in
+ * memory-bounded chunks (FrankenPHP worker mode), Meilisearch refresh queued
+ * after the transaction commits.
+ */
+final readonly class OrphanedAttributeValuePurger
+{
+    private const int CHUNK = 200;
+
+    public function __construct(
+        private EntityManagerInterface $em,
+        private Connection $connection,
+        private AttributesIndexedRebuilder $rebuilder,
+        private BulkReindexQueueInterface $reindexQueue,
+    ) {
+    }
+
+    /**
+     * Removes the attribute's orphaned values, rebuilds the affected objects'
+     * `attributes_indexed`, and deletes the attribute — all atomically.
+     */
+    public function purgeAndDelete(Attribute $attribute): void
+    {
+        $attributeId = $attribute->getId()->toRfc4122();
+
+        // tenant-safe: explicit tenant_id filter — the attribute was loaded
+        // through the TenantFilter-aware repository, so its id is already
+        // tenant-scoped; object_values carries tenant_id and we constrain on it.
+        $affectedIds = array_values(array_filter(
+            array_map(
+                static fn (mixed $v): string => \is_scalar($v) ? (string) $v : '',
+                $this->connection->fetchFirstColumn(
+                    'SELECT DISTINCT object_id FROM object_values WHERE attribute_id = ? AND tenant_id = ?',
+                    [$attributeId, $attribute->getTenant()?->getId()->toRfc4122()],
+                ),
+            ),
+            static fn (string $id): bool => '' !== $id,
+        ));
+
+        $this->em->wrapInTransaction(function () use ($attributeId, $attribute, $affectedIds): void {
+            // tenant-safe: explicit tenant_id filter; set-based purge of values
+            // that are unreachable from any form (attribute detached everywhere).
+            $this->connection->executeStatement(
+                'DELETE FROM object_values WHERE attribute_id = ? AND tenant_id = ?',
+                [$attributeId, $attribute->getTenant()?->getId()->toRfc4122()],
+            );
+
+            foreach (array_chunk($affectedIds, self::CHUNK) as $chunk) {
+                foreach ($chunk as $idRfc) {
+                    $object = $this->em->find(CatalogObject::class, Uuid::fromString($idRfc));
+                    if ($object instanceof CatalogObject) {
+                        // Drops the now-deleted attribute's key from the JSONB
+                        // cache and recomputes completeness from the survivors.
+                        $this->rebuilder->rebuild($object);
+                    }
+                }
+                $this->em->flush();
+                $this->em->clear();
+            }
+
+            // Re-find: the chunk `clear()` above detached the original entity.
+            $managed = $this->em->find(Attribute::class, Uuid::fromString($attributeId));
+            if ($managed instanceof Attribute) {
+                $this->em->remove($managed);
+                $this->em->flush();
+            }
+        });
+
+        // Outside the transaction: refresh the surviving objects' Meili docs so
+        // the dropped attribute field disappears from the index.
+        $this->reindexQueue->queueAll($affectedIds);
+    }
+}

--- a/apps/api/tests/Api/Catalog/DeleteOrphanedAttributeApiTest.php
+++ b/apps/api/tests/Api/Catalog/DeleteOrphanedAttributeApiTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Catalog;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\Entity\ObjectValue;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Provenance;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * An attribute detached from every ObjectType / AttributeGroup / Category is
+ * invisible in the modeling UI, so any leftover `object_values` can never be
+ * cleared by hand — yet the ON DELETE RESTRICT FK would block the attribute
+ * delete forever. DeleteAttributeHandler resolves that dead-end by cascading
+ * the orphaned values (rebuilding the `attributes_indexed` cache). When the
+ * attribute is still reachable it stays blocked (detach first).
+ */
+final class DeleteOrphanedAttributeApiTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function deletesOrphanedAttributeTogetherWithItsValues(): void
+    {
+        $tenant = $this->tenant();
+        $this->tenantContext()->set($tenant);
+        $em = $this->em();
+        $productType = $this->productType($tenant);
+
+        $attribute = new Attribute('orphan_color', ['en' => 'Orphan color'], AttributeType::Text);
+        $em->persist($attribute);
+        $object = new CatalogObject($productType, 'ORPH-001');
+        $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+        $em->persist($object);
+        $em->flush();
+
+        // Value present but attribute attached to NOTHING — the orphaned state.
+        $em->persist(new ObjectValue($object, $attribute, ['value' => 'taupe'], Provenance::Manual));
+        $object->updateAttributeIndex(['orphan_color' => ['value' => 'taupe']]);
+        $em->flush();
+
+        $attributeId = $attribute->getId()->toRfc4122();
+        $objectId = $object->getId()->toRfc4122();
+        $this->tenantContext()->clear();
+
+        $client = $this->authenticatedClient();
+        $response = $client->request('DELETE', '/api/attributes/'.$attributeId);
+        self::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+
+        $em->clear();
+        self::assertNull(
+            self::getContainer()->get(AttributeRepositoryInterface::class)->findById(Uuid::fromString($attributeId)),
+            'Orphaned attribute should be deleted.',
+        );
+        $remaining = $em->getConnection()->fetchOne(
+            'SELECT COUNT(*) FROM object_values WHERE attribute_id = ?',
+            [$attributeId],
+        );
+        self::assertSame(
+            0,
+            \is_scalar($remaining) ? (int) $remaining : -1,
+            'Orphaned values should be cascade-deleted.',
+        );
+        $indexed = $em->getConnection()->fetchOne(
+            'SELECT attributes_indexed FROM objects WHERE id = ?',
+            [$objectId],
+        );
+        self::assertIsString($indexed);
+        self::assertStringNotContainsString('orphan_color', $indexed, 'Cache must drop the deleted key.');
+    }
+
+    #[Test]
+    public function blocksDeleteWhileStillAttachedToObjectType(): void
+    {
+        $tenant = $this->tenant();
+        $this->tenantContext()->set($tenant);
+        $em = $this->em();
+        $productType = $this->productType($tenant);
+
+        $attribute = new Attribute('attached_color', ['en' => 'Attached color'], AttributeType::Text);
+        $em->persist($attribute);
+        $object = new CatalogObject($productType, 'ATT-001');
+        $object->transitionTo(CatalogObject::STATUS_PUBLISHED);
+        $em->persist($object);
+        $em->flush();
+
+        $em->persist(new ObjectTypeAttribute($productType, $attribute, false, 0));
+        $em->persist(new ObjectValue($object, $attribute, ['value' => 'navy'], Provenance::Manual));
+        $em->flush();
+
+        $attributeId = $attribute->getId()->toRfc4122();
+        $this->tenantContext()->clear();
+
+        $client = $this->authenticatedClient();
+        $client->request('DELETE', '/api/attributes/'.$attributeId);
+        self::assertResponseStatusCodeSame(Response::HTTP_CONFLICT);
+
+        $em->clear();
+        self::assertNotNull(
+            self::getContainer()->get(AttributeRepositoryInterface::class)->findById(Uuid::fromString($attributeId)),
+            'Attached attribute must NOT be deleted.',
+        );
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+
+    private function productType(Tenant $tenant): ObjectType
+    {
+        $type = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($type instanceof ObjectType);
+
+        return $type;
+    }
+
+    private function tenantContext(): TenantContext
+    {
+        return self::getContainer()->get(TenantContext::class);
+    }
+}


### PR DESCRIPTION
## Problem (ślepy zaułek)

Operator odpiął atrybut od typu Produkt, ale nie mógł go usunąć — `DeleteAttributeHandler` zwracał 409 „used by N object(s)". Atrybut odpięty od typu **znika z formularza**, więc jego wartości nie da się wyczyścić w UI, a niewyczyszczona wartość (FK `object_values.attribute_id` = ON DELETE RESTRICT) blokuje usunięcie **na zawsze**. Brak wyjścia przez UI.

## Rozwiązanie

Doprecyzowanie guardu usuwania:
- **Blok (409)** tylko gdy atrybut jest **osiągalny w modelu** — przypięty do `ObjectType`, `AttributeGroup` lub dystrybuowany przez overlay kategorii (wszystko rozwiązywalne w UI: odepnij / usuń z grupy). *Domyka też lukę:* stary warunek ignorował grupy i kategorie.
- Gdy atrybut **nieosiągalny nigdzie**, ale ma jeszcze wartości → są **osierocone** i kasowane kaskadowo razem z atrybutem.

`OrphanedAttributeValuePurger` robi kaskadę wzorcem z `ImportRollbackService`: set-based `DELETE` w transakcji, przebudowa `attributes_indexed` per-obiekt w paczkach po 200 (OOM-safe, worker mode), reindex Meili kolejkowany po commitcie. Dialog usuwania atrybutu informuje, że osierocone wartości zostaną usunięte.

## Weryfikacja (live stack, dane throwaway — NIE ruszałem danych operatora)

- **Osierocony** (atrybut z wartością, odpięty od wszystkiego) → `DELETE /api/attributes/{id}` = **204**; atrybut usunięty, `object_values` skasowane, `attributes_indexed` wyczyszczony (klucz `t`→`f`). ✅
- **Przypięty do typu** → **409** z komunikatem „attached to 1 object type(s), 0 group(s)…". ✅
- Cały scenariusz przez API (create attr → attach → produkt z wartością → detach → delete → weryfikacja w psql → sprzątanie). Dane testowe usunięte.
- **Bramki:** PHPStan max OK, `lint-raw-sql.sh` OK (marker `tenant-safe: explicit tenant_id filter`), Biome OK, php-cs-fixer OK. API test dołączony (uruchomi się w CI — lokalny test-env ma zepsuty passphrase JWT, niezwiązane).

> Uwaga: `UsageQueryService` ma 60s cache — tuż po odpięciu (jeśli wcześniej był odczyt usage „attached") delete może chwilowo 409 do wygaśnięcia TTL; dla od dawna odpiętego atrybutu (jak `kolor` operatora) działa od razu. Pre-existing zachowanie + FK safety-net, poza zakresem.

## Powiązane PR-y w toku
- #1715 asset/category closed kinds
- #1716 edycja nazwy produktu
- #1717 (ten) kaskada osieroconych wartości

🤖 Generated with [Claude Code](https://claude.com/claude-code)