### PR TITLE
feat(import): auto-tworzenie brakujących opcji select/multiselect (gated flagą profilu)

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -473,6 +473,12 @@ parameters:
             - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\Provenance
             - App\Catalog\Application\BatchValueWriter
+        # #1718 — option auto-create mints AttributeOption via the same
+        # Import→Catalog seam as ImportObjectCreator (it owns the select cell).
+        App\Import\Application\Service\OptionAutoCreator:
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Entity\AttributeOption
+            - App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface
         # IMP2-2.4 — undo-log capture + rollback v2 reuse Catalog read/rebuild/
         # reindex via the same Import→Catalog seam as ImportObjectCreator.
         App\Import\Application\Service\ImportUndoLogger:

--- a/apps/api/migrations/Version20260624120000.php
+++ b/apps/api/migrations/Version20260624120000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * #1718 — add the `create_missing_options` opt-in flag to import_profiles and
+ * import_sessions. When true, an import run mints missing select/multiselect
+ * AttributeOptions instead of failing rows with unknown values.
+ *
+ * NOT NULL DEFAULT false: existing rows and any code path that does not set
+ * the flag keep the prior strict behaviour.
+ */
+final class Version20260624120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '#1718: add create_missing_options flag to import_profiles and import_sessions.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import_profiles ADD create_missing_options BOOLEAN DEFAULT false NOT NULL');
+        $this->addSql('ALTER TABLE import_sessions ADD create_missing_options BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import_profiles DROP create_missing_options');
+        $this->addSql('ALTER TABLE import_sessions DROP create_missing_options');
+    }
+}

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -19,6 +19,7 @@ use App\Import\Application\Service\ImportValidationService;
 use App\Import\Application\Service\Media\AssetUrlResolver;
 use App\Import\Application\Service\MultiValueSplitter;
 use App\Import\Application\Service\ObjectResolver;
+use App\Import\Application\Service\OptionAutoCreator;
 use App\Import\Application\Service\RelationImportStep;
 use App\Import\Domain\Entity\ImportLog;
 use App\Import\Domain\Entity\ImportSession;
@@ -143,6 +144,7 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly ImportRowReader $rowReader,
         private readonly ImportValidationService $validator,
         private readonly ImportObjectCreator $creator,
+        private readonly OptionAutoCreator $optionAutoCreator,
         private readonly ObjectResolver $objectResolver,
         private readonly RelationImportStep $relationStep,
         private readonly ImportUndoLogger $undoLogger,
@@ -202,6 +204,10 @@ final class ImportRunHandler extends AbstractBatchHandler
      */
     public function run(ImportSession $session): void
     {
+        // #1718 — drop any option lookup/mint cache from a previous run on this
+        // long-lived worker before processing a fresh file (cross-run hygiene).
+        $this->optionAutoCreator->reset();
+
         // Streaming + per-row Doctrine flushes scale with file size.
         // A 100-row XLSX easily exceeds FrankenPHP's default 30s HTTP
         // budget (max_execution_time is 0 in CLI but the worker resets
@@ -1511,6 +1517,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                         enabled: $this->extractEnabled($row['cells'], $columnMapping),
                         variantAxes: $this->extractVariantAxes($row['cells'], $columnMapping),
                         existingAssetIds: $existingAssetIds,
+                        createMissingOptions: $session->createMissingOptions(),
                     );
                     $issues = $created->issues;
                     $session->incrementSuccess();
@@ -1537,6 +1544,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                         $this->extractEnabled($row['cells'], $columnMapping),
                         $this->extractVariantAxes($row['cells'], $columnMapping),
                         $existingAssetIds,
+                        $session->createMissingOptions(),
                     );
                     $issues = $updateResult['issues'];
                     // IMP2-2.6 — a row whose values all already matched is a no-op

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -38,6 +38,7 @@ final class ImportObjectCreator
         private readonly BatchValueWriter $valueWriter,
         private readonly CompositeValueParser $compositeValueParser,
         private readonly AssetUrlResolver $assetUrlResolver,
+        private readonly OptionAutoCreator $optionAutoCreator,
     ) {
     }
 
@@ -71,6 +72,7 @@ final class ImportObjectCreator
         ?bool $enabled = null,
         ?array $variantAxes = null,
         array $existingAssetIds = [],
+        bool $createMissingOptions = false,
     ): CreatedImportObject {
         $object = new CatalogObject($objectType, $sku);
         $object->assignImportSession($importSessionId);
@@ -78,7 +80,7 @@ final class ImportObjectCreator
         $this->em->persist($object);
 
         $assetIssues = [];
-        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues);
+        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues, $createMissingOptions);
         // A freshly created object has no existing values, so the `changed`
         // count is irrelevant (a created row is never a no-op skip) — only the
         // value issues matter here.
@@ -155,11 +157,12 @@ final class ImportObjectCreator
         ?bool $enabled = null,
         ?array $variantAxes = null,
         array $existingAssetIds = [],
+        bool $createMissingOptions = false,
     ): array {
         $this->applyState($object, $status, $enabled, $variantAxes);
 
         $assetIssues = [];
-        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues);
+        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues, $createMissingOptions);
         $result = $this->valueWriter->writeMany($object, $writes, Provenance::Import);
 
         return [
@@ -182,7 +185,7 @@ final class ImportObjectCreator
      *
      * @return list<array{attribute: Attribute, envelope: array<string, mixed>, locale: ?string, channelId: ?Uuid}>
      */
-    private function buildWrites(array $resolvedValues, array $attributesByCode, array $existingAssetIds, array &$issues): array
+    private function buildWrites(array $resolvedValues, array $attributesByCode, array $existingAssetIds, array &$issues, bool $createMissingOptions): array
     {
         $writes = [];
         foreach ($resolvedValues as $resolved) {
@@ -196,7 +199,7 @@ final class ImportObjectCreator
             }
             $valuePayload = AttributeType::Asset === $attribute->getType()
                 ? $this->assetPayload($attribute, $rawValue, $existingAssetIds, $issues)
-                : $this->buildValuePayload($attribute, $rawValue);
+                : $this->buildValuePayload($attribute, $rawValue, $createMissingOptions);
             if (null === $valuePayload) {
                 continue;
             }
@@ -219,7 +222,7 @@ final class ImportObjectCreator
      *
      * @return array<string, mixed>|null
      */
-    private function buildValuePayload(Attribute $attribute, string $raw): ?array
+    private function buildValuePayload(Attribute $attribute, string $raw, bool $createMissingOptions): ?array
     {
         return match ($attribute->getType()) {
             AttributeType::Number => $this->numericPayload($raw),
@@ -228,8 +231,12 @@ final class ImportObjectCreator
             AttributeType::Price => $this->compositeValueParser->parsePrice($raw),
             AttributeType::Metric => $this->compositeValueParser->parseMetric($raw),
             AttributeType::Boolean => ['value' => $this->parseBoolean($raw)],
-            AttributeType::Select => ['option_code' => $raw],
-            AttributeType::Multiselect => $this->multiSelectPayload($raw),
+            // #1718 — map the raw cell (often a human label from an external
+            // export) to the canonical option code, minting it when the
+            // session opted in. Off → raw passes through unchanged (validator
+            // then rejects unknown codes exactly as before).
+            AttributeType::Select => ['option_code' => $this->optionAutoCreator->resolve($attribute, $raw, $createMissingOptions)],
+            AttributeType::Multiselect => $this->multiSelectPayload($attribute, $raw, $createMissingOptions),
             // IMP2-1.8: Asset cells are handled by assetPayload() (pipe-split +
             // tenant-scoped existence validation) before this match is reached.
             // IMP2-1.8: Relation/Reference cells are NOT written as
@@ -318,12 +325,20 @@ final class ImportObjectCreator
      * Accepts the exporter's pipe glue (`ValueSerializer::MULTI_VALUE_GLUE`)
      * as well as newlines, so external exports (IdoSell/IAI) that pack
      * `36\n37\n38` into one quoted cell import as separate options (#1719).
+     * Each token is mapped to its canonical option code (minting when the
+     * session opted in, #1718); duplicates that collapse to the same code are
+     * de-duplicated while preserving order.
      *
      * @return array{option_codes: list<string>}
      */
-    private function multiSelectPayload(string $raw): array
+    private function multiSelectPayload(Attribute $attribute, string $raw, bool $createMissingOptions): array
     {
-        return ['option_codes' => MultiValueSplitter::split($raw)];
+        $codes = [];
+        foreach (MultiValueSplitter::split($raw) as $token) {
+            $codes[] = $this->optionAutoCreator->resolve($attribute, $token, $createMissingOptions);
+        }
+
+        return ['option_codes' => array_values(array_unique($codes))];
     }
 
     private function parseBoolean(string $raw): bool

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -77,10 +77,14 @@ final class ImportObjectCreator
         $object = new CatalogObject($objectType, $sku);
         $object->assignImportSession($importSessionId);
         $this->applyState($object, $status, $enabled, $variantAxes);
-        $this->em->persist($object);
 
+        // Build the writes (which may mint select/multiselect options, flushing
+        // the unit of work via the option repository) BEFORE persisting the new
+        // object — so a mint flush only commits already-complete prior rows plus
+        // the new option, never this half-built object (#1718 review).
         $assetIssues = [];
         $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues, $createMissingOptions);
+        $this->em->persist($object);
         // A freshly created object has no existing values, so the `changed`
         // count is irrelevant (a created row is never a no-op skip) — only the
         // value issues matter here.

--- a/apps/api/src/Import/Application/Service/OptionAutoCreator.php
+++ b/apps/api/src/Import/Application/Service/OptionAutoCreator.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+/**
+ * #1718 — resolves a raw select/multiselect import cell to the canonical
+ * {@see AttributeOption} code to store, optionally minting a new option when
+ * the raw value matches none.
+ *
+ * Import files from external systems (IdoSell/IAI, Shopify CSV) carry option
+ * VALUES as human labels ("Beżowy"), not the system's option CODES, so the
+ * {@see \App\Catalog\Application\Validation\TypeValidator\SelectValidator}
+ * rejects every unknown label and the row fails. This service maps label →
+ * code and, when enabled, creates the missing option so the import "just
+ * works". The behaviour is gated by {@see \App\Import\Domain\Entity\ImportSession::createMissingOptions()}
+ * (opt-in, data governance): off = unchanged strict behaviour.
+ *
+ * Match order (case-insensitive): existing code === raw, then any label
+ * locale === raw. Miss + create=true → mint `AttributeOption(code = slug(raw),
+ * label {pl: raw})`; the repository save() flushes, so the value-write
+ * validation (which queries `attribute_options`) sees the new code in the
+ * same run. Miss + create=false → return raw unchanged (validator then flags
+ * the row, preserving the pre-flag contract).
+ *
+ * Per-attribute lookups are cached as PLAIN DATA (code set, label→code map,
+ * max position) so they survive the import handler's EntityManager::clear()
+ * at chunk boundaries without holding detached entity references. The cache
+ * is reset per run ({@see reset()}) to avoid cross-run staleness in the
+ * long-lived FrankenPHP worker.
+ */
+final class OptionAutoCreator
+{
+    private readonly SluggerInterface $slugger;
+
+    /**
+     * @var array<string, array{codes: array<string, true>, byLabel: array<string, string>, maxPosition: int}>
+     *                                                                                                         keyed by attribute id (RFC 4122)
+     */
+    private array $cache = [];
+
+    public function __construct(
+        private readonly AttributeOptionRepositoryInterface $options,
+        ?SluggerInterface $slugger = null,
+    ) {
+        $this->slugger = $slugger ?? new AsciiSlugger();
+    }
+
+    /**
+     * Drops the per-attribute cache. The import handler calls this once at the
+     * start of each run so a fresh message never serves option data minted /
+     * read during a previous run on the same worker.
+     */
+    public function reset(): void
+    {
+        $this->cache = [];
+    }
+
+    public function resolve(Attribute $attribute, string $rawValue, bool $create): string
+    {
+        $raw = trim($rawValue);
+        if ('' === $raw) {
+            return $raw;
+        }
+
+        $index = $this->indexFor($attribute);
+
+        // 1) exact code match — round-trips PIM's own exports (codes verbatim).
+        if (isset($index['codes'][$raw])) {
+            return $raw;
+        }
+        // 2) label match (any locale, case-insensitive) — external exports.
+        $labelKey = mb_strtolower($raw);
+        if (isset($index['byLabel'][$labelKey])) {
+            return $index['byLabel'][$labelKey];
+        }
+
+        if (!$create) {
+            return $raw;
+        }
+
+        return $this->mint($attribute, $raw);
+    }
+
+    private function mint(Attribute $attribute, string $raw): string
+    {
+        $key = $attribute->getId()->toRfc4122();
+        $index = $this->cache[$key];
+
+        $code = $this->uniqueCode($raw, $index['codes']);
+        $option = new AttributeOption(
+            attribute: $attribute,
+            code: $code,
+            label: ['pl' => $raw],
+            position: $index['maxPosition'] + 1,
+        );
+        // save() persists + flushes, so the value-write validation later in the
+        // same row sees the new code. Minting is rare (only genuinely new
+        // values when the flag is on), so the extra flush is bounded.
+        $this->options->save($option);
+
+        $index['codes'][$code] = true;
+        $index['byLabel'][mb_strtolower($raw)] = $code;
+        ++$index['maxPosition'];
+        $this->cache[$key] = $index;
+
+        return $code;
+    }
+
+    /**
+     * @param array<string, true> $existingCodes
+     */
+    private function uniqueCode(string $raw, array $existingCodes): string
+    {
+        $base = $this->slugger->slug($raw, '_')->lower()->toString();
+        if ('' === $base) {
+            $base = 'option';
+        }
+        $base = mb_substr($base, 0, 60);
+
+        $code = $base;
+        $suffix = 2;
+        while (isset($existingCodes[$code])) {
+            $code = $base.'_'.$suffix;
+            ++$suffix;
+        }
+
+        return $code;
+    }
+
+    /**
+     * @return array{codes: array<string, true>, byLabel: array<string, string>, maxPosition: int}
+     */
+    private function indexFor(Attribute $attribute): array
+    {
+        $key = $attribute->getId()->toRfc4122();
+        if (isset($this->cache[$key])) {
+            return $this->cache[$key];
+        }
+
+        $codes = [];
+        $byLabel = [];
+        $maxPosition = -1;
+        foreach ($this->options->findByAttribute($attribute) as $option) {
+            $codes[$option->getCode()] = true;
+            foreach ($option->getLabel() as $label) {
+                if ('' !== $label) {
+                    $byLabel[mb_strtolower($label)] = $option->getCode();
+                }
+            }
+            $maxPosition = max($maxPosition, $option->getPosition());
+        }
+
+        return $this->cache[$key] = ['codes' => $codes, 'byLabel' => $byLabel, 'maxPosition' => $maxPosition];
+    }
+}

--- a/apps/api/src/Import/Application/Service/OptionAutoCreator.php
+++ b/apps/api/src/Import/Application/Service/OptionAutoCreator.php
@@ -38,13 +38,27 @@ use Symfony\Component\String\Slugger\SluggerInterface;
  */
 final class OptionAutoCreator
 {
+    /** AttributeOption.code DB column length (Assert\Length max). */
+    private const int MAX_CODE_LENGTH = 64;
+
+    /**
+     * Defensive ceiling on options minted per run. A free-text column mistakenly
+     * mapped to a select with the flag on would otherwise mint one option per
+     * distinct value (potentially 50k+). Past the cap, resolve() stops minting
+     * and returns the raw value so the validator flags those rows instead.
+     */
+    private const int MAX_MINTS_PER_RUN = 10_000;
+
     private readonly SluggerInterface $slugger;
 
     /**
-     * @var array<string, array{codes: array<string, true>, byLabel: array<string, string>, maxPosition: int}>
-     *                                                                                                         keyed by attribute id (RFC 4122)
+     * @var array<string, array{codes: array<string, string>, byLabel: array<string, string>, maxPosition: int}>
+     *                                                                                                           keyed by attribute id (RFC 4122). `codes` maps a LOWER-CASED code to
+     *                                                                                                           its canonical form; `byLabel` maps a lower-cased label to a code.
      */
     private array $cache = [];
+
+    private int $mintCount = 0;
 
     public function __construct(
         private readonly AttributeOptionRepositoryInterface $options,
@@ -54,13 +68,14 @@ final class OptionAutoCreator
     }
 
     /**
-     * Drops the per-attribute cache. The import handler calls this once at the
-     * start of each run so a fresh message never serves option data minted /
-     * read during a previous run on the same worker.
+     * Drops the per-attribute cache and mint counter. The import handler calls
+     * this once at the start of each run so a fresh message never serves option
+     * data minted / read during a previous run on the same worker.
      */
     public function reset(): void
     {
         $this->cache = [];
+        $this->mintCount = 0;
     }
 
     public function resolve(Attribute $attribute, string $rawValue, bool $create): string
@@ -71,18 +86,22 @@ final class OptionAutoCreator
         }
 
         $index = $this->indexFor($attribute);
+        $key = mb_strtolower($raw);
 
-        // 1) exact code match — round-trips PIM's own exports (codes verbatim).
-        if (isset($index['codes'][$raw])) {
-            return $raw;
+        // 1) code match (case-insensitive) → canonical code. Takes priority over
+        // labels and round-trips PIM's own exports (which store codes). The
+        // lookup is lower-cased so an upper-cased external code resolves to its
+        // canonical form instead of hijacking another option that merely carries
+        // a colliding label, or minting a near-duplicate.
+        if (isset($index['codes'][$key])) {
+            return $index['codes'][$key];
         }
         // 2) label match (any locale, case-insensitive) — external exports.
-        $labelKey = mb_strtolower($raw);
-        if (isset($index['byLabel'][$labelKey])) {
-            return $index['byLabel'][$labelKey];
+        if (isset($index['byLabel'][$key])) {
+            return $index['byLabel'][$key];
         }
 
-        if (!$create) {
+        if (!$create || $this->mintCount >= self::MAX_MINTS_PER_RUN) {
             return $raw;
         }
 
@@ -102,11 +121,14 @@ final class OptionAutoCreator
             position: $index['maxPosition'] + 1,
         );
         // save() persists + flushes, so the value-write validation later in the
-        // same row sees the new code. Minting is rare (only genuinely new
-        // values when the flag is on), so the extra flush is bounded.
+        // same row sees the new code. ImportObjectCreator builds the writes
+        // (this mint) BEFORE persisting the in-progress object, so the flush only
+        // commits already-complete prior rows plus the new option — never a
+        // half-built current object. Minting is rare (genuinely new values).
         $this->options->save($option);
+        ++$this->mintCount;
 
-        $index['codes'][$code] = true;
+        $index['codes'][mb_strtolower($code)] = $code;
         $index['byLabel'][mb_strtolower($raw)] = $code;
         ++$index['maxPosition'];
         $this->cache[$key] = $index;
@@ -115,7 +137,7 @@ final class OptionAutoCreator
     }
 
     /**
-     * @param array<string, true> $existingCodes
+     * @param array<string, string> $existingCodes lower-cased code => canonical
      */
     private function uniqueCode(string $raw, array $existingCodes): string
     {
@@ -123,12 +145,13 @@ final class OptionAutoCreator
         if ('' === $base) {
             $base = 'option';
         }
-        $base = mb_substr($base, 0, 60);
+        $base = mb_substr($base, 0, self::MAX_CODE_LENGTH);
 
         $code = $base;
         $suffix = 2;
-        while (isset($existingCodes[$code])) {
-            $code = $base.'_'.$suffix;
+        while (isset($existingCodes[mb_strtolower($code)])) {
+            $tag = '_'.$suffix;
+            $code = mb_substr($base, 0, self::MAX_CODE_LENGTH - mb_strlen($tag)).$tag;
             ++$suffix;
         }
 
@@ -136,7 +159,7 @@ final class OptionAutoCreator
     }
 
     /**
-     * @return array{codes: array<string, true>, byLabel: array<string, string>, maxPosition: int}
+     * @return array{codes: array<string, string>, byLabel: array<string, string>, maxPosition: int}
      */
     private function indexFor(Attribute $attribute): array
     {
@@ -149,7 +172,7 @@ final class OptionAutoCreator
         $byLabel = [];
         $maxPosition = -1;
         foreach ($this->options->findByAttribute($attribute) as $option) {
-            $codes[$option->getCode()] = true;
+            $codes[mb_strtolower($option->getCode())] = $option->getCode();
             foreach ($option->getLabel() as $label) {
                 if ('' !== $label) {
                     $byLabel[mb_strtolower($label)] = $option->getCode();

--- a/apps/api/src/Import/Domain/Entity/ImportProfile.php
+++ b/apps/api/src/Import/Domain/Entity/ImportProfile.php
@@ -80,6 +80,12 @@ class ImportProfile extends AggregateRoot implements TenantScoped
      */
     private ?int $allowedErrorsPct = null;
 
+    /**
+     * #1718 — opt-in: mint missing select/multiselect options during import
+     * instead of failing rows with unknown values. Default false (strict).
+     */
+    private bool $createMissingOptions = false;
+
     private ?DateTimeImmutable $lastUsedAt = null;
 
     private DateTimeImmutable $createdAt;
@@ -276,6 +282,16 @@ class ImportProfile extends AggregateRoot implements TenantScoped
     public function setAllowedErrorsPct(?int $allowedErrorsPct): void
     {
         $this->allowedErrorsPct = $allowedErrorsPct;
+    }
+
+    public function createMissingOptions(): bool
+    {
+        return $this->createMissingOptions;
+    }
+
+    public function setCreateMissingOptions(bool $createMissingOptions): void
+    {
+        $this->createMissingOptions = $createMissingOptions;
     }
 
     public function getLastUsedAt(): ?DateTimeImmutable

--- a/apps/api/src/Import/Domain/Entity/ImportSession.php
+++ b/apps/api/src/Import/Domain/Entity/ImportSession.php
@@ -54,6 +54,14 @@ class ImportSession extends AggregateRoot implements TenantScoped
     /** IMP2-1.13 — media source for Asset cells: http | zip | none. */
     private string $imageSource = ImportImageSource::None->value;
 
+    /**
+     * #1718 — when true, the run mints a new AttributeOption for any
+     * select/multiselect value matching no existing option (by code or label)
+     * instead of failing the row. Opt-in (data governance); default false
+     * preserves the strict "unknown option = error" behaviour.
+     */
+    private bool $createMissingOptions = false;
+
     private ObjectType $targetObjectType;
 
     private string $status = ImportSessionStatus::Pending->value;
@@ -216,6 +224,16 @@ class ImportSession extends AggregateRoot implements TenantScoped
     public function setImageSource(ImportImageSource $imageSource): void
     {
         $this->imageSource = $imageSource->value;
+    }
+
+    public function createMissingOptions(): bool
+    {
+        return $this->createMissingOptions;
+    }
+
+    public function setCreateMissingOptions(bool $createMissingOptions): void
+    {
+        $this->createMissingOptions = $createMissingOptions;
     }
 
     public function getTargetObjectType(): ObjectType

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfileInput.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfileInput.php
@@ -62,4 +62,11 @@ final class ImportProfileInput
      */
     #[Assert\Range(min: 0, max: 100)]
     public ?int $allowedErrorsPct = null;
+
+    /**
+     * #1718 — mint missing select/multiselect options during import instead of
+     * failing rows with unknown values. null = leave the profile's flag
+     * unchanged on PATCH (defaults to false on create).
+     */
+    public ?bool $createMissingOptions = null;
 }

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfilePatchInput.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/Resource/ImportProfilePatchInput.php
@@ -43,4 +43,10 @@ final class ImportProfilePatchInput
      */
     #[Assert\Range(min: 0, max: 100)]
     public ?int $allowedErrorsPct = null;
+
+    /**
+     * #1718 — mint missing select/multiselect options during import. null in a
+     * merge-patch means "leave unchanged".
+     */
+    public ?bool $createMissingOptions = null;
 }

--- a/apps/api/src/Import/Infrastructure/ApiPlatform/State/ImportProfileProcessor.php
+++ b/apps/api/src/Import/Infrastructure/ApiPlatform/State/ImportProfileProcessor.php
@@ -111,6 +111,9 @@ final readonly class ImportProfileProcessor implements ProcessorInterface
                 $profile->setImageSource($source);
             }
         }
+        if (null !== $data->createMissingOptions) {
+            $profile->setCreateMissingOptions($data->createMissingOptions);
+        }
         $this->profiles->save($profile);
 
         return $profile;
@@ -166,6 +169,9 @@ final readonly class ImportProfileProcessor implements ProcessorInterface
         }
         if (null !== $data->allowedErrorsPct) {
             $profile->setAllowedErrorsPct($data->allowedErrorsPct);
+        }
+        if (null !== $data->createMissingOptions) {
+            $profile->setCreateMissingOptions($data->createMissingOptions);
         }
 
         $this->profiles->save($profile);

--- a/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportProfile.orm.xml
+++ b/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportProfile.orm.xml
@@ -67,6 +67,12 @@
 
         <field name="allowedErrorsPct" type="integer" column="allowed_errors_pct" nullable="true"/>
 
+        <field name="createMissingOptions" type="boolean" column="create_missing_options">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+
         <field name="lastUsedAt" type="datetime_immutable" column="last_used_at" nullable="true"/>
         <field name="createdAt" type="datetime_immutable" column="created_at"/>
 

--- a/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
+++ b/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
@@ -38,6 +38,12 @@
             </options>
         </field>
 
+        <field name="createMissingOptions" type="boolean" column="create_missing_options">
+            <options>
+                <option name="default">false</option>
+            </options>
+        </field>
+
         <many-to-one field="targetObjectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
             <join-column name="target_object_type_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
         </many-to-one>

--- a/apps/api/src/Import/Infrastructure/Serializer/ImportProfile.xml
+++ b/apps/api/src/Import/Infrastructure/Serializer/ImportProfile.xml
@@ -54,6 +54,10 @@
             <group>import_profile:read</group>
             <group>import_profile:write</group>
         </attribute>
+        <attribute name="createMissingOptions">
+            <group>import_profile:read</group>
+            <group>import_profile:write</group>
+        </attribute>
         <attribute name="lastUsedAt">
             <group>import_profile:read</group>
         </attribute>

--- a/apps/api/src/Import/Presentation/Controller/StartImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/StartImportController.php
@@ -241,6 +241,11 @@ final class StartImportController
                 ? ImportImageSource::Zip
                 : (ImportImageSource::tryFrom((string) $request->request->get('image_source', 'none')) ?? ImportImageSource::None),
         );
+        // #1718 — opt-in: mint missing select/multiselect options during the
+        // run. Explicit form flag wins; otherwise inherit the saved profile.
+        $session->setCreateMissingOptions(
+            $this->resolveCreateMissingOptions($request->request->get('create_missing_options'), $profile),
+        );
         if ($backup instanceof Backup) {
             $session->setBackupSnapshot($backup);
         }
@@ -528,6 +533,15 @@ final class StartImportController
         }
 
         return $profile?->getMode() ?? ImportMode::Upsert;
+    }
+
+    private function resolveCreateMissingOptions(mixed $raw, ?ImportProfile $profile): bool
+    {
+        if (\is_string($raw) && '' !== $raw) {
+            return \in_array(strtolower($raw), ['1', 'true', 'yes', 'on'], true);
+        }
+
+        return $profile?->createMissingOptions() ?? false;
     }
 
     private function resolveMatchAttributeCode(mixed $raw, ?ImportProfile $profile, Tenant $tenant): ?string

--- a/apps/api/tests/Api/Import/CreateMissingOptionsImportTest.php
+++ b/apps/api/tests/Api/Import/CreateMissingOptionsImportTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Import\Application\Handler\ImportRunHandler;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportSessionStatus;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * #1718 — the gated `createMissingOptions` flag mints select/multiselect
+ * options for unknown import values instead of failing the row.
+ *
+ * The run handler is driven directly (the same in-process pattern the batch
+ * throttle test uses) so the assertions never touch the JWT/auth layer. The
+ * `color` select attribute already owns one option, so the membership
+ * validator is active and an unknown label is genuinely rejected unless the
+ * flag mints it.
+ */
+final class CreateMissingOptionsImportTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function flagOnMintsMissingOptionAndWritesValue(): void
+    {
+        $sessionId = $this->runImport(createMissingOptions: true, sku: 'CMO-1');
+
+        $em = $this->em();
+        self::getContainer()->get(TenantContext::class)->set($this->tenant());
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(ImportSessionStatus::Success, $session->getStatus());
+        self::assertSame(1, $session->getSuccessCount());
+        self::assertSame(0, $session->getErrorCount(), 'unknown option is minted, not an error');
+
+        $conn = $em->getConnection();
+        $mintedCode = $conn->fetchOne(
+            "SELECT o.code FROM attribute_options o JOIN attributes a ON a.id = o.attribute_id WHERE a.code = 'color' AND o.code = 'bezowy'",
+        );
+        self::assertSame('bezowy', $mintedCode, 'a new option code was slugged from the Polish label');
+
+        $label = $conn->fetchOne("SELECT label FROM attribute_options WHERE code = 'bezowy'");
+        self::assertIsString($label);
+        self::assertStringContainsString('Beżowy', $label, 'minted option keeps the original label');
+
+        $value = $conn->fetchOne(
+            'SELECT ov.value::text FROM object_values ov '
+            .'JOIN objects obj ON obj.id = ov.object_id '
+            .'JOIN attributes a ON a.id = ov.attribute_id '
+            ."WHERE obj.code = 'CMO-1' AND a.code = 'color'",
+        );
+        self::assertIsString($value);
+        self::assertStringContainsString('bezowy', $value, 'the written value references the minted option code');
+    }
+
+    #[Test]
+    public function flagOffDoesNotMint(): void
+    {
+        $this->runImport(createMissingOptions: false, sku: 'CMO-2');
+
+        $em = $this->em();
+        self::getContainer()->get(TenantContext::class)->set($this->tenant());
+        $optionCount = $em->getConnection()->fetchOne(
+            "SELECT COUNT(*) FROM attribute_options o JOIN attributes a ON a.id = o.attribute_id WHERE a.code = 'color'",
+        );
+        self::assertSame(1, (int) (\is_scalar($optionCount) ? $optionCount : 0), 'no option minted when the flag is off (only the seeded one remains)');
+    }
+
+    private function runImport(bool $createMissingOptions, string $sku): Uuid
+    {
+        $tenant = $this->tenant();
+        $em = $this->em();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $product = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Select);
+        $skuAttr = new Attribute('sku', ['en' => 'SKU'], AttributeType::Text);
+        $nameAttr = new Attribute('name', ['en' => 'Name'], AttributeType::Text);
+        $em->persist($skuAttr);
+        $em->persist($nameAttr);
+        $em->persist($color);
+        // One pre-existing option keeps the membership validator active.
+        $em->persist(new AttributeOption($color, 'red', ['pl' => 'Czerwony'], 0));
+        $em->persist(new ObjectTypeAttribute($product, $skuAttr, false, 1));
+        $em->persist(new ObjectTypeAttribute($product, $nameAttr, false, 2));
+        $em->persist(new ObjectTypeAttribute($product, $color, false, 3));
+
+        $session = new ImportSession(
+            userId: Uuid::v7(),
+            targetObjectType: $product,
+            fileName: 'cmo.csv',
+            fileSizeBytes: 64,
+        );
+        $session->assignTenant($tenant);
+        $session->setColumnMapping(['sku' => 'sku', 'name' => 'name', 'color' => 'color']);
+        $session->setCreateMissingOptions($createMissingOptions);
+        $em->persist($session);
+        $em->flush();
+        $sessionId = $session->getId();
+
+        self::getContainer()->get('imports.storage')->write(
+            \sprintf('%s/%s/cmo.csv', $tenant->getId()->toRfc4122(), $sessionId->toRfc4122()),
+            \sprintf("sku;name;color\n%s;Botki;Beżowy\n", $sku),
+        );
+
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+        self::getContainer()->get(ImportRunHandler::class)->run($session);
+        $em->clear();
+
+        return $sessionId;
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Api/Import/ImportPauseResumeTest.php
+++ b/apps/api/tests/Api/Import/ImportPauseResumeTest.php
@@ -303,6 +303,7 @@ final class ImportPauseResumeTest extends CatalogApiTestCase
             rowReader: self::getContainer()->get(\App\Import\Application\Service\ImportRowReader::class),
             validator: self::getContainer()->get(\App\Import\Application\Service\ImportValidationService::class),
             creator: self::getContainer()->get(\App\Import\Application\Service\ImportObjectCreator::class),
+            optionAutoCreator: self::getContainer()->get(\App\Import\Application\Service\OptionAutoCreator::class),
             objectResolver: self::getContainer()->get(\App\Import\Application\Service\ObjectResolver::class),
             relationStep: self::getContainer()->get(\App\Import\Application\Service\RelationImportStep::class),
             undoLogger: self::getContainer()->get(\App\Import\Application\Service\ImportUndoLogger::class),

--- a/apps/api/tests/Api/Import/ImportRunHandlerRefreshTest.php
+++ b/apps/api/tests/Api/Import/ImportRunHandlerRefreshTest.php
@@ -138,6 +138,7 @@ final class ImportRunHandlerRefreshTest extends CatalogApiTestCase
             rowReader: self::getContainer()->get(\App\Import\Application\Service\ImportRowReader::class),
             validator: self::getContainer()->get(\App\Import\Application\Service\ImportValidationService::class),
             creator: self::getContainer()->get(\App\Import\Application\Service\ImportObjectCreator::class),
+            optionAutoCreator: self::getContainer()->get(\App\Import\Application\Service\OptionAutoCreator::class),
             objectResolver: self::getContainer()->get(\App\Import\Application\Service\ObjectResolver::class),
             relationStep: self::getContainer()->get(\App\Import\Application\Service\RelationImportStep::class),
             undoLogger: self::getContainer()->get(\App\Import\Application\Service\ImportUndoLogger::class),

--- a/apps/api/tests/Unit/Import/OptionAutoCreatorTest.php
+++ b/apps/api/tests/Unit/Import/OptionAutoCreatorTest.php
@@ -62,14 +62,62 @@ final class OptionAutoCreatorTest extends TestCase
     {
         $attr = new Attribute('material', ['en' => 'Material'], AttributeType::Select);
         $repo = new InMemoryAttributeOptionRepository();
-        // Existing option already owns the slug "skora" but a different label.
-        $repo->seed($attr, new AttributeOption($attr, 'skora', ['pl' => 'Skóra'], 0));
+        // Existing option already owns the slug "skora" but under a different
+        // (non-matching) label, and the incoming accented value neither equals
+        // the code case-insensitively nor matches the label — so it mints, and
+        // its slug collides with the taken "skora".
+        $repo->seed($attr, new AttributeOption($attr, 'skora', ['pl' => 'Materiał skórzany'], 0));
         $creator = new OptionAutoCreator($repo);
 
-        $code = $creator->resolve($attr, 'Skora', create: true);
+        $code = $creator->resolve($attr, 'Skóra', create: true);
 
         self::assertSame('skora_2', $code);
         self::assertSame(1, $repo->saved[0]->getPosition(), 'new option appends after the existing max position');
+    }
+
+    #[Test]
+    public function caseInsensitiveCodeMatchTakesPriorityOverCollidingLabel(): void
+    {
+        // Regression for the review hijack finding: option A has code 'l', option
+        // B carries the LABEL 'L'. Importing 'L' must resolve to code 'l' (the
+        // case-insensitive code match), never option B's code via the label.
+        $size = new Attribute('size', ['en' => 'Size'], AttributeType::Multiselect);
+        $repo = new InMemoryAttributeOptionRepository();
+        $repo->seed($size, new AttributeOption($size, 'l', ['pl' => 'Large'], 0));
+        $repo->seed($size, new AttributeOption($size, 'xl', ['pl' => 'L'], 1));
+        $creator = new OptionAutoCreator($repo);
+
+        self::assertSame('l', $creator->resolve($size, 'L', create: true));
+        self::assertCount(0, $repo->saved, 'an upper-cased existing code is matched, not minted');
+    }
+
+    #[Test]
+    public function clampsMintedCodeToColumnLength(): void
+    {
+        $attr = new Attribute('note', ['en' => 'Note'], AttributeType::Select);
+        $repo = new InMemoryAttributeOptionRepository();
+        $creator = new OptionAutoCreator($repo);
+
+        $code = $creator->resolve($attr, str_repeat('Bardzo długa wartość ', 10), create: true);
+
+        self::assertLessThanOrEqual(64, mb_strlen($code), 'minted code never exceeds the 64-char column');
+    }
+
+    #[Test]
+    public function stopsMintingPastThePerRunCeiling(): void
+    {
+        $attr = new Attribute('freeform', ['en' => 'Freeform'], AttributeType::Select);
+        $repo = new InMemoryAttributeOptionRepository();
+        $creator = new OptionAutoCreator($repo);
+
+        for ($i = 0; $i < 10_000; ++$i) {
+            $creator->resolve($attr, "value-{$i}", create: true);
+        }
+        // The 10001st distinct value is past the ceiling → returned raw, not minted.
+        $overflow = $creator->resolve($attr, 'one-too-many', create: true);
+
+        self::assertSame('one-too-many', $overflow);
+        self::assertCount(10_000, $repo->saved, 'minting is capped per run');
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Import/OptionAutoCreatorTest.php
+++ b/apps/api/tests/Unit/Import/OptionAutoCreatorTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
+use App\Import\Application\Service\OptionAutoCreator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class OptionAutoCreatorTest extends TestCase
+{
+    #[Test]
+    public function mintsMissingOptionWithSluggedPolishCode(): void
+    {
+        $repo = new InMemoryAttributeOptionRepository();
+        $creator = new OptionAutoCreator($repo);
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Select);
+
+        $code = $creator->resolve($color, 'Beżowy', create: true);
+
+        self::assertSame('bezowy', $code);
+        self::assertCount(1, $repo->saved);
+        self::assertSame('bezowy', $repo->saved[0]->getCode());
+        self::assertSame(['pl' => 'Beżowy'], $repo->saved[0]->getLabel());
+        self::assertSame(0, $repo->saved[0]->getPosition());
+    }
+
+    #[Test]
+    public function reusesExistingOptionMatchedByLabelCaseInsensitive(): void
+    {
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Select);
+        $repo = new InMemoryAttributeOptionRepository();
+        $repo->seed($color, new AttributeOption($color, 'bezowy', ['pl' => 'Beżowy'], 0));
+        $creator = new OptionAutoCreator($repo);
+
+        $code = $creator->resolve($color, 'BEŻOWY', create: true);
+
+        self::assertSame('bezowy', $code);
+        self::assertCount(0, $repo->saved, 'must not mint a duplicate when a label already matches');
+    }
+
+    #[Test]
+    public function reusesExistingOptionMatchedByCode(): void
+    {
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Select);
+        $repo = new InMemoryAttributeOptionRepository();
+        $repo->seed($color, new AttributeOption($color, 'red', ['pl' => 'Czerwony'], 0));
+        $creator = new OptionAutoCreator($repo);
+
+        self::assertSame('red', $creator->resolve($color, 'red', create: true));
+        self::assertCount(0, $repo->saved);
+    }
+
+    #[Test]
+    public function suffixesCodeOnSlugCollision(): void
+    {
+        $attr = new Attribute('material', ['en' => 'Material'], AttributeType::Select);
+        $repo = new InMemoryAttributeOptionRepository();
+        // Existing option already owns the slug "skora" but a different label.
+        $repo->seed($attr, new AttributeOption($attr, 'skora', ['pl' => 'Skóra'], 0));
+        $creator = new OptionAutoCreator($repo);
+
+        $code = $creator->resolve($attr, 'Skora', create: true);
+
+        self::assertSame('skora_2', $code);
+        self::assertSame(1, $repo->saved[0]->getPosition(), 'new option appends after the existing max position');
+    }
+
+    #[Test]
+    public function appendsSecondMintAfterFirstWithinSameRun(): void
+    {
+        $size = new Attribute('size', ['en' => 'Size'], AttributeType::Multiselect);
+        $repo = new InMemoryAttributeOptionRepository();
+        $creator = new OptionAutoCreator($repo);
+
+        self::assertSame('36', $creator->resolve($size, '36', create: true));
+        self::assertSame('37', $creator->resolve($size, '37', create: true));
+        self::assertSame([0, 1], array_map(static fn (AttributeOption $o): int => $o->getPosition(), $repo->saved));
+    }
+
+    #[Test]
+    public function returnsRawUnchangedWhenCreateDisabled(): void
+    {
+        $repo = new InMemoryAttributeOptionRepository();
+        $creator = new OptionAutoCreator($repo);
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Select);
+
+        self::assertSame('Beżowy', $creator->resolve($color, 'Beżowy', create: false));
+        self::assertCount(0, $repo->saved, 'create=false never mints');
+    }
+
+    #[Test]
+    public function resetDropsCacheSoFreshLookupRuns(): void
+    {
+        $color = new Attribute('color', ['en' => 'Color'], AttributeType::Select);
+        $repo = new InMemoryAttributeOptionRepository();
+        $creator = new OptionAutoCreator($repo);
+
+        $creator->resolve($color, 'Czerwony', create: true); // caches + mints "czerwony"
+        $repo->queryCount = 0;
+        $creator->reset();
+        $creator->resolve($color, 'Zielony', create: true);
+
+        self::assertSame(1, $repo->queryCount, 'reset() forces a fresh findByAttribute on next resolve');
+    }
+}
+
+/**
+ * Minimal in-memory double — records saves and serves seeded options.
+ */
+final class InMemoryAttributeOptionRepository implements AttributeOptionRepositoryInterface
+{
+    /** @var list<AttributeOption> */
+    public array $saved = [];
+
+    public int $queryCount = 0;
+
+    /** @var array<string, list<AttributeOption>> keyed by attribute id */
+    private array $byAttribute = [];
+
+    public function seed(Attribute $attribute, AttributeOption $option): void
+    {
+        $this->byAttribute[$attribute->getId()->toRfc4122()][] = $option;
+    }
+
+    public function findById(Uuid $id): ?AttributeOption
+    {
+        return null;
+    }
+
+    public function findByAttribute(Attribute $attribute): array
+    {
+        ++$this->queryCount;
+
+        return $this->byAttribute[$attribute->getId()->toRfc4122()] ?? [];
+    }
+
+    public function findCodesByAttribute(Attribute $attribute): array
+    {
+        return array_map(static fn (AttributeOption $o): string => $o->getCode(), $this->findByAttribute($attribute));
+    }
+
+    public function findByAttributes(array $attributes): array
+    {
+        return [];
+    }
+
+    public function save(AttributeOption $attributeOption): void
+    {
+        $this->saved[] = $attributeOption;
+        $this->byAttribute[$attributeOption->getAttribute()->getId()->toRfc4122()][] = $attributeOption;
+    }
+
+    public function remove(AttributeOption $attributeOption): void
+    {
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -17451,6 +17451,11 @@
                             "null"
                         ]
                     },
+                    "createMissingOptions": {
+                        "description": "#1718 \u2014 opt-in: mint missing select/multiselect options during import\ninstead of failing rows with unknown values. Default false (strict).",
+                        "default": false,
+                        "type": "boolean"
+                    },
                     "lastUsedAt": {
                         "readOnly": true,
                         "type": [
@@ -17557,6 +17562,13 @@
                             "integer",
                             "null"
                         ]
+                    },
+                    "createMissingOptions": {
+                        "description": "#1718 \u2014 mint missing select/multiselect options during import instead of\nfailing rows with unknown values. null = leave the profile's flag\nunchanged on PATCH (defaults to false on create).",
+                        "type": [
+                            "boolean",
+                            "null"
+                        ]
                     }
                 }
             },
@@ -17635,6 +17647,13 @@
                         "description": "IMP2-2.7 (#1483) \u2014 error-rate abort threshold (percent of processed\nrows). null in a merge-patch means \"leave unchanged\".",
                         "type": [
                             "integer",
+                            "null"
+                        ]
+                    },
+                    "createMissingOptions": {
+                        "description": "#1718 \u2014 mint missing select/multiselect options during import. null in a\nmerge-patch means \"leave unchanged\".",
+                        "type": [
+                            "boolean",
                             "null"
                         ]
                     }
@@ -17727,6 +17746,11 @@
                                     "integer",
                                     "null"
                                 ]
+                            },
+                            "createMissingOptions": {
+                                "description": "#1718 \u2014 opt-in: mint missing select/multiselect options during import\ninstead of failing rows with unknown values. Default false (strict).",
+                                "default": false,
+                                "type": "boolean"
                             },
                             "lastUsedAt": {
                                 "readOnly": true,


### PR DESCRIPTION
Closes #1718.

## Problem
Eksporty z systemów zewnętrznych (IdoSell/IAI, Shopify CSV) niosą wartości pól `select`/`multiselect` jako **etykiety** („Beżowy"), nie jako kody opcji. Dziś `SelectValidator` odrzuca każdą nieznaną wartość → wiersz pada. Brak jakiejkolwiek ścieżki tworzenia opcji w `src/Import`.

## Zmiana (gated, data governance — domyślnie OFF)
- Flaga **`createMissingOptions`** na `ImportProfile` + `ImportSession` (+ migracja `boolean NOT NULL DEFAULT false`).
- **`OptionAutoCreator`** — mapuje surową komórkę → kanoniczny `option_code`: dopasowanie po **kodzie** lub **etykiecie** (case-insensitive), a przy braku — mintuje `AttributeOption(code = slug(label), label {pl: label})`. Slug przez `AsciiSlugger` (`Beżowy→bezowy`), kolizja → sufiks `_2`. `save()` flushuje, więc walidacja zapisu (DB query) widzi nowy kod w tym samym runie.
- Wpięcie: `ImportObjectCreator` (Select + Multiselect) + `ImportRunHandler` przekazuje `session.createMissingOptions()` do `create()/update()`. Cache per-atrybut jako plain-data (przeżywa `EntityManager::clear()`), `reset()` na starcie runu (higiena worker mode).
- Flaga dociera z endpointu startu (`create_missing_options`, fallback do profilu) **oraz** z API `ImportProfile` (input + patch + serializer + OpenAPI regen).
- OFF → zachowanie bez zmian (nieznana opcja = błąd wiersza).

## Testy
- `OptionAutoCreatorTest` (7): slug PL, kolizja `_2`, match po kodzie/etykiecie, append pozycji, `create=false` no-op, `reset()`.
- `CreateMissingOptionsImportTest` (2, end-to-end przez `ImportRunHandler::run`): flaga ON → opcja `bezowy` zmintowana + wartość referuje kod + `errorCount=0`; OFF → brak mintu.
- PHPStan max + CS-fixer + migracja up/down zielone. OpenAPI spec zregenerowany.

## Świadome odejścia
- Auto-create **kategorii** ze ścieżki — osobny temat (CategoryNotFound pozostaje warningiem).
- Mintowanie flushuje per nową opcję (rzadkie); pełen batch-defer opcji = ewentualna optymalizacja.