### PR TITLE
ci(test): sub-shard the api suite three ways (AUD-084)

### DIFF
--- a/.github/workflows/quality-php.yml
+++ b/.github/workflows/quality-php.yml
@@ -267,10 +267,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # AUD-084 — `api` was the dominant leg (~1412s, ~45% of it Catalog);
+        # split three ways (Catalog / Import+Identity / the rest via <exclude>)
+        # so the legs run concurrently. See phpunit.dist.xml testsuites.
         suite:
           - "unit,architecture"
           - "integration"
-          - "api"
+          - "api-catalog"
+          - "api-heavy"
+          - "api-rest"
     services:
       postgres:
         image: postgres:16-alpine

--- a/apps/api/phpunit.dist.xml
+++ b/apps/api/phpunit.dist.xml
@@ -31,6 +31,28 @@
         <testsuite name="api">
             <directory>tests/Api</directory>
         </testsuite>
+        <!-- AUD-084 — sub-shards of `api` for the CI matrix. The full `api`
+             suite above is the slowest leg (~1412s, ~45% of it is Catalog), so
+             splitting it three ways lets Catalog run in parallel with the rest
+             instead of gating the whole shard. `api` stays intact for local
+             single-process runs; CI runs these three legs concurrently. -->
+        <testsuite name="api-catalog">
+            <directory>tests/Api/Catalog</directory>
+        </testsuite>
+        <testsuite name="api-heavy">
+            <directory>tests/Api/Import</directory>
+            <directory>tests/Api/Identity</directory>
+        </testsuite>
+        <!-- Everything under tests/Api NOT in api-catalog / api-heavy. Defined
+             with <exclude> (a blacklist), NOT a whitelist of dirs: a new
+             tests/Api/<NewDir> auto-lands here and stays covered, instead of
+             being silently skipped by every shard (AUD-061 lesson). -->
+        <testsuite name="api-rest">
+            <directory>tests/Api</directory>
+            <exclude>tests/Api/Catalog</exclude>
+            <exclude>tests/Api/Import</exclude>
+            <exclude>tests/Api/Identity</exclude>
+        </testsuite>
         <!-- Static fitness tests: Deptrac analyse + custom PHPStan rules. -->
         <testsuite name="architecture">
             <directory>tests/Architecture</directory>


### PR DESCRIPTION
## Cel — AUD-084 (#1749)

Po #1747 wall-clock CI = `max(shard)`, a `PHPUnit (api)` = **1412s (~23.5 min)** dominuje (integration 251s / benchmark 242s / unit+arch 38s biegną równolegle i dawno kończą). ~46% z 739 testów api to `tests/Api/Catalog`.

## Zmiana

`api` rozbity na 3 leg-i matrycy (testsuite w `phpunit.dist.xml`):
- `api-catalog` — `tests/Api/Catalog` (339 testów)
- `api-heavy` — `tests/Api/Import` + `tests/Api/Identity` (256)
- `api-rest` — `tests/Api` **minus** powyższe przez `<exclude>` (144)

`api-rest` przez blacklistę (`<exclude>`), nie whitelistę — nowy `tests/Api/<Dir>` auto-wpada do pokrycia zamiast być cicho pominięty (lekcja AUD-061).

## Weryfikacja

- Pokrycie (lokalnie, `--list-tests`): **339 + 256 + 144 = 739 = pełny suite `api`** — zero luki/nakładki.
- YAML + XML poprawne.
- **Runtime + wall-clock → CI**: 6 legów (`unit,architecture` / `integration` / `api-catalog` / `api-heavy` / `api-rest`) + `phpunit-benchmark` muszą być zielone. Zmierzony wall-clock przed (~23.5 min) vs po — w komentarzu po merge.

Projekcja: api 1412 → ~640s (długim polem zostaje `api-catalog`); całe CI ~23.5 → **~11 min**.

Refs #1749
