### PR TITLE
fix(import): dry-run nie waliduje pominiętych kolumn z kropką w nazwie

### DIFF
--- a/apps/api/src/Import/Application/Service/ImportValidationService.php
+++ b/apps/api/src/Import/Application/Service/ImportValidationService.php
@@ -150,6 +150,14 @@ final readonly class ImportValidationService
         $categoryCellValue = null;
         $categoryColumnName = null;
         foreach ($columnMapping as $columnHeader => $attributeCode) {
+            // A column the operator skipped (or left unmapped) is not imported,
+            // so its header grammar is irrelevant. Supplier files routinely carry
+            // columns whose names contain a dot (e.g. "Imp.CodeNr") — without this
+            // guard they are misread as an `attribute.locale` suffix and rejected.
+            if (ReservedMappingTarget::SKIP === $attributeCode || '' === $attributeCode) {
+                continue;
+            }
+
             $parsed = $this->columnGrammar->parse($columnHeader, $tenant);
             if (null !== $parsed->unknownSuffix) {
                 $errors[] = new ValidationError(
@@ -168,9 +176,6 @@ final readonly class ImportValidationService
             // completeness, …) never carry an Attribute value — skip them
             // so re-importing an export does not flag them.
             if (SystemColumn::isSystem($columnHeader)) {
-                continue;
-            }
-            if (ReservedMappingTarget::SKIP === $attributeCode || '' === $attributeCode) {
                 continue;
             }
             // IMP2-1.8 — parent_sku is wired in the two-pass relation step

--- a/apps/api/tests/Api/Import/ValidateDryRunApiTest.php
+++ b/apps/api/tests/Api/Import/ValidateDryRunApiTest.php
@@ -76,6 +76,49 @@ final class ValidateDryRunApiTest extends CatalogApiTestCase
     }
 
     #[Test]
+    public function skippedColumnWithADotInItsNameIsNotGrammarValidated(): void
+    {
+        $this->seedAttributesAndDuplicates();
+
+        // Supplier files routinely carry columns whose names contain a dot
+        // (e.g. "Imp.CodeNr"). When the operator skips such a column it must not
+        // be misread as an `attribute.locale` suffix and rejected — the dry-run
+        // must match the import, which already ignores skipped columns.
+        $csvPath = tempnam(sys_get_temp_dir(), 'dryrun-skip-').'.csv';
+        file_put_contents($csvPath, "sku;Imp.CodeNr\nSKU-1;some-supplier-code\n");
+
+        try {
+            $client = $this->authenticatedClient();
+            $client->request('POST', '/api/import-sessions/validate-dry-run', [
+                'extra' => [
+                    'parameters' => [
+                        'target_object_type_id' => $this->objectTypeIdFor(ObjectKind::Product),
+                        'mapping' => json_encode(['sku' => 'sku', 'Imp.CodeNr' => 'skip'], JSON_THROW_ON_ERROR),
+                    ],
+                    'files' => [
+                        'file' => new UploadedFile($csvPath, 'supplier.csv', 'text/csv', null, true),
+                    ],
+                ],
+            ]);
+
+            self::assertResponseIsSuccessful();
+            $response = $client->getResponse();
+            self::assertNotNull($response);
+            $body = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertIsArray($body);
+
+            self::assertSame(0, $body['error_count'], 'A skipped dotted-name column must not raise a grammar error.');
+            self::assertSame(1, $body['success_count']);
+            self::assertStringNotContainsString(
+                'neither an active locale nor a channel code',
+                json_encode($body['top_errors'] ?? [], JSON_THROW_ON_ERROR),
+            );
+        } finally {
+            @unlink($csvPath);
+        }
+    }
+
+    #[Test]
     public function unsupportedExtensionReturns400(): void
     {
         $this->seedAttributesAndDuplicates();


### PR DESCRIPTION
## Summary
Podgląd (dry-run) importu produktów pokazywał setki błędów `suffix "CodeNr" is neither an active locale nor a channel code` dla **pominiętych** kolumn dostawcy z kropką w nazwie (np. `WarenNr / Imp.CodeNr`). To false positive — faktyczny import (`ImportRunHandler`) takie kolumny ignoruje. Fix wyrównuje dry-run do importu.

## Root cause
`ImportValidationService` parsował gramatykę `base.locale` PRZED sprawdzeniem `skip`/pusta. Kropka w nazwie → traktowana jak suffix locale → odrzucenie.

## Fix
Skip/empty-check przeniesiony na początek pętli, przed `columnGrammar->parse()` — pominięte kolumny nie są walidowane (jak w `ImportRunHandler:679`).

## Weryfikacja
- PHPStan max ✅ · php-cs-fixer ✅
- Test `skippedColumnWithADotInItsNameIsNotGrammarValidated`: kolumna `Imp.CodeNr` → skip + `sku` zmapowane → `error_count=0`, brak komunikatu o suffixie.
- **Live smoke** (plik dostawcy 1367 wierszy, wszystkie kolumny skip): przed — błędy gramatyki + missing sku; po — **tylko** `missing_required` (Missing "sku"). False-positive zniknął.

## Uwaga (nie bug)
„0 produktów OK" w tym pliku wynika z braku zmapowanego `sku` — import produktów wymaga mapowania kolumny → `sku` (+ atrybuty). Renaming kolumny też omija błąd gramatyki, ale nie zastępuje mapowania.

🤖 Generated with [Claude Code](https://claude.com/claude-code)