### PR TITLE
feat(import): backend importu definicji grup atrybutów

### DIFF
--- a/apps/api/deptrac.yaml
+++ b/apps/api/deptrac.yaml
@@ -508,6 +508,14 @@ parameters:
             - App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface
             - App\Catalog\Domain\Repository\AttributeRepositoryInterface
             - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
+        App\Import\Application\Service\Structural\AttributeGroupImportCreator:
+            - App\Catalog\Application\Command\CreateAttributeGroup\CreateAttributeGroupCommand
+            - App\Catalog\Application\Command\UpdateAttributeGroup\UpdateAttributeGroupCommand
+            - App\Catalog\Application\ObjectTypeAttributeGroupAssigner
+            - App\Catalog\Domain\Entity\AttributeGroup
+            - App\Catalog\Domain\Entity\ObjectType
+            - App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface
+            - App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface
         App\Import\Application\Service\Structural\AttributeOptionImporter:
             - App\Catalog\Domain\Entity\Attribute
             - App\Catalog\Domain\Entity\AttributeOption

--- a/apps/api/src/Catalog/Application/ObjectTypeAttributeGroupAssigner.php
+++ b/apps/api/src/Catalog/Application/ObjectTypeAttributeGroupAssigner.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Catalog\Application;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Idempotent attachment of an AttributeGroup to an ObjectType — the mirror of
+ * {@see ObjectTypeService::assignAttribute} for groups.
+ *
+ * The existing junction is left untouched; a missing one is created. A cheap
+ * DBAL existence check avoids hydrating the composite-key junction entity.
+ * Shared by the attach controller and the structural import creator so the
+ * "attach group to module" semantics live in one place.
+ */
+final readonly class ObjectTypeAttributeGroupAssigner
+{
+    public function __construct(
+        private EntityManagerInterface $em,
+        private Connection $connection,
+    ) {
+    }
+
+    public function assign(ObjectType $objectType, AttributeGroup $group): void
+    {
+        $existing = $this->connection->fetchOne(
+            'SELECT 1 FROM object_type_attribute_groups WHERE object_type_id = ? AND attribute_group_id = ?',
+            [$objectType->getId()->toRfc4122(), $group->getId()->toRfc4122()],
+        );
+        if (false === $existing) {
+            $this->em->persist(new ObjectTypeAttributeGroup($objectType, $group));
+            $this->em->flush();
+        }
+    }
+}

--- a/apps/api/src/Import/Application/Handler/StructuralImportRunHandler.php
+++ b/apps/api/src/Import/Application/Handler/StructuralImportRunHandler.php
@@ -6,6 +6,7 @@ namespace App\Import\Application\Handler;
 
 use App\Import\Application\Service\ImportProgressPublisher;
 use App\Import\Application\Service\ImportRowReader;
+use App\Import\Application\Service\Structural\AttributeGroupImportCreator;
 use App\Import\Application\Service\Structural\AttributeImportCreator;
 use App\Import\Application\Service\Structural\StructuralImportRowResult;
 use App\Import\Domain\Entity\ImportLog;
@@ -51,6 +52,7 @@ final class StructuralImportRunHandler
         private readonly ImportLogRepositoryInterface $importLogs,
         private readonly ImportProgressPublisher $progress,
         private readonly AttributeImportCreator $attributeCreator,
+        private readonly AttributeGroupImportCreator $attributeGroupCreator,
         private readonly TenantContext $tenantContext,
         private readonly FilesystemOperator $importsStorage,
         private readonly BulkOperationLock $bulkLock,
@@ -98,7 +100,7 @@ final class StructuralImportRunHandler
             return;
         }
         $kind = $session->getStructuralKind();
-        if ('attributes' !== $kind) {
+        if ('attributes' !== $kind && 'attribute_groups' !== $kind) {
             $session->markFailed(\sprintf('Unsupported structural import kind "%s".', $kind ?? 'null'));
             $this->sessions->save($session);
 
@@ -126,7 +128,9 @@ final class StructuralImportRunHandler
 
             $processed = 0;
             foreach ($this->rowReader->read($sourcePath) as $rowNumber => $cells) {
-                $result = $this->attributeCreator->create($rowNumber, $cells, $tenant);
+                $result = 'attribute_groups' === $kind
+                    ? $this->attributeGroupCreator->create($rowNumber, $cells, $tenant)
+                    : $this->attributeCreator->create($rowNumber, $cells, $tenant);
                 $this->applyOutcome($session, $result);
                 $persistedLogs = $this->persistLogs($session, $rowNumber, $result, $persistedLogs);
                 ++$processed;

--- a/apps/api/src/Import/Application/Service/Structural/AttributeGroupImportCreator.php
+++ b/apps/api/src/Import/Application/Service/Structural/AttributeGroupImportCreator.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Import\Application\Service\Structural;
+
+use App\Catalog\Application\Command\CreateAttributeGroup\CreateAttributeGroupCommand;
+use App\Catalog\Application\Command\UpdateAttributeGroup\UpdateAttributeGroupCommand;
+use App\Catalog\Application\ObjectTypeAttributeGroupAssigner;
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Import\Application\Service\ImportColumnGrammar;
+use App\Import\Application\Service\MultiValueSplitter;
+use App\Import\Domain\Enum\ImportErrorType;
+use App\Import\Domain\Enum\ImportLogLevel;
+use App\Shared\Domain\Tenant;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+
+/**
+ * Creates or updates one AttributeGroup definition from a structural-import
+ * row, the mirror of the `attribute_groups` export. Upserts by `code` (the
+ * natural key, unique per tenant). Empty optional cells leave the value
+ * untouched (operator decision); the `object_types` cell re-attaches the group
+ * to its modules additively (re-import never detaches). Unknown object-type
+ * codes are skipped with a warning, never failing the row. The `is_built_in`
+ * column is export-only metadata and is ignored here.
+ */
+final readonly class AttributeGroupImportCreator
+{
+    public function __construct(
+        private MessageBusInterface $commandBus,
+        private AttributeGroupRepositoryInterface $groups,
+        private ObjectTypeRepositoryInterface $objectTypes,
+        private ObjectTypeAttributeGroupAssigner $assigner,
+        private ImportColumnGrammar $grammar,
+    ) {
+    }
+
+    /**
+     * @param array<string, string|null> $cells header => raw cell value
+     */
+    public function create(int $rowNumber, array $cells, Tenant $tenant): StructuralImportRowResult
+    {
+        $result = new StructuralImportRowResult();
+
+        $code = trim($cells['code'] ?? '');
+        if ('' === $code) {
+            $result->setOutcome(StructuralImportRowResult::OUTCOME_ERROR);
+            $result->log(ImportLogLevel::Error, 'Wiersz pominięty: brak wymaganej kolumny "code".', ImportErrorType::MissingRequired->value, 'code');
+
+            return $result;
+        }
+        $result->code = $code;
+
+        $label = $this->extractLocalized($cells, 'label', $tenant);
+        $description = $this->extractLocalized($cells, 'description', $tenant);
+        $icon = $this->stringCell($cells['icon'] ?? null);
+        $color = $this->stringCell($cells['color'] ?? null);
+        $requiredSection = $this->boolCell($cells['is_required_section'] ?? null);
+        $shared = $this->boolCell($cells['is_shared'] ?? null);
+        $position = $this->intCell($cells['position'] ?? null);
+        $objectTypeCodes = MultiValueSplitter::split($cells['object_types'] ?? '');
+
+        $existing = $this->groups->findByCode($code, $tenant);
+
+        try {
+            $group = null === $existing
+                ? $this->createGroup($code, $label, $description, $icon, $color, $position, $requiredSection, $shared, $tenant, $result)
+                : $this->updateGroup($existing, $label, $description, $icon, $color, $position, $requiredSection, $shared, $result);
+        } catch (Throwable $exception) {
+            $result->setOutcome(StructuralImportRowResult::OUTCOME_ERROR);
+            $result->log(ImportLogLevel::Error, \sprintf('Grupa "%s": %s', $code, $exception->getMessage()), ImportErrorType::InvalidValue->value, 'code', $code);
+
+            return $result;
+        }
+
+        if (!$group instanceof AttributeGroup) {
+            return $result;
+        }
+
+        $this->assignObjectTypes($group, $objectTypeCodes, $tenant, $result);
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, string> $label
+     * @param array<string, string> $description
+     */
+    private function createGroup(
+        string $code,
+        array $label,
+        array $description,
+        ?string $icon,
+        ?string $color,
+        ?int $position,
+        ?bool $requiredSection,
+        ?bool $shared,
+        Tenant $tenant,
+        StructuralImportRowResult $result,
+    ): ?AttributeGroup {
+        $command = new CreateAttributeGroupCommand(
+            code: $code,
+            label: $label,
+            description: [] === $description ? null : $description,
+            icon: $icon,
+            color: $color,
+            position: $position ?? 0,
+            requiredSection: $requiredSection ?? false,
+            shared: $shared ?? true,
+        );
+        $newId = $this->dispatch($command);
+        $result->setOutcome(StructuralImportRowResult::OUTCOME_CREATED);
+
+        return $newId instanceof Uuid ? $this->groups->findById($newId) : $this->groups->findByCode($code, $tenant);
+    }
+
+    /**
+     * @param array<string, string> $label
+     * @param array<string, string> $description
+     */
+    private function updateGroup(
+        AttributeGroup $existing,
+        array $label,
+        array $description,
+        ?string $icon,
+        ?string $color,
+        ?int $position,
+        ?bool $requiredSection,
+        ?bool $shared,
+        StructuralImportRowResult $result,
+    ): AttributeGroup {
+        // Empty cells leave the value untouched (operator decision): pass null
+        // (don't touch) rather than the clear* flags.
+        $command = new UpdateAttributeGroupCommand(
+            id: $existing->getId(),
+            label: [] === $label ? null : $label,
+            description: [] === $description ? null : $description,
+            icon: $icon,
+            color: $color,
+            position: $position,
+            requiredSection: $requiredSection,
+            shared: $shared,
+        );
+        $this->dispatch($command);
+        $result->setOutcome(StructuralImportRowResult::OUTCOME_UPDATED);
+
+        return $existing;
+    }
+
+    /**
+     * @param list<string> $objectTypeCodes
+     */
+    private function assignObjectTypes(AttributeGroup $group, array $objectTypeCodes, Tenant $tenant, StructuralImportRowResult $result): void
+    {
+        foreach ($objectTypeCodes as $objectTypeCode) {
+            $objectType = $this->objectTypes->findByCode($objectTypeCode, $tenant);
+            if (!$objectType instanceof ObjectType) {
+                $result->log(ImportLogLevel::Warning, \sprintf('Pominięto nieznany typ obiektu "%s".', $objectTypeCode), ImportErrorType::InvalidValue->value, 'object_types', $objectTypeCode);
+
+                continue;
+            }
+            $this->assigner->assign($objectType, $group);
+        }
+    }
+
+    private function dispatch(object $command): mixed
+    {
+        try {
+            $envelope = $this->commandBus->dispatch($command);
+        } catch (HandlerFailedException $exception) {
+            throw $exception->getPrevious() ?? $exception;
+        }
+        $stamp = $envelope->last(HandledStamp::class);
+
+        return $stamp instanceof HandledStamp ? $stamp->getResult() : null;
+    }
+
+    /**
+     * @param array<string, string|null> $cells
+     *
+     * @return array<string, string>
+     */
+    private function extractLocalized(array $cells, string $base, Tenant $tenant): array
+    {
+        $out = [];
+        foreach ($cells as $header => $value) {
+            if (null === $value || '' === trim($value)) {
+                continue;
+            }
+            $parsed = $this->grammar->parse($header, $tenant);
+            if ($parsed->base === $base && null !== $parsed->locale) {
+                $out[$parsed->locale] = trim($value);
+            }
+        }
+
+        return $out;
+    }
+
+    private function stringCell(?string $raw): ?string
+    {
+        if (null === $raw) {
+            return null;
+        }
+        $raw = trim($raw);
+
+        return '' === $raw ? null : $raw;
+    }
+
+    private function boolCell(?string $raw): ?bool
+    {
+        if (null === $raw) {
+            return null;
+        }
+        $raw = strtolower(trim($raw));
+        if ('' === $raw) {
+            return null;
+        }
+
+        return \in_array($raw, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function intCell(?string $raw): ?int
+    {
+        if (null === $raw) {
+            return null;
+        }
+        $raw = trim($raw);
+
+        return '' === $raw || !is_numeric($raw) ? null : (int) $raw;
+    }
+}

--- a/apps/api/tests/Api/Import/StructuralAttributeGroupImportTest.php
+++ b/apps/api/tests/Api/Import/StructuralAttributeGroupImportTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\Import;
+
+use App\Catalog\Domain\Entity\AttributeGroup;
+use App\Catalog\Domain\Entity\ObjectType;
+use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
+use App\Catalog\Domain\ObjectKind;
+use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
+use App\Import\Application\Service\Structural\AttributeGroupImportCreator;
+use App\Import\Application\Service\Structural\StructuralImportRowResult;
+use App\Shared\Application\TenantContext;
+use App\Shared\Domain\Tenant;
+use App\Tests\Api\Catalog\CatalogApiTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Structural attribute-group import — the mirror of the `attribute_groups`
+ * export. Exercises {@see AttributeGroupImportCreator} directly so the core
+ * upsert + object-type attachment behaviour is covered without HTTP/MinIO.
+ */
+final class StructuralAttributeGroupImportTest extends CatalogApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        foreach ([['pl_PL', 'Polski', 'pl'], ['en_US', 'English', 'en']] as [$code, $label, $lang]) {
+            $locale = new Locale($code, $label, null, $lang);
+            $this->em()->persist($locale);
+            $this->em()->persist(new TenantLocale($locale));
+        }
+        $this->em()->flush();
+    }
+
+    #[Test]
+    public function createsNewGroupWithMetadataAndAttachesObjectType(): void
+    {
+        $tenant = $this->tenant();
+        $module = $this->customObjectType($tenant, 'widgets');
+
+        $result = $this->creator()->create(2, [
+            'code' => 'marketing',
+            'label.pl' => 'Marketing',
+            'label.en' => 'Marketing',
+            'description.pl' => 'Treści',
+            'icon' => 'megaphone',
+            'color' => '#ff0000',
+            'is_required_section' => 'true',
+            'is_shared' => 'true',
+            'position' => '3',
+            'object_types' => 'widgets',
+        ], $tenant);
+
+        self::assertSame(StructuralImportRowResult::OUTCOME_CREATED, $result->outcome);
+
+        $group = $this->groupRepo()->findByCode('marketing', $tenant);
+        self::assertInstanceOf(AttributeGroup::class, $group);
+        self::assertSame(['pl' => 'Marketing', 'en' => 'Marketing'], $group->getLabel());
+        self::assertSame('megaphone', $group->getIcon());
+        self::assertSame('#ff0000', $group->getColor());
+        self::assertTrue($group->isRequiredSection());
+        self::assertSame(3, $group->getPosition());
+        self::assertSame(1, $this->junctionCount($module, $group));
+    }
+
+    #[Test]
+    public function reimportIsIdempotentAndReportsUpdate(): void
+    {
+        $tenant = $this->tenant();
+        $module = $this->customObjectType($tenant, 'widgets');
+
+        $cells = ['code' => 'seo', 'label.en' => 'SEO', 'object_types' => 'widgets'];
+        $first = $this->creator()->create(2, $cells, $tenant);
+        self::assertSame(StructuralImportRowResult::OUTCOME_CREATED, $first->outcome);
+
+        $second = $this->creator()->create(2, $cells, $tenant);
+        self::assertSame(StructuralImportRowResult::OUTCOME_UPDATED, $second->outcome);
+
+        $group = $this->groupRepo()->findByCode('seo', $tenant);
+        self::assertInstanceOf(AttributeGroup::class, $group);
+        self::assertSame(1, $this->junctionCount($module, $group), 're-import must not duplicate the junction');
+    }
+
+    #[Test]
+    public function unknownObjectTypeWarnsButStillImportsTheGroup(): void
+    {
+        $tenant = $this->tenant();
+
+        $result = $this->creator()->create(2, [
+            'code' => 'logistics',
+            'label.en' => 'Logistics',
+            'object_types' => 'ghost_module',
+        ], $tenant);
+
+        self::assertSame(StructuralImportRowResult::OUTCOME_CREATED, $result->outcome);
+        self::assertInstanceOf(AttributeGroup::class, $this->groupRepo()->findByCode('logistics', $tenant));
+        self::assertNotEmpty($result->logs);
+        self::assertStringContainsString('ghost_module', $result->logs[0]['message']);
+    }
+
+    #[Test]
+    public function emptyCellsLeaveExistingValuesUntouchedOnUpdate(): void
+    {
+        $tenant = $this->tenant();
+
+        $this->creator()->create(2, ['code' => 'specs', 'label.en' => 'Specs', 'icon' => 'ruler'], $tenant);
+        // Re-import with no icon column at all — icon must be preserved.
+        $this->creator()->create(2, ['code' => 'specs', 'label.en' => 'Specifications'], $tenant);
+
+        $group = $this->groupRepo()->findByCode('specs', $tenant);
+        self::assertInstanceOf(AttributeGroup::class, $group);
+        self::assertSame('ruler', $group->getIcon(), 'empty/absent icon cell must not clear the value');
+        self::assertSame(['en' => 'Specifications'], $group->getLabel());
+    }
+
+    private function creator(): AttributeGroupImportCreator
+    {
+        return self::getContainer()->get(AttributeGroupImportCreator::class);
+    }
+
+    private function groupRepo(): AttributeGroupRepositoryInterface
+    {
+        return self::getContainer()->get(AttributeGroupRepositoryInterface::class);
+    }
+
+    private function junctionCount(ObjectType $objectType, AttributeGroup $group): int
+    {
+        return (int) $this->em()->createQuery(
+            'SELECT COUNT(j.position) FROM '.ObjectTypeAttributeGroup::class.' j WHERE j.objectType = :ot AND j.attributeGroup = :g',
+        )->setParameter('ot', $objectType)->setParameter('g', $group)->getSingleScalarResult();
+    }
+
+    private function customObjectType(Tenant $tenant, string $code): ObjectType
+    {
+        $module = new ObjectType($code, ObjectKind::Custom, ['pl' => $code, 'en' => $code]);
+        $module->assignTenant($tenant);
+        $this->em()->persist($module);
+        $this->em()->flush();
+
+        return $module;
+    }
+
+    private function tenant(): Tenant
+    {
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+
+        return $tenant;
+    }
+}


### PR DESCRIPTION
## Cel

Import **definicji grup atrybutów**, lustrzane odbicie eksportu `attribute_groups`. Po imporcie nowe/zmienione grupy pojawiają się w `/modeling/attribute-groups`, a kolumna `object_types` przypina je do wskazanych typów obiektów. Domyka backend importu (po #1741 atrybuty).

> Wcześniej #1742 (stacked na #1741) — zamknięty automatycznie po merge bazy; ten PR to ta sama zmiana przebazowana na `main`.

## Zmiany

- **`StructuralImportRunHandler`** routuje sesję po `structural_kind` → nowy `AttributeGroupImportCreator` dla `attribute_groups`.
- **`AttributeGroupImportCreator`** — upsert `AttributeGroup` po `code` przez komendy CQRS (`CreateAttributeGroup`/`UpdateAttributeGroup`); `object_types` → przypięcie do ObjectType.
- **`ObjectTypeAttributeGroupAssigner`** (Catalog\Application) — współdzielony, idempotentny serwis dołączania grupy do ObjectType.
- Te same decyzje operatora co import atrybutów: re-import additywny (nigdy nie odpina), puste komórki nie nadpisują (bez flag `clear*`), nieznane object types → warning + pominięcie. `is_built_in` ignorowane.

## Weryfikacja

- PHPStan max ✅ · php-cs-fixer ✅ · deptrac ✅
- `StructuralAttributeGroupImportTest` ✅ 4/4: create + przypięcie OT, idempotentny re-import (updated, brak duplikatu junctionu), nieznany OT → warning non-blocking, puste komórki nie czyszczą wartości.
- **Smoke-test na żywym stacku**: POST CSV (`structural_kind=attribute_groups`, `object_types=product`) → `HTTP 200 {"status":"success","success_count":1}`; grupa `smoke_group` w DB z ikoną/kolorem, przypięta do ObjectType `product`. Dane posprzątane.

## Następne
- PR FE: uproszczony 4-krokowy kreator importu (Dane → Źródło → Wykrywanie → Start) dla obu typów strukturalnych.

Refs #1382