### PR TITLE
feat(export): nowy typ eksportu grup atrybutów

### DIFF
--- a/apps/admin/e2e/exr-09-wizard-step1.spec.ts
+++ b/apps/admin/e2e/exr-09-wizard-step1.spec.ts
@@ -30,14 +30,19 @@ test.beforeEach(async ({ page }) => {
 
 test('every entity tile is selectable and Dalej advances', async ({ page }) => {
   const group = page.getByRole('radiogroup');
-  await expect(group.getByRole('radio')).toHaveCount(5);
+  await expect(group.getByRole('radio')).toHaveCount(6);
 
   // products selected by default with the WYBRANE badge
   const products = group.getByRole('radio', { name: /Produkty|Products/ });
   await expect(products).toHaveAttribute('aria-checked', 'true');
   await expect(products).toContainText(/wybrane|selected/);
 
-  for (const name of [/Schemat|Module schema/, /Atrybuty|Attributes/, /Kategorie|Categories/]) {
+  for (const name of [
+    /Schemat|Module schema/,
+    /Atrybuty|Attributes/,
+    /Grupy atrybutów|Attribute groups/,
+    /Kategorie|Categories/,
+  ]) {
     await group.getByRole('radio', { name }).click();
     await expect(group.getByRole('radio', { name })).toHaveAttribute('aria-checked', 'true');
   }

--- a/apps/admin/e2e/exr-16-entities.spec.ts
+++ b/apps/admin/e2e/exr-16-entities.spec.ts
@@ -93,7 +93,8 @@ test.beforeEach(async ({ page }) => {
 
 for (const entity of [
   { radio: /Schemat modułów|Module schema/, payload: 'module_schema' },
-  { radio: /Atrybuty i grupy|Attributes & groups/, payload: 'attributes_groups' },
+  { radio: /Atrybuty|Attributes/, payload: 'attributes_groups' },
+  { radio: /Grupy atrybutów|Attribute groups/, payload: 'attribute_groups' },
   { radio: /Kategorie|Categories/, payload: 'categories' },
 ]) {
   test(`structural happy path: ${entity.payload}`, async ({ page }) => {

--- a/apps/admin/src/features/exports/components/use-export-column-catalog.ts
+++ b/apps/admin/src/features/exports/components/use-export-column-catalog.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { jsonFetch } from '@/lib/http';
 
+import type { ExportEntityType } from '../wizard/types';
 import { BUILT_IN_COLUMN_GROUPS, type ColumnGroup } from './column-catalog';
 
 interface AttributeRow {
@@ -48,7 +49,7 @@ export interface ExportColumnCatalog {
 /** EXR-11 — per-entity catalog narrowing options for the wizard. */
 export interface ColumnCatalogOptions {
   /** ExportEntityType (EXR-04); defaults to `product` (legacy behavior). */
-  entityType?: 'product' | 'custom_module' | 'module_schema' | 'attributes_groups' | 'categories';
+  entityType?: ExportEntityType;
   /** Required for `custom_module` — narrows attributes to the OT junction. */
   objectTypeId?: string | null;
 }

--- a/apps/admin/src/features/exports/sessions/session-format.ts
+++ b/apps/admin/src/features/exports/sessions/session-format.ts
@@ -18,6 +18,8 @@ export function entityTypeLabelKey(entityType: string): string {
       return 'exports.entity.module_schema';
     case 'attributes_groups':
       return 'exports.entity.attributes_groups';
+    case 'attribute_groups':
+      return 'exports.entity.attribute_groups';
     case 'categories':
       return 'exports.entity.categories';
     default:

--- a/apps/admin/src/features/exports/wizard/steps/StepEntityType.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepEntityType.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { Boxes, FolderTree, Layers, Package, Tags } from 'lucide-react';
+import { Boxes, FolderTree, Group, Layers, Package, Tags } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { SelectableCard, SelectableCardGroup } from '@/components/ui-v2/selectable-card';
@@ -27,6 +27,7 @@ const ENTITY_DEFS: Array<{ id: ExportEntityType; icon: typeof Package }> = [
   { id: 'custom_module', icon: Boxes },
   { id: 'module_schema', icon: Layers },
   { id: 'attributes_groups', icon: Tags },
+  { id: 'attribute_groups', icon: Group },
   { id: 'categories', icon: FolderTree },
 ];
 

--- a/apps/admin/src/features/exports/wizard/steps/StepSummary.tsx
+++ b/apps/admin/src/features/exports/wizard/steps/StepSummary.tsx
@@ -1,4 +1,4 @@
-import { Boxes, FolderTree, Layers, Loader2, Package, Play, Tags } from 'lucide-react';
+import { Boxes, FolderTree, Group, Layers, Loader2, Package, Play, Tags } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
@@ -18,6 +18,7 @@ const ENTITY_ICONS: Record<string, typeof Package> = {
   custom_module: Boxes,
   module_schema: Layers,
   attributes_groups: Tags,
+  attribute_groups: Group,
   categories: FolderTree,
 };
 

--- a/apps/admin/src/features/exports/wizard/types.ts
+++ b/apps/admin/src/features/exports/wizard/types.ts
@@ -6,6 +6,7 @@ export type ExportEntityType =
   | 'custom_module'
   | 'module_schema'
   | 'attributes_groups'
+  | 'attribute_groups'
   | 'categories';
 
 export type ExportFormat = 'xlsx' | 'csv';

--- a/apps/admin/src/locales/en.json
+++ b/apps/admin/src/locales/en.json
@@ -2594,7 +2594,8 @@
       "module_schema": "Module schema",
       "categories": "Categories",
       "product": "Products",
-      "attributes_groups": "Attributes & groups"
+      "attributes_groups": "Attributes",
+      "attribute_groups": "Attribute groups"
     },
     "active": {
       "title": "Running",
@@ -2684,7 +2685,8 @@
         "module_schema": "Download module definitions, relations and configuration settings.",
         "categories": "Category tree structure, name translations and inheritance rules.",
         "product": "Export the main product catalog, variants, prices and related media.",
-        "attributes_groups": "Export the attribute dictionary, default values, types and group assignments."
+        "attributes_groups": "Export the attribute dictionary — types, default values, group and object-type assignments.",
+        "attribute_groups": "Export attribute-group definitions — labels, descriptions, icons and object-type assignments."
       },
       "custom_object_type_label": "Custom module",
       "custom_object_type_placeholder": "Choose a module…",
@@ -2772,7 +2774,14 @@
       "group_structure": "Structure"
     },
     "columns": {
-      "object_types": "Object types"
+      "object_types": "Object types",
+      "code": "Code",
+      "icon": "Icon",
+      "color": "Color",
+      "is_required_section": "Required section",
+      "is_shared": "Shared",
+      "position": "Position",
+      "is_built_in": "Built-in"
     },
     "profiles": {
       "run_success": "Profile “{{name}}” — export started",

--- a/apps/admin/src/locales/pl.json
+++ b/apps/admin/src/locales/pl.json
@@ -2646,7 +2646,8 @@
       "module_schema": "Schemat modułów",
       "categories": "Kategorie",
       "product": "Produkty",
-      "attributes_groups": "Atrybuty i grupy"
+      "attributes_groups": "Atrybuty",
+      "attribute_groups": "Grupy atrybutów"
     },
     "active": {
       "title": "W toku",
@@ -2736,7 +2737,8 @@
         "module_schema": "Pobierz strukturę definicji, relacje i ustawienia konfiguracyjne modułów.",
         "categories": "Struktura drzewa kategorii, tłumaczenia nazw oraz przypisane reguły dziedziczenia.",
         "product": "Eksportuj główny katalog produktów, warianty, ceny i powiązane multimedia.",
-        "attributes_groups": "Eksport słownika atrybutów, ich wartości domyślnych, typów oraz podziału na grupy."
+        "attributes_groups": "Eksport słownika atrybutów — typów, wartości domyślnych, przypisania do grup i typów obiektów.",
+        "attribute_groups": "Eksport definicji grup atrybutów — etykiet, opisów, ikon oraz przypisania do typów obiektów."
       },
       "custom_object_type_label": "Moduł własny",
       "custom_object_type_placeholder": "Wybierz moduł…",
@@ -2826,7 +2828,14 @@
       "group_structure": "Struktura"
     },
     "columns": {
-      "object_types": "Typy obiektów"
+      "object_types": "Typy obiektów",
+      "code": "Kod",
+      "icon": "Ikona",
+      "color": "Kolor",
+      "is_required_section": "Sekcja wymagana",
+      "is_shared": "Współdzielona",
+      "position": "Pozycja",
+      "is_built_in": "Systemowa"
     },
     "profiles": {
       "run_success": "Profil „{{name}}” — eksport uruchomiony",

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -414,6 +414,11 @@ parameters:
             - App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectRelationRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectValueRepositoryInterface
+        App\Export\Application\Builder\Structural\AttributeGroupsExportBuilder:
+            - App\Catalog\Domain\Entity\AttributeGroup
+            - App\Catalog\Domain\Entity\ObjectTypeAttributeGroup
+            - App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface
+            - App\Channel\Domain\Repository\TenantLocaleRepositoryInterface
         App\Export\Application\Builder\Structural\AttributesGroupsExportBuilder:
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Entity\AttributeGroupAttribute

--- a/apps/api/src/Catalog/Domain/Repository/AttributeGroupRepositoryInterface.php
+++ b/apps/api/src/Catalog/Domain/Repository/AttributeGroupRepositoryInterface.php
@@ -14,6 +14,14 @@ interface AttributeGroupRepositoryInterface
 
     public function findByCode(string $code, Tenant $tenant): ?AttributeGroup;
 
+    /**
+     * All groups owned by the tenant, ordered for deterministic export
+     * (position, then code).
+     *
+     * @return list<AttributeGroup>
+     */
+    public function findAllByTenant(Tenant $tenant): array;
+
     public function save(AttributeGroup $attributeGroup): void;
 
     public function remove(AttributeGroup $attributeGroup): void;

--- a/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineAttributeGroupRepository.php
+++ b/apps/api/src/Catalog/Infrastructure/Doctrine/Repository/DoctrineAttributeGroupRepository.php
@@ -25,6 +25,14 @@ class DoctrineAttributeGroupRepository extends ServiceEntityRepository implement
         return $this->findOneBy(['code' => $code, 'tenant' => $tenant]);
     }
 
+    public function findAllByTenant(Tenant $tenant): array
+    {
+        /** @var list<AttributeGroup> $result */
+        $result = $this->findBy(['tenant' => $tenant], ['position' => 'ASC', 'code' => 'ASC']);
+
+        return $result;
+    }
+
     public function findById(\Symfony\Component\Uid\Uuid $id): ?AttributeGroup
     {
         return parent::find($id->toRfc4122());

--- a/apps/api/src/Export/Application/Builder/Structural/AttributeGroupsExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/Structural/AttributeGroupsExportBuilder.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Export\Application\Builder\Structural;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
+use App\Export\Domain\Enum\ExportEntityType;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * `attribute_groups` export: the attribute-group dictionary.
+ *
+ * One row per AttributeGroup. Localised label/description fan out across the
+ * tenant's active locales (`label.pl`, `description.en`, …); an `object_types`
+ * column captures which ObjectTypes each group is attached to (via the
+ * `object_type_attribute_groups` junction) so a re-import can re-attach the
+ * group to the same modules. Mirrors the attribute dictionary export
+ * ({@see AttributesGroupsExportBuilder}) but for group definitions.
+ *
+ * Columns are dynamic: a new locale exports with no change here.
+ */
+final readonly class AttributeGroupsExportBuilder implements StructuralExportBuilderInterface
+{
+    public function __construct(
+        private AttributeGroupRepositoryInterface $groups,
+        private TenantLocaleRepositoryInterface $locales,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    public function supports(ExportEntityType $type): bool
+    {
+        return ExportEntityType::AttributeGroups === $type;
+    }
+
+    public function columns(Tenant $tenant): array
+    {
+        $columns = ['code'];
+        foreach ($this->localeCodes($tenant) as $code) {
+            $columns[] = 'label.'.$code;
+        }
+        foreach ($this->localeCodes($tenant) as $code) {
+            $columns[] = 'description.'.$code;
+        }
+        $columns[] = 'icon';
+        $columns[] = 'color';
+        $columns[] = 'is_required_section';
+        $columns[] = 'is_shared';
+        $columns[] = 'position';
+        $columns[] = 'object_types';
+        $columns[] = 'is_built_in';
+
+        return $columns;
+    }
+
+    public function rows(Tenant $tenant): iterable
+    {
+        $localeCodes = $this->localeCodes($tenant);
+
+        foreach ($this->groups->findAllByTenant($tenant) as $group) {
+            $label = $group->getLabel();
+            $description = $group->getDescription() ?? [];
+
+            $row = ['code' => $group->getCode()];
+            foreach ($localeCodes as $code) {
+                $row['label.'.$code] = $label[$code] ?? '';
+            }
+            foreach ($localeCodes as $code) {
+                $row['description.'.$code] = $description[$code] ?? '';
+            }
+            $row['icon'] = $group->getIcon() ?? '';
+            $row['color'] = $group->getColor() ?? '';
+            $row['is_required_section'] = $group->isRequiredSection() ? 'true' : 'false';
+            $row['is_shared'] = $group->isShared() ? 'true' : 'false';
+            $row['position'] = (string) $group->getPosition();
+            $row['object_types'] = implode('|', $this->objectTypeCodes($group));
+            $row['is_built_in'] = $group->isSystemGroup() ? 'true' : 'false';
+
+            yield $row;
+        }
+    }
+
+    public function count(Tenant $tenant): int
+    {
+        return \count($this->groups->findAllByTenant($tenant));
+    }
+
+    /**
+     * ObjectType codes the group is attached to, via the
+     * `object_type_attribute_groups` junction.
+     *
+     * @return list<string>
+     */
+    private function objectTypeCodes(AttributeGroup $group): array
+    {
+        /** @var list<string> $codes */
+        $codes = $this->em->createQuery(
+            'SELECT ot.code FROM '.ObjectTypeAttributeGroup::class.' j JOIN j.objectType ot'
+            .' WHERE j.attributeGroup = :g ORDER BY ot.code ASC',
+        )->setParameter('g', $group)->getSingleColumnResult();
+
+        return $codes;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function localeCodes(Tenant $tenant): array
+    {
+        $codes = [];
+        foreach ($this->locales->findActiveForTenant($tenant) as $tenantLocale) {
+            $codes[] = $tenantLocale->getLocale()->getCode();
+        }
+
+        return $codes;
+    }
+}

--- a/apps/api/src/Export/Domain/Enum/ExportEntityType.php
+++ b/apps/api/src/Export/Domain/Enum/ExportEntityType.php
@@ -15,7 +15,10 @@ namespace App\Export\Domain\Enum;
  *   - {@see self::CustomModule}     a user-defined ObjectType (is_built_in=false);
  *                                   requires `object_type_id`.
  *   - {@see self::ModuleSchema}     ObjectType definitions / configuration.
- *   - {@see self::AttributesGroups} attribute dictionary + groups.
+ *   - {@see self::AttributesGroups} attribute dictionary (one row per attribute).
+ *   - {@see self::AttributeGroups}  attribute-group definitions (one row per
+ *                                   group: label/description, icon, flags, the
+ *                                   ObjectTypes it is attached to).
  *   - {@see self::Categories}       category tree.
  *
  * `Product` and `CustomModule` are catalog-object backed, so they support
@@ -33,6 +36,7 @@ enum ExportEntityType: string
     case CustomModule = 'custom_module';
     case ModuleSchema = 'module_schema';
     case AttributesGroups = 'attributes_groups';
+    case AttributeGroups = 'attribute_groups';
     case Categories = 'categories';
 
     /**

--- a/apps/api/tests/Api/Export/StructuralExportApiTest.php
+++ b/apps/api/tests/Api/Export/StructuralExportApiTest.php
@@ -6,9 +6,11 @@ namespace App\Tests\Api\Export;
 
 use App\Catalog\Domain\AttributeType;
 use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroup;
 use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Entity\ObjectTypeAttribute;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
 use App\Export\Application\Sync\SyncExportRunner;
@@ -76,6 +78,34 @@ final class StructuralExportApiTest extends CatalogApiTestCase
         // Header is present and the attribute row carries its ObjectType code.
         self::assertStringContainsString('object_types', $csv);
         self::assertMatchesRegularExpression('/torque[^\n]*gizmos/', $csv);
+    }
+
+    #[Test]
+    public function attributeGroupsExportListsGroupDefinitionsWithObjectTypes(): void
+    {
+        $tenant = $this->tenant();
+        $module = new ObjectType('widgets', ObjectKind::Custom, ['pl' => 'Widżety', 'en' => 'Widgets']);
+        $module->assignTenant($tenant);
+        $group = new AttributeGroup(
+            'marketing',
+            ['pl' => 'Marketing', 'en' => 'Marketing'],
+            0,
+            null,
+            ['pl' => 'Treści marketingowe', 'en' => 'Marketing content'],
+            'megaphone',
+        );
+        $group->assignTenant($tenant);
+        $this->em()->persist($module);
+        $this->em()->persist($group);
+        $this->em()->persist(new ObjectTypeAttributeGroup($module, $group));
+        $this->em()->flush();
+
+        $csv = $this->runStructural($tenant, ExportEntityType::AttributeGroups);
+
+        self::assertStringContainsString('marketing', $csv);
+        self::assertStringContainsString('megaphone', $csv);
+        // The group row carries its attached ObjectType code in object_types.
+        self::assertMatchesRegularExpression('/marketing[^\n]*widgets/', $csv);
     }
 
     #[Test]

--- a/apps/api/tests/Unit/Export/ExportEntityTypeTest.php
+++ b/apps/api/tests/Unit/Export/ExportEntityTypeTest.php
@@ -28,6 +28,7 @@ final class ExportEntityTypeTest extends TestCase
             ExportEntityType::Product,
             ExportEntityType::ModuleSchema,
             ExportEntityType::AttributesGroups,
+            ExportEntityType::AttributeGroups,
             ExportEntityType::Categories,
         ] as $type) {
             self::assertFalse($type->requiresObjectType(), $type->value.' must forbid object_type_id');
@@ -45,6 +46,7 @@ final class ExportEntityTypeTest extends TestCase
         foreach ([
             ExportEntityType::ModuleSchema,
             ExportEntityType::AttributesGroups,
+            ExportEntityType::AttributeGroups,
             ExportEntityType::Categories,
         ] as $type) {
             self::assertFalse($type->supportsScopeAndFilter(), $type->value.' must not support scope/filter');


### PR DESCRIPTION
## Cel

Drugi krok planu „eksport + import definicji atrybutów i grup". Rozbija eksport „Atrybuty i grupy" na dwa osobne typy:

- **`attributes_groups`** (istniejący) — słownik **atrybutów**; kafelek przelabelowany na **„Atrybuty"**.
- **`attribute_groups`** (nowy) — definicje **grup atrybutów**: kod, wielojęzyczne label/description, ikona, kolor, flagi (`is_required_section`, `is_shared`), pozycja, oraz kolumna **`object_types`** (kody ObjectType, do których grupa jest przypięta).

Dzięki temu można wyeksportować osobno definicję atrybutów i osobno definicję grup, a kolumna `object_types` pozwoli re-importowi (PR3/PR4) przypiąć grupy z powrotem do właściwych typów obiektów.

## Zmiany

**Backend**
- `ExportEntityType::AttributeGroups = 'attribute_groups'` (strukturalny, executable — bez zmian w predykatach).
- `AttributeGroupsExportBuilder` — nowy structural builder (autokonfiguracja tagiem `app.export.structural_builder`; zero zmian w runnerze/preflight/columns).
- `AttributeGroupRepository::findAllByTenant` (interfejs + impl), uporządkowane wg position, code.
- Deptrac baseline dla nowego buildera (Export→Catalog seam, jak siostrzane buildery).

**Frontend**
- `ExportEntityType` union + nowy kafelek „Grupy atrybutów" (ikona `Group`), wiring w `StepSummary` (ikona) i `session-format` (label).
- Współdzielony typ `ExportEntityType` w `use-export-column-catalog` (zamiast zduplikowanej, węższej unii).
- i18n pl/en: relabel `attributes_groups` → „Atrybuty"/„Attributes", nowy `attribute_groups`, etykiety kolumn grup.

## Weryfikacja
- PHPStan max ✅ · php-cs-fixer ✅ · deptrac ✅
- `StructuralExportApiTest::attributeGroupsExportListsGroupDefinitionsWithObjectTypes` ✅ (label/description fan-out, ikona, `object_types`) + `ExportEntityTypeTest` rozszerzony o nowy case
- typecheck ✅ · biome ✅ · exports vitest ✅

## Następne
- PR3: import atrybutów (w toku) · PR4: import grup atrybutów

Refs #1382