### PR TITLE
perf(test): seed RBAC permission catalogue once via Foundry global_state (AUD-082)

### DIFF
--- a/apps/api/config/packages/zenstruck_foundry.yaml
+++ b/apps/api/config/packages/zenstruck_foundry.yaml
@@ -13,4 +13,14 @@ when@dev: &dev
     #        autowire: true
     #        autoconfigure: true
 
-when@test: *dev
+when@test:
+    zenstruck_foundry:
+        persistence:
+            # Flush only once per call of `PersistentObjectFactory::create()`
+            flush_once: true
+        # AUD-082 — seed the tenant-agnostic permission catalogue exactly once
+        # per test session instead of in every ApiTestCase::setUp(). Foundry
+        # commits global state before the per-test DAMA transaction, so it
+        # survives every rollback. See App\Tests\State\DefaultTestState.
+        global_state:
+            - 'App\Tests\State\DefaultTestState'

--- a/apps/api/config/services.yaml
+++ b/apps/api/config/services.yaml
@@ -549,3 +549,11 @@ when@test:
         App\Backup\Application\Service\BackupRunnerInterface:
             alias: App\Tests\Support\InMemoryBackupRunner
             public: true
+
+        # AUD-082 — invokable seeder run once via zenstruck_foundry.global_state
+        # (see config/packages/zenstruck_foundry.yaml). Autowires RbacSeeder +
+        # the EntityManager so the tenant-agnostic permission catalogue is
+        # committed before the per-test DAMA transaction.
+        App\Tests\State\DefaultTestState:
+            autowire: true
+            autoconfigure: true

--- a/apps/api/tests/Api/ApiConfigurator/ApiConfiguratorApiTestCase.php
+++ b/apps/api/tests/Api/ApiConfigurator/ApiConfiguratorApiTestCase.php
@@ -6,8 +6,6 @@ namespace App\Tests\Api\ApiConfigurator;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Symfony\Bundle\Test\Client;
-use App\DataFixtures\Identity\PrdPermissionFixtures;
-use App\Identity\Application\RbacSeeder;
 use App\Identity\Application\SeedTenantPrdRolesService;
 use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Rbac\RbacMatrix;
@@ -42,11 +40,8 @@ abstract class ApiConfiguratorApiTestCase extends ApiTestCase
         parent::setUp();
 
         $em = $this->em();
-        self::getContainer()->get(RbacSeeder::class)->seed();
-        // RBAC-P6 retrofit — same scaffolding as CatalogApiTestCase.
-        $prdPermissions = new PrdPermissionFixtures();
-        $prdPermissions->load($em);
-        $em->flush();
+        // RBAC permission catalogue seeded once per session via Foundry
+        // global_state (AUD-082, App\Tests\State\DefaultTestState).
 
         $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)
             ->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);

--- a/apps/api/tests/Api/Catalog/CatalogApiTestCase.php
+++ b/apps/api/tests/Api/Catalog/CatalogApiTestCase.php
@@ -7,8 +7,6 @@ namespace App\Tests\Api\Catalog;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Catalog\Application\BuiltInObjectTypeSeeder;
 use App\Catalog\Domain\ObjectKind;
-use App\DataFixtures\Identity\PrdPermissionFixtures;
-use App\Identity\Application\RbacSeeder;
 use App\Identity\Application\SeedTenantPrdRolesService;
 use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Rbac\RbacMatrix;
@@ -44,16 +42,9 @@ abstract class CatalogApiTestCase extends ApiTestCase
         parent::setUp();
 
         $em = $this->em();
-        self::getContainer()->get(RbacSeeder::class)->seed();
-        // RBAC-P6-005/006/007 retrofit — Phase 6 retrofit gates every
-        // controller method with PRD §3.2 granular codes (products.add,
-        // modeling.attribute_groups.add_edit, etc.). RbacSeeder only
-        // emits the legacy RbacMatrix 4-action × 19-resource set, so
-        // these tests need the PRD permission catalogue + tenant_owner
-        // role assigned to the test admin to clear EndpointGuardListener.
-        $prdPermissions = new PrdPermissionFixtures();
-        $prdPermissions->load($em);
-        $em->flush();
+        // RBAC permission catalogue (legacy global roles + PRD granular
+        // codes) is seeded once per session via Foundry global_state
+        // (AUD-082, App\Tests\State\DefaultTestState) — no per-test re-seed.
 
         $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)
             ->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);

--- a/apps/api/tests/Api/Channel/ChannelApiTestCase.php
+++ b/apps/api/tests/Api/Channel/ChannelApiTestCase.php
@@ -7,8 +7,6 @@ namespace App\Tests\Api\Channel;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use App\Catalog\Application\BuiltInObjectTypeSeeder;
 use App\Channel\Domain\Entity\Locale;
-use App\DataFixtures\Identity\PrdPermissionFixtures;
-use App\Identity\Application\RbacSeeder;
 use App\Identity\Application\SeedTenantPrdRolesService;
 use App\Identity\Domain\Entity\User;
 use App\Identity\Domain\Rbac\RbacMatrix;
@@ -41,11 +39,8 @@ abstract class ChannelApiTestCase extends ApiTestCase
         parent::setUp();
 
         $em = $this->em();
-        self::getContainer()->get(RbacSeeder::class)->seed();
-        // RBAC-P6 retrofit — same scaffolding as CatalogApiTestCase.
-        $prdPermissions = new PrdPermissionFixtures();
-        $prdPermissions->load($em);
-        $em->flush();
+        // RBAC permission catalogue seeded once per session via Foundry
+        // global_state (AUD-082, App\Tests\State\DefaultTestState).
 
         $superAdmin = self::getContainer()->get(RoleRepositoryInterface::class)
             ->findGlobalByCode(RbacMatrix::ROLE_SUPER_ADMIN);

--- a/apps/api/tests/State/DefaultTestState.php
+++ b/apps/api/tests/State/DefaultTestState.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\State;
+
+use App\DataFixtures\Identity\PrdPermissionFixtures;
+use App\Identity\Application\RbacSeeder;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * AUD-082 — global test state, loaded once via Foundry's `global_state`.
+ *
+ * Seeds the TENANT-AGNOSTIC permission catalogue exactly once per test
+ * session: the legacy {@see RbacSeeder} permissions + four built-in global
+ * roles, plus the granular PRD permission set ({@see PrdPermissionFixtures}).
+ * With DAMA enabled, Foundry commits global state BEFORE the per-test
+ * transaction and it survives every rollback (see
+ * {@see \Zenstruck\Foundry\ORM\ResetDatabase\DamaDatabaseResetter}), so the
+ * ~114 ApiTestCase subclasses no longer re-insert ~70 permission/role rows in
+ * every single setUp().
+ *
+ * Both seeders are idempotent (match-by-code), so any test that still calls
+ * them in its own setUp keeps working — the rows just already exist.
+ *
+ * Tenant-scoped data (the `demo` tenant, its PRD roles, the admin user, the
+ * built-in ObjectTypes) is intentionally NOT seeded here: ~18 Integration
+ * tests create their own `new Tenant('demo')` per test, so a committed global
+ * `demo` tenant would collide on the unique `tenants.code`. Globalising that
+ * needs a separate, wider refactor (tracked in #1745).
+ */
+final class DefaultTestState
+{
+    public function __construct(
+        private readonly RbacSeeder $rbacSeeder,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        $this->rbacSeeder->seed();
+        new PrdPermissionFixtures()->load($this->em);
+        $this->em->flush();
+    }
+}


### PR DESCRIPTION
## Cel — AUD-082 (#1745), bezpieczny podzbiór

Bazowe klasy `CatalogApiTestCase` / `ChannelApiTestCase` / `ApiConfiguratorApiTestCase` (~114 testów) w **każdym** `setUp()` ponownie seedowały **tenant-agnostyczny katalog uprawnień**: globalne role + permissions z `RbacSeeder` oraz ~56-kodowy zestaw PRD (`PrdPermissionFixtures`).

Przeniesione do **`zenstruck_foundry.global_state`** (`App\Tests\State\DefaultTestState`) — uruchamiane **raz na sesję**. Przy DAMA Foundry commituje global-state **przed** transakcją per-test i przeżywa rollback ([`DamaDatabaseResetter`](apps/api/vendor/zenstruck/foundry/src/ORM/ResetDatabase/DamaDatabaseResetter.php#L45-L56)). Oba seedery są idempotentne, więc ~18 testów Integration tworzących własny tenant działa bez zmian.

## Co świadomie ZOSTAJE per-test (i dlaczego)

Dane tenant-scoped (tenant `demo`, jego role PRD, admin, wbudowane ObjectType) **nie** idą do global-state: **18 testów Integration tworzy własny `new Tenant('demo')` per-test**, więc zacommitowany globalny `demo` kolidowałby na unikalnym `tenants.code`. Pełna globalizacja tenanta wymaga osobnego, szerszego refaktoru — udokumentowane w #1745.

## Weryfikacja

- Statycznie (lokalnie): `composer cs-check` 0/1221, PHPStan max — 0 błędów na zmienionych plikach, `php -l` OK.
- **Runtime — CI**: lokalny kontener `api` to worker prod-mode i nie odpala suitów bootujących kernel (`test.service_container` brak), więc poprawność i zysk czasu **weryfikuje CI** (pełny suite musi pozostać zielony). Decyzja merge/defer wg wyniku CI + zmierzonej delty na shardzie `api`/`integration`.

## Zakres

1 nowy plik (`tests/State/DefaultTestState.php`) + rejestracja service w `when@test` + `global_state` w foundry config + usunięcie bloku seed z 3 bazowych klas (importy posprzątane). Bez zmian w kodzie produkcyjnym.

Refs #1745
