### PR TITLE
feat(import): backend importu definicji atrybutów (API-first)

### DIFF
--- a/apps/api/config/packages/messenger.yaml
+++ b/apps/api/config/packages/messenger.yaml
@@ -141,6 +141,11 @@ framework:
             # on the same handler from the controller.
             App\Import\Domain\Message\ImportRunMessage: import
 
+            # Structural imports (attribute / attribute-group definitions). Same
+            # dedicated `import` queue; small files run inline from the start
+            # controller, larger ones hand off here.
+            App\Import\Domain\Message\StructuralImportRunMessage: import
+
             # IMP2-1.12 (#1475). Image-download batches buffered by the import
             # run and dispatched after the row phase. Same dedicated `import`
             # queue so media never starves UI-adjacent async jobs.

--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -487,6 +487,26 @@ parameters:
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\Entity\ObjectTypeAttribute
+        # Structural import (attribute / attribute-group definitions) upserts
+        # configuration entities through the Catalog CQRS commands + the shared
+        # idempotent assignment service — the same Import→Catalog seam as the
+        # CatalogObject importer, baselined here pending the #1466 burndown.
+        App\Import\Application\Service\Structural\AttributeImportCreator:
+            - App\Catalog\Application\Command\CreateAttribute\CreateAttributeCommand
+            - App\Catalog\Application\Command\UpdateAttribute\UpdateAttributeCommand
+            - App\Catalog\Application\ObjectTypeService
+            - App\Catalog\Domain\AttributeType
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Entity\AttributeGroup
+            - App\Catalog\Domain\Entity\AttributeGroupAttribute
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface
+            - App\Catalog\Domain\Repository\AttributeRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        App\Import\Application\Service\Structural\AttributeOptionImporter:
+            - App\Catalog\Domain\Entity\Attribute
+            - App\Catalog\Domain\Entity\AttributeOption
+            - App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface
         # IMP2-2.4 — undo-log capture + rollback v2 reuse Catalog read/rebuild/
         # reindex via the same Import→Catalog seam as ImportObjectCreator.
         App\Import\Application\Service\ImportUndoLogger:
@@ -499,6 +519,7 @@ parameters:
             - App\Catalog\Application\AttributesIndexedRebuilder
             - App\Catalog\Application\Reindex\BulkReindexQueueInterface
             - App\Catalog\Domain\Entity\CatalogObject
+            - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\Entity\ObjectValue
             - App\Catalog\Domain\Provenance
             - App\Catalog\Domain\Repository\ObjectValueRepositoryInterface
@@ -553,6 +574,8 @@ parameters:
             - App\Catalog\Domain\AttributeType
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Repository\AttributeRepositoryInterface
+        App\Import\Presentation\Controller\StartStructuralImportController:
+            - App\Identity\Domain\Entity\User
         App\Import\Presentation\Controller\TestImportSourceConnectionController:
             - App\Identity\Domain\Entity\User
         App\Import\Presentation\Controller\ValidateDryRunController:
@@ -572,6 +595,7 @@ parameters:
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Entity\CatalogObject
             - App\Catalog\Domain\Entity\ObjectCategory
+            - App\Catalog\Domain\Entity\ObjectType
             - App\Catalog\Domain\ObjectKind
             - App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectCategoryRepositoryInterface

--- a/apps/api/migrations/Version20260624140000.php
+++ b/apps/api/migrations/Version20260624140000.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Structural imports (attribute / attribute-group definitions) reuse the
+ * import_sessions table but carry no target ObjectType. Make
+ * target_object_type_id nullable and add a structural_kind discriminator
+ * (`attributes` | `attribute_groups`, null = the CatalogObject pipeline) so the
+ * worker can route a session to the structural handler.
+ */
+final class Version20260624140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make import_sessions.target_object_type_id nullable and add structural_kind.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import_sessions ALTER COLUMN target_object_type_id DROP NOT NULL');
+        $this->addSql('ALTER TABLE import_sessions ADD structural_kind VARCHAR(32) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE import_sessions DROP structural_kind');
+        $this->addSql('ALTER TABLE import_sessions ALTER COLUMN target_object_type_id SET NOT NULL');
+    }
+}

--- a/apps/api/src/Import/Application/Handler/ImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/ImportRunHandler.php
@@ -387,7 +387,7 @@ final class ImportRunHandler extends AbstractBatchHandler
                 $this->sessions->save($session);
                 $linkTenant = $session->getTenant();
                 if ($linkTenant instanceof Tenant) {
-                    $linkErrors = $this->relationStep->resolve($session->getTargetObjectType()->getKind(), $linkTenant);
+                    $linkErrors = $this->relationStep->resolve($this->requireTargetObjectType($session)->getKind(), $linkTenant);
                     $session = $this->refreshSession($session);
                     // Extend the lock past the (potentially long) relation pass.
                     $lock->refresh();
@@ -797,7 +797,7 @@ final class ImportRunHandler extends AbstractBatchHandler
 
         $existingOwners = $this->fetchIdentifierOwners(
             $tenant,
-            $session->getTargetObjectType()->getId()->toRfc4122(),
+            $this->requireTargetObjectType($session)->getId()->toRfc4122(),
             $valuesByAttributeId,
         );
 
@@ -1260,6 +1260,24 @@ final class ImportRunHandler extends AbstractBatchHandler
      *
      * Convention (spec §8.6): `{tenant_id}/{session_id}/{file_name}`.
      */
+    /**
+     * The CatalogObject pipeline always runs against a concrete ObjectType.
+     * Structural imports (attributes / attribute groups) carry no target and
+     * never reach this handler, so a null here is a programming error.
+     */
+    private function requireTargetObjectType(ImportSession $session): \App\Catalog\Domain\Entity\ObjectType
+    {
+        $target = $session->getTargetObjectType();
+        if (!$target instanceof \App\Catalog\Domain\Entity\ObjectType) {
+            throw new RuntimeException(\sprintf(
+                'Catalog import session %s has no target ObjectType.',
+                $session->getId()->toRfc4122(),
+            ));
+        }
+
+        return $target;
+    }
+
     private function stageSourceFile(ImportSession $session, Tenant $tenant): string
     {
         $remotePath = \sprintf(
@@ -1437,7 +1455,7 @@ final class ImportRunHandler extends AbstractBatchHandler
 
         $existingByKey = $this->objectResolver->resolveMany(
             $matchKeys,
-            $session->getTargetObjectType(),
+            $this->requireTargetObjectType($session),
             $tenant,
             $session->getMatchAttributeCode(),
         );
@@ -1510,7 +1528,7 @@ final class ImportRunHandler extends AbstractBatchHandler
 
                 if (ImportRowDecision::Create === $decision) {
                     $created = $this->creator->create(
-                        objectType: $session->getTargetObjectType(),
+                        objectType: $this->requireTargetObjectType($session),
                         sku: $this->skuFrom($row['resolvedValues'], $row['rowNumber']),
                         resolvedValues: $row['resolvedValues'],
                         attributesByCode: $attributesByCode,

--- a/apps/api/src/Import/Application/Handler/StructuralImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/StructuralImportRunHandler.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Handler;
+
+use App\Import\Application\Service\ImportProgressPublisher;
+use App\Import\Application\Service\ImportRowReader;
+use App\Import\Application\Service\Structural\AttributeImportCreator;
+use App\Import\Application\Service\Structural\StructuralImportRowResult;
+use App\Import\Domain\Entity\ImportLog;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Import\Domain\Enum\ImportSessionStatus;
+use App\Import\Domain\Message\StructuralImportRunMessage;
+use App\Import\Domain\Repository\ImportLogRepositoryInterface;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Shared\Application\BulkOperationInProgressException;
+use App\Shared\Application\BulkOperationLock;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use LogicException;
+use RuntimeException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * Runs a structural import (attribute / attribute-group definitions) — the
+ * mirror of the `attributes_groups` / `attribute_groups` exports.
+ *
+ * Reuses the import shell (ImportSession status/counters, ImportLog, Mercure
+ * progress, MinIO staging, the per-tenant bulk lock) but, unlike
+ * {@see ImportRunHandler}, dispatches each row to a structural creator that
+ * upserts configuration entities through the Catalog CQRS commands instead of
+ * writing CatalogObject + ObjectValue rows. No media / relation / rebuild
+ * phases — these entities have none.
+ */
+#[AsMessageHandler]
+final class StructuralImportRunHandler
+{
+    /** Defensive cap on persisted ImportLog rows (structural files are small). */
+    private const int MAX_PERSISTED_LOGS = 5_000;
+
+    public function __construct(
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly ImportRowReader $rowReader,
+        private readonly ImportLogRepositoryInterface $importLogs,
+        private readonly ImportProgressPublisher $progress,
+        private readonly AttributeImportCreator $attributeCreator,
+        private readonly TenantContext $tenantContext,
+        private readonly FilesystemOperator $importsStorage,
+        private readonly BulkOperationLock $bulkLock,
+    ) {
+    }
+
+    public function __invoke(StructuralImportRunMessage $message): void
+    {
+        $session = $this->sessions->findById($message->importSessionId);
+        if (!$session instanceof ImportSession) {
+            return;
+        }
+        $tenant = $session->getTenant();
+        if (!$tenant instanceof Tenant) {
+            $session->markFailed('Import session has no tenant assignment.');
+            $this->sessions->save($session);
+
+            return;
+        }
+        $this->tenantContext->set($tenant);
+
+        try {
+            $this->run($session);
+        } catch (BulkOperationInProgressException $exception) {
+            throw new RecoverableMessageHandlingException($exception->getMessage().' Will retry.', previous: $exception);
+        }
+    }
+
+    /**
+     * Drives the row loop. Public so the synchronous `<50 rows` path on the
+     * start endpoint can call into the same logic without Messenger.
+     */
+    public function run(ImportSession $session): void
+    {
+        set_time_limit(0);
+
+        $tenant = $session->getTenant();
+        if (!$tenant instanceof Tenant) {
+            $session->markFailed('Import session has no tenant assignment.');
+            $this->sessions->save($session);
+
+            return;
+        }
+        if (ImportSessionStatus::Paused === $session->getStatus()) {
+            return;
+        }
+        $kind = $session->getStructuralKind();
+        if ('attributes' !== $kind) {
+            $session->markFailed(\sprintf('Unsupported structural import kind "%s".', $kind ?? 'null'));
+            $this->sessions->save($session);
+
+            return;
+        }
+
+        $lock = $this->bulkLock->acquire($tenant);
+        if (null === $lock) {
+            throw new BulkOperationInProgressException($tenant);
+        }
+
+        try {
+            $session->markRunning();
+            $this->sessions->save($session);
+        } catch (LogicException) {
+            $lock->release();
+
+            return;
+        }
+
+        $persistedLogs = 0;
+        $sourcePath = null;
+        try {
+            $sourcePath = $this->stageSourceFile($session, $tenant);
+
+            $processed = 0;
+            foreach ($this->rowReader->read($sourcePath) as $rowNumber => $cells) {
+                $result = $this->attributeCreator->create($rowNumber, $cells, $tenant);
+                $this->applyOutcome($session, $result);
+                $persistedLogs = $this->persistLogs($session, $rowNumber, $result, $persistedLogs);
+                ++$processed;
+                $session->setTotalRows($processed);
+                $this->progress->progress($session, $processed, $result->code);
+            }
+
+            $session->markCompleted();
+            $this->sessions->save($session);
+            $this->progress->completed($session);
+        } catch (FilesystemException|RuntimeException $exception) {
+            $session->markFailed($exception->getMessage());
+            $this->sessions->save($session);
+        } finally {
+            $lock->release();
+            if (null !== $sourcePath && file_exists($sourcePath)) {
+                @unlink($sourcePath);
+            }
+        }
+    }
+
+    private function applyOutcome(ImportSession $session, StructuralImportRowResult $result): void
+    {
+        match ($result->outcome) {
+            StructuralImportRowResult::OUTCOME_CREATED => $session->incrementSuccess(),
+            StructuralImportRowResult::OUTCOME_UPDATED => $session->incrementUpdated(),
+            StructuralImportRowResult::OUTCOME_ERROR => $session->incrementError(),
+            default => $session->incrementSkipped(),
+        };
+    }
+
+    private function persistLogs(ImportSession $session, int $rowNumber, StructuralImportRowResult $result, int $persistedLogs): int
+    {
+        foreach ($result->logs as $log) {
+            if ($persistedLogs >= self::MAX_PERSISTED_LOGS) {
+                break;
+            }
+            $this->importLogs->save(new ImportLog(
+                importSession: $session,
+                rowNumber: $rowNumber,
+                level: $log['level'],
+                message: $log['message'],
+                sku: $result->code,
+                errorType: $log['errorType'],
+                columnName: $log['columnName'],
+                columnValue: $log['columnValue'],
+            ));
+            if (ImportLogLevel::Error === $log['level']) {
+                $this->progress->error(
+                    $session,
+                    $rowNumber,
+                    $result->code,
+                    $log['errorType'] ?? 'invalid_value',
+                    $log['message'],
+                );
+            }
+            ++$persistedLogs;
+        }
+
+        return $persistedLogs;
+    }
+
+    private function stageSourceFile(ImportSession $session, Tenant $tenant): string
+    {
+        $remotePath = \sprintf(
+            '%s/%s/%s',
+            $tenant->getId()->toRfc4122(),
+            $session->getId()->toRfc4122(),
+            $session->getFileName(),
+        );
+
+        try {
+            $stream = $this->importsStorage->readStream($remotePath);
+        } catch (FilesystemException $exception) {
+            throw new RuntimeException(\sprintf('Failed to read uploaded file at "%s".', $remotePath), previous: $exception);
+        }
+
+        $extension = pathinfo($session->getFileName(), PATHINFO_EXTENSION);
+        if ('' === $extension) {
+            $extension = 'csv';
+        }
+        $localPath = tempnam(sys_get_temp_dir(), 'pim-structural-import-').'.'.$extension;
+        $local = fopen($localPath, 'w');
+        if (false === $local) {
+            throw new RuntimeException(\sprintf('Failed to open temp file "%s" for writing.', $localPath));
+        }
+        stream_copy_to_stream($stream, $local);
+        fclose($local);
+
+        return $localPath;
+    }
+}

--- a/apps/api/src/Import/Application/Service/ImportRollbackService.php
+++ b/apps/api/src/Import/Application/Service/ImportRollbackService.php
@@ -7,6 +7,7 @@ namespace App\Import\Application\Service;
 use App\Catalog\Application\AttributesIndexedRebuilder;
 use App\Catalog\Application\Reindex\BulkReindexQueueInterface;
 use App\Catalog\Domain\Entity\CatalogObject;
+use App\Catalog\Domain\Entity\ObjectType;
 use App\Catalog\Domain\Provenance;
 use App\Catalog\Domain\Repository\ObjectValueRepositoryInterface;
 use App\Import\Domain\Entity\ImportSession;
@@ -80,7 +81,14 @@ final readonly class ImportRollbackService
         }
 
         try {
-            $kind = $session->getTargetObjectType()->getKind();
+            $targetObjectType = $session->getTargetObjectType();
+            if (!$targetObjectType instanceof ObjectType) {
+                // Structural imports (attributes / attribute groups) create
+                // configuration entities, not CatalogObjects, and are not
+                // rolled back through this catalog pipeline.
+                throw new LogicException('Structural import sessions cannot be rolled back through the catalog pipeline.');
+            }
+            $kind = $targetObjectType->getKind();
 
             // AUD-040 (W2-5) — the four DB steps (replay overwrites, rebuild the
             // restored caches, delete the created objects/values, flip the

--- a/apps/api/src/Import/Application/Service/Structural/AttributeImportCreator.php
+++ b/apps/api/src/Import/Application/Service/Structural/AttributeImportCreator.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service\Structural;
+
+use App\Catalog\Application\Command\CreateAttribute\CreateAttributeCommand;
+use App\Catalog\Application\Command\UpdateAttribute\UpdateAttributeCommand;
+use App\Catalog\Application\ObjectTypeService;
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\AttributeGroupAttribute;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Import\Application\Service\ImportColumnGrammar;
+use App\Import\Application\Service\MultiValueSplitter;
+use App\Import\Domain\Enum\ImportErrorType;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Shared\Domain\Tenant;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Creates or updates one Attribute definition from a structural-import row,
+ * the mirror of the `attributes_groups` export. Upserts by `code` (the natural
+ * key, unique per tenant): an unknown code dispatches CreateAttributeCommand, a
+ * known one UpdateAttributeCommand. Empty optional cells are left untouched
+ * (operator decision); the `object_types` and `groups` cells re-attach the
+ * attribute to its modules and groups additively (re-import never detaches).
+ * Unknown object-type / group codes are skipped with a warning, never failing
+ * the row.
+ */
+final readonly class AttributeImportCreator
+{
+    public function __construct(
+        private MessageBusInterface $commandBus,
+        private AttributeRepositoryInterface $attributes,
+        private AttributeGroupRepositoryInterface $groups,
+        private ObjectTypeRepositoryInterface $objectTypes,
+        private ObjectTypeService $objectTypeService,
+        private AttributeOptionImporter $optionImporter,
+        private ImportColumnGrammar $grammar,
+        private EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @param array<string, string|null> $cells header => raw cell value
+     */
+    public function create(int $rowNumber, array $cells, Tenant $tenant): StructuralImportRowResult
+    {
+        $result = new StructuralImportRowResult();
+
+        $code = trim($cells['code'] ?? '');
+        if ('' === $code) {
+            $result->setOutcome(StructuralImportRowResult::OUTCOME_ERROR);
+            $result->log(ImportLogLevel::Error, 'Wiersz pominięty: brak wymaganej kolumny "code".', ImportErrorType::MissingRequired->value, 'code');
+
+            return $result;
+        }
+        $result->code = $code;
+
+        $label = $this->extractLocalized($cells, 'label', $tenant);
+        $help = $this->extractLocalized($cells, 'help', $tenant);
+        $validationRules = $this->parseJsonObject($cells['validation_rules'] ?? null, $rowNumber, $result);
+        $options = $this->parseOptions($cells['options'] ?? null, $result);
+        $groupCodes = MultiValueSplitter::split($cells['groups'] ?? '');
+        $objectTypeCodes = MultiValueSplitter::split($cells['object_types'] ?? '');
+
+        $existing = $this->attributes->findByCode($code, $tenant);
+
+        try {
+            $attribute = null === $existing
+                ? $this->createAttribute($code, $cells, $label, $help, $validationRules, $tenant, $result)
+                : $this->updateAttribute($existing, $cells, $label, $help, $validationRules, $result);
+        } catch (Throwable $exception) {
+            $result->setOutcome(StructuralImportRowResult::OUTCOME_ERROR);
+            $result->log(ImportLogLevel::Error, \sprintf('Atrybut "%s": %s', $code, $exception->getMessage()), ImportErrorType::InvalidValue->value, 'code', $code);
+
+            return $result;
+        }
+
+        if (!$attribute instanceof Attribute) {
+            return $result;
+        }
+
+        $this->attachGroups($attribute, $groupCodes, $tenant, $result);
+        $this->assignObjectTypes($attribute, $objectTypeCodes, $tenant, $result);
+        if ($attribute->usesOptions() && [] !== $options) {
+            $this->optionImporter->sync($attribute, $options);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, string|null> $cells
+     * @param array<string, string>      $label
+     * @param array<string, string>      $help
+     * @param array<string, mixed>       $validationRules
+     */
+    private function createAttribute(
+        string $code,
+        array $cells,
+        array $label,
+        array $help,
+        array $validationRules,
+        Tenant $tenant,
+        StructuralImportRowResult $result,
+    ): ?Attribute {
+        $rawType = trim($cells['type'] ?? '');
+        $type = AttributeType::tryFrom($rawType);
+        if (!$type instanceof AttributeType) {
+            $result->setOutcome(StructuralImportRowResult::OUTCOME_ERROR);
+            $result->log(ImportLogLevel::Error, \sprintf('Atrybut "%s": nieznany typ "%s".', $code, $rawType), ImportErrorType::InvalidType->value, 'type', $rawType);
+
+            return null;
+        }
+
+        $command = new CreateAttributeCommand(
+            code: $code,
+            label: $label,
+            type: $type->value,
+            help: [] === $help ? null : $help,
+            localizable: $this->boolCell($cells['is_localizable'] ?? null) ?? false,
+            scopable: $this->boolCell($cells['is_scopable'] ?? null) ?? false,
+            required: $this->boolCell($cells['is_required'] ?? null) ?? false,
+            filterable: $this->boolCell($cells['is_filterable'] ?? null) ?? false,
+            validationRules: $validationRules,
+        );
+        $newId = $this->dispatch($command);
+        $attribute = $newId instanceof Uuid ? $this->attributes->findById($newId) : $this->attributes->findByCode($code, $tenant);
+        $result->setOutcome(StructuralImportRowResult::OUTCOME_CREATED);
+
+        return $attribute;
+    }
+
+    /**
+     * @param array<string, string|null> $cells
+     * @param array<string, string>      $label
+     * @param array<string, string>      $help
+     * @param array<string, mixed>       $validationRules
+     */
+    private function updateAttribute(
+        Attribute $existing,
+        array $cells,
+        array $label,
+        array $help,
+        array $validationRules,
+        StructuralImportRowResult $result,
+    ): Attribute {
+        // Empty cells leave the value untouched (operator decision): only pass
+        // a field when the file actually carried a value for it.
+        $isSystem = $existing->isSystem();
+        $localizable = $isSystem ? null : $this->boolCell($cells['is_localizable'] ?? null);
+        $scopable = $isSystem ? null : $this->boolCell($cells['is_scopable'] ?? null);
+        $required = $isSystem ? null : $this->boolCell($cells['is_required'] ?? null);
+        $filterable = $isSystem ? null : $this->boolCell($cells['is_filterable'] ?? null);
+        $rules = $isSystem ? null : ([] === $validationRules ? null : $validationRules);
+
+        if ($isSystem && $this->carriesStructuralChange($cells)) {
+            $result->log(ImportLogLevel::Warning, \sprintf('Atrybut systemowy "%s": zmieniono tylko etykietę/opis, pola strukturalne pominięto.', $existing->getCode()), ImportErrorType::InvalidValue->value, 'code', $existing->getCode());
+        }
+
+        $command = new UpdateAttributeCommand(
+            id: $existing->getId(),
+            label: [] === $label ? null : $label,
+            help: [] === $help ? null : $help,
+            localizable: $localizable,
+            scopable: $scopable,
+            required: $required,
+            filterable: $filterable,
+            validationRules: $rules,
+        );
+        $this->dispatch($command);
+        $result->setOutcome(StructuralImportRowResult::OUTCOME_UPDATED);
+
+        return $existing;
+    }
+
+    /**
+     * Additive group attachment: ensure an AttributeGroupAttribute junction for
+     * every known group code; never detaches. Unknown codes warn and skip.
+     *
+     * @param list<string> $groupCodes
+     */
+    private function attachGroups(Attribute $attribute, array $groupCodes, Tenant $tenant, StructuralImportRowResult $result): void
+    {
+        if ([] === $groupCodes) {
+            return;
+        }
+        $junctions = $this->em->getRepository(AttributeGroupAttribute::class);
+        $changed = false;
+        foreach ($groupCodes as $groupCode) {
+            $group = $this->groups->findByCode($groupCode, $tenant);
+            if (!$group instanceof AttributeGroup) {
+                $result->log(ImportLogLevel::Warning, \sprintf('Pominięto nieznaną grupę "%s".', $groupCode), ImportErrorType::InvalidValue->value, 'groups', $groupCode);
+
+                continue;
+            }
+            $existing = $junctions->findOneBy(['attributeGroup' => $group, 'attribute' => $attribute]);
+            if (null === $existing) {
+                $this->em->persist(new AttributeGroupAttribute($group, $attribute));
+                $changed = true;
+            }
+        }
+        if ($changed) {
+            $this->em->flush();
+        }
+    }
+
+    /**
+     * Idempotent ObjectType assignment via the shared service; unknown codes
+     * warn and skip.
+     *
+     * @param list<string> $objectTypeCodes
+     */
+    private function assignObjectTypes(Attribute $attribute, array $objectTypeCodes, Tenant $tenant, StructuralImportRowResult $result): void
+    {
+        foreach ($objectTypeCodes as $objectTypeCode) {
+            $objectType = $this->objectTypes->findByCode($objectTypeCode, $tenant);
+            if (!$objectType instanceof ObjectType) {
+                $result->log(ImportLogLevel::Warning, \sprintf('Pominięto nieznany typ obiektu "%s".', $objectTypeCode), ImportErrorType::InvalidValue->value, 'object_types', $objectTypeCode);
+
+                continue;
+            }
+            $this->objectTypeService->assignAttribute($objectType, $attribute);
+        }
+    }
+
+    private function dispatch(object $command): mixed
+    {
+        try {
+            $envelope = $this->commandBus->dispatch($command);
+        } catch (HandlerFailedException $exception) {
+            throw $exception->getPrevious() ?? $exception;
+        }
+        $stamp = $envelope->last(HandledStamp::class);
+
+        return $stamp instanceof HandledStamp ? $stamp->getResult() : null;
+    }
+
+    /**
+     * @param array<string, string|null> $cells
+     *
+     * @return array<string, string>
+     */
+    private function extractLocalized(array $cells, string $base, Tenant $tenant): array
+    {
+        $out = [];
+        foreach ($cells as $header => $value) {
+            if (null === $value || '' === trim($value)) {
+                continue;
+            }
+            $parsed = $this->grammar->parse($header, $tenant);
+            if ($parsed->base === $base && null !== $parsed->locale) {
+                $out[$parsed->locale] = trim($value);
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function parseJsonObject(?string $raw, int $rowNumber, StructuralImportRowResult $result): array
+    {
+        $raw = null === $raw ? '' : trim($raw);
+        if ('' === $raw || '{}' === $raw || '[]' === $raw) {
+            return [];
+        }
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            $result->log(ImportLogLevel::Warning, \sprintf('Wiersz %d: nieprawidłowy JSON w "validation_rules" — pominięto.', $rowNumber), ImportErrorType::InvalidValue->value, 'validation_rules', $raw);
+
+            return [];
+        }
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($decoded as $key => $value) {
+            $normalized[(string) $key] = $value;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return list<array{code: string, label: array<string, string>}>
+     */
+    private function parseOptions(?string $raw, StructuralImportRowResult $result): array
+    {
+        $raw = null === $raw ? '' : trim($raw);
+        if ('' === $raw || '[]' === $raw) {
+            return [];
+        }
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            $result->log(ImportLogLevel::Warning, 'Nieprawidłowy JSON w "options" — pominięto wartości słownikowe.', ImportErrorType::InvalidValue->value, 'options', $raw);
+
+            return [];
+        }
+        if (!\is_array($decoded)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($decoded as $entry) {
+            if (!\is_array($entry) || !isset($entry['code']) || !\is_scalar($entry['code'])) {
+                continue;
+            }
+            $optionCode = trim((string) $entry['code']);
+            if ('' === $optionCode) {
+                continue;
+            }
+            $label = [];
+            if (isset($entry['label']) && \is_array($entry['label'])) {
+                foreach ($entry['label'] as $locale => $text) {
+                    if (\is_scalar($text)) {
+                        $label[(string) $locale] = (string) $text;
+                    }
+                }
+            }
+            $out[] = ['code' => $optionCode, 'label' => $label];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, string|null> $cells
+     */
+    private function carriesStructuralChange(array $cells): bool
+    {
+        foreach (['is_localizable', 'is_scopable', 'is_required', 'is_filterable', 'validation_rules'] as $key) {
+            $value = $cells[$key] ?? null;
+            if (null !== $value && '' !== trim($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function boolCell(?string $raw): ?bool
+    {
+        if (null === $raw) {
+            return null;
+        }
+        $raw = strtolower(trim($raw));
+        if ('' === $raw) {
+            return null;
+        }
+
+        return \in_array($raw, ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/apps/api/src/Import/Application/Service/Structural/AttributeOptionImporter.php
+++ b/apps/api/src/Import/Application/Service/Structural/AttributeOptionImporter.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service\Structural;
+
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeOption;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Upserts the select/multiselect options carried by an attribute import row's
+ * `options` JSON cell. Mirrors the create logic of
+ * {@see \App\Catalog\Presentation\Controller\AttributeOptionsController} (dedupe
+ * by `(attribute, code)`, auto-assign position) but without the HTTP layer.
+ *
+ * Additive by decision: a re-import adds new options and refreshes labels of
+ * existing ones; it never deletes options dropped from the file. Tenant is
+ * stamped on prePersist (AttributeOption implements TenantScoped).
+ */
+final readonly class AttributeOptionImporter
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private AttributeOptionRepositoryInterface $options,
+    ) {
+    }
+
+    /**
+     * @param list<array{code: string, label: array<string, string>}> $rows
+     */
+    public function sync(Attribute $attribute, array $rows): void
+    {
+        if ([] === $rows) {
+            return;
+        }
+
+        $existing = [];
+        $maxPosition = -1;
+        foreach ($this->options->findByAttribute($attribute) as $option) {
+            $existing[$option->getCode()] = $option;
+            $maxPosition = max($maxPosition, $option->getPosition());
+        }
+
+        foreach ($rows as $row) {
+            $code = $row['code'];
+            $label = $row['label'];
+            $current = $existing[$code] ?? null;
+            if ($current instanceof AttributeOption) {
+                if ([] !== $label) {
+                    $current->rename($label);
+                }
+
+                continue;
+            }
+
+            $option = new AttributeOption($attribute, $code, $label, ++$maxPosition);
+            $this->em->persist($option);
+            $existing[$code] = $option;
+        }
+
+        $this->em->flush();
+    }
+}

--- a/apps/api/src/Import/Application/Service/Structural/StructuralImportRowResult.php
+++ b/apps/api/src/Import/Application/Service/Structural/StructuralImportRowResult.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service\Structural;
+
+use App\Import\Domain\Enum\ImportLogLevel;
+
+/**
+ * Per-row outcome of a structural import (attribute / attribute-group).
+ *
+ * The creator decides the {@see $outcome} (which session counter the row
+ * bumps) and appends any number of {@see $logs} — a row may succeed yet still
+ * carry warnings (e.g. an unknown object_type reference that was skipped). The
+ * {@see StructuralImportRunHandler} reads this back to update the session and
+ * persist the ImportLog rows.
+ *
+ * @phpstan-type RowLog array{level: ImportLogLevel, message: string, errorType: ?string, columnName: ?string, columnValue: ?string}
+ */
+final class StructuralImportRowResult
+{
+    public const string OUTCOME_CREATED = 'created';
+    public const string OUTCOME_UPDATED = 'updated';
+    public const string OUTCOME_SKIPPED = 'skipped';
+    public const string OUTCOME_ERROR = 'error';
+
+    /** @var self::OUTCOME_* */
+    public string $outcome = self::OUTCOME_SKIPPED;
+
+    /** Natural key of the row (attribute/group code), for logs + progress. */
+    public ?string $code = null;
+
+    /** @var list<RowLog> */
+    public array $logs = [];
+
+    /**
+     * @param self::OUTCOME_* $outcome
+     */
+    public function setOutcome(string $outcome): void
+    {
+        $this->outcome = $outcome;
+    }
+
+    public function log(
+        ImportLogLevel $level,
+        string $message,
+        ?string $errorType = null,
+        ?string $columnName = null,
+        ?string $columnValue = null,
+    ): void {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => $message,
+            'errorType' => $errorType,
+            'columnName' => $columnName,
+            'columnValue' => $columnValue,
+        ];
+    }
+}

--- a/apps/api/src/Import/Domain/Entity/ImportSession.php
+++ b/apps/api/src/Import/Domain/Entity/ImportSession.php
@@ -62,7 +62,19 @@ class ImportSession extends AggregateRoot implements TenantScoped
      */
     private bool $createMissingOptions = false;
 
-    private ObjectType $targetObjectType;
+    /**
+     * Null for structural imports (attributes / attribute groups), which create
+     * configuration entities rather than CatalogObjects of an ObjectType.
+     */
+    private ?ObjectType $targetObjectType = null;
+
+    /**
+     * Structural import discriminator: `attributes` | `attribute_groups`, or
+     * null for the CatalogObject pipeline (product / custom_module / category).
+     * Lets the worker route a session to the structural handler instead of
+     * {@see \App\Import\Application\Handler\ImportRunHandler}.
+     */
+    private ?string $structuralKind = null;
 
     private string $status = ImportSessionStatus::Pending->value;
 
@@ -146,17 +158,19 @@ class ImportSession extends AggregateRoot implements TenantScoped
 
     public function __construct(
         Uuid $userId,
-        ObjectType $targetObjectType,
+        ?ObjectType $targetObjectType,
         string $fileName,
         int $fileSizeBytes,
         ?ImportProfile $profile = null,
         ?string $zipFileName = null,
         ?int $zipFileSizeBytes = null,
         ?Uuid $id = null,
+        ?string $structuralKind = null,
     ) {
         $this->id = $id ?? Uuid::v7();
         $this->userId = $userId;
         $this->targetObjectType = $targetObjectType;
+        $this->structuralKind = $structuralKind;
         $this->fileName = $fileName;
         $this->fileSizeBytes = $fileSizeBytes;
         $this->profile = $profile;
@@ -236,9 +250,19 @@ class ImportSession extends AggregateRoot implements TenantScoped
         $this->createMissingOptions = $createMissingOptions;
     }
 
-    public function getTargetObjectType(): ObjectType
+    public function getTargetObjectType(): ?ObjectType
     {
         return $this->targetObjectType;
+    }
+
+    public function getStructuralKind(): ?string
+    {
+        return $this->structuralKind;
+    }
+
+    public function isStructural(): bool
+    {
+        return null !== $this->structuralKind;
     }
 
     public function getStatus(): ImportSessionStatus

--- a/apps/api/src/Import/Domain/Message/StructuralImportRunMessage.php
+++ b/apps/api/src/Import/Domain/Message/StructuralImportRunMessage.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Domain\Message;
+
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Async marker for a structural import (attribute / attribute-group
+ * definitions). Routed to the `import` transport (see
+ * config/packages/messenger.yaml); the handler loads the
+ * {@see \App\Import\Domain\Entity\ImportSession} by id and creates/updates
+ * the configuration entities. Mirrors {@see ImportRunMessage} but is handled
+ * by {@see \App\Import\Application\Handler\StructuralImportRunHandler}.
+ */
+final readonly class StructuralImportRunMessage
+{
+    public function __construct(
+        public Uuid $importSessionId,
+        public Uuid $tenantId,
+    ) {
+    }
+}

--- a/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
+++ b/apps/api/src/Import/Infrastructure/Doctrine/Orm/Mapping/ImportSession.orm.xml
@@ -45,8 +45,10 @@
         </field>
 
         <many-to-one field="targetObjectType" target-entity="App\Catalog\Domain\Entity\ObjectType">
-            <join-column name="target_object_type_id" referenced-column-name="id" nullable="false" on-delete="RESTRICT"/>
+            <join-column name="target_object_type_id" referenced-column-name="id" nullable="true" on-delete="RESTRICT"/>
         </many-to-one>
+
+        <field name="structuralKind" type="string" length="32" column="structural_kind" nullable="true"/>
 
         <field name="status" type="string" length="32">
             <options>

--- a/apps/api/src/Import/Presentation/Controller/ListImportSessionsController.php
+++ b/apps/api/src/Import/Presentation/Controller/ListImportSessionsController.php
@@ -144,7 +144,8 @@ final class ListImportSessionsController
             'duration_sec' => $durationSec,
             'profile_name' => $profile?->getName(),
             'profile_id' => $profile?->getId()->toRfc4122(),
-            'target_object_type_code' => $session->getTargetObjectType()->getCode(),
+            'target_object_type_code' => $session->getTargetObjectType()?->getCode(),
+            'structural_kind' => $session->getStructuralKind(),
             'mode' => $session->getMode()->value,
             'backup' => self::serializeBackup($session->getBackupSnapshot()),
         ];

--- a/apps/api/src/Import/Presentation/Controller/StartStructuralImportController.php
+++ b/apps/api/src/Import/Presentation/Controller/StartStructuralImportController.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Presentation\Controller;
+
+use App\Identity\Contracts\Attribute\RequiresPermission;
+use App\Identity\Domain\Entity\User;
+use App\Import\Application\Handler\StructuralImportRunHandler;
+use App\Import\Application\Service\Archive\ArchiveSecurityException;
+use App\Import\Application\Service\Archive\XlsxArchiveGuard;
+use App\Import\Application\Service\StagedFileService;
+use App\Import\Domain\Entity\ImportSession;
+use App\Import\Domain\Entity\StagedFile;
+use App\Import\Domain\Message\StructuralImportRunMessage;
+use App\Import\Domain\Repository\ImportSessionRepositoryInterface;
+use App\Shared\Application\TenantContext;
+use App\Shared\Infrastructure\Messenger\Stamp\TenantStamp;
+use DateTimeInterface;
+use InvalidArgumentException;
+use League\Flysystem\FilesystemException;
+use League\Flysystem\FilesystemOperator;
+use RuntimeException;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * Start a structural import (attribute / attribute-group definitions) — the
+ * mirror of the `attributes_groups` / `attribute_groups` exports.
+ *
+ * Unlike {@see StartImportController} this carries no `target_object_type_id`
+ * (the rows create configuration entities, not CatalogObjects) and requires a
+ * `structural_kind` of `attributes` | `attribute_groups`. Small files (< 50
+ * data rows) run inline; larger ones hand off to the worker via
+ * {@see StructuralImportRunMessage}.
+ *
+ * Multipart fields: `structural_kind`, plus either `staged_file_id` (uploaded
+ * once at parse-preview) or a fresh `file`.
+ */
+final class StartStructuralImportController
+{
+    private const int SYNC_THRESHOLD_ROWS = 50;
+    private const int DEFAULT_MAX_ROWS = 200_000;
+    private const int DEFAULT_MAX_FILE_BYTES = 100 * 1024 * 1024;
+
+    private const array ALLOWED_KINDS = ['attributes', 'attribute_groups'];
+
+    public function __construct(
+        private readonly ImportSessionRepositoryInterface $sessions,
+        private readonly StructuralImportRunHandler $runHandler,
+        private readonly MessageBusInterface $bus,
+        private readonly Security $security,
+        private readonly TenantContext $tenantContext,
+        private readonly FilesystemOperator $importsStorage,
+        private readonly StagedFileService $stagedFiles,
+        private readonly RateLimiterFactoryInterface $importTriggerLimiter,
+        private readonly XlsxArchiveGuard $xlsxArchiveGuard,
+    ) {
+    }
+
+    #[Route(path: '/api/structural-import-sessions', name: 'imports_structural_start', methods: ['POST'])]
+    #[RequiresPermission(module: 'imports', action: 'run')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new UnauthorizedHttpException('JWT', 'Authenticated user required.');
+        }
+        $tenant = $user->getTenant();
+        $this->tenantContext->set($tenant);
+
+        $reservation = $this->importTriggerLimiter->create($tenant->getId()->toRfc4122())->consume();
+        if (!$reservation->isAccepted()) {
+            throw new TooManyRequestsHttpException(
+                max(0, $reservation->getRetryAfter()->getTimestamp() - time()),
+                'Przekroczono limit importów dla tego tenanta. Spróbuj ponownie później.',
+            );
+        }
+
+        $kind = (string) $request->request->get('structural_kind', '');
+        if (!\in_array($kind, self::ALLOWED_KINDS, true)) {
+            throw new BadRequestHttpException(\sprintf('"structural_kind" must be one of: %s.', implode(', ', self::ALLOWED_KINDS)));
+        }
+
+        $stagedFile = $this->resolveStagedFile($request, $user);
+        $file = $request->files->get('file');
+        if (null === $stagedFile && !$file instanceof UploadedFile) {
+            throw new BadRequestHttpException('Either "staged_file_id" or a "file" multipart field is required.');
+        }
+        $localPath = null !== $stagedFile ? $this->stagedFiles->downloadToTemp($stagedFile) : $file->getPathname();
+        $originalName = null !== $stagedFile ? $stagedFile->getFileName() : $file->getClientOriginalName();
+        if ('' === $originalName) {
+            $originalName = 'upload.csv';
+        }
+        $fileSizeBytes = null !== $stagedFile ? $stagedFile->getSizeBytes() : (int) $file->getSize();
+
+        if ($fileSizeBytes > self::DEFAULT_MAX_FILE_BYTES) {
+            throw new UnprocessableEntityHttpException(\sprintf(
+                'Plik (%d B) przekracza limit %d MB.',
+                $fileSizeBytes,
+                intdiv(self::DEFAULT_MAX_FILE_BYTES, 1024 * 1024),
+            ));
+        }
+
+        if (str_ends_with(strtolower($originalName), '.xlsx')) {
+            try {
+                $this->xlsxArchiveGuard->validate($localPath);
+            } catch (ArchiveSecurityException $exception) {
+                throw new UnprocessableEntityHttpException($exception->getMessage(), $exception);
+            }
+        }
+
+        $dataRowCount = str_ends_with(strtolower($originalName), '.csv')
+            ? $this->countDataRows($localPath, self::DEFAULT_MAX_ROWS + 1)
+            : self::SYNC_THRESHOLD_ROWS + 1;
+        if ($dataRowCount > self::DEFAULT_MAX_ROWS) {
+            throw new UnprocessableEntityHttpException(\sprintf('Plik przekracza limit %d wierszy.', self::DEFAULT_MAX_ROWS));
+        }
+
+        $session = new ImportSession(
+            userId: $user->getId(),
+            targetObjectType: null,
+            fileName: $originalName,
+            fileSizeBytes: $fileSizeBytes,
+            structuralKind: $kind,
+        );
+        $this->sessions->save($session);
+
+        $remotePath = \sprintf('%s/%s/%s', $tenant->getId()->toRfc4122(), $session->getId()->toRfc4122(), $session->getFileName());
+        try {
+            if (null !== $stagedFile) {
+                $this->stagedFiles->copyToKey($stagedFile, $remotePath);
+            } else {
+                $stream = fopen($localPath, 'r');
+                if (false === $stream) {
+                    throw new RuntimeException('Failed to open uploaded file for reading.');
+                }
+                try {
+                    $this->importsStorage->writeStream($remotePath, $stream);
+                } finally {
+                    if (\is_resource($stream)) {
+                        fclose($stream);
+                    }
+                }
+            }
+        } catch (FilesystemException|RuntimeException $exception) {
+            $session->markFailed(\sprintf('Failed to stage uploaded file: %s', $exception->getMessage()));
+            $this->sessions->save($session);
+            throw new BadRequestHttpException('Failed to stage the uploaded file.', $exception);
+        } finally {
+            if (null !== $stagedFile) {
+                @unlink($localPath);
+            }
+        }
+
+        if ($dataRowCount <= self::SYNC_THRESHOLD_ROWS) {
+            $reload = $this->sessions->findById($session->getId());
+            if ($reload instanceof ImportSession) {
+                $this->runHandler->run($reload);
+                $reload = $this->sessions->findById($session->getId()) ?? $reload;
+
+                return new JsonResponse($this->serialise($reload), Response::HTTP_OK);
+            }
+        }
+
+        $this->bus->dispatch(new StructuralImportRunMessage(
+            importSessionId: $session->getId(),
+            tenantId: $tenant->getId(),
+        ), [new TenantStamp($tenant->getId())]);
+
+        return new JsonResponse($this->serialise($session), Response::HTTP_ACCEPTED);
+    }
+
+    private function resolveStagedFile(Request $request, User $user): ?StagedFile
+    {
+        $raw = (string) $request->request->get('staged_file_id', '');
+        if ('' === $raw) {
+            return null;
+        }
+        try {
+            $id = Uuid::fromString($raw);
+        } catch (InvalidArgumentException) {
+            throw new BadRequestHttpException(\sprintf('Invalid staged_file_id "%s".', $raw));
+        }
+        $staged = $this->stagedFiles->resolveOwned($id, $user->getTenant(), $user->getId());
+        if (null === $staged) {
+            throw new NotFoundHttpException(\sprintf('Staged file "%s" was not found.', $raw));
+        }
+
+        return $staged;
+    }
+
+    private function countDataRows(string $path, int $cap): int
+    {
+        $handle = @fopen($path, 'r');
+        if (false === $handle) {
+            return $cap;
+        }
+        $count = -1; // header line
+        try {
+            while (false !== ($line = fgets($handle))) {
+                if ('' === trim($line)) {
+                    continue;
+                }
+                ++$count;
+                if ($count >= $cap) {
+                    return $count;
+                }
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return max(0, $count);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serialise(ImportSession $session): array
+    {
+        return [
+            'id' => $session->getId()->toRfc4122(),
+            'status' => $session->getStatus()->value,
+            'structural_kind' => $session->getStructuralKind(),
+            'total_rows' => $session->getTotalRows(),
+            'success_count' => $session->getSuccessCount(),
+            'error_count' => $session->getErrorCount(),
+            'updated_count' => $session->getUpdatedCount(),
+            'skipped_count' => $session->getSkippedCount(),
+            'started_at' => $session->getStartedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+            'completed_at' => $session->getCompletedAt()?->format(DateTimeInterface::RFC3339_EXTENDED),
+        ];
+    }
+}

--- a/apps/api/tests/Api/Import/StructuralAttributeImportTest.php
+++ b/apps/api/tests/Api/Import/StructuralAttributeImportTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\AttributeType;
+use App\Catalog\Domain\Entity\Attribute;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
+use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeAttributeRepositoryInterface;
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Import\Application\Service\Structural\AttributeImportCreator;
+use App\Import\Application\Service\Structural\StructuralImportRowResult;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Structural attribute import — the mirror of the `attributes_groups` export.
+ * Exercises {@see AttributeImportCreator} directly (no HTTP/MinIO) so the core
+ * upsert + assignment behaviour is covered independently of auth/staging.
+ */
+final class StructuralAttributeImportTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Active tenant locales pl/en — the column grammar (IMP2-1.6) validates
+        // `label.pl` / `label.en` suffixes against this registry; the
+        // schema-built test DB ships no locale seeds.
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        foreach ([['pl_PL', 'Polski', 'pl'], ['en_US', 'English', 'en']] as [$code, $label, $lang]) {
+            $locale = new Locale($code, $label, null, $lang);
+            $this->em()->persist($locale);
+            $this->em()->persist(new TenantLocale($locale));
+        }
+        $this->em()->flush();
+    }
+
+    #[Test]
+    public function createsNewAttributeAndAssignsObjectTypeAndGroup(): void
+    {
+        $tenant = $this->tenant();
+        $module = $this->customObjectType($tenant, 'widgets');
+        $this->group($tenant, 'marketing');
+
+        $result = $this->creator()->create(2, [
+            'code' => 'tagline',
+            'type' => 'text',
+            'label.pl' => 'Hasło',
+            'label.en' => 'Tagline',
+            'is_localizable' => 'true',
+            'groups' => 'marketing',
+            'object_types' => 'widgets',
+        ], $tenant);
+
+        self::assertSame(StructuralImportRowResult::OUTCOME_CREATED, $result->outcome);
+
+        $attribute = $this->attributes()->findByCode('tagline', $tenant);
+        self::assertInstanceOf(Attribute::class, $attribute);
+        self::assertSame(AttributeType::Text, $attribute->getType());
+        self::assertSame(['pl' => 'Hasło', 'en' => 'Tagline'], $attribute->getLabel());
+        self::assertTrue($attribute->isLocalizable());
+
+        // Assigned to the module and the group.
+        self::assertNotNull($this->junctions()->findOne($module, $attribute));
+        self::assertContains('marketing', $this->groupCodesOf($attribute));
+    }
+
+    #[Test]
+    public function reimportIsIdempotentAndReportsUpdate(): void
+    {
+        $tenant = $this->tenant();
+        $module = $this->customObjectType($tenant, 'widgets');
+
+        $cells = ['code' => 'sku_ref', 'type' => 'text', 'label.en' => 'SKU', 'object_types' => 'widgets'];
+        $first = $this->creator()->create(2, $cells, $tenant);
+        self::assertSame(StructuralImportRowResult::OUTCOME_CREATED, $first->outcome);
+
+        $second = $this->creator()->create(2, $cells, $tenant);
+        self::assertSame(StructuralImportRowResult::OUTCOME_UPDATED, $second->outcome);
+
+        $attribute = $this->attributes()->findByCode('sku_ref', $tenant);
+        self::assertInstanceOf(Attribute::class, $attribute);
+        // No duplicate junction on re-import.
+        self::assertCount(1, $this->junctions()->findByAttribute($attribute));
+    }
+
+    #[Test]
+    public function unknownObjectTypeWarnsButStillImportsTheRow(): void
+    {
+        $tenant = $this->tenant();
+
+        $result = $this->creator()->create(2, [
+            'code' => 'weight',
+            'type' => 'number',
+            'object_types' => 'does_not_exist',
+        ], $tenant);
+
+        self::assertSame(StructuralImportRowResult::OUTCOME_CREATED, $result->outcome);
+        self::assertInstanceOf(Attribute::class, $this->attributes()->findByCode('weight', $tenant));
+        self::assertNotEmpty($result->logs, 'unknown object type should emit a warning');
+        self::assertStringContainsString('does_not_exist', $result->logs[0]['message']);
+    }
+
+    #[Test]
+    public function invalidTypeFailsTheRowWithoutCreatingAnAttribute(): void
+    {
+        $tenant = $this->tenant();
+
+        $result = $this->creator()->create(2, ['code' => 'broken', 'type' => 'not_a_type'], $tenant);
+
+        self::assertSame(StructuralImportRowResult::OUTCOME_ERROR, $result->outcome);
+        self::assertNull($this->attributes()->findByCode('broken', $tenant));
+    }
+
+    #[Test]
+    public function selectAttributeImportsItsOptions(): void
+    {
+        $tenant = $this->tenant();
+
+        $result = $this->creator()->create(2, [
+            'code' => 'color',
+            'type' => 'select',
+            'label.en' => 'Color',
+            'options' => json_encode([
+                ['code' => 'red', 'label' => ['en' => 'Red']],
+                ['code' => 'blue', 'label' => ['en' => 'Blue']],
+            ], JSON_THROW_ON_ERROR),
+        ], $tenant);
+
+        self::assertSame(StructuralImportRowResult::OUTCOME_CREATED, $result->outcome);
+        $attribute = $this->attributes()->findByCode('color', $tenant);
+        self::assertInstanceOf(Attribute::class, $attribute);
+        $codes = array_map(static fn ($o) => $o->getCode(), $this->options()->findByAttribute($attribute));
+        self::assertContains('red', $codes);
+        self::assertContains('blue', $codes);
+    }
+
+    private function creator(): AttributeImportCreator
+    {
+        return self::getContainer()->get(AttributeImportCreator::class);
+    }
+
+    private function attributes(): AttributeRepositoryInterface
+    {
+        return self::getContainer()->get(AttributeRepositoryInterface::class);
+    }
+
+    private function options(): AttributeOptionRepositoryInterface
+    {
+        return self::getContainer()->get(AttributeOptionRepositoryInterface::class);
+    }
+
+    private function junctions(): ObjectTypeAttributeRepositoryInterface
+    {
+        return self::getContainer()->get(ObjectTypeAttributeRepositoryInterface::class);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function groupCodesOf(Attribute $attribute): array
+    {
+        /** @var list<string> $codes */
+        $codes = $this->em()->createQuery(
+            'SELECT g.code FROM '.\App\Catalog\Domain\Entity\AttributeGroupAttribute::class.' j JOIN j.attributeGroup g WHERE j.attribute = :a',
+        )->setParameter('a', $attribute)->getSingleColumnResult();
+
+        return $codes;
+    }
+
+    private function customObjectType(Tenant $tenant, string $code): ObjectType
+    {
+        $module = new ObjectType($code, ObjectKind::Custom, ['pl' => $code, 'en' => $code]);
+        $module->assignTenant($tenant);
+        $this->em()->persist($module);
+        $this->em()->flush();
+
+        return $module;
+    }
+
+    private function group(Tenant $tenant, string $code): AttributeGroup
+    {
+        $group = new AttributeGroup($code, ['pl' => $code, 'en' => $code]);
+        $group->assignTenant($tenant);
+        $this->em()->persist($group);
+        $this->em()->flush();
+
+        return $group;
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        return $tenant;
+    }
+}

--- a/docs/api-spec/v0.json
+++ b/docs/api-spec/v0.json
@@ -14404,6 +14404,32 @@
                 "x-cortex-permission": "user.admin"
             }
         },
+        "/api/structural-import-sessions": {
+            "post": {
+                "operationId": "api_structural_import_sessions_post",
+                "tags": [
+                    "structural-import-sessions"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    }
+                },
+                "summary": "Api structural import sessions",
+                "description": "Custom controller route.",
+                "parameters": [],
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "x-pim-source": "custom-route",
+                "x-cortex-permission": "imports.run"
+            }
+        },
         "/api/tenant": {
             "get": {
                 "operationId": "api_tenant_get",


### PR DESCRIPTION
## Cel

Trzeci krok planu — **import definicji atrybutów**, lustrzane odbicie eksportu `attributes_groups`. Po imporcie nowe/zmienione atrybuty pojawiają się w `/modeling/attributes` (nieodróżnialne od ręcznie dodanych), a kolumna `object_types` automatycznie przypina je do wskazanych typów obiektów — gotowe do użycia przy dodawaniu Produktu lub własnego ObjectType.

**Zakres tego PR-a: backend (API-first).** Endpoint działa end-to-end (smoke-test niżej). Podpięcie kafelka w kreatorze importu (`/integrations/imports/new`) idzie w osobnym PR FE razem z importem grup (wspólne zmiany kreatora).

## Architektura

Dedykowana ścieżka „structural import" — reuse powłoki importu (`ImportSession`, `ImportLog`, Mercure, staging MinIO, per-tenant bulk lock), ale wykonanie odgałęzione do handlera, który **upsertuje encje konfiguracyjne przez istniejące komendy CQRS** (`CreateAttribute`/`UpdateAttribute`) zamiast pisać `CatalogObject`+`ObjectValue`.

- **`ImportSession`**: `target_object_type_id` teraz nullable + nowy `structural_kind` (`attributes`|`attribute_groups`). Migracja + ORM. Callerzy katalogowi pól targetu osłonięci guardem.
- **`POST /api/structural-import-sessions`** (`StartStructuralImportController`) — bez `target_object_type_id`, wymaga `structural_kind`; <50 wierszy inline, więcej → `StructuralImportRunMessage` (kolejka `import`).
- **`StructuralImportRunHandler`** + **`AttributeImportCreator`** + **`AttributeOptionImporter`**:
  - upsert po `code` (klucz naturalny per tenant),
  - `object_types` → idempotentne `ObjectTypeAttribute` (`ObjectTypeService::assignAttribute`),
  - `groups` → additywne `AttributeGroupAttribute`,
  - `options` JSON → `AttributeOption`,
  - **decyzje operatora**: re-import tylko dodaje/aktualizuje (nigdy nie usuwa przypisań), puste komórki nie nadpisują wartości, nieznane kody object type/grupy → ostrzeżenie + pominięcie (wiersz i tak się importuje).

## Weryfikacja

- PHPStan max ✅ · php-cs-fixer ✅ · deptrac ✅
- `StructuralAttributeImportTest` ✅ 5/5: create, idempotentny re-import (updated, brak duplikatów junctionów), nieznany OT → warning non-blocking, invalid type → błąd wiersza, opcje select.
- **Smoke-test na żywym stacku** (`https://pim.localhost`, admin@demo.localhost):
  - POST CSV (`code;type;label.pl;label.en;object_types`, 2 wiersze, `object_types=product`) → `HTTP 200 {"status":"success","success_count":2}`
  - `GET /api/attributes` → `smoke_material` (text), `smoke_warranty` (number) obecne
  - DB: oba przypisane do ObjectType `product` (`object_type_attributes`)
  - re-import tego samego pliku → `{"status":"success","updated_count":2}`, junctiony nadal 1×1 (zero duplikatów)
  - dane smoke posprzątane

## Następne
- PR4: backend importu grup atrybutów (`AttributeGroupImportCreator` + `ObjectTypeAttributeGroupAssigner`)
- PR5 (FE): kafelki „Atrybuty"/„Grupy atrybutów" aktywne w kreatorze importu + dry-run + E2E

Refs #1382