### PR TITLE
feat(export): kolumna object_types w eksporcie atrybutów

### DIFF
--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2771,6 +2771,9 @@
     "column_picker": {
       "group_structure": "Structure"
     },
+    "columns": {
+      "object_types": "Object types"
+    },
     "profiles": {
       "run_success": "Profile “{{name}}” — export started",
       "run_failed": "Failed to run the profile export",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2825,6 +2825,9 @@
     "column_picker": {
       "group_structure": "Struktura"
     },
+    "columns": {
+      "object_types": "Typy obiektów"
+    },
     "profiles": {
       "run_success": "Profil „{{name}}” — eksport uruchomiony",
       "run_failed": "Nie udało się uruchomić eksportu z profilu",

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -417,6 +417,7 @@ parameters:
         App\Export\Application\Builder\Structural\AttributesGroupsExportBuilder:
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Entity\AttributeGroupAttribute
+            - App\Catalog\Domain\Entity\ObjectTypeAttribute
             - App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface
             - App\Catalog\Domain\Repository\AttributeRepositoryInterface
             - App\Channel\Domain\Repository\TenantLocaleRepositoryInterface

--- a/apps/api/src/Export/Application/Builder/Structural/AttributesGroupsExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/Structural/AttributesGroupsExportBuilder.php
@@ -6,6 +6,7 @@ namespace App\Export\Application\Builder\Structural;
 
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
 use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
@@ -20,10 +21,10 @@ use const JSON_THROW_ON_ERROR;
  * EXR-06 (#1382) — `attributes_groups` export: the attribute dictionary.
  *
  * One row per attribute. Localised label/help fan out across the tenant's
- * active locales (`label.pl`, `label.en`, …) and a joined `groups` column
- * captures the attribute→group membership. The dedicated per-group metadata
- * sheet (XLSX second sheet / CSV-in-ZIP) is deferred — see the PR — but the
- * `groups` column already records which groups each attribute belongs to.
+ * active locales (`label.pl`, `label.en`, …); a joined `groups` column
+ * captures the attribute→group membership and an `object_types` column the
+ * attribute→ObjectType assignment (so a re-import can re-attach each attribute
+ * to the same modules).
  *
  * Columns are dynamic: a new attribute type, locale, or select option exports
  * with no change here.
@@ -57,6 +58,7 @@ final readonly class AttributesGroupsExportBuilder implements StructuralExportBu
         $columns[] = 'is_scopable';
         $columns[] = 'options';
         $columns[] = 'groups';
+        $columns[] = 'object_types';
         $columns[] = 'is_built_in';
         $columns[] = 'created_at';
 
@@ -83,6 +85,7 @@ final readonly class AttributesGroupsExportBuilder implements StructuralExportBu
             $row['is_scopable'] = $attribute->isScopable() ? 'true' : 'false';
             $row['options'] = $this->optionsJson($attribute);
             $row['groups'] = implode('|', $this->groupCodes($attribute));
+            $row['object_types'] = implode('|', $this->objectTypeCodes($attribute));
             $row['is_built_in'] = $attribute->isSystem() ? 'true' : 'false';
             $row['created_at'] = $attribute->getCreatedAt()->format(DateTimeInterface::ATOM);
 
@@ -117,6 +120,24 @@ final readonly class AttributesGroupsExportBuilder implements StructuralExportBu
         $codes = $this->em->createQuery(
             'SELECT g.code FROM '.AttributeGroupAttribute::class.' j JOIN j.attributeGroup g'
             .' WHERE j.attribute = :a ORDER BY g.code ASC',
+        )->setParameter('a', $attribute)->getSingleColumnResult();
+
+        return $codes;
+    }
+
+    /**
+     * ObjectType codes the attribute is assigned to, via the
+     * `object_type_attributes` junction. Pipe-joined into the `object_types`
+     * column so a re-import can re-attach the attribute to the same modules.
+     *
+     * @return list<string>
+     */
+    private function objectTypeCodes(Attribute $attribute): array
+    {
+        /** @var list<string> $codes */
+        $codes = $this->em->createQuery(
+            'SELECT ot.code FROM '.ObjectTypeAttribute::class.' j JOIN j.objectType ot'
+            .' WHERE j.attribute = :a ORDER BY ot.code ASC',
         )->setParameter('a', $attribute)->getSingleColumnResult();
 
         return $codes;

--- a/apps/api/tests/Api/Export/StructuralExportApiTest.php
+++ b/apps/api/tests/Api/Export/StructuralExportApiTest.php
@@ -8,6 +8,7 @@ use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Export\Application\Sync\SyncExportRunner;
@@ -55,6 +56,26 @@ final class StructuralExportApiTest extends CatalogApiTestCase
         $csv = $this->runStructural($tenant, ExportEntityType::AttributesGroups);
 
         self::assertStringContainsString('horsepower', $csv);
+    }
+
+    #[Test]
+    public function attributesExportListsAssignedObjectTypes(): void
+    {
+        $tenant = $this->tenant();
+        $module = new ObjectType('gizmos', ObjectKind::Custom, ['pl' => 'Gizma', 'en' => 'Gizmos']);
+        $module->assignTenant($tenant);
+        $attribute = new Attribute('torque', ['pl' => 'Moment', 'en' => 'Torque'], AttributeType::Text);
+        $attribute->assignTenant($tenant);
+        $this->em()->persist($module);
+        $this->em()->persist($attribute);
+        $this->em()->persist(new ObjectTypeAttribute($module, $attribute));
+        $this->em()->flush();
+
+        $csv = $this->runStructural($tenant, ExportEntityType::AttributesGroups);
+
+        // Header is present and the attribute row carries its ObjectType code.
+        self::assertStringContainsString('object_types', $csv);
+        self::assertMatchesRegularExpression('/torque[^\n]*gizmos/', $csv);
     }
 
     #[Test]


### PR DESCRIPTION
## Cel

Pierwszy krok planu „eksport + import definicji atrybutów i grup". Eksport atrybutów (`attributes_groups`) dostaje nową kolumnę **`object_types`** — kody ObjectType, do których atrybut jest przypisany (junction `object_type_attributes`), obok istniejącej kolumny `groups`.

Dzięki temu re-import (kolejne PR-y) będzie mógł automatycznie przypiąć atrybuty z powrotem do tych samych modułów, tak by były od razu dostępne przy dodawaniu Produktu lub własnego ObjectType.

## Zmiany

- `AttributesGroupsExportBuilder` — nowa kolumna `object_types` (zaraz po `groups`) + prywatna metoda `objectTypeCodes()` (DQL na `ObjectTypeAttribute` join `ObjectType.code`, wzór jak istniejące `groupCodes()`).
- i18n `exports.columns.object_types` (pl: „Typy obiektów", en: „Object types") — etykieta w pickerze kolumn.
- Test `StructuralExportApiTest::attributesExportListsAssignedObjectTypes` — atrybut przypisany do custom ObjectType pojawia się z kodem OT w kolumnie.

## Weryfikacja

- PHPStan max: ✅ (zmienione pliki)
- php-cs-fixer: ✅ (0 fixes)
- `StructuralExportApiTest` (ścieżka bez auth): ✅ 4/4 (testy auth-owe failują lokalnie na nieparsowalnym kluczu JWT — pre-existing env, zielone w CI)
- biome na plikach locale: ✅

## Następne PR-y (z planu)
- PR2: nowy typ eksportu `attribute_groups` (definicje grup) + relabel kafelka na „Atrybuty"
- PR3/PR4: import atrybutów i grup (lustrzane odbicie eksportu)

Refs #1382