### PR TITLE
fix(export): eksport strukturalny używa krótkich kodów locale (naprawa pustych nazw)

### DIFF
--- a/apps/api/src/Export/Application/Builder/Structural/AttributeGroupsExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/Structural/AttributeGroupsExportBuilder.php
@@ -7,6 +7,7 @@ namespace App\Export\Application\Builder\Structural;
 use App\Catalog\Domain\Entity\AttributeGroup;
 use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
 use App\Catalog\Domain\Repository\AttributeGroupRepositoryInterface;
+use App\Channel\Contracts\LocaleCodeResolverInterface;
 use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
 use App\Export\Domain\Enum\ExportEntityType;
 use App\Shared\Domain\Tenant;
@@ -29,6 +30,7 @@ final readonly class AttributeGroupsExportBuilder implements StructuralExportBui
     public function __construct(
         private AttributeGroupRepositoryInterface $groups,
         private TenantLocaleRepositoryInterface $locales,
+        private LocaleCodeResolverInterface $localeResolver,
         private EntityManagerInterface $em,
     ) {
     }
@@ -112,11 +114,14 @@ final readonly class AttributeGroupsExportBuilder implements StructuralExportBui
      */
     private function localeCodes(Tenant $tenant): array
     {
+        // Short codes (`pl`, not `pl_PL`): the JSONB label/description keys, the
+        // workspace locales and the import grammar all use the short form, so
+        // `label.{short}` is what round-trips on re-import.
         $codes = [];
         foreach ($this->locales->findActiveForTenant($tenant) as $tenantLocale) {
-            $codes[] = $tenantLocale->getLocale()->getCode();
+            $codes[$this->localeResolver->toShort($tenantLocale->getLocale()->getCode())] = true;
         }
 
-        return $codes;
+        return array_keys($codes);
     }
 }

--- a/apps/api/src/Export/Application/Builder/Structural/AttributesGroupsExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/Structural/AttributesGroupsExportBuilder.php
@@ -9,6 +9,7 @@ use App\Catalog\Domain\Entity\AttributeGroupAttribute;
 use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\Repository\AttributeOptionRepositoryInterface;
 use App\Catalog\Domain\Repository\AttributeRepositoryInterface;
+use App\Channel\Contracts\LocaleCodeResolverInterface;
 use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
 use App\Export\Domain\Enum\ExportEntityType;
 use App\Shared\Domain\Tenant;
@@ -35,6 +36,7 @@ final readonly class AttributesGroupsExportBuilder implements StructuralExportBu
         private AttributeRepositoryInterface $attributes,
         private AttributeOptionRepositoryInterface $options,
         private TenantLocaleRepositoryInterface $locales,
+        private LocaleCodeResolverInterface $localeResolver,
         private EntityManagerInterface $em,
     ) {
     }
@@ -148,11 +150,14 @@ final readonly class AttributesGroupsExportBuilder implements StructuralExportBu
      */
     private function localeCodes(Tenant $tenant): array
     {
+        // Short codes (`pl`, not `pl_PL`): the JSONB label/help keys, the
+        // workspace locales and the import grammar all use the short form, so
+        // `label.{short}` is what round-trips on re-import.
         $codes = [];
         foreach ($this->locales->findActiveForTenant($tenant) as $tenantLocale) {
-            $codes[] = $tenantLocale->getLocale()->getCode();
+            $codes[$this->localeResolver->toShort($tenantLocale->getLocale()->getCode())] = true;
         }
 
-        return $codes;
+        return array_keys($codes);
     }
 }

--- a/apps/api/src/Export/Application/Builder/Structural/CategoriesExportBuilder.php
+++ b/apps/api/src/Export/Application/Builder/Structural/CategoriesExportBuilder.php
@@ -8,6 +8,7 @@ use App\Catalog\Domain\Entity\CatalogObject;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\CatalogObjectRepositoryInterface;
 use App\Catalog\Domain\Repository\CategoryAttributeGroupRepositoryInterface;
+use App\Channel\Contracts\LocaleCodeResolverInterface;
 use App\Channel\Domain\Repository\TenantLocaleRepositoryInterface;
 use App\Export\Domain\Enum\ExportEntityType;
 use App\Shared\Domain\Tenant;
@@ -26,6 +27,7 @@ final readonly class CategoriesExportBuilder implements StructuralExportBuilderI
         private CatalogObjectRepositoryInterface $objects,
         private CategoryAttributeGroupRepositoryInterface $categoryGroups,
         private TenantLocaleRepositoryInterface $locales,
+        private LocaleCodeResolverInterface $localeResolver,
     ) {
     }
 
@@ -137,11 +139,13 @@ final readonly class CategoriesExportBuilder implements StructuralExportBuilderI
      */
     private function localeCodes(Tenant $tenant): array
     {
+        // Short codes (`pl`, not `pl_PL`): the JSONB name keys and the import
+        // grammar use the short form, so `name.{short}` is what round-trips.
         $codes = [];
         foreach ($this->locales->findActiveForTenant($tenant) as $tenantLocale) {
-            $codes[] = $tenantLocale->getLocale()->getCode();
+            $codes[$this->localeResolver->toShort($tenantLocale->getLocale()->getCode())] = true;
         }
 
-        return $codes;
+        return array_keys($codes);
     }
 }

--- a/apps/api/tests/Api/Export/StructuralExportApiTest.php
+++ b/apps/api/tests/Api/Export/StructuralExportApiTest.php
@@ -13,6 +13,8 @@ use App\Catalog\Domain\Entity\ObjectTypeAttribute;
 use App\Catalog\Domain\Entity\ObjectTypeAttributeGroup;
 use App\Catalog\Domain\ObjectKind;
 use App\Catalog\Domain\Repository\ObjectTypeRepositoryInterface;
+use App\Channel\Domain\Entity\Locale;
+use App\Channel\Domain\Entity\TenantLocale;
 use App\Export\Application\Sync\SyncExportRunner;
 use App\Export\Domain\Entity\ExportSession;
 use App\Export\Domain\Enum\ExportEntityType;
@@ -31,6 +33,25 @@ use Symfony\Component\Uid\Uuid;
  */
 final class StructuralExportApiTest extends CatalogApiTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Active locales pl/en so the structural builders fan out label/help/
+        // description columns. The short code (`pl`) — not the full `pl_PL` —
+        // is what the JSONB labels are keyed by and what the import grammar
+        // expects, so the export columns must use it for a clean round-trip.
+        $tenant = $this->em()->getRepository(Tenant::class)->findOneBy(['code' => self::TENANT_CODE]);
+        \assert($tenant instanceof Tenant);
+        self::getContainer()->get(TenantContext::class)->set($tenant);
+        foreach ([['pl_PL', 'Polski', 'pl'], ['en_US', 'English', 'en']] as [$code, $label, $lang]) {
+            $locale = new Locale($code, $label, null, $lang);
+            $this->em()->persist($locale);
+            $this->em()->persist(new TenantLocale($locale));
+        }
+        $this->em()->flush();
+    }
+
     #[Test]
     public function moduleSchemaExportListsObjectTypes(): void
     {
@@ -88,7 +109,7 @@ final class StructuralExportApiTest extends CatalogApiTestCase
         $module->assignTenant($tenant);
         $group = new AttributeGroup(
             'marketing',
-            ['pl' => 'Marketing', 'en' => 'Marketing'],
+            ['pl' => 'Marketing PL', 'en' => 'Marketing EN'],
             0,
             null,
             ['pl' => 'Treści marketingowe', 'en' => 'Marketing content'],
@@ -104,6 +125,12 @@ final class StructuralExportApiTest extends CatalogApiTestCase
 
         self::assertStringContainsString('marketing', $csv);
         self::assertStringContainsString('megaphone', $csv);
+        // Localised name exports under the SHORT locale code (`label.pl`), not
+        // the full `label.pl_PL`, and carries the actual value — the bug that
+        // made the name column come out empty.
+        self::assertStringContainsString('label.pl', $csv);
+        self::assertStringNotContainsString('label.pl_PL', $csv);
+        self::assertStringContainsString('Marketing PL', $csv);
         // The group row carries its attached ObjectType code in object_types.
         self::assertMatchesRegularExpression('/marketing[^\n]*widgets/', $csv);
     }


### PR DESCRIPTION
## Summary
Eksport strukturalny (Atrybuty / Grupy atrybutów / Kategorie) zwracał **puste kolumny nazw** (`label.*` / `name.*`), a re-import nie wczytywał nazwy (locale pl). Naprawa: kolumny używają **krótkiego kodu locale** (`label.pl`), zgodnego z kluczami JSONB i gramatyką importu.

## Root cause
Buildery fanowały kolumny po pełnym kodzie `getLocale()->getCode()` → `label.pl_PL`. JSONB encji jest kluczowany krótko (`{"pl": ...}`), a `ImportColumnGrammar` rozpoznaje tylko krótkie kody. Stąd `$label['pl_PL'] ?? ''` → pusto przy eksporcie, i nierozpoznany suffix przy imporcie.

## Backend changes
- `AttributesGroupsExportBuilder`, `AttributeGroupsExportBuilder`, `CategoriesExportBuilder`: `localeCodes()` rozwiązuje aktywne locale do krótkiej formy przez `LocaleCodeResolverInterface::toShort()` (Channel\Contracts — dozwolone w Export), z dedupem.

## Quality gates
- PHPStan max ✅ · deptrac ✅ · php-cs-fixer ✅
- `StructuralExportApiTest`: seed locales pl/en + asercja, że grupa eksportuje `label.pl` **z wartością** ("Marketing PL") i **nie** `label.pl_PL`. (2 testy auth-owe failują lokalnie na kluczu JWT — zielone w CI.)
- **Live smoke**: eksport grup → `importowana_grupa;"importowana grupa z ręczną nazwą"` (przed: pusto); eksport atrybutów → `accessory;...;Akcesoria;Accessory`; import grupy z `label.pl=Nazwa Testowa PL` → DB `{"pl":"Nazwa Testowa PL","en":...}`. Round-trip ✅.

## Smoke test plan (operator)
1. Eksport „Grupy atrybutów" → kolumna `label.pl` ma nazwy (nie pusto).
2. Edytuj nazwę w pliku → import → nazwa zapisana w `/modeling/attribute-groups`.

## Świadome odejścia
- Naprawione też `CategoriesExportBuilder` (ten sam root cause — `name.pl_PL`) mimo że zgłoszenie dotyczyło atrybutów/grup; zostawienie znanego buga byłoby niespójne.

Closes #1753

🤖 Generated with [Claude Code](https://claude.com/claude-code)