### PR TITLE
fix(import): usuń przycisk „Stwórz nowy atrybut” z mapowania — gubi mapowanie

### DIFF
--- a/apps/admin/src/features/imports/hooks/useImportWizard.ts
+++ b/apps/admin/src/features/imports/hooks/useImportWizard.ts
@@ -105,22 +105,13 @@ interface WizardController {
   next: () => void;
   back: () => void;
   reset: () => void;
-  /** Persist for cross-page round-trips (e.g. "Stwórz nowy atrybut"). */
-  persist: () => void;
-  /** Restore after returning from /modeling — wipes the saved snapshot. */
-  restore: () => void;
 }
 
-const STORAGE_KEY = 'pim.imports.wizard';
-
 /**
- * Holds the wizard's cross-step state (spec §4 user flow). The
- * persistence path is the deep-link to /modeling/attributes/new
- * during Step 2: the user creates a custom attribute and lands back
- * on the same wizard, mid-flight. {@link persist} writes the
- * non-File fields to localStorage; {@link restore} pulls them back
- * once the page rehydrates. Files cannot be serialised, so the user
- * re-uploads the source after the round-trip — UX surfaces a hint.
+ * Holds the wizard's cross-step state (spec §4 user flow). State lives only
+ * for the lifetime of the wizard mount — there is deliberately no localStorage
+ * round-trip: the uploaded File cannot be serialised, so a deep-link away and
+ * back used to drop the mapping (#1737).
  */
 export function useImportWizard(): WizardController {
   const [state, setState] = React.useState<WizardState>(INITIAL_STATE);
@@ -155,50 +146,7 @@ export function useImportWizard(): WizardController {
 
   const reset = React.useCallback(() => {
     setState(INITIAL_STATE);
-    if (typeof window !== 'undefined') {
-      window.localStorage.removeItem(STORAGE_KEY);
-    }
   }, []);
 
-  const persist = React.useCallback(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    const persisted = {
-      step: state.step,
-      entityType: state.entityType,
-      locale: state.locale,
-      encoding: state.encoding,
-      delimiter: state.delimiter,
-      imageSource: state.imageSource,
-      profileId: state.profileId,
-      saveAsProfileName: state.saveAsProfileName,
-      targetObjectTypeId: state.targetObjectTypeId,
-      mapping: state.mapping,
-      stagedFileId: state.stagedFileId,
-      doBackup: state.doBackup,
-      emailNotification: state.emailNotification,
-      createMissingOptions: state.createMissingOptions,
-    };
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
-  }, [state]);
-
-  const restore = React.useCallback(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (raw === null) {
-      return;
-    }
-    try {
-      const parsed = JSON.parse(raw) as Partial<WizardState>;
-      setState((prev) => ({ ...prev, ...parsed }));
-    } catch {
-      // Stale snapshot — drop it.
-    }
-    window.localStorage.removeItem(STORAGE_KEY);
-  }, []);
-
-  return { state, setField, patchMapping, next, back, reset, persist, restore };
+  return { state, setField, patchMapping, next, back, reset };
 }

--- a/apps/admin/src/features/imports/wizard/ImportWizardPage.tsx
+++ b/apps/admin/src/features/imports/wizard/ImportWizardPage.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useImportWizard } from '@/features/imports/hooks/useImportWizard';
@@ -22,15 +22,6 @@ import { type WizardStep, WizardStepper } from './WizardStepper';
 export function ImportWizardPage(): React.ReactElement {
   const { t } = useTranslation();
   const wizard = useImportWizard();
-
-  // Honour the deep-link round-trip from `/modeling/attributes/new`:
-  // the operator clicked "+ Stwórz atrybut" on Step 2, came back
-  // here, we restore mapping state so the table picks up where
-  // they left off.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: restore() only on mount
-  React.useEffect(() => {
-    wizard.restore();
-  }, []);
 
   const steps: ReadonlyArray<WizardStep> = [
     {

--- a/apps/admin/src/features/imports/wizard/StepMapping.tsx
+++ b/apps/admin/src/features/imports/wizard/StepMapping.tsx
@@ -1,7 +1,6 @@
 import { useApiUrl, useCustom, useList } from '@refinedev/core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
 
 import { Button } from '@/components/ui/button';
 import { Combobox, type ComboboxOption } from '@/components/ui/combobox';
@@ -58,14 +57,14 @@ const ENABLED_VALUE = '__enabled__';
 /**
  * Spec §5.3 — column mapping. Streams the uploaded headers + first
  * sample row to the IMP-02 endpoint, renders the mapping table on
- * top of the IMP-08 Combobox, and persists the picks back through
- * `useImportWizard`. The "+ Stwórz nowy atrybut" CTA snapshots the
- * wizard state to localStorage and deep-links to /modeling — the
- * round-trip restore lives on the hook.
+ * top of the IMP-08 Combobox, and writes the picks back through
+ * `useImportWizard`. Missing attributes are no longer created via a
+ * deep-link round-trip (#1737, it dropped the mapping) — the run mints
+ * them when "create missing options/attributes" is enabled (#1728).
  */
 export function StepMapping({ wizard }: StepMappingProps): React.ReactElement {
   const { t } = useTranslation();
-  const { state, setField, patchMapping, next, back, persist } = wizard;
+  const { state, setField, patchMapping, next, back } = wizard;
   const [computedOpen, setComputedOpen] = React.useState(false);
   const apiUrl = useApiUrl();
 
@@ -298,13 +297,6 @@ export function StepMapping({ wizard }: StepMappingProps): React.ReactElement {
 
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <Button asChild variant="outline" size="sm" onClick={() => persist()}>
-            <Link to="/modeling/attributes">
-              {t('imports.wizard.create_attribute', {
-                defaultValue: '+ Stwórz nowy atrybut',
-              })}
-            </Link>
-          </Button>
           <Button variant="outline" size="sm" onClick={() => setComputedOpen(true)}>
             {t('imports.mapping.computed_cta', { defaultValue: 'Nowa kolumna obliczona' })}
           </Button>

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2300,8 +2300,7 @@
       "next": "Next",
       "back": "Back",
       "cancel": "Cancel",
-      "run": "Run import",
-      "create_attribute": "Create new attribute"
+      "run": "Run import"
     },
     "upload": {
       "drop_csv": "Drop CSV / Excel file or pick one",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2350,8 +2350,7 @@
       "next": "Dalej",
       "back": "Wstecz",
       "cancel": "Anuluj",
-      "run": "Uruchom import",
-      "create_attribute": "Stwórz nowy atrybut"
+      "run": "Uruchom import"
     },
     "upload": {
       "drop_csv": "Przeciągnij plik CSV/Excel lub wybierz",


### PR DESCRIPTION
Closes #1737.

## Problem
Przycisk „+ Stwórz nowy atrybut” na kroku Mapowanie zrzucał stan wizarda do localStorage i deep-linkował do /modeling. **File nie jest serializowalny** → powrót = „Wgranie pliku nie powiodło się” i **całe mapowanie wyparowywało**. Po E2 (#1728) przycisk jest redundantny (auto-create atrybutów flagą).

## Zmiana (FE-only)
- Usunięty przycisk + nieużywany import `Link` + `persist` z `StepMapping`.
- Usunięty osierocony `restore()` useEffect w `ImportWizardPage`.
- Usunięte martwe `persist`/`restore`/`STORAGE_KEY` z `useImportWizard`.
- Usunięty nieużywany klucz i18n `imports.wizard.create_attribute` (pl+en, parytet OK).
- Zostaje: „Nowa kolumna obliczona” (operator prosił tylko o ten jeden przycisk).

## Gates
tsc 0, Biome strict 0, parytet i18n pl/en OK. Playwright 6-step wizard nie referencuje usuniętego przycisku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)