### PR TITLE
fix(import): newline jako separator multi-value w komórce (multiselect, kategorie)

### DIFF
--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -17,6 +17,7 @@ use App\Import\Application\Service\ImportRowReader;
 use App\Import\Application\Service\ImportUndoLogger;
 use App\Import\Application\Service\ImportValidationService;
 use App\Import\Application\Service\Media\AssetUrlResolver;
+use App\Import\Application\Service\MultiValueSplitter;
 use App\Import\Application\Service\ObjectResolver;
 use App\Import\Application\Service\RelationImportStep;
 use App\Import\Domain\Entity\ImportLog;
@@ -982,10 +983,9 @@ final class ImportRunHandler extends AbstractBatchHandler
                 continue;
             }
 
-            return array_values(array_filter(
-                array_map('trim', explode('|', $cell)),
-                static fn (string $code): bool => '' !== $code,
-            ));
+            // Pipe or newline (#1719) — external exports pack category lists
+            // with embedded newlines in one quoted cell.
+            return MultiValueSplitter::split($cell);
         }
 
         return [];

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -314,20 +314,16 @@ final class ImportObjectCreator
     }
 
     /**
-     * Splits the pipe-joined token list the exporter writes for
-     * multiselect values (`ValueSerializer::MULTI_VALUE_GLUE`) back into
-     * an option-code array.
+     * Splits the multi-value token list back into an option-code array.
+     * Accepts the exporter's pipe glue (`ValueSerializer::MULTI_VALUE_GLUE`)
+     * as well as newlines, so external exports (IdoSell/IAI) that pack
+     * `36\n37\n38` into one quoted cell import as separate options (#1719).
      *
      * @return array{option_codes: list<string>}
      */
     private function multiSelectPayload(string $raw): array
     {
-        $codes = array_values(array_filter(
-            array_map('trim', explode('|', $raw)),
-            static fn (string $code): bool => '' !== $code,
-        ));
-
-        return ['option_codes' => $codes];
+        return ['option_codes' => MultiValueSplitter::split($raw)];
     }
 
     private function parseBoolean(string $raw): bool

--- a/apps/api/src/Import/Application/Service/ImportValidationService.php
+++ b/apps/api/src/Import/Application/Service/ImportValidationService.php
@@ -309,13 +309,10 @@ final readonly class ImportValidationService
         }
 
         if (null !== $categoryCellValue) {
-            // IMP2-1.7: validate every code in the pipe-separated list.
-            // Each missing code warns separately; the row still imports with
-            // whichever codes resolved (the writer skips the rest).
-            $codes = array_values(array_filter(
-                array_map('trim', explode('|', $categoryCellValue)),
-                static fn (string $code): bool => '' !== $code,
-            ));
+            // IMP2-1.7: validate every code in the multi-value list (pipe or
+            // newline, #1719). Each missing code warns separately; the row
+            // still imports with whichever codes resolved (writer skips rest).
+            $codes = MultiValueSplitter::split($categoryCellValue);
             foreach ($codes as $code) {
                 if (null === $this->catalogObjects->findByCode($code, ObjectKind::Category, $tenant)) {
                     $errors[] = new ValidationError(

--- a/apps/api/src/Import/Application/Service/MultiValueSplitter.php
+++ b/apps/api/src/Import/Application/Service/MultiValueSplitter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+/**
+ * Splits a single import cell that packs several values into one field
+ * (multiselect option codes, `__category__` code lists).
+ *
+ * Accepts BOTH the PIM exporter's pipe glue
+ * ({@see \App\Catalog\Application\ValueSerializer} `MULTI_VALUE_GLUE`) AND
+ * newlines / carriage returns, because external exports (IdoSell/IAI and
+ * other e-commerce platforms) wrap multi-value lists with embedded newlines
+ * inside a single quoted CSV cell (#1719). The pipe path stays fully
+ * round-trip compatible with PIM's own exports.
+ *
+ * Tokens are trimmed and empties dropped. Scalar attributes (`text`,
+ * `select`, `wysiwyg`) deliberately do NOT use this — there a newline is
+ * legitimate content, not a separator.
+ */
+final class MultiValueSplitter
+{
+    /**
+     * @return list<string>
+     */
+    public static function split(string $raw): array
+    {
+        $parts = preg_split('/[|\r\n]+/u', $raw);
+        if (false === $parts) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map('trim', $parts),
+            static fn (string $token): bool => '' !== $token,
+        ));
+    }
+}

--- a/apps/api/tests/Unit/Import/MultiValueSplitterTest.php
+++ b/apps/api/tests/Unit/Import/MultiValueSplitterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Import\Application\Service\MultiValueSplitter;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class MultiValueSplitterTest extends TestCase
+{
+    #[Test]
+    public function splitsPipeListForBackwardCompat(): void
+    {
+        self::assertSame(['a', 'b', 'c'], MultiValueSplitter::split('a|b|c'));
+    }
+
+    #[Test]
+    public function splitsNewlineListFromExternalExports(): void
+    {
+        // IdoSell/IAI packs `36\n37\n38\n39\n40\n41` into one quoted CSV cell.
+        self::assertSame(
+            ['36', '37', '38', '39', '40', '41'],
+            MultiValueSplitter::split("36\n37\n38\n39\n40\n41"),
+        );
+    }
+
+    #[Test]
+    public function splitsMixedPipeAndNewline(): void
+    {
+        self::assertSame(['a', 'b', 'c'], MultiValueSplitter::split("a|b\nc"));
+    }
+
+    #[Test]
+    public function splitsCarriageReturnNewline(): void
+    {
+        self::assertSame(['a', 'b'], MultiValueSplitter::split("a\r\nb"));
+    }
+
+    #[Test]
+    public function trimsTokensAndDropsEmpties(): void
+    {
+        self::assertSame(['a', 'b'], MultiValueSplitter::split("a| \n |b\n"));
+    }
+
+    #[Test]
+    public function singleValueStaysSingle(): void
+    {
+        self::assertSame(['Beżowy'], MultiValueSplitter::split('Beżowy'));
+    }
+
+    #[Test]
+    public function emptyCellYieldsEmptyList(): void
+    {
+        self::assertSame([], MultiValueSplitter::split(''));
+        self::assertSame([], MultiValueSplitter::split("\n|\n"));
+    }
+}


### PR DESCRIPTION
Closes #1719.

## Problem
Eksporty IdoSell/IAI pakują listy multi-value (rozmiary `36\n37\n38…`, listy kategorii) rozdzielając je **znakiem nowej linii** wewnątrz cudzysłowów. Importer dzielił komórki tylko po `|`, więc taka lista trafiała jako jeden token.

## Zmiana
- Nowy `MultiValueSplitter::split()` — dzieli po `|` **oraz** `\r`/`\n`, trim + filtr pustych. Pipe pozostaje w pełni round-trip-kompatybilny z eksportami PIM.
- Wpięty w 3 miejsca: `ImportObjectCreator::multiSelectPayload()`, `ImportValidationService` (walidacja kategorii), `ImportRunHandler::extractCategoryCodes()` (write-path).
- Bez zmian: assety (tokenizer już whitespace-aware), pola skalarne (`text`/`select`/`wysiwyg` — tam `\n` to treść, nie separator), variant axes/relacje.

## Testy
- `MultiValueSplitterTest` — 7 przypadków: pipe (regresja), newline, mieszane, CRLF, trim+empty, single, empty.
- Pełny `tests/Unit/Import` — 161 OK.
- PHPStan max + CS-fixer zielone.

## Świadome odejścia
Separator wykrywany sztywno (`|`/`\n`/`\r`), bez konfiguracji per-profil — YAGNI dla MVP.