### PR TITLE
docs(import): skrypt transform IdoSell/IAI → CSV PIM + runbook importu estetino

### DIFF
--- a/docs/runbook/import-idosell-estetino.md
+++ b/docs/runbook/import-idosell-estetino.md
@@ -1,0 +1,103 @@
+# Runbook — import produktów z eksportu IdoSell/IAI (estetino)
+
+Procedura A→Z importu pliku eksportu IdoSell/IAI (np.
+`products_export-estetino.pl-2026-06-23_22.29.csv`) do PIM **bez błędu**, z
+auto-utworzeniem brakujących opcji select, pobraniem zdjęć z URL i obsługą
+wielu wartości upakowanych w jednej komórce.
+
+## Dlaczego potrzebny jest transform
+
+Eksport IdoSell jest **EAV-pivoted**: wszystkie parametry produktu (Marka,
+Kolor, Materiał…) siedzą w dwóch równoległych kolumnach
+(`/parameters/parameter@name[pol]` + `/parameters/parameter/value@name[pol]`,
+listy rozdzielone `\n`, wyrównane pozycyjnie), a nie jako osobne kolumny.
+Importer PIM mapuje **kolumna → atrybut**, więc nie rozczyta tego wprost.
+`tools/transform-idosell.py` un-pivotuje parametry na osobne kolumny i mapuje
+stałe pola IdoSell na kody atrybutów PIM, odrzucając ~230 kolumn-szumu.
+
+Wsparcie wbudowane w importer:
+- **newline jako separator multi-value** (#1719) — `rozmiar`/kategorie z `\n`.
+- **auto-create opcji select/multiselect** za flagą profilu/sesji (#1718).
+- **pobieranie zdjęć z URL** (Asset, `AssetUrlResolver` tokenizuje po whitespace/`|`).
+
+## Krok 0 — Pre-flight
+
+- Stack up: `docker compose ps` — wszystkie healthy. **Worker musi być `Up`,
+  nie `Restarting`** — pobranie zdjęć jest dispatchowane async na transport
+  `import`; bez workera obrazy nie wejdą. W razie pętli restartów:
+  `docker compose restart worker`.
+- Login: `admin@demo.localhost` / `changeme` na `https://pim.localhost`.
+
+## Krok 1 — Model: atrybuty na ObjectType „Produkt"
+
+Importer tworzy *opcje*, ale **nie tworzy atrybutów**. Na ObjectType Product
+muszą istnieć atrybuty o kodach = nagłówkach transformu. Utwórz przez
+Modelowanie (UI) lub seed/API. Opcje select/multiselect **zostaw puste** —
+wypełni je auto-create przy imporcie.
+
+| Kod | Typ | Uwagi |
+|---|---|---|
+| `name` (`name.pl`) | text | zwykle już jest |
+| `short_description` | textarea | |
+| `description` | wysiwyg | HTML z IdoSell |
+| `cena` | price | envelope `{amount, currency}` (`331.50 PLN`) |
+| `rozmiar` | multiselect | `36\|37\|…` — opcje auto-create |
+| `zdjecia` | asset | URL-e pobierane z HTTP |
+| `marka` | select | |
+| `kolor` | select | |
+| `material` | select | |
+| `material_wkladki` | select | |
+| `wysokosc_obcasa` | number | |
+| `obwod_cholewki` | number | |
+| `wysokosc_cholewki` | number | |
+| `symbol_producenta` | text | |
+
+Kategoria `Buty damskie/Botki` (kolumna `__category__`): utwórz ją raz w UI,
+albo zaakceptuj że nieznana kategoria = **warning** (wiersz i tak wejdzie,
+import się nie wywróci). Importer nie tworzy kategorii ze ścieżki.
+
+## Krok 2 — Transform
+
+```bash
+python3 tools/transform-idosell.py \
+  "Zrodla/importy/products_export-estetino.pl-2026-06-23_22.29.csv"
+# → Zrodla/importy/products_export-estetino.pl-2026-06-23_22.29-pim.csv
+```
+
+Skrypt loguje na stderr parametry spoza słownika `PARAM_TO_CODE` (slugowane
+generycznie) — uzupełnij mapę i dodaj odpowiadający atrybut, jeśli któryś
+ma trafić jako osobna kolumna.
+
+## Krok 3 — Kreator importu
+
+`https://pim.localhost/integrations/imports/new`:
+
+1. **Dane** → kafel „Produkty".
+2. **Źródło** → upload `…-pim.csv`. Źródło zdjęć: **HTTP**.
+3. **Wykrywanie** → UTF-8, przecinek (auto).
+4. **Mapowanie** → auto-map trafia po kodzie (nagłówki = kody atrybutów);
+   `__category__` zostaje jako reserved target.
+5. **Reguły** → tryb **UPSERT**, match key **`sku`**, zaznacz
+   **„Twórz brakujące opcje (select/multiselect)"**.
+6. **Podgląd** → dry-run: 0 błędów blokujących (nieznane opcje select NIE są
+   walidowane na dry-run — sprawdzane przy zapisie, gdzie auto-create je tworzy).
+7. **Start** → commit → strona sesji (progress przez Mercure).
+
+## Krok 4 — Weryfikacja (smoke test)
+
+- **Network DevTools**: `parse-preview` / `validate-dry-run` /
+  `POST /api/import-sessions` = 200/201.
+- **Katalog**: produkt `BD-KOW-ZAMSZ-TAUPE` „Botki kowbojki zamszowe beżowe
+  Butdam": `cena = 331,50 PLN`, `rozmiar` = 36–41 (6 opcji),
+  select `kolor=Beżowy` / `material` / `marka` **z auto-utworzonymi opcjami**,
+  number wysokość/obwód, `zdjecia` = 4 assety pobrane z URL (po przejściu
+  kolejki workera).
+- **DevTools Console**: brak czerwonych błędów.
+- **Raport sesji** (`/report.csv`): 1 wiersz, status created/updated, 0 errors.
+
+## Świadome ograniczenia
+
+- Stock per rozmiar, ceny POS/hurt/marketplace, hotspots, `responsible_entity`
+  — pomijane (poza modelem PIM dla tego scope).
+- Rozmiary jako multiselect, nie warianty — brak osobnych SKU per rozmiar.
+- Auto-create kategorii ze ścieżki poza zakresem — kategoria ręcznie.

--- a/tools/transform-idosell.py
+++ b/tools/transform-idosell.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Transform an IdoSell/IAI product export CSV into a PIM-native, column-per-
+attribute CSV the import wizard can map 1:1 by attribute code.
+
+The IdoSell export is EAV-pivoted: every product parameter lives in two
+parallel newline-lists (``/parameters/parameter@name[pol]`` and
+``/parameters/parameter/value@name[pol]``), aligned by position. The PIM
+importer maps one column to one attribute, so it cannot read that shape. This
+script un-pivots the parameters into their own columns, maps the fixed IdoSell
+fields to PIM attribute codes, and drops the ~230 IdoSell-only columns.
+
+Usage:
+    python3 tools/transform-idosell.py INPUT.csv [OUTPUT.csv]
+
+Defaults OUTPUT to ``INPUT-pim.csv``. Multi-value cells (sizes, image URLs)
+are joined with ``|`` — the importer accepts pipe and newline (#1719).
+Select/multiselect VALUES stay as human labels; an import run with
+"create missing options" (#1718) mints the options on the fly.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+import unicodedata
+from pathlib import Path
+
+# IdoSell parameter name (pol) -> PIM attribute code. Anything not listed is
+# slugged generically and reported on stderr so the map can be extended.
+PARAM_TO_CODE: dict[str, str] = {
+    "Marka": "marka",
+    "Kolor": "kolor",
+    "Materiał": "material",
+    "Materiał wkładki": "material_wkladki",
+    "Wysokość obcasa (cm)": "wysokosc_obcasa",
+    "Obwód cholewki (cm)": "obwod_cholewki",
+    "Wysokość cholewki (cm)": "wysokosc_cholewki",
+    "Symbol producenta": "symbol_producenta",
+}
+
+# Fixed output columns (header order). Parameter columns are appended after
+# these, in the order their names first appear across the file.
+FIXED_COLUMNS = [
+    "sku",
+    "name.pl",
+    "short_description.pl",
+    "description.pl",
+    "cena",
+    "rozmiar",
+    "zdjecia",
+    "__category__",
+]
+
+
+def slugify(value: str) -> str:
+    """ASCII-fold + snake_case, matching how PIM attribute codes read."""
+    norm = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode()
+    slug = "".join(ch if ch.isalnum() else "_" for ch in norm.lower()).strip("_")
+    while "__" in slug:
+        slug = slug.replace("__", "_")
+    return slug or "param"
+
+
+def split_lines(cell: str | None) -> list[str]:
+    return [part.strip() for part in (cell or "").split("\n") if part.strip()]
+
+
+def join_multi(cell: str | None) -> str:
+    return "|".join(split_lines(cell))
+
+
+def transform(src: Path, dst: Path) -> None:
+    with src.open(encoding="utf-8", newline="") as fh:
+        rows = list(csv.DictReader(fh))
+
+    unknown_params: set[str] = set()
+    param_codes_order: list[str] = []
+    out_rows: list[dict[str, str]] = []
+
+    for row in rows:
+        out: dict[str, str] = {
+            "sku": (row.get("@code_producer") or "").strip(),
+            "name.pl": (row.get("/description/name[pol]") or "").strip(),
+            "short_description.pl": (row.get("/description/short_desc[pol]") or "").strip(),
+            "description.pl": (row.get("/description/long_desc[pol]") or "").strip(),
+            "rozmiar": join_multi(row.get("/sizes/size@name")),
+            "zdjecia": join_multi(row.get("/images/large/image@url")),
+            "__category__": (row.get("/category@name[pol]") or "").strip(),
+        }
+
+        gross = (row.get("/price@gross") or "").strip()
+        currency = (row.get("@currency") or "").strip()
+        out["cena"] = f"{gross} {currency}".strip() if gross else ""
+
+        # Un-pivot parameters: positionally align the name-list with the value-list.
+        names = split_lines(row.get("/parameters/parameter@name[pol]"))
+        values = split_lines(row.get("/parameters/parameter/value@name[pol]"))
+        for name, value in zip(names, values):
+            code = PARAM_TO_CODE.get(name)
+            if code is None:
+                code = slugify(name)
+                unknown_params.add(f"{name} -> {code}")
+            if code not in param_codes_order and code not in FIXED_COLUMNS:
+                param_codes_order.append(code)
+            out[code] = value
+
+        # Fallback: producer name fills "marka" when there is no Marka parameter.
+        if not out.get("marka"):
+            producer = (row.get("/producer@name") or "").strip()
+            if producer:
+                out["marka"] = producer
+                if "marka" not in param_codes_order:
+                    param_codes_order.append("marka")
+
+        out_rows.append(out)
+
+    header = FIXED_COLUMNS + param_codes_order
+    with dst.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=header, extrasaction="ignore")
+        writer.writeheader()
+        for out in out_rows:
+            writer.writerow({col: out.get(col, "") for col in header})
+
+    print(f"Wrote {len(out_rows)} row(s) x {len(header)} columns -> {dst}")
+    print("Columns:", ", ".join(header))
+    if unknown_params:
+        print("\nParameters not in the known map (slugged generically):", file=sys.stderr)
+        for entry in sorted(unknown_params):
+            print(f"  - {entry}", file=sys.stderr)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit(f"usage: {sys.argv[0]} INPUT.csv [OUTPUT.csv]")
+    src = Path(sys.argv[1])
+    dst = Path(sys.argv[2]) if len(sys.argv) > 2 else src.with_name(f"{src.stem}-pim.csv")
+    transform(src, dst)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1720.

## Co
- **`tools/transform-idosell.py`** — un-pivotuje eksport IdoSell/IAI (parametry w dwóch równoległych newline-listach) do **CSV natywnego dla PIM** (kolumna-na-atrybut), który kreator mapuje 1:1 po kodzie atrybutu. Mapuje stałe pola (sku, name.pl, cena, rozmiar, zdjecia, opisy, `__category__`) + un-pivot parametrów (marka, kolor, materiał, wymiary…). Odrzuca ~230 kolumn-szumu IdoSell. Loguje parametry spoza słownika.
- **`docs/runbook/import-idosell-estetino.md`** — procedura A→Z: pre-flight (worker!), model (~14 atrybutów na Product), transform, kreator (UPSERT + match key `sku` + ✔ Twórz brakujące opcje + Image source HTTP), weryfikacja.

## Lokalizacja
Ticket pierwotnie wskazywał `Zrodla/importy/` — ten katalog jest **`.gitignore`** (lokalny staging operatora). Przeniosłem do trackowanych: skrypt → `tools/` (jak `tools/create-rbac-issues.py`), runbook → `docs/runbook/`.

## Weryfikacja
`python3 tools/transform-idosell.py <plik estetino>` → 1 wiersz × 16 kolumn; `sku=BD-KOW-ZAMSZ-TAUPE`, `cena=331.50 PLN`, `rozmiar=36\|37\|38\|39\|40\|41`, 4 URL-e zdjęć, wszystkie selecty jako etykiety (opcje domknie auto-create przy imporcie, #1718).

Zależy operacyjnie od zmergowanych #1718 (auto-opcje) + #1719 (newline) + #1721 (checkbox).