### PR TITLE
feat(import): checkbox „Twórz brakujące opcje" w kreatorze (StepRules) + plumbing

### DIFF
--- a/apps/admin/e2e/1429-import-wizard-6-steps.spec.ts
+++ b/apps/admin/e2e/1429-import-wizard-6-steps.spec.ts
@@ -67,6 +67,13 @@ test('NUI-10 — wizard walks six steps and commits an import session', async ({
   // Step 5 — Reguły: truth card + disabled mode tiles.
   await expect(page.getByText(/upsert (po identyfikatorze|by identifier)/i)).toBeVisible();
   await expect(page.getByText('UPSERT', { exact: true })).toBeVisible();
+  // #1718 — the "create missing options" checkbox is real (not mocked); toggle it on.
+  const createOptions = page.getByRole('checkbox', {
+    name: /brakujące opcje|missing options/i,
+  });
+  await expect(createOptions).toBeVisible();
+  await createOptions.check();
+  await expect(createOptions).toBeChecked();
   await page.getByRole('button', { name: /dalej|next/i }).click();
 
   // Step 6 — Podgląd: dry-run resolves with KPIs.
@@ -85,6 +92,8 @@ test('NUI-10 — wizard walks six steps and commits an import session', async ({
     ),
     page.getByRole('button', { name: /uruchom import|run import/i }).click(),
   ]);
+  // #1718 — the opt-in flag toggled on the Reguły step reaches the start payload.
+  expect(commitResponse.request().postData() ?? '').toContain('create_missing_options');
   test.skip(
     commitResponse.status() === 409,
     'PROD-05 bulk lock held by a concurrent suite operation',

--- a/apps/admin/src/features/imports/hooks/useImportWizard.ts
+++ b/apps/admin/src/features/imports/hooks/useImportWizard.ts
@@ -68,6 +68,11 @@ export interface WizardState {
   emailNotification: boolean;
   /** IMP2-1.3 (#1465) — write strategy sent to POST /api/import-sessions. */
   mode: 'CREATE' | 'UPDATE' | 'UPSERT';
+  /**
+   * #1718 — when true, the run mints missing select/multiselect options
+   * instead of failing rows with unknown values. Opt-in (data governance).
+   */
+  createMissingOptions: boolean;
 }
 
 const INITIAL_STATE: WizardState = {
@@ -84,6 +89,7 @@ const INITIAL_STATE: WizardState = {
   targetObjectTypeId: null,
   mapping: {},
   mode: 'UPSERT',
+  createMissingOptions: false,
   suggestions: [],
   parsed: null,
   stagedFileId: null,
@@ -172,6 +178,7 @@ export function useImportWizard(): WizardController {
       stagedFileId: state.stagedFileId,
       doBackup: state.doBackup,
       emailNotification: state.emailNotification,
+      createMissingOptions: state.createMissingOptions,
     };
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
   }, [state]);

--- a/apps/admin/src/features/imports/wizard/StepConfirm.tsx
+++ b/apps/admin/src/features/imports/wizard/StepConfirm.tsx
@@ -66,6 +66,8 @@ export function StepConfirmPlaceholder({ wizard }: StepConfirmProps): React.Reac
       formData.set('backup_id', backupId);
     }
     formData.set('mode', state.mode);
+    // #1718 — opt-in: mint missing select/multiselect options during the run.
+    formData.set('create_missing_options', state.createMissingOptions ? '1' : '0');
     // IMP2-1.13 — image source + optional ZIP of images (was never sent before).
     formData.set('image_source', state.imageSource);
     if (state.imageSource === 'zip' && state.zipFile) {

--- a/apps/admin/src/features/imports/wizard/StepRules.tsx
+++ b/apps/admin/src/features/imports/wizard/StepRules.tsx
@@ -141,6 +141,36 @@ export function StepRules({ wizard }: StepRulesProps): React.ReactElement {
               </label>
             ))}
           </div>
+
+          <div className="mt-5 text-[13.5px] font-semibold">
+            {t('imports.rules.options_title', { defaultValue: 'Opcje słownikowe' })}
+          </div>
+          <div className="mt-0.5 text-[12px] text-zinc-500">
+            {t('imports.rules.options_subtitle', {
+              defaultValue: 'Co zrobić z wartościami select/multiselect spoza istniejącej listy',
+            })}
+          </div>
+          <label className="mt-3 flex cursor-pointer items-start gap-2.5 text-[12.5px]">
+            <input
+              type="checkbox"
+              checked={state.createMissingOptions}
+              onChange={(event) => setField('createMissingOptions', event.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded"
+            />
+            <span>
+              <span className="font-medium text-zinc-800">
+                {t('imports.rules.create_missing_options', {
+                  defaultValue: 'Twórz brakujące opcje (select/multiselect)',
+                })}
+              </span>
+              <span className="mt-0.5 block text-[11.5px] leading-relaxed text-zinc-500">
+                {t('imports.rules.create_missing_options_hint', {
+                  defaultValue:
+                    'Nieznane wartości zostaną dodane jako nowe opcje atrybutu (provenance: import). Domyślnie wyłączone — nieznana wartość kończy wiersz błędem.',
+                })}
+              </span>
+            </span>
+          </label>
         </div>
 
         <div className="relative rounded-2xl border border-zinc-100 bg-white p-5 shadow-sm">

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2474,7 +2474,11 @@
       "v_unique": "Identifier uniqueness (file + database)",
       "v_allowed": "Allowed values (select/multiselect)",
       "v_range": "Range check (numeric bounds)",
-      "v_regex": "Per-column regex (e.g. EAN ^[0-9]{13}$)"
+      "v_regex": "Per-column regex (e.g. EAN ^[0-9]{13}$)",
+      "options_title": "Dictionary options",
+      "options_subtitle": "What to do with select/multiselect values outside the existing list",
+      "create_missing_options": "Create missing options (select/multiselect)",
+      "create_missing_options_hint": "Unknown values are added as new attribute options (provenance: import). Off by default — an unknown value fails the row."
     },
     "computed": {
       "title": "New computed column",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2524,7 +2524,11 @@
       "v_unique": "Unikalność identyfikatora (plik + baza)",
       "v_allowed": "Dozwolone wartości (select/multiselect)",
       "v_range": "Range check (zakresy liczbowe)",
-      "v_regex": "Regex per kolumna (np. EAN ^[0-9]{13}$)"
+      "v_regex": "Regex per kolumna (np. EAN ^[0-9]{13}$)",
+      "options_title": "Opcje słownikowe",
+      "options_subtitle": "Co zrobić z wartościami select/multiselect spoza istniejącej listy",
+      "create_missing_options": "Twórz brakujące opcje (select/multiselect)",
+      "create_missing_options_hint": "Nieznane wartości zostaną dodane jako nowe opcje atrybutu (provenance: import). Domyślnie wyłączone — nieznana wartość kończy wiersz błędem."
     },
     "computed": {
       "title": "Nowa kolumna obliczona",


### PR DESCRIPTION
Closes #1721. Zależy od #1718 (zmergowany).

## Zmiana (FE)
Udostępnia flagę backendową `createMissingOptions` (#1718) jako **opt-in checkbox** na kroku „Reguły" kreatora importu. Domyślnie **odznaczony** (data governance).

- **`StepRules.tsx`** — nowa sekcja „Opcje słownikowe" z realnym (nie-mock) checkboxem + hint o konsekwencjach (provenance: import).
- **`useImportWizard.ts`** — pole `createMissingOptions` w stanie (default `false`), przenoszone przez `persist()` w round-tripie do `/modeling`.
- **`StepConfirm.tsx`** — `formData.set('create_missing_options', state.createMissingOptions ? '1' : '0')` w `POST /api/import-sessions`.
- **i18n** — `imports.rules.options_title|options_subtitle|create_missing_options|create_missing_options_hint` w `pl` i `en` (parytet zweryfikowany).

## Testy / bramki
- Playwright `1429-import-wizard-6-steps`: checkbox renderuje się, jest zaznaczalny (`toBeChecked`), a pole `create_missing_options` trafia do payloadu startu.
- `tsc --noEmit` 0, Biome strict 0, parytet locale pl/en OK.

## Świadome odejścia
- „Zapisz jako profil" w obecnym flow nie POST-uje ustawień profilu z kroku Reguły — backend (#1718) już przyjmuje `createMissingOptions` na API `ImportProfile`, więc gdy save-as-profile zostanie podłączony, flaga pojedzie bez zmian BE.