### PR TITLE
feat(import): auto-tworzenie brakujących atrybutów przy imporcie (gated, każdy ObjectType)

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2477,8 +2477,8 @@
       "v_regex": "Per-column regex (e.g. EAN ^[0-9]{13}$)",
       "options_title": "Dictionary options",
       "options_subtitle": "What to do with select/multiselect values outside the existing list",
-      "create_missing_options": "Create missing options (select/multiselect)",
-      "create_missing_options_hint": "Unknown values are added as new attribute options (provenance: import). Off by default — an unknown value fails the row."
+      "create_missing_options": "Create missing options and attributes",
+      "create_missing_options_hint": "Unknown select/multiselect values are added as new options, and mapped columns with no attribute in the model create a new attribute (provenance: import). Off by default — otherwise an unknown value fails the row and a column without an attribute is skipped."
     },
     "computed": {
       "title": "New computed column",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2527,8 +2527,8 @@
       "v_regex": "Regex per kolumna (np. EAN ^[0-9]{13}$)",
       "options_title": "Opcje słownikowe",
       "options_subtitle": "Co zrobić z wartościami select/multiselect spoza istniejącej listy",
-      "create_missing_options": "Twórz brakujące opcje (select/multiselect)",
-      "create_missing_options_hint": "Nieznane wartości zostaną dodane jako nowe opcje atrybutu (provenance: import). Domyślnie wyłączone — nieznana wartość kończy wiersz błędem."
+      "create_missing_options": "Twórz brakujące opcje i atrybuty",
+      "create_missing_options_hint": "Nieznane wartości select/multiselect zostaną dodane jako nowe opcje, a zmapowane kolumny bez atrybutu w modelu utworzą nowy atrybut (provenance: import). Domyślnie wyłączone — w przeciwnym razie nieznana wartość kończy wiersz błędem, a kolumna bez atrybutu jest pomijana."
     },
     "computed": {
       "title": "Nowa kolumna obliczona",

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -479,6 +479,13 @@ parameters:
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Entity\AttributeOption
             - App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface
+        # #1728 — attribute auto-create mints Attribute + ObjectTypeAttribute via
+        # the same Import→Catalog seam as ImportObjectCreator.
+        App\Import\Application\Service\AttributeAutoCreator:
+            - App\Catalog\Domain\AttributeType
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Entity\ObjectTypeAttribute
         # IMP2-2.4 — undo-log capture + rollback v2 reuse Catalog read/rebuild/
         # reindex via the same Import→Catalog seam as ImportObjectCreator.
         App\Import\Application\Service\ImportUndoLogger:

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -9,6 +9,7 @@ use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectCategory;
 use App\Catalog\Domain\ObjectKind;
+use App\Import\Application\Service\AttributeAutoCreator;
 use App\Import\Application\Service\ImportColumnGrammar;
 use App\Import\Application\Service\ImportObjectCreator;
 use App\Import\Application\Service\ImportProgressPublisher;
@@ -145,6 +146,7 @@ final class ImportRunHandler extends AbstractBatchHandler
         private readonly ImportValidationService $validator,
         private readonly ImportObjectCreator $creator,
         private readonly OptionAutoCreator $optionAutoCreator,
+        private readonly AttributeAutoCreator $attributeAutoCreator,
         private readonly ObjectResolver $objectResolver,
         private readonly RelationImportStep $relationStep,
         private readonly ImportUndoLogger $undoLogger,
@@ -204,9 +206,10 @@ final class ImportRunHandler extends AbstractBatchHandler
      */
     public function run(ImportSession $session): void
     {
-        // #1718 — drop any option lookup/mint cache from a previous run on this
-        // long-lived worker before processing a fresh file (cross-run hygiene).
+        // #1718 / #1728 — drop any option/attribute mint cache from a previous
+        // run on this long-lived worker before processing a fresh file.
         $this->optionAutoCreator->reset();
+        $this->attributeAutoCreator->reset();
 
         // Streaming + per-row Doctrine flushes scale with file size.
         // A 100-row XLSX easily exceeds FrankenPHP's default 30s HTTP

--- a/apps/api/src/Import/Application/Service/AttributeAutoCreator.php
+++ b/apps/api/src/Import/Application/Service/AttributeAutoCreator.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * #1728 — mints a missing {@see Attribute} during an import run and attaches it
+ * to the target {@see ObjectType}, so a mapped column whose attribute code does
+ * not exist yet is created instead of silently dropped.
+ *
+ * Gated by the same opt-in as option auto-create (#1718,
+ * {@see \App\Import\Domain\Entity\ImportSession::createMissingOptions()}): off =
+ * the column stays unmapped (no value written), preserving prior behaviour.
+ *
+ * Works for ANY ObjectType (product, category, custom) — `ObjectTypeAttribute`
+ * is kind-agnostic. Type is inferred conservatively from the first value
+ * (numeric → Number, otherwise Text); select/multiselect are never guessed
+ * (a fresh Text/Number attribute carries no options). The operator can migrate
+ * the type afterwards.
+ *
+ * Minted attributes are cached by code per run (so a column mints once across
+ * all chunks) and the cache is reset per run for worker-mode hygiene; a per-run
+ * ceiling stops a mis-mapped column from minting unbounded attributes.
+ */
+final class AttributeAutoCreator
+{
+    /** Defensive ceiling: a mis-mapped column must not mint unbounded attributes. */
+    private const int MAX_CREATES_PER_RUN = 200;
+
+    /** @var array<string, Attribute> attribute code => minted attribute (this run) */
+    private array $created = [];
+
+    private int $createCount = 0;
+
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Drops the per-run cache + counter. The import handler calls this once at
+     * the start of each run.
+     */
+    public function reset(): void
+    {
+        $this->created = [];
+        $this->createCount = 0;
+    }
+
+    /**
+     * Returns the attribute already minted this run for $code, or mints a new
+     * one (type inferred from $sampleValue) attached to $objectType. Null once
+     * the per-run ceiling is hit — the caller then skips the column.
+     */
+    public function ensure(string $code, ObjectType $objectType, string $sampleValue): ?Attribute
+    {
+        if (isset($this->created[$code])) {
+            return $this->created[$code];
+        }
+        if ($this->createCount >= self::MAX_CREATES_PER_RUN) {
+            return null;
+        }
+
+        $label = $this->humanize($code);
+        $attribute = new Attribute($code, ['pl' => $label, 'en' => $label], $this->inferType($sampleValue));
+        $this->em->persist($attribute);
+        // Attach to the target ObjectType so the new attribute is part of its
+        // editable model. sortOrder is parked high so minted attributes sort
+        // after the curated ones.
+        $this->em->persist(new ObjectTypeAttribute($objectType, $attribute, false, 1000 + $this->createCount));
+        // One flush persists + tenant-stamps both rows and makes the attribute
+        // visible to the value-write validation in the same row. Safe because
+        // ImportObjectCreator builds writes BEFORE persisting the in-progress
+        // object (the #1718 ordering), so no half-built object is flushed.
+        $this->em->flush();
+
+        $this->created[$code] = $attribute;
+        ++$this->createCount;
+
+        return $attribute;
+    }
+
+    private function inferType(string $sampleValue): AttributeType
+    {
+        $normalised = str_replace(',', '.', trim($sampleValue));
+
+        return '' !== $normalised && is_numeric($normalised) ? AttributeType::Number : AttributeType::Text;
+    }
+
+    private function humanize(string $code): string
+    {
+        $words = trim(str_replace('_', ' ', $code));
+
+        return '' === $words ? $code : ucfirst($words);
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportObjectCreator.php
+++ b/apps/api/src/Import/Application/Service/ImportObjectCreator.php
@@ -39,6 +39,7 @@ final class ImportObjectCreator
         private readonly CompositeValueParser $compositeValueParser,
         private readonly AssetUrlResolver $assetUrlResolver,
         private readonly OptionAutoCreator $optionAutoCreator,
+        private readonly AttributeAutoCreator $attributeAutoCreator,
     ) {
     }
 
@@ -83,7 +84,7 @@ final class ImportObjectCreator
         // object — so a mint flush only commits already-complete prior rows plus
         // the new option, never this half-built object (#1718 review).
         $assetIssues = [];
-        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues, $createMissingOptions);
+        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues, $createMissingOptions, $objectType);
         $this->em->persist($object);
         // A freshly created object has no existing values, so the `changed`
         // count is irrelevant (a created row is never a no-op skip) — only the
@@ -166,7 +167,7 @@ final class ImportObjectCreator
         $this->applyState($object, $status, $enabled, $variantAxes);
 
         $assetIssues = [];
-        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues, $createMissingOptions);
+        $writes = $this->buildWrites($resolvedValues, $attributesByCode, $existingAssetIds, $assetIssues, $createMissingOptions, $object->getObjectType());
         $result = $this->valueWriter->writeMany($object, $writes, Provenance::Import);
 
         return [
@@ -189,7 +190,7 @@ final class ImportObjectCreator
      *
      * @return list<array{attribute: Attribute, envelope: array<string, mixed>, locale: ?string, channelId: ?Uuid}>
      */
-    private function buildWrites(array $resolvedValues, array $attributesByCode, array $existingAssetIds, array &$issues, bool $createMissingOptions): array
+    private function buildWrites(array $resolvedValues, array $attributesByCode, array $existingAssetIds, array &$issues, bool $createMissingOptions, ObjectType $objectType): array
     {
         $writes = [];
         foreach ($resolvedValues as $resolved) {
@@ -198,6 +199,12 @@ final class ImportObjectCreator
                 continue;
             }
             $attribute = $attributesByCode[$resolved->attributeCode] ?? null;
+            if (!$attribute instanceof Attribute && $createMissingOptions) {
+                // #1728 — the same opt-in mints a missing attribute (type
+                // inferred) attached to the target ObjectType, so a mapped
+                // column with no attribute yet is created, not dropped.
+                $attribute = $this->attributeAutoCreator->ensure($resolved->attributeCode, $objectType, $rawValue);
+            }
             if (!$attribute instanceof Attribute) {
                 continue;
             }

--- a/apps/api/tests/Api/Import/CreateMissingAttributesImportTest.php
+++ b/apps/api/tests/Api/Import/CreateMissingAttributesImportTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Import\Application\Handler\ImportRunHandler;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportSessionStatus;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Shared\Infrastructure\Doctrine\Filter\TenantFilterConfigurator;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * #1728 — the gated `createMissingOptions` flag also mints a missing Attribute
+ * (type inferred) attached to the target ObjectType, so a mapped column with no
+ * attribute in the model is created instead of dropped. Driven through the run
+ * handler directly (no JWT/auth layer), like the option-create test.
+ */
+final class CreateMissingAttributesImportTest extends CatalogApiTestCase
+{
+    #[Test]
+    public function flagOnMintsAttributesWithInferredTypeAndWritesValues(): void
+    {
+        $sessionId = $this->runImport(createMissingOptions: true, sku: 'CMA-1');
+
+        $em = $this->em();
+        self::getContainer()->get(TenantContext::class)->set($this->tenant());
+        $session = $em->find(ImportSession::class, $sessionId);
+        \assert($session instanceof ImportSession);
+        self::assertSame(ImportSessionStatus::Success, $session->getStatus());
+        self::assertSame(0, $session->getErrorCount());
+
+        $conn = $em->getConnection();
+        $textType = $conn->fetchOne("SELECT type FROM attributes WHERE code = 'symbol_producenta'");
+        self::assertSame('text', $textType, 'non-numeric column → text attribute');
+        $numberType = $conn->fetchOne("SELECT type FROM attributes WHERE code = 'obwod_cholewki'");
+        self::assertSame('number', $numberType, 'all-numeric column → number attribute (inferred)');
+
+        // Both minted attributes are attached to the target (product) ObjectType.
+        $attached = $conn->fetchOne(
+            'SELECT COUNT(*) FROM object_type_attributes ota '
+            .'JOIN attributes a ON a.id = ota.attribute_id '
+            .'JOIN object_types ot ON ot.id = ota.object_type_id '
+            ."WHERE ot.kind = 'product' AND a.code IN ('symbol_producenta', 'obwod_cholewki')",
+        );
+        self::assertSame(2, (int) (\is_scalar($attached) ? $attached : 0), 'minted attributes attached to the ObjectType');
+
+        $value = $conn->fetchOne(
+            'SELECT ov.value::text FROM object_values ov '
+            .'JOIN objects obj ON obj.id = ov.object_id '
+            .'JOIN attributes a ON a.id = ov.attribute_id '
+            ."WHERE obj.code = 'CMA-1' AND a.code = 'symbol_producenta'",
+        );
+        self::assertIsString($value);
+        self::assertStringContainsString('KOW-ZAMSZ', $value, 'value written to the minted attribute');
+    }
+
+    #[Test]
+    public function flagOffDoesNotMintAttributes(): void
+    {
+        $this->runImport(createMissingOptions: false, sku: 'CMA-2');
+
+        $em = $this->em();
+        self::getContainer()->get(TenantContext::class)->set($this->tenant());
+        $count = $em->getConnection()->fetchOne(
+            "SELECT COUNT(*) FROM attributes WHERE code IN ('symbol_producenta', 'obwod_cholewki')",
+        );
+        self::assertSame(0, (int) (\is_scalar($count) ? $count : 0), 'no attribute minted when the flag is off');
+    }
+
+    private function runImport(bool $createMissingOptions, string $sku): Uuid
+    {
+        $tenant = $this->tenant();
+        $em = $this->em();
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        $product = self::getContainer()->get(ObjectTypeRepositoryInterface::class)
+            ->findBuiltInByKind(ObjectKind::Product, $tenant);
+        \assert($product instanceof ObjectType);
+
+        $session = new ImportSession(
+            userId: Uuid::v7(),
+            targetObjectType: $product,
+            fileName: 'cma.csv',
+            fileSizeBytes: 64,
+        );
+        $session->assignTenant($tenant);
+        // symbol_producenta + obwod_cholewki do not exist in the model → minted
+        // when the flag is on (text + number by inference).
+        $session->setColumnMapping([
+            'sku' => 'sku',
+            'symbol_producenta' => 'symbol_producenta',
+            'obwod_cholewki' => 'obwod_cholewki',
+        ]);
+        $session->setCreateMissingOptions($createMissingOptions);
+        $em->persist($session);
+        $em->flush();
+        $sessionId = $session->getId();
+
+        self::getContainer()->get('imports.storage')->write(
+            \sprintf('%s/%s/cma.csv', $tenant->getId()->toRfc4122(), $sessionId->toRfc4122()),
+            \sprintf("sku;symbol_producenta;obwod_cholewki\n%s;KOW-ZAMSZ-TAUPE;28\n", $sku),
+        );
+
+        self::getContainer()->get(TenantFilterConfigurator::class)->apply();
+        self::getContainer()->get(ImportRunHandler::class)->run($session);
+        $em->clear();
+
+        return $sessionId;
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+
+        return $tenant;
+    }
+}

--- a/apps/api/tests/Api/Import/ImportPauseResumeTest.php
+++ b/apps/api/tests/Api/Import/ImportPauseResumeTest.php
@@ -304,6 +304,7 @@ final class ImportPauseResumeTest extends CatalogApiTestCase
             validator: self::getContainer()->get(\App\Import\Application\Service\ImportValidationService::class),
             creator: self::getContainer()->get(\App\Import\Application\Service\ImportObjectCreator::class),
             optionAutoCreator: self::getContainer()->get(\App\Import\Application\Service\OptionAutoCreator::class),
+            attributeAutoCreator: self::getContainer()->get(\App\Import\Application\Service\AttributeAutoCreator::class),
             objectResolver: self::getContainer()->get(\App\Import\Application\Service\ObjectResolver::class),
             relationStep: self::getContainer()->get(\App\Import\Application\Service\RelationImportStep::class),
             undoLogger: self::getContainer()->get(\App\Import\Application\Service\ImportUndoLogger::class),

--- a/apps/api/tests/Api/Import/ImportRunHandlerRefreshTest.php
+++ b/apps/api/tests/Api/Import/ImportRunHandlerRefreshTest.php
@@ -139,6 +139,7 @@ final class ImportRunHandlerRefreshTest extends CatalogApiTestCase
             validator: self::getContainer()->get(\App\Import\Application\Service\ImportValidationService::class),
             creator: self::getContainer()->get(\App\Import\Application\Service\ImportObjectCreator::class),
             optionAutoCreator: self::getContainer()->get(\App\Import\Application\Service\OptionAutoCreator::class),
+            attributeAutoCreator: self::getContainer()->get(\App\Import\Application\Service\AttributeAutoCreator::class),
             objectResolver: self::getContainer()->get(\App\Import\Application\Service\ObjectResolver::class),
             relationStep: self::getContainer()->get(\App\Import\Application\Service\RelationImportStep::class),
             undoLogger: self::getContainer()->get(\App\Import\Application\Service\ImportUndoLogger::class),


### PR DESCRIPTION
Closes #1728.

## Zmiana
Opt-in „Twórz brakujące opcje" (#1718) **dodatkowo tworzy brakujący atrybut**, gdy zmapowana kolumna ma kod bez atrybutu w modelu — zamiast cicho pomijać kolumnę.
- **`AttributeAutoCreator`** — mintuje `Attribute` (typ inferowany: numeryczne → Number, inaczej Text) + podpina do docelowego ObjectType junctionem `ObjectTypeAttribute`. **Kind-agnostyczny** (product/category/custom).
- Wpięty w `ImportObjectCreator::buildWrites` (ścieżka tej samej flagi co opcje); `ImportRunHandler` resetuje cache per run. Cap mintów/run + reset (higiena worker mode). Build-before-persist (#1718) trzyma flush bezpieczny.
- Checkbox w kreatorze: label/hint zaktualizowane na „opcje i atrybuty" (pl/en).

## Testy
`CreateMissingAttributesImportTest` (2, end-to-end): flaga ON → `symbol_producenta` (text) + `obwod_cholewki` (number) utworzone, podpięte do ObjectType, wartości zapisane, `errorCount=0`; OFF → brak mintu. PHPStan max + Deptrac + Unit/Import 171 zielone.

## Świadome odejścia
Inferencja typu zachowawcza (number/text); date/bool/price = follow-up (operator może zmienić typ przez MigrateAttributeType). Select/multiselect nie są zgadywane (nowy atrybut text/number nie ma opcji).