### PR TITLE
feat(import): zaimportowane zdjęcia trafiają do folderu obiektu w DAM (folderCode)

### DIFF
--- a/apps/api/src/Asset/Application/AssetIngestor.php
+++ b/apps/api/src/Asset/Application/AssetIngestor.php
@@ -40,7 +40,7 @@ final readonly class AssetIngestor implements AssetIngestorInterface
     ) {
     }
 
-    public function ingest(string $absolutePath, string $originalFilename): AssetIngestResult
+    public function ingest(string $absolutePath, string $originalFilename, ?string $folderCode = null): AssetIngestResult
     {
         $extension = $this->sniffExtension($absolutePath, $originalFilename);
 
@@ -77,7 +77,7 @@ final readonly class AssetIngestor implements AssetIngestorInterface
             if (!copy($absolutePath, $staged)) {
                 throw new RuntimeException(\sprintf('Failed to stage media file "%s".', $absolutePath));
             }
-            $asset = $this->uploader->upload(new File($staged));
+            $asset = $this->uploader->upload(new File($staged), folderCode: $folderCode);
 
             return new AssetIngestResult($asset->getId(), false);
         } catch (DuplicateAssetException $exception) {

--- a/apps/api/src/Asset/Contracts/AssetIngestorInterface.php
+++ b/apps/api/src/Asset/Contracts/AssetIngestorInterface.php
@@ -23,10 +23,14 @@ interface AssetIngestorInterface
     /**
      * Validate + dedup + store the binary at $absolutePath.
      *
-     * @param string $absolutePath     local path to the already-fetched bytes
-     * @param string $originalFilename filename to record on the Asset (e.g. URL basename)
+     * @param string  $absolutePath     local path to the already-fetched bytes
+     * @param string  $originalFilename filename to record on the Asset (e.g. URL basename)
+     * @param ?string $folderCode       logical library folder for a NEWLY stored asset
+     *                                  (e.g. `product-<uuid>` so imported images land in the
+     *                                  object's folder, matching manual upload). A content-hash
+     *                                  dedup hit keeps the existing asset's folder.
      *
      * @throws UnsupportedMediaFormatException when the bytes are not jpg/png/webp
      */
-    public function ingest(string $absolutePath, string $originalFilename): AssetIngestResult;
+    public function ingest(string $absolutePath, string $originalFilename, ?string $folderCode = null): AssetIngestResult;
 }

--- a/apps/api/src/Import/Application/Handler/ImageDownloadHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImageDownloadHandler.php
@@ -230,6 +230,17 @@ final class ImageDownloadHandler extends AbstractBatchHandler
     }
 
     /**
+     * E1 (#1727) — imported images land in the target object's library folder,
+     * matching the manual product upload convention (`product-<objectId>`), so
+     * they are browsable under the object's folder instead of the library root.
+     * A content-hash dedup hit keeps the already-stored asset's folder.
+     */
+    private function folderCodeFor(ImageDownloadJob $job): string
+    {
+        return 'product-'.$job->objectId;
+    }
+
+    /**
      * @param list<array{job: ImageDownloadJob, type: ImportErrorType, message: string, value: string}> $pendingLogs by ref
      */
     private function fetchAndIngest(ImageDownloadJob $job, string $url, array &$pendingLogs): ?string
@@ -276,7 +287,7 @@ final class ImageDownloadHandler extends AbstractBatchHandler
                 fclose($handle);
             }
 
-            return $this->assetIngestor->ingest($localPath, $this->filenameFor($url))->assetId->toRfc4122();
+            return $this->assetIngestor->ingest($localPath, $this->filenameFor($url), $this->folderCodeFor($job))->assetId->toRfc4122();
         } catch (UnsupportedMediaFormatException $exception) {
             $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageFormatUnsupported, 'message' => \sprintf('URL "%s": %s', $url, $exception->getMessage()), 'value' => $url];
 
@@ -409,7 +420,7 @@ final class ImageDownloadHandler extends AbstractBatchHandler
                 return null;
             }
 
-            return $this->assetIngestor->ingest($tmp, $name)->assetId->toRfc4122();
+            return $this->assetIngestor->ingest($tmp, $name, $this->folderCodeFor($job))->assetId->toRfc4122();
         } catch (UnsupportedMediaFormatException $exception) {
             $pendingLogs[] = ['job' => $job, 'type' => ImportErrorType::ImageFormatUnsupported, 'message' => \sprintf('ZIP entry "%s": %s', $name, $exception->getMessage()), 'value' => $name];
 

--- a/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
+++ b/apps/api/tests/Api/Import/ImageDownloadHandlerTest.php
@@ -81,6 +81,10 @@ final class ImageDownloadHandlerTest extends CatalogApiTestCase
 
         $assetId = $em->getConnection()->fetchOne('SELECT id FROM assets ORDER BY created_at DESC LIMIT 1');
         self::assertIsString($assetId);
+        // E1 (#1727) — the imported image lands in the object's library folder
+        // (`product-<objectId>`), matching the manual product upload convention.
+        $folder = $em->getConnection()->fetchOne('SELECT folder_code FROM assets WHERE id = :id', ['id' => $assetId]);
+        self::assertSame('product-'.$objectId, $folder, 'imported image is filed under the object folder');
         $links = $em->getConnection()->fetchOne('SELECT COUNT(*) FROM product_assets WHERE product_id = :p', ['p' => $objectId]);
         self::assertSame(1, (int) (\is_scalar($links) ? $links : 0), 'asset linked to the product');
         $envelope = $em->getConnection()->fetchOne(


### PR DESCRIPTION
Closes #1727.

## Problem
Import zdjęć z URL lądował w **korzeniu biblioteki** (`folderCode = NULL`), a manualny upload z karty produktu filuje je pod `product-<objectId>`. Te same media dla produktu były w dwóch różnych miejscach.

## Zmiana
- `AssetIngestorInterface::ingest()` + `AssetIngestor` — opcjonalny `?string $folderCode` przekazywany do `AssetUploader::upload()` (który już go obsługiwał).
- `ImageDownloadHandler` — przekazuje `folderCode = "product-<objectId>"` przy ingest (obie ścieżki: HTTP + ZIP).
- Dedup po content-hash zachowuje folder istniejącego assetu (idempotentnie — nie przenosi między folderami).

## Test
`ImageDownloadHandlerTest::downloadsLinksAndWritesEnvelope` — dochodzi asercja `folder_code = product-<objectId>`. PHPStan max + Deptrac (Import→Asset_Contracts) zielone.

## Świadome odejścia
Konwencja `product-<id>` + junction `product_assets` są dziś product-centryczne; pełna generalizacja folderów per-obiekt dla custom ObjectType = follow-up (#1729).